### PR TITLE
docs: improvements to lua annotation generation

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -104,20 +104,20 @@ function vim.api.nvim__unpack(str) end
 --- Adds a highlight to buffer.
 --- Useful for plugins that dynamically generate highlights to a buffer (like
 --- a semantic highlighter or linter). The function adds a single highlight to
---- a buffer. Unlike `|matchaddpos()|` highlights follow changes to line
+--- a buffer. Unlike [matchaddpos()](help://matchaddpos()) highlights follow changes to line
 --- numbering (as lines are inserted/removed above the highlighted line), like
 --- signs and marks do.
 --- Namespaces are used for batch deletion/updating of a set of highlights. To
---- create a namespace, use `|nvim_create_namespace()|` which returns a
+--- create a namespace, use [nvim_create_namespace()](help://nvim_create_namespace()) which returns a
 --- namespace id. Pass it in to this function as `ns_id` to add highlights to
 --- the namespace. All highlights in the same namespace can then be cleared
---- with single call to `|nvim_buf_clear_namespace()|`. If the highlight never
+--- with single call to [nvim_buf_clear_namespace()](help://nvim_buf_clear_namespace()). If the highlight never
 --- will be deleted by an API call, pass `ns_id = -1`.
 --- As a shorthand, `ns_id = 0` can be used to create a new namespace for the
 --- highlight, the allocated id is then returned. If `hl_group` is the empty
 --- string no highlight is added, but a new `ns_id` is still returned. This is
 --- supported for backwards compatibility, new code should use
---- `|nvim_create_namespace()|` to create a new empty namespace.
+--- [nvim_create_namespace()](help://nvim_create_namespace()) to create a new empty namespace.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param ns_id integer namespace to use or -1 for ungrouped highlight
@@ -207,7 +207,7 @@ function vim.api.nvim_buf_attach(buffer, send_buffer, opts) end
 --- a temporary scratch window (called the "autocmd window" for historical
 --- reasons) will be used.
 --- This is useful e.g. to call Vimscript functions that only work with the
---- current buffer/window currently, like `|termopen()|`.
+--- current buffer/window currently, like [termopen()](help://termopen()).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param fun function Function to call inside the buffer (currently Lua callable
@@ -222,9 +222,9 @@ function vim.api.nvim_buf_call(buffer, fun) end
 --- @param line_end integer
 function vim.api.nvim_buf_clear_highlight(buffer, ns_id, line_start, line_end) end
 
---- Clears `|namespace|`d objects (highlights, `|extmarks|`, virtual text) from a
+--- Clears [namespace](help://namespace)d objects (highlights, [extmarks](help://extmarks), virtual text) from a
 --- region.
---- Lines are 0-indexed. `|api-indexing|` To clear the namespace in the entire
+--- Lines are 0-indexed. [api-indexing](help://api-indexing) To clear the namespace in the entire
 --- buffer, specify line_start=0 and line_end=-1.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
@@ -234,7 +234,7 @@ function vim.api.nvim_buf_clear_highlight(buffer, ns_id, line_start, line_end) e
 ---  clear to end of buffer.
 function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) end
 
---- Creates a buffer-local command `|user-commands|`.
+--- Creates a buffer-local command [user-commands](help://user-commands).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer.
 --- @param name string
@@ -242,22 +242,22 @@ function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) e
 --- @param opts vim.api.keyset.user_command
 function vim.api.nvim_buf_create_user_command(buffer, name, command, opts) end
 
---- Removes an `|extmark|`.
+--- Removes an [extmark](help://extmark).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
+--- @param ns_id integer Namespace id from [nvim_create_namespace()](help://nvim_create_namespace())
 --- @param id integer Extmark id
 --- @return boolean
 function vim.api.nvim_buf_del_extmark(buffer, ns_id, id) end
 
---- Unmaps a buffer-local `|mapping|` for the given mode.
+--- Unmaps a buffer-local [mapping](help://mapping) for the given mode.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string
 --- @param lhs string
 function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
 
---- Deletes a named mark in the buffer. See `|mark-motions|`.
+--- Deletes a named mark in the buffer. See [mark-motions](help://mark-motions).
 ---
 --- @param buffer integer Buffer to set the mark on
 --- @param name string Mark name
@@ -265,8 +265,8 @@ function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
 function vim.api.nvim_buf_del_mark(buffer, name) end
 
 --- Delete a buffer-local user-defined command.
---- Only commands created with `|:command-buffer|` or
---- `|nvim_buf_create_user_command()|` can be deleted with this function.
+--- Only commands created with [:command-buffer](help://:command-buffer) or
+--- [nvim_buf_create_user_command()](help://nvim_buf_create_user_command()) can be deleted with this function.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer.
 --- @param name string Name of the command to delete.
@@ -278,12 +278,12 @@ function vim.api.nvim_buf_del_user_command(buffer, name) end
 --- @param name string Variable name
 function vim.api.nvim_buf_del_var(buffer, name) end
 
---- Deletes the buffer. See `|:bwipeout|`
+--- Deletes the buffer. See [:bwipeout](help://:bwipeout)
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param opts table<string,any> Optional parameters. Keys:
 ---  • force: Force deletion and ignore unsaved changes.
----  • unload: Unloaded only, do not delete. See `|:bunload|`
+---  • unload: Unloaded only, do not delete. See [:bunload](help://:bunload)
 function vim.api.nvim_buf_delete(buffer, opts) end
 
 --- Deactivates buffer-update events on the channel.
@@ -298,17 +298,17 @@ function vim.api.nvim_buf_detach(buffer) end
 --- @return integer
 function vim.api.nvim_buf_get_changedtick(buffer) end
 
---- Gets a map of buffer-local `|user-commands|`.
+--- Gets a map of buffer-local [user-commands](help://user-commands).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param opts vim.api.keyset.get_commands Optional parameters. Currently not used.
 --- @return table<string,any>
 function vim.api.nvim_buf_get_commands(buffer, opts) end
 
---- Gets the position (0-indexed) of an `|extmark|`.
+--- Gets the position (0-indexed) of an [extmark](help://extmark).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
+--- @param ns_id integer Namespace id from [nvim_create_namespace()](help://nvim_create_namespace())
 --- @param id integer Extmark id
 --- @param opts table<string,any> Optional parameters. Keys:
 ---  • details: Whether to include the details dict
@@ -317,8 +317,8 @@ function vim.api.nvim_buf_get_commands(buffer, opts) end
 --- @return integer[]
 function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 
---- Gets `|extmarks|` in "traversal order" from a `|charwise|` region defined by
---- buffer positions (inclusive, 0-indexed `|api-indexing|`).
+--- Gets [extmarks](help://extmarks) in "traversal order" from a [charwise](help://charwise) region defined by
+--- buffer positions (inclusive, 0-indexed [api-indexing](help://api-indexing)).
 --- Region can be given as (row,col) tuples, or valid extmark ids (whose
 --- positions define the bounds). 0 and -1 are understood as (0,0) and (-1,-1)
 --- respectively, thus the following are equivalent:
@@ -349,13 +349,13 @@ function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 ---
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `|nvim_create_namespace()|` or -1 for all
+--- @param ns_id integer Namespace id from [nvim_create_namespace()](help://nvim_create_namespace()) or -1 for all
 ---  namespaces
 --- @param start any Start of range: a 0-indexed (row, col) or valid extmark id
----  (whose position defines the bound). `|api-indexing|`
+---  (whose position defines the bound). [api-indexing](help://api-indexing)
 --- @param end_ any End of range (inclusive): a 0-indexed (row, col) or valid
 ---  extmark id (whose position defines the bound).
----  `|api-indexing|`
+---  [api-indexing](help://api-indexing)
 --- @param opts vim.api.keyset.get_extmarks Optional parameters. Keys:
 ---  • limit: Maximum number of marks to return
 ---  • details: Whether to include the details dict
@@ -368,7 +368,7 @@ function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 --- @return any[]
 function vim.api.nvim_buf_get_extmarks(buffer, ns_id, start, end_, opts) end
 
---- Gets a list of buffer-local `|mapping|` definitions.
+--- Gets a list of buffer-local [mapping](help://mapping) definitions.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string Mode short-name ("n", "i", "v", ...)
@@ -390,9 +390,9 @@ function vim.api.nvim_buf_get_keymap(buffer, mode) end
 function vim.api.nvim_buf_get_lines(buffer, start, end_, strict_indexing) end
 
 --- Returns a `(row,col)` tuple representing the position of the named mark.
---- "End of line" column position is returned as `|v:maxcol|` (big number). See
---- `|mark-motions|`.
---- Marks are (1,0)-indexed. `|api-indexing|`
+--- "End of line" column position is returned as [v:maxcol](help://v:maxcol) (big number). See
+--- [mark-motions](help://mark-motions).
+--- Marks are (1,0)-indexed. [api-indexing](help://api-indexing)
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param name string Mark name
@@ -410,12 +410,12 @@ function vim.api.nvim_buf_get_name(buffer) end
 --- @return integer
 function vim.api.nvim_buf_get_number(buffer) end
 
---- Returns the byte offset of a line (0-indexed). `|api-indexing|`
+--- Returns the byte offset of a line (0-indexed). [api-indexing](help://api-indexing)
 --- Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
 --- 'fileformat' and 'fileencoding' are ignored. The line index just after the
 --- last line gives the total byte-count of the buffer. A final EOL byte is
 --- counted if it would be written, see 'eol'.
---- Unlike `|line2byte()|`, throws error for out-of-bounds indexing. Returns -1
+--- Unlike [line2byte()](help://line2byte()), throws error for out-of-bounds indexing. Returns -1
 --- for unloaded buffer.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
@@ -430,11 +430,11 @@ function vim.api.nvim_buf_get_offset(buffer, index) end
 function vim.api.nvim_buf_get_option(buffer, name) end
 
 --- Gets a range from the buffer.
---- This differs from `|nvim_buf_get_lines()|` in that it allows retrieving only
+--- This differs from [nvim_buf_get_lines()](help://nvim_buf_get_lines()) in that it allows retrieving only
 --- portions of a line.
 --- Indexing is zero-based. Row indices are end-inclusive, and column indices
 --- are end-exclusive.
---- Prefer `|nvim_buf_get_lines()|` when retrieving entire lines.
+--- Prefer [nvim_buf_get_lines()](help://nvim_buf_get_lines()) when retrieving entire lines.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param start_row integer First line index
@@ -452,7 +452,7 @@ function vim.api.nvim_buf_get_text(buffer, start_row, start_col, end_row, end_co
 --- @return any
 function vim.api.nvim_buf_get_var(buffer, name) end
 
---- Checks if a buffer is valid and loaded. See `|api-buffer|` for more info
+--- Checks if a buffer is valid and loaded. See [api-buffer](help://api-buffer) for more info
 --- about unloaded buffers.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
@@ -471,7 +471,7 @@ function vim.api.nvim_buf_is_valid(buffer) end
 --- @return integer
 function vim.api.nvim_buf_line_count(buffer) end
 
---- Creates or updates an `|extmark|`.
+--- Creates or updates an [extmark](help://extmark).
 --- By default a new extmark is created when no id is passed in, but it is
 --- also possible to create a new mark by passing in a previously unused id or
 --- move an existing mark by passing in its id. The caller must then keep
@@ -485,9 +485,9 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- range (no highlighting).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
---- @param line integer Line where to place the mark, 0-based. `|api-indexing|`
---- @param col integer Column where to place the mark, 0-based. `|api-indexing|`
+--- @param ns_id integer Namespace id from [nvim_create_namespace()](help://nvim_create_namespace())
+--- @param line integer Line where to place the mark, 0-based. [api-indexing](help://api-indexing)
+--- @param col integer Column where to place the mark, 0-based. [api-indexing](help://api-indexing)
 --- @param opts vim.api.keyset.set_extmark Optional parameters.
 ---  • id : id of the extmark to edit.
 ---  • end_row : ending line of the mark, 0-based inclusive.
@@ -504,7 +504,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---    highlight groups that will be stacked (highest priority
 ---    last). A highlight group can be supplied either as a
 ---    string or as an integer, the latter which can be obtained
----    using `|nvim_get_hl_id_by_name()|`.
+---    using [nvim_get_hl_id_by_name()](help://nvim_get_hl_id_by_name()).
 ---  • virt_text_pos : position of virtual text. Possible values:
 ---    • "eol": right after eol character (default).
 ---    • "overlay": display over the specified column, without
@@ -541,7 +541,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---  • virt_lines_above: place virtual lines above instead.
 ---  • virt_lines_leftcol: Place extmarks in the leftmost column
 ---    of the window, bypassing sign and number columns.
----  • ephemeral : for use with `|nvim_set_decoration_provider()|`
+---  • ephemeral : for use with [nvim_set_decoration_provider()](help://nvim_set_decoration_provider())
 ---    callbacks. The mark will only be used for the current
 ---    redraw cycle, and not be permantently stored in the
 ---    buffer.
@@ -575,10 +575,10 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---    the mark and 'cursorline' is enabled. Note: ranges are
 ---    unsupported and decorations are only applied to start_row
 ---  • conceal: string which should be either empty or a single
----    character. Enable concealing similar to `|:syn-conceal|`.
----    When a character is supplied it is used as `|:syn-cchar|`.
+---    character. Enable concealing similar to [:syn-conceal](help://:syn-conceal).
+---    When a character is supplied it is used as [:syn-cchar](help://:syn-cchar).
 ---    "hl_group" is used as highlight for the cchar if provided,
----    otherwise it defaults to `|hl-Conceal|`.
+---    otherwise it defaults to [hl-Conceal](help://hl-Conceal).
 ---  • spell: boolean indicating that spell checking should be
 ---    performed within this extmark
 ---  • ui_watched: boolean that indicates the mark should be
@@ -588,7 +588,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- @return integer
 function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
 
---- Sets a buffer-local `|mapping|` for the given mode.
+--- Sets a buffer-local [mapping](help://mapping) for the given mode.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string
@@ -614,8 +614,8 @@ function vim.api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts) end
 function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replacement) end
 
 --- Sets a named mark in the given buffer, all marks are allowed
---- file/uppercase, visual, last change, etc. See `|mark-motions|`.
---- Marks are (1,0)-indexed. `|api-indexing|`
+--- file/uppercase, visual, last change, etc. See [mark-motions](help://mark-motions).
+--- Marks are (1,0)-indexed. [api-indexing](help://api-indexing)
 ---
 --- @param buffer integer Buffer to set the mark on
 --- @param name string Mark name
@@ -638,7 +638,7 @@ function vim.api.nvim_buf_set_name(buffer, name) end
 function vim.api.nvim_buf_set_option(buffer, name, value) end
 
 --- Sets (replaces) a range in the buffer
---- This is recommended over `|nvim_buf_set_lines()|` when only modifying parts
+--- This is recommended over [nvim_buf_set_lines()](help://nvim_buf_set_lines()) when only modifying parts
 --- of a line, as extmarks will be preserved on non-modified parts of the
 --- touched lines.
 --- Indexing is zero-based. Row indices are end-inclusive, and column indices
@@ -646,9 +646,9 @@ function vim.api.nvim_buf_set_option(buffer, name, value) end
 --- To insert text at a given `(row, column)` location, use `start_row =
 --- end_row = row` and `start_col = end_col = col`. To delete the text in a
 --- range, use `replacement = {}`.
---- Prefer `|nvim_buf_set_lines()|` if you are only adding or deleting entire
+--- Prefer [nvim_buf_set_lines()](help://nvim_buf_set_lines()) if you are only adding or deleting entire
 --- lines.
---- Prefer `|nvim_put()|` if you want to insert text at the cursor position.
+--- Prefer [nvim_put()](help://nvim_put()) if you want to insert text at the cursor position.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param start_row integer First line index
@@ -679,7 +679,7 @@ function vim.api.nvim_buf_set_virtual_text(buffer, src_id, line, chunks, opts) e
 --- 1. To perform several requests from an async context atomically, i.e.
 ---  without interleaving redraws, RPC requests from other clients, or user
 ---  interactions (however API methods may trigger autocommands or event
----  processing which have such side effects, e.g. `|:sleep|` may wake
+---  processing which have such side effects, e.g. [:sleep](help://:sleep) may wake
 ---  timers).
 --- 2. To minimize RPC overhead (roundtrips) of a sequence of many requests.
 ---
@@ -690,10 +690,10 @@ function vim.api.nvim_buf_set_virtual_text(buffer, src_id, line, chunks, opts) e
 --- @return any[]
 function vim.api.nvim_call_atomic(calls) end
 
---- Calls a Vimscript `|Dictionary-function|` with the given arguments.
+--- Calls a Vimscript [Dictionary-function](help://Dictionary-function) with the given arguments.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
---- @param dict any Dictionary, or String evaluating to a Vimscript `|self|` dict
+--- @param dict any Dictionary, or String evaluating to a Vimscript [self](help://self) dict
 --- @param fn string Name of the function defined on the Vimscript dict
 --- @param args any[] Function arguments packed in an Array
 --- @return any
@@ -708,19 +708,19 @@ function vim.api.nvim_call_dict_function(dict, fn, args) end
 function vim.api.nvim_call_function(fn, args) end
 
 --- Send data to channel `id`. For a job, it writes it to the stdin of the
---- process. For the stdio channel `|channel-stdio|`, it writes to Nvim's
---- stdout. For an internal terminal instance (`|nvim_open_term()|`) it writes
---- directly to terminal output. See `|channel-bytes|` for more information.
+--- process. For the stdio channel [channel-stdio](help://channel-stdio), it writes to Nvim's
+--- stdout. For an internal terminal instance ([nvim_open_term()](help://nvim_open_term())) it writes
+--- directly to terminal output. See [channel-bytes](help://channel-bytes) for more information.
 --- This function writes raw data, not RPC messages. If the channel was
 --- created with `rpc=true` then the channel expects RPC messages, use
---- `|vim.rpcnotify()|` and `|vim.rpcrequest()|` instead.
+--- [vim.rpcnotify()](help://vim.rpcnotify()) and [vim.rpcrequest()](help://vim.rpcrequest()) instead.
 ---
 --- @param chan integer id of the channel
 --- @param data string data to write. 8-bit clean: can contain NUL bytes.
 function vim.api.nvim_chan_send(chan, data) end
 
 --- Clears all autocommands selected by {opts}. To delete autocmds see
---- `|nvim_del_autocmd()|`.
+--- [nvim_del_autocmd()](help://nvim_del_autocmd()).
 ---
 --- @param opts vim.api.keyset.clear_autocmds Parameters
 ---  • event: (string|table) Examples:
@@ -738,7 +738,7 @@ function vim.api.nvim_chan_send(chan, data) end
 ---    • NOTE: Cannot be used with {buffer}
 ---
 ---  • buffer: (bufnr)
----    • clear only `|autocmd-buflocal|` autocommands.
+---    • clear only [autocmd-buflocal](help://autocmd-buflocal) autocommands.
 ---    • NOTE: Cannot be used with {pattern}
 ---
 ---  • group: (string|int) The augroup name or id.
@@ -746,20 +746,20 @@ function vim.api.nvim_chan_send(chan, data) end
 function vim.api.nvim_clear_autocmds(opts) end
 
 --- Executes an Ex command.
---- Unlike `|nvim_command()|` this command takes a structured Dictionary instead
+--- Unlike [nvim_command()](help://nvim_command()) this command takes a structured Dictionary instead
 --- of a String. This allows for easier construction and manipulation of an Ex
 --- command. This also allows for things such as having spaces inside a
 --- command argument, expanding filenames in a command that otherwise doesn't
 --- expand filenames, etc. Command arguments may also be Number, Boolean or
 --- String.
 --- The first argument may also be used instead of count for commands that
---- support it in order to make their usage simpler with `|vim.cmd()|`. For
+--- support it in order to make their usage simpler with [vim.cmd()](help://vim.cmd()). For
 --- example, instead of `vim.cmd.bdelete{ count = 2 }`, you may do
 --- `vim.cmd.bdelete(2)`.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
 --- @param cmd vim.api.keyset.cmd Command to execute. Must be a Dictionary that can contain the
----  same values as the return value of `|nvim_parse_cmd()|` except
+---  same values as the return value of [nvim_parse_cmd()](help://nvim_parse_cmd()) except
 ---  "addr", "nargs" and "nextcmd" which are ignored if provided.
 ---  All values except for "cmd" are optional.
 --- @param opts vim.api.keyset.cmd_opts Optional parameters.
@@ -770,11 +770,11 @@ function vim.api.nvim_cmd(cmd, opts) end
 
 --- Executes an Ex command.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
---- Prefer using `|nvim_cmd()|` or `|nvim_exec2()|` over this. To evaluate
+--- Prefer using [nvim_cmd()](help://nvim_cmd()) or [nvim_exec2()](help://nvim_exec2()) over this. To evaluate
 --- multiple lines of Vim script or an Ex command directly, use
---- `|nvim_exec2()|`. To construct an Ex command using a structured format and
---- then execute it, use `|nvim_cmd()|`. To modify an Ex command before
---- evaluating it, use `|nvim_parse_cmd()|` in conjunction with `|nvim_cmd()|`.
+--- [nvim_exec2()](help://nvim_exec2()). To construct an Ex command using a structured format and
+--- then execute it, use [nvim_cmd()](help://nvim_cmd()). To modify an Ex command before
+--- evaluating it, use [nvim_parse_cmd()](help://nvim_parse_cmd()) in conjunction with [nvim_cmd()](help://nvim_cmd()).
 ---
 --- @param command string Ex command string
 function vim.api.nvim_command(command) end
@@ -784,7 +784,7 @@ function vim.api.nvim_command(command) end
 --- @return string
 function vim.api.nvim_command_output(command) end
 
---- Create or get an autocommand group `|autocmd-groups|`.
+--- Create or get an autocommand group [autocmd-groups](help://autocmd-groups).
 --- To get an existing group id, do:
 --- ```lua
 --- local id = vim.api.nvim_create_augroup("MyGroup", {
@@ -796,11 +796,11 @@ function vim.api.nvim_command_output(command) end
 --- @param name string String: The name of the group
 --- @param opts vim.api.keyset.create_augroup Dictionary Parameters
 ---  • clear (bool) optional: defaults to true. Clear existing
----    commands if the group already exists `|autocmd-groups|`.
+---    commands if the group already exists [autocmd-groups](help://autocmd-groups).
 --- @return integer
 function vim.api.nvim_create_augroup(name, opts) end
 
---- Creates an `|autocommand|` event handler, defined by `callback` (Lua function or Vimscript function name string) or `command` (Ex command string).
+--- Creates an [autocommand](help://autocommand) event handler, defined by `callback` (Lua function or Vimscript function name string) or `command` (Ex command string).
 --- Example using Lua callback:
 --- ```lua
 --- vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
@@ -817,7 +817,7 @@ function vim.api.nvim_create_augroup(name, opts) end
 ---   command = "echo 'Entering a C or C++ file'",
 --- })
 --- ```
---- Note: `pattern` is NOT automatically expanded (unlike with `|:autocmd|`),
+--- Note: `pattern` is NOT automatically expanded (unlike with [:autocmd](help://:autocmd)),
 --- thus names like "$HOME" and "~" must be expanded explicitly:
 --- ```lua
 --- pattern = vim.fn.expand("~") .. "/some/path/*.py"
@@ -830,9 +830,9 @@ function vim.api.nvim_create_augroup(name, opts) end
 ---   • group (string|integer) optional: autocommand group name or
 ---     id to match against.
 ---   • pattern (string|array) optional: pattern(s) to match
----     literally `|autocmd-pattern|`.
+---     literally [autocmd-pattern](help://autocmd-pattern).
 ---   • buffer (integer) optional: buffer number for buffer-local
----     autocommands `|autocmd-buflocal|`. Cannot be used with
+---     autocommands [autocmd-buflocal](help://autocmd-buflocal). Cannot be used with
 ---     {pattern}.
 ---   • desc (string) optional: description (for documentation and
 ---     troubleshooting).
@@ -843,27 +843,27 @@ function vim.api.nvim_create_augroup(name, opts) end
 ---     these keys:
 ---     • id: (number) autocommand id
 ---     • event: (string) name of the triggered event
----       `|autocmd-events|`
+---       [autocmd-events](help://autocmd-events)
 ---     • group: (number|nil) autocommand group id, if any
----     • match: (string) expanded value of `|<amatch>|`
----     • buf: (number) expanded value of `|<abuf>|`
----     • file: (string) expanded value of `|<afile>|`
+---     • match: (string) expanded value of [<amatch>](help://<amatch>)
+---     • buf: (number) expanded value of [<abuf>](help://<abuf>)
+---     • file: (string) expanded value of [<afile>](help://<afile>)
 ---     • data: (any) arbitrary data passed from
----       `|nvim_exec_autocmds()|`
+---       [nvim_exec_autocmds()](help://nvim_exec_autocmds())
 ---
 ---   • command (string) optional: Vim command to execute on event.
 ---     Cannot be used with {callback}
 ---   • once (boolean) optional: defaults to false. Run the
----     autocommand only once `|autocmd-once|`.
+---     autocommand only once [autocmd-once](help://autocmd-once).
 ---   • nested (boolean) optional: defaults to false. Run nested
----     autocommands `|autocmd-nested|`.
+---     autocommands [autocmd-nested](help://autocmd-nested).
 --- @return integer
 function vim.api.nvim_create_autocmd(event, opts) end
 
 --- Creates a new, empty, unnamed buffer.
 ---
 --- @param listed boolean Sets 'buflisted'
---- @param scratch boolean Creates a "throwaway" `|scratch-buffer|` for temporary work
+--- @param scratch boolean Creates a "throwaway" [scratch-buffer](help://scratch-buffer) for temporary work
 ---   (always 'nomodified'). Also sets 'nomodeline' on the
 ---   buffer.
 --- @return integer
@@ -871,7 +871,7 @@ function vim.api.nvim_create_buf(listed, scratch) end
 
 --- Creates a new namespace or gets an existing one. *namespace*
 --- Namespaces are used for buffer highlights and virtual text, see
---- `|nvim_buf_add_highlight()|` and `|nvim_buf_set_extmark()|`.
+--- [nvim_buf_add_highlight()](help://nvim_buf_add_highlight()) and [nvim_buf_set_extmark()](help://nvim_buf_set_extmark()).
 --- Namespaces can be named or anonymous. If `name` matches an existing
 --- namespace, the associated id is returned. If `name` is an empty string a
 --- new, anonymous namespace is created.
@@ -880,8 +880,8 @@ function vim.api.nvim_create_buf(listed, scratch) end
 --- @return integer
 function vim.api.nvim_create_namespace(name) end
 
---- Creates a global `|user-commands|` command.
---- For Lua usage see `|lua-guide-commands-create|`.
+--- Creates a global [user-commands](help://user-commands) command.
+--- For Lua usage see [lua-guide-commands-create](help://lua-guide-commands-create).
 --- Example:
 --- ```vim
 --- :call nvim_create_user_command('SayHello', 'echo "Hello world!"', {'bang': v:true})
@@ -898,44 +898,44 @@ function vim.api.nvim_create_namespace(name) end
 ---   argument that contains the following keys:
 ---   • name: (string) Command name
 ---   • args: (string) The args passed to the command, if any
----     `|<args>|`
+---     [<args>](help://<args>)
 ---   • fargs: (table) The args split by unescaped whitespace
 ---     (when more than one argument is allowed), if any
----     `|<f-args>|`
----   • nargs: (string) Number of arguments `|:command-nargs|`
+---     [<f-args>](help://<f-args>)
+---   • nargs: (string) Number of arguments [:command-nargs](help://:command-nargs)
 ---   • bang: (boolean) "true" if the command was executed with a
----     ! modifier `|<bang>|`
+---     ! modifier [<bang>](help://<bang>)
 ---   • line1: (number) The starting line of the command range
----     `|<line1>|`
+---     [<line1>](help://<line1>)
 ---   • line2: (number) The final line of the command range
----     `|<line2>|`
+---     [<line2>](help://<line2>)
 ---   • range: (number) The number of items in the command range:
----     0, 1, or 2 `|<range>|`
----   • count: (number) Any count supplied `|<count>|`
----   • reg: (string) The optional register, if specified `|<reg>|`
----   • mods: (string) Command modifiers, if any `|<mods>|`
+---     0, 1, or 2 [<range>](help://<range>)
+---   • count: (number) Any count supplied [<count>](help://<count>)
+---   • reg: (string) The optional register, if specified [<reg>](help://<reg>)
+---   • mods: (string) Command modifiers, if any [<mods>](help://<mods>)
 ---   • smods: (table) Command modifiers in a structured format.
 ---     Has the same structure as the "mods" key of
----     `|nvim_parse_cmd()|`.
---- @param opts vim.api.keyset.user_command Optional `|command-attributes|`.
----   • Set boolean attributes such as `|:command-bang|` or
----     `|:command-bar|` to true (but not `|:command-buffer|`, use
----     `|nvim_buf_create_user_command()|` instead).
----   • "complete" `|:command-complete|` also accepts a Lua
+---     [nvim_parse_cmd()](help://nvim_parse_cmd()).
+--- @param opts vim.api.keyset.user_command Optional [command-attributes](help://command-attributes).
+---   • Set boolean attributes such as [:command-bang](help://:command-bang) or
+---     [:command-bar](help://:command-bar) to true (but not [:command-buffer](help://:command-buffer), use
+---     [nvim_buf_create_user_command()](help://nvim_buf_create_user_command()) instead).
+---   • "complete" [:command-complete](help://:command-complete) also accepts a Lua
 ---     function which works like
----     `|:command-completion-customlist|`.
+---     [:command-completion-customlist](help://:command-completion-customlist).
 ---   • Other parameters:
 ---     • desc: (string) Used for listing the command when a Lua
 ---       function is used for {command}.
 ---     • force: (boolean, default true) Override any previous
 ---       definition.
 ---     • preview: (function) Preview callback for 'inccommand'
----       `|:command-preview|`
+---       [:command-preview](help://:command-preview)
 function vim.api.nvim_create_user_command(name, command, opts) end
 
 --- Delete an autocommand group by id.
---- To get a group id one can use `|nvim_get_autocmds()|`.
---- NOTE: behavior differs from `|:augroup-delete|`. When deleting a group,
+--- To get a group id one can use [nvim_get_autocmds()](help://nvim_get_autocmds()).
+--- NOTE: behavior differs from [:augroup-delete](help://:augroup-delete). When deleting a group,
 --- autocommands contained in this group will also be deleted and cleared.
 --- This group will no longer exist.
 ---
@@ -943,7 +943,7 @@ function vim.api.nvim_create_user_command(name, command, opts) end
 function vim.api.nvim_del_augroup_by_id(id) end
 
 --- Delete an autocommand group by name.
---- NOTE: behavior differs from `|:augroup-delete|`. When deleting a group,
+--- NOTE: behavior differs from [:augroup-delete](help://:augroup-delete). When deleting a group,
 --- autocommands contained in this group will also be deleted and cleared.
 --- This group will no longer exist.
 ---
@@ -952,21 +952,21 @@ function vim.api.nvim_del_augroup_by_name(name) end
 
 --- Deletes an autocommand by id.
 ---
---- @param id integer Integer Autocommand id returned by `|nvim_create_autocmd()|`
+--- @param id integer Integer Autocommand id returned by [nvim_create_autocmd()](help://nvim_create_autocmd())
 function vim.api.nvim_del_autocmd(id) end
 
 --- Deletes the current line.
 ---
 function vim.api.nvim_del_current_line() end
 
---- Unmaps a global `|mapping|` for the given mode.
---- To unmap a buffer-local mapping, use `|nvim_buf_del_keymap()|`.
+--- Unmaps a global [mapping](help://mapping) for the given mode.
+--- To unmap a buffer-local mapping, use [nvim_buf_del_keymap()](help://nvim_buf_del_keymap()).
 ---
 --- @param mode string
 --- @param lhs string
 function vim.api.nvim_del_keymap(mode, lhs) end
 
---- Deletes an uppercase/file named mark. See `|mark-motions|`.
+--- Deletes an uppercase/file named mark. See [mark-motions](help://mark-motions).
 ---
 --- @param name string Mark name
 --- @return boolean
@@ -987,7 +987,7 @@ function vim.api.nvim_del_var(name) end
 --- @param chunks any[] A list of [text, hl_group] arrays, each representing a text
 ---   chunk with specified highlight. `hl_group` element can be
 ---   omitted for no highlight.
---- @param history boolean if true, add to `|message-history|`.
+--- @param history boolean if true, add to [message-history](help://message-history).
 --- @param opts vim.api.keyset.echo_opts Optional parameters.
 ---   • verbose: Message was printed as a result of 'verbose'
 ---     option if Nvim was invoked with -V3log_file, the message
@@ -1011,7 +1011,7 @@ function vim.api.nvim_err_writeln(str) end
 --- @param data string
 function vim.api.nvim_error_event(lvl, data) end
 
---- Evaluates a Vimscript `|expression|`. Dictionaries and Lists are recursively
+--- Evaluates a Vimscript [expression](help://expression). Dictionaries and Lists are recursively
 --- expanded.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
@@ -1023,7 +1023,7 @@ function vim.api.nvim_eval(expr) end
 ---
 --- @param str string Statusline string (see 'statusline').
 --- @param opts vim.api.keyset.eval_statusline Optional parameters.
----  • winid: (number) `|window-ID|` of the window to use as context
+---  • winid: (number) [window-ID](help://window-ID) of the window to use as context
 ---    for statusline.
 ---  • maxwidth: (number) Maximum width of statusline.
 ---  • fillchar: (string) Character to fill blank spaces in the
@@ -1046,33 +1046,33 @@ function vim.api.nvim_eval_statusline(str, opts) end
 function vim.api.nvim_exec(src, output) end
 
 --- Executes Vimscript (multiline block of Ex commands), like anonymous
---- `|:source|`.
---- Unlike `|nvim_command()|` this function supports heredocs, script-scope
+--- [:source](help://:source).
+--- Unlike [nvim_command()](help://nvim_command()) this function supports heredocs, script-scope
 --- (s:), etc.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
 --- @param src string Vimscript code
 --- @param opts vim.api.keyset.exec_opts Optional parameters.
 ---  • output: (boolean, default false) Whether to capture and
----    return all (non-error, non-shell `|:!|`) output.
+---    return all (non-error, non-shell [:!](help://:!)) output.
 --- @return table<string,any>
 function vim.api.nvim_exec2(src, opts) end
 
 --- Execute all autocommands for {event} that match the corresponding {opts}
---- `|autocmd-execute|`.
+--- [autocmd-execute](help://autocmd-execute).
 ---
 --- @param event any (String|Array) The event or events to execute
 --- @param opts vim.api.keyset.exec_autocmds Dictionary of autocommand options:
 ---   • group (string|integer) optional: the autocommand group name
----     or id to match against. `|autocmd-groups|`.
+---     or id to match against. [autocmd-groups](help://autocmd-groups).
 ---   • pattern (string|array) optional: defaults to "*"
----     `|autocmd-pattern|`. Cannot be used with {buffer}.
+---     [autocmd-pattern](help://autocmd-pattern). Cannot be used with {buffer}.
 ---   • buffer (integer) optional: buffer number
----     `|autocmd-buflocal|`. Cannot be used with {pattern}.
+---     [autocmd-buflocal](help://autocmd-buflocal). Cannot be used with {pattern}.
 ---   • modeline (bool) optional: defaults to true. Process the
----     modeline after the autocommands `|<nomodeline>|`.
+---     modeline after the autocommands [<nomodeline>](help://<nomodeline>).
 ---   • data (any): arbitrary data to send to the autocommand
----     callback. See `|nvim_create_autocmd()|` for details.
+---     callback. See [nvim_create_autocmd()](help://nvim_create_autocmd()) for details.
 function vim.api.nvim_exec_autocmds(event, opts) end
 
 --- Execute Lua code. Parameters (if any) are available as `...` inside the
@@ -1092,10 +1092,10 @@ function vim.api.nvim_exec_lua(code, args) end
 function vim.api.nvim_execute_lua(code, args) end
 
 --- Sends input-keys to Nvim, subject to various quirks controlled by `mode`
---- flags. This is a blocking call, unlike `|nvim_input()|`.
+--- flags. This is a blocking call, unlike [nvim_input()](help://nvim_input()).
 --- On execution error: does not fail, but updates v:errmsg.
---- To input sequences like <C-o> use `|nvim_replace_termcodes()|` (typically
---- with escape_ks=false) to replace `|keycodes|`, then pass the result to
+--- To input sequences like <C-o> use [nvim_replace_termcodes()](help://nvim_replace_termcodes()) (typically
+--- with escape_ks=false) to replace [keycodes](help://keycodes), then pass the result to
 --- nvim_feedkeys().
 --- Example:
 --- ```vim
@@ -1105,21 +1105,21 @@ function vim.api.nvim_execute_lua(code, args) end
 ---
 ---
 --- @param keys string to be typed
---- @param mode string behavior flags, see `|feedkeys()|`
+--- @param mode string behavior flags, see [feedkeys()](help://feedkeys())
 --- @param escape_ks boolean If true, escape K_SPECIAL bytes in `keys`. This should be
----   false if you already used `|nvim_replace_termcodes()|`, and
+---   false if you already used [nvim_replace_termcodes()](help://nvim_replace_termcodes()), and
 ---   true otherwise.
 function vim.api.nvim_feedkeys(keys, mode, escape_ks) end
 
 --- Gets the option information for all options.
 --- The dictionary has the full option names as keys and option metadata
---- dictionaries as detailed at `|nvim_get_option_info2()|`.
+--- dictionaries as detailed at [nvim_get_option_info2()](help://nvim_get_option_info2()).
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_all_options_info() end
 
 --- Returns a 2-tuple (Array), where item 0 is the current channel id and item
---- 1 is the `|api-metadata|` map (Dictionary).
+--- 1 is the [api-metadata](help://api-metadata) map (Dictionary).
 ---
 --- @return any[]
 function vim.api.nvim_get_api_info() end
@@ -1146,11 +1146,11 @@ function vim.api.nvim_get_api_info() end
 ---  • group (string|integer): the autocommand group name or id to
 ---    match against.
 ---  • event (string|array): event or events to match against
----    `|autocmd-events|`.
+---    [autocmd-events](help://autocmd-events).
 ---  • pattern (string|array): pattern or patterns to match against
----    `|autocmd-pattern|`. Cannot be used with {buffer}
+---    [autocmd-pattern](help://autocmd-pattern). Cannot be used with {buffer}
 ---  • buffer: Buffer number or list of buffer numbers for buffer
----    local autocommands `|autocmd-buflocal|`. Cannot be used with
+---    local autocommands [autocmd-buflocal](help://autocmd-buflocal). Cannot be used with
 ---    {pattern}
 --- @return any[]
 function vim.api.nvim_get_autocmds(opts) end
@@ -1161,7 +1161,7 @@ function vim.api.nvim_get_autocmds(opts) end
 --- @return table<string,any>
 function vim.api.nvim_get_chan_info(chan) end
 
---- Returns the 24-bit RGB value of a `|nvim_get_color_map()|` color name or
+--- Returns the 24-bit RGB value of a [nvim_get_color_map()](help://nvim_get_color_map()) color name or
 --- "#rrggbb" hexadecimal string.
 --- Example:
 --- ```vim
@@ -1182,7 +1182,7 @@ function vim.api.nvim_get_color_by_name(name) end
 function vim.api.nvim_get_color_map() end
 
 --- Gets a map of global (non-buffer-local) Ex commands.
---- Currently only `|user-commands|` are supported, not builtin Ex commands.
+--- Currently only [user-commands](help://user-commands) are supported, not builtin Ex commands.
 ---
 --- @param opts vim.api.keyset.get_commands Optional parameters. Currently only supports {"builtin":false}
 --- @return table<string,any>
@@ -1191,7 +1191,7 @@ function vim.api.nvim_get_commands(opts) end
 --- Gets a map of the current editor state.
 ---
 --- @param opts vim.api.keyset.context Optional parameters.
----  • types: List of `|context-types|` ("regs", "jumps", "bufs",
+---  • types: List of [context-types](help://context-types) ("regs", "jumps", "bufs",
 ---    "gvars", …) to gather, or empty for "all".
 --- @return table<string,any>
 function vim.api.nvim_get_context(opts) end
@@ -1219,13 +1219,13 @@ function vim.api.nvim_get_current_win() end
 --- Gets all or specific highlight groups in a namespace.
 ---
 --- @param ns_id integer Get highlight groups for namespace ns_id
----   `|nvim_get_namespaces()|`. Use 0 to get global highlight groups
----   `|:highlight|`.
+---   [nvim_get_namespaces()](help://nvim_get_namespaces()). Use 0 to get global highlight groups
+---   [:highlight](help://:highlight).
 --- @param opts vim.api.keyset.get_highlight Options dict:
 ---   • name: (string) Get a highlight definition by name.
 ---   • id: (integer) Get a highlight definition by id.
 ---   • link: (boolean, default true) Show linked group name
----     instead of effective definition `|:hi-link|`.
+---     instead of effective definition [:hi-link](help://:hi-link).
 ---   • create: (boolean, default true) When highlight group
 ---     doesn't exist create it.
 --- @return table<string,any>
@@ -1244,7 +1244,7 @@ function vim.api.nvim_get_hl_by_id(hl_id, rgb) end
 function vim.api.nvim_get_hl_by_name(name, rgb) end
 
 --- Gets a highlight group by name
---- similar to `|hlID()|`, but allocates a new ID if not present.
+--- similar to [hlID()](help://hlID()), but allocates a new ID if not present.
 ---
 --- @param name string
 --- @return integer
@@ -1253,14 +1253,14 @@ function vim.api.nvim_get_hl_id_by_name(name) end
 --- Gets the active highlight namespace.
 ---
 --- @param opts vim.api.keyset.get_ns Optional parameters
----  • winid: (number) `|window-ID|` for retrieving a window's
+---  • winid: (number) [window-ID](help://window-ID) for retrieving a window's
 ---    highlight namespace. A value of -1 is returned when
----    `|nvim_win_set_hl_ns()|` has not been called for the window
+---    [nvim_win_set_hl_ns()](help://nvim_win_set_hl_ns()) has not been called for the window
 ---    (or was called with a namespace of -1).
 --- @return integer
 function vim.api.nvim_get_hl_ns(opts) end
 
---- Gets a list of global (non-buffer-local) `|mapping|` definitions.
+--- Gets a list of global (non-buffer-local) [mapping](help://mapping) definitions.
 ---
 --- @param mode string Mode short-name ("n", "i", "v", ...)
 --- @return table<string,any>[]
@@ -1268,21 +1268,21 @@ function vim.api.nvim_get_keymap(mode) end
 
 --- Returns a `(row, col, buffer, buffername)` tuple representing the position
 --- of the uppercase/file named mark. "End of line" column position is
---- returned as `|v:maxcol|` (big number). See `|mark-motions|`.
---- Marks are (1,0)-indexed. `|api-indexing|`
+--- returned as [v:maxcol](help://v:maxcol) (big number). See [mark-motions](help://mark-motions).
+--- Marks are (1,0)-indexed. [api-indexing](help://api-indexing)
 ---
 --- @param name string Mark name
 --- @param opts table<string,any> Optional parameters. Reserved for future use.
 --- @return any[]
 function vim.api.nvim_get_mark(name, opts) end
 
---- Gets the current mode. `|mode()|` "blocking" is true if Nvim is waiting for
+--- Gets the current mode. [mode()](help://mode()) "blocking" is true if Nvim is waiting for
 --- input.
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_mode() end
 
---- Gets existing, non-anonymous `|namespace|`s.
+--- Gets existing, non-anonymous [namespace](help://namespace)s.
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_namespaces() end
@@ -1319,29 +1319,29 @@ function vim.api.nvim_get_option_info(name) end
 ---
 --- @param name string Option name
 --- @param opts vim.api.keyset.option Optional parameters
----  • scope: One of "global" or "local". Analogous to `|:setglobal|`
----    and `|:setlocal|`, respectively.
----  • win: `|window-ID|`. Used for getting window local options.
+---  • scope: One of "global" or "local". Analogous to [:setglobal](help://:setglobal)
+---    and [:setlocal](help://:setlocal), respectively.
+---  • win: [window-ID](help://window-ID). Used for getting window local options.
 ---  • buf: Buffer number. Used for getting buffer local options.
 ---    Implies {scope} is "local".
 --- @return table<string,any>
 function vim.api.nvim_get_option_info2(name, opts) end
 
 --- Gets the value of an option. The behavior of this function matches that of
---- `|:set|`: the local value of an option is returned if it exists; otherwise,
+--- [:set](help://:set): the local value of an option is returned if it exists; otherwise,
 --- the global value is returned. Local values always correspond to the
 --- current buffer or window, unless "buf" or "win" is set in {opts}.
 ---
 --- @param name string Option name
 --- @param opts vim.api.keyset.option Optional parameters
----  • scope: One of "global" or "local". Analogous to `|:setglobal|`
----    and `|:setlocal|`, respectively.
----  • win: `|window-ID|`. Used for getting window local options.
+---  • scope: One of "global" or "local". Analogous to [:setglobal](help://:setglobal)
+---    and [:setlocal](help://:setlocal), respectively.
+---  • win: [window-ID](help://window-ID). Used for getting window local options.
 ---  • buf: Buffer number. Used for getting buffer local options.
 ---    Implies {scope} is "local".
----  • filetype: `|filetype|`. Used to get the default option for a
+---  • filetype: [filetype](help://filetype). Used to get the default option for a
 ---    specific filetype. Cannot be used with any other option.
----    Note: this will trigger `|ftplugin|` and all `|FileType|`
+---    Note: this will trigger [ftplugin](help://ftplugin) and all [FileType](help://FileType)
 ---    autocommands for the corresponding filetype.
 --- @return any
 function vim.api.nvim_get_option_value(name, opts) end
@@ -1382,7 +1382,7 @@ function vim.api.nvim_get_var(name) end
 --- @return any
 function vim.api.nvim_get_vvar(name) end
 
---- Queues raw user-input. Unlike `|nvim_feedkeys()|`, this uses a low-level
+--- Queues raw user-input. Unlike [nvim_feedkeys()](help://nvim_feedkeys()), this uses a low-level
 --- input buffer and the call is non-blocking (input is processed
 --- asynchronously by the eventloop).
 --- On execution error: does not fail, but updates v:errmsg.
@@ -1404,14 +1404,14 @@ function vim.api.nvim_input(keys) end
 ---  same specifiers are used as for a key press, except that
 ---  the "-" separator is optional, so "C-A-", "c-a" and "CA"
 ---  can all be used to specify Ctrl+Alt+click.
---- @param grid integer Grid number if the client uses `|ui-multigrid|`, else 0.
+--- @param grid integer Grid number if the client uses [ui-multigrid](help://ui-multigrid), else 0.
 --- @param row integer Mouse row-position (zero-based, like redraw events)
 --- @param col integer Mouse column-position (zero-based, like redraw events)
 function vim.api.nvim_input_mouse(button, action, modifier, grid, row, col) end
 
 --- Gets the current list of buffer handles
 --- Includes unlisted (unloaded/deleted) buffers, like `:ls!`. Use
---- `|nvim_buf_is_loaded()|` to check if a buffer is loaded.
+--- [nvim_buf_is_loaded()](help://nvim_buf_is_loaded()) to check if a buffer is loaded.
 ---
 --- @return integer[]
 function vim.api.nvim_list_bufs() end
@@ -1421,7 +1421,7 @@ function vim.api.nvim_list_bufs() end
 --- @return any[]
 function vim.api.nvim_list_chans() end
 
---- Gets the paths contained in `|runtime-search-path|`.
+--- Gets the paths contained in [runtime-search-path](help://runtime-search-path).
 ---
 --- @return string[]
 function vim.api.nvim_list_runtime_paths() end
@@ -1441,9 +1441,9 @@ function vim.api.nvim_list_uis() end
 --- @return integer[]
 function vim.api.nvim_list_wins() end
 
---- Sets the current editor state from the given `|context|` map.
+--- Sets the current editor state from the given [context](help://context) map.
 ---
---- @param dict table<string,any> `|Context|` map.
+--- @param dict table<string,any> [Context](help://Context) map.
 --- @return any
 function vim.api.nvim_load_context(dict) end
 
@@ -1464,9 +1464,9 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- terminal sequences returned as part of a rpc message, or similar.
 --- Note: to directly initiate the terminal using the right size, display the
 --- buffer in a configured window before calling this. For instance, for a
---- floating display, first create an empty buffer using `|nvim_create_buf()|`,
---- then display it using `|nvim_open_win()|`, and then call this function. Then
---- `|nvim_chan_send()|` can be called immediately to process sequences in a
+--- floating display, first create an empty buffer using [nvim_create_buf()](help://nvim_create_buf()),
+--- then display it using [nvim_open_win()](help://nvim_open_win()), and then call this function. Then
+--- [nvim_chan_send()](help://nvim_chan_send()) can be called immediately to process sequences in a
 --- virtual terminal having the intended size.
 ---
 --- @param buffer integer the buffer to use (expected to be empty)
@@ -1474,8 +1474,8 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 ---  • on_input: Lua callback for input sent, i e keypresses in
 ---    terminal mode. Note: keypresses are sent raw as they would
 ---    be to the pty master end. For instance, a carriage return
----    is sent as a "\r", not as a "\n". `|textlock|` applies. It
----    is possible to call `|nvim_chan_send()|` directly in the
+---    is sent as a "\r", not as a "\n". [textlock](help://textlock) applies. It
+---    is possible to call [nvim_chan_send()](help://nvim_chan_send()) directly in the
 ---    callback however. ["input", term, bufnr, data]
 --- @return integer
 function vim.api.nvim_open_term(buffer, opts) end
@@ -1484,9 +1484,9 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- Currently this is used to open floating and external windows. Floats are
 --- windows that are drawn above the split layout, at some anchor position in
 --- some other window. Floats can be drawn internally or by external GUI with
---- the `|ui-multigrid|` extension. External windows are only supported with
+--- the [ui-multigrid](help://ui-multigrid) extension. External windows are only supported with
 --- multigrid GUIs, and are displayed as separate top-level windows.
---- For a general overview of floats, see `|api-floatwin|`.
+--- For a general overview of floats, see [api-floatwin](help://api-floatwin).
 --- Exactly one of `external` and `relative` must be specified. The `width`
 --- and `height` of the new window must be specified.
 --- With relative=editor (row=0,col=0) refers to the top-left corner of the
@@ -1522,7 +1522,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---    • "cursor" Cursor position in current window.
 ---    • "mouse" Mouse position
 ---
----  • win: `|window-ID|` for relative="win".
+---  • win: [window-ID](help://window-ID) for relative="win".
 ---  • anchor: Decides which corner of the float to place at
 ---    (row,col):
 ---    • "NW" northwest (default)
@@ -1546,7 +1546,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---    be fractional.
 ---  • focusable: Enable focus by user actions (wincmds, mouse
 ---    events). Defaults to true. Non-focusable windows can be
----    entered by `|nvim_set_current_win()|`.
+---    entered by [nvim_set_current_win()](help://nvim_set_current_win()).
 ---  • external: GUI should display the window as an external
 ---    top-level window. Currently accepts no other positioning
 ---    configuration together with this.
@@ -1571,7 +1571,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---      'colorcolumn' is cleared. 'statuscolumn' is changed to
 ---      empty. The end-of-buffer region is hidden by setting
 ---      `eob` flag of 'fillchars' to a space char, and clearing
----      the `|hl-EndOfBuffer|` region in 'winhighlight'.
+---      the [hl-EndOfBuffer](help://hl-EndOfBuffer) region in 'winhighlight'.
 ---
 ---  • border: Style of (optional) window border. This can either
 ---    be a string or an array. The string values are
@@ -1613,7 +1613,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---    option. Value can be one of "left", "center", or "right".
 ---    Default is `"left"`.
 ---  • noautocmd: If true then no buffer-related autocommand
----    events such as `|BufEnter|`, `|BufLeave|` or `|BufWinEnter|` may
+---    events such as [BufEnter](help://BufEnter), [BufLeave](help://BufLeave) or [BufWinEnter](help://BufWinEnter) may
 ---    fire from calling this function.
 ---  • fixed: If true when anchor is NW or SW, the float window
 ---    would be kept fixed even if the window would be truncated.
@@ -1661,7 +1661,7 @@ function vim.api.nvim_parse_expression(expr, flags, highlight) end
 
 --- Pastes at cursor, in any mode.
 --- Invokes the `vim.paste` handler, which handles each mode appropriately.
---- Sets redo/undo. Faster than `|nvim_input()|`. Lines break at LF ("\n").
+--- Sets redo/undo. Faster than [nvim_input()](help://nvim_input()). Lines break at LF ("\n").
 --- Errors ('nomodifiable', `vim.paste()` failure, …) are reflected in `err`
 --- but do not affect the return value (which is strictly decided by
 --- `vim.paste()`). On error, subsequent calls are ignored ("drained") until
@@ -1678,40 +1678,40 @@ function vim.api.nvim_parse_expression(expr, flags, highlight) end
 function vim.api.nvim_paste(data, crlf, phase) end
 
 --- Puts text at cursor, in any mode.
---- Compare `|:put|` and `|p|` which are always linewise.
+--- Compare [:put](help://:put) and [p](help://p) which are always linewise.
 ---
---- @param lines string[] `|readfile()|`-style list of lines. `|channel-lines|`
---- @param type string Edit behavior: any `|getregtype()|` result, or:
----  • "b" `|blockwise-visual|` mode (may include width, e.g. "b3")
----  • "c" `|charwise|` mode
----  • "l" `|linewise|` mode
----  • "" guess by contents, see `|setreg()|`
---- @param after boolean If true insert after cursor (like `|p|`), or before (like
----  `|P|`).
+--- @param lines string[] [readfile()](help://readfile())-style list of lines. [channel-lines](help://channel-lines)
+--- @param type string Edit behavior: any [getregtype()](help://getregtype()) result, or:
+---  • "b" [blockwise-visual](help://blockwise-visual) mode (may include width, e.g. "b3")
+---  • "c" [charwise](help://charwise) mode
+---  • "l" [linewise](help://linewise) mode
+---  • "" guess by contents, see [setreg()](help://setreg())
+--- @param after boolean If true insert after cursor (like [p](help://p)), or before (like
+---  [P](help://P)).
 --- @param follow boolean If true place cursor at end of inserted text.
 function vim.api.nvim_put(lines, type, after, follow) end
 
---- Replaces terminal codes and `|keycodes|` (<CR>, <Esc>, ...) in a string with
+--- Replaces terminal codes and [keycodes](help://keycodes) (<CR>, <Esc>, ...) in a string with
 --- the internal representation.
 ---
 --- @param str string String to be converted.
 --- @param from_part boolean Legacy Vim parameter. Usually true.
 --- @param do_lt boolean Also translate <lt>. Ignored if `special` is false.
---- @param special boolean Replace `|keycodes|`, e.g. <CR> becomes a "\r" char.
+--- @param special boolean Replace [keycodes](help://keycodes), e.g. <CR> becomes a "\r" char.
 --- @return string
 function vim.api.nvim_replace_termcodes(str, from_part, do_lt, special) end
 
 --- Selects an item in the completion popup menu.
---- If neither `|ins-completion|` nor `|cmdline-completion|` popup menu is active
+--- If neither [ins-completion](help://ins-completion) nor [cmdline-completion](help://cmdline-completion) popup menu is active
 --- this API call is silently ignored. Useful for an external UI using
---- `|ui-popupmenu|` to control the popup menu with the mouse. Can also be used
---- in a mapping; use <Cmd> `|:map-cmd|` or a Lua mapping to ensure the mapping
+--- [ui-popupmenu](help://ui-popupmenu) to control the popup menu with the mouse. Can also be used
+--- in a mapping; use <Cmd> [:map-cmd](help://:map-cmd) or a Lua mapping to ensure the mapping
 --- doesn't end completion mode.
 ---
 --- @param item integer Index (zero-based) of the item to select. Value of -1
 ---  selects nothing and restores the original text.
---- @param insert boolean For `|ins-completion|`, whether the selection should be
----  inserted in the buffer. Ignored for `|cmdline-completion|`.
+--- @param insert boolean For [ins-completion](help://ins-completion), whether the selection should be
+---  inserted in the buffer. Ignored for [cmdline-completion](help://cmdline-completion).
 --- @param finish boolean Finish the completion and dismiss the popup menu. Implies
 ---  {insert}.
 --- @param opts table<string,any> Optional parameters. Reserved for future use.
@@ -1740,7 +1740,7 @@ function vim.api.nvim_select_popupmenu_item(item, insert, finish, opts) end
 ---  user.
 ---  • "remote" remote client connected "Nvim flavored"
 ---    MessagePack-RPC (responses must be in reverse order of
----    requests). `|msgpack-rpc|`
+---    requests). [msgpack-rpc](help://msgpack-rpc)
 ---  • "msgpack-rpc" remote client connected to Nvim via
 ---    fully MessagePack-RPC compliant protocol.
 ---  • "ui" gui frontend
@@ -1795,11 +1795,11 @@ function vim.api.nvim_set_current_tabpage(tabpage) end
 --- @param window integer Window handle
 function vim.api.nvim_set_current_win(window) end
 
---- Set or change decoration provider for a `|namespace|`
+--- Set or change decoration provider for a [namespace](help://namespace)
 --- This is a very general purpose interface for having Lua callbacks being
 --- triggered during the redraw code.
---- The expected usage is to set `|extmarks|` for the currently redrawn buffer.
---- `|nvim_buf_set_extmark()|` can be called to add marks on a per-window or
+--- The expected usage is to set [extmarks](help://extmarks) for the currently redrawn buffer.
+--- [nvim_buf_set_extmark()](help://nvim_buf_set_extmark()) can be called to add marks on a per-window or
 --- per-lines basis. Use the `ephemeral` key to only use the mark for the
 --- current screen redraw (the callback will be called again for the next
 --- redraw ).
@@ -1819,7 +1819,7 @@ function vim.api.nvim_set_current_win(window) end
 --- Note: It is not allowed to remove or update extmarks in 'on_line'
 --- callbacks.
 ---
---- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
+--- @param ns_id integer Namespace id from [nvim_create_namespace()](help://nvim_create_namespace())
 --- @param opts vim.api.keyset.set_decoration_provider Table of callbacks:
 ---   • on_start: called first on each screen redraw ["start",
 ---     tick]
@@ -1837,10 +1837,10 @@ function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 
 --- Sets a highlight group.
 ---
---- @param ns_id integer Namespace id for this highlight `|nvim_create_namespace()|`.
----   Use 0 to set a highlight group globally `|:highlight|`.
+--- @param ns_id integer Namespace id for this highlight [nvim_create_namespace()](help://nvim_create_namespace()).
+---   Use 0 to set a highlight group globally [:highlight](help://:highlight).
 ---   Highlights from non-global namespaces are not active by
----   default, use `|nvim_set_hl_ns()|` or `|nvim_win_set_hl_ns()|` to
+---   default, use [nvim_set_hl_ns()](help://nvim_set_hl_ns()) or [nvim_win_set_hl_ns()](help://nvim_win_set_hl_ns()) to
 ---   activate them.
 --- @param name string Highlight group name, e.g. "ErrorMsg"
 --- @param val vim.api.keyset.highlight Highlight definition map, accepts the following keys:
@@ -1860,36 +1860,36 @@ function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 ---   • reverse: boolean
 ---   • nocombine: boolean
 ---   • link: name of another highlight group to link to, see
----     `|:hi-link|`.
----   • default: Don't override existing definition `|:hi-default|`
----   • ctermfg: Sets foreground of cterm color `|ctermfg|`
----   • ctermbg: Sets background of cterm color `|ctermbg|`
----   • cterm: cterm attribute map, like `|highlight-args|`. If not
+---     [:hi-link](help://:hi-link).
+---   • default: Don't override existing definition [:hi-default](help://:hi-default)
+---   • ctermfg: Sets foreground of cterm color [ctermfg](help://ctermfg)
+---   • ctermbg: Sets background of cterm color [ctermbg](help://ctermbg)
+---   • cterm: cterm attribute map, like [highlight-args](help://highlight-args). If not
 ---     set, cterm attributes will match those from the attribute
 ---     map documented above.
 ---   • force: if true force update the highlight group when it
 ---     exists.
 function vim.api.nvim_set_hl(ns_id, name, val) end
 
---- Set active namespace for highlights defined with `|nvim_set_hl()|`. This can
---- be set for a single window, see `|nvim_win_set_hl_ns()|`.
+--- Set active namespace for highlights defined with [nvim_set_hl()](help://nvim_set_hl()). This can
+--- be set for a single window, see [nvim_win_set_hl_ns()](help://nvim_win_set_hl_ns()).
 ---
 --- @param ns_id integer the namespace to use
 function vim.api.nvim_set_hl_ns(ns_id) end
 
---- Set active namespace for highlights defined with `|nvim_set_hl()|` while
+--- Set active namespace for highlights defined with [nvim_set_hl()](help://nvim_set_hl()) while
 --- redrawing.
 --- This function meant to be called while redrawing, primarily from
---- `|nvim_set_decoration_provider()|` on_win and on_line callbacks, which are
+--- [nvim_set_decoration_provider()](help://nvim_set_decoration_provider()) on_win and on_line callbacks, which are
 --- allowed to change the namespace during a redraw cycle.
 ---
 --- @param ns_id integer the namespace to activate
 function vim.api.nvim_set_hl_ns_fast(ns_id) end
 
---- Sets a global `|mapping|` for the given mode.
---- To set a buffer-local mapping, use `|nvim_buf_set_keymap()|`.
---- Unlike `|:map|`, leading/trailing whitespace is accepted as part of the
---- {lhs} or {rhs}. Empty {rhs} is `|<Nop>|`. `|keycodes|` are replaced as usual.
+--- Sets a global [mapping](help://mapping) for the given mode.
+--- To set a buffer-local mapping, use [nvim_buf_set_keymap()](help://nvim_buf_set_keymap()).
+--- Unlike [:map](help://:map), leading/trailing whitespace is accepted as part of the
+--- {lhs} or {rhs}. Empty {rhs} is [<Nop>](help://<Nop>). [keycodes](help://keycodes) are replaced as usual.
 --- Example:
 --- ```vim
 --- call nvim_set_keymap('n', ' <NL>', '', {'nowait': v:true})
@@ -1901,19 +1901,19 @@ function vim.api.nvim_set_hl_ns_fast(ns_id) end
 ---
 ---
 --- @param mode string Mode short-name (map command prefix: "n", "i", "v", "x", …) or
----  "!" for `|:map!|`, or empty string for `|:map|`. "ia", "ca" or
+---  "!" for [:map!](help://:map!), or empty string for [:map](help://:map). "ia", "ca" or
 ---  "!a" for abbreviation in Insert mode, Cmdline mode, or both,
 ---  respectively
---- @param lhs string Left-hand-side `|{lhs}|` of the mapping.
---- @param rhs string Right-hand-side `|{rhs}|` of the mapping.
---- @param opts vim.api.keyset.keymap Optional parameters map: Accepts all `|:map-arguments|` as keys
----  except `|<buffer>|`, values are booleans (default false). Also:
----  • "noremap" disables `|recursive_mapping|`, like `|:noremap|`
+--- @param lhs string Left-hand-side [{lhs}](help://{lhs}) of the mapping.
+--- @param rhs string Right-hand-side [{rhs}](help://{rhs}) of the mapping.
+--- @param opts vim.api.keyset.keymap Optional parameters map: Accepts all [:map-arguments](help://:map-arguments) as keys
+---  except [<buffer>](help://<buffer>), values are booleans (default false). Also:
+---  • "noremap" disables [recursive_mapping](help://recursive_mapping), like [:noremap](help://:noremap)
 ---  • "desc" human-readable description.
 ---  • "callback" Lua function called in place of {rhs}.
 ---  • "replace_keycodes" (boolean) When "expr" is true, replace
 ---    keycodes in the resulting string (see
----    `|nvim_replace_termcodes()|`). Returning nil from the Lua
+---    [nvim_replace_termcodes()](help://nvim_replace_termcodes())). Returning nil from the Lua
 ---    "callback" is equivalent to returning an empty string.
 function vim.api.nvim_set_keymap(mode, lhs, rhs, opts) end
 
@@ -1923,7 +1923,7 @@ function vim.api.nvim_set_keymap(mode, lhs, rhs, opts) end
 function vim.api.nvim_set_option(name, value) end
 
 --- Sets the value of an option. The behavior of this function matches that of
---- `|:set|`: for global-local options, both the global and local value are set
+--- [:set](help://:set): for global-local options, both the global and local value are set
 --- unless otherwise specified with {scope}.
 --- Note the options {win} and {buf} cannot be used together.
 ---
@@ -1931,8 +1931,8 @@ function vim.api.nvim_set_option(name, value) end
 --- @param value any New option value
 --- @param opts vim.api.keyset.option Optional parameters
 ---   • scope: One of "global" or "local". Analogous to
----     `|:setglobal|` and `|:setlocal|`, respectively.
----   • win: `|window-ID|`. Used for setting window local option.
+---     [:setglobal](help://:setglobal) and [:setlocal](help://:setlocal), respectively.
+---   • win: [window-ID](help://window-ID). Used for setting window local option.
 ---   • buf: Buffer number. Used for setting buffer local option.
 function vim.api.nvim_set_option_value(name, value, opts) end
 
@@ -2005,24 +2005,24 @@ function vim.api.nvim_tabpage_list_wins(tabpage) end
 function vim.api.nvim_tabpage_set_var(tabpage, name, value) end
 
 --- Activates UI events on the channel.
---- Entry point of all UI clients. Allows `|--embed|` to continue startup.
+--- Entry point of all UI clients. Allows [--embed](help://--embed) to continue startup.
 --- Implies that the client is ready to show the UI. Adds the client to the
---- list of UIs. `|nvim_list_uis()|`
+--- list of UIs. [nvim_list_uis()](help://nvim_list_uis())
 ---
 --- @param width integer Requested screen columns
 --- @param height integer Requested screen rows
---- @param options table<string,any> `|ui-option|` map
+--- @param options table<string,any> [ui-option](help://ui-option) map
 function vim.api.nvim_ui_attach(width, height, options) end
 
 --- Deactivates UI events on the channel.
---- Removes the client from the list of UIs. `|nvim_list_uis()|`
+--- Removes the client from the list of UIs. [nvim_list_uis()](help://nvim_list_uis())
 ---
 function vim.api.nvim_ui_detach() end
 
 --- Tells Nvim the geometry of the popupmenu, to align floating windows with
 --- an external popup menu.
 --- Note that this method is not to be confused with
---- `|nvim_ui_pum_set_height()|`, which sets the number of visible items in the
+--- [nvim_ui_pum_set_height()](help://nvim_ui_pum_set_height()), which sets the number of visible items in the
 --- popup menu, while this function sets the bounding box of the popup menu,
 --- including visual elements such as borders and sliders. Floats need not use
 --- the same font size, nor be anchored to exact grid corners, so one can set
@@ -2073,7 +2073,7 @@ function vim.api.nvim_unsubscribe(event) end
 --- @return any
 function vim.api.nvim_win_call(window, fun) end
 
---- Closes the window (like `|:close|` with a `|window-ID|`).
+--- Closes the window (like [:close](help://:close) with a [window-ID](help://window-ID)).
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @param force boolean Behave like `:close!` The last window of a buffer with
@@ -2094,7 +2094,7 @@ function vim.api.nvim_win_del_var(window, name) end
 function vim.api.nvim_win_get_buf(window) end
 
 --- Gets window configuration.
---- The returned value may be given to `|nvim_open_win()|`.
+--- The returned value may be given to [nvim_open_win()](help://nvim_open_win()).
 --- `relative` is empty for normal windows.
 ---
 --- @param window integer Window handle, or 0 for current window
@@ -2103,7 +2103,7 @@ function vim.api.nvim_win_get_config(window) end
 
 --- Gets the (1,0)-indexed, buffer-relative cursor position for a given window
 --- (different windows showing the same buffer have independent cursor
---- positions). `|api-indexing|`
+--- positions). [api-indexing](help://api-indexing)
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @return integer[]
@@ -2152,11 +2152,11 @@ function vim.api.nvim_win_get_var(window, name) end
 --- @return integer
 function vim.api.nvim_win_get_width(window) end
 
---- Closes the window and hide the buffer it contains (like `|:hide|` with a
---- `|window-ID|`).
---- Like `|:hide|` the buffer becomes hidden unless another window is editing
---- it, or 'bufhidden' is `unload`, `delete` or `wipe` as opposed to `|:close|`
---- or `|nvim_win_close()|`, which will close the buffer.
+--- Closes the window and hide the buffer it contains (like [:hide](help://:hide) with a
+--- [window-ID](help://window-ID)).
+--- Like [:hide](help://:hide) the buffer becomes hidden unless another window is editing
+--- it, or 'bufhidden' is `unload`, `delete` or `wipe` as opposed to [:close](help://:close)
+--- or [nvim_win_close()](help://nvim_win_close()), which will close the buffer.
 ---
 --- @param window integer Window handle, or 0 for current window
 function vim.api.nvim_win_hide(window) end
@@ -2179,10 +2179,10 @@ function vim.api.nvim_win_set_buf(window, buffer) end
 --- changed. `row`/`col` and `relative` must be reconfigured together.
 ---
 --- @param window integer Window handle, or 0 for current window
---- @param config vim.api.keyset.float_config Map defining the window configuration, see `|nvim_open_win()|`
+--- @param config vim.api.keyset.float_config Map defining the window configuration, see [nvim_open_win()](help://nvim_open_win())
 function vim.api.nvim_win_set_config(window, config) end
 
---- Sets the (1,0)-indexed cursor position in the window. `|api-indexing|` This
+--- Sets the (1,0)-indexed cursor position in the window. [api-indexing](help://api-indexing) This
 --- scrolls the window even if it is not the current one.
 ---
 --- @param window integer Window handle, or 0 for current window
@@ -2196,7 +2196,7 @@ function vim.api.nvim_win_set_cursor(window, pos) end
 function vim.api.nvim_win_set_height(window, height) end
 
 --- Set highlight namespace for a window. This will use highlights defined
---- with `|nvim_set_hl()|` for this namespace, but fall back to global
+--- with [nvim_set_hl()](help://nvim_set_hl()) for this namespace, but fall back to global
 --- highlights (ns=0) when missing.
 --- This takes precedence over the 'winhighlight' option.
 ---
@@ -2230,7 +2230,7 @@ function vim.api.nvim_win_set_width(window, width) end
 --- line, unless the line is on "start_row" and "start_vcol" is specified.
 --- Diff filler or virtual lines below the last buffer line are counted in the
 --- result when "end_row" is omitted.
---- Line indexing is similar to `|nvim_buf_get_text()|`.
+--- Line indexing is similar to [nvim_buf_get_text()](help://nvim_buf_get_text()).
 ---
 --- @param window integer Window handle, or 0 for current window.
 --- @param opts vim.api.keyset.win_text_height Optional parameters:

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -104,20 +104,20 @@ function vim.api.nvim__unpack(str) end
 --- Adds a highlight to buffer.
 --- Useful for plugins that dynamically generate highlights to a buffer (like
 --- a semantic highlighter or linter). The function adds a single highlight to
---- a buffer. Unlike `matchaddpos()` highlights follow changes to line
+--- a buffer. Unlike `|matchaddpos()|` highlights follow changes to line
 --- numbering (as lines are inserted/removed above the highlighted line), like
 --- signs and marks do.
 --- Namespaces are used for batch deletion/updating of a set of highlights. To
---- create a namespace, use `nvim_create_namespace()` which returns a
+--- create a namespace, use `|nvim_create_namespace()|` which returns a
 --- namespace id. Pass it in to this function as `ns_id` to add highlights to
 --- the namespace. All highlights in the same namespace can then be cleared
---- with single call to `nvim_buf_clear_namespace()`. If the highlight never
+--- with single call to `|nvim_buf_clear_namespace()|`. If the highlight never
 --- will be deleted by an API call, pass `ns_id = -1`.
 --- As a shorthand, `ns_id = 0` can be used to create a new namespace for the
 --- highlight, the allocated id is then returned. If `hl_group` is the empty
 --- string no highlight is added, but a new `ns_id` is still returned. This is
 --- supported for backwards compatibility, new code should use
---- `nvim_create_namespace()` to create a new empty namespace.
+--- `|nvim_create_namespace()|` to create a new empty namespace.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param ns_id integer namespace to use or -1 for ungrouped highlight
@@ -125,77 +125,77 @@ function vim.api.nvim__unpack(str) end
 --- @param line integer Line to highlight (zero-indexed)
 --- @param col_start integer Start of (byte-indexed) column range to highlight
 --- @param col_end integer End of (byte-indexed) column range to highlight, or -1 to
----                  highlight to end of line
+---   highlight to end of line
 --- @return integer
 function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start, col_end) end
 
 --- Activates buffer-update events on a channel, or as Lua callbacks.
 --- Example (Lua): capture buffer updates in a global `events` variable (use
 --- "vim.print(events)" to see its contents):
----
 --- ```lua
----     events = {}
----     vim.api.nvim_buf_attach(0, false, {
----       on_lines = function(...)
----         table.insert(events, {...})
----       end,
----     })
+--- events = {}
+--- vim.api.nvim_buf_attach(0, false, {
+---   on_lines = function(...)
+---     table.insert(events, {...})
+---   end,
+--- })
 --- ```
+---
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param send_buffer boolean True if the initial notification should contain the
----                    whole buffer: first notification will be
----                    `nvim_buf_lines_event`. Else the first notification
----                    will be `nvim_buf_changedtick_event`. Not for Lua
----                    callbacks.
+---   whole buffer: first notification will be
+---   `nvim_buf_lines_event`. Else the first notification
+---   will be `nvim_buf_changedtick_event`. Not for Lua
+---   callbacks.
 --- @param opts table<string,function> Optional parameters.
----                    • on_lines: Lua callback invoked on change. Return `true` to detach. Args:
----                      • the string "lines"
----                      • buffer handle
----                      • b:changedtick
----                      • first line that changed (zero-indexed)
----                      • last line that was changed
----                      • last line in the updated range
----                      • byte count of previous contents
----                      • deleted_codepoints (if `utf_sizes` is true)
----                      • deleted_codeunits (if `utf_sizes` is true)
+---   • on_lines: Lua callback invoked on change. Return `true` to detach. Args:
+---     • the string "lines"
+---     • buffer handle
+---     • b:changedtick
+---     • first line that changed (zero-indexed)
+---     • last line that was changed
+---     • last line in the updated range
+---     • byte count of previous contents
+---     • deleted_codepoints (if `utf_sizes` is true)
+---     • deleted_codeunits (if `utf_sizes` is true)
 ---
----                    • on_bytes: Lua callback invoked on change. This
----                      callback receives more granular information about the
----                      change compared to on_lines. Return `true` to detach. Args:
----                      • the string "bytes"
----                      • buffer handle
----                      • b:changedtick
----                      • start row of the changed text (zero-indexed)
----                      • start column of the changed text
----                      • byte offset of the changed text (from the start of
----                        the buffer)
----                      • old end row of the changed text
----                      • old end column of the changed text
----                      • old end byte length of the changed text
----                      • new end row of the changed text
----                      • new end column of the changed text
----                      • new end byte length of the changed text
+---   • on_bytes: Lua callback invoked on change. This
+---     callback receives more granular information about the
+---     change compared to on_lines. Return `true` to detach. Args:
+---     • the string "bytes"
+---     • buffer handle
+---     • b:changedtick
+---     • start row of the changed text (zero-indexed)
+---     • start column of the changed text
+---     • byte offset of the changed text (from the start of
+---       the buffer)
+---     • old end row of the changed text
+---     • old end column of the changed text
+---     • old end byte length of the changed text
+---     • new end row of the changed text
+---     • new end column of the changed text
+---     • new end byte length of the changed text
 ---
----                    • on_changedtick: Lua callback invoked on changedtick
----                      increment without text change. Args:
----                      • the string "changedtick"
----                      • buffer handle
----                      • b:changedtick
+---   • on_changedtick: Lua callback invoked on changedtick
+---     increment without text change. Args:
+---     • the string "changedtick"
+---     • buffer handle
+---     • b:changedtick
 ---
----                    • on_detach: Lua callback invoked on detach. Args:
----                      • the string "detach"
----                      • buffer handle
+---   • on_detach: Lua callback invoked on detach. Args:
+---     • the string "detach"
+---     • buffer handle
 ---
----                    • on_reload: Lua callback invoked on reload. The entire
----                      buffer content should be considered changed. Args:
----                      • the string "reload"
----                      • buffer handle
+---   • on_reload: Lua callback invoked on reload. The entire
+---     buffer content should be considered changed. Args:
+---     • the string "reload"
+---     • buffer handle
 ---
----                    • utf_sizes: include UTF-32 and UTF-16 size of the
----                      replaced region, as args to `on_lines`.
----                    • preview: also attach to command preview (i.e.
----                      'inccommand') events.
+---   • utf_sizes: include UTF-32 and UTF-16 size of the
+---     replaced region, as args to `on_lines`.
+---   • preview: also attach to command preview (i.e.
+---     'inccommand') events.
 --- @return boolean
 function vim.api.nvim_buf_attach(buffer, send_buffer, opts) end
 
@@ -207,11 +207,11 @@ function vim.api.nvim_buf_attach(buffer, send_buffer, opts) end
 --- a temporary scratch window (called the "autocmd window" for historical
 --- reasons) will be used.
 --- This is useful e.g. to call Vimscript functions that only work with the
---- current buffer/window currently, like `termopen()`.
+--- current buffer/window currently, like `|termopen()|`.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param fun function Function to call inside the buffer (currently Lua callable
----               only)
+---  only)
 --- @return any
 function vim.api.nvim_buf_call(buffer, fun) end
 
@@ -222,19 +222,19 @@ function vim.api.nvim_buf_call(buffer, fun) end
 --- @param line_end integer
 function vim.api.nvim_buf_clear_highlight(buffer, ns_id, line_start, line_end) end
 
---- Clears `namespace`d objects (highlights, `extmarks`, virtual text) from a
+--- Clears `|namespace|`d objects (highlights, `|extmarks|`, virtual text) from a
 --- region.
---- Lines are 0-indexed. `api-indexing` To clear the namespace in the entire
+--- Lines are 0-indexed. `|api-indexing|` To clear the namespace in the entire
 --- buffer, specify line_start=0 and line_end=-1.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param ns_id integer Namespace to clear, or -1 to clear all namespaces.
 --- @param line_start integer Start of range of lines to clear
 --- @param line_end integer End of range of lines to clear (exclusive) or -1 to
----                   clear to end of buffer.
+---  clear to end of buffer.
 function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) end
 
---- Creates a buffer-local command `user-commands`.
+--- Creates a buffer-local command `|user-commands|`.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer.
 --- @param name string
@@ -242,22 +242,22 @@ function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) e
 --- @param opts vim.api.keyset.user_command
 function vim.api.nvim_buf_create_user_command(buffer, name, command, opts) end
 
---- Removes an `extmark`.
+--- Removes an `|extmark|`.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `nvim_create_namespace()`
+--- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
 --- @param id integer Extmark id
 --- @return boolean
 function vim.api.nvim_buf_del_extmark(buffer, ns_id, id) end
 
---- Unmaps a buffer-local `mapping` for the given mode.
+--- Unmaps a buffer-local `|mapping|` for the given mode.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string
 --- @param lhs string
 function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
 
---- Deletes a named mark in the buffer. See `mark-motions`.
+--- Deletes a named mark in the buffer. See `|mark-motions|`.
 ---
 --- @param buffer integer Buffer to set the mark on
 --- @param name string Mark name
@@ -265,8 +265,8 @@ function vim.api.nvim_buf_del_keymap(buffer, mode, lhs) end
 function vim.api.nvim_buf_del_mark(buffer, name) end
 
 --- Delete a buffer-local user-defined command.
---- Only commands created with `:command-buffer` or
---- `nvim_buf_create_user_command()` can be deleted with this function.
+--- Only commands created with `|:command-buffer|` or
+--- `|nvim_buf_create_user_command()|` can be deleted with this function.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer.
 --- @param name string Name of the command to delete.
@@ -278,12 +278,12 @@ function vim.api.nvim_buf_del_user_command(buffer, name) end
 --- @param name string Variable name
 function vim.api.nvim_buf_del_var(buffer, name) end
 
---- Deletes the buffer. See `:bwipeout`
+--- Deletes the buffer. See `|:bwipeout|`
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param opts table<string,any> Optional parameters. Keys:
----               • force: Force deletion and ignore unsaved changes.
----               • unload: Unloaded only, do not delete. See `:bunload`
+---  • force: Force deletion and ignore unsaved changes.
+---  • unload: Unloaded only, do not delete. See `|:bunload|`
 function vim.api.nvim_buf_delete(buffer, opts) end
 
 --- Deactivates buffer-update events on the channel.
@@ -298,79 +298,77 @@ function vim.api.nvim_buf_detach(buffer) end
 --- @return integer
 function vim.api.nvim_buf_get_changedtick(buffer) end
 
---- Gets a map of buffer-local `user-commands`.
+--- Gets a map of buffer-local `|user-commands|`.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param opts vim.api.keyset.get_commands Optional parameters. Currently not used.
 --- @return table<string,any>
 function vim.api.nvim_buf_get_commands(buffer, opts) end
 
---- Gets the position (0-indexed) of an `extmark`.
+--- Gets the position (0-indexed) of an `|extmark|`.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `nvim_create_namespace()`
+--- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
 --- @param id integer Extmark id
 --- @param opts table<string,any> Optional parameters. Keys:
----               • details: Whether to include the details dict
----               • hl_name: Whether to include highlight group name instead
----                 of id, true if omitted
+---  • details: Whether to include the details dict
+---  • hl_name: Whether to include highlight group name instead
+---    of id, true if omitted
 --- @return integer[]
 function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 
---- Gets `extmarks` in "traversal order" from a `charwise` region defined by
---- buffer positions (inclusive, 0-indexed `api-indexing`).
+--- Gets `|extmarks|` in "traversal order" from a `|charwise|` region defined by
+--- buffer positions (inclusive, 0-indexed `|api-indexing|`).
 --- Region can be given as (row,col) tuples, or valid extmark ids (whose
 --- positions define the bounds). 0 and -1 are understood as (0,0) and (-1,-1)
 --- respectively, thus the following are equivalent:
----
 --- ```lua
----     vim.api.nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
----     vim.api.nvim_buf_get_extmarks(0, my_ns, {0,0}, {-1,-1}, {})
+--- vim.api.nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
+--- vim.api.nvim_buf_get_extmarks(0, my_ns, {0,0}, {-1,-1}, {})
 --- ```
----
 --- If `end` is less than `start`, traversal works backwards. (Useful with
 --- `limit`, to get the first marks prior to a given position.)
 --- Note: when using extmark ranges (marks with a end_row/end_col position)
 --- the `overlap` option might be useful. Otherwise only the start position of
 --- an extmark will be considered.
 --- Example:
----
 --- ```lua
----     local api = vim.api
----     local pos = api.nvim_win_get_cursor(0)
----     local ns  = api.nvim_create_namespace('my-plugin')
----     -- Create new extmark at line 1, column 1.
----     local m1  = api.nvim_buf_set_extmark(0, ns, 0, 0, {})
----     -- Create new extmark at line 3, column 1.
----     local m2  = api.nvim_buf_set_extmark(0, ns, 2, 0, {})
----     -- Get extmarks only from line 3.
----     local ms  = api.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
----     -- Get all marks in this buffer + namespace.
----     local all = api.nvim_buf_get_extmarks(0, ns, 0, -1, {})
----     vim.print(ms)
+--- local api = vim.api
+--- local pos = api.nvim_win_get_cursor(0)
+--- local ns  = api.nvim_create_namespace('my-plugin')
+--- -- Create new extmark at line 1, column 1.
+--- local m1  = api.nvim_buf_set_extmark(0, ns, 0, 0, {})
+--- -- Create new extmark at line 3, column 1.
+--- local m2  = api.nvim_buf_set_extmark(0, ns, 2, 0, {})
+--- -- Get extmarks only from line 3.
+--- local ms  = api.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
+--- -- Get all marks in this buffer + namespace.
+--- local all = api.nvim_buf_get_extmarks(0, ns, 0, -1, {})
+--- vim.print(ms)
 --- ```
 ---
+---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `nvim_create_namespace()` or -1 for all
----               namespaces
+--- @param ns_id integer Namespace id from `|nvim_create_namespace()|` or -1 for all
+---  namespaces
 --- @param start any Start of range: a 0-indexed (row, col) or valid extmark id
----               (whose position defines the bound). `api-indexing`
+---  (whose position defines the bound). `|api-indexing|`
 --- @param end_ any End of range (inclusive): a 0-indexed (row, col) or valid
----               extmark id (whose position defines the bound).
----               `api-indexing`
+---  extmark id (whose position defines the bound).
+---  `|api-indexing|`
 --- @param opts vim.api.keyset.get_extmarks Optional parameters. Keys:
----               • limit: Maximum number of marks to return
----               • details: Whether to include the details dict
----               • hl_name: Whether to include highlight group name instead
----                 of id, true if omitted
----               • overlap: Also include marks which overlap the range, even
----                 if their start position is less than `start`
----               • type: Filter marks by type: "highlight", "sign",
----                 "virt_text" and "virt_lines"
+---  • limit: Maximum number of marks to return
+---  • details: Whether to include the details dict
+---  • hl_name: Whether to include highlight group name instead
+---    of id, true if omitted
+---  • overlap: Also include marks which overlap the range, even
+---    if their start position is less than `start`
+---  • type: Filter marks by type: "highlight", "sign",
+---    "virt_text" and "virt_lines"
 --- @return any[]
 function vim.api.nvim_buf_get_extmarks(buffer, ns_id, start, end_, opts) end
 
---- Gets a list of buffer-local `mapping` definitions.
+--- Gets a list of buffer-local `|mapping|` definitions.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string Mode short-name ("n", "i", "v", ...)
@@ -392,9 +390,9 @@ function vim.api.nvim_buf_get_keymap(buffer, mode) end
 function vim.api.nvim_buf_get_lines(buffer, start, end_, strict_indexing) end
 
 --- Returns a `(row,col)` tuple representing the position of the named mark.
---- "End of line" column position is returned as `v:maxcol` (big number). See
---- `mark-motions`.
---- Marks are (1,0)-indexed. `api-indexing`
+--- "End of line" column position is returned as `|v:maxcol|` (big number). See
+--- `|mark-motions|`.
+--- Marks are (1,0)-indexed. `|api-indexing|`
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param name string Mark name
@@ -412,12 +410,12 @@ function vim.api.nvim_buf_get_name(buffer) end
 --- @return integer
 function vim.api.nvim_buf_get_number(buffer) end
 
---- Returns the byte offset of a line (0-indexed). `api-indexing`
+--- Returns the byte offset of a line (0-indexed). `|api-indexing|`
 --- Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
 --- 'fileformat' and 'fileencoding' are ignored. The line index just after the
 --- last line gives the total byte-count of the buffer. A final EOL byte is
 --- counted if it would be written, see 'eol'.
---- Unlike `line2byte()`, throws error for out-of-bounds indexing. Returns -1
+--- Unlike `|line2byte()|`, throws error for out-of-bounds indexing. Returns -1
 --- for unloaded buffer.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
@@ -432,11 +430,11 @@ function vim.api.nvim_buf_get_offset(buffer, index) end
 function vim.api.nvim_buf_get_option(buffer, name) end
 
 --- Gets a range from the buffer.
---- This differs from `nvim_buf_get_lines()` in that it allows retrieving only
+--- This differs from `|nvim_buf_get_lines()|` in that it allows retrieving only
 --- portions of a line.
 --- Indexing is zero-based. Row indices are end-inclusive, and column indices
 --- are end-exclusive.
---- Prefer `nvim_buf_get_lines()` when retrieving entire lines.
+--- Prefer `|nvim_buf_get_lines()|` when retrieving entire lines.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param start_row integer First line index
@@ -454,7 +452,7 @@ function vim.api.nvim_buf_get_text(buffer, start_row, start_col, end_row, end_co
 --- @return any
 function vim.api.nvim_buf_get_var(buffer, name) end
 
---- Checks if a buffer is valid and loaded. See `api-buffer` for more info
+--- Checks if a buffer is valid and loaded. See `|api-buffer|` for more info
 --- about unloaded buffers.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
@@ -473,7 +471,7 @@ function vim.api.nvim_buf_is_valid(buffer) end
 --- @return integer
 function vim.api.nvim_buf_line_count(buffer) end
 
---- Creates or updates an `extmark`.
+--- Creates or updates an `|extmark|`.
 --- By default a new extmark is created when no id is passed in, but it is
 --- also possible to create a new mark by passing in a previously unused id or
 --- move an existing mark by passing in its id. The caller must then keep
@@ -487,110 +485,110 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- range (no highlighting).
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param ns_id integer Namespace id from `nvim_create_namespace()`
---- @param line integer Line where to place the mark, 0-based. `api-indexing`
---- @param col integer Column where to place the mark, 0-based. `api-indexing`
+--- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
+--- @param line integer Line where to place the mark, 0-based. `|api-indexing|`
+--- @param col integer Column where to place the mark, 0-based. `|api-indexing|`
 --- @param opts vim.api.keyset.set_extmark Optional parameters.
----               • id : id of the extmark to edit.
----               • end_row : ending line of the mark, 0-based inclusive.
----               • end_col : ending col of the mark, 0-based exclusive.
----               • hl_group : name of the highlight group used to highlight
----                 this mark.
----               • hl_eol : when true, for a multiline highlight covering the
----                 EOL of a line, continue the highlight for the rest of the
----                 screen line (just like for diff and cursorline highlight).
----               • virt_text : virtual text to link to this mark. A list of
----                 [text, highlight] tuples, each representing a text chunk
----                 with specified highlight. `highlight` element can either
----                 be a single highlight group, or an array of multiple
----                 highlight groups that will be stacked (highest priority
----                 last). A highlight group can be supplied either as a
----                 string or as an integer, the latter which can be obtained
----                 using `nvim_get_hl_id_by_name()`.
----               • virt_text_pos : position of virtual text. Possible values:
----                 • "eol": right after eol character (default).
----                 • "overlay": display over the specified column, without
----                   shifting the underlying text.
----                 • "right_align": display right aligned in the window.
----                 • "inline": display at the specified column, and shift the
----                   buffer text to the right as needed.
+---  • id : id of the extmark to edit.
+---  • end_row : ending line of the mark, 0-based inclusive.
+---  • end_col : ending col of the mark, 0-based exclusive.
+---  • hl_group : name of the highlight group used to highlight
+---    this mark.
+---  • hl_eol : when true, for a multiline highlight covering the
+---    EOL of a line, continue the highlight for the rest of the
+---    screen line (just like for diff and cursorline highlight).
+---  • virt_text : virtual text to link to this mark. A list of
+---    [text, highlight] tuples, each representing a text chunk
+---    with specified highlight. `highlight` element can either
+---    be a single highlight group, or an array of multiple
+---    highlight groups that will be stacked (highest priority
+---    last). A highlight group can be supplied either as a
+---    string or as an integer, the latter which can be obtained
+---    using `|nvim_get_hl_id_by_name()|`.
+---  • virt_text_pos : position of virtual text. Possible values:
+---    • "eol": right after eol character (default).
+---    • "overlay": display over the specified column, without
+---      shifting the underlying text.
+---    • "right_align": display right aligned in the window.
+---    • "inline": display at the specified column, and shift the
+---      buffer text to the right as needed.
 ---
----               • virt_text_win_col : position the virtual text at a fixed
----                 window column (starting from the first text column of the
----                 screen line) instead of "virt_text_pos".
----               • virt_text_hide : hide the virtual text when the background
----                 text is selected or hidden because of scrolling with
----                 'nowrap' or 'smoothscroll'. Currently only affects
----                 "overlay" virt_text.
----               • hl_mode : control how highlights are combined with the
----                 highlights of the text. Currently only affects virt_text
----                 highlights, but might affect `hl_group` in later versions.
----                 • "replace": only show the virt_text color. This is the
----                   default.
----                 • "combine": combine with background text color.
----                 • "blend": blend with background text color. Not supported
----                   for "inline" virt_text.
+---  • virt_text_win_col : position the virtual text at a fixed
+---    window column (starting from the first text column of the
+---    screen line) instead of "virt_text_pos".
+---  • virt_text_hide : hide the virtual text when the background
+---    text is selected or hidden because of scrolling with
+---    'nowrap' or 'smoothscroll'. Currently only affects
+---    "overlay" virt_text.
+---  • hl_mode : control how highlights are combined with the
+---    highlights of the text. Currently only affects virt_text
+---    highlights, but might affect `hl_group` in later versions.
+---    • "replace": only show the virt_text color. This is the
+---      default.
+---    • "combine": combine with background text color.
+---    • "blend": blend with background text color. Not supported
+---      for "inline" virt_text.
 ---
----               • virt_lines : virtual lines to add next to this mark This
----                 should be an array over lines, where each line in turn is
----                 an array over [text, highlight] tuples. In general, buffer
----                 and window options do not affect the display of the text.
----                 In particular 'wrap' and 'linebreak' options do not take
----                 effect, so the number of extra screen lines will always
----                 match the size of the array. However the 'tabstop' buffer
----                 option is still used for hard tabs. By default lines are
----                 placed below the buffer line containing the mark.
----               • virt_lines_above: place virtual lines above instead.
----               • virt_lines_leftcol: Place extmarks in the leftmost column
----                 of the window, bypassing sign and number columns.
----               • ephemeral : for use with `nvim_set_decoration_provider()`
----                 callbacks. The mark will only be used for the current
----                 redraw cycle, and not be permantently stored in the
----                 buffer.
----               • right_gravity : boolean that indicates the direction the
----                 extmark will be shifted in when new text is inserted (true
----                 for right, false for left). Defaults to true.
----               • end_right_gravity : boolean that indicates the direction
----                 the extmark end position (if it exists) will be shifted in
----                 when new text is inserted (true for right, false for
----                 left). Defaults to false.
----               • priority: a priority value for the highlight group or sign
----                 attribute. For example treesitter highlighting uses a
----                 value of 100.
----               • strict: boolean that indicates extmark should not be
----                 placed if the line or column value is past the end of the
----                 buffer or end of the line respectively. Defaults to true.
----               • sign_text: string of length 1-2 used to display in the
----                 sign column. Note: ranges are unsupported and decorations
----                 are only applied to start_row
----               • sign_hl_group: name of the highlight group used to
----                 highlight the sign column text. Note: ranges are
----                 unsupported and decorations are only applied to start_row
----               • number_hl_group: name of the highlight group used to
----                 highlight the number column. Note: ranges are unsupported
----                 and decorations are only applied to start_row
----               • line_hl_group: name of the highlight group used to
----                 highlight the whole line. Note: ranges are unsupported and
----                 decorations are only applied to start_row
----               • cursorline_hl_group: name of the highlight group used to
----                 highlight the line when the cursor is on the same line as
----                 the mark and 'cursorline' is enabled. Note: ranges are
----                 unsupported and decorations are only applied to start_row
----               • conceal: string which should be either empty or a single
----                 character. Enable concealing similar to `:syn-conceal`.
----                 When a character is supplied it is used as `:syn-cchar`.
----                 "hl_group" is used as highlight for the cchar if provided,
----                 otherwise it defaults to `hl-Conceal`.
----               • spell: boolean indicating that spell checking should be
----                 performed within this extmark
----               • ui_watched: boolean that indicates the mark should be
----                 drawn by a UI. When set, the UI will receive win_extmark
----                 events. Note: the mark is positioned by virt_text
----                 attributes. Can be used together with virt_text.
+---  • virt_lines : virtual lines to add next to this mark This
+---    should be an array over lines, where each line in turn is
+---    an array over [text, highlight] tuples. In general, buffer
+---    and window options do not affect the display of the text.
+---    In particular 'wrap' and 'linebreak' options do not take
+---    effect, so the number of extra screen lines will always
+---    match the size of the array. However the 'tabstop' buffer
+---    option is still used for hard tabs. By default lines are
+---    placed below the buffer line containing the mark.
+---  • virt_lines_above: place virtual lines above instead.
+---  • virt_lines_leftcol: Place extmarks in the leftmost column
+---    of the window, bypassing sign and number columns.
+---  • ephemeral : for use with `|nvim_set_decoration_provider()|`
+---    callbacks. The mark will only be used for the current
+---    redraw cycle, and not be permantently stored in the
+---    buffer.
+---  • right_gravity : boolean that indicates the direction the
+---    extmark will be shifted in when new text is inserted (true
+---    for right, false for left). Defaults to true.
+---  • end_right_gravity : boolean that indicates the direction
+---    the extmark end position (if it exists) will be shifted in
+---    when new text is inserted (true for right, false for
+---    left). Defaults to false.
+---  • priority: a priority value for the highlight group or sign
+---    attribute. For example treesitter highlighting uses a
+---    value of 100.
+---  • strict: boolean that indicates extmark should not be
+---    placed if the line or column value is past the end of the
+---    buffer or end of the line respectively. Defaults to true.
+---  • sign_text: string of length 1-2 used to display in the
+---    sign column. Note: ranges are unsupported and decorations
+---    are only applied to start_row
+---  • sign_hl_group: name of the highlight group used to
+---    highlight the sign column text. Note: ranges are
+---    unsupported and decorations are only applied to start_row
+---  • number_hl_group: name of the highlight group used to
+---    highlight the number column. Note: ranges are unsupported
+---    and decorations are only applied to start_row
+---  • line_hl_group: name of the highlight group used to
+---    highlight the whole line. Note: ranges are unsupported and
+---    decorations are only applied to start_row
+---  • cursorline_hl_group: name of the highlight group used to
+---    highlight the line when the cursor is on the same line as
+---    the mark and 'cursorline' is enabled. Note: ranges are
+---    unsupported and decorations are only applied to start_row
+---  • conceal: string which should be either empty or a single
+---    character. Enable concealing similar to `|:syn-conceal|`.
+---    When a character is supplied it is used as `|:syn-cchar|`.
+---    "hl_group" is used as highlight for the cchar if provided,
+---    otherwise it defaults to `|hl-Conceal|`.
+---  • spell: boolean indicating that spell checking should be
+---    performed within this extmark
+---  • ui_watched: boolean that indicates the mark should be
+---    drawn by a UI. When set, the UI will receive win_extmark
+---    events. Note: the mark is positioned by virt_text
+---    attributes. Can be used together with virt_text.
 --- @return integer
 function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
 
---- Sets a buffer-local `mapping` for the given mode.
+--- Sets a buffer-local `|mapping|` for the given mode.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param mode string
@@ -616,8 +614,8 @@ function vim.api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts) end
 function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replacement) end
 
 --- Sets a named mark in the given buffer, all marks are allowed
---- file/uppercase, visual, last change, etc. See `mark-motions`.
---- Marks are (1,0)-indexed. `api-indexing`
+--- file/uppercase, visual, last change, etc. See `|mark-motions|`.
+--- Marks are (1,0)-indexed. `|api-indexing|`
 ---
 --- @param buffer integer Buffer to set the mark on
 --- @param name string Mark name
@@ -640,7 +638,7 @@ function vim.api.nvim_buf_set_name(buffer, name) end
 function vim.api.nvim_buf_set_option(buffer, name, value) end
 
 --- Sets (replaces) a range in the buffer
---- This is recommended over `nvim_buf_set_lines()` when only modifying parts
+--- This is recommended over `|nvim_buf_set_lines()|` when only modifying parts
 --- of a line, as extmarks will be preserved on non-modified parts of the
 --- touched lines.
 --- Indexing is zero-based. Row indices are end-inclusive, and column indices
@@ -648,9 +646,9 @@ function vim.api.nvim_buf_set_option(buffer, name, value) end
 --- To insert text at a given `(row, column)` location, use `start_row =
 --- end_row = row` and `start_col = end_col = col`. To delete the text in a
 --- range, use `replacement = {}`.
---- Prefer `nvim_buf_set_lines()` if you are only adding or deleting entire
+--- Prefer `|nvim_buf_set_lines()|` if you are only adding or deleting entire
 --- lines.
---- Prefer `nvim_put()` if you want to insert text at the cursor position.
+--- Prefer `|nvim_put()|` if you want to insert text at the cursor position.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param start_row integer First line index
@@ -679,23 +677,23 @@ function vim.api.nvim_buf_set_virtual_text(buffer, src_id, line, chunks, opts) e
 --- Calls many API methods atomically.
 --- This has two main usages:
 --- 1. To perform several requests from an async context atomically, i.e.
----    without interleaving redraws, RPC requests from other clients, or user
----    interactions (however API methods may trigger autocommands or event
----    processing which have such side effects, e.g. `:sleep` may wake
----    timers).
+---  without interleaving redraws, RPC requests from other clients, or user
+---  interactions (however API methods may trigger autocommands or event
+---  processing which have such side effects, e.g. `|:sleep|` may wake
+---  timers).
 --- 2. To minimize RPC overhead (roundtrips) of a sequence of many requests.
 ---
 ---
 --- @param calls any[] an array of calls, where each call is described by an array
----              with two elements: the request name, and an array of
----              arguments.
+---   with two elements: the request name, and an array of
+---   arguments.
 --- @return any[]
 function vim.api.nvim_call_atomic(calls) end
 
---- Calls a Vimscript `Dictionary-function` with the given arguments.
+--- Calls a Vimscript `|Dictionary-function|` with the given arguments.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
---- @param dict any Dictionary, or String evaluating to a Vimscript `self` dict
+--- @param dict any Dictionary, or String evaluating to a Vimscript `|self|` dict
 --- @param fn string Name of the function defined on the Vimscript dict
 --- @param args any[] Function arguments packed in an Array
 --- @return any
@@ -710,73 +708,73 @@ function vim.api.nvim_call_dict_function(dict, fn, args) end
 function vim.api.nvim_call_function(fn, args) end
 
 --- Send data to channel `id`. For a job, it writes it to the stdin of the
---- process. For the stdio channel `channel-stdio`, it writes to Nvim's
---- stdout. For an internal terminal instance (`nvim_open_term()`) it writes
---- directly to terminal output. See `channel-bytes` for more information.
+--- process. For the stdio channel `|channel-stdio|`, it writes to Nvim's
+--- stdout. For an internal terminal instance (`|nvim_open_term()|`) it writes
+--- directly to terminal output. See `|channel-bytes|` for more information.
 --- This function writes raw data, not RPC messages. If the channel was
 --- created with `rpc=true` then the channel expects RPC messages, use
---- `vim.rpcnotify()` and `vim.rpcrequest()` instead.
+--- `|vim.rpcnotify()|` and `|vim.rpcrequest()|` instead.
 ---
 --- @param chan integer id of the channel
 --- @param data string data to write. 8-bit clean: can contain NUL bytes.
 function vim.api.nvim_chan_send(chan, data) end
 
 --- Clears all autocommands selected by {opts}. To delete autocmds see
---- `nvim_del_autocmd()`.
+--- `|nvim_del_autocmd()|`.
 ---
 --- @param opts vim.api.keyset.clear_autocmds Parameters
----             • event: (string|table) Examples:
----               • event: "pat1"
----               • event: { "pat1" }
----               • event: { "pat1", "pat2", "pat3" }
+---  • event: (string|table) Examples:
+---    • event: "pat1"
+---    • event: { "pat1" }
+---    • event: { "pat1", "pat2", "pat3" }
 ---
----             • pattern: (string|table)
----               • pattern or patterns to match exactly.
----                 • For example, if you have `*.py` as that pattern for the
----                   autocmd, you must pass `*.py` exactly to clear it.
----                   `test.py` will not match the pattern.
+---  • pattern: (string|table)
+---    • pattern or patterns to match exactly.
+---      • For example, if you have `*.py` as that pattern for the
+---        autocmd, you must pass `*.py` exactly to clear it.
+---        `test.py` will not match the pattern.
 ---
----               • defaults to clearing all patterns.
----               • NOTE: Cannot be used with {buffer}
+---    • defaults to clearing all patterns.
+---    • NOTE: Cannot be used with {buffer}
 ---
----             • buffer: (bufnr)
----               • clear only `autocmd-buflocal` autocommands.
----               • NOTE: Cannot be used with {pattern}
+---  • buffer: (bufnr)
+---    • clear only `|autocmd-buflocal|` autocommands.
+---    • NOTE: Cannot be used with {pattern}
 ---
----             • group: (string|int) The augroup name or id.
----               • NOTE: If not passed, will only delete autocmds not in any group.
+---  • group: (string|int) The augroup name or id.
+---    • NOTE: If not passed, will only delete autocmds not in any group.
 function vim.api.nvim_clear_autocmds(opts) end
 
 --- Executes an Ex command.
---- Unlike `nvim_command()` this command takes a structured Dictionary instead
+--- Unlike `|nvim_command()|` this command takes a structured Dictionary instead
 --- of a String. This allows for easier construction and manipulation of an Ex
 --- command. This also allows for things such as having spaces inside a
 --- command argument, expanding filenames in a command that otherwise doesn't
 --- expand filenames, etc. Command arguments may also be Number, Boolean or
 --- String.
 --- The first argument may also be used instead of count for commands that
---- support it in order to make their usage simpler with `vim.cmd()`. For
+--- support it in order to make their usage simpler with `|vim.cmd()|`. For
 --- example, instead of `vim.cmd.bdelete{ count = 2 }`, you may do
 --- `vim.cmd.bdelete(2)`.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
 --- @param cmd vim.api.keyset.cmd Command to execute. Must be a Dictionary that can contain the
----             same values as the return value of `nvim_parse_cmd()` except
----             "addr", "nargs" and "nextcmd" which are ignored if provided.
----             All values except for "cmd" are optional.
+---  same values as the return value of `|nvim_parse_cmd()|` except
+---  "addr", "nargs" and "nextcmd" which are ignored if provided.
+---  All values except for "cmd" are optional.
 --- @param opts vim.api.keyset.cmd_opts Optional parameters.
----             • output: (boolean, default false) Whether to return command
----               output.
+---  • output: (boolean, default false) Whether to return command
+---    output.
 --- @return string
 function vim.api.nvim_cmd(cmd, opts) end
 
 --- Executes an Ex command.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
---- Prefer using `nvim_cmd()` or `nvim_exec2()` over this. To evaluate
+--- Prefer using `|nvim_cmd()|` or `|nvim_exec2()|` over this. To evaluate
 --- multiple lines of Vim script or an Ex command directly, use
---- `nvim_exec2()`. To construct an Ex command using a structured format and
---- then execute it, use `nvim_cmd()`. To modify an Ex command before
---- evaluating it, use `nvim_parse_cmd()` in conjunction with `nvim_cmd()`.
+--- `|nvim_exec2()|`. To construct an Ex command using a structured format and
+--- then execute it, use `|nvim_cmd()|`. To modify an Ex command before
+--- evaluating it, use `|nvim_parse_cmd()|` in conjunction with `|nvim_cmd()|`.
 ---
 --- @param command string Ex command string
 function vim.api.nvim_command(command) end
@@ -786,98 +784,94 @@ function vim.api.nvim_command(command) end
 --- @return string
 function vim.api.nvim_command_output(command) end
 
---- Create or get an autocommand group `autocmd-groups`.
+--- Create or get an autocommand group `|autocmd-groups|`.
 --- To get an existing group id, do:
----
 --- ```lua
----     local id = vim.api.nvim_create_augroup("MyGroup", {
----         clear = false
----     })
+--- local id = vim.api.nvim_create_augroup("MyGroup", {
+---     clear = false
+--- })
 --- ```
+---
 ---
 --- @param name string String: The name of the group
 --- @param opts vim.api.keyset.create_augroup Dictionary Parameters
----             • clear (bool) optional: defaults to true. Clear existing
----               commands if the group already exists `autocmd-groups`.
+---  • clear (bool) optional: defaults to true. Clear existing
+---    commands if the group already exists `|autocmd-groups|`.
 --- @return integer
 function vim.api.nvim_create_augroup(name, opts) end
 
---- Creates an `autocommand` event handler, defined by `callback` (Lua function or Vimscript function name string) or `command` (Ex command string).
+--- Creates an `|autocommand|` event handler, defined by `callback` (Lua function or Vimscript function name string) or `command` (Ex command string).
 --- Example using Lua callback:
----
 --- ```lua
----     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
----       pattern = {"*.c", "*.h"},
----       callback = function(ev)
----         print(string.format('event fired: %s', vim.inspect(ev)))
----       end
----     })
+--- vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
+---   pattern = {"*.c", "*.h"},
+---   callback = function(ev)
+---     print(string.format('event fired: %s', vim.inspect(ev)))
+---   end
+--- })
 --- ```
----
 --- Example using an Ex command as the handler:
----
 --- ```lua
----     vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
----       pattern = {"*.c", "*.h"},
----       command = "echo 'Entering a C or C++ file'",
----     })
+--- vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
+---   pattern = {"*.c", "*.h"},
+---   command = "echo 'Entering a C or C++ file'",
+--- })
 --- ```
----
---- Note: `pattern` is NOT automatically expanded (unlike with `:autocmd`),
+--- Note: `pattern` is NOT automatically expanded (unlike with `|:autocmd|`),
 --- thus names like "$HOME" and "~" must be expanded explicitly:
----
 --- ```lua
----     pattern = vim.fn.expand("~") .. "/some/path/*.py"
+--- pattern = vim.fn.expand("~") .. "/some/path/*.py"
 --- ```
+---
 ---
 --- @param event any (string|array) Event(s) that will trigger the handler
----              (`callback` or `command`).
+---   (`callback` or `command`).
 --- @param opts vim.api.keyset.create_autocmd Options dict:
----              • group (string|integer) optional: autocommand group name or
----                id to match against.
----              • pattern (string|array) optional: pattern(s) to match
----                literally `autocmd-pattern`.
----              • buffer (integer) optional: buffer number for buffer-local
----                autocommands `autocmd-buflocal`. Cannot be used with
----                {pattern}.
----              • desc (string) optional: description (for documentation and
----                troubleshooting).
----              • callback (function|string) optional: Lua function (or
----                Vimscript function name, if string) called when the
----                event(s) is triggered. Lua callback can return true to
----                delete the autocommand, and receives a table argument with
----                these keys:
----                • id: (number) autocommand id
----                • event: (string) name of the triggered event
----                  `autocmd-events`
----                • group: (number|nil) autocommand group id, if any
----                • match: (string) expanded value of `<amatch>`
----                • buf: (number) expanded value of `<abuf>`
----                • file: (string) expanded value of `<afile>`
----                • data: (any) arbitrary data passed from
----                  `nvim_exec_autocmds()`
+---   • group (string|integer) optional: autocommand group name or
+---     id to match against.
+---   • pattern (string|array) optional: pattern(s) to match
+---     literally `|autocmd-pattern|`.
+---   • buffer (integer) optional: buffer number for buffer-local
+---     autocommands `|autocmd-buflocal|`. Cannot be used with
+---     {pattern}.
+---   • desc (string) optional: description (for documentation and
+---     troubleshooting).
+---   • callback (function|string) optional: Lua function (or
+---     Vimscript function name, if string) called when the
+---     event(s) is triggered. Lua callback can return true to
+---     delete the autocommand, and receives a table argument with
+---     these keys:
+---     • id: (number) autocommand id
+---     • event: (string) name of the triggered event
+---       `|autocmd-events|`
+---     • group: (number|nil) autocommand group id, if any
+---     • match: (string) expanded value of `|<amatch>|`
+---     • buf: (number) expanded value of `|<abuf>|`
+---     • file: (string) expanded value of `|<afile>|`
+---     • data: (any) arbitrary data passed from
+---       `|nvim_exec_autocmds()|`
 ---
----              • command (string) optional: Vim command to execute on event.
----                Cannot be used with {callback}
----              • once (boolean) optional: defaults to false. Run the
----                autocommand only once `autocmd-once`.
----              • nested (boolean) optional: defaults to false. Run nested
----                autocommands `autocmd-nested`.
+---   • command (string) optional: Vim command to execute on event.
+---     Cannot be used with {callback}
+---   • once (boolean) optional: defaults to false. Run the
+---     autocommand only once `|autocmd-once|`.
+---   • nested (boolean) optional: defaults to false. Run nested
+---     autocommands `|autocmd-nested|`.
 --- @return integer
 function vim.api.nvim_create_autocmd(event, opts) end
 
 --- Creates a new, empty, unnamed buffer.
 ---
 --- @param listed boolean Sets 'buflisted'
---- @param scratch boolean Creates a "throwaway" `scratch-buffer` for temporary work
----                (always 'nomodified'). Also sets 'nomodeline' on the
----                buffer.
+--- @param scratch boolean Creates a "throwaway" `|scratch-buffer|` for temporary work
+---   (always 'nomodified'). Also sets 'nomodeline' on the
+---   buffer.
 --- @return integer
 function vim.api.nvim_create_buf(listed, scratch) end
 
 --- Creates a new namespace or gets an existing one. *namespace*
 --- Namespaces are used for buffer highlights and virtual text, see
---- `nvim_buf_add_highlight()` and `nvim_buf_set_extmark()`.
+--- `|nvim_buf_add_highlight()|` and `|nvim_buf_set_extmark()|`.
 --- Namespaces can be named or anonymous. If `name` matches an existing
 --- namespace, the associated id is returned. If `name` is an empty string a
 --- new, anonymous namespace is created.
@@ -886,62 +880,62 @@ function vim.api.nvim_create_buf(listed, scratch) end
 --- @return integer
 function vim.api.nvim_create_namespace(name) end
 
---- Creates a global `user-commands` command.
---- For Lua usage see `lua-guide-commands-create`.
+--- Creates a global `|user-commands|` command.
+--- For Lua usage see `|lua-guide-commands-create|`.
 --- Example:
----
 --- ```vim
----     :call nvim_create_user_command('SayHello', 'echo "Hello world!"', {'bang': v:true})
----     :SayHello
----     Hello world!
+--- :call nvim_create_user_command('SayHello', 'echo "Hello world!"', {'bang': v:true})
+--- :SayHello
+--- Hello world!
 --- ```
 ---
+---
 --- @param name string Name of the new user command. Must begin with an uppercase
----                letter.
+---   letter.
 --- @param command any Replacement command to execute when this user command is
----                executed. When called from Lua, the command can also be a
----                Lua function. The function is called with a single table
----                argument that contains the following keys:
----                • name: (string) Command name
----                • args: (string) The args passed to the command, if any
----                  `<args>`
----                • fargs: (table) The args split by unescaped whitespace
----                  (when more than one argument is allowed), if any
----                  `<f-args>`
----                • nargs: (string) Number of arguments `:command-nargs`
----                • bang: (boolean) "true" if the command was executed with a
----                  ! modifier `<bang>`
----                • line1: (number) The starting line of the command range
----                  `<line1>`
----                • line2: (number) The final line of the command range
----                  `<line2>`
----                • range: (number) The number of items in the command range:
----                  0, 1, or 2 `<range>`
----                • count: (number) Any count supplied `<count>`
----                • reg: (string) The optional register, if specified `<reg>`
----                • mods: (string) Command modifiers, if any `<mods>`
----                • smods: (table) Command modifiers in a structured format.
----                  Has the same structure as the "mods" key of
----                  `nvim_parse_cmd()`.
---- @param opts vim.api.keyset.user_command Optional `command-attributes`.
----                • Set boolean attributes such as `:command-bang` or
----                  `:command-bar` to true (but not `:command-buffer`, use
----                  `nvim_buf_create_user_command()` instead).
----                • "complete" `:command-complete` also accepts a Lua
----                  function which works like
----                  `:command-completion-customlist`.
----                • Other parameters:
----                  • desc: (string) Used for listing the command when a Lua
----                    function is used for {command}.
----                  • force: (boolean, default true) Override any previous
----                    definition.
----                  • preview: (function) Preview callback for 'inccommand'
----                    `:command-preview`
+---   executed. When called from Lua, the command can also be a
+---   Lua function. The function is called with a single table
+---   argument that contains the following keys:
+---   • name: (string) Command name
+---   • args: (string) The args passed to the command, if any
+---     `|<args>|`
+---   • fargs: (table) The args split by unescaped whitespace
+---     (when more than one argument is allowed), if any
+---     `|<f-args>|`
+---   • nargs: (string) Number of arguments `|:command-nargs|`
+---   • bang: (boolean) "true" if the command was executed with a
+---     ! modifier `|<bang>|`
+---   • line1: (number) The starting line of the command range
+---     `|<line1>|`
+---   • line2: (number) The final line of the command range
+---     `|<line2>|`
+---   • range: (number) The number of items in the command range:
+---     0, 1, or 2 `|<range>|`
+---   • count: (number) Any count supplied `|<count>|`
+---   • reg: (string) The optional register, if specified `|<reg>|`
+---   • mods: (string) Command modifiers, if any `|<mods>|`
+---   • smods: (table) Command modifiers in a structured format.
+---     Has the same structure as the "mods" key of
+---     `|nvim_parse_cmd()|`.
+--- @param opts vim.api.keyset.user_command Optional `|command-attributes|`.
+---   • Set boolean attributes such as `|:command-bang|` or
+---     `|:command-bar|` to true (but not `|:command-buffer|`, use
+---     `|nvim_buf_create_user_command()|` instead).
+---   • "complete" `|:command-complete|` also accepts a Lua
+---     function which works like
+---     `|:command-completion-customlist|`.
+---   • Other parameters:
+---     • desc: (string) Used for listing the command when a Lua
+---       function is used for {command}.
+---     • force: (boolean, default true) Override any previous
+---       definition.
+---     • preview: (function) Preview callback for 'inccommand'
+---       `|:command-preview|`
 function vim.api.nvim_create_user_command(name, command, opts) end
 
 --- Delete an autocommand group by id.
---- To get a group id one can use `nvim_get_autocmds()`.
---- NOTE: behavior differs from `:augroup-delete`. When deleting a group,
+--- To get a group id one can use `|nvim_get_autocmds()|`.
+--- NOTE: behavior differs from `|:augroup-delete|`. When deleting a group,
 --- autocommands contained in this group will also be deleted and cleared.
 --- This group will no longer exist.
 ---
@@ -949,7 +943,7 @@ function vim.api.nvim_create_user_command(name, command, opts) end
 function vim.api.nvim_del_augroup_by_id(id) end
 
 --- Delete an autocommand group by name.
---- NOTE: behavior differs from `:augroup-delete`. When deleting a group,
+--- NOTE: behavior differs from `|:augroup-delete|`. When deleting a group,
 --- autocommands contained in this group will also be deleted and cleared.
 --- This group will no longer exist.
 ---
@@ -958,21 +952,21 @@ function vim.api.nvim_del_augroup_by_name(name) end
 
 --- Deletes an autocommand by id.
 ---
---- @param id integer Integer Autocommand id returned by `nvim_create_autocmd()`
+--- @param id integer Integer Autocommand id returned by `|nvim_create_autocmd()|`
 function vim.api.nvim_del_autocmd(id) end
 
 --- Deletes the current line.
 ---
 function vim.api.nvim_del_current_line() end
 
---- Unmaps a global `mapping` for the given mode.
---- To unmap a buffer-local mapping, use `nvim_buf_del_keymap()`.
+--- Unmaps a global `|mapping|` for the given mode.
+--- To unmap a buffer-local mapping, use `|nvim_buf_del_keymap()|`.
 ---
 --- @param mode string
 --- @param lhs string
 function vim.api.nvim_del_keymap(mode, lhs) end
 
---- Deletes an uppercase/file named mark. See `mark-motions`.
+--- Deletes an uppercase/file named mark. See `|mark-motions|`.
 ---
 --- @param name string Mark name
 --- @return boolean
@@ -991,14 +985,14 @@ function vim.api.nvim_del_var(name) end
 --- Echo a message.
 ---
 --- @param chunks any[] A list of [text, hl_group] arrays, each representing a text
----                chunk with specified highlight. `hl_group` element can be
----                omitted for no highlight.
---- @param history boolean if true, add to `message-history`.
+---   chunk with specified highlight. `hl_group` element can be
+---   omitted for no highlight.
+--- @param history boolean if true, add to `|message-history|`.
 --- @param opts vim.api.keyset.echo_opts Optional parameters.
----                • verbose: Message was printed as a result of 'verbose'
----                  option if Nvim was invoked with -V3log_file, the message
----                  will be redirected to the log_file and suppressed from
----                  direct output.
+---   • verbose: Message was printed as a result of 'verbose'
+---     option if Nvim was invoked with -V3log_file, the message
+---     will be redirected to the log_file and suppressed from
+---     direct output.
 function vim.api.nvim_echo(chunks, history, opts) end
 
 --- Writes a message to the Vim error buffer. Does not append "\n", the
@@ -1017,7 +1011,7 @@ function vim.api.nvim_err_writeln(str) end
 --- @param data string
 function vim.api.nvim_error_event(lvl, data) end
 
---- Evaluates a Vimscript `expression`. Dictionaries and Lists are recursively
+--- Evaluates a Vimscript `|expression|`. Dictionaries and Lists are recursively
 --- expanded.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
@@ -1029,19 +1023,19 @@ function vim.api.nvim_eval(expr) end
 ---
 --- @param str string Statusline string (see 'statusline').
 --- @param opts vim.api.keyset.eval_statusline Optional parameters.
----             • winid: (number) `window-ID` of the window to use as context
----               for statusline.
----             • maxwidth: (number) Maximum width of statusline.
----             • fillchar: (string) Character to fill blank spaces in the
----               statusline (see 'fillchars'). Treated as single-width even
----               if it isn't.
----             • highlights: (boolean) Return highlight information.
----             • use_winbar: (boolean) Evaluate winbar instead of statusline.
----             • use_tabline: (boolean) Evaluate tabline instead of
----               statusline. When true, {winid} is ignored. Mutually
----               exclusive with {use_winbar}.
----             • use_statuscol_lnum: (number) Evaluate statuscolumn for this
----               line number instead of statusline.
+---  • winid: (number) `|window-ID|` of the window to use as context
+---    for statusline.
+---  • maxwidth: (number) Maximum width of statusline.
+---  • fillchar: (string) Character to fill blank spaces in the
+---    statusline (see 'fillchars'). Treated as single-width even
+---    if it isn't.
+---  • highlights: (boolean) Return highlight information.
+---  • use_winbar: (boolean) Evaluate winbar instead of statusline.
+---  • use_tabline: (boolean) Evaluate tabline instead of
+---    statusline. When true, {winid} is ignored. Mutually
+---    exclusive with {use_winbar}.
+---  • use_statuscol_lnum: (number) Evaluate statuscolumn for this
+---    line number instead of statusline.
 --- @return table<string,any>
 function vim.api.nvim_eval_statusline(str, opts) end
 
@@ -1052,33 +1046,33 @@ function vim.api.nvim_eval_statusline(str, opts) end
 function vim.api.nvim_exec(src, output) end
 
 --- Executes Vimscript (multiline block of Ex commands), like anonymous
---- `:source`.
---- Unlike `nvim_command()` this function supports heredocs, script-scope
+--- `|:source|`.
+--- Unlike `|nvim_command()|` this function supports heredocs, script-scope
 --- (s:), etc.
 --- On execution error: fails with Vimscript error, updates v:errmsg.
 ---
 --- @param src string Vimscript code
 --- @param opts vim.api.keyset.exec_opts Optional parameters.
----             • output: (boolean, default false) Whether to capture and
----               return all (non-error, non-shell `:!`) output.
+---  • output: (boolean, default false) Whether to capture and
+---    return all (non-error, non-shell `|:!|`) output.
 --- @return table<string,any>
 function vim.api.nvim_exec2(src, opts) end
 
 --- Execute all autocommands for {event} that match the corresponding {opts}
---- `autocmd-execute`.
+--- `|autocmd-execute|`.
 ---
 --- @param event any (String|Array) The event or events to execute
 --- @param opts vim.api.keyset.exec_autocmds Dictionary of autocommand options:
----              • group (string|integer) optional: the autocommand group name
----                or id to match against. `autocmd-groups`.
----              • pattern (string|array) optional: defaults to "*"
----                `autocmd-pattern`. Cannot be used with {buffer}.
----              • buffer (integer) optional: buffer number
----                `autocmd-buflocal`. Cannot be used with {pattern}.
----              • modeline (bool) optional: defaults to true. Process the
----                modeline after the autocommands `<nomodeline>`.
----              • data (any): arbitrary data to send to the autocommand
----                callback. See `nvim_create_autocmd()` for details.
+---   • group (string|integer) optional: the autocommand group name
+---     or id to match against. `|autocmd-groups|`.
+---   • pattern (string|array) optional: defaults to "*"
+---     `|autocmd-pattern|`. Cannot be used with {buffer}.
+---   • buffer (integer) optional: buffer number
+---     `|autocmd-buflocal|`. Cannot be used with {pattern}.
+---   • modeline (bool) optional: defaults to true. Process the
+---     modeline after the autocommands `|<nomodeline>|`.
+---   • data (any): arbitrary data to send to the autocommand
+---     callback. See `|nvim_create_autocmd()|` for details.
 function vim.api.nvim_exec_autocmds(event, opts) end
 
 --- Execute Lua code. Parameters (if any) are available as `...` inside the
@@ -1098,68 +1092,66 @@ function vim.api.nvim_exec_lua(code, args) end
 function vim.api.nvim_execute_lua(code, args) end
 
 --- Sends input-keys to Nvim, subject to various quirks controlled by `mode`
---- flags. This is a blocking call, unlike `nvim_input()`.
+--- flags. This is a blocking call, unlike `|nvim_input()|`.
 --- On execution error: does not fail, but updates v:errmsg.
---- To input sequences like <C-o> use `nvim_replace_termcodes()` (typically
---- with escape_ks=false) to replace `keycodes`, then pass the result to
+--- To input sequences like <C-o> use `|nvim_replace_termcodes()|` (typically
+--- with escape_ks=false) to replace `|keycodes|`, then pass the result to
 --- nvim_feedkeys().
 --- Example:
----
 --- ```vim
----     :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
----     :call nvim_feedkeys(key, 'n', v:false)
+--- :let key = nvim_replace_termcodes("<C-o>", v:true, v:false, v:true)
+--- :call nvim_feedkeys(key, 'n', v:false)
 --- ```
 ---
+---
 --- @param keys string to be typed
---- @param mode string behavior flags, see `feedkeys()`
+--- @param mode string behavior flags, see `|feedkeys()|`
 --- @param escape_ks boolean If true, escape K_SPECIAL bytes in `keys`. This should be
----                  false if you already used `nvim_replace_termcodes()`, and
----                  true otherwise.
+---   false if you already used `|nvim_replace_termcodes()|`, and
+---   true otherwise.
 function vim.api.nvim_feedkeys(keys, mode, escape_ks) end
 
 --- Gets the option information for all options.
 --- The dictionary has the full option names as keys and option metadata
---- dictionaries as detailed at `nvim_get_option_info2()`.
+--- dictionaries as detailed at `|nvim_get_option_info2()|`.
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_all_options_info() end
 
 --- Returns a 2-tuple (Array), where item 0 is the current channel id and item
---- 1 is the `api-metadata` map (Dictionary).
+--- 1 is the `|api-metadata|` map (Dictionary).
 ---
 --- @return any[]
 function vim.api.nvim_get_api_info() end
 
 --- Get all autocommands that match the corresponding {opts}.
 --- These examples will get autocommands matching ALL the given criteria:
----
 --- ```lua
----     -- Matches all criteria
----     autocommands = vim.api.nvim_get_autocmds({
----       group = "MyGroup",
----       event = {"BufEnter", "BufWinEnter"},
----       pattern = {"*.c", "*.h"}
----     })
+--- -- Matches all criteria
+--- autocommands = vim.api.nvim_get_autocmds({
+---   group = "MyGroup",
+---   event = {"BufEnter", "BufWinEnter"},
+---   pattern = {"*.c", "*.h"}
+--- })
 ---
----     -- All commands from one group
----     autocommands = vim.api.nvim_get_autocmds({
----       group = "MyGroup",
----     })
+--- -- All commands from one group
+--- autocommands = vim.api.nvim_get_autocmds({
+---   group = "MyGroup",
+--- })
 --- ```
----
 --- NOTE: When multiple patterns or events are provided, it will find all the
 --- autocommands that match any combination of them.
 ---
 --- @param opts vim.api.keyset.get_autocmds Dictionary with at least one of the following:
----             • group (string|integer): the autocommand group name or id to
----               match against.
----             • event (string|array): event or events to match against
----               `autocmd-events`.
----             • pattern (string|array): pattern or patterns to match against
----               `autocmd-pattern`. Cannot be used with {buffer}
----             • buffer: Buffer number or list of buffer numbers for buffer
----               local autocommands `autocmd-buflocal`. Cannot be used with
----               {pattern}
+---  • group (string|integer): the autocommand group name or id to
+---    match against.
+---  • event (string|array): event or events to match against
+---    `|autocmd-events|`.
+---  • pattern (string|array): pattern or patterns to match against
+---    `|autocmd-pattern|`. Cannot be used with {buffer}
+---  • buffer: Buffer number or list of buffer numbers for buffer
+---    local autocommands `|autocmd-buflocal|`. Cannot be used with
+---    {pattern}
 --- @return any[]
 function vim.api.nvim_get_autocmds(opts) end
 
@@ -1169,14 +1161,14 @@ function vim.api.nvim_get_autocmds(opts) end
 --- @return table<string,any>
 function vim.api.nvim_get_chan_info(chan) end
 
---- Returns the 24-bit RGB value of a `nvim_get_color_map()` color name or
+--- Returns the 24-bit RGB value of a `|nvim_get_color_map()|` color name or
 --- "#rrggbb" hexadecimal string.
 --- Example:
----
 --- ```vim
----     :echo nvim_get_color_by_name("Pink")
----     :echo nvim_get_color_by_name("#cbcbcb")
+--- :echo nvim_get_color_by_name("Pink")
+--- :echo nvim_get_color_by_name("#cbcbcb")
 --- ```
+---
 ---
 --- @param name string Color name or "#rrggbb" string
 --- @return integer
@@ -1190,7 +1182,7 @@ function vim.api.nvim_get_color_by_name(name) end
 function vim.api.nvim_get_color_map() end
 
 --- Gets a map of global (non-buffer-local) Ex commands.
---- Currently only `user-commands` are supported, not builtin Ex commands.
+--- Currently only `|user-commands|` are supported, not builtin Ex commands.
 ---
 --- @param opts vim.api.keyset.get_commands Optional parameters. Currently only supports {"builtin":false}
 --- @return table<string,any>
@@ -1199,8 +1191,8 @@ function vim.api.nvim_get_commands(opts) end
 --- Gets a map of the current editor state.
 ---
 --- @param opts vim.api.keyset.context Optional parameters.
----             • types: List of `context-types` ("regs", "jumps", "bufs",
----               "gvars", …) to gather, or empty for "all".
+---  • types: List of `|context-types|` ("regs", "jumps", "bufs",
+---    "gvars", …) to gather, or empty for "all".
 --- @return table<string,any>
 function vim.api.nvim_get_context(opts) end
 
@@ -1227,15 +1219,15 @@ function vim.api.nvim_get_current_win() end
 --- Gets all or specific highlight groups in a namespace.
 ---
 --- @param ns_id integer Get highlight groups for namespace ns_id
----              `nvim_get_namespaces()`. Use 0 to get global highlight groups
----              `:highlight`.
+---   `|nvim_get_namespaces()|`. Use 0 to get global highlight groups
+---   `|:highlight|`.
 --- @param opts vim.api.keyset.get_highlight Options dict:
----              • name: (string) Get a highlight definition by name.
----              • id: (integer) Get a highlight definition by id.
----              • link: (boolean, default true) Show linked group name
----                instead of effective definition `:hi-link`.
----              • create: (boolean, default true) When highlight group
----                doesn't exist create it.
+---   • name: (string) Get a highlight definition by name.
+---   • id: (integer) Get a highlight definition by id.
+---   • link: (boolean, default true) Show linked group name
+---     instead of effective definition `|:hi-link|`.
+---   • create: (boolean, default true) When highlight group
+---     doesn't exist create it.
 --- @return table<string,any>
 function vim.api.nvim_get_hl(ns_id, opts) end
 
@@ -1252,7 +1244,7 @@ function vim.api.nvim_get_hl_by_id(hl_id, rgb) end
 function vim.api.nvim_get_hl_by_name(name, rgb) end
 
 --- Gets a highlight group by name
---- similar to `hlID()`, but allocates a new ID if not present.
+--- similar to `|hlID()|`, but allocates a new ID if not present.
 ---
 --- @param name string
 --- @return integer
@@ -1261,14 +1253,14 @@ function vim.api.nvim_get_hl_id_by_name(name) end
 --- Gets the active highlight namespace.
 ---
 --- @param opts vim.api.keyset.get_ns Optional parameters
----             • winid: (number) `window-ID` for retrieving a window's
----               highlight namespace. A value of -1 is returned when
----               `nvim_win_set_hl_ns()` has not been called for the window
----               (or was called with a namespace of -1).
+---  • winid: (number) `|window-ID|` for retrieving a window's
+---    highlight namespace. A value of -1 is returned when
+---    `|nvim_win_set_hl_ns()|` has not been called for the window
+---    (or was called with a namespace of -1).
 --- @return integer
 function vim.api.nvim_get_hl_ns(opts) end
 
---- Gets a list of global (non-buffer-local) `mapping` definitions.
+--- Gets a list of global (non-buffer-local) `|mapping|` definitions.
 ---
 --- @param mode string Mode short-name ("n", "i", "v", ...)
 --- @return table<string,any>[]
@@ -1276,21 +1268,21 @@ function vim.api.nvim_get_keymap(mode) end
 
 --- Returns a `(row, col, buffer, buffername)` tuple representing the position
 --- of the uppercase/file named mark. "End of line" column position is
---- returned as `v:maxcol` (big number). See `mark-motions`.
---- Marks are (1,0)-indexed. `api-indexing`
+--- returned as `|v:maxcol|` (big number). See `|mark-motions|`.
+--- Marks are (1,0)-indexed. `|api-indexing|`
 ---
 --- @param name string Mark name
 --- @param opts table<string,any> Optional parameters. Reserved for future use.
 --- @return any[]
 function vim.api.nvim_get_mark(name, opts) end
 
---- Gets the current mode. `mode()` "blocking" is true if Nvim is waiting for
+--- Gets the current mode. `|mode()|` "blocking" is true if Nvim is waiting for
 --- input.
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_mode() end
 
---- Gets existing, non-anonymous `namespace`s.
+--- Gets existing, non-anonymous `|namespace|`s.
 ---
 --- @return table<string,any>
 function vim.api.nvim_get_namespaces() end
@@ -1327,30 +1319,30 @@ function vim.api.nvim_get_option_info(name) end
 ---
 --- @param name string Option name
 --- @param opts vim.api.keyset.option Optional parameters
----             • scope: One of "global" or "local". Analogous to `:setglobal`
----               and `:setlocal`, respectively.
----             • win: `window-ID`. Used for getting window local options.
----             • buf: Buffer number. Used for getting buffer local options.
----               Implies {scope} is "local".
+---  • scope: One of "global" or "local". Analogous to `|:setglobal|`
+---    and `|:setlocal|`, respectively.
+---  • win: `|window-ID|`. Used for getting window local options.
+---  • buf: Buffer number. Used for getting buffer local options.
+---    Implies {scope} is "local".
 --- @return table<string,any>
 function vim.api.nvim_get_option_info2(name, opts) end
 
 --- Gets the value of an option. The behavior of this function matches that of
---- `:set`: the local value of an option is returned if it exists; otherwise,
+--- `|:set|`: the local value of an option is returned if it exists; otherwise,
 --- the global value is returned. Local values always correspond to the
 --- current buffer or window, unless "buf" or "win" is set in {opts}.
 ---
 --- @param name string Option name
 --- @param opts vim.api.keyset.option Optional parameters
----             • scope: One of "global" or "local". Analogous to `:setglobal`
----               and `:setlocal`, respectively.
----             • win: `window-ID`. Used for getting window local options.
----             • buf: Buffer number. Used for getting buffer local options.
----               Implies {scope} is "local".
----             • filetype: `filetype`. Used to get the default option for a
----               specific filetype. Cannot be used with any other option.
----               Note: this will trigger `ftplugin` and all `FileType`
----               autocommands for the corresponding filetype.
+---  • scope: One of "global" or "local". Analogous to `|:setglobal|`
+---    and `|:setlocal|`, respectively.
+---  • win: `|window-ID|`. Used for getting window local options.
+---  • buf: Buffer number. Used for getting buffer local options.
+---    Implies {scope} is "local".
+---  • filetype: `|filetype|`. Used to get the default option for a
+---    specific filetype. Cannot be used with any other option.
+---    Note: this will trigger `|ftplugin|` and all `|FileType|`
+---    autocommands for the corresponding filetype.
 --- @return any
 function vim.api.nvim_get_option_value(name, opts) end
 
@@ -1390,7 +1382,7 @@ function vim.api.nvim_get_var(name) end
 --- @return any
 function vim.api.nvim_get_vvar(name) end
 
---- Queues raw user-input. Unlike `nvim_feedkeys()`, this uses a low-level
+--- Queues raw user-input. Unlike `|nvim_feedkeys()|`, this uses a low-level
 --- input buffer and the call is non-blocking (input is processed
 --- asynchronously by the eventloop).
 --- On execution error: does not fail, but updates v:errmsg.
@@ -1404,22 +1396,22 @@ function vim.api.nvim_input(keys) end
 --- processed soon by the event loop.
 ---
 --- @param button string Mouse button: one of "left", "right", "middle", "wheel",
----                 "move".
+---  "move".
 --- @param action string For ordinary buttons, one of "press", "drag", "release".
----                 For the wheel, one of "up", "down", "left", "right".
----                 Ignored for "move".
+---  For the wheel, one of "up", "down", "left", "right".
+---  Ignored for "move".
 --- @param modifier string String of modifiers each represented by a single char. The
----                 same specifiers are used as for a key press, except that
----                 the "-" separator is optional, so "C-A-", "c-a" and "CA"
----                 can all be used to specify Ctrl+Alt+click.
---- @param grid integer Grid number if the client uses `ui-multigrid`, else 0.
+---  same specifiers are used as for a key press, except that
+---  the "-" separator is optional, so "C-A-", "c-a" and "CA"
+---  can all be used to specify Ctrl+Alt+click.
+--- @param grid integer Grid number if the client uses `|ui-multigrid|`, else 0.
 --- @param row integer Mouse row-position (zero-based, like redraw events)
 --- @param col integer Mouse column-position (zero-based, like redraw events)
 function vim.api.nvim_input_mouse(button, action, modifier, grid, row, col) end
 
 --- Gets the current list of buffer handles
 --- Includes unlisted (unloaded/deleted) buffers, like `:ls!`. Use
---- `nvim_buf_is_loaded()` to check if a buffer is loaded.
+--- `|nvim_buf_is_loaded()|` to check if a buffer is loaded.
 ---
 --- @return integer[]
 function vim.api.nvim_list_bufs() end
@@ -1429,7 +1421,7 @@ function vim.api.nvim_list_bufs() end
 --- @return any[]
 function vim.api.nvim_list_chans() end
 
---- Gets the paths contained in `runtime-search-path`.
+--- Gets the paths contained in `|runtime-search-path|`.
 ---
 --- @return string[]
 function vim.api.nvim_list_runtime_paths() end
@@ -1449,9 +1441,9 @@ function vim.api.nvim_list_uis() end
 --- @return integer[]
 function vim.api.nvim_list_wins() end
 
---- Sets the current editor state from the given `context` map.
+--- Sets the current editor state from the given `|context|` map.
 ---
---- @param dict table<string,any> `Context` map.
+--- @param dict table<string,any> `|Context|` map.
 --- @return any
 function vim.api.nvim_load_context(dict) end
 
@@ -1472,19 +1464,19 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- terminal sequences returned as part of a rpc message, or similar.
 --- Note: to directly initiate the terminal using the right size, display the
 --- buffer in a configured window before calling this. For instance, for a
---- floating display, first create an empty buffer using `nvim_create_buf()`,
---- then display it using `nvim_open_win()`, and then call this function. Then
---- `nvim_chan_send()` can be called immediately to process sequences in a
+--- floating display, first create an empty buffer using `|nvim_create_buf()|`,
+--- then display it using `|nvim_open_win()|`, and then call this function. Then
+--- `|nvim_chan_send()|` can be called immediately to process sequences in a
 --- virtual terminal having the intended size.
 ---
 --- @param buffer integer the buffer to use (expected to be empty)
 --- @param opts table<string,function> Optional parameters.
----               • on_input: Lua callback for input sent, i e keypresses in
----                 terminal mode. Note: keypresses are sent raw as they would
----                 be to the pty master end. For instance, a carriage return
----                 is sent as a "\r", not as a "\n". `textlock` applies. It
----                 is possible to call `nvim_chan_send()` directly in the
----                 callback however. ["input", term, bufnr, data]
+---  • on_input: Lua callback for input sent, i e keypresses in
+---    terminal mode. Note: keypresses are sent raw as they would
+---    be to the pty master end. For instance, a carriage return
+---    is sent as a "\r", not as a "\n". `|textlock|` applies. It
+---    is possible to call `|nvim_chan_send()|` directly in the
+---    callback however. ["input", term, bufnr, data]
 --- @return integer
 function vim.api.nvim_open_term(buffer, opts) end
 
@@ -1492,9 +1484,9 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- Currently this is used to open floating and external windows. Floats are
 --- windows that are drawn above the split layout, at some anchor position in
 --- some other window. Floats can be drawn internally or by external GUI with
---- the `ui-multigrid` extension. External windows are only supported with
+--- the `|ui-multigrid|` extension. External windows are only supported with
 --- multigrid GUIs, and are displayed as separate top-level windows.
---- For a general overview of floats, see `api-floatwin`.
+--- For a general overview of floats, see `|api-floatwin|`.
 --- Exactly one of `external` and `relative` must be specified. The `width`
 --- and `height` of the new window must be specified.
 --- With relative=editor (row=0,col=0) refers to the top-left corner of the
@@ -1507,127 +1499,125 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- could let floats hover outside of the main window like a tooltip, but this
 --- should not be used to specify arbitrary WM screen positions.
 --- Example (Lua): window-relative float
----
 --- ```lua
----     vim.api.nvim_open_win(0, false,
----       {relative='win', row=3, col=3, width=12, height=3})
+--- vim.api.nvim_open_win(0, false,
+---   {relative='win', row=3, col=3, width=12, height=3})
 --- ```
----
 --- Example (Lua): buffer-relative float (travels as buffer is scrolled)
----
 --- ```lua
----     vim.api.nvim_open_win(0, false,
----       {relative='win', width=12, height=3, bufpos={100,10}})
----     })
+--- vim.api.nvim_open_win(0, false,
+---   {relative='win', width=12, height=3, bufpos={100,10}})
+--- })
 --- ```
+---
 ---
 --- @param buffer integer Buffer to display, or 0 for current buffer
 --- @param enter boolean Enter the window (make it the current window)
 --- @param config vim.api.keyset.float_config Map defining the window configuration. Keys:
----               • relative: Sets the window layout to "floating", placed at
----                 (row,col) coordinates relative to:
----                 • "editor" The global editor grid
----                 • "win" Window given by the `win` field, or current
----                   window.
----                 • "cursor" Cursor position in current window.
----                 • "mouse" Mouse position
+---  • relative: Sets the window layout to "floating", placed at
+---    (row,col) coordinates relative to:
+---    • "editor" The global editor grid
+---    • "win" Window given by the `win` field, or current
+---      window.
+---    • "cursor" Cursor position in current window.
+---    • "mouse" Mouse position
 ---
----               • win: `window-ID` for relative="win".
----               • anchor: Decides which corner of the float to place at
----                 (row,col):
----                 • "NW" northwest (default)
----                 • "NE" northeast
----                 • "SW" southwest
----                 • "SE" southeast
+---  • win: `|window-ID|` for relative="win".
+---  • anchor: Decides which corner of the float to place at
+---    (row,col):
+---    • "NW" northwest (default)
+---    • "NE" northeast
+---    • "SW" southwest
+---    • "SE" southeast
 ---
----               • width: Window width (in character cells). Minimum of 1.
----               • height: Window height (in character cells). Minimum of 1.
----               • bufpos: Places float relative to buffer text (only when
----                 relative="win"). Takes a tuple of zero-indexed [line,
----                 column]. `row` and `col` if given are applied relative to this position, else they
----                 default to:
----                 • `row=1` and `col=0` if `anchor` is "NW" or "NE"
----                 • `row=0` and `col=0` if `anchor` is "SW" or "SE" (thus
----                   like a tooltip near the buffer text).
+---  • width: Window width (in character cells). Minimum of 1.
+---  • height: Window height (in character cells). Minimum of 1.
+---  • bufpos: Places float relative to buffer text (only when
+---    relative="win"). Takes a tuple of zero-indexed [line,
+---    column]. `row` and `col` if given are applied relative to this position, else they
+---    default to:
+---    • `row=1` and `col=0` if `anchor` is "NW" or "NE"
+---    • `row=0` and `col=0` if `anchor` is "SW" or "SE" (thus
+---      like a tooltip near the buffer text).
 ---
----               • row: Row position in units of "screen cell height", may be
----                 fractional.
----               • col: Column position in units of "screen cell width", may
----                 be fractional.
----               • focusable: Enable focus by user actions (wincmds, mouse
----                 events). Defaults to true. Non-focusable windows can be
----                 entered by `nvim_set_current_win()`.
----               • external: GUI should display the window as an external
----                 top-level window. Currently accepts no other positioning
----                 configuration together with this.
----               • zindex: Stacking order. floats with higher `zindex` go on top on floats with lower indices. Must be larger
----                 than zero. The following screen elements have hard-coded
----                 z-indices:
----                 • 100: insert completion popupmenu
----                 • 200: message scrollback
----                 • 250: cmdline completion popupmenu (when
----                   wildoptions+=pum) The default value for floats are 50.
----                   In general, values below 100 are recommended, unless
----                   there is a good reason to overshadow builtin elements.
+---  • row: Row position in units of "screen cell height", may be
+---    fractional.
+---  • col: Column position in units of "screen cell width", may
+---    be fractional.
+---  • focusable: Enable focus by user actions (wincmds, mouse
+---    events). Defaults to true. Non-focusable windows can be
+---    entered by `|nvim_set_current_win()|`.
+---  • external: GUI should display the window as an external
+---    top-level window. Currently accepts no other positioning
+---    configuration together with this.
+---  • zindex: Stacking order. floats with higher `zindex` go on top on floats with lower indices. Must be larger
+---    than zero. The following screen elements have hard-coded
+---    z-indices:
+---    • 100: insert completion popupmenu
+---    • 200: message scrollback
+---    • 250: cmdline completion popupmenu (when
+---      wildoptions+=pum) The default value for floats are 50.
+---      In general, values below 100 are recommended, unless
+---      there is a good reason to overshadow builtin elements.
 ---
----               • style: (optional) Configure the appearance of the window.
----                 Currently only supports one value:
----                 • "minimal" Nvim will display the window with many UI
----                   options disabled. This is useful when displaying a
----                   temporary float where the text should not be edited.
----                   Disables 'number', 'relativenumber', 'cursorline',
----                   'cursorcolumn', 'foldcolumn', 'spell' and 'list'
----                   options. 'signcolumn' is changed to `auto` and
----                   'colorcolumn' is cleared. 'statuscolumn' is changed to
----                   empty. The end-of-buffer region is hidden by setting
----                   `eob` flag of 'fillchars' to a space char, and clearing
----                   the `hl-EndOfBuffer` region in 'winhighlight'.
+---  • style: (optional) Configure the appearance of the window.
+---    Currently only supports one value:
+---    • "minimal" Nvim will display the window with many UI
+---      options disabled. This is useful when displaying a
+---      temporary float where the text should not be edited.
+---      Disables 'number', 'relativenumber', 'cursorline',
+---      'cursorcolumn', 'foldcolumn', 'spell' and 'list'
+---      options. 'signcolumn' is changed to `auto` and
+---      'colorcolumn' is cleared. 'statuscolumn' is changed to
+---      empty. The end-of-buffer region is hidden by setting
+---      `eob` flag of 'fillchars' to a space char, and clearing
+---      the `|hl-EndOfBuffer|` region in 'winhighlight'.
 ---
----               • border: Style of (optional) window border. This can either
----                 be a string or an array. The string values are
----                 • "none": No border (default).
----                 • "single": A single line box.
----                 • "double": A double line box.
----                 • "rounded": Like "single", but with rounded corners ("╭"
----                   etc.).
----                 • "solid": Adds padding by a single whitespace cell.
----                 • "shadow": A drop shadow effect by blending with the
----                   background.
----                 • If it is an array, it should have a length of eight or
----                   any divisor of eight. The array will specifify the eight
----                   chars building up the border in a clockwise fashion
----                   starting with the top-left corner. As an example, the
----                   double box style could be specified as [ "╔", "═" ,"╗",
----                   "║", "╝", "═", "╚", "║" ]. If the number of chars are
----                   less than eight, they will be repeated. Thus an ASCII
----                   border could be specified as [ "/", "-", "\\", "|" ], or
----                   all chars the same as [ "x" ]. An empty string can be
----                   used to turn off a specific border, for instance, [ "",
----                   "", "", ">", "", "", "", "<" ] will only make vertical
----                   borders but not horizontal ones. By default,
----                   `FloatBorder` highlight is used, which links to
----                   `WinSeparator` when not defined. It could also be
----                   specified by character: [ ["+", "MyCorner"], ["x",
----                   "MyBorder"] ].
+---  • border: Style of (optional) window border. This can either
+---    be a string or an array. The string values are
+---    • "none": No border (default).
+---    • "single": A single line box.
+---    • "double": A double line box.
+---    • "rounded": Like "single", but with rounded corners ("╭"
+---      etc.).
+---    • "solid": Adds padding by a single whitespace cell.
+---    • "shadow": A drop shadow effect by blending with the
+---      background.
+---    • If it is an array, it should have a length of eight or
+---      any divisor of eight. The array will specifify the eight
+---      chars building up the border in a clockwise fashion
+---      starting with the top-left corner. As an example, the
+---      double box style could be specified as [ "╔", "═" ,"╗",
+---      "║", "╝", "═", "╚", "║" ]. If the number of chars are
+---      less than eight, they will be repeated. Thus an ASCII
+---      border could be specified as [ "/", "-", "\\", "|" ], or
+---      all chars the same as [ "x" ]. An empty string can be
+---      used to turn off a specific border, for instance, [ "",
+---      "", "", ">", "", "", "", "<" ] will only make vertical
+---      borders but not horizontal ones. By default,
+---      `FloatBorder` highlight is used, which links to
+---      `WinSeparator` when not defined. It could also be
+---      specified by character: [ ["+", "MyCorner"], ["x",
+---      "MyBorder"] ].
 ---
----               • title: Title (optional) in window border, string or list.
----                 List should consist of `[text, highlight]` tuples. If
----                 string, the default highlight group is `FloatTitle`.
----               • title_pos: Title position. Must be set with `title`
----                 option. Value can be one of "left", "center", or "right".
----                 Default is `"left"`.
----               • footer: Footer (optional) in window border, string or
----                 list. List should consist of `[text, highlight]` tuples.
----                 If string, the default highlight group is `FloatFooter`.
----               • footer_pos: Footer position. Must be set with `footer`
----                 option. Value can be one of "left", "center", or "right".
----                 Default is `"left"`.
----               • noautocmd: If true then no buffer-related autocommand
----                 events such as `BufEnter`, `BufLeave` or `BufWinEnter` may
----                 fire from calling this function.
----               • fixed: If true when anchor is NW or SW, the float window
----                 would be kept fixed even if the window would be truncated.
----               • hide: If true the floating window will be hidden.
+---  • title: Title (optional) in window border, string or list.
+---    List should consist of `[text, highlight]` tuples. If
+---    string, the default highlight group is `FloatTitle`.
+---  • title_pos: Title position. Must be set with `title`
+---    option. Value can be one of "left", "center", or "right".
+---    Default is `"left"`.
+---  • footer: Footer (optional) in window border, string or
+---    list. List should consist of `[text, highlight]` tuples.
+---    If string, the default highlight group is `FloatFooter`.
+---  • footer_pos: Footer position. Must be set with `footer`
+---    option. Value can be one of "left", "center", or "right".
+---    Default is `"left"`.
+---  • noautocmd: If true then no buffer-related autocommand
+---    events such as `|BufEnter|`, `|BufLeave|` or `|BufWinEnter|` may
+---    fire from calling this function.
+---  • fixed: If true when anchor is NW or SW, the float window
+---    would be kept fixed even if the window would be truncated.
+---  • hide: If true the floating window will be hidden.
 --- @return integer
 function vim.api.nvim_open_win(buffer, enter, config) end
 
@@ -1649,29 +1639,29 @@ function vim.api.nvim_parse_cmd(str, opts) end
 ---
 --- @param expr string Expression to parse. Always treated as a single line.
 --- @param flags string Flags:
----                  • "m" if multiple expressions in a row are allowed (only
----                    the first one will be parsed),
----                  • "E" if EOC tokens are not allowed (determines whether
----                    they will stop parsing process or be recognized as an
----                    operator/space, though also yielding an error).
----                  • "l" when needing to start parsing with lvalues for
----                    ":let" or ":for". Common flag sets:
----                  • "m" to parse like for ":echo".
----                  • "E" to parse like for "<C-r>=".
----                  • empty string for ":call".
----                  • "lm" to parse for ":let".
+---   • "m" if multiple expressions in a row are allowed (only
+---     the first one will be parsed),
+---   • "E" if EOC tokens are not allowed (determines whether
+---     they will stop parsing process or be recognized as an
+---     operator/space, though also yielding an error).
+---   • "l" when needing to start parsing with lvalues for
+---     ":let" or ":for". Common flag sets:
+---   • "m" to parse like for ":echo".
+---   • "E" to parse like for "<C-r>=".
+---   • empty string for ":call".
+---   • "lm" to parse for ":let".
 --- @param highlight boolean If true, return value will also include "highlight" key
----                  containing array of 4-tuples (arrays) (Integer, Integer,
----                  Integer, String), where first three numbers define the
----                  highlighted region and represent line, starting column
----                  and ending column (latter exclusive: one should highlight
----                  region [start_col, end_col)).
+---   containing array of 4-tuples (arrays) (Integer, Integer,
+---   Integer, String), where first three numbers define the
+---   highlighted region and represent line, starting column
+---   and ending column (latter exclusive: one should highlight
+---   region [start_col, end_col)).
 --- @return table<string,any>
 function vim.api.nvim_parse_expression(expr, flags, highlight) end
 
 --- Pastes at cursor, in any mode.
 --- Invokes the `vim.paste` handler, which handles each mode appropriately.
---- Sets redo/undo. Faster than `nvim_input()`. Lines break at LF ("\n").
+--- Sets redo/undo. Faster than `|nvim_input()|`. Lines break at LF ("\n").
 --- Errors ('nomodifiable', `vim.paste()` failure, …) are reflected in `err`
 --- but do not affect the return value (which is strictly decided by
 --- `vim.paste()`). On error, subsequent calls are ignored ("drained") until
@@ -1680,50 +1670,50 @@ function vim.api.nvim_parse_expression(expr, flags, highlight) end
 --- @param data string Multiline input. May be binary (containing NUL bytes).
 --- @param crlf boolean Also break lines at CR and CRLF.
 --- @param phase integer -1: paste in a single call (i.e. without streaming). To
----              "stream" a paste, call `nvim_paste` sequentially with these `phase` values:
----              • 1: starts the paste (exactly once)
----              • 2: continues the paste (zero or more times)
----              • 3: ends the paste (exactly once)
+---   "stream" a paste, call `nvim_paste` sequentially with these `phase` values:
+---   • 1: starts the paste (exactly once)
+---   • 2: continues the paste (zero or more times)
+---   • 3: ends the paste (exactly once)
 --- @return boolean
 function vim.api.nvim_paste(data, crlf, phase) end
 
 --- Puts text at cursor, in any mode.
---- Compare `:put` and `p` which are always linewise.
+--- Compare `|:put|` and `|p|` which are always linewise.
 ---
---- @param lines string[] `readfile()`-style list of lines. `channel-lines`
---- @param type string Edit behavior: any `getregtype()` result, or:
----               • "b" `blockwise-visual` mode (may include width, e.g. "b3")
----               • "c" `charwise` mode
----               • "l" `linewise` mode
----               • "" guess by contents, see `setreg()`
---- @param after boolean If true insert after cursor (like `p`), or before (like
----               `P`).
+--- @param lines string[] `|readfile()|`-style list of lines. `|channel-lines|`
+--- @param type string Edit behavior: any `|getregtype()|` result, or:
+---  • "b" `|blockwise-visual|` mode (may include width, e.g. "b3")
+---  • "c" `|charwise|` mode
+---  • "l" `|linewise|` mode
+---  • "" guess by contents, see `|setreg()|`
+--- @param after boolean If true insert after cursor (like `|p|`), or before (like
+---  `|P|`).
 --- @param follow boolean If true place cursor at end of inserted text.
 function vim.api.nvim_put(lines, type, after, follow) end
 
---- Replaces terminal codes and `keycodes` (<CR>, <Esc>, ...) in a string with
+--- Replaces terminal codes and `|keycodes|` (<CR>, <Esc>, ...) in a string with
 --- the internal representation.
 ---
 --- @param str string String to be converted.
 --- @param from_part boolean Legacy Vim parameter. Usually true.
 --- @param do_lt boolean Also translate <lt>. Ignored if `special` is false.
---- @param special boolean Replace `keycodes`, e.g. <CR> becomes a "\r" char.
+--- @param special boolean Replace `|keycodes|`, e.g. <CR> becomes a "\r" char.
 --- @return string
 function vim.api.nvim_replace_termcodes(str, from_part, do_lt, special) end
 
 --- Selects an item in the completion popup menu.
---- If neither `ins-completion` nor `cmdline-completion` popup menu is active
+--- If neither `|ins-completion|` nor `|cmdline-completion|` popup menu is active
 --- this API call is silently ignored. Useful for an external UI using
---- `ui-popupmenu` to control the popup menu with the mouse. Can also be used
---- in a mapping; use <Cmd> `:map-cmd` or a Lua mapping to ensure the mapping
+--- `|ui-popupmenu|` to control the popup menu with the mouse. Can also be used
+--- in a mapping; use <Cmd> `|:map-cmd|` or a Lua mapping to ensure the mapping
 --- doesn't end completion mode.
 ---
 --- @param item integer Index (zero-based) of the item to select. Value of -1
----               selects nothing and restores the original text.
---- @param insert boolean For `ins-completion`, whether the selection should be
----               inserted in the buffer. Ignored for `cmdline-completion`.
+---  selects nothing and restores the original text.
+--- @param insert boolean For `|ins-completion|`, whether the selection should be
+---  inserted in the buffer. Ignored for `|cmdline-completion|`.
 --- @param finish boolean Finish the completion and dismiss the popup menu. Implies
----               {insert}.
+---  {insert}.
 --- @param opts table<string,any> Optional parameters. Reserved for future use.
 function vim.api.nvim_select_popupmenu_item(item, insert, finish, opts) end
 
@@ -1737,47 +1727,47 @@ function vim.api.nvim_select_popupmenu_item(item, insert, finish, opts) end
 ---
 --- @param name string Short name for the connected client
 --- @param version table<string,any> Dictionary describing the version, with these (optional)
----                   keys:
----                   • "major" major version (defaults to 0 if not set, for
----                     no release yet)
----                   • "minor" minor version
----                   • "patch" patch number
----                   • "prerelease" string describing a prerelease, like
----                     "dev" or "beta1"
----                   • "commit" hash or similar identifier of commit
+---  keys:
+---  • "major" major version (defaults to 0 if not set, for
+---    no release yet)
+---  • "minor" minor version
+---  • "patch" patch number
+---  • "prerelease" string describing a prerelease, like
+---    "dev" or "beta1"
+---  • "commit" hash or similar identifier of commit
 --- @param type string Must be one of the following values. Client libraries
----                   should default to "remote" unless overridden by the
----                   user.
----                   • "remote" remote client connected "Nvim flavored"
----                     MessagePack-RPC (responses must be in reverse order of
----                     requests). `msgpack-rpc`
----                   • "msgpack-rpc" remote client connected to Nvim via
----                     fully MessagePack-RPC compliant protocol.
----                   • "ui" gui frontend
----                   • "embedder" application using Nvim as a component (for
----                     example, IDE/editor implementing a vim mode).
----                   • "host" plugin host, typically started by nvim
----                   • "plugin" single plugin, started by nvim
+---  should default to "remote" unless overridden by the
+---  user.
+---  • "remote" remote client connected "Nvim flavored"
+---    MessagePack-RPC (responses must be in reverse order of
+---    requests). `|msgpack-rpc|`
+---  • "msgpack-rpc" remote client connected to Nvim via
+---    fully MessagePack-RPC compliant protocol.
+---  • "ui" gui frontend
+---  • "embedder" application using Nvim as a component (for
+---    example, IDE/editor implementing a vim mode).
+---  • "host" plugin host, typically started by nvim
+---  • "plugin" single plugin, started by nvim
 --- @param methods table<string,any> Builtin methods in the client. For a host, this does not
----                   include plugin methods which will be discovered later.
----                   The key should be the method name, the values are dicts
----                   with these (optional) keys (more keys may be added in
----                   future versions of Nvim, thus unknown keys are ignored.
----                   Clients must only use keys defined in this or later
----                   versions of Nvim):
----                   • "async" if true, send as a notification. If false or
----                     unspecified, use a blocking request
----                   • "nargs" Number of arguments. Could be a single integer
----                     or an array of two integers, minimum and maximum
----                     inclusive.
+---  include plugin methods which will be discovered later.
+---  The key should be the method name, the values are dicts
+---  with these (optional) keys (more keys may be added in
+---  future versions of Nvim, thus unknown keys are ignored.
+---  Clients must only use keys defined in this or later
+---  versions of Nvim):
+---  • "async" if true, send as a notification. If false or
+---    unspecified, use a blocking request
+---  • "nargs" Number of arguments. Could be a single integer
+---    or an array of two integers, minimum and maximum
+---    inclusive.
 --- @param attributes table<string,any> Arbitrary string:string map of informal client
----                   properties. Suggested keys:
----                   • "website": Client homepage URL (e.g. GitHub
----                     repository)
----                   • "license": License description ("Apache 2", "GPLv3",
----                     "MIT", …)
----                   • "logo": URI or path to image, preferably small logo or
----                     icon. .png or .svg format is preferred.
+---  properties. Suggested keys:
+---  • "website": Client homepage URL (e.g. GitHub
+---    repository)
+---  • "license": License description ("Apache 2", "GPLv3",
+---    "MIT", …)
+---  • "logo": URI or path to image, preferably small logo or
+---    icon. .png or .svg format is preferred.
 function vim.api.nvim_set_client_info(name, version, type, methods, attributes) end
 
 --- Sets the current buffer.
@@ -1805,11 +1795,11 @@ function vim.api.nvim_set_current_tabpage(tabpage) end
 --- @param window integer Window handle
 function vim.api.nvim_set_current_win(window) end
 
---- Set or change decoration provider for a `namespace`
+--- Set or change decoration provider for a `|namespace|`
 --- This is a very general purpose interface for having Lua callbacks being
 --- triggered during the redraw code.
---- The expected usage is to set `extmarks` for the currently redrawn buffer.
---- `nvim_buf_set_extmark()` can be called to add marks on a per-window or
+--- The expected usage is to set `|extmarks|` for the currently redrawn buffer.
+--- `|nvim_buf_set_extmark()|` can be called to add marks on a per-window or
 --- per-lines basis. Use the `ephemeral` key to only use the mark for the
 --- current screen redraw (the callback will be called again for the next
 --- redraw ).
@@ -1829,104 +1819,102 @@ function vim.api.nvim_set_current_win(window) end
 --- Note: It is not allowed to remove or update extmarks in 'on_line'
 --- callbacks.
 ---
---- @param ns_id integer Namespace id from `nvim_create_namespace()`
+--- @param ns_id integer Namespace id from `|nvim_create_namespace()|`
 --- @param opts vim.api.keyset.set_decoration_provider Table of callbacks:
----              • on_start: called first on each screen redraw ["start",
----                tick]
----              • on_buf: called for each buffer being redrawn (before window
----                callbacks) ["buf", bufnr, tick]
----              • on_win: called when starting to redraw a specific window.
----                botline_guess is an approximation that does not exceed the
----                last line number. ["win", winid, bufnr, topline,
----                botline_guess]
----              • on_line: called for each buffer line being redrawn. (The
----                interaction with fold lines is subject to change) ["win",
----                winid, bufnr, row]
----              • on_end: called at the end of a redraw cycle ["end", tick]
+---   • on_start: called first on each screen redraw ["start",
+---     tick]
+---   • on_buf: called for each buffer being redrawn (before window
+---     callbacks) ["buf", bufnr, tick]
+---   • on_win: called when starting to redraw a specific window.
+---     botline_guess is an approximation that does not exceed the
+---     last line number. ["win", winid, bufnr, topline,
+---     botline_guess]
+---   • on_line: called for each buffer line being redrawn. (The
+---     interaction with fold lines is subject to change) ["win",
+---     winid, bufnr, row]
+---   • on_end: called at the end of a redraw cycle ["end", tick]
 function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 
 --- Sets a highlight group.
 ---
---- @param ns_id integer Namespace id for this highlight `nvim_create_namespace()`.
----              Use 0 to set a highlight group globally `:highlight`.
----              Highlights from non-global namespaces are not active by
----              default, use `nvim_set_hl_ns()` or `nvim_win_set_hl_ns()` to
----              activate them.
+--- @param ns_id integer Namespace id for this highlight `|nvim_create_namespace()|`.
+---   Use 0 to set a highlight group globally `|:highlight|`.
+---   Highlights from non-global namespaces are not active by
+---   default, use `|nvim_set_hl_ns()|` or `|nvim_win_set_hl_ns()|` to
+---   activate them.
 --- @param name string Highlight group name, e.g. "ErrorMsg"
 --- @param val vim.api.keyset.highlight Highlight definition map, accepts the following keys:
----              • fg (or foreground): color name or "#RRGGBB", see note.
----              • bg (or background): color name or "#RRGGBB", see note.
----              • sp (or special): color name or "#RRGGBB"
----              • blend: integer between 0 and 100
----              • bold: boolean
----              • standout: boolean
----              • underline: boolean
----              • undercurl: boolean
----              • underdouble: boolean
----              • underdotted: boolean
----              • underdashed: boolean
----              • strikethrough: boolean
----              • italic: boolean
----              • reverse: boolean
----              • nocombine: boolean
----              • link: name of another highlight group to link to, see
----                `:hi-link`.
----              • default: Don't override existing definition `:hi-default`
----              • ctermfg: Sets foreground of cterm color `ctermfg`
----              • ctermbg: Sets background of cterm color `ctermbg`
----              • cterm: cterm attribute map, like `highlight-args`. If not
----                set, cterm attributes will match those from the attribute
----                map documented above.
----              • force: if true force update the highlight group when it
----                exists.
+---   • fg (or foreground): color name or "#RRGGBB", see note.
+---   • bg (or background): color name or "#RRGGBB", see note.
+---   • sp (or special): color name or "#RRGGBB"
+---   • blend: integer between 0 and 100
+---   • bold: boolean
+---   • standout: boolean
+---   • underline: boolean
+---   • undercurl: boolean
+---   • underdouble: boolean
+---   • underdotted: boolean
+---   • underdashed: boolean
+---   • strikethrough: boolean
+---   • italic: boolean
+---   • reverse: boolean
+---   • nocombine: boolean
+---   • link: name of another highlight group to link to, see
+---     `|:hi-link|`.
+---   • default: Don't override existing definition `|:hi-default|`
+---   • ctermfg: Sets foreground of cterm color `|ctermfg|`
+---   • ctermbg: Sets background of cterm color `|ctermbg|`
+---   • cterm: cterm attribute map, like `|highlight-args|`. If not
+---     set, cterm attributes will match those from the attribute
+---     map documented above.
+---   • force: if true force update the highlight group when it
+---     exists.
 function vim.api.nvim_set_hl(ns_id, name, val) end
 
---- Set active namespace for highlights defined with `nvim_set_hl()`. This can
---- be set for a single window, see `nvim_win_set_hl_ns()`.
+--- Set active namespace for highlights defined with `|nvim_set_hl()|`. This can
+--- be set for a single window, see `|nvim_win_set_hl_ns()|`.
 ---
 --- @param ns_id integer the namespace to use
 function vim.api.nvim_set_hl_ns(ns_id) end
 
---- Set active namespace for highlights defined with `nvim_set_hl()` while
+--- Set active namespace for highlights defined with `|nvim_set_hl()|` while
 --- redrawing.
 --- This function meant to be called while redrawing, primarily from
---- `nvim_set_decoration_provider()` on_win and on_line callbacks, which are
+--- `|nvim_set_decoration_provider()|` on_win and on_line callbacks, which are
 --- allowed to change the namespace during a redraw cycle.
 ---
 --- @param ns_id integer the namespace to activate
 function vim.api.nvim_set_hl_ns_fast(ns_id) end
 
---- Sets a global `mapping` for the given mode.
---- To set a buffer-local mapping, use `nvim_buf_set_keymap()`.
---- Unlike `:map`, leading/trailing whitespace is accepted as part of the
---- {lhs} or {rhs}. Empty {rhs} is `<Nop>`. `keycodes` are replaced as usual.
+--- Sets a global `|mapping|` for the given mode.
+--- To set a buffer-local mapping, use `|nvim_buf_set_keymap()|`.
+--- Unlike `|:map|`, leading/trailing whitespace is accepted as part of the
+--- {lhs} or {rhs}. Empty {rhs} is `|<Nop>|`. `|keycodes|` are replaced as usual.
 --- Example:
----
 --- ```vim
----     call nvim_set_keymap('n', ' <NL>', '', {'nowait': v:true})
+--- call nvim_set_keymap('n', ' <NL>', '', {'nowait': v:true})
 --- ```
----
 --- is equivalent to:
----
 --- ```vim
----     nmap <nowait> <Space><NL> <Nop>
+--- nmap <nowait> <Space><NL> <Nop>
 --- ```
+---
 ---
 --- @param mode string Mode short-name (map command prefix: "n", "i", "v", "x", …) or
----             "!" for `:map!`, or empty string for `:map`. "ia", "ca" or
----             "!a" for abbreviation in Insert mode, Cmdline mode, or both,
----             respectively
---- @param lhs string Left-hand-side `{lhs}` of the mapping.
---- @param rhs string Right-hand-side `{rhs}` of the mapping.
---- @param opts vim.api.keyset.keymap Optional parameters map: Accepts all `:map-arguments` as keys
----             except `<buffer>`, values are booleans (default false). Also:
----             • "noremap" disables `recursive_mapping`, like `:noremap`
----             • "desc" human-readable description.
----             • "callback" Lua function called in place of {rhs}.
----             • "replace_keycodes" (boolean) When "expr" is true, replace
----               keycodes in the resulting string (see
----               `nvim_replace_termcodes()`). Returning nil from the Lua
----               "callback" is equivalent to returning an empty string.
+---  "!" for `|:map!|`, or empty string for `|:map|`. "ia", "ca" or
+---  "!a" for abbreviation in Insert mode, Cmdline mode, or both,
+---  respectively
+--- @param lhs string Left-hand-side `|{lhs}|` of the mapping.
+--- @param rhs string Right-hand-side `|{rhs}|` of the mapping.
+--- @param opts vim.api.keyset.keymap Optional parameters map: Accepts all `|:map-arguments|` as keys
+---  except `|<buffer>|`, values are booleans (default false). Also:
+---  • "noremap" disables `|recursive_mapping|`, like `|:noremap|`
+---  • "desc" human-readable description.
+---  • "callback" Lua function called in place of {rhs}.
+---  • "replace_keycodes" (boolean) When "expr" is true, replace
+---    keycodes in the resulting string (see
+---    `|nvim_replace_termcodes()|`). Returning nil from the Lua
+---    "callback" is equivalent to returning an empty string.
 function vim.api.nvim_set_keymap(mode, lhs, rhs, opts) end
 
 --- @deprecated
@@ -1935,17 +1923,17 @@ function vim.api.nvim_set_keymap(mode, lhs, rhs, opts) end
 function vim.api.nvim_set_option(name, value) end
 
 --- Sets the value of an option. The behavior of this function matches that of
---- `:set`: for global-local options, both the global and local value are set
+--- `|:set|`: for global-local options, both the global and local value are set
 --- unless otherwise specified with {scope}.
 --- Note the options {win} and {buf} cannot be used together.
 ---
 --- @param name string Option name
 --- @param value any New option value
 --- @param opts vim.api.keyset.option Optional parameters
----              • scope: One of "global" or "local". Analogous to
----                `:setglobal` and `:setlocal`, respectively.
----              • win: `window-ID`. Used for setting window local option.
----              • buf: Buffer number. Used for setting buffer local option.
+---   • scope: One of "global" or "local". Analogous to
+---     `|:setglobal|` and `|:setlocal|`, respectively.
+---   • win: `|window-ID|`. Used for setting window local option.
+---   • buf: Buffer number. Used for setting buffer local option.
 function vim.api.nvim_set_option_value(name, value, opts) end
 
 --- Sets a global (g:) variable.
@@ -2017,24 +2005,24 @@ function vim.api.nvim_tabpage_list_wins(tabpage) end
 function vim.api.nvim_tabpage_set_var(tabpage, name, value) end
 
 --- Activates UI events on the channel.
---- Entry point of all UI clients. Allows `--embed` to continue startup.
+--- Entry point of all UI clients. Allows `|--embed|` to continue startup.
 --- Implies that the client is ready to show the UI. Adds the client to the
---- list of UIs. `nvim_list_uis()`
+--- list of UIs. `|nvim_list_uis()|`
 ---
 --- @param width integer Requested screen columns
 --- @param height integer Requested screen rows
---- @param options table<string,any> `ui-option` map
+--- @param options table<string,any> `|ui-option|` map
 function vim.api.nvim_ui_attach(width, height, options) end
 
 --- Deactivates UI events on the channel.
---- Removes the client from the list of UIs. `nvim_list_uis()`
+--- Removes the client from the list of UIs. `|nvim_list_uis()|`
 ---
 function vim.api.nvim_ui_detach() end
 
 --- Tells Nvim the geometry of the popupmenu, to align floating windows with
 --- an external popup menu.
 --- Note that this method is not to be confused with
---- `nvim_ui_pum_set_height()`, which sets the number of visible items in the
+--- `|nvim_ui_pum_set_height()|`, which sets the number of visible items in the
 --- popup menu, while this function sets the bounding box of the popup menu,
 --- including visual elements such as borders and sliders. Floats need not use
 --- the same font size, nor be anchored to exact grid corners, so one can set
@@ -2081,16 +2069,16 @@ function vim.api.nvim_unsubscribe(event) end
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @param fun function Function to call inside the window (currently Lua callable
----               only)
+---  only)
 --- @return any
 function vim.api.nvim_win_call(window, fun) end
 
---- Closes the window (like `:close` with a `window-ID`).
+--- Closes the window (like `|:close|` with a `|window-ID|`).
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @param force boolean Behave like `:close!` The last window of a buffer with
----               unwritten changes can be closed. The buffer will become
----               hidden, even if 'hidden' is not set.
+---  unwritten changes can be closed. The buffer will become
+---  hidden, even if 'hidden' is not set.
 function vim.api.nvim_win_close(window, force) end
 
 --- Removes a window-scoped (w:) variable
@@ -2106,7 +2094,7 @@ function vim.api.nvim_win_del_var(window, name) end
 function vim.api.nvim_win_get_buf(window) end
 
 --- Gets window configuration.
---- The returned value may be given to `nvim_open_win()`.
+--- The returned value may be given to `|nvim_open_win()|`.
 --- `relative` is empty for normal windows.
 ---
 --- @param window integer Window handle, or 0 for current window
@@ -2115,7 +2103,7 @@ function vim.api.nvim_win_get_config(window) end
 
 --- Gets the (1,0)-indexed, buffer-relative cursor position for a given window
 --- (different windows showing the same buffer have independent cursor
---- positions). `api-indexing`
+--- positions). `|api-indexing|`
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @return integer[]
@@ -2164,11 +2152,11 @@ function vim.api.nvim_win_get_var(window, name) end
 --- @return integer
 function vim.api.nvim_win_get_width(window) end
 
---- Closes the window and hide the buffer it contains (like `:hide` with a
---- `window-ID`).
---- Like `:hide` the buffer becomes hidden unless another window is editing
---- it, or 'bufhidden' is `unload`, `delete` or `wipe` as opposed to `:close`
---- or `nvim_win_close()`, which will close the buffer.
+--- Closes the window and hide the buffer it contains (like `|:hide|` with a
+--- `|window-ID|`).
+--- Like `|:hide|` the buffer becomes hidden unless another window is editing
+--- it, or 'bufhidden' is `unload`, `delete` or `wipe` as opposed to `|:close|`
+--- or `|nvim_win_close()|`, which will close the buffer.
 ---
 --- @param window integer Window handle, or 0 for current window
 function vim.api.nvim_win_hide(window) end
@@ -2191,10 +2179,10 @@ function vim.api.nvim_win_set_buf(window, buffer) end
 --- changed. `row`/`col` and `relative` must be reconfigured together.
 ---
 --- @param window integer Window handle, or 0 for current window
---- @param config vim.api.keyset.float_config Map defining the window configuration, see `nvim_open_win()`
+--- @param config vim.api.keyset.float_config Map defining the window configuration, see `|nvim_open_win()|`
 function vim.api.nvim_win_set_config(window, config) end
 
---- Sets the (1,0)-indexed cursor position in the window. `api-indexing` This
+--- Sets the (1,0)-indexed cursor position in the window. `|api-indexing|` This
 --- scrolls the window even if it is not the current one.
 ---
 --- @param window integer Window handle, or 0 for current window
@@ -2208,7 +2196,7 @@ function vim.api.nvim_win_set_cursor(window, pos) end
 function vim.api.nvim_win_set_height(window, height) end
 
 --- Set highlight namespace for a window. This will use highlights defined
---- with `nvim_set_hl()` for this namespace, but fall back to global
+--- with `|nvim_set_hl()|` for this namespace, but fall back to global
 --- highlights (ns=0) when missing.
 --- This takes precedence over the 'winhighlight' option.
 ---
@@ -2242,19 +2230,19 @@ function vim.api.nvim_win_set_width(window, width) end
 --- line, unless the line is on "start_row" and "start_vcol" is specified.
 --- Diff filler or virtual lines below the last buffer line are counted in the
 --- result when "end_row" is omitted.
---- Line indexing is similar to `nvim_buf_get_text()`.
+--- Line indexing is similar to `|nvim_buf_get_text()|`.
 ---
 --- @param window integer Window handle, or 0 for current window.
 --- @param opts vim.api.keyset.win_text_height Optional parameters:
----               • start_row: Starting line index, 0-based inclusive. When
----                 omitted start at the very top.
----               • end_row: Ending line index, 0-based inclusive. When
----                 omitted end at the very bottom.
----               • start_vcol: Starting virtual column index on "start_row",
----                 0-based inclusive, rounded down to full screen lines. When
----                 omitted include the whole line.
----               • end_vcol: Ending virtual column index on "end_row",
----                 0-based exclusive, rounded up to full screen lines. When
----                 omitted include the whole line.
+---  • start_row: Starting line index, 0-based inclusive. When
+---    omitted start at the very top.
+---  • end_row: Ending line index, 0-based inclusive. When
+---    omitted end at the very bottom.
+---  • start_vcol: Starting virtual column index on "start_row",
+---    0-based inclusive, rounded down to full screen lines. When
+---    omitted include the whole line.
+---  • end_vcol: Ending virtual column index on "end_row",
+---    0-based exclusive, rounded up to full screen lines. When
+---    omitted include the whole line.
 --- @return table<string,any>
 function vim.api.nvim_win_text_height(window, opts) end

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -36,7 +36,7 @@ vim.go.ari = vim.go.allowrevins
 --- also be given when calling setcellwidths().
 ---
 --- The values are overruled for characters specified with
---- `|setcellwidths()|`.
+--- [setcellwidths()](help://setcellwidths()).
 ---
 --- There are a number of CJK fonts for which the width of glyphs for
 --- those characters are solely based on how many octets they take in
@@ -72,7 +72,7 @@ vim.go.ambw = vim.go.ambiwidth
 --- - Disable the use of 'keymap' (without changing its value).
 --- Note that 'arabicshape' and 'delcombine' are not reset (it is a global
 --- option).
---- Also see `|arabic.txt|`.
+--- Also see [arabic.txt](help://arabic.txt).
 ---
 --- @type boolean
 vim.o.arabic = false
@@ -91,7 +91,7 @@ vim.wo.arab = vim.wo.arabic
 --- When disabled the display shows each character's true stand-alone
 --- form.
 --- Arabic is a complex language which requires other settings, for
---- further details see `|arabic.txt|`.
+--- further details see [arabic.txt](help://arabic.txt).
 ---
 --- @type boolean
 vim.o.arabicshape = true
@@ -134,7 +134,7 @@ vim.bo.ai = vim.bo.autoindent
 --- it has not been changed inside of Vim, automatically read it again.
 --- When the file has been deleted this is not done, so you have the text
 --- from before it was deleted.  When it appears again then it is read.
---- `|timestamp|`
+--- [timestamp](help://timestamp)
 --- If this option has a local value, use this command to switch back to
 --- using the global value:
 --- ```
@@ -182,12 +182,12 @@ vim.go.autowriteall = vim.o.autowriteall
 vim.go.awa = vim.go.autowriteall
 
 --- When set to "dark" or "light", adjusts the default color groups for
---- that background type.  The `|TUI|` or other UI sets this on startup
---- (triggering `|OptionSet|`) if it can detect the background color.
+--- that background type.  The [TUI](help://TUI) or other UI sets this on startup
+--- (triggering [OptionSet](help://OptionSet)) if it can detect the background color.
 ---
 --- This option does NOT change the background color, it tells Nvim what
 --- the "inherited" (terminal/GUI) background looks like.
---- See `|:hi-normal|` if you want to set the background color explicitly.
+--- See [:hi-normal](help://:hi-normal) if you want to set the background color explicitly.
 ---         *g:colors_name*
 --- When a color scheme is loaded (the "g:colors_name" variable is set)
 --- setting 'background' will cause the color scheme to be reloaded.  If
@@ -242,7 +242,7 @@ vim.go.bs = vim.go.backspace
 --- written, reset this option and set the 'writebackup' option (this is
 --- the default).  If you do not want a backup file at all reset both
 --- options (use this if your file system is almost full).  See the
---- `|backup-table|` for more explanations.
+--- [backup-table](help://backup-table) for more explanations.
 --- When the 'backupskip' pattern matches, a backup is not made anyway.
 --- When 'patchmode' is set, the backup may be renamed to become the
 --- oldest version of a file.
@@ -348,9 +348,9 @@ vim.go.bkc = vim.go.backupcopy
 --- separating comma is following, you must use "//", since "\\" will
 --- include the comma in the file name. Therefore it is recommended to
 --- use '//', instead of '\\'.
---- - Environment variables are expanded `|:set_env|`.
+--- - Environment variables are expanded [:set_env](help://:set_env).
 --- - Careful with '\' characters, type one before a space, type two to
---- get one in the option (see `|option-backslash|`), for example:
+--- get one in the option (see [option-backslash](help://option-backslash)), for example:
 --- ```
 ---   :set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 --- ```
@@ -361,10 +361,10 @@ vim.go.bkc = vim.go.backupcopy
 --- ```
 --- You must create a ".backup" directory in each directory and in your
 --- home directory for this to work properly.
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -397,8 +397,8 @@ vim.go.bex = vim.go.backupext
 --- A list of file patterns.  When one of the patterns matches with the
 --- name of the file which is written, no backup file is created.  Both
 --- the specified file name and the full path name of the file are used.
---- The pattern is used like with `|:autocmd|`, see `|autocmd-pattern|`.
---- Watch out for special characters, see `|option-backslash|`.
+--- The pattern is used like with [:autocmd](help://:autocmd), see [autocmd-pattern](help://autocmd-pattern).
+--- Watch out for special characters, see [option-backslash](help://option-backslash).
 --- When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
 --- default value.  "/tmp/*" is only used for Unix.
 ---
@@ -414,7 +414,7 @@ vim.go.bex = vim.go.backupext
 --- ```
 --- Note that the default also makes sure that "crontab -e" works (when a
 --- backup would be made by renaming the original file crontab won't see
---- the newly created file).  Also see 'backupcopy' and `|crontab|`.
+--- the newly created file).  Also see 'backupcopy' and [crontab](help://crontab).
 ---
 --- @type string
 vim.o.backupskip = "/tmp/*"
@@ -432,24 +432,24 @@ vim.go.bsk = vim.go.backupskip
 --- backspace   When hitting <BS> or <Del> and deleting results in an
 --- error.
 --- cursor      Fail to move around using the cursor keys or
---- <PageUp>/<PageDown> in `|Insert-mode|`.
---- complete    Error occurred when using `|i_CTRL-X_CTRL-K|` or
---- `|i_CTRL-X_CTRL-T|`.
---- copy      Cannot copy char from insert mode using `|i_CTRL-Y|` or
---- `|i_CTRL-E|`.
+--- <PageUp>/<PageDown> in [Insert-mode](help://Insert-mode).
+--- complete    Error occurred when using [i_CTRL-X_CTRL-K](help://i_CTRL-X_CTRL-K) or
+--- [i_CTRL-X_CTRL-T](help://i_CTRL-X_CTRL-T).
+--- copy      Cannot copy char from insert mode using [i_CTRL-Y](help://i_CTRL-Y) or
+--- [i_CTRL-E](help://i_CTRL-E).
 --- ctrlg      Unknown Char after <C-G> in Insert mode.
 --- error      Other Error occurred (e.g. try to join last line)
---- (mostly used in `|Normal-mode|` or `|Cmdline-mode|`).
---- esc      hitting <Esc> in `|Normal-mode|`.
+--- (mostly used in [Normal-mode](help://Normal-mode) or [Cmdline-mode](help://Cmdline-mode)).
+--- esc      hitting <Esc> in [Normal-mode](help://Normal-mode).
 --- hangul      Ignored.
 --- lang      Calling the beep module for Lua/Mzscheme/TCL.
---- mess      No output available for `|g<|`.
+--- mess      No output available for [g<](help://g<).
 --- showmatch   Error occurred for 'showmatch' function.
---- operator    Empty region error `|cpo-E|`.
---- register    Unknown register after <C-R> in `|Insert-mode|`.
---- shell      Bell from shell output `|:!|`.
+--- operator    Empty region error [cpo-E](help://cpo-E).
+--- register    Unknown register after <C-R> in [Insert-mode](help://Insert-mode).
+--- shell      Bell from shell output [:!](help://:!).
 --- spell      Error happened on spell suggest.
---- wildmode    More matches in `|cmdline-completion|` available
+--- wildmode    More matches in [cmdline-completion](help://cmdline-completion) available
 --- (depends on the 'wildmode' setting).
 ---
 --- This is most useful to fine tune when in Insert mode the bell should
@@ -464,7 +464,7 @@ vim.go.belloff = vim.o.belloff
 vim.go.bo = vim.go.belloff
 
 --- This option should be set before editing a binary file.  You can also
---- use the `|-b|` Vim argument.  When this option is switched on a few
+--- use the [-b](help://-b) Vim argument.  When this option is switched on a few
 --- options will be changed (also when it already was on):
 --- 'textwidth'  will be set to 0
 --- 'wrapmargin' will be set to 0
@@ -482,7 +482,7 @@ vim.go.bo = vim.go.belloff
 --- The previous values of these options are remembered and restored when
 --- 'bin' is switched from on to off.  Each buffer has its own set of
 --- saved option values.
---- To edit a file with 'binary' set you can use the `|++bin|` argument.
+--- To edit a file with 'binary' set you can use the [++bin](help://++bin) argument.
 --- This avoids you have to do ":set bin", which would have effect for all
 --- files you edit.
 --- When writing a file the <EOL> for the last line is only written if
@@ -588,19 +588,19 @@ vim.go.bsdir = vim.go.browsedir
 --- hide    hide the buffer (don't unload it), even if 'hidden' is
 ---   not set
 --- unload  unload the buffer, even if 'hidden' is set; the
----   `|:hide|` command will also unload the buffer
+---   [:hide](help://:hide) command will also unload the buffer
 --- delete  delete the buffer from the buffer list, even if
----   'hidden' is set; the `|:hide|` command will also delete
----   the buffer, making it behave like `|:bdelete|`
+---   'hidden' is set; the [:hide](help://:hide) command will also delete
+---   the buffer, making it behave like [:bdelete](help://:bdelete)
 --- wipe    wipe the buffer from the buffer list, even if
----   'hidden' is set; the `|:hide|` command will also wipe
----   out the buffer, making it behave like `|:bwipeout|`
+---   'hidden' is set; the [:hide](help://:hide) command will also wipe
+---   out the buffer, making it behave like [:bwipeout](help://:bwipeout)
 ---
 --- CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
 --- are lost without a warning.  Also, these values may break autocommands
 --- that switch between buffers temporarily.
 --- This option is used together with 'buftype' and 'swapfile' to specify
---- special kinds of buffers.   See `|special-buffers|`.
+--- special kinds of buffers.   See [special-buffers](help://special-buffers).
 ---
 --- @type string
 vim.o.bufhidden = ""
@@ -622,48 +622,49 @@ vim.bo.bl = vim.bo.buflisted
 
 --- The value of this option specifies the type of a buffer:
 --- <empty>  normal buffer
---- acwrite  buffer will always be written with `|BufWriteCmd|`s
+--- acwrite  buffer will always be written with [BufWriteCmd](help://BufWriteCmd)s
 --- help    help buffer (do not set this manually)
 --- nofile  buffer is not related to a file, will not be written
 --- nowrite  buffer will not be written
---- quickfix  list of errors `|:cwindow|` or locations `|:lwindow|`
---- terminal  `|terminal-emulator|` buffer
+--- quickfix  list of errors [:cwindow](help://:cwindow) or locations [:lwindow](help://:lwindow)
+--- terminal  [terminal-emulator](help://terminal-emulator) buffer
 --- prompt  buffer where only the last line can be edited, meant
----   to be used by a plugin, see `|prompt-buffer|`
+---   to be used by a plugin, see [prompt-buffer](help://prompt-buffer)
 ---
 --- This option is used together with 'bufhidden' and 'swapfile' to
---- specify special kinds of buffers.   See `|special-buffers|`.
---- Also see `|win_gettype()|`, which returns the type of the window.
+--- specify special kinds of buffers.   See [special-buffers](help://special-buffers).
+--- Also see [win_gettype()](help://win_gettype()), which returns the type of the window.
 ---
 --- Be careful with changing this option, it can have many side effects!
 --- One such effect is that Vim will not check the timestamp of the file,
 --- if the file is changed by another program this will not be noticed.
 ---
 --- A "quickfix" buffer is only used for the error list and the location
---- list.  This value is set by the `|:cwindow|` and `|:lwindow|` commands and
+--- list.  This value is set by the [:cwindow](help://:cwindow) and [:lwindow](help://:lwindow) commands and
 --- you are not supposed to change it.
 ---
 --- "nofile" and "nowrite" buffers are similar:
 --- both:    The buffer is not to be written to disk, ":w" doesn't
 ---   work (":w filename" does work though).
---- both:    The buffer is never considered to be `|'modified'|`.
+--- both:    The buffer is never considered to be ['modified'](help://'modified').
 ---   There is no warning when the changes will be lost, for
 ---   example when you quit Vim.
 --- both:    A swap file is only created when using too much memory
 ---   (when 'swapfile' has been reset there is never a swap
 ---   file).
 --- nofile only:  The buffer name is fixed, it is not handled like a
----   file name.  It is not modified in response to a `|:cd|`
+---   file name.  It is not modified in response to a [:cd](help://:cd)
 ---   command.
 --- both:    When using ":e bufname" and already editing "bufname"
 ---   the buffer is made empty and autocommands are
----   triggered as usual for `|:edit|`.
+---   triggered as usual for [:edit](help://:edit).
 ---           *E676*
 --- "acwrite" implies that the buffer name is not related to a file, like
 --- "nofile", but it will be written.  Thus, in contrast to "nofile" and
 --- "nowrite", ":w" does work and a modified buffer can't be abandoned
---- without saving.  For writing there must be matching `|BufWriteCmd|,
---- |FileWriteCmd|` or `|FileAppendCmd|` autocommands.
+--- without saving.  For writing there must be matching [BufWriteCmd|,
+--- |FileWriteCmd](help://BufWriteCmd|,
+--- |FileWriteCmd) or [FileAppendCmd](help://FileAppendCmd) autocommands.
 ---
 --- @type string
 vim.o.buftype = ""
@@ -687,8 +688,8 @@ vim.o.cmp = vim.o.casemap
 vim.go.casemap = vim.o.casemap
 vim.go.cmp = vim.go.casemap
 
---- When on, `|:cd|`, `|:tcd|` and `|:lcd|` without an argument changes the
---- current working directory to the `|$HOME|` directory like in Unix.
+--- When on, [:cd](help://:cd), [:tcd](help://:tcd) and [:lcd](help://:lcd) without an argument changes the
+--- current working directory to the [$HOME](help://$HOME) directory like in Unix.
 --- When off, those commands just print the current directory name.
 --- On Unix this option has no effect.
 ---
@@ -699,11 +700,11 @@ vim.go.cdhome = vim.o.cdhome
 vim.go.cdh = vim.go.cdhome
 
 --- This is a list of directories which will be searched when using the
---- `|:cd|`, `|:tcd|` and `|:lcd|` commands, provided that the directory being
+--- [:cd](help://:cd), [:tcd](help://:tcd) and [:lcd](help://:lcd) commands, provided that the directory being
 --- searched for has a relative path, not an absolute part starting with
 --- "/", "./" or "../", the 'cdpath' option is not used then.
 --- The 'cdpath' option's value has the same form and semantics as
---- `|'path'|`.  Also see `|file-searching|`.
+--- ['path'](help://'path').  Also see [file-searching](help://file-searching).
 --- The default value is taken from $CDPATH, with a "," prepended to look
 --- in the current directory first.
 --- If the default value taken from $CDPATH is not what you want, include
@@ -712,7 +713,7 @@ vim.go.cdh = vim.go.cdhome
 --- ```
 --- :let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
 --- ```
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 --- (parts of 'cdpath' can be passed to the shell to expand file names).
 ---
@@ -730,15 +731,15 @@ vim.go.cd = vim.go.cdpath
 --- :exe "set cedit=\\<C-Y>"
 --- :exe "set cedit=\\<Esc>"
 --- ```
---- `|Nvi|` also has this option, but it only uses the first character.
---- See `|cmdwin|`.
+--- [Nvi](help://Nvi) also has this option, but it only uses the first character.
+--- See [cmdwin](help://cmdwin).
 ---
 --- @type string
 vim.o.cedit = "\6"
 vim.go.cedit = vim.o.cedit
 
---- `|channel|` connected to the buffer, or 0 if no channel is connected.
---- In a `|:terminal|` buffer this is the terminal channel.
+--- [channel](help://channel) connected to the buffer, or 0 if no channel is connected.
+--- In a [:terminal](help://:terminal) buffer this is the terminal channel.
 --- Read-only.
 ---
 --- @type integer
@@ -751,11 +752,11 @@ vim.bo.channel = vim.o.channel
 --- 'charconvert' is not used when the internal iconv() function is
 --- supported and is able to do the conversion.  Using iconv() is
 --- preferred, because it is much faster.
---- 'charconvert' is not used when reading stdin `|--|`, because there is no
+--- 'charconvert' is not used when reading stdin [--](help://--), because there is no
 --- file to convert from.  You will have to save the text in a file first.
 --- The expression must return zero, false or an empty string for success,
 --- non-zero or true for failure.
---- See `|encoding-names|` for possible encoding names.
+--- See [encoding-names](help://encoding-names) for possible encoding names.
 --- Additionally, names given in 'fileencodings' and 'fileencoding' are
 --- used.
 --- Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
@@ -777,7 +778,7 @@ vim.bo.channel = vim.o.channel
 --- v:fname_in    name of the input file
 --- v:fname_out    name of the output file
 --- Note that v:fname_in and v:fname_out will never be the same.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -793,7 +794,7 @@ vim.go.ccv = vim.go.charconvert
 --- If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
 --- the "=" operator indents using this algorithm rather than calling an
 --- external program.
---- See `|C-indenting|`.
+--- See [C-indenting](help://C-indenting).
 --- When you don't like the way 'cindent' works, try the 'smartindent'
 --- option or 'indentexpr'.
 ---
@@ -806,8 +807,8 @@ vim.bo.cin = vim.bo.cindent
 --- A list of keys that, when typed in Insert mode, cause reindenting of
 --- the current line.  Only used if 'cindent' is on and 'indentexpr' is
 --- empty.
---- For the format of this option see `|cinkeys-format|`.
---- See `|C-indenting|`.
+--- For the format of this option see [cinkeys-format](help://cinkeys-format).
+--- See [C-indenting](help://C-indenting).
 ---
 --- @type string
 vim.o.cinkeys = "0{,0},0),0],:,0#,!^F,o,O,e"
@@ -816,8 +817,8 @@ vim.bo.cinkeys = vim.o.cinkeys
 vim.bo.cink = vim.bo.cinkeys
 
 --- The 'cinoptions' affect the way 'cindent' reindents lines in a C
---- program.  See `|cinoptions-values|` for the values of this option, and
---- `|C-indenting|` for info on C indenting in general.
+--- program.  See [cinoptions-values](help://cinoptions-values) for the values of this option, and
+--- [C-indenting](help://C-indenting) for info on C indenting in general.
 ---
 --- @type string
 vim.o.cinoptions = ""
@@ -825,7 +826,7 @@ vim.o.cino = vim.o.cinoptions
 vim.bo.cinoptions = vim.o.cinoptions
 vim.bo.cino = vim.bo.cinoptions
 
---- Keywords that are interpreted as a C++ scope declaration by `|cino-g|`.
+--- Keywords that are interpreted as a C++ scope declaration by [cino-g](help://cino-g).
 --- Useful e.g. for working with the Qt framework that defines additional
 --- scope declarations "signals", "public slots" and "private slots":
 --- ```
@@ -862,17 +863,17 @@ vim.bo.cinw = vim.bo.cinwords
 --- used regardless of whether "unnamed" is in 'clipboard'
 --- or not.  The clipboard register can always be
 --- explicitly accessed using the "* notation.  Also see
---- `|clipboard|`.
+--- [clipboard](help://clipboard).
 ---
 ---       *clipboard-unnamedplus*
 --- unnamedplus  A variant of the "unnamed" flag which uses the
---- clipboard register "+" (`|quoteplus|`) instead of
+--- clipboard register "+" ([quoteplus](help://quoteplus)) instead of
 --- register "*" for all yank, delete, change and put
 --- operations which would normally go to the unnamed
 --- register.  When "unnamed" is also included to the
 --- option, yank and delete operations (but not put)
 --- will additionally copy the text into register
---- "*". See `|clipboard|`.
+--- "*". See [clipboard](help://clipboard).
 ---
 --- @type string
 vim.o.clipboard = ""
@@ -881,7 +882,7 @@ vim.go.clipboard = vim.o.clipboard
 vim.go.cb = vim.go.clipboard
 
 --- Number of screen lines to use for the command-line.  Helps avoiding
---- `|hit-enter|` prompts.
+--- [hit-enter](help://hit-enter) prompts.
 --- The value of this option is stored with the tab page, so that each tab
 --- page can have a different value.
 ---
@@ -901,7 +902,7 @@ vim.o.ch = vim.o.cmdheight
 vim.go.cmdheight = vim.o.cmdheight
 vim.go.ch = vim.go.cmdheight
 
---- Number of screen lines to use for the command-line window. `|cmdwin|`
+--- Number of screen lines to use for the command-line window. [cmdwin](help://cmdwin)
 ---
 --- @type integer
 vim.o.cmdwinheight = 7
@@ -910,7 +911,7 @@ vim.go.cmdwinheight = vim.o.cmdwinheight
 vim.go.cwh = vim.go.cmdwinheight
 
 --- 'colorcolumn' is a comma-separated list of screen columns that are
---- highlighted with ColorColumn `|hl-ColorColumn|`.  Useful to align
+--- highlighted with ColorColumn [hl-ColorColumn](help://hl-ColorColumn).  Useful to align
 --- text.  Will make screen redrawing slower.
 --- The screen column can be an absolute number, or a number preceded with
 --- '+' or '-', which is added to or subtracted from 'textwidth'.
@@ -932,7 +933,7 @@ vim.wo.cc = vim.wo.colorcolumn
 --- initialization and does not have to be set by hand.
 --- When Vim is running in the GUI or in a resizable window, setting this
 --- option will cause the window size to be changed.  When you only want
---- to use the size for the GUI, put the command in your `|ginit.vim|` file.
+--- to use the size for the GUI, put the command in your [ginit.vim](help://ginit.vim) file.
 --- When you set this option and Vim is unable to change the physical
 --- number of columns of the display, the display may be messed up.  For
 --- the GUI it is always possible and Vim limits the number of columns to
@@ -950,7 +951,7 @@ vim.go.columns = vim.o.columns
 vim.go.co = vim.go.columns
 
 --- A comma-separated list of strings that can start a comment line.  See
---- `|format-comments|`.  See `|option-backslash|` about using backslashes to
+--- [format-comments](help://format-comments).  See [option-backslash](help://option-backslash) about using backslashes to
 --- insert a space.
 ---
 --- @type string
@@ -961,7 +962,7 @@ vim.bo.com = vim.bo.comments
 
 --- A template for a comment.  The "%s" in the value is replaced with the
 --- comment text.  For example, C uses "/*%s*/". Currently only used to
---- add markers for folding, see `|fold-marker|`.
+--- add markers for folding, see [fold-marker](help://fold-marker).
 ---
 --- @type string
 vim.o.commentstring = ""
@@ -969,9 +970,9 @@ vim.o.cms = vim.o.commentstring
 vim.bo.commentstring = vim.o.commentstring
 vim.bo.cms = vim.bo.commentstring
 
---- This option specifies how keyword completion `|ins-completion|` works
+--- This option specifies how keyword completion [ins-completion](help://ins-completion) works
 --- when CTRL-P or CTRL-N are used.  It is also used for whole-line
---- completion `|i_CTRL-X_CTRL-L|`.  It indicates the type of completion
+--- completion [i_CTRL-X_CTRL-L](help://i_CTRL-X_CTRL-L).  It indicates the type of completion
 --- and the places to scan.  It is a comma-separated list of flags:
 --- .  scan the current buffer ('wrapscan' is ignored)
 --- w  scan buffers from other windows
@@ -979,7 +980,7 @@ vim.bo.cms = vim.bo.commentstring
 --- u  scan the unloaded buffers that are in the buffer list
 --- U  scan the buffers that are not in the buffer list
 --- k  scan the files given with the 'dictionary' option
---- kspell  use the currently active spell checking `|spell|`
+--- kspell  use the currently active spell checking [spell](help://spell)
 --- k{dict}  scan the file {dict}.  Several "k" flags can be given,
 --- patterns are valid too.  For example:
 --- ```
@@ -990,18 +991,18 @@ vim.bo.cms = vim.bo.commentstring
 --- are valid too.
 --- i  scan current and included files
 --- d  scan current and included files for defined name or macro
---- `|i_CTRL-X_CTRL-D|`
+--- [i_CTRL-X_CTRL-D](help://i_CTRL-X_CTRL-D)
 --- ]  tag completion
 --- t  same as "]"
 ---
---- Unloaded buffers are not loaded, thus their autocmds `|:autocmd|` are
+--- Unloaded buffers are not loaded, thus their autocmds [:autocmd](help://:autocmd) are
 --- not executed, this may lead to unexpected completions from some files
 --- (gzipped files for example).  Unloaded buffers are not scanned for
 --- whole-line completion.
 ---
 --- As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
---- based expansion (e.g., dictionary `|i_CTRL-X_CTRL-K|`, included patterns
---- `|i_CTRL-X_CTRL-I|`, tags `|i_CTRL-X_CTRL-]|` and normal expansions).
+--- based expansion (e.g., dictionary [i_CTRL-X_CTRL-K](help://i_CTRL-X_CTRL-K), included patterns
+--- [i_CTRL-X_CTRL-I](help://i_CTRL-X_CTRL-I), tags [i_CTRL-X_CTRL-]](help://i_CTRL-X_CTRL-]) and normal expansions).
 ---
 --- @type string
 vim.o.complete = ".,w,b,u,t"
@@ -1010,12 +1011,12 @@ vim.bo.complete = vim.o.complete
 vim.bo.cpt = vim.bo.complete
 
 --- This option specifies a function to be used for Insert mode completion
---- with CTRL-X CTRL-U. `|i_CTRL-X_CTRL-U|`
---- See `|complete-functions|` for an explanation of how the function is
+--- with CTRL-X CTRL-U. [i_CTRL-X_CTRL-U](help://i_CTRL-X_CTRL-U)
+--- See [complete-functions](help://complete-functions) for an explanation of how the function is
 --- invoked and what it should return.  The value can be the name of a
---- function, a `|lambda|` or a `|Funcref|`. See `|option-value-function|` for
+--- function, a [lambda](help://lambda) or a [Funcref](help://Funcref). See [option-value-function](help://option-value-function) for
 --- more information.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -1025,11 +1026,11 @@ vim.bo.completefunc = vim.o.completefunc
 vim.bo.cfu = vim.bo.completefunc
 
 --- A comma-separated list of options for Insert mode completion
---- `|ins-completion|`.  The supported values are:
+--- [ins-completion](help://ins-completion).  The supported values are:
 ---
 ---  menu      Use a popup menu to show the possible completions.  The
 ---     menu is only shown when there is more than one match and
----     sufficient colors are available.  `|ins-completion-menu|`
+---     sufficient colors are available.  [ins-completion-menu](help://ins-completion-menu)
 ---
 ---  menuone  Use the popup menu also when there is only one match.
 ---     Useful when there is additional information about the
@@ -1099,19 +1100,19 @@ vim.o.cocu = vim.o.concealcursor
 vim.wo.concealcursor = vim.o.concealcursor
 vim.wo.cocu = vim.wo.concealcursor
 
---- Determine how text with the "conceal" syntax attribute `|:syn-conceal|`
+--- Determine how text with the "conceal" syntax attribute [:syn-conceal](help://:syn-conceal)
 --- is shown:
 ---
 --- Value    Effect ~
 --- 0    Text is shown normally
 --- 1    Each block of concealed text is replaced with one
 --- character.  If the syntax item does not have a custom
---- replacement character defined (see `|:syn-cchar|`) the
+--- replacement character defined (see [:syn-cchar](help://:syn-cchar)) the
 --- character defined in 'listchars' is used.
 --- It is highlighted with the "Conceal" highlight group.
 --- 2    Concealed text is completely hidden unless it has a
 --- custom replacement character defined (see
---- `|:syn-cchar|`).
+--- [:syn-cchar](help://:syn-cchar)).
 --- 3    Concealed text is completely hidden.
 ---
 --- Note: in the cursor line concealed text is not hidden, so that you can
@@ -1127,11 +1128,11 @@ vim.wo.cole = vim.wo.conceallevel
 --- When 'confirm' is on, certain operations that would normally
 --- fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
 --- instead raise a dialog asking if you wish to save the current
---- file(s).  You can still use a ! to unconditionally `|abandon|` a buffer.
+--- file(s).  You can still use a ! to unconditionally [abandon](help://abandon) a buffer.
 --- If 'confirm' is off you can still activate confirmation for one
---- command only (this is most useful in mappings) with the `|:confirm|`
+--- command only (this is most useful in mappings) with the [:confirm](help://:confirm)
 --- command.
---- Also see the `|confirm()|` function and the 'v' flag in 'guioptions'.
+--- Also see the [confirm()](help://confirm()) function and the 'v' flag in 'guioptions'.
 ---
 --- @type boolean
 vim.o.confirm = false
@@ -1141,7 +1142,7 @@ vim.go.cf = vim.go.confirm
 
 --- Copy the structure of the existing lines indent when autoindenting a
 --- new line.  Normally the new indent is reconstructed by a series of
---- tabs followed by spaces as required (unless `|'expandtab'|` is enabled,
+--- tabs followed by spaces as required (unless ['expandtab'](help://'expandtab') is enabled,
 --- in which case only spaces are used).  Enabling this option makes the
 --- new line copy whatever characters were used for indenting on the
 --- existing line.  'expandtab' has no effect on these characters, a Tab
@@ -1161,7 +1162,7 @@ vim.bo.ci = vim.bo.copyindent
 --- 'cpoptions' stands for "compatible-options".
 --- Commas can be added for readability.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `|add-option-flags|`.
+--- "+=" and "-=" feature of ":set" [add-option-flags](help://add-option-flags).
 ---
 ---   contains  behavior  ~
 ---             *cpo-a*
@@ -1179,7 +1180,7 @@ vim.bo.ci = vim.bo.copyindent
 ---   command.  Use a CTRL-V instead of a backslash to
 ---   include the '|' in the mapping.  Applies to all
 ---   mapping, abbreviation, menu and autocmd commands.
----   See also `|map_bar|`.
+---   See also [map_bar](help://map_bar).
 ---             *cpo-B*
 --- B  A backslash has no special meaning in mappings,
 ---   abbreviations, user commands and the "to" part of the
@@ -1197,15 +1198,15 @@ vim.bo.ci = vim.bo.copyindent
 ---   "/abab", without 'c' there are five matches.
 ---             *cpo-C*
 --- C  Do not concatenate sourced lines that start with a
----   backslash.  See `|line-continuation|`.
+---   backslash.  See [line-continuation](help://line-continuation).
 ---             *cpo-d*
 --- d  Using "./" in the 'tags' option doesn't mean to use
 ---   the tags file relative to the current file, but the
 ---   tags file in the current directory.
 ---             *cpo-D*
 --- D  Can't use CTRL-K to enter a digraph after Normal mode
----   commands with a character argument, like `|r|`, `|f|` and
----   `|t|`.
+---   commands with a character argument, like [r](help://r), [f](help://f) and
+---   [t](help://t).
 ---             *cpo-e*
 --- e  When executing a register with ":@r", always add a
 ---   <CR> to the last line, also when the register is not
@@ -1226,7 +1227,7 @@ vim.bo.ci = vim.bo.copyindent
 --- F  When included, a ":write" command with a file name
 ---   argument will set the file name for the current
 ---   buffer, if the current buffer doesn't have a file name
----   yet.  Also see `|cpo-P|`.
+---   yet.  Also see [cpo-P](help://cpo-P).
 ---             *cpo-i*
 --- i  When included, interrupting the reading of a file will
 ---   leave it modified.
@@ -1234,7 +1235,7 @@ vim.bo.ci = vim.bo.copyindent
 --- I  When moving the cursor up or down just after inserting
 ---   indent for 'autoindent', do not delete the indent.
 ---             *cpo-J*
---- J  A `|sentence|` has to be followed by two spaces after
+--- J  A [sentence](help://sentence) has to be followed by two spaces after
 ---   the '.', '!' or '?'.  A <Tab> is not recognized as
 ---   white space.
 ---             *cpo-K*
@@ -1246,18 +1247,18 @@ vim.bo.ci = vim.bo.copyindent
 ---             *cpo-l*
 --- l  Backslash in a [] range in a search pattern is taken
 ---   literally, only "\]", "\^", "\-" and "\\" are special.
----   See `|/[]|`
+---   See [/[]](help:///[])
 ---      'l' included: "/[ \t]"  finds <Space>, '\' and 't'
 ---      'l' excluded: "/[ \t]"  finds <Space> and <Tab>
 ---             *cpo-L*
 --- L  When the 'list' option is set, 'wrapmargin',
 ---   'textwidth', 'softtabstop' and Virtual Replace mode
----   (see `|gR|`) count a <Tab> as two characters, instead of
+---   (see [gR](help://gR)) count a <Tab> as two characters, instead of
 ---   the normal behavior of a <Tab>.
 ---             *cpo-m*
 --- m  When included, a showmatch will always wait half a
 ---   second.  When not included, a showmatch will wait half
----   a second or until a character is typed.  `|'showmatch'|`
+---   a second or until a character is typed.  ['showmatch'](help://'showmatch')
 ---             *cpo-M*
 --- M  When excluded, "%" matching will take backslashes into
 ---   account.  Thus in "( \( )" and "\( ( \)" the outer
@@ -1282,7 +1283,7 @@ vim.bo.ci = vim.bo.copyindent
 --- P  When included, a ":write" command that appends to a
 ---   file will set the file name for the current buffer, if
 ---   the current buffer doesn't have a file name yet and
----   the 'F' flag is also included `|cpo-F|`.
+---   the 'F' flag is also included [cpo-F](help://cpo-F).
 ---             *cpo-q*
 --- q  When joining multiple lines leave the cursor at the
 ---   position where it would be when joining two lines.
@@ -1291,7 +1292,7 @@ vim.bo.ci = vim.bo.copyindent
 ---   command, instead of the actually used search string.
 ---             *cpo-R*
 --- R  Remove marks from filtered lines.  Without this flag
----   marks are kept like `|:keepmarks|` was used.
+---   marks are kept like [:keepmarks](help://:keepmarks) was used.
 ---             *cpo-s*
 --- s  Set buffer options when entering the buffer for the
 ---   first time.  This is like it is in Vim version 3.0.
@@ -1316,7 +1317,7 @@ vim.bo.ci = vim.bo.copyindent
 ---   the history for search pattern, but doesn't change the
 ---   last used search pattern.
 ---             *cpo-u*
---- u  Undo is Vi compatible.  See `|undo-two-ways|`.
+--- u  Undo is Vi compatible.  See [undo-two-ways](help://undo-two-ways).
 ---             *cpo-v*
 --- v  Backspaced characters remain visible on the screen in
 ---   Insert mode.  Without this flag the characters are
@@ -1329,7 +1330,7 @@ vim.bo.ci = vim.bo.copyindent
 ---             *cpo-x*
 --- x  <Esc> on the command-line executes the command-line.
 ---   The default in Vim is to abandon the command-line,
----   because <Esc> normally aborts a command.  `|c_<Esc>|`
+---   because <Esc> normally aborts a command.  [c_<Esc>](help://c_<Esc>)
 ---             *cpo-X*
 --- X  When using a count with "R" the replaced text is
 ---   deleted only once.  Also when repeating "R" with "."
@@ -1377,13 +1378,13 @@ vim.bo.ci = vim.bo.copyindent
 --- >  When appending to a register, put a line break before
 ---   the appended text.
 ---             *cpo-;*
---- ;  When using `|,|` or `|;|` to repeat the last `|t|` search
+--- ;  When using [,](help://,) or [;](help://;) to repeat the last [t](help://t) search
 ---   and the cursor is right in front of the searched
 ---   character, the cursor won't move. When not included,
 ---   the cursor would skip over it and jump to the
 ---   following occurrence.
 ---             *cpo-_*
---- _  When using `|cw|` on a word, do not include the
+--- _  When using [cw](help://cw) on a word, do not include the
 ---   whitespace following the word in the motion.
 ---
 --- @type string
@@ -1407,7 +1408,7 @@ vim.wo.cursorbind = vim.o.cursorbind
 vim.wo.crb = vim.wo.cursorbind
 
 --- Highlight the screen column of the cursor with CursorColumn
---- `|hl-CursorColumn|`.  Useful to align text.  Will make screen redrawing
+--- [hl-CursorColumn](help://hl-CursorColumn).  Useful to align text.  Will make screen redrawing
 --- slower.
 --- If you only want the highlighting in the current window you can use
 --- these autocommands:
@@ -1422,7 +1423,7 @@ vim.o.cuc = vim.o.cursorcolumn
 vim.wo.cursorcolumn = vim.o.cursorcolumn
 vim.wo.cuc = vim.wo.cursorcolumn
 
---- Highlight the text line of the cursor with CursorLine `|hl-CursorLine|`.
+--- Highlight the text line of the cursor with CursorLine [hl-CursorLine](help://hl-CursorLine).
 --- Useful to easily spot the cursor.  Will make screen redrawing slower.
 --- When Visual mode is active the highlighting isn't used to make it
 --- easier to see the selected text.
@@ -1436,11 +1437,11 @@ vim.wo.cul = vim.wo.cursorline
 --- Comma-separated list of settings for how 'cursorline' is displayed.
 --- Valid values:
 --- "line"    Highlight the text line of the cursor with
---- CursorLine `|hl-CursorLine|`.
+--- CursorLine [hl-CursorLine](help://hl-CursorLine).
 --- "screenline"  Highlight only the screen line of the cursor with
---- CursorLine `|hl-CursorLine|`.
+--- CursorLine [hl-CursorLine](help://hl-CursorLine).
 --- "number"  Highlight the line number of the cursor with
---- CursorLineNr `|hl-CursorLineNr|`.
+--- CursorLineNr [hl-CursorLineNr](help://hl-CursorLineNr).
 ---
 --- Special value:
 --- "both"    Alias for the values "line,number".
@@ -1457,7 +1458,7 @@ vim.wo.culopt = vim.wo.cursorlineopt
 --- msg  Error messages that would otherwise be omitted will be given
 --- anyway.
 --- throw  Error messages that would otherwise be omitted will be given
---- anyway and also throw an exception and set `|v:errmsg|`.
+--- anyway and also throw an exception and set [v:errmsg](help://v:errmsg).
 --- beep  A message will be given when otherwise only a beep would be
 --- produced.
 --- The values can be combined, separated by a comma.
@@ -1470,12 +1471,12 @@ vim.go.debug = vim.o.debug
 
 --- Pattern to be used to find a macro definition.  It is a search
 --- pattern, just like for the "/" command.  This option is used for the
---- commands like "[i" and "[d" `|include-search|`.  The 'isident' option is
+--- commands like "[i" and "[d" [include-search](help://include-search).  The 'isident' option is
 --- used to recognize the defined name after the match:
 --- ```
 --- {match with 'define'}{non-ID chars}{defined name}{non-ID char}
 --- ```
---- See `|option-backslash|` about inserting backslashes to include a space
+--- See [option-backslash](help://option-backslash) about inserting backslashes to include a space
 --- or backslash.
 --- For C++ this value would be useful, to include const type declarations:
 --- ```
@@ -1522,24 +1523,24 @@ vim.go.delcombine = vim.o.delcombine
 vim.go.deco = vim.go.delcombine
 
 --- List of file names, separated by commas, that are used to lookup words
---- for keyword completion commands `|i_CTRL-X_CTRL-K|`.  Each file should
+--- for keyword completion commands [i_CTRL-X_CTRL-K](help://i_CTRL-X_CTRL-K).  Each file should
 --- contain a list of words.  This can be one word per line, or several
 --- words per line, separated by non-keyword characters (white space is
 --- preferred).  Maximum line length is 510 bytes.
 ---
 --- When this option is empty or an entry "spell" is present, and spell
 --- checking is enabled, words in the word lists for the currently active
---- 'spelllang' are used. See `|spell|`.
+--- 'spelllang' are used. See [spell](help://spell).
 ---
 --- To include a comma in a file name precede it with a backslash.  Spaces
 --- after a comma are ignored, otherwise spaces are included in the file
---- name.  See `|option-backslash|` about using backslashes.
---- This has nothing to do with the `|Dictionary|` variable type.
+--- name.  See [option-backslash](help://option-backslash) about using backslashes.
+--- This has nothing to do with the [Dictionary](help://Dictionary) variable type.
 --- Where to find a list of words?
 --- - BSD/macOS include the "/usr/share/dict/words" file.
 --- - Try "apt install spell" to get the "/usr/share/dict/words" file on
 --- apt-managed systems (Debian/Ubuntu).
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.
 --- Backticks cannot be used in this option for security reasons.
@@ -1553,15 +1554,15 @@ vim.go.dictionary = vim.o.dictionary
 vim.go.dict = vim.go.dictionary
 
 --- Join the current window in the group of windows that shows differences
---- between files.  See `|diff-mode|`.
+--- between files.  See [diff-mode](help://diff-mode).
 ---
 --- @type boolean
 vim.o.diff = false
 vim.wo.diff = vim.o.diff
 
 --- Expression which is evaluated to obtain a diff file (either ed-style
---- or unified-style) from two versions of a file.  See `|diff-diffexpr|`.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- or unified-style) from two versions of a file.  See [diff-diffexpr](help://diff-diffexpr).
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -1586,7 +1587,7 @@ vim.go.dex = vim.go.diffexpr
 ---     since folds require a line in between, also
 ---     for a deleted line. Set it to a very large
 ---     value (999999) to disable folding completely.
----     See `|fold-diff|`.
+---     See [fold-diff](help://fold-diff).
 ---
 --- iblank    Ignore changes where lines are all blank.  Adds
 ---     the "-B" flag to the "diff" command if
@@ -1685,7 +1686,7 @@ vim.go.diffopt = vim.o.diffopt
 vim.go.dip = vim.go.diffopt
 
 --- Enable the entering of digraphs in Insert mode with {char1} <BS>
---- {char2}.  See `|digraphs|`.
+--- {char2}.  See [digraphs](help://digraphs).
 ---
 --- @type boolean
 vim.o.digraph = false
@@ -1700,7 +1701,7 @@ vim.go.dg = vim.go.digraph
 --- possible.  If it is not possible in any directory, but last
 --- directory listed in the option does not exist, it is created.
 --- - Empty means that no swap file will be used (recovery is
---- impossible!) and no `|E303|` error will be given.
+--- impossible!) and no [E303](help://E303) error will be given.
 --- - A directory "." means to put the swap file in the same directory as
 --- the edited file.  On Unix, a dot is prepended to the file name, so
 --- it doesn't show in a directory listing.  On MS-Windows the "hidden"
@@ -1722,19 +1723,19 @@ vim.go.dg = vim.go.digraph
 --- name, precede it with a backslash.
 --- - To include a comma in a directory name precede it with a backslash.
 --- - A directory name may end in an ':' or '/'.
---- - Environment variables are expanded `|:set_env|`.
+--- - Environment variables are expanded [:set_env](help://:set_env).
 --- - Careful with '\' characters, type one before a space, type two to
---- get one in the option (see `|option-backslash|`), for example:
+--- get one in the option (see [option-backslash](help://option-backslash)), for example:
 --- ```
 ---   :set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 --- ```
 --- Editing the same file twice will result in a warning.  Using "/tmp" on
 --- is discouraged: if the system crashes you lose the swap file. And
 --- others on the computer may be able to see the files.
---- Use `|:set+=|` and `|:set-=|` when adding or removing directories from the
+--- Use [:set+=](help://:set+=) and [:set-=](help://:set-=) when adding or removing directories from the
 --- list, this avoids problems if the Nvim default is changed.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -1753,13 +1754,13 @@ vim.go.dir = vim.go.directory
 --- column of the last screen line.  Overrules "lastline".
 --- uhex    Show unprintable characters hexadecimal as <xx>
 --- instead of using ^C and ~C.
---- msgsep    Obsolete flag. Allowed but takes no effect. `|msgsep|`
+--- msgsep    Obsolete flag. Allowed but takes no effect. [msgsep](help://msgsep)
 ---
 --- When neither "lastline" nor "truncate" is included, a last line that
 --- doesn't fit is replaced with "@" lines.
 ---
 --- The "@" character can be changed by setting the "lastline" item in
---- 'fillchars'.  The character is highlighted with `|hl-NonText|`.
+--- 'fillchars'.  The character is highlighted with [hl-NonText](help://hl-NonText).
 ---
 --- @type string
 vim.o.display = "lastline"
@@ -1782,7 +1783,7 @@ vim.go.ead = vim.go.eadirection
 --- This excludes "text emoji" characters, which are normally displayed as
 --- single width.  Unfortunately there is no good specification for this
 --- and it has been determined on trial-and-error basis.  Use the
---- `|setcellwidths()|` function to change the behavior.
+--- [setcellwidths()](help://setcellwidths()) function to change the behavior.
 ---
 --- @type boolean
 vim.o.emoji = true
@@ -1790,7 +1791,7 @@ vim.o.emo = vim.o.emoji
 vim.go.emoji = vim.o.emoji
 vim.go.emo = vim.go.emoji
 
---- String-encoding used internally and for `|RPC|` communication.
+--- String-encoding used internally and for [RPC](help://RPC) communication.
 --- Always UTF-8.
 ---
 --- See 'fileencoding' to control file-content encoding.
@@ -1806,7 +1807,7 @@ vim.go.enc = vim.go.encoding
 --- When writing a file and this option is off and the 'binary' option
 --- is on, or 'fixeol' option is off, no CTRL-Z will be written at the
 --- end of the file.
---- See `|eol-and-eof|` for example settings.
+--- See [eol-and-eof](help://eol-and-eof) for example settings.
 ---
 --- @type boolean
 vim.o.endoffile = false
@@ -1825,7 +1826,7 @@ vim.bo.eof = vim.bo.endoffile
 --- to remember the presence of a <EOL> for the last line in the file, so
 --- that when you write the file the situation from the original file can
 --- be kept.  But you can change it if you want to.
---- See `|eol-and-eof|` for example settings.
+--- See [eol-and-eof](help://eol-and-eof) for example settings.
 ---
 --- @type boolean
 vim.o.endofline = true
@@ -1857,9 +1858,9 @@ vim.go.ea = vim.go.equalalways
 --- External program to use for "=" command.  When this option is empty
 --- the internal formatting functions are used; either 'lisp', 'cindent'
 --- or 'indentexpr'.
---- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
+--- Environment variables are expanded [:set_env](help://:set_env).  See [option-backslash](help://option-backslash)
 --- about including spaces and backslashes.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -1882,13 +1883,13 @@ vim.o.eb = vim.o.errorbells
 vim.go.errorbells = vim.o.errorbells
 vim.go.eb = vim.go.errorbells
 
---- Name of the errorfile for the QuickFix mode (see `|:cf|`).
+--- Name of the errorfile for the QuickFix mode (see [:cf](help://:cf)).
 --- When the "-q" command-line argument is used, 'errorfile' is set to the
---- following argument.  See `|-q|`.
+--- following argument.  See [-q](help://-q).
 --- NOT used for the ":make" command.  See 'makeef' for that.
---- Environment variables are expanded `|:set_env|`.
---- See `|option-backslash|` about including spaces and backslashes.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- Environment variables are expanded [:set_env](help://:set_env).
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -1898,7 +1899,7 @@ vim.go.errorfile = vim.o.errorfile
 vim.go.ef = vim.go.errorfile
 
 --- Scanf-like description of the format for the lines in the error file
---- (see `|errorformat|`).
+--- (see [errorformat](help://errorformat)).
 ---
 --- @type string
 vim.o.errorformat = "%*[^\"]\"%f\"%*\\D%l: %m,\"%f\"%*\\D%l: %m,%-Gg%\\?make[%*\\d]: *** [%f:%l:%m,%-Gg%\\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,\"%f\"\\, line %l%*\\D%c%*[^ ] %m,%D%*\\a[%*\\d]: Entering directory %*[`']%f',%X%*\\a[%*\\d]: Leaving directory %*[`']%f',%D%*\\a: Entering directory %*[`']%f',%X%*\\a: Leaving directory %*[`']%f',%DMaking %*\\a in %f,%f|%l| %m"
@@ -1925,7 +1926,7 @@ vim.go.ei = vim.go.eventignore
 --- In Insert mode: Use the appropriate number of spaces to insert a
 --- <Tab>.  Spaces are used in indents with the '>' and '<' commands and
 --- when 'autoindent' is on.  To insert a real tab when 'expandtab' is
---- on, use CTRL-V<Tab>.  See also `|:retab|` and `|ins-expandtab|`.
+--- on, use CTRL-V<Tab>.  See also [:retab](help://:retab) and [ins-expandtab](help://ins-expandtab).
 ---
 --- @type boolean
 vim.o.expandtab = false
@@ -1934,14 +1935,14 @@ vim.bo.expandtab = vim.o.expandtab
 vim.bo.et = vim.bo.expandtab
 
 --- Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
---- current directory, if the file is in the `|trust|` list. Use `|:trust|` to
---- manage trusted files. See also `|vim.secure.read()|`.
+--- current directory, if the file is in the [trust](help://trust) list. Use [:trust](help://:trust) to
+--- manage trusted files. See also [vim.secure.read()](help://vim.secure.read()).
 ---
---- Compare 'exrc' to `|editorconfig|`:
+--- Compare 'exrc' to [editorconfig](help://editorconfig):
 --- - 'exrc' can execute any code; editorconfig only specifies settings.
 --- - 'exrc' is Nvim-specific; editorconfig works in other editors.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type boolean
@@ -1961,13 +1962,13 @@ vim.go.ex = vim.go.exrc
 --- WARNING: Conversion to a non-Unicode encoding can cause loss of
 --- information!
 ---
---- See `|encoding-names|` for the possible values.  Additionally, values may be
+--- See [encoding-names](help://encoding-names) for the possible values.  Additionally, values may be
 --- specified that can be handled by the converter, see
---- `|mbyte-conversion|`.
+--- [mbyte-conversion](help://mbyte-conversion).
 ---
 --- When reading a file 'fileencoding' will be set from 'fileencodings'.
 --- To read a file in a certain encoding it won't work by setting
---- 'fileencoding', use the `|++enc|` argument.  One exception: when
+--- 'fileencoding', use the [++enc](help://++enc) argument.  One exception: when
 --- 'fileencodings' is empty the value of 'fileencoding' is used.
 --- For a new file the global value of 'fileencoding' is used.
 ---
@@ -1975,7 +1976,7 @@ vim.go.ex = vim.go.exrc
 --- When the option is set, the value is converted to lowercase.  Thus
 --- you can set it with uppercase values too.  '_' characters are
 --- replaced with '-'.  If a name is recognized from the list at
---- `|encoding-names|`, it is replaced by the standard name.  For example
+--- [encoding-names](help://encoding-names), it is replaced by the standard name.  For example
 --- "ISO8859-2" becomes "iso-8859-2".
 ---
 --- When this option is set, after starting to edit a file, the 'modified'
@@ -2001,7 +2002,7 @@ vim.bo.fenc = vim.bo.fileencoding
 --- 'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
 --- an empty string, which means that UTF-8 is used.
 --- WARNING: Conversion can cause loss of information! You can use
---- the `|++bad|` argument to specify what is done with characters
+--- the [++bad](help://++bad) argument to specify what is done with characters
 --- that can't be converted.
 --- For an empty file or a file with only ASCII characters most encodings
 --- will work and the first entry of 'fileencodings' will be used (except
@@ -2014,7 +2015,7 @@ vim.bo.fenc = vim.bo.fileencoding
 --- ```
 --- This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
 --- non-blank characters.
---- When the `|++enc|` argument is used then the value of 'fileencodings' is
+--- When the [++enc](help://++enc) argument is used then the value of 'fileencodings' is
 --- not used.
 --- Note that 'fileencodings' is not used for a new file, the global value
 --- of 'fileencoding' is used instead.  You can set it with:
@@ -2033,7 +2034,7 @@ vim.bo.fenc = vim.bo.fileencoding
 --- environment.  It is useful when your environment uses a non-latin1
 --- encoding, such as Russian.
 --- When a file contains an illegal UTF-8 byte sequence it won't be
---- recognized as "utf-8".  You can use the `|8g8|` command to find the
+--- recognized as "utf-8".  You can use the [8g8](help://8g8) command to find the
 --- illegal byte sequence.
 --- WRONG VALUES:      WHAT'S WRONG:
 --- latin1,utf-8    "latin1" will always be used
@@ -2057,7 +2058,7 @@ vim.go.fencs = vim.go.fileencodings
 --- unix    <NL>
 --- mac      <CR>
 --- When "dos" is used, CTRL-Z at the end of a file is ignored.
---- See `|file-formats|` and `|file-read|`.
+--- See [file-formats](help://file-formats) and [file-read](help://file-read).
 --- For the character encoding of the file see 'fileencoding'.
 --- When 'binary' is set, the value of 'fileformat' is ignored, file I/O
 --- works like it was set to "unix".
@@ -2117,7 +2118,7 @@ vim.bo.ff = vim.bo.fileformat
 --- is done.  This is based on the first <NL> in the file: If there is a
 --- <CR> in front of it, Dos format is used, otherwise Unix format is
 --- used.
---- Also see `|file-formats|`.
+--- Also see [file-formats](help://file-formats).
 ---
 --- @type string
 vim.o.fileformats = "unix,dos"
@@ -2140,14 +2141,14 @@ vim.go.fic = vim.go.fileignorecase
 --- name.
 --- Otherwise this option does not always reflect the current file type.
 --- This option is normally set when the file type is detected.  To enable
---- this use the ":filetype on" command. `|:filetype|`
+--- this use the ":filetype on" command. [:filetype](help://:filetype)
 --- Setting this option to a different value is most useful in a modeline,
 --- for a file for which the file type is not automatically recognized.
 --- Example, for in an IDL file:
 --- ```
 --- /* vim: set filetype=idl : */
 --- ```
---- `|FileType|` `|filetypes|`
+--- [FileType](help://FileType) [filetypes](help://filetypes)
 --- When a dot appears in the value then this separates two filetype
 --- names.  Example:
 --- ```
@@ -2175,10 +2176,10 @@ vim.bo.ft = vim.bo.filetype
 --- stl    ' '    statusline of the current window
 --- stlnc    ' '    statusline of the non-current windows
 --- wbr    ' '    window bar
---- horiz    '─' or '-'  horizontal separators `|:split|`
+--- horiz    '─' or '-'  horizontal separators [:split](help://:split)
 --- horizup  '┴' or '-'  upwards facing horizontal separator
 --- horizdown  '┬' or '-'  downwards facing horizontal separator
---- vert    '│' or '|'  vertical separators `|:vsplit|`
+--- vert    '│' or '|'  vertical separators [:vsplit](help://:vsplit)
 --- vertleft  '┤' or '|'  left facing vertical separator
 --- vertright  '├' or '|'  right facing vertical separator
 --- verthoriz  '┼' or '+'  overlapping vertical and horizontal
@@ -2215,20 +2216,20 @@ vim.bo.ft = vim.bo.filetype
 ---
 --- The highlighting used for these items:
 --- item    highlight group ~
---- stl    StatusLine    `|hl-StatusLine|`
---- stlnc    StatusLineNC    `|hl-StatusLineNC|`
---- wbr    WinBar      `|hl-WinBar|` or `|hl-WinBarNC|`
---- horiz    WinSeparator    `|hl-WinSeparator|`
---- horizup  WinSeparator    `|hl-WinSeparator|`
---- horizdown  WinSeparator    `|hl-WinSeparator|`
---- vert    WinSeparator    `|hl-WinSeparator|`
---- vertleft  WinSeparator    `|hl-WinSeparator|`
---- vertright  WinSeparator    `|hl-WinSeparator|`
---- verthoriz  WinSeparator    `|hl-WinSeparator|`
---- fold    Folded      `|hl-Folded|`
---- diff    DiffDelete    `|hl-DiffDelete|`
---- eob    EndOfBuffer    `|hl-EndOfBuffer|`
---- lastline  NonText      `|hl-NonText|`
+--- stl    StatusLine    [hl-StatusLine](help://hl-StatusLine)
+--- stlnc    StatusLineNC    [hl-StatusLineNC](help://hl-StatusLineNC)
+--- wbr    WinBar      [hl-WinBar](help://hl-WinBar) or [hl-WinBarNC](help://hl-WinBarNC)
+--- horiz    WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- horizup  WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- horizdown  WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- vert    WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- vertleft  WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- vertright  WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- verthoriz  WinSeparator    [hl-WinSeparator](help://hl-WinSeparator)
+--- fold    Folded      [hl-Folded](help://hl-Folded)
+--- diff    DiffDelete    [hl-DiffDelete](help://hl-DiffDelete)
+--- eob    EndOfBuffer    [hl-EndOfBuffer](help://hl-EndOfBuffer)
+--- lastline  NonText      [hl-NonText](help://hl-NonText)
 ---
 --- @type string
 vim.o.fillchars = ""
@@ -2244,7 +2245,7 @@ vim.go.fcs = vim.go.fillchars
 --- When the 'binary' option is set the value of this option doesn't
 --- matter.
 --- See the 'endofline' option.
---- See `|eol-and-eof|` for example settings.
+--- See [eol-and-eof](help://eol-and-eof) for example settings.
 ---
 --- @type boolean
 vim.o.fixendofline = true
@@ -2268,7 +2269,7 @@ vim.go.fcl = vim.go.foldclose
 ---   selected level
 --- "0":          to disable foldcolumn
 --- "[1-9]":      to display a fixed number of columns
---- See `|folding|`.
+--- See [folding](help://folding).
 ---
 --- @type string
 vim.o.foldcolumn = "0"
@@ -2279,10 +2280,10 @@ vim.wo.fdc = vim.wo.foldcolumn
 --- When off, all folds are open.  This option can be used to quickly
 --- switch between showing all text unfolded and viewing the text with
 --- folds (including manually opened or closed folds).  It can be toggled
---- with the `|zi|` command.  The 'foldcolumn' will remain blank when
+--- with the [zi](help://zi) command.  The 'foldcolumn' will remain blank when
 --- 'foldenable' is off.
 --- This option is set by commands that create a new fold or close a fold.
---- See `|folding|`.
+--- See [folding](help://folding).
 ---
 --- @type boolean
 vim.o.foldenable = true
@@ -2293,15 +2294,15 @@ vim.wo.fen = vim.wo.foldenable
 --- The expression used for when 'foldmethod' is "expr".  It is evaluated
 --- for each line to obtain its fold level.  The context is set to the
 --- script where 'foldexpr' was set, script-local items can be accessed.
---- See `|fold-expr|` for the usage.
+--- See [fold-expr](help://fold-expr) for the usage.
 ---
---- The expression will be evaluated in the `|sandbox|` if set from a
---- modeline, see `|sandbox-option|`.
---- This option can't be set from a `|modeline|` when the 'diff' option is
+--- The expression will be evaluated in the [sandbox](help://sandbox) if set from a
+--- modeline, see [sandbox-option](help://sandbox-option).
+--- This option can't be set from a [modeline](help://modeline) when the 'diff' option is
 --- on or the 'modelineexpr' option is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'foldexpr' `|textlock|`.
+--- evaluating 'foldexpr' [textlock](help://textlock).
 ---
 --- @type string
 vim.o.foldexpr = "0"
@@ -2312,7 +2313,7 @@ vim.wo.fde = vim.wo.foldexpr
 --- Used only when 'foldmethod' is "indent".  Lines starting with
 --- characters in 'foldignore' will get their fold level from surrounding
 --- lines.  White space is skipped before checking for this character.
---- The default "#" works well for C programs.  See `|fold-indent|`.
+--- The default "#" works well for C programs.  See [fold-indent](help://fold-indent).
 ---
 --- @type string
 vim.o.foldignore = "#"
@@ -2323,8 +2324,8 @@ vim.wo.fdi = vim.wo.foldignore
 --- Sets the fold level: Folds with a higher level will be closed.
 --- Setting this option to zero will close all folds.  Higher numbers will
 --- close fewer folds.
---- This option is set by commands like `|zm|`, `|zM|` and `|zR|`.
---- See `|fold-foldlevel|`.
+--- This option is set by commands like [zm](help://zm), [zM](help://zM) and [zR](help://zR).
+--- See [fold-foldlevel](help://fold-foldlevel).
 ---
 --- @type integer
 vim.o.foldlevel = 0
@@ -2336,7 +2337,7 @@ vim.wo.fdl = vim.wo.foldlevel
 --- Useful to always start editing with all folds closed (value zero),
 --- some folds closed (one) or no folds closed (99).
 --- This is done before reading any modeline, thus a setting in a modeline
---- overrules this option.  Starting to edit a file for `|diff-mode|` also
+--- overrules this option.  Starting to edit a file for [diff-mode](help://diff-mode) also
 --- ignores this option and closes all folds.
 --- It is also done before BufReadPre autocommands, to allow an autocmd to
 --- overrule the 'foldlevel' value for specific files.
@@ -2351,7 +2352,7 @@ vim.go.fdls = vim.go.foldlevelstart
 --- The start and end marker used when 'foldmethod' is "marker".  There
 --- must be one comma, which separates the start and end marker.  The
 --- marker is a literal string (a regular expression would be too slow).
---- See `|fold-marker|`.
+--- See [fold-marker](help://fold-marker).
 ---
 --- @type string
 vim.o.foldmarker = "{{{,}}}"
@@ -2360,12 +2361,12 @@ vim.wo.foldmarker = vim.o.foldmarker
 vim.wo.fmr = vim.wo.foldmarker
 
 --- The kind of folding used for the current window.  Possible values:
---- `|fold-manual|`  manual      Folds are created manually.
---- `|fold-indent|`  indent      Lines with equal indent form a fold.
---- `|fold-expr|`  expr      'foldexpr' gives the fold level of a line.
---- `|fold-marker|`  marker      Markers are used to specify folds.
---- `|fold-syntax|`  syntax      Syntax highlighting items specify folds.
---- `|fold-diff|`  diff      Fold text that is not changed.
+--- [fold-manual](help://fold-manual)  manual      Folds are created manually.
+--- [fold-indent](help://fold-indent)  indent      Lines with equal indent form a fold.
+--- [fold-expr](help://fold-expr)  expr      'foldexpr' gives the fold level of a line.
+--- [fold-marker](help://fold-marker)  marker      Markers are used to specify folds.
+--- [fold-syntax](help://fold-syntax)  syntax      Syntax highlighting items specify folds.
+--- [fold-diff](help://fold-diff)  diff      Fold text that is not changed.
 ---
 --- @type string
 vim.o.foldmethod = "manual"
@@ -2401,7 +2402,7 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- command moves the cursor into a closed fold.  It is a comma-separated
 --- list of items.
 --- NOTE: When the command is part of a mapping this option is not used.
---- Add the `|zv|` command to the mapping to get the same effect.
+--- Add the [zv](help://zv) command to the mapping to get the same effect.
 --- (rationale: the mapping may want to control opening folds itself)
 ---
 --- item    commands ~
@@ -2415,7 +2416,7 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- quickfix  ":cn", ":crew", ":make", etc.
 --- search    search for a pattern: "/", "n", "*", "gd", etc.
 ---     (not for a search pattern in a ":" command)
----     Also for `|[s|` and `|]s|`.
+---     Also for [[s](help://[s) and []s](help://]s).
 --- tag    jumping to a tag: ":ta", CTRL-T, etc.
 --- undo    undo or redo: "u" and CTRL-R
 --- When a movement command is used for an operator (e.g., "dl" or "y%")
@@ -2425,7 +2426,7 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- very difficult to move onto a closed fold.
 --- In insert mode the folds containing the cursor will always be open
 --- when text is inserted.
---- To close folds you can re-apply 'foldlevel' with the `|zx|` command or
+--- To close folds you can re-apply 'foldlevel' with the [zx](help://zx) command or
 --- set the 'foldclose' option to "all".
 ---
 --- @type string
@@ -2436,15 +2437,15 @@ vim.go.fdo = vim.go.foldopen
 
 --- An expression which is used to specify the text displayed for a closed
 --- fold.  The context is set to the script where 'foldexpr' was set,
---- script-local items can be accessed.  See `|fold-foldtext|` for the
+--- script-local items can be accessed.  See [fold-foldtext](help://fold-foldtext) for the
 --- usage.
 ---
---- The expression will be evaluated in the `|sandbox|` if set from a
---- modeline, see `|sandbox-option|`.
+--- The expression will be evaluated in the [sandbox](help://sandbox) if set from a
+--- modeline, see [sandbox-option](help://sandbox-option).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'foldtext' `|textlock|`.
+--- evaluating 'foldtext' [textlock](help://textlock).
 ---
 --- @type string
 vim.o.foldtext = "foldtext()"
@@ -2452,13 +2453,13 @@ vim.o.fdt = vim.o.foldtext
 vim.wo.foldtext = vim.o.foldtext
 vim.wo.fdt = vim.wo.foldtext
 
---- Expression which is evaluated to format a range of lines for the `|gq|`
+--- Expression which is evaluated to format a range of lines for the [gq](help://gq)
 --- operator or automatic formatting (see 'formatoptions').  When this
 --- option is empty 'formatprg' is used.
 ---
---- The `|v:lnum|`  variable holds the first line to be formatted.
---- The `|v:count|` variable holds the number of lines to be formatted.
---- The `|v:char|`  variable holds the character that is going to be
+--- The [v:lnum](help://v:lnum)  variable holds the first line to be formatted.
+--- The [v:count](help://v:count) variable holds the number of lines to be formatted.
+--- The [v:char](help://v:char)  variable holds the character that is going to be
 ---       inserted if the expression is being evaluated due to
 ---       automatic formatting.  This can be empty.  Don't insert
 ---       it yet!
@@ -2468,19 +2469,19 @@ vim.wo.fdt = vim.wo.foldtext
 --- :set formatexpr=mylang#Format()
 --- ```
 --- This will invoke the mylang#Format() function in the
---- autoload/mylang.vim file in 'runtimepath'. `|autoload|`
+--- autoload/mylang.vim file in 'runtimepath'. [autoload](help://autoload)
 ---
 --- The expression is also evaluated when 'textwidth' is set and adding
 --- text beyond that limit.  This happens under the same conditions as
 --- when internal formatting is used.  Make sure the cursor is kept in the
---- same spot relative to the text then!  The `|mode()|` function will
+--- same spot relative to the text then!  The [mode()](help://mode()) function will
 --- return "i" or "R" in this situation.
 ---
 --- When the expression evaluates to non-zero Vim will fall back to using
 --- the internal format mechanism.
 ---
---- If the expression starts with s: or `|<SID>|`, then it is replaced with
---- the script ID (`|local-function|`). Example:
+--- If the expression starts with s: or [<SID>](help://<SID>), then it is replaced with
+--- the script ID ([local-function](help://local-function)). Example:
 --- ```
 --- set formatexpr=s:MyFormatExpr()
 --- set formatexpr=<SID>SomeFormatExpr()
@@ -2488,8 +2489,8 @@ vim.wo.fdt = vim.wo.foldtext
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
 ---
---- The expression will be evaluated in the `|sandbox|` when set from a
---- modeline, see `|sandbox-option|`.  That stops the option from working,
+--- The expression will be evaluated in the [sandbox](help://sandbox) when set from a
+--- modeline, see [sandbox-option](help://sandbox-option).  That stops the option from working,
 --- since changing the buffer text is not allowed.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 --- NOTE: This option is set to "" when 'compatible' is set.
@@ -2503,7 +2504,7 @@ vim.bo.fex = vim.bo.formatexpr
 --- A pattern that is used to recognize a list header.  This is used for
 --- the "n" flag in 'formatoptions'.
 --- The pattern must match exactly the text that will be the indent for
---- the line below it.  You can use `|/\ze|` to mark the end of the match
+--- the line below it.  You can use [/\ze](help:///\ze) to mark the end of the match
 --- while still checking more characters.  There must be a character
 --- following the pattern, when it matches the whole line it is handled
 --- like there is no match.
@@ -2517,10 +2518,10 @@ vim.bo.formatlistpat = vim.o.formatlistpat
 vim.bo.flp = vim.bo.formatlistpat
 
 --- This is a sequence of letters which describes how automatic
---- formatting is to be done.  See `|fo-table|`.  Commas can be inserted for
+--- formatting is to be done.  See [fo-table](help://fo-table).  Commas can be inserted for
 --- readability.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `|add-option-flags|`.
+--- "+=" and "-=" feature of ":set" [add-option-flags](help://add-option-flags).
 ---
 --- @type string
 vim.o.formatoptions = "tcqj"
@@ -2529,15 +2530,15 @@ vim.bo.formatoptions = vim.o.formatoptions
 vim.bo.fo = vim.bo.formatoptions
 
 --- The name of an external program that will be used to format the lines
---- selected with the `|gq|` operator.  The program must take the input on
+--- selected with the [gq](help://gq) operator.  The program must take the input on
 --- stdin and produce the output on stdout.  The Unix program "fmt" is
 --- such a program.
 --- If the 'formatexpr' option is not empty it will be used instead.
 --- Otherwise, if 'formatprg' option is an empty string, the internal
---- format function will be used `|C-indenting|`.
---- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
+--- format function will be used [C-indenting](help://C-indenting).
+--- Environment variables are expanded [:set_env](help://:set_env).  See [option-backslash](help://option-backslash)
 --- about including spaces and backslashes.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -2549,18 +2550,18 @@ vim.go.formatprg = vim.o.formatprg
 vim.go.fp = vim.go.formatprg
 
 --- When on, the OS function fsync() will be called after saving a file
---- (`|:write|`, `|writefile()|`, …), `|swap-file|`, `|undo-persistence|` and `|shada-file|`.
+--- ([:write](help://:write), [writefile()](help://writefile()), …), [swap-file](help://swap-file), [undo-persistence](help://undo-persistence) and [shada-file](help://shada-file).
 --- This flushes the file to disk, ensuring that it is safely written.
 --- Slow on some systems: writing buffers, quitting Nvim, and other
 --- operations may sometimes take a few seconds.
 ---
 --- Files are ALWAYS flushed ('fsync' is ignored) when:
---- - `|CursorHold|` event is triggered
---- - `|:preserve|` is called
+--- - [CursorHold](help://CursorHold) event is triggered
+--- - [:preserve](help://:preserve) is called
 --- - system signals low battery life
 --- - Nvim exits abnormally
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type boolean
@@ -2572,7 +2573,7 @@ vim.go.fs = vim.go.fsync
 --- When on, the ":substitute" flag 'g' is default on.  This means that
 --- all matches in a line are substituted instead of one.  When a 'g' flag
 --- is given to a ":substitute" command, this will toggle the substitution
---- of all or one match.  See `|complex-change|`.
+--- of all or one match.  See [complex-change](help://complex-change).
 ---
 --- command    'gdefault' on  'gdefault' off  ~
 --- :s///      subst. all    subst. one
@@ -2591,7 +2592,7 @@ vim.go.gd = vim.go.gdefault
 
 --- Format to recognize for the ":grep" command output.
 --- This is a scanf-like string that uses the same format as the
---- 'errorformat' option: see `|errorformat|`.
+--- 'errorformat' option: see [errorformat](help://errorformat).
 ---
 --- @type string
 vim.o.grepformat = "%f:%l:%m,%f:%l%m,%f  %l%m"
@@ -2599,22 +2600,22 @@ vim.o.gfm = vim.o.grepformat
 vim.go.grepformat = vim.o.grepformat
 vim.go.gfm = vim.go.grepformat
 
---- Program to use for the `|:grep|` command.  This option may contain '%'
+--- Program to use for the [:grep](help://:grep) command.  This option may contain '%'
 --- and '#' characters, which are expanded like when used in a command-
 --- line.  The placeholder "$*" is allowed to specify where the arguments
---- will be included.  Environment variables are expanded `|:set_env|`.  See
---- `|option-backslash|` about including spaces and backslashes.
+--- will be included.  Environment variables are expanded [:set_env](help://:set_env).  See
+--- [option-backslash](help://option-backslash) about including spaces and backslashes.
 --- When your "grep" accepts the "-H" argument, use this to make ":grep"
 --- also work well with a single file:
 --- ```
 --- :set grepprg=grep\ -nH
 --- ```
---- Special value: When 'grepprg' is set to "internal" the `|:grep|` command
---- works like `|:vimgrep|`, `|:lgrep|` like `|:lvimgrep|`, `|:grepadd|` like
---- `|:vimgrepadd|` and `|:lgrepadd|` like `|:lvimgrepadd|`.
---- See also the section `|:make_makeprg|`, since most of the comments there
+--- Special value: When 'grepprg' is set to "internal" the [:grep](help://:grep) command
+--- works like [:vimgrep](help://:vimgrep), [:lgrep](help://:lgrep) like [:lvimgrep](help://:lvimgrep), [:grepadd](help://:grepadd) like
+--- [:vimgrepadd](help://:vimgrepadd) and [:lgrepadd](help://:lgrepadd) like [:lvimgrepadd](help://:lvimgrepadd).
+--- See also the section [:make_makeprg](help://:make_makeprg), since most of the comments there
 --- apply equally to 'grepprg'.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -2626,7 +2627,7 @@ vim.go.grepprg = vim.o.grepprg
 vim.go.gp = vim.go.grepprg
 
 --- Configures the cursor style for each mode. Works in the GUI and many
---- terminals.  See `|tui-cursor-shape|`.
+--- terminals.  See [tui-cursor-shape](help://tui-cursor-shape).
 ---
 --- To disable cursor-styling, reset the option:
 --- ```
@@ -2675,15 +2676,15 @@ vim.go.gp = vim.go.grepprg
 --- {group-name}
 ---   Highlight group that decides the color and font of the
 ---   cursor.
----   In the `|TUI|`:
----   - `|inverse|`/reverse and no group-name are interpreted
+---   In the [TUI](help://TUI):
+---   - [inverse](help://inverse)/reverse and no group-name are interpreted
 ---     as "host-terminal default cursor colors" which
 ---     typically means "inverted bg and fg colors".
----   - `|ctermfg|` and `|guifg|` are ignored.
+---   - [ctermfg](help://ctermfg) and [guifg](help://guifg) are ignored.
 --- {group-name}/{group-name}
 ---   Two highlight group names, the first is used when
 ---   no language mappings are used, the other when they
----   are. `|language-mapping|`
+---   are. [language-mapping](help://language-mapping)
 ---
 --- Examples of parts:
 ---  n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
@@ -2729,7 +2730,7 @@ vim.go.gcr = vim.go.guicursor
 --- Spaces after a comma are ignored.  To include a comma in a font name
 --- precede it with a backslash.  Setting an option requires an extra
 --- backslash before a space and a backslash.  See also
---- `|option-backslash|`.  For example:
+--- [option-backslash](help://option-backslash).  For example:
 --- ```
 ---   :set guifont=Screen15,\ 7x13,font\\,with\\,commas
 --- ```
@@ -2809,7 +2810,7 @@ vim.go.gfw = vim.go.guifontwide
 --- sequence of letters which describes what components and options of the
 --- GUI should be used.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `|add-option-flags|`.
+--- "+=" and "-=" feature of ":set" [add-option-flags](help://add-option-flags).
 ---
 --- Valid letters are as follows:
 ---           *guioptions_a* *'go-a'*
@@ -2858,7 +2859,7 @@ vim.go.gfw = vim.go.guifontwide
 ---             *'go-M'*
 --- 'M'  The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
 --- that this flag must be added in the vimrc file, before
---- switching on syntax or filetype recognition (when the `|gvimrc|`
+--- switching on syntax or filetype recognition (when the [gvimrc](help://gvimrc)
 --- file is sourced the system menu has already been loaded; the
 --- `:syntax on` and `:filetype on` commands load the menu too).
 ---             *'go-g'*
@@ -2879,13 +2880,13 @@ vim.go.gfw = vim.go.guifontwide
 ---             *'go-b'*
 --- 'b'  Bottom (horizontal) scrollbar is present.  Its size depends on
 --- the longest visible line, or on the cursor line if the 'h'
---- flag is included. `|gui-horiz-scroll|`
+--- flag is included. [gui-horiz-scroll](help://gui-horiz-scroll)
 ---             *'go-h'*
 --- 'h'  Limit horizontal scrollbar size to the length of the cursor
---- line.  Reduces computations. `|gui-horiz-scroll|`
+--- line.  Reduces computations. [gui-horiz-scroll](help://gui-horiz-scroll)
 ---
 --- And yes, you may even have scrollbars on the left AND the right if
---- you really want to :-).  See `|gui-scrollbars|` for more information.
+--- you really want to :-).  See [gui-scrollbars](help://gui-scrollbars) for more information.
 ---
 ---             *'go-v'*
 --- 'v'  Use a vertical button layout for dialogs.  When not included,
@@ -2895,7 +2896,7 @@ vim.go.gfw = vim.go.guifontwide
 --- 'p'  Use Pointer callbacks for X11 GUI.  This is required for some
 --- window managers.  If the cursor is not blinking or hollow at
 --- the right moment, try adding this flag.  This must be done
---- before starting the GUI.  Set it in your `|gvimrc|`.  Adding or
+--- before starting the GUI.  Set it in your [gvimrc](help://gvimrc).  Adding or
 --- removing it after the GUI has started has no effect.
 ---             *'go-k'*
 --- 'k'  Keep the GUI window size when adding/removing a scrollbar, or
@@ -2913,12 +2914,12 @@ vim.go.go = vim.go.guioptions
 
 --- When non-empty describes the text to use in a label of the GUI tab
 --- pages line.  When empty and when the result is empty Vim will use a
---- default label.  See `|setting-guitablabel|` for more info.
+--- default label.  See [setting-guitablabel](help://setting-guitablabel) for more info.
 ---
 --- The format of this option is like that of 'statusline'.
 --- 'guitabtooltip' is used for the tooltip, see below.
---- The expression will be evaluated in the `|sandbox|` when set from a
---- modeline, see `|sandbox-option|`.
+--- The expression will be evaluated in the [sandbox](help://sandbox) when set from a
+--- modeline, see [sandbox-option](help://sandbox-option).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- Only used when the GUI tab pages line is displayed.  'e' must be
@@ -2934,7 +2935,7 @@ vim.go.gtl = vim.go.guitablabel
 --- When non-empty describes the text to use in a tooltip for the GUI tab
 --- pages line.  When empty Vim will use a default tooltip.
 --- This option is otherwise just like 'guitablabel' above.
---- You can include a line break.  Simplest method is to use `|:let|`:
+--- You can include a line break.  Simplest method is to use [:let](help://:let):
 --- ```
 --- :let &guitabtooltip = "line one\nline two"
 --- ```
@@ -2948,11 +2949,11 @@ vim.go.gtt = vim.go.guitabtooltip
 --- Name of the main help file.  All distributed help files should be
 --- placed together in one directory.  Additionally, all "doc" directories
 --- in 'runtimepath' will be used.
---- Environment variables are expanded `|:set_env|`.  For example:
+--- Environment variables are expanded [:set_env](help://:set_env).  For example:
 --- "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
---- tried.  Also see `|$VIMRUNTIME|` and `|option-backslash|` about including
+--- tried.  Also see [$VIMRUNTIME](help://$VIMRUNTIME) and [option-backslash](help://option-backslash) about including
 --- spaces and backslashes.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -2984,9 +2985,9 @@ vim.go.hh = vim.go.helpheight
 --- ```
 --- This will first search German, then Italian and finally English help
 --- files.
---- When using `|CTRL-]|` and ":help!" in a non-English help file Vim will
+--- When using [CTRL-]](help://CTRL-]) and ":help!" in a non-English help file Vim will
 --- try to find the tag in the current language before using this option.
---- See `|help-translated|`.
+--- See [help-translated](help://help-translated).
 ---
 --- @type string
 vim.o.helplang = ""
@@ -2995,8 +2996,8 @@ vim.go.helplang = vim.o.helplang
 vim.go.hlg = vim.go.helplang
 
 --- When off a buffer is unloaded (including loss of undo information)
---- when it is `|abandon|`ed.  When on a buffer becomes hidden when it is
---- `|abandon|`ed.  A buffer displayed in another window does not become
+--- when it is [abandon](help://abandon)ed.  When on a buffer becomes hidden when it is
+--- [abandon](help://abandon)ed.  A buffer displayed in another window does not become
 --- hidden, of course.
 ---
 --- Commands that move through the buffer list sometimes hide a buffer
@@ -3004,10 +3005,10 @@ vim.go.hlg = vim.go.helplang
 --- - the buffer is modified
 --- - 'autowrite' is off or writing is not possible
 --- - the '!' flag was used
---- Also see `|windows|`.
+--- Also see [windows](help://windows).
 ---
 --- To hide a specific buffer use the 'bufhidden' option.
---- 'hidden' is set for one command with ":hide {command}" `|:hide|`.
+--- 'hidden' is set for one command with ":hide {command}" [:hide](help://:hide).
 ---
 --- @type boolean
 vim.o.hidden = true
@@ -3017,7 +3018,7 @@ vim.go.hid = vim.go.hidden
 
 --- A history of ":" commands, and a history of previous search patterns
 --- is remembered.  This option decides how many entries may be stored in
---- each of these histories (see `|cmdline-editing|`).
+--- each of these histories (see [cmdline-editing](help://cmdline-editing)).
 --- The maximum value is 10000.
 ---
 --- @type integer
@@ -3027,15 +3028,15 @@ vim.go.history = vim.o.history
 vim.go.hi = vim.go.history
 
 --- When there is a previous search pattern, highlight all its matches.
---- The `|hl-Search|` highlight group determines the highlighting for all
---- matches not under the cursor while the `|hl-CurSearch|` highlight group
+--- The [hl-Search](help://hl-Search) highlight group determines the highlighting for all
+--- matches not under the cursor while the [hl-CurSearch](help://hl-CurSearch) highlight group
 --- (if defined) determines the highlighting for the match under the
---- cursor. If `|hl-CurSearch|` is not defined, then `|hl-Search|` is used for
+--- cursor. If [hl-CurSearch](help://hl-CurSearch) is not defined, then [hl-Search](help://hl-Search) is used for
 --- both. Note that only the matching text is highlighted, any offsets
 --- are not applied.
---- See also: 'incsearch' and `|:match|`.
+--- See also: 'incsearch' and [:match](help://:match).
 --- When you get bored looking at the highlighted matches, you can turn it
---- off with `|:nohlsearch|`.  This does not change the option value, as
+--- off with [:nohlsearch](help://:nohlsearch).  This does not change the option value, as
 --- soon as you use a search command, the highlighting comes back.
 --- 'redrawtime' specifies the maximum time spent on finding matches.
 --- When the search pattern can match an end-of-line, Vim will try to
@@ -3044,7 +3045,7 @@ vim.go.hi = vim.go.history
 --- line below a closed fold.  A match in a previous line which is not
 --- drawn may not continue in a newly drawn line.
 --- You can specify whether the highlight status is restored on startup
---- with the 'h' flag in 'shada' `|shada-h|`.
+--- with the 'h' flag in 'shada' [shada-h](help://shada-h).
 ---
 --- @type boolean
 vim.o.hlsearch = true
@@ -3074,11 +3075,11 @@ vim.go.icon = vim.o.icon
 vim.o.iconstring = ""
 vim.go.iconstring = vim.o.iconstring
 
---- Ignore case in search patterns, `|cmdline-completion|`, when
---- searching in the tags file, and `|expr-==|`.
+--- Ignore case in search patterns, [cmdline-completion](help://cmdline-completion), when
+--- searching in the tags file, and [expr-==](help://expr-==).
 --- Also see 'smartcase' and 'tagcase'.
 --- Can be overruled by using "\c" or "\C" in the pattern, see
---- `|/ignorecase|`.
+--- [/ignorecase](help:///ignorecase).
 ---
 --- @type boolean
 vim.o.ignorecase = false
@@ -3122,7 +3123,7 @@ vim.go.imd = vim.go.imdisable
 --- This makes :lmap and IM turn off automatically when leaving Insert
 --- mode.
 --- Note that this option changes when using CTRL-^ in Insert mode
---- `|i_CTRL-^|`.
+--- [i_CTRL-^](help://i_CTRL-^).
 --- The value is set to 1 when setting 'keymap' to a valid keymap name.
 --- It is also used for the argument of commands like "r" and "f".
 ---
@@ -3140,7 +3141,7 @@ vim.bo.imi = vim.bo.iminsert
 --- 1  :lmap is ON and IM is off
 --- 2  :lmap is off and IM is ON
 --- Note that this option changes when using CTRL-^ in Command-line mode
---- `|c_CTRL-^|`.
+--- [c_CTRL-^](help://c_CTRL-^).
 --- The value is set to 1 when it is not -1 and setting the 'keymap'
 --- option to a valid keymap name.
 ---
@@ -3150,8 +3151,9 @@ vim.o.ims = vim.o.imsearch
 vim.bo.imsearch = vim.o.imsearch
 vim.bo.ims = vim.bo.imsearch
 
---- When nonempty, shows the effects of `|:substitute|`, `|:smagic|,
---- |:snomagic|` and user commands with the `|:command-preview|` flag as you
+--- When nonempty, shows the effects of [:substitute](help://:substitute), [:smagic|,
+--- |:snomagic](help://:smagic|,
+--- |:snomagic) and user commands with the [:command-preview](help://:command-preview) flag as you
 --- type.
 ---
 --- Possible values:
@@ -3162,7 +3164,7 @@ vim.bo.ims = vim.bo.imsearch
 ---
 --- If the preview for built-in commands is too slow (exceeds
 --- 'redrawtime') then 'inccommand' is automatically disabled until
---- `|Command-line-mode|` is done.
+--- [Command-line-mode](help://Command-line-mode) is done.
 ---
 --- @type string
 vim.o.inccommand = "nosplit"
@@ -3171,7 +3173,7 @@ vim.go.inccommand = vim.o.inccommand
 vim.go.icm = vim.go.inccommand
 
 --- Pattern to be used to find an include command.  It is a search
---- pattern, just like for the "/" command (See `|pattern|`).  This option
+--- pattern, just like for the "/" command (See [pattern](help://pattern)).  This option
 --- is used for the commands "[i", "]I", "[d", etc.
 --- Normally the 'isfname' option is used to recognize the file name that
 --- comes after the matched pattern.  But if "\zs" appears in the pattern
@@ -3179,7 +3181,7 @@ vim.go.icm = vim.go.inccommand
 --- appears, is used as the file name.  Use this to include characters
 --- that are not in 'isfname', such as a space.  You can then use
 --- 'includeexpr' to process the matched text.
---- See `|option-backslash|` about including spaces and backslashes.
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
 ---
 --- @type string
 vim.o.include = ""
@@ -3201,12 +3203,12 @@ vim.go.inc = vim.go.include
 --- ```
 --- :setlocal includeexpr=tr(v:fname,'.','/')
 --- ```
---- Also used for the `|gf|` command if an unmodified file name can't be
+--- Also used for the [gf](help://gf) command if an unmodified file name can't be
 --- found.  Allows doing "gf" on the name after an 'include' statement.
---- Also used for `|<cfile>|`.
+--- Also used for [<cfile>](help://<cfile>).
 ---
---- If the expression starts with s: or `|<SID>|`, then it is replaced with
---- the script ID (`|local-function|`). Example:
+--- If the expression starts with s: or [<SID>](help://<SID>), then it is replaced with
+--- the script ID ([local-function](help://local-function)). Example:
 --- ```
 --- setlocal includeexpr=s:MyIncludeExpr(v:fname)
 --- setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
@@ -3214,12 +3216,12 @@ vim.go.inc = vim.go.include
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
 ---
---- The expression will be evaluated in the `|sandbox|` when set from a
---- modeline, see `|sandbox-option|`.
+--- The expression will be evaluated in the [sandbox](help://sandbox) when set from a
+--- modeline, see [sandbox-option](help://sandbox-option).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'includeexpr' `|textlock|`.
+--- evaluating 'includeexpr' [textlock](help://textlock).
 ---
 --- @type string
 vim.o.includeexpr = ""
@@ -3236,11 +3238,11 @@ vim.bo.inex = vim.bo.includeexpr
 --- still need to finish the search command with <Enter> to move the
 --- cursor to the match.
 --- You can use the CTRL-G and CTRL-T keys to move to the next and
---- previous match. `|c_CTRL-G|` `|c_CTRL-T|`
+--- previous match. [c_CTRL-G](help://c_CTRL-G) [c_CTRL-T](help://c_CTRL-T)
 --- Vim only searches for about half a second.  With a complicated
 --- pattern and/or a lot of text the match may not be found.  This is to
 --- avoid that Vim hangs while you are typing the pattern.
---- The `|hl-IncSearch|` highlight group determines the highlighting.
+--- The [hl-IncSearch](help://hl-IncSearch) highlight group determines the highlighting.
 --- When 'hlsearch' is on, all matched strings are highlighted too while
 --- typing a search command. See also: 'hlsearch'.
 --- If you don't want to turn 'hlsearch' on, but want to highlight all
@@ -3267,17 +3269,17 @@ vim.go.incsearch = vim.o.incsearch
 vim.go.is = vim.go.incsearch
 
 --- Expression which is evaluated to obtain the proper indent for a line.
---- It is used when a new line is created, for the `|=|` operator and
+--- It is used when a new line is created, for the [=](help://=) operator and
 --- in Insert mode as specified with the 'indentkeys' option.
 --- When this option is not empty, it overrules the 'cindent' and
 --- 'smartindent' indenting.  When 'lisp' is set, this option is
 --- is only used when 'lispoptions' contains "expr:1".
---- The expression is evaluated with `|v:lnum|` set to the line number for
+--- The expression is evaluated with [v:lnum](help://v:lnum) set to the line number for
 --- which the indent is to be computed.  The cursor is also in this line
 --- when the expression is evaluated (but it may be moved around).
 ---
---- If the expression starts with s: or `|<SID>|`, then it is replaced with
---- the script ID (`|local-function|`). Example:
+--- If the expression starts with s: or [<SID>](help://<SID>), then it is replaced with
+--- the script ID ([local-function](help://local-function)). Example:
 --- ```
 --- set indentexpr=s:MyIndentExpr()
 --- set indentexpr=<SID>SomeIndentExpr()
@@ -3288,8 +3290,8 @@ vim.go.is = vim.go.incsearch
 --- The expression must return the number of spaces worth of indent.  It
 --- can return "-1" to keep the current indent (this means 'autoindent' is
 --- used for the indent).
---- Functions useful for computing the indent are `|indent()|`, `|cindent()|`
---- and `|lispindent()|`.
+--- Functions useful for computing the indent are [indent()](help://indent()), [cindent()](help://cindent())
+--- and [lispindent()](help://lispindent()).
 --- The evaluation of the expression must not have side effects!  It must
 --- not change the text, jump to another window, etc.  Afterwards the
 --- cursor position is always restored, thus the cursor may be moved.
@@ -3299,14 +3301,14 @@ vim.go.is = vim.go.incsearch
 --- ```
 --- Error messages will be suppressed, unless the 'debug' option contains
 --- "msg".
---- See `|indent-expression|`.
+--- See [indent-expression](help://indent-expression).
 ---
---- The expression will be evaluated in the `|sandbox|` when set from a
---- modeline, see `|sandbox-option|`.
+--- The expression will be evaluated in the [sandbox](help://sandbox) when set from a
+--- modeline, see [sandbox-option](help://sandbox-option).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'indentexpr' `|textlock|`.
+--- evaluating 'indentexpr' [textlock](help://textlock).
 ---
 --- @type string
 vim.o.indentexpr = ""
@@ -3316,8 +3318,8 @@ vim.bo.inde = vim.bo.indentexpr
 
 --- A list of keys that, when typed in Insert mode, cause reindenting of
 --- the current line.  Only happens if 'indentexpr' isn't empty.
---- The format is identical to 'cinkeys', see `|indentkeys-format|`.
---- See `|C-indenting|` and `|indent-expression|`.
+--- The format is identical to 'cinkeys', see [indentkeys-format](help://indentkeys-format).
+--- See [C-indenting](help://C-indenting) and [indent-expression](help://indent-expression).
 ---
 --- @type string
 vim.o.indentkeys = "0{,0},0),0],:,0#,!^F,o,O,e"
@@ -3325,7 +3327,7 @@ vim.o.indk = vim.o.indentkeys
 vim.bo.indentkeys = vim.o.indentkeys
 vim.bo.indk = vim.bo.indentkeys
 
---- When doing keyword completion in insert mode `|ins-completion|`, and
+--- When doing keyword completion in insert mode [ins-completion](help://ins-completion), and
 --- 'ignorecase' is also on, the case of the match is adjusted depending
 --- on the typed text.  If the typed text contains a lowercase letter
 --- where the match has an upper case letter, the completed part is made
@@ -3342,7 +3344,7 @@ vim.bo.inf = vim.bo.infercase
 
 --- The characters specified by this option are included in file names and
 --- path names.  Filenames are used for commands like "gf", "[i" and in
---- the tags file.  It is also used for "\f" in a `|pattern|`.
+--- the tags file.  It is also used for "\f" in a [pattern](help://pattern).
 --- Multi-byte characters 256 and above are always included, only the
 --- characters up to 255 are specified with this option.
 --- For UTF-8 the characters 0xa0 to 0xff are included as well.
@@ -3384,7 +3386,7 @@ vim.bo.inf = vim.bo.infercase
 --- A comma can be excluded by prepending a '^'.  Example:
 --- " -~,^,,9"  All characters from space to '~', excluding
 ---     comma, plus <Tab>.
---- See `|option-backslash|` about including spaces and backslashes.
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
 ---
 --- @type string
 vim.o.isfname = "@,48-57,/,.,-,_,+,,,#,$,%,~,="
@@ -3395,7 +3397,7 @@ vim.go.isf = vim.go.isfname
 --- The characters given by this option are included in identifiers.
 --- Identifiers are used in recognizing environment variables and after a
 --- match of the 'define' option.  It is also used for "\i" in a
---- `|pattern|`.  See 'isfname' for a description of the format of this
+--- [pattern](help://pattern).  See 'isfname' for a description of the format of this
 --- option.  For '@' only characters up to 255 are used.
 --- Careful: If you change this option, it might break expanding
 --- environment variables.  E.g., when '/' is included and Vim tries to
@@ -3409,7 +3411,7 @@ vim.go.isident = vim.o.isident
 vim.go.isi = vim.go.isident
 
 --- Keywords are used in searching and recognizing with many commands:
---- "w", "*", "[i", etc.  It is also used for "\k" in a `|pattern|`.  See
+--- "w", "*", "[i", etc.  It is also used for "\k" in a [pattern](help://pattern).  See
 --- 'isfname' for a description of the format of this option.  For '@'
 --- characters above 255 check the "word" character class (any character
 --- that is not white space or punctuation).
@@ -3419,7 +3421,7 @@ vim.go.isi = vim.go.isident
 --- command).
 --- When the 'lisp' option is on the '-' character is always included.
 --- This option also influences syntax highlighting, unless the syntax
---- uses `|:syn-iskeyword|`.
+--- uses [:syn-iskeyword](help://:syn-iskeyword).
 ---
 --- @type string
 vim.o.iskeyword = "@,48-57,_,192-255"
@@ -3428,7 +3430,7 @@ vim.bo.iskeyword = vim.o.iskeyword
 vim.bo.isk = vim.bo.iskeyword
 
 --- The characters given by this option are displayed directly on the
---- screen.  It is also used for "\p" in a `|pattern|`.  The characters from
+--- screen.  It is also used for "\p" in a [pattern](help://pattern).  The characters from
 --- space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
 --- even when they are not included in 'isprint' or excluded.  See
 --- 'isfname' for a description of the format of this option.
@@ -3445,7 +3447,7 @@ vim.bo.isk = vim.bo.iskeyword
 --- When 'display' contains "uhex" all unprintable characters are
 --- displayed as <xx>.
 --- The SpecialKey highlighting will be used for unprintable characters.
---- `|hl-SpecialKey|`
+--- [hl-SpecialKey](help://hl-SpecialKey)
 ---
 --- Multi-byte characters 256 and above are always included, only the
 --- characters up to 255 are specified with this option.  When a character
@@ -3469,16 +3471,16 @@ vim.o.js = vim.o.joinspaces
 vim.go.joinspaces = vim.o.joinspaces
 vim.go.js = vim.go.joinspaces
 
---- List of words that change the behavior of the `|jumplist|`.
+--- List of words that change the behavior of the [jumplist](help://jumplist).
 --- stack         Make the jumplist behave like the tagstack.
 ---   Relative location of entries in the jumplist is
 ---   preserved at the cost of discarding subsequent entries
 ---   when navigating backwards in the jumplist and then
----   jumping to a location.  `|jumplist-stack|`
+---   jumping to a location.  [jumplist-stack](help://jumplist-stack)
 ---
---- view          When moving through the jumplist, `|changelist|`,
----   `|alternate-file|` or using `|mark-motions|` try to
----   restore the `|mark-view|` in which the action occurred.
+--- view          When moving through the jumplist, [changelist](help://changelist),
+---   [alternate-file](help://alternate-file) or using [mark-motions](help://mark-motions) try to
+---   restore the [mark-view](help://mark-view) in which the action occurred.
 ---
 --- @type string
 vim.o.jumpoptions = ""
@@ -3486,7 +3488,7 @@ vim.o.jop = vim.o.jumpoptions
 vim.go.jumpoptions = vim.o.jumpoptions
 vim.go.jop = vim.go.jumpoptions
 
---- Name of a keyboard mapping.  See `|mbyte-keymap|`.
+--- Name of a keyboard mapping.  See [mbyte-keymap](help://mbyte-keymap).
 --- Setting this option to a valid keymap name has the side effect of
 --- setting 'iminsert' to one, so that the keymap becomes effective.
 --- 'imsearch' is also set to one, unless it was -1
@@ -3513,21 +3515,21 @@ vim.o.km = vim.o.keymodel
 vim.go.keymodel = vim.o.keymodel
 vim.go.km = vim.go.keymodel
 
---- Program to use for the `|K|` command.  Environment variables are
---- expanded `|:set_env|`.  ":help" may be used to access the Vim internal
+--- Program to use for the [K](help://K) command.  Environment variables are
+--- expanded [:set_env](help://:set_env).  ":help" may be used to access the Vim internal
 --- help.  (Note that previously setting the global option to the empty
 --- value did this, which is now deprecated.)
 --- When the first character is ":", the command is invoked as a Vim
 --- Ex command prefixed with [count].
 --- When "man" or "man -s" is used, Vim will automatically translate
 --- a [count] for the "K" command to a section number.
---- See `|option-backslash|` about including spaces and backslashes.
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
 --- Example:
 --- ```
 --- :set keywordprg=man\ -s
 --- :set keywordprg=:Man
 --- ```
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -3548,7 +3550,7 @@ vim.go.kp = vim.go.keywordprg
 --- mapped in Insert mode.
 --- Also consider setting 'langremap' to off, to prevent 'langmap' from
 --- applying to characters resulting from a mapping.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- Example (for Greek, in UTF-8):        *greek*
@@ -3597,7 +3599,7 @@ vim.go.lmap = vim.go.langmap
 --- ```
 --- :set langmenu=nl_NL.ISO_8859-1
 --- ```
---- When 'langmenu' is empty, `|v:lang|` is used.
+--- When 'langmenu' is empty, [v:lang](help://v:lang) is used.
 --- Only normal file name characters can be used, `/\*?[|<>` are illegal.
 --- If your $LANG is set to a non-English language but you do want to use
 --- the English menus:
@@ -3637,7 +3639,7 @@ vim.go.lrm = vim.go.langremap
 --- 2: always
 --- 3: always and ONLY the last window
 --- The screen looks nicer with a status line if you have several
---- windows, but it takes another screen line. `|status-line|`
+--- windows, but it takes another screen line. [status-line](help://status-line)
 ---
 --- @type integer
 vim.o.laststatus = 2
@@ -3648,7 +3650,7 @@ vim.go.ls = vim.go.laststatus
 --- When this option is set, the screen will not be redrawn while
 --- executing macros, registers and other commands that have not been
 --- typed.  Also, updating the window title is postponed.  To force an
---- update use `|:redraw|`.
+--- update use [:redraw](help://:redraw).
 --- This may occasionally cause display errors.  It is only meant to be set
 --- temporarily when performing an operation where redrawing may cause
 --- flickering or cause a slow down.
@@ -3680,7 +3682,7 @@ vim.wo.lbr = vim.wo.linebreak
 --- terminal initialization code.
 --- When Vim is running in the GUI or in a resizable window, setting this
 --- option will cause the window size to be changed.  When you only want
---- to use the size for the GUI, put the command in your `|gvimrc|` file.
+--- to use the size for the GUI, put the command in your [gvimrc](help://gvimrc) file.
 --- Vim limits the number of lines to what fits on the screen.  You can
 --- use this command to get the tallest window possible:
 --- ```
@@ -3721,7 +3723,7 @@ vim.o.lisp = false
 vim.bo.lisp = vim.o.lisp
 
 --- Comma-separated list of items that influence the Lisp indenting when
---- enabled with the `|'lisp'|` option.  Currently only one item is
+--- enabled with the ['lisp'](help://'lisp') option.  Currently only one item is
 --- supported:
 --- expr:1  use 'indentexpr' for Lisp indenting when it is set
 --- expr:0  do not use 'indentexpr' for Lisp indenting (default)
@@ -3735,7 +3737,7 @@ vim.bo.lispoptions = vim.o.lispoptions
 vim.bo.lop = vim.bo.lispoptions
 
 --- Comma-separated list of words that influence the Lisp indenting when
---- enabled with the `|'lisp'|` option.
+--- enabled with the ['lisp'](help://'lisp') option.
 ---
 --- @type string
 vim.o.lispwords = "defun,define,defmacro,set!,lambda,if,case,let,flet,let*,letrec,do,do*,define-syntax,let-syntax,letrec-syntax,destructuring-bind,defpackage,defparameter,defstruct,deftype,defvar,do-all-symbols,do-external-symbols,do-symbols,dolist,dotimes,ecase,etypecase,eval-when,labels,macrolet,multiple-value-bind,multiple-value-call,multiple-value-prog1,multiple-value-setq,prog1,progv,typecase,unless,unwind-protect,when,with-input-from-string,with-open-file,with-open-stream,with-output-to-string,with-package-iterator,define-condition,handler-bind,handler-case,restart-bind,restart-case,with-simple-restart,store-value,use-value,muffle-warning,abort,continue,with-slots,with-slots*,with-accessors,with-accessors*,defclass,defmethod,print-unreadable-object"
@@ -3764,7 +3766,7 @@ vim.go.lw = vim.go.lispwords
 vim.o.list = false
 vim.wo.list = vim.o.list
 
---- Strings to use in 'list' mode and for the `|:list|` command.  It is a
+--- Strings to use in 'list' mode and for the [:list](help://:list) command.  It is a
 --- comma-separated list of string settings.
 ---
 ---           *lcs-eol*
@@ -3823,8 +3825,8 @@ vim.wo.list = vim.o.list
 --- ```
 ---           *lcs-leadmultispace*
 --- leadmultispace:c...
----   Like the `|lcs-multispace|` value, but for leading
----   spaces only.  Also overrides `|lcs-lead|` for leading
+---   Like the [lcs-multispace](help://lcs-multispace) value, but for leading
+---   spaces only.  Also overrides [lcs-lead](help://lcs-lead) for leading
 ---   multiple spaces.
 ---   `:set listchars=leadmultispace:---+` shows ten
 ---   consecutive leading spaces as:
@@ -3871,8 +3873,8 @@ vim.wo.list = vim.o.list
 ---   :set lcs=tab:>-,eol:<,nbsp:%
 ---   :set lcs=extends:>,precedes:<
 --- ```
---- `|hl-NonText|` highlighting will be used for "eol", "extends" and
---- "precedes". `|hl-Whitespace|` for "nbsp", "space", "tab", "multispace",
+--- [hl-NonText](help://hl-NonText) highlighting will be used for "eol", "extends" and
+--- "precedes". [hl-Whitespace](help://hl-Whitespace) for "nbsp", "space", "tab", "multispace",
 --- "lead" and "trail".
 ---
 --- @type string
@@ -3883,11 +3885,11 @@ vim.wo.lcs = vim.wo.listchars
 vim.go.listchars = vim.o.listchars
 vim.go.lcs = vim.go.listchars
 
---- When on the plugin scripts are loaded when starting up `|load-plugins|`.
---- This option can be reset in your `|vimrc|` file to disable the loading
+--- When on the plugin scripts are loaded when starting up [load-plugins](help://load-plugins).
+--- This option can be reset in your [vimrc](help://vimrc) file to disable the loading
 --- of plugins.
 --- Note that using the "-u NONE" and "--noplugin" command line arguments
---- reset this option. `|-u|` `|--noplugin|`
+--- reset this option. [-u](help://-u) [--noplugin](help://--noplugin)
 ---
 --- @type boolean
 vim.o.loadplugins = true
@@ -3896,27 +3898,27 @@ vim.go.loadplugins = vim.o.loadplugins
 vim.go.lpl = vim.go.loadplugins
 
 --- Changes the special characters that can be used in search patterns.
---- See `|pattern|`.
+--- See [pattern](help://pattern).
 --- WARNING: Switching this option off most likely breaks plugins!  That
 --- is because many patterns assume it's on and will fail when it's off.
 --- Only switch it off when working with old Vi scripts.  In any other
 --- situation write patterns that work when 'magic' is on.  Include "\M"
---- when you want to `|/\M|`.
+--- when you want to [/\M](help:///\M).
 ---
 --- @type boolean
 vim.o.magic = true
 vim.go.magic = vim.o.magic
 
---- Name of the errorfile for the `|:make|` command (see `|:make_makeprg|`)
---- and the `|:grep|` command.
+--- Name of the errorfile for the [:make](help://:make) command (see [:make_makeprg](help://:make_makeprg))
+--- and the [:grep](help://:grep) command.
 --- When it is empty, an internally generated temp file will be used.
 --- When "##" is included, it is replaced by a number to make the name
 --- unique.  This makes sure that the ":make" command doesn't overwrite an
 --- existing file.
 --- NOT used for the ":cf" command.  See 'errorfile' for that.
---- Environment variables are expanded `|:set_env|`.
---- See `|option-backslash|` about including spaces and backslashes.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- Environment variables are expanded [:set_env](help://:set_env).
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -3946,11 +3948,11 @@ vim.bo.menc = vim.bo.makeencoding
 vim.go.makeencoding = vim.o.makeencoding
 vim.go.menc = vim.go.makeencoding
 
---- Program to use for the ":make" command.  See `|:make_makeprg|`.
---- This option may contain '%' and '#' characters (see  `|:_%|` and `|:_#|`),
---- which are expanded to the current and alternate file name.  Use `|::S|`
+--- Program to use for the ":make" command.  See [:make_makeprg](help://:make_makeprg).
+--- This option may contain '%' and '#' characters (see  [:_%](help://:_%) and [:_#](help://:_#)),
+--- which are expanded to the current and alternate file name.  Use [::S](help://::S)
 --- to escape file names in case they contain special characters.
---- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
+--- Environment variables are expanded [:set_env](help://:set_env).  See [option-backslash](help://option-backslash)
 --- about including spaces and backslashes.
 --- Note that a '|' must be escaped twice: once for ":set" and once for
 --- the interpretation of a command.  When you use a filter called
@@ -3963,7 +3965,7 @@ vim.go.menc = vim.go.makeencoding
 --- ```
 --- :set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
 --- ```
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -3974,7 +3976,7 @@ vim.bo.mp = vim.bo.makeprg
 vim.go.makeprg = vim.o.makeprg
 vim.go.mp = vim.go.makeprg
 
---- Characters that form pairs.  The `|%|` command jumps from one to the
+--- Characters that form pairs.  The [%](help://%) command jumps from one to the
 --- other.
 --- Only character pairs are allowed that are different, thus you cannot
 --- jump between two double quotes.
@@ -3990,7 +3992,7 @@ vim.go.mp = vim.go.makeprg
 --- :au FileType c,cpp,java set mps+==:;
 --- ```
 --- For a more advanced way of using "%", see the matchit.vim plugin in
---- the $VIMRUNTIME/plugin directory. `|add-local-help|`
+--- the $VIMRUNTIME/plugin directory. [add-local-help](help://add-local-help)
 ---
 --- @type string
 vim.o.matchpairs = "(:),{:},[:]"
@@ -4013,8 +4015,8 @@ vim.go.mat = vim.go.matchtime
 --- more depth, set 'maxfuncdepth' to a bigger number.  But this will use
 --- more memory, there is the danger of failing when memory is exhausted.
 --- Increasing this limit above 200 also changes the maximum for Ex
---- command recursion, see `|E169|`.
---- See also `|:function|`.
+--- command recursion, see [E169](help://E169).
+--- See also [:function](help://:function).
 --- Also used for maximum depth of callback functions.
 ---
 --- @type integer
@@ -4027,7 +4029,7 @@ vim.go.mfd = vim.go.maxfuncdepth
 --- character to be used.  This normally catches endless mappings, like
 --- ":map x y" with ":map y x".  It still does not catch ":map g wg",
 --- because the 'w' is used before the next mapping is done.  See also
---- `|key-mapping|`.
+--- [key-mapping](help://key-mapping).
 ---
 --- @type integer
 vim.o.maxmapdepth = 1000
@@ -4064,7 +4066,7 @@ vim.o.mis = vim.o.menuitems
 vim.go.menuitems = vim.o.menuitems
 vim.go.mis = vim.go.menuitems
 
---- Parameters for `|:mkspell|`.  This tunes when to start compressing the
+--- Parameters for [:mkspell](help://:mkspell).  This tunes when to start compressing the
 --- word tree.  Compression can be slow when there are many words, but
 --- it's needed to avoid running out of memory.  The amount of memory used
 --- per word depends very much on how similar the words are, that's why
@@ -4097,10 +4099,10 @@ vim.go.mis = vim.go.menuitems
 --- ```
 --- :set mkspellmem=900000,3000,800
 --- ```
---- If you have less than 512 Mbyte `|:mkspell|` may fail for some
+--- If you have less than 512 Mbyte [:mkspell](help://:mkspell) may fail for some
 --- languages, no matter what you set 'mkspellmem' to.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`.
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox).
 ---
 --- @type string
 vim.o.mkspellmem = "460000,2000,500"
@@ -4110,7 +4112,7 @@ vim.go.msm = vim.go.mkspellmem
 
 --- If 'modeline' is on 'modelines' gives the number of lines that is
 --- checked for set commands.  If 'modeline' is off or 'modelines' is zero
---- no lines are checked.  See `|modeline|`.
+--- no lines are checked.  See [modeline](help://modeline).
 ---
 --- @type boolean
 vim.o.modeline = true
@@ -4120,8 +4122,8 @@ vim.bo.ml = vim.bo.modeline
 
 --- When on allow some options that are an expression to be set in the
 --- modeline.  Check the option for whether it is affected by
---- 'modelineexpr'.  Also see `|modeline|`.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- 'modelineexpr'.  Also see [modeline](help://modeline).
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type boolean
@@ -4132,7 +4134,7 @@ vim.go.mle = vim.go.modelineexpr
 
 --- If 'modeline' is on 'modelines' gives the number of lines that is
 --- checked for set commands.  If 'modeline' is off or 'modelines' is zero
---- no lines are checked.  See `|modeline|`.
+--- no lines are checked.  See [modeline](help://modeline).
 ---
 ---
 --- @type integer
@@ -4143,7 +4145,7 @@ vim.go.mls = vim.go.modelines
 
 --- When off the buffer contents cannot be changed.  The 'fileformat' and
 --- 'fileencoding' options also can't be changed.
---- Can be reset on startup with the `|-M|` command line argument.
+--- Can be reset on startup with the [-M](help://-M) command line argument.
 ---
 --- @type boolean
 vim.o.modifiable = true
@@ -4154,7 +4156,7 @@ vim.bo.ma = vim.bo.modifiable
 --- When on, the buffer is considered to be modified.  This option is set
 --- when:
 --- 1. A change was made to the text since it was last written.  Using the
----  `|undo|` command to go back to the original text will reset the
+---  [undo](help://undo) command to go back to the original text will reset the
 ---  option.  But undoing changes that were made before writing the
 ---  buffer will set the option again, since the text is different from
 ---  when it was written.
@@ -4166,7 +4168,7 @@ vim.bo.ma = vim.bo.modifiable
 ---  Similarly for 'eol' and 'bomb'.
 --- This option is not set when a change is made to the buffer as the
 --- result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
---- FileAppendPost or VimLeave autocommand event.  See `|gzip-example|` for
+--- FileAppendPost or VimLeave autocommand event.  See [gzip-example](help://gzip-example) for
 --- an explanation.
 --- When 'buftype' is "nowrite" or "nofile" this option may be set, but
 --- will be ignored.
@@ -4180,7 +4182,7 @@ vim.bo.modified = vim.o.modified
 vim.bo.mod = vim.bo.modified
 
 --- When on, listings pause when the whole screen is filled.  You will get
---- the `|more-prompt|`.  When this option is off there are no pauses, the
+--- the [more-prompt](help://more-prompt).  When this option is off there are no pauses, the
 --- listing continues until finished.
 ---
 --- @type boolean
@@ -4202,19 +4204,19 @@ vim.go.more = vim.o.more
 --- c  Command-line mode
 --- h  all previous modes when editing a help file
 --- a  all previous modes
---- r  for `|hit-enter|` and `|more-prompt|` prompt
+--- r  for [hit-enter](help://hit-enter) and [more-prompt](help://more-prompt) prompt
 ---
 --- Left-click anywhere in a text buffer to place the cursor there.  This
---- works with operators too, e.g. type `|d|` then left-click to delete text
+--- works with operators too, e.g. type [d](help://d) then left-click to delete text
 --- from the current cursor position to the position where you clicked.
 ---
---- Drag the `|status-line|` or vertical separator of a window to resize it.
+--- Drag the [status-line](help://status-line) or vertical separator of a window to resize it.
 ---
 --- If enabled for "v" (Visual mode) then double-click selects word-wise,
 --- triple-click makes it line-wise, and quadruple-click makes it
 --- rectangular block-wise.
 ---
---- For scrolling with a mouse wheel see `|scroll-mouse-wheel|`.
+--- For scrolling with a mouse wheel see [scroll-mouse-wheel](help://scroll-mouse-wheel).
 ---
 --- Note: When enabling the mouse in a terminal, copy/paste will use the
 --- "* register if possible. See also 'clipboard'.
@@ -4275,10 +4277,10 @@ vim.go.mh = vim.go.mousehide
 --- middle click      paste    paste
 ---
 --- In the "popup" model the right mouse button produces a pop-up menu.
---- Nvim creates a default `|popup-menu|` but you can redefine it.
+--- Nvim creates a default [popup-menu](help://popup-menu) but you can redefine it.
 ---
 --- Note that you can further refine the meaning of buttons with mappings.
---- See `|mouse-overview|`.  But mappings are NOT used for modeless selection.
+--- See [mouse-overview](help://mouse-overview).  But mappings are NOT used for modeless selection.
 ---
 --- Example:
 --- ```
@@ -4319,7 +4321,7 @@ vim.go.mousemoveevent = vim.o.mousemoveevent
 vim.go.mousemev = vim.go.mousemoveevent
 
 --- This option controls the number of lines / columns to scroll by when
---- scrolling with a mouse wheel (`|scroll-mouse-wheel|`). The option is
+--- scrolling with a mouse wheel ([scroll-mouse-wheel](help://scroll-mouse-wheel)). The option is
 --- a comma-separated list. Each part consists of a direction and a count
 --- as follows:
 --- direction:count,direction:count
@@ -4420,7 +4422,7 @@ vim.go.mouset = vim.go.mousetime
 
 --- This defines what bases Vim will consider for numbers when using the
 --- CTRL-A and CTRL-X commands for adding to and subtracting from a number
---- respectively; see `|CTRL-A|` for more info on these commands.
+--- respectively; see [CTRL-A](help://CTRL-A) for more info on these commands.
 --- alpha  If included, single alphabetical characters will be
 --- incremented or decremented.  This is useful for a list with a
 --- letter index a), b), etc.    *octal-nrformats*
@@ -4457,8 +4459,8 @@ vim.bo.nf = vim.bo.nrformats
 --- Use the 'numberwidth' option to adjust the room for the line number.
 --- When a long, wrapped line doesn't start with the first character, '-'
 --- characters are put before the number.
---- For highlighting see `|hl-LineNr|`, `|hl-CursorLineNr|`, and the
---- `|:sign-define|` "numhl" argument.
+--- For highlighting see [hl-LineNr](help://hl-LineNr), [hl-CursorLineNr](help://hl-CursorLineNr), and the
+--- [:sign-define](help://:sign-define) "numhl" argument.
 ---         *number_relativenumber*
 --- The 'relativenumber' option changes the displayed number to be
 --- relative to the cursor.  Together with 'number' there are these
@@ -4497,14 +4499,14 @@ vim.wo.numberwidth = vim.o.numberwidth
 vim.wo.nuw = vim.wo.numberwidth
 
 --- This option specifies a function to be used for Insert mode omni
---- completion with CTRL-X CTRL-O. `|i_CTRL-X_CTRL-O|`
---- See `|complete-functions|` for an explanation of how the function is
+--- completion with CTRL-X CTRL-O. [i_CTRL-X_CTRL-O](help://i_CTRL-X_CTRL-O)
+--- See [complete-functions](help://complete-functions) for an explanation of how the function is
 --- invoked and what it should return.  The value can be the name of a
---- function, a `|lambda|` or a `|Funcref|`. See `|option-value-function|` for
+--- function, a [lambda](help://lambda) or a [Funcref](help://Funcref). See [option-value-function](help://option-value-function) for
 --- more information.
 --- This option is usually set by a filetype plugin:
---- `|:filetype-plugin-on|`
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- [:filetype-plugin-on](help://:filetype-plugin-on)
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -4526,12 +4528,12 @@ vim.o.odev = vim.o.opendevice
 vim.go.opendevice = vim.o.opendevice
 vim.go.odev = vim.go.opendevice
 
---- This option specifies a function to be called by the `|g@|` operator.
---- See `|:map-operator|` for more info and an example.  The value can be
---- the name of a function, a `|lambda|` or a `|Funcref|`. See
---- `|option-value-function|` for more information.
+--- This option specifies a function to be called by the [g@](help://g@) operator.
+--- See [:map-operator](help://:map-operator) for more info and an example.  The value can be
+--- the name of a function, a [lambda](help://lambda) or a [Funcref](help://Funcref). See
+--- [option-value-function](help://option-value-function) for more information.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -4541,7 +4543,7 @@ vim.go.operatorfunc = vim.o.operatorfunc
 vim.go.opfunc = vim.go.operatorfunc
 
 --- Directories used to find packages.
---- See `|packages|` and `|packages-runtimepath|`.
+--- See [packages](help://packages) and [packages-runtimepath](help://packages-runtimepath).
 ---
 --- @type string
 vim.o.packpath = "..."
@@ -4550,7 +4552,7 @@ vim.go.packpath = vim.o.packpath
 vim.go.pp = vim.go.packpath
 
 --- Specifies the nroff macros that separate paragraphs.  These are pairs
---- of two letters (see `|object-motions|`).
+--- of two letters (see [object-motions](help://object-motions)).
 ---
 --- @type string
 vim.o.paragraphs = "IPLPPPQPP TPHPLIPpLpItpplpipbp"
@@ -4559,7 +4561,7 @@ vim.go.paragraphs = vim.o.paragraphs
 vim.go.para = vim.go.paragraphs
 
 --- Expression which is evaluated to apply a patch to a file and generate
---- the resulting new version of the file.  See `|diff-patchexpr|`.
+--- the resulting new version of the file.  See [diff-patchexpr](help://diff-patchexpr).
 ---
 --- @type string
 vim.o.patchexpr = ""
@@ -4591,7 +4593,7 @@ vim.go.patchmode = vim.o.patchmode
 vim.go.pm = vim.go.patchmode
 
 --- This is a list of directories which will be searched when using the
---- `|gf|`, [f, ]f, ^Wf, `|:find|`, `|:sfind|`, `|:tabfind|` and other commands,
+--- [gf](help://gf), [f, ]f, ^Wf, [:find](help://:find), [:sfind](help://:sfind), [:tabfind](help://:tabfind) and other commands,
 --- provided that the file being searched for has a relative path (not
 --- starting with "/", "./" or "../").  The directories in the 'path'
 --- option may be relative or absolute.
@@ -4620,11 +4622,11 @@ vim.go.pm = vim.go.patchmode
 --- :set path=,,
 --- ```
 --- - A directory name may end in a ':' or '/'.
---- - Environment variables are expanded `|:set_env|`.
---- - When using `|netrw.vim|` URLs can be used.  For example, adding
+--- - Environment variables are expanded [:set_env](help://:set_env).
+--- - When using [netrw.vim](help://netrw.vim) URLs can be used.  For example, adding
 --- "https://www.vim.org" will make ":find index.html" work.
 --- - Search upwards and downwards in a directory tree using "*", "**" and
---- ";".  See `|file-searching|` for info and syntax.
+--- ";".  See [file-searching](help://file-searching) for info and syntax.
 --- - Careful with '\' characters, type two to get one in the option:
 --- ```
 --- :set path=.,c:\\include
@@ -4638,8 +4640,8 @@ vim.go.pm = vim.go.patchmode
 --- The maximum length is limited.  How much depends on the system, mostly
 --- it is something like 256 or 1024 characters.
 --- You can check if all the include files are found, using the value of
---- 'path', see `|:checkpath|`.
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- 'path', see [:checkpath](help://:checkpath).
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.  To remove the current directory use:
 --- ```
@@ -4668,7 +4670,7 @@ vim.go.pa = vim.go.path
 
 --- When changing the indent of the current line, preserve as much of the
 --- indent structure as possible.  Normally the indent is replaced by a
---- series of tabs followed by spaces as required (unless `|'expandtab'|` is
+--- series of tabs followed by spaces as required (unless ['expandtab'](help://'expandtab') is
 --- enabled, in which case only spaces are used).  Enabling this option
 --- means the indent will preserve as many existing characters as possible
 --- for indenting, and only add additional tabs or spaces as required.
@@ -4677,7 +4679,7 @@ vim.go.pa = vim.go.path
 --- NOTE: When using ">>" multiple times the resulting indent is a mix of
 --- tabs and spaces.  You might not like this.
 --- Also see 'copyindent'.
---- Use `|:retab|` to clean up white space.
+--- Use [:retab](help://:retab) to clean up white space.
 ---
 --- @type boolean
 vim.o.preserveindent = false
@@ -4685,8 +4687,8 @@ vim.o.pi = vim.o.preserveindent
 vim.bo.preserveindent = vim.o.preserveindent
 vim.bo.pi = vim.bo.preserveindent
 
---- Default height for a preview window.  Used for `|:ptag|` and associated
---- commands.  Used for `|CTRL-W_}|` when no count is given.
+--- Default height for a preview window.  Used for [:ptag](help://:ptag) and associated
+--- commands.  Used for [CTRL-W_}](help://CTRL-W_}) when no count is given.
 ---
 --- @type integer
 vim.o.previewheight = 12
@@ -4696,7 +4698,7 @@ vim.go.pvh = vim.go.previewheight
 
 --- Identifies the preview window.  Only one window can have this option
 --- set.  It's normally not set directly, but by using one of the commands
---- `|:ptag|`, `|:pedit|`, etc.
+--- [:ptag](help://:ptag), [:pedit](help://:pedit), etc.
 ---
 --- @type boolean
 vim.o.previewwindow = false
@@ -4704,12 +4706,12 @@ vim.o.pvw = vim.o.previewwindow
 vim.wo.previewwindow = vim.o.previewwindow
 vim.wo.pvw = vim.wo.previewwindow
 
---- Enables pseudo-transparency for the `|popup-menu|`. Valid values are in
+--- Enables pseudo-transparency for the [popup-menu](help://popup-menu). Valid values are in
 --- the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
 --- transparent background. Values between 0-30 are typically most useful.
 ---
 --- It is possible to override the level for individual highlights within
---- the popupmenu using `|highlight-blend|`. For instance, to enable
+--- the popupmenu using [highlight-blend](help://highlight-blend). For instance, to enable
 --- transparency but force the current selected element to be fully opaque:
 --- ```
 --- :set pumblend=15
@@ -4724,7 +4726,7 @@ vim.go.pumblend = vim.o.pumblend
 vim.go.pb = vim.go.pumblend
 
 --- Maximum number of items to show in the popup menu
---- (`|ins-completion-menu|`). Zero means "use available screen space".
+--- ([ins-completion-menu](help://ins-completion-menu)). Zero means "use available screen space".
 ---
 --- @type integer
 vim.o.pumheight = 0
@@ -4732,7 +4734,7 @@ vim.o.ph = vim.o.pumheight
 vim.go.pumheight = vim.o.pumheight
 vim.go.ph = vim.go.pumheight
 
---- Minimum width for the popup menu (`|ins-completion-menu|`).  If the
+--- Minimum width for the popup menu ([ins-completion-menu](help://ins-completion-menu)).  If the
 --- cursor column + 'pumwidth' exceeds screen width, the popup menu is
 --- nudged to fit on the screen.
 ---
@@ -4743,10 +4745,10 @@ vim.go.pumwidth = vim.o.pumwidth
 vim.go.pw = vim.go.pumwidth
 
 --- Specifies the python version used for pyx* functions and commands
---- `|python_x|`.  As only Python 3 is supported, this always has the value
+--- [python_x](help://python_x).  As only Python 3 is supported, this always has the value
 --- `3`. Setting any other value is an error.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type integer
@@ -4759,12 +4761,12 @@ vim.go.pyx = vim.go.pyxversion
 --- in the quickfix and location list windows.  This can be used to
 --- customize the information displayed in the quickfix or location window
 --- for each entry in the corresponding quickfix or location list.  See
---- `|quickfix-window-function|` for an explanation of how to write the
+--- [quickfix-window-function](help://quickfix-window-function) for an explanation of how to write the
 --- function and an example.  The value can be the name of a function, a
---- `|lambda|` or a `|Funcref|`. See `|option-value-function|` for more
+--- [lambda](help://lambda) or a [Funcref](help://Funcref). See [option-value-function](help://option-value-function) for more
 --- information.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -4774,7 +4776,7 @@ vim.go.quickfixtextfunc = vim.o.quickfixtextfunc
 vim.go.qftf = vim.go.quickfixtextfunc
 
 --- The characters that are used to escape quotes in a string.  Used for
---- objects like a', a" and a` `|a'|`.
+--- objects like a', a" and a` [a'](help://a').
 --- When one of the characters in this option is found inside a string,
 --- the following character will be skipped.  The default value makes the
 --- text "foo\"bar\\" considered to be one string.
@@ -4838,12 +4840,12 @@ vim.go.redrawdebug = vim.o.redrawdebug
 vim.go.rdb = vim.go.redrawdebug
 
 --- Time in milliseconds for redrawing the display.  Applies to
---- 'hlsearch', 'inccommand', `|:match|` highlighting and syntax
+--- 'hlsearch', 'inccommand', [:match](help://:match) highlighting and syntax
 --- highlighting.
 --- When redrawing takes more than this many milliseconds no further
 --- matches will be highlighted.
 --- For syntax highlighting the time applies per window.  When over the
---- limit syntax highlighting is disabled until `|CTRL-L|` is used.
+--- limit syntax highlighting is disabled until [CTRL-L](help://CTRL-L) is used.
 --- This is used to avoid that Vim hangs when using a very complicated
 --- pattern.
 ---
@@ -4853,7 +4855,7 @@ vim.o.rdt = vim.o.redrawtime
 vim.go.redrawtime = vim.o.redrawtime
 vim.go.rdt = vim.go.redrawtime
 
---- This selects the default regexp engine. `|two-engines|`
+--- This selects the default regexp engine. [two-engines](help://two-engines)
 --- The possible values are:
 --- 0  automatic selection
 --- 1  old engine
@@ -4873,7 +4875,7 @@ vim.go.regexpengine = vim.o.regexpengine
 vim.go.re = vim.go.regexpengine
 
 --- Show the line number relative to the line with the cursor in front of
---- each line. Relative line numbers help you use the `|count|` you can
+--- each line. Relative line numbers help you use the [count](help://count) you can
 --- precede some vertical motion commands (e.g. j k + -) with, without
 --- having to calculate it yourself. Especially useful in combination with
 --- other commands (e.g. y d c < > gq gw =).
@@ -4883,11 +4885,11 @@ vim.go.re = vim.go.regexpengine
 --- number.
 --- When a long, wrapped line doesn't start with the first character, '-'
 --- characters are put before the number.
---- See `|hl-LineNr|`  and `|hl-CursorLineNr|` for the highlighting used for
+--- See [hl-LineNr](help://hl-LineNr)  and [hl-CursorLineNr](help://hl-CursorLineNr) for the highlighting used for
 --- the number.
 ---
 --- The number in front of the cursor line also depends on the value of
---- 'number', see `|number_relativenumber|` for all combinations of the two
+--- 'number', see [number_relativenumber](help://number_relativenumber) for all combinations of the two
 --- options.
 ---
 --- @type boolean
@@ -4907,7 +4909,7 @@ vim.o.report = 2
 vim.go.report = vim.o.report
 
 --- Inserting characters in Insert mode will work backwards.  See "typing
---- backwards" `|ins-reverse|`.  This option can be toggled with the CTRL-_
+--- backwards" [ins-reverse](help://ins-reverse).  This option can be toggled with the CTRL-_
 --- command in Insert mode, when 'allowrevins' is set.
 ---
 --- @type boolean
@@ -4924,7 +4926,7 @@ vim.go.ri = vim.go.revins
 --- simultaneously, or to view the same file in both ways (this is
 --- useful whenever you have a mixed text file with both right-to-left
 --- and left-to-right strings so that both sets are displayed properly
---- in different windows).  Also see `|rileft.txt|`.
+--- in different windows).  Also see [rileft.txt](help://rileft.txt).
 ---
 --- @type boolean
 vim.o.rightleft = false
@@ -4967,7 +4969,7 @@ vim.wo.rlc = vim.wo.rightleftcmd
 --- For an empty line "0-1" is shown.
 --- For an empty buffer the line number will also be zero: "0,0-1".
 --- If you don't want to see the ruler all the time but want to know where
---- you are, use "g CTRL-G" `|g_CTRL-G|`.
+--- you are, use "g CTRL-G" [g_CTRL-G](help://g_CTRL-G).
 ---
 --- @type boolean
 vim.o.ruler = true
@@ -4994,36 +4996,36 @@ vim.go.rulerformat = vim.o.rulerformat
 vim.go.ruf = vim.go.rulerformat
 
 --- List of directories to be searched for these runtime files:
---- filetype.lua  filetypes `|new-filetype|`
---- autoload/  automatically loaded scripts `|autoload-functions|`
---- colors/  color scheme files `|:colorscheme|`
---- compiler/  compiler files `|:compiler|`
---- doc/    documentation `|write-local-help|`
---- ftplugin/  filetype plugins `|write-filetype-plugin|`
---- indent/  indent scripts `|indent-expression|`
---- keymap/  key mapping files `|mbyte-keymap|`
---- lang/    menu translations `|:menutrans|`
---- lua/    `|Lua|` plugins
---- menu.vim  GUI menus `|menu.vim|`
---- pack/    packages `|:packadd|`
---- parser/  `|treesitter|` syntax parsers
---- plugin/  plugin scripts `|write-plugin|`
---- queries/  `|treesitter|` queries
---- rplugin/  `|remote-plugin|` scripts
---- spell/  spell checking files `|spell|`
---- syntax/  syntax files `|mysyntaxfile|`
---- tutor/  tutorial files `|:Tutor|`
+--- filetype.lua  filetypes [new-filetype](help://new-filetype)
+--- autoload/  automatically loaded scripts [autoload-functions](help://autoload-functions)
+--- colors/  color scheme files [:colorscheme](help://:colorscheme)
+--- compiler/  compiler files [:compiler](help://:compiler)
+--- doc/    documentation [write-local-help](help://write-local-help)
+--- ftplugin/  filetype plugins [write-filetype-plugin](help://write-filetype-plugin)
+--- indent/  indent scripts [indent-expression](help://indent-expression)
+--- keymap/  key mapping files [mbyte-keymap](help://mbyte-keymap)
+--- lang/    menu translations [:menutrans](help://:menutrans)
+--- lua/    [Lua](help://Lua) plugins
+--- menu.vim  GUI menus [menu.vim](help://menu.vim)
+--- pack/    packages [:packadd](help://:packadd)
+--- parser/  [treesitter](help://treesitter) syntax parsers
+--- plugin/  plugin scripts [write-plugin](help://write-plugin)
+--- queries/  [treesitter](help://treesitter) queries
+--- rplugin/  [remote-plugin](help://remote-plugin) scripts
+--- spell/  spell checking files [spell](help://spell)
+--- syntax/  syntax files [mysyntaxfile](help://mysyntaxfile)
+--- tutor/  tutorial files [:Tutor](help://:Tutor)
 ---
---- And any other file searched for with the `|:runtime|` command.
+--- And any other file searched for with the [:runtime](help://:runtime) command.
 ---
 --- Defaults are setup to search these locations:
 --- 1. Your home directory, for personal preferences.
----  Given by `stdpath("config")`.  `|$XDG_CONFIG_HOME|`
+---  Given by `stdpath("config")`.  [$XDG_CONFIG_HOME](help://$XDG_CONFIG_HOME)
 --- 2. Directories which must contain configuration files according to
----  `|xdg|` ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
+---  [xdg](help://xdg) ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
 ---  preferences from system administrator.
 --- 3. Data home directory, for plugins installed by user.
----  Given by `stdpath("data")/site`.  `|$XDG_DATA_HOME|`
+---  Given by `stdpath("data")/site`.  [$XDG_DATA_HOME](help://$XDG_DATA_HOME)
 --- 4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
 ---  This is for plugins which were installed by system administrator,
 ---  but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
@@ -5031,7 +5033,7 @@ vim.go.ruf = vim.go.rulerformat
 ---  expected to install site plugins to /usr/share/nvim/site.
 --- 5. Session state directory, for state data such as swap, backupdir,
 ---  viewdir, undodir, etc.
----  Given by `stdpath("state")`.  `|$XDG_STATE_HOME|`
+---  Given by `stdpath("state")`.  [$XDG_STATE_HOME](help://$XDG_STATE_HOME)
 --- 6. $VIMRUNTIME, for files distributed with Nvim.
 ---           *after-directory*
 --- 7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
@@ -5039,16 +5041,16 @@ vim.go.ruf = vim.go.rulerformat
 ---  distributed defaults or system-wide settings (rarely needed).
 ---
 ---           *packages-runtimepath*
---- "start" packages will also be searched (`|runtime-search-path|`) for
+--- "start" packages will also be searched ([runtime-search-path](help://runtime-search-path)) for
 --- runtime files after these, though such packages are not explicitly
 --- reported in &runtimepath. But "opt" packages are explicitly added to
---- &runtimepath by `|:packadd|`.
+--- &runtimepath by [:packadd](help://:packadd).
 ---
 --- Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
 --- wildcards are allowed, but can significantly slow down searching for
 --- runtime files.  For speed, use as few items as possible and avoid
 --- wildcards.
---- See `|:runtime|`.
+--- See [:runtime](help://:runtime).
 --- Example:
 --- ```
 --- :set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
@@ -5060,7 +5062,7 @@ vim.go.ruf = vim.go.rulerformat
 --- distributed runtime files.  You can put a directory after $VIMRUNTIME
 --- to find files which add to distributed runtime files.
 ---
---- With `|--clean|` the home directory entries are not included.
+--- With [--clean](help://--clean) the home directory entries are not included.
 ---
 --- @type string
 vim.o.runtimepath = "..."
@@ -5070,7 +5072,7 @@ vim.go.rtp = vim.go.runtimepath
 
 --- Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 --- set to half the number of lines in the window when the window size
---- changes.  This may happen when enabling the `|status-line|` or
+--- changes.  This may happen when enabling the [status-line](help://status-line) or
 --- 'tabline' option after setting the 'scroll' option.
 --- If you give a count to the CTRL-U or CTRL-D command it will
 --- be used as the new value for 'scroll'.  Reset to half the window
@@ -5085,7 +5087,7 @@ vim.wo.scr = vim.wo.scroll
 --- Maximum number of lines kept beyond the visible screen. Lines at the
 --- top are deleted if new lines exceed this limit.
 --- Minimum is 1, maximum is 100000.
---- Only in `|terminal|` buffers.
+--- Only in [terminal](help://terminal) buffers.
 ---
 --- Note: Lines that are not visible and kept in scrollback are not
 --- reflown when the terminal buffer is resized horizontally.
@@ -5096,11 +5098,11 @@ vim.o.scbk = vim.o.scrollback
 vim.bo.scrollback = vim.o.scrollback
 vim.bo.scbk = vim.bo.scrollback
 
---- See also `|scroll-binding|`.  When this option is set, scrolling the
+--- See also [scroll-binding](help://scroll-binding).  When this option is set, scrolling the
 --- current window also scrolls other scrollbind windows (windows that
 --- also have this option set).  This option is useful for viewing the
 --- differences between two versions of a file, see 'diff'.
---- See `|'scrollopt'|` for options that determine how this option should be
+--- See ['scrollopt'](help://'scrollopt') for options that determine how this option should be
 --- interpreted.
 --- This option is mostly reset when splitting a window to edit another
 --- file.  This means that ":split | edit file" results in two windows
@@ -5170,7 +5172,7 @@ vim.go.so = vim.go.scrolloff
 ---    scrolled to keep the same relative offset.  When
 ---    going back to the other window, it still uses the
 ---    same relative offset.
---- Also see `|scroll-binding|`.
+--- Also see [scroll-binding](help://scroll-binding).
 --- When 'diff' mode is active there always is vertical scroll binding,
 --- even when "ver" isn't there.
 ---
@@ -5181,7 +5183,7 @@ vim.go.scrollopt = vim.o.scrollopt
 vim.go.sbo = vim.go.scrollopt
 
 --- Specifies the nroff macros that separate sections.  These are pairs of
---- two letters (See `|object-motions|`).  The default makes a section start
+--- two letters (See [object-motions](help://object-motions)).  The default makes a section start
 --- at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
 ---
 --- @type string
@@ -5220,7 +5222,7 @@ vim.go.sel = vim.go.selection
 ---  mouse  when using the mouse
 ---  key    when using shifted special keys
 ---  cmd    when using "v", "V" or CTRL-V
---- See `|Select-mode|`.
+--- See [Select-mode](help://Select-mode).
 ---
 --- @type string
 vim.o.selectmode = ""
@@ -5228,7 +5230,7 @@ vim.o.slm = vim.o.selectmode
 vim.go.selectmode = vim.o.selectmode
 vim.go.slm = vim.go.selectmode
 
---- Changes the effect of the `|:mksession|` command.  It is a comma-
+--- Changes the effect of the [:mksession](help://:mksession) command.  It is a comma-
 --- separated list of words.  Each word enables saving and restoring
 --- something:
 ---  word    save and restore ~
@@ -5258,8 +5260,8 @@ vim.go.slm = vim.go.selectmode
 ---   restored
 ---  winpos  position of the whole Vim window
 ---  winsize  window sizes
----  slash  `|deprecated|` Always enabled. Uses "/" in filenames.
----  unix    `|deprecated|` Always enabled. Uses "\n" line endings.
+---  slash  [deprecated](help://deprecated) Always enabled. Uses "/" in filenames.
+---  unix    [deprecated](help://deprecated) Always enabled. Uses "\n" line endings.
 ---
 --- Don't include both "curdir" and "sesdir". When neither is included
 --- filenames are stored as absolute paths.
@@ -5273,7 +5275,7 @@ vim.go.sessionoptions = vim.o.sessionoptions
 vim.go.ssop = vim.go.sessionoptions
 
 --- When non-empty, the shada file is read upon startup and written
---- when exiting Vim (see `|shada-file|`).  The string should be a comma-
+--- when exiting Vim (see [shada-file](help://shada-file)).  The string should be a comma-
 --- separated list of parameters, each consisting of a single character
 --- identifying the particular parameter, followed by a number or string
 --- which specifies the value of that parameter.  If a particular
@@ -5298,7 +5300,7 @@ vim.go.ssop = vim.go.sessionoptions
 --- restored.  If Vim is started without a file name argument, the
 --- buffer list is restored from the shada file.  Quickfix
 --- ('buftype'), unlisted ('buflisted'), unnamed and buffers on
---- removable media (`|shada-r|`) are not saved.
+--- removable media ([shada-r](help://shada-r)) are not saved.
 --- When followed by a number, the number specifies the maximum
 --- number of buffers that are stored.  Without a number all
 --- buffers are stored.
@@ -5306,8 +5308,8 @@ vim.go.ssop = vim.go.sessionoptions
 --- '  Maximum number of previously edited files for which the marks
 --- are remembered.  This parameter must always be included when
 --- 'shada' is non-empty.
---- Including this item also means that the `|jumplist|` and the
---- `|changelist|` are stored in the shada file.
+--- Including this item also means that the [jumplist](help://jumplist) and the
+--- [changelist](help://changelist) are stored in the shada file.
 ---           *shada-/*
 --- /  Maximum number of items in the search pattern history to be
 --- saved.  If non-zero, then the previous search and substitute
@@ -5332,7 +5334,7 @@ vim.go.ssop = vim.go.sessionoptions
 --- f  Whether file marks need to be stored.  If zero, file marks ('0
 --- to '9, 'A to 'Z) are not stored.  When not present or when
 --- non-zero, they are all stored.  '0 is used for the current
---- cursor position (when exiting or when doing `|:wshada|`).
+--- cursor position (when exiting or when doing [:wshada](help://:wshada)).
 ---           *shada-h*
 --- h  Disable the effect of 'hlsearch' when loading the shada
 --- file.  When not included, it depends on whether ":nohlsearch"
@@ -5378,10 +5380,10 @@ vim.go.ssop = vim.go.sessionoptions
 --- no %    The buffer list will not be saved nor read back.
 --- no h    'hlsearch' highlighting will be restored.
 ---
---- When setting 'shada' from an empty value you can use `|:rshada|` to
+--- When setting 'shada' from an empty value you can use [:rshada](help://:rshada) to
 --- load the contents of the file, this is not done automatically.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5390,11 +5392,11 @@ vim.o.sd = vim.o.shada
 vim.go.shada = vim.o.shada
 vim.go.sd = vim.go.shada
 
---- When non-empty, overrides the file name used for `|shada|` (viminfo).
+--- When non-empty, overrides the file name used for [shada](help://shada) (viminfo).
 --- When equal to "NONE" no shada file will be read or written.
---- This option can be set with the `|-i|` command line flag.  The `|--clean|`
+--- This option can be set with the [-i](help://-i) command line flag.  The [--clean](help://--clean)
 --- command line flag sets it to "NONE".
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5407,8 +5409,8 @@ vim.go.sdf = vim.go.shadafile
 --- value also check these options: 'shellpipe', 'shellslash'
 --- 'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
 --- It is allowed to give an argument to the command, e.g.  "csh -f".
---- See `|option-backslash|` about including spaces and backslashes.
---- Environment variables are expanded `|:set_env|`.
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
+--- Environment variables are expanded [:set_env](help://:set_env).
 ---
 --- If the name of the shell contains a space, you need to enclose it in
 --- quotes.  Example with quotes:
@@ -5416,7 +5418,7 @@ vim.go.sdf = vim.go.shadafile
 --- :set shell=\"c:\program\ files\unix\sh.exe\"\ -f
 --- ```
 --- Note the backslash before each quote (to avoid starting a comment) and
---- each space (to avoid ending the option value), so better use `|:let-&|`
+--- each space (to avoid ending the option value), so better use [:let-&](help://:let-&)
 --- like this:
 --- ```
 --- :let &shell='"C:\Program Files\unix\sh.exe" -f'
@@ -5440,8 +5442,8 @@ vim.go.sdf = vim.go.shadafile
 ---  'a"b', '"a\b"' is the same as "a\b" again.
 --- 4. Outside of quotes backslash always means itself, it cannot be used
 ---  to escape quote: 'a\"b"' is the same as "a\b".
---- Note that such processing is done after `|:set|` did its own round of
---- unescaping, so to keep yourself sane use `|:let-&|` like shown above.
+--- Note that such processing is done after [:set](help://:set) did its own round of
+--- unescaping, so to keep yourself sane use [:let-&](help://:let-&) like shown above.
 ---           *shell-powershell*
 --- To use PowerShell:
 --- ```
@@ -5451,7 +5453,7 @@ vim.go.sdf = vim.go.shadafile
 --- let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
 --- set shellquote= shellxquote=
 --- ```
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5466,10 +5468,10 @@ vim.go.sh = vim.go.shell
 --- to set this option by the user.
 --- On Unix it can have more than one flag.  Each white space separated
 --- part is passed as an argument to the shell command.
---- See `|option-backslash|` about including spaces and backslashes.
---- See `|shell-unquoting|` which talks about separating this option into
+--- See [option-backslash](help://option-backslash) about including spaces and backslashes.
+--- See [shell-unquoting](help://shell-unquoting) which talks about separating this option into
 --- multiple arguments.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5479,7 +5481,7 @@ vim.go.shellcmdflag = vim.o.shellcmdflag
 vim.go.shcf = vim.go.shellcmdflag
 
 --- String to be used to put the output of the ":make" command in the
---- error file.  See also `|:make_makeprg|`.  See `|option-backslash|` about
+--- error file.  See also [:make_makeprg](help://:make_makeprg).  See [option-backslash](help://option-backslash) about
 --- including spaces and backslashes.
 --- The name of the temporary file can be represented by "%s" if necessary
 --- (the file name is appended automatically if no %s appears in the value
@@ -5504,7 +5506,7 @@ vim.go.shcf = vim.go.shellcmdflag
 --- Don't forget to precede the space with a backslash: ":set sp=\ ".
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5522,7 +5524,7 @@ vim.go.sp = vim.go.shellpipe
 --- or bash, where it should be "\"".  The default is adjusted according
 --- the value of 'shell', to reduce the need to set this option by the
 --- user.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5532,7 +5534,7 @@ vim.go.shellquote = vim.o.shellquote
 vim.go.shq = vim.go.shellquote
 
 --- String to be used to put the output of a filter command in a temporary
---- file.  See also `|:!|`.  See `|option-backslash|` about including spaces
+--- file.  See also [:!](help://:!).  See [option-backslash](help://option-backslash) about including spaces
 --- and backslashes.
 --- The name of the temporary file can be represented by "%s" if necessary
 --- (the file name is appended automatically if no %s appears in the value
@@ -5550,7 +5552,7 @@ vim.go.shq = vim.go.shellquote
 --- explicitly set before.
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5586,10 +5588,11 @@ vim.go.ssl = vim.go.shellslash
 --- and the 'shell' command does not need to support redirection.
 --- The advantage of using a temp file is that the file type and encoding
 --- can be detected.
---- The `|FilterReadPre|`, `|FilterReadPost|` and `|FilterWritePre|,
---- |FilterWritePost|` autocommands event are not triggered when
+--- The [FilterReadPre](help://FilterReadPre), [FilterReadPost](help://FilterReadPost) and [FilterWritePre|,
+--- |FilterWritePost](help://FilterWritePre|,
+--- |FilterWritePost) autocommands event are not triggered when
 --- 'shelltemp' is off.
---- `|system()|` does not respect this option, it always uses pipes.
+--- [system()](help://system()) does not respect this option, it always uses pipes.
 ---
 --- @type boolean
 vim.o.shelltemp = true
@@ -5614,7 +5617,7 @@ vim.go.sxe = vim.go.shellxescape
 --- When the value is '(' then ')' is appended. When the value is '"('
 --- then ')"' is appended.
 --- When the value is '(' then also see 'shellxescape'.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -5634,8 +5637,8 @@ vim.go.shiftround = vim.o.shiftround
 vim.go.sr = vim.go.shiftround
 
 --- Number of spaces to use for each step of (auto)indent.  Used for
---- `|'cindent'|`, `|>>|`, `|<<|`, etc.
---- When zero the 'tabstop' value will be used.  Use the `|shiftwidth()|`
+--- ['cindent'](help://'cindent'), [>>](help://>>), [<<](help://<<), etc.
+--- When zero the 'tabstop' value will be used.  Use the [shiftwidth()](help://shiftwidth())
 --- function to get the effective shiftwidth value.
 ---
 --- @type integer
@@ -5644,7 +5647,7 @@ vim.o.sw = vim.o.shiftwidth
 vim.bo.shiftwidth = vim.o.shiftwidth
 vim.bo.sw = vim.bo.shiftwidth
 
---- This option helps to avoid all the `|hit-enter|` prompts caused by file
+--- This option helps to avoid all the [hit-enter](help://hit-enter) prompts caused by file
 --- messages, for example  with CTRL-G, and to avoid some other messages.
 --- It is a list of flags:
 ---  flag  meaning when present  ~
@@ -5674,8 +5677,8 @@ vim.bo.sw = vim.bo.shiftwidth
 --- A  don't give the "ATTENTION" message when an existing  *shm-A*
 --- swap file is found
 --- I  don't give the intro message when starting Vim,    *shm-I*
---- see `|:intro|`
---- c  don't give `|ins-completion-menu|` messages; for    *shm-c*
+--- see [:intro](help://:intro)
+--- c  don't give [ins-completion-menu](help://ins-completion-menu) messages; for    *shm-c*
 --- example, "-- XXX completion (YYY)", "match 1 of 2", "The only
 --- match", "Pattern not found", "Back at original", etc.
 --- C  don't give messages while scanning for ins-completion  *shm-C*
@@ -5710,7 +5713,7 @@ vim.go.shm = vim.go.shortmess
 --- Only printable single-cell characters are allowed, excluding <Tab> and
 --- comma (in a future version the comma might be used to separate the
 --- part that is shown at the end and at the start of a line).
---- The `|hl-NonText|` highlight group determines the highlighting.
+--- The [hl-NonText](help://hl-NonText) highlight group determines the highlighting.
 --- Note that tabs after the showbreak will be displayed differently.
 --- If you want the 'showbreak' to appear in between line numbers, add the
 --- "n" flag to 'cpoptions'.
@@ -5764,7 +5767,7 @@ vim.o.sloc = vim.o.showcmdloc
 vim.go.showcmdloc = vim.o.showcmdloc
 vim.go.sloc = vim.go.showcmdloc
 
---- When completing a word in insert mode (see `|ins-completion|`) from the
+--- When completing a word in insert mode (see [ins-completion](help://ins-completion)) from the
 --- tags file, show both the tag name and a tidied-up form of the search
 --- pattern (if there is one) as possible matches.  Thus, if you have
 --- matched a C function, you can see a template for what arguments are
@@ -5792,7 +5795,7 @@ vim.go.sft = vim.go.showfulltag
 --- matches for.  'rightleft' and 'revins' are used to look for opposite
 --- matches.
 --- Also see the matchparen plugin for highlighting the match when moving
---- around `|pi_paren.txt|`.
+--- around [pi_paren.txt](help://pi_paren.txt).
 --- Note: Use of the short form is rated PG.
 ---
 --- @type boolean
@@ -5802,7 +5805,7 @@ vim.go.showmatch = vim.o.showmatch
 vim.go.sm = vim.go.showmatch
 
 --- If in Insert, Replace or Visual mode put a message on the last line.
---- The `|hl-ModeMsg|` highlight group determines the highlighting.
+--- The [hl-ModeMsg](help://hl-ModeMsg) highlight group determines the highlighting.
 --- The option has no effect when 'cmdheight' is zero.
 ---
 --- @type boolean
@@ -5818,7 +5821,7 @@ vim.go.smd = vim.go.showmode
 --- 2: always
 --- This is both for the GUI and non-GUI implementation of the tab pages
 --- line.
---- See `|tab-page|` for more information about tab pages.
+--- See [tab-page](help://tab-page) for more information about tab pages.
 ---
 --- @type integer
 vim.o.showtabline = 1
@@ -5840,7 +5843,7 @@ vim.go.ss = vim.go.sidescroll
 
 --- The minimal number of screen columns to keep to the left and to the
 --- right of the cursor if 'nowrap' is set.  Setting this option to a
---- value greater than 0 while having `|'sidescroll'|` also at a non-zero
+--- value greater than 0 while having ['sidescroll'](help://'sidescroll') also at a non-zero
 --- value makes some context visible in the line you are scrolling in
 --- horizontally (except at beginning of the line).  Setting this option
 --- to a large value (like 999) has the effect of keeping the cursor
@@ -5913,7 +5916,7 @@ vim.go.scs = vim.go.smartcase
 --- Do smart autoindenting when starting a new line.  Works for C-like
 --- programs, but can also be used for other languages.  'cindent' does
 --- something like this, works better in most cases, but is more strict,
---- see `|C-indenting|`.  When 'cindent' is on or 'indentexpr' is set,
+--- see [C-indenting](help://C-indenting).  When 'cindent' is on or 'indentexpr' is set,
 --- setting 'si' has no effect.  'indentexpr' is a more advanced
 --- alternative.
 --- Normally 'autoindent' should also be on when using 'smartindent'.
@@ -5942,9 +5945,9 @@ vim.bo.si = vim.bo.smartindent
 --- line.
 --- When off, a <Tab> always inserts blanks according to 'tabstop' or
 --- 'softtabstop'.  'shiftwidth' is only used for shifting text left or
---- right `|shift-left-right|`.
+--- right [shift-left-right](help://shift-left-right).
 --- What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
---- option.  Also see `|ins-expandtab|`.  When 'expandtab' is not set, the
+--- option.  Also see [ins-expandtab](help://ins-expandtab).  When 'expandtab' is not set, the
 --- number of spaces is minimized by using <Tab>s.
 ---
 --- @type boolean
@@ -5956,7 +5959,7 @@ vim.go.sta = vim.go.smarttab
 --- Scrolling works with screen lines.  When 'wrap' is set and the first
 --- line in the window wraps part of it may not be visible, as if it is
 --- above the window. "<<<" is displayed at the start of the first line,
---- highlighted with `|hl-NonText|`.
+--- highlighted with [hl-NonText](help://hl-NonText).
 --- You may also want to add "lastline" to the 'display' option to show as
 --- much of the last line as possible.
 --- NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
@@ -5976,12 +5979,12 @@ vim.wo.sms = vim.wo.smoothscroll
 --- commands like "x" still work on the actual characters.
 --- When 'sts' is zero, this feature is off.
 --- When 'sts' is negative, the value of 'shiftwidth' is used.
---- See also `|ins-expandtab|`.  When 'expandtab' is not set, the number of
+--- See also [ins-expandtab](help://ins-expandtab).  When 'expandtab' is not set, the number of
 --- spaces is minimized by using <Tab>s.
 --- The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
 --- set.
 ---
---- The value of 'softtabstop' will be ignored if `|'varsofttabstop'|` is set
+--- The value of 'softtabstop' will be ignored if ['varsofttabstop'](help://'varsofttabstop') is set
 --- to anything other than an empty string.
 ---
 --- @type integer
@@ -5990,7 +5993,7 @@ vim.o.sts = vim.o.softtabstop
 vim.bo.softtabstop = vim.o.softtabstop
 vim.bo.sts = vim.bo.softtabstop
 
---- When on spell checking will be done.  See `|spell|`.
+--- When on spell checking will be done.  See [spell](help://spell).
 --- The languages are specified with 'spelllang'.
 ---
 --- @type boolean
@@ -5999,13 +6002,13 @@ vim.wo.spell = vim.o.spell
 
 --- Pattern to locate the end of a sentence.  The following word will be
 --- checked to start with a capital letter.  If not then it is highlighted
---- with SpellCap `|hl-SpellCap|` (unless the word is also badly spelled).
+--- with SpellCap [hl-SpellCap](help://hl-SpellCap) (unless the word is also badly spelled).
 --- When this check is not wanted make this option empty.
 --- Only used when 'spell' is set.
---- Be careful with special characters, see `|option-backslash|` about
+--- Be careful with special characters, see [option-backslash](help://option-backslash) about
 --- including spaces and backslashes.
 --- To set this option automatically depending on the language, see
---- `|set-spc-auto|`.
+--- [set-spc-auto](help://set-spc-auto).
 ---
 --- @type string
 vim.o.spellcapcheck = "[.?!]\\_[\\])'\"\\t ]\\+"
@@ -6013,13 +6016,13 @@ vim.o.spc = vim.o.spellcapcheck
 vim.bo.spellcapcheck = vim.o.spellcapcheck
 vim.bo.spc = vim.bo.spellcapcheck
 
---- Name of the word list file where words are added for the `|zg|` and `|zw|`
+--- Name of the word list file where words are added for the [zg](help://zg) and [zw](help://zw)
 --- commands.  It must end in ".{encoding}.add".  You need to include the
 --- path, otherwise the file is placed in the current directory.
 --- The path may include characters from 'isfname', space, comma and '@'.
 --- *E765*
 --- It may also be a comma-separated list of names.  A count before the
---- `|zg|` and `|zw|` commands can be used to access each.  This allows using
+--- [zg](help://zg) and [zw](help://zw) commands can be used to access each.  This allows using
 --- a personal word list file and a project word list file.
 --- When a word is added while this option is empty Vim will set it for
 --- you: Using the first directory in 'runtimepath' that is writable.  If
@@ -6032,7 +6035,7 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- name if you want to.  However, it will then only be used when
 --- 'spellfile' is set to it, for entries in 'spelllang' only files
 --- without region name will be found.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -6069,16 +6072,16 @@ vim.bo.spf = vim.bo.spellfile
 --- (_xx is an underscore, two letters and followed by a non-letter).
 --- This is mainly for testing purposes.  You must make sure the correct
 --- encoding is used, Vim doesn't check it.
---- How the related spell files are found is explained here: `|spell-load|`.
+--- How the related spell files are found is explained here: [spell-load](help://spell-load).
 ---
---- If the `|spellfile.vim|` plugin is active and you use a language name
+--- If the [spellfile.vim](help://spellfile.vim) plugin is active and you use a language name
 --- for which Vim cannot find the .spl file in 'runtimepath' the plugin
 --- will ask you if you want to download the file.
 ---
 --- After this option has been set successfully, Vim will source the files
 --- "spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
 --- up to the first character that is not an ASCII letter or number and
---- not a dash.  Also see `|set-spc-auto|`.
+--- not a dash.  Also see [set-spc-auto](help://set-spc-auto).
 ---
 --- @type string
 vim.o.spelllang = "en"
@@ -6102,8 +6105,8 @@ vim.o.spo = vim.o.spelloptions
 vim.bo.spelloptions = vim.o.spelloptions
 vim.bo.spo = vim.bo.spelloptions
 
---- Methods used for spelling suggestions.  Both for the `|z=|` command and
---- the `|spellsuggest()|` function.  This is a comma-separated list of
+--- Methods used for spelling suggestions.  Both for the [z=](help://z=) command and
+--- the [spellsuggest()](help://spellsuggest()) function.  This is a comma-separated list of
 --- items:
 ---
 --- best    Internal method that works best for English.  Finds
@@ -6121,8 +6124,8 @@ vim.bo.spo = vim.bo.spelloptions
 ---   character inserts/deletes/swaps.  Works well for
 ---   simple typing mistakes.
 ---
---- {number}  The maximum number of suggestions listed for `|z=|`.
----   Not used for `|spellsuggest()|`.  The number of
+--- {number}  The maximum number of suggestions listed for [z=](help://z=).
+---   Not used for [spellsuggest()](help://spellsuggest()).  The number of
 ---   suggestions is never more than the value of 'lines'
 ---   minus two.
 ---
@@ -6147,14 +6150,14 @@ vim.bo.spo = vim.bo.spelloptions
 ---   The file is used for all languages.
 ---
 --- expr:{expr}  Evaluate expression {expr}.  Use a function to avoid
----   trouble with spaces.  `|v:val|` holds the badly spelled
+---   trouble with spaces.  [v:val](help://v:val) holds the badly spelled
 ---   word.  The expression must evaluate to a List of
 ---   Lists, each with a suggestion and a score.
 ---   Example:
 ---     [['the', 33], ['that', 44]] ~
----   Set 'verbose' and use `|z=|` to see the scores that the
+---   Set 'verbose' and use [z=](help://z=) to see the scores that the
 ---   internal methods use.  A lower score is better.
----   This may invoke `|spellsuggest()|` if you temporarily
+---   This may invoke [spellsuggest()](help://spellsuggest()) if you temporarily
 ---   set 'spellsuggest' to exclude the "expr:" part.
 ---   Errors are silently ignored, unless you set the
 ---   'verbose' option to a non-zero value.
@@ -6164,7 +6167,7 @@ vim.bo.spo = vim.bo.spelloptions
 --- ```
 --- :set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
 --- ```
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -6174,7 +6177,7 @@ vim.go.spellsuggest = vim.o.spellsuggest
 vim.go.sps = vim.go.spellsuggest
 
 --- When on, splitting a window will put the new window below the current
---- one. `|:split|`
+--- one. [:split](help://:split)
 ---
 --- @type boolean
 vim.o.splitbelow = false
@@ -6202,7 +6205,7 @@ vim.go.splitkeep = vim.o.splitkeep
 vim.go.spk = vim.go.splitkeep
 
 --- When on, splitting a window will put the new window right of the
---- current one. `|:vsplit|`
+--- current one. [:vsplit](help://:vsplit)
 ---
 --- @type boolean
 vim.o.splitright = false
@@ -6244,9 +6247,9 @@ vim.go.sol = vim.go.startofline
 --- 'statuscolumn'. Even when they are not included, the status column width
 --- will adapt to the 'signcolumn' and 'foldcolumn' width.
 ---
---- The `|v:lnum|`    variable holds the line number to be drawn.
---- The `|v:relnum|`  variable holds the relative line number to be drawn.
---- The `|v:virtnum|` variable is negative when drawing virtual lines, zero
+--- The [v:lnum](help://v:lnum)    variable holds the line number to be drawn.
+--- The [v:relnum](help://v:relnum)  variable holds the relative line number to be drawn.
+--- The [v:virtnum](help://v:virtnum) variable is negative when drawing virtual lines, zero
 ---       when drawing the actual buffer line, and positive when
 ---       drawing the wrapped part of a buffer line.
 ---
@@ -6286,7 +6289,7 @@ vim.wo.statuscolumn = vim.o.statuscolumn
 vim.wo.stc = vim.wo.statuscolumn
 
 --- When non-empty, this option determines the content of the status line.
---- Also see `|status-line|`.
+--- Also see [status-line](help://status-line).
 ---
 --- The option consists of printf style '%' items interspersed with
 --- normal text.  Each status line item is of the form:
@@ -6299,7 +6302,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- ```
 --- :set statusline=%!MyStatusLine()
 --- ```
---- The *g:statusline_winid* variable will be set to the `|window-ID|` of the
+--- The *g:statusline_winid* variable will be set to the [window-ID](help://window-ID) of the
 --- window that the status line belongs to.
 --- The result can contain %{} items that will be evaluated too.
 --- Note that the "%!" expression is evaluated in the context of the
@@ -6312,7 +6315,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- unpredictable.
 ---
 --- Note that the only effect of 'ruler' when this option is set (and
---- 'laststatus' is 2 or 3) is controlling the output of `|CTRL-G|`.
+--- 'laststatus' is 2 or 3) is controlling the output of [CTRL-G](help://CTRL-G).
 ---
 --- field      meaning ~
 --- -      Left justify the item.  The default is right justified
@@ -6350,7 +6353,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
 --- Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
 --- q S   "[Quickfix List]", "[Location List]" or empty.
---- k S   Value of "b:keymap_name" or 'keymap' when `|:lmap|` mappings are
+--- k S   Value of "b:keymap_name" or 'keymap' when [:lmap](help://:lmap) mappings are
 ---     being used: "<keymap>"
 --- n N   Buffer number.
 --- b N   Value of character under cursor.
@@ -6363,7 +6366,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- c N   Column number (byte index).
 --- v N   Virtual column number (screen column).
 --- V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
---- p N   Percentage through file in lines as in `|CTRL-G|`.
+--- p N   Percentage through file in lines as in [CTRL-G](help://CTRL-G).
 --- P S   Percentage through file of displayed window.  This is like the
 ---     percentage described for 'ruler'.  Always 3 in length, unless
 ---     translated.
@@ -6373,7 +6376,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- { NF  Evaluate expression between "%{" and "}" and substitute result.
 ---     Note that there is no "%" before the closing "}".  The
 ---     expression cannot contain a "}" character, call a function to
----     work around that.  See `|stl-%{|` below.
+---     work around that.  See [stl-%{](help://stl-%{) below.
 --- `{%` -  This is almost same as "{" except the result of the expression is
 ---     re-evaluated as a statusline format string.  Thus if the
 ---     return value of expr contains "%" items they will get expanded.
@@ -6415,14 +6418,14 @@ vim.wo.stc = vim.wo.statuscolumn
 ---        modifier was pressed, "c" for control, "a" for alt and "m"
 ---        for meta; currently if modifier is not pressed string
 ---        contains space instead, but one should not rely on presence
----        of spaces or specific order of modifiers: use `|stridx()|` to
+---        of spaces or specific order of modifiers: use [stridx()](help://stridx()) to
 ---        test whether some modifier is present; string is guaranteed
 ---        to contain only ASCII letters and spaces, one letter per
 ---        modifier; "?" modifier may also be present, but its presence
 ---        is a bug that denotes that new mouse button recognition was
 ---        added without modifying code that reacts on mouse clicks on
 ---        this label.
----     Use `|getmousepos()|`.winid in the specified function to get the
+---     Use [getmousepos()](help://getmousepos()).winid in the specified function to get the
 ---     corresponding window id of the clicked item.
 --- \< -   Where to truncate line if too long.  Default is at the start.
 ---     No width fields allowed.
@@ -6439,7 +6442,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---     minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
 ---     The difference between User{N} and StatusLine will be applied to
 ---     StatusLineNC for the statusline of non-current windows.
----     The number N must be between 1 and 9.  See `|hl-User1..9|`
+---     The number N must be between 1 and 9.  See [hl-User1..9](help://hl-User1..9)
 ---
 --- When displaying a flag, Vim removes the leading comma, if any, when
 --- that flag comes right after plaintext.  This will make a nice display
@@ -6459,15 +6462,15 @@ vim.wo.stc = vim.wo.statuscolumn
 --- temporarily to that of the window (and buffer) whose statusline is
 --- currently being drawn.  The expression will evaluate in this context.
 --- The variable "g:actual_curbuf" is set to the `bufnr()` number of the
---- real current buffer and "g:actual_curwin" to the `|window-ID|` of the
+--- real current buffer and "g:actual_curwin" to the [window-ID](help://window-ID) of the
 --- real current window.  These values are strings.
 ---
---- The 'statusline' option will be evaluated in the `|sandbox|` if set from
---- a modeline, see `|sandbox-option|`.
+--- The 'statusline' option will be evaluated in the [sandbox](help://sandbox) if set from
+--- a modeline, see [sandbox-option](help://sandbox-option).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'statusline' `|textlock|`.
+--- evaluating 'statusline' [textlock](help://textlock).
 ---
 --- If the statusline is not updated when you want it (e.g., after setting
 --- a variable that's used in an expression), you can force an update by
@@ -6499,7 +6502,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- ```
 --- :set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
 --- ```
---- In the `|:autocmd|`'s:
+--- In the [:autocmd](help://:autocmd)'s:
 --- ```
 --- :let b:gzflag = 1
 --- ```
@@ -6523,13 +6526,13 @@ vim.go.statusline = vim.o.statusline
 vim.go.stl = vim.go.statusline
 
 --- Files with these suffixes get a lower priority when multiple files
---- match a wildcard.  See `|suffixes|`.  Commas can be used to separate the
+--- match a wildcard.  See [suffixes](help://suffixes).  Commas can be used to separate the
 --- suffixes.  Spaces after the comma are ignored.  A dot is also seen as
 --- the start of a suffix.  To avoid a dot or comma being recognized as a
---- separator, precede it with a backslash (see `|option-backslash|` about
+--- separator, precede it with a backslash (see [option-backslash](help://option-backslash) about
 --- including spaces and backslashes).
 --- See 'wildignore' for completely ignoring files.
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- suffixes from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -6557,18 +6560,18 @@ vim.bo.sua = vim.bo.suffixesadd
 --- Careful: All text will be in memory:
 --- - Don't use this for big files.
 --- - Recovery will be impossible!
---- A swapfile will only be present when `|'updatecount'|` is non-zero and
+--- A swapfile will only be present when ['updatecount'](help://'updatecount') is non-zero and
 --- 'swapfile' is set.
 --- When 'swapfile' is reset, the swap file for the current buffer is
 --- immediately deleted.  When 'swapfile' is set, and 'updatecount' is
 --- non-zero, a swap file is immediately created.
---- Also see `|swap-file|`.
+--- Also see [swap-file](help://swap-file).
 --- If you want to open a new buffer without creating a swap file for it,
---- use the `|:noswapfile|` modifier.
+--- use the [:noswapfile](help://:noswapfile) modifier.
 --- See 'directory' for where the swap file is created.
 ---
 --- This option is used together with 'bufhidden' and 'buftype' to
---- specify special kinds of buffers.   See `|special-buffers|`.
+--- specify special kinds of buffers.   See [special-buffers](help://special-buffers).
 ---
 --- @type boolean
 vim.o.swapfile = true
@@ -6578,12 +6581,13 @@ vim.bo.swf = vim.bo.swapfile
 
 --- This option controls the behavior when switching between buffers.
 --- This option is checked, when
---- - jumping to errors with the `|quickfix|` commands (`|:cc|`, `|:cn|`, `|:cp|`,
+--- - jumping to errors with the [quickfix](help://quickfix) commands ([:cc](help://:cc), [:cn](help://:cn), [:cp](help://:cp),
 --- etc.)
---- - jumping to a tag using the `|:stag|` command.
---- - opening a file using the `|CTRL-W_f|` or `|CTRL-W_F|` command.
---- - jumping to a buffer using a buffer split command (e.g.  `|:sbuffer|,
---- |:sbnext|`, or `|:sbrewind|`).
+--- - jumping to a tag using the [:stag](help://:stag) command.
+--- - opening a file using the [CTRL-W_f](help://CTRL-W_f) or [CTRL-W_F](help://CTRL-W_F) command.
+--- - jumping to a buffer using a buffer split command (e.g.  [:sbuffer|,
+--- |:sbnext](help://:sbuffer|,
+--- |:sbnext), or [:sbrewind](help://:sbrewind)).
 --- Possible values (comma-separated list):
 ---  useopen  If included, jump to the first open window in the
 ---   current tab page that contains the specified buffer
@@ -6592,7 +6596,7 @@ vim.bo.swf = vim.bo.swapfile
 ---  usetab  Like "useopen", but also consider windows in other tab
 ---   pages.
 ---  split  If included, split the current window before loading
----   a buffer for a `|quickfix|` command that display errors.
+---   a buffer for a [quickfix](help://quickfix) command that display errors.
 ---   Otherwise: do not split, use current window (when used
 ---   in the quickfix window: the previously used window or
 ---   split if there is no other window).
@@ -6600,7 +6604,7 @@ vim.bo.swf = vim.bo.swapfile
 ---  newtab  Like "split", but open a new tab page.  Overrules
 ---   "split" when both are present.
 ---  uselast  If included, jump to the previously used window when
----   jumping to errors with `|quickfix|` commands.
+---   jumping to errors with [quickfix](help://quickfix) commands.
 ---
 --- @type string
 vim.o.switchbuf = "uselast"
@@ -6661,7 +6665,7 @@ vim.bo.syn = vim.bo.syntax
 
 --- When non-empty, this option determines the content of the tab pages
 --- line at the top of the Vim window.  When empty Vim will use a default
---- tab pages line.  See `|setting-tabline|` for more info.
+--- tab pages line.  See [setting-tabline](help://setting-tabline) for more info.
 ---
 --- The tab pages line only appears as specified with the 'showtabline'
 --- option and only when there is no GUI tab line.  When 'e' is in
@@ -6669,12 +6673,12 @@ vim.bo.syn = vim.bo.syntax
 --- instead.  Note that the two tab pages lines are very different.
 ---
 --- The value is evaluated like with 'statusline'.  You can use
---- `|tabpagenr()|`, `|tabpagewinnr()|` and `|tabpagebuflist()|` to figure out
+--- [tabpagenr()](help://tabpagenr()), [tabpagewinnr()](help://tabpagewinnr()) and [tabpagebuflist()](help://tabpagebuflist()) to figure out
 --- the text to be displayed.  Use "%1T" for the first label, "%2T" for
 --- the second one, etc.  Use "%X" items for closing labels.
 ---
 --- When changing something that is used in 'tabline' that does not
---- trigger it to be updated, use `|:redrawtabline|`.
+--- trigger it to be updated, use [:redrawtabline](help://:redrawtabline).
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- Keep in mind that only one of the tab pages is the current one, others
@@ -6686,8 +6690,8 @@ vim.o.tal = vim.o.tabline
 vim.go.tabline = vim.o.tabline
 vim.go.tal = vim.go.tabline
 
---- Maximum number of tab pages to be opened by the `|-p|` command line
---- argument or the ":tab all" command. `|tabpage|`
+--- Maximum number of tab pages to be opened by the [-p](help://-p) command line
+--- argument or the ":tab all" command. [tabpage](help://tabpage)
 ---
 --- @type integer
 vim.o.tabpagemax = 50
@@ -6696,7 +6700,7 @@ vim.go.tabpagemax = vim.o.tabpagemax
 vim.go.tpm = vim.go.tabpagemax
 
 --- Number of spaces that a <Tab> in the file counts for.  Also see
---- the `|:retab|` command, and the 'softtabstop' option.
+--- the [:retab](help://:retab) command, and the 'softtabstop' option.
 ---
 --- Note: Setting 'tabstop' to any other value than 8 can make your file
 --- appear wrong in many places.
@@ -6722,7 +6726,7 @@ vim.go.tpm = vim.go.tabpagemax
 ---  You do need to check if no Tabs exist in the file, just like in the
 ---  item just above.
 --- 4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
----  `|modeline|` to set these values when editing the file again.  Only
+---  [modeline](help://modeline) to set these values when editing the file again.  Only
 ---  works when using Vim to edit the file, other tools assume a tabstop
 ---  is worth 8 spaces.
 --- 5. Always set 'tabstop' and 'shiftwidth' to the same value, and
@@ -6732,7 +6736,7 @@ vim.go.tpm = vim.go.tabpagemax
 ---  though.  Otherwise aligned comments will be wrong when 'tabstop' is
 ---  changed.
 ---
---- The value of 'tabstop' will be ignored if `|'vartabstop'|` is set to
+--- The value of 'tabstop' will be ignored if ['vartabstop'](help://'vartabstop') is set to
 --- anything other than an empty string.
 ---
 --- @type integer
@@ -6741,7 +6745,7 @@ vim.o.ts = vim.o.tabstop
 vim.bo.tabstop = vim.o.tabstop
 vim.bo.ts = vim.bo.tabstop
 
---- When searching for a tag (e.g., for the `|:ta|` command), Vim can either
+--- When searching for a tag (e.g., for the [:ta](help://:ta) command), Vim can either
 --- use a binary search or a linear search in a tags file.  Binary
 --- searching makes searching for a tag a LOT faster, but a linear search
 --- will find more tags if the tags file wasn't properly sorted.
@@ -6816,9 +6820,9 @@ vim.go.tc = vim.go.tagcase
 
 --- This option specifies a function to be used to perform tag searches.
 --- The function gets the tag pattern and should return a List of matching
---- tags.  See `|tag-function|` for an explanation of how to write the
+--- tags.  See [tag-function](help://tag-function) for an explanation of how to write the
 --- function and an example.  The value can be the name of a function, a
---- `|lambda|` or a `|Funcref|`. See `|option-value-function|` for more
+--- [lambda](help://lambda) or a [Funcref](help://Funcref). See [option-value-function](help://option-value-function) for more
 --- information.
 ---
 --- @type string
@@ -6846,19 +6850,19 @@ vim.go.tr = vim.go.tagrelative
 
 --- Filenames for the tag command, separated by spaces or commas.  To
 --- include a space or comma in a file name, precede it with backslashes
---- (see `|option-backslash|` about including spaces/commas and backslashes).
+--- (see [option-backslash](help://option-backslash) about including spaces/commas and backslashes).
 --- When a file name starts with "./", the '.' is replaced with the path
 --- of the current file.  But only when the 'd' flag is not included in
---- 'cpoptions'.  Environment variables are expanded `|:set_env|`.  Also see
---- `|tags-option|`.
+--- 'cpoptions'.  Environment variables are expanded [:set_env](help://:set_env).  Also see
+--- [tags-option](help://tags-option).
 --- "*", "**" and other wildcards can be used to search for tags files in
---- a directory tree.  See `|file-searching|`.  E.g., "/lib/**/tags" will
+--- a directory tree.  See [file-searching](help://file-searching).  E.g., "/lib/**/tags" will
 --- find all files named "tags" below "/lib".  The filename itself cannot
 --- contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
 --- files called "tags?".
---- The `|tagfiles()|` function can be used to get a list of the file names
+--- The [tagfiles()](help://tagfiles()) function can be used to get a list of the file names
 --- actually used.
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- file names from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -6870,7 +6874,7 @@ vim.bo.tag = vim.bo.tags
 vim.go.tags = vim.o.tags
 vim.go.tag = vim.go.tags
 
---- When on, the `|tagstack|` is used normally.  When off, a ":tag" or
+--- When on, the [tagstack](help://tagstack) is used normally.  When off, a ":tag" or
 --- ":tselect" command with an argument will not push the tag onto the
 --- tagstack.  A following ":tag" without an argument, a ":pop" command or
 --- any other command that uses the tagstack will use the unmodified
@@ -6891,7 +6895,7 @@ vim.go.tgst = vim.go.tagstack
 --- 'arabic' is set and the value of 'arabicshape' will be ignored.
 --- Note that setting 'termbidi' has the immediate effect that
 --- 'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
---- For further details see `|arabic.txt|`.
+--- For further details see [arabic.txt](help://arabic.txt).
 ---
 --- @type boolean
 vim.o.termbidi = false
@@ -6899,8 +6903,8 @@ vim.o.tbidi = vim.o.termbidi
 vim.go.termbidi = vim.o.termbidi
 vim.go.tbidi = vim.go.termbidi
 
---- Enables 24-bit RGB color in the `|TUI|`.  Uses "gui" `|:highlight|`
---- attributes instead of "cterm" attributes. `|guifg|`
+--- Enables 24-bit RGB color in the [TUI](help://TUI).  Uses "gui" [:highlight](help://:highlight)
+--- attributes instead of "cterm" attributes. [guifg](help://guifg)
 --- Requires an ISO-8613-3 compatible terminal.
 ---
 --- @type boolean
@@ -6938,7 +6942,7 @@ vim.go.tpf = vim.go.termpastefilter
 --- broken after white space to get this width.  A zero value disables
 --- this.
 --- When 'textwidth' is zero, 'wrapmargin' may be used.  See also
---- 'formatoptions' and `|ins-textwidth|`.
+--- 'formatoptions' and [ins-textwidth](help://ins-textwidth).
 --- When 'formatexpr' is set it will be used to break the line.
 ---
 --- @type integer
@@ -6948,16 +6952,16 @@ vim.bo.textwidth = vim.o.textwidth
 vim.bo.tw = vim.bo.textwidth
 
 --- List of file names, separated by commas, that are used to lookup words
---- for thesaurus completion commands `|i_CTRL-X_CTRL-T|`.  See
---- `|compl-thesaurus|`.
+--- for thesaurus completion commands [i_CTRL-X_CTRL-T](help://i_CTRL-X_CTRL-T).  See
+--- [compl-thesaurus](help://compl-thesaurus).
 ---
 --- This option is not used if 'thesaurusfunc' is set, either for the
 --- buffer or globally.
 ---
 --- To include a comma in a file name precede it with a backslash.  Spaces
 --- after a comma are ignored, otherwise spaces are included in the file
---- name.  See `|option-backslash|` about using backslashes.  The use of
---- `|:set+=|` and `|:set-=|` is preferred when adding or removing directories
+--- name.  See [option-backslash](help://option-backslash) about using backslashes.  The use of
+--- [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing directories
 --- from the list.  This avoids problems when a future version uses
 --- another default.  Backticks cannot be used in this option for security
 --- reasons.
@@ -6971,11 +6975,11 @@ vim.go.thesaurus = vim.o.thesaurus
 vim.go.tsr = vim.go.thesaurus
 
 --- This option specifies a function to be used for thesaurus completion
---- with CTRL-X CTRL-T. `|i_CTRL-X_CTRL-T|` See `|compl-thesaurusfunc|`.
---- The value can be the name of a function, a `|lambda|` or a `|Funcref|`.
---- See `|option-value-function|` for more information.
+--- with CTRL-X CTRL-T. [i_CTRL-X_CTRL-T](help://i_CTRL-X_CTRL-T) See [compl-thesaurusfunc](help://compl-thesaurusfunc).
+--- The value can be the name of a function, a [lambda](help://lambda) or a [Funcref](help://Funcref).
+--- See [option-value-function](help://option-value-function) for more information.
 ---
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -7023,7 +7027,7 @@ vim.go.tm = vim.go.timeoutlen
 --- =    indicates the file is read-only
 --- =+    indicates the file is read-only and modified
 --- (path)    is the path of the file being edited
---- - NVIM    the server name `|v:servername|` or "NVIM"
+--- - NVIM    the server name [v:servername](help://v:servername) or "NVIM"
 ---
 --- @type boolean
 vim.o.title = false
@@ -7045,7 +7049,7 @@ vim.go.titlelen = vim.o.titlelen
 
 --- If not empty, this option will be used to set the window title when
 --- exiting.  Only if 'title' is enabled.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -7081,7 +7085,7 @@ vim.o.titlestring = ""
 vim.go.titlestring = vim.o.titlestring
 
 --- This option and 'ttimeoutlen' determine the behavior when part of a
---- key code sequence has been received by the `|TUI|`.
+--- key code sequence has been received by the [TUI](help://TUI).
 ---
 --- For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
 --- set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
@@ -7119,8 +7123,8 @@ vim.go.ttm = vim.go.ttimeoutlen
 --- When reading all entries are tried to find an undo file.  The first
 --- undo file that exists is used.  When it cannot be read an error is
 --- given, no further entry is used.
---- See `|undo-persistence|`.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- See [undo-persistence](help://undo-persistence).
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
@@ -7137,7 +7141,7 @@ vim.go.udir = vim.go.undodir
 --- writing a buffer to a file, and restores undo history from the same
 --- file on buffer read.
 --- The directory where the undo file is stored is specified by 'undodir'.
---- For more information about this feature see `|undo-persistence|`.
+--- For more information about this feature see [undo-persistence](help://undo-persistence).
 --- The undo file is not read when 'undoreload' causes the buffer from
 --- before a reload to be saved for undo.
 --- When 'undofile' is turned off the undo file is NOT deleted.
@@ -7158,7 +7162,7 @@ vim.bo.udf = vim.bo.undofile
 --- ```
 --- But you can also get Vi compatibility by including the 'u' flag in
 --- 'cpoptions', and still be able to use CTRL-R to repeat undo.
---- Also see `|undo-two-ways|`.
+--- Also see [undo-two-ways](help://undo-two-ways).
 --- Set to -1 for no undo at all.  You might want to do this only for the
 --- current buffer:
 --- ```
@@ -7168,7 +7172,7 @@ vim.bo.udf = vim.bo.undofile
 ---
 --- The local value is set to -123456 when the global value is to be used.
 ---
---- Also see `|clear-undo|`.
+--- Also see [clear-undo](help://clear-undo).
 ---
 --- @type integer
 vim.o.undolevels = 1000
@@ -7180,7 +7184,7 @@ vim.go.ul = vim.go.undolevels
 
 --- Save the whole buffer for undo when reloading it.  This applies to the
 --- ":e!" command and reloading for when the buffer changed outside of
---- Vim. `|FileChangedShell|`
+--- Vim. [FileChangedShell](help://FileChangedShell)
 --- The save only happens when this option is negative or when the number
 --- of lines is smaller than the value of this option.
 --- Set this option to zero to disable undo for a reload.
@@ -7198,14 +7202,14 @@ vim.go.ur = vim.go.undoreload
 
 --- After typing this many characters the swap file will be written to
 --- disk.  When zero, no swap file will be created at all (see chapter on
---- recovery `|crash-recovery|`).  'updatecount' is set to zero by starting
---- Vim with the "-n" option, see `|startup|`.  When editing in readonly
+--- recovery [crash-recovery](help://crash-recovery)).  'updatecount' is set to zero by starting
+--- Vim with the "-n" option, see [startup](help://startup).  When editing in readonly
 --- mode this option will be initialized to 10000.
---- The swapfile can be disabled per buffer with `|'swapfile'|`.
+--- The swapfile can be disabled per buffer with ['swapfile'](help://'swapfile').
 --- When 'updatecount' is set from zero to non-zero, swap files are
 --- created for all buffers that have 'swapfile' set.  When 'updatecount'
 --- is set to zero, existing swap files are not deleted.
---- This option has no meaning in buffers where `|'buftype'|` is "nofile"
+--- This option has no meaning in buffers where ['buftype'](help://'buftype') is "nofile"
 --- or "nowrite".
 ---
 --- @type integer
@@ -7215,8 +7219,8 @@ vim.go.updatecount = vim.o.updatecount
 vim.go.uc = vim.go.updatecount
 
 --- If this many milliseconds nothing is typed the swap file will be
---- written to disk (see `|crash-recovery|`).  Also used for the
---- `|CursorHold|` autocommand event.
+--- written to disk (see [crash-recovery](help://crash-recovery)).  Also used for the
+--- [CursorHold](help://CursorHold) autocommand event.
 ---
 --- @type integer
 vim.o.updatetime = 4000
@@ -7239,7 +7243,7 @@ vim.go.ut = vim.go.updatetime
 --- This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
 --- for every column thereafter.
 ---
---- Note that the value of `|'softtabstop'|` will be ignored while
+--- Note that the value of ['softtabstop'](help://'softtabstop') will be ignored while
 --- 'varsofttabstop' is set.
 ---
 --- @type string
@@ -7257,7 +7261,7 @@ vim.bo.vsts = vim.bo.varsofttabstop
 --- This will make the first tab 4 spaces wide, the second 20 spaces,
 --- the third 10 spaces, and all following tabs 8 spaces.
 ---
---- Note that the value of `|'tabstop'|` will be ignored while 'vartabstop'
+--- Note that the value of ['tabstop'](help://'tabstop') will be ignored while 'vartabstop'
 --- is set.
 ---
 --- @type string
@@ -7266,7 +7270,7 @@ vim.o.vts = vim.o.vartabstop
 vim.bo.vartabstop = vim.o.vartabstop
 vim.bo.vts = vim.bo.vartabstop
 
---- Sets the verbosity level.  Also set by `|-V|` and `|:verbose|`.
+--- Sets the verbosity level.  Also set by [-V](help://-V) and [:verbose](help://:verbose).
 ---
 --- Tracing of options in Lua scripts is activated at level 1; Lua scripts
 --- are not traced with verbose=0, for performance.
@@ -7277,7 +7281,7 @@ vim.bo.vts = vim.bo.vartabstop
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
 --- 1  Lua assignments to options, mappings, etc.
---- 2  When a file is ":source"'ed, or `|shada|` file is read or written.
+--- 2  When a file is ":source"'ed, or [shada](help://shada) file is read or written.
 --- 3  UI info, terminal capabilities.
 --- 4  Shell commands.
 --- 5  Every searched tags file and include file.
@@ -7303,7 +7307,7 @@ vim.go.vbs = vim.go.verbose
 --- Writing to the file ends when Vim exits or when 'verbosefile' is made
 --- empty.  Writes are buffered, thus may not show up for some time.
 --- Setting 'verbosefile' to a new value is like making it empty first.
---- The difference with `|:redir|` is that verbose messages are not
+--- The difference with [:redir](help://:redir) is that verbose messages are not
 --- displayed when 'verbosefile' is set.
 ---
 --- @type string
@@ -7312,8 +7316,8 @@ vim.o.vfile = vim.o.verbosefile
 vim.go.verbosefile = vim.o.verbosefile
 vim.go.vfile = vim.go.verbosefile
 
---- Name of the directory where to store files for `|:mkview|`.
---- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
+--- Name of the directory where to store files for [:mkview](help://:mkview).
+--- This option cannot be set from a [modeline](help://modeline) or in the [sandbox](help://sandbox), for
 --- security reasons.
 ---
 --- @type string
@@ -7322,18 +7326,18 @@ vim.o.vdir = vim.o.viewdir
 vim.go.viewdir = vim.o.viewdir
 vim.go.vdir = vim.go.viewdir
 
---- Changes the effect of the `|:mkview|` command.  It is a comma-separated
+--- Changes the effect of the [:mkview](help://:mkview) command.  It is a comma-separated
 --- list of words.  Each word enables saving and restoring something:
 ---  word    save and restore ~
 ---  cursor  cursor position in file and in window
----  curdir  local current directory, if set with `|:lcd|`
+---  curdir  local current directory, if set with [:lcd](help://:lcd)
 ---  folds  manually created folds, opened/closed folds and local
 ---   fold options
 ---  options  options and mappings local to a window or buffer (not
 ---   global values for local options)
 ---  localoptions same as "options"
----  slash  `|deprecated|` Always enabled. Uses "/" in filenames.
----  unix    `|deprecated|` Always enabled. Uses "\n" line endings.
+---  slash  [deprecated](help://deprecated) Always enabled. Uses "/" in filenames.
+---  unix    [deprecated](help://deprecated) Always enabled. Uses "\n" line endings.
 ---
 --- @type string
 vim.o.viewoptions = "folds,cursor,curdir"
@@ -7359,7 +7363,7 @@ vim.go.vop = vim.go.viewoptions
 --- after the last character of the line.  This makes some commands more
 --- consistent.  Previously the cursor was always past the end of the line
 --- if the line was empty.  But it is far from Vi compatible.  It may also
---- break some plugins or Vim scripts.  For example because `|l|` can move
+--- break some plugins or Vim scripts.  For example because [l](help://l) can move
 --- the cursor after the last character.  Use with care!
 --- Using the `$` command will move to the last character in the line, not
 --- past it.  This may actually move the cursor to the left!
@@ -7428,7 +7432,7 @@ vim.go.ww = vim.go.whichwrap
 
 --- Character you have to type to start wildcard expansion in the
 --- command-line, as specified with 'wildmode'.
---- More info here: `|cmdline-completion|`.
+--- More info here: [cmdline-completion](help://cmdline-completion).
 --- The character is not recognized when used inside a macro.  See
 --- 'wildcharm' for that.
 --- Some keys will not work, such as CTRL-C, <CR> and Enter.
@@ -7447,7 +7451,7 @@ vim.go.wc = vim.go.wildchar
 
 --- 'wildcharm' works exactly like 'wildchar', except that it is
 --- recognized when used inside a macro.  You can find "spare" command-line
---- keys suitable for this option by looking at `|ex-edit-index|`.  Normally
+--- keys suitable for this option by looking at [ex-edit-index](help://ex-edit-index).  Normally
 --- you'll never actually type 'wildcharm', just use it in mappings that
 --- automatically invoke completion mode, e.g.:
 --- ```
@@ -7463,16 +7467,16 @@ vim.go.wildcharm = vim.o.wildcharm
 vim.go.wcm = vim.go.wildcharm
 
 --- A list of file patterns.  A file that matches with one of these
---- patterns is ignored when expanding `|wildcards|`, completing file or
---- directory names, and influences the result of `|expand()|`, `|glob()|` and
---- `|globpath()|` unless a flag is passed to disable this.
---- The pattern is used like with `|:autocmd|`, see `|autocmd-pattern|`.
+--- patterns is ignored when expanding [wildcards](help://wildcards), completing file or
+--- directory names, and influences the result of [expand()](help://expand()), [glob()](help://glob()) and
+--- [globpath()](help://globpath()) unless a flag is passed to disable this.
+--- The pattern is used like with [:autocmd](help://:autocmd), see [autocmd-pattern](help://autocmd-pattern).
 --- Also see 'suffixes'.
 --- Example:
 --- ```
 --- :set wildignore=*.o,*.obj
 --- ```
---- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
+--- The use of [:set+=](help://:set+=) and [:set-=](help://:set-=) is preferred when adding or removing
 --- a pattern from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -7503,7 +7507,7 @@ vim.go.wic = vim.go.wildignorecase
 --- Keys that show the previous/next match, such as <Tab> or
 --- CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
 --- 'wildmode' must specify "full": "longest" and "list" do not start
---- 'wildmenu' mode. You can check the current mode with `|wildmenumode()|`.
+--- 'wildmenu' mode. You can check the current mode with [wildmenumode()](help://wildmenumode()).
 --- The menu is cancelled when a key is hit that is not used for selecting
 --- a completion.
 ---
@@ -7530,7 +7534,7 @@ vim.go.wic = vim.go.wildignorecase
 --- :cnoremap <Left> <Space><BS><Left>
 --- :cnoremap <Right> <Space><BS><Right>
 --- ```
---- `|hl-WildMenu|` highlights the current match.
+--- [hl-WildMenu](help://hl-WildMenu) highlights the current match.
 ---
 --- @type boolean
 vim.o.wildmenu = true
@@ -7590,7 +7594,7 @@ vim.go.wmnu = vim.go.wildmenu
 --- :set wildmode=longest,list
 --- ```
 --- Complete longest common string, then list alternatives.
---- More info here: `|cmdline-completion|`.
+--- More info here: [cmdline-completion](help://cmdline-completion).
 ---
 --- @type string
 vim.o.wildmode = "full"
@@ -7598,9 +7602,9 @@ vim.o.wim = vim.o.wildmode
 vim.go.wildmode = vim.o.wildmode
 vim.go.wim = vim.go.wildmode
 
---- A list of words that change how `|cmdline-completion|` is done.
+--- A list of words that change how [cmdline-completion](help://cmdline-completion) is done.
 --- The following values are supported:
---- fuzzy    Use `|fuzzy-matching|` to find completion matches. When
+--- fuzzy    Use [fuzzy-matching](help://fuzzy-matching) to find completion matches. When
 ---   this value is specified, wildcard expansion will not
 ---   be used for completion.  The matches will be sorted by
 ---   the "best match" rather than alphabetically sorted.
@@ -7609,7 +7613,7 @@ vim.go.wim = vim.go.wildmode
 ---   is not supported for file and directory names and
 ---   instead wildcard expansion is used.
 --- pum    Display the completion matches using the popup menu
----   in the same style as the `|ins-completion-menu|`.
+---   in the same style as the [ins-completion-menu](help://ins-completion-menu).
 --- tagfile  When using CTRL-D to list matching tags, the kind of
 ---   tag and the file of the tag is listed.  Only one match
 ---   is displayed per line.  Often used tag kinds are:
@@ -7650,7 +7654,7 @@ vim.go.wak = vim.go.winaltkeys
 --- 'statusline'.
 ---
 --- When changing something that is used in 'winbar' that does not trigger
---- it to be updated, use `|:redrawstatus|`.
+--- it to be updated, use [:redrawstatus](help://:redrawstatus).
 ---
 --- Floating windows do not use the global value of 'winbar'. The
 --- window-local value of 'winbar' must be set for a floating window to
@@ -7678,7 +7682,7 @@ vim.o.winbl = vim.o.winblend
 vim.wo.winblend = vim.o.winblend
 vim.wo.winbl = vim.wo.winblend
 
---- Window height used for `|CTRL-F|` and `|CTRL-B|` when there is only one
+--- Window height used for [CTRL-F](help://CTRL-F) and [CTRL-B](help://CTRL-B) when there is only one
 --- window and the value is smaller than 'lines' minus one.  The screen
 --- will scroll 'window' minus two lines, with a minimum of one.
 --- When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
@@ -7695,8 +7699,8 @@ vim.go.window = vim.o.window
 vim.go.wi = vim.go.window
 
 --- Keep the window height when windows are opened or closed and
---- 'equalalways' is set.  Also for `|CTRL-W_=|`.  Set by default for the
---- `|preview-window|` and `|quickfix-window|`.
+--- 'equalalways' is set.  Also for [CTRL-W_=](help://CTRL-W_=).  Set by default for the
+--- [preview-window](help://preview-window) and [quickfix-window](help://quickfix-window).
 --- The height may be changed anyway when running out of room.
 ---
 --- @type boolean
@@ -7706,7 +7710,7 @@ vim.wo.winfixheight = vim.o.winfixheight
 vim.wo.wfh = vim.wo.winfixheight
 
 --- Keep the window width when windows are opened or closed and
---- 'equalalways' is set.  Also for `|CTRL-W_=|`.
+--- 'equalalways' is set.  Also for [CTRL-W_=](help://CTRL-W_=).
 --- The width may be changed anyway when running out of room.
 ---
 --- @type boolean
@@ -7724,7 +7728,7 @@ vim.wo.wfw = vim.wo.winfixwidth
 --- Other windows will be only 'winminheight' high.  This has the drawback
 --- that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
 --- to create only two windows, set the option after startup is done,
---- using the `|VimEnter|` event:
+--- using the [VimEnter](help://VimEnter) event:
 --- ```
 --- au VimEnter * set winheight=999
 --- ```
@@ -7741,12 +7745,12 @@ vim.go.winheight = vim.o.winheight
 vim.go.wh = vim.go.winheight
 
 --- Window-local highlights.  Comma-delimited list of highlight
---- `|group-name|` pairs "{hl-from}:{hl-to},..." where each {hl-from} is
---- a `|highlight-groups|` item to be overridden by {hl-to} group in
+--- [group-name](help://group-name) pairs "{hl-from}:{hl-to},..." where each {hl-from} is
+--- a [highlight-groups](help://highlight-groups) item to be overridden by {hl-to} group in
 --- the window.
 ---
 --- Note: highlight namespaces take precedence over 'winhighlight'.
---- See `|nvim_win_set_hl_ns()|` and `|nvim_set_hl()|`.
+--- See [nvim_win_set_hl_ns()](help://nvim_win_set_hl_ns()) and [nvim_set_hl()](help://nvim_set_hl()).
 ---
 --- Highlights of vertical separators are determined by the window to the
 --- left of the separator.  The 'tabline' highlight of a tabpage is
@@ -7828,8 +7832,8 @@ vim.go.wiw = vim.go.winwidth
 --- :set sidescroll=5
 --- :set listchars+=precedes:<,extends:>
 --- ```
---- See 'sidescroll', 'listchars' and `|wrap-off|`.
---- This option can't be set from a `|modeline|` when the 'diff' option is
+--- See 'sidescroll', 'listchars' and [wrap-off](help://wrap-off).
+--- This option can't be set from a [modeline](help://modeline) when the 'diff' option is
 --- on.
 ---
 --- @type boolean
@@ -7842,7 +7846,7 @@ vim.wo.wrap = vim.o.wrap
 --- Options that add a margin, such as 'number' and 'foldcolumn', cause
 --- the text width to be further reduced.
 --- When 'textwidth' is non-zero, this option is not used.
---- See also 'formatoptions' and `|ins-textwidth|`.
+--- See also 'formatoptions' and [ins-textwidth](help://ins-textwidth).
 ---
 --- @type integer
 vim.o.wrapmargin = 0
@@ -7850,8 +7854,8 @@ vim.o.wm = vim.o.wrapmargin
 vim.bo.wrapmargin = vim.o.wrapmargin
 vim.bo.wm = vim.bo.wrapmargin
 
---- Searches wrap around the end of the file.  Also applies to `|]s|` and
---- `|[s|`, searching for spelling mistakes.
+--- Searches wrap around the end of the file.  Also applies to []s](help://]s) and
+--- [[s](help://[s), searching for spelling mistakes.
 ---
 --- @type boolean
 vim.o.wrapscan = true
@@ -7861,7 +7865,7 @@ vim.go.ws = vim.go.wrapscan
 
 --- Allows writing files.  When not set, writing a file is not allowed.
 --- Can be used for a view-only mode, where modifications to the text are
---- still allowed.  Can be reset with the `|-m|` or `|-M|` command line
+--- still allowed.  Can be reset with the [-m](help://-m) or [-M](help://-M) command line
 --- argument.  Filtering text is still possible, even though this requires
 --- writing a temporary file.
 ---
@@ -7885,7 +7889,7 @@ vim.go.wa = vim.go.writeany
 --- lose both the original file and what you were writing.  Only reset
 --- this option if your file system is almost full and it makes the write
 --- fail (and make sure not to exit Vim until the write was successful).
---- See `|backup-table|` for another explanation.
+--- See [backup-table](help://backup-table) for another explanation.
 --- When the 'backupskip' pattern matches, a backup is not made anyway.
 --- Depending on 'backupcopy' the backup is a new file or the original
 --- file renamed (and a new file is written).

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -27,16 +27,16 @@ vim.go.ari = vim.go.allowrevins
 --- letters, Cyrillic letters).
 ---
 --- There are currently two possible values:
---- "single":	Use the same width as characters in US-ASCII.  This is
---- 		expected by most users.
---- "double":	Use twice the width of ASCII characters.
---- 						*E834* *E835*
+--- "single":  Use the same width as characters in US-ASCII.  This is
+--- expected by most users.
+--- "double":  Use twice the width of ASCII characters.
+---         *E834* *E835*
 --- The value "double" cannot be used if 'listchars' or 'fillchars'
 --- contains a character that would be double width.  These errors may
 --- also be given when calling setcellwidths().
 ---
 --- The values are overruled for characters specified with
---- `setcellwidths()`.
+--- `|setcellwidths()|`.
 ---
 --- There are a number of CJK fonts for which the width of glyphs for
 --- those characters are solely based on how many octets they take in
@@ -64,7 +64,7 @@ vim.go.ambw = vim.go.ambiwidth
 --- - Set the 'rightleft' option, unless 'termbidi' is set.
 --- - Set the 'arabicshape' option, unless 'termbidi' is set.
 --- - Set the 'keymap' option to "arabic"; in Insert mode CTRL-^ toggles
----   between typing English and Arabic key mapping.
+--- between typing English and Arabic key mapping.
 --- - Set the 'delcombine' option
 ---
 --- Resetting this option will:
@@ -72,7 +72,7 @@ vim.go.ambw = vim.go.ambiwidth
 --- - Disable the use of 'keymap' (without changing its value).
 --- Note that 'arabicshape' and 'delcombine' are not reset (it is a global
 --- option).
---- Also see `arabic.txt`.
+--- Also see `|arabic.txt|`.
 ---
 --- @type boolean
 vim.o.arabic = false
@@ -84,14 +84,14 @@ vim.wo.arab = vim.wo.arabic
 --- corrections that need to take place for displaying the Arabic language
 --- take effect.  Shaping, in essence, gets enabled; the term is a broad
 --- one which encompasses:
----   a) the changing/morphing of characters based on their location
----      within a word (initial, medial, final and stand-alone).
----   b) the enabling of the ability to compose characters
----   c) the enabling of the required combining of some characters
+--- a) the changing/morphing of characters based on their location
+---    within a word (initial, medial, final and stand-alone).
+--- b) the enabling of the ability to compose characters
+--- c) the enabling of the required combining of some characters
 --- When disabled the display shows each character's true stand-alone
 --- form.
 --- Arabic is a complex language which requires other settings, for
---- further details see `arabic.txt`.
+--- further details see `|arabic.txt|`.
 ---
 --- @type boolean
 vim.o.arabicshape = true
@@ -134,13 +134,12 @@ vim.bo.ai = vim.bo.autoindent
 --- it has not been changed inside of Vim, automatically read it again.
 --- When the file has been deleted this is not done, so you have the text
 --- from before it was deleted.  When it appears again then it is read.
---- `timestamp`
+--- `|timestamp|`
 --- If this option has a local value, use this command to switch back to
 --- using the global value:
 --- ```
---- 	:set autoread<
+--- :set autoread<
 --- ```
----
 ---
 --- @type boolean
 vim.o.autoread = true
@@ -183,13 +182,13 @@ vim.go.autowriteall = vim.o.autowriteall
 vim.go.awa = vim.go.autowriteall
 
 --- When set to "dark" or "light", adjusts the default color groups for
---- that background type.  The `TUI` or other UI sets this on startup
---- (triggering `OptionSet`) if it can detect the background color.
+--- that background type.  The `|TUI|` or other UI sets this on startup
+--- (triggering `|OptionSet|`) if it can detect the background color.
 ---
 --- This option does NOT change the background color, it tells Nvim what
 --- the "inherited" (terminal/GUI) background looks like.
---- See `:hi-normal` if you want to set the background color explicitly.
---- 					*g:colors_name*
+--- See `|:hi-normal|` if you want to set the background color explicitly.
+---         *g:colors_name*
 --- When a color scheme is loaded (the "g:colors_name" variable is set)
 --- setting 'background' will cause the color scheme to be reloaded.  If
 --- the color scheme adjusts to the value of 'background' this will work.
@@ -199,9 +198,9 @@ vim.go.awa = vim.go.autowriteall
 --- Normally this option would be set in the vimrc file.  Possibly
 --- depending on the terminal name.  Example:
 --- ```
---- 	:if $TERM ==# "xterm"
---- 	:  set background=dark
---- 	:endif
+--- :if $TERM ==# "xterm"
+--- :  set background=dark
+--- :endif
 --- ```
 --- When this option is set, the default settings for the highlight groups
 --- will change.  To use other settings, place ":highlight" commands AFTER
@@ -220,13 +219,13 @@ vim.go.bg = vim.go.background
 --- Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
 --- mode.  This is a list of items, separated by commas.  Each item allows
 --- a way to backspace over something:
---- value	effect	~
---- indent	allow backspacing over autoindent
---- eol	allow backspacing over line breaks (join lines)
---- start	allow backspacing over the start of insert; CTRL-W and CTRL-U
---- 	stop once at the start of insert.
---- nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
---- 	insert.
+--- value  effect  ~
+--- indent  allow backspacing over autoindent
+--- eol  allow backspacing over line breaks (join lines)
+--- start  allow backspacing over the start of insert; CTRL-W and CTRL-U
+--- stop once at the start of insert.
+--- nostop  like start, except CTRL-W and CTRL-U do not stop at the start of
+--- insert.
 ---
 --- When the value is empty, Vi compatible backspacing is used, none of
 --- the ways mentioned for the items above are possible.
@@ -243,7 +242,7 @@ vim.go.bs = vim.go.backspace
 --- written, reset this option and set the 'writebackup' option (this is
 --- the default).  If you do not want a backup file at all reset both
 --- options (use this if your file system is almost full).  See the
---- `backup-table` for more explanations.
+--- `|backup-table|` for more explanations.
 --- When the 'backupskip' pattern matches, a backup is not made anyway.
 --- When 'patchmode' is set, the backup may be renamed to become the
 --- oldest version of a file.
@@ -258,25 +257,25 @@ vim.go.bk = vim.go.backup
 --- done.  This is a comma-separated list of words.
 ---
 --- The main values are:
---- "yes"	make a copy of the file and overwrite the original one
---- "no"	rename the file and write a new one
---- "auto"	one of the previous, what works best
+--- "yes"  make a copy of the file and overwrite the original one
+--- "no"  rename the file and write a new one
+--- "auto"  one of the previous, what works best
 ---
 --- Extra values that can be combined with the ones above are:
---- "breaksymlink"	always break symlinks when writing
---- "breakhardlink"	always break hardlinks when writing
+--- "breaksymlink"  always break symlinks when writing
+--- "breakhardlink"  always break hardlinks when writing
 ---
 --- Making a copy and overwriting the original file:
 --- - Takes extra time to copy the file.
 --- + When the file has special attributes, is a (hard/symbolic) link or
----   has a resource fork, all this is preserved.
+--- has a resource fork, all this is preserved.
 --- - When the file is a link the backup will have the name of the link,
----   not of the real file.
+--- not of the real file.
 ---
 --- Renaming the file and writing a new one:
 --- + It's fast.
 --- - Sometimes not all attributes of the file can be copied to the new
----   file.
+--- file.
 --- - When the file is a link the new file will not be a link.
 ---
 --- The "auto" value is the middle way: When Vim sees that renaming the
@@ -292,7 +291,7 @@ vim.go.bk = vim.go.backup
 --- useful for example in source trees where all the files are symbolic or
 --- hard links and any changes should stay in the local source tree, not
 --- be propagated back to the original source.
---- 						*crontab*
+---           *crontab*
 --- One situation where "no" and "auto" will cause problems: A program
 --- that opens a file, invokes Vim to edit that file, and then tests if
 --- the open file was changed (through the file descriptor) will check the
@@ -326,47 +325,46 @@ vim.go.bkc = vim.go.backupcopy
 
 --- List of directories for the backup file, separated with commas.
 --- - The backup file will be created in the first directory in the list
----   where this is possible.  If none of the directories exist Nvim will
----   attempt to create the last directory in the list.
+--- where this is possible.  If none of the directories exist Nvim will
+--- attempt to create the last directory in the list.
 --- - Empty means that no backup file will be created ('patchmode' is
----   impossible!).  Writing may fail because of this.
+--- impossible!).  Writing may fail because of this.
 --- - A directory "." means to put the backup file in the same directory
----   as the edited file.
+--- as the edited file.
 --- - A directory starting with "./" (or ".\" for MS-Windows) means to put
----   the backup file relative to where the edited file is.  The leading
----   "." is replaced with the path name of the edited file.
----   ("." inside a directory name has no special meaning).
+--- the backup file relative to where the edited file is.  The leading
+--- "." is replaced with the path name of the edited file.
+--- ("." inside a directory name has no special meaning).
 --- - Spaces after the comma are ignored, other spaces are considered part
----   of the directory name.  To have a space at the start of a directory
----   name, precede it with a backslash.
+--- of the directory name.  To have a space at the start of a directory
+--- name, precede it with a backslash.
 --- - To include a comma in a directory name precede it with a backslash.
 --- - A directory name may end in an '/'.
 --- - For Unix and Win32, if a directory ends in two path separators "//",
----   the swap file name will be built from the complete path to the file
----   with all path separators changed to percent '%' signs. This will
----   ensure file name uniqueness in the backup directory.
----   On Win32, it is also possible to end with "\\".  However, When a
----   separating comma is following, you must use "//", since "\\" will
----   include the comma in the file name. Therefore it is recommended to
----   use '//', instead of '\\'.
---- - Environment variables are expanded `:set_env`.
+--- the swap file name will be built from the complete path to the file
+--- with all path separators changed to percent '%' signs. This will
+--- ensure file name uniqueness in the backup directory.
+--- On Win32, it is also possible to end with "\\".  However, When a
+--- separating comma is following, you must use "//", since "\\" will
+--- include the comma in the file name. Therefore it is recommended to
+--- use '//', instead of '\\'.
+--- - Environment variables are expanded `|:set_env|`.
 --- - Careful with '\' characters, type one before a space, type two to
----   get one in the option (see `option-backslash`), for example:
+--- get one in the option (see `|option-backslash|`), for example:
 --- ```
----     :set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
+---   :set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 --- ```
----
 --- See also 'backup' and 'writebackup' options.
 --- If you want to hide your backup files on Unix, consider this value:
 --- ```
---- 	:set backupdir=./.backup,~/.backup,.,/tmp
+--- :set backupdir=./.backup,~/.backup,.,/tmp
 --- ```
 --- You must create a ".backup" directory in each directory and in your
 --- home directory for this to work properly.
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -386,7 +384,7 @@ vim.go.bdir = vim.go.backupdir
 --- autocommand to change 'backupext' just before writing the file to
 --- include a timestamp.
 --- ```
---- 	:au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
+--- :au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
 --- ```
 --- Use 'backupdir' to put the backup in a different directory.
 ---
@@ -399,8 +397,8 @@ vim.go.bex = vim.go.backupext
 --- A list of file patterns.  When one of the patterns matches with the
 --- name of the file which is written, no backup file is created.  Both
 --- the specified file name and the full path name of the file are used.
---- The pattern is used like with `:autocmd`, see `autocmd-pattern`.
---- Watch out for special characters, see `option-backslash`.
+--- The pattern is used like with `|:autocmd|`, see `|autocmd-pattern|`.
+--- Watch out for special characters, see `|option-backslash|`.
 --- When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
 --- default value.  "/tmp/*" is only used for Unix.
 ---
@@ -411,13 +409,12 @@ vim.go.bex = vim.go.backupext
 ---
 --- Note that environment variables are not expanded.  If you want to use
 --- $HOME you must expand it explicitly, e.g.:
----
 --- ```vim
---- 	:let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+--- :let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 --- ```
 --- Note that the default also makes sure that "crontab -e" works (when a
 --- backup would be made by renaming the original file crontab won't see
---- the newly created file).  Also see 'backupcopy' and `crontab`.
+--- the newly created file).  Also see 'backupcopy' and `|crontab|`.
 ---
 --- @type string
 vim.o.backupskip = "/tmp/*"
@@ -430,30 +427,30 @@ vim.go.bsk = vim.go.backupskip
 --- will be silenced. This is most useful to specify specific events in
 --- insert mode to be silenced.
 ---
---- item	    meaning when present	~
---- all	    All events.
+--- item      meaning when present  ~
+--- all      All events.
 --- backspace   When hitting <BS> or <Del> and deleting results in an
---- 	    error.
---- cursor	    Fail to move around using the cursor keys or
---- 	    <PageUp>/<PageDown> in `Insert-mode`.
---- complete    Error occurred when using `i_CTRL-X_CTRL-K` or
---- 	    `i_CTRL-X_CTRL-T`.
---- copy	    Cannot copy char from insert mode using `i_CTRL-Y` or
---- 	    `i_CTRL-E`.
---- ctrlg	    Unknown Char after <C-G> in Insert mode.
---- error	    Other Error occurred (e.g. try to join last line)
---- 	    (mostly used in `Normal-mode` or `Cmdline-mode`).
---- esc	    hitting <Esc> in `Normal-mode`.
---- hangul	    Ignored.
---- lang	    Calling the beep module for Lua/Mzscheme/TCL.
---- mess	    No output available for `g<`.
+--- error.
+--- cursor      Fail to move around using the cursor keys or
+--- <PageUp>/<PageDown> in `|Insert-mode|`.
+--- complete    Error occurred when using `|i_CTRL-X_CTRL-K|` or
+--- `|i_CTRL-X_CTRL-T|`.
+--- copy      Cannot copy char from insert mode using `|i_CTRL-Y|` or
+--- `|i_CTRL-E|`.
+--- ctrlg      Unknown Char after <C-G> in Insert mode.
+--- error      Other Error occurred (e.g. try to join last line)
+--- (mostly used in `|Normal-mode|` or `|Cmdline-mode|`).
+--- esc      hitting <Esc> in `|Normal-mode|`.
+--- hangul      Ignored.
+--- lang      Calling the beep module for Lua/Mzscheme/TCL.
+--- mess      No output available for `|g<|`.
 --- showmatch   Error occurred for 'showmatch' function.
---- operator    Empty region error `cpo-E`.
---- register    Unknown register after <C-R> in `Insert-mode`.
---- shell	    Bell from shell output `:!`.
---- spell	    Error happened on spell suggest.
---- wildmode    More matches in `cmdline-completion` available
---- 	    (depends on the 'wildmode' setting).
+--- operator    Empty region error `|cpo-E|`.
+--- register    Unknown register after <C-R> in `|Insert-mode|`.
+--- shell      Bell from shell output `|:!|`.
+--- spell      Error happened on spell suggest.
+--- wildmode    More matches in `|cmdline-completion|` available
+--- (depends on the 'wildmode' setting).
 ---
 --- This is most useful to fine tune when in Insert mode the bell should
 --- be rung. For Normal mode and Ex commands, the bell is often rung to
@@ -467,12 +464,12 @@ vim.go.belloff = vim.o.belloff
 vim.go.bo = vim.go.belloff
 
 --- This option should be set before editing a binary file.  You can also
---- use the `-b` Vim argument.  When this option is switched on a few
+--- use the `|-b|` Vim argument.  When this option is switched on a few
 --- options will be changed (also when it already was on):
---- 	'textwidth'  will be set to 0
---- 	'wrapmargin' will be set to 0
---- 	'modeline'   will be off
---- 	'expandtab'  will be off
+--- 'textwidth'  will be set to 0
+--- 'wrapmargin' will be set to 0
+--- 'modeline'   will be off
+--- 'expandtab'  will be off
 --- Also, 'fileformat' and 'fileformats' options will not be used, the
 --- file is read and written like 'fileformat' was "unix" (a single <NL>
 --- separates lines).
@@ -485,7 +482,7 @@ vim.go.bo = vim.go.belloff
 --- The previous values of these options are remembered and restored when
 --- 'bin' is switched from on to off.  Each buffer has its own set of
 --- saved option values.
---- To edit a file with 'binary' set you can use the `++bin` argument.
+--- To edit a file with 'binary' set you can use the `|++bin|` argument.
 --- This avoids you have to do ":set bin", which would have effect for all
 --- files you edit.
 --- When writing a file the <EOL> for the last line is only written if
@@ -504,7 +501,7 @@ vim.bo.bin = vim.bo.binary
 --- - this option is on
 --- - the 'binary' option is off
 --- - 'fileencoding' is "utf-8", "ucs-2", "ucs-4" or one of the little/big
----   endian variants.
+--- endian variants.
 --- Some applications use the BOM to recognize the encoding of the file.
 --- Often used for UCS-2 files on MS-Windows.  For other applications it
 --- causes trouble, for example: "cat file1 file2" makes the BOM of file2
@@ -540,31 +537,31 @@ vim.wo.bri = vim.wo.breakindent
 
 --- Settings for 'breakindent'. It can consist of the following optional
 --- items and must be separated by a comma:
---- 	min:{n}	    Minimum text width that will be kept after
---- 		    applying 'breakindent', even if the resulting
---- 		    text should normally be narrower. This prevents
---- 		    text indented almost to the right window border
---- 		    occupying lot of vertical space when broken.
---- 		    (default: 20)
---- 	shift:{n}   After applying 'breakindent', the wrapped line's
---- 		    beginning will be shifted by the given number of
---- 		    characters.  It permits dynamic French paragraph
---- 		    indentation (negative) or emphasizing the line
---- 		    continuation (positive).
---- 		    (default: 0)
---- 	sbr	    Display the 'showbreak' value before applying the
---- 		    additional indent.
---- 		    (default: off)
---- 	list:{n}    Adds an additional indent for lines that match a
---- 		    numbered or bulleted list (using the
---- 		    'formatlistpat' setting).
---- 	list:-1	    Uses the length of a match with 'formatlistpat'
---- 		    for indentation.
---- 		    (default: 0)
---- 	column:{n}  Indent at column {n}. Will overrule the other
---- 		    sub-options. Note: an additional indent may be
---- 		    added for the 'showbreak' setting.
---- 		    (default: off)
+--- min:{n}      Minimum text width that will be kept after
+---       applying 'breakindent', even if the resulting
+---       text should normally be narrower. This prevents
+---       text indented almost to the right window border
+---       occupying lot of vertical space when broken.
+---       (default: 20)
+--- shift:{n}   After applying 'breakindent', the wrapped line's
+---       beginning will be shifted by the given number of
+---       characters.  It permits dynamic French paragraph
+---       indentation (negative) or emphasizing the line
+---       continuation (positive).
+---       (default: 0)
+--- sbr      Display the 'showbreak' value before applying the
+---       additional indent.
+---       (default: off)
+--- list:{n}    Adds an additional indent for lines that match a
+---       numbered or bulleted list (using the
+---       'formatlistpat' setting).
+--- list:-1      Uses the length of a match with 'formatlistpat'
+---       for indentation.
+---       (default: 0)
+--- column:{n}  Indent at column {n}. Will overrule the other
+---       sub-options. Note: an additional indent may be
+---       added for the 'showbreak' setting.
+---       (default: off)
 ---
 --- @type string
 vim.o.breakindentopt = ""
@@ -573,11 +570,11 @@ vim.wo.breakindentopt = vim.o.breakindentopt
 vim.wo.briopt = vim.wo.breakindentopt
 
 --- Which directory to use for the file browser:
----    last		Use same directory as with last file browser, where a
---- 		file was opened or saved.
----    buffer	Use the directory of the related buffer.
----    current	Use the current directory.
----    {path}	Use the specified directory
+---  last    Use same directory as with last file browser, where a
+---   file was opened or saved.
+---  buffer  Use the directory of the related buffer.
+---  current  Use the current directory.
+---  {path}  Use the specified directory
 ---
 --- @type string
 vim.o.browsedir = ""
@@ -587,23 +584,23 @@ vim.go.bsdir = vim.go.browsedir
 
 --- This option specifies what happens when a buffer is no longer
 --- displayed in a window:
----   <empty>	follow the global 'hidden' option
----   hide		hide the buffer (don't unload it), even if 'hidden' is
---- 		not set
----   unload	unload the buffer, even if 'hidden' is set; the
---- 		`:hide` command will also unload the buffer
----   delete	delete the buffer from the buffer list, even if
---- 		'hidden' is set; the `:hide` command will also delete
---- 		the buffer, making it behave like `:bdelete`
----   wipe		wipe the buffer from the buffer list, even if
---- 		'hidden' is set; the `:hide` command will also wipe
---- 		out the buffer, making it behave like `:bwipeout`
+--- <empty>  follow the global 'hidden' option
+--- hide    hide the buffer (don't unload it), even if 'hidden' is
+---   not set
+--- unload  unload the buffer, even if 'hidden' is set; the
+---   `|:hide|` command will also unload the buffer
+--- delete  delete the buffer from the buffer list, even if
+---   'hidden' is set; the `|:hide|` command will also delete
+---   the buffer, making it behave like `|:bdelete|`
+--- wipe    wipe the buffer from the buffer list, even if
+---   'hidden' is set; the `|:hide|` command will also wipe
+---   out the buffer, making it behave like `|:bwipeout|`
 ---
 --- CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
 --- are lost without a warning.  Also, these values may break autocommands
 --- that switch between buffers temporarily.
 --- This option is used together with 'buftype' and 'swapfile' to specify
---- special kinds of buffers.   See `special-buffers`.
+--- special kinds of buffers.   See `|special-buffers|`.
 ---
 --- @type string
 vim.o.bufhidden = ""
@@ -624,49 +621,49 @@ vim.bo.buflisted = vim.o.buflisted
 vim.bo.bl = vim.bo.buflisted
 
 --- The value of this option specifies the type of a buffer:
----   <empty>	normal buffer
----   acwrite	buffer will always be written with `BufWriteCmd`s
----   help		help buffer (do not set this manually)
----   nofile	buffer is not related to a file, will not be written
----   nowrite	buffer will not be written
----   quickfix	list of errors `:cwindow` or locations `:lwindow`
----   terminal	`terminal-emulator` buffer
----   prompt	buffer where only the last line can be edited, meant
---- 		to be used by a plugin, see `prompt-buffer`
+--- <empty>  normal buffer
+--- acwrite  buffer will always be written with `|BufWriteCmd|`s
+--- help    help buffer (do not set this manually)
+--- nofile  buffer is not related to a file, will not be written
+--- nowrite  buffer will not be written
+--- quickfix  list of errors `|:cwindow|` or locations `|:lwindow|`
+--- terminal  `|terminal-emulator|` buffer
+--- prompt  buffer where only the last line can be edited, meant
+---   to be used by a plugin, see `|prompt-buffer|`
 ---
 --- This option is used together with 'bufhidden' and 'swapfile' to
---- specify special kinds of buffers.   See `special-buffers`.
---- Also see `win_gettype()`, which returns the type of the window.
+--- specify special kinds of buffers.   See `|special-buffers|`.
+--- Also see `|win_gettype()|`, which returns the type of the window.
 ---
 --- Be careful with changing this option, it can have many side effects!
 --- One such effect is that Vim will not check the timestamp of the file,
 --- if the file is changed by another program this will not be noticed.
 ---
 --- A "quickfix" buffer is only used for the error list and the location
---- list.  This value is set by the `:cwindow` and `:lwindow` commands and
+--- list.  This value is set by the `|:cwindow|` and `|:lwindow|` commands and
 --- you are not supposed to change it.
 ---
 --- "nofile" and "nowrite" buffers are similar:
---- both:		The buffer is not to be written to disk, ":w" doesn't
---- 		work (":w filename" does work though).
---- both:		The buffer is never considered to be `'modified'`.
---- 		There is no warning when the changes will be lost, for
---- 		example when you quit Vim.
---- both:		A swap file is only created when using too much memory
---- 		(when 'swapfile' has been reset there is never a swap
---- 		file).
---- nofile only:	The buffer name is fixed, it is not handled like a
---- 		file name.  It is not modified in response to a `:cd`
---- 		command.
---- both:		When using ":e bufname" and already editing "bufname"
---- 		the buffer is made empty and autocommands are
---- 		triggered as usual for `:edit`.
---- 						*E676*
+--- both:    The buffer is not to be written to disk, ":w" doesn't
+---   work (":w filename" does work though).
+--- both:    The buffer is never considered to be `|'modified'|`.
+---   There is no warning when the changes will be lost, for
+---   example when you quit Vim.
+--- both:    A swap file is only created when using too much memory
+---   (when 'swapfile' has been reset there is never a swap
+---   file).
+--- nofile only:  The buffer name is fixed, it is not handled like a
+---   file name.  It is not modified in response to a `|:cd|`
+---   command.
+--- both:    When using ":e bufname" and already editing "bufname"
+---   the buffer is made empty and autocommands are
+---   triggered as usual for `|:edit|`.
+---           *E676*
 --- "acwrite" implies that the buffer name is not related to a file, like
 --- "nofile", but it will be written.  Thus, in contrast to "nofile" and
 --- "nowrite", ":w" does work and a modified buffer can't be abandoned
---- without saving.  For writing there must be matching `BufWriteCmd|,
---- |FileWriteCmd` or `FileAppendCmd` autocommands.
+--- without saving.  For writing there must be matching `|BufWriteCmd|,
+--- |FileWriteCmd|` or `|FileAppendCmd|` autocommands.
 ---
 --- @type string
 vim.o.buftype = ""
@@ -676,13 +673,13 @@ vim.bo.bt = vim.bo.buftype
 
 --- Specifies details about changing the case of letters.  It may contain
 --- these words, separated by a comma:
---- internal	Use internal case mapping functions, the current
---- 		locale does not change the case mapping. When
---- 		"internal" is omitted, the towupper() and towlower()
---- 		system library functions are used when available.
---- keepascii	For the ASCII characters (0x00 to 0x7f) use the US
---- 		case mapping, the current locale is not effective.
---- 		This probably only matters for Turkish.
+--- internal  Use internal case mapping functions, the current
+--- locale does not change the case mapping. When
+--- "internal" is omitted, the towupper() and towlower()
+--- system library functions are used when available.
+--- keepascii  For the ASCII characters (0x00 to 0x7f) use the US
+--- case mapping, the current locale is not effective.
+--- This probably only matters for Turkish.
 ---
 --- @type string
 vim.o.casemap = "internal,keepascii"
@@ -690,8 +687,8 @@ vim.o.cmp = vim.o.casemap
 vim.go.casemap = vim.o.casemap
 vim.go.cmp = vim.go.casemap
 
---- When on, `:cd`, `:tcd` and `:lcd` without an argument changes the
---- current working directory to the `$HOME` directory like in Unix.
+--- When on, `|:cd|`, `|:tcd|` and `|:lcd|` without an argument changes the
+--- current working directory to the `|$HOME|` directory like in Unix.
 --- When off, those commands just print the current directory name.
 --- On Unix this option has no effect.
 ---
@@ -702,20 +699,20 @@ vim.go.cdhome = vim.o.cdhome
 vim.go.cdh = vim.go.cdhome
 
 --- This is a list of directories which will be searched when using the
---- `:cd`, `:tcd` and `:lcd` commands, provided that the directory being
+--- `|:cd|`, `|:tcd|` and `|:lcd|` commands, provided that the directory being
 --- searched for has a relative path, not an absolute part starting with
 --- "/", "./" or "../", the 'cdpath' option is not used then.
 --- The 'cdpath' option's value has the same form and semantics as
---- `'path'`.  Also see `file-searching`.
+--- `|'path'|`.  Also see `|file-searching|`.
 --- The default value is taken from $CDPATH, with a "," prepended to look
 --- in the current directory first.
 --- If the default value taken from $CDPATH is not what you want, include
 --- a modified version of the following command in your vimrc file to
 --- override it:
 --- ```
----   :let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
+--- :let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
 --- ```
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 --- (parts of 'cdpath' can be passed to the shell to expand file names).
 ---
@@ -730,18 +727,18 @@ vim.go.cd = vim.go.cdpath
 --- The key can be specified as a single character, but it is difficult to
 --- type.  The preferred way is to use the <> notation.  Examples:
 --- ```
---- 	:exe "set cedit=\\<C-Y>"
---- 	:exe "set cedit=\\<Esc>"
+--- :exe "set cedit=\\<C-Y>"
+--- :exe "set cedit=\\<Esc>"
 --- ```
---- `Nvi` also has this option, but it only uses the first character.
---- See `cmdwin`.
+--- `|Nvi|` also has this option, but it only uses the first character.
+--- See `|cmdwin|`.
 ---
 --- @type string
 vim.o.cedit = "\6"
 vim.go.cedit = vim.o.cedit
 
---- `channel` connected to the buffer, or 0 if no channel is connected.
---- In a `:terminal` buffer this is the terminal channel.
+--- `|channel|` connected to the buffer, or 0 if no channel is connected.
+--- In a `|:terminal|` buffer this is the terminal channel.
 --- Read-only.
 ---
 --- @type integer
@@ -754,11 +751,11 @@ vim.bo.channel = vim.o.channel
 --- 'charconvert' is not used when the internal iconv() function is
 --- supported and is able to do the conversion.  Using iconv() is
 --- preferred, because it is much faster.
---- 'charconvert' is not used when reading stdin `--`, because there is no
+--- 'charconvert' is not used when reading stdin `|--|`, because there is no
 --- file to convert from.  You will have to save the text in a file first.
 --- The expression must return zero, false or an empty string for success,
 --- non-zero or true for failure.
---- See `encoding-names` for possible encoding names.
+--- See `|encoding-names|` for possible encoding names.
 --- Additionally, names given in 'fileencodings' and 'fileencoding' are
 --- used.
 --- Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
@@ -766,21 +763,21 @@ vim.bo.channel = vim.o.channel
 --- Also used for Unicode conversion.
 --- Example:
 --- ```
---- 	set charconvert=CharConvert()
---- 	fun CharConvert()
---- 	  system("recode "
---- 		\ .. v:charconvert_from .. ".." .. v:charconvert_to
---- 		\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
---- 	  return v:shell_error
---- 	endfun
+--- set charconvert=CharConvert()
+--- fun CharConvert()
+---   system("recode "
+---   \ .. v:charconvert_from .. ".." .. v:charconvert_to
+---   \ .. " <" .. v:fname_in .. " >" .. v:fname_out)
+---   return v:shell_error
+--- endfun
 --- ```
 --- The related Vim variables are:
---- 	v:charconvert_from	name of the current encoding
---- 	v:charconvert_to	name of the desired encoding
---- 	v:fname_in		name of the input file
---- 	v:fname_out		name of the output file
+--- v:charconvert_from  name of the current encoding
+--- v:charconvert_to  name of the desired encoding
+--- v:fname_in    name of the input file
+--- v:fname_out    name of the output file
 --- Note that v:fname_in and v:fname_out will never be the same.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -796,7 +793,7 @@ vim.go.ccv = vim.go.charconvert
 --- If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
 --- the "=" operator indents using this algorithm rather than calling an
 --- external program.
---- See `C-indenting`.
+--- See `|C-indenting|`.
 --- When you don't like the way 'cindent' works, try the 'smartindent'
 --- option or 'indentexpr'.
 ---
@@ -809,8 +806,8 @@ vim.bo.cin = vim.bo.cindent
 --- A list of keys that, when typed in Insert mode, cause reindenting of
 --- the current line.  Only used if 'cindent' is on and 'indentexpr' is
 --- empty.
---- For the format of this option see `cinkeys-format`.
---- See `C-indenting`.
+--- For the format of this option see `|cinkeys-format|`.
+--- See `|C-indenting|`.
 ---
 --- @type string
 vim.o.cinkeys = "0{,0},0),0],:,0#,!^F,o,O,e"
@@ -819,8 +816,8 @@ vim.bo.cinkeys = vim.o.cinkeys
 vim.bo.cink = vim.bo.cinkeys
 
 --- The 'cinoptions' affect the way 'cindent' reindents lines in a C
---- program.  See `cinoptions-values` for the values of this option, and
---- `C-indenting` for info on C indenting in general.
+--- program.  See `|cinoptions-values|` for the values of this option, and
+--- `|C-indenting|` for info on C indenting in general.
 ---
 --- @type string
 vim.o.cinoptions = ""
@@ -828,13 +825,12 @@ vim.o.cino = vim.o.cinoptions
 vim.bo.cinoptions = vim.o.cinoptions
 vim.bo.cino = vim.bo.cinoptions
 
---- Keywords that are interpreted as a C++ scope declaration by `cino-g`.
+--- Keywords that are interpreted as a C++ scope declaration by `|cino-g|`.
 --- Useful e.g. for working with the Qt framework that defines additional
 --- scope declarations "signals", "public slots" and "private slots":
 --- ```
---- 	set cinscopedecls+=signals,public\ slots,private\ slots
+--- set cinscopedecls+=signals,public\ slots,private\ slots
 --- ```
----
 ---
 --- @type string
 vim.o.cinscopedecls = "public,protected,private"
@@ -858,25 +854,25 @@ vim.bo.cinw = vim.bo.cinwords
 --- This option is a list of comma-separated names.
 --- These names are recognized:
 ---
---- 					*clipboard-unnamed*
---- unnamed		When included, Vim will use the clipboard register "*"
---- 		for all yank, delete, change and put operations which
---- 		would normally go to the unnamed register.  When a
---- 		register is explicitly specified, it will always be
---- 		used regardless of whether "unnamed" is in 'clipboard'
---- 		or not.  The clipboard register can always be
---- 		explicitly accessed using the "* notation.  Also see
---- 		`clipboard`.
+---       *clipboard-unnamed*
+--- unnamed    When included, Vim will use the clipboard register "*"
+--- for all yank, delete, change and put operations which
+--- would normally go to the unnamed register.  When a
+--- register is explicitly specified, it will always be
+--- used regardless of whether "unnamed" is in 'clipboard'
+--- or not.  The clipboard register can always be
+--- explicitly accessed using the "* notation.  Also see
+--- `|clipboard|`.
 ---
---- 					*clipboard-unnamedplus*
---- unnamedplus	A variant of the "unnamed" flag which uses the
---- 		clipboard register "+" (`quoteplus`) instead of
---- 		register "*" for all yank, delete, change and put
---- 		operations which would normally go to the unnamed
---- 		register.  When "unnamed" is also included to the
---- 		option, yank and delete operations (but not put)
---- 		will additionally copy the text into register
---- 		"*". See `clipboard`.
+---       *clipboard-unnamedplus*
+--- unnamedplus  A variant of the "unnamed" flag which uses the
+--- clipboard register "+" (`|quoteplus|`) instead of
+--- register "*" for all yank, delete, change and put
+--- operations which would normally go to the unnamed
+--- register.  When "unnamed" is also included to the
+--- option, yank and delete operations (but not put)
+--- will additionally copy the text into register
+--- "*". See `|clipboard|`.
 ---
 --- @type string
 vim.o.clipboard = ""
@@ -885,7 +881,7 @@ vim.go.clipboard = vim.o.clipboard
 vim.go.cb = vim.go.clipboard
 
 --- Number of screen lines to use for the command-line.  Helps avoiding
---- `hit-enter` prompts.
+--- `|hit-enter|` prompts.
 --- The value of this option is stored with the tab page, so that each tab
 --- page can have a different value.
 ---
@@ -905,7 +901,7 @@ vim.o.ch = vim.o.cmdheight
 vim.go.cmdheight = vim.o.cmdheight
 vim.go.ch = vim.go.cmdheight
 
---- Number of screen lines to use for the command-line window. `cmdwin`
+--- Number of screen lines to use for the command-line window. `|cmdwin|`
 ---
 --- @type integer
 vim.o.cmdwinheight = 7
@@ -914,16 +910,15 @@ vim.go.cmdwinheight = vim.o.cmdwinheight
 vim.go.cwh = vim.go.cmdwinheight
 
 --- 'colorcolumn' is a comma-separated list of screen columns that are
---- highlighted with ColorColumn `hl-ColorColumn`.  Useful to align
+--- highlighted with ColorColumn `|hl-ColorColumn|`.  Useful to align
 --- text.  Will make screen redrawing slower.
 --- The screen column can be an absolute number, or a number preceded with
 --- '+' or '-', which is added to or subtracted from 'textwidth'.
 --- ```
---- 	:set cc=+1	  " highlight column after 'textwidth'
---- 	:set cc=+1,+2,+3  " highlight three columns after 'textwidth'
---- 	:hi ColorColumn ctermbg=lightgrey guibg=lightgrey
+--- :set cc=+1    " highlight column after 'textwidth'
+--- :set cc=+1,+2,+3  " highlight three columns after 'textwidth'
+--- :hi ColorColumn ctermbg=lightgrey guibg=lightgrey
 --- ```
----
 --- When 'textwidth' is zero then the items with '-' and '+' are not used.
 --- A maximum of 256 columns are highlighted.
 ---
@@ -937,14 +932,14 @@ vim.wo.cc = vim.wo.colorcolumn
 --- initialization and does not have to be set by hand.
 --- When Vim is running in the GUI or in a resizable window, setting this
 --- option will cause the window size to be changed.  When you only want
---- to use the size for the GUI, put the command in your `ginit.vim` file.
+--- to use the size for the GUI, put the command in your `|ginit.vim|` file.
 --- When you set this option and Vim is unable to change the physical
 --- number of columns of the display, the display may be messed up.  For
 --- the GUI it is always possible and Vim limits the number of columns to
 --- what fits on the screen.  You can use this command to get the widest
 --- window possible:
 --- ```
---- 	:set columns=9999
+--- :set columns=9999
 --- ```
 --- Minimum value is 12, maximum value is 10000.
 ---
@@ -955,7 +950,7 @@ vim.go.columns = vim.o.columns
 vim.go.co = vim.go.columns
 
 --- A comma-separated list of strings that can start a comment line.  See
---- `format-comments`.  See `option-backslash` about using backslashes to
+--- `|format-comments|`.  See `|option-backslash|` about using backslashes to
 --- insert a space.
 ---
 --- @type string
@@ -966,7 +961,7 @@ vim.bo.com = vim.bo.comments
 
 --- A template for a comment.  The "%s" in the value is replaced with the
 --- comment text.  For example, C uses "/*%s*/". Currently only used to
---- add markers for folding, see `fold-marker`.
+--- add markers for folding, see `|fold-marker|`.
 ---
 --- @type string
 vim.o.commentstring = ""
@@ -974,39 +969,39 @@ vim.o.cms = vim.o.commentstring
 vim.bo.commentstring = vim.o.commentstring
 vim.bo.cms = vim.bo.commentstring
 
---- This option specifies how keyword completion `ins-completion` works
+--- This option specifies how keyword completion `|ins-completion|` works
 --- when CTRL-P or CTRL-N are used.  It is also used for whole-line
---- completion `i_CTRL-X_CTRL-L`.  It indicates the type of completion
+--- completion `|i_CTRL-X_CTRL-L|`.  It indicates the type of completion
 --- and the places to scan.  It is a comma-separated list of flags:
---- .	scan the current buffer ('wrapscan' is ignored)
---- w	scan buffers from other windows
---- b	scan other loaded buffers that are in the buffer list
---- u	scan the unloaded buffers that are in the buffer list
---- U	scan the buffers that are not in the buffer list
---- k	scan the files given with the 'dictionary' option
---- kspell  use the currently active spell checking `spell`
---- k{dict}	scan the file {dict}.  Several "k" flags can be given,
---- 	patterns are valid too.  For example:
+--- .  scan the current buffer ('wrapscan' is ignored)
+--- w  scan buffers from other windows
+--- b  scan other loaded buffers that are in the buffer list
+--- u  scan the unloaded buffers that are in the buffer list
+--- U  scan the buffers that are not in the buffer list
+--- k  scan the files given with the 'dictionary' option
+--- kspell  use the currently active spell checking `|spell|`
+--- k{dict}  scan the file {dict}.  Several "k" flags can be given,
+--- patterns are valid too.  For example:
 --- ```
---- 		:set cpt=k/usr/dict/*,k~/spanish
+---   :set cpt=k/usr/dict/*,k~/spanish
 --- ```
---- s	scan the files given with the 'thesaurus' option
---- s{tsr}	scan the file {tsr}.  Several "s" flags can be given, patterns
---- 	are valid too.
---- i	scan current and included files
---- d	scan current and included files for defined name or macro
---- 	`i_CTRL-X_CTRL-D`
---- ]	tag completion
---- t	same as "]"
+--- s  scan the files given with the 'thesaurus' option
+--- s{tsr}  scan the file {tsr}.  Several "s" flags can be given, patterns
+--- are valid too.
+--- i  scan current and included files
+--- d  scan current and included files for defined name or macro
+--- `|i_CTRL-X_CTRL-D|`
+--- ]  tag completion
+--- t  same as "]"
 ---
---- Unloaded buffers are not loaded, thus their autocmds `:autocmd` are
+--- Unloaded buffers are not loaded, thus their autocmds `|:autocmd|` are
 --- not executed, this may lead to unexpected completions from some files
 --- (gzipped files for example).  Unloaded buffers are not scanned for
 --- whole-line completion.
 ---
 --- As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
---- based expansion (e.g., dictionary `i_CTRL-X_CTRL-K`, included patterns
---- `i_CTRL-X_CTRL-I`, tags `i_CTRL-X_CTRL-]` and normal expansions).
+--- based expansion (e.g., dictionary `|i_CTRL-X_CTRL-K|`, included patterns
+--- `|i_CTRL-X_CTRL-I|`, tags `|i_CTRL-X_CTRL-]|` and normal expansions).
 ---
 --- @type string
 vim.o.complete = ".,w,b,u,t"
@@ -1015,12 +1010,12 @@ vim.bo.complete = vim.o.complete
 vim.bo.cpt = vim.bo.complete
 
 --- This option specifies a function to be used for Insert mode completion
---- with CTRL-X CTRL-U. `i_CTRL-X_CTRL-U`
---- See `complete-functions` for an explanation of how the function is
+--- with CTRL-X CTRL-U. `|i_CTRL-X_CTRL-U|`
+--- See `|complete-functions|` for an explanation of how the function is
 --- invoked and what it should return.  The value can be the name of a
---- function, a `lambda` or a `Funcref`. See `option-value-function` for
+--- function, a `|lambda|` or a `|Funcref|`. See `|option-value-function|` for
 --- more information.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -1030,33 +1025,33 @@ vim.bo.completefunc = vim.o.completefunc
 vim.bo.cfu = vim.bo.completefunc
 
 --- A comma-separated list of options for Insert mode completion
---- `ins-completion`.  The supported values are:
+--- `|ins-completion|`.  The supported values are:
 ---
----    menu	    Use a popup menu to show the possible completions.  The
---- 	    menu is only shown when there is more than one match and
---- 	    sufficient colors are available.  `ins-completion-menu`
+---  menu      Use a popup menu to show the possible completions.  The
+---     menu is only shown when there is more than one match and
+---     sufficient colors are available.  `|ins-completion-menu|`
 ---
----    menuone  Use the popup menu also when there is only one match.
---- 	    Useful when there is additional information about the
---- 	    match, e.g., what file it comes from.
+---  menuone  Use the popup menu also when there is only one match.
+---     Useful when there is additional information about the
+---     match, e.g., what file it comes from.
 ---
----    longest  Only insert the longest common text of the matches.  If
---- 	    the menu is displayed you can use CTRL-L to add more
---- 	    characters.  Whether case is ignored depends on the kind
---- 	    of completion.  For buffer text the 'ignorecase' option is
---- 	    used.
+---  longest  Only insert the longest common text of the matches.  If
+---     the menu is displayed you can use CTRL-L to add more
+---     characters.  Whether case is ignored depends on the kind
+---     of completion.  For buffer text the 'ignorecase' option is
+---     used.
 ---
----    preview  Show extra information about the currently selected
---- 	    completion in the preview window.  Only works in
---- 	    combination with "menu" or "menuone".
+---  preview  Show extra information about the currently selected
+---     completion in the preview window.  Only works in
+---     combination with "menu" or "menuone".
 ---
----   noinsert  Do not insert any text for a match until the user selects
---- 	    a match from the menu. Only works in combination with
---- 	    "menu" or "menuone". No effect if "longest" is present.
+--- noinsert  Do not insert any text for a match until the user selects
+---     a match from the menu. Only works in combination with
+---     "menu" or "menuone". No effect if "longest" is present.
 ---
----   noselect  Do not select a match in the menu, force the user to
---- 	    select one from the menu. Only works in combination with
---- 	    "menu" or "menuone".
+--- noselect  Do not select a match in the menu, force the user to
+---     select one from the menu. Only works in combination with
+---     "menu" or "menuone".
 ---
 --- @type string
 vim.o.completeopt = "menu,preview"
@@ -1064,15 +1059,15 @@ vim.o.cot = vim.o.completeopt
 vim.go.completeopt = vim.o.completeopt
 vim.go.cot = vim.go.completeopt
 
---- 		only for MS-Windows
+---   only for MS-Windows
 --- When this option is set it overrules 'shellslash' for completion:
 --- - When this option is set to "slash", a forward slash is used for path
----   completion in insert mode. This is useful when editing HTML tag, or
----   Makefile with 'noshellslash' on MS-Windows.
+--- completion in insert mode. This is useful when editing HTML tag, or
+--- Makefile with 'noshellslash' on MS-Windows.
 --- - When this option is set to "backslash", backslash is used. This is
----   useful when editing a batch file with 'shellslash' set on MS-Windows.
+--- useful when editing a batch file with 'shellslash' set on MS-Windows.
 --- - When this option is empty, same character is used as for
----   'shellslash'.
+--- 'shellslash'.
 --- For Insert mode completion the buffer-local value is used.  For
 --- command line completion the global value is used.
 ---
@@ -1085,10 +1080,10 @@ vim.bo.csl = vim.bo.completeslash
 --- Sets the modes in which text in the cursor line can also be concealed.
 --- When the current mode is listed then concealing happens just like in
 --- other lines.
----   n		Normal mode
----   v		Visual mode
----   i		Insert mode
----   c		Command line editing, for 'incsearch'
+--- n    Normal mode
+--- v    Visual mode
+--- i    Insert mode
+--- c    Command line editing, for 'incsearch'
 ---
 --- 'v' applies to all lines in the Visual area, not only the cursor.
 --- A useful value is "nc".  This is used in help files.  So long as you
@@ -1104,20 +1099,20 @@ vim.o.cocu = vim.o.concealcursor
 vim.wo.concealcursor = vim.o.concealcursor
 vim.wo.cocu = vim.wo.concealcursor
 
---- Determine how text with the "conceal" syntax attribute `:syn-conceal`
+--- Determine how text with the "conceal" syntax attribute `|:syn-conceal|`
 --- is shown:
 ---
---- Value		Effect ~
---- 0		Text is shown normally
---- 1		Each block of concealed text is replaced with one
---- 		character.  If the syntax item does not have a custom
---- 		replacement character defined (see `:syn-cchar`) the
---- 		character defined in 'listchars' is used.
---- 		It is highlighted with the "Conceal" highlight group.
---- 2		Concealed text is completely hidden unless it has a
---- 		custom replacement character defined (see
---- 		`:syn-cchar`).
---- 3		Concealed text is completely hidden.
+--- Value    Effect ~
+--- 0    Text is shown normally
+--- 1    Each block of concealed text is replaced with one
+--- character.  If the syntax item does not have a custom
+--- replacement character defined (see `|:syn-cchar|`) the
+--- character defined in 'listchars' is used.
+--- It is highlighted with the "Conceal" highlight group.
+--- 2    Concealed text is completely hidden unless it has a
+--- custom replacement character defined (see
+--- `|:syn-cchar|`).
+--- 3    Concealed text is completely hidden.
 ---
 --- Note: in the cursor line concealed text is not hidden, so that you can
 --- edit and copy the text.  This can be changed with the 'concealcursor'
@@ -1132,11 +1127,11 @@ vim.wo.cole = vim.wo.conceallevel
 --- When 'confirm' is on, certain operations that would normally
 --- fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
 --- instead raise a dialog asking if you wish to save the current
---- file(s).  You can still use a ! to unconditionally `abandon` a buffer.
+--- file(s).  You can still use a ! to unconditionally `|abandon|` a buffer.
 --- If 'confirm' is off you can still activate confirmation for one
---- command only (this is most useful in mappings) with the `:confirm`
+--- command only (this is most useful in mappings) with the `|:confirm|`
 --- command.
---- Also see the `confirm()` function and the 'v' flag in 'guioptions'.
+--- Also see the `|confirm()|` function and the 'v' flag in 'guioptions'.
 ---
 --- @type boolean
 vim.o.confirm = false
@@ -1146,7 +1141,7 @@ vim.go.cf = vim.go.confirm
 
 --- Copy the structure of the existing lines indent when autoindenting a
 --- new line.  Normally the new indent is reconstructed by a series of
---- tabs followed by spaces as required (unless `'expandtab'` is enabled,
+--- tabs followed by spaces as required (unless `|'expandtab'|` is enabled,
 --- in which case only spaces are used).  Enabling this option makes the
 --- new line copy whatever characters were used for indenting on the
 --- existing line.  'expandtab' has no effect on these characters, a Tab
@@ -1166,230 +1161,230 @@ vim.bo.ci = vim.bo.copyindent
 --- 'cpoptions' stands for "compatible-options".
 --- Commas can be added for readability.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `add-option-flags`.
+--- "+=" and "-=" feature of ":set" `|add-option-flags|`.
 ---
----     contains	behavior	~
---- 							*cpo-a*
---- 	a	When included, a ":read" command with a file name
---- 		argument will set the alternate file name for the
---- 		current window.
---- 							*cpo-A*
---- 	A	When included, a ":write" command with a file name
---- 		argument will set the alternate file name for the
---- 		current window.
---- 							*cpo-b*
---- 	b	"\|" in a ":map" command is recognized as the end of
---- 		the map command.  The '\' is included in the mapping,
---- 		the text after the '|' is interpreted as the next
---- 		command.  Use a CTRL-V instead of a backslash to
---- 		include the '|' in the mapping.  Applies to all
---- 		mapping, abbreviation, menu and autocmd commands.
---- 		See also `map_bar`.
---- 							*cpo-B*
---- 	B	A backslash has no special meaning in mappings,
---- 		abbreviations, user commands and the "to" part of the
---- 		menu commands.  Remove this flag to be able to use a
---- 		backslash like a CTRL-V.  For example, the command
---- 		":map X \\<Esc>" results in X being mapped to:
---- 			'B' included:	"\^["	 (^[ is a real <Esc>)
---- 			'B' excluded:	"<Esc>"  (5 characters)
---- 							*cpo-c*
---- 	c	Searching continues at the end of any match at the
---- 		cursor position, but not further than the start of the
---- 		next line.  When not present searching continues
---- 		one character from the cursor position.  With 'c'
---- 		"abababababab" only gets three matches when repeating
---- 		"/abab", without 'c' there are five matches.
---- 							*cpo-C*
---- 	C	Do not concatenate sourced lines that start with a
---- 		backslash.  See `line-continuation`.
---- 							*cpo-d*
---- 	d	Using "./" in the 'tags' option doesn't mean to use
---- 		the tags file relative to the current file, but the
---- 		tags file in the current directory.
---- 							*cpo-D*
---- 	D	Can't use CTRL-K to enter a digraph after Normal mode
---- 		commands with a character argument, like `r`, `f` and
---- 		`t`.
---- 							*cpo-e*
---- 	e	When executing a register with ":@r", always add a
---- 		<CR> to the last line, also when the register is not
---- 		linewise.  If this flag is not present, the register
---- 		is not linewise and the last line does not end in a
---- 		<CR>, then the last line is put on the command-line
---- 		and can be edited before hitting <CR>.
---- 							*cpo-E*
---- 	E	It is an error when using "y", "d", "c", "g~", "gu" or
---- 		"gU" on an Empty region.  The operators only work when
---- 		at least one character is to be operated on.  Example:
---- 		This makes "y0" fail in the first column.
---- 							*cpo-f*
---- 	f	When included, a ":read" command with a file name
---- 		argument will set the file name for the current buffer,
---- 		if the current buffer doesn't have a file name yet.
---- 							*cpo-F*
---- 	F	When included, a ":write" command with a file name
---- 		argument will set the file name for the current
---- 		buffer, if the current buffer doesn't have a file name
---- 		yet.  Also see `cpo-P`.
---- 							*cpo-i*
---- 	i	When included, interrupting the reading of a file will
---- 		leave it modified.
---- 							*cpo-I*
---- 	I	When moving the cursor up or down just after inserting
---- 		indent for 'autoindent', do not delete the indent.
---- 							*cpo-J*
---- 	J	A `sentence` has to be followed by two spaces after
---- 		the '.', '!' or '?'.  A <Tab> is not recognized as
---- 		white space.
---- 							*cpo-K*
---- 	K	Don't wait for a key code to complete when it is
---- 		halfway through a mapping.  This breaks mapping
---- 		<F1><F1> when only part of the second <F1> has been
---- 		read.  It enables cancelling the mapping by typing
---- 		<F1><Esc>.
---- 							*cpo-l*
---- 	l	Backslash in a [] range in a search pattern is taken
---- 		literally, only "\]", "\^", "\-" and "\\" are special.
---- 		See `/[]`
---- 		   'l' included: "/[ \t]"  finds <Space>, '\' and 't'
---- 		   'l' excluded: "/[ \t]"  finds <Space> and <Tab>
---- 							*cpo-L*
---- 	L	When the 'list' option is set, 'wrapmargin',
---- 		'textwidth', 'softtabstop' and Virtual Replace mode
---- 		(see `gR`) count a <Tab> as two characters, instead of
---- 		the normal behavior of a <Tab>.
---- 							*cpo-m*
---- 	m	When included, a showmatch will always wait half a
---- 		second.  When not included, a showmatch will wait half
---- 		a second or until a character is typed.  `'showmatch'`
---- 							*cpo-M*
---- 	M	When excluded, "%" matching will take backslashes into
---- 		account.  Thus in "( \( )" and "\( ( \)" the outer
---- 		parenthesis match.  When included "%" ignores
---- 		backslashes, which is Vi compatible.
---- 							*cpo-n*
---- 	n	When included, the column used for 'number' and
---- 		'relativenumber' will also be used for text of wrapped
---- 		lines.
---- 							*cpo-o*
---- 	o	Line offset to search command is not remembered for
---- 		next search.
---- 							*cpo-O*
---- 	O	Don't complain if a file is being overwritten, even
---- 		when it didn't exist when editing it.  This is a
---- 		protection against a file unexpectedly created by
---- 		someone else.  Vi didn't complain about this.
---- 							*cpo-p*
---- 	p	Vi compatible Lisp indenting.  When not present, a
---- 		slightly better algorithm is used.
---- 							*cpo-P*
---- 	P	When included, a ":write" command that appends to a
---- 		file will set the file name for the current buffer, if
---- 		the current buffer doesn't have a file name yet and
---- 		the 'F' flag is also included `cpo-F`.
---- 							*cpo-q*
---- 	q	When joining multiple lines leave the cursor at the
---- 		position where it would be when joining two lines.
---- 							*cpo-r*
---- 	r	Redo ("." command) uses "/" to repeat a search
---- 		command, instead of the actually used search string.
---- 							*cpo-R*
---- 	R	Remove marks from filtered lines.  Without this flag
---- 		marks are kept like `:keepmarks` was used.
---- 							*cpo-s*
---- 	s	Set buffer options when entering the buffer for the
---- 		first time.  This is like it is in Vim version 3.0.
---- 		And it is the default.  If not present the options are
---- 		set when the buffer is created.
---- 							*cpo-S*
---- 	S	Set buffer options always when entering a buffer
---- 		(except 'readonly', 'fileformat', 'filetype' and
---- 		'syntax').  This is the (most) Vi compatible setting.
---- 		The options are set to the values in the current
---- 		buffer.  When you change an option and go to another
---- 		buffer, the value is copied.  Effectively makes the
---- 		buffer options global to all buffers.
+---   contains  behavior  ~
+---             *cpo-a*
+--- a  When included, a ":read" command with a file name
+---   argument will set the alternate file name for the
+---   current window.
+---             *cpo-A*
+--- A  When included, a ":write" command with a file name
+---   argument will set the alternate file name for the
+---   current window.
+---             *cpo-b*
+--- b  "\|" in a ":map" command is recognized as the end of
+---   the map command.  The '\' is included in the mapping,
+---   the text after the '|' is interpreted as the next
+---   command.  Use a CTRL-V instead of a backslash to
+---   include the '|' in the mapping.  Applies to all
+---   mapping, abbreviation, menu and autocmd commands.
+---   See also `|map_bar|`.
+---             *cpo-B*
+--- B  A backslash has no special meaning in mappings,
+---   abbreviations, user commands and the "to" part of the
+---   menu commands.  Remove this flag to be able to use a
+---   backslash like a CTRL-V.  For example, the command
+---   ":map X \\<Esc>" results in X being mapped to:
+---     'B' included:  "\^["   (^[ is a real <Esc>)
+---     'B' excluded:  "<Esc>"  (5 characters)
+---             *cpo-c*
+--- c  Searching continues at the end of any match at the
+---   cursor position, but not further than the start of the
+---   next line.  When not present searching continues
+---   one character from the cursor position.  With 'c'
+---   "abababababab" only gets three matches when repeating
+---   "/abab", without 'c' there are five matches.
+---             *cpo-C*
+--- C  Do not concatenate sourced lines that start with a
+---   backslash.  See `|line-continuation|`.
+---             *cpo-d*
+--- d  Using "./" in the 'tags' option doesn't mean to use
+---   the tags file relative to the current file, but the
+---   tags file in the current directory.
+---             *cpo-D*
+--- D  Can't use CTRL-K to enter a digraph after Normal mode
+---   commands with a character argument, like `|r|`, `|f|` and
+---   `|t|`.
+---             *cpo-e*
+--- e  When executing a register with ":@r", always add a
+---   <CR> to the last line, also when the register is not
+---   linewise.  If this flag is not present, the register
+---   is not linewise and the last line does not end in a
+---   <CR>, then the last line is put on the command-line
+---   and can be edited before hitting <CR>.
+---             *cpo-E*
+--- E  It is an error when using "y", "d", "c", "g~", "gu" or
+---   "gU" on an Empty region.  The operators only work when
+---   at least one character is to be operated on.  Example:
+---   This makes "y0" fail in the first column.
+---             *cpo-f*
+--- f  When included, a ":read" command with a file name
+---   argument will set the file name for the current buffer,
+---   if the current buffer doesn't have a file name yet.
+---             *cpo-F*
+--- F  When included, a ":write" command with a file name
+---   argument will set the file name for the current
+---   buffer, if the current buffer doesn't have a file name
+---   yet.  Also see `|cpo-P|`.
+---             *cpo-i*
+--- i  When included, interrupting the reading of a file will
+---   leave it modified.
+---             *cpo-I*
+--- I  When moving the cursor up or down just after inserting
+---   indent for 'autoindent', do not delete the indent.
+---             *cpo-J*
+--- J  A `|sentence|` has to be followed by two spaces after
+---   the '.', '!' or '?'.  A <Tab> is not recognized as
+---   white space.
+---             *cpo-K*
+--- K  Don't wait for a key code to complete when it is
+---   halfway through a mapping.  This breaks mapping
+---   <F1><F1> when only part of the second <F1> has been
+---   read.  It enables cancelling the mapping by typing
+---   <F1><Esc>.
+---             *cpo-l*
+--- l  Backslash in a [] range in a search pattern is taken
+---   literally, only "\]", "\^", "\-" and "\\" are special.
+---   See `|/[]|`
+---      'l' included: "/[ \t]"  finds <Space>, '\' and 't'
+---      'l' excluded: "/[ \t]"  finds <Space> and <Tab>
+---             *cpo-L*
+--- L  When the 'list' option is set, 'wrapmargin',
+---   'textwidth', 'softtabstop' and Virtual Replace mode
+---   (see `|gR|`) count a <Tab> as two characters, instead of
+---   the normal behavior of a <Tab>.
+---             *cpo-m*
+--- m  When included, a showmatch will always wait half a
+---   second.  When not included, a showmatch will wait half
+---   a second or until a character is typed.  `|'showmatch'|`
+---             *cpo-M*
+--- M  When excluded, "%" matching will take backslashes into
+---   account.  Thus in "( \( )" and "\( ( \)" the outer
+---   parenthesis match.  When included "%" ignores
+---   backslashes, which is Vi compatible.
+---             *cpo-n*
+--- n  When included, the column used for 'number' and
+---   'relativenumber' will also be used for text of wrapped
+---   lines.
+---             *cpo-o*
+--- o  Line offset to search command is not remembered for
+---   next search.
+---             *cpo-O*
+--- O  Don't complain if a file is being overwritten, even
+---   when it didn't exist when editing it.  This is a
+---   protection against a file unexpectedly created by
+---   someone else.  Vi didn't complain about this.
+---             *cpo-p*
+--- p  Vi compatible Lisp indenting.  When not present, a
+---   slightly better algorithm is used.
+---             *cpo-P*
+--- P  When included, a ":write" command that appends to a
+---   file will set the file name for the current buffer, if
+---   the current buffer doesn't have a file name yet and
+---   the 'F' flag is also included `|cpo-F|`.
+---             *cpo-q*
+--- q  When joining multiple lines leave the cursor at the
+---   position where it would be when joining two lines.
+---             *cpo-r*
+--- r  Redo ("." command) uses "/" to repeat a search
+---   command, instead of the actually used search string.
+---             *cpo-R*
+--- R  Remove marks from filtered lines.  Without this flag
+---   marks are kept like `|:keepmarks|` was used.
+---             *cpo-s*
+--- s  Set buffer options when entering the buffer for the
+---   first time.  This is like it is in Vim version 3.0.
+---   And it is the default.  If not present the options are
+---   set when the buffer is created.
+---             *cpo-S*
+--- S  Set buffer options always when entering a buffer
+---   (except 'readonly', 'fileformat', 'filetype' and
+---   'syntax').  This is the (most) Vi compatible setting.
+---   The options are set to the values in the current
+---   buffer.  When you change an option and go to another
+---   buffer, the value is copied.  Effectively makes the
+---   buffer options global to all buffers.
 ---
---- 		's'    'S'     copy buffer options
---- 		no     no      when buffer created
---- 		yes    no      when buffer first entered (default)
---- 		 X     yes     each time when buffer entered (vi comp.)
---- 							*cpo-t*
---- 	t	Search pattern for the tag command is remembered for
---- 		"n" command.  Otherwise Vim only puts the pattern in
---- 		the history for search pattern, but doesn't change the
---- 		last used search pattern.
---- 							*cpo-u*
---- 	u	Undo is Vi compatible.  See `undo-two-ways`.
---- 							*cpo-v*
---- 	v	Backspaced characters remain visible on the screen in
---- 		Insert mode.  Without this flag the characters are
---- 		erased from the screen right away.  With this flag the
---- 		screen newly typed text overwrites backspaced
---- 		characters.
---- 							*cpo-W*
---- 	W	Don't overwrite a readonly file.  When omitted, ":w!"
---- 		overwrites a readonly file, if possible.
---- 							*cpo-x*
---- 	x	<Esc> on the command-line executes the command-line.
---- 		The default in Vim is to abandon the command-line,
---- 		because <Esc> normally aborts a command.  `c_<Esc>`
---- 							*cpo-X*
---- 	X	When using a count with "R" the replaced text is
---- 		deleted only once.  Also when repeating "R" with "."
---- 		and a count.
---- 							*cpo-y*
---- 	y	A yank command can be redone with ".".  Think twice if
---- 		you really want to use this, it may break some
---- 		plugins, since most people expect "." to only repeat a
---- 		change.
---- 							*cpo-Z*
---- 	Z	When using "w!" while the 'readonly' option is set,
---- 		don't reset 'readonly'.
---- 							*cpo-!*
---- 	!	When redoing a filter command, use the last used
---- 		external command, whatever it was.  Otherwise the last
---- 		used -filter- command is used.
---- 							*cpo-$*
---- 	$	When making a change to one line, don't redisplay the
---- 		line, but put a '$' at the end of the changed text.
---- 		The changed text will be overwritten when you type the
---- 		new text.  The line is redisplayed if you type any
---- 		command that moves the cursor from the insertion
---- 		point.
---- 							*cpo-%*
---- 	%	Vi-compatible matching is done for the "%" command.
---- 		Does not recognize "#if", "#endif", etc.
---- 		Does not recognize "/*" and "*/".
---- 		Parens inside single and double quotes are also
---- 		counted, causing a string that contains a paren to
---- 		disturb the matching.  For example, in a line like
---- 		"if (strcmp("foo(", s))" the first paren does not
---- 		match the last one.  When this flag is not included,
---- 		parens inside single and double quotes are treated
---- 		specially.  When matching a paren outside of quotes,
---- 		everything inside quotes is ignored.  When matching a
---- 		paren inside quotes, it will find the matching one (if
---- 		there is one).  This works very well for C programs.
---- 		This flag is also used for other features, such as
---- 		C-indenting.
---- 							*cpo-+*
---- 	+	When included, a ":write file" command will reset the
---- 		'modified' flag of the buffer, even though the buffer
---- 		itself may still be different from its file.
---- 							*cpo->*
---- 	>	When appending to a register, put a line break before
---- 		the appended text.
---- 							*cpo-;*
---- 	;	When using `,` or `;` to repeat the last `t` search
---- 		and the cursor is right in front of the searched
---- 		character, the cursor won't move. When not included,
---- 		the cursor would skip over it and jump to the
---- 		following occurrence.
---- 							*cpo-_*
---- 	_	When using `cw` on a word, do not include the
---- 		whitespace following the word in the motion.
+---   's'    'S'     copy buffer options
+---   no     no      when buffer created
+---   yes    no      when buffer first entered (default)
+---    X     yes     each time when buffer entered (vi comp.)
+---             *cpo-t*
+--- t  Search pattern for the tag command is remembered for
+---   "n" command.  Otherwise Vim only puts the pattern in
+---   the history for search pattern, but doesn't change the
+---   last used search pattern.
+---             *cpo-u*
+--- u  Undo is Vi compatible.  See `|undo-two-ways|`.
+---             *cpo-v*
+--- v  Backspaced characters remain visible on the screen in
+---   Insert mode.  Without this flag the characters are
+---   erased from the screen right away.  With this flag the
+---   screen newly typed text overwrites backspaced
+---   characters.
+---             *cpo-W*
+--- W  Don't overwrite a readonly file.  When omitted, ":w!"
+---   overwrites a readonly file, if possible.
+---             *cpo-x*
+--- x  <Esc> on the command-line executes the command-line.
+---   The default in Vim is to abandon the command-line,
+---   because <Esc> normally aborts a command.  `|c_<Esc>|`
+---             *cpo-X*
+--- X  When using a count with "R" the replaced text is
+---   deleted only once.  Also when repeating "R" with "."
+---   and a count.
+---             *cpo-y*
+--- y  A yank command can be redone with ".".  Think twice if
+---   you really want to use this, it may break some
+---   plugins, since most people expect "." to only repeat a
+---   change.
+---             *cpo-Z*
+--- Z  When using "w!" while the 'readonly' option is set,
+---   don't reset 'readonly'.
+---             *cpo-!*
+--- !  When redoing a filter command, use the last used
+---   external command, whatever it was.  Otherwise the last
+---   used -filter- command is used.
+---             *cpo-$*
+--- $  When making a change to one line, don't redisplay the
+---   line, but put a '$' at the end of the changed text.
+---   The changed text will be overwritten when you type the
+---   new text.  The line is redisplayed if you type any
+---   command that moves the cursor from the insertion
+---   point.
+---             *cpo-%*
+--- %  Vi-compatible matching is done for the "%" command.
+---   Does not recognize "#if", "#endif", etc.
+---   Does not recognize "/*" and "*/".
+---   Parens inside single and double quotes are also
+---   counted, causing a string that contains a paren to
+---   disturb the matching.  For example, in a line like
+---   "if (strcmp("foo(", s))" the first paren does not
+---   match the last one.  When this flag is not included,
+---   parens inside single and double quotes are treated
+---   specially.  When matching a paren outside of quotes,
+---   everything inside quotes is ignored.  When matching a
+---   paren inside quotes, it will find the matching one (if
+---   there is one).  This works very well for C programs.
+---   This flag is also used for other features, such as
+---   C-indenting.
+---             *cpo-+*
+--- +  When included, a ":write file" command will reset the
+---   'modified' flag of the buffer, even though the buffer
+---   itself may still be different from its file.
+---             *cpo->*
+--- >  When appending to a register, put a line break before
+---   the appended text.
+---             *cpo-;*
+--- ;  When using `|,|` or `|;|` to repeat the last `|t|` search
+---   and the cursor is right in front of the searched
+---   character, the cursor won't move. When not included,
+---   the cursor would skip over it and jump to the
+---   following occurrence.
+---             *cpo-_*
+--- _  When using `|cw|` on a word, do not include the
+---   whitespace following the word in the motion.
 ---
 --- @type string
 vim.o.cpoptions = "aABceFs_"
@@ -1412,15 +1407,14 @@ vim.wo.cursorbind = vim.o.cursorbind
 vim.wo.crb = vim.wo.cursorbind
 
 --- Highlight the screen column of the cursor with CursorColumn
---- `hl-CursorColumn`.  Useful to align text.  Will make screen redrawing
+--- `|hl-CursorColumn|`.  Useful to align text.  Will make screen redrawing
 --- slower.
 --- If you only want the highlighting in the current window you can use
 --- these autocommands:
 --- ```
---- 	au WinLeave * set nocursorline nocursorcolumn
---- 	au WinEnter * set cursorline cursorcolumn
+--- au WinLeave * set nocursorline nocursorcolumn
+--- au WinEnter * set cursorline cursorcolumn
 --- ```
----
 ---
 --- @type boolean
 vim.o.cursorcolumn = false
@@ -1428,7 +1422,7 @@ vim.o.cuc = vim.o.cursorcolumn
 vim.wo.cursorcolumn = vim.o.cursorcolumn
 vim.wo.cuc = vim.wo.cursorcolumn
 
---- Highlight the text line of the cursor with CursorLine `hl-CursorLine`.
+--- Highlight the text line of the cursor with CursorLine `|hl-CursorLine|`.
 --- Useful to easily spot the cursor.  Will make screen redrawing slower.
 --- When Visual mode is active the highlighting isn't used to make it
 --- easier to see the selected text.
@@ -1441,15 +1435,15 @@ vim.wo.cul = vim.wo.cursorline
 
 --- Comma-separated list of settings for how 'cursorline' is displayed.
 --- Valid values:
---- "line"		Highlight the text line of the cursor with
---- 		CursorLine `hl-CursorLine`.
---- "screenline"	Highlight only the screen line of the cursor with
---- 		CursorLine `hl-CursorLine`.
---- "number"	Highlight the line number of the cursor with
---- 		CursorLineNr `hl-CursorLineNr`.
+--- "line"    Highlight the text line of the cursor with
+--- CursorLine `|hl-CursorLine|`.
+--- "screenline"  Highlight only the screen line of the cursor with
+--- CursorLine `|hl-CursorLine|`.
+--- "number"  Highlight the line number of the cursor with
+--- CursorLineNr `|hl-CursorLineNr|`.
 ---
 --- Special value:
---- "both"		Alias for the values "line,number".
+--- "both"    Alias for the values "line,number".
 ---
 --- "line" and "screenline" cannot be used together.
 ---
@@ -1460,12 +1454,12 @@ vim.wo.cursorlineopt = vim.o.cursorlineopt
 vim.wo.culopt = vim.wo.cursorlineopt
 
 --- These values can be used:
---- msg	Error messages that would otherwise be omitted will be given
---- 	anyway.
---- throw	Error messages that would otherwise be omitted will be given
---- 	anyway and also throw an exception and set `v:errmsg`.
---- beep	A message will be given when otherwise only a beep would be
---- 	produced.
+--- msg  Error messages that would otherwise be omitted will be given
+--- anyway.
+--- throw  Error messages that would otherwise be omitted will be given
+--- anyway and also throw an exception and set `|v:errmsg|`.
+--- beep  A message will be given when otherwise only a beep would be
+--- produced.
 --- The values can be combined, separated by a comma.
 --- "msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
 --- 'indentexpr'.
@@ -1476,33 +1470,32 @@ vim.go.debug = vim.o.debug
 
 --- Pattern to be used to find a macro definition.  It is a search
 --- pattern, just like for the "/" command.  This option is used for the
---- commands like "[i" and "[d" `include-search`.  The 'isident' option is
+--- commands like "[i" and "[d" `|include-search|`.  The 'isident' option is
 --- used to recognize the defined name after the match:
 --- ```
---- 	{match with 'define'}{non-ID chars}{defined name}{non-ID char}
+--- {match with 'define'}{non-ID chars}{defined name}{non-ID char}
 --- ```
---- See `option-backslash` about inserting backslashes to include a space
+--- See `|option-backslash|` about inserting backslashes to include a space
 --- or backslash.
 --- For C++ this value would be useful, to include const type declarations:
 --- ```
---- 	^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
+--- ^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
 --- ```
 --- You can also use "\ze" just before the name and continue the pattern
 --- to check what is following.  E.g. for Javascript, if a function is
 --- defined with `func_name = function(args)`:
 --- ```
---- 	^\s*\ze\i\+\s*=\s*function(
+--- ^\s*\ze\i\+\s*=\s*function(
 --- ```
 --- If the function is defined with `func_name : function() {...`:
 --- ```
----         ^\s*\ze\i\+\s*[:]\s*(*function\s*(
+---       ^\s*\ze\i\+\s*[:]\s*(*function\s*(
 --- ```
 --- When using the ":set" command, you need to double the backslashes!
 --- To avoid that use `:let` with a single quote string:
 --- ```
---- 	let &l:define = '^\s*\ze\k\+\s*=\s*function('
+--- let &l:define = '^\s*\ze\k\+\s*=\s*function('
 --- ```
----
 ---
 --- @type string
 vim.o.define = ""
@@ -1529,24 +1522,24 @@ vim.go.delcombine = vim.o.delcombine
 vim.go.deco = vim.go.delcombine
 
 --- List of file names, separated by commas, that are used to lookup words
---- for keyword completion commands `i_CTRL-X_CTRL-K`.  Each file should
+--- for keyword completion commands `|i_CTRL-X_CTRL-K|`.  Each file should
 --- contain a list of words.  This can be one word per line, or several
 --- words per line, separated by non-keyword characters (white space is
 --- preferred).  Maximum line length is 510 bytes.
 ---
 --- When this option is empty or an entry "spell" is present, and spell
 --- checking is enabled, words in the word lists for the currently active
---- 'spelllang' are used. See `spell`.
+--- 'spelllang' are used. See `|spell|`.
 ---
 --- To include a comma in a file name precede it with a backslash.  Spaces
 --- after a comma are ignored, otherwise spaces are included in the file
---- name.  See `option-backslash` about using backslashes.
---- This has nothing to do with the `Dictionary` variable type.
+--- name.  See `|option-backslash|` about using backslashes.
+--- This has nothing to do with the `|Dictionary|` variable type.
 --- Where to find a list of words?
 --- - BSD/macOS include the "/usr/share/dict/words" file.
 --- - Try "apt install spell" to get the "/usr/share/dict/words" file on
----   apt-managed systems (Debian/Ubuntu).
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- apt-managed systems (Debian/Ubuntu).
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.
 --- Backticks cannot be used in this option for security reasons.
@@ -1560,15 +1553,15 @@ vim.go.dictionary = vim.o.dictionary
 vim.go.dict = vim.go.dictionary
 
 --- Join the current window in the group of windows that shows differences
---- between files.  See `diff-mode`.
+--- between files.  See `|diff-mode|`.
 ---
 --- @type boolean
 vim.o.diff = false
 vim.wo.diff = vim.o.diff
 
 --- Expression which is evaluated to obtain a diff file (either ed-style
---- or unified-style) from two versions of a file.  See `diff-diffexpr`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- or unified-style) from two versions of a file.  See `|diff-diffexpr|`.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -1580,111 +1573,110 @@ vim.go.dex = vim.go.diffexpr
 --- Option settings for diff mode.  It can consist of the following items.
 --- All are optional.  Items must be separated by a comma.
 ---
---- 	filler		Show filler lines, to keep the text
---- 			synchronized with a window that has inserted
---- 			lines at the same position.  Mostly useful
---- 			when windows are side-by-side and 'scrollbind'
---- 			is set.
+--- filler    Show filler lines, to keep the text
+---     synchronized with a window that has inserted
+---     lines at the same position.  Mostly useful
+---     when windows are side-by-side and 'scrollbind'
+---     is set.
 ---
---- 	context:{n}	Use a context of {n} lines between a change
---- 			and a fold that contains unchanged lines.
---- 			When omitted a context of six lines is used.
---- 			When using zero the context is actually one,
---- 			since folds require a line in between, also
---- 			for a deleted line. Set it to a very large
---- 			value (999999) to disable folding completely.
---- 			See `fold-diff`.
+--- context:{n}  Use a context of {n} lines between a change
+---     and a fold that contains unchanged lines.
+---     When omitted a context of six lines is used.
+---     When using zero the context is actually one,
+---     since folds require a line in between, also
+---     for a deleted line. Set it to a very large
+---     value (999999) to disable folding completely.
+---     See `|fold-diff|`.
 ---
---- 	iblank		Ignore changes where lines are all blank.  Adds
---- 			the "-B" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
---- 			NOTE: the diff windows will get out of sync,
---- 			because no differences between blank lines are
---- 			taken into account.
+--- iblank    Ignore changes where lines are all blank.  Adds
+---     the "-B" flag to the "diff" command if
+---     'diffexpr' is empty.  Check the documentation
+---     of the "diff" command for what this does
+---     exactly.
+---     NOTE: the diff windows will get out of sync,
+---     because no differences between blank lines are
+---     taken into account.
 ---
---- 	icase		Ignore changes in case of text.  "a" and "A"
---- 			are considered the same.  Adds the "-i" flag
---- 			to the "diff" command if 'diffexpr' is empty.
+--- icase    Ignore changes in case of text.  "a" and "A"
+---     are considered the same.  Adds the "-i" flag
+---     to the "diff" command if 'diffexpr' is empty.
 ---
---- 	iwhite		Ignore changes in amount of white space.  Adds
---- 			the "-b" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.  It should ignore adding trailing
---- 			white space, but not leading white space.
+--- iwhite    Ignore changes in amount of white space.  Adds
+---     the "-b" flag to the "diff" command if
+---     'diffexpr' is empty.  Check the documentation
+---     of the "diff" command for what this does
+---     exactly.  It should ignore adding trailing
+---     white space, but not leading white space.
 ---
---- 	iwhiteall	Ignore all white space changes.  Adds
---- 			the "-w" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
+--- iwhiteall  Ignore all white space changes.  Adds
+---     the "-w" flag to the "diff" command if
+---     'diffexpr' is empty.  Check the documentation
+---     of the "diff" command for what this does
+---     exactly.
 ---
---- 	iwhiteeol	Ignore white space changes at end of line.
---- 			Adds the "-Z" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
+--- iwhiteeol  Ignore white space changes at end of line.
+---     Adds the "-Z" flag to the "diff" command if
+---     'diffexpr' is empty.  Check the documentation
+---     of the "diff" command for what this does
+---     exactly.
 ---
---- 	horizontal	Start diff mode with horizontal splits (unless
---- 			explicitly specified otherwise).
+--- horizontal  Start diff mode with horizontal splits (unless
+---     explicitly specified otherwise).
 ---
---- 	vertical	Start diff mode with vertical splits (unless
---- 			explicitly specified otherwise).
+--- vertical  Start diff mode with vertical splits (unless
+---     explicitly specified otherwise).
 ---
---- 	closeoff	When a window is closed where 'diff' is set
---- 			and there is only one window remaining in the
---- 			same tab page with 'diff' set, execute
---- 			`:diffoff` in that window.  This undoes a
---- 			`:diffsplit` command.
+--- closeoff  When a window is closed where 'diff' is set
+---     and there is only one window remaining in the
+---     same tab page with 'diff' set, execute
+---     `:diffoff` in that window.  This undoes a
+---     `:diffsplit` command.
 ---
---- 	hiddenoff	Do not use diff mode for a buffer when it
---- 			becomes hidden.
+--- hiddenoff  Do not use diff mode for a buffer when it
+---     becomes hidden.
 ---
---- 	foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
---- 			starting diff mode.  Without this 2 is used.
+--- foldcolumn:{n}  Set the 'foldcolumn' option to {n} when
+---     starting diff mode.  Without this 2 is used.
 ---
---- 	followwrap	Follow the 'wrap' option and leave as it is.
+--- followwrap  Follow the 'wrap' option and leave as it is.
 ---
---- 	internal	Use the internal diff library.  This is
---- 			ignored when 'diffexpr' is set.  *E960*
---- 			When running out of memory when writing a
---- 			buffer this item will be ignored for diffs
---- 			involving that buffer.  Set the 'verbose'
---- 			option to see when this happens.
+--- internal  Use the internal diff library.  This is
+---     ignored when 'diffexpr' is set.  *E960*
+---     When running out of memory when writing a
+---     buffer this item will be ignored for diffs
+---     involving that buffer.  Set the 'verbose'
+---     option to see when this happens.
 ---
---- 	indent-heuristic
---- 			Use the indent heuristic for the internal
---- 			diff library.
+--- indent-heuristic
+---     Use the indent heuristic for the internal
+---     diff library.
 ---
---- 	linematch:{n}   Enable a second stage diff on each generated
---- 			hunk in order to align lines. When the total
---- 			number of lines in a hunk exceeds {n}, the
---- 			second stage diff will not be performed as
---- 			very large hunks can cause noticeable lag. A
---- 			recommended setting is "linematch:60", as this
---- 			will enable alignment for a 2 buffer diff with
---- 			hunks of up to 30 lines each, or a 3 buffer
---- 			diff with hunks of up to 20 lines each.
+--- linematch:{n}   Enable a second stage diff on each generated
+---     hunk in order to align lines. When the total
+---     number of lines in a hunk exceeds {n}, the
+---     second stage diff will not be performed as
+---     very large hunks can cause noticeable lag. A
+---     recommended setting is "linematch:60", as this
+---     will enable alignment for a 2 buffer diff with
+---     hunks of up to 30 lines each, or a 3 buffer
+---     diff with hunks of up to 20 lines each.
 ---
---- 	algorithm:{text} Use the specified diff algorithm with the
---- 			internal diff engine. Currently supported
---- 			algorithms are:
---- 			myers      the default algorithm
---- 			minimal    spend extra time to generate the
---- 				   smallest possible diff
---- 			patience   patience diff algorithm
---- 			histogram  histogram diff algorithm
+--- algorithm:{text} Use the specified diff algorithm with the
+---     internal diff engine. Currently supported
+---     algorithms are:
+---     myers      the default algorithm
+---     minimal    spend extra time to generate the
+---          smallest possible diff
+---     patience   patience diff algorithm
+---     histogram  histogram diff algorithm
 ---
 --- Examples:
 --- ```
---- 	:set diffopt=internal,filler,context:4
---- 	:set diffopt=
---- 	:set diffopt=internal,filler,foldcolumn:3
---- 	:set diffopt-=internal  " do NOT use the internal diff parser
+--- :set diffopt=internal,filler,context:4
+--- :set diffopt=
+--- :set diffopt=internal,filler,foldcolumn:3
+--- :set diffopt-=internal  " do NOT use the internal diff parser
 --- ```
----
 ---
 --- @type string
 vim.o.diffopt = "internal,filler,closeoff"
@@ -1693,7 +1685,7 @@ vim.go.diffopt = vim.o.diffopt
 vim.go.dip = vim.go.diffopt
 
 --- Enable the entering of digraphs in Insert mode with {char1} <BS>
---- {char2}.  See `digraphs`.
+--- {char2}.  See `|digraphs|`.
 ---
 --- @type boolean
 vim.o.digraph = false
@@ -1705,45 +1697,44 @@ vim.go.dg = vim.go.digraph
 ---
 --- Possible items:
 --- - The swap file will be created in the first directory where this is
----   possible.  If it is not possible in any directory, but last
----   directory listed in the option does not exist, it is created.
+--- possible.  If it is not possible in any directory, but last
+--- directory listed in the option does not exist, it is created.
 --- - Empty means that no swap file will be used (recovery is
----   impossible!) and no `E303` error will be given.
+--- impossible!) and no `|E303|` error will be given.
 --- - A directory "." means to put the swap file in the same directory as
----   the edited file.  On Unix, a dot is prepended to the file name, so
----   it doesn't show in a directory listing.  On MS-Windows the "hidden"
----   attribute is set and a dot prepended if possible.
+--- the edited file.  On Unix, a dot is prepended to the file name, so
+--- it doesn't show in a directory listing.  On MS-Windows the "hidden"
+--- attribute is set and a dot prepended if possible.
 --- - A directory starting with "./" (or ".\" for MS-Windows) means to put
----   the swap file relative to where the edited file is.  The leading "."
----   is replaced with the path name of the edited file.
+--- the swap file relative to where the edited file is.  The leading "."
+--- is replaced with the path name of the edited file.
 --- - For Unix and Win32, if a directory ends in two path separators "//",
----   the swap file name will be built from the complete path to the file
----   with all path separators replaced by percent '%' signs (including
----   the colon following the drive letter on Win32). This will ensure
----   file name uniqueness in the preserve directory.
----   On Win32, it is also possible to end with "\\".  However, When a
----   separating comma is following, you must use "//", since "\\" will
----   include the comma in the file name. Therefore it is recommended to
----   use '//', instead of '\\'.
+--- the swap file name will be built from the complete path to the file
+--- with all path separators replaced by percent '%' signs (including
+--- the colon following the drive letter on Win32). This will ensure
+--- file name uniqueness in the preserve directory.
+--- On Win32, it is also possible to end with "\\".  However, When a
+--- separating comma is following, you must use "//", since "\\" will
+--- include the comma in the file name. Therefore it is recommended to
+--- use '//', instead of '\\'.
 --- - Spaces after the comma are ignored, other spaces are considered part
----   of the directory name.  To have a space at the start of a directory
----   name, precede it with a backslash.
+--- of the directory name.  To have a space at the start of a directory
+--- name, precede it with a backslash.
 --- - To include a comma in a directory name precede it with a backslash.
 --- - A directory name may end in an ':' or '/'.
---- - Environment variables are expanded `:set_env`.
+--- - Environment variables are expanded `|:set_env|`.
 --- - Careful with '\' characters, type one before a space, type two to
----   get one in the option (see `option-backslash`), for example:
+--- get one in the option (see `|option-backslash|`), for example:
 --- ```
----     :set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
+---   :set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 --- ```
----
 --- Editing the same file twice will result in a warning.  Using "/tmp" on
 --- is discouraged: if the system crashes you lose the swap file. And
 --- others on the computer may be able to see the files.
---- Use `:set+=` and `:set-=` when adding or removing directories from the
+--- Use `|:set+=|` and `|:set-=|` when adding or removing directories from the
 --- list, this avoids problems if the Nvim default is changed.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -1754,21 +1745,21 @@ vim.go.dir = vim.go.directory
 
 --- Change the way text is displayed.  This is a comma-separated list of
 --- flags:
---- lastline	When included, as much as possible of the last line
---- 		in a window will be displayed.  "@@@" is put in the
---- 		last columns of the last screen line to indicate the
---- 		rest of the line is not displayed.
---- truncate	Like "lastline", but "@@@" is displayed in the first
---- 		column of the last screen line.  Overrules "lastline".
---- uhex		Show unprintable characters hexadecimal as <xx>
---- 		instead of using ^C and ~C.
---- msgsep		Obsolete flag. Allowed but takes no effect. `msgsep`
+--- lastline  When included, as much as possible of the last line
+--- in a window will be displayed.  "@@@" is put in the
+--- last columns of the last screen line to indicate the
+--- rest of the line is not displayed.
+--- truncate  Like "lastline", but "@@@" is displayed in the first
+--- column of the last screen line.  Overrules "lastline".
+--- uhex    Show unprintable characters hexadecimal as <xx>
+--- instead of using ^C and ~C.
+--- msgsep    Obsolete flag. Allowed but takes no effect. `|msgsep|`
 ---
 --- When neither "lastline" nor "truncate" is included, a last line that
 --- doesn't fit is replaced with "@" lines.
 ---
 --- The "@" character can be changed by setting the "lastline" item in
---- 'fillchars'.  The character is highlighted with `hl-NonText`.
+--- 'fillchars'.  The character is highlighted with `|hl-NonText|`.
 ---
 --- @type string
 vim.o.display = "lastline"
@@ -1777,9 +1768,9 @@ vim.go.display = vim.o.display
 vim.go.dy = vim.go.display
 
 --- Tells when the 'equalalways' option applies:
---- 	ver	vertically, width of windows is not affected
---- 	hor	horizontally, height of windows is not affected
---- 	both	width and height of windows is affected
+--- ver  vertically, width of windows is not affected
+--- hor  horizontally, height of windows is not affected
+--- both  width and height of windows is affected
 ---
 --- @type string
 vim.o.eadirection = "both"
@@ -1791,7 +1782,7 @@ vim.go.ead = vim.go.eadirection
 --- This excludes "text emoji" characters, which are normally displayed as
 --- single width.  Unfortunately there is no good specification for this
 --- and it has been determined on trial-and-error basis.  Use the
---- `setcellwidths()` function to change the behavior.
+--- `|setcellwidths()|` function to change the behavior.
 ---
 --- @type boolean
 vim.o.emoji = true
@@ -1799,7 +1790,7 @@ vim.o.emo = vim.o.emoji
 vim.go.emoji = vim.o.emoji
 vim.go.emo = vim.go.emoji
 
---- String-encoding used internally and for `RPC` communication.
+--- String-encoding used internally and for `|RPC|` communication.
 --- Always UTF-8.
 ---
 --- See 'fileencoding' to control file-content encoding.
@@ -1815,7 +1806,7 @@ vim.go.enc = vim.go.encoding
 --- When writing a file and this option is off and the 'binary' option
 --- is on, or 'fixeol' option is off, no CTRL-Z will be written at the
 --- end of the file.
---- See `eol-and-eof` for example settings.
+--- See `|eol-and-eof|` for example settings.
 ---
 --- @type boolean
 vim.o.endoffile = false
@@ -1834,7 +1825,7 @@ vim.bo.eof = vim.bo.endoffile
 --- to remember the presence of a <EOL> for the last line in the file, so
 --- that when you write the file the situation from the original file can
 --- be kept.  But you can change it if you want to.
---- See `eol-and-eof` for example settings.
+--- See `|eol-and-eof|` for example settings.
 ---
 --- @type boolean
 vim.o.endofline = true
@@ -1866,9 +1857,9 @@ vim.go.ea = vim.go.equalalways
 --- External program to use for "=" command.  When this option is empty
 --- the internal formatting functions are used; either 'lisp', 'cindent'
 --- or 'indentexpr'.
---- Environment variables are expanded `:set_env`.  See `option-backslash`
+--- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
 --- about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -1891,13 +1882,13 @@ vim.o.eb = vim.o.errorbells
 vim.go.errorbells = vim.o.errorbells
 vim.go.eb = vim.go.errorbells
 
---- Name of the errorfile for the QuickFix mode (see `:cf`).
+--- Name of the errorfile for the QuickFix mode (see `|:cf|`).
 --- When the "-q" command-line argument is used, 'errorfile' is set to the
---- following argument.  See `-q`.
+--- following argument.  See `|-q|`.
 --- NOT used for the ":make" command.  See 'makeef' for that.
---- Environment variables are expanded `:set_env`.
---- See `option-backslash` about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- Environment variables are expanded `|:set_env|`.
+--- See `|option-backslash|` about including spaces and backslashes.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -1907,7 +1898,7 @@ vim.go.errorfile = vim.o.errorfile
 vim.go.ef = vim.go.errorfile
 
 --- Scanf-like description of the format for the lines in the error file
---- (see `errorformat`).
+--- (see `|errorformat|`).
 ---
 --- @type string
 vim.o.errorformat = "%*[^\"]\"%f\"%*\\D%l: %m,\"%f\"%*\\D%l: %m,%-Gg%\\?make[%*\\d]: *** [%f:%l:%m,%-Gg%\\?make: *** [%f:%l:%m,%-G%f:%l: (Each undeclared identifier is reported only once,%-G%f:%l: for each function it appears in.),%-GIn file included from %f:%l:%c:,%-GIn file included from %f:%l:%c\\,,%-GIn file included from %f:%l:%c,%-GIn file included from %f:%l,%-G%*[ ]from %f:%l:%c,%-G%*[ ]from %f:%l:,%-G%*[ ]from %f:%l\\,,%-G%*[ ]from %f:%l,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,\"%f\"\\, line %l%*\\D%c%*[^ ] %m,%D%*\\a[%*\\d]: Entering directory %*[`']%f',%X%*\\a[%*\\d]: Leaving directory %*[`']%f',%D%*\\a: Entering directory %*[`']%f',%X%*\\a: Leaving directory %*[`']%f',%DMaking %*\\a in %f,%f|%l| %m"
@@ -1922,9 +1913,8 @@ vim.go.efm = vim.go.errorformat
 --- events are ignored, autocommands will not be executed.
 --- Otherwise this is a comma-separated list of event names.  Example:
 --- ```
----     :set ei=WinEnter,WinLeave
+--- :set ei=WinEnter,WinLeave
 --- ```
----
 ---
 --- @type string
 vim.o.eventignore = ""
@@ -1935,7 +1925,7 @@ vim.go.ei = vim.go.eventignore
 --- In Insert mode: Use the appropriate number of spaces to insert a
 --- <Tab>.  Spaces are used in indents with the '>' and '<' commands and
 --- when 'autoindent' is on.  To insert a real tab when 'expandtab' is
---- on, use CTRL-V<Tab>.  See also `:retab` and `ins-expandtab`.
+--- on, use CTRL-V<Tab>.  See also `|:retab|` and `|ins-expandtab|`.
 ---
 --- @type boolean
 vim.o.expandtab = false
@@ -1944,14 +1934,14 @@ vim.bo.expandtab = vim.o.expandtab
 vim.bo.et = vim.bo.expandtab
 
 --- Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
---- current directory, if the file is in the `trust` list. Use `:trust` to
---- manage trusted files. See also `vim.secure.read()`.
+--- current directory, if the file is in the `|trust|` list. Use `|:trust|` to
+--- manage trusted files. See also `|vim.secure.read()|`.
 ---
---- Compare 'exrc' to `editorconfig`:
+--- Compare 'exrc' to `|editorconfig|`:
 --- - 'exrc' can execute any code; editorconfig only specifies settings.
 --- - 'exrc' is Nvim-specific; editorconfig works in other editors.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type boolean
@@ -1971,13 +1961,13 @@ vim.go.ex = vim.go.exrc
 --- WARNING: Conversion to a non-Unicode encoding can cause loss of
 --- information!
 ---
---- See `encoding-names` for the possible values.  Additionally, values may be
+--- See `|encoding-names|` for the possible values.  Additionally, values may be
 --- specified that can be handled by the converter, see
---- `mbyte-conversion`.
+--- `|mbyte-conversion|`.
 ---
 --- When reading a file 'fileencoding' will be set from 'fileencodings'.
 --- To read a file in a certain encoding it won't work by setting
---- 'fileencoding', use the `++enc` argument.  One exception: when
+--- 'fileencoding', use the `|++enc|` argument.  One exception: when
 --- 'fileencodings' is empty the value of 'fileencoding' is used.
 --- For a new file the global value of 'fileencoding' is used.
 ---
@@ -1985,7 +1975,7 @@ vim.go.ex = vim.go.exrc
 --- When the option is set, the value is converted to lowercase.  Thus
 --- you can set it with uppercase values too.  '_' characters are
 --- replaced with '-'.  If a name is recognized from the list at
---- `encoding-names`, it is replaced by the standard name.  For example
+--- `|encoding-names|`, it is replaced by the standard name.  For example
 --- "ISO8859-2" becomes "iso-8859-2".
 ---
 --- When this option is set, after starting to edit a file, the 'modified'
@@ -2010,26 +2000,26 @@ vim.bo.fenc = vim.bo.fileencoding
 --- in the list is tried.  When an encoding is found that works,
 --- 'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
 --- an empty string, which means that UTF-8 is used.
---- 	WARNING: Conversion can cause loss of information! You can use
---- 	the `++bad` argument to specify what is done with characters
---- 	that can't be converted.
+--- WARNING: Conversion can cause loss of information! You can use
+--- the `|++bad|` argument to specify what is done with characters
+--- that can't be converted.
 --- For an empty file or a file with only ASCII characters most encodings
 --- will work and the first entry of 'fileencodings' will be used (except
 --- "ucs-bom", which requires the BOM to be present).  If you prefer
 --- another encoding use an BufReadPost autocommand event to test if your
 --- preferred encoding is to be used.  Example:
 --- ```
---- 	au BufReadPost * if search('\S', 'w') == 0 |
---- 		\ set fenc=iso-2022-jp | endif
+--- au BufReadPost * if search('\S', 'w') == 0 |
+---   \ set fenc=iso-2022-jp | endif
 --- ```
 --- This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
 --- non-blank characters.
---- When the `++enc` argument is used then the value of 'fileencodings' is
+--- When the `|++enc|` argument is used then the value of 'fileencodings' is
 --- not used.
 --- Note that 'fileencodings' is not used for a new file, the global value
 --- of 'fileencoding' is used instead.  You can set it with:
 --- ```
---- 	:setglobal fenc=iso-8859-2
+--- :setglobal fenc=iso-8859-2
 --- ```
 --- This means that a non-existing file may get a different encoding than
 --- an empty file.
@@ -2043,13 +2033,13 @@ vim.bo.fenc = vim.bo.fileencoding
 --- environment.  It is useful when your environment uses a non-latin1
 --- encoding, such as Russian.
 --- When a file contains an illegal UTF-8 byte sequence it won't be
---- recognized as "utf-8".  You can use the `8g8` command to find the
+--- recognized as "utf-8".  You can use the `|8g8|` command to find the
 --- illegal byte sequence.
---- WRONG VALUES:			WHAT'S WRONG:
---- 	latin1,utf-8		"latin1" will always be used
---- 	utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
---- 				file
---- 	cp1250,latin1		"cp1250" will always be used
+--- WRONG VALUES:      WHAT'S WRONG:
+--- latin1,utf-8    "latin1" will always be used
+--- utf-8,ucs-bom,latin1  BOM won't be recognized in an utf-8
+---       file
+--- cp1250,latin1    "cp1250" will always be used
 --- If 'fileencodings' is empty, 'fileencoding' is not modified.
 --- See 'fileencoding' for the possible values.
 --- Setting this option does not have an effect until the next time a file
@@ -2063,11 +2053,11 @@ vim.go.fencs = vim.go.fileencodings
 
 --- This gives the <EOL> of the current buffer, which is used for
 --- reading/writing the buffer from/to a file:
----     dos	    <CR><NL>
----     unix    <NL>
----     mac	    <CR>
+--- dos      <CR><NL>
+--- unix    <NL>
+--- mac      <CR>
 --- When "dos" is used, CTRL-Z at the end of a file is ignored.
---- See `file-formats` and `file-read`.
+--- See `|file-formats|` and `|file-read|`.
 --- For the character encoding of the file see 'fileencoding'.
 --- When 'binary' is set, the value of 'fileformat' is ignored, file I/O
 --- works like it was set to "unix".
@@ -2087,32 +2077,32 @@ vim.bo.ff = vim.bo.fileformat
 --- starting to edit a new buffer and when reading a file into an existing
 --- buffer:
 --- - When empty, the format defined with 'fileformat' will be used
----   always.  It is not set automatically.
+--- always.  It is not set automatically.
 --- - When set to one name, that format will be used whenever a new buffer
----   is opened.  'fileformat' is set accordingly for that buffer.  The
----   'fileformats' name will be used when a file is read into an existing
----   buffer, no matter what 'fileformat' for that buffer is set to.
+--- is opened.  'fileformat' is set accordingly for that buffer.  The
+--- 'fileformats' name will be used when a file is read into an existing
+--- buffer, no matter what 'fileformat' for that buffer is set to.
 --- - When more than one name is present, separated by commas, automatic
----   <EOL> detection will be done when reading a file.  When starting to
----   edit a file, a check is done for the <EOL>:
----   1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
----      'fileformat' is set to "dos".
----   2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
----      is set to "unix".  Note that when a <NL> is found without a
----      preceding <CR>, "unix" is preferred over "dos".
----   3. If 'fileformat' has not yet been set, and if a <CR> is found, and
----      if 'fileformats' includes "mac", 'fileformat' is set to "mac".
----      This means that "mac" is only chosen when:
----       "unix" is not present or no <NL> is found in the file, and
----       "dos" is not present or no <CR><NL> is found in the file.
----      Except: if "unix" was chosen, but there is a <CR> before
----      the first <NL>, and there appear to be more <CR>s than <NL>s in
----      the first few lines, "mac" is used.
----   4. If 'fileformat' is still not set, the first name from
----      'fileformats' is used.
----   When reading a file into an existing buffer, the same is done, but
----   this happens like 'fileformat' has been set appropriately for that
----   file only, the option is not changed.
+--- <EOL> detection will be done when reading a file.  When starting to
+--- edit a file, a check is done for the <EOL>:
+--- 1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
+---    'fileformat' is set to "dos".
+--- 2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
+---    is set to "unix".  Note that when a <NL> is found without a
+---    preceding <CR>, "unix" is preferred over "dos".
+--- 3. If 'fileformat' has not yet been set, and if a <CR> is found, and
+---    if 'fileformats' includes "mac", 'fileformat' is set to "mac".
+---    This means that "mac" is only chosen when:
+---     "unix" is not present or no <NL> is found in the file, and
+---     "dos" is not present or no <CR><NL> is found in the file.
+---    Except: if "unix" was chosen, but there is a <CR> before
+---    the first <NL>, and there appear to be more <CR>s than <NL>s in
+---    the first few lines, "mac" is used.
+--- 4. If 'fileformat' is still not set, the first name from
+---    'fileformats' is used.
+--- When reading a file into an existing buffer, the same is done, but
+--- this happens like 'fileformat' has been set appropriately for that
+--- file only, the option is not changed.
 --- When 'binary' is set, the value of 'fileformats' is not used.
 ---
 --- When Vim starts up with an empty buffer the first item is used.  You
@@ -2122,12 +2112,12 @@ vim.bo.ff = vim.bo.fileformat
 --- are ":source"ed and for vimrc files, automatic <EOL> detection may be
 --- done:
 --- - When 'fileformats' is empty, there is no automatic detection.  Dos
----   format will be used.
+--- format will be used.
 --- - When 'fileformats' is set to one or more names, automatic detection
----   is done.  This is based on the first <NL> in the file: If there is a
----   <CR> in front of it, Dos format is used, otherwise Unix format is
----   used.
---- Also see `file-formats`.
+--- is done.  This is based on the first <NL> in the file: If there is a
+--- <CR> in front of it, Dos format is used, otherwise Unix format is
+--- used.
+--- Also see `|file-formats|`.
 ---
 --- @type string
 vim.o.fileformats = "unix,dos"
@@ -2150,18 +2140,18 @@ vim.go.fic = vim.go.fileignorecase
 --- name.
 --- Otherwise this option does not always reflect the current file type.
 --- This option is normally set when the file type is detected.  To enable
---- this use the ":filetype on" command. `:filetype`
+--- this use the ":filetype on" command. `|:filetype|`
 --- Setting this option to a different value is most useful in a modeline,
 --- for a file for which the file type is not automatically recognized.
 --- Example, for in an IDL file:
 --- ```
---- 	/* vim: set filetype=idl : */
+--- /* vim: set filetype=idl : */
 --- ```
---- `FileType` `filetypes`
+--- `|FileType|` `|filetypes|`
 --- When a dot appears in the value then this separates two filetype
 --- names.  Example:
 --- ```
---- 	/* vim: set filetype=c.doxygen : */
+--- /* vim: set filetype=c.doxygen : */
 --- ```
 --- This will use the "c" filetype first, then the "doxygen" filetype.
 --- This works both for filetype plugins and for syntax files.  More than
@@ -2181,26 +2171,26 @@ vim.bo.ft = vim.bo.filetype
 --- It is a comma-separated list of items.  Each item has a name, a colon
 --- and the value of that item:
 ---
----   item		default		Used for ~
----   stl		' '		statusline of the current window
----   stlnc		' '		statusline of the non-current windows
----   wbr		' '		window bar
----   horiz		'─' or '-'	horizontal separators `:split`
----   horizup	'┴' or '-'	upwards facing horizontal separator
----   horizdown	'┬' or '-'	downwards facing horizontal separator
----   vert		'│' or '|'	vertical separators `:vsplit`
----   vertleft	'┤' or '|'	left facing vertical separator
----   vertright	'├' or '|'	right facing vertical separator
----   verthoriz	'┼' or '+'	overlapping vertical and horizontal
---- 				separator
----   fold		'·' or '-'	filling 'foldtext'
----   foldopen	'-'		mark the beginning of a fold
----   foldclose	'+'		show a closed fold
----   foldsep	'│' or '|'      open fold middle marker
----   diff		'-'		deleted lines of the 'diff' option
----   msgsep	' '		message separator 'display'
----   eob		'~'		empty lines at the end of a buffer
----   lastline	'@'		'display' contains lastline/truncate
+--- item    default    Used for ~
+--- stl    ' '    statusline of the current window
+--- stlnc    ' '    statusline of the non-current windows
+--- wbr    ' '    window bar
+--- horiz    '─' or '-'  horizontal separators `|:split|`
+--- horizup  '┴' or '-'  upwards facing horizontal separator
+--- horizdown  '┬' or '-'  downwards facing horizontal separator
+--- vert    '│' or '|'  vertical separators `|:vsplit|`
+--- vertleft  '┤' or '|'  left facing vertical separator
+--- vertright  '├' or '|'  right facing vertical separator
+--- verthoriz  '┼' or '+'  overlapping vertical and horizontal
+---       separator
+--- fold    '·' or '-'  filling 'foldtext'
+--- foldopen  '-'    mark the beginning of a fold
+--- foldclose  '+'    show a closed fold
+--- foldsep  '│' or '|'      open fold middle marker
+--- diff    '-'    deleted lines of the 'diff' option
+--- msgsep  ' '    message separator 'display'
+--- eob    '~'    empty lines at the end of a buffer
+--- lastline  '@'    'display' contains lastline/truncate
 ---
 --- Any one that is omitted will fall back to the default.
 ---
@@ -2214,7 +2204,7 @@ vim.bo.ft = vim.bo.filetype
 ---
 --- Example:
 --- ```
----     :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
+---   :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
 --- ```
 --- This is similar to the default, except that these characters will also
 --- be used when there is highlighting.
@@ -2224,21 +2214,21 @@ vim.bo.ft = vim.bo.filetype
 --- characters are not supported.
 ---
 --- The highlighting used for these items:
----   item		highlight group ~
----   stl		StatusLine		`hl-StatusLine`
----   stlnc		StatusLineNC		`hl-StatusLineNC`
----   wbr		WinBar			`hl-WinBar` or `hl-WinBarNC`
----   horiz		WinSeparator		`hl-WinSeparator`
----   horizup	WinSeparator		`hl-WinSeparator`
----   horizdown	WinSeparator		`hl-WinSeparator`
----   vert		WinSeparator		`hl-WinSeparator`
----   vertleft	WinSeparator		`hl-WinSeparator`
----   vertright	WinSeparator		`hl-WinSeparator`
----   verthoriz	WinSeparator		`hl-WinSeparator`
----   fold		Folded			`hl-Folded`
----   diff		DiffDelete		`hl-DiffDelete`
----   eob		EndOfBuffer		`hl-EndOfBuffer`
----   lastline	NonText			`hl-NonText`
+--- item    highlight group ~
+--- stl    StatusLine    `|hl-StatusLine|`
+--- stlnc    StatusLineNC    `|hl-StatusLineNC|`
+--- wbr    WinBar      `|hl-WinBar|` or `|hl-WinBarNC|`
+--- horiz    WinSeparator    `|hl-WinSeparator|`
+--- horizup  WinSeparator    `|hl-WinSeparator|`
+--- horizdown  WinSeparator    `|hl-WinSeparator|`
+--- vert    WinSeparator    `|hl-WinSeparator|`
+--- vertleft  WinSeparator    `|hl-WinSeparator|`
+--- vertright  WinSeparator    `|hl-WinSeparator|`
+--- verthoriz  WinSeparator    `|hl-WinSeparator|`
+--- fold    Folded      `|hl-Folded|`
+--- diff    DiffDelete    `|hl-DiffDelete|`
+--- eob    EndOfBuffer    `|hl-EndOfBuffer|`
+--- lastline  NonText      `|hl-NonText|`
 ---
 --- @type string
 vim.o.fillchars = ""
@@ -2254,7 +2244,7 @@ vim.go.fcs = vim.go.fillchars
 --- When the 'binary' option is set the value of this option doesn't
 --- matter.
 --- See the 'endofline' option.
---- See `eol-and-eof` for example settings.
+--- See `|eol-and-eof|` for example settings.
 ---
 --- @type boolean
 vim.o.fixendofline = true
@@ -2273,12 +2263,12 @@ vim.go.foldclose = vim.o.foldclose
 vim.go.fcl = vim.go.foldclose
 
 --- When and how to draw the foldcolumn. Valid values are:
----     "auto":       resize to the minimum amount of folds to display.
----     "auto:[1-9]": resize to accommodate multiple folds up to the
---- 		  selected level
----     "0":          to disable foldcolumn
----     "[1-9]":      to display a fixed number of columns
---- See `folding`.
+--- "auto":       resize to the minimum amount of folds to display.
+--- "auto:[1-9]": resize to accommodate multiple folds up to the
+---   selected level
+--- "0":          to disable foldcolumn
+--- "[1-9]":      to display a fixed number of columns
+--- See `|folding|`.
 ---
 --- @type string
 vim.o.foldcolumn = "0"
@@ -2289,10 +2279,10 @@ vim.wo.fdc = vim.wo.foldcolumn
 --- When off, all folds are open.  This option can be used to quickly
 --- switch between showing all text unfolded and viewing the text with
 --- folds (including manually opened or closed folds).  It can be toggled
---- with the `zi` command.  The 'foldcolumn' will remain blank when
+--- with the `|zi|` command.  The 'foldcolumn' will remain blank when
 --- 'foldenable' is off.
 --- This option is set by commands that create a new fold or close a fold.
---- See `folding`.
+--- See `|folding|`.
 ---
 --- @type boolean
 vim.o.foldenable = true
@@ -2303,15 +2293,15 @@ vim.wo.fen = vim.wo.foldenable
 --- The expression used for when 'foldmethod' is "expr".  It is evaluated
 --- for each line to obtain its fold level.  The context is set to the
 --- script where 'foldexpr' was set, script-local items can be accessed.
---- See `fold-expr` for the usage.
+--- See `|fold-expr|` for the usage.
 ---
---- The expression will be evaluated in the `sandbox` if set from a
---- modeline, see `sandbox-option`.
---- This option can't be set from a `modeline` when the 'diff' option is
+--- The expression will be evaluated in the `|sandbox|` if set from a
+--- modeline, see `|sandbox-option|`.
+--- This option can't be set from a `|modeline|` when the 'diff' option is
 --- on or the 'modelineexpr' option is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'foldexpr' `textlock`.
+--- evaluating 'foldexpr' `|textlock|`.
 ---
 --- @type string
 vim.o.foldexpr = "0"
@@ -2322,7 +2312,7 @@ vim.wo.fde = vim.wo.foldexpr
 --- Used only when 'foldmethod' is "indent".  Lines starting with
 --- characters in 'foldignore' will get their fold level from surrounding
 --- lines.  White space is skipped before checking for this character.
---- The default "#" works well for C programs.  See `fold-indent`.
+--- The default "#" works well for C programs.  See `|fold-indent|`.
 ---
 --- @type string
 vim.o.foldignore = "#"
@@ -2333,8 +2323,8 @@ vim.wo.fdi = vim.wo.foldignore
 --- Sets the fold level: Folds with a higher level will be closed.
 --- Setting this option to zero will close all folds.  Higher numbers will
 --- close fewer folds.
---- This option is set by commands like `zm`, `zM` and `zR`.
---- See `fold-foldlevel`.
+--- This option is set by commands like `|zm|`, `|zM|` and `|zR|`.
+--- See `|fold-foldlevel|`.
 ---
 --- @type integer
 vim.o.foldlevel = 0
@@ -2346,7 +2336,7 @@ vim.wo.fdl = vim.wo.foldlevel
 --- Useful to always start editing with all folds closed (value zero),
 --- some folds closed (one) or no folds closed (99).
 --- This is done before reading any modeline, thus a setting in a modeline
---- overrules this option.  Starting to edit a file for `diff-mode` also
+--- overrules this option.  Starting to edit a file for `|diff-mode|` also
 --- ignores this option and closes all folds.
 --- It is also done before BufReadPre autocommands, to allow an autocmd to
 --- overrule the 'foldlevel' value for specific files.
@@ -2361,7 +2351,7 @@ vim.go.fdls = vim.go.foldlevelstart
 --- The start and end marker used when 'foldmethod' is "marker".  There
 --- must be one comma, which separates the start and end marker.  The
 --- marker is a literal string (a regular expression would be too slow).
---- See `fold-marker`.
+--- See `|fold-marker|`.
 ---
 --- @type string
 vim.o.foldmarker = "{{{,}}}"
@@ -2370,12 +2360,12 @@ vim.wo.foldmarker = vim.o.foldmarker
 vim.wo.fmr = vim.wo.foldmarker
 
 --- The kind of folding used for the current window.  Possible values:
---- `fold-manual`	manual	    Folds are created manually.
---- `fold-indent`	indent	    Lines with equal indent form a fold.
---- `fold-expr`	expr	    'foldexpr' gives the fold level of a line.
---- `fold-marker`	marker	    Markers are used to specify folds.
---- `fold-syntax`	syntax	    Syntax highlighting items specify folds.
---- `fold-diff`	diff	    Fold text that is not changed.
+--- `|fold-manual|`  manual      Folds are created manually.
+--- `|fold-indent|`  indent      Lines with equal indent form a fold.
+--- `|fold-expr|`  expr      'foldexpr' gives the fold level of a line.
+--- `|fold-marker|`  marker      Markers are used to specify folds.
+--- `|fold-syntax|`  syntax      Syntax highlighting items specify folds.
+--- `|fold-diff|`  diff      Fold text that is not changed.
 ---
 --- @type string
 vim.o.foldmethod = "manual"
@@ -2411,23 +2401,23 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- command moves the cursor into a closed fold.  It is a comma-separated
 --- list of items.
 --- NOTE: When the command is part of a mapping this option is not used.
---- Add the `zv` command to the mapping to get the same effect.
+--- Add the `|zv|` command to the mapping to get the same effect.
 --- (rationale: the mapping may want to control opening folds itself)
 ---
---- 	item		commands ~
---- 	all		any
---- 	block		(, {, [[, [{, etc.
---- 	hor		horizontal movements: "l", "w", "fx", etc.
---- 	insert		any command in Insert mode
---- 	jump		far jumps: "G", "gg", etc.
---- 	mark		jumping to a mark: "'m", CTRL-O, etc.
---- 	percent		"%"
---- 	quickfix	":cn", ":crew", ":make", etc.
---- 	search		search for a pattern: "/", "n", "*", "gd", etc.
---- 			(not for a search pattern in a ":" command)
---- 			Also for `[s` and `]s`.
---- 	tag		jumping to a tag: ":ta", CTRL-T, etc.
---- 	undo		undo or redo: "u" and CTRL-R
+--- item    commands ~
+--- all    any
+--- block    (, {, [[, [{, etc.
+--- hor    horizontal movements: "l", "w", "fx", etc.
+--- insert    any command in Insert mode
+--- jump    far jumps: "G", "gg", etc.
+--- mark    jumping to a mark: "'m", CTRL-O, etc.
+--- percent    "%"
+--- quickfix  ":cn", ":crew", ":make", etc.
+--- search    search for a pattern: "/", "n", "*", "gd", etc.
+---     (not for a search pattern in a ":" command)
+---     Also for `|[s|` and `|]s|`.
+--- tag    jumping to a tag: ":ta", CTRL-T, etc.
+--- undo    undo or redo: "u" and CTRL-R
 --- When a movement command is used for an operator (e.g., "dl" or "y%")
 --- this option is not used.  This means the operator will include the
 --- whole closed fold.
@@ -2435,7 +2425,7 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- very difficult to move onto a closed fold.
 --- In insert mode the folds containing the cursor will always be open
 --- when text is inserted.
---- To close folds you can re-apply 'foldlevel' with the `zx` command or
+--- To close folds you can re-apply 'foldlevel' with the `|zx|` command or
 --- set the 'foldclose' option to "all".
 ---
 --- @type string
@@ -2446,15 +2436,15 @@ vim.go.fdo = vim.go.foldopen
 
 --- An expression which is used to specify the text displayed for a closed
 --- fold.  The context is set to the script where 'foldexpr' was set,
---- script-local items can be accessed.  See `fold-foldtext` for the
+--- script-local items can be accessed.  See `|fold-foldtext|` for the
 --- usage.
 ---
---- The expression will be evaluated in the `sandbox` if set from a
---- modeline, see `sandbox-option`.
+--- The expression will be evaluated in the `|sandbox|` if set from a
+--- modeline, see `|sandbox-option|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'foldtext' `textlock`.
+--- evaluating 'foldtext' `|textlock|`.
 ---
 --- @type string
 vim.o.foldtext = "foldtext()"
@@ -2462,44 +2452,44 @@ vim.o.fdt = vim.o.foldtext
 vim.wo.foldtext = vim.o.foldtext
 vim.wo.fdt = vim.wo.foldtext
 
---- Expression which is evaluated to format a range of lines for the `gq`
+--- Expression which is evaluated to format a range of lines for the `|gq|`
 --- operator or automatic formatting (see 'formatoptions').  When this
 --- option is empty 'formatprg' is used.
 ---
---- The `v:lnum`  variable holds the first line to be formatted.
---- The `v:count` variable holds the number of lines to be formatted.
---- The `v:char`  variable holds the character that is going to be
---- 	      inserted if the expression is being evaluated due to
---- 	      automatic formatting.  This can be empty.  Don't insert
---- 	      it yet!
+--- The `|v:lnum|`  variable holds the first line to be formatted.
+--- The `|v:count|` variable holds the number of lines to be formatted.
+--- The `|v:char|`  variable holds the character that is going to be
+---       inserted if the expression is being evaluated due to
+---       automatic formatting.  This can be empty.  Don't insert
+---       it yet!
 ---
 --- Example:
 --- ```
---- 	:set formatexpr=mylang#Format()
+--- :set formatexpr=mylang#Format()
 --- ```
 --- This will invoke the mylang#Format() function in the
---- autoload/mylang.vim file in 'runtimepath'. `autoload`
+--- autoload/mylang.vim file in 'runtimepath'. `|autoload|`
 ---
 --- The expression is also evaluated when 'textwidth' is set and adding
 --- text beyond that limit.  This happens under the same conditions as
 --- when internal formatting is used.  Make sure the cursor is kept in the
---- same spot relative to the text then!  The `mode()` function will
+--- same spot relative to the text then!  The `|mode()|` function will
 --- return "i" or "R" in this situation.
 ---
 --- When the expression evaluates to non-zero Vim will fall back to using
 --- the internal format mechanism.
 ---
---- If the expression starts with s: or `<SID>`, then it is replaced with
---- the script ID (`local-function`). Example:
+--- If the expression starts with s: or `|<SID>|`, then it is replaced with
+--- the script ID (`|local-function|`). Example:
 --- ```
---- 	set formatexpr=s:MyFormatExpr()
---- 	set formatexpr=<SID>SomeFormatExpr()
+--- set formatexpr=s:MyFormatExpr()
+--- set formatexpr=<SID>SomeFormatExpr()
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
 ---
---- The expression will be evaluated in the `sandbox` when set from a
---- modeline, see `sandbox-option`.  That stops the option from working,
+--- The expression will be evaluated in the `|sandbox|` when set from a
+--- modeline, see `|sandbox-option|`.  That stops the option from working,
 --- since changing the buffer text is not allowed.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 --- NOTE: This option is set to "" when 'compatible' is set.
@@ -2513,7 +2503,7 @@ vim.bo.fex = vim.bo.formatexpr
 --- A pattern that is used to recognize a list header.  This is used for
 --- the "n" flag in 'formatoptions'.
 --- The pattern must match exactly the text that will be the indent for
---- the line below it.  You can use `/\ze` to mark the end of the match
+--- the line below it.  You can use `|/\ze|` to mark the end of the match
 --- while still checking more characters.  There must be a character
 --- following the pattern, when it matches the whole line it is handled
 --- like there is no match.
@@ -2527,10 +2517,10 @@ vim.bo.formatlistpat = vim.o.formatlistpat
 vim.bo.flp = vim.bo.formatlistpat
 
 --- This is a sequence of letters which describes how automatic
---- formatting is to be done.  See `fo-table`.  Commas can be inserted for
+--- formatting is to be done.  See `|fo-table|`.  Commas can be inserted for
 --- readability.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `add-option-flags`.
+--- "+=" and "-=" feature of ":set" `|add-option-flags|`.
 ---
 --- @type string
 vim.o.formatoptions = "tcqj"
@@ -2539,15 +2529,15 @@ vim.bo.formatoptions = vim.o.formatoptions
 vim.bo.fo = vim.bo.formatoptions
 
 --- The name of an external program that will be used to format the lines
---- selected with the `gq` operator.  The program must take the input on
+--- selected with the `|gq|` operator.  The program must take the input on
 --- stdin and produce the output on stdout.  The Unix program "fmt" is
 --- such a program.
 --- If the 'formatexpr' option is not empty it will be used instead.
 --- Otherwise, if 'formatprg' option is an empty string, the internal
---- format function will be used `C-indenting`.
---- Environment variables are expanded `:set_env`.  See `option-backslash`
+--- format function will be used `|C-indenting|`.
+--- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
 --- about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -2559,18 +2549,18 @@ vim.go.formatprg = vim.o.formatprg
 vim.go.fp = vim.go.formatprg
 
 --- When on, the OS function fsync() will be called after saving a file
---- (`:write`, `writefile()`, …), `swap-file`, `undo-persistence` and `shada-file`.
+--- (`|:write|`, `|writefile()|`, …), `|swap-file|`, `|undo-persistence|` and `|shada-file|`.
 --- This flushes the file to disk, ensuring that it is safely written.
 --- Slow on some systems: writing buffers, quitting Nvim, and other
 --- operations may sometimes take a few seconds.
 ---
 --- Files are ALWAYS flushed ('fsync' is ignored) when:
---- - `CursorHold` event is triggered
---- - `:preserve` is called
+--- - `|CursorHold|` event is triggered
+--- - `|:preserve|` is called
 --- - system signals low battery life
 --- - Nvim exits abnormally
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type boolean
@@ -2582,12 +2572,12 @@ vim.go.fs = vim.go.fsync
 --- When on, the ":substitute" flag 'g' is default on.  This means that
 --- all matches in a line are substituted instead of one.  When a 'g' flag
 --- is given to a ":substitute" command, this will toggle the substitution
---- of all or one match.  See `complex-change`.
+--- of all or one match.  See `|complex-change|`.
 ---
---- 	command		'gdefault' on	'gdefault' off	~
---- 	:s///		  subst. all	  subst. one
---- 	:s///g		  subst. one	  subst. all
---- 	:s///gg		  subst. all	  subst. one
+--- command    'gdefault' on  'gdefault' off  ~
+--- :s///      subst. all    subst. one
+--- :s///g      subst. one    subst. all
+--- :s///gg      subst. all    subst. one
 ---
 --- DEPRECATED: Setting this option may break plugins that are not aware
 --- of this option.  Also, many users get confused that adding the /g flag
@@ -2601,7 +2591,7 @@ vim.go.gd = vim.go.gdefault
 
 --- Format to recognize for the ":grep" command output.
 --- This is a scanf-like string that uses the same format as the
---- 'errorformat' option: see `errorformat`.
+--- 'errorformat' option: see `|errorformat|`.
 ---
 --- @type string
 vim.o.grepformat = "%f:%l:%m,%f:%l%m,%f  %l%m"
@@ -2609,22 +2599,22 @@ vim.o.gfm = vim.o.grepformat
 vim.go.grepformat = vim.o.grepformat
 vim.go.gfm = vim.go.grepformat
 
---- Program to use for the `:grep` command.  This option may contain '%'
+--- Program to use for the `|:grep|` command.  This option may contain '%'
 --- and '#' characters, which are expanded like when used in a command-
 --- line.  The placeholder "$*" is allowed to specify where the arguments
---- will be included.  Environment variables are expanded `:set_env`.  See
---- `option-backslash` about including spaces and backslashes.
+--- will be included.  Environment variables are expanded `|:set_env|`.  See
+--- `|option-backslash|` about including spaces and backslashes.
 --- When your "grep" accepts the "-H" argument, use this to make ":grep"
 --- also work well with a single file:
 --- ```
---- 	:set grepprg=grep\ -nH
+--- :set grepprg=grep\ -nH
 --- ```
---- Special value: When 'grepprg' is set to "internal" the `:grep` command
---- works like `:vimgrep`, `:lgrep` like `:lvimgrep`, `:grepadd` like
---- `:vimgrepadd` and `:lgrepadd` like `:lvimgrepadd`.
---- See also the section `:make_makeprg`, since most of the comments there
+--- Special value: When 'grepprg' is set to "internal" the `|:grep|` command
+--- works like `|:vimgrep|`, `|:lgrep|` like `|:lvimgrep|`, `|:grepadd|` like
+--- `|:vimgrepadd|` and `|:lgrepadd|` like `|:lvimgrepadd|`.
+--- See also the section `|:make_makeprg|`, since most of the comments there
 --- apply equally to 'grepprg'.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -2636,82 +2626,82 @@ vim.go.grepprg = vim.o.grepprg
 vim.go.gp = vim.go.grepprg
 
 --- Configures the cursor style for each mode. Works in the GUI and many
---- terminals.  See `tui-cursor-shape`.
+--- terminals.  See `|tui-cursor-shape|`.
 ---
 --- To disable cursor-styling, reset the option:
 --- ```
---- 	:set guicursor=
+--- :set guicursor=
 --- ```
 --- To enable mode shapes, "Cursor" highlight, and blinking:
 --- ```
---- 	:set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
---- 	  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
---- 	  \,sm:block-blinkwait175-blinkoff150-blinkon175
+--- :set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
+---   \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
+---   \,sm:block-blinkwait175-blinkoff150-blinkon175
 --- ```
 --- The option is a comma-separated list of parts.  Each part consists of a
 --- mode-list and an argument-list:
---- 	mode-list:argument-list,mode-list:argument-list,..
+--- mode-list:argument-list,mode-list:argument-list,..
 --- The mode-list is a dash separated list of these modes:
---- 	n	Normal mode
---- 	v	Visual mode
---- 	ve	Visual mode with 'selection' "exclusive" (same as 'v',
---- 		if not specified)
---- 	o	Operator-pending mode
---- 	i	Insert mode
---- 	r	Replace mode
---- 	c	Command-line Normal (append) mode
---- 	ci	Command-line Insert mode
---- 	cr	Command-line Replace mode
---- 	sm	showmatch in Insert mode
---- 	a	all modes
+--- n  Normal mode
+--- v  Visual mode
+--- ve  Visual mode with 'selection' "exclusive" (same as 'v',
+---   if not specified)
+--- o  Operator-pending mode
+--- i  Insert mode
+--- r  Replace mode
+--- c  Command-line Normal (append) mode
+--- ci  Command-line Insert mode
+--- cr  Command-line Replace mode
+--- sm  showmatch in Insert mode
+--- a  all modes
 --- The argument-list is a dash separated list of these arguments:
---- 	hor{N}	horizontal bar, {N} percent of the character height
---- 	ver{N}	vertical bar, {N} percent of the character width
---- 	block	block cursor, fills the whole character
---- 		- Only one of the above three should be present.
---- 		- Default is "block" for each mode.
---- 	blinkwait{N}				*cursor-blinking*
---- 	blinkon{N}
---- 	blinkoff{N}
---- 		blink times for cursor: blinkwait is the delay before
---- 		the cursor starts blinking, blinkon is the time that
---- 		the cursor is shown and blinkoff is the time that the
---- 		cursor is not shown.  Times are in msec.  When one of
---- 		the numbers is zero, there is no blinking. E.g.:
+--- hor{N}  horizontal bar, {N} percent of the character height
+--- ver{N}  vertical bar, {N} percent of the character width
+--- block  block cursor, fills the whole character
+---   - Only one of the above three should be present.
+---   - Default is "block" for each mode.
+--- blinkwait{N}        *cursor-blinking*
+--- blinkon{N}
+--- blinkoff{N}
+---   blink times for cursor: blinkwait is the delay before
+---   the cursor starts blinking, blinkon is the time that
+---   the cursor is shown and blinkoff is the time that the
+---   cursor is not shown.  Times are in msec.  When one of
+---   the numbers is zero, there is no blinking. E.g.:
 --- ```
---- 			:set guicursor=n:blinkon0
+---     :set guicursor=n:blinkon0
 --- ```
 --- - Default is "blinkon0" for each mode.
---- 	{group-name}
---- 		Highlight group that decides the color and font of the
---- 		cursor.
---- 		In the `TUI`:
---- 		- `inverse`/reverse and no group-name are interpreted
---- 		  as "host-terminal default cursor colors" which
---- 		  typically means "inverted bg and fg colors".
---- 		- `ctermfg` and `guifg` are ignored.
---- 	{group-name}/{group-name}
---- 		Two highlight group names, the first is used when
---- 		no language mappings are used, the other when they
---- 		are. `language-mapping`
+--- {group-name}
+---   Highlight group that decides the color and font of the
+---   cursor.
+---   In the `|TUI|`:
+---   - `|inverse|`/reverse and no group-name are interpreted
+---     as "host-terminal default cursor colors" which
+---     typically means "inverted bg and fg colors".
+---   - `|ctermfg|` and `|guifg|` are ignored.
+--- {group-name}/{group-name}
+---   Two highlight group names, the first is used when
+---   no language mappings are used, the other when they
+---   are. `|language-mapping|`
 ---
 --- Examples of parts:
----    n-c-v:block-nCursor	In Normal, Command-line and Visual mode, use a
---- 			block cursor with colors from the "nCursor"
---- 			highlight group
----    n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
---- 			In Normal et al. modes, use a block cursor
---- 			with the default colors defined by the host
---- 			terminal.  In Insert-like modes, use
---- 			a vertical bar cursor with colors from
---- 			"Cursor" highlight group.  In Replace-like
---- 			modes, use an underline cursor with
---- 			default colors.
----    i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
---- 			In Insert and Command-line Insert mode, use a
---- 			30% vertical bar cursor with colors from the
---- 			"iCursor" highlight group.  Blink a bit
---- 			faster.
+---  n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
+---     block cursor with colors from the "nCursor"
+---     highlight group
+---  n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
+---     In Normal et al. modes, use a block cursor
+---     with the default colors defined by the host
+---     terminal.  In Insert-like modes, use
+---     a vertical bar cursor with colors from
+---     "Cursor" highlight group.  In Replace-like
+---     modes, use an underline cursor with
+---     default colors.
+---  i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
+---     In Insert and Command-line Insert mode, use a
+---     30% vertical bar cursor with colors from the
+---     "iCursor" highlight group.  Blink a bit
+---     faster.
 ---
 --- The 'a' mode is different.  It will set the given argument-list for
 --- all modes.  It does not reset anything to defaults.  This can be used
@@ -2720,10 +2710,9 @@ vim.go.gp = vim.go.grepprg
 ---
 --- Examples of cursor highlighting:
 --- ```
----     :highlight Cursor gui=reverse guifg=NONE guibg=NONE
----     :highlight Cursor gui=NONE guifg=bg guibg=fg
+---   :highlight Cursor gui=reverse guifg=NONE guibg=NONE
+---   :highlight Cursor gui=NONE guifg=bg guibg=fg
 --- ```
----
 ---
 --- @type string
 vim.o.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"
@@ -2740,9 +2729,9 @@ vim.go.gcr = vim.go.guicursor
 --- Spaces after a comma are ignored.  To include a comma in a font name
 --- precede it with a backslash.  Setting an option requires an extra
 --- backslash before a space and a backslash.  See also
---- `option-backslash`.  For example:
+--- `|option-backslash|`.  For example:
 --- ```
----     :set guifont=Screen15,\ 7x13,font\\,with\\,commas
+---   :set guifont=Screen15,\ 7x13,font\\,with\\,commas
 --- ```
 --- will make Vim try to use the font "Screen15" first, and if it fails it
 --- will try to use "7x13" and then "font,with,commas" instead.
@@ -2756,7 +2745,7 @@ vim.go.gcr = vim.go.guicursor
 ---
 --- For Win32 and Mac OS:
 --- ```
----     :set guifont=*
+---   :set guifont=*
 --- ```
 --- will bring up a font requester, where you can pick the font you want.
 ---
@@ -2764,7 +2753,7 @@ vim.go.gcr = vim.go.guicursor
 ---
 --- For Mac OSX you can use something like this:
 --- ```
----     :set guifont=Monaco:h10
+---   :set guifont=Monaco:h10
 --- ```
 --- *E236*
 --- Note that the fonts must be mono-spaced (all characters have the same
@@ -2773,29 +2762,28 @@ vim.go.gcr = vim.go.guicursor
 --- To preview a font on X11, you might be able to use the "xfontsel"
 --- program.  The "xlsfonts" program gives a list of all available fonts.
 ---
---- For the Win32 GUI					*E244* *E245*
+--- For the Win32 GUI          *E244* *E245*
 --- - takes these options in the font name:
---- 	hXX - height is XX (points, can be floating-point)
---- 	wXX - width is XX (points, can be floating-point)
---- 	b   - bold
---- 	i   - italic
---- 	u   - underline
---- 	s   - strikeout
---- 	cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
---- 	      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
---- 	      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
---- 	      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
---- 	      Normally you would use "cDEFAULT".
+--- hXX - height is XX (points, can be floating-point)
+--- wXX - width is XX (points, can be floating-point)
+--- b   - bold
+--- i   - italic
+--- u   - underline
+--- s   - strikeout
+--- cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
+---       BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
+---       HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
+---       SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
+---       Normally you would use "cDEFAULT".
 ---
----   Use a ':' to separate the options.
+--- Use a ':' to separate the options.
 --- - A '_' can be used in the place of a space, so you don't need to use
----   backslashes to escape the spaces.
+--- backslashes to escape the spaces.
 --- - Examples:
 --- ```
----     :set guifont=courier_new:h12:w5:b:cRUSSIAN
----     :set guifont=Andale_Mono:h7.5:w4.5
+---   :set guifont=courier_new:h12:w5:b:cRUSSIAN
+---   :set guifont=Andale_Mono:h7.5:w4.5
 --- ```
----
 ---
 --- @type string
 vim.o.guifont = ""
@@ -2821,101 +2809,101 @@ vim.go.gfw = vim.go.guifontwide
 --- sequence of letters which describes what components and options of the
 --- GUI should be used.
 --- To avoid problems with flags that are added in the future, use the
---- "+=" and "-=" feature of ":set" `add-option-flags`.
+--- "+=" and "-=" feature of ":set" `|add-option-flags|`.
 ---
 --- Valid letters are as follows:
---- 						*guioptions_a* *'go-a'*
----   'a'	Autoselect:  If present, then whenever VISUAL mode is started,
---- 	or the Visual area extended, Vim tries to become the owner of
---- 	the windowing system's global selection.  This means that the
---- 	Visually highlighted text is available for pasting into other
---- 	applications as well as into Vim itself.  When the Visual mode
---- 	ends, possibly due to an operation on the text, or when an
---- 	application wants to paste the selection, the highlighted text
---- 	is automatically yanked into the "* selection register.
---- 	Thus the selection is still available for pasting into other
---- 	applications after the VISUAL mode has ended.
---- 	    If not present, then Vim won't become the owner of the
---- 	windowing system's global selection unless explicitly told to
---- 	by a yank or delete operation for the "* register.
---- 	The same applies to the modeless selection.
---- 							*'go-P'*
----   'P'	Like autoselect but using the "+ register instead of the "*
---- 	register.
---- 							*'go-A'*
----   'A'	Autoselect for the modeless selection.  Like 'a', but only
---- 	applies to the modeless selection.
+---           *guioptions_a* *'go-a'*
+--- 'a'  Autoselect:  If present, then whenever VISUAL mode is started,
+--- or the Visual area extended, Vim tries to become the owner of
+--- the windowing system's global selection.  This means that the
+--- Visually highlighted text is available for pasting into other
+--- applications as well as into Vim itself.  When the Visual mode
+--- ends, possibly due to an operation on the text, or when an
+--- application wants to paste the selection, the highlighted text
+--- is automatically yanked into the "* selection register.
+--- Thus the selection is still available for pasting into other
+--- applications after the VISUAL mode has ended.
+---     If not present, then Vim won't become the owner of the
+--- windowing system's global selection unless explicitly told to
+--- by a yank or delete operation for the "* register.
+--- The same applies to the modeless selection.
+---             *'go-P'*
+--- 'P'  Like autoselect but using the "+ register instead of the "*
+--- register.
+---             *'go-A'*
+--- 'A'  Autoselect for the modeless selection.  Like 'a', but only
+--- applies to the modeless selection.
 ---
---- 	    'guioptions'   autoselect Visual  autoselect modeless ~
---- 		 ""		 -			 -
---- 		 "a"		yes			yes
---- 		 "A"		 -			yes
---- 		 "aA"		yes			yes
+---     'guioptions'   autoselect Visual  autoselect modeless ~
+---    ""     -       -
+---    "a"    yes      yes
+---    "A"     -      yes
+---    "aA"    yes      yes
 ---
---- 							*'go-c'*
----   'c'	Use console dialogs instead of popup dialogs for simple
---- 	choices.
---- 							*'go-d'*
----   'd'	Use dark theme variant if available.
---- 							*'go-e'*
----   'e'	Add tab pages when indicated with 'showtabline'.
---- 	'guitablabel' can be used to change the text in the labels.
---- 	When 'e' is missing a non-GUI tab pages line may be used.
---- 	The GUI tabs are only supported on some systems, currently
---- 	Mac OS/X and MS-Windows.
---- 							*'go-i'*
----   'i'	Use a Vim icon.
---- 							*'go-m'*
----   'm'	Menu bar is present.
---- 							*'go-M'*
----   'M'	The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
---- 	that this flag must be added in the vimrc file, before
---- 	switching on syntax or filetype recognition (when the `gvimrc`
---- 	file is sourced the system menu has already been loaded; the
---- 	`:syntax on` and `:filetype on` commands load the menu too).
---- 							*'go-g'*
----   'g'	Grey menu items: Make menu items that are not active grey.  If
---- 	'g' is not included inactive menu items are not shown at all.
---- 							*'go-T'*
----   'T'	Include Toolbar.  Currently only in Win32 GUI.
---- 							*'go-r'*
----   'r'	Right-hand scrollbar is always present.
---- 							*'go-R'*
----   'R'	Right-hand scrollbar is present when there is a vertically
---- 	split window.
---- 							*'go-l'*
----   'l'	Left-hand scrollbar is always present.
---- 							*'go-L'*
----   'L'	Left-hand scrollbar is present when there is a vertically
---- 	split window.
---- 							*'go-b'*
----   'b'	Bottom (horizontal) scrollbar is present.  Its size depends on
---- 	the longest visible line, or on the cursor line if the 'h'
---- 	flag is included. `gui-horiz-scroll`
---- 							*'go-h'*
----   'h'	Limit horizontal scrollbar size to the length of the cursor
---- 	line.  Reduces computations. `gui-horiz-scroll`
+---             *'go-c'*
+--- 'c'  Use console dialogs instead of popup dialogs for simple
+--- choices.
+---             *'go-d'*
+--- 'd'  Use dark theme variant if available.
+---             *'go-e'*
+--- 'e'  Add tab pages when indicated with 'showtabline'.
+--- 'guitablabel' can be used to change the text in the labels.
+--- When 'e' is missing a non-GUI tab pages line may be used.
+--- The GUI tabs are only supported on some systems, currently
+--- Mac OS/X and MS-Windows.
+---             *'go-i'*
+--- 'i'  Use a Vim icon.
+---             *'go-m'*
+--- 'm'  Menu bar is present.
+---             *'go-M'*
+--- 'M'  The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
+--- that this flag must be added in the vimrc file, before
+--- switching on syntax or filetype recognition (when the `|gvimrc|`
+--- file is sourced the system menu has already been loaded; the
+--- `:syntax on` and `:filetype on` commands load the menu too).
+---             *'go-g'*
+--- 'g'  Grey menu items: Make menu items that are not active grey.  If
+--- 'g' is not included inactive menu items are not shown at all.
+---             *'go-T'*
+--- 'T'  Include Toolbar.  Currently only in Win32 GUI.
+---             *'go-r'*
+--- 'r'  Right-hand scrollbar is always present.
+---             *'go-R'*
+--- 'R'  Right-hand scrollbar is present when there is a vertically
+--- split window.
+---             *'go-l'*
+--- 'l'  Left-hand scrollbar is always present.
+---             *'go-L'*
+--- 'L'  Left-hand scrollbar is present when there is a vertically
+--- split window.
+---             *'go-b'*
+--- 'b'  Bottom (horizontal) scrollbar is present.  Its size depends on
+--- the longest visible line, or on the cursor line if the 'h'
+--- flag is included. `|gui-horiz-scroll|`
+---             *'go-h'*
+--- 'h'  Limit horizontal scrollbar size to the length of the cursor
+--- line.  Reduces computations. `|gui-horiz-scroll|`
 ---
 --- And yes, you may even have scrollbars on the left AND the right if
---- you really want to :-).  See `gui-scrollbars` for more information.
+--- you really want to :-).  See `|gui-scrollbars|` for more information.
 ---
---- 							*'go-v'*
----   'v'	Use a vertical button layout for dialogs.  When not included,
---- 	a horizontal layout is preferred, but when it doesn't fit a
---- 	vertical layout is used anyway.  Not supported in GTK 3.
---- 							*'go-p'*
----   'p'	Use Pointer callbacks for X11 GUI.  This is required for some
---- 	window managers.  If the cursor is not blinking or hollow at
---- 	the right moment, try adding this flag.  This must be done
---- 	before starting the GUI.  Set it in your `gvimrc`.  Adding or
---- 	removing it after the GUI has started has no effect.
---- 							*'go-k'*
----   'k'	Keep the GUI window size when adding/removing a scrollbar, or
---- 	toolbar, tabline, etc.  Instead, the behavior is similar to
---- 	when the window is maximized and will adjust 'lines' and
---- 	'columns' to fit to the window.  Without the 'k' flag Vim will
---- 	try to keep 'lines' and 'columns' the same when adding and
---- 	removing GUI components.
+---             *'go-v'*
+--- 'v'  Use a vertical button layout for dialogs.  When not included,
+--- a horizontal layout is preferred, but when it doesn't fit a
+--- vertical layout is used anyway.  Not supported in GTK 3.
+---             *'go-p'*
+--- 'p'  Use Pointer callbacks for X11 GUI.  This is required for some
+--- window managers.  If the cursor is not blinking or hollow at
+--- the right moment, try adding this flag.  This must be done
+--- before starting the GUI.  Set it in your `|gvimrc|`.  Adding or
+--- removing it after the GUI has started has no effect.
+---             *'go-k'*
+--- 'k'  Keep the GUI window size when adding/removing a scrollbar, or
+--- toolbar, tabline, etc.  Instead, the behavior is similar to
+--- when the window is maximized and will adjust 'lines' and
+--- 'columns' to fit to the window.  Without the 'k' flag Vim will
+--- try to keep 'lines' and 'columns' the same when adding and
+--- removing GUI components.
 ---
 --- @type string
 vim.o.guioptions = ""
@@ -2925,12 +2913,12 @@ vim.go.go = vim.go.guioptions
 
 --- When non-empty describes the text to use in a label of the GUI tab
 --- pages line.  When empty and when the result is empty Vim will use a
---- default label.  See `setting-guitablabel` for more info.
+--- default label.  See `|setting-guitablabel|` for more info.
 ---
 --- The format of this option is like that of 'statusline'.
 --- 'guitabtooltip' is used for the tooltip, see below.
---- The expression will be evaluated in the `sandbox` when set from a
---- modeline, see `sandbox-option`.
+--- The expression will be evaluated in the `|sandbox|` when set from a
+--- modeline, see `|sandbox-option|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- Only used when the GUI tab pages line is displayed.  'e' must be
@@ -2946,11 +2934,10 @@ vim.go.gtl = vim.go.guitablabel
 --- When non-empty describes the text to use in a tooltip for the GUI tab
 --- pages line.  When empty Vim will use a default tooltip.
 --- This option is otherwise just like 'guitablabel' above.
---- You can include a line break.  Simplest method is to use `:let`:
+--- You can include a line break.  Simplest method is to use `|:let|`:
 --- ```
---- 	:let &guitabtooltip = "line one\nline two"
+--- :let &guitabtooltip = "line one\nline two"
 --- ```
----
 ---
 --- @type string
 vim.o.guitabtooltip = ""
@@ -2961,11 +2948,11 @@ vim.go.gtt = vim.go.guitabtooltip
 --- Name of the main help file.  All distributed help files should be
 --- placed together in one directory.  Additionally, all "doc" directories
 --- in 'runtimepath' will be used.
---- Environment variables are expanded `:set_env`.  For example:
+--- Environment variables are expanded `|:set_env|`.  For example:
 --- "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
---- tried.  Also see `$VIMRUNTIME` and `option-backslash` about including
+--- tried.  Also see `|$VIMRUNTIME|` and `|option-backslash|` about including
 --- spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -2993,13 +2980,13 @@ vim.go.hh = vim.go.helpheight
 --- language and not in the English help.
 --- Example:
 --- ```
---- 	:set helplang=de,it
+--- :set helplang=de,it
 --- ```
 --- This will first search German, then Italian and finally English help
 --- files.
---- When using `CTRL-]` and ":help!" in a non-English help file Vim will
+--- When using `|CTRL-]|` and ":help!" in a non-English help file Vim will
 --- try to find the tag in the current language before using this option.
---- See `help-translated`.
+--- See `|help-translated|`.
 ---
 --- @type string
 vim.o.helplang = ""
@@ -3008,8 +2995,8 @@ vim.go.helplang = vim.o.helplang
 vim.go.hlg = vim.go.helplang
 
 --- When off a buffer is unloaded (including loss of undo information)
---- when it is `abandon`ed.  When on a buffer becomes hidden when it is
---- `abandon`ed.  A buffer displayed in another window does not become
+--- when it is `|abandon|`ed.  When on a buffer becomes hidden when it is
+--- `|abandon|`ed.  A buffer displayed in another window does not become
 --- hidden, of course.
 ---
 --- Commands that move through the buffer list sometimes hide a buffer
@@ -3017,10 +3004,10 @@ vim.go.hlg = vim.go.helplang
 --- - the buffer is modified
 --- - 'autowrite' is off or writing is not possible
 --- - the '!' flag was used
---- Also see `windows`.
+--- Also see `|windows|`.
 ---
 --- To hide a specific buffer use the 'bufhidden' option.
---- 'hidden' is set for one command with ":hide {command}" `:hide`.
+--- 'hidden' is set for one command with ":hide {command}" `|:hide|`.
 ---
 --- @type boolean
 vim.o.hidden = true
@@ -3030,7 +3017,7 @@ vim.go.hid = vim.go.hidden
 
 --- A history of ":" commands, and a history of previous search patterns
 --- is remembered.  This option decides how many entries may be stored in
---- each of these histories (see `cmdline-editing`).
+--- each of these histories (see `|cmdline-editing|`).
 --- The maximum value is 10000.
 ---
 --- @type integer
@@ -3040,15 +3027,15 @@ vim.go.history = vim.o.history
 vim.go.hi = vim.go.history
 
 --- When there is a previous search pattern, highlight all its matches.
---- The `hl-Search` highlight group determines the highlighting for all
---- matches not under the cursor while the `hl-CurSearch` highlight group
+--- The `|hl-Search|` highlight group determines the highlighting for all
+--- matches not under the cursor while the `|hl-CurSearch|` highlight group
 --- (if defined) determines the highlighting for the match under the
---- cursor. If `hl-CurSearch` is not defined, then `hl-Search` is used for
+--- cursor. If `|hl-CurSearch|` is not defined, then `|hl-Search|` is used for
 --- both. Note that only the matching text is highlighted, any offsets
 --- are not applied.
---- See also: 'incsearch' and `:match`.
+--- See also: 'incsearch' and `|:match|`.
 --- When you get bored looking at the highlighted matches, you can turn it
---- off with `:nohlsearch`.  This does not change the option value, as
+--- off with `|:nohlsearch|`.  This does not change the option value, as
 --- soon as you use a search command, the highlighting comes back.
 --- 'redrawtime' specifies the maximum time spent on finding matches.
 --- When the search pattern can match an end-of-line, Vim will try to
@@ -3057,7 +3044,7 @@ vim.go.hi = vim.go.history
 --- line below a closed fold.  A match in a previous line which is not
 --- drawn may not continue in a newly drawn line.
 --- You can specify whether the highlight status is restored on startup
---- with the 'h' flag in 'shada' `shada-h`.
+--- with the 'h' flag in 'shada' `|shada-h|`.
 ---
 --- @type boolean
 vim.o.hlsearch = true
@@ -3087,11 +3074,11 @@ vim.go.icon = vim.o.icon
 vim.o.iconstring = ""
 vim.go.iconstring = vim.o.iconstring
 
---- Ignore case in search patterns, `cmdline-completion`, when
---- searching in the tags file, and `expr-==`.
+--- Ignore case in search patterns, `|cmdline-completion|`, when
+--- searching in the tags file, and `|expr-==|`.
 --- Also see 'smartcase' and 'tagcase'.
 --- Can be overruled by using "\c" or "\C" in the pattern, see
---- `/ignorecase`.
+--- `|/ignorecase|`.
 ---
 --- @type boolean
 vim.o.ignorecase = false
@@ -3124,18 +3111,18 @@ vim.go.imd = vim.go.imdisable
 
 --- Specifies whether :lmap or an Input Method (IM) is to be used in
 --- Insert mode.  Valid values:
---- 	0	:lmap is off and IM is off
---- 	1	:lmap is ON and IM is off
---- 	2	:lmap is off and IM is ON
+--- 0  :lmap is off and IM is off
+--- 1  :lmap is ON and IM is off
+--- 2  :lmap is off and IM is ON
 --- To always reset the option to zero when leaving Insert mode with <Esc>
 --- this can be used:
 --- ```
---- 	:inoremap <ESC> <ESC>:set iminsert=0<CR>
+--- :inoremap <ESC> <ESC>:set iminsert=0<CR>
 --- ```
 --- This makes :lmap and IM turn off automatically when leaving Insert
 --- mode.
 --- Note that this option changes when using CTRL-^ in Insert mode
---- `i_CTRL-^`.
+--- `|i_CTRL-^|`.
 --- The value is set to 1 when setting 'keymap' to a valid keymap name.
 --- It is also used for the argument of commands like "r" and "f".
 ---
@@ -3147,13 +3134,13 @@ vim.bo.imi = vim.bo.iminsert
 
 --- Specifies whether :lmap or an Input Method (IM) is to be used when
 --- entering a search pattern.  Valid values:
---- 	-1	the value of 'iminsert' is used, makes it look like
---- 		'iminsert' is also used when typing a search pattern
---- 	0	:lmap is off and IM is off
---- 	1	:lmap is ON and IM is off
---- 	2	:lmap is off and IM is ON
+--- -1  the value of 'iminsert' is used, makes it look like
+---   'iminsert' is also used when typing a search pattern
+--- 0  :lmap is off and IM is off
+--- 1  :lmap is ON and IM is off
+--- 2  :lmap is off and IM is ON
 --- Note that this option changes when using CTRL-^ in Command-line mode
---- `c_CTRL-^`.
+--- `|c_CTRL-^|`.
 --- The value is set to 1 when it is not -1 and setting the 'keymap'
 --- option to a valid keymap name.
 ---
@@ -3163,19 +3150,19 @@ vim.o.ims = vim.o.imsearch
 vim.bo.imsearch = vim.o.imsearch
 vim.bo.ims = vim.bo.imsearch
 
---- When nonempty, shows the effects of `:substitute`, `:smagic|,
---- |:snomagic` and user commands with the `:command-preview` flag as you
+--- When nonempty, shows the effects of `|:substitute|`, `|:smagic|,
+--- |:snomagic|` and user commands with the `|:command-preview|` flag as you
 --- type.
 ---
 --- Possible values:
---- 	nosplit	Shows the effects of a command incrementally in the
---- 		buffer.
---- 	split	Like "nosplit", but also shows partial off-screen
---- 		results in a preview window.
+--- nosplit  Shows the effects of a command incrementally in the
+---   buffer.
+--- split  Like "nosplit", but also shows partial off-screen
+---   results in a preview window.
 ---
 --- If the preview for built-in commands is too slow (exceeds
 --- 'redrawtime') then 'inccommand' is automatically disabled until
---- `Command-line-mode` is done.
+--- `|Command-line-mode|` is done.
 ---
 --- @type string
 vim.o.inccommand = "nosplit"
@@ -3184,7 +3171,7 @@ vim.go.inccommand = vim.o.inccommand
 vim.go.icm = vim.go.inccommand
 
 --- Pattern to be used to find an include command.  It is a search
---- pattern, just like for the "/" command (See `pattern`).  This option
+--- pattern, just like for the "/" command (See `|pattern|`).  This option
 --- is used for the commands "[i", "]I", "[d", etc.
 --- Normally the 'isfname' option is used to recognize the file name that
 --- comes after the matched pattern.  But if "\zs" appears in the pattern
@@ -3192,7 +3179,7 @@ vim.go.icm = vim.go.inccommand
 --- appears, is used as the file name.  Use this to include characters
 --- that are not in 'isfname', such as a space.  You can then use
 --- 'includeexpr' to process the matched text.
---- See `option-backslash` about including spaces and backslashes.
+--- See `|option-backslash|` about including spaces and backslashes.
 ---
 --- @type string
 vim.o.include = ""
@@ -3205,35 +3192,34 @@ vim.go.inc = vim.go.include
 --- Expression to be used to transform the string found with the 'include'
 --- option to a file name.  Mostly useful to change "." to "/" for Java:
 --- ```
---- 	:setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+--- :setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 --- ```
 --- The "v:fname" variable will be set to the file name that was detected.
 --- Note the double backslash: the `:set` command first halves them, then
 --- one remains in the value, where "\." matches a dot literally.  For
 --- simple character replacements `tr()` avoids the need for escaping:
 --- ```
---- 	:setlocal includeexpr=tr(v:fname,'.','/')
+--- :setlocal includeexpr=tr(v:fname,'.','/')
 --- ```
----
---- Also used for the `gf` command if an unmodified file name can't be
+--- Also used for the `|gf|` command if an unmodified file name can't be
 --- found.  Allows doing "gf" on the name after an 'include' statement.
---- Also used for `<cfile>`.
+--- Also used for `|<cfile>|`.
 ---
---- If the expression starts with s: or `<SID>`, then it is replaced with
---- the script ID (`local-function`). Example:
+--- If the expression starts with s: or `|<SID>|`, then it is replaced with
+--- the script ID (`|local-function|`). Example:
 --- ```
---- 	setlocal includeexpr=s:MyIncludeExpr(v:fname)
---- 	setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
+--- setlocal includeexpr=s:MyIncludeExpr(v:fname)
+--- setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
 ---
---- The expression will be evaluated in the `sandbox` when set from a
---- modeline, see `sandbox-option`.
+--- The expression will be evaluated in the `|sandbox|` when set from a
+--- modeline, see `|sandbox-option|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'includeexpr' `textlock`.
+--- evaluating 'includeexpr' `|textlock|`.
 ---
 --- @type string
 vim.o.includeexpr = ""
@@ -3250,24 +3236,23 @@ vim.bo.inex = vim.bo.includeexpr
 --- still need to finish the search command with <Enter> to move the
 --- cursor to the match.
 --- You can use the CTRL-G and CTRL-T keys to move to the next and
---- previous match. `c_CTRL-G` `c_CTRL-T`
+--- previous match. `|c_CTRL-G|` `|c_CTRL-T|`
 --- Vim only searches for about half a second.  With a complicated
 --- pattern and/or a lot of text the match may not be found.  This is to
 --- avoid that Vim hangs while you are typing the pattern.
---- The `hl-IncSearch` highlight group determines the highlighting.
+--- The `|hl-IncSearch|` highlight group determines the highlighting.
 --- When 'hlsearch' is on, all matched strings are highlighted too while
 --- typing a search command. See also: 'hlsearch'.
 --- If you don't want to turn 'hlsearch' on, but want to highlight all
 --- matches while searching, you can turn on and off 'hlsearch' with
 --- autocmd.  Example:
 --- ```
---- 	augroup vimrc-incsearch-highlight
---- 	  autocmd!
---- 	  autocmd CmdlineEnter /,\? :set hlsearch
---- 	  autocmd CmdlineLeave /,\? :set nohlsearch
---- 	augroup END
+--- augroup vimrc-incsearch-highlight
+---   autocmd!
+---   autocmd CmdlineEnter /,\? :set hlsearch
+---   autocmd CmdlineLeave /,\? :set nohlsearch
+--- augroup END
 --- ```
----
 --- CTRL-L can be used to add one character from after the current match
 --- to the command line.  If 'ignorecase' and 'smartcase' are set and the
 --- command line has no uppercase characters, the added character is
@@ -3282,20 +3267,20 @@ vim.go.incsearch = vim.o.incsearch
 vim.go.is = vim.go.incsearch
 
 --- Expression which is evaluated to obtain the proper indent for a line.
---- It is used when a new line is created, for the `=` operator and
+--- It is used when a new line is created, for the `|=|` operator and
 --- in Insert mode as specified with the 'indentkeys' option.
 --- When this option is not empty, it overrules the 'cindent' and
 --- 'smartindent' indenting.  When 'lisp' is set, this option is
 --- is only used when 'lispoptions' contains "expr:1".
---- The expression is evaluated with `v:lnum` set to the line number for
+--- The expression is evaluated with `|v:lnum|` set to the line number for
 --- which the indent is to be computed.  The cursor is also in this line
 --- when the expression is evaluated (but it may be moved around).
 ---
---- If the expression starts with s: or `<SID>`, then it is replaced with
---- the script ID (`local-function`). Example:
+--- If the expression starts with s: or `|<SID>|`, then it is replaced with
+--- the script ID (`|local-function|`). Example:
 --- ```
---- 	set indentexpr=s:MyIndentExpr()
---- 	set indentexpr=<SID>SomeIndentExpr()
+--- set indentexpr=s:MyIndentExpr()
+--- set indentexpr=<SID>SomeIndentExpr()
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
@@ -3303,25 +3288,25 @@ vim.go.is = vim.go.incsearch
 --- The expression must return the number of spaces worth of indent.  It
 --- can return "-1" to keep the current indent (this means 'autoindent' is
 --- used for the indent).
---- Functions useful for computing the indent are `indent()`, `cindent()`
---- and `lispindent()`.
+--- Functions useful for computing the indent are `|indent()|`, `|cindent()|`
+--- and `|lispindent()|`.
 --- The evaluation of the expression must not have side effects!  It must
 --- not change the text, jump to another window, etc.  Afterwards the
 --- cursor position is always restored, thus the cursor may be moved.
 --- Normally this option would be set to call a function:
 --- ```
---- 	:set indentexpr=GetMyIndent()
+--- :set indentexpr=GetMyIndent()
 --- ```
 --- Error messages will be suppressed, unless the 'debug' option contains
 --- "msg".
---- See `indent-expression`.
+--- See `|indent-expression|`.
 ---
---- The expression will be evaluated in the `sandbox` when set from a
---- modeline, see `sandbox-option`.
+--- The expression will be evaluated in the `|sandbox|` when set from a
+--- modeline, see `|sandbox-option|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'indentexpr' `textlock`.
+--- evaluating 'indentexpr' `|textlock|`.
 ---
 --- @type string
 vim.o.indentexpr = ""
@@ -3331,8 +3316,8 @@ vim.bo.inde = vim.bo.indentexpr
 
 --- A list of keys that, when typed in Insert mode, cause reindenting of
 --- the current line.  Only happens if 'indentexpr' isn't empty.
---- The format is identical to 'cinkeys', see `indentkeys-format`.
---- See `C-indenting` and `indent-expression`.
+--- The format is identical to 'cinkeys', see `|indentkeys-format|`.
+--- See `|C-indenting|` and `|indent-expression|`.
 ---
 --- @type string
 vim.o.indentkeys = "0{,0},0),0],:,0#,!^F,o,O,e"
@@ -3340,7 +3325,7 @@ vim.o.indk = vim.o.indentkeys
 vim.bo.indentkeys = vim.o.indentkeys
 vim.bo.indk = vim.bo.indentkeys
 
---- When doing keyword completion in insert mode `ins-completion`, and
+--- When doing keyword completion in insert mode `|ins-completion|`, and
 --- 'ignorecase' is also on, the case of the match is adjusted depending
 --- on the typed text.  If the typed text contains a lowercase letter
 --- where the match has an upper case letter, the completed part is made
@@ -3357,7 +3342,7 @@ vim.bo.inf = vim.bo.infercase
 
 --- The characters specified by this option are included in file names and
 --- path names.  Filenames are used for commands like "gf", "[i" and in
---- the tags file.  It is also used for "\f" in a `pattern`.
+--- the tags file.  It is also used for "\f" in a `|pattern|`.
 --- Multi-byte characters 256 and above are always included, only the
 --- characters up to 255 are specified with this option.
 --- For UTF-8 the characters 0xa0 to 0xff are included as well.
@@ -3379,27 +3364,27 @@ vim.bo.inf = vim.bo.infercase
 --- character numbers with '-' in between.  A character number can be a
 --- decimal number between 0 and 255 or the ASCII character itself (does
 --- not work for digits).  Example:
---- 	"_,-,128-140,#-43"	(include '_' and '-' and the range
---- 				128 to 140 and '#' to 43)
+--- "_,-,128-140,#-43"  (include '_' and '-' and the range
+---       128 to 140 and '#' to 43)
 --- If a part starts with '^', the following character number or range
 --- will be excluded from the option.  The option is interpreted from left
 --- to right.  Put the excluded character after the range where it is
 --- included.  To include '^' itself use it as the last character of the
 --- option or the end of a range.  Example:
---- 	"^a-z,#,^"	(exclude 'a' to 'z', include '#' and '^')
+--- "^a-z,#,^"  (exclude 'a' to 'z', include '#' and '^')
 --- If the character is '@', all characters where isalpha() returns TRUE
 --- are included.  Normally these are the characters a to z and A to Z,
 --- plus accented characters.  To include '@' itself use "@-@".  Examples:
---- 	"@,^a-z"	All alphabetic characters, excluding lower
---- 			case ASCII letters.
---- 	"a-z,A-Z,@-@"	All letters plus the '@' character.
+--- "@,^a-z"  All alphabetic characters, excluding lower
+---     case ASCII letters.
+--- "a-z,A-Z,@-@"  All letters plus the '@' character.
 --- A comma can be included by using it where a character number is
 --- expected.  Example:
---- 	"48-57,,,_"	Digits, comma and underscore.
+--- "48-57,,,_"  Digits, comma and underscore.
 --- A comma can be excluded by prepending a '^'.  Example:
---- 	" -~,^,,9"	All characters from space to '~', excluding
---- 			comma, plus <Tab>.
---- See `option-backslash` about including spaces and backslashes.
+--- " -~,^,,9"  All characters from space to '~', excluding
+---     comma, plus <Tab>.
+--- See `|option-backslash|` about including spaces and backslashes.
 ---
 --- @type string
 vim.o.isfname = "@,48-57,/,.,-,_,+,,,#,$,%,~,="
@@ -3410,7 +3395,7 @@ vim.go.isf = vim.go.isfname
 --- The characters given by this option are included in identifiers.
 --- Identifiers are used in recognizing environment variables and after a
 --- match of the 'define' option.  It is also used for "\i" in a
---- `pattern`.  See 'isfname' for a description of the format of this
+--- `|pattern|`.  See 'isfname' for a description of the format of this
 --- option.  For '@' only characters up to 255 are used.
 --- Careful: If you change this option, it might break expanding
 --- environment variables.  E.g., when '/' is included and Vim tries to
@@ -3424,7 +3409,7 @@ vim.go.isident = vim.o.isident
 vim.go.isi = vim.go.isident
 
 --- Keywords are used in searching and recognizing with many commands:
---- "w", "*", "[i", etc.  It is also used for "\k" in a `pattern`.  See
+--- "w", "*", "[i", etc.  It is also used for "\k" in a `|pattern|`.  See
 --- 'isfname' for a description of the format of this option.  For '@'
 --- characters above 255 check the "word" character class (any character
 --- that is not white space or punctuation).
@@ -3434,7 +3419,7 @@ vim.go.isi = vim.go.isident
 --- command).
 --- When the 'lisp' option is on the '-' character is always included.
 --- This option also influences syntax highlighting, unless the syntax
---- uses `:syn-iskeyword`.
+--- uses `|:syn-iskeyword|`.
 ---
 --- @type string
 vim.o.iskeyword = "@,48-57,_,192-255"
@@ -3443,24 +3428,24 @@ vim.bo.iskeyword = vim.o.iskeyword
 vim.bo.isk = vim.bo.iskeyword
 
 --- The characters given by this option are displayed directly on the
---- screen.  It is also used for "\p" in a `pattern`.  The characters from
+--- screen.  It is also used for "\p" in a `|pattern|`.  The characters from
 --- space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
 --- even when they are not included in 'isprint' or excluded.  See
 --- 'isfname' for a description of the format of this option.
 ---
 --- Non-printable characters are displayed with two characters:
---- 	  0 -  31	"^@" - "^_"
---- 	 32 - 126	always single characters
---- 	   127		"^?"
---- 	128 - 159	"~@" - "~_"
---- 	160 - 254	"| " - "|~"
---- 	   255		"~?"
+---   0 -  31  "^@" - "^_"
+---  32 - 126  always single characters
+---    127    "^?"
+--- 128 - 159  "~@" - "~_"
+--- 160 - 254  "| " - "|~"
+---    255    "~?"
 --- Illegal bytes from 128 to 255 (invalid UTF-8) are
 --- displayed as <xx>, with the hexadecimal value of the byte.
 --- When 'display' contains "uhex" all unprintable characters are
 --- displayed as <xx>.
 --- The SpecialKey highlighting will be used for unprintable characters.
---- `hl-SpecialKey`
+--- `|hl-SpecialKey|`
 ---
 --- Multi-byte characters 256 and above are always included, only the
 --- characters up to 255 are specified with this option.  When a character
@@ -3484,16 +3469,16 @@ vim.o.js = vim.o.joinspaces
 vim.go.joinspaces = vim.o.joinspaces
 vim.go.js = vim.go.joinspaces
 
---- List of words that change the behavior of the `jumplist`.
----   stack         Make the jumplist behave like the tagstack.
---- 		Relative location of entries in the jumplist is
---- 		preserved at the cost of discarding subsequent entries
---- 		when navigating backwards in the jumplist and then
---- 		jumping to a location.  `jumplist-stack`
+--- List of words that change the behavior of the `|jumplist|`.
+--- stack         Make the jumplist behave like the tagstack.
+---   Relative location of entries in the jumplist is
+---   preserved at the cost of discarding subsequent entries
+---   when navigating backwards in the jumplist and then
+---   jumping to a location.  `|jumplist-stack|`
 ---
----   view          When moving through the jumplist, `changelist|,
---- 		|alternate-file` or using `mark-motions` try to
---- 		restore the `mark-view` in which the action occurred.
+--- view          When moving through the jumplist, `|changelist|`,
+---   `|alternate-file|` or using `|mark-motions|` try to
+---   restore the `|mark-view|` in which the action occurred.
 ---
 --- @type string
 vim.o.jumpoptions = ""
@@ -3501,7 +3486,7 @@ vim.o.jop = vim.o.jumpoptions
 vim.go.jumpoptions = vim.o.jumpoptions
 vim.go.jop = vim.go.jumpoptions
 
---- Name of a keyboard mapping.  See `mbyte-keymap`.
+--- Name of a keyboard mapping.  See `|mbyte-keymap|`.
 --- Setting this option to a valid keymap name has the side effect of
 --- setting 'iminsert' to one, so that the keymap becomes effective.
 --- 'imsearch' is also set to one, unless it was -1
@@ -3515,10 +3500,10 @@ vim.bo.kmp = vim.bo.keymap
 
 --- List of comma-separated words, which enable special things that keys
 --- can do.  These values can be used:
----    startsel	Using a shifted special key starts selection (either
---- 		Select mode or Visual mode, depending on "key" being
---- 		present in 'selectmode').
----    stopsel	Using a not-shifted special key stops selection.
+---  startsel  Using a shifted special key starts selection (either
+---   Select mode or Visual mode, depending on "key" being
+---   present in 'selectmode').
+---  stopsel  Using a not-shifted special key stops selection.
 --- Special keys in this context are the cursor keys, <End>, <Home>,
 --- <PageUp> and <PageDown>.
 ---
@@ -3528,21 +3513,21 @@ vim.o.km = vim.o.keymodel
 vim.go.keymodel = vim.o.keymodel
 vim.go.km = vim.go.keymodel
 
---- Program to use for the `K` command.  Environment variables are
---- expanded `:set_env`.  ":help" may be used to access the Vim internal
+--- Program to use for the `|K|` command.  Environment variables are
+--- expanded `|:set_env|`.  ":help" may be used to access the Vim internal
 --- help.  (Note that previously setting the global option to the empty
 --- value did this, which is now deprecated.)
 --- When the first character is ":", the command is invoked as a Vim
 --- Ex command prefixed with [count].
 --- When "man" or "man -s" is used, Vim will automatically translate
 --- a [count] for the "K" command to a section number.
---- See `option-backslash` about including spaces and backslashes.
+--- See `|option-backslash|` about including spaces and backslashes.
 --- Example:
 --- ```
---- 	:set keywordprg=man\ -s
---- 	:set keywordprg=:Man
+--- :set keywordprg=man\ -s
+--- :set keywordprg=:Man
 --- ```
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -3563,24 +3548,23 @@ vim.go.kp = vim.go.keywordprg
 --- mapped in Insert mode.
 --- Also consider setting 'langremap' to off, to prevent 'langmap' from
 --- applying to characters resulting from a mapping.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
---- Example (for Greek, in UTF-8):				*greek*
+--- Example (for Greek, in UTF-8):        *greek*
 --- ```
----     :set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
+--- :set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
 --- ```
 --- Example (exchanges meaning of z and y for commands):
 --- ```
----     :set langmap=zy,yz,ZY,YZ
+--- :set langmap=zy,yz,ZY,YZ
 --- ```
----
 --- The 'langmap' option is a list of parts, separated with commas.  Each
 --- part can be in one of two forms:
 --- 1.  A list of pairs.  Each pair is a "from" character immediately
----     followed by the "to" character.  Examples: "aA", "aAbBcC".
+--- followed by the "to" character.  Examples: "aA", "aAbBcC".
 --- 2.  A list of "from" characters, a semi-colon and a list of "to"
----     characters.  Example: "abc;ABC"
+--- characters.  Example: "abc;ABC"
 --- Example: "aA,fgh;FGH,cCdDeE"
 --- Special characters need to be preceded with a backslash.  These are
 --- ";", ',', '"', '|' and backslash itself.
@@ -3606,27 +3590,27 @@ vim.go.lmap = vim.go.langmap
 --- Language to use for menu translation.  Tells which file is loaded
 --- from the "lang" directory in 'runtimepath':
 --- ```
---- 	"lang/menu_" .. &langmenu .. ".vim"
+--- "lang/menu_" .. &langmenu .. ".vim"
 --- ```
 --- (without the spaces).  For example, to always use the Dutch menus, no
 --- matter what $LANG is set to:
 --- ```
---- 	:set langmenu=nl_NL.ISO_8859-1
+--- :set langmenu=nl_NL.ISO_8859-1
 --- ```
---- When 'langmenu' is empty, `v:lang` is used.
+--- When 'langmenu' is empty, `|v:lang|` is used.
 --- Only normal file name characters can be used, `/\*?[|<>` are illegal.
 --- If your $LANG is set to a non-English language but you do want to use
 --- the English menus:
 --- ```
---- 	:set langmenu=none
+--- :set langmenu=none
 --- ```
 --- This option must be set before loading menus, switching on filetype
 --- detection or syntax highlighting.  Once the menus are defined setting
 --- this option has no effect.  But you could do this:
 --- ```
---- 	:source $VIMRUNTIME/delmenu.vim
---- 	:set langmenu=de_DE.ISO_8859-1
---- 	:source $VIMRUNTIME/menu.vim
+--- :source $VIMRUNTIME/delmenu.vim
+--- :set langmenu=de_DE.ISO_8859-1
+--- :source $VIMRUNTIME/menu.vim
 --- ```
 --- Warning: This deletes all menus that you defined yourself!
 ---
@@ -3648,12 +3632,12 @@ vim.go.lrm = vim.go.langremap
 
 --- The value of this option influences when the last window will have a
 --- status line:
---- 	0: never
---- 	1: only if there are at least two windows
---- 	2: always
---- 	3: always and ONLY the last window
+--- 0: never
+--- 1: only if there are at least two windows
+--- 2: always
+--- 3: always and ONLY the last window
 --- The screen looks nicer with a status line if you have several
---- windows, but it takes another screen line. `status-line`
+--- windows, but it takes another screen line. `|status-line|`
 ---
 --- @type integer
 vim.o.laststatus = 2
@@ -3664,7 +3648,7 @@ vim.go.ls = vim.go.laststatus
 --- When this option is set, the screen will not be redrawn while
 --- executing macros, registers and other commands that have not been
 --- typed.  Also, updating the window title is postponed.  To force an
---- update use `:redraw`.
+--- update use `|:redraw|`.
 --- This may occasionally cause display errors.  It is only meant to be set
 --- temporarily when performing an operation where redrawing may cause
 --- flickering or cause a slow down.
@@ -3696,11 +3680,11 @@ vim.wo.lbr = vim.wo.linebreak
 --- terminal initialization code.
 --- When Vim is running in the GUI or in a resizable window, setting this
 --- option will cause the window size to be changed.  When you only want
---- to use the size for the GUI, put the command in your `gvimrc` file.
+--- to use the size for the GUI, put the command in your `|gvimrc|` file.
 --- Vim limits the number of lines to what fits on the screen.  You can
 --- use this command to get the tallest window possible:
 --- ```
---- 	:set lines=999
+--- :set lines=999
 --- ```
 --- Minimum value is 2, maximum value is 1000.
 ---
@@ -3708,7 +3692,7 @@ vim.wo.lbr = vim.wo.linebreak
 vim.o.lines = 24
 vim.go.lines = vim.o.lines
 
---- 		only in the GUI
+--- only in the GUI
 --- Number of pixel lines inserted between characters.  Useful if the font
 --- uses the full character cell height, making lines touch each other.
 --- When non-zero there is room for underlining.
@@ -3737,10 +3721,10 @@ vim.o.lisp = false
 vim.bo.lisp = vim.o.lisp
 
 --- Comma-separated list of items that influence the Lisp indenting when
---- enabled with the `'lisp'` option.  Currently only one item is
+--- enabled with the `|'lisp'|` option.  Currently only one item is
 --- supported:
---- 	expr:1	use 'indentexpr' for Lisp indenting when it is set
---- 	expr:0	do not use 'indentexpr' for Lisp indenting (default)
+--- expr:1  use 'indentexpr' for Lisp indenting when it is set
+--- expr:0  do not use 'indentexpr' for Lisp indenting (default)
 --- Note that when using 'indentexpr' the `=` operator indents all the
 --- lines, otherwise the first line is not indented (Vi-compatible).
 ---
@@ -3751,7 +3735,7 @@ vim.bo.lispoptions = vim.o.lispoptions
 vim.bo.lop = vim.bo.lispoptions
 
 --- Comma-separated list of words that influence the Lisp indenting when
---- enabled with the `'lisp'` option.
+--- enabled with the `|'lisp'|` option.
 ---
 --- @type string
 vim.o.lispwords = "defun,define,defmacro,set!,lambda,if,case,let,flet,let*,letrec,do,do*,define-syntax,let-syntax,letrec-syntax,destructuring-bind,defpackage,defparameter,defstruct,deftype,defvar,do-all-symbols,do-external-symbols,do-symbols,dolist,dotimes,ecase,etypecase,eval-when,labels,macrolet,multiple-value-bind,multiple-value-call,multiple-value-prog1,multiple-value-setq,prog1,progv,typecase,unless,unwind-protect,when,with-input-from-string,with-open-file,with-open-stream,with-output-to-string,with-package-iterator,define-condition,handler-bind,handler-case,restart-bind,restart-case,with-simple-restart,store-value,use-value,muffle-warning,abort,continue,with-slots,with-slots*,with-accessors,with-accessors*,defclass,defmethod,print-unreadable-object"
@@ -3770,9 +3754,8 @@ vim.go.lw = vim.go.lispwords
 --- occupies, not at the end as usual in Normal mode.  To get this cursor
 --- position while displaying Tabs with spaces, use:
 --- ```
---- 	:set list lcs=tab:\ \
+--- :set list lcs=tab:\ \
 --- ```
----
 --- Note that list mode will also affect formatting (set with 'textwidth'
 --- or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
 --- changing the way tabs are displayed.
@@ -3781,117 +3764,115 @@ vim.go.lw = vim.go.lispwords
 vim.o.list = false
 vim.wo.list = vim.o.list
 
---- Strings to use in 'list' mode and for the `:list` command.  It is a
+--- Strings to use in 'list' mode and for the `|:list|` command.  It is a
 --- comma-separated list of string settings.
 ---
---- 						*lcs-eol*
----   eol:c		Character to show at the end of each line.  When
---- 		omitted, there is no extra character at the end of the
---- 		line.
---- 						*lcs-tab*
----   tab:xy[z]	Two or three characters to be used to show a tab.
---- 		The third character is optional.
+---           *lcs-eol*
+--- eol:c    Character to show at the end of each line.  When
+---   omitted, there is no extra character at the end of the
+---   line.
+---           *lcs-tab*
+--- tab:xy[z]  Two or three characters to be used to show a tab.
+---   The third character is optional.
 ---
----   tab:xy	The 'x' is always used, then 'y' as many times as will
---- 		fit.  Thus "tab:>-" displays:
+--- tab:xy  The 'x' is always used, then 'y' as many times as will
+---   fit.  Thus "tab:>-" displays:
 --- ```
----
+---     >
+---     >-
+---     >--
+---     etc.
 --- ```
---- 			>-
---- 			>--
---- 			etc.
+--- tab:xyz  The 'z' is always used, then 'x' is prepended, and
+---   then 'y' is used as many times as will fit.  Thus
+---   "tab:<->" displays:
 --- ```
----
----   tab:xyz	The 'z' is always used, then 'x' is prepended, and
---- 		then 'y' is used as many times as will fit.  Thus
---- 		"tab:<->" displays:
+---     >
 --- ```
----
 --- ```
---- 			<>
---- 			<->
---- 			<-->
---- 			etc.
 --- ```
----
---- 		When "tab:" is omitted, a tab is shown as ^I.
---- 						*lcs-space*
----   space:c	Character to show for a space.  When omitted, spaces
---- 		are left blank.
---- 						*lcs-multispace*
----   multispace:c...
---- 		One or more characters to use cyclically to show for
---- 		multiple consecutive spaces.  Overrides the "space"
---- 		setting, except for single spaces.  When omitted, the
---- 		"space" setting is used.  For example,
---- 		`:set listchars=multispace:---+` shows ten consecutive
---- 		spaces as:
+--- -
 --- ```
---- 			---+---+--
 --- ```
----
---- 						*lcs-lead*
----   lead:c	Character to show for leading spaces.  When omitted,
---- 		leading spaces are blank.  Overrides the "space" and
---- 		"multispace" settings for leading spaces.  You can
---- 		combine it with "tab:", for example:
+--- --
 --- ```
---- 			:set listchars+=tab:>-,lead:.
+---     etc.
 --- ```
----
---- 						*lcs-leadmultispace*
----   leadmultispace:c...
---- 		Like the `lcs-multispace` value, but for leading
---- 		spaces only.  Also overrides `lcs-lead` for leading
---- 		multiple spaces.
---- 		`:set listchars=leadmultispace:---+` shows ten
---- 		consecutive leading spaces as:
+---   When "tab:" is omitted, a tab is shown as ^I.
+---           *lcs-space*
+--- space:c  Character to show for a space.  When omitted, spaces
+---   are left blank.
+---           *lcs-multispace*
+--- multispace:c...
+---   One or more characters to use cyclically to show for
+---   multiple consecutive spaces.  Overrides the "space"
+---   setting, except for single spaces.  When omitted, the
+---   "space" setting is used.  For example,
+---   `:set listchars=multispace:---+` shows ten consecutive
+---   spaces as:
 --- ```
---- 			---+---+--XXX
+---     ---+---+--
 --- ```
----
---- 		Where "XXX" denotes the first non-blank characters in
---- 		the line.
---- 						*lcs-trail*
----   trail:c	Character to show for trailing spaces.  When omitted,
---- 		trailing spaces are blank.  Overrides the "space" and
---- 		"multispace" settings for trailing spaces.
---- 						*lcs-extends*
----   extends:c	Character to show in the last column, when 'wrap' is
---- 		off and the line continues beyond the right of the
---- 		screen.
---- 						*lcs-precedes*
----   precedes:c	Character to show in the first visible column of the
---- 		physical line, when there is text preceding the
---- 		character visible in the first column.
---- 						*lcs-conceal*
----   conceal:c	Character to show in place of concealed text, when
---- 		'conceallevel' is set to 1.  A space when omitted.
---- 						*lcs-nbsp*
----   nbsp:c	Character to show for a non-breakable space character
---- 		(0xA0 (160 decimal) and U+202F).  Left blank when
---- 		omitted.
+---           *lcs-lead*
+--- lead:c  Character to show for leading spaces.  When omitted,
+---   leading spaces are blank.  Overrides the "space" and
+---   "multispace" settings for leading spaces.  You can
+---   combine it with "tab:", for example:
+--- ```
+---     :set listchars+=tab:>-,lead:.
+--- ```
+---           *lcs-leadmultispace*
+--- leadmultispace:c...
+---   Like the `|lcs-multispace|` value, but for leading
+---   spaces only.  Also overrides `|lcs-lead|` for leading
+---   multiple spaces.
+---   `:set listchars=leadmultispace:---+` shows ten
+---   consecutive leading spaces as:
+--- ```
+---     ---+---+--XXX
+--- ```
+---   Where "XXX" denotes the first non-blank characters in
+---   the line.
+---           *lcs-trail*
+--- trail:c  Character to show for trailing spaces.  When omitted,
+---   trailing spaces are blank.  Overrides the "space" and
+---   "multispace" settings for trailing spaces.
+---           *lcs-extends*
+--- extends:c  Character to show in the last column, when 'wrap' is
+---   off and the line continues beyond the right of the
+---   screen.
+---           *lcs-precedes*
+--- precedes:c  Character to show in the first visible column of the
+---   physical line, when there is text preceding the
+---   character visible in the first column.
+---           *lcs-conceal*
+--- conceal:c  Character to show in place of concealed text, when
+---   'conceallevel' is set to 1.  A space when omitted.
+---           *lcs-nbsp*
+--- nbsp:c  Character to show for a non-breakable space character
+---   (0xA0 (160 decimal) and U+202F).  Left blank when
+---   omitted.
 ---
 --- The characters ':' and ',' should not be used.  UTF-8 characters can
 --- be used.  All characters must be single width.
 ---
 --- Each character can be specified as hex:
 --- ```
---- 	set listchars=eol:\\x24
---- 	set listchars=eol:\\u21b5
---- 	set listchars=eol:\\U000021b5
+--- set listchars=eol:\\x24
+--- set listchars=eol:\\u21b5
+--- set listchars=eol:\\U000021b5
 --- ```
 --- Note that a double backslash is used.  The number of hex characters
 --- must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
 ---
 --- Examples:
 --- ```
----     :set lcs=tab:>-,trail:-
----     :set lcs=tab:>-,eol:<,nbsp:%
----     :set lcs=extends:>,precedes:<
+---   :set lcs=tab:>-,trail:-
+---   :set lcs=tab:>-,eol:<,nbsp:%
+---   :set lcs=extends:>,precedes:<
 --- ```
---- `hl-NonText` highlighting will be used for "eol", "extends" and
---- "precedes". `hl-Whitespace` for "nbsp", "space", "tab", "multispace",
+--- `|hl-NonText|` highlighting will be used for "eol", "extends" and
+--- "precedes". `|hl-Whitespace|` for "nbsp", "space", "tab", "multispace",
 --- "lead" and "trail".
 ---
 --- @type string
@@ -3902,11 +3883,11 @@ vim.wo.lcs = vim.wo.listchars
 vim.go.listchars = vim.o.listchars
 vim.go.lcs = vim.go.listchars
 
---- When on the plugin scripts are loaded when starting up `load-plugins`.
---- This option can be reset in your `vimrc` file to disable the loading
+--- When on the plugin scripts are loaded when starting up `|load-plugins|`.
+--- This option can be reset in your `|vimrc|` file to disable the loading
 --- of plugins.
 --- Note that using the "-u NONE" and "--noplugin" command line arguments
---- reset this option. `-u` `--noplugin`
+--- reset this option. `|-u|` `|--noplugin|`
 ---
 --- @type boolean
 vim.o.loadplugins = true
@@ -3915,27 +3896,27 @@ vim.go.loadplugins = vim.o.loadplugins
 vim.go.lpl = vim.go.loadplugins
 
 --- Changes the special characters that can be used in search patterns.
---- See `pattern`.
+--- See `|pattern|`.
 --- WARNING: Switching this option off most likely breaks plugins!  That
 --- is because many patterns assume it's on and will fail when it's off.
 --- Only switch it off when working with old Vi scripts.  In any other
 --- situation write patterns that work when 'magic' is on.  Include "\M"
---- when you want to `/\M`.
+--- when you want to `|/\M|`.
 ---
 --- @type boolean
 vim.o.magic = true
 vim.go.magic = vim.o.magic
 
---- Name of the errorfile for the `:make` command (see `:make_makeprg`)
---- and the `:grep` command.
+--- Name of the errorfile for the `|:make|` command (see `|:make_makeprg|`)
+--- and the `|:grep|` command.
 --- When it is empty, an internally generated temp file will be used.
 --- When "##" is included, it is replaced by a number to make the name
 --- unique.  This makes sure that the ":make" command doesn't overwrite an
 --- existing file.
 --- NOT used for the ":cf" command.  See 'errorfile' for that.
---- Environment variables are expanded `:set_env`.
---- See `option-backslash` about including spaces and backslashes.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- Environment variables are expanded `|:set_env|`.
+--- See `|option-backslash|` about including spaces and backslashes.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -3954,9 +3935,8 @@ vim.go.mef = vim.go.makeef
 --- enabled, setting 'makeencoding' to "char" has the same effect as
 --- setting to the system locale encoding.  Example:
 --- ```
---- 	:set makeencoding=char	" system locale is used
+--- :set makeencoding=char  " system locale is used
 --- ```
----
 ---
 --- @type string
 vim.o.makeencoding = ""
@@ -3966,24 +3946,24 @@ vim.bo.menc = vim.bo.makeencoding
 vim.go.makeencoding = vim.o.makeencoding
 vim.go.menc = vim.go.makeencoding
 
---- Program to use for the ":make" command.  See `:make_makeprg`.
---- This option may contain '%' and '#' characters (see  `:_%` and `:_#`),
---- which are expanded to the current and alternate file name.  Use `::S`
+--- Program to use for the ":make" command.  See `|:make_makeprg|`.
+--- This option may contain '%' and '#' characters (see  `|:_%|` and `|:_#|`),
+--- which are expanded to the current and alternate file name.  Use `|::S|`
 --- to escape file names in case they contain special characters.
---- Environment variables are expanded `:set_env`.  See `option-backslash`
+--- Environment variables are expanded `|:set_env|`.  See `|option-backslash|`
 --- about including spaces and backslashes.
 --- Note that a '|' must be escaped twice: once for ":set" and once for
 --- the interpretation of a command.  When you use a filter called
 --- "myfilter" do it like this:
 --- ```
----     :set makeprg=gmake\ \\\|\ myfilter
+--- :set makeprg=gmake\ \\\|\ myfilter
 --- ```
 --- The placeholder "$*" can be given (even multiple times) to specify
 --- where the arguments will be included, for example:
 --- ```
----     :set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
+--- :set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
 --- ```
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -3994,7 +3974,7 @@ vim.bo.mp = vim.bo.makeprg
 vim.go.makeprg = vim.o.makeprg
 vim.go.mp = vim.go.makeprg
 
---- Characters that form pairs.  The `%` command jumps from one to the
+--- Characters that form pairs.  The `|%|` command jumps from one to the
 --- other.
 --- Only character pairs are allowed that are different, thus you cannot
 --- jump between two double quotes.
@@ -4002,15 +3982,15 @@ vim.go.mp = vim.go.makeprg
 --- The pairs must be separated by a comma.  Example for including '<' and
 --- '>' (for HTML):
 --- ```
---- 	:set mps+=<:>
+--- :set mps+=<:>
 --- ```
 --- A more exotic example, to jump between the '=' and ';' in an
 --- assignment, useful for languages like C and Java:
 --- ```
---- 	:au FileType c,cpp,java set mps+==:;
+--- :au FileType c,cpp,java set mps+==:;
 --- ```
 --- For a more advanced way of using "%", see the matchit.vim plugin in
---- the $VIMRUNTIME/plugin directory. `add-local-help`
+--- the $VIMRUNTIME/plugin directory. `|add-local-help|`
 ---
 --- @type string
 vim.o.matchpairs = "(:),{:},[:]"
@@ -4033,8 +4013,8 @@ vim.go.mat = vim.go.matchtime
 --- more depth, set 'maxfuncdepth' to a bigger number.  But this will use
 --- more memory, there is the danger of failing when memory is exhausted.
 --- Increasing this limit above 200 also changes the maximum for Ex
---- command recursion, see `E169`.
---- See also `:function`.
+--- command recursion, see `|E169|`.
+--- See also `|:function|`.
 --- Also used for maximum depth of callback functions.
 ---
 --- @type integer
@@ -4047,7 +4027,7 @@ vim.go.mfd = vim.go.maxfuncdepth
 --- character to be used.  This normally catches endless mappings, like
 --- ":map x y" with ":map y x".  It still does not catch ":map g wg",
 --- because the 'w' is used before the next mapping is done.  See also
---- `key-mapping`.
+--- `|key-mapping|`.
 ---
 --- @type integer
 vim.o.maxmapdepth = 1000
@@ -4057,7 +4037,7 @@ vim.go.mmd = vim.go.maxmapdepth
 
 --- Maximum amount of memory (in Kbyte) to use for pattern matching.
 --- The maximum value is about 2000000.  Use this to work without a limit.
---- 						*E363*
+--- *E363*
 --- When Vim runs into the limit it gives an error message and mostly
 --- behaves like CTRL-C was typed.
 --- Running into the limit often means that the pattern is very
@@ -4084,7 +4064,7 @@ vim.o.mis = vim.o.menuitems
 vim.go.menuitems = vim.o.menuitems
 vim.go.mis = vim.go.menuitems
 
---- Parameters for `:mkspell`.  This tunes when to start compressing the
+--- Parameters for `|:mkspell|`.  This tunes when to start compressing the
 --- word tree.  Compression can be slow when there are many words, but
 --- it's needed to avoid running out of memory.  The amount of memory used
 --- per word depends very much on how similar the words are, that's why
@@ -4092,9 +4072,8 @@ vim.go.mis = vim.go.menuitems
 ---
 --- There are three numbers, separated by commas:
 --- ```
---- 	{start},{inc},{added}
+--- {start},{inc},{added}
 --- ```
----
 --- For most languages the uncompressed word tree fits in memory.  {start}
 --- gives the amount of memory in Kbyte that can be used before any
 --- compression is done.  It should be a bit smaller than the amount of
@@ -4116,12 +4095,12 @@ vim.go.mis = vim.go.menuitems
 --- Hungarian.  The default works for when you have about 512 Mbyte.  If
 --- you have 1 Gbyte you could use:
 --- ```
---- 	:set mkspellmem=900000,3000,800
+--- :set mkspellmem=900000,3000,800
 --- ```
---- If you have less than 512 Mbyte `:mkspell` may fail for some
+--- If you have less than 512 Mbyte `|:mkspell|` may fail for some
 --- languages, no matter what you set 'mkspellmem' to.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`.
 ---
 --- @type string
 vim.o.mkspellmem = "460000,2000,500"
@@ -4131,7 +4110,7 @@ vim.go.msm = vim.go.mkspellmem
 
 --- If 'modeline' is on 'modelines' gives the number of lines that is
 --- checked for set commands.  If 'modeline' is off or 'modelines' is zero
---- no lines are checked.  See `modeline`.
+--- no lines are checked.  See `|modeline|`.
 ---
 --- @type boolean
 vim.o.modeline = true
@@ -4141,8 +4120,8 @@ vim.bo.ml = vim.bo.modeline
 
 --- When on allow some options that are an expression to be set in the
 --- modeline.  Check the option for whether it is affected by
---- 'modelineexpr'.  Also see `modeline`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- 'modelineexpr'.  Also see `|modeline|`.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type boolean
@@ -4153,7 +4132,7 @@ vim.go.mle = vim.go.modelineexpr
 
 --- If 'modeline' is on 'modelines' gives the number of lines that is
 --- checked for set commands.  If 'modeline' is off or 'modelines' is zero
---- no lines are checked.  See `modeline`.
+--- no lines are checked.  See `|modeline|`.
 ---
 ---
 --- @type integer
@@ -4164,7 +4143,7 @@ vim.go.mls = vim.go.modelines
 
 --- When off the buffer contents cannot be changed.  The 'fileformat' and
 --- 'fileencoding' options also can't be changed.
---- Can be reset on startup with the `-M` command line argument.
+--- Can be reset on startup with the `|-M|` command line argument.
 ---
 --- @type boolean
 vim.o.modifiable = true
@@ -4175,19 +4154,19 @@ vim.bo.ma = vim.bo.modifiable
 --- When on, the buffer is considered to be modified.  This option is set
 --- when:
 --- 1. A change was made to the text since it was last written.  Using the
----    `undo` command to go back to the original text will reset the
----    option.  But undoing changes that were made before writing the
----    buffer will set the option again, since the text is different from
----    when it was written.
+---  `|undo|` command to go back to the original text will reset the
+---  option.  But undoing changes that were made before writing the
+---  buffer will set the option again, since the text is different from
+---  when it was written.
 --- 2. 'fileformat' or 'fileencoding' is different from its original
----    value.  The original value is set when the buffer is read or
----    written.  A ":set nomodified" command also resets the original
----    values to the current values and the 'modified' option will be
----    reset.
----    Similarly for 'eol' and 'bomb'.
+---  value.  The original value is set when the buffer is read or
+---  written.  A ":set nomodified" command also resets the original
+---  values to the current values and the 'modified' option will be
+---  reset.
+---  Similarly for 'eol' and 'bomb'.
 --- This option is not set when a change is made to the buffer as the
 --- result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
---- FileAppendPost or VimLeave autocommand event.  See `gzip-example` for
+--- FileAppendPost or VimLeave autocommand event.  See `|gzip-example|` for
 --- an explanation.
 --- When 'buftype' is "nowrite" or "nofile" this option may be set, but
 --- will be ignored.
@@ -4201,7 +4180,7 @@ vim.bo.modified = vim.o.modified
 vim.bo.mod = vim.bo.modified
 
 --- When on, listings pause when the whole screen is filled.  You will get
---- the `more-prompt`.  When this option is off there are no pauses, the
+--- the `|more-prompt|`.  When this option is off there are no pauses, the
 --- listing continues until finished.
 ---
 --- @type boolean
@@ -4211,41 +4190,40 @@ vim.go.more = vim.o.more
 --- Enables mouse support. For example, to enable the mouse in Normal mode
 --- and Visual mode:
 --- ```
---- 	:set mouse=nv
+--- :set mouse=nv
 --- ```
----
 --- To temporarily disable mouse support, hold the shift key while using
 --- the mouse.
 ---
 --- Mouse support can be enabled for different modes:
---- 	n	Normal mode
---- 	v	Visual mode
---- 	i	Insert mode
---- 	c	Command-line mode
---- 	h	all previous modes when editing a help file
---- 	a	all previous modes
---- 	r	for `hit-enter` and `more-prompt` prompt
+--- n  Normal mode
+--- v  Visual mode
+--- i  Insert mode
+--- c  Command-line mode
+--- h  all previous modes when editing a help file
+--- a  all previous modes
+--- r  for `|hit-enter|` and `|more-prompt|` prompt
 ---
 --- Left-click anywhere in a text buffer to place the cursor there.  This
---- works with operators too, e.g. type `d` then left-click to delete text
+--- works with operators too, e.g. type `|d|` then left-click to delete text
 --- from the current cursor position to the position where you clicked.
 ---
---- Drag the `status-line` or vertical separator of a window to resize it.
+--- Drag the `|status-line|` or vertical separator of a window to resize it.
 ---
 --- If enabled for "v" (Visual mode) then double-click selects word-wise,
 --- triple-click makes it line-wise, and quadruple-click makes it
 --- rectangular block-wise.
 ---
---- For scrolling with a mouse wheel see `scroll-mouse-wheel`.
+--- For scrolling with a mouse wheel see `|scroll-mouse-wheel|`.
 ---
 --- Note: When enabling the mouse in a terminal, copy/paste will use the
 --- "* register if possible. See also 'clipboard'.
 ---
 --- Related options:
---- 'mousefocus'	window focus follows mouse pointer
---- 'mousemodel'	what mouse button does which action
---- 'mousehide'	hide mouse pointer while typing text
---- 'selectmode'	whether to start Select mode or Visual mode
+--- 'mousefocus'  window focus follows mouse pointer
+--- 'mousemodel'  what mouse button does which action
+--- 'mousehide'  hide mouse pointer while typing text
+--- 'selectmode'  whether to start Select mode or Visual mode
 ---
 --- @type string
 vim.o.mouse = "nvi"
@@ -4263,7 +4241,7 @@ vim.o.mousef = vim.o.mousefocus
 vim.go.mousefocus = vim.o.mousefocus
 vim.go.mousef = vim.go.mousefocus
 
---- 		only in the GUI
+--- only in the GUI
 --- When on, the mouse pointer is hidden when characters are typed.
 --- The mouse pointer is restored when the mouse is moved.
 ---
@@ -4275,53 +4253,52 @@ vim.go.mh = vim.go.mousehide
 
 --- Sets the model to use for the mouse.  The name mostly specifies what
 --- the right mouse button is used for:
----    extend	Right mouse button extends a selection.  This works
---- 		like in an xterm.
----    popup	Right mouse button pops up a menu.  The shifted left
---- 		mouse button extends a selection.  This works like
---- 		with Microsoft Windows.
----    popup_setpos Like "popup", but the cursor will be moved to the
---- 		position where the mouse was clicked, and thus the
---- 		selected operation will act upon the clicked object.
---- 		If clicking inside a selection, that selection will
---- 		be acted upon, i.e. no cursor move.  This implies of
---- 		course, that right clicking outside a selection will
---- 		end Visual mode.
+---  extend  Right mouse button extends a selection.  This works
+---   like in an xterm.
+---  popup  Right mouse button pops up a menu.  The shifted left
+---   mouse button extends a selection.  This works like
+---   with Microsoft Windows.
+---  popup_setpos Like "popup", but the cursor will be moved to the
+---   position where the mouse was clicked, and thus the
+---   selected operation will act upon the clicked object.
+---   If clicking inside a selection, that selection will
+---   be acted upon, i.e. no cursor move.  This implies of
+---   course, that right clicking outside a selection will
+---   end Visual mode.
 --- Overview of what button does what for each model:
---- mouse		    extend		popup(_setpos) ~
---- left click	    place cursor	place cursor
---- left drag	    start selection	start selection
---- shift-left	    search word		extend selection
---- right click	    extend selection	popup menu (place cursor)
---- right drag	    extend selection	-
---- middle click	    paste		paste
+--- mouse        extend    popup(_setpos) ~
+--- left click      place cursor  place cursor
+--- left drag      start selection  start selection
+--- shift-left      search word    extend selection
+--- right click      extend selection  popup menu (place cursor)
+--- right drag      extend selection  -
+--- middle click      paste    paste
 ---
 --- In the "popup" model the right mouse button produces a pop-up menu.
---- Nvim creates a default `popup-menu` but you can redefine it.
+--- Nvim creates a default `|popup-menu|` but you can redefine it.
 ---
 --- Note that you can further refine the meaning of buttons with mappings.
---- See `mouse-overview`.  But mappings are NOT used for modeless selection.
+--- See `|mouse-overview|`.  But mappings are NOT used for modeless selection.
 ---
 --- Example:
 --- ```
----    :map <S-LeftMouse>     <RightMouse>
----    :map <S-LeftDrag>      <RightDrag>
----    :map <S-LeftRelease>   <RightRelease>
----    :map <2-S-LeftMouse>   <2-RightMouse>
----    :map <2-S-LeftDrag>    <2-RightDrag>
----    :map <2-S-LeftRelease> <2-RightRelease>
----    :map <3-S-LeftMouse>   <3-RightMouse>
----    :map <3-S-LeftDrag>    <3-RightDrag>
----    :map <3-S-LeftRelease> <3-RightRelease>
----    :map <4-S-LeftMouse>   <4-RightMouse>
----    :map <4-S-LeftDrag>    <4-RightDrag>
----    :map <4-S-LeftRelease> <4-RightRelease>
+---  :map <S-LeftMouse>     <RightMouse>
+---  :map <S-LeftDrag>      <RightDrag>
+---  :map <S-LeftRelease>   <RightRelease>
+---  :map <2-S-LeftMouse>   <2-RightMouse>
+---  :map <2-S-LeftDrag>    <2-RightDrag>
+---  :map <2-S-LeftRelease> <2-RightRelease>
+---  :map <3-S-LeftMouse>   <3-RightMouse>
+---  :map <3-S-LeftDrag>    <3-RightDrag>
+---  :map <3-S-LeftRelease> <3-RightRelease>
+---  :map <4-S-LeftMouse>   <4-RightMouse>
+---  :map <4-S-LeftDrag>    <4-RightDrag>
+---  :map <4-S-LeftRelease> <4-RightRelease>
 --- ```
----
 --- Mouse commands requiring the CTRL modifier can be simulated by typing
 --- the "g" key before using the mouse:
----     "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
----     "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
+---   "g<LeftMouse>"  is "<C-LeftMouse>  (jump to tag under mouse click)
+---   "g<RightMouse>" is "<C-RightMouse>  ("CTRL-T")
 ---
 --- @type string
 vim.o.mousemodel = "popup_setpos"
@@ -4342,10 +4319,10 @@ vim.go.mousemoveevent = vim.o.mousemoveevent
 vim.go.mousemev = vim.go.mousemoveevent
 
 --- This option controls the number of lines / columns to scroll by when
---- scrolling with a mouse wheel (`scroll-mouse-wheel`). The option is
+--- scrolling with a mouse wheel (`|scroll-mouse-wheel|`). The option is
 --- a comma-separated list. Each part consists of a direction and a count
 --- as follows:
---- 	direction:count,direction:count
+--- direction:count,direction:count
 --- Direction is one of either "hor" or "ver". "hor" controls horizontal
 --- scrolling and "ver" controls vertical scrolling. Count sets the amount
 --- to scroll by for the given direction, it should be a non negative
@@ -4356,7 +4333,7 @@ vim.go.mousemev = vim.go.mousemoveevent
 ---
 --- Example:
 --- ```
---- 	:set mousescroll=ver:5,hor:2
+--- :set mousescroll=ver:5,hor:2
 --- ```
 --- Will make Nvim scroll 5 lines at a time when scrolling vertically, and
 --- scroll 2 columns at a time when scrolling horizontally.
@@ -4369,49 +4346,49 @@ vim.go.mousescroll = vim.o.mousescroll
 --- different modes.  The option is a comma-separated list of parts, much
 --- like used for 'guicursor'.  Each part consist of a mode/location-list
 --- and an argument-list:
---- 	mode-list:shape,mode-list:shape,..
+--- mode-list:shape,mode-list:shape,..
 --- The mode-list is a dash separated list of these modes/locations:
---- 		In a normal window: ~
---- 	n	Normal mode
---- 	v	Visual mode
---- 	ve	Visual mode with 'selection' "exclusive" (same as 'v',
---- 		if not specified)
---- 	o	Operator-pending mode
---- 	i	Insert mode
---- 	r	Replace mode
+---   In a normal window: ~
+--- n  Normal mode
+--- v  Visual mode
+--- ve  Visual mode with 'selection' "exclusive" (same as 'v',
+---   if not specified)
+--- o  Operator-pending mode
+--- i  Insert mode
+--- r  Replace mode
 ---
---- 		Others: ~
---- 	c	appending to the command-line
---- 	ci	inserting in the command-line
---- 	cr	replacing in the command-line
---- 	m	at the 'Hit ENTER' or 'More' prompts
---- 	ml	idem, but cursor in the last line
---- 	e	any mode, pointer below last window
---- 	s	any mode, pointer on a status line
---- 	sd	any mode, while dragging a status line
---- 	vs	any mode, pointer on a vertical separator line
---- 	vd	any mode, while dragging a vertical separator line
---- 	a	everywhere
+---   Others: ~
+--- c  appending to the command-line
+--- ci  inserting in the command-line
+--- cr  replacing in the command-line
+--- m  at the 'Hit ENTER' or 'More' prompts
+--- ml  idem, but cursor in the last line
+--- e  any mode, pointer below last window
+--- s  any mode, pointer on a status line
+--- sd  any mode, while dragging a status line
+--- vs  any mode, pointer on a vertical separator line
+--- vd  any mode, while dragging a vertical separator line
+--- a  everywhere
 ---
 --- The shape is one of the following:
---- avail	name		looks like ~
---- w x	arrow		Normal mouse pointer
---- w x	blank		no pointer at all (use with care!)
---- w x	beam		I-beam
---- w x	updown		up-down sizing arrows
---- w x	leftright	left-right sizing arrows
---- w x	busy		The system's usual busy pointer
---- w x	no		The system's usual "no input" pointer
----   x	udsizing	indicates up-down resizing
----   x	lrsizing	indicates left-right resizing
----   x	crosshair	like a big thin +
----   x	hand1		black hand
----   x	hand2		white hand
----   x	pencil		what you write with
----   x	question	big ?
----   x	rightup-arrow	arrow pointing right-up
---- w x	up-arrow	arrow pointing up
----   x	<number>	any X11 pointer number (see X11/cursorfont.h)
+--- avail  name    looks like ~
+--- w x  arrow    Normal mouse pointer
+--- w x  blank    no pointer at all (use with care!)
+--- w x  beam    I-beam
+--- w x  updown    up-down sizing arrows
+--- w x  leftright  left-right sizing arrows
+--- w x  busy    The system's usual busy pointer
+--- w x  no    The system's usual "no input" pointer
+--- x  udsizing  indicates up-down resizing
+--- x  lrsizing  indicates left-right resizing
+--- x  crosshair  like a big thin +
+--- x  hand1    black hand
+--- x  hand2    white hand
+--- x  pencil    what you write with
+--- x  question  big ?
+--- x  rightup-arrow  arrow pointing right-up
+--- w x  up-arrow  arrow pointing up
+--- x  <number>  any X11 pointer number (see X11/cursorfont.h)
 ---
 --- The "avail" column contains a 'w' if the shape is available for Win32,
 --- x for X11.
@@ -4420,7 +4397,7 @@ vim.go.mousescroll = vim.o.mousescroll
 ---
 --- Example:
 --- ```
---- 	:set mouseshape=s:udsizing,m:no
+--- :set mouseshape=s:udsizing,m:no
 --- ```
 --- will make the mouse turn to a sizing arrow over the status lines and
 --- indicate no input when the hit-enter prompt is displayed (since
@@ -4443,27 +4420,27 @@ vim.go.mouset = vim.go.mousetime
 
 --- This defines what bases Vim will consider for numbers when using the
 --- CTRL-A and CTRL-X commands for adding to and subtracting from a number
---- respectively; see `CTRL-A` for more info on these commands.
---- alpha	If included, single alphabetical characters will be
---- 	incremented or decremented.  This is useful for a list with a
---- 	letter index a), b), etc.		*octal-nrformats*
---- octal	If included, numbers that start with a zero will be considered
---- 	to be octal.  Example: Using CTRL-A on "007" results in "010".
---- hex	If included, numbers starting with "0x" or "0X" will be
---- 	considered to be hexadecimal.  Example: Using CTRL-X on
---- 	"0x100" results in "0x0ff".
---- bin	If included, numbers starting with "0b" or "0B" will be
---- 	considered to be binary.  Example: Using CTRL-X on
---- 	"0b1000" subtracts one, resulting in "0b0111".
+--- respectively; see `|CTRL-A|` for more info on these commands.
+--- alpha  If included, single alphabetical characters will be
+--- incremented or decremented.  This is useful for a list with a
+--- letter index a), b), etc.    *octal-nrformats*
+--- octal  If included, numbers that start with a zero will be considered
+--- to be octal.  Example: Using CTRL-A on "007" results in "010".
+--- hex  If included, numbers starting with "0x" or "0X" will be
+--- considered to be hexadecimal.  Example: Using CTRL-X on
+--- "0x100" results in "0x0ff".
+--- bin  If included, numbers starting with "0b" or "0B" will be
+--- considered to be binary.  Example: Using CTRL-X on
+--- "0b1000" subtracts one, resulting in "0b0111".
 --- unsigned    If included, numbers are recognized as unsigned. Thus a
---- 	leading dash or negative sign won't be considered as part of
---- 	the number.  Examples:
---- 	    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
---- 	    (without "unsigned" it would become "9-2021").
---- 	    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
---- 	    (without "unsigned" it would become "9-2019").
---- 	    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
---- 	    (2^64 - 1) has no effect, overflow is prevented.
+--- leading dash or negative sign won't be considered as part of
+--- the number.  Examples:
+---     Using CTRL-X on "2020" in "9-2020" results in "9-2019"
+---     (without "unsigned" it would become "9-2021").
+---     Using CTRL-A on "2020" in "9-2020" results in "9-2021"
+---     (without "unsigned" it would become "9-2019").
+---     Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
+---     (2^64 - 1) has no effect, overflow is prevented.
 --- Numbers which simply begin with a digit in the range 1-9 are always
 --- considered decimal.  This also happens for numbers that are not
 --- recognized as octal or hex.
@@ -4480,22 +4457,21 @@ vim.bo.nf = vim.bo.nrformats
 --- Use the 'numberwidth' option to adjust the room for the line number.
 --- When a long, wrapped line doesn't start with the first character, '-'
 --- characters are put before the number.
---- For highlighting see `hl-LineNr`, `hl-CursorLineNr`, and the
---- `:sign-define` "numhl" argument.
---- 					*number_relativenumber*
+--- For highlighting see `|hl-LineNr|`, `|hl-CursorLineNr|`, and the
+--- `|:sign-define|` "numhl" argument.
+---         *number_relativenumber*
 --- The 'relativenumber' option changes the displayed number to be
 --- relative to the cursor.  Together with 'number' there are these
 --- four combinations (cursor in line 3):
 ---
---- 	'nonu'          'nu'            'nonu'          'nu'
---- 	'nornu'         'nornu'         'rnu'           'rnu'
+--- 'nonu'          'nu'            'nonu'          'nu'
+--- 'nornu'         'nornu'         'rnu'           'rnu'
 --- ```
----     |apple          |  1 apple      |  2 apple      |  2 apple
----     |pear           |  2 pear       |  1 pear       |  1 pear
----     |nobody         |  3 nobody     |  0 nobody     |3   nobody
----     |there          |  4 there      |  1 there      |  1 there
+---   |apple          |  1 apple      |  2 apple      |  2 apple
+---   |pear           |  2 pear       |  1 pear       |  1 pear
+---   |nobody         |  3 nobody     |  0 nobody     |3   nobody
+---   |there          |  4 there      |  1 there      |  1 there
 --- ```
----
 ---
 --- @type boolean
 vim.o.number = false
@@ -4521,14 +4497,14 @@ vim.wo.numberwidth = vim.o.numberwidth
 vim.wo.nuw = vim.wo.numberwidth
 
 --- This option specifies a function to be used for Insert mode omni
---- completion with CTRL-X CTRL-O. `i_CTRL-X_CTRL-O`
---- See `complete-functions` for an explanation of how the function is
+--- completion with CTRL-X CTRL-O. `|i_CTRL-X_CTRL-O|`
+--- See `|complete-functions|` for an explanation of how the function is
 --- invoked and what it should return.  The value can be the name of a
---- function, a `lambda` or a `Funcref`. See `option-value-function` for
+--- function, a `|lambda|` or a `|Funcref|`. See `|option-value-function|` for
 --- more information.
 --- This option is usually set by a filetype plugin:
---- `:filetype-plugin-on`
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- `|:filetype-plugin-on|`
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -4537,7 +4513,7 @@ vim.o.ofu = vim.o.omnifunc
 vim.bo.omnifunc = vim.o.omnifunc
 vim.bo.ofu = vim.bo.omnifunc
 
---- 		only for Windows
+--- only for Windows
 --- Enable reading and writing from devices.  This may get Vim stuck on a
 --- device that can be opened but doesn't actually do the I/O.  Therefore
 --- it is off by default.
@@ -4550,12 +4526,12 @@ vim.o.odev = vim.o.opendevice
 vim.go.opendevice = vim.o.opendevice
 vim.go.odev = vim.go.opendevice
 
---- This option specifies a function to be called by the `g@` operator.
---- See `:map-operator` for more info and an example.  The value can be
---- the name of a function, a `lambda` or a `Funcref`. See
---- `option-value-function` for more information.
+--- This option specifies a function to be called by the `|g@|` operator.
+--- See `|:map-operator|` for more info and an example.  The value can be
+--- the name of a function, a `|lambda|` or a `|Funcref|`. See
+--- `|option-value-function|` for more information.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -4565,7 +4541,7 @@ vim.go.operatorfunc = vim.o.operatorfunc
 vim.go.opfunc = vim.go.operatorfunc
 
 --- Directories used to find packages.
---- See `packages` and `packages-runtimepath`.
+--- See `|packages|` and `|packages-runtimepath|`.
 ---
 --- @type string
 vim.o.packpath = "..."
@@ -4574,7 +4550,7 @@ vim.go.packpath = vim.o.packpath
 vim.go.pp = vim.go.packpath
 
 --- Specifies the nroff macros that separate paragraphs.  These are pairs
---- of two letters (see `object-motions`).
+--- of two letters (see `|object-motions|`).
 ---
 --- @type string
 vim.o.paragraphs = "IPLPPPQPP TPHPLIPpLpItpplpipbp"
@@ -4583,7 +4559,7 @@ vim.go.paragraphs = vim.o.paragraphs
 vim.go.para = vim.go.paragraphs
 
 --- Expression which is evaluated to apply a patch to a file and generate
---- the resulting new version of the file.  See `diff-patchexpr`.
+--- the resulting new version of the file.  See `|diff-patchexpr|`.
 ---
 --- @type string
 vim.o.patchexpr = ""
@@ -4615,69 +4591,69 @@ vim.go.patchmode = vim.o.patchmode
 vim.go.pm = vim.go.patchmode
 
 --- This is a list of directories which will be searched when using the
---- `gf`, [f, ]f, ^Wf, `:find`, `:sfind`, `:tabfind` and other commands,
+--- `|gf|`, [f, ]f, ^Wf, `|:find|`, `|:sfind|`, `|:tabfind|` and other commands,
 --- provided that the file being searched for has a relative path (not
 --- starting with "/", "./" or "../").  The directories in the 'path'
 --- option may be relative or absolute.
 --- - Use commas to separate directory names:
 --- ```
---- 	:set path=.,/usr/local/include,/usr/include
+--- :set path=.,/usr/local/include,/usr/include
 --- ```
 --- - Spaces can also be used to separate directory names.  To have a
----   space in a directory name, precede it with an extra backslash, and
----   escape the space:
+--- space in a directory name, precede it with an extra backslash, and
+--- escape the space:
 --- ```
---- 	:set path=.,/dir/with\\\ space
+--- :set path=.,/dir/with\\\ space
 --- ```
 --- - To include a comma in a directory name precede it with an extra
----   backslash:
+--- backslash:
 --- ```
---- 	:set path=.,/dir/with\\,comma
+--- :set path=.,/dir/with\\,comma
 --- ```
 --- - To search relative to the directory of the current file, use:
 --- ```
---- 	:set path=.
+--- :set path=.
 --- ```
 --- - To search in the current directory use an empty string between two
----   commas:
+--- commas:
 --- ```
---- 	:set path=,,
+--- :set path=,,
 --- ```
 --- - A directory name may end in a ':' or '/'.
---- - Environment variables are expanded `:set_env`.
---- - When using `netrw.vim` URLs can be used.  For example, adding
----   "https://www.vim.org" will make ":find index.html" work.
+--- - Environment variables are expanded `|:set_env|`.
+--- - When using `|netrw.vim|` URLs can be used.  For example, adding
+--- "https://www.vim.org" will make ":find index.html" work.
 --- - Search upwards and downwards in a directory tree using "*", "**" and
----   ";".  See `file-searching` for info and syntax.
+--- ";".  See `|file-searching|` for info and syntax.
 --- - Careful with '\' characters, type two to get one in the option:
 --- ```
---- 	:set path=.,c:\\include
+--- :set path=.,c:\\include
 --- ```
 --- Or just use '/' instead:
 --- ```
---- 	:set path=.,c:/include
+--- :set path=.,c:/include
 --- ```
 --- Don't forget "." or files won't even be found in the same directory as
 --- the file!
 --- The maximum length is limited.  How much depends on the system, mostly
 --- it is something like 256 or 1024 characters.
 --- You can check if all the include files are found, using the value of
---- 'path', see `:checkpath`.
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- 'path', see `|:checkpath|`.
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- directories from the list.  This avoids problems when a future version
 --- uses another default.  To remove the current directory use:
 --- ```
---- 	:set path-=
+--- :set path-=
 --- ```
 --- To add the current directory use:
 --- ```
---- 	:set path+=
+--- :set path+=
 --- ```
 --- To use an environment variable, you probably need to replace the
 --- separator.  Here is an example to append $INCL, in which directory
 --- names are separated with a semi-colon:
 --- ```
---- 	:let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
+--- :let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
 --- ```
 --- Replace the ';' with a ':' or whatever separator is used.  Note that
 --- this doesn't work when $INCL contains a comma or white space.
@@ -4692,7 +4668,7 @@ vim.go.pa = vim.go.path
 
 --- When changing the indent of the current line, preserve as much of the
 --- indent structure as possible.  Normally the indent is replaced by a
---- series of tabs followed by spaces as required (unless `'expandtab'` is
+--- series of tabs followed by spaces as required (unless `|'expandtab'|` is
 --- enabled, in which case only spaces are used).  Enabling this option
 --- means the indent will preserve as many existing characters as possible
 --- for indenting, and only add additional tabs or spaces as required.
@@ -4701,7 +4677,7 @@ vim.go.pa = vim.go.path
 --- NOTE: When using ">>" multiple times the resulting indent is a mix of
 --- tabs and spaces.  You might not like this.
 --- Also see 'copyindent'.
---- Use `:retab` to clean up white space.
+--- Use `|:retab|` to clean up white space.
 ---
 --- @type boolean
 vim.o.preserveindent = false
@@ -4709,8 +4685,8 @@ vim.o.pi = vim.o.preserveindent
 vim.bo.preserveindent = vim.o.preserveindent
 vim.bo.pi = vim.bo.preserveindent
 
---- Default height for a preview window.  Used for `:ptag` and associated
---- commands.  Used for `CTRL-W_}` when no count is given.
+--- Default height for a preview window.  Used for `|:ptag|` and associated
+--- commands.  Used for `|CTRL-W_}|` when no count is given.
 ---
 --- @type integer
 vim.o.previewheight = 12
@@ -4720,7 +4696,7 @@ vim.go.pvh = vim.go.previewheight
 
 --- Identifies the preview window.  Only one window can have this option
 --- set.  It's normally not set directly, but by using one of the commands
---- `:ptag`, `:pedit`, etc.
+--- `|:ptag|`, `|:pedit|`, etc.
 ---
 --- @type boolean
 vim.o.previewwindow = false
@@ -4728,18 +4704,17 @@ vim.o.pvw = vim.o.previewwindow
 vim.wo.previewwindow = vim.o.previewwindow
 vim.wo.pvw = vim.wo.previewwindow
 
---- Enables pseudo-transparency for the `popup-menu`. Valid values are in
+--- Enables pseudo-transparency for the `|popup-menu|`. Valid values are in
 --- the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
 --- transparent background. Values between 0-30 are typically most useful.
 ---
 --- It is possible to override the level for individual highlights within
---- the popupmenu using `highlight-blend`. For instance, to enable
+--- the popupmenu using `|highlight-blend|`. For instance, to enable
 --- transparency but force the current selected element to be fully opaque:
 --- ```
---- 	:set pumblend=15
---- 	:hi PmenuSel blend=0
+--- :set pumblend=15
+--- :hi PmenuSel blend=0
 --- ```
----
 --- UI-dependent. Works best with RGB colors. 'termguicolors'
 ---
 --- @type integer
@@ -4749,7 +4724,7 @@ vim.go.pumblend = vim.o.pumblend
 vim.go.pb = vim.go.pumblend
 
 --- Maximum number of items to show in the popup menu
---- (`ins-completion-menu`). Zero means "use available screen space".
+--- (`|ins-completion-menu|`). Zero means "use available screen space".
 ---
 --- @type integer
 vim.o.pumheight = 0
@@ -4757,7 +4732,7 @@ vim.o.ph = vim.o.pumheight
 vim.go.pumheight = vim.o.pumheight
 vim.go.ph = vim.go.pumheight
 
---- Minimum width for the popup menu (`ins-completion-menu`).  If the
+--- Minimum width for the popup menu (`|ins-completion-menu|`).  If the
 --- cursor column + 'pumwidth' exceeds screen width, the popup menu is
 --- nudged to fit on the screen.
 ---
@@ -4768,10 +4743,10 @@ vim.go.pumwidth = vim.o.pumwidth
 vim.go.pw = vim.go.pumwidth
 
 --- Specifies the python version used for pyx* functions and commands
---- `python_x`.  As only Python 3 is supported, this always has the value
+--- `|python_x|`.  As only Python 3 is supported, this always has the value
 --- `3`. Setting any other value is an error.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type integer
@@ -4784,12 +4759,12 @@ vim.go.pyx = vim.go.pyxversion
 --- in the quickfix and location list windows.  This can be used to
 --- customize the information displayed in the quickfix or location window
 --- for each entry in the corresponding quickfix or location list.  See
---- `quickfix-window-function` for an explanation of how to write the
+--- `|quickfix-window-function|` for an explanation of how to write the
 --- function and an example.  The value can be the name of a function, a
---- `lambda` or a `Funcref`. See `option-value-function` for more
+--- `|lambda|` or a `|Funcref|`. See `|option-value-function|` for more
 --- information.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -4799,7 +4774,7 @@ vim.go.quickfixtextfunc = vim.o.quickfixtextfunc
 vim.go.qftf = vim.go.quickfixtextfunc
 
 --- The characters that are used to escape quotes in a string.  Used for
---- objects like a', a" and a` `a'`.
+--- objects like a', a" and a` `|a'|`.
 --- When one of the characters in this option is found inside a string,
 --- the following character will be skipped.  The default value makes the
 --- text "foo\"bar\\" considered to be one string.
@@ -4828,33 +4803,33 @@ vim.bo.ro = vim.bo.readonly
 --- Flags to change the way redrawing works, for debugging purposes.
 --- Most useful with 'writedelay' set to some reasonable value.
 --- Supports the following flags:
----     compositor	Indicate each redraw event handled by the compositor
---- 		by briefly flashing the redrawn regions in colors
---- 		indicating the redraw type. These are the highlight
---- 		groups used (and their default colors):
---- 	RedrawDebugNormal   gui=reverse   normal redraw passed through
---- 	RedrawDebugClear    guibg=Yellow  clear event passed through
---- 	RedrawDebugComposed guibg=Green   redraw event modified by the
---- 					  compositor (due to
---- 					  overlapping grids, etc)
---- 	RedrawDebugRecompose guibg=Red    redraw generated by the
---- 					  compositor itself, due to a
---- 					  grid being moved or deleted.
----     line	introduce a delay after each line drawn on the screen.
---- 		When using the TUI or another single-grid UI, "compositor"
---- 		gives more information and should be preferred (every
---- 		line is processed as a separate event by the compositor)
----     flush	introduce a delay after each "flush" event.
----     nothrottle	Turn off throttling of the message grid. This is an
---- 		optimization that joins many small scrolls to one
---- 		larger scroll when drawing the message area (with
---- 		'display' msgsep flag active).
----     invalid	Enable stricter checking (abort) of inconsistencies
---- 		of the internal screen state. This is mostly
---- 		useful when running nvim inside a debugger (and
---- 		the test suite).
----     nodelta	Send all internally redrawn cells to the UI, even if
---- 		they are unchanged from the already displayed state.
+---   compositor  Indicate each redraw event handled by the compositor
+---   by briefly flashing the redrawn regions in colors
+---   indicating the redraw type. These are the highlight
+---   groups used (and their default colors):
+--- RedrawDebugNormal   gui=reverse   normal redraw passed through
+--- RedrawDebugClear    guibg=Yellow  clear event passed through
+--- RedrawDebugComposed guibg=Green   redraw event modified by the
+---           compositor (due to
+---           overlapping grids, etc)
+--- RedrawDebugRecompose guibg=Red    redraw generated by the
+---           compositor itself, due to a
+---           grid being moved or deleted.
+---   line  introduce a delay after each line drawn on the screen.
+---   When using the TUI or another single-grid UI, "compositor"
+---   gives more information and should be preferred (every
+---   line is processed as a separate event by the compositor)
+---   flush  introduce a delay after each "flush" event.
+---   nothrottle  Turn off throttling of the message grid. This is an
+---   optimization that joins many small scrolls to one
+---   larger scroll when drawing the message area (with
+---   'display' msgsep flag active).
+---   invalid  Enable stricter checking (abort) of inconsistencies
+---   of the internal screen state. This is mostly
+---   useful when running nvim inside a debugger (and
+---   the test suite).
+---   nodelta  Send all internally redrawn cells to the UI, even if
+---   they are unchanged from the already displayed state.
 ---
 --- @type string
 vim.o.redrawdebug = ""
@@ -4863,12 +4838,12 @@ vim.go.redrawdebug = vim.o.redrawdebug
 vim.go.rdb = vim.go.redrawdebug
 
 --- Time in milliseconds for redrawing the display.  Applies to
---- 'hlsearch', 'inccommand', `:match` highlighting and syntax
+--- 'hlsearch', 'inccommand', `|:match|` highlighting and syntax
 --- highlighting.
 --- When redrawing takes more than this many milliseconds no further
 --- matches will be highlighted.
 --- For syntax highlighting the time applies per window.  When over the
---- limit syntax highlighting is disabled until `CTRL-L` is used.
+--- limit syntax highlighting is disabled until `|CTRL-L|` is used.
 --- This is used to avoid that Vim hangs when using a very complicated
 --- pattern.
 ---
@@ -4878,11 +4853,11 @@ vim.o.rdt = vim.o.redrawtime
 vim.go.redrawtime = vim.o.redrawtime
 vim.go.rdt = vim.go.redrawtime
 
---- This selects the default regexp engine. `two-engines`
+--- This selects the default regexp engine. `|two-engines|`
 --- The possible values are:
---- 	0	automatic selection
---- 	1	old engine
---- 	2	NFA engine
+--- 0  automatic selection
+--- 1  old engine
+--- 2  NFA engine
 --- Note that when using the NFA engine and the pattern contains something
 --- that is not supported the pattern will not match.  This is only useful
 --- for debugging the regexp engine.
@@ -4898,7 +4873,7 @@ vim.go.regexpengine = vim.o.regexpengine
 vim.go.re = vim.go.regexpengine
 
 --- Show the line number relative to the line with the cursor in front of
---- each line. Relative line numbers help you use the `count` you can
+--- each line. Relative line numbers help you use the `|count|` you can
 --- precede some vertical motion commands (e.g. j k + -) with, without
 --- having to calculate it yourself. Especially useful in combination with
 --- other commands (e.g. y d c < > gq gw =).
@@ -4908,11 +4883,11 @@ vim.go.re = vim.go.regexpengine
 --- number.
 --- When a long, wrapped line doesn't start with the first character, '-'
 --- characters are put before the number.
---- See `hl-LineNr`  and `hl-CursorLineNr` for the highlighting used for
+--- See `|hl-LineNr|`  and `|hl-CursorLineNr|` for the highlighting used for
 --- the number.
 ---
 --- The number in front of the cursor line also depends on the value of
---- 'number', see `number_relativenumber` for all combinations of the two
+--- 'number', see `|number_relativenumber|` for all combinations of the two
 --- options.
 ---
 --- @type boolean
@@ -4932,7 +4907,7 @@ vim.o.report = 2
 vim.go.report = vim.o.report
 
 --- Inserting characters in Insert mode will work backwards.  See "typing
---- backwards" `ins-reverse`.  This option can be toggled with the CTRL-_
+--- backwards" `|ins-reverse|`.  This option can be toggled with the CTRL-_
 --- command in Insert mode, when 'allowrevins' is set.
 ---
 --- @type boolean
@@ -4949,7 +4924,7 @@ vim.go.ri = vim.go.revins
 --- simultaneously, or to view the same file in both ways (this is
 --- useful whenever you have a mixed text file with both right-to-left
 --- and left-to-right strings so that both sets are displayed properly
---- in different windows).  Also see `rileft.txt`.
+--- in different windows).  Also see `|rileft.txt|`.
 ---
 --- @type boolean
 vim.o.rightleft = false
@@ -4960,7 +4935,7 @@ vim.wo.rl = vim.wo.rightleft
 --- Each word in this option enables the command line editing to work in
 --- right-to-left mode for a group of commands:
 ---
---- 	search		"/" and "?" commands
+--- search    "/" and "?" commands
 ---
 --- This is useful for languages such as Hebrew, Arabic and Farsi.
 --- The 'rightleft' option must be set for 'rightleftcmd' to take effect.
@@ -4974,10 +4949,10 @@ vim.wo.rlc = vim.wo.rightleftcmd
 --- Show the line and column number of the cursor position, separated by a
 --- comma.  When there is room, the relative position of the displayed
 --- text in the file is shown on the far right:
---- 	Top	first line is visible
---- 	Bot	last line is visible
---- 	All	first and last line are visible
---- 	45%	relative position in the file
+--- Top  first line is visible
+--- Bot  last line is visible
+--- All  first and last line are visible
+--- 45%  relative position in the file
 --- If 'rulerformat' is set, it will determine the contents of the ruler.
 --- Each window has its own ruler.  If a window has a status line, the
 --- ruler is shown there.  If a window doesn't have a status line and
@@ -4992,7 +4967,7 @@ vim.wo.rlc = vim.wo.rightleftcmd
 --- For an empty line "0-1" is shown.
 --- For an empty buffer the line number will also be zero: "0,0-1".
 --- If you don't want to see the ruler all the time but want to know where
---- you are, use "g CTRL-G" `g_CTRL-G`.
+--- you are, use "g CTRL-G" `|g_CTRL-G|`.
 ---
 --- @type boolean
 vim.o.ruler = true
@@ -5009,9 +4984,8 @@ vim.go.ru = vim.go.ruler
 --- characters wide, put "%15(" at the start and "%)" at the end.
 --- Example:
 --- ```
---- 	:set rulerformat=%15(%c%V\ %p%%%)
+--- :set rulerformat=%15(%c%V\ %p%%%)
 --- ```
----
 ---
 --- @type string
 vim.o.rulerformat = ""
@@ -5020,64 +4994,64 @@ vim.go.rulerformat = vim.o.rulerformat
 vim.go.ruf = vim.go.rulerformat
 
 --- List of directories to be searched for these runtime files:
----   filetype.lua	filetypes `new-filetype`
----   autoload/	automatically loaded scripts `autoload-functions`
----   colors/	color scheme files `:colorscheme`
----   compiler/	compiler files `:compiler`
----   doc/		documentation `write-local-help`
----   ftplugin/	filetype plugins `write-filetype-plugin`
----   indent/	indent scripts `indent-expression`
----   keymap/	key mapping files `mbyte-keymap`
----   lang/		menu translations `:menutrans`
----   lua/		`Lua` plugins
----   menu.vim	GUI menus `menu.vim`
----   pack/		packages `:packadd`
----   parser/	`treesitter` syntax parsers
----   plugin/	plugin scripts `write-plugin`
----   queries/	`treesitter` queries
----   rplugin/	`remote-plugin` scripts
----   spell/	spell checking files `spell`
----   syntax/	syntax files `mysyntaxfile`
----   tutor/	tutorial files `:Tutor`
+--- filetype.lua  filetypes `|new-filetype|`
+--- autoload/  automatically loaded scripts `|autoload-functions|`
+--- colors/  color scheme files `|:colorscheme|`
+--- compiler/  compiler files `|:compiler|`
+--- doc/    documentation `|write-local-help|`
+--- ftplugin/  filetype plugins `|write-filetype-plugin|`
+--- indent/  indent scripts `|indent-expression|`
+--- keymap/  key mapping files `|mbyte-keymap|`
+--- lang/    menu translations `|:menutrans|`
+--- lua/    `|Lua|` plugins
+--- menu.vim  GUI menus `|menu.vim|`
+--- pack/    packages `|:packadd|`
+--- parser/  `|treesitter|` syntax parsers
+--- plugin/  plugin scripts `|write-plugin|`
+--- queries/  `|treesitter|` queries
+--- rplugin/  `|remote-plugin|` scripts
+--- spell/  spell checking files `|spell|`
+--- syntax/  syntax files `|mysyntaxfile|`
+--- tutor/  tutorial files `|:Tutor|`
 ---
---- And any other file searched for with the `:runtime` command.
+--- And any other file searched for with the `|:runtime|` command.
 ---
 --- Defaults are setup to search these locations:
 --- 1. Your home directory, for personal preferences.
----    Given by `stdpath("config")`.  `$XDG_CONFIG_HOME`
+---  Given by `stdpath("config")`.  `|$XDG_CONFIG_HOME|`
 --- 2. Directories which must contain configuration files according to
----    `xdg` ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
----    preferences from system administrator.
+---  `|xdg|` ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
+---  preferences from system administrator.
 --- 3. Data home directory, for plugins installed by user.
----    Given by `stdpath("data")/site`.  `$XDG_DATA_HOME`
+---  Given by `stdpath("data")/site`.  `|$XDG_DATA_HOME|`
 --- 4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
----    This is for plugins which were installed by system administrator,
----    but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
----    to /usr/local/share/:/usr/share/, so system administrators are
----    expected to install site plugins to /usr/share/nvim/site.
+---  This is for plugins which were installed by system administrator,
+---  but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
+---  to /usr/local/share/:/usr/share/, so system administrators are
+---  expected to install site plugins to /usr/share/nvim/site.
 --- 5. Session state directory, for state data such as swap, backupdir,
----    viewdir, undodir, etc.
----    Given by `stdpath("state")`.  `$XDG_STATE_HOME`
+---  viewdir, undodir, etc.
+---  Given by `stdpath("state")`.  `|$XDG_STATE_HOME|`
 --- 6. $VIMRUNTIME, for files distributed with Nvim.
---- 						*after-directory*
+---           *after-directory*
 --- 7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
----    ordering.  This is for preferences to overrule or add to the
----    distributed defaults or system-wide settings (rarely needed).
+---  ordering.  This is for preferences to overrule or add to the
+---  distributed defaults or system-wide settings (rarely needed).
 ---
---- 						*packages-runtimepath*
---- "start" packages will also be searched (`runtime-search-path`) for
+---           *packages-runtimepath*
+--- "start" packages will also be searched (`|runtime-search-path|`) for
 --- runtime files after these, though such packages are not explicitly
 --- reported in &runtimepath. But "opt" packages are explicitly added to
---- &runtimepath by `:packadd`.
+--- &runtimepath by `|:packadd|`.
 ---
 --- Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
 --- wildcards are allowed, but can significantly slow down searching for
 --- runtime files.  For speed, use as few items as possible and avoid
 --- wildcards.
---- See `:runtime`.
+--- See `|:runtime|`.
 --- Example:
 --- ```
---- 	:set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
+--- :set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
 --- ```
 --- This will use the directory "~/vimruntime" first (containing your
 --- personal Nvim runtime files), then "/mygroup/vim", and finally
@@ -5086,7 +5060,7 @@ vim.go.ruf = vim.go.rulerformat
 --- distributed runtime files.  You can put a directory after $VIMRUNTIME
 --- to find files which add to distributed runtime files.
 ---
---- With `--clean` the home directory entries are not included.
+--- With `|--clean|` the home directory entries are not included.
 ---
 --- @type string
 vim.o.runtimepath = "..."
@@ -5096,7 +5070,7 @@ vim.go.rtp = vim.go.runtimepath
 
 --- Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 --- set to half the number of lines in the window when the window size
---- changes.  This may happen when enabling the `status-line` or
+--- changes.  This may happen when enabling the `|status-line|` or
 --- 'tabline' option after setting the 'scroll' option.
 --- If you give a count to the CTRL-U or CTRL-D command it will
 --- be used as the new value for 'scroll'.  Reset to half the window
@@ -5111,7 +5085,7 @@ vim.wo.scr = vim.wo.scroll
 --- Maximum number of lines kept beyond the visible screen. Lines at the
 --- top are deleted if new lines exceed this limit.
 --- Minimum is 1, maximum is 100000.
---- Only in `terminal` buffers.
+--- Only in `|terminal|` buffers.
 ---
 --- Note: Lines that are not visible and kept in scrollback are not
 --- reflown when the terminal buffer is resized horizontally.
@@ -5122,11 +5096,11 @@ vim.o.scbk = vim.o.scrollback
 vim.bo.scrollback = vim.o.scrollback
 vim.bo.scbk = vim.bo.scrollback
 
---- See also `scroll-binding`.  When this option is set, scrolling the
+--- See also `|scroll-binding|`.  When this option is set, scrolling the
 --- current window also scrolls other scrollbind windows (windows that
 --- also have this option set).  This option is useful for viewing the
 --- differences between two versions of a file, see 'diff'.
---- See `'scrollopt'` for options that determine how this option should be
+--- See `|'scrollopt'|` for options that determine how this option should be
 --- interpreted.
 --- This option is mostly reset when splitting a window to edit another
 --- file.  This means that ":split | edit file" results in two windows
@@ -5159,8 +5133,8 @@ vim.go.sj = vim.go.scrolljump
 --- After using the local value, go back the global value with one of
 --- these two:
 --- ```
---- 	setlocal scrolloff<
---- 	setlocal scrolloff=-1
+--- setlocal scrolloff<
+--- setlocal scrolloff=-1
 --- ```
 --- For scrolling horizontally see 'sidescrolloff'.
 ---
@@ -5176,27 +5150,27 @@ vim.go.so = vim.go.scrolloff
 --- 'scrollbind' windows should behave.  'sbo' stands for ScrollBind
 --- Options.
 --- The following words are available:
----     ver		Bind vertical scrolling for 'scrollbind' windows
----     hor		Bind horizontal scrolling for 'scrollbind' windows
----     jump	Applies to the offset between two windows for vertical
---- 		scrolling.  This offset is the difference in the first
---- 		displayed line of the bound windows.  When moving
---- 		around in a window, another 'scrollbind' window may
---- 		reach a position before the start or after the end of
---- 		the buffer.  The offset is not changed though, when
---- 		moving back the 'scrollbind' window will try to scroll
---- 		to the desired position when possible.
---- 		When now making that window the current one, two
---- 		things can be done with the relative offset:
---- 		1. When "jump" is not included, the relative offset is
---- 		   adjusted for the scroll position in the new current
---- 		   window.  When going back to the other window, the
---- 		   new relative offset will be used.
---- 		2. When "jump" is included, the other windows are
---- 		   scrolled to keep the same relative offset.  When
---- 		   going back to the other window, it still uses the
---- 		   same relative offset.
---- Also see `scroll-binding`.
+--- ver    Bind vertical scrolling for 'scrollbind' windows
+--- hor    Bind horizontal scrolling for 'scrollbind' windows
+--- jump  Applies to the offset between two windows for vertical
+--- scrolling.  This offset is the difference in the first
+--- displayed line of the bound windows.  When moving
+--- around in a window, another 'scrollbind' window may
+--- reach a position before the start or after the end of
+--- the buffer.  The offset is not changed though, when
+--- moving back the 'scrollbind' window will try to scroll
+--- to the desired position when possible.
+--- When now making that window the current one, two
+--- things can be done with the relative offset:
+--- 1. When "jump" is not included, the relative offset is
+---    adjusted for the scroll position in the new current
+---    window.  When going back to the other window, the
+---    new relative offset will be used.
+--- 2. When "jump" is included, the other windows are
+---    scrolled to keep the same relative offset.  When
+---    going back to the other window, it still uses the
+---    same relative offset.
+--- Also see `|scroll-binding|`.
 --- When 'diff' mode is active there always is vertical scroll binding,
 --- even when "ver" isn't there.
 ---
@@ -5207,7 +5181,7 @@ vim.go.scrollopt = vim.o.scrollopt
 vim.go.sbo = vim.go.scrollopt
 
 --- Specifies the nroff macros that separate sections.  These are pairs of
---- two letters (See `object-motions`).  The default makes a section start
+--- two letters (See `|object-motions|`).  The default makes a section start
 --- at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
 ---
 --- @type string
@@ -5219,10 +5193,10 @@ vim.go.sect = vim.go.sections
 --- This option defines the behavior of the selection.  It is only used
 --- in Visual and Select mode.
 --- Possible values:
----    value	past line     inclusive ~
----    old		   no		yes
----    inclusive	   yes		yes
----    exclusive	   yes		no
+---  value  past line     inclusive ~
+---  old       no    yes
+---  inclusive     yes    yes
+---  exclusive     yes    no
 --- "past line" means that the cursor is allowed to be positioned one
 --- character past the line.
 --- "inclusive" means that the last character of the selection is included
@@ -5243,10 +5217,10 @@ vim.go.sel = vim.go.selection
 --- This is a comma-separated list of words, which specifies when to start
 --- Select mode instead of Visual mode, when a selection is started.
 --- Possible values:
----    mouse	when using the mouse
----    key		when using shifted special keys
----    cmd		when using "v", "V" or CTRL-V
---- See `Select-mode`.
+---  mouse  when using the mouse
+---  key    when using shifted special keys
+---  cmd    when using "v", "V" or CTRL-V
+--- See `|Select-mode|`.
 ---
 --- @type string
 vim.o.selectmode = ""
@@ -5254,38 +5228,38 @@ vim.o.slm = vim.o.selectmode
 vim.go.selectmode = vim.o.selectmode
 vim.go.slm = vim.go.selectmode
 
---- Changes the effect of the `:mksession` command.  It is a comma-
+--- Changes the effect of the `|:mksession|` command.  It is a comma-
 --- separated list of words.  Each word enables saving and restoring
 --- something:
----    word		save and restore ~
----    blank	empty windows
----    buffers	hidden and unloaded buffers, not just those in windows
----    curdir	the current directory
----    folds	manually created folds, opened/closed folds and local
---- 		fold options
----    globals	global variables that start with an uppercase letter
---- 		and contain at least one lowercase letter.  Only
---- 		String and Number types are stored.
----    help		the help window
----    localoptions	options and mappings local to a window or buffer (not
---- 		global values for local options)
----    options	all options and mappings (also global values for local
---- 		options)
----    skiprtp	exclude 'runtimepath' and 'packpath' from the options
----    resize	size of the Vim window: 'lines' and 'columns'
----    sesdir	the directory in which the session file is located
---- 		will become the current directory (useful with
---- 		projects accessed over a network from different
---- 		systems)
----    tabpages	all tab pages; without this only the current tab page
---- 		is restored, so that you can make a session for each
---- 		tab page separately
----    terminal	include terminal windows where the command can be
---- 		restored
----    winpos	position of the whole Vim window
----    winsize	window sizes
----    slash	`deprecated` Always enabled. Uses "/" in filenames.
----    unix		`deprecated` Always enabled. Uses "\n" line endings.
+---  word    save and restore ~
+---  blank  empty windows
+---  buffers  hidden and unloaded buffers, not just those in windows
+---  curdir  the current directory
+---  folds  manually created folds, opened/closed folds and local
+---   fold options
+---  globals  global variables that start with an uppercase letter
+---   and contain at least one lowercase letter.  Only
+---   String and Number types are stored.
+---  help    the help window
+---  localoptions  options and mappings local to a window or buffer (not
+---   global values for local options)
+---  options  all options and mappings (also global values for local
+---   options)
+---  skiprtp  exclude 'runtimepath' and 'packpath' from the options
+---  resize  size of the Vim window: 'lines' and 'columns'
+---  sesdir  the directory in which the session file is located
+---   will become the current directory (useful with
+---   projects accessed over a network from different
+---   systems)
+---  tabpages  all tab pages; without this only the current tab page
+---   is restored, so that you can make a session for each
+---   tab page separately
+---  terminal  include terminal windows where the command can be
+---   restored
+---  winpos  position of the whole Vim window
+---  winsize  window sizes
+---  slash  `|deprecated|` Always enabled. Uses "/" in filenames.
+---  unix    `|deprecated|` Always enabled. Uses "\n" line endings.
 ---
 --- Don't include both "curdir" and "sesdir". When neither is included
 --- filenames are stored as absolute paths.
@@ -5299,116 +5273,115 @@ vim.go.sessionoptions = vim.o.sessionoptions
 vim.go.ssop = vim.go.sessionoptions
 
 --- When non-empty, the shada file is read upon startup and written
---- when exiting Vim (see `shada-file`).  The string should be a comma-
+--- when exiting Vim (see `|shada-file|`).  The string should be a comma-
 --- separated list of parameters, each consisting of a single character
 --- identifying the particular parameter, followed by a number or string
 --- which specifies the value of that parameter.  If a particular
 --- character is left out, then the default value is used for that
 --- parameter.  The following is a list of the identifying characters and
 --- the effect of their value.
---- CHAR	VALUE	~
---- 						*shada-!*
---- !	When included, save and restore global variables that start
---- 	with an uppercase letter, and don't contain a lowercase
---- 	letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
---- 	and "_K_L_M" are not.  Nested List and Dict items may not be
---- 	read back correctly, you end up with an empty item.
---- 						*shada-quote*
---- "	Maximum number of lines saved for each register.  Old name of
---- 	the '<' item, with the disadvantage that you need to put a
---- 	backslash before the ", otherwise it will be recognized as the
---- 	start of a comment!
---- 						*shada-%*
---- %	When included, save and restore the buffer list.  If Vim is
---- 	started with a file name argument, the buffer list is not
---- 	restored.  If Vim is started without a file name argument, the
---- 	buffer list is restored from the shada file.  Quickfix
---- 	('buftype'), unlisted ('buflisted'), unnamed and buffers on
---- 	removable media (`shada-r`) are not saved.
---- 	When followed by a number, the number specifies the maximum
---- 	number of buffers that are stored.  Without a number all
---- 	buffers are stored.
---- 						*shada-'*
---- '	Maximum number of previously edited files for which the marks
---- 	are remembered.  This parameter must always be included when
---- 	'shada' is non-empty.
---- 	Including this item also means that the `jumplist` and the
---- 	`changelist` are stored in the shada file.
---- 						*shada-/*
---- /	Maximum number of items in the search pattern history to be
---- 	saved.  If non-zero, then the previous search and substitute
---- 	patterns are also saved.  When not included, the value of
---- 	'history' is used.
---- 						*shada-:*
---- :	Maximum number of items in the command-line history to be
---- 	saved.  When not included, the value of 'history' is used.
---- 						*shada-<*
---- \<	Maximum number of lines saved for each register.  If zero then
---- 	registers are not saved.  When not included, all lines are
---- 	saved.  '"' is the old name for this item.
---- 	Also see the 's' item below: limit specified in KiB.
---- 						*shada-@*
---- @	Maximum number of items in the input-line history to be
---- 	saved.  When not included, the value of 'history' is used.
---- 						*shada-c*
---- c	Dummy option, kept for compatibility reasons.  Has no actual
---- 	effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
---- 	to UTF-8 as well.
---- 						*shada-f*
---- f	Whether file marks need to be stored.  If zero, file marks ('0
---- 	to '9, 'A to 'Z) are not stored.  When not present or when
---- 	non-zero, they are all stored.  '0 is used for the current
---- 	cursor position (when exiting or when doing `:wshada`).
---- 						*shada-h*
---- h	Disable the effect of 'hlsearch' when loading the shada
---- 	file.  When not included, it depends on whether ":nohlsearch"
---- 	has been used since the last search command.
---- 						*shada-n*
---- n	Name of the shada file.  The name must immediately follow
---- 	the 'n'.  Must be at the end of the option!  If the
---- 	'shadafile' option is set, that file name overrides the one
---- 	given here with 'shada'.  Environment variables are
---- 	expanded when opening the file, not when setting the option.
---- 						*shada-r*
---- r	Removable media.  The argument is a string (up to the next
---- 	',').  This parameter can be given several times.  Each
---- 	specifies the start of a path for which no marks will be
---- 	stored.  This is to avoid removable media.  For Windows you
---- 	could use "ra:,rb:".  You can also use it for temp files,
---- 	e.g., for Unix: "r/tmp".  Case is ignored.
---- 						*shada-s*
---- s	Maximum size of an item contents in KiB.  If zero then nothing
---- 	is saved.  Unlike Vim this applies to all items, except for
---- 	the buffer list and header.  Full item size is off by three
---- 	unsigned integers: with `s10` maximum item size may be 1 byte
---- 	(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
---- 	integer) + 3 bytes (item size: up to 16-bit integer because
---- 	2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
---- 	contents size) = 10253 bytes.
+--- CHAR  VALUE  ~
+---           *shada-!*
+--- !  When included, save and restore global variables that start
+--- with an uppercase letter, and don't contain a lowercase
+--- letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
+--- and "_K_L_M" are not.  Nested List and Dict items may not be
+--- read back correctly, you end up with an empty item.
+---           *shada-quote*
+--- "  Maximum number of lines saved for each register.  Old name of
+--- the '<' item, with the disadvantage that you need to put a
+--- backslash before the ", otherwise it will be recognized as the
+--- start of a comment!
+---           *shada-%*
+--- %  When included, save and restore the buffer list.  If Vim is
+--- started with a file name argument, the buffer list is not
+--- restored.  If Vim is started without a file name argument, the
+--- buffer list is restored from the shada file.  Quickfix
+--- ('buftype'), unlisted ('buflisted'), unnamed and buffers on
+--- removable media (`|shada-r|`) are not saved.
+--- When followed by a number, the number specifies the maximum
+--- number of buffers that are stored.  Without a number all
+--- buffers are stored.
+---           *shada-'*
+--- '  Maximum number of previously edited files for which the marks
+--- are remembered.  This parameter must always be included when
+--- 'shada' is non-empty.
+--- Including this item also means that the `|jumplist|` and the
+--- `|changelist|` are stored in the shada file.
+---           *shada-/*
+--- /  Maximum number of items in the search pattern history to be
+--- saved.  If non-zero, then the previous search and substitute
+--- patterns are also saved.  When not included, the value of
+--- 'history' is used.
+---           *shada-:*
+--- :  Maximum number of items in the command-line history to be
+--- saved.  When not included, the value of 'history' is used.
+---           *shada-<*
+--- \<  Maximum number of lines saved for each register.  If zero then
+--- registers are not saved.  When not included, all lines are
+--- saved.  '"' is the old name for this item.
+--- Also see the 's' item below: limit specified in KiB.
+---           *shada-@*
+--- @  Maximum number of items in the input-line history to be
+--- saved.  When not included, the value of 'history' is used.
+---           *shada-c*
+--- c  Dummy option, kept for compatibility reasons.  Has no actual
+--- effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
+--- to UTF-8 as well.
+---           *shada-f*
+--- f  Whether file marks need to be stored.  If zero, file marks ('0
+--- to '9, 'A to 'Z) are not stored.  When not present or when
+--- non-zero, they are all stored.  '0 is used for the current
+--- cursor position (when exiting or when doing `|:wshada|`).
+---           *shada-h*
+--- h  Disable the effect of 'hlsearch' when loading the shada
+--- file.  When not included, it depends on whether ":nohlsearch"
+--- has been used since the last search command.
+---           *shada-n*
+--- n  Name of the shada file.  The name must immediately follow
+--- the 'n'.  Must be at the end of the option!  If the
+--- 'shadafile' option is set, that file name overrides the one
+--- given here with 'shada'.  Environment variables are
+--- expanded when opening the file, not when setting the option.
+---           *shada-r*
+--- r  Removable media.  The argument is a string (up to the next
+--- ',').  This parameter can be given several times.  Each
+--- specifies the start of a path for which no marks will be
+--- stored.  This is to avoid removable media.  For Windows you
+--- could use "ra:,rb:".  You can also use it for temp files,
+--- e.g., for Unix: "r/tmp".  Case is ignored.
+---           *shada-s*
+--- s  Maximum size of an item contents in KiB.  If zero then nothing
+--- is saved.  Unlike Vim this applies to all items, except for
+--- the buffer list and header.  Full item size is off by three
+--- unsigned integers: with `s10` maximum item size may be 1 byte
+--- (type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+--- integer) + 3 bytes (item size: up to 16-bit integer because
+--- 2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
+--- contents size) = 10253 bytes.
 ---
 --- Example:
 --- ```
----     :set shada='50,<1000,s100,:0,n~/nvim/shada
+---   :set shada='50,<1000,s100,:0,n~/nvim/shada
 --- ```
+--- '50    Marks will be remembered for the last 50 files you
+---   edited.
+--- <1000    Contents of registers (up to 1000 lines each) will be
+---   remembered.
+--- s100    Items with contents occupying more then 100 KiB are
+---   skipped.
+--- :0    Command-line history will not be saved.
+--- n~/nvim/shada  The name of the file to use is "~/nvim/shada".
+--- no /    Since '/' is not specified, the default will be used,
+---   that is, save all of the search history, and also the
+---   previous search and substitute patterns.
+--- no %    The buffer list will not be saved nor read back.
+--- no h    'hlsearch' highlighting will be restored.
 ---
---- '50		Marks will be remembered for the last 50 files you
---- 		edited.
---- <1000		Contents of registers (up to 1000 lines each) will be
---- 		remembered.
---- s100		Items with contents occupying more then 100 KiB are
---- 		skipped.
---- :0		Command-line history will not be saved.
---- n~/nvim/shada	The name of the file to use is "~/nvim/shada".
---- no /		Since '/' is not specified, the default will be used,
---- 		that is, save all of the search history, and also the
---- 		previous search and substitute patterns.
---- no %		The buffer list will not be saved nor read back.
---- no h		'hlsearch' highlighting will be restored.
----
---- When setting 'shada' from an empty value you can use `:rshada` to
+--- When setting 'shada' from an empty value you can use `|:rshada|` to
 --- load the contents of the file, this is not done automatically.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5417,11 +5390,11 @@ vim.o.sd = vim.o.shada
 vim.go.shada = vim.o.shada
 vim.go.sd = vim.go.shada
 
---- When non-empty, overrides the file name used for `shada` (viminfo).
+--- When non-empty, overrides the file name used for `|shada|` (viminfo).
 --- When equal to "NONE" no shada file will be read or written.
---- This option can be set with the `-i` command line flag.  The `--clean`
+--- This option can be set with the `|-i|` command line flag.  The `|--clean|`
 --- command line flag sets it to "NONE".
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5434,51 +5407,51 @@ vim.go.sdf = vim.go.shadafile
 --- value also check these options: 'shellpipe', 'shellslash'
 --- 'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
 --- It is allowed to give an argument to the command, e.g.  "csh -f".
---- See `option-backslash` about including spaces and backslashes.
---- Environment variables are expanded `:set_env`.
+--- See `|option-backslash|` about including spaces and backslashes.
+--- Environment variables are expanded `|:set_env|`.
 ---
 --- If the name of the shell contains a space, you need to enclose it in
 --- quotes.  Example with quotes:
 --- ```
---- 	:set shell=\"c:\program\ files\unix\sh.exe\"\ -f
+--- :set shell=\"c:\program\ files\unix\sh.exe\"\ -f
 --- ```
 --- Note the backslash before each quote (to avoid starting a comment) and
---- each space (to avoid ending the option value), so better use `:let-&`
+--- each space (to avoid ending the option value), so better use `|:let-&|`
 --- like this:
 --- ```
---- 	:let &shell='"C:\Program Files\unix\sh.exe" -f'
+--- :let &shell='"C:\Program Files\unix\sh.exe" -f'
 --- ```
 --- Also note that the "-f" is not inside the quotes, because it is not
 --- part of the command name.
---- 						*shell-unquoting*
+---           *shell-unquoting*
 --- Rules regarding quotes:
 --- 1. Option is split on space and tab characters that are not inside
----    quotes: "abc def" runs shell named "abc" with additional argument
----    "def", '"abc def"' runs shell named "abc def" with no additional
----    arguments (here and below: additional means “additional to
----    'shellcmdflag'”).
+---  quotes: "abc def" runs shell named "abc" with additional argument
+---  "def", '"abc def"' runs shell named "abc def" with no additional
+---  arguments (here and below: additional means “additional to
+---  'shellcmdflag'”).
 --- 2. Quotes in option may be present in any position and any number:
----    '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
----    to just "abc".
+---  '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
+---  to just "abc".
 --- 3. Inside quotes backslash preceding backslash means one backslash.
----    Backslash preceding quote means one quote. Backslash preceding
----    anything else means backslash and next character literally:
----    '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
----    'a"b', '"a\b"' is the same as "a\b" again.
+---  Backslash preceding quote means one quote. Backslash preceding
+---  anything else means backslash and next character literally:
+---  '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
+---  'a"b', '"a\b"' is the same as "a\b" again.
 --- 4. Outside of quotes backslash always means itself, it cannot be used
----    to escape quote: 'a\"b"' is the same as "a\b".
---- Note that such processing is done after `:set` did its own round of
---- unescaping, so to keep yourself sane use `:let-&` like shown above.
---- 						*shell-powershell*
+---  to escape quote: 'a\"b"' is the same as "a\b".
+--- Note that such processing is done after `|:set|` did its own round of
+--- unescaping, so to keep yourself sane use `|:let-&|` like shown above.
+---           *shell-powershell*
 --- To use PowerShell:
 --- ```
---- 	let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
---- 	let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
---- 	let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
---- 	let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
---- 	set shellquote= shellxquote=
+--- let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
+--- let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
+--- let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+--- let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
+--- set shellquote= shellxquote=
 --- ```
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5493,10 +5466,10 @@ vim.go.sh = vim.go.shell
 --- to set this option by the user.
 --- On Unix it can have more than one flag.  Each white space separated
 --- part is passed as an argument to the shell command.
---- See `option-backslash` about including spaces and backslashes.
---- See `shell-unquoting` which talks about separating this option into
+--- See `|option-backslash|` about including spaces and backslashes.
+--- See `|shell-unquoting|` which talks about separating this option into
 --- multiple arguments.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5506,7 +5479,7 @@ vim.go.shellcmdflag = vim.o.shellcmdflag
 vim.go.shcf = vim.go.shellcmdflag
 
 --- String to be used to put the output of the ":make" command in the
---- error file.  See also `:make_makeprg`.  See `option-backslash` about
+--- error file.  See also `|:make_makeprg|`.  See `|option-backslash|` about
 --- including spaces and backslashes.
 --- The name of the temporary file can be represented by "%s" if necessary
 --- (the file name is appended automatically if no %s appears in the value
@@ -5531,7 +5504,7 @@ vim.go.shcf = vim.go.shellcmdflag
 --- Don't forget to precede the space with a backslash: ":set sp=\ ".
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5549,7 +5522,7 @@ vim.go.sp = vim.go.shellpipe
 --- or bash, where it should be "\"".  The default is adjusted according
 --- the value of 'shell', to reduce the need to set this option by the
 --- user.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5559,7 +5532,7 @@ vim.go.shellquote = vim.o.shellquote
 vim.go.shq = vim.go.shellquote
 
 --- String to be used to put the output of a filter command in a temporary
---- file.  See also `:!`.  See `option-backslash` about including spaces
+--- file.  See also `|:!|`.  See `|option-backslash|` about including spaces
 --- and backslashes.
 --- The name of the temporary file can be represented by "%s" if necessary
 --- (the file name is appended automatically if no %s appears in the value
@@ -5577,7 +5550,7 @@ vim.go.shq = vim.go.shellquote
 --- explicitly set before.
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5586,7 +5559,7 @@ vim.o.srr = vim.o.shellredir
 vim.go.shellredir = vim.o.shellredir
 vim.go.srr = vim.go.shellredir
 
---- 		only for MS-Windows
+---   only for MS-Windows
 --- When set, a forward slash is used when expanding file names.  This is
 --- useful when a Unix-like shell is used instead of cmd.exe.  Backward
 --- slashes can still be typed, but they are changed to forward slashes by
@@ -5597,7 +5570,7 @@ vim.go.srr = vim.go.shellredir
 --- 'shellslash' only works when a backslash can be used as a path
 --- separator.  To test if this is so use:
 --- ```
---- 	if exists('+shellslash')
+--- if exists('+shellslash')
 --- ```
 --- Also see 'completeslash'.
 ---
@@ -5613,10 +5586,10 @@ vim.go.ssl = vim.go.shellslash
 --- and the 'shell' command does not need to support redirection.
 --- The advantage of using a temp file is that the file type and encoding
 --- can be detected.
---- The `FilterReadPre`, `FilterReadPost` and `FilterWritePre|,
---- |FilterWritePost` autocommands event are not triggered when
+--- The `|FilterReadPre|`, `|FilterReadPost|` and `|FilterWritePre|,
+--- |FilterWritePost|` autocommands event are not triggered when
 --- 'shelltemp' is off.
---- `system()` does not respect this option, it always uses pipes.
+--- `|system()|` does not respect this option, it always uses pipes.
 ---
 --- @type boolean
 vim.o.shelltemp = true
@@ -5641,7 +5614,7 @@ vim.go.sxe = vim.go.shellxescape
 --- When the value is '(' then ')' is appended. When the value is '"('
 --- then ')"' is appended.
 --- When the value is '(' then also see 'shellxescape'.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -5661,8 +5634,8 @@ vim.go.shiftround = vim.o.shiftround
 vim.go.sr = vim.go.shiftround
 
 --- Number of spaces to use for each step of (auto)indent.  Used for
---- `'cindent'`, `>>`, `<<`, etc.
---- When zero the 'tabstop' value will be used.  Use the `shiftwidth()`
+--- `|'cindent'|`, `|>>|`, `|<<|`, etc.
+--- When zero the 'tabstop' value will be used.  Use the `|shiftwidth()|`
 --- function to get the effective shiftwidth value.
 ---
 --- @type integer
@@ -5671,56 +5644,56 @@ vim.o.sw = vim.o.shiftwidth
 vim.bo.shiftwidth = vim.o.shiftwidth
 vim.bo.sw = vim.bo.shiftwidth
 
---- This option helps to avoid all the `hit-enter` prompts caused by file
+--- This option helps to avoid all the `|hit-enter|` prompts caused by file
 --- messages, for example  with CTRL-G, and to avoid some other messages.
 --- It is a list of flags:
----  flag	meaning when present	~
----   l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
----   m	use "[+]" instead of "[Modified]"			*shm-m*
----   r	use "[RO]" instead of "[readonly]"			*shm-r*
----   w	use "[w]" instead of "written" for file write message	*shm-w*
---- 	and "[a]" instead of "appended" for ':w >> file' command
----   a	all of the above abbreviations				*shm-a*
+---  flag  meaning when present  ~
+--- l  use "999L, 888B" instead of "999 lines, 888 bytes"  *shm-l*
+--- m  use "[+]" instead of "[Modified]"      *shm-m*
+--- r  use "[RO]" instead of "[readonly]"      *shm-r*
+--- w  use "[w]" instead of "written" for file write message  *shm-w*
+--- and "[a]" instead of "appended" for ':w >> file' command
+--- a  all of the above abbreviations        *shm-a*
 ---
----   o	overwrite message for writing a file with subsequent	*shm-o*
---- 	message for reading a file (useful for ":wn" or when
---- 	'autowrite' on)
----   O	message for reading a file overwrites any previous	*shm-O*
---- 	message;  also for quickfix message (e.g., ":cn")
----   s	don't give "search hit BOTTOM, continuing at TOP" or	*shm-s*
---- 	"search hit TOP, continuing at BOTTOM" messages; when using
---- 	the search count do not show "W" after the count message (see
---- 	S below)
----   t	truncate file message at the start if it is too long	*shm-t*
---- 	to fit on the command-line, "<" will appear in the left most
---- 	column; ignored in Ex mode
----   T	truncate other messages in the middle if they are too	*shm-T*
---- 	long to fit on the command line; "..." will appear in the
---- 	middle; ignored in Ex mode
----   W	don't give "written" or "[w]" when writing a file	*shm-W*
----   A	don't give the "ATTENTION" message when an existing	*shm-A*
---- 	swap file is found
----   I	don't give the intro message when starting Vim,		*shm-I*
---- 	see `:intro`
----   c	don't give `ins-completion-menu` messages; for		*shm-c*
---- 	example, "-- XXX completion (YYY)", "match 1 of 2", "The only
---- 	match", "Pattern not found", "Back at original", etc.
----   C	don't give messages while scanning for ins-completion	*shm-C*
---- 	items, for instance "scanning tags"
----   q	use "recording" instead of "recording @a"		*shm-q*
----   F	don't give the file info when editing a file, like	*shm-F*
---- 	`:silent` was used for the command
----   S	do not show search count message when searching, e.g.	*shm-S*
---- 	"[1/5]"
+--- o  overwrite message for writing a file with subsequent  *shm-o*
+--- message for reading a file (useful for ":wn" or when
+--- 'autowrite' on)
+--- O  message for reading a file overwrites any previous  *shm-O*
+--- message;  also for quickfix message (e.g., ":cn")
+--- s  don't give "search hit BOTTOM, continuing at TOP" or  *shm-s*
+--- "search hit TOP, continuing at BOTTOM" messages; when using
+--- the search count do not show "W" after the count message (see
+--- S below)
+--- t  truncate file message at the start if it is too long  *shm-t*
+--- to fit on the command-line, "<" will appear in the left most
+--- column; ignored in Ex mode
+--- T  truncate other messages in the middle if they are too  *shm-T*
+--- long to fit on the command line; "..." will appear in the
+--- middle; ignored in Ex mode
+--- W  don't give "written" or "[w]" when writing a file  *shm-W*
+--- A  don't give the "ATTENTION" message when an existing  *shm-A*
+--- swap file is found
+--- I  don't give the intro message when starting Vim,    *shm-I*
+--- see `|:intro|`
+--- c  don't give `|ins-completion-menu|` messages; for    *shm-c*
+--- example, "-- XXX completion (YYY)", "match 1 of 2", "The only
+--- match", "Pattern not found", "Back at original", etc.
+--- C  don't give messages while scanning for ins-completion  *shm-C*
+--- items, for instance "scanning tags"
+--- q  use "recording" instead of "recording @a"    *shm-q*
+--- F  don't give the file info when editing a file, like  *shm-F*
+--- `:silent` was used for the command
+--- S  do not show search count message when searching, e.g.  *shm-S*
+--- "[1/5]"
 ---
 --- This gives you the opportunity to avoid that a change between buffers
 --- requires you to hit <Enter>, but still gives as useful a message as
 --- possible for the space available.  To get the whole message that you
 --- would have got with 'shm' empty, use ":file!"
 --- Useful values:
----     shm=	No abbreviation of message.
----     shm=a	Abbreviation, but no loss of information.
----     shm=at	Abbreviation, and truncate message when necessary.
+---   shm=  No abbreviation of message.
+---   shm=a  Abbreviation, but no loss of information.
+---   shm=at  Abbreviation, and truncate message when necessary.
 ---
 --- @type string
 vim.o.shortmess = "ltToOCF"
@@ -5731,22 +5704,21 @@ vim.go.shm = vim.go.shortmess
 --- String to put at the start of lines that have been wrapped.  Useful
 --- values are "> " or "+++ ":
 --- ```
---- 	:let &showbreak = "> "
---- 	:let &showbreak = '+++ '
+--- :let &showbreak = "> "
+--- :let &showbreak = '+++ '
 --- ```
 --- Only printable single-cell characters are allowed, excluding <Tab> and
 --- comma (in a future version the comma might be used to separate the
 --- part that is shown at the end and at the start of a line).
---- The `hl-NonText` highlight group determines the highlighting.
+--- The `|hl-NonText|` highlight group determines the highlighting.
 --- Note that tabs after the showbreak will be displayed differently.
 --- If you want the 'showbreak' to appear in between line numbers, add the
 --- "n" flag to 'cpoptions'.
 --- A window-local value overrules a global value.  If the global value is
 --- set and you want no value in the current window use NONE:
 --- ```
---- 	:setlocal showbreak=NONE
+--- :setlocal showbreak=NONE
 --- ```
----
 ---
 --- @type string
 vim.o.showbreak = ""
@@ -5760,11 +5732,11 @@ vim.go.sbr = vim.go.showbreak
 --- option off if your terminal is slow.
 --- In Visual mode the size of the selected area is shown:
 --- - When selecting characters within a line, the number of characters.
----   If the number of bytes is different it is also displayed: "2-6"
----   means two characters and six bytes.
+--- If the number of bytes is different it is also displayed: "2-6"
+--- means two characters and six bytes.
 --- - When selecting more than one line, the number of lines.
 --- - When selecting a block, the size in screen characters:
----   {lines}x{columns}.
+--- {lines}x{columns}.
 --- This information can be displayed in an alternative location using the
 --- 'showcmdloc' option, useful when 'cmdheight' is 0.
 ---
@@ -5776,9 +5748,9 @@ vim.go.sc = vim.go.showcmd
 
 --- This option can be used to display the (partially) entered command in
 --- another location.  Possible values are:
----   last		Last line of the screen (default).
----   statusline	Status line of the current window.
----   tabline	First line of the screen if 'showtabline' is enabled.
+--- last    Last line of the screen (default).
+--- statusline  Status line of the current window.
+--- tabline  First line of the screen if 'showtabline' is enabled.
 --- Setting this option to "statusline" or "tabline" means that these will
 --- be redrawn whenever the command changes, which can be on every key
 --- pressed.
@@ -5792,7 +5764,7 @@ vim.o.sloc = vim.o.showcmdloc
 vim.go.showcmdloc = vim.o.showcmdloc
 vim.go.sloc = vim.go.showcmdloc
 
---- When completing a word in insert mode (see `ins-completion`) from the
+--- When completing a word in insert mode (see `|ins-completion|`) from the
 --- tags file, show both the tag name and a tidied-up form of the search
 --- pattern (if there is one) as possible matches.  Thus, if you have
 --- matched a C function, you can see a template for what arguments are
@@ -5820,7 +5792,7 @@ vim.go.sft = vim.go.showfulltag
 --- matches for.  'rightleft' and 'revins' are used to look for opposite
 --- matches.
 --- Also see the matchparen plugin for highlighting the match when moving
---- around `pi_paren.txt`.
+--- around `|pi_paren.txt|`.
 --- Note: Use of the short form is rated PG.
 ---
 --- @type boolean
@@ -5830,7 +5802,7 @@ vim.go.showmatch = vim.o.showmatch
 vim.go.sm = vim.go.showmatch
 
 --- If in Insert, Replace or Visual mode put a message on the last line.
---- The `hl-ModeMsg` highlight group determines the highlighting.
+--- The `|hl-ModeMsg|` highlight group determines the highlighting.
 --- The option has no effect when 'cmdheight' is zero.
 ---
 --- @type boolean
@@ -5841,12 +5813,12 @@ vim.go.smd = vim.go.showmode
 
 --- The value of this option specifies when the line with tab page labels
 --- will be displayed:
---- 	0: never
---- 	1: only if there are at least two tab pages
---- 	2: always
+--- 0: never
+--- 1: only if there are at least two tab pages
+--- 2: always
 --- This is both for the GUI and non-GUI implementation of the tab pages
 --- line.
---- See `tab-page` for more information about tab pages.
+--- See `|tab-page|` for more information about tab pages.
 ---
 --- @type integer
 vim.o.showtabline = 1
@@ -5868,7 +5840,7 @@ vim.go.ss = vim.go.sidescroll
 
 --- The minimal number of screen columns to keep to the left and to the
 --- right of the cursor if 'nowrap' is set.  Setting this option to a
---- value greater than 0 while having `'sidescroll'` also at a non-zero
+--- value greater than 0 while having `|'sidescroll'|` also at a non-zero
 --- value makes some context visible in the line you are scrolling in
 --- horizontally (except at beginning of the line).  Setting this option
 --- to a large value (like 999) has the effect of keeping the cursor
@@ -5877,18 +5849,16 @@ vim.go.ss = vim.go.sidescroll
 --- After using the local value, go back the global value with one of
 --- these two:
 --- ```
---- 	setlocal sidescrolloff<
---- 	setlocal sidescrolloff=-1
+--- setlocal sidescrolloff<
+--- setlocal sidescrolloff=-1
 --- ```
----
 --- Example: Try this together with 'sidescroll' and 'listchars' as
---- 	 in the following example to never allow the cursor to move
---- 	 onto the "extends" character:
+---  in the following example to never allow the cursor to move
+---  onto the "extends" character:
 --- ```
---- 	 :set nowrap sidescroll=1 listchars=extends:>,precedes:<
---- 	 :set sidescrolloff=1
+---  :set nowrap sidescroll=1 listchars=extends:>,precedes:<
+---  :set sidescrolloff=1
 --- ```
----
 ---
 --- @type integer
 vim.o.sidescrolloff = 0
@@ -5899,21 +5869,21 @@ vim.go.sidescrolloff = vim.o.sidescrolloff
 vim.go.siso = vim.go.sidescrolloff
 
 --- When and how to draw the signcolumn. Valid values are:
----    "auto"	only when there is a sign to display
----    "auto:[1-9]" resize to accommodate multiple signs up to the
----                 given number (maximum 9), e.g. "auto:4"
----    "auto:[1-8]-[2-9]"
----                 resize to accommodate multiple signs up to the
---- 		given maximum number (maximum 9) while keeping
---- 		at least the given minimum (maximum 8) fixed
---- 		space. The minimum number should always be less
---- 		than the maximum number, e.g. "auto:2-5"
----    "no"		never
----    "yes"	always
----    "yes:[1-9]"  always, with fixed space for signs up to the given
----                 number (maximum 9), e.g. "yes:3"
----    "number"	display signs in the 'number' column. If the number
---- 		column is not present, then behaves like "auto".
+---  "auto"  only when there is a sign to display
+---  "auto:[1-9]" resize to accommodate multiple signs up to the
+---               given number (maximum 9), e.g. "auto:4"
+---  "auto:[1-8]-[2-9]"
+---               resize to accommodate multiple signs up to the
+---   given maximum number (maximum 9) while keeping
+---   at least the given minimum (maximum 8) fixed
+---   space. The minimum number should always be less
+---   than the maximum number, e.g. "auto:2-5"
+---  "no"    never
+---  "yes"  always
+---  "yes:[1-9]"  always, with fixed space for signs up to the given
+---               number (maximum 9), e.g. "yes:3"
+---  "number"  display signs in the 'number' column. If the number
+---   column is not present, then behaves like "auto".
 ---
 --- Note regarding "orphaned signs": with signcolumn numbers higher than
 --- 1, deleting lines will also remove the associated signs automatically,
@@ -5943,7 +5913,7 @@ vim.go.scs = vim.go.smartcase
 --- Do smart autoindenting when starting a new line.  Works for C-like
 --- programs, but can also be used for other languages.  'cindent' does
 --- something like this, works better in most cases, but is more strict,
---- see `C-indenting`.  When 'cindent' is on or 'indentexpr' is set,
+--- see `|C-indenting|`.  When 'cindent' is on or 'indentexpr' is set,
 --- setting 'si' has no effect.  'indentexpr' is a more advanced
 --- alternative.
 --- Normally 'autoindent' should also be on when using 'smartindent'.
@@ -5972,9 +5942,9 @@ vim.bo.si = vim.bo.smartindent
 --- line.
 --- When off, a <Tab> always inserts blanks according to 'tabstop' or
 --- 'softtabstop'.  'shiftwidth' is only used for shifting text left or
---- right `shift-left-right`.
+--- right `|shift-left-right|`.
 --- What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
---- option.  Also see `ins-expandtab`.  When 'expandtab' is not set, the
+--- option.  Also see `|ins-expandtab|`.  When 'expandtab' is not set, the
 --- number of spaces is minimized by using <Tab>s.
 ---
 --- @type boolean
@@ -5986,7 +5956,7 @@ vim.go.sta = vim.go.smarttab
 --- Scrolling works with screen lines.  When 'wrap' is set and the first
 --- line in the window wraps part of it may not be visible, as if it is
 --- above the window. "<<<" is displayed at the start of the first line,
---- highlighted with `hl-NonText`.
+--- highlighted with `|hl-NonText|`.
 --- You may also want to add "lastline" to the 'display' option to show as
 --- much of the last line as possible.
 --- NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
@@ -6006,12 +5976,12 @@ vim.wo.sms = vim.wo.smoothscroll
 --- commands like "x" still work on the actual characters.
 --- When 'sts' is zero, this feature is off.
 --- When 'sts' is negative, the value of 'shiftwidth' is used.
---- See also `ins-expandtab`.  When 'expandtab' is not set, the number of
+--- See also `|ins-expandtab|`.  When 'expandtab' is not set, the number of
 --- spaces is minimized by using <Tab>s.
 --- The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
 --- set.
 ---
---- The value of 'softtabstop' will be ignored if `'varsofttabstop'` is set
+--- The value of 'softtabstop' will be ignored if `|'varsofttabstop'|` is set
 --- to anything other than an empty string.
 ---
 --- @type integer
@@ -6020,7 +5990,7 @@ vim.o.sts = vim.o.softtabstop
 vim.bo.softtabstop = vim.o.softtabstop
 vim.bo.sts = vim.bo.softtabstop
 
---- When on spell checking will be done.  See `spell`.
+--- When on spell checking will be done.  See `|spell|`.
 --- The languages are specified with 'spelllang'.
 ---
 --- @type boolean
@@ -6029,13 +5999,13 @@ vim.wo.spell = vim.o.spell
 
 --- Pattern to locate the end of a sentence.  The following word will be
 --- checked to start with a capital letter.  If not then it is highlighted
---- with SpellCap `hl-SpellCap` (unless the word is also badly spelled).
+--- with SpellCap `|hl-SpellCap|` (unless the word is also badly spelled).
 --- When this check is not wanted make this option empty.
 --- Only used when 'spell' is set.
---- Be careful with special characters, see `option-backslash` about
+--- Be careful with special characters, see `|option-backslash|` about
 --- including spaces and backslashes.
 --- To set this option automatically depending on the language, see
---- `set-spc-auto`.
+--- `|set-spc-auto|`.
 ---
 --- @type string
 vim.o.spellcapcheck = "[.?!]\\_[\\])'\"\\t ]\\+"
@@ -6043,13 +6013,13 @@ vim.o.spc = vim.o.spellcapcheck
 vim.bo.spellcapcheck = vim.o.spellcapcheck
 vim.bo.spc = vim.bo.spellcapcheck
 
---- Name of the word list file where words are added for the `zg` and `zw`
+--- Name of the word list file where words are added for the `|zg|` and `|zw|`
 --- commands.  It must end in ".{encoding}.add".  You need to include the
 --- path, otherwise the file is placed in the current directory.
 --- The path may include characters from 'isfname', space, comma and '@'.
---- 							*E765*
+--- *E765*
 --- It may also be a comma-separated list of names.  A count before the
---- `zg` and `zw` commands can be used to access each.  This allows using
+--- `|zg|` and `|zw|` commands can be used to access each.  This allows using
 --- a personal word list file and a project word list file.
 --- When a word is added while this option is empty Vim will set it for
 --- you: Using the first directory in 'runtimepath' that is writable.  If
@@ -6062,7 +6032,7 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- name if you want to.  However, it will then only be used when
 --- 'spellfile' is set to it, for entries in 'spelllang' only files
 --- without region name will be found.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -6074,7 +6044,7 @@ vim.bo.spf = vim.bo.spellfile
 --- A comma-separated list of word list names.  When the 'spell' option is
 --- on spellchecking will be done for these languages.  Example:
 --- ```
---- 	set spelllang=en_us,nl,medical
+--- set spelllang=en_us,nl,medical
 --- ```
 --- This means US English, Dutch and medical words are recognized.  Words
 --- that are not recognized will be highlighted.
@@ -6093,22 +6063,22 @@ vim.bo.spf = vim.bo.spellfile
 --- words.
 --- Note that the "medical" dictionary does not exist, it is just an
 --- example of a longer name.
---- 						*E757*
+---           *E757*
 --- As a special case the name of a .spl file can be given as-is.  The
 --- first "_xx" in the name is removed and used as the region name
 --- (_xx is an underscore, two letters and followed by a non-letter).
 --- This is mainly for testing purposes.  You must make sure the correct
 --- encoding is used, Vim doesn't check it.
---- How the related spell files are found is explained here: `spell-load`.
+--- How the related spell files are found is explained here: `|spell-load|`.
 ---
---- If the `spellfile.vim` plugin is active and you use a language name
+--- If the `|spellfile.vim|` plugin is active and you use a language name
 --- for which Vim cannot find the .spl file in 'runtimepath' the plugin
 --- will ask you if you want to download the file.
 ---
 --- After this option has been set successfully, Vim will source the files
 --- "spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
 --- up to the first character that is not an ASCII letter or number and
---- not a dash.  Also see `set-spc-auto`.
+--- not a dash.  Also see `|set-spc-auto|`.
 ---
 --- @type string
 vim.o.spelllang = "en"
@@ -6117,14 +6087,14 @@ vim.bo.spelllang = vim.o.spelllang
 vim.bo.spl = vim.bo.spelllang
 
 --- A comma-separated list of options for spell checking:
---- camel		When a word is CamelCased, assume "Cased" is a
---- 		separate word: every upper-case character in a word
---- 		that comes after a lower case character indicates the
---- 		start of a new word.
---- noplainbuffer	Only spellcheck a buffer when 'syntax' is enabled,
---- 		or when extmarks are set within the buffer. Only
---- 		designated regions of the buffer are spellchecked in
---- 		this case.
+--- camel    When a word is CamelCased, assume "Cased" is a
+--- separate word: every upper-case character in a word
+--- that comes after a lower case character indicates the
+--- start of a new word.
+--- noplainbuffer  Only spellcheck a buffer when 'syntax' is enabled,
+--- or when extmarks are set within the buffer. Only
+--- designated regions of the buffer are spellchecked in
+--- this case.
 ---
 --- @type string
 vim.o.spelloptions = ""
@@ -6132,70 +6102,69 @@ vim.o.spo = vim.o.spelloptions
 vim.bo.spelloptions = vim.o.spelloptions
 vim.bo.spo = vim.bo.spelloptions
 
---- Methods used for spelling suggestions.  Both for the `z=` command and
---- the `spellsuggest()` function.  This is a comma-separated list of
+--- Methods used for spelling suggestions.  Both for the `|z=|` command and
+--- the `|spellsuggest()|` function.  This is a comma-separated list of
 --- items:
 ---
---- best		Internal method that works best for English.  Finds
---- 		changes like "fast" and uses a bit of sound-a-like
---- 		scoring to improve the ordering.
+--- best    Internal method that works best for English.  Finds
+---   changes like "fast" and uses a bit of sound-a-like
+---   scoring to improve the ordering.
 ---
---- double		Internal method that uses two methods and mixes the
---- 		results.  The first method is "fast", the other method
---- 		computes how much the suggestion sounds like the bad
---- 		word.  That only works when the language specifies
---- 		sound folding.  Can be slow and doesn't always give
---- 		better results.
+--- double    Internal method that uses two methods and mixes the
+---   results.  The first method is "fast", the other method
+---   computes how much the suggestion sounds like the bad
+---   word.  That only works when the language specifies
+---   sound folding.  Can be slow and doesn't always give
+---   better results.
 ---
---- fast		Internal method that only checks for simple changes:
---- 		character inserts/deletes/swaps.  Works well for
---- 		simple typing mistakes.
+--- fast    Internal method that only checks for simple changes:
+---   character inserts/deletes/swaps.  Works well for
+---   simple typing mistakes.
 ---
---- {number}	The maximum number of suggestions listed for `z=`.
---- 		Not used for `spellsuggest()`.  The number of
---- 		suggestions is never more than the value of 'lines'
---- 		minus two.
+--- {number}  The maximum number of suggestions listed for `|z=|`.
+---   Not used for `|spellsuggest()|`.  The number of
+---   suggestions is never more than the value of 'lines'
+---   minus two.
 ---
 --- timeout:{millisec}   Limit the time searching for suggestions to
---- 		{millisec} milli seconds.  Applies to the following
---- 		methods.  When omitted the limit is 5000. When
---- 		negative there is no limit.
+---   {millisec} milli seconds.  Applies to the following
+---   methods.  When omitted the limit is 5000. When
+---   negative there is no limit.
 ---
 --- file:{filename} Read file {filename}, which must have two columns,
---- 		separated by a slash.  The first column contains the
---- 		bad word, the second column the suggested good word.
---- 		Example:
---- 			theribal/terrible ~
---- 		Use this for common mistakes that do not appear at the
---- 		top of the suggestion list with the internal methods.
---- 		Lines without a slash are ignored, use this for
---- 		comments.
---- 		The word in the second column must be correct,
---- 		otherwise it will not be used.  Add the word to an
---- 		".add" file if it is currently flagged as a spelling
---- 		mistake.
---- 		The file is used for all languages.
+---   separated by a slash.  The first column contains the
+---   bad word, the second column the suggested good word.
+---   Example:
+---     theribal/terrible ~
+---   Use this for common mistakes that do not appear at the
+---   top of the suggestion list with the internal methods.
+---   Lines without a slash are ignored, use this for
+---   comments.
+---   The word in the second column must be correct,
+---   otherwise it will not be used.  Add the word to an
+---   ".add" file if it is currently flagged as a spelling
+---   mistake.
+---   The file is used for all languages.
 ---
---- expr:{expr}	Evaluate expression {expr}.  Use a function to avoid
---- 		trouble with spaces.  `v:val` holds the badly spelled
---- 		word.  The expression must evaluate to a List of
---- 		Lists, each with a suggestion and a score.
---- 		Example:
---- 			[['the', 33], ['that', 44]] ~
---- 		Set 'verbose' and use `z=` to see the scores that the
---- 		internal methods use.  A lower score is better.
---- 		This may invoke `spellsuggest()` if you temporarily
---- 		set 'spellsuggest' to exclude the "expr:" part.
---- 		Errors are silently ignored, unless you set the
---- 		'verbose' option to a non-zero value.
+--- expr:{expr}  Evaluate expression {expr}.  Use a function to avoid
+---   trouble with spaces.  `|v:val|` holds the badly spelled
+---   word.  The expression must evaluate to a List of
+---   Lists, each with a suggestion and a score.
+---   Example:
+---     [['the', 33], ['that', 44]] ~
+---   Set 'verbose' and use `|z=|` to see the scores that the
+---   internal methods use.  A lower score is better.
+---   This may invoke `|spellsuggest()|` if you temporarily
+---   set 'spellsuggest' to exclude the "expr:" part.
+---   Errors are silently ignored, unless you set the
+---   'verbose' option to a non-zero value.
 ---
 --- Only one of "best", "double" or "fast" may be used.  The others may
 --- appear several times in any order.  Example:
 --- ```
---- 	:set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+--- :set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
 --- ```
----
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -6205,7 +6174,7 @@ vim.go.spellsuggest = vim.o.spellsuggest
 vim.go.sps = vim.go.spellsuggest
 
 --- When on, splitting a window will put the new window below the current
---- one. `:split`
+--- one. `|:split|`
 ---
 --- @type boolean
 vim.o.splitbelow = false
@@ -6217,9 +6186,9 @@ vim.go.sb = vim.go.splitbelow
 --- closing or resizing horizontal splits.
 ---
 --- Possible values are:
----   cursor	Keep the same relative cursor position.
----   screen	Keep the text on the same screen line.
----   topline	Keep the topline the same.
+--- cursor  Keep the same relative cursor position.
+--- screen  Keep the text on the same screen line.
+--- topline  Keep the topline the same.
 ---
 --- For the "screen" and "topline" values, the cursor position will be
 --- changed when necessary. In this case, the jumplist will be populated
@@ -6233,7 +6202,7 @@ vim.go.splitkeep = vim.o.splitkeep
 vim.go.spk = vim.go.splitkeep
 
 --- When on, splitting a window will put the new window right of the
---- current one. `:vsplit`
+--- current one. `|:vsplit|`
 ---
 --- @type boolean
 vim.o.splitright = false
@@ -6266,20 +6235,20 @@ vim.go.sol = vim.go.startofline
 --- Some of the items from the 'statusline' format are different for
 --- 'statuscolumn':
 ---
---- %l	line number of currently drawn line
---- %r	relative line number of currently drawn line
---- %s	sign column for currently drawn line
---- %C	fold column for currently drawn line
+--- %l  line number of currently drawn line
+--- %r  relative line number of currently drawn line
+--- %s  sign column for currently drawn line
+--- %C  fold column for currently drawn line
 ---
 --- NOTE: To draw the sign and fold columns, their items must be included in
 --- 'statuscolumn'. Even when they are not included, the status column width
 --- will adapt to the 'signcolumn' and 'foldcolumn' width.
 ---
---- The `v:lnum`    variable holds the line number to be drawn.
---- The `v:relnum`  variable holds the relative line number to be drawn.
---- The `v:virtnum` variable is negative when drawing virtual lines, zero
---- 	      when drawing the actual buffer line, and positive when
---- 	      drawing the wrapped part of a buffer line.
+--- The `|v:lnum|`    variable holds the line number to be drawn.
+--- The `|v:relnum|`  variable holds the relative line number to be drawn.
+--- The `|v:virtnum|` variable is negative when drawing virtual lines, zero
+---       when drawing the actual buffer line, and positive when
+---       drawing the wrapped part of a buffer line.
 ---
 --- NOTE: The %@ click execute function item is supported as well but the
 --- specified function will be the same for each row in the same column.
@@ -6287,26 +6256,25 @@ vim.go.sol = vim.go.startofline
 --- handler should be written with this in mind.
 ---
 --- Examples:
----
 --- ```vim
---- 	" Relative number with bar separator and click handlers:
---- 	:set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
+--- " Relative number with bar separator and click handlers:
+--- :set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
 ---
---- 	" Right aligned relative cursor line number:
---- 	:let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+--- " Right aligned relative cursor line number:
+--- :let &stc='%=%{v:relnum?v:relnum:v:lnum} '
 ---
---- 	" Line numbers in hexadecimal for non wrapped part of lines:
---- 	:let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
+--- " Line numbers in hexadecimal for non wrapped part of lines:
+--- :let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
 ---
---- 	" Human readable line numbers with thousands separator:
---- 	:let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
---- 		   . '%(\\d\\d\\d\\)\\+$",",","g")}'
+--- " Human readable line numbers with thousands separator:
+--- :let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
+---      . '%(\\d\\d\\d\\)\\+$",",","g")}'
 ---
---- 	" Both relative and absolute line numbers with different
---- 	" highlighting for odd and even relative numbers:
---- 	:let &stc='%#NonText#%{&nu?v:lnum:""}' .
---- 	 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
---- 	 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
+--- " Both relative and absolute line numbers with different
+--- " highlighting for odd and even relative numbers:
+--- :let &stc='%#NonText#%{&nu?v:lnum:""}' .
+---  '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
+---  '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
 --- ```
 --- WARNING: this expression is evaluated for each screen line so defining
 --- an expensive expression can negatively affect render performance.
@@ -6318,20 +6286,20 @@ vim.wo.statuscolumn = vim.o.statuscolumn
 vim.wo.stc = vim.wo.statuscolumn
 
 --- When non-empty, this option determines the content of the status line.
---- Also see `status-line`.
+--- Also see `|status-line|`.
 ---
 --- The option consists of printf style '%' items interspersed with
 --- normal text.  Each status line item is of the form:
----   %-0{minwid}.{maxwid}{item}
+--- %-0{minwid}.{maxwid}{item}
 --- All fields except the {item} are optional.  A single percent sign can
 --- be given as "%%".
 ---
 --- When the option starts with "%!" then it is used as an expression,
 --- evaluated and the result is used as the option value.  Example:
 --- ```
---- 	:set statusline=%!MyStatusLine()
+--- :set statusline=%!MyStatusLine()
 --- ```
---- The *g:statusline_winid* variable will be set to the `window-ID` of the
+--- The *g:statusline_winid* variable will be set to the `|window-ID|` of the
 --- window that the status line belongs to.
 --- The result can contain %{} items that will be evaluated too.
 --- Note that the "%!" expression is evaluated in the context of the
@@ -6344,31 +6312,31 @@ vim.wo.stc = vim.wo.statuscolumn
 --- unpredictable.
 ---
 --- Note that the only effect of 'ruler' when this option is set (and
---- 'laststatus' is 2 or 3) is controlling the output of `CTRL-G`.
+--- 'laststatus' is 2 or 3) is controlling the output of `|CTRL-G|`.
 ---
---- field	    meaning ~
---- -	    Left justify the item.  The default is right justified
---- 	    when minwid is larger than the length of the item.
---- 0	    Leading zeroes in numeric items.  Overridden by "-".
---- minwid	    Minimum width of the item, padding as set by "-" & "0".
---- 	    Value must be 50 or less.
---- maxwid	    Maximum width of the item.  Truncation occurs with a "<"
---- 	    on the left for text items.  Numeric items will be
---- 	    shifted down to maxwid-2 digits followed by ">"number
---- 	    where number is the amount of missing digits, much like
---- 	    an exponential notation.
---- item	    A one letter code as described below.
+--- field      meaning ~
+--- -      Left justify the item.  The default is right justified
+---     when minwid is larger than the length of the item.
+--- 0      Leading zeroes in numeric items.  Overridden by "-".
+--- minwid      Minimum width of the item, padding as set by "-" & "0".
+---     Value must be 50 or less.
+--- maxwid      Maximum width of the item.  Truncation occurs with a "<"
+---     on the left for text items.  Numeric items will be
+---     shifted down to maxwid-2 digits followed by ">"number
+---     where number is the amount of missing digits, much like
+---     an exponential notation.
+--- item      A one letter code as described below.
 ---
 --- Following is a description of the possible statusline items.  The
 --- second character in "item" is the type:
---- 	N for number
---- 	S for string
---- 	F for flags as described below
---- 	- not applicable
+--- N for number
+--- S for string
+--- F for flags as described below
+--- - not applicable
 ---
 --- item  meaning ~
 --- f S   Path to the file in the buffer, as typed or relative to current
----       directory.
+---     directory.
 --- F S   Full path to the file in the buffer.
 --- t S   File name (tail) of file in the buffer.
 --- m F   Modified flag, text is "[+]"; "[-]" if 'modifiable' is off.
@@ -6382,96 +6350,96 @@ vim.wo.stc = vim.wo.statuscolumn
 --- y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
 --- Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
 --- q S   "[Quickfix List]", "[Location List]" or empty.
---- k S   Value of "b:keymap_name" or 'keymap' when `:lmap` mappings are
----       being used: "<keymap>"
+--- k S   Value of "b:keymap_name" or 'keymap' when `|:lmap|` mappings are
+---     being used: "<keymap>"
 --- n N   Buffer number.
 --- b N   Value of character under cursor.
 --- B N   As above, in hexadecimal.
 --- o N   Byte number in file of byte under cursor, first byte is 1.
----       Mnemonic: Offset from start of file (with one added)
+---     Mnemonic: Offset from start of file (with one added)
 --- O N   As above, in hexadecimal.
 --- l N   Line number.
 --- L N   Number of lines in buffer.
 --- c N   Column number (byte index).
 --- v N   Virtual column number (screen column).
 --- V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
---- p N   Percentage through file in lines as in `CTRL-G`.
+--- p N   Percentage through file in lines as in `|CTRL-G|`.
 --- P S   Percentage through file of displayed window.  This is like the
----       percentage described for 'ruler'.  Always 3 in length, unless
----       translated.
+---     percentage described for 'ruler'.  Always 3 in length, unless
+---     translated.
 --- S S   'showcmd' content, see 'showcmdloc'.
 --- a S   Argument list status as in default title.  ({current} of {max})
----       Empty if the argument file count is zero or one.
+---     Empty if the argument file count is zero or one.
 --- { NF  Evaluate expression between "%{" and "}" and substitute result.
----       Note that there is no "%" before the closing "}".  The
----       expression cannot contain a "}" character, call a function to
----       work around that.  See `stl-%{` below.
+---     Note that there is no "%" before the closing "}".  The
+---     expression cannot contain a "}" character, call a function to
+---     work around that.  See `|stl-%{|` below.
 --- `{%` -  This is almost same as "{" except the result of the expression is
----       re-evaluated as a statusline format string.  Thus if the
----       return value of expr contains "%" items they will get expanded.
----       The expression can contain the "}" character, the end of
----       expression is denoted by "%}".
----       For example:
+---     re-evaluated as a statusline format string.  Thus if the
+---     return value of expr contains "%" items they will get expanded.
+---     The expression can contain the "}" character, the end of
+---     expression is denoted by "%}".
+---     For example:
 --- ```
---- 	func! Stl_filename() abort
---- 	    return "%t"
---- 	endfunc
+--- func! Stl_filename() abort
+---     return "%t"
+--- endfunc
 --- ```
 --- `stl=%{Stl_filename()}`   results in `"%t"`
----         `stl=%{%Stl_filename()%}` results in `"Name of current file"`
+---       `stl=%{%Stl_filename()%}` results in `"Name of current file"`
 --- %} -  End of "{%" expression
 --- ( -   Start of item group.  Can be used for setting the width and
----       alignment of a section.  Must be followed by %) somewhere.
+---     alignment of a section.  Must be followed by %) somewhere.
 --- ) -   End of item group.  No width fields allowed.
 --- T N   For 'tabline': start of tab page N label.  Use %T or %X to end
----       the label.  Clicking this label with left mouse button switches
----       to the specified tab page.
+---     the label.  Clicking this label with left mouse button switches
+---     to the specified tab page.
 --- X N   For 'tabline': start of close tab N label.  Use %X or %T to end
----       the label, e.g.: %3Xclose%X.  Use %999X for a "close current
----       tab" label.    Clicking this label with left mouse button closes
----       specified tab page.
+---     the label, e.g.: %3Xclose%X.  Use %999X for a "close current
+---     tab" label.    Clicking this label with left mouse button closes
+---     specified tab page.
 --- @ N   Start of execute function label. Use %X or %T to
----       end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
----       label runs specified function: in the example when clicking once
----       using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
----       '    ')" expression will be run.  Function receives the
----       following arguments in order:
----       1. minwid field value or zero if no N was specified
----       2. number of mouse clicks to detect multiple clicks
----       3. mouse button used: "l", "r" or "m" for left, right or middle
----          button respectively; one should not rely on third argument
----          being only "l", "r" or "m": any other non-empty string value
----          that contains only ASCII lower case letters may be expected
----          for other mouse buttons
----       4. modifiers pressed: string which contains "s" if shift
----          modifier was pressed, "c" for control, "a" for alt and "m"
----          for meta; currently if modifier is not pressed string
----          contains space instead, but one should not rely on presence
----          of spaces or specific order of modifiers: use `stridx()` to
----          test whether some modifier is present; string is guaranteed
----          to contain only ASCII letters and spaces, one letter per
----          modifier; "?" modifier may also be present, but its presence
----          is a bug that denotes that new mouse button recognition was
----          added without modifying code that reacts on mouse clicks on
----          this label.
----       Use `getmousepos()`.winid in the specified function to get the
----       corresponding window id of the clicked item.
+---     end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
+---     label runs specified function: in the example when clicking once
+---     using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
+---     '    ')" expression will be run.  Function receives the
+---     following arguments in order:
+---     1. minwid field value or zero if no N was specified
+---     2. number of mouse clicks to detect multiple clicks
+---     3. mouse button used: "l", "r" or "m" for left, right or middle
+---        button respectively; one should not rely on third argument
+---        being only "l", "r" or "m": any other non-empty string value
+---        that contains only ASCII lower case letters may be expected
+---        for other mouse buttons
+---     4. modifiers pressed: string which contains "s" if shift
+---        modifier was pressed, "c" for control, "a" for alt and "m"
+---        for meta; currently if modifier is not pressed string
+---        contains space instead, but one should not rely on presence
+---        of spaces or specific order of modifiers: use `|stridx()|` to
+---        test whether some modifier is present; string is guaranteed
+---        to contain only ASCII letters and spaces, one letter per
+---        modifier; "?" modifier may also be present, but its presence
+---        is a bug that denotes that new mouse button recognition was
+---        added without modifying code that reacts on mouse clicks on
+---        this label.
+---     Use `|getmousepos()|`.winid in the specified function to get the
+---     corresponding window id of the clicked item.
 --- \< -   Where to truncate line if too long.  Default is at the start.
----       No width fields allowed.
+---     No width fields allowed.
 --- = -   Separation point between alignment sections.  Each section will
----       be separated by an equal number of spaces.  With one %= what
----       comes after it will be right-aligned.  With two %= there is a
----       middle part, with white space left and right of it.
----       No width fields allowed.
+---     be separated by an equal number of spaces.  With one %= what
+---     comes after it will be right-aligned.  With two %= there is a
+---     middle part, with white space left and right of it.
+---     No width fields allowed.
 --- # -   Set highlight group.  The name must follow and then a # again.
----       Thus use %#HLname# for highlight group HLname.  The same
----       highlighting is used, also for the statusline of non-current
----       windows.
+---     Thus use %#HLname# for highlight group HLname.  The same
+---     highlighting is used, also for the statusline of non-current
+---     windows.
 --- * -   Set highlight group to User{N}, where {N} is taken from the
----       minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
----       The difference between User{N} and StatusLine will be applied to
----       StatusLineNC for the statusline of non-current windows.
----       The number N must be between 1 and 9.  See `hl-User1..9`
+---     minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
+---     The difference between User{N} and StatusLine will be applied to
+---     StatusLineNC for the statusline of non-current windows.
+---     The number N must be between 1 and 9.  See `|hl-User1..9|`
 ---
 --- When displaying a flag, Vim removes the leading comma, if any, when
 --- that flag comes right after plaintext.  This will make a nice display
@@ -6482,24 +6450,24 @@ vim.wo.stc = vim.wo.statuscolumn
 --- become empty.  This will make a group like the following disappear
 --- completely from the statusline when none of the flags are set.
 --- ```
---- 	:set statusline=...%(\ [%M%R%H]%)...
+--- :set statusline=...%(\ [%M%R%H]%)...
 --- ```
 --- Beware that an expression is evaluated each and every time the status
 --- line is displayed.
---- 			*stl-%{* *g:actual_curbuf* *g:actual_curwin*
+---     *stl-%{* *g:actual_curbuf* *g:actual_curwin*
 --- While evaluating %{} the current buffer and current window will be set
 --- temporarily to that of the window (and buffer) whose statusline is
 --- currently being drawn.  The expression will evaluate in this context.
 --- The variable "g:actual_curbuf" is set to the `bufnr()` number of the
---- real current buffer and "g:actual_curwin" to the `window-ID` of the
+--- real current buffer and "g:actual_curwin" to the `|window-ID|` of the
 --- real current window.  These values are strings.
 ---
---- The 'statusline' option will be evaluated in the `sandbox` if set from
---- a modeline, see `sandbox-option`.
+--- The 'statusline' option will be evaluated in the `|sandbox|` if set from
+--- a modeline, see `|sandbox-option|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- It is not allowed to change text or jump to another window while
---- evaluating 'statusline' `textlock`.
+--- evaluating 'statusline' `|textlock|`.
 ---
 --- If the statusline is not updated when you want it (e.g., after setting
 --- a variable that's used in an expression), you can force an update by
@@ -6516,36 +6484,35 @@ vim.wo.stc = vim.wo.statuscolumn
 --- Examples:
 --- Emulate standard status line with 'ruler' set
 --- ```
----   :set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
+--- :set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
 --- ```
 --- Similar, but add ASCII value of char under the cursor (like "ga")
 --- ```
----   :set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
+--- :set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
 --- ```
 --- Display byte count and byte value, modified flag in red.
 --- ```
----   :set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
----   :hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
+--- :set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
+--- :hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
 --- ```
 --- Display a ,GZ flag if a compressed file is loaded
 --- ```
----   :set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
+--- :set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
 --- ```
---- In the `:autocmd`'s:
+--- In the `|:autocmd|`'s:
 --- ```
----   :let b:gzflag = 1
+--- :let b:gzflag = 1
 --- ```
 --- And:
 --- ```
----   :unlet b:gzflag
+--- :unlet b:gzflag
 --- ```
 --- And define this function:
 --- ```
----   :function VarExists(var, val)
----   :    if exists(a:var) | return a:val | else | return '' | endif
----   :endfunction
+--- :function VarExists(var, val)
+--- :    if exists(a:var) | return a:val | else | return '' | endif
+--- :endfunction
 --- ```
----
 ---
 --- @type string
 vim.o.statusline = ""
@@ -6556,13 +6523,13 @@ vim.go.statusline = vim.o.statusline
 vim.go.stl = vim.go.statusline
 
 --- Files with these suffixes get a lower priority when multiple files
---- match a wildcard.  See `suffixes`.  Commas can be used to separate the
+--- match a wildcard.  See `|suffixes|`.  Commas can be used to separate the
 --- suffixes.  Spaces after the comma are ignored.  A dot is also seen as
 --- the start of a suffix.  To avoid a dot or comma being recognized as a
---- separator, precede it with a backslash (see `option-backslash` about
+--- separator, precede it with a backslash (see `|option-backslash|` about
 --- including spaces and backslashes).
 --- See 'wildignore' for completely ignoring files.
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- suffixes from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -6575,9 +6542,8 @@ vim.go.su = vim.go.suffixes
 --- Comma-separated list of suffixes, which are used when searching for a
 --- file for the "gf", "[I", etc. commands.  Example:
 --- ```
---- 	:set suffixesadd=.java
+--- :set suffixesadd=.java
 --- ```
----
 ---
 --- @type string
 vim.o.suffixesadd = ""
@@ -6589,20 +6555,20 @@ vim.bo.sua = vim.bo.suffixesadd
 --- swapfile is not wanted for a specific buffer.  For example, with
 --- confidential information that even root must not be able to access.
 --- Careful: All text will be in memory:
---- 	- Don't use this for big files.
---- 	- Recovery will be impossible!
---- A swapfile will only be present when `'updatecount'` is non-zero and
+--- - Don't use this for big files.
+--- - Recovery will be impossible!
+--- A swapfile will only be present when `|'updatecount'|` is non-zero and
 --- 'swapfile' is set.
 --- When 'swapfile' is reset, the swap file for the current buffer is
 --- immediately deleted.  When 'swapfile' is set, and 'updatecount' is
 --- non-zero, a swap file is immediately created.
---- Also see `swap-file`.
+--- Also see `|swap-file|`.
 --- If you want to open a new buffer without creating a swap file for it,
---- use the `:noswapfile` modifier.
+--- use the `|:noswapfile|` modifier.
 --- See 'directory' for where the swap file is created.
 ---
 --- This option is used together with 'bufhidden' and 'buftype' to
---- specify special kinds of buffers.   See `special-buffers`.
+--- specify special kinds of buffers.   See `|special-buffers|`.
 ---
 --- @type boolean
 vim.o.swapfile = true
@@ -6612,29 +6578,29 @@ vim.bo.swf = vim.bo.swapfile
 
 --- This option controls the behavior when switching between buffers.
 --- This option is checked, when
---- - jumping to errors with the `quickfix` commands (`:cc`, `:cn`, `:cp`,
----   etc.)
---- - jumping to a tag using the `:stag` command.
---- - opening a file using the `CTRL-W_f` or `CTRL-W_F` command.
---- - jumping to a buffer using a buffer split command (e.g.  `:sbuffer`,
----   `:sbnext`, or `:sbrewind`).
+--- - jumping to errors with the `|quickfix|` commands (`|:cc|`, `|:cn|`, `|:cp|`,
+--- etc.)
+--- - jumping to a tag using the `|:stag|` command.
+--- - opening a file using the `|CTRL-W_f|` or `|CTRL-W_F|` command.
+--- - jumping to a buffer using a buffer split command (e.g.  `|:sbuffer|,
+--- |:sbnext|`, or `|:sbrewind|`).
 --- Possible values (comma-separated list):
----    useopen	If included, jump to the first open window in the
---- 		current tab page that contains the specified buffer
---- 		(if there is one).  Otherwise: Do not examine other
---- 		windows.
----    usetab	Like "useopen", but also consider windows in other tab
---- 		pages.
----    split	If included, split the current window before loading
---- 		a buffer for a `quickfix` command that display errors.
---- 		Otherwise: do not split, use current window (when used
---- 		in the quickfix window: the previously used window or
---- 		split if there is no other window).
----    vsplit	Just like "split" but split vertically.
----    newtab	Like "split", but open a new tab page.  Overrules
---- 		"split" when both are present.
----    uselast	If included, jump to the previously used window when
---- 		jumping to errors with `quickfix` commands.
+---  useopen  If included, jump to the first open window in the
+---   current tab page that contains the specified buffer
+---   (if there is one).  Otherwise: Do not examine other
+---   windows.
+---  usetab  Like "useopen", but also consider windows in other tab
+---   pages.
+---  split  If included, split the current window before loading
+---   a buffer for a `|quickfix|` command that display errors.
+---   Otherwise: do not split, use current window (when used
+---   in the quickfix window: the previously used window or
+---   split if there is no other window).
+---  vsplit  Just like "split" but split vertically.
+---  newtab  Like "split", but open a new tab page.  Overrules
+---   "split" when both are present.
+---  uselast  If included, jump to the previously used window when
+---   jumping to errors with `|quickfix|` commands.
 ---
 --- @type string
 vim.o.switchbuf = "uselast"
@@ -6662,24 +6628,24 @@ vim.bo.smc = vim.bo.synmaxcol
 --- This option is most useful in a modeline, for a file which syntax is
 --- not automatically recognized.  Example, in an IDL file:
 --- ```
---- 	/* vim: set syntax=idl : */
+--- /* vim: set syntax=idl : */
 --- ```
 --- When a dot appears in the value then this separates two filetype
 --- names.  Example:
 --- ```
---- 	/* vim: set syntax=c.doxygen : */
+--- /* vim: set syntax=c.doxygen : */
 --- ```
 --- This will use the "c" syntax first, then the "doxygen" syntax.
 --- Note that the second one must be prepared to be loaded as an addition,
 --- otherwise it will be skipped.  More than one dot may appear.
 --- To switch off syntax highlighting for the current file, use:
 --- ```
---- 	:set syntax=OFF
+--- :set syntax=OFF
 --- ```
 --- To switch syntax highlighting on according to the current value of the
 --- 'filetype' option:
 --- ```
---- 	:set syntax=ON
+--- :set syntax=ON
 --- ```
 --- What actually happens when setting the 'syntax' option is that the
 --- Syntax autocommand event is triggered with the value as argument.
@@ -6695,7 +6661,7 @@ vim.bo.syn = vim.bo.syntax
 
 --- When non-empty, this option determines the content of the tab pages
 --- line at the top of the Vim window.  When empty Vim will use a default
---- tab pages line.  See `setting-tabline` for more info.
+--- tab pages line.  See `|setting-tabline|` for more info.
 ---
 --- The tab pages line only appears as specified with the 'showtabline'
 --- option and only when there is no GUI tab line.  When 'e' is in
@@ -6703,12 +6669,12 @@ vim.bo.syn = vim.bo.syntax
 --- instead.  Note that the two tab pages lines are very different.
 ---
 --- The value is evaluated like with 'statusline'.  You can use
---- `tabpagenr()`, `tabpagewinnr()` and `tabpagebuflist()` to figure out
+--- `|tabpagenr()|`, `|tabpagewinnr()|` and `|tabpagebuflist()|` to figure out
 --- the text to be displayed.  Use "%1T" for the first label, "%2T" for
 --- the second one, etc.  Use "%X" items for closing labels.
 ---
 --- When changing something that is used in 'tabline' that does not
---- trigger it to be updated, use `:redrawtabline`.
+--- trigger it to be updated, use `|:redrawtabline|`.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- Keep in mind that only one of the tab pages is the current one, others
@@ -6720,8 +6686,8 @@ vim.o.tal = vim.o.tabline
 vim.go.tabline = vim.o.tabline
 vim.go.tal = vim.go.tabline
 
---- Maximum number of tab pages to be opened by the `-p` command line
---- argument or the ":tab all" command. `tabpage`
+--- Maximum number of tab pages to be opened by the `|-p|` command line
+--- argument or the ":tab all" command. `|tabpage|`
 ---
 --- @type integer
 vim.o.tabpagemax = 50
@@ -6730,7 +6696,7 @@ vim.go.tabpagemax = vim.o.tabpagemax
 vim.go.tpm = vim.go.tabpagemax
 
 --- Number of spaces that a <Tab> in the file counts for.  Also see
---- the `:retab` command, and the 'softtabstop' option.
+--- the `|:retab|` command, and the 'softtabstop' option.
 ---
 --- Note: Setting 'tabstop' to any other value than 8 can make your file
 --- appear wrong in many places.
@@ -6738,35 +6704,35 @@ vim.go.tpm = vim.go.tabpagemax
 ---
 --- There are four main ways to use tabs in Vim:
 --- 1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
----    (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
----    will use a mix of tabs and spaces, but typing <Tab> and <BS> will
----    behave like a tab appears every 4 (or 3) characters.
----    This is the recommended way, the file will look the same with other
----    tools and when listing it in a terminal.
+---  (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
+---  will use a mix of tabs and spaces, but typing <Tab> and <BS> will
+---  behave like a tab appears every 4 (or 3) characters.
+---  This is the recommended way, the file will look the same with other
+---  tools and when listing it in a terminal.
 --- 2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
----    'expandtab'.  This way you will always insert spaces.  The
----    formatting will never be messed up when 'tabstop' is changed (leave
----    it at 8 just in case).  The file will be a bit larger.
----    You do need to check if no Tabs exist in the file.  You can get rid
----    of them by first setting 'expandtab' and using `%retab!`, making
----    sure the value of 'tabstop' is set correctly.
+---  'expandtab'.  This way you will always insert spaces.  The
+---  formatting will never be messed up when 'tabstop' is changed (leave
+---  it at 8 just in case).  The file will be a bit larger.
+---  You do need to check if no Tabs exist in the file.  You can get rid
+---  of them by first setting 'expandtab' and using `%retab!`, making
+---  sure the value of 'tabstop' is set correctly.
 --- 3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
----    'expandtab'.  This way you will always insert spaces.  The
----    formatting will never be messed up when 'tabstop' is changed.
----    You do need to check if no Tabs exist in the file, just like in the
----    item just above.
+---  'expandtab'.  This way you will always insert spaces.  The
+---  formatting will never be messed up when 'tabstop' is changed.
+---  You do need to check if no Tabs exist in the file, just like in the
+---  item just above.
 --- 4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
----    `modeline` to set these values when editing the file again.  Only
----    works when using Vim to edit the file, other tools assume a tabstop
----    is worth 8 spaces.
+---  `|modeline|` to set these values when editing the file again.  Only
+---  works when using Vim to edit the file, other tools assume a tabstop
+---  is worth 8 spaces.
 --- 5. Always set 'tabstop' and 'shiftwidth' to the same value, and
----    'noexpandtab'.  This should then work (for initial indents only)
----    for any tabstop setting that people use.  It might be nice to have
----    tabs after the first non-blank inserted as spaces if you do this
----    though.  Otherwise aligned comments will be wrong when 'tabstop' is
----    changed.
+---  'noexpandtab'.  This should then work (for initial indents only)
+---  for any tabstop setting that people use.  It might be nice to have
+---  tabs after the first non-blank inserted as spaces if you do this
+---  though.  Otherwise aligned comments will be wrong when 'tabstop' is
+---  changed.
 ---
---- The value of 'tabstop' will be ignored if `'vartabstop'` is set to
+--- The value of 'tabstop' will be ignored if `|'vartabstop'|` is set to
 --- anything other than an empty string.
 ---
 --- @type integer
@@ -6775,7 +6741,7 @@ vim.o.ts = vim.o.tabstop
 vim.bo.tabstop = vim.o.tabstop
 vim.bo.ts = vim.bo.tabstop
 
---- When searching for a tag (e.g., for the `:ta` command), Vim can either
+--- When searching for a tag (e.g., for the `|:ta|` command), Vim can either
 --- use a binary search or a linear search in a tags file.  Binary
 --- searching makes searching for a tag a LOT faster, but a linear search
 --- will find more tags if the tags file wasn't properly sorted.
@@ -6791,7 +6757,7 @@ vim.bo.ts = vim.bo.tabstop
 --- Linear searching is done anyway, for one file, when Vim finds a line
 --- at the start of the file indicating that it's not sorted:
 --- ```
----    !_TAG_FILE_SORTED	0	/some comment/
+---  !_TAG_FILE_SORTED  0  /some comment/
 --- ```
 --- [The whitespace before and after the '0' must be a single <Tab>]
 ---
@@ -6834,11 +6800,11 @@ vim.go.tbs = vim.go.tagbsearch
 
 --- This option specifies how case is handled when searching the tags
 --- file:
----    followic	Follow the 'ignorecase' option
----    followscs    Follow the 'smartcase' and 'ignorecase' options
----    ignore	Ignore case
----    match	Match case
----    smart	Ignore case unless an upper case letter is used
+---  followic  Follow the 'ignorecase' option
+---  followscs    Follow the 'smartcase' and 'ignorecase' options
+---  ignore  Ignore case
+---  match  Match case
+---  smart  Ignore case unless an upper case letter is used
 ---
 --- @type string
 vim.o.tagcase = "followic"
@@ -6850,9 +6816,9 @@ vim.go.tc = vim.go.tagcase
 
 --- This option specifies a function to be used to perform tag searches.
 --- The function gets the tag pattern and should return a List of matching
---- tags.  See `tag-function` for an explanation of how to write the
+--- tags.  See `|tag-function|` for an explanation of how to write the
 --- function and an example.  The value can be the name of a function, a
---- `lambda` or a `Funcref`. See `option-value-function` for more
+--- `|lambda|` or a `|Funcref|`. See `|option-value-function|` for more
 --- information.
 ---
 --- @type string
@@ -6880,19 +6846,19 @@ vim.go.tr = vim.go.tagrelative
 
 --- Filenames for the tag command, separated by spaces or commas.  To
 --- include a space or comma in a file name, precede it with backslashes
---- (see `option-backslash` about including spaces/commas and backslashes).
+--- (see `|option-backslash|` about including spaces/commas and backslashes).
 --- When a file name starts with "./", the '.' is replaced with the path
 --- of the current file.  But only when the 'd' flag is not included in
---- 'cpoptions'.  Environment variables are expanded `:set_env`.  Also see
---- `tags-option`.
+--- 'cpoptions'.  Environment variables are expanded `|:set_env|`.  Also see
+--- `|tags-option|`.
 --- "*", "**" and other wildcards can be used to search for tags files in
---- a directory tree.  See `file-searching`.  E.g., "/lib/**/tags" will
+--- a directory tree.  See `|file-searching|`.  E.g., "/lib/**/tags" will
 --- find all files named "tags" below "/lib".  The filename itself cannot
 --- contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
 --- files called "tags?".
---- The `tagfiles()` function can be used to get a list of the file names
+--- The `|tagfiles()|` function can be used to get a list of the file names
 --- actually used.
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- file names from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -6904,7 +6870,7 @@ vim.bo.tag = vim.bo.tags
 vim.go.tags = vim.o.tags
 vim.go.tag = vim.go.tags
 
---- When on, the `tagstack` is used normally.  When off, a ":tag" or
+--- When on, the `|tagstack|` is used normally.  When off, a ":tag" or
 --- ":tselect" command with an argument will not push the tag onto the
 --- tagstack.  A following ":tag" without an argument, a ":pop" command or
 --- any other command that uses the tagstack will use the unmodified
@@ -6925,7 +6891,7 @@ vim.go.tgst = vim.go.tagstack
 --- 'arabic' is set and the value of 'arabicshape' will be ignored.
 --- Note that setting 'termbidi' has the immediate effect that
 --- 'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
---- For further details see `arabic.txt`.
+--- For further details see `|arabic.txt|`.
 ---
 --- @type boolean
 vim.o.termbidi = false
@@ -6933,8 +6899,8 @@ vim.o.tbidi = vim.o.termbidi
 vim.go.termbidi = vim.o.termbidi
 vim.go.tbidi = vim.go.termbidi
 
---- Enables 24-bit RGB color in the `TUI`.  Uses "gui" `:highlight`
---- attributes instead of "cterm" attributes. `guifg`
+--- Enables 24-bit RGB color in the `|TUI|`.  Uses "gui" `|:highlight|`
+--- attributes instead of "cterm" attributes. `|guifg|`
 --- Requires an ISO-8613-3 compatible terminal.
 ---
 --- @type boolean
@@ -6947,20 +6913,20 @@ vim.go.tgc = vim.go.termguicolors
 --- to be removed from the text pasted into the terminal window. The
 --- supported values are:
 ---
----    BS	    Backspace
+---  BS      Backspace
 ---
----    HT	    TAB
+---  HT      TAB
 ---
----    FF	    Form feed
+---  FF      Form feed
 ---
----    ESC	    Escape
+---  ESC      Escape
 ---
----    DEL	    DEL
+---  DEL      DEL
 ---
----    C0	    Other control characters, excluding Line feed and
---- 	    Carriage return < ' '
+---  C0      Other control characters, excluding Line feed and
+---     Carriage return < ' '
 ---
----    C1	    Control characters 0x80...0x9F
+---  C1      Control characters 0x80...0x9F
 ---
 --- @type string
 vim.o.termpastefilter = "BS,HT,ESC,DEL"
@@ -6972,7 +6938,7 @@ vim.go.tpf = vim.go.termpastefilter
 --- broken after white space to get this width.  A zero value disables
 --- this.
 --- When 'textwidth' is zero, 'wrapmargin' may be used.  See also
---- 'formatoptions' and `ins-textwidth`.
+--- 'formatoptions' and `|ins-textwidth|`.
 --- When 'formatexpr' is set it will be used to break the line.
 ---
 --- @type integer
@@ -6982,16 +6948,16 @@ vim.bo.textwidth = vim.o.textwidth
 vim.bo.tw = vim.bo.textwidth
 
 --- List of file names, separated by commas, that are used to lookup words
---- for thesaurus completion commands `i_CTRL-X_CTRL-T`.  See
---- `compl-thesaurus`.
+--- for thesaurus completion commands `|i_CTRL-X_CTRL-T|`.  See
+--- `|compl-thesaurus|`.
 ---
 --- This option is not used if 'thesaurusfunc' is set, either for the
 --- buffer or globally.
 ---
 --- To include a comma in a file name precede it with a backslash.  Spaces
 --- after a comma are ignored, otherwise spaces are included in the file
---- name.  See `option-backslash` about using backslashes.  The use of
---- `:set+=` and `:set-=` is preferred when adding or removing directories
+--- name.  See `|option-backslash|` about using backslashes.  The use of
+--- `|:set+=|` and `|:set-=|` is preferred when adding or removing directories
 --- from the list.  This avoids problems when a future version uses
 --- another default.  Backticks cannot be used in this option for security
 --- reasons.
@@ -7005,11 +6971,11 @@ vim.go.thesaurus = vim.o.thesaurus
 vim.go.tsr = vim.go.thesaurus
 
 --- This option specifies a function to be used for thesaurus completion
---- with CTRL-X CTRL-T. `i_CTRL-X_CTRL-T` See `compl-thesaurusfunc`.
---- The value can be the name of a function, a `lambda` or a `Funcref`.
---- See `option-value-function` for more information.
+--- with CTRL-X CTRL-T. `|i_CTRL-X_CTRL-T|` See `|compl-thesaurusfunc|`.
+--- The value can be the name of a function, a `|lambda|` or a `|Funcref|`.
+--- See `|option-value-function|` for more information.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -7049,15 +7015,15 @@ vim.go.tm = vim.go.timeoutlen
 
 --- When on, the title of the window will be set to the value of
 --- 'titlestring' (if it is not empty), or to:
---- 	filename [+=-] (path) - NVIM
+--- filename [+=-] (path) - NVIM
 --- Where:
---- 	filename	the name of the file being edited
---- 	-		indicates the file cannot be modified, 'ma' off
---- 	+		indicates the file was modified
---- 	=		indicates the file is read-only
---- 	=+		indicates the file is read-only and modified
---- 	(path)		is the path of the file being edited
---- 	- NVIM		the server name `v:servername` or "NVIM"
+--- filename  the name of the file being edited
+--- -    indicates the file cannot be modified, 'ma' off
+--- +    indicates the file was modified
+--- =    indicates the file is read-only
+--- =+    indicates the file is read-only and modified
+--- (path)    is the path of the file being edited
+--- - NVIM    the server name `|v:servername|` or "NVIM"
 ---
 --- @type boolean
 vim.o.title = false
@@ -7079,7 +7045,7 @@ vim.go.titlelen = vim.o.titlelen
 
 --- If not empty, this option will be used to set the window title when
 --- exiting.  Only if 'title' is enabled.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -7095,14 +7061,14 @@ vim.go.titleold = vim.o.titleold
 ---
 --- Example:
 --- ```
----     :auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
----     :set title titlestring=%<%F%=%l/%L-%P titlelen=70
+--- :auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
+--- :set title titlestring=%<%F%=%l/%L-%P titlelen=70
 --- ```
 --- The value of 'titlelen' is used to align items in the middle or right
 --- of the available space.
 --- Some people prefer to have the file name first:
 --- ```
----     :set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
+--- :set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
 --- ```
 --- Note the use of "%{ }" and an expression to get the path of the file,
 --- without the file name.  The "%( %)" constructs are used to add a
@@ -7115,7 +7081,7 @@ vim.o.titlestring = ""
 vim.go.titlestring = vim.o.titlestring
 
 --- This option and 'ttimeoutlen' determine the behavior when part of a
---- key code sequence has been received by the `TUI`.
+--- key code sequence has been received by the `|TUI|`.
 ---
 --- For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
 --- set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
@@ -7153,8 +7119,8 @@ vim.go.ttm = vim.go.ttimeoutlen
 --- When reading all entries are tried to find an undo file.  The first
 --- undo file that exists is used.  When it cannot be read an error is
 --- given, no further entry is used.
---- See `undo-persistence`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- See `|undo-persistence|`.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
@@ -7171,7 +7137,7 @@ vim.go.udir = vim.go.undodir
 --- writing a buffer to a file, and restores undo history from the same
 --- file on buffer read.
 --- The directory where the undo file is stored is specified by 'undodir'.
---- For more information about this feature see `undo-persistence`.
+--- For more information about this feature see `|undo-persistence|`.
 --- The undo file is not read when 'undoreload' causes the buffer from
 --- before a reload to be saved for undo.
 --- When 'undofile' is turned off the undo file is NOT deleted.
@@ -7188,21 +7154,21 @@ vim.bo.udf = vim.bo.undofile
 --- Set to 0 for Vi compatibility: One level of undo and "u" undoes
 --- itself:
 --- ```
---- 	set ul=0
+--- set ul=0
 --- ```
 --- But you can also get Vi compatibility by including the 'u' flag in
 --- 'cpoptions', and still be able to use CTRL-R to repeat undo.
---- Also see `undo-two-ways`.
+--- Also see `|undo-two-ways|`.
 --- Set to -1 for no undo at all.  You might want to do this only for the
 --- current buffer:
 --- ```
---- 	setlocal ul=-1
+--- setlocal ul=-1
 --- ```
 --- This helps when you run out of memory for a single change.
 ---
 --- The local value is set to -123456 when the global value is to be used.
 ---
---- Also see `clear-undo`.
+--- Also see `|clear-undo|`.
 ---
 --- @type integer
 vim.o.undolevels = 1000
@@ -7214,7 +7180,7 @@ vim.go.ul = vim.go.undolevels
 
 --- Save the whole buffer for undo when reloading it.  This applies to the
 --- ":e!" command and reloading for when the buffer changed outside of
---- Vim. `FileChangedShell`
+--- Vim. `|FileChangedShell|`
 --- The save only happens when this option is negative or when the number
 --- of lines is smaller than the value of this option.
 --- Set this option to zero to disable undo for a reload.
@@ -7232,14 +7198,14 @@ vim.go.ur = vim.go.undoreload
 
 --- After typing this many characters the swap file will be written to
 --- disk.  When zero, no swap file will be created at all (see chapter on
---- recovery `crash-recovery`).  'updatecount' is set to zero by starting
---- Vim with the "-n" option, see `startup`.  When editing in readonly
+--- recovery `|crash-recovery|`).  'updatecount' is set to zero by starting
+--- Vim with the "-n" option, see `|startup|`.  When editing in readonly
 --- mode this option will be initialized to 10000.
---- The swapfile can be disabled per buffer with `'swapfile'`.
+--- The swapfile can be disabled per buffer with `|'swapfile'|`.
 --- When 'updatecount' is set from zero to non-zero, swap files are
 --- created for all buffers that have 'swapfile' set.  When 'updatecount'
 --- is set to zero, existing swap files are not deleted.
---- This option has no meaning in buffers where `'buftype'` is "nofile"
+--- This option has no meaning in buffers where `|'buftype'|` is "nofile"
 --- or "nowrite".
 ---
 --- @type integer
@@ -7249,8 +7215,8 @@ vim.go.updatecount = vim.o.updatecount
 vim.go.uc = vim.go.updatecount
 
 --- If this many milliseconds nothing is typed the swap file will be
---- written to disk (see `crash-recovery`).  Also used for the
---- `CursorHold` autocommand event.
+--- written to disk (see `|crash-recovery|`).  Also used for the
+--- `|CursorHold|` autocommand event.
 ---
 --- @type integer
 vim.o.updatetime = 4000
@@ -7268,12 +7234,12 @@ vim.go.ut = vim.go.updatetime
 --- start in the 9th column and comments in the 41st, it may be useful
 --- to use the following:
 --- ```
---- 	:set varsofttabstop=8,32,8
+--- :set varsofttabstop=8,32,8
 --- ```
 --- This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
 --- for every column thereafter.
 ---
---- Note that the value of `'softtabstop'` will be ignored while
+--- Note that the value of `|'softtabstop'|` will be ignored while
 --- 'varsofttabstop' is set.
 ---
 --- @type string
@@ -7286,12 +7252,12 @@ vim.bo.vsts = vim.bo.varsofttabstop
 --- separated by commas.  Each value corresponds to one tab, with the
 --- final value applying to all subsequent tabs. For example:
 --- ```
---- 	:set vartabstop=4,20,10,8
+--- :set vartabstop=4,20,10,8
 --- ```
 --- This will make the first tab 4 spaces wide, the second 20 spaces,
 --- the third 10 spaces, and all following tabs 8 spaces.
 ---
---- Note that the value of `'tabstop'` will be ignored while 'vartabstop'
+--- Note that the value of `|'tabstop'|` will be ignored while 'vartabstop'
 --- is set.
 ---
 --- @type string
@@ -7300,7 +7266,7 @@ vim.o.vts = vim.o.vartabstop
 vim.bo.vartabstop = vim.o.vartabstop
 vim.bo.vts = vim.bo.vartabstop
 
---- Sets the verbosity level.  Also set by `-V` and `:verbose`.
+--- Sets the verbosity level.  Also set by `|-V|` and `|:verbose|`.
 ---
 --- Tracing of options in Lua scripts is activated at level 1; Lua scripts
 --- are not traced with verbose=0, for performance.
@@ -7310,19 +7276,19 @@ vim.bo.vts = vim.bo.vartabstop
 ---
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
---- 1	Lua assignments to options, mappings, etc.
---- 2	When a file is ":source"'ed, or `shada` file is read or written.
---- 3	UI info, terminal capabilities.
---- 4	Shell commands.
---- 5	Every searched tags file and include file.
---- 8	Files for which a group of autocommands is executed.
---- 9	Executed autocommands.
---- 11	Finding items in a path.
---- 12	Vimscript function calls.
---- 13	When an exception is thrown, caught, finished, or discarded.
---- 14	Anything pending in a ":finally" clause.
---- 15	Ex commands from a script (truncated at 200 characters).
---- 16	Ex commands.
+--- 1  Lua assignments to options, mappings, etc.
+--- 2  When a file is ":source"'ed, or `|shada|` file is read or written.
+--- 3  UI info, terminal capabilities.
+--- 4  Shell commands.
+--- 5  Every searched tags file and include file.
+--- 8  Files for which a group of autocommands is executed.
+--- 9  Executed autocommands.
+--- 11  Finding items in a path.
+--- 12  Vimscript function calls.
+--- 13  When an exception is thrown, caught, finished, or discarded.
+--- 14  Anything pending in a ":finally" clause.
+--- 15  Ex commands from a script (truncated at 200 characters).
+--- 16  Ex commands.
 ---
 --- If 'verbosefile' is set then the verbose messages are not displayed.
 ---
@@ -7337,7 +7303,7 @@ vim.go.vbs = vim.go.verbose
 --- Writing to the file ends when Vim exits or when 'verbosefile' is made
 --- empty.  Writes are buffered, thus may not show up for some time.
 --- Setting 'verbosefile' to a new value is like making it empty first.
---- The difference with `:redir` is that verbose messages are not
+--- The difference with `|:redir|` is that verbose messages are not
 --- displayed when 'verbosefile' is set.
 ---
 --- @type string
@@ -7346,8 +7312,8 @@ vim.o.vfile = vim.o.verbosefile
 vim.go.verbosefile = vim.o.verbosefile
 vim.go.vfile = vim.go.verbosefile
 
---- Name of the directory where to store files for `:mkview`.
---- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- Name of the directory where to store files for `|:mkview|`.
+--- This option cannot be set from a `|modeline|` or in the `|sandbox|`, for
 --- security reasons.
 ---
 --- @type string
@@ -7356,18 +7322,18 @@ vim.o.vdir = vim.o.viewdir
 vim.go.viewdir = vim.o.viewdir
 vim.go.vdir = vim.go.viewdir
 
---- Changes the effect of the `:mkview` command.  It is a comma-separated
+--- Changes the effect of the `|:mkview|` command.  It is a comma-separated
 --- list of words.  Each word enables saving and restoring something:
----    word		save and restore ~
----    cursor	cursor position in file and in window
----    curdir	local current directory, if set with `:lcd`
----    folds	manually created folds, opened/closed folds and local
---- 		fold options
----    options	options and mappings local to a window or buffer (not
---- 		global values for local options)
----    localoptions same as "options"
----    slash	`deprecated` Always enabled. Uses "/" in filenames.
----    unix		`deprecated` Always enabled. Uses "\n" line endings.
+---  word    save and restore ~
+---  cursor  cursor position in file and in window
+---  curdir  local current directory, if set with `|:lcd|`
+---  folds  manually created folds, opened/closed folds and local
+---   fold options
+---  options  options and mappings local to a window or buffer (not
+---   global values for local options)
+---  localoptions same as "options"
+---  slash  `|deprecated|` Always enabled. Uses "/" in filenames.
+---  unix    `|deprecated|` Always enabled. Uses "\n" line endings.
 ---
 --- @type string
 vim.o.viewoptions = "folds,cursor,curdir"
@@ -7376,14 +7342,14 @@ vim.go.viewoptions = vim.o.viewoptions
 vim.go.vop = vim.go.viewoptions
 
 --- A comma-separated list of these words:
----     block	Allow virtual editing in Visual block mode.
----     insert	Allow virtual editing in Insert mode.
----     all		Allow virtual editing in all modes.
----     onemore	Allow the cursor to move just past the end of the line
----     none	When used as the local value, do not allow virtual
---- 		editing even when the global value is set.  When used
---- 		as the global value, "none" is the same as "".
----     NONE	Alternative spelling of "none".
+--- block  Allow virtual editing in Visual block mode.
+--- insert  Allow virtual editing in Insert mode.
+--- all    Allow virtual editing in all modes.
+--- onemore  Allow the cursor to move just past the end of the line
+--- none  When used as the local value, do not allow virtual
+--- editing even when the global value is set.  When used
+--- as the global value, "none" is the same as "".
+--- NONE  Alternative spelling of "none".
 ---
 --- Virtual editing means that the cursor can be positioned where there is
 --- no actual character.  This can be halfway into a tab or beyond the end
@@ -7393,7 +7359,7 @@ vim.go.vop = vim.go.viewoptions
 --- after the last character of the line.  This makes some commands more
 --- consistent.  Previously the cursor was always past the end of the line
 --- if the line was empty.  But it is far from Vi compatible.  It may also
---- break some plugins or Vim scripts.  For example because `l` can move
+--- break some plugins or Vim scripts.  For example because `|l|` can move
 --- the cursor after the last character.  Use with care!
 --- Using the `$` command will move to the last character in the line, not
 --- past it.  This may actually move the cursor to the left!
@@ -7428,19 +7394,19 @@ vim.go.warn = vim.o.warn
 --- Allow specified keys that move the cursor left/right to move to the
 --- previous/next line when the cursor is on the first/last character in
 --- the line.  Concatenate characters to allow this for these keys:
---- 	char   key	  mode	~
---- 	 b    <BS>	 Normal and Visual
---- 	 s    <Space>	 Normal and Visual
---- 	 h    "h"	 Normal and Visual (not recommended)
---- 	 l    "l"	 Normal and Visual (not recommended)
---- 	 <    <Left>	 Normal and Visual
---- 	 >    <Right>	 Normal and Visual
---- 	 ~    "~"	 Normal
---- 	 [    <Left>	 Insert and Replace
---- 	 ]    <Right>	 Insert and Replace
+--- char   key    mode  ~
+---  b    <BS>   Normal and Visual
+---  s    <Space>   Normal and Visual
+---  h    "h"   Normal and Visual (not recommended)
+---  l    "l"   Normal and Visual (not recommended)
+---  <    <Left>   Normal and Visual
+---  >    <Right>   Normal and Visual
+---  ~    "~"   Normal
+---  [    <Left>   Insert and Replace
+---  ]    <Right>   Insert and Replace
 --- For example:
 --- ```
---- 	:set ww=<,>,[,]
+--- :set ww=<,>,[,]
 --- ```
 --- allows wrap only when cursor keys are used.
 --- When the movement keys are used in combination with a delete or change
@@ -7462,7 +7428,7 @@ vim.go.ww = vim.go.whichwrap
 
 --- Character you have to type to start wildcard expansion in the
 --- command-line, as specified with 'wildmode'.
---- More info here: `cmdline-completion`.
+--- More info here: `|cmdline-completion|`.
 --- The character is not recognized when used inside a macro.  See
 --- 'wildcharm' for that.
 --- Some keys will not work, such as CTRL-C, <CR> and Enter.
@@ -7470,9 +7436,8 @@ vim.go.ww = vim.go.whichwrap
 --- command-line as a failsafe measure.
 --- Although 'wc' is a number option, you can set it to a special key:
 --- ```
---- 	:set wc=<Tab>
+--- :set wc=<Tab>
 --- ```
----
 ---
 --- @type integer
 vim.o.wildchar = 9
@@ -7482,12 +7447,12 @@ vim.go.wc = vim.go.wildchar
 
 --- 'wildcharm' works exactly like 'wildchar', except that it is
 --- recognized when used inside a macro.  You can find "spare" command-line
---- keys suitable for this option by looking at `ex-edit-index`.  Normally
+--- keys suitable for this option by looking at `|ex-edit-index|`.  Normally
 --- you'll never actually type 'wildcharm', just use it in mappings that
 --- automatically invoke completion mode, e.g.:
 --- ```
---- 	:set wcm=<C-Z>
---- 	:cnoremap ss so $vim/sessions/*.vim<C-Z>
+--- :set wcm=<C-Z>
+--- :cnoremap ss so $vim/sessions/*.vim<C-Z>
 --- ```
 --- Then after typing :ss you can use CTRL-P & CTRL-N.
 ---
@@ -7498,16 +7463,16 @@ vim.go.wildcharm = vim.o.wildcharm
 vim.go.wcm = vim.go.wildcharm
 
 --- A list of file patterns.  A file that matches with one of these
---- patterns is ignored when expanding `wildcards`, completing file or
---- directory names, and influences the result of `expand()`, `glob()` and
---- `globpath()` unless a flag is passed to disable this.
---- The pattern is used like with `:autocmd`, see `autocmd-pattern`.
+--- patterns is ignored when expanding `|wildcards|`, completing file or
+--- directory names, and influences the result of `|expand()|`, `|glob()|` and
+--- `|globpath()|` unless a flag is passed to disable this.
+--- The pattern is used like with `|:autocmd|`, see `|autocmd-pattern|`.
 --- Also see 'suffixes'.
 --- Example:
 --- ```
---- 	:set wildignore=*.o,*.obj
+--- :set wildignore=*.o,*.obj
 --- ```
---- The use of `:set+=` and `:set-=` is preferred when adding or removing
+--- The use of `|:set+=|` and `|:set-=|` is preferred when adding or removing
 --- a pattern from the list.  This avoids problems when a future version
 --- uses another default.
 ---
@@ -7538,35 +7503,34 @@ vim.go.wic = vim.go.wildignorecase
 --- Keys that show the previous/next match, such as <Tab> or
 --- CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
 --- 'wildmode' must specify "full": "longest" and "list" do not start
---- 'wildmenu' mode. You can check the current mode with `wildmenumode()`.
+--- 'wildmenu' mode. You can check the current mode with `|wildmenumode()|`.
 --- The menu is cancelled when a key is hit that is not used for selecting
 --- a completion.
 ---
 --- While the menu is active these keys have special meanings:
---- CTRL-P		- go to the previous entry
---- CTRL-N		- go to the next entry
---- <Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
---- <PageUp>	- select a match several entries back
---- <PageDown>	- select a match several entries further
---- <Up>		- in filename/menu name completion: move up into
---- 		  parent directory or parent menu.
---- <Down>		- in filename/menu name completion: move into a
---- 		  subdirectory or submenu.
---- <CR>		- in menu completion, when the cursor is just after a
---- 		  dot: move into a submenu.
---- CTRL-E		- end completion, go back to what was there before
---- 		  selecting a match.
---- CTRL-Y		- accept the currently selected match and stop
---- 		  completion.
+--- CTRL-P    - go to the previous entry
+--- CTRL-N    - go to the next entry
+--- <Left> <Right>  - select previous/next match (like CTRL-P/CTRL-N)
+--- <PageUp>  - select a match several entries back
+--- <PageDown>  - select a match several entries further
+--- <Up>    - in filename/menu name completion: move up into
+---     parent directory or parent menu.
+--- <Down>    - in filename/menu name completion: move into a
+---     subdirectory or submenu.
+--- <CR>    - in menu completion, when the cursor is just after a
+---     dot: move into a submenu.
+--- CTRL-E    - end completion, go back to what was there before
+---     selecting a match.
+--- CTRL-Y    - accept the currently selected match and stop
+---     completion.
 ---
 --- If you want <Left> and <Right> to move the cursor instead of selecting
 --- a different match, use this:
 --- ```
---- 	:cnoremap <Left> <Space><BS><Left>
---- 	:cnoremap <Right> <Space><BS><Right>
+--- :cnoremap <Left> <Space><BS><Left>
+--- :cnoremap <Right> <Space><BS><Right>
 --- ```
----
---- `hl-WildMenu` highlights the current match.
+--- `|hl-WildMenu|` highlights the current match.
 ---
 --- @type boolean
 vim.o.wildmenu = true
@@ -7582,51 +7546,51 @@ vim.go.wmnu = vim.go.wildmenu
 ---
 --- Each part consists of a colon separated list consisting of the
 --- following possible values:
---- ""		Complete only the first match.
---- "full"		Complete the next full match.  After the last match,
---- 		the original string is used and then the first match
---- 		again.  Will also start 'wildmenu' if it is enabled.
---- "longest"	Complete till longest common string.  If this doesn't
---- 		result in a longer string, use the next part.
---- "list"		When more than one match, list all matches.
---- "lastused"	When completing buffer names and more than one buffer
---- 		matches, sort buffers by time last used (other than
---- 		the current buffer).
+--- ""    Complete only the first match.
+--- "full"    Complete the next full match.  After the last match,
+---   the original string is used and then the first match
+---   again.  Will also start 'wildmenu' if it is enabled.
+--- "longest"  Complete till longest common string.  If this doesn't
+---   result in a longer string, use the next part.
+--- "list"    When more than one match, list all matches.
+--- "lastused"  When completing buffer names and more than one buffer
+---   matches, sort buffers by time last used (other than
+---   the current buffer).
 --- When there is only a single match, it is fully completed in all cases.
 ---
 --- Examples of useful colon-separated values:
---- "longest:full"	Like "longest", but also start 'wildmenu' if it is
---- 		enabled.  Will not complete to the next full match.
---- "list:full"	When more than one match, list all matches and
---- 		complete first match.
---- "list:longest"	When more than one match, list all matches and
---- 		complete till longest common string.
+--- "longest:full"  Like "longest", but also start 'wildmenu' if it is
+---   enabled.  Will not complete to the next full match.
+--- "list:full"  When more than one match, list all matches and
+---   complete first match.
+--- "list:longest"  When more than one match, list all matches and
+---   complete till longest common string.
 --- "list:lastused" When more than one buffer matches, list all matches
---- 		and sort buffers by time last used (other than the
---- 		current buffer).
+---   and sort buffers by time last used (other than the
+---   current buffer).
 ---
 --- Examples:
 --- ```
---- 	:set wildmode=full
+--- :set wildmode=full
 --- ```
 --- Complete first full match, next match, etc.  (the default)
 --- ```
---- 	:set wildmode=longest,full
+--- :set wildmode=longest,full
 --- ```
 --- Complete longest common string, then each full match
 --- ```
---- 	:set wildmode=list:full
+--- :set wildmode=list:full
 --- ```
 --- List all matches and complete each full match
 --- ```
---- 	:set wildmode=list,full
+--- :set wildmode=list,full
 --- ```
 --- List all matches without completing, then each full match
 --- ```
---- 	:set wildmode=longest,list
+--- :set wildmode=longest,list
 --- ```
 --- Complete longest common string, then list alternatives.
---- More info here: `cmdline-completion`.
+--- More info here: `|cmdline-completion|`.
 ---
 --- @type string
 vim.o.wildmode = "full"
@@ -7634,23 +7598,23 @@ vim.o.wim = vim.o.wildmode
 vim.go.wildmode = vim.o.wildmode
 vim.go.wim = vim.go.wildmode
 
---- A list of words that change how `cmdline-completion` is done.
+--- A list of words that change how `|cmdline-completion|` is done.
 --- The following values are supported:
----   fuzzy		Use `fuzzy-matching` to find completion matches. When
---- 		this value is specified, wildcard expansion will not
---- 		be used for completion.  The matches will be sorted by
---- 		the "best match" rather than alphabetically sorted.
---- 		This will find more matches than the wildcard
---- 		expansion. Currently fuzzy matching based completion
---- 		is not supported for file and directory names and
---- 		instead wildcard expansion is used.
----   pum		Display the completion matches using the popup menu
---- 		in the same style as the `ins-completion-menu`.
----   tagfile	When using CTRL-D to list matching tags, the kind of
---- 		tag and the file of the tag is listed.	Only one match
---- 		is displayed per line.  Often used tag kinds are:
---- 			d	#define
---- 			f	function
+--- fuzzy    Use `|fuzzy-matching|` to find completion matches. When
+---   this value is specified, wildcard expansion will not
+---   be used for completion.  The matches will be sorted by
+---   the "best match" rather than alphabetically sorted.
+---   This will find more matches than the wildcard
+---   expansion. Currently fuzzy matching based completion
+---   is not supported for file and directory names and
+---   instead wildcard expansion is used.
+--- pum    Display the completion matches using the popup menu
+---   in the same style as the `|ins-completion-menu|`.
+--- tagfile  When using CTRL-D to list matching tags, the kind of
+---   tag and the file of the tag is listed.  Only one match
+---   is displayed per line.  Often used tag kinds are:
+---     d  #define
+---     f  function
 ---
 --- @type string
 vim.o.wildoptions = "pum,tagfile"
@@ -7658,18 +7622,18 @@ vim.o.wop = vim.o.wildoptions
 vim.go.wildoptions = vim.o.wildoptions
 vim.go.wop = vim.go.wildoptions
 
---- 		only used in Win32
+---   only used in Win32
 --- Some GUI versions allow the access to menu entries by using the ALT
 --- key in combination with a character that appears underlined in the
 --- menu.  This conflicts with the use of the ALT key for mappings and
 --- entering special characters.  This option tells what to do:
----   no	Don't use ALT keys for menus.  ALT key combinations can be
---- 	mapped, but there is no automatic handling.
----   yes	ALT key handling is done by the windowing system.  ALT key
---- 	combinations cannot be mapped.
----   menu	Using ALT in combination with a character that is a menu
---- 	shortcut key, will be handled by the windowing system.  Other
---- 	keys can be mapped.
+--- no  Don't use ALT keys for menus.  ALT key combinations can be
+--- mapped, but there is no automatic handling.
+--- yes  ALT key handling is done by the windowing system.  ALT key
+--- combinations cannot be mapped.
+--- menu  Using ALT in combination with a character that is a menu
+--- shortcut key, will be handled by the windowing system.  Other
+--- keys can be mapped.
 --- If the menu is disabled by excluding 'm' from 'guioptions', the ALT
 --- key is never used for the menu.
 --- This option is not used for <F10>; on Win32.
@@ -7686,7 +7650,7 @@ vim.go.wak = vim.go.winaltkeys
 --- 'statusline'.
 ---
 --- When changing something that is used in 'winbar' that does not trigger
---- it to be updated, use `:redrawstatus`.
+--- it to be updated, use `|:redrawstatus|`.
 ---
 --- Floating windows do not use the global value of 'winbar'. The
 --- window-local value of 'winbar' must be set for a floating window to
@@ -7714,7 +7678,7 @@ vim.o.winbl = vim.o.winblend
 vim.wo.winblend = vim.o.winblend
 vim.wo.winbl = vim.wo.winblend
 
---- Window height used for `CTRL-F` and `CTRL-B` when there is only one
+--- Window height used for `|CTRL-F|` and `|CTRL-B|` when there is only one
 --- window and the value is smaller than 'lines' minus one.  The screen
 --- will scroll 'window' minus two lines, with a minimum of one.
 --- When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
@@ -7731,8 +7695,8 @@ vim.go.window = vim.o.window
 vim.go.wi = vim.go.window
 
 --- Keep the window height when windows are opened or closed and
---- 'equalalways' is set.  Also for `CTRL-W_=`.  Set by default for the
---- `preview-window` and `quickfix-window`.
+--- 'equalalways' is set.  Also for `|CTRL-W_=|`.  Set by default for the
+--- `|preview-window|` and `|quickfix-window|`.
 --- The height may be changed anyway when running out of room.
 ---
 --- @type boolean
@@ -7742,7 +7706,7 @@ vim.wo.winfixheight = vim.o.winfixheight
 vim.wo.wfh = vim.wo.winfixheight
 
 --- Keep the window width when windows are opened or closed and
---- 'equalalways' is set.  Also for `CTRL-W_=`.
+--- 'equalalways' is set.  Also for `|CTRL-W_=|`.
 --- The width may be changed anyway when running out of room.
 ---
 --- @type boolean
@@ -7760,9 +7724,9 @@ vim.wo.wfw = vim.wo.winfixwidth
 --- Other windows will be only 'winminheight' high.  This has the drawback
 --- that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
 --- to create only two windows, set the option after startup is done,
---- using the `VimEnter` event:
+--- using the `|VimEnter|` event:
 --- ```
---- 	au VimEnter * set winheight=999
+--- au VimEnter * set winheight=999
 --- ```
 --- Minimum value is 1.
 --- The height is not adjusted after one of the commands that change the
@@ -7777,12 +7741,12 @@ vim.go.winheight = vim.o.winheight
 vim.go.wh = vim.go.winheight
 
 --- Window-local highlights.  Comma-delimited list of highlight
---- `group-name` pairs "{hl-from}:{hl-to},..." where each {hl-from} is
---- a `highlight-groups` item to be overridden by {hl-to} group in
+--- `|group-name|` pairs "{hl-from}:{hl-to},..." where each {hl-from} is
+--- a `|highlight-groups|` item to be overridden by {hl-to} group in
 --- the window.
 ---
 --- Note: highlight namespaces take precedence over 'winhighlight'.
---- See `nvim_win_set_hl_ns()` and `nvim_set_hl()`.
+--- See `|nvim_win_set_hl_ns()|` and `|nvim_set_hl()|`.
 ---
 --- Highlights of vertical separators are determined by the window to the
 --- left of the separator.  The 'tabline' highlight of a tabpage is
@@ -7792,9 +7756,8 @@ vim.go.wh = vim.go.winheight
 ---
 --- Example: show a different color for non-current windows:
 --- ```
---- 	set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
+--- set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
 --- ```
----
 ---
 --- @type string
 vim.o.winhighlight = ""
@@ -7862,11 +7825,11 @@ vim.go.wiw = vim.go.winwidth
 --- 'linebreak' to get the break at a word boundary.
 --- To make scrolling horizontally a bit more useful, try this:
 --- ```
---- 	:set sidescroll=5
---- 	:set listchars+=precedes:<,extends:>
+--- :set sidescroll=5
+--- :set listchars+=precedes:<,extends:>
 --- ```
---- See 'sidescroll', 'listchars' and `wrap-off`.
---- This option can't be set from a `modeline` when the 'diff' option is
+--- See 'sidescroll', 'listchars' and `|wrap-off|`.
+--- This option can't be set from a `|modeline|` when the 'diff' option is
 --- on.
 ---
 --- @type boolean
@@ -7879,7 +7842,7 @@ vim.wo.wrap = vim.o.wrap
 --- Options that add a margin, such as 'number' and 'foldcolumn', cause
 --- the text width to be further reduced.
 --- When 'textwidth' is non-zero, this option is not used.
---- See also 'formatoptions' and `ins-textwidth`.
+--- See also 'formatoptions' and `|ins-textwidth|`.
 ---
 --- @type integer
 vim.o.wrapmargin = 0
@@ -7887,8 +7850,8 @@ vim.o.wm = vim.o.wrapmargin
 vim.bo.wrapmargin = vim.o.wrapmargin
 vim.bo.wm = vim.bo.wrapmargin
 
---- Searches wrap around the end of the file.  Also applies to `]s` and
---- `[s`, searching for spelling mistakes.
+--- Searches wrap around the end of the file.  Also applies to `|]s|` and
+--- `|[s|`, searching for spelling mistakes.
 ---
 --- @type boolean
 vim.o.wrapscan = true
@@ -7898,7 +7861,7 @@ vim.go.ws = vim.go.wrapscan
 
 --- Allows writing files.  When not set, writing a file is not allowed.
 --- Can be used for a view-only mode, where modifications to the text are
---- still allowed.  Can be reset with the `-m` or `-M` command line
+--- still allowed.  Can be reset with the `|-m|` or `|-M|` command line
 --- argument.  Filtering text is still possible, even though this requires
 --- writing a temporary file.
 ---
@@ -7922,7 +7885,7 @@ vim.go.wa = vim.go.writeany
 --- lose both the original file and what you were writing.  Only reset
 --- this option if your file system is almost full and it makes the write
 --- fail (and make sure not to exit Vim until the write was successful).
---- See `backup-table` for another explanation.
+--- See `|backup-table|` for another explanation.
 --- When the 'backupskip' pattern matches, a backup is not made anyway.
 --- Depending on 'backupcopy' the backup is a new file or the original
 --- file renamed (and a new file is written).

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4,46 +4,61 @@
 error('Cannot require a meta file')
 
 --- Return the absolute value of {expr}.  When {expr} evaluates to
---- a |Float| abs() returns a |Float|.  When {expr} can be
---- converted to a |Number| abs() returns a |Number|.  Otherwise
+--- a `|Float|` abs() returns a `|Float|`.  When {expr} can be
+--- converted to a `|Number|` abs() returns a `|Number|`.  Otherwise
 --- abs() gives an error message and returns -1.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo abs(1.456)
---- <  1.456  >vim
+--- ```
+--- 1.456
+--- ```vim
 ---   echo abs(-5.456)
---- <  5.456  >vim
+--- ```
+--- 5.456
+--- ```vim
 ---   echo abs(-4)
---- <  4
+--- ```
+--- 4
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.abs(expr) end
 
 --- Return the arc cosine of {expr} measured in radians, as a
---- |Float| in the range of [0, pi].
---- {expr} must evaluate to a |Float| or a |Number| in the range
+--- `|Float|` in the range of [0, pi].
+--- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
 --- [-1, 1].
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
---- 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo acos(0)
---- <  1.570796 >vim
+--- ```
+--- 1.570796
+--- ```vim
 ---   echo acos(-0.5)
---- <  2.094395
+--- ```
+--- 2.094395
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.acos(expr) end
 
---- Append the item {expr} to |List| or |Blob| {object}.  Returns
---- the resulting |List| or |Blob|.  Examples: >vim
+--- Append the item {expr} to `|List|` or `|Blob|` {object}.  Returns
+--- the resulting `|List|` or `|Blob|`.  Examples:
+--- ```vim
 ---   let alist = add([1, 2, 3], item)
 ---   call add(mylist, "woodstock")
---- <Note that when {expr} is a |List| it is appended as a single
---- item.  Use |extend()| to concatenate |Lists|.
---- When {object} is a |Blob| then {expr} must be a number.
---- Use |insert()| to add an item at another position.
---- Returns 1 if {object} is not a |List| or a |Blob|.
+--- ```
+--- Note that when {expr} is a `|List|` it is appended as a single
+--- item.  Use `|extend()|` to concatenate `|Lists|`.
+--- When {object} is a `|Blob|` then {expr} must be a number.
+--- Use `|insert()|` to add an item at another position.
+--- Returns 1 if {object} is not a `|List|` or a `|Blob|`.
+---
 ---
 --- @param object any
 --- @param expr any
@@ -53,62 +68,68 @@ function vim.fn.add(object, expr) end
 --- Bitwise AND on the two arguments.  The arguments are converted
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `or()` and `xor()`.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let flag = and(bits, 0x80)
---- <
+--- ```
 ---
 --- @param expr any
 --- @param expr1 any
 --- @return integer
 vim.fn['and'] = function(expr, expr1) end
 
---- Returns Dictionary of |api-metadata|.
+--- Returns Dictionary of `|api-metadata|`.
 ---
---- View it in a nice human-readable format: >vim
+--- View it in a nice human-readable format:
+--- ```vim
 ---        lua vim.print(vim.fn.api_info())
---- <
+--- ```
 ---
 --- @return table
 function vim.fn.api_info() end
 
---- When {text} is a |List|: Append each item of the |List| as a
+--- When {text} is a `|List|`: Append each item of the `|List|` as a
 --- text line below line {lnum} in the current buffer.
 --- Otherwise append {text} as one text line below line {lnum} in
 --- the current buffer.
 --- Any type of item is accepted and converted to a String.
 --- {lnum} can be zero to insert a line before the first one.
---- {lnum} is used like with |getline()|.
+--- {lnum} is used like with `|getline()|`.
 --- Returns 1 for failure ({lnum} out of range or out of memory),
 --- 0 for success.  When {text} is an empty list zero is returned,
---- no matter the value of {lnum}.  Example: >vim
+--- no matter the value of {lnum}.  Example:
+--- ```vim
 ---   let failed = append(line('$'), "# THE END")
 ---   let failed = append(0, ["Chapter 1", "the beginning"])
---- <
+--- ```
 ---
 --- @param lnum integer
 --- @param text any
 --- @return 0|1
 function vim.fn.append(lnum, text) end
 
---- Like |append()| but append the text in buffer {expr}.
+--- Like `|append()|` but append the text in buffer {expr}.
 ---
 --- This function works only for loaded buffers. First call
---- |bufload()| if needed.
+--- `|bufload()|` if needed.
 ---
---- For the use of {buf}, see |bufname()|.
+--- For the use of {buf}, see `|bufname()|`.
 ---
 --- {lnum} is the line number to append below.  Note that using
---- |line()| would use the current buffer, not the one appending
+--- `|line()|` would use the current buffer, not the one appending
 --- to.  Use "$" to append at the end of the buffer.  Other string
 --- values are not supported.
 ---
 --- On success 0 is returned, on failure 1 is returned.
 ---
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
---- error message is given. Example: >vim
+--- error message is given. Example:
+--- ```vim
 ---   let failed = appendbufline(13, 0, "# THE START")
---- <However, when {text} is an empty list then no error is given
+--- ```
+--- However, when {text} is an empty list then no error is given
 --- for an invalid {lnum}, since {lnum} isn't actually used.
+---
 ---
 --- @param buf any
 --- @param lnum integer
@@ -117,7 +138,7 @@ function vim.fn.append(lnum, text) end
 function vim.fn.appendbufline(buf, lnum, text) end
 
 --- The result is the number of files in the argument list.  See
---- |arglist|.
+--- `|arglist|`.
 --- If {winid} is not supplied, the argument list of the current
 --- window is used.
 --- If {winid} is -1, the global argument list is used.
@@ -130,21 +151,21 @@ function vim.fn.appendbufline(buf, lnum, text) end
 function vim.fn.argc(winid) end
 
 --- The result is the current index in the argument list.  0 is
---- the first file.  argc() - 1 is the last one.  See |arglist|.
+--- the first file.  argc() - 1 is the last one.  See `|arglist|`.
 ---
 --- @return integer
 function vim.fn.argidx() end
 
 --- Return the argument list ID.  This is a number which
 --- identifies the argument list being used.  Zero is used for the
---- global argument list.  See |arglist|.
+--- global argument list.  See `|arglist|`.
 --- Returns -1 if the arguments are invalid.
 ---
 --- Without arguments use the current window.
 --- With {winnr} only use this window in the current tab page.
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.
---- {winnr} can be the window number or the |window-ID|.
+--- {winnr} can be the window number or the `|window-ID|`.
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -152,18 +173,20 @@ function vim.fn.argidx() end
 function vim.fn.arglistid(winnr, tabnr) end
 
 --- The result is the {nr}th file in the argument list.  See
---- |arglist|.  "argv(0)" is the first one.  Example: >vim
+--- `|arglist|`.  "argv(0)" is the first one.  Example:
+--- ```vim
 ---   let i = 0
 ---   while i < argc()
 ---     let f = escape(fnameescape(argv(i)), '.')
 ---     exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
 ---     let i = i + 1
 ---   endwhile
---- <Without the {nr} argument, or when {nr} is -1, a |List| with
---- the whole |arglist| is returned.
+--- ```
+--- Without the {nr} argument, or when {nr} is -1, a `|List|` with
+--- the whole `|arglist|` is returned.
 ---
---- The {winid} argument specifies the window ID, see |argc()|.
---- For the Vim command line arguments see |v:argv|.
+--- The {winid} argument specifies the window ID, see `|argc()|`.
+--- For the Vim command line arguments see `|v:argv|`.
 ---
 --- Returns an empty string if {nr}th argument is not present in
 --- the argument list.  Returns an empty List if the {winid}
@@ -174,34 +197,40 @@ function vim.fn.arglistid(winnr, tabnr) end
 --- @return string|string[]
 function vim.fn.argv(nr, winid) end
 
---- Return the arc sine of {expr} measured in radians, as a |Float|
+--- Return the arc sine of {expr} measured in radians, as a `|Float|`
 --- in the range of [-pi/2, pi/2].
---- {expr} must evaluate to a |Float| or a |Number| in the range
+--- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
 --- [-1, 1].
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
---- 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo asin(0.8)
---- <  0.927295 >vim
+--- ```
+--- 0.927295
+--- ```vim
 ---   echo asin(-0.5)
---- <  -0.523599
+--- ```
+--- -0.523599
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.asin(expr) end
 
---- Run {cmd} and add an error message to |v:errors| if it does
+--- Run {cmd} and add an error message to `|v:errors|` if it does
 --- NOT produce a beep or visual bell.
---- Also see |assert_fails()|, |assert_nobeep()| and
---- |assert-return|.
+--- Also see `|assert_fails()|`, `|assert_nobeep()|` and
+--- `|assert-return|`.
+---
 ---
 --- @param cmd any
 --- @return 0|1
 function vim.fn.assert_beeps(cmd) end
 
 --- When {expected} and {actual} are not equal an error message is
---- added to |v:errors| and 1 is returned.  Otherwise zero is
---- returned. |assert-return|
+--- added to `|v:errors|` and 1 is returned.  Otherwise zero is
+--- returned. `|assert-return|`
 --- The error is in the form "Expected {expected} but got
 --- {actual}".  When {msg} is present it is prefixed to that.
 ---
@@ -209,10 +238,13 @@ function vim.fn.assert_beeps(cmd) end
 --- from the Number 4.  And the number 4 is different from the
 --- Float 4.0.  The value of 'ignorecase' is not used here, case
 --- always matters.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   assert_equal('foo', 'bar')
---- <Will result in a string to be added to |v:errors|:
+--- ```
+--- Will result in a string to be added to `|v:errors|`:
 ---   test.vim line 12: Expected 'foo' but got 'bar' ~
+---
 ---
 --- @param expected any
 --- @param actual any
@@ -221,50 +253,56 @@ function vim.fn.assert_beeps(cmd) end
 function vim.fn.assert_equal(expected, actual, msg) end
 
 --- When the files {fname-one} and {fname-two} do not contain
---- exactly the same text an error message is added to |v:errors|.
---- Also see |assert-return|.
+--- exactly the same text an error message is added to `|v:errors|`.
+--- Also see `|assert-return|`.
 --- When {fname-one} or {fname-two} does not exist the error will
 --- mention that.
+---
 ---
 --- @return 0|1
 function vim.fn.assert_equalfile() end
 
 --- When v:exception does not contain the string {error} an error
---- message is added to |v:errors|.  Also see |assert-return|.
+--- message is added to `|v:errors|`.  Also see `|assert-return|`.
 --- This can be used to assert that a command throws an exception.
 --- Using the error number, followed by a colon, avoids problems
---- with translations: >vim
+--- with translations:
+--- ```vim
 ---   try
 ---     commandthatfails
 ---     call assert_false(1, 'command should have failed')
 ---   catch
 ---     call assert_exception('E492:')
 ---   endtry
---- <
+--- ```
 ---
 --- @param error any
 --- @param msg? any
 --- @return 0|1
 function vim.fn.assert_exception(error, msg) end
 
---- Run {cmd} and add an error message to |v:errors| if it does
+--- Run {cmd} and add an error message to `|v:errors|` if it does
 --- NOT produce an error or when {error} is not found in the
---- error message.  Also see |assert-return|.
+--- error message.  Also see `|assert-return|`.
 ---
 --- When {error} is a string it must be found literally in the
 --- first reported error. Most often this will be the error code,
---- including the colon, e.g. "E123:". >vim
+--- including the colon, e.g. "E123:".
+--- ```vim
 ---   assert_fails('bad cmd', 'E987:')
---- <
---- When {error} is a |List| with one or two strings, these are
+--- ```
+--- When {error} is a `|List|` with one or two strings, these are
 --- used as patterns.  The first pattern is matched against the
---- first reported error: >vim
+--- first reported error:
+--- ```vim
 ---   assert_fails('cmd', ['E987:.*expected bool'])
---- <The second pattern, if present, is matched against the last
+--- ```
+--- The second pattern, if present, is matched against the last
 --- reported error.  To only match the last error use an empty
---- string for the first error: >vim
+--- string for the first error:
+--- ```vim
 ---   assert_fails('cmd', ['', 'E987:'])
---- <
+--- ```
 --- If {msg} is empty then it is not used.  Do this to get the
 --- default message when passing the {lnum} argument.
 ---
@@ -278,7 +316,8 @@ function vim.fn.assert_exception(error, msg) end
 --- {lnum} is located in.
 ---
 --- Note that beeping is not considered an error, and some failing
---- commands only beep.  Use |assert_beeps()| for those.
+--- commands only beep.  Use `|assert_beeps()|` for those.
+---
 ---
 --- @param cmd any
 --- @param error? any
@@ -289,22 +328,23 @@ function vim.fn.assert_exception(error, msg) end
 function vim.fn.assert_fails(cmd, error, msg, lnum, context) end
 
 --- When {actual} is not false an error message is added to
---- |v:errors|, like with |assert_equal()|.
+--- `|v:errors|`, like with `|assert_equal()|`.
 --- The error is in the form "Expected False but got {actual}".
 --- When {msg} is present it is prepended to that.
---- Also see |assert-return|.
+--- Also see `|assert-return|`.
 ---
 --- A value is false when it is zero. When {actual} is not a
 --- number the assert fails.
+---
 ---
 --- @param actual any
 --- @param msg? any
 --- @return 0|1
 function vim.fn.assert_false(actual, msg) end
 
---- This asserts number and |Float| values.  When {actual}  is lower
+--- This asserts number and `|Float|` values.  When {actual}  is lower
 --- than {lower} or higher than {upper} an error message is added
---- to |v:errors|.  Also see |assert-return|.
+--- to `|v:errors|`.  Also see `|assert-return|`.
 --- The error is in the form "Expected range {lower} - {upper},
 --- but got {actual}".  When {msg} is present it is prefixed to
 --- that.
@@ -317,11 +357,11 @@ function vim.fn.assert_false(actual, msg) end
 function vim.fn.assert_inrange(lower, upper, actual, msg) end
 
 --- When {pattern} does not match {actual} an error message is
---- added to |v:errors|.  Also see |assert-return|.
+--- added to `|v:errors|`.  Also see `|assert-return|`.
 --- The error is in the form "Pattern {pattern} does not match
 --- {actual}".  When {msg} is present it is prefixed to that.
 ---
---- {pattern} is used as with |expr-=~|: The matching is always done
+--- {pattern} is used as with `|expr-=~|`: The matching is always done
 --- like 'magic' was set and 'cpoptions' is empty, no matter what
 --- the actual value of 'magic' or 'cpoptions' is.
 ---
@@ -329,10 +369,13 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- Use "^" and "$" to match with the start and end of the text.
 --- Use both to match the whole text.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   assert_match('^f.*o$', 'foobar')
---- <Will result in a string to be added to |v:errors|:
+--- ```
+--- Will result in a string to be added to `|v:errors|`:
 ---   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+---
 ---
 --- @param pattern any
 --- @param actual any
@@ -340,17 +383,19 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- @return 0|1
 function vim.fn.assert_match(pattern, actual, msg) end
 
---- Run {cmd} and add an error message to |v:errors| if it
+--- Run {cmd} and add an error message to `|v:errors|` if it
 --- produces a beep or visual bell.
---- Also see |assert_beeps()|.
+--- Also see `|assert_beeps()|`.
+---
 ---
 --- @param cmd any
 --- @return 0|1
 function vim.fn.assert_nobeep(cmd) end
 
 --- The opposite of `assert_equal()`: add an error message to
---- |v:errors| when {expected} and {actual} are equal.
---- Also see |assert-return|.
+--- `|v:errors|` when {expected} and {actual} are equal.
+--- Also see `|assert-return|`.
+---
 ---
 --- @param expected any
 --- @param actual any
@@ -359,8 +404,9 @@ function vim.fn.assert_nobeep(cmd) end
 function vim.fn.assert_notequal(expected, actual, msg) end
 
 --- The opposite of `assert_match()`: add an error message to
---- |v:errors| when {pattern} matches {actual}.
---- Also see |assert-return|.
+--- `|v:errors|` when {pattern} matches {actual}.
+--- Also see `|assert-return|`.
+---
 ---
 --- @param pattern any
 --- @param actual any
@@ -371,16 +417,18 @@ function vim.fn.assert_notmatch(pattern, actual, msg) end
 --- Report a test failure directly, using String {msg}.
 --- Always returns one.
 ---
+---
 --- @param msg any
 --- @return 0|1
 function vim.fn.assert_report(msg) end
 
 --- When {actual} is not true an error message is added to
---- |v:errors|, like with |assert_equal()|.
---- Also see |assert-return|.
---- A value is |TRUE| when it is a non-zero number or |v:true|.
---- When {actual} is not a number or |v:true| the assert fails.
+--- `|v:errors|`, like with `|assert_equal()|`.
+--- Also see `|assert-return|`.
+--- A value is `|TRUE|` when it is a non-zero number or `|v:true|`.
+--- When {actual} is not a number or `|v:true|` the assert fails.
 --- When {msg} is given it precedes the default message.
+---
 ---
 --- @param actual any
 --- @param msg? any
@@ -388,29 +436,39 @@ function vim.fn.assert_report(msg) end
 function vim.fn.assert_true(actual, msg) end
 
 --- Return the principal value of the arc tangent of {expr}, in
---- the range [-pi/2, +pi/2] radians, as a |Float|.
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- the range [-pi/2, +pi/2] radians, as a `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo atan(100)
---- <  1.560797 >vim
+--- ```
+--- 1.560797
+--- ```vim
 ---   echo atan(-4.01)
---- <  -1.326405
+--- ```
+--- -1.326405
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.atan(expr) end
 
 --- Return the arc tangent of {expr1} / {expr2}, measured in
---- radians, as a |Float| in the range [-pi, pi].
---- {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
---- |Number|.
---- Examples: >vim
+--- radians, as a `|Float|` in the range [-pi, pi].
+--- {expr1} and {expr2} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr1} or {expr2} is not a `|Float|` or a
+--- `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo atan2(-1, 1)
---- <  -0.785398 >vim
+--- ```
+--- -0.785398
+--- ```vim
 ---   echo atan2(1, -1)
---- <  2.356194
+--- ```
+--- 2.356194
+---
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -418,20 +476,23 @@ function vim.fn.atan(expr) end
 function vim.fn.atan2(expr1, expr2) end
 
 --- Return a List containing the number value of each byte in Blob
---- {blob}.  Examples: >vim
+--- {blob}.  Examples:
+--- ```vim
 ---   blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
 ---   blob2list(0z)    " returns []
---- <Returns an empty List on error.  |list2blob()| does the
+--- ```
+--- Returns an empty List on error.  `|list2blob()|` does the
 --- opposite.
+---
 ---
 --- @param blob any
 --- @return any[]
 function vim.fn.blob2list(blob) end
 
 --- Put up a file requester.  This only works when "has("browse")"
---- returns |TRUE| (only in some GUI versions).
+--- returns `|TRUE|` (only in some GUI versions).
 --- The input fields are:
----     {save}  when |TRUE|, select file to write
+---     {save}  when `|TRUE|`, select file to write
 ---     {title}  title for the requester
 ---     {initdir}  directory to start browsing in
 ---     {default}  default file name
@@ -446,7 +507,7 @@ function vim.fn.blob2list(blob) end
 function vim.fn.browse(save, title, initdir, default) end
 
 --- Put up a directory requester.  This only works when
---- "has("browse")" returns |TRUE| (only in some GUI versions).
+--- "has("browse")" returns `|TRUE|` (only in some GUI versions).
 --- On systems where a directory browser is not supported a file
 --- browser is used.  In that case: select a file in the directory
 --- to be used.
@@ -468,17 +529,19 @@ function vim.fn.browsedir(title, initdir) end
 --- created buffer.  When {name} is an empty string then a new
 --- buffer is always created.
 --- The buffer will not have 'buflisted' set and not be loaded
---- yet.  To add some text to the buffer use this: >vim
+--- yet.  To add some text to the buffer use this:
+--- ```vim
 ---   let bufnr = bufadd('someName')
 ---   call bufload(bufnr)
 ---   call setbufline(bufnr, 1, ['some', 'text'])
---- <Returns 0 on error.
+--- ```
+--- Returns 0 on error.
 ---
 --- @param name string
 --- @return integer
 function vim.fn.bufadd(name) end
 
---- The result is a Number, which is |TRUE| if a buffer called
+--- The result is a Number, which is `|TRUE|` if a buffer called
 --- {buf} exists.
 --- If the {buf} argument is a number, buffer numbers are used.
 --- Number zero is the alternate buffer for the current window.
@@ -491,42 +554,44 @@ function vim.fn.bufadd(name) end
 --- - A URL name.
 --- Unlisted buffers will be found.
 --- Note that help files are listed by their short name in the
---- output of |:buffers|, but bufexists() requires using their
+--- output of `|:buffers|`, but bufexists() requires using their
 --- long name to be able to find them.
 --- bufexists() may report a buffer exists, but to use the name
---- with a |:buffer| command you may need to use |expand()|.  Esp
+--- with a `|:buffer|` command you may need to use `|expand()|`.  Esp
 --- for MS-Windows 8.3 names in the form "c:\DOCUME~1"
 --- Use "bufexists(0)" to test for the existence of an alternate
 --- file name.
+---
 ---
 --- @param buf any
 --- @return 0|1
 function vim.fn.bufexists(buf) end
 
 --- @deprecated
---- Obsolete name for |bufexists()|.
+--- Obsolete name for `|bufexists()|`.
 ---
 --- @param ... any
 --- @return 0|1
 function vim.fn.buffer_exists(...) end
 
 --- @deprecated
---- Obsolete name for |bufname()|.
+--- Obsolete name for `|bufname()|`.
 ---
 --- @param ... any
 --- @return string
 function vim.fn.buffer_name(...) end
 
 --- @deprecated
---- Obsolete name for |bufnr()|.
+--- Obsolete name for `|bufnr()|`.
 ---
 --- @param ... any
 --- @return integer
 function vim.fn.buffer_number(...) end
 
---- The result is a Number, which is |TRUE| if a buffer called
+--- The result is a Number, which is `|TRUE|` if a buffer called
 --- {buf} exists and is listed (has the 'buflisted' option set).
---- The {buf} argument is used like with |bufexists()|.
+--- The {buf} argument is used like with `|bufexists()|`.
+---
 ---
 --- @param buf any
 --- @return 0|1
@@ -539,14 +604,16 @@ function vim.fn.buflisted(buf) end
 --- file then no file is read (e.g., when 'buftype' is "nofile").
 --- If there is an existing swap file for the file of the buffer,
 --- there will be no dialog, the buffer will be loaded anyway.
---- The {buf} argument is used like with |bufexists()|.
+--- The {buf} argument is used like with `|bufexists()|`.
+---
 ---
 --- @param buf any
 function vim.fn.bufload(buf) end
 
---- The result is a Number, which is |TRUE| if a buffer called
+--- The result is a Number, which is `|TRUE|` if a buffer called
 --- {buf} exists and is loaded (shown in a window or hidden).
---- The {buf} argument is used like with |bufexists()|.
+--- The {buf} argument is used like with `|bufexists()|`.
+---
 ---
 --- @param buf any
 --- @return 0|1
@@ -558,7 +625,7 @@ function vim.fn.bufloaded(buf) end
 --- If {buf} is omitted the current buffer is used.
 --- If {buf} is a Number, that buffer number's name is given.
 --- Number zero is the alternate buffer for the current window.
---- If {buf} is a String, it is used as a |file-pattern| to match
+--- If {buf} is a String, it is used as a `|file-pattern|` to match
 --- with the buffer names.  This is always done like 'magic' is
 --- set and 'cpoptions' is empty.  When there is more than one
 --- match an empty string is returned.
@@ -572,61 +639,71 @@ function vim.fn.bufloaded(buf) end
 --- with a listed buffer, that one is returned.  Next unlisted
 --- buffers are searched for.
 --- If the {buf} is a String, but you want to use it as a buffer
---- number, force it to be a Number by adding zero to it: >vim
+--- number, force it to be a Number by adding zero to it:
+--- ```vim
 ---   echo bufname("3" + 0)
---- <If the buffer doesn't exist, or doesn't have a name, an empty
---- string is returned. >vim
+--- ```
+--- If the buffer doesn't exist, or doesn't have a name, an empty
+--- string is returned.
+--- ```vim
 ---   echo bufname("#")  " alternate buffer name
 ---   echo bufname(3)    " name of buffer 3
 ---   echo bufname("%")  " name of current buffer
 ---   echo bufname("file2")  " name of buffer where "file2" matches.
---- <
+--- ```
 ---
 --- @param buf? any
 --- @return string
 function vim.fn.bufname(buf) end
 
 --- The result is the number of a buffer, as it is displayed by
---- the `:ls` command.  For the use of {buf}, see |bufname()|
+--- the `:ls` command.  For the use of {buf}, see `|bufname()|`
 --- above.
 --- If the buffer doesn't exist, -1 is returned.  Or, if the
 --- {create} argument is present and TRUE, a new, unlisted,
 --- buffer is created and its number is returned.
---- bufnr("$") is the last buffer: >vim
+--- bufnr("$") is the last buffer:
+--- ```vim
 ---   let last_buffer = bufnr("$")
---- <The result is a Number, which is the highest buffer number
+--- ```
+--- The result is a Number, which is the highest buffer number
 --- of existing buffers.  Note that not all buffers with a smaller
 --- number necessarily exist, because ":bwipeout" may have removed
 --- them.  Use bufexists() to test for the existence of a buffer.
+---
 ---
 --- @param buf? any
 --- @param create? any
 --- @return integer
 function vim.fn.bufnr(buf, create) end
 
---- The result is a Number, which is the |window-ID| of the first
+--- The result is a Number, which is the `|window-ID|` of the first
 --- window associated with buffer {buf}.  For the use of {buf},
---- see |bufname()| above.  If buffer {buf} doesn't exist or
---- there is no such window, -1 is returned.  Example: >vim
+--- see `|bufname()|` above.  If buffer {buf} doesn't exist or
+--- there is no such window, -1 is returned.  Example:
+--- ```vim
 ---
 ---   echo "A window containing buffer 1 is " .. (bufwinid(1))
---- <
---- Only deals with the current tab page.  See |win_findbuf()| for
+--- ```
+--- Only deals with the current tab page.  See `|win_findbuf()|` for
 --- finding more.
+---
 ---
 --- @param buf any
 --- @return integer
 function vim.fn.bufwinid(buf) end
 
---- Like |bufwinid()| but return the window number instead of the
---- |window-ID|.
+--- Like `|bufwinid()|` but return the window number instead of the
+--- `|window-ID|`.
 --- If buffer {buf} doesn't exist or there is no such window, -1
---- is returned.  Example: >vim
+--- is returned.  Example:
+--- ```vim
 ---
 ---   echo "A window containing buffer 1 is " .. (bufwinnr(1))
+--- ```
+--- The number can be used with `|CTRL-W_w|` and ":wincmd w"
+--- `|:wincmd|`.
 ---
---- <The number can be used with |CTRL-W_w| and ":wincmd w"
---- |:wincmd|.
 ---
 --- @param buf any
 --- @return integer
@@ -637,9 +714,10 @@ function vim.fn.bufwinnr(buf) end
 --- end-of-line character, depending on the 'fileformat' option
 --- for the current buffer.  The first character has byte count
 --- one.
---- Also see |line2byte()|, |go| and |:goto|.
+--- Also see `|line2byte()|`, `|go|` and `|:goto|`.
 ---
 --- Returns -1 if the {byte} value is invalid.
+---
 ---
 --- @param byte any
 --- @return integer
@@ -652,7 +730,7 @@ function vim.fn.byte2line(byte) end
 --- equal to {nr}.
 --- Composing characters are not counted separately, their byte
 --- length is added to the preceding base character.  See
---- |byteidxcomp()| below for counting composing characters
+--- `|byteidxcomp()|` below for counting composing characters
 --- separately.
 --- When {utf16} is present and TRUE, {nr} is used as the UTF-16
 --- index in the String {expr} instead of as the character index.
@@ -660,25 +738,30 @@ function vim.fn.byte2line(byte) end
 --- with 16-bit words.  If the specified UTF-16 index is in the
 --- middle of a character (e.g. in a 4-byte character), then the
 --- byte index of the first byte in the character is returned.
---- Refer to |string-offset-encoding| for more information.
---- Example : >vim
+--- Refer to `|string-offset-encoding|` for more information.
+--- Example :
+--- ```vim
 ---   echo matchstr(str, ".", byteidx(str, 3))
---- <will display the fourth character.  Another way to do the
---- same: >vim
+--- ```
+--- will display the fourth character.  Another way to do the
+--- same:
+--- ```vim
 ---   let s = strpart(str, byteidx(str, 3))
 ---   echo strpart(s, 0, byteidx(s, 1))
---- <Also see |strgetchar()| and |strcharpart()|.
+--- ```
+--- Also see `|strgetchar()|` and `|strcharpart()|`.
 ---
 --- If there are less than {nr} characters -1 is returned.
 --- If there are exactly {nr} characters the length of the string
 --- in bytes is returned.
---- See |charidx()| and |utf16idx()| for getting the character and
+--- See `|charidx()|` and `|utf16idx()|` for getting the character and
 --- UTF-16 index respectively from the byte index.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo byteidx('a😊😊', 2)  " returns 5
 ---   echo byteidx('a😊😊', 2, 1)  " returns 1
 ---   echo byteidx('a😊😊', 3, 1)  " returns 5
---- <
+--- ```
 ---
 --- @param expr any
 --- @param nr integer
@@ -687,14 +770,17 @@ function vim.fn.byte2line(byte) end
 function vim.fn.byteidx(expr, nr, utf16) end
 
 --- Like byteidx(), except that a composing character is counted
---- as a separate character.  Example: >vim
+--- as a separate character.  Example:
+--- ```vim
 ---   let s = 'e' .. nr2char(0x301)
 ---   echo byteidx(s, 1)
 ---   echo byteidxcomp(s, 1)
 ---   echo byteidxcomp(s, 2)
---- <The first and third echo result in 3 ('e' plus composing
+--- ```
+--- The first and third echo result in 3 ('e' plus composing
 --- character is 3 bytes), the second echo results in 1 ('e' is
 --- one byte).
+---
 ---
 --- @param expr any
 --- @param nr integer
@@ -702,13 +788,14 @@ function vim.fn.byteidx(expr, nr, utf16) end
 --- @return integer
 function vim.fn.byteidxcomp(expr, nr, utf16) end
 
---- Call function {func} with the items in |List| {arglist} as
+--- Call function {func} with the items in `|List|` {arglist} as
 --- arguments.
---- {func} can either be a |Funcref| or the name of a function.
+--- {func} can either be a `|Funcref|` or the name of a function.
 --- a:firstline and a:lastline are set to the cursor line.
 --- Returns the return value of the called function.
 --- {dict} is for functions with the "dict" attribute.  It will be
---- used to set the local variable "self". |Dictionary-function|
+--- used to set the local variable "self". `|Dictionary-function|`
+---
 ---
 --- @param func any
 --- @param arglist any
@@ -717,17 +804,24 @@ function vim.fn.byteidxcomp(expr, nr, utf16) end
 function vim.fn.call(func, arglist, dict) end
 
 --- Return the smallest integral value greater than or equal to
---- {expr} as a |Float| (round up).
---- {expr} must evaluate to a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} as a `|Float|` (round up).
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo ceil(1.456)
---- <  2.0  >vim
+--- ```
+--- 2.0
+--- ```vim
 ---   echo ceil(-5.456)
---- <  -5.0  >vim
+--- ```
+--- -5.0
+--- ```vim
 ---   echo ceil(4.0)
---- <  4.0
+--- ```
+--- 4.0
 ---
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+---
 ---
 --- @param expr any
 --- @return number
@@ -748,8 +842,8 @@ function vim.fn.ceil(expr) end
 function vim.fn.chanclose(id, stream) end
 
 --- Return the number of the most recent change.  This is the same
---- number as what is displayed with |:undolist| and can be used
---- with the |:undo| command.
+--- number as what is displayed with `|:undolist|` and can be used
+--- with the `|:undo|` command.
 --- When a change was made it is the number of that change.  After
 --- redo it is the number of the redone change.  After undo it is
 --- one less than the number of the undone change.
@@ -759,21 +853,23 @@ function vim.fn.chanclose(id, stream) end
 function vim.fn.changenr() end
 
 --- Send data to channel {id}. For a job, it writes it to the
---- stdin of the process. For the stdio channel |channel-stdio|,
+--- stdin of the process. For the stdio channel `|channel-stdio|`,
 --- it writes to Nvim's stdout.  Returns the number of bytes
 --- written if the write succeeded, 0 otherwise.
---- See |channel-bytes| for more information.
+--- See `|channel-bytes|` for more information.
 ---
---- {data} may be a string, string convertible, |Blob|, or a list.
+--- {data} may be a string, string convertible, `|Blob|`, or a list.
 --- If {data} is a list, the items will be joined by newlines; any
 --- newlines in an item will be sent as NUL. To send a final
---- newline, include a final empty string. Example: >vim
+--- newline, include a final empty string. Example:
+--- ```vim
 ---   call chansend(id, ["abc", "123\n456", ""])
---- <will send "abc<NL>123<NUL>456<NL>".
+--- ```
+--- will send "abc<NL>123<NUL>456<NL>".
 ---
 --- chansend() writes raw data, not RPC messages.  If the channel
 --- was created with `"rpc":v:true` then the channel expects RPC
---- messages, use |rpcnotify()| and |rpcrequest()| instead.
+--- messages, use `|rpcnotify()|` and `|rpcrequest()|` instead.
 ---
 --- @param id any
 --- @param data any
@@ -781,18 +877,21 @@ function vim.fn.changenr() end
 function vim.fn.chansend(id, data) end
 
 --- Return Number value of the first char in {string}.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo char2nr(" ")  " returns 32
 ---   echo char2nr("ABC")  " returns 65
 ---   echo char2nr("á")  " returns 225
 ---   echo char2nr("á"[0])  " returns 195
 ---   echo char2nr("\<M-x>")  " returns 128
---- <Non-ASCII characters are always treated as UTF-8 characters.
+--- ```
+--- Non-ASCII characters are always treated as UTF-8 characters.
 --- {utf8} is ignored, it exists only for backwards-compatibility.
 --- A combining character is a separate character.
---- |nr2char()| does the opposite.
+--- `|nr2char()|` does the opposite.
 ---
---- Returns 0 if {string} is not a |String|.
+--- Returns 0 if {string} is not a `|String|`.
+---
 ---
 --- @param string string
 --- @param utf8? any
@@ -807,19 +906,21 @@ function vim.fn.char2nr(string, utf8) end
 ---   3  emoji
 ---   other  specific Unicode class
 --- The class is used in patterns and word motions.
---- Returns 0 if {string} is not a |String|.
+--- Returns 0 if {string} is not a `|String|`.
 ---
 --- @param string string
 --- @return 0|1|2|3|'other'
 function vim.fn.charclass(string) end
 
---- Same as |col()| but returns the character index of the column
+--- Same as `|col()|` but returns the character index of the column
 --- position given with {expr} instead of the byte position.
 ---
 --- Example:
---- With the cursor on '세' in line 5 with text "여보세요": >vim
+--- With the cursor on '세' in line 5 with text "여보세요":
+--- ```vim
 ---   echo charcol('.')  " returns 3
 ---   echo col('.')    " returns 7
+--- ```
 ---
 --- @param expr any
 --- @param winid? integer
@@ -831,10 +932,10 @@ function vim.fn.charcol(expr, winid) end
 --- If there are no multibyte characters the returned value is
 --- equal to {idx}.
 ---
---- When {countcc} is omitted or |FALSE|, then composing characters
+--- When {countcc} is omitted or `|FALSE|`, then composing characters
 --- are not counted separately, their byte length is added to the
 --- preceding base character.
---- When {countcc} is |TRUE|, then composing characters are
+--- When {countcc} is `|TRUE|`, then composing characters are
 --- counted as separate characters.
 ---
 --- When {utf16} is present and TRUE, {idx} is used as the UTF-16
@@ -848,16 +949,17 @@ function vim.fn.charcol(expr, winid) end
 --- not a string, the second argument is not a number or when the
 --- third argument is present and is not zero or one.
 ---
---- See |byteidx()| and |byteidxcomp()| for getting the byte index
---- from the character index and |utf16idx()| for getting the
+--- See `|byteidx()|` and `|byteidxcomp()|` for getting the byte index
+--- from the character index and `|utf16idx()|` for getting the
 --- UTF-16 index from the character index.
---- Refer to |string-offset-encoding| for more information.
---- Examples: >vim
+--- Refer to `|string-offset-encoding|` for more information.
+--- Examples:
+--- ```vim
 ---   echo charidx('áb́ć', 3)    " returns 1
 ---   echo charidx('áb́ć', 6, 1)  " returns 4
 ---   echo charidx('áb́ć', 16)    " returns -1
 ---   echo charidx('a😊😊', 4, 0, 1)  " returns 2
---- <
+--- ```
 ---
 --- @param string string
 --- @param idx integer
@@ -870,9 +972,9 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 --- the directory change depends on the directory of the current
 --- window:
 ---   - If the current window has a window-local directory
----     (|:lcd|), then changes the window local directory.
+---     (`|:lcd|`), then changes the window local directory.
 ---   - Otherwise, if the current tabpage has a local
----     directory (|:tcd|) then changes the tabpage local
+---     directory (`|:tcd|`) then changes the tabpage local
 ---     directory.
 ---   - Otherwise, changes the global directory.
 --- {dir} must be a String.
@@ -880,12 +982,14 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 --- this to another chdir() to restore the directory.
 --- On failure, returns an empty string.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let save_dir = chdir(newdir)
 ---   if save_dir != ""
 ---      " ... do some work
 ---      call chdir(save_dir)
 ---   endif
+--- ```
 ---
 --- @param dir string
 --- @return string
@@ -894,18 +998,20 @@ function vim.fn.chdir(dir) end
 --- Get the amount of indent for line {lnum} according the C
 --- indenting rules, as with 'cindent'.
 --- The indent is counted in spaces, the value of 'tabstop' is
---- relevant.  {lnum} is used just like in |getline()|.
+--- relevant.  {lnum} is used just like in `|getline()|`.
 --- When {lnum} is invalid -1 is returned.
---- See |C-indenting|.
+--- See `|C-indenting|`.
+---
 ---
 --- @param lnum integer
 --- @return integer
 function vim.fn.cindent(lnum) end
 
 --- Clears all matches previously defined for the current window
---- by |matchadd()| and the |:match| commands.
+--- by `|matchadd()|` and the `|:match|` commands.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
+---
 ---
 --- @param win? any
 function vim.fn.clearmatches(win) end
@@ -919,33 +1025,37 @@ function vim.fn.clearmatches(win) end
 ---       returned)
 ---     v       In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
+---       returns the cursor position.  Differs from `|'<|` in
 ---       that it's updated right away.
---- Additionally {expr} can be [lnum, col]: a |List| with the line
+--- Additionally {expr} can be [lnum, col]: a `|List|` with the line
 --- and column number. Most useful when the column is "$", to get
 --- the last column of a specific line.  When "lnum" or "col" is
 --- out of range then col() returns zero.
 --- With the optional {winid} argument the values are obtained for
 --- that window instead of the current window.
---- To get the line number use |line()|.  To get both use
---- |getpos()|.
---- For the screen column position use |virtcol()|.  For the
---- character position use |charcol()|.
+--- To get the line number use `|line()|`.  To get both use
+--- `|getpos()|`.
+--- For the screen column position use `|virtcol()|`.  For the
+--- character position use `|charcol()|`.
 --- Note that only marks in the current file can be used.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo col(".")      " column of cursor
 ---   echo col("$")      " length of cursor line plus one
 ---   echo col("'t")      " column of mark t
 ---   echo col("'" .. markname)  " column of mark markname
---- <The first column is 1.  Returns 0 if {expr} is invalid or when
+--- ```
+--- The first column is 1.  Returns 0 if {expr} is invalid or when
 --- the window with ID {winid} is not found.
 --- For an uppercase mark the column may actually be in another
 --- buffer.
 --- For the cursor position, when 'virtualedit' is active, the
 --- column is one higher if the cursor is after the end of the
 --- line.  Also, when using a <Cmd> mapping the cursor isn't
---- moved, this can be used to obtain the column in Insert mode: >vim
+--- moved, this can be used to obtain the column in Insert mode:
+--- ```vim
 ---   imap <F2> <Cmd>echo col(".").."\n"<CR>
+--- ```
 ---
 --- @param expr any
 --- @param winid? integer
@@ -954,22 +1064,23 @@ function vim.fn.col(expr, winid) end
 
 --- Set the matches for Insert mode completion.
 --- Can only be used in Insert mode.  You need to use a mapping
---- with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
+--- with CTRL-R = (see `|i_CTRL-R|`).  It does not work after CTRL-O
 --- or with an expression mapping.
 --- {startcol} is the byte offset in the line where the completed
 --- text start.  The text up to the cursor is the original text
 --- that will be replaced by the matches.  Use col('.') for an
 --- empty string.  "col('.') - 1" will replace one character by a
 --- match.
---- {matches} must be a |List|.  Each |List| item is one match.
---- See |complete-items| for the kind of items that are possible.
+--- {matches} must be a `|List|`.  Each `|List|` item is one match.
+--- See `|complete-items|` for the kind of items that are possible.
 --- "longest" in 'completeopt' is ignored.
 --- Note that the after calling this function you need to avoid
 --- inserting anything that would cause completion to stop.
 --- The match can be selected with CTRL-N and CTRL-P as usual with
 --- Insert mode completion.  The popup menu will appear if
---- specified, see |ins-completion-menu|.
---- Example: >vim
+--- specified, see `|ins-completion-menu|`.
+--- Example:
+--- ```vim
 ---   inoremap <F5> <C-R>=ListMonths()<CR>
 ---
 ---   func ListMonths()
@@ -978,8 +1089,10 @@ function vim.fn.col(expr, winid) end
 ---       \ 'October', 'November', 'December'])
 ---     return ''
 ---   endfunc
---- <This isn't very useful, but it shows how it works.  Note that
+--- ```
+--- This isn't very useful, but it shows how it works.  Note that
 --- an empty string is returned to avoid a zero being inserted.
+---
 ---
 --- @param startcol any
 --- @param matches any
@@ -990,8 +1103,9 @@ function vim.fn.complete(startcol, matches) end
 --- Returns 0 for failure (empty string or out of memory),
 --- 1 when the match was added, 2 when the match was already in
 --- the list.
---- See |complete-functions| for an explanation of {expr}.  It is
+--- See `|complete-functions|` for an explanation of {expr}.  It is
 --- the same as one item in the list that 'omnifunc' would return.
+---
 ---
 --- @param expr any
 --- @return 0|1|2
@@ -999,7 +1113,7 @@ function vim.fn.complete_add(expr) end
 
 --- Check for a key typed while looking for completion matches.
 --- This is to be used when looking for matches takes some time.
---- Returns |TRUE| when searching for matches is to be aborted,
+--- Returns `|TRUE|` when searching for matches is to be aborted,
 --- zero otherwise.
 --- Only to be used by the function specified with the
 --- 'completefunc' option.
@@ -1007,17 +1121,17 @@ function vim.fn.complete_add(expr) end
 --- @return 0|1
 function vim.fn.complete_check() end
 
---- Returns a |Dictionary| with information about Insert mode
---- completion.  See |ins-completion|.
+--- Returns a `|Dictionary|` with information about Insert mode
+--- completion.  See `|ins-completion|`.
 --- The items are:
 ---    mode    Current completion mode name string.
----     See |complete_info_mode| for the values.
----    pum_visible  |TRUE| if popup menu is visible.
----     See |pumvisible()|.
+---     See `|complete_info_mode|` for the values.
+---    pum_visible  `|TRUE|` if popup menu is visible.
+---     See `|pumvisible()|`.
 ---    items  List of completion matches.  Each item is a
 ---     dictionary containing the entries "word",
 ---     "abbr", "menu", "kind", "info" and "user_data".
----     See |complete-items|.
+---     See `|complete-items|`.
 ---    selected  Selected item index.  First index is zero.
 ---     Index is -1 if no item is selected (showing
 ---     typed text only, or the last completion after
@@ -1028,22 +1142,22 @@ function vim.fn.complete_check() end
 ---           *complete_info_mode*
 --- mode values are:
 ---    ""         Not in completion mode
----    "keyword"       Keyword completion |i_CTRL-X_CTRL-N|
----    "ctrl_x"       Just pressed CTRL-X |i_CTRL-X|
----    "scroll"       Scrolling with |i_CTRL-X_CTRL-E| or
----          |i_CTRL-X_CTRL-Y|
----    "whole_line"       Whole lines |i_CTRL-X_CTRL-L|
----    "files"       File names |i_CTRL-X_CTRL-F|
----    "tags"       Tags |i_CTRL-X_CTRL-]|
----    "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
----    "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
----    "dictionary"       Dictionary |i_CTRL-X_CTRL-K|
----    "thesaurus"       Thesaurus |i_CTRL-X_CTRL-T|
----    "cmdline"       Vim Command line |i_CTRL-X_CTRL-V|
----    "function"       User defined completion |i_CTRL-X_CTRL-U|
----    "omni"       Omni completion |i_CTRL-X_CTRL-O|
----    "spell"       Spelling suggestions |i_CTRL-X_s|
----    "eval"       |complete()| completion
+---    "keyword"       Keyword completion `|i_CTRL-X_CTRL-N|`
+---    "ctrl_x"       Just pressed CTRL-X `|i_CTRL-X|`
+---    "scroll"       Scrolling with `|i_CTRL-X_CTRL-E|` or
+---          `|i_CTRL-X_CTRL-Y|`
+---    "whole_line"       Whole lines `|i_CTRL-X_CTRL-L|`
+---    "files"       File names `|i_CTRL-X_CTRL-F|`
+---    "tags"       Tags `|i_CTRL-X_CTRL-]|`
+---    "path_defines"    Definition completion `|i_CTRL-X_CTRL-D|`
+---    "path_patterns"   Include completion `|i_CTRL-X_CTRL-I|`
+---    "dictionary"       Dictionary `|i_CTRL-X_CTRL-K|`
+---    "thesaurus"       Thesaurus `|i_CTRL-X_CTRL-T|`
+---    "cmdline"       Vim Command line `|i_CTRL-X_CTRL-V|`
+---    "function"       User defined completion `|i_CTRL-X_CTRL-U|`
+---    "omni"       Omni completion `|i_CTRL-X_CTRL-O|`
+---    "spell"       Spelling suggestions `|i_CTRL-X_s|`
+---    "eval"       `|complete()|` completion
 ---    "unknown"       Other internal modes
 ---
 --- If the optional {what} list argument is supplied, then only
@@ -1051,18 +1165,20 @@ function vim.fn.complete_check() end
 --- {what} are silently ignored.
 ---
 --- To get the position and size of the popup menu, see
---- |pum_getpos()|. It's also available in |v:event| during the
---- |CompleteChanged| event.
+--- `|pum_getpos()|`. It's also available in `|v:event|` during the
+--- `|CompleteChanged|` event.
 ---
---- Returns an empty |Dictionary| on error.
+--- Returns an empty `|Dictionary|` on error.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Get all items
 ---   call complete_info()
 ---   " Get only 'mode'
 ---   call complete_info(['mode'])
 ---   " Get only 'mode' and 'pum_visible'
 ---   call complete_info(['mode', 'pum_visible'])
+--- ```
 ---
 --- @param what? any
 --- @return table
@@ -1079,13 +1195,17 @@ function vim.fn.complete_info(what) end
 --- some systems the string is wrapped when it doesn't fit.
 ---
 --- {choices} is a String, with the individual choices separated
---- by '\n', e.g. >vim
+--- by '\n', e.g.
+--- ```vim
 ---   confirm("Save changes?", "&Yes\n&No\n&Cancel")
---- <The letter after the '&' is the shortcut key for that choice.
+--- ```
+--- The letter after the '&' is the shortcut key for that choice.
 --- Thus you can type 'c' to select "Cancel".  The shortcut does
---- not need to be the first letter: >vim
+--- not need to be the first letter:
+--- ```vim
 ---   confirm("file has been modified", "&Save\nSave &All")
---- <For the console, the first letter of each choice is used as
+--- ```
+--- For the console, the first letter of each choice is used as
 --- the default shortcut key.  Case is ignored.
 ---
 --- The optional {type} String argument gives the type of dialog.
@@ -1102,7 +1222,8 @@ function vim.fn.complete_info(what) end
 --- If the user aborts the dialog by pressing <Esc>, CTRL-C,
 --- or another valid interrupt key, confirm() returns 0.
 ---
---- An example: >vim
+--- An example:
+--- ```vim
 ---    let choice = confirm("What do you want?",
 ---       \ "&Apples\n&Oranges\n&Bananas", 2)
 ---    if choice == 0
@@ -1112,12 +1233,14 @@ function vim.fn.complete_info(what) end
 ---    else
 ---   echo "I prefer bananas myself."
 ---    endif
---- <In a GUI dialog, buttons are used.  The layout of the buttons
+--- ```
+--- In a GUI dialog, buttons are used.  The layout of the buttons
 --- depends on the 'v' flag in 'guioptions'.  If it is included,
 --- the buttons are always put vertically.  Otherwise,  confirm()
 --- tries to put the buttons in one horizontal line.  If they
 --- don't fit, a vertical layout is used anyway.  For some systems
 --- the horizontal layout is always used.
+---
 ---
 --- @param msg any
 --- @param choices? any
@@ -1128,55 +1251,66 @@ function vim.fn.confirm(msg, choices, default, type) end
 
 --- Make a copy of {expr}.  For Numbers and Strings this isn't
 --- different from using {expr} directly.
---- When {expr} is a |List| a shallow copy is created.  This means
---- that the original |List| can be changed without changing the
+--- When {expr} is a `|List|` a shallow copy is created.  This means
+--- that the original `|List|` can be changed without changing the
 --- copy, and vice versa.  But the items are identical, thus
---- changing an item changes the contents of both |Lists|.
---- A |Dictionary| is copied in a similar way as a |List|.
---- Also see |deepcopy()|.
+--- changing an item changes the contents of both `|Lists|`.
+--- A `|Dictionary|` is copied in a similar way as a `|List|`.
+--- Also see `|deepcopy()|`.
 ---
 --- @param expr any
 --- @return any
 function vim.fn.copy(expr) end
 
---- Return the cosine of {expr}, measured in radians, as a |Float|.
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- Return the cosine of {expr}, measured in radians, as a `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo cos(100)
---- <  0.862319 >vim
+--- ```
+--- 0.862319
+--- ```vim
 ---   echo cos(-4.01)
---- <  -0.646043
+--- ```
+--- -0.646043
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.cos(expr) end
 
---- Return the hyperbolic cosine of {expr} as a |Float| in the range
+--- Return the hyperbolic cosine of {expr} as a `|Float|` in the range
 --- [1, inf].
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo cosh(0.5)
---- <  1.127626 >vim
+--- ```
+--- 1.127626
+--- ```vim
 ---   echo cosh(-0.5)
---- <  -1.127626
+--- ```
+--- -1.127626
+---
 ---
 --- @param expr any
 --- @return number
 function vim.fn.cosh(expr) end
 
 --- Return the number of times an item with value {expr} appears
---- in |String|, |List| or |Dictionary| {comp}.
+--- in `|String|`, `|List|` or `|Dictionary|` {comp}.
 ---
 --- If {start} is given then start with the item with this index.
---- {start} can only be used with a |List|.
+--- {start} can only be used with a `|List|`.
 ---
---- When {ic} is given and it's |TRUE| then case is ignored.
+--- When {ic} is given and it's `|TRUE|` then case is ignored.
 ---
 --- When {comp} is a string then the number of not overlapping
 --- occurrences of {expr} is returned. Zero is returned when
 --- {expr} is an empty string.
+---
 ---
 --- @param comp any
 --- @param expr any
@@ -1185,33 +1319,33 @@ function vim.fn.cosh(expr) end
 --- @return integer
 function vim.fn.count(comp, expr, ic, start) end
 
---- Returns a |Dictionary| representing the |context| at {index}
---- from the top of the |context-stack| (see |context-dict|).
+--- Returns a `|Dictionary|` representing the `|context|` at {index}
+--- from the top of the `|context-stack|` (see `|context-dict|`).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
 --- @param index? any
 --- @return table
 function vim.fn.ctxget(index) end
 
---- Pops and restores the |context| at the top of the
---- |context-stack|.
+--- Pops and restores the `|context|` at the top of the
+--- `|context-stack|`.
 ---
 --- @return any
 function vim.fn.ctxpop() end
 
---- Pushes the current editor state (|context|) on the
---- |context-stack|.
---- If {types} is given and is a |List| of |String|s, it specifies
---- which |context-types| to include in the pushed context.
+--- Pushes the current editor state (`|context|`) on the
+--- `|context-stack|`.
+--- If {types} is given and is a `|List|` of `|String|`s, it specifies
+--- which `|context-types|` to include in the pushed context.
 --- Otherwise, all context types are included.
 ---
 --- @param types? any
 --- @return any
 function vim.fn.ctxpush(types) end
 
---- Sets the |context| at {index} from the top of the
---- |context-stack| to that represented by {context}.
---- {context} is a Dictionary with context data (|context-dict|).
+--- Sets the `|context|` at {index} from the top of the
+--- `|context-stack|` to that represented by {context}.
+--- {context} is a Dictionary with context data (`|context-dict|`).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
 --- @param context any
@@ -1219,7 +1353,7 @@ function vim.fn.ctxpush(types) end
 --- @return any
 function vim.fn.ctxset(context, index) end
 
---- Returns the size of the |context-stack|.
+--- Returns the size of the `|context-stack|`.
 ---
 --- @return any
 function vim.fn.ctxsize() end
@@ -1233,19 +1367,19 @@ function vim.fn.cursor(lnum, col, off) end
 --- Positions the cursor at the column (byte count) {col} in the
 --- line {lnum}.  The first column is one.
 ---
---- When there is one argument {list} this is used as a |List|
+--- When there is one argument {list} this is used as a `|List|`
 --- with two, three or four item:
 ---   [{lnum}, {col}]
 ---   [{lnum}, {col}, {off}]
 ---   [{lnum}, {col}, {off}, {curswant}]
---- This is like the return value of |getpos()| or |getcurpos()|,
+--- This is like the return value of `|getpos()|` or `|getcurpos()|`,
 --- but without the first item.
 ---
 --- To position the cursor using {col} as the character count, use
---- |setcursorcharpos()|.
+--- `|setcursorcharpos()|`.
 ---
 --- Does not change the jumplist.
---- {lnum} is used like with |getline()|, except that if {lnum} is
+--- {lnum} is used like with `|getline()|`, except that if {lnum} is
 --- zero, the cursor will stay in the current line.
 --- If {lnum} is greater than the number of lines in the buffer,
 --- the cursor will be positioned at the last line in the buffer.
@@ -1261,17 +1395,19 @@ function vim.fn.cursor(lnum, col, off) end
 --- position within a <Tab> or after the last character.
 --- Returns 0 when the position could be set, -1 otherwise.
 ---
+---
 --- @param list any
 --- @return any
 function vim.fn.cursor(list) end
 
 --- Specifically used to interrupt a program being debugged.  It
 --- will cause process {pid} to get a SIGTRAP.  Behavior for other
---- processes is undefined. See |terminal-debug|.
+--- processes is undefined. See `|terminal-debug|`.
 --- (Sends a SIGINT to a process {pid} other than MS-Windows)
 ---
---- Returns |TRUE| if successfully interrupted the program.
---- Otherwise returns |FALSE|.
+--- Returns `|TRUE|` if successfully interrupted the program.
+--- Otherwise returns `|FALSE|`.
+---
 ---
 --- @param pid any
 --- @return any
@@ -1279,22 +1415,23 @@ function vim.fn.debugbreak(pid) end
 
 --- Make a copy of {expr}.  For Numbers and Strings this isn't
 --- different from using {expr} directly.
---- When {expr} is a |List| a full copy is created.  This means
---- that the original |List| can be changed without changing the
---- copy, and vice versa.  When an item is a |List|, a copy for it
+--- When {expr} is a `|List|` a full copy is created.  This means
+--- that the original `|List|` can be changed without changing the
+--- copy, and vice versa.  When an item is a `|List|`, a copy for it
 --- is made, recursively.  Thus changing an item in the copy does
---- not change the contents of the original |List|.
+--- not change the contents of the original `|List|`.
 ---
---- When {noref} is omitted or zero a contained |List| or
---- |Dictionary| is only copied once.  All references point to
+--- When {noref} is omitted or zero a contained `|List|` or
+--- `|Dictionary|` is only copied once.  All references point to
 --- this single copy.  With {noref} set to 1 every occurrence of a
---- |List| or |Dictionary| results in a new copy.  This also means
+--- `|List|` or `|Dictionary|` results in a new copy.  This also means
 --- that a cyclic reference causes deepcopy() to fail.
 ---             *E724*
 --- Nesting is possible up to 100 levels.  When there is an item
 --- that refers back to a higher level making a deep copy with
 --- {noref} set to 1 will fail.
---- Also see |copy()|.
+--- Also see `|copy()|`.
+---
 ---
 --- @param expr any
 --- @param noref? any
@@ -1319,6 +1456,7 @@ function vim.fn.deepcopy(expr, noref) end
 --- operation was successful and -1/true when the deletion failed
 --- or partly failed.
 ---
+---
 --- @param fname string
 --- @param flags? string
 --- @return integer
@@ -1329,13 +1467,14 @@ function vim.fn.delete(fname, flags) end
 --- On success 0 is returned, on failure 1 is returned.
 ---
 --- This function works only for loaded buffers. First call
---- |bufload()| if needed.
+--- `|bufload()|` if needed.
 ---
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 ---
---- {first} and {last} are used like with |getline()|. Note that
---- when using |line()| this refers to the current buffer. Use "$"
+--- {first} and {last} are used like with `|getline()|`. Note that
+--- when using `|line()|` this refers to the current buffer. Use "$"
 --- to refer to the last line in buffer {buf}.
+---
 ---
 --- @param buf any
 --- @param first any
@@ -1353,13 +1492,14 @@ function vim.fn.deletebufline(buf, first, last) end
 --- After this is called, every change on {dict} and on keys
 --- matching {pattern} will result in {callback} being invoked.
 ---
---- For example, to watch all global variables: >vim
+--- For example, to watch all global variables:
+--- ```vim
 ---   silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
 ---   function! OnDictChanged(d,k,z)
 ---     echomsg string(a:k) string(a:z)
 ---   endfunction
 ---   call dictwatcheradd(g:, '*', 'OnDictChanged')
---- <
+--- ```
 --- For now {pattern} only accepts very simple patterns that can
 --- contain a "*" at the end of the string, in which case it will
 --- match every key that begins with the substring before the "*".
@@ -1388,8 +1528,8 @@ function vim.fn.deletebufline(buf, first, last) end
 --- @return any
 function vim.fn.dictwatcheradd(dict, pattern, callback) end
 
---- Removes a watcher added  with |dictwatcheradd()|. All three
---- arguments must match the ones passed to |dictwatcheradd()| in
+--- Removes a watcher added  with `|dictwatcheradd()|`. All three
+--- arguments must match the ones passed to `|dictwatcheradd()|` in
 --- order for the watcher to be successfully deleted.
 ---
 --- @param dict any
@@ -1398,11 +1538,11 @@ function vim.fn.dictwatcheradd(dict, pattern, callback) end
 --- @return any
 function vim.fn.dictwatcherdel(dict, pattern, callback) end
 
---- Returns |TRUE| when autocommands are being executed and the
+--- Returns `|TRUE|` when autocommands are being executed and the
 --- FileType event has been triggered at least once.  Can be used
 --- to avoid triggering the FileType event again in the scripts
---- that detect the file type. |FileType|
---- Returns |FALSE| when `:setf FALLBACK` was used.
+--- that detect the file type. `|FileType|`
+--- Returns `|FALSE|` when `:setf FALLBACK` was used.
 --- When editing another file, the counter is reset, thus this
 --- really checks if the FileType event has been triggered for the
 --- current buffer.  This allows an autocommand that starts
@@ -1416,9 +1556,10 @@ function vim.fn.did_filetype() end
 --- These are the lines that were inserted at this point in
 --- another diff'ed window.  These filler lines are shown in the
 --- display but don't exist in the buffer.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- Returns 0 if the current window is not in diff mode.
+---
 ---
 --- @param lnum integer
 --- @return any
@@ -1427,12 +1568,13 @@ function vim.fn.diff_filler(lnum) end
 --- Returns the highlight ID for diff mode at line {lnum} column
 --- {col} (byte index).  When the current line does not have a
 --- diff change zero is returned.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- {col} is 1 for the leftmost column, {lnum} is 1 for the first
 --- line.
---- The highlight ID can be used with |synIDattr()| to obtain
+--- The highlight ID can be used with `|synIDattr()|` to obtain
 --- syntax information about the highlighting.
+---
 ---
 --- @param lnum integer
 --- @param col integer
@@ -1444,16 +1586,17 @@ function vim.fn.diff_hlID(lnum, col) end
 --- characters, or the digraph of {chars} does not exist, an error
 --- is given and an empty string is returned.
 ---
---- Also see |digraph_getlist()|.
+--- Also see `|digraph_getlist()|`.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 --- " Get a built-in digraph
 --- echo digraph_get('00')    " Returns '∞'
 ---
 --- " Get a user-defined digraph
 --- call digraph_set('aa', 'あ')
 --- echo digraph_get('aa')    " Returns 'あ'
---- <
+--- ```
 ---
 --- @param chars any
 --- @return any
@@ -1463,15 +1606,16 @@ function vim.fn.digraph_get(chars) end
 --- and it is TRUE, return all digraphs, including the default
 --- digraphs.  Otherwise, return only user-defined digraphs.
 ---
---- Also see |digraph_get()|.
+--- Also see `|digraph_get()|`.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 --- " Get user-defined digraphs
 --- echo digraph_getlist()
 ---
 --- " Get all the digraphs, including default digraphs
 --- echo digraph_getlist(1)
---- <
+--- ```
 ---
 --- @param listall? any
 --- @return any
@@ -1481,78 +1625,93 @@ function vim.fn.digraph_getlist(listall) end
 --- with two characters.  {digraph} is a string with one UTF-8
 --- encoded character.  *E1215*
 --- Be careful, composing characters are NOT ignored.  This
---- function is similar to |:digraphs| command, but useful to add
+--- function is similar to `|:digraphs|` command, but useful to add
 --- digraphs start with a white space.
 ---
---- The function result is v:true if |digraph| is registered.  If
+--- The function result is v:true if `|digraph|` is registered.  If
 --- this fails an error message is given and v:false is returned.
 ---
 --- If you want to define multiple digraphs at once, you can use
---- |digraph_setlist()|.
+--- `|digraph_setlist()|`.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call digraph_set('  ', 'あ')
---- <
---- Can be used as a |method|: >vim
+--- ```
+--- Can be used as a `|method|`:
+--- ```vim
 ---   GetString()->digraph_set('あ')
---- <
+--- ```
 ---
 --- @param chars any
 --- @param digraph any
 --- @return any
 function vim.fn.digraph_set(chars, digraph) end
 
---- Similar to |digraph_set()| but this function can add multiple
+--- Similar to `|digraph_set()|` but this function can add multiple
 --- digraphs at once.  {digraphlist} is a list composed of lists,
 --- where each list contains two strings with {chars} and
---- {digraph} as in |digraph_set()|. *E1216*
---- Example: >vim
+--- {digraph} as in `|digraph_set()|`. *E1216*
+--- Example:
+--- ```vim
 ---     call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
---- <
---- It is similar to the following: >vim
+--- ```
+--- It is similar to the following:
+--- ```vim
 ---     for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
 ---     call digraph_set(chars, digraph)
 ---     endfor
---- <Except that the function returns after the first error,
+--- ```
+--- Except that the function returns after the first error,
 --- following digraphs will not be added.
 ---
---- Can be used as a |method|: >vim
+--- Can be used as a `|method|`:
+--- ```vim
 ---     GetList()->digraph_setlist()
---- <
+--- ```
 ---
 --- @param digraphlist any
 --- @return any
 function vim.fn.digraph_setlist(digraphlist) end
 
 --- Return the Number 1 if {expr} is empty, zero otherwise.
---- - A |List| or |Dictionary| is empty when it does not have any
+--- - A `|List|` or `|Dictionary|` is empty when it does not have any
 ---   items.
---- - A |String| is empty when its length is zero.
---- - A |Number| and |Float| are empty when their value is zero.
---- - |v:false| and |v:null| are empty, |v:true| is not.
---- - A |Blob| is empty when its length is zero.
+--- - A `|String|` is empty when its length is zero.
+--- - A `|Number|` and `|Float|` are empty when their value is zero.
+--- - `|v:false|` and `|v:null|` are empty, `|v:true|` is not.
+--- - A `|Blob|` is empty when its length is zero.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.empty(expr) end
 
 --- Return all of environment variables as dictionary. You can
---- check if an environment variable exists like this: >vim
+--- check if an environment variable exists like this:
+--- ```vim
 ---   echo has_key(environ(), 'HOME')
---- <Note that the variable name may be CamelCase; to ignore case
---- use this: >vim
+--- ```
+--- Note that the variable name may be CamelCase; to ignore case
+--- use this:
+--- ```vim
 ---   echo index(keys(environ()), 'HOME', 0, 1) != -1
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.environ() end
 
 --- Escape the characters in {chars} that occur in {string} with a
---- backslash.  Example: >vim
+--- backslash.  Example:
+--- ```vim
 ---   echo escape('c:\program files\vim', ' \')
---- <results in: >
+--- ```
+--- results in:
+--- ```
 ---   c:\\program\ files\\vim
---- <Also see |shellescape()| and |fnameescape()|.
+--- ```
+--- Also see `|shellescape()|` and `|fnameescape()|`.
+---
 ---
 --- @param string string
 --- @param chars any
@@ -1560,10 +1719,11 @@ function vim.fn.environ() end
 function vim.fn.escape(string, chars) end
 
 --- Evaluate {string} and return the result.  Especially useful to
---- turn the result of |string()| back into the original value.
+--- turn the result of `|string()|` back into the original value.
 --- This works for Numbers, Floats, Strings, Blobs and composites
---- of them.  Also works for |Funcref|s that refer to existing
+--- of them.  Also works for `|Funcref|`s that refer to existing
 --- functions.
+---
 ---
 --- @param string string
 --- @return any
@@ -1592,26 +1752,31 @@ function vim.fn.eventhandler() end
 --- On MS-Windows it only checks if the file exists and is not a
 --- directory, not if it's really executable.
 --- On Windows an executable in the same directory as Vim is
---- always found (it is added to $PATH at |startup|).
+--- always found (it is added to $PATH at `|startup|`).
 --- The result is a Number:
 ---   1  exists
 ---   0  does not exist
 ---   -1  not implemented on this system
---- |exepath()| can be used to get the full path of an executable.
+--- `|exepath()|` can be used to get the full path of an executable.
+---
 ---
 --- @param expr any
 --- @return 0|1|-1
 function vim.fn.executable(expr) end
 
 --- Execute {command} and capture its output.
---- If {command} is a |String|, returns {command} output.
---- If {command} is a |List|, returns concatenated outputs.
+--- If {command} is a `|String|`, returns {command} output.
+--- If {command} is a `|List|`, returns concatenated outputs.
 --- Line continuations in {command} are not recognized.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo execute('echon "foo"')
---- <  foo >vim
+--- ```
+--- foo
+--- ```vim
 ---   echo execute(['echon "foo"', 'echon "bar"'])
---- <  foobar
+--- ```
+--- foobar
 ---
 --- The optional {silent} argument can have these values:
 ---   ""    no `:silent` used
@@ -1620,15 +1785,17 @@ function vim.fn.executable(expr) end
 --- The default is "silent".  Note that with "silent!", unlike
 --- `:redir`, error messages are dropped.
 ---
---- To get a list of lines use `split()` on the result: >vim
+--- To get a list of lines use `split()` on the result:
+--- ```vim
 ---   execute('args')->split("\n")
----
---- <This function is not available in the |sandbox|.
+--- ```
+--- This function is not available in the `|sandbox|`.
 --- Note: If nested, an outer execute() will not observe output of
 --- the inner calls.
 --- Note: Text attributes (highlights) are not captured.
 --- To execute a command in another window than the current one
 --- use `win_execute()`.
+---
 ---
 --- @param command string|string[]
 --- @param silent? ''|'silent'|'silent!'
@@ -1638,31 +1805,36 @@ function vim.fn.execute(command, silent) end
 --- Returns the full path of {expr} if it is an executable and
 --- given as a (partial or full) path or is found in $PATH.
 --- Returns empty string otherwise.
---- If {expr} starts with "./" the |current-directory| is used.
+--- If {expr} starts with "./" the `|current-directory|` is used.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.exepath(expr) end
 
---- The result is a Number, which is |TRUE| if {expr} is
+--- The result is a Number, which is `|TRUE|` if {expr} is
 --- defined, zero otherwise.
 ---
---- For checking for a supported feature use |has()|.
---- For checking if a file exists use |filereadable()|.
+--- For checking for a supported feature use `|has()|`.
+--- For checking if a file exists use `|filereadable()|`.
 ---
 --- The {expr} argument is a string, which contains one of these:
 ---   varname    internal variable (see
----   dict.key  |internal-variables|).  Also works
----   list[i]    for |curly-braces-names|, |Dictionary|
----       entries, |List| items, etc.
+---   dict.key  `|internal-variables|`).  Also works
+---   list[i]    for `|curly-braces-names|`, `|Dictionary|`
+---       entries, `|List|` items, etc.
 ---       Beware that evaluating an index may
 ---       cause an error message for an invalid
----       expression.  E.g.: >vim
+---       expression.  E.g.:
+--- ```vim
 ---          let l = [1, 2, 3]
 ---          echo exists("l[5]")
---- <         0 >vim
+--- ```
+--- 0
+--- ```vim
 ---          echo exists("l[xx]")
---- <         E121: Undefined variable: xx
+--- ```
+--- E121: Undefined variable: xx
 ---          0
 ---   &option-name  Vim option (only checks if it exists,
 ---       not if it really works)
@@ -1670,20 +1842,20 @@ function vim.fn.exepath(expr) end
 ---   $ENVNAME  environment variable (could also be
 ---       done by comparing with an empty
 ---       string)
----   `*funcname`  built-in function (see |functions|)
+---   `*funcname`  built-in function (see `|functions|`)
 ---       or user defined function (see
----       |user-function|). Also works for a
+---       `|user-function|`). Also works for a
 ---       variable that is a Funcref.
 ---   :cmdname  Ex command: built-in command, user
----       command or command modifier |:command|.
+---       command or command modifier `|:command|`.
 ---       Returns:
 ---       1  for match with start of a command
 ---       2  full match with a command
 ---       3  matches several user commands
 ---       To check for a supported command
 ---       always check the return value to be 2.
----   :2match    The |:2match| command.
----   :3match    The |:3match| command (but you
+---   :2match    The `|:2match|` command.
+---   :3match    The `|:3match|` command (but you
 ---       probably should not use it, it is
 ---       reserved for internal usage)
 ---   #event    autocommand defined for this event
@@ -1701,7 +1873,8 @@ function vim.fn.exepath(expr) end
 ---   ##event    autocommand for this event is
 ---       supported.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo exists("&mouse")
 ---   echo exists("$HOSTNAME")
 ---   echo exists("*strftime")
@@ -1715,35 +1888,47 @@ function vim.fn.exepath(expr) end
 ---   echo exists("#filetypeindent#FileType")
 ---   echo exists("#filetypeindent#FileType#*")
 ---   echo exists("##ColorScheme")
---- <There must be no space between the symbol (&/$/*/#) and the
+--- ```
+--- There must be no space between the symbol (&/$/*/#) and the
 --- name.
 --- There must be no extra characters after the name, although in
 --- a few cases this is ignored.  That may become stricter in the
 --- future, thus don't count on it!
---- Working example: >vim
+--- Working example:
+--- ```vim
 ---   echo exists(":make")
---- <NOT working example: >vim
+--- ```
+--- NOT working example:
+--- ```vim
 ---   echo exists(":make install")
----
---- <Note that the argument must be a string, not the name of the
---- variable itself.  For example: >vim
+--- ```
+--- Note that the argument must be a string, not the name of the
+--- variable itself.  For example:
+--- ```vim
 ---   echo exists(bufcount)
---- <This doesn't check for existence of the "bufcount" variable,
+--- ```
+--- This doesn't check for existence of the "bufcount" variable,
 --- but gets the value of "bufcount", and checks if that exists.
+---
 ---
 --- @param expr any
 --- @return 0|1
 function vim.fn.exists(expr) end
 
---- Return the exponential of {expr} as a |Float| in the range
+--- Return the exponential of {expr} as a `|Float|` in the range
 --- [0, inf].
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo exp(2)
---- <  7.389056 >vim
+--- ```
+--- 7.389056
+--- ```vim
 ---   echo exp(-1)
---- <  0.367879
+--- ```
+--- 0.367879
+---
 ---
 --- @param expr any
 --- @return any
@@ -1752,7 +1937,7 @@ function vim.fn.exp(expr) end
 --- Expand wildcards and the following special keywords in
 --- {string}.  'wildignorecase' applies.
 ---
---- If {list} is given and it is |TRUE|, a List will be returned.
+--- If {list} is given and it is `|TRUE|`, a List will be returned.
 --- Otherwise the result is a String and when there are several
 --- matches, they are separated by <NL> characters.
 ---
@@ -1761,7 +1946,7 @@ function vim.fn.exp(expr) end
 --- not start with '%', '#' or '<', see below.
 ---
 --- When {string} starts with '%', '#' or '<', the expansion is
---- done like for the |cmdline-special| variables with their
+--- done like for the `|cmdline-special|` variables with their
 --- associated modifiers.  Here is a short overview:
 ---
 ---   %    current file name
@@ -1778,7 +1963,7 @@ function vim.fn.exp(expr) end
 ---   <sflnum>  script file line number, also when in
 ---       a function
 ---   <SID>    "<SNR>123_"  where "123" is the
----       current script ID  |<SID>|
+---       current script ID  `|<SID>|`
 ---   <script>  sourced script file, or script file
 ---       where the current function was defined
 ---   <stack>    call stack
@@ -1793,21 +1978,28 @@ function vim.fn.exp(expr) end
 ---   :r    root (one extension removed)
 ---   :e    extension only
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let &tags = expand("%:p:h") .. "/tags"
---- <Note that when expanding a string that starts with '%', '#' or
---- '<', any following text is ignored.  This does NOT work: >vim
+--- ```
+--- Note that when expanding a string that starts with '%', '#' or
+--- '<', any following text is ignored.  This does NOT work:
+--- ```vim
 ---   let doesntwork = expand("%:h.bak")
---- <Use this: >vim
+--- ```
+--- Use this:
+--- ```vim
 ---   let doeswork = expand("%:h") .. ".bak"
---- <Also note that expanding "<cfile>" and others only returns the
+--- ```
+--- Also note that expanding "<cfile>" and others only returns the
 --- referenced file name without further expansion.  If "<cfile>"
 --- is "~/.cshrc", you need to do another expand() to have the
---- "~/" expanded into the path of the home directory: >vim
+--- "~/" expanded into the path of the home directory:
+--- ```vim
 ---   echo expand(expand("<cfile>"))
---- <
+--- ```
 --- There cannot be white space between the variables and the
---- following modifier.  The |fnamemodify()| function can be used
+--- following modifier.  The `|fnamemodify()|` function can be used
 --- to modify normal file names.
 ---
 --- When using '%' or '#', and the current or alternate file name
@@ -1821,23 +2013,25 @@ function vim.fn.exp(expr) end
 --- When {string} does not start with '%', '#' or '<', it is
 --- expanded like a file name is expanded on the command line.
 --- 'suffixes' and 'wildignore' are used, unless the optional
---- {nosuf} argument is given and it is |TRUE|.
+--- {nosuf} argument is given and it is `|TRUE|`.
 --- Names for non-existing files are included.  The "**" item can
 --- be used to search in a directory tree.  For example, to find
---- all "README" files in the current directory and below: >vim
+--- all "README" files in the current directory and below:
+--- ```vim
 ---   echo expand("**/README")
---- <
+--- ```
 --- expand() can also be used to expand variables and environment
 --- variables that are only known in a shell.  But this can be
 --- slow, because a shell may be used to do the expansion.  See
---- |expr-env-expand|.
+--- `|expr-env-expand|`.
 --- The expanded variable is still handled like a list of file
 --- names.  When an environment variable cannot be expanded, it is
 --- left unchanged.  Thus ":echo expand('$FOOBAR')" results in
 --- "$FOOBAR".
 ---
---- See |glob()| for finding existing files.  See |system()| for
+--- See `|glob()|` for finding existing files.  See `|system()|` for
 --- getting the raw output of an external command.
+---
 ---
 --- @param string string
 --- @param nosuf? boolean
@@ -1847,7 +2041,7 @@ function vim.fn.expand(string, nosuf, list) end
 
 --- Expand special items in String {string} like what is done for
 --- an Ex command such as `:edit`.  This expands special keywords,
---- like with |expand()|, and environment variables, anywhere in
+--- like with `|expand()|`, and environment variables, anywhere in
 --- {string}.  "~user" and "~/path" are only expanded at the
 --- start.
 ---
@@ -1860,39 +2054,45 @@ function vim.fn.expand(string, nosuf, list) end
 --- Returns the expanded string.  If an error is encountered
 --- during expansion, the unmodified {string} is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo expandcmd('make %<.o')
---- < >
+--- ```
+--- ```
 ---   make /path/runtime/doc/builtin.o
---- < >vim
+--- ```
+--- ```vim
 ---   echo expandcmd('make %<.o', {'errmsg': v:true})
---- <
+--- ```
 ---
 --- @param string string
 --- @param options? table
 --- @return any
 function vim.fn.expandcmd(string, options) end
 
---- {expr1} and {expr2} must be both |Lists| or both
---- |Dictionaries|.
+--- {expr1} and {expr2} must be both `|Lists|` or both
+--- `|Dictionaries|`.
 ---
---- If they are |Lists|: Append {expr2} to {expr1}.
+--- If they are `|Lists|`: Append {expr2} to {expr1}.
 --- If {expr3} is given insert the items of {expr2} before the
 --- item with index {expr3} in {expr1}.  When {expr3} is zero
 --- insert before the first item.  When {expr3} is equal to
 --- len({expr1}) then {expr2} is appended.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo sort(extend(mylist, [7, 5]))
 ---   call extend(mylist, [2, 3], 1)
---- <When {expr1} is the same List as {expr2} then the number of
+--- ```
+--- When {expr1} is the same List as {expr2} then the number of
 --- items copied is equal to the original length of the List.
 --- E.g., when {expr3} is 1 you get N new copies of the first item
 --- (where N is the original length of the List).
---- Use |add()| to concatenate one item to a list.  To concatenate
---- two lists into a new list use the + operator: >vim
+--- Use `|add()|` to concatenate one item to a list.  To concatenate
+--- two lists into a new list use the + operator:
+--- ```vim
 ---   let newlist = [1, 2, 3] + [4, 5]
---- <
---- If they are |Dictionaries|:
+--- ```
+--- If they are `|Dictionaries|`:
 --- Add all entries from {expr2} to {expr1}.
 --- If a key exists in both {expr1} and {expr2} then {expr3} is
 --- used to decide what to do:
@@ -1908,13 +2108,14 @@ function vim.fn.expandcmd(string, options) end
 --- fails.
 --- Returns {expr1}.  Returns 0 on error.
 ---
+---
 --- @param expr1 any
 --- @param expr2 any
 --- @param expr3? any
 --- @return any
 function vim.fn.extend(expr1, expr2, expr3) end
 
---- Like |extend()| but instead of adding items to {expr1} a new
+--- Like `|extend()|` but instead of adding items to {expr1} a new
 --- List or Dictionary is created and returned.  {expr1} remains
 --- unchanged.
 ---
@@ -1937,10 +2138,10 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 --- {string}.
 ---
 --- To include special keys into {string}, use double-quotes
---- and "\..." notation |expr-quote|. For example,
+--- and "\..." notation `|expr-quote|`. For example,
 --- feedkeys("\<CR>") simulates pressing of the <Enter> key. But
 --- feedkeys('\<CR>') pushes 5 characters.
---- The |<Ignore>| keycode may be used to exit the
+--- The `|<Ignore>|` keycode may be used to exit the
 --- wait-for-character without doing anything.
 ---
 --- {mode} is a String, which can contain these character flags:
@@ -1968,33 +2169,38 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 ---
 --- Return value is always 0.
 ---
+---
 --- @param string string
 --- @param mode? string
 --- @return any
 function vim.fn.feedkeys(string, mode) end
 
 --- @deprecated
---- Obsolete name for |filereadable()|.
+--- Obsolete name for `|filereadable()|`.
 ---
 --- @param file string
 --- @return any
 function vim.fn.file_readable(file) end
 
---- The result is a Number, which is |TRUE| when a file with the
+--- The result is a Number, which is `|TRUE|` when a file with the
 --- name {file} exists, and can be read.  If {file} doesn't exist,
---- or is a directory, the result is |FALSE|.  {file} is any
+--- or is a directory, the result is `|FALSE|`.  {file} is any
 --- expression, which is used as a String.
 --- If you don't care about the file being readable you can use
---- |glob()|.
---- {file} is used as-is, you may want to expand wildcards first: >vim
+--- `|glob()|`.
+--- {file} is used as-is, you may want to expand wildcards first:
+--- ```vim
 ---   echo filereadable('~/.vimrc')
---- < >
+--- ```
+--- ```
 ---   0
---- < >vim
+--- ```
+--- ```vim
 ---   echo filereadable(expand('~/.vimrc'))
---- < >
+--- ```
+--- ```
 ---   1
---- <
+--- ```
 ---
 --- @param file string
 --- @return 0|1
@@ -2005,61 +2211,75 @@ function vim.fn.filereadable(file) end
 --- exist, or is not writable, the result is 0.  If {file} is a
 --- directory, and we can write to it, the result is 2.
 ---
+---
 --- @param file string
 --- @return 0|1
 function vim.fn.filewritable(file) end
 
---- {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
+--- {expr1} must be a `|List|`, `|String|`, `|Blob|` or `|Dictionary|`.
 --- For each item in {expr1} evaluate {expr2} and when the result
---- is zero or false remove the item from the |List| or
---- |Dictionary|.  Similarly for each byte in a |Blob| and each
---- character in a |String|.
+--- is zero or false remove the item from the `|List|` or
+--- `|Dictionary|`.  Similarly for each byte in a `|Blob|` and each
+--- character in a `|String|`.
 ---
---- {expr2} must be a |string| or |Funcref|.
+--- {expr2} must be a `|string|` or `|Funcref|`.
 ---
---- If {expr2} is a |string|, inside {expr2} |v:val| has the value
---- of the current item.  For a |Dictionary| |v:key| has the key
---- of the current item and for a |List| |v:key| has the index of
---- the current item.  For a |Blob| |v:key| has the index of the
---- current byte. For a |String| |v:key| has the index of the
+--- If {expr2} is a `|string|`, inside {expr2} `|v:val|` has the value
+--- of the current item.  For a `|Dictionary|` `|v:key|` has the key
+--- of the current item and for a `|List|` `|v:key|` has the index of
+--- the current item.  For a `|Blob|` `|v:key|` has the index of the
+--- current byte. For a `|String|` `|v:key|` has the index of the
 --- current character.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   call filter(mylist, 'v:val !~ "OLD"')
---- <Removes the items where "OLD" appears. >vim
+--- ```
+--- Removes the items where "OLD" appears.
+--- ```vim
 ---   call filter(mydict, 'v:key >= 8')
---- <Removes the items with a key below 8. >vim
+--- ```
+--- Removes the items with a key below 8.
+--- ```vim
 ---   call filter(var, 0)
---- <Removes all the items, thus clears the |List| or |Dictionary|.
+--- ```
+--- Removes all the items, thus clears the `|List|` or `|Dictionary|`.
 ---
 --- Note that {expr2} is the result of expression and is then
 --- used as an expression again.  Often it is good to use a
---- |literal-string| to avoid having to double backslashes.
+--- `|literal-string|` to avoid having to double backslashes.
 ---
---- If {expr2} is a |Funcref| it must take two arguments:
+--- If {expr2} is a `|Funcref|` it must take two arguments:
 ---   1. the key or the index of the current item.
 ---   2. the value of the current item.
---- The function must return |TRUE| if the item should be kept.
---- Example that keeps the odd items of a list: >vim
+--- The function must return `|TRUE|` if the item should be kept.
+--- Example that keeps the odd items of a list:
+--- ```vim
 ---   func Odd(idx, val)
 ---     return a:idx % 2 == 1
 ---   endfunc
 ---   call filter(mylist, function('Odd'))
---- <It is shorter when using a |lambda|: >vim
+--- ```
+--- It is shorter when using a `|lambda|`:
+--- ```vim
 ---   call filter(myList, {idx, val -> idx * val <= 42})
---- <If you do not use "val" you can leave it out: >vim
+--- ```
+--- If you do not use "val" you can leave it out:
+--- ```vim
 ---   call filter(myList, {idx -> idx % 2 == 1})
---- <
---- For a |List| and a |Dictionary| the operation is done
+--- ```
+--- For a `|List|` and a `|Dictionary|` the operation is done
 --- in-place.  If you want it to remain unmodified make a copy
---- first: >vim
+--- first:
+--- ```vim
 ---   let l = filter(copy(mylist), 'v:val =~ "KEEP"')
----
---- <Returns {expr1}, the |List| or |Dictionary| that was filtered,
---- or a new |Blob| or |String|.
+--- ```
+--- Returns {expr1}, the `|List|` or `|Dictionary|` that was filtered,
+--- or a new `|Blob|` or `|String|`.
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
 --- When {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
+---
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -2067,7 +2287,7 @@ function vim.fn.filewritable(file) end
 function vim.fn.filter(expr1, expr2) end
 
 --- Find directory {name} in {path}.  Supports both downwards and
---- upwards recursive directory searches.  See |file-searching|
+--- upwards recursive directory searches.  See `|file-searching|`
 --- for the syntax of {path}.
 ---
 --- Returns the path of the first found match.  When the found
@@ -2077,11 +2297,12 @@ function vim.fn.filter(expr1, expr2) end
 ---
 --- If the optional {count} is given, find {count}'s occurrence of
 --- {name} in {path} instead of the first one.
---- When {count} is negative return all the matches in a |List|.
+--- When {count} is negative return all the matches in a `|List|`.
 ---
 --- Returns an empty string if the directory is not found.
 ---
 --- This is quite similar to the ex-command `:find`.
+---
 ---
 --- @param name string
 --- @param path? string
@@ -2089,12 +2310,15 @@ function vim.fn.filter(expr1, expr2) end
 --- @return any
 function vim.fn.finddir(name, path, count) end
 
---- Just like |finddir()|, but find a file instead of a directory.
+--- Just like `|finddir()|`, but find a file instead of a directory.
 --- Uses 'suffixesadd'.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo findfile("tags.vim", ".;")
---- <Searches from the directory of the current file upwards until
+--- ```
+--- Searches from the directory of the current file upwards until
 --- it finds the file "tags.vim".
+---
 ---
 --- @param name string
 --- @param path? string
@@ -2103,9 +2327,9 @@ function vim.fn.finddir(name, path, count) end
 function vim.fn.findfile(name, path, count) end
 
 --- Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
---- the result is a |List| without nesting, as if {maxdepth} is
+--- the result is a `|List|` without nesting, as if {maxdepth} is
 --- a very large number.
---- The {list} is changed in place, use |flattennew()| if you do
+--- The {list} is changed in place, use `|flattennew()|` if you do
 --- not want that.
 ---             *E900*
 --- {maxdepth} means how deep in nested lists changes are made.
@@ -2114,18 +2338,23 @@ function vim.fn.findfile(name, path, count) end
 ---
 --- If there is an error the number zero is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo flatten([1, [2, [3, 4]], 5])
---- <  [1, 2, 3, 4, 5] >vim
+--- ```
+--- [1, 2, 3, 4, 5]
+--- ```vim
 ---   echo flatten([1, [2, [3, 4]], 5], 1)
---- <  [1, 2, [3, 4], 5]
+--- ```
+--- [1, 2, [3, 4], 5]
+---
 ---
 --- @param list any
 --- @param maxdepth? any
 --- @return any[]|0
 function vim.fn.flatten(list, maxdepth) end
 
---- Like |flatten()| but first make a copy of {list}.
+--- Like `|flatten()|` but first make a copy of {list}.
 ---
 --- @param list any
 --- @param maxdepth? any
@@ -2134,40 +2363,58 @@ function vim.fn.flattennew(list, maxdepth) end
 
 --- Convert {expr} to a Number by omitting the part after the
 --- decimal point.
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0 if {expr} is not a |Float| or a |Number|.
---- When the value of {expr} is out of range for a |Number| the
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0 if {expr} is not a `|Float|` or a `|Number|`.
+--- When the value of {expr} is out of range for a `|Number|` the
 --- result is truncated to 0x7fffffff or -0x7fffffff (or when
 --- 64-bit Number support is enabled, 0x7fffffffffffffff or
 --- -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
 --- 64-bit Number support is enabled, -0x8000000000000000).
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo float2nr(3.95)
---- <  3  >vim
+--- ```
+--- 3
+--- ```vim
 ---   echo float2nr(-23.45)
---- <  -23  >vim
+--- ```
+--- -23
+--- ```vim
 ---   echo float2nr(1.0e100)
---- <  2147483647  (or 9223372036854775807) >vim
+--- ```
+--- 2147483647  (or 9223372036854775807)
+--- ```vim
 ---   echo float2nr(-1.0e150)
---- <  -2147483647 (or -9223372036854775807) >vim
+--- ```
+--- -2147483647 (or -9223372036854775807)
+--- ```vim
 ---   echo float2nr(1.0e-100)
---- <  0
+--- ```
+--- 0
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.float2nr(expr) end
 
 --- Return the largest integral value less than or equal to
---- {expr} as a |Float| (round down).
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} as a `|Float|` (round down).
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo floor(1.856)
---- <  1.0  >vim
+--- ```
+--- 1.0
+--- ```vim
 ---   echo floor(-5.456)
---- <  -6.0  >vim
+--- ```
+--- -6.0
+--- ```vim
 ---   echo floor(4.0)
---- <  4.0
+--- ```
+--- 4.0
+---
 ---
 --- @param expr any
 --- @return any
@@ -2178,15 +2425,20 @@ function vim.fn.floor(expr) end
 --- for some integer i such that if {expr2} is non-zero, the
 --- result has the same sign as {expr1} and magnitude less than
 --- the magnitude of {expr2}.  If {expr2} is zero, the value
---- returned is zero.  The value returned is a |Float|.
---- {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
---- |Number|.
---- Examples: >vim
+--- returned is zero.  The value returned is a `|Float|`.
+--- {expr1} and {expr2} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr1} or {expr2} is not a `|Float|` or a
+--- `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo fmod(12.33, 1.22)
---- <  0.13 >vim
+--- ```
+--- 0.13
+--- ```vim
 ---   echo fmod(-12.33, 1.22)
---- <  -0.13
+--- ```
+--- -0.13
+---
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -2199,15 +2451,18 @@ function vim.fn.fmod(expr1, expr2) end
 --- For most systems the characters escaped are
 --- " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
 --- appears in a filename, it depends on the value of 'isfname'.
---- A leading '+' and '>' is also escaped (special after |:edit|
---- and |:write|).  And a "-" by itself (special after |:cd|).
+--- A leading '+' and '>' is also escaped (special after `|:edit|`
+--- and `|:write|`).  And a "-" by itself (special after `|:cd|`).
 --- Returns an empty string on error.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let fname = '+some str%nge|name'
 ---   exe "edit " .. fnameescape(fname)
---- <results in executing: >vim
+--- ```
+--- results in executing:
+--- ```vim
 ---   edit \+some\ str\%nge\|name
---- <
+--- ```
 ---
 --- @param string string
 --- @return string
@@ -2215,19 +2470,24 @@ function vim.fn.fnameescape(string) end
 
 --- Modify file name {fname} according to {mods}.  {mods} is a
 --- string of characters like it is used for file names on the
---- command line.  See |filename-modifiers|.
---- Example: >vim
+--- command line.  See `|filename-modifiers|`.
+--- Example:
+--- ```vim
 ---   echo fnamemodify("main.c", ":p:h")
---- <results in: >
+--- ```
+--- results in:
+--- ```
 ---   /home/user/vim/vim/src
---- <If {mods} is empty or an unsupported modifier is used then
+--- ```
+--- If {mods} is empty or an unsupported modifier is used then
 --- {fname} is returned.
 --- When {fname} is empty then with {mods} ":h" returns ".", so
 --- that `:cd` can be used with it.  This is different from
 --- expand('%:h') without a buffer name, which returns an empty
 --- string.
 --- Note: Environment variables don't work in {fname}, use
---- |expand()| first then.
+--- `|expand()|` first then.
+---
 ---
 --- @param fname string
 --- @param mods string
@@ -2237,8 +2497,9 @@ function vim.fn.fnamemodify(fname, mods) end
 --- The result is a Number.  If the line {lnum} is in a closed
 --- fold, the result is the number of the first line in that fold.
 --- If the line {lnum} is not in a closed fold, -1 is returned.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
+---
 ---
 --- @param lnum integer
 --- @return integer
@@ -2247,8 +2508,9 @@ function vim.fn.foldclosed(lnum) end
 --- The result is a Number.  If the line {lnum} is in a closed
 --- fold, the result is the number of the last line in that fold.
 --- If the line {lnum} is not in a closed fold, -1 is returned.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
+---
 ---
 --- @param lnum integer
 --- @return integer
@@ -2262,8 +2524,9 @@ function vim.fn.foldclosedend(lnum) end
 --- returned for lines where folds are still to be updated and the
 --- foldlevel is unknown.  As a special case the level of the
 --- previous line is usually available.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
+---
 ---
 --- @param lnum integer
 --- @return integer
@@ -2272,10 +2535,12 @@ function vim.fn.foldlevel(lnum) end
 --- Returns a String, to be displayed for a closed fold.  This is
 --- the default function used for the 'foldtext' option and should
 --- only be called from evaluating 'foldtext'.  It uses the
---- |v:foldstart|, |v:foldend| and |v:folddashes| variables.
---- The returned string looks like this: >
+--- `|v:foldstart|`, `|v:foldend|` and `|v:folddashes|` variables.
+--- The returned string looks like this:
+--- ```
 ---   +-- 45 lines: abcdef
---- <The number of leading dashes depends on the foldlevel.  The
+--- ```
+--- The number of leading dashes depends on the foldlevel.  The
 --- "45" is the number of lines in the fold.  "abcdef" is the text
 --- in the first non-blank line of the fold.  Leading white space,
 --- "//" or "/*" and the text from the 'foldmarker' and
@@ -2292,16 +2557,17 @@ function vim.fn.foldtext() end
 --- {lnum}.  Evaluates 'foldtext' in the appropriate context.
 --- When there is no closed fold at {lnum} an empty string is
 --- returned.
---- {lnum} is used like with |getline()|.  Thus "." is the current
+--- {lnum} is used like with `|getline()|`.  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- Useful when exporting folded text, e.g., to HTML.
+---
 ---
 --- @param lnum integer
 --- @return string
 function vim.fn.foldtextresult(lnum) end
 
 --- Get the full command name from a short abbreviated command
---- name; see |20.2| for details on command abbreviations.
+--- name; see `|20.2|` for details on command abbreviations.
 ---
 --- The string argument {name} may start with a `:` and can
 --- include a [range], these are skipped and not returned.
@@ -2311,20 +2577,22 @@ function vim.fn.foldtextresult(lnum) end
 --- For example `fullcommand('s')`, `fullcommand('sub')`,
 --- `fullcommand(':%substitute')` all return "substitute".
 ---
+---
 --- @param name string
 --- @return string
 function vim.fn.fullcommand(name) end
 
---- Just like |function()|, but the returned Funcref will lookup
+--- Just like `|function()|`, but the returned Funcref will lookup
 --- the function by reference, not by name.  This matters when the
 --- function {name} is redefined later.
 ---
---- Unlike |function()|, {name} must be an existing user function.
+--- Unlike `|function()|`, {name} must be an existing user function.
 --- It only works for an autoloaded function if it has already
 --- been loaded (to avoid mistakenly loading the autoload script
---- when only intending to use the function name, use |function()|
+--- when only intending to use the function name, use `|function()|`
 --- instead). {name} cannot be a builtin function.
 --- Returns 0 on error.
+---
 ---
 --- @param name string
 --- @param arglist? any
@@ -2332,18 +2600,19 @@ function vim.fn.fullcommand(name) end
 --- @return any
 function vim.fn.funcref(name, arglist, dict) end
 
---- Return a |Funcref| variable that refers to function {name}.
+--- Return a `|Funcref|` variable that refers to function {name}.
 --- {name} can be the name of a user defined function or an
 --- internal function.
 ---
 --- {name} can also be a Funcref or a partial. When it is a
 --- partial the dict stored in it will be used and the {dict}
---- argument is not allowed. E.g.: >vim
+--- argument is not allowed. E.g.:
+--- ```vim
 ---   let FuncWithArg = function(dict.Func, [arg])
 ---   let Broken = function(dict.Func, [arg], dict)
---- <
+--- ```
 --- When using the Funcref the function will be found by {name},
---- also when it was redefined later. Use |funcref()| to keep the
+--- also when it was redefined later. Use `|funcref()|` to keep the
 --- same function.
 ---
 --- When {arglist} or {dict} is present this creates a partial.
@@ -2351,29 +2620,36 @@ function vim.fn.funcref(name, arglist, dict) end
 --- the Funcref and will be used when the Funcref is called.
 ---
 --- The arguments are passed to the function in front of other
---- arguments, but after any argument from |method|.  Example: >vim
+--- arguments, but after any argument from `|method|`.  Example:
+--- ```vim
 ---   func Callback(arg1, arg2, name)
 ---   "...
 ---   endfunc
 ---   let Partial = function('Callback', ['one', 'two'])
 ---   "...
 ---   call Partial('name')
---- <Invokes the function as with: >vim
+--- ```
+--- Invokes the function as with:
+--- ```vim
 ---   call Callback('one', 'two', 'name')
----
---- <With a |method|: >vim
+--- ```
+--- With a `|method|`:
+--- ```vim
 ---   func Callback(one, two, three)
 ---   "...
 ---   endfunc
 ---   let Partial = function('Callback', ['two'])
 ---   "...
 ---   eval 'one'->Partial('three')
---- <Invokes the function as with: >vim
+--- ```
+--- Invokes the function as with:
+--- ```vim
 ---   call Callback('one', 'two', 'three')
----
---- <The function() call can be nested to add more arguments to the
+--- ```
+--- The function() call can be nested to add more arguments to the
 --- Funcref.  The extra arguments are appended to the list of
---- arguments.  Example: >vim
+--- arguments.  Example:
+--- ```vim
 ---   func Callback(arg1, arg2, name)
 ---   "...
 ---   endfunc
@@ -2381,11 +2657,14 @@ function vim.fn.funcref(name, arglist, dict) end
 ---   let Func2 = function(Func, ['two'])
 ---   "...
 ---   call Func2('name')
---- <Invokes the function as with: >vim
+--- ```
+--- Invokes the function as with:
+--- ```vim
 ---   call Callback('one', 'two', 'name')
----
---- <The Dictionary is only useful when calling a "dict" function.
---- In that case the {dict} is passed in as "self". Example: >vim
+--- ```
+--- The Dictionary is only useful when calling a "dict" function.
+--- In that case the {dict} is passed in as "self". Example:
+--- ```vim
 ---   function Callback() dict
 ---      echo "called for " .. self.name
 ---   endfunction
@@ -2394,13 +2673,16 @@ function vim.fn.funcref(name, arglist, dict) end
 ---   let Func = function('Callback', context)
 ---   "...
 ---   call Func()  " will echo: called for example
---- <The use of function() is not needed when there are no extra
+--- ```
+--- The use of function() is not needed when there are no extra
 --- arguments, these two are equivalent, if Callback() is defined
---- as context.Callback(): >vim
+--- as context.Callback():
+--- ```vim
 ---   let Func = function('Callback', context)
 ---   let Func = context.Callback
----
---- <The argument list and the Dictionary can be combined: >vim
+--- ```
+--- The argument list and the Dictionary can be combined:
+--- ```vim
 ---   function Callback(arg1, count) dict
 ---   "...
 ---   endfunction
@@ -2408,10 +2690,13 @@ function vim.fn.funcref(name, arglist, dict) end
 ---   let Func = function('Callback', ['one'], context)
 ---   "...
 ---   call Func(500)
---- <Invokes the function as with: >vim
+--- ```
+--- Invokes the function as with:
+--- ```vim
 ---   call context.Callback('one', 500)
---- <
+--- ```
 --- Returns 0 on error.
+---
 ---
 --- @param name string
 --- @param arglist? any
@@ -2419,15 +2704,15 @@ function vim.fn.funcref(name, arglist, dict) end
 --- @return any
 vim.fn['function'] = function(name, arglist, dict) end
 
---- Cleanup unused |Lists| and |Dictionaries| that have circular
+--- Cleanup unused `|Lists|` and `|Dictionaries|` that have circular
 --- references.
 ---
 --- There is hardly ever a need to invoke this function, as it is
 --- automatically done when Vim runs out of memory or is waiting
 --- for the user to press a key after 'updatetime'.  Items without
 --- circular references are always freed when they become unused.
---- This is useful if you have deleted a very big |List| and/or
---- |Dictionary| with circular references in a script that runs
+--- This is useful if you have deleted a very big `|List|` and/or
+--- `|Dictionary|` with circular references in a script that runs
 --- for a long time.
 ---
 --- When the optional {atexit} argument is one, garbage
@@ -2442,7 +2727,7 @@ vim.fn['function'] = function(name, arglist, dict) end
 --- @return any
 function vim.fn.garbagecollect(atexit) end
 
---- Get item {idx} from |List| {list}.  When this item is not
+--- Get item {idx} from `|List|` {list}.  When this item is not
 --- available return {default}.  Return zero when {default} is
 --- omitted.
 ---
@@ -2452,7 +2737,7 @@ function vim.fn.garbagecollect(atexit) end
 --- @return any
 function vim.fn.get(list, idx, default) end
 
---- Get byte {idx} from |Blob| {blob}.  When this byte is not
+--- Get byte {idx} from `|Blob|` {blob}.  When this byte is not
 --- available return {default}.  Return -1 when {default} is
 --- omitted.
 ---
@@ -2462,11 +2747,13 @@ function vim.fn.get(list, idx, default) end
 --- @return any
 function vim.fn.get(blob, idx, default) end
 
---- Get item with key {key} from |Dictionary| {dict}.  When this
+--- Get item with key {key} from `|Dictionary|` {dict}.  When this
 --- item is not available return {default}.  Return zero when
---- {default} is omitted.  Useful example: >vim
+--- {default} is omitted.  Useful example:
+--- ```vim
 ---   let val = get(g:, 'var_name', 'default')
---- <This gets the value of g:var_name if it exists, and uses
+--- ```
+--- This gets the value of g:var_name if it exists, and uses
 --- "default" when it does not exist.
 ---
 --- @param dict table<string,any>
@@ -2497,7 +2784,7 @@ function vim.fn.getbufinfo(buf) end
 --- Without an argument information about all the buffers is
 --- returned.
 ---
---- When the argument is a |Dictionary| only the buffers matching
+--- When the argument is a `|Dictionary|` only the buffers matching
 --- the specified criteria are returned.  The following keys can
 --- be specified in {dict}:
 ---   buflisted  include only listed buffers.
@@ -2505,7 +2792,7 @@ function vim.fn.getbufinfo(buf) end
 ---   bufmodified  include only modified buffers.
 ---
 --- Otherwise, {buf} specifies a particular buffer to return
---- information for.  For the use of {buf}, see |bufname()|
+--- information for.  For the use of {buf}, see `|bufname()|`
 --- above.  If the buffer is found the returned List has one item.
 --- Otherwise the result is an empty list.
 ---
@@ -2516,7 +2803,7 @@ function vim.fn.getbufinfo(buf) end
 ---   changedtick  Number of changes made to the buffer.
 ---   hidden    TRUE if the buffer is hidden.
 ---   lastused  Timestamp in seconds, like
----       |localtime()|, when the buffer was
+---       `|localtime()|`, when the buffer was
 ---       last used.
 ---   listed    TRUE if the buffer is listed.
 ---   lnum    Line number used for the buffer when
@@ -2525,9 +2812,10 @@ function vim.fn.getbufinfo(buf) end
 ---       displayed in the window in the past.
 ---       If you want the line number of the
 ---       last known cursor position in a given
----       window, use |line()|: >vim
+---       window, use `|line()|`:
+--- ```vim
 ---         echo line('.', {winid})
---- <
+--- ```
 ---   linecount  Number of lines in the buffer (only
 ---       valid when loaded)
 ---   loaded    TRUE if the buffer is loaded.
@@ -2540,10 +2828,11 @@ function vim.fn.getbufinfo(buf) end
 ---           name  sign name
 ---   variables  A reference to the dictionary with
 ---       buffer-local variables.
----   windows    List of |window-ID|s that display this
+---   windows    List of `|window-ID|`s that display this
 ---       buffer
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   for buf in getbufinfo()
 ---       echo buf.name
 ---   endfor
@@ -2552,38 +2841,41 @@ function vim.fn.getbufinfo(buf) end
 ---     " ....
 ---       endif
 ---   endfor
---- <
---- To get buffer-local options use: >vim
+--- ```
+--- To get buffer-local options use:
+--- ```vim
 ---   getbufvar({bufnr}, '&option_name')
---- <
+--- ```
 ---
 --- @param dict? vim.fn.getbufinfo.dict
 --- @return vim.fn.getbufinfo.ret.item[]
 function vim.fn.getbufinfo(dict) end
 
---- Return a |List| with the lines starting from {lnum} to {end}
+--- Return a `|List|` with the lines starting from {lnum} to {end}
 --- (inclusive) in the buffer {buf}.  If {end} is omitted, a
---- |List| with only the line {lnum} is returned.  See
+--- `|List|` with only the line {lnum} is returned.  See
 --- `getbufoneline()` for only getting the line.
 ---
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 ---
 --- For {lnum} and {end} "$" can be used for the last line of the
 --- buffer.  Otherwise a number must be used.
 ---
 --- When {lnum} is smaller than 1 or bigger than the number of
---- lines in the buffer, an empty |List| is returned.
+--- lines in the buffer, an empty `|List|` is returned.
 ---
 --- When {end} is greater than the number of lines in the buffer,
 --- it is treated as {end} is set to the number of lines in the
---- buffer.  When {end} is before {lnum} an empty |List| is
+--- buffer.  When {end} is before {lnum} an empty `|List|` is
 --- returned.
 ---
 --- This function works only for loaded buffers.  For unloaded and
---- non-existing buffers, an empty |List| is returned.
+--- non-existing buffers, an empty `|List|` is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let lines = getbufline(bufnr("myfile"), 1, "$")
+--- ```
 ---
 --- @param buf any
 --- @param lnum integer
@@ -2603,21 +2895,23 @@ function vim.fn.getbufoneline(buf, lnum) end
 --- {varname} in buffer {buf}.  Note that the name without "b:"
 --- must be used.
 --- The {varname} argument is a string.
---- When {varname} is empty returns a |Dictionary| with all the
+--- When {varname} is empty returns a `|Dictionary|` with all the
 --- buffer-local variables.
---- When {varname} is equal to "&" returns a |Dictionary| with all
+--- When {varname} is equal to "&" returns a `|Dictionary|` with all
 --- the buffer-local options.
 --- Otherwise, when {varname} starts with "&" returns the value of
 --- a buffer-local option.
 --- This also works for a global or buffer-local option, but it
 --- doesn't work for a global variable, window-local variable or
 --- window-local option.
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 --- When the buffer or variable doesn't exist {def} or an empty
 --- string is returned, there is no error message.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   let bufmodified = getbufvar(1, "&mod")
 ---   echo "todo myvar = " .. getbufvar("todo", "myvar")
+--- ```
 ---
 --- @param buf any
 --- @param varname string
@@ -2625,16 +2919,16 @@ function vim.fn.getbufoneline(buf, lnum) end
 --- @return any
 function vim.fn.getbufvar(buf, varname, def) end
 
---- Returns a |List| of cell widths of character ranges overridden
---- by |setcellwidths()|.  The format is equal to the argument of
---- |setcellwidths()|.  If no character ranges have their cell
+--- Returns a `|List|` of cell widths of character ranges overridden
+--- by `|setcellwidths()|`.  The format is equal to the argument of
+--- `|setcellwidths()|`.  If no character ranges have their cell
 --- widths overridden, an empty List is returned.
 ---
 --- @return any
 function vim.fn.getcellwidths() end
 
---- Returns the |changelist| for the buffer {buf}. For the use
---- of {buf}, see |bufname()| above. If buffer {buf} doesn't
+--- Returns the `|changelist|` for the buffer {buf}. For the use
+--- of {buf}, see `|bufname()|` above. If buffer {buf} doesn't
 --- exist, an empty list is returned.
 ---
 --- The returned list contains two entries: a list with the change
@@ -2648,6 +2942,7 @@ function vim.fn.getcellwidths() end
 --- position refers to the position in the list. For other
 --- buffers, it is set to the length of the list.
 ---
+---
 --- @param buf? integer|string
 --- @return table[]
 function vim.fn.getchangelist(buf) end
@@ -2658,11 +2953,11 @@ function vim.fn.getchangelist(buf) end
 ---   Return zero otherwise.
 --- If [expr] is 1, only check if a character is available, it is
 ---   not consumed.  Return zero if no character available.
---- If you prefer always getting a string use |getcharstr()|.
+--- If you prefer always getting a string use `|getcharstr()|`.
 ---
 --- Without [expr] and when [expr] is 0 a whole character or
 --- special key is returned.  If it is a single character, the
---- result is a Number.  Use |nr2char()| to convert it to a String.
+--- result is a Number.  Use `|nr2char()|` to convert it to a String.
 --- Otherwise a String is returned with the encoded character.
 --- For a special key it's a String with a sequence of bytes
 --- starting with 0x80 (decimal: 128).  This is the same value as
@@ -2681,18 +2976,19 @@ function vim.fn.getchangelist(buf) end
 --- Use getcharmod() to obtain any additional modifiers.
 ---
 --- When the user clicks a mouse button, the mouse event will be
---- returned.  The position can then be found in |v:mouse_col|,
---- |v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
---- |getmousepos()| can also be used.  Mouse move events will be
+--- returned.  The position can then be found in `|v:mouse_col|,
+--- |v:mouse_lnum|`, `|v:mouse_winid|` and `|v:mouse_win|.
+--- |getmousepos()|` can also be used.  Mouse move events will be
 --- ignored.
---- This example positions the mouse as it would normally happen: >vim
+--- This example positions the mouse as it would normally happen:
+--- ```vim
 ---   let c = getchar()
 ---   if c == "\<LeftMouse>" && v:mouse_win > 0
 ---     exe v:mouse_win .. "wincmd w"
 ---     exe v:mouse_lnum
 ---     exe "normal " .. v:mouse_col .. "|"
 ---   endif
---- <
+--- ```
 --- There is no prompt, you will somehow have to make clear to the
 --- user that a character has to be typed.  The screen is not
 --- redrawn, e.g. when resizing the window.
@@ -2700,10 +2996,13 @@ function vim.fn.getchangelist(buf) end
 --- There is no mapping for the character.
 --- Key codes are replaced, thus when the user presses the <Del>
 --- key you get the code for the <Del> key, not the raw character
---- sequence.  Examples: >vim
+--- sequence.  Examples:
+--- ```vim
 ---   getchar() == "\<Del>"
 ---   getchar() == "\<S-Left>"
---- <This example redefines "f" to ignore case: >vim
+--- ```
+--- This example redefines "f" to ignore case:
+--- ```vim
 ---   nmap f :call FindChar()<CR>
 ---   function FindChar()
 ---     let c = nr2char(getchar())
@@ -2714,7 +3013,7 @@ function vim.fn.getchangelist(buf) end
 ---       endif
 ---     endwhile
 ---   endfunction
---- <
+--- ```
 ---
 --- @return integer
 function vim.fn.getchar() end
@@ -2737,18 +3036,19 @@ function vim.fn.getchar() end
 --- @return integer
 function vim.fn.getcharmod() end
 
---- Get the position for String {expr}. Same as |getpos()| but the
+--- Get the position for String {expr}. Same as `|getpos()|` but the
 --- column number in the returned List is a character index
 --- instead of a byte index.
---- If |getpos()| returns a very large column number, equal to
---- |v:maxcol|, then getcharpos() will return the character index
+--- If `|getpos()|` returns a very large column number, equal to
+--- `|v:maxcol|`, then getcharpos() will return the character index
 --- of the last character.
 ---
 --- Example:
---- With the cursor on '세' in line 5 with text "여보세요": >vim
+--- With the cursor on '세' in line 5 with text "여보세요":
+--- ```vim
 ---   getcharpos('.')    returns [0, 5, 3, 0]
 ---   getpos('.')    returns [0, 5, 7, 0]
---- <
+--- ```
 ---
 --- @param expr any
 --- @return integer[]
@@ -2758,20 +3058,22 @@ function vim.fn.getcharpos(expr) end
 --- with the following entries:
 ---
 ---     char  character previously used for a character
----     search (|t|, |f|, |T|, or |F|); empty string
+---     search (`|t|`, `|f|`, `|T|`, or `|F|`); empty string
 ---     if no character search has been performed
 ---     forward  direction of character search; 1 for forward,
 ---     0 for backward
----     until  type of character search; 1 for a |t| or |T|
----     character search, 0 for an |f| or |F|
+---     until  type of character search; 1 for a `|t|` or `|T|`
+---     character search, 0 for an `|f|` or `|F|`
 ---     character search
 ---
---- This can be useful to always have |;| and |,| search
+--- This can be useful to always have `|;|` and `|,|` search
 --- forward/backward regardless of the direction of the previous
---- character search: >vim
+--- character search:
+--- ```vim
 ---   nnoremap <expr> ; getcharsearch().forward ? ';' : ','
 ---   nnoremap <expr> , getcharsearch().forward ? ',' : ';'
---- <Also see |setcharsearch()|.
+--- ```
+--- Also see `|setcharsearch()|`.
 ---
 --- @return table[]
 function vim.fn.getcharsearch() end
@@ -2784,7 +3086,7 @@ function vim.fn.getcharsearch() end
 --- If [expr] is 1 or true, only check if a character is
 ---   available, it is not consumed.  Return an empty string
 ---   if no character is available.
---- Otherwise this works like |getchar()|, except that a number
+--- Otherwise this works like `|getchar()|`, except that a number
 --- result is converted to a string.
 ---
 --- @return string
@@ -2792,24 +3094,26 @@ function vim.fn.getcharstr() end
 
 --- Return the type of the current command-line completion.
 --- Only works when the command line is being edited, thus
---- requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
---- See |:command-completion| for the return string.
---- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
---- |setcmdline()|.
+--- requires use of `|c_CTRL-\_e|` or `|c_CTRL-R_=|`.
+--- See `|:command-completion|` for the return string.
+--- Also see `|getcmdtype()|`, `|setcmdpos()|`, `|getcmdline()|` and
+--- `|setcmdline()|`.
 --- Returns an empty string when completion is not defined.
 ---
 --- @return string
 function vim.fn.getcmdcompltype() end
 
 --- Return the current command-line.  Only works when the command
---- line is being edited, thus requires use of |c_CTRL-\_e| or
---- |c_CTRL-R_=|.
---- Example: >vim
+--- line is being edited, thus requires use of `|c_CTRL-\_e|` or
+--- `|c_CTRL-R_=|`.
+--- Example:
+--- ```vim
 ---   cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
---- <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
---- |setcmdline()|.
+--- ```
+--- Also see `|getcmdtype()|`, `|getcmdpos()|`, `|setcmdpos()|` and
+--- `|setcmdline()|`.
 --- Returns an empty string when entering a password or using
---- |inputsecret()|.
+--- `|inputsecret()|`.
 ---
 --- @return string
 function vim.fn.getcmdline() end
@@ -2817,22 +3121,22 @@ function vim.fn.getcmdline() end
 --- Return the position of the cursor in the command line as a
 --- byte count.  The first column is 1.
 --- Only works when editing the command line, thus requires use of
---- |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+--- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
 --- Returns 0 otherwise.
---- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
---- |setcmdline()|.
+--- Also see `|getcmdtype()|`, `|setcmdpos()|`, `|getcmdline()|` and
+--- `|setcmdline()|`.
 ---
 --- @return integer
 function vim.fn.getcmdpos() end
 
 --- Return the screen position of the cursor in the command line
 --- as a byte count.  The first column is 1.
---- Instead of |getcmdpos()|, it adds the prompt position.
+--- Instead of `|getcmdpos()|`, it adds the prompt position.
 --- Only works when editing the command line, thus requires use of
---- |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+--- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
 --- Returns 0 otherwise.
---- Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
---- |setcmdline()|.
+--- Also see `|getcmdpos()|`, `|setcmdpos()|`, `|getcmdline()|` and
+--- `|setcmdline()|`.
 ---
 --- @return any
 function vim.fn.getcmdscreenpos() end
@@ -2840,22 +3144,22 @@ function vim.fn.getcmdscreenpos() end
 --- Return the current command-line type. Possible return values
 --- are:
 ---     :  normal Ex command
----     >  debug mode command |debug-mode|
+---     >  debug mode command `|debug-mode|`
 ---     /  forward search command
 ---     ?  backward search command
----     \@  |input()| command
----     `-`  |:insert| or |:append| command
----     =  |i_CTRL-R_=|
+---     @  `|input()|` command
+---     `-`  `|:insert|` or `|:append|` command
+---     =  `|i_CTRL-R_=|`
 --- Only works when editing the command line, thus requires use of
---- |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+--- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
 --- Returns an empty string otherwise.
---- Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
+--- Also see `|getcmdpos()|`, `|setcmdpos()|` and `|getcmdline()|`.
 ---
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
 function vim.fn.getcmdtype() end
 
---- Return the current |command-line-window| type. Possible return
---- values are the same as |getcmdtype()|. Returns an empty string
+--- Return the current `|command-line-window|` type. Possible return
+--- values are the same as `|getcmdtype()|`. Returns an empty string
 --- when not in the command-line window.
 ---
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
@@ -2868,38 +3172,38 @@ function vim.fn.getcmdwintype() end
 --- arglist    file names in argument list
 --- augroup    autocmd groups
 --- buffer    buffer names
---- breakpoint  |:breakadd| and |:breakdel| suboptions
---- cmdline    |cmdline-completion| result
+--- breakpoint  `|:breakadd|` and `|:breakdel|` suboptions
+--- cmdline    `|cmdline-completion|` result
 --- color    color schemes
 --- command    Ex command
 --- compiler  compilers
 --- custom,{func}  custom completion, defined via {func}
 --- customlist,{func} custom completion, defined via {func}
---- diff_buffer  |:diffget| and |:diffput| completion
+--- diff_buffer  `|:diffget|` and `|:diffput|` completion
 --- dir    directory names
 --- environment  environment variable names
 --- event    autocommand events
 --- expression  Vim expression
 --- file    file and directory names
---- file_in_path  file and directory names in |'path'|
---- filetype  filetype names |'filetype'|
+--- file_in_path  file and directory names in `|'path'|`
+--- filetype  filetype names `|'filetype'|`
 --- function  function name
 --- help    help subjects
 --- highlight  highlight groups
---- history    |:history| suboptions
+--- history    `|:history|` suboptions
 --- locale    locale names (as output of locale -a)
 --- mapclear  buffer argument
 --- mapping    mapping name
 --- menu    menus
---- messages  |:messages| suboptions
+--- messages  `|:messages|` suboptions
 --- option    options
---- packadd    optional package |pack-add| names
---- runtime    |:runtime| completion
---- scriptnames  sourced script names |:scriptnames|
+--- packadd    optional package `|pack-add|` names
+--- runtime    `|:runtime|` completion
+--- scriptnames  sourced script names `|:scriptnames|`
 --- shellcmd  Shell command
---- sign    |:sign| suboptions
---- syntax    syntax file names |'syntax'|
---- syntime    |:syntime| suboptions
+--- sign    `|:sign|` suboptions
+--- syntax    syntax file names `|'syntax'|`
+--- syntime    `|:syntime|` suboptions
 --- tag    tags
 --- tag_listfiles  tags, file names
 --- user    user names
@@ -2907,7 +3211,7 @@ function vim.fn.getcmdwintype() end
 ---
 --- If {pat} is an empty string, then all the matches are
 --- returned.  Otherwise only items matching {pat} are returned.
---- See |wildcards| for the use of special characters in {pat}.
+--- See `|wildcards|` for the use of special characters in {pat}.
 ---
 --- If the optional {filtered} flag is set to 1, then 'wildignore'
 --- is applied to filter the results.  Otherwise all the matches
@@ -2920,13 +3224,15 @@ function vim.fn.getcmdwintype() end
 --- If you do not want this you can make 'wildoptions' empty
 --- before calling getcompletion() and restore it afterwards.
 ---
---- If {type} is "cmdline", then the |cmdline-completion| result is
+--- If {type} is "cmdline", then the `|cmdline-completion|` result is
 --- returned.  For example, to complete the possible values after
---- a ":call" command: >vim
+--- a ":call" command:
+--- ```vim
 ---   echo getcompletion('call ', 'cmdline')
---- <
+--- ```
 --- If there are no matches, an empty list is returned.  An
 --- invalid value for {type} produces an error.
+---
 ---
 --- @param pat any
 --- @param type any
@@ -2938,57 +3244,64 @@ function vim.fn.getcompletion(pat, type, filtered) end
 --- includes an extra "curswant" item in the list:
 ---     [0, lnum, col, off, curswant] ~
 --- The "curswant" number is the preferred column when moving the
---- cursor vertically.  After |$| command it will be a very large
---- number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
---- |getpos()|.
+--- cursor vertically.  After `|$|` command it will be a very large
+--- number equal to `|v:maxcol|`.  Also see `|getcursorcharpos()|` and
+--- `|getpos()|`.
 --- The first "bufnum" item is always zero. The byte position of
 --- the cursor is returned in "col". To get the character
---- position, use |getcursorcharpos()|.
+--- position, use `|getcursorcharpos()|`.
 ---
 --- The optional {winid} argument can specify the window.  It can
---- be the window number or the |window-ID|.  The last known
+--- be the window number or the `|window-ID|`.  The last known
 --- cursor position is returned, this may be invalid for the
 --- current value of the buffer if it is not the current window.
 --- If {winid} is invalid a list with zeroes is returned.
 ---
---- This can be used to save and restore the cursor position: >vim
+--- This can be used to save and restore the cursor position:
+--- ```vim
 ---   let save_cursor = getcurpos()
 ---   MoveTheCursorAround
 ---   call setpos('.', save_cursor)
---- <Note that this only works within the window.  See
---- |winrestview()| for restoring more state.
+--- ```
+--- Note that this only works within the window.  See
+--- `|winrestview()|` for restoring more state.
+---
 ---
 --- @param winid? integer
 --- @return any
 function vim.fn.getcurpos(winid) end
 
---- Same as |getcurpos()| but the column number in the returned
+--- Same as `|getcurpos()|` but the column number in the returned
 --- List is a character index instead of a byte index.
 ---
 --- Example:
---- With the cursor on '보' in line 3 with text "여보세요": >vim
+--- With the cursor on '보' in line 3 with text "여보세요":
+--- ```vim
 ---   getcursorcharpos()  " returns [0, 3, 2, 0, 3]
 ---   getcurpos()    " returns [0, 3, 4, 0, 3]
---- <
+--- ```
 ---
 --- @param winid? integer
 --- @return any
 function vim.fn.getcursorcharpos(winid) end
 
 --- With no arguments, returns the name of the effective
---- |current-directory|. With {winnr} or {tabnr} the working
+--- `|current-directory|`. With {winnr} or {tabnr} the working
 --- directory of that scope is returned, and 'autochdir' is
 --- ignored.
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing tab number implies 0.
---- Thus the following are equivalent: >vim
+--- Thus the following are equivalent:
+--- ```vim
 ---   getcwd(0)
 ---   getcwd(0, 0)
---- <If {winnr} is -1 it is ignored, only the tab is resolved.
---- {winnr} can be the window number or the |window-ID|.
+--- ```
+--- If {winnr} is -1 it is ignored, only the tab is resolved.
+--- {winnr} can be the window number or the `|window-ID|`.
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
---- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+--- Throw error if the arguments are invalid. `|E5000|` `|E5001|` `|E5002|`
+---
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -2996,12 +3309,14 @@ function vim.fn.getcursorcharpos(winid) end
 function vim.fn.getcwd(winnr, tabnr) end
 
 --- Return the value of environment variable {name}.  The {name}
---- argument is a string, without a leading '$'.  Example: >vim
+--- argument is a string, without a leading '$'.  Example:
+--- ```vim
 ---   myHome = getenv('HOME')
----
---- <When the variable does not exist |v:null| is returned.  That
+--- ```
+--- When the variable does not exist `|v:null|` is returned.  That
 --- is different from a variable set to an empty string.
---- See also |expr-env|.
+--- See also `|expr-env|`.
+---
 ---
 --- @param name string
 --- @return string
@@ -3009,13 +3324,13 @@ function vim.fn.getenv(name) end
 
 --- Without an argument returns the name of the normal font being
 --- used.  Like what is used for the Normal highlight group
---- |hl-Normal|.
+--- `|hl-Normal|`.
 --- With an argument a check is done whether String {name} is a
 --- valid font name.  If not then an empty string is returned.
 --- Otherwise the actual font name is returned, or {name} if the
 --- GUI does not support obtaining the real name.
 --- Only works when the GUI is running, thus not in your vimrc or
---- gvimrc file.  Use the |GUIEnter| autocommand to use this
+--- gvimrc file.  Use the `|GUIEnter|` autocommand to use this
 --- function just after the GUI has started.
 ---
 --- @param name? string
@@ -3030,13 +3345,15 @@ function vim.fn.getfontname(name) end
 --- "rwx" flags represent, in turn, the permissions of the owner
 --- of the file, the group the file belongs to, and other users.
 --- If a user does not have a given permission the flag for this
---- is replaced with the string "-".  Examples: >vim
+--- is replaced with the string "-".  Examples:
+--- ```vim
 ---   echo getfperm("/etc/passwd")
 ---   echo getfperm(expand("~/.config/nvim/init.vim"))
---- <This will hopefully (from a security point of view) display
+--- ```
+--- This will hopefully (from a security point of view) display
 --- the string "rw-r--r--" or even "rw-------".
 ---
---- For setting permissions use |setfperm()|.
+--- For setting permissions use `|setfperm()|`.
 ---
 --- @param fname string
 --- @return string
@@ -3049,6 +3366,7 @@ function vim.fn.getfperm(fname) end
 --- If the size of {fname} is too big to fit in a Number then -2
 --- is returned.
 ---
+---
 --- @param fname string
 --- @return integer
 function vim.fn.getfsize(fname) end
@@ -3056,8 +3374,9 @@ function vim.fn.getfsize(fname) end
 --- The result is a Number, which is the last modification time of
 --- the given file {fname}.  The value is measured as seconds
 --- since 1st Jan 1970, and may be passed to strftime().  See also
---- |localtime()| and |strftime()|.
+--- `|localtime()|` and `|strftime()|`.
 --- If the file {fname} can't be found -1 is returned.
+---
 ---
 --- @param fname string
 --- @return integer
@@ -3076,21 +3395,24 @@ function vim.fn.getftime(fname) end
 ---   Socket      "socket"
 ---   FIFO      "fifo"
 ---   All other    "other"
---- Example: >vim
+--- Example:
+--- ```vim
 ---   getftype("/home")
---- <Note that a type such as "link" will only be returned on
+--- ```
+--- Note that a type such as "link" will only be returned on
 --- systems that support it.  On some systems only "dir" and
 --- "file" are returned.
+---
 ---
 --- @param fname string
 --- @return 'file'|'dir'|'link'|'bdev'|'cdev'|'socket'|'fifo'|'other'
 function vim.fn.getftype(fname) end
 
---- Returns the |jumplist| for the specified window.
+--- Returns the `|jumplist|` for the specified window.
 ---
 --- Without arguments use the current window.
 --- With {winnr} only use this window in the current tab page.
---- {winnr} can also be a |window-ID|.
+--- {winnr} can also be a `|window-ID|`.
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.  If {winnr} or {tabnr} is invalid, an empty list is
 --- returned.
@@ -3105,134 +3427,149 @@ function vim.fn.getftype(fname) end
 ---   filename  filename if available
 ---   lnum    line number
 ---
+---
 --- @param winnr? integer
 --- @param tabnr? integer
 --- @return vim.fn.getjumplist.ret
 function vim.fn.getjumplist(winnr, tabnr) end
 
 --- Without {end} the result is a String, which is line {lnum}
---- from the current buffer.  Example: >vim
+--- from the current buffer.  Example:
+--- ```vim
 ---   getline(1)
---- <When {lnum} is a String that doesn't start with a
---- digit, |line()| is called to translate the String into a Number.
---- To get the line under the cursor: >vim
+--- ```
+--- When {lnum} is a String that doesn't start with a
+--- digit, `|line()|` is called to translate the String into a Number.
+--- To get the line under the cursor:
+--- ```vim
 ---   getline(".")
---- <When {lnum} is a number smaller than 1 or bigger than the
+--- ```
+--- When {lnum} is a number smaller than 1 or bigger than the
 --- number of lines in the buffer, an empty string is returned.
 ---
---- When {end} is given the result is a |List| where each item is
+--- When {end} is given the result is a `|List|` where each item is
 --- a line from the current buffer in the range {lnum} to {end},
 --- including line {end}.
 --- {end} is used in the same way as {lnum}.
 --- Non-existing lines are silently omitted.
---- When {end} is before {lnum} an empty |List| is returned.
---- Example: >vim
+--- When {end} is before {lnum} an empty `|List|` is returned.
+--- Example:
+--- ```vim
 ---   let start = line('.')
 ---   let end = search("^$") - 1
 ---   let lines = getline(start, end)
----
---- <To get lines from another buffer see |getbufline()| and
---- |getbufoneline()|
+--- ```
+--- To get lines from another buffer see `|getbufline()|` and
+--- `|getbufoneline()|`
 ---
 --- @param lnum integer
 --- @param end_? any
 --- @return string|string[]
 function vim.fn.getline(lnum, end_) end
 
---- Returns a |List| with all the entries in the location list for
---- window {nr}.  {nr} can be the window number or the |window-ID|.
+--- Returns a `|List|` with all the entries in the location list for
+--- window {nr}.  {nr} can be the window number or the `|window-ID|`.
 --- When {nr} is zero the current window is used.
 ---
 --- For a location list window, the displayed location list is
 --- returned.  For an invalid window number {nr}, an empty list is
---- returned. Otherwise, same as |getqflist()|.
+--- returned. Otherwise, same as `|getqflist()|`.
 ---
 --- If the optional {what} dictionary argument is supplied, then
 --- returns the items listed in {what} as a dictionary. Refer to
---- |getqflist()| for the supported items in {what}.
+--- `|getqflist()|` for the supported items in {what}.
 ---
---- In addition to the items supported by |getqflist()| in {what},
---- the following item is supported by |getloclist()|:
+--- In addition to the items supported by `|getqflist()|` in {what},
+--- the following item is supported by `|getloclist()|`:
 ---
 ---   filewinid  id of the window used to display files
 ---       from the location list. This field is
 ---       applicable only when called from a
 ---       location list window. See
----       |location-list-file-window| for more
+---       `|location-list-file-window|` for more
 ---       details.
 ---
---- Returns a |Dictionary| with default values if there is no
+--- Returns a `|Dictionary|` with default values if there is no
 --- location list for the window {nr}.
 --- Returns an empty Dictionary if window {nr} does not exist.
 ---
---- Examples (See also |getqflist-examples|): >vim
+--- Examples (See also `|getqflist-examples|`):
+--- ```vim
 ---   echo getloclist(3, {'all': 0})
 ---   echo getloclist(5, {'filewinid': 0})
---- <
+--- ```
 ---
 --- @param nr integer
 --- @param what? any
 --- @return any
 function vim.fn.getloclist(nr, what) end
 
---- Without the {buf} argument returns a |List| with information
---- about all the global marks. |mark|
+--- Without the {buf} argument returns a `|List|` with information
+--- about all the global marks. `|mark|`
 ---
 --- If the optional {buf} argument is specified, returns the
 --- local marks defined in buffer {buf}.  For the use of {buf},
---- see |bufname()|.  If {buf} is invalid, an empty list is
+--- see `|bufname()|`.  If {buf} is invalid, an empty list is
 --- returned.
 ---
---- Each item in the returned List is a |Dict| with the following:
+--- Each item in the returned List is a `|Dict|` with the following:
 ---     mark   name of the mark prefixed by "'"
----     pos     a |List| with the position of the mark:
+---     pos     a `|List|` with the position of the mark:
 ---     [bufnum, lnum, col, off]
----      Refer to |getpos()| for more information.
+---      Refer to `|getpos()|` for more information.
 ---     file   file name
 ---
---- Refer to |getpos()| for getting information about a specific
+--- Refer to `|getpos()|` for getting information about a specific
 --- mark.
+---
 ---
 --- @param buf? any
 --- @return any
 function vim.fn.getmarklist(buf) end
 
---- Returns a |List| with all matches previously defined for the
---- current window by |matchadd()| and the |:match| commands.
---- |getmatches()| is useful in combination with |setmatches()|,
---- as |setmatches()| can restore a list of matches saved by
---- |getmatches()|.
+--- Returns a `|List|` with all matches previously defined for the
+--- current window by `|matchadd()|` and the `|:match|` commands.
+--- `|getmatches()|` is useful in combination with `|setmatches()|`,
+--- as `|setmatches()|` can restore a list of matches saved by
+--- `|getmatches()|`.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.  If {win} is invalid,
 --- an empty list is returned.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo getmatches()
---- < >
+--- ```
+--- ```
 ---   [{"group": "MyGroup1", "pattern": "TODO",
 ---   "priority": 10, "id": 1}, {"group": "MyGroup2",
 ---   "pattern": "FIXME", "priority": 10, "id": 2}]
---- < >vim
+--- ```
+--- ```vim
 ---   let m = getmatches()
 ---   call clearmatches()
 ---   echo getmatches()
---- < >
+--- ```
+--- ```
 ---   []
---- < >vim
+--- ```
+--- ```vim
 ---   call setmatches(m)
 ---   echo getmatches()
---- < >
+--- ```
+--- ```
 ---   [{"group": "MyGroup1", "pattern": "TODO",
 ---   "priority": 10, "id": 1}, {"group": "MyGroup2",
 ---   "pattern": "FIXME", "priority": 10, "id": 2}]
---- < >vim
+--- ```
+--- ```vim
 ---   unlet m
---- <
+--- ```
 ---
 --- @param win? any
 --- @return any
 function vim.fn.getmatches(win) end
 
---- Returns a |Dictionary| with the last known position of the
+--- Returns a `|Dictionary|` with the last known position of the
 --- mouse.  This can be used in a mapping for a mouse click.  The
 --- items are:
 ---   screenrow  screen row
@@ -3259,8 +3596,8 @@ function vim.fn.getmatches(win) end
 --- If the mouse is over a focusable floating window then that
 --- window is used.
 ---
---- When using |getchar()| the Vim variables |v:mouse_lnum|,
---- |v:mouse_col| and |v:mouse_winid| also provide these values.
+--- When using `|getchar()|` the Vim variables `|v:mouse_lnum|,
+--- |v:mouse_col|` and `|v:mouse_winid|` also provide these values.
 ---
 --- @return vim.fn.getmousepos.ret
 function vim.fn.getmousepos() end
@@ -3272,9 +3609,9 @@ function vim.fn.getmousepos() end
 function vim.fn.getpid() end
 
 --- Get the position for String {expr}.  For possible values of
---- {expr} see |line()|.  For getting the cursor position see
---- |getcurpos()|.
---- The result is a |List| with four numbers:
+--- {expr} see `|line()|`.  For getting the cursor position see
+--- `|getcurpos()|`.
+--- The result is a `|List|` with four numbers:
 ---     [bufnum, lnum, col, off]
 --- "bufnum" is zero, unless a mark like '0 or 'A is used, then it
 --- is the buffer number of the mark.
@@ -3286,24 +3623,27 @@ function vim.fn.getpid() end
 --- character.
 --- Note that for '< and '> Visual mode matters: when it is "V"
 --- (visual line mode) the column of '< is zero and the column of
---- '> is a large number equal to |v:maxcol|.
+--- '> is a large number equal to `|v:maxcol|`.
 --- The column number in the returned List is the byte position
 --- within the line. To get the character position in the line,
---- use |getcharpos()|.
---- A very large column number equal to |v:maxcol| can be returned,
+--- use `|getcharpos()|`.
+--- A very large column number equal to `|v:maxcol|` can be returned,
 --- in which case it means "after the end of the line".
 --- If {expr} is invalid, returns a list with all zeros.
---- This can be used to save and restore the position of a mark: >vim
+--- This can be used to save and restore the position of a mark:
+--- ```vim
 ---   let save_a_mark = getpos("'a")
 ---   " ...
 ---   call setpos("'a", save_a_mark)
---- <Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+--- ```
+--- Also see `|getcharpos()|`, `|getcurpos()|` and `|setpos()|`.
+---
 ---
 --- @param expr string
 --- @return integer[]
 function vim.fn.getpos(expr) end
 
---- Returns a |List| with all the current quickfix errors.  Each
+--- Returns a `|List|` with all the current quickfix errors.  Each
 --- list item is a dictionary with these entries:
 ---   bufnr  number of buffer that has the file name, use
 ---     bufname() to get the name
@@ -3313,13 +3653,13 @@ function vim.fn.getpos(expr) end
 ---     end of line number if the item is multiline
 ---   col  column number (first column is 1)
 ---   end_col  end of column number if the item has range
----   vcol  |TRUE|: "col" is visual column
----     |FALSE|: "col" is byte index
+---   vcol  `|TRUE|`: "col" is visual column
+---     `|FALSE|`: "col" is byte index
 ---   nr  error number
 ---   pattern  search pattern used to locate the error
 ---   text  description of the error
 ---   type  type of the error, 'E', '1', etc.
----   valid  |TRUE|: recognized error message
+---   valid  `|TRUE|`: recognized error message
 ---   user_data
 ---     custom data associated with the item, can be
 ---     any type.
@@ -3331,42 +3671,43 @@ function vim.fn.getpos(expr) end
 --- you may need to explicitly check for zero).
 ---
 --- Useful application: Find pattern matches in multiple files and
---- do something with them: >vim
+--- do something with them:
+--- ```vim
 ---   vimgrep /theword/jg *.c
 ---   for d in getqflist()
 ---      echo bufname(d.bufnr) ':' d.lnum '=' d.text
 ---   endfor
---- <
+--- ```
 --- If the optional {what} dictionary argument is supplied, then
 --- returns only the items listed in {what} as a dictionary. The
 --- following string items are supported in {what}:
 ---   changedtick  get the total number of changes made
----       to the list |quickfix-changedtick|
----   context  get the |quickfix-context|
+---       to the list `|quickfix-changedtick|`
+---   context  get the `|quickfix-context|`
 ---   efm  errorformat to use when parsing "lines". If
 ---     not present, then the 'errorformat' option
 ---     value is used.
 ---   id  get information for the quickfix list with
----     |quickfix-ID|; zero means the id for the
+---     `|quickfix-ID|`; zero means the id for the
 ---     current list or the list specified by "nr"
 ---   idx  get information for the quickfix entry at this
 ---     index in the list specified by "id" or "nr".
 ---     If set to zero, then uses the current entry.
----     See |quickfix-index|
+---     See `|quickfix-index|`
 ---   items  quickfix list entries
 ---   lines  parse a list of lines using 'efm' and return
----     the resulting entries.  Only a |List| type is
+---     the resulting entries.  Only a `|List|` type is
 ---     accepted.  The current quickfix list is not
----     modified. See |quickfix-parse|.
+---     modified. See `|quickfix-parse|`.
 ---   nr  get information for this quickfix list; zero
 ---     means the current quickfix list and "$" means
 ---     the last quickfix list
 ---   qfbufnr number of the buffer displayed in the quickfix
 ---     window. Returns 0 if the quickfix buffer is
----     not present. See |quickfix-buffer|.
+---     not present. See `|quickfix-buffer|`.
 ---   size  number of entries in the quickfix list
----   title  get the list title |quickfix-title|
----   winid  get the quickfix |window-ID|
+---   title  get the list title `|quickfix-title|`
+---   winid  get the quickfix `|window-ID|`
 ---   all  all of the above quickfix properties
 --- Non-string items in {what} are ignored. To get the value of a
 --- particular item, set it to zero.
@@ -3382,10 +3723,10 @@ function vim.fn.getpos(expr) end
 ---
 --- The returned dictionary contains the following entries:
 ---   changedtick  total number of changes made to the
----       list |quickfix-changedtick|
----   context  quickfix list context. See |quickfix-context|
+---       list `|quickfix-changedtick|`
+---   context  quickfix list context. See `|quickfix-context|`
 ---     If not present, set to "".
----   id  quickfix list ID |quickfix-ID|. If not
+---   id  quickfix list ID `|quickfix-ID|`. If not
 ---     present, set to 0.
 ---   idx  index of the quickfix entry in the list. If not
 ---     present, set to 0.
@@ -3398,39 +3739,43 @@ function vim.fn.getpos(expr) end
 ---     present, set to 0.
 ---   title  quickfix list title text. If not present, set
 ---     to "".
----   winid  quickfix |window-ID|. If not present, set to 0
+---   winid  quickfix `|window-ID|`. If not present, set to 0
 ---
---- Examples (See also |getqflist-examples|): >vim
+--- Examples (See also `|getqflist-examples|`):
+--- ```vim
 ---   echo getqflist({'all': 1})
 ---   echo getqflist({'nr': 2, 'title': 1})
 ---   echo getqflist({'lines' : ["F1:10:L10"]})
---- <
+--- ```
 ---
 --- @param what? any
 --- @return any
 function vim.fn.getqflist(what) end
 
 --- The result is a String, which is the contents of register
---- {regname}.  Example: >vim
+--- {regname}.  Example:
+--- ```vim
 ---   let cliptext = getreg('*')
---- <When register {regname} was not set the result is an empty
+--- ```
+--- When register {regname} was not set the result is an empty
 --- string.
 --- The {regname} argument must be a string.
 ---
 --- getreg('=') returns the last evaluated value of the expression
 --- register.  (For use in maps.)
 --- getreg('=', 1) returns the expression itself, so that it can
---- be restored with |setreg()|.  For other registers the extra
+--- be restored with `|setreg()|`.  For other registers the extra
 --- argument is ignored, thus you can always give it.
 ---
---- If {list} is present and |TRUE|, the result type is changed
---- to |List|. Each list item is one text line. Use it if you care
+--- If {list} is present and `|TRUE|`, the result type is changed
+--- to `|List|`. Each list item is one text line. Use it if you care
 --- about zero bytes possibly present inside register: without
 --- third argument both NLs and zero bytes are represented as NLs
---- (see |NL-used-for-Nul|).
+--- (see `|NL-used-for-Nul|`).
 --- When the register was not set an empty list is returned.
 ---
---- If {regname} is not specified, |v:register| is used.
+--- If {regname} is not specified, `|v:register|` is used.
+---
 ---
 --- @param regname? string
 --- @param list? any
@@ -3443,13 +3788,13 @@ function vim.fn.getreg(regname, list) end
 ---       {regname}, like
 ---       getreg({regname}, 1, 1).
 ---   regtype    the type of register {regname}, as in
----       |getregtype()|.
+---       `|getregtype()|`.
 ---   isunnamed  Boolean flag, v:true if this register
 ---       is currently pointed to by the unnamed
 ---       register.
 ---   points_to  for the unnamed register, gives the
 ---       single letter name of the register
----       currently pointed to (see |quotequote|).
+---       currently pointed to (see `|quotequote|`).
 ---       For example, after deleting a line
 ---       with `dd`, this field will be "1",
 ---       which is the register that got the
@@ -3457,8 +3802,9 @@ function vim.fn.getreg(regname, list) end
 ---
 --- The {regname} argument is a string.  If {regname} is invalid
 --- or not set, an empty Dictionary will be returned.
---- If {regname} is not specified, |v:register| is used.
---- The returned Dictionary can be passed to |setreg()|.
+--- If {regname} is not specified, `|v:register|` is used.
+--- The returned Dictionary can be passed to `|setreg()|`.
+---
 ---
 --- @param regname? string
 --- @return table
@@ -3466,19 +3812,20 @@ function vim.fn.getreginfo(regname) end
 
 --- The result is a String, which is type of register {regname}.
 --- The value will be one of:
----     "v"      for |charwise| text
----     "V"      for |linewise| text
----     "<CTRL-V>{width}"  for |blockwise-visual| text
+---     "v"      for `|charwise|` text
+---     "V"      for `|linewise|` text
+---     "<CTRL-V>{width}"  for `|blockwise-visual|` text
 ---     ""      for an empty or unknown register
 --- <CTRL-V> is one character with value 0x16.
 --- The {regname} argument is a string.  If {regname} is not
---- specified, |v:register| is used.
+--- specified, `|v:register|` is used.
+---
 ---
 --- @param regname? string
 --- @return string
 function vim.fn.getregtype(regname) end
 
---- Returns a |List| with information about all the sourced Vim
+--- Returns a `|List|` with information about all the sourced Vim
 --- scripts in the order they were sourced, like what
 --- `:scriptnames` shows.
 ---
@@ -3488,11 +3835,11 @@ function vim.fn.getregtype(regname) end
 ---     and "sid" is not specified, information about
 ---     scripts with a name that match the pattern
 ---     "name" are returned.
----     sid    Script ID |<SID>|.  If specified, only
+---     sid    Script ID `|<SID>|`.  If specified, only
 ---     information about the script with ID "sid" is
 ---     returned and "name" is ignored.
 ---
---- Each item in the returned List is a |Dict| with the following
+--- Each item in the returned List is a `|Dict|` with the following
 --- items:
 ---     autoload  Always set to FALSE.
 ---     functions   List of script-local function names defined in
@@ -3500,7 +3847,7 @@ function vim.fn.getregtype(regname) end
 ---     script is specified using the "sid" item in
 ---     {opts}.
 ---     name  Vim script file name.
----     sid    Script ID |<SID>|.
+---     sid    Script ID `|<SID>|`.
 ---     variables   A dictionary with the script-local variables.
 ---     Present only when a particular script is
 ---     specified using the "sid" item in {opts}.
@@ -3509,39 +3856,42 @@ function vim.fn.getregtype(regname) end
 ---     this dictionary.
 ---     version  Vimscript version, always 1
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo getscriptinfo({'name': 'myscript'})
 ---   echo getscriptinfo({'sid': 15}).variables
---- <
+--- ```
 ---
 --- @param opts? table
 --- @return any
 function vim.fn.getscriptinfo(opts) end
 
 --- If {tabnr} is not specified, then information about all the
---- tab pages is returned as a |List|. Each List item is a
---- |Dictionary|.  Otherwise, {tabnr} specifies the tab page
+--- tab pages is returned as a `|List|`. Each List item is a
+--- `|Dictionary|`.  Otherwise, {tabnr} specifies the tab page
 --- number and information about that one is returned.  If the tab
 --- page does not exist an empty List is returned.
 ---
---- Each List item is a |Dictionary| with the following entries:
+--- Each List item is a `|Dictionary|` with the following entries:
 ---   tabnr    tab page number.
 ---   variables  a reference to the dictionary with
 ---       tabpage-local variables
----   windows    List of |window-ID|s in the tab page.
+---   windows    List of `|window-ID|`s in the tab page.
+---
 ---
 --- @param tabnr? integer
 --- @return any
 function vim.fn.gettabinfo(tabnr) end
 
 --- Get the value of a tab-local variable {varname} in tab page
---- {tabnr}. |t:var|
+--- {tabnr}. `|t:var|`
 --- Tabs are numbered starting with one.
 --- The {varname} argument is a string.  When {varname} is empty a
 --- dictionary with all tab-local variables is returned.
 --- Note that the name without "t:" must be used.
 --- When the tab or variable doesn't exist {def} or an empty
 --- string is returned, there is no error message.
+---
 ---
 --- @param tabnr integer
 --- @param varname string
@@ -3554,26 +3904,28 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 --- The {varname} argument is a string.  When {varname} is empty a
 --- dictionary with all window-local variables is returned.
 --- When {varname} is equal to "&" get the values of all
---- window-local options in a |Dictionary|.
+--- window-local options in a `|Dictionary|`.
 --- Otherwise, when {varname} starts with "&" get the value of a
 --- window-local option.
 --- Note that {varname} must be the name without "w:".
 --- Tabs are numbered starting with one.  For the current tabpage
---- use |getwinvar()|.
---- {winnr} can be the window number or the |window-ID|.
+--- use `|getwinvar()|`.
+--- {winnr} can be the window number or the `|window-ID|`.
 --- When {winnr} is zero the current window is used.
 --- This also works for a global option, buffer-local option and
 --- window-local option, but it doesn't work for a global variable
 --- or buffer-local variable.
 --- When the tab, window or variable doesn't exist {def} or an
 --- empty string is returned, there is no error message.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   let list_is_on = gettabwinvar(1, 2, '&list')
 ---   echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
---- <
---- To obtain all window-local variables use: >vim
+--- ```
+--- To obtain all window-local variables use:
+--- ```vim
 ---   gettabwinvar({tabnr}, {winnr}, '&')
---- <
+--- ```
 ---
 --- @param tabnr integer
 --- @param winnr integer
@@ -3583,7 +3935,7 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 
 --- The result is a Dict, which is the tag stack of window {winnr}.
---- {winnr} can be the window number or the |window-ID|.
+--- {winnr} can be the window number or the `|window-ID|`.
 --- When {winnr} is not specified, the current window is used.
 --- When window {winnr} doesn't exist, an empty Dict is returned.
 ---
@@ -3600,14 +3952,15 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 --- entries:
 ---   bufnr    buffer number of the current jump
 ---   from    cursor position before the tag jump.
----       See |getpos()| for the format of the
+---       See `|getpos()|` for the format of the
 ---       returned list.
 ---   matchnr    current matching tag number. Used when
 ---       multiple matching tags are found for a
 ---       name.
 ---   tagname    name of the tag
 ---
---- See |tagstack| for more information about the tag stack.
+--- See `|tagstack|` for more information about the tag stack.
+---
 ---
 --- @param winnr? integer
 --- @return any
@@ -3627,16 +3980,16 @@ function vim.fn.gettagstack(winnr) end
 --- @return any
 function vim.fn.gettext(text) end
 
---- Returns information about windows as a |List| with Dictionaries.
+--- Returns information about windows as a `|List|` with Dictionaries.
 ---
 --- If {winid} is given Information about the window with that ID
---- is returned, as a |List| with one item.  If the window does not
+--- is returned, as a `|List|` with one item.  If the window does not
 --- exist the result is an empty list.
 ---
 --- Without {winid} information about all the windows in all the
 --- tab pages is returned.
 ---
---- Each List item is a |Dictionary| with the following entries:
+--- Each List item is a `|Dictionary|` with the following entries:
 ---   botline    last complete displayed buffer line
 ---   bufnr    number of buffer in the window
 ---   height    window height (excluding winbar)
@@ -3651,21 +4004,22 @@ function vim.fn.gettext(text) end
 ---   winbar    1 if the window has a toolbar, 0
 ---       otherwise
 ---   wincol    leftmost screen column of the window;
----       "col" from |win_screenpos()|
+---       "col" from `|win_screenpos()|`
 ---   textoff    number of columns occupied by any
 ---       'foldcolumn', 'signcolumn' and line
 ---       number in front of the text
----   winid    |window-ID|
+---   winid    `|window-ID|`
 ---   winnr    window number
 ---   winrow    topmost screen line of the window;
----       "row" from |win_screenpos()|
+---       "row" from `|win_screenpos()|`
+---
 ---
 --- @param winid? integer
 --- @return vim.fn.getwininfo.ret.item[]
 function vim.fn.getwininfo(winid) end
 
---- The result is a |List| with two numbers, the result of
---- |getwinposx()| and |getwinposy()| combined:
+--- The result is a `|List|` with two numbers, the result of
+--- `|getwinposx()|` and `|getwinposy()|` combined:
 ---   [x-pos, y-pos]
 --- {timeout} can be used to specify how long to wait in msec for
 --- a response from the terminal.  When omitted 100 msec is used.
@@ -3674,7 +4028,8 @@ function vim.fn.getwininfo(winid) end
 --- When using a value less than 10 and no response is received
 --- within that time, a previously reported position is returned,
 --- if available.  This can be used to poll for the position and
---- do some work in the meantime: >vim
+--- do some work in the meantime:
+--- ```vim
 ---   while 1
 ---     let res = getwinpos(1)
 ---     if res[0] >= 0
@@ -3682,7 +4037,7 @@ function vim.fn.getwininfo(winid) end
 ---     endif
 ---     " Do some work here
 ---   endwhile
---- <
+--- ```
 ---
 --- @param timeout? integer
 --- @return any
@@ -3704,10 +4059,12 @@ function vim.fn.getwinposx() end
 --- @return integer
 function vim.fn.getwinposy() end
 
---- Like |gettabwinvar()| for the current tabpage.
---- Examples: >vim
+--- Like `|gettabwinvar()|` for the current tabpage.
+--- Examples:
+--- ```vim
 ---   let list_is_on = getwinvar(2, '&list')
 ---   echo "myvar = " .. getwinvar(1, 'myvar')
+--- ```
 ---
 --- @param winnr integer
 --- @param varname string
@@ -3715,16 +4072,16 @@ function vim.fn.getwinposy() end
 --- @return any
 function vim.fn.getwinvar(winnr, varname, def) end
 
---- Expand the file wildcards in {expr}.  See |wildcards| for the
+--- Expand the file wildcards in {expr}.  See `|wildcards|` for the
 --- use of special characters.
 ---
---- Unless the optional {nosuf} argument is given and is |TRUE|,
+--- Unless the optional {nosuf} argument is given and is `|TRUE|`,
 --- the 'suffixes' and 'wildignore' options apply: Names matching
 --- one of the patterns in 'wildignore' will be skipped and
 --- 'suffixes' affect the ordering of matches.
 --- 'wildignorecase' always applies.
 ---
---- When {list} is present and it is |TRUE| the result is a |List|
+--- When {list} is present and it is `|TRUE|` the result is a `|List|`
 --- with all matching files. The advantage of using a List is,
 --- you also get filenames containing newlines correctly.
 --- Otherwise the result is a String and when there are several
@@ -3732,23 +4089,26 @@ function vim.fn.getwinvar(winnr, varname, def) end
 ---
 --- If the expansion fails, the result is an empty String or List.
 ---
---- You can also use |readdir()| if you need to do complicated
+--- You can also use `|readdir()|` if you need to do complicated
 --- things, such as limiting the number of matches.
 ---
 --- A name for a non-existing file is not included.  A symbolic
 --- link is only included if it points to an existing file.
 --- However, when the {alllinks} argument is present and it is
---- |TRUE| then all symbolic links are included.
+--- `|TRUE|` then all symbolic links are included.
 ---
 --- For most systems backticks can be used to get files names from
---- any external command.  Example: >vim
+--- any external command.  Example:
+--- ```vim
 ---   let tagfiles = glob("`find . -name tags -print`")
 ---   let &tags = substitute(tagfiles, "\n", ",", "g")
---- <The result of the program inside the backticks should be one
+--- ```
+--- The result of the program inside the backticks should be one
 --- item per line.  Spaces inside an item are allowed.
 ---
---- See |expand()| for expanding special Vim variables.  See
---- |system()| for getting the raw output of an external command.
+--- See `|expand()|` for expanding special Vim variables.  See
+--- `|system()|` for getting the raw output of an external command.
+---
 ---
 --- @param expr any
 --- @param nosuf? boolean
@@ -3757,58 +4117,68 @@ function vim.fn.getwinvar(winnr, varname, def) end
 --- @return any
 function vim.fn.glob(expr, nosuf, list, alllinks) end
 
---- Convert a file pattern, as used by glob(), into a search
---- pattern.  The result can be used to match with a string that
---- is a file name.  E.g. >vim
----   if filename =~ glob2regpat('Make*.mak')
----     " ...
----   endif
---- <This is equivalent to: >vim
----   if filename =~ '^Make.*\.mak$'
----     " ...
----   endif
---- <When {string} is an empty string the result is "^$", match an
---- empty string.
---- Note that the result depends on the system.  On MS-Windows
---- a backslash usually means a path separator.
+---     Convert a file pattern, as used by glob(), into a search
+---     pattern.  The result can be used to match with a string that
+---     is a file name.  E.g.
+--- ```vim
+---       if filename =~ glob2regpat('Make*.mak')
+---   " ...
+--- endif
+--- ```
+--- This is equivalent to:
+--- ```vim
+---       if filename =~ '^Make.*\.mak$'
+---   " ...
+--- endif
+--- ```
+--- When {string} is an empty string the result is "^$", match an
+---     empty string.
+---     Note that the result depends on the system.  On MS-Windows
+---     a backslash usually means a path separator.
+---
 ---
 --- @param string string
 --- @return any
 function vim.fn.glob2regpat(string) end
 
 --- Perform glob() for String {expr} on all directories in {path}
---- and concatenate the results.  Example: >vim
+--- and concatenate the results.  Example:
+--- ```vim
 ---   echo globpath(&rtp, "syntax/c.vim")
---- <
+--- ```
 --- {path} is a comma-separated list of directory names.  Each
 --- directory name is prepended to {expr} and expanded like with
---- |glob()|.  A path separator is inserted when needed.
+--- `|glob()|`.  A path separator is inserted when needed.
 --- To add a comma inside a directory name escape it with a
 --- backslash.  Note that on MS-Windows a directory may have a
 --- trailing backslash, remove it if you put a comma after it.
 --- If the expansion fails for one of the directories, there is no
 --- error message.
 ---
---- Unless the optional {nosuf} argument is given and is |TRUE|,
+--- Unless the optional {nosuf} argument is given and is `|TRUE|`,
 --- the 'suffixes' and 'wildignore' options apply: Names matching
 --- one of the patterns in 'wildignore' will be skipped and
 --- 'suffixes' affect the ordering of matches.
 ---
---- When {list} is present and it is |TRUE| the result is a |List|
+--- When {list} is present and it is `|TRUE|` the result is a `|List|`
 --- with all matching files. The advantage of using a List is, you
 --- also get filenames containing newlines correctly. Otherwise
 --- the result is a String and when there are several matches,
---- they are separated by <NL> characters.  Example: >vim
+--- they are separated by <NL> characters.  Example:
+--- ```vim
 ---   echo globpath(&rtp, "syntax/c.vim", 0, 1)
---- <
---- {allinks} is used as with |glob()|.
+--- ```
+--- {allinks} is used as with `|glob()|`.
 ---
 --- The "**" item can be used to search in a directory tree.
 --- For example, to find all "README.txt" files in the directories
---- in 'runtimepath' and below: >vim
+--- in 'runtimepath' and below:
+--- ```vim
 ---   echo globpath(&rtp, "**/README.txt")
---- <Upwards search and limiting the depth of "**" is not
+--- ```
+--- Upwards search and limiting the depth of "**" is not
 --- supported, thus using 'path' will not always work properly.
+---
 ---
 --- @param path string
 --- @param expr any
@@ -3820,78 +4190,86 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 
 --- Returns 1 if {feature} is supported, 0 otherwise.  The
 --- {feature} argument is a feature name like "nvim-0.2.1" or
---- "win32", see below.  See also |exists()|.
+--- "win32", see below.  See also `|exists()|`.
 ---
---- To get the system name use |vim.uv|.os_uname() in Lua: >lua
+--- To get the system name use `|vim.uv|`.os_uname() in Lua:
+--- ```lua
 ---   print(vim.uv.os_uname().sysname)
----
---- <If the code has a syntax error then Vimscript may skip the
---- rest of the line.  Put |:if| and |:endif| on separate lines to
---- avoid the syntax error: >vim
+--- ```
+--- If the code has a syntax error then Vimscript may skip the
+--- rest of the line.  Put `|:if|` and `|:endif|` on separate lines to
+--- avoid the syntax error:
+--- ```vim
 ---   if has('feature')
 ---     let x = this_breaks_without_the_feature()
 ---   endif
---- <
+--- ```
 --- Vim's compile-time feature-names (prefixed with "+") are not
 --- recognized because Nvim is always compiled with all possible
---- features. |feature-compile|
+--- features. `|feature-compile|`
 ---
 --- Feature names can be:
 --- 1.  Nvim version. For example the "nvim-0.2.1" feature means
----     that Nvim is version 0.2.1 or later: >vim
+---     that Nvim is version 0.2.1 or later:
+--- ```vim
 ---   if has("nvim-0.2.1")
 ---     " ...
 ---   endif
----
---- <2.  Runtime condition or other pseudo-feature. For example the
----     "win32" feature checks if the current system is Windows: >vim
+--- ```
+--- 2.  Runtime condition or other pseudo-feature. For example the
+---     "win32" feature checks if the current system is Windows:
+--- ```vim
 ---   if has("win32")
 ---     " ...
 ---   endif
---- <          *feature-list*
+--- ```
+--- *feature-list*
 ---     List of supported pseudo-feature names:
----   acl    |ACL| support.
+---   acl    `|ACL|` support.
 ---   bsd    BSD system (not macOS, use "mac" for that).
----   clipboard  |clipboard| provider is available.
+---   clipboard  `|clipboard|` provider is available.
 ---   fname_case  Case in file names matters (for Darwin and MS-Windows
 ---       this is not present).
 ---   gui_running  Nvim has a GUI.
----   iconv    Can use |iconv()| for conversion.
+---   iconv    Can use `|iconv()|` for conversion.
 ---   linux    Linux system.
 ---   mac    MacOS system.
 ---   nvim    This is Nvim.
----   python3    Legacy Vim |python3| interface. |has-python|
----   pythonx    Legacy Vim |python_x| interface. |has-pythonx|
+---   python3    Legacy Vim `|python3|` interface. `|has-python|`
+---   pythonx    Legacy Vim `|python_x|` interface. `|has-pythonx|`
 ---   sun    SunOS system.
 ---   ttyin    input is a terminal (tty).
 ---   ttyout    output is a terminal (tty).
 ---   unix    Unix system.
----   *vim_starting*  True during |startup|.
+---   *vim_starting*  True during `|startup|`.
 ---   win32    Windows system (32 or 64 bit).
 ---   win64    Windows system (64 bit).
 ---   wsl    WSL (Windows Subsystem for Linux) system.
 ---
 ---           *has-patch*
 --- 3.  Vim patch. For example the "patch123" feature means that
----     Vim patch 123 at the current |v:version| was included: >vim
+---     Vim patch 123 at the current `|v:version|` was included:
+--- ```vim
 ---   if v:version > 602 || v:version == 602 && has("patch148")
 ---     " ...
 ---   endif
----
---- <4.  Vim version. For example the "patch-7.4.237" feature means
----     that Nvim is Vim-compatible to version 7.4.237 or later. >vim
+--- ```
+--- 4.  Vim version. For example the "patch-7.4.237" feature means
+---     that Nvim is Vim-compatible to version 7.4.237 or later.
+--- ```vim
 ---   if has("patch-7.4.237")
 ---     " ...
 ---   endif
---- <
+--- ```
 ---
 --- @param feature any
 --- @return 0|1
 function vim.fn.has(feature) end
 
---- The result is a Number, which is TRUE if |Dictionary| {dict}
+--- The result is a Number, which is TRUE if `|Dictionary|` {dict}
 --- has an entry with key {key}.  FALSE otherwise. The {key}
 --- argument is a string.
+---
 ---
 --- @param dict any
 --- @param key any
@@ -3899,20 +4277,23 @@ function vim.fn.has(feature) end
 function vim.fn.has_key(dict, key) end
 
 --- The result is a Number, which is 1 when the window has set a
---- local path via |:lcd| or when {winnr} is -1 and the tabpage
---- has set a local path via |:tcd|, otherwise 0.
+--- local path via `|:lcd|` or when {winnr} is -1 and the tabpage
+--- has set a local path via `|:tcd|`, otherwise 0.
 ---
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing argument implies 0.
---- Thus the following are equivalent: >vim
+--- Thus the following are equivalent:
+--- ```vim
 ---   echo haslocaldir()
 ---   echo haslocaldir(0)
 ---   echo haslocaldir(0, 0)
---- <With {winnr} use that window in the current tabpage.
+--- ```
+--- With {winnr} use that window in the current tabpage.
 --- With {winnr} and {tabnr} use the window in that tabpage.
---- {winnr} can be the window number or the |window-ID|.
+--- {winnr} can be the window number or the `|window-ID|`.
 --- If {winnr} is -1 it is ignored, only the tab is resolved.
---- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+--- Throw error if the arguments are invalid. `|E5000|` `|E5001|` `|E5002|`
+---
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -3924,7 +4305,7 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 --- mapped to) and this mapping exists in one of the modes
 --- indicated by {mode}.
 --- The arguments {what} and {mode} are strings.
---- When {abbr} is there and it is |TRUE| use abbreviations
+--- When {abbr} is there and it is `|TRUE|` use abbreviations
 --- instead of mappings.  Don't forget to specify Insert and/or
 --- Command-line mode.
 --- Both the global mappings and the mappings local to the current
@@ -3942,12 +4323,15 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 --- When {mode} is omitted, "nvo" is used.
 ---
 --- This function is useful to check if a mapping already exists
---- to a function in a Vim script.  Example: >vim
+--- to a function in a Vim script.  Example:
+--- ```vim
 ---   if !hasmapto('\ABCdoit')
 ---      map <Leader>d \ABCdoit
 ---   endif
---- <This installs the mapping to "\ABCdoit" only if there isn't
+--- ```
+--- This installs the mapping to "\ABCdoit" only if there isn't
 --- already a mapping to "\ABCdoit".
+---
 ---
 --- @param what any
 --- @param mode? string
@@ -3956,14 +4340,14 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 function vim.fn.hasmapto(what, mode, abbr) end
 
 --- @deprecated
---- Obsolete name for |hlID()|.
+--- Obsolete name for `|hlID()|`.
 ---
 --- @param name string
 --- @return any
 function vim.fn.highlightID(name) end
 
 --- @deprecated
---- Obsolete name for |hlexists()|.
+--- Obsolete name for `|hlexists()|`.
 ---
 --- @param name string
 --- @return any
@@ -3974,7 +4358,7 @@ function vim.fn.highlight_exists(name) end
 ---   "cmd"   or ":"    command line history
 ---   "search" or "/"   search pattern history
 ---   "expr"   or "="   typed expression history
----   "input"  or "\@"    input line history
+---   "input"  or "@"    input line history
 ---   "debug"  or ">"   debug command history
 ---   empty      the current or last used history
 --- The {history} string does not need to be the whole name, one
@@ -3984,47 +4368,54 @@ function vim.fn.highlight_exists(name) end
 --- The result is a Number: TRUE if the operation was successful,
 --- otherwise FALSE is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call histadd("input", strftime("%Y %b %d"))
 ---   let date=input("Enter date: ")
---- <This function is not available in the |sandbox|.
+--- ```
+--- This function is not available in the `|sandbox|`.
+---
 ---
 --- @param history any
 --- @param item any
 --- @return 0|1
 function vim.fn.histadd(history, item) end
 
---- Clear {history}, i.e. delete all its entries.  See |hist-names|
+--- Clear {history}, i.e. delete all its entries.  See `|hist-names|`
 --- for the possible values of {history}.
 ---
 --- If the parameter {item} evaluates to a String, it is used as a
 --- regular expression.  All entries matching that expression will
 --- be removed from the history (if there are any).
---- Upper/lowercase must match, unless "\c" is used |/\c|.
+--- Upper/lowercase must match, unless "\c" is used `|/\c|`.
 --- If {item} evaluates to a Number, it will be interpreted as
---- an index, see |:history-indexing|.  The respective entry will
+--- an index, see `|:history-indexing|`.  The respective entry will
 --- be removed if it exists.
 ---
 --- The result is TRUE for a successful operation, otherwise FALSE
 --- is returned.
 ---
 --- Examples:
---- Clear expression register history: >vim
+--- Clear expression register history:
+--- ```vim
 ---   call histdel("expr")
---- <
---- Remove all entries starting with "*" from the search history: >vim
+--- ```
+--- Remove all entries starting with "*" from the search history:
+--- ```vim
 ---   call histdel("/", '^\*')
---- <
---- The following three are equivalent: >vim
+--- ```
+--- The following three are equivalent:
+--- ```vim
 ---   call histdel("search", histnr("search"))
 ---   call histdel("search", -1)
 ---   call histdel("search", '^' .. histget("search", -1) .. '$')
---- <
+--- ```
 --- To delete the last search pattern and use the last-but-one for
---- the "n" command and 'hlsearch': >vim
+--- the "n" command and 'hlsearch':
+--- ```vim
 ---   call histdel("search", -1)
----   let \@/ = histget("search", -1)
---- <
+---   let @/ = histget("search", -1)
+--- ```
 ---
 --- @param history any
 --- @param item? any
@@ -4032,19 +4423,21 @@ function vim.fn.histadd(history, item) end
 function vim.fn.histdel(history, item) end
 
 --- The result is a String, the entry with Number {index} from
---- {history}.  See |hist-names| for the possible values of
---- {history}, and |:history-indexing| for {index}.  If there is
+--- {history}.  See `|hist-names|` for the possible values of
+--- {history}, and `|:history-indexing|` for {index}.  If there is
 --- no such entry, an empty String is returned.  When {index} is
 --- omitted, the most recent item from the history is used.
 ---
 --- Examples:
---- Redo the second last search from history. >vim
+--- Redo the second last search from history.
+--- ```vim
 ---   execute '/' .. histget("search", -2)
----
---- <Define an Ex command ":H {num}" that supports re-execution of
---- the {num}th entry from the output of |:history|. >vim
+--- ```
+--- Define an Ex command ":H {num}" that supports re-execution of
+--- the {num}th entry from the output of `|:history|`.
+--- ```vim
 ---   command -nargs=1 H execute histget("cmd", 0+<args>)
---- <
+--- ```
 ---
 --- @param history any
 --- @param index? any
@@ -4052,11 +4445,13 @@ function vim.fn.histdel(history, item) end
 function vim.fn.histget(history, index) end
 
 --- The result is the Number of the current entry in {history}.
---- See |hist-names| for the possible values of {history}.
+--- See `|hist-names|` for the possible values of {history}.
 --- If an error occurred, -1 is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let inp_index = histnr("expr")
+--- ```
 ---
 --- @param history any
 --- @return integer
@@ -4067,9 +4462,10 @@ function vim.fn.histnr(history) end
 --- zero is returned.
 --- This can be used to retrieve information about the highlight
 --- group.  For example, to get the background color of the
---- "Comment" group: >vim
+--- "Comment" group:
+--- ```vim
 ---   echo synIDattr(synIDtrans(hlID("Comment")), "bg")
---- <
+--- ```
 ---
 --- @param name string
 --- @return integer
@@ -4080,6 +4476,7 @@ function vim.fn.hlID(name) end
 --- defined in some way.  Not necessarily when highlighting has
 --- been defined for it, it may also have been used for a syntax
 --- item.
+---
 ---
 --- @param name string
 --- @return 0|1
@@ -4103,14 +4500,15 @@ function vim.fn.hostname() end
 --- from/to UCS-2 is automatically changed to use UTF-8.  You
 --- cannot use UCS-2 in a string anyway, because of the NUL bytes.
 ---
+---
 --- @param string string
 --- @param from any
 --- @param to any
 --- @return any
 function vim.fn.iconv(string, from, to) end
 
---- Returns a |String| which is a unique identifier of the
---- container type (|List|, |Dict|, |Blob| and |Partial|). It is
+--- Returns a `|String|` which is a unique identifier of the
+--- container type (`|List|`, `|Dict|`, `|Blob|` and `|Partial|`). It is
 --- guaranteed that for the mentioned types `id(v1) ==# id(v2)`
 --- returns true iff `type(v1) == type(v2) && v1 is v2`.
 --- Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
@@ -4132,38 +4530,41 @@ function vim.fn.id(expr) end
 --- The result is a Number, which is indent of line {lnum} in the
 --- current buffer.  The indent is counted in spaces, the value
 --- of 'tabstop' is relevant.  {lnum} is used just like in
---- |getline()|.
+--- `|getline()|`.
 --- When {lnum} is invalid -1 is returned.
+---
 ---
 --- @param lnum integer
 --- @return integer
 function vim.fn.indent(lnum) end
 
 --- Find {expr} in {object} and return its index.  See
---- |indexof()| for using a lambda to select the item.
+--- `|indexof()|` for using a lambda to select the item.
 ---
---- If {object} is a |List| return the lowest index where the item
+--- If {object} is a `|List|` return the lowest index where the item
 --- has a value equal to {expr}.  There is no automatic
 --- conversion, so the String "4" is different from the Number 4.
 --- And the Number 4 is different from the Float 4.0.  The value
 --- of 'ignorecase' is not used here, case matters as indicated by
 --- the {ic} argument.
 ---
---- If {object} is a |Blob| return the lowest index where the byte
+--- If {object} is a `|Blob|` return the lowest index where the byte
 --- value is equal to {expr}.
 ---
 --- If {start} is given then start looking at the item with index
 --- {start} (may be negative for an item relative to the end).
 ---
---- When {ic} is given and it is |TRUE|, ignore case.  Otherwise
+--- When {ic} is given and it is `|TRUE|`, ignore case.  Otherwise
 --- case must match.
 ---
 --- -1 is returned when {expr} is not found in {object}.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let idx = index(words, "the")
 ---   if index(numbers, 123) >= 0
 ---     " ...
 ---   endif
+--- ```
 ---
 --- @param object any
 --- @param expr any
@@ -4173,28 +4574,28 @@ function vim.fn.indent(lnum) end
 function vim.fn.index(object, expr, start, ic) end
 
 --- Returns the index of an item in {object} where {expr} is
---- v:true.  {object} must be a |List| or a |Blob|.
+--- v:true.  {object} must be a `|List|` or a `|Blob|`.
 ---
---- If {object} is a |List|, evaluate {expr} for each item in the
+--- If {object} is a `|List|`, evaluate {expr} for each item in the
 --- List until the expression is v:true and return the index of
 --- this item.
 ---
---- If {object} is a |Blob| evaluate {expr} for each byte in the
+--- If {object} is a `|Blob|` evaluate {expr} for each byte in the
 --- Blob until the expression is v:true and return the index of
 --- this byte.
 ---
---- {expr} must be a |string| or |Funcref|.
+--- {expr} must be a `|string|` or `|Funcref|`.
 ---
---- If {expr} is a |string|: If {object} is a |List|, inside
---- {expr} |v:key| has the index of the current List item and
---- |v:val| has the value of the item.  If {object} is a |Blob|,
---- inside {expr} |v:key| has the index of the current byte and
---- |v:val| has the byte value.
+--- If {expr} is a `|string|`: If {object} is a `|List|`, inside
+--- {expr} `|v:key|` has the index of the current List item and
+--- `|v:val|` has the value of the item.  If {object} is a `|Blob|`,
+--- inside {expr} `|v:key|` has the index of the current byte and
+--- `|v:val|` has the byte value.
 ---
---- If {expr} is a |Funcref| it must take two arguments:
+--- If {expr} is a `|Funcref|` it must take two arguments:
 ---   1. the key or the index of the current item.
 ---   2. the value of the current item.
---- The function must return |TRUE| if the item is found and the
+--- The function must return `|TRUE|` if the item is found and the
 --- search should stop.
 ---
 --- The optional argument {opts} is a Dict and supports the
@@ -4203,11 +4604,13 @@ function vim.fn.index(object, expr, start, ic) end
 ---     index; may be negative for an item relative to
 ---     the end
 --- Returns -1 when {expr} evaluates to v:false for all the items.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let l = [#{n: 10}, #{n: 20}, #{n: 30}]
 ---   echo indexof(l, "v:val.n == 20")
 ---   echo indexof(l, {i, v -> v.n == 30})
 ---   echo indexof(l, "v:val.n == 20", #{startidx: 1})
+--- ```
 ---
 --- @param object any
 --- @param expr any
@@ -4236,31 +4639,34 @@ function vim.fn.input(prompt, text, completion) end
 --- completion    nothing  Same as {completion} in the first form.
 --- cancelreturn  ""       The value returned when the dialog is
 ---                        cancelled.
---- highlight     nothing  Highlight handler: |Funcref|.
+--- highlight     nothing  Highlight handler: `|Funcref|`.
 ---
---- The highlighting set with |:echohl| is used for the prompt.
+--- The highlighting set with `|:echohl|` is used for the prompt.
 --- The input is entered just like a command-line, with the same
 --- editing commands and mappings.  There is a separate history
 --- for lines typed for input().
---- Example: >vim
+--- Example:
+--- ```vim
 ---   if input("Coffee or beer? ") == "beer"
 ---     echo "Cheers!"
 ---   endif
---- <
+--- ```
 --- If the optional {text} argument is present and not empty, this
 --- is used for the default reply, as if the user typed this.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let color = input("Color? ", "white")
----
---- <The optional {completion} argument specifies the type of
+--- ```
+--- The optional {completion} argument specifies the type of
 --- completion supported for the input.  Without it completion is
 --- not performed.  The supported completion types are the same as
 --- that can be supplied to a user-defined command using the
---- "-complete=" argument.  Refer to |:command-completion| for
---- more information.  Example: >vim
+--- "-complete=" argument.  Refer to `|:command-completion|` for
+--- more information.  Example:
+--- ```vim
 ---   let fname = input("File: ", "", "file")
----
---- <      *input()-highlight* *E5400* *E5402*
+--- ```
+--- *input()-highlight* *E5400* *E5402*
 --- The optional `highlight` key allows specifying function which
 --- will be used for highlighting user input.  This function
 --- receives user input as its only argument and must return
@@ -4268,7 +4674,7 @@ function vim.fn.input(prompt, text, completion) end
 --- where
 ---   hl_start_col is the first highlighted column,
 ---   hl_end_col is the last highlighted column (+ 1!),
----   hl_group is |:hi| group used for highlighting.
+---   hl_group is `|:hi|` group used for highlighting.
 ---             *E5403* *E5404* *E5405* *E5406*
 --- Both hl_start_col and hl_end_col + 1 must point to the start
 --- of the multibyte character (highlighting must not break
@@ -4278,7 +4684,8 @@ function vim.fn.input(prompt, text, completion) end
 --- sections must be ordered so that next hl_start_col is greater
 --- then or equal to previous hl_end_col.
 ---
---- Example (try some input with parentheses): >vim
+--- Example (try some input with parentheses):
+--- ```vim
 ---   highlight RBP1 guibg=Red ctermbg=red
 ---   highlight RBP2 guibg=Yellow ctermbg=yellow
 ---   highlight RBP3 guibg=Green ctermbg=green
@@ -4301,12 +4708,12 @@ function vim.fn.input(prompt, text, completion) end
 ---     return ret
 ---   endfunction
 ---   call input({'prompt':'>','highlight':'RainbowParens'})
---- <
+--- ```
 --- Highlight function is called at least once for each new
 --- displayed input string, before command-line is redrawn.  It is
 --- expected that function is pure for the duration of one input()
 --- call, i.e. it produces the same output for the same input, so
---- output may be memoized.  Function is run like under |:silent|
+--- output may be memoized.  Function is run like under `|:silent|`
 --- modifier. If the function causes any errors, it will be
 --- skipped for the duration of the current input() call.
 ---
@@ -4318,31 +4725,33 @@ function vim.fn.input(prompt, text, completion) end
 --- Note: When input() is called from within a mapping it will
 --- consume remaining characters from that mapping, because a
 --- mapping is handled like the characters were typed.
---- Use |inputsave()| before input() and |inputrestore()|
+--- Use `|inputsave()|` before input() and `|inputrestore()|`
 --- after input() to avoid that.  Another solution is to avoid
 --- that further characters follow in the mapping, e.g., by using
---- |:execute| or |:normal|.
+--- `|:execute|` or `|:normal|`.
 ---
---- Example with a mapping: >vim
+--- Example with a mapping:
+--- ```vim
 ---   nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
 ---   function GetFoo()
 ---     call inputsave()
 ---     let g:Foo = input("enter search pattern: ")
 ---     call inputrestore()
 ---   endfunction
+--- ```
 ---
 --- @param opts table
 --- @return any
 function vim.fn.input(opts) end
 
 --- @deprecated
---- Use |input()| instead.
+--- Use `|input()|` instead.
 ---
 --- @param ... any
 --- @return any
 function vim.fn.inputdialog(...) end
 
---- {textlist} must be a |List| of strings.  This |List| is
+--- {textlist} must be a `|List|` of strings.  This `|List|` is
 --- displayed, one string per line.  The user will be prompted to
 --- enter a number, which is returned.
 --- The user can also select an item by clicking on it with the
@@ -4354,15 +4763,17 @@ function vim.fn.inputdialog(...) end
 --- Make sure {textlist} has less than 'lines' entries, otherwise
 --- it won't work.  It's a good idea to put the entry number at
 --- the start of the string.  And put a prompt in the first item.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let color = inputlist(['Select color:', '1. red',
 ---     \ '2. green', '3. blue'])
+--- ```
 ---
 --- @param textlist any
 --- @return any
 function vim.fn.inputlist(textlist) end
 
---- Restore typeahead that was saved with a previous |inputsave()|.
+--- Restore typeahead that was saved with a previous `|inputsave()|`.
 --- Should be called the same number of times inputsave() is
 --- called.  Calling it more often is harmless though.
 --- Returns TRUE when there is nothing to restore, FALSE otherwise.
@@ -4380,36 +4791,40 @@ function vim.fn.inputrestore() end
 --- @return any
 function vim.fn.inputsave() end
 
---- This function acts much like the |input()| function with but
+--- This function acts much like the `|input()|` function with but
 --- two exceptions:
 --- a) the user's response will be displayed as a sequence of
 --- asterisks ("*") thereby keeping the entry secret, and
 --- b) the user's response will not be recorded on the input
---- |history| stack.
+--- `|history|` stack.
 --- The result is a String, which is whatever the user actually
 --- typed on the command-line in response to the issued prompt.
 --- NOTE: Command-line completion is not supported.
+---
 ---
 --- @param prompt any
 --- @param text? any
 --- @return any
 function vim.fn.inputsecret(prompt, text) end
 
---- When {object} is a |List| or a |Blob| insert {item} at the start
+--- When {object} is a `|List|` or a `|Blob|` insert {item} at the start
 --- of it.
 ---
 --- If {idx} is specified insert {item} before the item with index
 --- {idx}.  If {idx} is zero it goes before the first item, just
 --- like omitting {idx}.  A negative {idx} is also possible, see
---- |list-index|.  -1 inserts just before the last item.
+--- `|list-index|`.  -1 inserts just before the last item.
 ---
---- Returns the resulting |List| or |Blob|.  Examples: >vim
+--- Returns the resulting `|List|` or `|Blob|`.  Examples:
+--- ```vim
 ---   let mylist = insert([2, 3, 5], 1)
 ---   call insert(mylist, 4, -1)
 ---   call insert(mylist, 6, len(mylist))
---- <The last example can be done simpler with |add()|.
---- Note that when {item} is a |List| it is inserted as a single
---- item.  Use |extend()| to concatenate |Lists|.
+--- ```
+--- The last example can be done simpler with `|add()|`.
+--- Note that when {item} is a `|List|` it is inserted as a single
+--- item.  Use `|extend()|` to concatenate `|Lists|`.
+---
 ---
 --- @param object any
 --- @param item any
@@ -4420,7 +4835,8 @@ function vim.fn.insert(object, item, idx) end
 --- Interrupt script execution.  It works more or less like the
 --- user typing CTRL-C, most commands won't execute and control
 --- returns to the user.  This is useful to abort execution
---- from lower down, e.g. in an autocommand.  Example: >vim
+--- from lower down, e.g. in an autocommand.  Example:
+--- ```vim
 --- function s:check_typoname(file)
 ---    if fnamemodify(a:file, ':t') == '['
 ---        echomsg 'Maybe typo'
@@ -4428,92 +4844,106 @@ function vim.fn.insert(object, item, idx) end
 ---    endif
 --- endfunction
 --- au BufWritePre * call s:check_typoname(expand('<amatch>'))
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.interrupt() end
 
 --- Bitwise invert.  The argument is converted to a number.  A
---- List, Dict or Float argument causes an error.  Example: >vim
+--- List, Dict or Float argument causes an error.  Example:
+--- ```vim
 ---   let bits = invert(bits)
---- <
+--- ```
 ---
 --- @param expr any
 --- @return any
 function vim.fn.invert(expr) end
 
---- The result is a Number, which is |TRUE| when a directory
+--- The result is a Number, which is `|TRUE|` when a directory
 --- with the name {directory} exists.  If {directory} doesn't
---- exist, or isn't a directory, the result is |FALSE|.  {directory}
+--- exist, or isn't a directory, the result is `|FALSE|`.  {directory}
 --- is any expression, which is used as a String.
+---
 ---
 --- @param directory any
 --- @return 0|1
 function vim.fn.isdirectory(directory) end
 
 --- Return 1 if {expr} is a positive infinity, or -1 a negative
---- infinity, otherwise 0. >vim
+--- infinity, otherwise 0.
+--- ```vim
 ---   echo isinf(1.0 / 0.0)
---- <  1 >vim
+--- ```
+--- 1
+--- ```vim
 ---   echo isinf(-1.0 / 0.0)
---- <  -1
+--- ```
+--- -1
+---
 ---
 --- @param expr any
 --- @return 1|0|-1
 function vim.fn.isinf(expr) end
 
---- The result is a Number, which is |TRUE| when {expr} is the
+--- The result is a Number, which is `|TRUE|` when {expr} is the
 --- name of a locked variable.
 --- The string argument {expr} must be the name of a variable,
---- |List| item or |Dictionary| entry, not the variable itself!
---- Example: >vim
+--- `|List|` item or `|Dictionary|` entry, not the variable itself!
+--- Example:
+--- ```vim
 ---   let alist = [0, ['a', 'b'], 2, 3]
 ---   lockvar 1 alist
 ---   echo islocked('alist')    " 1
 ---   echo islocked('alist[1]')  " 0
+--- ```
+--- When {expr} is a variable that does not exist you get an error
+--- message.  Use `|exists()|` to check for existence.
 ---
---- <When {expr} is a variable that does not exist you get an error
---- message.  Use |exists()| to check for existence.
 ---
 --- @param expr any
 --- @return 0|1
 function vim.fn.islocked(expr) end
 
---- Return |TRUE| if {expr} is a float with value NaN. >vim
+--- Return `|TRUE|` if {expr} is a float with value NaN.
+--- ```vim
 ---   echo isnan(0.0 / 0.0)
---- <  1
+--- ```
+--- 1
+---
 ---
 --- @param expr any
 --- @return 0|1
 function vim.fn.isnan(expr) end
 
---- Return a |List| with all the key-value pairs of {dict}.  Each
---- |List| item is a list with two items: the key of a {dict}
---- entry and the value of this entry.  The |List| is in arbitrary
---- order.  Also see |keys()| and |values()|.
---- Example: >vim
+--- Return a `|List|` with all the key-value pairs of {dict}.  Each
+--- `|List|` item is a list with two items: the key of a {dict}
+--- entry and the value of this entry.  The `|List|` is in arbitrary
+--- order.  Also see `|keys()|` and `|values()|`.
+--- Example:
+--- ```vim
 ---   for [key, value] in items(mydict)
 ---      echo key .. ': ' .. value
 ---   endfor
+--- ```
 ---
 --- @param dict any
 --- @return any
 function vim.fn.items(dict) end
 
 --- @deprecated
---- Obsolete name for |chanclose()|
+--- Obsolete name for `|chanclose()|`
 ---
 --- @param ... any
 --- @return any
 function vim.fn.jobclose(...) end
 
---- Return the PID (process id) of |job-id| {job}.
+--- Return the PID (process id) of `|job-id|` {job}.
 ---
 --- @param job any
 --- @return integer
 function vim.fn.jobpid(job) end
 
---- Resize the pseudo terminal window of |job-id| {job} to {width}
+--- Resize the pseudo terminal window of `|job-id|` {job} to {width}
 --- columns and {height} rows.
 --- Fails if the job was not started with `"pty":v:true`.
 ---
@@ -4524,45 +4954,52 @@ function vim.fn.jobpid(job) end
 function vim.fn.jobresize(job, width, height) end
 
 --- @deprecated
---- Obsolete name for |chansend()|
+--- Obsolete name for `|chansend()|`
 ---
 --- @param ... any
 --- @return any
 function vim.fn.jobsend(...) end
 
---- Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
+--- Note: Prefer `|vim.system()|` in Lua (unless using the `pty` option).
 ---
 --- Spawns {cmd} as a job.
 --- If {cmd} is a List it runs directly (no 'shell').
---- If {cmd} is a String it runs in the 'shell', like this: >vim
+--- If {cmd} is a String it runs in the 'shell', like this:
+--- ```vim
 ---   call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
---- <(See |shell-unquoting| for details.)
+--- ```
+--- (See `|shell-unquoting|` for details.)
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
---- <
---- Returns |job-id| on success, 0 on invalid arguments (or job
+--- ```
+--- Returns `|job-id|` on success, 0 on invalid arguments (or job
 --- table is full), -1 if {cmd}[0] or 'shell' is not executable.
---- The returned job-id is a valid |channel-id| representing the
---- job's stdio streams. Use |chansend()| (or |rpcnotify()| and
---- |rpcrequest()| if "rpc" was enabled) to send data to stdin and
---- |chanclose()| to close the streams without stopping the job.
+--- The returned job-id is a valid `|channel-id|` representing the
+--- job's stdio streams. Use `|chansend()|` (or `|rpcnotify()|` and
+--- `|rpcrequest()|` if "rpc" was enabled) to send data to stdin and
+--- `|chanclose()|` to close the streams without stopping the job.
 ---
---- See |job-control| and |RPC|.
+--- See `|job-control|` and `|RPC|`.
 ---
 --- NOTE: on Windows if {cmd} is a List:
 ---   - cmd[0] must be an executable (not a "built-in"). If it is
----     in $PATH it can be called by name, without an extension: >vim
+---     in $PATH it can be called by name, without an extension:
+--- ```vim
 ---       call jobstart(['ping', 'neovim.io'])
---- <    If it is a full or partial path, extension is required: >vim
+--- ```
+--- If it is a full or partial path, extension is required:
+--- ```vim
 ---       call jobstart(['System32\ping.exe', 'neovim.io'])
---- <  - {cmd} is collapsed to a string of quoted args as expected
+--- ```
+--- - {cmd} is collapsed to a string of quoted args as expected
 ---     by CommandLineToArgvW https://msdn.microsoft.com/bb776391
 ---     unless cmd[0] is some form of "cmd.exe".
 ---
 ---           *jobstart-env*
 --- The job environment is initialized as follows:
----   $NVIM                is set to |v:servername| of the parent Nvim
+---   $NVIM                is set to `|v:servername|` of the parent Nvim
 ---   $NVIM_LISTEN_ADDRESS is unset
 ---   $NVIM_LOG_FILE       is unset
 ---   $VIM                 is unset
@@ -4573,19 +5010,19 @@ function vim.fn.jobsend(...) end
 --- {opts} is a dictionary with these keys:
 ---   clear_env:  (boolean) `env` defines the job environment
 ---         exactly, instead of merging current environment.
----   cwd:        (string, default=|current-directory|) Working
+---   cwd:        (string, default=`|current-directory|`) Working
 ---         directory of the job.
 ---   detach:     (boolean) Detach the job process: it will not be
 ---         killed when Nvim exits. If the process exits
 ---         before Nvim, `on_exit` will be invoked.
 ---   env:        (dict) Map of environment variable name:value
 ---         pairs extending (or replace with "clear_env")
----         the current environment. |jobstart-env|
+---         the current environment. `|jobstart-env|`
 ---   height:     (number) Height of the `pty` terminal.
----   |on_exit|:    (function) Callback invoked when the job exits.
----   |on_stdout|:  (function) Callback invoked when the job emits
+---   `|on_exit|`:    (function) Callback invoked when the job exits.
+---   `|on_stdout|`:  (function) Callback invoked when the job emits
 ---         stdout data.
----   |on_stderr|:  (function) Callback invoked when the job emits
+---   `|on_stderr|`:  (function) Callback invoked when the job emits
 ---         stderr data.
 ---   overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
 ---         stdio passed to the child process. Only on
@@ -4593,38 +5030,38 @@ function vim.fn.jobsend(...) end
 ---   pty:        (boolean) Connect the job to a new pseudo
 ---         terminal, and its streams to the master file
 ---         descriptor. `on_stdout` receives all output,
----         `on_stderr` is ignored. |terminal-start|
----   rpc:        (boolean) Use |msgpack-rpc| to communicate with
+---         `on_stderr` is ignored. `|terminal-start|`
+---   rpc:        (boolean) Use `|msgpack-rpc|` to communicate with
 ---         the job over stdio. Then `on_stdout` is ignored,
 ---         but `on_stderr` can still be used.
 ---   stderr_buffered: (boolean) Collect data until EOF (stream closed)
----         before invoking `on_stderr`. |channel-buffered|
+---         before invoking `on_stderr`. `|channel-buffered|`
 ---   stdout_buffered: (boolean) Collect data until EOF (stream
----         closed) before invoking `on_stdout`. |channel-buffered|
+---         closed) before invoking `on_stdout`. `|channel-buffered|`
 ---   stdin:      (string) Either "pipe" (default) to connect the
 ---         job's stdin to a channel or "null" to disconnect
 ---         stdin.
 ---   width:      (number) Width of the `pty` terminal.
 ---
---- {opts} is passed as |self| dictionary to the callback; the
+--- {opts} is passed as `|self|` dictionary to the callback; the
 --- caller may set other keys to pass application-specific data.
 ---
 --- Returns:
----   - |channel-id| on success
+---   - `|channel-id|` on success
 ---   - 0 on invalid arguments
 ---   - -1 if {cmd}[0] is not executable.
---- See also |job-control|, |channel|, |msgpack-rpc|.
+--- See also `|job-control|`, `|channel|`, `|msgpack-rpc|`.
 ---
 --- @param cmd any
 --- @param opts? table
 --- @return any
 function vim.fn.jobstart(cmd, opts) end
 
---- Stop |job-id| {id} by sending SIGTERM to the job process. If
+--- Stop `|job-id|` {id} by sending SIGTERM to the job process. If
 --- the process does not terminate after a timeout then SIGKILL
---- will be sent. When the job terminates its |on_exit| handler
+--- will be sent. When the job terminates its `|on_exit|` handler
 --- (if any) will be invoked.
---- See |job-control|.
+--- See `|job-control|`.
 ---
 --- Returns 1 for valid job id, 0 for invalid id, including jobs have
 --- exited or stopped.
@@ -4633,24 +5070,25 @@ function vim.fn.jobstart(cmd, opts) end
 --- @return any
 function vim.fn.jobstop(id) end
 
---- Waits for jobs and their |on_exit| handlers to complete.
+--- Waits for jobs and their `|on_exit|` handlers to complete.
 ---
---- {jobs} is a List of |job-id|s to wait for.
+--- {jobs} is a List of `|job-id|`s to wait for.
 --- {timeout} is the maximum waiting time in milliseconds. If
 --- omitted or -1, wait forever.
 ---
---- Timeout of 0 can be used to check the status of a job: >vim
+--- Timeout of 0 can be used to check the status of a job:
+--- ```vim
 ---   let running = jobwait([{job-id}], 0)[0] == -1
---- <
+--- ```
 --- During jobwait() callbacks for jobs not in the {jobs} list may
---- be invoked. The screen will not redraw unless |:redraw| is
+--- be invoked. The screen will not redraw unless `|:redraw|` is
 --- invoked by a callback.
 ---
 --- Returns a list of len({jobs}) integers, where each integer is
 --- the status of the corresponding job:
 ---   Exit-code, if the job exited
 ---   -1 if the timeout was exceeded
----   -2 if the job was interrupted (by |CTRL-C|)
+---   -2 if the job was interrupted (by `|CTRL-C|`)
 ---   -3 if the job-id is invalid
 ---
 --- @param jobs any
@@ -4662,21 +5100,24 @@ function vim.fn.jobwait(jobs, timeout) end
 --- When {sep} is specified it is put in between the items.  If
 --- {sep} is omitted a single space is used.
 --- Note that {sep} is not added at the end.  You might want to
---- add it there too: >vim
+--- add it there too:
+--- ```vim
 ---   let lines = join(mylist, "\n") .. "\n"
---- <String items are used as-is.  |Lists| and |Dictionaries| are
---- converted into a string like with |string()|.
---- The opposite function is |split()|.
+--- ```
+--- String items are used as-is.  `|Lists|` and `|Dictionaries|` are
+--- converted into a string like with `|string()|`.
+--- The opposite function is `|split()|`.
+---
 ---
 --- @param list any
 --- @param sep? any
 --- @return any
 function vim.fn.join(list, sep) end
 
---- Convert {expr} from JSON object.  Accepts |readfile()|-style
+--- Convert {expr} from JSON object.  Accepts `|readfile()|`-style
 --- list as the input, as well as regular string.  May output any
 --- Vim value. In the following cases it will output
---- |msgpack-special-dict|:
+--- `|msgpack-special-dict|`:
 --- 1. Dictionary contains duplicate key.
 --- 2. Dictionary contains empty key.
 --- 3. String contains NUL byte.  Two special dictionaries: for
@@ -4688,37 +5129,43 @@ function vim.fn.join(list, sep) end
 --- recommended and the only one required to be supported.
 --- Non-UTF-8 characters are an error.
 ---
+---
 --- @param expr any
 --- @return any
 function vim.fn.json_decode(expr) end
 
 --- Convert {expr} into a JSON string.  Accepts
---- |msgpack-special-dict| as the input.  Will not convert
---- |Funcref|s, mappings with non-string keys (can be created as
---- |msgpack-special-dict|), values with self-referencing
+--- `|msgpack-special-dict|` as the input.  Will not convert
+--- `|Funcref|`s, mappings with non-string keys (can be created as
+--- `|msgpack-special-dict|`), values with self-referencing
 --- containers, strings which contain non-UTF-8 characters,
 --- pseudo-UTF-8 strings which contain codepoints reserved for
 --- surrogate pairs (such strings are not valid UTF-8 strings).
 --- Non-printable characters are converted into "\u1234" escapes
 --- or special escapes like "\t", other are dumped as-is.
---- |Blob|s are converted to arrays of the individual bytes.
+--- `|Blob|`s are converted to arrays of the individual bytes.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.json_encode(expr) end
 
---- Return a |List| with all the keys of {dict}.  The |List| is in
---- arbitrary order.  Also see |items()| and |values()|.
+--- Return a `|List|` with all the keys of {dict}.  The `|List|` is in
+--- arbitrary order.  Also see `|items()|` and `|values()|`.
+---
 ---
 --- @param dict any
 --- @return any
 function vim.fn.keys(dict) end
 
 --- Turn the internal byte representation of keys into a form that
---- can be used for |:map|.  E.g. >vim
+--- can be used for `|:map|`.  E.g.
+--- ```vim
 ---   let xx = "\<C-Home>"
 ---   echo keytrans(xx)
---- <  <C-Home>
+--- ```
+--- <C-Home>
+---
 ---
 --- @param string string
 --- @return any
@@ -4732,13 +5179,14 @@ function vim.fn.last_buffer_nr() end
 
 --- The result is a Number, which is the length of the argument.
 --- When {expr} is a String or a Number the length in bytes is
---- used, as with |strlen()|.
---- When {expr} is a |List| the number of items in the |List| is
+--- used, as with `|strlen()|`.
+--- When {expr} is a `|List|` the number of items in the `|List|` is
 --- returned.
---- When {expr} is a |Blob| the number of bytes is returned.
---- When {expr} is a |Dictionary| the number of entries in the
---- |Dictionary| is returned.
+--- When {expr} is a `|Blob|` the number of bytes is returned.
+--- When {expr} is a `|Dictionary|` the number of entries in the
+--- `|Dictionary|` is returned.
 --- Otherwise an error is given and returns zero.
+---
 ---
 --- @param expr any
 --- @return any
@@ -4782,8 +5230,10 @@ function vim.fn.len(expr) end
 --- the DLL is not in the usual places.
 --- For Unix: When compiling your own plugins, remember that the
 --- object code must be compiled as position-independent ('PIC').
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo libcall("libc.so", "getenv", "HOME")
+--- ```
 ---
 --- @param libname string
 --- @param funcname string
@@ -4791,13 +5241,14 @@ function vim.fn.len(expr) end
 --- @return any
 function vim.fn.libcall(libname, funcname, argument) end
 
---- Just like |libcall()|, but used for a function that returns an
+--- Just like `|libcall()|`, but used for a function that returns an
 --- int instead of a string.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo libcallnr("/usr/lib/libc.so", "getpid", "")
 ---   call libcallnr("libc.so", "printf", "Hello World!\n")
 ---   call libcallnr("libc.so", "sleep", 10)
---- <
+--- ```
 ---
 --- @param libname string
 --- @param funcname string
@@ -4818,23 +5269,25 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 ---       less than "w0" if no lines are visible)
 ---     v      In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
+---       returns the cursor position.  Differs from `|'<|` in
 ---       that it's updated right away.
 --- Note that a mark in another file can be used.  The line number
 --- then applies to another buffer.
---- To get the column number use |col()|.  To get both use
---- |getpos()|.
+--- To get the column number use `|col()|`.  To get both use
+--- `|getpos()|`.
 --- With the optional {winid} argument the values are obtained for
 --- that window instead of the current window.
 --- Returns 0 for invalid values of {expr} and {winid}.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo line(".")      " line number of the cursor
 ---   echo line(".", winid)    " idem, in window "winid"
 ---   echo line("'t")      " line number of mark t
 ---   echo line("'" .. marker)  " line number of mark marker
---- <
+--- ```
 --- To jump to the last known position when opening a file see
---- |last-position-jump|.
+--- `|last-position-jump|`.
+---
 ---
 --- @param expr any
 --- @param winid? integer
@@ -4846,12 +5299,15 @@ function vim.fn.line(expr, winid) end
 --- the 'fileformat' option for the current buffer.  The first
 --- line returns 1. UTF-8 encoding is used, 'fileencoding' is
 --- ignored.  This can also be used to get the byte count for the
---- line just below the last line: >vim
+--- line just below the last line:
+--- ```vim
 ---   echo line2byte(line("$") + 1)
---- <This is the buffer size plus one.  If 'fileencoding' is empty
+--- ```
+--- This is the buffer size plus one.  If 'fileencoding' is empty
 --- it is the file size plus one.  {lnum} is used like with
---- |getline()|.  When {lnum} is invalid -1 is returned.
---- Also see |byte2line()|, |go| and |:goto|.
+--- `|getline()|`.  When {lnum} is invalid -1 is returned.
+--- Also see `|byte2line()|`, `|go|` and `|:goto|`.
+---
 ---
 --- @param lnum integer
 --- @return integer
@@ -4860,40 +5316,50 @@ function vim.fn.line2byte(lnum) end
 --- Get the amount of indent for line {lnum} according the lisp
 --- indenting rules, as with 'lisp'.
 --- The indent is counted in spaces, the value of 'tabstop' is
---- relevant.  {lnum} is used just like in |getline()|.
+--- relevant.  {lnum} is used just like in `|getline()|`.
 --- When {lnum} is invalid, -1 is returned.
+---
 ---
 --- @param lnum integer
 --- @return any
 function vim.fn.lispindent(lnum) end
 
 --- Return a Blob concatenating all the number values in {list}.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo list2blob([1, 2, 3, 4])  " returns 0z01020304
 ---   echo list2blob([])    " returns 0z
---- <Returns an empty Blob on error.  If one of the numbers is
+--- ```
+--- Returns an empty Blob on error.  If one of the numbers is
 --- negative or more than 255 error *E1239* is given.
 ---
---- |blob2list()| does the opposite.
+--- `|blob2list()|` does the opposite.
+---
 ---
 --- @param list any
 --- @return any
 function vim.fn.list2blob(list) end
 
 --- Convert each number in {list} to a character string can
---- concatenate them all.  Examples: >vim
+--- concatenate them all.  Examples:
+--- ```vim
 ---   echo list2str([32])    " returns " "
 ---   echo list2str([65, 66, 67])  " returns "ABC"
---- <The same can be done (slowly) with: >vim
+--- ```
+--- The same can be done (slowly) with:
+--- ```vim
 ---   echo join(map(list, {nr, val -> nr2char(val)}), '')
---- <|str2list()| does the opposite.
+--- ```
+--- `|str2list()|` does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
---- With UTF-8 composing characters work as expected: >vim
+--- With UTF-8 composing characters work as expected:
+--- ```vim
 ---   echo list2str([97, 769])  " returns "á"
---- <
+--- ```
 --- Returns an empty string on error.
+---
 ---
 --- @param list any
 --- @param utf8? any
@@ -4901,90 +5367,111 @@ function vim.fn.list2blob(list) end
 function vim.fn.list2str(list, utf8) end
 
 --- Return the current time, measured as seconds since 1st Jan
---- 1970.  See also |strftime()|, |strptime()| and |getftime()|.
+--- 1970.  See also `|strftime()|`, `|strptime()|` and `|getftime()|`.
 ---
 --- @return any
 function vim.fn.localtime() end
 
---- Return the natural logarithm (base e) of {expr} as a |Float|.
---- {expr} must evaluate to a |Float| or a |Number| in the range
+--- Return the natural logarithm (base e) of {expr} as a `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
 --- (0, inf].
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo log(10)
---- <  2.302585 >vim
+--- ```
+--- 2.302585
+--- ```vim
 ---   echo log(exp(5))
---- <  5.0
+--- ```
+--- 5.0
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.log(expr) end
 
---- Return the logarithm of Float {expr} to base 10 as a |Float|.
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- Return the logarithm of Float {expr} to base 10 as a `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo log10(1000)
---- <  3.0 >vim
+--- ```
+--- 3.0
+--- ```vim
 ---   echo log10(0.01)
---- <  -2.0
+--- ```
+--- -2.0
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.log10(expr) end
 
---- {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
---- When {expr1} is a |List|| or |Dictionary|, replace each
+--- {expr1} must be a `|List|`, `|String|`, `|Blob|` or `|Dictionary|`.
+--- When {expr1} is a `|List||` or `|Dictionary|`, replace each
 --- item in {expr1} with the result of evaluating {expr2}.
---- For a |Blob| each byte is replaced.
---- For a |String|, each character, including composing
+--- For a `|Blob|` each byte is replaced.
+--- For a `|String|`, each character, including composing
 --- characters, is replaced.
---- If the item type changes you may want to use |mapnew()| to
+--- If the item type changes you may want to use `|mapnew()|` to
 --- create a new List or Dictionary.
 ---
---- {expr2} must be a |String| or |Funcref|.
+--- {expr2} must be a `|String|` or `|Funcref|`.
 ---
---- If {expr2} is a |String|, inside {expr2} |v:val| has the value
---- of the current item.  For a |Dictionary| |v:key| has the key
---- of the current item and for a |List| |v:key| has the index of
---- the current item.  For a |Blob| |v:key| has the index of the
---- current byte. For a |String| |v:key| has the index of the
+--- If {expr2} is a `|String|`, inside {expr2} `|v:val|` has the value
+--- of the current item.  For a `|Dictionary|` `|v:key|` has the key
+--- of the current item and for a `|List|` `|v:key|` has the index of
+--- the current item.  For a `|Blob|` `|v:key|` has the index of the
+--- current byte. For a `|String|` `|v:key|` has the index of the
 --- current character.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call map(mylist, '"> " .. v:val .. " <"')
---- <This puts "> " before and " <" after each item in "mylist".
+--- ```
+--- This puts "> " before and " <" after each item in "mylist".
 ---
 --- Note that {expr2} is the result of an expression and is then
 --- used as an expression again.  Often it is good to use a
---- |literal-string| to avoid having to double backslashes.  You
+--- `|literal-string|` to avoid having to double backslashes.  You
 --- still have to double ' quotes
 ---
---- If {expr2} is a |Funcref| it is called with two arguments:
+--- If {expr2} is a `|Funcref|` it is called with two arguments:
 ---   1. The key or the index of the current item.
 ---   2. the value of the current item.
 --- The function must return the new value of the item. Example
---- that changes each value by "key-value": >vim
+--- that changes each value by "key-value":
+--- ```vim
 ---   func KeyValue(key, val)
 ---     return a:key .. '-' .. a:val
 ---   endfunc
 ---   call map(myDict, function('KeyValue'))
---- <It is shorter when using a |lambda|: >vim
+--- ```
+--- It is shorter when using a `|lambda|`:
+--- ```vim
 ---   call map(myDict, {key, val -> key .. '-' .. val})
---- <If you do not use "val" you can leave it out: >vim
+--- ```
+--- If you do not use "val" you can leave it out:
+--- ```vim
 ---   call map(myDict, {key -> 'item: ' .. key})
---- <If you do not use "key" you can use a short name: >vim
+--- ```
+--- If you do not use "key" you can use a short name:
+--- ```vim
 ---   call map(myDict, {_, val -> 'item: ' .. val})
---- <
---- The operation is done in-place for a |List| and |Dictionary|.
---- If you want it to remain unmodified make a copy first: >vim
+--- ```
+--- The operation is done in-place for a `|List|` and `|Dictionary|`.
+--- If you want it to remain unmodified make a copy first:
+--- ```vim
 ---   let tlist = map(copy(mylist), ' v:val .. "\t"')
----
---- <Returns {expr1}, the |List| or |Dictionary| that was filtered,
---- or a new |Blob| or |String|.
+--- ```
+--- Returns {expr1}, the `|List|` or `|Dictionary|` that was filtered,
+--- or a new `|Blob|` or `|String|`.
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
 --- When {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
+---
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -5012,15 +5499,15 @@ function vim.fn.map(expr1, expr2) end
 ---   "c"  Cmd-line
 ---   "s"  Select
 ---   "x"  Visual
----   "l"  langmap |language-mapping|
+---   "l"  langmap `|language-mapping|`
 ---   "t"  Terminal
 ---   ""  Normal, Visual and Operator-pending
 --- When {mode} is omitted, the modes for "" are used.
 ---
---- When {abbr} is there and it is |TRUE| use abbreviations
+--- When {abbr} is there and it is `|TRUE|` use abbreviations
 --- instead of mappings.
 ---
---- When {dict} is there and it is |TRUE| return a dictionary
+--- When {dict} is there and it is `|TRUE|` return a dictionary
 --- containing all the information of the mapping with the
 --- following items:
 ---   "lhs"       The {lhs} of the mapping as it would be typed
@@ -5028,31 +5515,33 @@ function vim.fn.map(expr1, expr2) end
 ---   "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
 ---         form, only present when it differs from "lhsraw"
 ---   "rhs"       The {rhs} of the mapping as typed.
----   "silent"   1 for a |:map-silent| mapping, else 0.
+---   "silent"   1 for a `|:map-silent|` mapping, else 0.
 ---   "noremap"  1 if the {rhs} of the mapping is not remappable.
 ---   "script"   1 if mapping was defined with <script>.
----   "expr"     1 for an expression mapping (|:map-<expr>|).
----   "buffer"   1 for a buffer local mapping (|:map-local|).
+---   "expr"     1 for an expression mapping (`|:map-<expr>|`).
+---   "buffer"   1 for a buffer local mapping (`|:map-local|`).
 ---   "mode"     Modes for which the mapping is defined. In
 ---        addition to the modes mentioned above, these
 ---        characters will be used:
 ---        " "     Normal, Visual and Operator-pending
 ---        "!"     Insert and Commandline mode
----          (|mapmode-ic|)
+---          (`|mapmode-ic|`)
 ---   "sid"       The script local ID, used for <sid> mappings
----        (|<SID>|).  Negative for special contexts.
+---        (`|<SID>|`).  Negative for special contexts.
 ---   "lnum"     The line number in "sid", zero if unknown.
 ---   "nowait"   Do not wait for other, longer mappings.
----        (|:map-<nowait>|).
+---        (`|:map-<nowait>|`).
 ---
 --- The dictionary can be used to restore a mapping with
---- |mapset()|.
+--- `|mapset()|`.
 ---
 --- The mappings local to the current buffer are checked first,
 --- then the global mappings.
 --- This function can be used to map a key even when it's already
---- mapped, and have it do the original mapping too.  Sketch: >vim
+--- mapped, and have it do the original mapping too.  Sketch:
+--- ```vim
 ---   exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+--- ```
 ---
 --- @param name string
 --- @param mode? string
@@ -5062,7 +5551,7 @@ function vim.fn.map(expr1, expr2) end
 function vim.fn.maparg(name, mode, abbr, dict) end
 
 --- Check if there is a mapping that matches with {name} in mode
---- {mode}.  See |maparg()| for {mode} and special names in
+--- {mode}.  See `|maparg()|` for {mode} and special names in
 --- {name}.
 --- When {abbr} is there and it is non-zero use abbreviations
 --- instead of mappings.
@@ -5086,12 +5575,15 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 --- The mappings local to the current buffer are checked first,
 --- then the global mappings.
 --- This function can be used to check if a mapping can be added
---- without being ambiguous.  Example: >vim
+--- without being ambiguous.  Example:
+--- ```vim
 ---   if mapcheck("_vv") == ""
 ---      map _vv :set guifont=7x13<CR>
 ---   endif
---- <This avoids adding the "_vv" mapping when there already is a
+--- ```
+--- This avoids adding the "_vv" mapping when there already is a
 --- mapping for "_v" or for "_vvv".
+---
 ---
 --- @param name string
 --- @param mode? string
@@ -5099,27 +5591,29 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 --- @return any
 function vim.fn.mapcheck(name, mode, abbr) end
 
---- Like |map()| but instead of replacing items in {expr1} a new
+--- Like `|map()|` but instead of replacing items in {expr1} a new
 --- List or Dictionary is created and returned.  {expr1} remains
 --- unchanged.  Items can still be changed by {expr2}, if you
---- don't want that use |deepcopy()| first.
+--- don't want that use `|deepcopy()|` first.
 ---
 --- @param expr1 any
 --- @param expr2 any
 --- @return any
 function vim.fn.mapnew(expr1, expr2) end
 
---- Restore a mapping from a dictionary returned by |maparg()|.
+--- Restore a mapping from a dictionary returned by `|maparg()|`.
 --- {mode} and {abbr} should be the same as for the call to
---- |maparg()|. *E460*
+--- `|maparg()|`. *E460*
 --- {mode} is used to define the mode in which the mapping is set,
 --- not the "mode" entry in {dict}.
---- Example for saving and restoring a mapping: >vim
+--- Example for saving and restoring a mapping:
+--- ```vim
 ---   let save_map = maparg('K', 'n', 0, 1)
 ---   nnoremap K somethingelse
 ---   " ...
 ---   call mapset('n', 0, save_map)
---- <Note that if you are going to replace a map in several modes,
+--- ```
+--- Note that if you are going to replace a map in several modes,
 --- e.g. with `:map!`, you need to save the mapping for all of
 --- them, since they can differ.
 ---
@@ -5129,40 +5623,51 @@ function vim.fn.mapnew(expr1, expr2) end
 --- @return any
 function vim.fn.mapset(mode, abbr, dict) end
 
---- When {expr} is a |List| then this returns the index of the
+--- When {expr} is a `|List|` then this returns the index of the
 --- first item where {pat} matches.  Each item is used as a
---- String, |Lists| and |Dictionaries| are used as echoed.
+--- String, `|Lists|` and `|Dictionaries|` are used as echoed.
 ---
 --- Otherwise, {expr} is used as a String.  The result is a
 --- Number, which gives the index (byte offset) in {expr} where
 --- {pat} matches.
 ---
---- A match at the first character or |List| item returns zero.
+--- A match at the first character or `|List|` item returns zero.
 --- If there is no match -1 is returned.
 ---
---- For getting submatches see |matchlist()|.
---- Example: >vim
+--- For getting submatches see `|matchlist()|`.
+--- Example:
+--- ```vim
 ---   echo match("testing", "ing")  " results in 4
 ---   echo match([1, 'x'], '\a')  " results in 1
---- <See |string-match| for how {pat} is used.
+--- ```
+--- See `|string-match|` for how {pat} is used.
 ---             *strpbrk()*
---- Vim doesn't have a strpbrk() function.  But you can do: >vim
+--- Vim doesn't have a strpbrk() function.  But you can do:
+--- ```vim
 ---   let sepidx = match(line, '[.,;: \t]')
---- <            *strcasestr()*
+--- ```
+--- *strcasestr()*
 --- Vim doesn't have a strcasestr() function.  But you can add
---- "\c" to the pattern to ignore case: >vim
+--- "\c" to the pattern to ignore case:
+--- ```vim
 ---   let idx = match(haystack, '\cneedle')
---- <
+--- ```
 --- If {start} is given, the search starts from byte index
---- {start} in a String or item {start} in a |List|.
+--- {start} in a String or item {start} in a `|List|`.
 --- The result, however, is still the index counted from the
---- first character/item.  Example: >vim
+--- first character/item.  Example:
+--- ```vim
 ---   echo match("testing", "ing", 2)
---- <result is again "4". >vim
+--- ```
+--- result is again "4".
+--- ```vim
 ---   echo match("testing", "ing", 4)
---- <result is again "4". >vim
+--- ```
+--- result is again "4".
+--- ```vim
 ---   echo match("testing", "t", 2)
---- <result is "3".
+--- ```
+--- result is "3".
 --- For a String, if {start} > 0 then it is like the string starts
 --- {start} bytes later, thus "^" will match at {start}.  Except
 --- when {count} is given, then it's like matches before the
@@ -5171,17 +5676,19 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- For a String, if {start} < 0, it will be set to 0.  For a list
 --- the index is counted from the end.
 --- If {start} is out of range ({start} > strlen({expr}) for a
---- String or {start} > len({expr}) for a |List|) -1 is returned.
+--- String or {start} > len({expr}) for a `|List|`) -1 is returned.
 ---
 --- When {count} is given use the {count}th match.  When a match
 --- is found in a String the search for the next one starts one
---- character further.  Thus this example results in 1: >vim
+--- character further.  Thus this example results in 1:
+--- ```vim
 ---   echo match("testing", "..", 0, 2)
---- <In a |List| the search continues in the next item.
+--- ```
+--- In a `|List|` the search continues in the next item.
 --- Note that when {count} is added the way {start} works changes,
 --- see above.
 ---
---- See |pattern| for the patterns that are accepted.
+--- See `|pattern|` for the patterns that are accepted.
 --- The 'ignorecase' option is used to set the ignore-caseness of
 --- the pattern.  'smartcase' is NOT used.  The matching is always
 --- done like 'magic' is set and 'cpoptions' is empty.
@@ -5189,6 +5696,7 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- pattern is using "*" (any number of matches) it tends to find
 --- zero matches at the start instead of a number of matches
 --- further down in the text.
+---
 ---
 --- @param expr any
 --- @param pat any
@@ -5200,7 +5708,7 @@ function vim.fn.match(expr, pat, start, count) end
 --- Defines a pattern to be highlighted in the current window (a
 --- "match").  It will be highlighted with {group}.  Returns an
 --- identification number (ID), which can be used to delete the
---- match using |matchdelete()|.  The ID is bound to the window.
+--- match using `|matchdelete()|`.  The ID is bound to the window.
 --- Matching is case sensitive and magic, unless case sensitivity
 --- or magicness are explicitly overridden in {pattern}.  The
 --- 'magic', 'smartcase' and 'ignorecase' options are not used.
@@ -5222,37 +5730,41 @@ function vim.fn.match(expr, pat, start, count) end
 --- match ID.  If a specified ID is already taken, an error
 --- message will appear and the match will not be added.  An ID
 --- is specified as a positive integer (zero excluded).  IDs 1, 2
---- and 3 are reserved for |:match|, |:2match| and |:3match|,
---- respectively.  3 is reserved for use by the |matchparen|
+--- and 3 are reserved for `|:match|`, `|:2match|` and `|:3match|`,
+--- respectively.  3 is reserved for use by the `|matchparen|`
 --- plugin.
---- If the {id} argument is not specified or -1, |matchadd()|
+--- If the {id} argument is not specified or -1, `|matchadd()|`
 --- automatically chooses a free ID, which is at least 1000.
 ---
 --- The optional {dict} argument allows for further custom
 --- values. Currently this is used to specify a match specific
---- conceal character that will be shown for |hl-Conceal|
+--- conceal character that will be shown for `|hl-Conceal|`
 --- highlighted matches. The dict can have the following members:
 ---
 ---   conceal      Special character to show instead of the
----         match (only for |hl-Conceal| highlighted
----         matches, see |:syn-cchar|)
+---         match (only for `|hl-Conceal|` highlighted
+---         matches, see `|:syn-cchar|`)
 ---   window      Instead of the current window use the
 ---         window with this number or window ID.
 ---
 --- The number of matches is not limited, as it is the case with
---- the |:match| commands.
+--- the `|:match|` commands.
 ---
 --- Returns -1 on error.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   highlight MyGroup ctermbg=green guibg=green
 ---   let m = matchadd("MyGroup", "TODO")
---- <Deletion of the pattern: >vim
+--- ```
+--- Deletion of the pattern:
+--- ```vim
 ---   call matchdelete(m)
+--- ```
+--- A list of matches defined by `|matchadd()|` and `|:match|` are
+--- available from `|getmatches()|`.  All matches can be deleted in
+--- one operation by `|clearmatches()|`.
 ---
---- <A list of matches defined by |matchadd()| and |:match| are
---- available from |getmatches()|.  All matches can be deleted in
---- one operation by |clearmatches()|.
 ---
 --- @param group any
 --- @param pattern any
@@ -5262,8 +5774,8 @@ function vim.fn.match(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchadd(group, pattern, priority, id, dict) end
 
---- Same as |matchadd()|, but requires a list of positions {pos}
---- instead of a pattern. This command is faster than |matchadd()|
+--- Same as `|matchadd()|`, but requires a list of positions {pos}
+--- instead of a pattern. This command is faster than `|matchadd()|`
 --- because it does not require to handle regular expressions and
 --- sets buffer line boundaries to redraw screen. It is supposed
 --- to be used when fast match additions and deletions are
@@ -5278,7 +5790,7 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- - A list with two numbers, e.g., [23, 11]. The first number is
 ---   the line number, the second one is the column number (first
 ---   column is 1, the value must correspond to the byte index as
----   |col()| would return).  The character at this position will
+---   `|col()|` would return).  The character at this position will
 ---   be highlighted.
 --- - A list with three numbers, e.g., [23, 11, 3]. As above, but
 ---   the third number gives the length of the highlight in bytes.
@@ -5289,14 +5801,18 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 ---
 --- Returns -1 on error.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   highlight MyGroup ctermbg=green guibg=green
 ---   let m = matchaddpos("MyGroup", [[23, 24], 34])
---- <Deletion of the pattern: >vim
+--- ```
+--- Deletion of the pattern:
+--- ```vim
 ---   call matchdelete(m)
+--- ```
+--- Matches added by `|matchaddpos()|` are returned by
+--- `|getmatches()|`.
 ---
---- <Matches added by |matchaddpos()| are returned by
---- |getmatches()|.
 ---
 --- @param group any
 --- @param pos any
@@ -5306,50 +5822,61 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- @return any
 function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 
---- Selects the {nr} match item, as set with a |:match|,
---- |:2match| or |:3match| command.
---- Return a |List| with two elements:
+--- Selects the {nr} match item, as set with a `|:match|,
+--- |:2match|` or `|:3match|` command.
+--- Return a `|List|` with two elements:
 ---   The name of the highlight group used
 ---   The pattern used.
---- When {nr} is not 1, 2 or 3 returns an empty |List|.
+--- When {nr} is not 1, 2 or 3 returns an empty `|List|`.
 --- When there is no match item set returns ['', ''].
---- This is useful to save and restore a |:match|.
---- Highlighting matches using the |:match| commands are limited
---- to three matches. |matchadd()| does not have this limitation.
+--- This is useful to save and restore a `|:match|`.
+--- Highlighting matches using the `|:match|` commands are limited
+--- to three matches. `|matchadd()|` does not have this limitation.
+---
 ---
 --- @param nr integer
 --- @return any
 function vim.fn.matcharg(nr) end
 
---- Deletes a match with ID {id} previously defined by |matchadd()|
---- or one of the |:match| commands.  Returns 0 if successful,
---- otherwise -1.  See example for |matchadd()|.  All matches can
---- be deleted in one operation by |clearmatches()|.
+--- Deletes a match with ID {id} previously defined by `|matchadd()|`
+--- or one of the `|:match|` commands.  Returns 0 if successful,
+--- otherwise -1.  See example for `|matchadd()|`.  All matches can
+--- be deleted in one operation by `|clearmatches()|`.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
+---
 ---
 --- @param id any
 --- @param win? any
 --- @return any
 function vim.fn.matchdelete(id, win) end
 
---- Same as |match()|, but return the index of first character
---- after the match.  Example: >vim
+--- Same as `|match()|`, but return the index of first character
+--- after the match.  Example:
+--- ```vim
 ---   echo matchend("testing", "ing")
---- <results in "7".
+--- ```
+--- results in "7".
 ---           *strspn()* *strcspn()*
 --- Vim doesn't have a strspn() or strcspn() function, but you can
---- do it with matchend(): >vim
+--- do it with matchend():
+--- ```vim
 ---   let span = matchend(line, '[a-zA-Z]')
 ---   let span = matchend(line, '[^a-zA-Z]')
---- <Except that -1 is returned when there are no matches.
+--- ```
+--- Except that -1 is returned when there are no matches.
 ---
---- The {start}, if given, has the same meaning as for |match()|. >vim
+--- The {start}, if given, has the same meaning as for `|match()|`.
+--- ```vim
 ---   echo matchend("testing", "ing", 2)
---- <results in "7". >vim
+--- ```
+--- results in "7".
+--- ```vim
 ---   echo matchend("testing", "ing", 5)
---- <result is "-1".
---- When {expr} is a |List| the result is equal to |match()|.
+--- ```
+--- result is "-1".
+--- When {expr} is a `|List|` the result is equal to `|match()|`.
+---
 ---
 --- @param expr any
 --- @param pat any
@@ -5358,7 +5885,7 @@ function vim.fn.matchdelete(id, win) end
 --- @return any
 function vim.fn.matchend(expr, pat, start, count) end
 
---- If {list} is a list of strings, then returns a |List| with all
+--- If {list} is a list of strings, then returns a `|List|` with all
 --- the strings in {list} that fuzzy match {str}. The strings in
 --- the returned list are sorted based on the matching score.
 ---
@@ -5375,7 +5902,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 ---     key    Key of the item which is fuzzy matched against
 ---     {str}. The value of this item should be a
 ---     string.
----     text_cb  |Funcref| that will be called for every item
+---     text_cb  `|Funcref|` that will be called for every item
 ---     in {list} to get the text for fuzzy matching.
 ---     This should accept a dictionary item as the
 ---     argument and return the text for that item to
@@ -5395,30 +5922,46 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- When {limit} is given, matchfuzzy() will find up to this
 --- number of matches in {list} and return them in sorted order.
 ---
---- Refer to |fuzzy-matching| for more information about fuzzy
+--- Refer to `|fuzzy-matching|` for more information about fuzzy
 --- matching strings.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---    echo matchfuzzy(["clay", "crow"], "cay")
---- <results in ["clay"]. >vim
+--- ```
+--- results in ["clay"].
+--- ```vim
 ---    echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
---- <results in a list of buffer names fuzzy matching "ndl". >vim
+--- ```
+--- results in a list of buffer names fuzzy matching "ndl".
+--- ```vim
 ---    echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
---- <results in a list of buffer information dicts with buffer
---- names fuzzy matching "ndl". >vim
+--- ```
+--- results in a list of buffer information dicts with buffer
+--- names fuzzy matching "ndl".
+--- ```vim
 ---    echo getbufinfo()->matchfuzzy("spl",
 ---         \ {'text_cb' : {v -> v.name}})
---- <results in a list of buffer information dicts with buffer
---- names fuzzy matching "spl". >vim
+--- ```
+--- results in a list of buffer information dicts with buffer
+--- names fuzzy matching "spl".
+--- ```vim
 ---    echo v:oldfiles->matchfuzzy("test")
---- <results in a list of file names fuzzy matching "test". >vim
+--- ```
+--- results in a list of file names fuzzy matching "test".
+--- ```vim
 ---    let l = readfile("buffer.c")->matchfuzzy("str")
---- <results in a list of lines in "buffer.c" fuzzy matching "str". >vim
+--- ```
+--- results in a list of lines in "buffer.c" fuzzy matching "str".
+--- ```vim
 ---    echo ['one two', 'two one']->matchfuzzy('two one')
---- <results in `['two one', 'one two']` . >vim
+--- ```
+--- results in `['two one', 'one two']` .
+--- ```vim
 ---    echo ['one two', 'two one']->matchfuzzy('two one',
 ---         \ {'matchseq': 1})
---- <results in `['two one']`.
+--- ```
+--- results in `['two one']`.
 ---
 --- @param list any
 --- @param str any
@@ -5426,10 +5969,10 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchfuzzy(list, str, dict) end
 
---- Same as |matchfuzzy()|, but returns the list of matched
+--- Same as `|matchfuzzy()|`, but returns the list of matched
 --- strings, the list of character positions where characters
 --- in {str} matches and a list of matching scores.  You can
---- use |byteidx()| to convert a character position to a byte
+--- use `|byteidx()|` to convert a character position to a byte
 --- position.
 ---
 --- If {str} matches multiple times in a string, then only the
@@ -5438,14 +5981,20 @@ function vim.fn.matchfuzzy(list, str, dict) end
 --- If there are no matching strings or there is an error, then a
 --- list with three empty list items is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo matchfuzzypos(['testing'], 'tsg')
---- <results in [["testing"], [[0, 2, 6]], [99]] >vim
+--- ```
+--- results in [["testing"], [[0, 2, 6]], [99]]
+--- ```vim
 ---   echo matchfuzzypos(['clay', 'lacy'], 'la')
---- <results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
+--- ```
+--- results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]]
+--- ```vim
 ---   echo [{'text': 'hello', 'id' : 10}]
 ---     \ ->matchfuzzypos('ll', {'key' : 'text'})
---- <results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
+--- ```
+--- results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 ---
 --- @param list any
 --- @param str any
@@ -5453,16 +6002,19 @@ function vim.fn.matchfuzzy(list, str, dict) end
 --- @return any
 function vim.fn.matchfuzzypos(list, str, dict) end
 
---- Same as |match()|, but return a |List|.  The first item in the
+--- Same as `|match()|`, but return a `|List|`.  The first item in the
 --- list is the matched string, same as what matchstr() would
 --- return.  Following items are submatches, like "\1", "\2", etc.
---- in |:substitute|.  When an optional submatch didn't match an
---- empty string is used.  Example: >vim
+--- in `|:substitute|`.  When an optional submatch didn't match an
+--- empty string is used.  Example:
+--- ```vim
 ---   echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
---- <Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
+--- ```
+--- Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
 --- When there is no match an empty list is returned.
 ---
 --- You can pass in a List, but that is not very useful.
+---
 ---
 --- @param expr any
 --- @param pat any
@@ -5471,17 +6023,24 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 --- @return any
 function vim.fn.matchlist(expr, pat, start, count) end
 
---- Same as |match()|, but return the matched string.  Example: >vim
+--- Same as `|match()|`, but return the matched string.  Example:
+--- ```vim
 ---   echo matchstr("testing", "ing")
---- <results in "ing".
+--- ```
+--- results in "ing".
 --- When there is no match "" is returned.
---- The {start}, if given, has the same meaning as for |match()|. >vim
+--- The {start}, if given, has the same meaning as for `|match()|`.
+--- ```vim
 ---   echo matchstr("testing", "ing", 2)
---- <results in "ing". >vim
+--- ```
+--- results in "ing".
+--- ```vim
 ---   echo matchstr("testing", "ing", 5)
---- <result is "".
---- When {expr} is a |List| then the matching item is returned.
+--- ```
+--- result is "".
+--- When {expr} is a `|List|` then the matching item is returned.
 --- The type isn't changed, it's not necessarily a String.
+---
 ---
 --- @param expr any
 --- @param pat any
@@ -5490,22 +6049,31 @@ function vim.fn.matchlist(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchstr(expr, pat, start, count) end
 
---- Same as |matchstr()|, but return the matched string, the start
---- position and the end position of the match.  Example: >vim
+--- Same as `|matchstr()|`, but return the matched string, the start
+--- position and the end position of the match.  Example:
+--- ```vim
 ---   echo matchstrpos("testing", "ing")
---- <results in ["ing", 4, 7].
+--- ```
+--- results in ["ing", 4, 7].
 --- When there is no match ["", -1, -1] is returned.
---- The {start}, if given, has the same meaning as for |match()|. >vim
+--- The {start}, if given, has the same meaning as for `|match()|`.
+--- ```vim
 ---   echo matchstrpos("testing", "ing", 2)
---- <results in ["ing", 4, 7]. >vim
+--- ```
+--- results in ["ing", 4, 7].
+--- ```vim
 ---   echo matchstrpos("testing", "ing", 5)
---- <result is ["", -1, -1].
---- When {expr} is a |List| then the matching item, the index
+--- ```
+--- result is ["", -1, -1].
+--- When {expr} is a `|List|` then the matching item, the index
 --- of first item where {pat} matches, the start position and the
---- end position of the match are returned. >vim
+--- end position of the match are returned.
+--- ```vim
 ---   echo matchstrpos([1, '__x'], '\a')
---- <result is ["x", 1, 2, 3].
+--- ```
+--- result is ["x", 1, 2, 3].
 --- The type isn't changed, it's not necessarily a String.
+---
 ---
 --- @param expr any
 --- @param pat any
@@ -5514,38 +6082,42 @@ function vim.fn.matchstr(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchstrpos(expr, pat, start, count) end
 
---- Return the maximum value of all items in {expr}. Example: >vim
+--- Return the maximum value of all items in {expr}. Example:
+--- ```vim
 ---   echo max([apples, pears, oranges])
----
---- <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+--- ```
+--- {expr} can be a `|List|` or a `|Dictionary|`.  For a Dictionary,
 --- it returns the maximum of all values in the Dictionary.
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
----                 an error.  An empty |List| or |Dictionary| results in zero.
+---                 an error.  An empty `|List|` or `|Dictionary|` results in zero.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.max(expr) end
 
---- Returns a |List| of |Dictionaries| describing |menus| (defined
---- by |:menu|, |:amenu|, …), including |hidden-menus|.
+--- Returns a `|List|` of `|Dictionaries|` describing `|menus|` (defined
+--- by `|:menu|`, `|:amenu|`, …), including `|hidden-menus|`.
 ---
 --- {path} matches a menu by name, or all menus if {path} is an
---- empty string.  Example: >vim
+--- empty string.  Example:
+--- ```vim
 ---   echo menu_get('File','')
 ---   echo menu_get('')
---- <
---- {modes} is a string of zero or more modes (see |maparg()| or
---- |creating-menus| for the list of modes). "a" means "all".
+--- ```
+--- {modes} is a string of zero or more modes (see `|maparg()|` or
+--- `|creating-menus|` for the list of modes). "a" means "all".
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   nnoremenu &Test.Test inormal
 ---   inoremenu Test.Test insert
 ---   vnoremenu Test.Test x
 ---   echo menu_get("")
----
---- <returns something like this: >
----
+--- ```
+--- returns something like this:
+--- ```
 ---   [ {
 ---     "hidden": 0,
 ---     "name": "Test",
@@ -5570,7 +6142,7 @@ function vim.fn.max(expr) end
 ---       "shortcut": 0
 ---     } ]
 ---   } ]
---- <
+--- ```
 ---
 --- @param path string
 --- @param modes? any
@@ -5595,13 +6167,13 @@ function vim.fn.menu_get(path, modes) end
 ---   "!"  Insert and Cmd-line
 --- When {mode} is omitted, the modes for "" are used.
 ---
---- Returns a |Dictionary| containing the following items:
----   accel    menu item accelerator text |menu-text|
+--- Returns a `|Dictionary|` containing the following items:
+---   accel    menu item accelerator text `|menu-text|`
 ---   display  display name (name without '&')
 ---   enabled  v:true if this menu item is enabled
----     Refer to |:menu-enable|
+---     Refer to `|:menu-enable|`
 ---   icon    name of the icon file (for toolbar)
----     |toolbar-icon|
+---     `|toolbar-icon|`
 ---   iconidx  index of a built-in icon
 ---   modes    modes for which the menu is defined. In
 ---     addition to the modes mentioned above, these
@@ -5610,25 +6182,26 @@ function vim.fn.menu_get(path, modes) end
 ---   name    menu item name.
 ---   noremenu  v:true if the {rhs} of the menu item is not
 ---     remappable else v:false.
----   priority  menu order priority |menu-priority|
+---   priority  menu order priority `|menu-priority|`
 ---   rhs    right-hand-side of the menu item. The returned
 ---     string has special characters translated like
 ---     in the output of the ":menu" command listing.
 ---     When the {rhs} of a menu item is empty, then
 ---     "<Nop>" is returned.
 ---   script  v:true if script-local remapping of {rhs} is
----     allowed else v:false.  See |:menu-script|.
+---     allowed else v:false.  See `|:menu-script|`.
 ---   shortcut  shortcut key (character after '&' in
----     the menu name) |menu-shortcut|
+---     the menu name) `|menu-shortcut|`
 ---   silent  v:true if the menu item is created
----     with <silent> argument |:menu-silent|
----   submenus  |List| containing the names of
+---     with <silent> argument `|:menu-silent|`
+---   submenus  `|List|` containing the names of
 ---     all the submenus.  Present only if the menu
 ---     item has submenus.
 ---
 --- Returns an empty dictionary if the menu item is not found.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo menu_info('Edit.Cut')
 ---   echo menu_info('File.Save', 'n')
 ---
@@ -5645,21 +6218,23 @@ function vim.fn.menu_get(path, modes) end
 ---   for topmenu in menu_info('').submenus
 ---     call ShowMenu(topmenu, '')
 ---   endfor
---- <
+--- ```
 ---
 --- @param name string
 --- @param mode? string
 --- @return any
 function vim.fn.menu_info(name, mode) end
 
---- Return the minimum value of all items in {expr}. Example: >vim
+--- Return the minimum value of all items in {expr}. Example:
+--- ```vim
 ---   echo min([apples, pears, oranges])
----
---- <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+--- ```
+--- {expr} can be a `|List|` or a `|Dictionary|`.  For a Dictionary,
 --- it returns the minimum of all values in the Dictionary.
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
---- an error.  An empty |List| or |Dictionary| results in zero.
+--- an error.  An empty `|List|` or `|Dictionary|` results in zero.
+---
 ---
 --- @param expr any
 --- @return any
@@ -5674,31 +6249,38 @@ function vim.fn.min(expr) end
 --- created as necessary.
 ---
 --- If {flags} contains "D" then {name} is deleted at the end of
---- the current function, as with: >vim
+--- the current function, as with:
+--- ```vim
 ---   defer delete({name}, 'd')
---- <
+--- ```
 --- If {flags} contains "R" then {name} is deleted recursively at
---- the end of the current function, as with: >vim
+--- the end of the current function, as with:
+--- ```vim
 ---   defer delete({name}, 'rf')
---- <Note that when {name} has more than one part and "p" is used
+--- ```
+--- Note that when {name} has more than one part and "p" is used
 --- some directories may already exist.  Only the first one that
 --- is created and what it contains is scheduled to be deleted.
---- E.g. when using: >vim
+--- E.g. when using:
+--- ```vim
 ---   call mkdir('subdir/tmp/autoload', 'pR')
---- <and "subdir" already exists then "subdir/tmp" will be
---- scheduled for deletion, like with: >vim
+--- ```
+--- and "subdir" already exists then "subdir/tmp" will be
+--- scheduled for deletion, like with:
+--- ```vim
 ---   defer delete('subdir/tmp', 'rf')
---- <
+--- ```
 --- If {prot} is given it is used to set the protection bits of
 --- the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 --- the user, readable for others).  Use 0o700 to make it
 --- unreadable for others.
 ---
 --- {prot} is applied for all parts of {name}.  Thus if you create
---- /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+--- /tmp/foo/bar then /tmp/foo will be created with 0o700. Example:
+--- ```vim
 ---   call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
----
---- <This function is not available in the |sandbox|.
+--- ```
+--- This function is not available in the `|sandbox|`.
 ---
 --- If you try to create an existing directory with {flags} set to
 --- "p" mkdir() will silently exit.
@@ -5706,6 +6288,7 @@ function vim.fn.min(expr) end
 --- The function result is a Number, which is TRUE if the call was
 --- successful or FALSE if the directory creation failed or partly
 --- failed.
+---
 ---
 --- @param name string
 --- @param flags? string
@@ -5715,45 +6298,45 @@ function vim.fn.mkdir(name, flags, prot) end
 
 --- Return a string that indicates the current mode.
 --- If [expr] is supplied and it evaluates to a non-zero Number or
---- a non-empty String (|non-zero-arg|), then the full mode is
+--- a non-empty String (`|non-zero-arg|`), then the full mode is
 --- returned, otherwise only the first letter is returned.
---- Also see |state()|.
+--- Also see `|state()|`.
 ---
 ---    n      Normal
 ---    no      Operator-pending
----    nov      Operator-pending (forced charwise |o_v|)
----    noV      Operator-pending (forced linewise |o_V|)
----    noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
+---    nov      Operator-pending (forced charwise `|o_v|`)
+---    noV      Operator-pending (forced linewise `|o_V|`)
+---    noCTRL-V Operator-pending (forced blockwise `|o_CTRL-V|`)
 ---     CTRL-V is one character
----    niI      Normal using |i_CTRL-O| in |Insert-mode|
----    niR      Normal using |i_CTRL-O| in |Replace-mode|
----    niV      Normal using |i_CTRL-O| in |Virtual-Replace-mode|
----    nt      Normal in |terminal-emulator| (insert goes to
+---    niI      Normal using `|i_CTRL-O|` in `|Insert-mode|`
+---    niR      Normal using `|i_CTRL-O|` in `|Replace-mode|`
+---    niV      Normal using `|i_CTRL-O|` in `|Virtual-Replace-mode|`
+---    nt      Normal in `|terminal-emulator|` (insert goes to
 ---     Terminal mode)
----    ntT      Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
+---    ntT      Normal using `|t_CTRL-\_CTRL-O|` in `|Terminal-mode|`
 ---    v      Visual by character
----    vs      Visual by character using |v_CTRL-O| in Select mode
+---    vs      Visual by character using `|v_CTRL-O|` in Select mode
 ---    V      Visual by line
----    Vs      Visual by line using |v_CTRL-O| in Select mode
+---    Vs      Visual by line using `|v_CTRL-O|` in Select mode
 ---    CTRL-V   Visual blockwise
----    CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
+---    CTRL-Vs  Visual blockwise using `|v_CTRL-O|` in Select mode
 ---    s      Select by character
 ---    S      Select by line
 ---    CTRL-S   Select blockwise
 ---    i      Insert
----    ic      Insert mode completion |compl-generic|
----    ix      Insert mode |i_CTRL-X| completion
----    R      Replace |R|
----    Rc      Replace mode completion |compl-generic|
----    Rx      Replace mode |i_CTRL-X| completion
----    Rv      Virtual Replace |gR|
----    Rvc      Virtual Replace mode completion |compl-generic|
----    Rvx      Virtual Replace mode |i_CTRL-X| completion
+---    ic      Insert mode completion `|compl-generic|`
+---    ix      Insert mode `|i_CTRL-X|` completion
+---    R      Replace `|R|`
+---    Rc      Replace mode completion `|compl-generic|`
+---    Rx      Replace mode `|i_CTRL-X|` completion
+---    Rv      Virtual Replace `|gR|`
+---    Rvc      Virtual Replace mode completion `|compl-generic|`
+---    Rvx      Virtual Replace mode `|i_CTRL-X|` completion
 ---    c      Command-line editing
----    cv      Vim Ex mode |gQ|
+---    cv      Vim Ex mode `|gQ|`
 ---    r      Hit-enter prompt
 ---    rm      The -- more -- prompt
----    r?      A |:confirm| query of some sort
+---    r?      A `|:confirm|` query of some sort
 ---    !      Shell or external command is executing
 ---    t      Terminal mode: keys go to the job
 ---
@@ -5762,136 +6345,151 @@ function vim.fn.mkdir(name, flags, prot) end
 --- Note that in the future more modes and more specific modes may
 --- be added. It's better not to compare the whole string but only
 --- the leading character(s).
---- Also see |visualmode()|.
+--- Also see `|visualmode()|`.
+---
 ---
 --- @return any
 function vim.fn.mode() end
 
 --- Convert a list of Vimscript objects to msgpack. Returned value is a
---- |readfile()|-style list. When {type} contains "B", a |Blob| is
---- returned instead. Example: >vim
+--- `|readfile()|`-style list. When {type} contains "B", a `|Blob|` is
+--- returned instead. Example:
+--- ```vim
 ---   call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
---- <or, using a |Blob|: >vim
+--- ```
+--- or, using a `|Blob|`:
+--- ```vim
 ---   call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
---- <
+--- ```
 --- This will write the single 0x80 byte to a `fname.mpack` file
 --- (dictionary with zero items is represented by 0x80 byte in
 --- messagepack).
 ---
 --- Limitations:        *E5004* *E5005*
---- 1. |Funcref|s cannot be dumped.
+--- 1. `|Funcref|`s cannot be dumped.
 --- 2. Containers that reference themselves cannot be dumped.
 --- 3. Dictionary keys are always dumped as STR strings.
---- 4. Other strings and |Blob|s are always dumped as BIN strings.
---- 5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
+--- 4. Other strings and `|Blob|`s are always dumped as BIN strings.
+--- 5. Points 3. and 4. do not apply to `|msgpack-special-dict|`s.
 ---
 --- @param list any
 --- @param type? any
 --- @return any
 function vim.fn.msgpackdump(list, type) end
 
---- Convert a |readfile()|-style list or a |Blob| to a list of
+--- Convert a `|readfile()|`-style list or a `|Blob|` to a list of
 --- Vimscript objects.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let fname = expand('~/.config/nvim/shada/main.shada')
 ---   let mpack = readfile(fname, 'b')
 ---   let shada_objects = msgpackparse(mpack)
---- <This will read ~/.config/nvim/shada/main.shada file to
+--- ```
+--- This will read ~/.config/nvim/shada/main.shada file to
 --- `shada_objects` list.
 ---
 --- Limitations:
 --- 1. Mapping ordering is not preserved unless messagepack
 ---    mapping is dumped using generic mapping
----    (|msgpack-special-map|).
+---    (`|msgpack-special-map|`).
 --- 2. Since the parser aims to preserve all data untouched
 ---    (except for 1.) some strings are parsed to
----    |msgpack-special-dict| format which is not convenient to
+---    `|msgpack-special-dict|` format which is not convenient to
 ---    use.
 ---           *msgpack-special-dict*
 --- Some messagepack strings may be parsed to special
 --- dictionaries. Special dictionaries are dictionaries which
 ---
 --- 1. Contain exactly two keys: `_TYPE` and `_VAL`.
---- 2. `_TYPE` key is one of the types found in |v:msgpack_types|
+--- 2. `_TYPE` key is one of the types found in `|v:msgpack_types|`
 ---    variable.
 --- 3. Value for `_VAL` has the following format (Key column
----    contains name of the key from |v:msgpack_types|):
+---    contains name of the key from `|v:msgpack_types|`):
 ---
 --- Key  Value ~
 --- nil  Zero, ignored when dumping.  Not returned by
----   |msgpackparse()| since |v:null| was introduced.
+---   `|msgpackparse()|` since `|v:null|` was introduced.
 --- boolean  One or zero.  When dumping it is only checked that
----   value is a |Number|.  Not returned by |msgpackparse()|
----   since |v:true| and |v:false| were introduced.
---- integer  |List| with four numbers: sign (-1 or 1), highest two
+---   value is a `|Number|`.  Not returned by `|msgpackparse()|`
+---   since `|v:true|` and `|v:false|` were introduced.
+--- integer  `|List|` with four numbers: sign (-1 or 1), highest two
 ---   bits, number with bits from 62nd to 31st, lowest 31
 ---   bits. I.e. to get actual number one will need to use
----   code like >
+---   code like
+--- ```
 ---     _VAL[0] * ((_VAL[1] << 62)
 ---                & (_VAL[2] << 31)
 ---                & _VAL[3])
---- <  Special dictionary with this type will appear in
----   |msgpackparse()| output under one of the following
+--- ```
+--- Special dictionary with this type will appear in
+---   `|msgpackparse()|` output under one of the following
 ---   circumstances:
----   1. |Number| is 32-bit and value is either above
+---   1. `|Number|` is 32-bit and value is either above
 ---      INT32_MAX or below INT32_MIN.
----   2. |Number| is 64-bit and value is above INT64_MAX. It
+---   2. `|Number|` is 64-bit and value is above INT64_MAX. It
 ---      cannot possibly be below INT64_MIN because msgpack
 ---      C parser does not support such values.
---- float  |Float|. This value cannot possibly appear in
----   |msgpackparse()| output.
---- string  |readfile()|-style list of strings. This value will
----   appear in |msgpackparse()| output if string contains
+--- float  `|Float|`. This value cannot possibly appear in
+---   `|msgpackparse()|` output.
+--- string  `|readfile()|`-style list of strings. This value will
+---   appear in `|msgpackparse()|` output if string contains
 ---   zero byte or if string is a mapping key and mapping is
 ---   being represented as special dictionary for other
 ---   reasons.
---- binary  |String|, or |Blob| if binary string contains zero
----   byte. This value cannot appear in |msgpackparse()|
+--- binary  `|String|`, or `|Blob|` if binary string contains zero
+---   byte. This value cannot appear in `|msgpackparse()|`
 ---   output since blobs were introduced.
---- array  |List|. This value cannot appear in |msgpackparse()|
+--- array  `|List|`. This value cannot appear in `|msgpackparse()|`
 ---   output.
 ---           *msgpack-special-map*
---- map  |List| of |List|s with two items (key and value) each.
----   This value will appear in |msgpackparse()| output if
+--- map  `|List|` of `|List|`s with two items (key and value) each.
+---   This value will appear in `|msgpackparse()|` output if
 ---   parsed mapping contains one of the following keys:
 ---   1. Any key that is not a string (including keys which
 ---      are binary strings).
 ---   2. String with NUL byte inside.
 ---   3. Duplicate key.
 ---   4. Empty key.
---- ext  |List| with two values: first is a signed integer
+--- ext  `|List|` with two values: first is a signed integer
 ---   representing extension type. Second is
----   |readfile()|-style list of strings.
+---   `|readfile()|`-style list of strings.
 ---
 --- @param data any
 --- @return any
 function vim.fn.msgpackparse(data) end
 
 --- Return the line number of the first line at or below {lnum}
---- that is not blank.  Example: >vim
+--- that is not blank.  Example:
+--- ```vim
 ---   if getline(nextnonblank(1)) =~ "Java" | endif
---- <When {lnum} is invalid or there is no non-blank line at or
+--- ```
+--- When {lnum} is invalid or there is no non-blank line at or
 --- below it, zero is returned.
---- {lnum} is used like with |getline()|.
---- See also |prevnonblank()|.
+--- {lnum} is used like with `|getline()|`.
+--- See also `|prevnonblank()|`.
+---
 ---
 --- @param lnum integer
 --- @return any
 function vim.fn.nextnonblank(lnum) end
 
 --- Return a string with a single character, which has the number
---- value {expr}.  Examples: >vim
----   echo nr2char(64)    " returns '\@'
+--- value {expr}.  Examples:
+--- ```vim
+---   echo nr2char(64)    " returns '@'
 ---   echo nr2char(32)    " returns ' '
---- <Example for "utf-8": >vim
+--- ```
+--- Example for "utf-8":
+--- ```vim
 ---   echo nr2char(300)    " returns I with bow character
---- <
+--- ```
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
 --- Note that a NUL character in the file is specified with
 --- nr2char(10), because NULs are represented with newline
 --- characters.  nr2char(0) is a real NUL and terminates the
 --- string, thus results in an empty string.
+---
 ---
 --- @param expr any
 --- @param utf8? any
@@ -5901,10 +6499,11 @@ function vim.fn.nr2char(expr, utf8) end
 --- Bitwise OR on the two arguments.  The arguments are converted
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `and()` and `xor()`.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let bits = or(bits, 0x80)
----
---- <Rationale: The reason this is a function and not using the "|"
+--- ```
+--- Rationale: The reason this is a function and not using the "|"
 --- character like many languages, is that Vi has always used "|"
 --- to separate commands.  In many places it would not be clear if
 --- "|" is an operator or a command separator.
@@ -5918,48 +6517,62 @@ vim.fn['or'] = function(expr, expr1) end
 --- result.  The tail, the file name, is kept as-is.  The other
 --- components in the path are reduced to {len} letters in length.
 --- If {len} is omitted or smaller than 1 then 1 is used (single
---- letters).  Leading '~' and '.' characters are kept.  Examples: >vim
+--- letters).  Leading '~' and '.' characters are kept.  Examples:
+--- ```vim
 ---   echo pathshorten('~/.config/nvim/autoload/file1.vim')
---- <  ~/.c/n/a/file1.vim ~
---- >vim
+--- ```
+--- ~/.c/n/a/file1.vim ~
+--- ```vim
 ---   echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
---- <  ~/.co/nv/au/file2.vim ~
+--- ```
+--- ~/.co/nv/au/file2.vim ~
 --- It doesn't matter if the path exists or not.
 --- Returns an empty string on error.
+---
 ---
 --- @param path string
 --- @param len? any
 --- @return any
 function vim.fn.pathshorten(path, len) end
 
---- Evaluate |perl| expression {expr} and return its result
+--- Evaluate `|perl|` expression {expr} and return its result
 --- converted to Vim data structures.
 --- Numbers and strings are returned as they are (strings are
 --- copied though).
---- Lists are represented as Vim |List| type.
---- Dictionaries are represented as Vim |Dictionary| type,
+--- Lists are represented as Vim `|List|` type.
+--- Dictionaries are represented as Vim `|Dictionary|` type,
 --- non-string keys result in error.
 ---
 --- Note: If you want an array or hash, {expr} must return a
 --- reference to it.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo perleval('[1 .. 4]')
---- <  [1, 2, 3, 4]
+--- ```
+--- [1, 2, 3, 4]
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.perleval(expr) end
 
---- Return the power of {x} to the exponent {y} as a |Float|.
---- {x} and {y} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
---- Examples: >vim
+--- Return the power of {x} to the exponent {y} as a `|Float|`.
+--- {x} and {y} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {x} or {y} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo pow(3, 3)
---- <  27.0 >vim
+--- ```
+--- 27.0
+--- ```vim
 ---   echo pow(2, 16)
---- <  65536.0 >vim
+--- ```
+--- 65536.0
+--- ```vim
 ---   echo pow(32, 0.20)
---- <  2.0
+--- ```
+--- 2.0
+---
 ---
 --- @param x any
 --- @param y any
@@ -5967,27 +6580,33 @@ function vim.fn.perleval(expr) end
 function vim.fn.pow(x, y) end
 
 --- Return the line number of the first line at or above {lnum}
---- that is not blank.  Example: >vim
+--- that is not blank.  Example:
+--- ```vim
 ---   let ind = indent(prevnonblank(v:lnum - 1))
---- <When {lnum} is invalid or there is no non-blank line at or
+--- ```
+--- When {lnum} is invalid or there is no non-blank line at or
 --- above it, zero is returned.
---- {lnum} is used like with |getline()|.
---- Also see |nextnonblank()|.
+--- {lnum} is used like with `|getline()|`.
+--- Also see `|nextnonblank()|`.
+---
 ---
 --- @param lnum integer
 --- @return any
 function vim.fn.prevnonblank(lnum) end
 
 --- Return a String with {fmt}, where "%" items are replaced by
---- the formatted form of their respective arguments.  Example: >vim
+--- the formatted form of their respective arguments.  Example:
+--- ```vim
 ---   echo printf("%4d: E%d %.30s", lnum, errno, msg)
---- <May result in:
+--- ```
+--- May result in:
 ---   "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 ---
---- When used as a |method| the base is passed as the second
---- argument: >vim
+--- When used as a `|method|` the base is passed as the second
+--- argument:
+--- ```vim
 ---   Compute()->printf("result: %d")
---- <
+--- ```
 --- You can use `call()` to pass the items as a list.
 ---
 --- Often used items are:
@@ -6089,16 +6708,18 @@ function vim.fn.prevnonblank(lnum) end
 --- Number argument supplies the field width or precision.  A
 --- negative field width is treated as a left adjustment flag
 --- followed by a positive field width; a negative precision is
---- treated as though it were missing.  Example: >vim
+--- treated as though it were missing.  Example:
+--- ```vim
 ---   echo printf("%d: %.*s", nr, width, line)
---- <This limits the length of the text used from "line" to
+--- ```
+--- This limits the length of the text used from "line" to
 --- "width" bytes.
 ---
 --- If the argument to be formatted is specified using a posional
 --- argument specifier, and a '*' is used to indicate that a
 --- number argument is to be used to specify the width or
 --- precision, the argument(s) to be used must also be specified
---- using a {n$} positional argument specifier. See |printf-$|.
+--- using a {n$} positional argument specifier. See `|printf-$|`.
 ---
 --- The conversion specifiers and their meanings are:
 ---
@@ -6156,11 +6777,13 @@ function vim.fn.prevnonblank(lnum) end
 ---   (out of range or dividing by zero) results in "inf"
 ---    or "-inf" with %f (INF or -INF with %F).
 ---    "0.0 / 0.0" results in "nan" with %f (NAN with %F).
----   Example: >vim
+---   Example:
+--- ```vim
 ---     echo printf("%.2f", 12.115)
---- <    12.12
+--- ```
+--- 12.12
 ---   Note that roundoff depends on the system libraries.
----   Use |round()| when in doubt.
+---   Use `|round()|` when in doubt.
 ---
 ---           *printf-e* *printf-E*
 --- e E  The Float argument is converted into a string of the
@@ -6197,97 +6820,134 @@ function vim.fn.prevnonblank(lnum) end
 --- more readable when the order of words is different from the
 --- corresponding message in English. To accommodate translations
 --- having a different word order, positional arguments may be
---- used to indicate this. For instance: >vim
+--- used to indicate this. For instance:
+--- ```vim
 ---
 ---   #, c-format
 ---   msgid "%s returning %s"
 ---   msgstr "waarde %2$s komt terug van %1$s"
---- <
+--- ```
 --- In this example, the sentence has its 2 string arguments reversed
---- in the output. >vim
+--- in the output.
+--- ```vim
 ---
 ---   echo printf(
 ---     "In The Netherlands, vim's creator's name is: %1$s %2$s",
 ---     "Bram", "Moolenaar")
---- <  In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+--- ```
+--- In The Netherlands, vim's creator's name is: Bram Moolenaar
+--- ```vim
 ---
 ---   echo printf(
 ---     "In Belgium, vim's creator's name is: %2$s %1$s",
 ---     "Bram", "Moolenaar")
---- <  In Belgium, vim's creator's name is: Moolenaar Bram
+--- ```
+--- In Belgium, vim's creator's name is: Moolenaar Bram
 ---
 --- Width (and precision) can be specified using the '*' specifier.
 --- In this case, you must specify the field width position in the
---- argument list. >vim
+--- argument list.
+--- ```vim
 ---
 ---   echo printf("%1$*2$.*3$d", 1, 2, 3)
---- <  001 >vim
+--- ```
+--- 001
+--- ```vim
 ---   echo printf("%2$*3$.*1$d", 1, 2, 3)
---- <    2 >vim
+--- ```
+--- 2
+--- ```vim
 ---   echo printf("%3$*1$.*2$d", 1, 2, 3)
---- <  03 >vim
+--- ```
+--- 03
+--- ```vim
 ---   echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
---- <  1.414
+--- ```
+--- 1.414
 ---
 --- You can mix specifying the width and/or precision directly
---- and via positional arguments: >vim
+--- and via positional arguments:
+--- ```vim
 ---
 ---   echo printf("%1$4.*2$f", 1.4142135, 6)
---- <  1.414214 >vim
+--- ```
+--- 1.414214
+--- ```vim
 ---   echo printf("%1$*2$.4f", 1.4142135, 6)
---- <  1.4142 >vim
+--- ```
+--- 1.4142
+--- ```vim
 ---   echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
---- <    1.41
+--- ```
+--- 1.41
 ---
 ---           *E1500*
---- You cannot mix positional and non-positional arguments: >vim
+--- You cannot mix positional and non-positional arguments:
+--- ```vim
 ---   echo printf("%s%1$s", "One", "Two")
---- <  E1500: Cannot mix positional and non-positional
+--- ```
+--- E1500: Cannot mix positional and non-positional
 ---   arguments: %s%1$s
 ---
 ---           *E1501*
---- You cannot skip a positional argument in a format string: >vim
+--- You cannot skip a positional argument in a format string:
+--- ```vim
 ---   echo printf("%3$s%1$s", "One", "Two", "Three")
---- <  E1501: format argument 2 unused in $-style
+--- ```
+--- E1501: format argument 2 unused in $-style
 ---   format: %3$s%1$s
 ---
 ---           *E1502*
---- You can re-use a [field-width] (or [precision]) argument: >vim
+--- You can re-use a [field-width] (or [precision]) argument:
+--- ```vim
 ---   echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
---- <  1 at width 2 is: 01
+--- ```
+--- 1 at width 2 is: 01
 ---
---- However, you can't use it as a different type: >vim
+--- However, you can't use it as a different type:
+--- ```vim
 ---   echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
---- <  E1502: Positional argument 2 used as field
+--- ```
+--- E1502: Positional argument 2 used as field
 ---   width reused as different type: long int/int
 ---
 ---           *E1503*
 --- When a positional argument is used, but not the correct number
---- or arguments is given, an error is raised: >vim
+--- or arguments is given, an error is raised:
+--- ```vim
 ---   echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
---- <  E1503: Positional argument 3 out of bounds:
+--- ```
+--- E1503: Positional argument 3 out of bounds:
 ---   %1$d at width %2$d is: %01$*2$.*3$d
 ---
---- Only the first error is reported: >vim
+--- Only the first error is reported:
+--- ```vim
 ---   echo printf("%01$*2$.*3$d %4$d", 1, 2)
---- <  E1503: Positional argument 3 out of bounds:
+--- ```
+--- E1503: Positional argument 3 out of bounds:
 ---   %01$*2$.*3$d %4$d
 ---
 ---           *E1504*
---- A positional argument can be used more than once: >vim
+--- A positional argument can be used more than once:
+--- ```vim
 ---   echo printf("%1$s %2$s %1$s", "One", "Two")
---- <  One Two One
+--- ```
+--- One Two One
 ---
---- However, you can't use a different type the second time: >vim
+--- However, you can't use a different type the second time:
+--- ```vim
 ---   echo printf("%1$s %2$s %1$d", "One", "Two")
---- <  E1504: Positional argument 1 type used
+--- ```
+--- E1504: Positional argument 1 type used
 ---   inconsistently: int/string
 ---
 ---           *E1505*
 --- Various other errors that lead to a format string being
---- wrongly formatted lead to: >vim
+--- wrongly formatted lead to:
+--- ```vim
 ---   echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
---- <  E1505: Invalid format specifier:
+--- ```
+--- E1505: Invalid format specifier:
 ---   %1$d at width %2$d is: %01$*2$.3$d
 ---
 ---           *E1507*
@@ -6297,16 +6957,18 @@ function vim.fn.prevnonblank(lnum) end
 --- into this, copying the exact format string and parameters that
 --- were used.
 ---
+---
 --- @param fmt any
 --- @param expr1? any
 --- @return any
 function vim.fn.printf(fmt, expr1) end
 
 --- Returns the effective prompt text for buffer {buf}.  {buf} can
---- be a buffer name or number.  See |prompt-buffer|.
+--- be a buffer name or number.  See `|prompt-buffer|`.
 ---
 --- If the buffer doesn't exist or isn't a prompt buffer, an empty
 --- string is returned.
+---
 ---
 --- @param buf any
 --- @return any
@@ -6327,7 +6989,8 @@ function vim.fn.prompt_getprompt(buf) end
 --- The callback is invoked with one argument, which is the text
 --- that was entered at the prompt.  This can be an empty string
 --- if the user only typed Enter.
---- Example: >vim
+--- Example:
+--- ```vim
 ---    func s:TextEntered(text)
 ---      if a:text == 'exit' || a:text == 'quit'
 ---        stopinsert
@@ -6342,6 +7005,7 @@ function vim.fn.prompt_getprompt(buf) end
 ---      endif
 ---    endfunc
 ---    call prompt_setcallback(bufnr(), function('s:TextEntered'))
+--- ```
 ---
 --- @param buf any
 --- @param expr any
@@ -6356,6 +7020,7 @@ function vim.fn.prompt_setcallback(buf, expr) end
 --- mode.  Without setting a callback Vim will exit Insert mode,
 --- as in any buffer.
 ---
+---
 --- @param buf any
 --- @param expr any
 --- @return any
@@ -6364,32 +7029,33 @@ function vim.fn.prompt_setinterrupt(buf, expr) end
 --- Set prompt for buffer {buf} to {text}.  You most likely want
 --- {text} to end in a space.
 --- The result is only visible if {buf} has 'buftype' set to
---- "prompt".  Example: >vim
+--- "prompt".  Example:
+--- ```vim
 ---   call prompt_setprompt(bufnr(''), 'command: ')
---- <
+--- ```
 ---
 --- @param buf any
 --- @param text any
 --- @return any
 function vim.fn.prompt_setprompt(buf, text) end
 
---- If the popup menu (see |ins-completion-menu|) is not visible,
---- returns an empty |Dictionary|, otherwise, returns a
---- |Dictionary| with the following keys:
+--- If the popup menu (see `|ins-completion-menu|`) is not visible,
+--- returns an empty `|Dictionary|`, otherwise, returns a
+--- `|Dictionary|` with the following keys:
 ---   height    nr of items visible
 ---   width    screen cells
 ---   row    top screen row (0 first row)
 ---   col    leftmost screen column (0 first col)
 ---   size    total nr of items
----   scrollbar  |TRUE| if scrollbar is visible
+---   scrollbar  `|TRUE|` if scrollbar is visible
 ---
---- The values are the same as in |v:event| during |CompleteChanged|.
+--- The values are the same as in `|v:event|` during `|CompleteChanged|`.
 ---
 --- @return any
 function vim.fn.pum_getpos() end
 
 --- Returns non-zero when the popup menu is visible, zero
---- otherwise.  See |ins-completion-menu|.
+--- otherwise.  See `|ins-completion-menu|`.
 --- This can be used to avoid some things that would remove the
 --- popup menu.
 ---
@@ -6401,9 +7067,10 @@ function vim.fn.pumvisible() end
 --- Numbers and strings are returned as they are (strings are
 --- copied though, Unicode strings are additionally converted to
 --- UTF-8).
---- Lists are represented as Vim |List| type.
---- Dictionaries are represented as Vim |Dictionary| type with
+--- Lists are represented as Vim `|List|` type.
+--- Dictionaries are represented as Vim `|Dictionary|` type with
 --- keys converted to strings.
+---
 ---
 --- @param expr any
 --- @return any
@@ -6413,9 +7080,10 @@ function vim.fn.py3eval(expr) end
 --- converted to Vim data structures.
 --- Numbers and strings are returned as they are (strings are
 --- copied though).
---- Lists are represented as Vim |List| type.
---- Dictionaries are represented as Vim |Dictionary| type,
+--- Lists are represented as Vim `|List|` type.
+--- Dictionaries are represented as Vim `|Dictionary|` type,
 --- non-string keys result in error.
+---
 ---
 --- @param expr any
 --- @return any
@@ -6423,8 +7091,9 @@ function vim.fn.pyeval(expr) end
 
 --- Evaluate Python expression {expr} and return its result
 --- converted to Vim data structures.
---- Uses Python 2 or 3, see |python_x| and 'pyxversion'.
---- See also: |pyeval()|, |py3eval()|
+--- Uses Python 2 or 3, see `|python_x|` and 'pyxversion'.
+--- See also: `|pyeval()|`, `|py3eval()|`
+---
 ---
 --- @param expr any
 --- @return any
@@ -6433,23 +7102,24 @@ function vim.fn.pyxeval(expr) end
 --- Return a pseudo-random Number generated with an xoshiro128**
 --- algorithm using seed {expr}.  The returned number is 32 bits,
 --- also on 64 bits systems, for consistency.
---- {expr} can be initialized by |srand()| and will be updated by
+--- {expr} can be initialized by `|srand()|` and will be updated by
 --- rand().  If {expr} is omitted, an internal seed value is used
 --- and updated.
 --- Returns -1 if {expr} is invalid.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo rand()
 ---   let seed = srand()
 ---   echo rand(seed)
 ---   echo rand(seed) % 16  " random number 0 - 15
---- <
+--- ```
 ---
 --- @param expr? any
 --- @return any
 function vim.fn.rand(expr) end
 
---- Returns a |List| with Numbers:
+--- Returns a `|List|` with Numbers:
 --- - If only {expr} is specified: [0, 1, ..., {expr} - 1]
 --- - If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
 --- - If {stride} is specified: [{expr}, {expr} + {stride}, ...,
@@ -6458,14 +7128,15 @@ function vim.fn.rand(expr) end
 --- When the maximum is one before the start the result is an
 --- empty list.  When the maximum is more than one before the
 --- start this is an error.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo range(4)    " [0, 1, 2, 3]
 ---   echo range(2, 4)  " [2, 3, 4]
 ---   echo range(2, 9, 3)  " [2, 5, 8]
 ---   echo range(2, -2, -1)  " [2, 1, 0, -1, -2]
 ---   echo range(0)    " []
 ---   echo range(2, 0)  " error!
---- <
+--- ```
 ---
 --- @param expr any
 --- @param max? any
@@ -6473,28 +7144,34 @@ function vim.fn.rand(expr) end
 --- @return any
 function vim.fn.range(expr, max, stride) end
 
---- Read file {fname} in binary mode and return a |Blob|.
+--- Read file {fname} in binary mode and return a `|Blob|`.
 --- If {offset} is specified, read the file from the specified
 --- offset.  If it is a negative value, it is used as an offset
---- from the end of the file.  E.g., to read the last 12 bytes: >vim
+--- from the end of the file.  E.g., to read the last 12 bytes:
+--- ```vim
 ---   echo readblob('file.bin', -12)
---- <If {size} is specified, only the specified size will be read.
---- E.g. to read the first 100 bytes of a file: >vim
+--- ```
+--- If {size} is specified, only the specified size will be read.
+--- E.g. to read the first 100 bytes of a file:
+--- ```vim
 ---   echo readblob('file.bin', 0, 100)
---- <If {size} is -1 or omitted, the whole data starting from
+--- ```
+--- If {size} is -1 or omitted, the whole data starting from
 --- {offset} will be read.
 --- This can be also used to read the data from a character device
 --- on Unix when {size} is explicitly set.  Only if the device
 --- supports seeking {offset} can be used.  Otherwise it should be
---- zero.  E.g. to read 10 bytes from a serial console: >vim
+--- zero.  E.g. to read 10 bytes from a serial console:
+--- ```vim
 ---   echo readblob('/dev/ttyS0', 0, 10)
---- <When the file can't be opened an error message is given and
---- the result is an empty |Blob|.
+--- ```
+--- When the file can't be opened an error message is given and
+--- the result is an empty `|Blob|`.
 --- When the offset is beyond the end of the file the result is an
 --- empty blob.
 --- When trying to read more bytes than are available the result
 --- is truncated.
---- Also see |readfile()| and |writefile()|.
+--- Also see `|readfile()|` and `|writefile()|`.
 ---
 --- @param fname string
 --- @param offset? any
@@ -6503,7 +7180,7 @@ function vim.fn.range(expr, max, stride) end
 function vim.fn.readblob(fname, offset, size) end
 
 --- Return a list with file and directory names in {directory}.
---- You can also use |glob()| if you don't need to do complicated
+--- You can also use `|glob()|` if you don't need to do complicated
 --- things, such as limiting the number of matches.
 ---
 --- When {expr} is omitted all entries are included.
@@ -6514,29 +7191,34 @@ function vim.fn.readblob(fname, offset, size) end
 ---   added to the list.
 ---   If {expr} results in 1 then this entry will be added
 ---   to the list.
---- Each time {expr} is evaluated |v:val| is set to the entry name.
+--- Each time {expr} is evaluated `|v:val|` is set to the entry name.
 --- When {expr} is a function the name is passed as the argument.
---- For example, to get a list of files ending in ".txt": >vim
+--- For example, to get a list of files ending in ".txt":
+--- ```vim
 ---   echo readdir(dirname, {n -> n =~ '.txt$'})
---- <To skip hidden and backup files: >vim
+--- ```
+--- To skip hidden and backup files:
+--- ```vim
 ---   echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
----
---- <If you want to get a directory tree: >vim
+--- ```
+--- If you want to get a directory tree:
+--- ```vim
 ---   function! s:tree(dir)
 ---       return {a:dir : map(readdir(a:dir),
 ---       \ {_, x -> isdirectory(x) ?
 ---       \          {x : s:tree(a:dir .. '/' .. x)} : x})}
 ---   endfunction
 ---   echo s:tree(".")
---- <
+--- ```
 --- Returns an empty List on error.
+---
 ---
 --- @param directory any
 --- @param expr? any
 --- @return any
 function vim.fn.readdir(directory, expr) end
 
---- Read file {fname} and return a |List|, each line of the file
+--- Read file {fname} and return a `|List|`, each line of the file
 --- as an item.  Lines are broken at NL characters.  Macintosh
 --- files separated with CR will result in a single long line
 --- (unless a NL appears somewhere).
@@ -6551,22 +7233,25 @@ function vim.fn.readdir(directory, expr) end
 --- - Any UTF-8 byte order mark is removed from the text.
 --- When {max} is given this specifies the maximum number of lines
 --- to be read.  Useful if you only want to check the first ten
---- lines of a file: >vim
+--- lines of a file:
+--- ```vim
 ---   for line in readfile(fname, '', 10)
 ---     if line =~ 'Date' | echo line | endif
 ---   endfor
---- <When {max} is negative -{max} lines from the end of the file
+--- ```
+--- When {max} is negative -{max} lines from the end of the file
 --- are returned, or as many as there are.
 --- When {max} is zero the result is an empty list.
 --- Note that without {max} the whole file is read into memory.
 --- Also note that there is no recognition of encoding.  Read a
 --- file into a buffer if you need to.
---- Deprecated (use |readblob()| instead): When {type} contains
---- "B" a |Blob| is returned with the binary data of the file
+--- Deprecated (use `|readblob()|` instead): When {type} contains
+--- "B" a `|Blob|` is returned with the binary data of the file
 --- unmodified.
 --- When the file can't be opened an error message is given and
 --- the result is an empty list.
---- Also see |writefile()|.
+--- Also see `|writefile()|`.
+---
 ---
 --- @param fname string
 --- @param type? any
@@ -6575,7 +7260,7 @@ function vim.fn.readdir(directory, expr) end
 function vim.fn.readfile(fname, type, max) end
 
 --- {func} is called for every item in {object}, which can be a
---- |String|, |List| or a |Blob|.  {func} is called with two
+--- `|String|`, `|List|` or a `|Blob|`.  {func} is called with two
 --- arguments: the result so far and current item.  After
 --- processing all items the result is returned.
 ---
@@ -6584,12 +7269,13 @@ function vim.fn.readfile(fname, type, max) end
 --- item.  If {initial} is not given and {object} is empty no
 --- result can be computed, an E998 error is given.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo reduce([1, 3, 5], { acc, val -> acc + val })
 ---   echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
 ---   echo reduce(0z1122, { acc, val -> 2 * acc + val })
 ---   echo reduce('xyz', { acc, val -> acc .. ',' .. val })
---- <
+--- ```
 ---
 --- @param object any
 --- @param func any
@@ -6599,20 +7285,20 @@ function vim.fn.reduce(object, func, initial) end
 
 --- Returns the single letter name of the register being executed.
 --- Returns an empty string when no register is being executed.
---- See |\@|.
+--- See `|@|`.
 ---
 --- @return any
 function vim.fn.reg_executing() end
 
 --- Returns the single letter name of the last recorded register.
 --- Returns an empty string when nothing was recorded yet.
---- See |q| and |Q|.
+--- See `|q|` and `|Q|`.
 ---
 --- @return any
 function vim.fn.reg_recorded() end
 
 --- Returns the single letter name of the register being recorded.
---- Returns an empty string when not recording.  See |q|.
+--- Returns an empty string when not recording.  See `|q|`.
 ---
 --- @return any
 function vim.fn.reg_recording() end
@@ -6626,12 +7312,12 @@ function vim.fn.reltime(start) end
 
 --- Return an item that represents a time value.  The item is a
 --- list with items that depend on the system.
---- The item can be passed to |reltimestr()| to convert it to a
---- string or |reltimefloat()| to convert to a Float.
+--- The item can be passed to `|reltimestr()|` to convert it to a
+--- string or `|reltimefloat()|` to convert to a Float.
 ---
 --- Without an argument it returns the current "relative time", an
 --- implementation-defined value meaningful only when used as an
---- argument to |reltime()|, |reltimestr()| and |reltimefloat()|.
+--- argument to `|reltime()|`, `|reltimestr()|` and `|reltimefloat()|`.
 ---
 --- With one argument it returns the time passed since the time
 --- specified in the argument.
@@ -6641,7 +7327,7 @@ function vim.fn.reltime(start) end
 --- The {start} and {end} arguments must be values returned by
 --- reltime().  Returns zero on error.
 ---
---- Note: |localtime()| returns the current (non-relative) time.
+--- Note: `|localtime()|` returns the current (non-relative) time.
 ---
 --- @param start? any
 --- @param end_? any
@@ -6655,8 +7341,9 @@ function vim.fn.reltime(start, end_) end
 ---   call MyFunction()
 ---   let seconds = reltimefloat(reltime(start))
 --- See the note of reltimestr() about overhead.
---- Also see |profiling|.
+--- Also see `|profiling|`.
 --- If there is an error an empty string is returned
+---
 ---
 --- @param time any
 --- @return any
@@ -6664,16 +7351,21 @@ function vim.fn.reltimefloat(time) end
 
 --- Return a String that represents the time value of {time}.
 --- This is the number of seconds, a dot and the number of
---- microseconds.  Example: >vim
+--- microseconds.  Example:
+--- ```vim
 ---   let start = reltime()
 ---   call MyFunction()
 ---   echo reltimestr(reltime(start))
---- <Note that overhead for the commands will be added to the time.
+--- ```
+--- Note that overhead for the commands will be added to the time.
 --- Leading spaces are used to make the string align nicely.  You
---- can use split() to remove it. >vim
+--- can use split() to remove it.
+--- ```vim
 ---   echo split(reltimestr(reltime(start)))[0]
---- <Also see |profiling|.
+--- ```
+--- Also see `|profiling|`.
 --- If there is an error an empty string is returned
+---
 ---
 --- @param time any
 --- @return any
@@ -6684,19 +7376,21 @@ function vim.fn.reltimestr(time) end
 --- @return any
 function vim.fn.remove(list, idx) end
 
---- Without {end}: Remove the item at {idx} from |List| {list} and
+--- Without {end}: Remove the item at {idx} from `|List|` {list} and
 --- return the item.
 --- With {end}: Remove items from {idx} to {end} (inclusive) and
---- return a |List| with these items.  When {idx} points to the same
+--- return a `|List|` with these items.  When {idx} points to the same
 --- item as {end} a list with one item is returned.  When {end}
 --- points to an item before {idx} this is an error.
---- See |list-index| for possible values of {idx} and {end}.
+--- See `|list-index|` for possible values of {idx} and {end}.
 --- Returns zero on error.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo "last item: " .. remove(mylist, -1)
 ---   call remove(mylist, 0, 9)
---- <
---- Use |delete()| to remove a file.
+--- ```
+--- Use `|delete()|` to remove a file.
+---
 ---
 --- @param list any
 --- @param idx integer
@@ -6709,17 +7403,18 @@ function vim.fn.remove(list, idx, end_) end
 --- @return any
 function vim.fn.remove(blob, idx) end
 
---- Without {end}: Remove the byte at {idx} from |Blob| {blob} and
+--- Without {end}: Remove the byte at {idx} from `|Blob|` {blob} and
 --- return the byte.
 --- With {end}: Remove bytes from {idx} to {end} (inclusive) and
---- return a |Blob| with these bytes.  When {idx} points to the same
---- byte as {end} a |Blob| with one byte is returned.  When {end}
+--- return a `|Blob|` with these bytes.  When {idx} points to the same
+--- byte as {end} a `|Blob|` with one byte is returned.  When {end}
 --- points to a byte before {idx} this is an error.
 --- Returns zero on error.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo "last byte: " .. remove(myblob, -1)
 ---   call remove(mylist, 0, 9)
---- <
+--- ```
 ---
 --- @param blob any
 --- @param idx integer
@@ -6728,9 +7423,11 @@ function vim.fn.remove(blob, idx) end
 function vim.fn.remove(blob, idx, end_) end
 
 --- Remove the entry from {dict} with key {key} and return it.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo "removed " .. remove(dict, "one")
---- <If there is no {key} in {dict} this is an error.
+--- ```
+--- If there is no {key} in {dict} this is an error.
 --- Returns zero on error.
 ---
 --- @param dict any
@@ -6743,7 +7440,8 @@ function vim.fn.remove(dict, key) end
 --- result is a Number, which is 0 if the file was renamed
 --- successfully, and non-zero when the renaming failed.
 --- NOTE: If {to} exists it is overwritten without warning.
---- This function is not available in the |sandbox|.
+--- This function is not available in the `|sandbox|`.
+---
 ---
 --- @param from any
 --- @param to any
@@ -6751,13 +7449,18 @@ function vim.fn.remove(dict, key) end
 function vim.fn.rename(from, to) end
 
 --- Repeat {expr} {count} times and return the concatenated
---- result.  Example: >vim
+--- result.  Example:
+--- ```vim
 ---   let separator = repeat('-', 80)
---- <When {count} is zero or negative the result is empty.
---- When {expr} is a |List| or a |Blob| the result is {expr}
---- concatenated {count} times.  Example: >vim
+--- ```
+--- When {count} is zero or negative the result is empty.
+--- When {expr} is a `|List|` or a `|Blob|` the result is {expr}
+--- concatenated {count} times.  Example:
+--- ```vim
 ---   let longlist = repeat(['a', 'b'], 3)
---- <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+--- ```
+--- Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+---
 ---
 --- @param expr any
 --- @param count any
@@ -6771,51 +7474,61 @@ vim.fn['repeat'] = function(expr, count) end
 --- To cope with link cycles, resolving of symbolic links is
 --- stopped after 100 iterations.
 --- On other systems, return the simplified {filename}.
---- The simplification step is done as by |simplify()|.
+--- The simplification step is done as by `|simplify()|`.
 --- resolve() keeps a leading path component specifying the
 --- current directory (provided the result is still a relative
 --- path name) and also keeps a trailing path separator.
+---
 ---
 --- @param filename any
 --- @return any
 function vim.fn.resolve(filename) end
 
 --- Reverse the order of items in {object}.  {object} can be a
---- |List|, a |Blob| or a |String|.  For a List and a Blob the
+--- `|List|`, a `|Blob|` or a `|String|`.  For a List and a Blob the
 --- items are reversed in-place and {object} is returned.
 --- For a String a new String is returned.
 --- Returns zero if {object} is not a List, Blob or a String.
 --- If you want a List or Blob to remain unmodified make a copy
---- first: >vim
+--- first:
+--- ```vim
 ---   let revlist = reverse(copy(mylist))
---- <
+--- ```
 ---
 --- @param object any
 --- @return any
 function vim.fn.reverse(object) end
 
 --- Round off {expr} to the nearest integral value and return it
---- as a |Float|.  If {expr} lies halfway between two integral
+--- as a `|Float|`.  If {expr} lies halfway between two integral
 --- values, then use the larger one (away from zero).
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo round(0.456)
---- <  0.0  >vim
+--- ```
+--- 0.0
+--- ```vim
 ---   echo round(4.5)
---- <  5.0 >vim
+--- ```
+--- 5.0
+--- ```vim
 ---   echo round(-4.5)
---- <  -5.0
+--- ```
+--- -5.0
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.round(expr) end
 
---- Sends {event} to {channel} via |RPC| and returns immediately.
+--- Sends {event} to {channel} via `|RPC|` and returns immediately.
 --- If {channel} is 0, the event is broadcast to all channels.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   au VimLeave call rpcnotify(0, "leaving")
---- <
+--- ```
 ---
 --- @param channel any
 --- @param event any
@@ -6824,10 +7537,11 @@ function vim.fn.round(expr) end
 function vim.fn.rpcnotify(channel, event, args) end
 
 --- Sends a request to {channel} to invoke {method} via
---- |RPC| and blocks until a response is received.
---- Example: >vim
+--- `|RPC|` and blocks until a response is received.
+--- Example:
+--- ```vim
 ---   let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
---- <
+--- ```
 ---
 --- @param channel any
 --- @param method any
@@ -6835,11 +7549,14 @@ function vim.fn.rpcnotify(channel, event, args) end
 --- @return any
 function vim.fn.rpcrequest(channel, method, args) end
 
---- Deprecated. Replace  >vim
+--- Deprecated. Replace
+--- ```vim
 ---   let id = rpcstart('prog', ['arg1', 'arg2'])
---- <with >vim
+--- ```
+--- with
+--- ```vim
 ---   let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
---- <
+--- ```
 ---
 --- @param prog any
 --- @param argv? any
@@ -6847,7 +7564,7 @@ function vim.fn.rpcrequest(channel, method, args) end
 function vim.fn.rpcstart(prog, argv) end
 
 --- @deprecated
---- Use |jobstop()| instead to stop any job, or
+--- Use `|jobstop()|` instead to stop any job, or
 --- `chanclose(id, "rpc")` to close RPC communication
 --- without stopping the job. Use chanclose(id) to close
 --- any socket.
@@ -6860,19 +7577,21 @@ function vim.fn.rpcstop(...) end
 --- converted to Vim data structures.
 --- Numbers, floats and strings are returned as they are (strings
 --- are copied though).
---- Arrays are represented as Vim |List| type.
---- Hashes are represented as Vim |Dictionary| type.
+--- Arrays are represented as Vim `|List|` type.
+--- Hashes are represented as Vim `|Dictionary|` type.
 --- Other objects are represented as strings resulted from their
 --- "Object#to_s" method.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.rubyeval(expr) end
 
---- Like |screenchar()|, but return the attribute.  This is a rather
+--- Like `|screenchar()|`, but return the attribute.  This is a rather
 --- arbitrary number that can only be used to compare to the
 --- attribute at other positions.
 --- Returns -1 when row or col is out of range.
+---
 ---
 --- @param row any
 --- @param col integer
@@ -6888,16 +7607,18 @@ function vim.fn.screenattr(row, col) end
 --- This is mainly to be used for testing.
 --- Returns -1 when row or col is out of range.
 ---
+---
 --- @param row any
 --- @param col integer
 --- @return any
 function vim.fn.screenchar(row, col) end
 
---- The result is a |List| of Numbers.  The first number is the same
---- as what |screenchar()| returns.  Further numbers are
+--- The result is a `|List|` of Numbers.  The first number is the same
+--- as what `|screenchar()|` returns.  Further numbers are
 --- composing characters on top of the base character.
 --- This is mainly to be used for testing.
 --- Returns an empty List when row or col is out of range.
+---
 ---
 --- @param row any
 --- @param col integer
@@ -6912,11 +7633,12 @@ function vim.fn.screenchars(row, col) end
 --- in a command (e.g. ":echo screencol()") it will return the
 --- column inside the command line, which is 1 when the command is
 --- executed. To get the cursor position in the file use one of
---- the following mappings: >vim
+--- the following mappings:
+--- ```vim
 ---   nnoremap <expr> GG ":echom " .. screencol() .. "\n"
 ---   nnoremap <silent> GG :echom screencol()<CR>
 ---   noremap GG <Cmd>echom screencol()<Cr>
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.screencol() end
@@ -6936,13 +7658,14 @@ function vim.fn.screencol() end
 --- The "curscol" value is where the cursor would be placed.  For
 --- a Tab it would be the same as "endcol", while for a double
 --- width character it would be the same as "col".
---- The |conceal| feature is ignored here, the column numbers are
+--- The `|conceal|` feature is ignored here, the column numbers are
 --- as if 'conceallevel' is zero.  You can set the cursor to the
---- right position and use |screencol()| to get the value with
---- |conceal| taken into account.
+--- right position and use `|screencol()|` to get the value with
+--- `|conceal|` taken into account.
 --- If the position is in a closed fold the screen position of the
 --- first character is returned, {col} is not used.
 --- Returns an empty Dict if {winid} is invalid.
+---
 ---
 --- @param winid integer
 --- @param lnum integer
@@ -6953,19 +7676,20 @@ function vim.fn.screenpos(winid, lnum, col) end
 --- The result is a Number, which is the current screen row of the
 --- cursor.  The top line has number one.
 --- This function is mainly used for testing.
---- Alternatively you can use |winline()|.
+--- Alternatively you can use `|winline()|`.
 ---
---- Note: Same restrictions as with |screencol()|.
+--- Note: Same restrictions as with `|screencol()|`.
 ---
 --- @return any
 function vim.fn.screenrow() end
 
 --- The result is a String that contains the base character and
 --- any composing characters at position [row, col] on the screen.
---- This is like |screenchars()| but returning a String with the
+--- This is like `|screenchars()|` but returning a String with the
 --- characters.
 --- This is mainly to be used for testing.
 --- Returns an empty String when row or col is out of range.
+---
 ---
 --- @param row any
 --- @param col integer
@@ -6973,7 +7697,7 @@ function vim.fn.screenrow() end
 function vim.fn.screenstring(row, col) end
 
 --- Search for regexp pattern {pattern}.  The search starts at the
---- cursor position (you can use |cursor()| to set it).
+--- cursor position (you can use `|cursor()|` to set it).
 ---
 --- When a match has been found its line number is returned.
 --- If there is no match a 0 is returned and the cursor doesn't
@@ -7002,8 +7726,8 @@ function vim.fn.screenstring(row, col) end
 --- skipped.  When the 'c' flag is present in 'cpo' the next
 --- search starts after the match.  Without the 'c' flag the next
 --- search starts one column after the start of the match.  This
---- matters for overlapping matches.  See |cpo-c|.  You can also
---- insert "\ze" to change where the match ends, see  |/\ze|.
+--- matters for overlapping matches.  See `|cpo-c|`.  You can also
+--- insert "\ze" to change where the match ends, see  `|/\ze|`.
 ---
 --- When searching backwards and the 'z' flag is given then the
 --- search starts in column zero, thus no match in the current
@@ -7012,10 +7736,12 @@ function vim.fn.screenstring(row, col) end
 ---
 --- When the {stopline} argument is given then the search stops
 --- after searching this line.  This is useful to restrict the
---- search to a range of lines.  Examples: >vim
+--- search to a range of lines.  Examples:
+--- ```vim
 ---   let match = search('(', 'b', line("w0"))
 ---   let end = search('END', '', line("w$"))
---- <When {stopline} is used and it is not zero this also implies
+--- ```
+--- When {stopline} is used and it is not zero this also implies
 --- that the search does not wrap around the end of the file.
 --- A zero value is equal to not giving the argument.
 ---
@@ -7038,12 +7764,13 @@ function vim.fn.screenstring(row, col) end
 --- With the 'p' flag the returned value is one more than the
 --- first sub-match in \(\).  One if none of them matched but the
 --- whole pattern did match.
---- To get the column number too use |searchpos()|.
+--- To get the column number too use `|searchpos()|`.
 ---
 --- The cursor will be positioned at the match, unless the 'n'
 --- flag is used.
 ---
---- Example (goes over all files in the argument list): >vim
+--- Example (goes over all files in the argument list):
+--- ```vim
 ---     let n = 1
 ---     while n <= argc()      " loop over all files in arglist
 ---       exe "argument " .. n
@@ -7058,10 +7785,12 @@ function vim.fn.screenstring(row, col) end
 ---       update        " write the file if modified
 ---       let n = n + 1
 ---     endwhile
---- <
---- Example for using some flags: >vim
----     echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
---- <This will search for the keywords "if", "else", and "endif"
+--- ```
+--- Example for using some flags:
+--- ```vim
+---     echo search('\<if\`|\(else\)\|`\(endif\)', 'ncpe')
+--- ```
+--- This will search for the keywords "if", "else", and "endif"
 --- under or after the cursor.  Because of the 'p' flag, it
 --- returns 1, 2, or 3 depending on which keyword is found, or 0
 --- if the search fails.  With the cursor on the first word of the
@@ -7071,6 +7800,7 @@ function vim.fn.screenstring(row, col) end
 --- finds the "endif" and returns 3.  The same thing happens
 --- without the 'e' flag if the cursor is on the "f" of "if".
 --- The 'n' flag tells the function not to move the cursor.
+---
 ---
 --- @param pattern any
 --- @param flags? string
@@ -7084,27 +7814,28 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- without the "S" flag in 'shortmess'.  This works even if
 --- 'shortmess' does contain the "S" flag.
 ---
---- This returns a |Dictionary|. The dictionary is empty if the
+--- This returns a `|Dictionary|`. The dictionary is empty if the
 --- previous pattern was not set and "pattern" was not specified.
 ---
 ---   key    type    meaning ~
----   current  |Number|  current position of match;
+---   current  `|Number|`  current position of match;
 ---         0 if the cursor position is
 ---         before the first match
----   exact_match  |Boolean|  1 if "current" is matched on
+---   exact_match  `|Boolean|`  1 if "current" is matched on
 ---         "pos", otherwise 0
----   total    |Number|  total count of matches found
----   incomplete  |Number|  0: search was fully completed
+---   total    `|Number|`  total count of matches found
+---   incomplete  `|Number|`  0: search was fully completed
 ---         1: recomputing was timed out
 ---         2: max count exceeded
 ---
 --- For {options} see further down.
 ---
---- To get the last search count when |n| or |N| was pressed, call
+--- To get the last search count when `|n|` or `|N|` was pressed, call
 --- this function with `recompute: 0` . This sometimes returns
---- wrong information because |n| and |N|'s maximum count is 99.
+--- wrong information because `|n|` and `|N|`'s maximum count is 99.
 --- If it exceeded 99 the result must be max count + 1 (100). If
---- you want to get correct information, specify `recompute: 1`: >vim
+--- you want to get correct information, specify `recompute: 1`:
+--- ```vim
 ---
 ---   " result == maxcount + 1 (100) when many matches
 ---   let result = searchcount(#{recompute: 0})
@@ -7112,26 +7843,27 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " Below returns correct result (recompute defaults
 ---   " to 1)
 ---   let result = searchcount()
---- <
---- The function is useful to add the count to 'statusline': >vim
+--- ```
+--- The function is useful to add the count to 'statusline':
+--- ```vim
 ---   function! LastSearchCount() abort
 ---     let result = searchcount(#{recompute: 0})
 ---     if empty(result)
 ---       return ''
 ---     endif
 ---     if result.incomplete ==# 1     " timed out
----       return printf(' /%s [?/??]', \@/)
+---       return printf(' /%s [?/??]', @/)
 ---     elseif result.incomplete ==# 2 " max count exceeded
 ---       if result.total > result.maxcount &&
 ---       \  result.current > result.maxcount
----         return printf(' /%s [>%d/>%d]', \@/,
+---         return printf(' /%s [>%d/>%d]', @/,
 ---         \             result.current, result.total)
 ---       elseif result.total > result.maxcount
----         return printf(' /%s [%d/>%d]', \@/,
+---         return printf(' /%s [%d/>%d]', @/,
 ---         \             result.current, result.total)
 ---       endif
 ---     endif
----     return printf(' /%s [%d/%d]', \@/,
+---     return printf(' /%s [%d/%d]', @/,
 ---     \             result.current, result.total)
 ---   endfunction
 ---   let &statusline ..= '%{LastSearchCount()}'
@@ -7140,9 +7872,10 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " 'hlsearch' was on
 ---   " let &statusline ..=
 ---   " \   '%{v:hlsearch ? LastSearchCount() : ""}'
---- <
+--- ```
 --- You can also update the search count, which can be useful in a
---- |CursorMoved| or |CursorMovedI| autocommand: >vim
+--- `|CursorMoved|` or `|CursorMovedI|` autocommand:
+--- ```vim
 ---
 ---   autocmd CursorMoved,CursorMovedI *
 ---     \ let s:searchcount_timer = timer_start(
@@ -7154,9 +7887,10 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---       redrawstatus
 ---     endif
 ---   endfunction
---- <
+--- ```
 --- This can also be used to count matched texts with specified
---- pattern in the current buffer using "pattern":  >vim
+--- pattern in the current buffer using "pattern":
+--- ```vim
 ---
 ---   " Count '\<foo\>' in this buffer
 ---   " (Note that it also updates search count)
@@ -7165,40 +7899,43 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " To restore old search count by old pattern,
 ---   " search again
 ---   call searchcount()
---- <
---- {options} must be a |Dictionary|. It can contain:
+--- ```
+--- {options} must be a `|Dictionary|`. It can contain:
 ---   key    type    meaning ~
----   recompute  |Boolean|  if |TRUE|, recompute the count
----         like |n| or |N| was executed.
+---   recompute  `|Boolean|`  if `|TRUE|`, recompute the count
+---         like `|n|` or `|N|` was executed.
 ---         otherwise returns the last
----         computed result (when |n| or
----         |N| was used when "S" is not
+---         computed result (when `|n|` or
+---         `|N|` was used when "S" is not
 ---         in 'shortmess', or this
 ---         function was called).
----         (default: |TRUE|)
----   pattern  |String|  recompute if this was given
----         and different with |\@/|.
+---         (default: `|TRUE|`)
+---   pattern  `|String|`  recompute if this was given
+---         and different with `|@/|`.
 ---         this works as same as the
 ---         below command is executed
----         before calling this function >vim
----           let \@/ = pattern
---- <        (default: |\@/|)
----   timeout  |Number|  0 or negative number is no
+---         before calling this function
+--- ```vim
+---           let @/ = pattern
+--- ```
+--- (default: `|@/|`)
+---   timeout  `|Number|`  0 or negative number is no
 ---         timeout. timeout milliseconds
 ---         for recomputing the result
 ---         (default: 0)
----   maxcount  |Number|  0 or negative number is no
+---   maxcount  `|Number|`  0 or negative number is no
 ---         limit. max count of matched
 ---         text while recomputing the
 ---         result.  if search exceeded
 ---         total count, "total" value
 ---         becomes `maxcount + 1`
 ---         (default: 0)
----   pos    |List|    `[lnum, col, off]` value
+---   pos    `|List|`    `[lnum, col, off]` value
 ---         when recomputing the result.
 ---         this changes "current" result
----         value. see |cursor()|, |getpos()|
+---         value. see `|cursor()|`, `|getpos()|`
 ---         (default: cursor's position)
+---
 ---
 --- @param options? table
 --- @return any
@@ -7206,8 +7943,8 @@ function vim.fn.searchcount(options) end
 
 --- Search for the declaration of {name}.
 ---
---- With a non-zero {global} argument it works like |gD|, find
---- first match in the file.  Otherwise it works like |gd|, find
+--- With a non-zero {global} argument it works like `|gD|`, find
+--- first match in the file.  Otherwise it works like `|gd|`, find
 --- first match in the function.
 ---
 --- With a non-zero {thisblock} argument matches in a {} block
@@ -7216,11 +7953,12 @@ function vim.fn.searchcount(options) end
 ---
 --- Moves the cursor to the found match.
 --- Returns zero for success, non-zero for failure.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   if searchdecl('myvar') == 0
 ---      echo getline('.')
 ---   endif
---- <
+--- ```
 ---
 --- @param name string
 --- @param global? any
@@ -7238,16 +7976,18 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- returned and the cursor doesn't move.  No error message is
 --- given.
 ---
---- {start}, {middle} and {end} are patterns, see |pattern|.  They
+--- {start}, {middle} and {end} are patterns, see `|pattern|`.  They
 --- must not contain \( \) pairs.  Use of \%( \) is allowed.  When
 --- {middle} is not empty, it is found when searching from either
 --- direction, but only when not in a nested start-end pair.  A
---- typical use is: >vim
+--- typical use is:
+--- ```vim
 ---   echo searchpair('\<if\>', '\<else\>', '\<endif\>')
---- <By leaving {middle} empty the "else" is skipped.
+--- ```
+--- By leaving {middle} empty the "else" is skipped.
 ---
 --- {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
---- |search()|.  Additionally:
+--- `|search()|`.  Additionally:
 --- 'r'  Repeat until no more matches found; will find the
 ---   outer pair.  Implies the 'W' flag.
 --- 'm'  Return number of matches instead of line number with
@@ -7266,19 +8006,21 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- {skip} can be a string, a lambda, a funcref or a partial.
 --- Anything else makes the function fail.
 ---
---- For {stopline} and {timeout} see |search()|.
+--- For {stopline} and {timeout} see `|search()|`.
 ---
 --- The value of 'ignorecase' is used.  'magic' is ignored, the
 --- patterns are used like it's on.
 ---
 --- The search starts exactly at the cursor.  A match with
 --- {start}, {middle} or {end} at the next character, in the
---- direction of searching, is the first one found.  Example: >vim
+--- direction of searching, is the first one found.  Example:
+--- ```vim
 ---   if 1
 ---     if 2
 ---     endif 2
 ---   endif 1
---- <When starting at the "if 2", with the cursor on the "i", and
+--- ```
+--- When starting at the "if 2", with the cursor on the "i", and
 --- searching forwards, the "endif 2" is found.  When starting on
 --- the character just before the "if 2", the "endif 1" will be
 --- found.  That's because the "if 2" will be found first, and
@@ -7289,58 +8031,66 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- that when the cursor is inside a match with the end it finds
 --- the matching start.
 ---
---- Example, to find the "endif" command in a Vim script: >vim
+--- Example, to find the "endif" command in a Vim script:
+--- ```vim
 ---
 ---   echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
 ---   \ 'getline(".") =~ "^\\s*\""')
----
---- <The cursor must be at or after the "if" for which a match is
+--- ```
+--- The cursor must be at or after the "if" for which a match is
 --- to be found.  Note that single-quote strings are used to avoid
 --- having to double the backslashes.  The skip expression only
 --- catches comments at the start of a line, not after a command.
 --- Also, a word "en" or "if" halfway through a line is considered
 --- a match.
---- Another example, to search for the matching "{" of a "}": >vim
+--- Another example, to search for the matching "{" of a "}":
+--- ```vim
 ---
 ---   echo searchpair('{', '', '}', 'bW')
----
---- <This works when the cursor is at or before the "}" for which a
+--- ```
+--- This works when the cursor is at or before the "}" for which a
 --- match is to be found.  To reject matches that syntax
---- highlighting recognized as strings: >vim
+--- highlighting recognized as strings:
+--- ```vim
 ---
 ---   echo searchpair('{', '', '}', 'bW',
 ---        \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.searchpair() end
 
---- Same as |searchpair()|, but returns a |List| with the line and
---- column position of the match. The first element of the |List|
+--- Same as `|searchpair()|`, but returns a `|List|` with the line and
+--- column position of the match. The first element of the `|List|`
 --- is the line number and the second element is the byte index of
 --- the column position of the match.  If no match is found,
---- returns [0, 0]. >vim
+--- returns [0, 0].
+--- ```vim
 ---
 ---   let [lnum,col] = searchpairpos('{', '', '}', 'n')
---- <
---- See |match-parens| for a bigger and more useful example.
+--- ```
+--- See `|match-parens|` for a bigger and more useful example.
 ---
 --- @return any
 function vim.fn.searchpairpos() end
 
---- Same as |search()|, but returns a |List| with the line and
---- column position of the match. The first element of the |List|
+--- Same as `|search()|`, but returns a `|List|` with the line and
+--- column position of the match. The first element of the `|List|`
 --- is the line number and the second element is the byte index of
 --- the column position of the match. If no match is found,
 --- returns [0, 0].
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let [lnum, col] = searchpos('mypattern', 'n')
----
---- <When the 'p' flag is given then there is an extra item with
---- the sub-pattern match number |search()-sub-match|.  Example: >vim
+--- ```
+--- When the 'p' flag is given then there is an extra item with
+--- the sub-pattern match number `|search()-sub-match|`.  Example:
+--- ```vim
 ---   let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
---- <In this example "submatch" is 2 when a lowercase letter is
---- found |/\l|, 3 when an uppercase letter is found |/\u|.
+--- ```
+--- In this example "submatch" is 2 when a lowercase letter is
+--- found `|/\l|`, 3 when an uppercase letter is found `|/\u|`.
+---
 ---
 --- @param pattern any
 --- @param flags? string
@@ -7351,16 +8101,17 @@ function vim.fn.searchpairpos() end
 function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 
 --- Returns a list of server addresses, or empty if all servers
---- were stopped. |serverstart()| |serverstop()|
---- Example: >vim
+--- were stopped. `|serverstart()|` `|serverstop()|`
+--- Example:
+--- ```vim
 ---   echo serverlist()
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.serverlist() end
 
 --- Opens a socket or named pipe at {address} and listens for
---- |RPC| messages. Clients can send |API| commands to the
+--- `|RPC|` messages. Clients can send `|API|` commands to the
 --- returned address to control Nvim.
 ---
 --- Returns the address string (which may differ from the
@@ -7371,26 +8122,33 @@ function vim.fn.serverlist() end
 ---   assigns a random port).
 --- - Else {address} is the path to a named pipe (except on Windows).
 ---   - If {address} has no slashes ("/") it is treated as the
----     "name" part of a generated path in this format: >vim
+---     "name" part of a generated path in this format:
+--- ```vim
 ---   stdpath("run").."/{name}.{pid}.{counter}"
---- <  - If {address} is omitted the name is "nvim". >vim
+--- ```
+--- - If {address} is omitted the name is "nvim".
+--- ```vim
 ---   echo serverstart()
---- < >
+--- ```
+--- ```
 ---   => /tmp/nvim.bram/oknANW/nvim.15430.5
---- <
---- Example bash command to list all Nvim servers: >bash
+--- ```
+--- Example bash command to list all Nvim servers:
+--- ```bash
 ---   ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
----
---- <Example named pipe: >vim
+--- ```
+--- Example named pipe:
+--- ```vim
 ---   if has('win32')
 ---     echo serverstart('\\.\pipe\nvim-pipe-1234')
 ---   else
 ---     echo serverstart('nvim.sock')
 ---   endif
---- <
---- Example TCP/IP address: >vim
+--- ```
+--- Example TCP/IP address:
+--- ```vim
 ---   echo serverstart('::1:12345')
---- <
+--- ```
 ---
 --- @param address? any
 --- @return any
@@ -7398,29 +8156,29 @@ function vim.fn.serverstart(address) end
 
 --- Closes the pipe or socket at {address}.
 --- Returns TRUE if {address} is valid, else FALSE.
---- If |v:servername| is stopped it is set to the next available
---- address in |serverlist()|.
+--- If `|v:servername|` is stopped it is set to the next available
+--- address in `|serverlist()|`.
 ---
 --- @param address any
 --- @return any
 function vim.fn.serverstop(address) end
 
 --- Set line {lnum} to {text} in buffer {buf}.  This works like
---- |setline()| for the specified buffer.
+--- `|setline()|` for the specified buffer.
 ---
 --- This function works only for loaded buffers. First call
---- |bufload()| if needed.
+--- `|bufload()|` if needed.
 ---
---- To insert lines use |appendbufline()|.
+--- To insert lines use `|appendbufline()|`.
 ---
 --- {text} can be a string to set one line, or a List of strings
 --- to set multiple lines.  If the List extends below the last
 --- line then those lines are added.  If the List is empty then
 --- nothing is changed and zero is returned.
 ---
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 ---
---- {lnum} is used like with |setline()|.
+--- {lnum} is used like with `|setline()|`.
 --- Use "$" to refer to the last line in buffer {buf}.
 --- When {lnum} is just below the last line the {text} will be
 --- added below the last line.
@@ -7428,6 +8186,7 @@ function vim.fn.serverstop(address) end
 ---
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given.
+---
 ---
 --- @param buf any
 --- @param lnum integer
@@ -7440,13 +8199,16 @@ function vim.fn.setbufline(buf, lnum, text) end
 --- This also works for a global or local window option, but it
 --- doesn't work for a global or local window variable.
 --- For a local window option the global value is unchanged.
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 --- The {varname} argument is a string.
 --- Note that the variable name without "b:" must be used.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   call setbufvar(1, "&mod", 1)
 ---   call setbufvar("todo", "myvar", "foobar")
---- <This function is not available in the |sandbox|.
+--- ```
+--- This function is not available in the `|sandbox|`.
+---
 ---
 --- @param buf any
 --- @param varname string
@@ -7457,13 +8219,14 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- Specify overrides for cell widths of character ranges.  This
 --- tells Vim how wide characters are when displayed in the
 --- terminal, counted in screen cells.  The values override
---- 'ambiwidth'.  Example: >vim
+--- 'ambiwidth'.  Example:
+--- ```vim
 ---    call setcellwidths([
 ---     \ [0x111, 0x111, 1],
 ---     \ [0x2194, 0x2199, 2],
 ---     \ ])
----
---- <The {list} argument is a List of Lists with each three
+--- ```
+--- The {list} argument is a List of Lists with each three
 --- numbers: [{low}, {high}, {width}].  *E1109* *E1110*
 --- {low} and {high} can be the same, in which case this refers to
 --- one character.  Otherwise it is the range of characters from
@@ -7478,10 +8241,11 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- If the new value causes 'fillchars' or 'listchars' to become
 --- invalid it is rejected and an error is given.
 ---
---- To clear the overrides pass an empty {list}: >vim
+--- To clear the overrides pass an empty {list}:
+--- ```vim
 ---    call setcellwidths([])
----
---- <You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
+--- ```
+--- You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
 --- the effect for known emoji characters.  Move the cursor
 --- through the text to check if the cell widths of your terminal
 --- match with what Vim knows about each emoji.  If it doesn't
@@ -7491,15 +8255,20 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- @return any
 function vim.fn.setcellwidths(list) end
 
---- Same as |setpos()| but uses the specified column number as the
+--- Same as `|setpos()|` but uses the specified column number as the
 --- character index instead of the byte index in the line.
 ---
 --- Example:
---- With the text "여보세요" in line 8: >vim
+--- With the text "여보세요" in line 8:
+--- ```vim
 ---   call setcharpos('.', [0, 8, 4, 0])
---- <positions the cursor on the fourth character '요'. >vim
+--- ```
+--- positions the cursor on the fourth character '요'.
+--- ```vim
 ---   call setpos('.', [0, 8, 4, 0])
---- <positions the cursor on the second character '보'.
+--- ```
+--- positions the cursor on the second character '보'.
+---
 ---
 --- @param expr any
 --- @param list any
@@ -7510,20 +8279,23 @@ function vim.fn.setcharpos(expr, list) end
 --- which contains one or more of the following entries:
 ---
 ---     char  character which will be used for a subsequent
----     |,| or |;| command; an empty string clears the
+---     `|,|` or `|;|` command; an empty string clears the
 ---     character search
 ---     forward  direction of character search; 1 for forward,
 ---     0 for backward
----     until  type of character search; 1 for a |t| or |T|
----     character search, 0 for an |f| or |F|
+---     until  type of character search; 1 for a `|t|` or `|T|`
+---     character search, 0 for an `|f|` or `|F|`
 ---     character search
 ---
 --- This can be useful to save/restore a user's character search
---- from a script: >vim
+--- from a script:
+--- ```vim
 ---   let prevsearch = getcharsearch()
 ---   " Perform a command which clobbers user's search
 ---   call setcharsearch(prevsearch)
---- <Also see |getcharsearch()|.
+--- ```
+--- Also see `|getcharsearch()|`.
+---
 ---
 --- @param dict any
 --- @return any
@@ -7535,6 +8307,7 @@ function vim.fn.setcharsearch(dict) end
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
 ---
+---
 --- @param str any
 --- @param pos? any
 --- @return any
@@ -7542,17 +8315,18 @@ function vim.fn.setcmdline(str, pos) end
 
 --- Set the cursor position in the command line to byte position
 --- {pos}.  The first position is 1.
---- Use |getcmdpos()| to obtain the current position.
+--- Use `|getcmdpos()|` to obtain the current position.
 --- Only works while editing the command line, thus you must use
---- |c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
---- |c_CTRL-\_e| and |c_CTRL-R_CTRL-R| with '=' the position is
+--- `|c_CTRL-\_e|`, `|c_CTRL-R_=|` or `|c_CTRL-R_CTRL-R|` with '='.  For
+--- `|c_CTRL-\_e|` and `|c_CTRL-R_CTRL-R|` with '=' the position is
 --- set after the command line is set to the expression.  For
---- |c_CTRL-R_=| it is set after evaluating the expression but
+--- `|c_CTRL-R_=|` it is set after evaluating the expression but
 --- before inserting the resulting text.
 --- When the number is too big the cursor is put at the end of the
 --- line.  A number smaller than one has undefined results.
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
+---
 ---
 --- @param pos any
 --- @return any
@@ -7564,25 +8338,32 @@ function vim.fn.setcmdpos(pos) end
 --- @return any
 function vim.fn.setcursorcharpos(lnum, col, off) end
 
---- Same as |cursor()| but uses the specified column number as the
+--- Same as `|cursor()|` but uses the specified column number as the
 --- character index instead of the byte index in the line.
 ---
 --- Example:
---- With the text "여보세요" in line 4: >vim
+--- With the text "여보세요" in line 4:
+--- ```vim
 ---   call setcursorcharpos(4, 3)
---- <positions the cursor on the third character '세'. >vim
+--- ```
+--- positions the cursor on the third character '세'.
+--- ```vim
 ---   call cursor(4, 3)
---- <positions the cursor on the first character '여'.
+--- ```
+--- positions the cursor on the first character '여'.
+---
 ---
 --- @param list any
 --- @return any
 function vim.fn.setcursorcharpos(list) end
 
---- Set environment variable {name} to {val}.  Example: >vim
+--- Set environment variable {name} to {val}.  Example:
+--- ```vim
 ---   call setenv('HOME', '/home/myhome')
+--- ```
+--- When {val} is `|v:null|` the environment variable is deleted.
+--- See also `|expr-env|`.
 ---
---- <When {val} is |v:null| the environment variable is deleted.
---- See also |expr-env|.
 ---
 --- @param name string
 --- @param val any
@@ -7603,7 +8384,7 @@ function vim.fn.setenv(name, val) end
 ---
 --- Returns non-zero for success, zero for failure.
 ---
---- To read permissions see |getfperm()|.
+--- To read permissions see `|getfperm()|`.
 ---
 --- @param fname string
 --- @param mode string
@@ -7611,10 +8392,10 @@ function vim.fn.setenv(name, val) end
 function vim.fn.setfperm(fname, mode) end
 
 --- Set line {lnum} of the current buffer to {text}.  To insert
---- lines use |append()|. To set lines in another buffer use
---- |setbufline()|.
+--- lines use `|append()|`. To set lines in another buffer use
+--- `|setbufline()|`.
 ---
---- {lnum} is used like with |getline()|.
+--- {lnum} is used like with `|getline()|`.
 --- When {lnum} is just below the last line the {text} will be
 --- added below the last line.
 --- {text} can be any type or a List of any type, each item is
@@ -7624,18 +8405,23 @@ function vim.fn.setfperm(fname, mode) end
 --- If this succeeds, FALSE is returned.  If this fails (most likely
 --- because {lnum} is invalid) TRUE is returned.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call setline(5, strftime("%c"))
----
---- <When {text} is a |List| then line {lnum} and following lines
---- will be set to the items in the list.  Example: >vim
+--- ```
+--- When {text} is a `|List|` then line {lnum} and following lines
+--- will be set to the items in the list.  Example:
+--- ```vim
 ---   call setline(5, ['aaa', 'bbb', 'ccc'])
---- <This is equivalent to: >vim
+--- ```
+--- This is equivalent to:
+--- ```vim
 ---   for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
 ---     call setline(n, l)
 ---   endfor
+--- ```
+--- Note: The '[ and '] marks are not set.
 ---
---- <Note: The '[ and '] marks are not set.
 ---
 --- @param lnum integer
 --- @param text any
@@ -7643,19 +8429,20 @@ function vim.fn.setfperm(fname, mode) end
 function vim.fn.setline(lnum, text) end
 
 --- Create or replace or add to the location list for window {nr}.
---- {nr} can be the window number or the |window-ID|.
+--- {nr} can be the window number or the `|window-ID|`.
 --- When {nr} is zero the current window is used.
 ---
 --- For a location list window, the displayed location list is
 --- modified.  For an invalid window number {nr}, -1 is returned.
---- Otherwise, same as |setqflist()|.
---- Also see |location-list|.
+--- Otherwise, same as `|setqflist()|`.
+--- Also see `|location-list|`.
 ---
---- For {action} see |setqflist-action|.
+--- For {action} see `|setqflist-action|`.
 ---
 --- If the optional {what} dictionary argument is supplied, then
---- only the items listed in {what} are set. Refer to |setqflist()|
+--- only the items listed in {what} are set. Refer to `|setqflist()|`
 --- for the list of supported keys in {what}.
+---
 ---
 --- @param nr integer
 --- @param list any
@@ -7664,12 +8451,13 @@ function vim.fn.setline(lnum, text) end
 --- @return any
 function vim.fn.setloclist(nr, list, action, what) end
 
---- Restores a list of matches saved by |getmatches()| for the
+--- Restores a list of matches saved by `|getmatches()|` for the
 --- current window.  Returns 0 if successful, otherwise -1.  All
 --- current matches are cleared before the list is restored.  See
---- example for |getmatches()|.
+--- example for `|getmatches()|`.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
+---
 ---
 --- @param list any
 --- @param win? any
@@ -7680,14 +8468,14 @@ function vim.fn.setmatches(list, win) end
 ---   .  the cursor
 ---   'x  mark x
 ---
---- {list} must be a |List| with four or five numbers:
+--- {list} must be a `|List|` with four or five numbers:
 ---     [bufnum, lnum, col, off]
 ---     [bufnum, lnum, col, off, curswant]
 ---
 --- "bufnum" is the buffer number.  Zero can be used for the
 --- current buffer.  When setting an uppercase mark "bufnum" is
 --- used for the mark position.  For other marks it specifies the
---- buffer to set the mark in.  You can use the |bufnr()| function
+--- buffer to set the mark in.  You can use the `|bufnr()|` function
 --- to turn a file name into a buffer number.
 --- For setting the cursor and the ' mark "bufnum" is ignored,
 --- since these are associated with a window, not a buffer.
@@ -7696,7 +8484,7 @@ function vim.fn.setmatches(list, win) end
 --- "lnum" and "col" are the position in the buffer.  The first
 --- column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
 --- smaller than 1 then 1 is used. To use the character count
---- instead of the byte count, use |setcharpos()|.
+--- instead of the byte count, use `|setcharpos()|`.
 ---
 --- The "off" number is only used when 'virtualedit' is set. Then
 --- it is the offset in screen columns from the start of the
@@ -7716,13 +8504,14 @@ function vim.fn.setmatches(list, win) end
 --- Returns 0 when the position could be set, -1 otherwise.
 --- An error message is given if {expr} is invalid.
 ---
---- Also see |setcharpos()|, |getpos()| and |getcurpos()|.
+--- Also see `|setcharpos()|`, `|getpos()|` and `|getcurpos()|`.
 ---
 --- This does not restore the preferred column for moving
---- vertically; if you set the cursor position with this, |j| and
---- |k| motions will jump to previous columns!  Use |cursor()| to
+--- vertically; if you set the cursor position with this, `|j|` and
+--- `|k|` motions will jump to previous columns!  Use `|cursor()|` to
 --- also set the preferred column.  Also see the "curswant" key in
---- |winrestview()|.
+--- `|winrestview()|`.
+---
 ---
 --- @param expr any
 --- @param list any
@@ -7775,7 +8564,7 @@ function vim.fn.setpos(expr, list) end
 --- If you supply an empty {list}, the quickfix list will be
 --- cleared.
 --- Note that the list is not exactly the same as what
---- |getqflist()| returns.
+--- `|getqflist()|` returns.
 ---
 --- {action} values:    *setqflist-action* *E927*
 --- 'a'  The items from {list} are added to the existing
@@ -7784,9 +8573,10 @@ function vim.fn.setpos(expr, list) end
 ---
 --- 'r'  The items from the current quickfix list are replaced
 ---   with the items from {list}.  This can also be used to
----   clear the list: >vim
+---   clear the list:
+--- ```vim
 ---     call setqflist([], 'r')
---- <
+--- ```
 --- 'f'  All the quickfix lists in the quickfix stack are
 ---   freed.
 ---
@@ -7797,22 +8587,22 @@ function vim.fn.setpos(expr, list) end
 --- set "nr" in {what} to "$".
 ---
 --- The following items can be specified in dictionary {what}:
----     context  quickfix list context. See |quickfix-context|
+---     context  quickfix list context. See `|quickfix-context|`
 ---     efm    errorformat to use when parsing text from
 ---     "lines". If this is not present, then the
 ---     'errorformat' option value is used.
----     See |quickfix-parse|
----     id    quickfix list identifier |quickfix-ID|
+---     See `|quickfix-parse|`
+---     id    quickfix list identifier `|quickfix-ID|`
 ---     idx    index of the current entry in the quickfix
 ---     list specified by "id" or "nr". If set to '$',
 ---     then the last entry in the list is set as the
----     current entry.  See |quickfix-index|
+---     current entry.  See `|quickfix-index|`
 ---     items  list of quickfix entries. Same as the {list}
 ---     argument.
 ---     lines  use 'errorformat' to parse a list of lines and
 ---     add the resulting entries to the quickfix list
----     {nr} or {id}.  Only a |List| value is supported.
----     See |quickfix-parse|
+---     {nr} or {id}.  Only a `|List|` value is supported.
+---     See `|quickfix-parse|`
 ---     nr    list number in the quickfix stack; zero
 ---     means the current quickfix list and "$" means
 ---     the last quickfix list.
@@ -7820,9 +8610,9 @@ function vim.fn.setpos(expr, list) end
 ---     function to get the text to display in the
 ---     quickfix window.  The value can be the name of
 ---     a function or a funcref or a lambda.  Refer to
----     |quickfix-window-function| for an explanation
+---     `|quickfix-window-function|` for an explanation
 ---     of how to write the function and an example.
----     title  quickfix list title text. See |quickfix-title|
+---     title  quickfix list title text. See `|quickfix-title|`
 --- Unsupported keys in {what} are ignored.
 --- If the "nr" item is not present, then the current quickfix list
 --- is modified. When creating a new quickfix list, "nr" can be
@@ -7831,16 +8621,18 @@ function vim.fn.setpos(expr, list) end
 --- list is modified, "id" should be used instead of "nr" to
 --- specify the list.
 ---
---- Examples (See also |setqflist-examples|): >vim
+--- Examples (See also `|setqflist-examples|`):
+--- ```vim
 ---    call setqflist([], 'r', {'title': 'My search'})
 ---    call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
 ---    call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
---- <
+--- ```
 --- Returns zero for success, -1 for failure.
 ---
 --- This function can be used to create a quickfix list
 --- independent of the 'errorformat' setting.  Use a command like
 --- `:cc 1` to jump to the first position.
+---
 ---
 --- @param list any
 --- @param action? any
@@ -7849,18 +8641,18 @@ function vim.fn.setpos(expr, list) end
 function vim.fn.setqflist(list, action, what) end
 
 --- Set the register {regname} to {value}.
---- If {regname} is "" or "\@", the unnamed register '"' is used.
+--- If {regname} is "" or "@", the unnamed register '"' is used.
 --- The {regname} argument is a string.
 ---
---- {value} may be any value returned by |getreg()| or
---- |getreginfo()|, including a |List| or |Dict|.
+--- {value} may be any value returned by `|getreg()|` or
+--- `|getreginfo()|`, including a `|List|` or `|Dict|`.
 --- If {options} contains "a" or {regname} is upper case,
 --- then the value is appended.
 ---
 --- {options} can also contain a register type specification:
----     "c" or "v"        |charwise| mode
----     "l" or "V"        |linewise| mode
----     "b" or "<CTRL-V>" |blockwise-visual| mode
+---     "c" or "v"        `|charwise|` mode
+---     "l" or "V"        `|linewise|` mode
+---     "b" or "<CTRL-V>" `|blockwise-visual|` mode
 --- If a number immediately follows "b" or "<CTRL-V>" then this is
 --- used as the width of the selection - if it is not specified
 --- then the width of the block is set to the number of characters
@@ -7875,33 +8667,40 @@ function vim.fn.setqflist(list, action, what) end
 --- Returns zero for success, non-zero for failure.
 ---
 ---           *E883*
---- Note: you may not use |List| containing more than one item to
+--- Note: you may not use `|List|` containing more than one item to
 ---       set search and expression registers. Lists containing no
 ---       items act like empty strings.
 ---
---- Examples: >vim
----   call setreg(v:register, \@*)
----   call setreg('*', \@%, 'ac')
+--- Examples:
+--- ```vim
+---   call setreg(v:register, @*)
+---   call setreg('*', @%, 'ac')
 ---   call setreg('a', "1\n2\n3", 'b5')
 ---   call setreg('"', { 'points_to': 'a'})
----
---- <This example shows using the functions to save and restore a
---- register: >vim
+--- ```
+--- This example shows using the functions to save and restore a
+--- register:
+--- ```vim
 ---   let var_a = getreginfo()
 ---   call setreg('a', var_a)
---- <or: >vim
+--- ```
+--- or:
+--- ```vim
 ---   let var_a = getreg('a', 1, 1)
 ---   let var_amode = getregtype('a')
 ---   " ....
 ---   call setreg('a', var_a, var_amode)
---- <Note: you may not reliably restore register value
---- without using the third argument to |getreg()| as without it
+--- ```
+--- Note: you may not reliably restore register value
+--- without using the third argument to `|getreg()|` as without it
 --- newlines are represented as newlines AND Nul bytes are
---- represented as newlines as well, see |NL-used-for-Nul|.
+--- represented as newlines as well, see `|NL-used-for-Nul|`.
 ---
 --- You can also change the type of a register by appending
---- nothing: >vim
+--- nothing:
+--- ```vim
 ---   call setreg('a', '', 'al')
+--- ```
 ---
 --- @param regname string
 --- @param value any
@@ -7910,11 +8709,12 @@ function vim.fn.setqflist(list, action, what) end
 function vim.fn.setreg(regname, value, options) end
 
 --- Set tab-local variable {varname} to {val} in tab page {tabnr}.
---- |t:var|
+--- `|t:var|`
 --- The {varname} argument is a string.
 --- Note that the variable name without "t:" must be used.
 --- Tabs are numbered starting with one.
---- This function is not available in the |sandbox|.
+--- This function is not available in the `|sandbox|`.
+---
 ---
 --- @param tabnr integer
 --- @param varname string
@@ -7925,17 +8725,20 @@ function vim.fn.settabvar(tabnr, varname, val) end
 --- Set option or local variable {varname} in window {winnr} to
 --- {val}.
 --- Tabs are numbered starting with one.  For the current tabpage
---- use |setwinvar()|.
---- {winnr} can be the window number or the |window-ID|.
+--- use `|setwinvar()|`.
+--- {winnr} can be the window number or the `|window-ID|`.
 --- When {winnr} is zero the current window is used.
 --- This also works for a global or local buffer option, but it
 --- doesn't work for a global or local buffer variable.
 --- For a local buffer option the global value is unchanged.
 --- Note that the variable name without "w:" must be used.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   call settabwinvar(1, 1, "&list", 0)
 ---   call settabwinvar(3, 2, "myvar", "foobar")
---- <This function is not available in the |sandbox|.
+--- ```
+--- This function is not available in the `|sandbox|`.
+---
 ---
 --- @param tabnr integer
 --- @param winnr integer
@@ -7945,10 +8748,10 @@ function vim.fn.settabvar(tabnr, varname, val) end
 function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 
 --- Modify the tag stack of the window {nr} using {dict}.
---- {nr} can be the window number or the |window-ID|.
+--- {nr} can be the window number or the `|window-ID|`.
 ---
 --- For a list of supported items in {dict}, refer to
---- |gettagstack()|. "curidx" takes effect before changing the tag
+--- `|gettagstack()|`. "curidx" takes effect before changing the tag
 --- stack.
 ---           *E962*
 --- How the tag stack is modified depends on the {action}
@@ -7966,16 +8769,18 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 ---
 --- Returns zero for success, -1 for failure.
 ---
---- Examples (for more examples see |tagstack-examples|):
----     Empty the tag stack of window 3: >vim
+--- Examples (for more examples see `|tagstack-examples|`):
+---     Empty the tag stack of window 3:
+--- ```vim
 ---   call settagstack(3, {'items' : []})
----
---- <    Save and restore the tag stack: >vim
+--- ```
+--- Save and restore the tag stack:
+--- ```vim
 ---   let stack = gettagstack(1003)
 ---   " do something else
 ---   call settagstack(1003, stack)
 ---   unlet stack
---- <
+--- ```
 ---
 --- @param nr integer
 --- @param dict any
@@ -7983,10 +8788,12 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 --- @return any
 function vim.fn.settagstack(nr, dict, action) end
 
---- Like |settabwinvar()| for the current tab page.
---- Examples: >vim
+--- Like `|settabwinvar()|` for the current tab page.
+--- Examples:
+--- ```vim
 ---   call setwinvar(1, "&list", 0)
 ---   call setwinvar(2, "myvar", "foobar")
+--- ```
 ---
 --- @param nr integer
 --- @param varname string
@@ -7996,6 +8803,7 @@ function vim.fn.setwinvar(nr, varname, val) end
 
 --- Returns a String with 64 hex characters, which is the SHA256
 --- checksum of {string}.
+---
 ---
 --- @param string string
 --- @return any
@@ -8008,28 +8816,33 @@ function vim.fn.sha256(string) end
 --- Otherwise encloses {string} in single-quotes and replaces all
 --- "'" with "'\''".
 ---
---- If {special} is a |non-zero-arg|:
+--- If {special} is a `|non-zero-arg|`:
 --- - Special items such as "!", "%", "#" and "<cword>" will be
 ---   preceded by a backslash. The backslash will be removed again
----   by the |:!| command.
+---   by the `|:!|` command.
 --- - The <NL> character is escaped.
 ---
 --- If 'shell' contains "csh" in the tail:
 --- - The "!" character will be escaped. This is because csh and
 ---   tcsh use "!" for history replacement even in single-quotes.
 --- - The <NL> character is escaped (twice if {special} is
----   a |non-zero-arg|).
+---   a `|non-zero-arg|`).
 ---
 --- If 'shell' contains "fish" in the tail, the "\" character will
 --- be escaped because in fish it is used as an escape character
 --- inside single quotes.
 ---
---- Example of use with a |:!| command: >vim
+--- Example of use with a `|:!|` command:
+--- ```vim
 ---     exe '!dir ' .. shellescape(expand('<cfile>'), 1)
---- <This results in a directory listing for the file under the
---- cursor.  Example of use with |system()|: >vim
+--- ```
+--- This results in a directory listing for the file under the
+--- cursor.  Example of use with `|system()|`:
+--- ```vim
 ---     call system("chmod +w -- " .. shellescape(expand("%")))
---- <See also |::S|.
+--- ```
+--- See also `|::S|`.
+---
 ---
 --- @param string string
 --- @param special? any
@@ -8039,7 +8852,8 @@ function vim.fn.shellescape(string, special) end
 --- Returns the effective value of 'shiftwidth'. This is the
 --- 'shiftwidth' value unless it is zero, in which case it is the
 --- 'tabstop' value.  To be backwards compatible in indent
---- plugins, use this: >vim
+--- plugins, use this:
+--- ```vim
 ---   if exists('*shiftwidth')
 ---     func s:sw()
 ---       return shiftwidth()
@@ -8049,12 +8863,14 @@ function vim.fn.shellescape(string, special) end
 ---       return &sw
 ---     endfunc
 ---   endif
---- <And then use s:sw() instead of &sw.
+--- ```
+--- And then use s:sw() instead of &sw.
 ---
 --- When there is one argument {col} this is used as column number
 --- for which to return the 'shiftwidth' value. This matters for the
 --- 'vartabstop' feature. If no {col} argument is given, column 1
 --- will be assumed.
+---
 ---
 --- @param col? integer
 --- @return integer
@@ -8066,7 +8882,7 @@ function vim.fn.shiftwidth(col) end
 function vim.fn.sign_define(name, dict) end
 
 --- Define a new sign named {name} or modify the attributes of an
---- existing sign.  This is similar to the |:sign-define| command.
+--- existing sign.  This is similar to the `|:sign-define|` command.
 ---
 --- Prefix {name} with a unique text to avoid name collisions.
 --- There is no {group} like with placing signs.
@@ -8097,7 +8913,8 @@ function vim.fn.sign_define(name, dict) end
 --- {list} is used, then returns a List of values one for each
 --- defined sign.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   call sign_define("mySign", {
 ---     \ "text" : "=>",
 ---     \ "texthl" : "Error",
@@ -8108,14 +8925,14 @@ function vim.fn.sign_define(name, dict) end
 ---     \ {'name' : 'sign2',
 ---     \  'text' : '!!'}
 ---     \ ])
---- <
+--- ```
 ---
 --- @param list vim.fn.sign_define.dict[]
 --- @return (0|-1)[]
 function vim.fn.sign_define(list) end
 
 --- Get a list of defined signs and their attributes.
---- This is similar to the |:sign-list| command.
+--- This is similar to the `|:sign-list|` command.
 ---
 --- If the {name} is not supplied, then a list of all the defined
 --- signs is returned. Otherwise the attribute of the specified
@@ -8141,35 +8958,36 @@ function vim.fn.sign_define(list) end
 --- Returns an empty List if there are no signs and when {name} is
 --- not found.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Get a list of all the defined signs
 ---   echo sign_getdefined()
 ---
 ---   " Get the attribute of the sign named mySign
 ---   echo sign_getdefined("mySign")
---- <
+--- ```
 ---
 --- @param name? string
 --- @return vim.fn.sign_getdefined.ret.item[]
 function vim.fn.sign_getdefined(name) end
 
 --- Return a list of signs placed in a buffer or all the buffers.
---- This is similar to the |:sign-place-list| command.
+--- This is similar to the `|:sign-place-list|` command.
 ---
 --- If the optional buffer name {buf} is specified, then only the
 --- list of signs placed in that buffer is returned.  For the use
---- of {buf}, see |bufname()|. The optional {dict} can contain
+--- of {buf}, see `|bufname()|`. The optional {dict} can contain
 --- the following entries:
 ---    group  select only signs in this group
 ---    id    select sign with this identifier
 ---    lnum    select signs placed in this line. For the use
----     of {lnum}, see |line()|.
+---     of {lnum}, see `|line()|`.
 --- If {group} is "*", then signs in all the groups including the
 --- global group are returned. If {group} is not supplied or is an
 --- empty string, then only signs in the global group are
 --- returned.  If no arguments are supplied, then signs in the
 --- global group placed in all the buffers are returned.
---- See |sign-group|.
+--- See `|sign-group|`.
 ---
 --- Each list item in the returned value is a dictionary with the
 --- following entries:
@@ -8191,7 +9009,8 @@ function vim.fn.sign_getdefined(name) end
 --- Returns an empty list on failure or if there are no placed
 --- signs.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Get a List of signs placed in eval.c in the
 ---   " global group
 ---   echo sign_getplaced("eval.c")
@@ -8211,7 +9030,7 @@ function vim.fn.sign_getdefined(name) end
 ---
 ---   " Get a List of all the placed signs
 ---   echo sign_getplaced()
---- <
+--- ```
 ---
 --- @param buf? any
 --- @param dict? vim.fn.sign_getplaced.dict
@@ -8220,18 +9039,19 @@ function vim.fn.sign_getplaced(buf, dict) end
 
 --- Open the buffer {buf} or jump to the window that contains
 --- {buf} and position the cursor at sign {id} in group {group}.
---- This is similar to the |:sign-jump| command.
+--- This is similar to the `|:sign-jump|` command.
 ---
 --- If {group} is an empty string, then the global group is used.
---- For the use of {buf}, see |bufname()|.
+--- For the use of {buf}, see `|bufname()|`.
 ---
 --- Returns the line number of the sign. Returns -1 if the
 --- arguments are invalid.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   " Jump to sign 10 in the current buffer
 ---   call sign_jump(10, '', '')
---- <
+--- ```
 ---
 --- @param id integer
 --- @param group string
@@ -8241,25 +9061,25 @@ function vim.fn.sign_jump(id, group, buf) end
 
 --- Place the sign defined as {name} at line {lnum} in file or
 --- buffer {buf} and assign {id} and {group} to sign.  This is
---- similar to the |:sign-place| command.
+--- similar to the `|:sign-place|` command.
 ---
 --- If the sign identifier {id} is zero, then a new identifier is
 --- allocated.  Otherwise the specified number is used. {group} is
 --- the sign group name. To use the global sign group, use an
 --- empty string.  {group} functions as a namespace for {id}, thus
---- two groups can use the same IDs. Refer to |sign-identifier|
---- and |sign-group| for more information.
+--- two groups can use the same IDs. Refer to `|sign-identifier|`
+--- and `|sign-group|` for more information.
 ---
 --- {name} refers to a defined sign.
 --- {buf} refers to a buffer name or number. For the accepted
---- values, see |bufname()|.
+--- values, see `|bufname()|`.
 ---
 --- The optional {dict} argument supports the following entries:
 ---   lnum    line number in the file or buffer
 ---       {buf} where the sign is to be placed.
----       For the accepted values, see |line()|.
+---       For the accepted values, see `|line()|`.
 ---   priority  priority of the sign. See
----       |sign-priority| for more information.
+---       `|sign-priority|` for more information.
 ---
 --- If the optional {dict} is not specified, then it modifies the
 --- placed sign {id} in group {group} to use the defined sign
@@ -8267,7 +9087,8 @@ function vim.fn.sign_jump(id, group, buf) end
 ---
 --- Returns the sign identifier on success and -1 on failure.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Place a sign named sign1 with id 5 at line 20 in
 ---   " buffer json.c
 ---   call sign_place(5, '', 'sign1', 'json.c',
@@ -8285,7 +9106,7 @@ function vim.fn.sign_jump(id, group, buf) end
 ---   " at line 40 in buffer json.c with priority 90
 ---   call sign_place(10, 'g3', 'sign4', 'json.c',
 ---       \ {'lnum' : 40, 'priority' : 90})
---- <
+--- ```
 ---
 --- @param id any
 --- @param group any
@@ -8296,30 +9117,30 @@ function vim.fn.sign_jump(id, group, buf) end
 function vim.fn.sign_place(id, group, name, buf, dict) end
 
 --- Place one or more signs.  This is similar to the
---- |sign_place()| function.  The {list} argument specifies the
+--- `|sign_place()|` function.  The {list} argument specifies the
 --- List of signs to place. Each list item is a dict with the
 --- following sign attributes:
 ---     buffer  Buffer name or number. For the accepted
----     values, see |bufname()|.
+---     values, see `|bufname()|`.
 ---     group  Sign group. {group} functions as a namespace
 ---     for {id}, thus two groups can use the same
 ---     IDs. If not specified or set to an empty
 ---     string, then the global group is used.   See
----     |sign-group| for more information.
+---     `|sign-group|` for more information.
 ---     id    Sign identifier. If not specified or zero,
 ---     then a new unique identifier is allocated.
 ---     Otherwise the specified number is used. See
----     |sign-identifier| for more information.
+---     `|sign-identifier|` for more information.
 ---     lnum  Line number in the buffer where the sign is to
 ---     be placed. For the accepted values, see
----     |line()|.
----     name  Name of the sign to place. See |sign_define()|
+---     `|line()|`.
+---     name  Name of the sign to place. See `|sign_define()|`
 ---     for more information.
 ---     priority  Priority of the sign. When multiple signs are
 ---     placed on a line, the sign with the highest
 ---     priority is used. If not specified, the
 ---     default value of 10 is used. See
----     |sign-priority| for more information.
+---     `|sign-priority|` for more information.
 ---
 --- If {id} refers to an existing sign, then the existing sign is
 --- modified to use the specified {name} and/or {priority}.
@@ -8327,7 +9148,8 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 --- Returns a List of sign identifiers. If failed to place a
 --- sign, the corresponding list item is set to -1.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Place sign s1 with id 5 at line 20 and id 10 at line
 ---   " 30 in buffer a.c
 ---   let [n1, n2] = sign_placelist([
@@ -8351,7 +9173,7 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 ---     \  'buffer' : 'a.c',
 ---     \  'lnum' : 50}
 ---     \ ])
---- <
+--- ```
 ---
 --- @param list vim.fn.sign_placelist.list.item[]
 --- @return integer[]
@@ -8362,7 +9184,7 @@ function vim.fn.sign_placelist(list) end
 function vim.fn.sign_undefine(name) end
 
 --- Deletes a previously defined sign {name}. This is similar to
---- the |:sign-undefine| command. If {name} is not supplied, then
+--- the `|:sign-undefine|` command. If {name} is not supplied, then
 --- deletes all the defined signs.
 ---
 --- The one argument {list} can be used to undefine a list of
@@ -8372,7 +9194,8 @@ function vim.fn.sign_undefine(name) end
 --- {list} call, returns a list of values one for each undefined
 --- sign.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Delete a sign named mySign
 ---   call sign_undefine("mySign")
 ---
@@ -8381,14 +9204,14 @@ function vim.fn.sign_undefine(name) end
 ---
 ---   " Delete all the signs
 ---   call sign_undefine()
---- <
+--- ```
 ---
 --- @param list? string[]
 --- @return integer[]
 function vim.fn.sign_undefine(list) end
 
 --- Remove a previously placed sign in one or more buffers.  This
---- is similar to the |:sign-unplace| command.
+--- is similar to the `|:sign-unplace|` command.
 ---
 --- {group} is the sign group name. To use the global sign group,
 --- use an empty string.  If {group} is set to "*", then all the
@@ -8396,14 +9219,15 @@ function vim.fn.sign_undefine(list) end
 --- The signs in {group} are selected based on the entries in
 --- {dict}.  The following optional entries in {dict} are
 --- supported:
----   buffer  buffer name or number. See |bufname()|.
+---   buffer  buffer name or number. See `|bufname()|`.
 ---   id  sign identifier
 --- If {dict} is not supplied, then all the signs in {group} are
 --- removed.
 ---
 --- Returns 0 on success and -1 on failure.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " Remove sign 10 from buffer a.vim
 ---   call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
 ---
@@ -8427,6 +9251,7 @@ function vim.fn.sign_undefine(list) end
 ---
 ---   " Remove all the placed signs from all the buffers
 ---   call sign_unplace('*')
+--- ```
 ---
 --- @param group string
 --- @param dict? vim.fn.sign_unplace.dict
@@ -8434,12 +9259,12 @@ function vim.fn.sign_undefine(list) end
 function vim.fn.sign_unplace(group, dict) end
 
 --- Remove previously placed signs from one or more buffers.  This
---- is similar to the |sign_unplace()| function.
+--- is similar to the `|sign_unplace()|` function.
 ---
 --- The {list} argument specifies the List of signs to remove.
 --- Each list item is a dict with the following sign attributes:
 ---     buffer  buffer name or number. For the accepted
----     values, see |bufname()|. If not specified,
+---     values, see `|bufname()|`. If not specified,
 ---     then the specified sign is removed from all
 ---     the buffers.
 ---     group  sign group name. If not specified or set to an
@@ -8452,14 +9277,15 @@ function vim.fn.sign_unplace(group, dict) end
 --- Returns a List where an entry is set to 0 if the corresponding
 --- sign was successfully removed or -1 on failure.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   " Remove sign with id 10 from buffer a.vim and sign
 ---   " with id 20 from buffer b.vim
 ---   call sign_unplacelist([
 ---     \ {'id' : 10, 'buffer' : "a.vim"},
 ---     \ {'id' : 20, 'buffer' : 'b.vim'},
 ---     \ ])
---- <
+--- ```
 ---
 --- @param list vim.fn.sign_unplacelist.list.item
 --- @return (0|-1)[]
@@ -8473,52 +9299,66 @@ function vim.fn.sign_unplacelist(list) end
 --- not removed either. On Unix "//path" is unchanged, but
 --- "///path" is simplified to "/path" (this follows the Posix
 --- standard).
---- Example: >vim
+--- Example:
+--- ```vim
 ---   simplify("./dir/.././/file/") == "./file/"
---- <Note: The combination "dir/.." is only removed if "dir" is
+--- ```
+--- Note: The combination "dir/.." is only removed if "dir" is
 --- a searchable directory or does not exist.  On Unix, it is also
 --- removed when "dir" is a symbolic link within the same
 --- directory.  In order to resolve all the involved symbolic
---- links before simplifying the path name, use |resolve()|.
+--- links before simplifying the path name, use `|resolve()|`.
+---
 ---
 --- @param filename any
 --- @return any
 function vim.fn.simplify(filename) end
 
---- Return the sine of {expr}, measured in radians, as a |Float|.
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- Return the sine of {expr}, measured in radians, as a `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo sin(100)
---- <  -0.506366 >vim
+--- ```
+--- -0.506366
+--- ```vim
 ---   echo sin(-4.01)
---- <  0.763301
+--- ```
+--- 0.763301
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.sin(expr) end
 
---- Return the hyperbolic sine of {expr} as a |Float| in the range
+--- Return the hyperbolic sine of {expr} as a `|Float|` in the range
 --- [-inf, inf].
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo sinh(0.5)
---- <  0.521095 >vim
+--- ```
+--- 0.521095
+--- ```vim
 ---   echo sinh(-0.9)
---- <  -1.026517
+--- ```
+--- -1.026517
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.sinh(expr) end
 
---- Similar to using a |slice| "expr[start : end]", but "end" is
+--- Similar to using a `|slice|` "expr[start : end]", but "end" is
 --- used exclusive.  And for a string the indexes are used as
 --- character indexes instead of byte indexes.
 --- Also, composing characters are not counted.
 --- When {end} is omitted the slice continues to the last item.
 --- When {end} is -1 the last item is omitted.
 --- Returns an empty value if {start} or {end} are invalid.
+---
 ---
 --- @param expr any
 --- @param start any
@@ -8533,18 +9373,18 @@ function vim.fn.slice(expr, start, end_) end
 --- should be an ip adderess or host name, and port the port
 --- number.
 ---
---- For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
---- |luv-tcp-handle|.
+--- For "pipe" mode, see `|luv-pipe-handle|`. For "tcp" mode, see
+--- `|luv-tcp-handle|`.
 ---
---- Returns a |channel| ID. Close the socket with |chanclose()|.
---- Use |chansend()| to send data over a bytes socket, and
---- |rpcrequest()| and |rpcnotify()| to communicate with a RPC
+--- Returns a `|channel|` ID. Close the socket with `|chanclose()|`.
+--- Use `|chansend()|` to send data over a bytes socket, and
+--- `|rpcrequest()|` and `|rpcnotify()|` to communicate with a RPC
 --- socket.
 ---
 --- {opts} is an optional dictionary with these keys:
----   |on_data| : callback invoked when data was read from socket
----   data_buffered : read socket data in |channel-buffered| mode.
----   rpc     : If set, |msgpack-rpc| will be used to communicate
+---   `|on_data|` : callback invoked when data was read from socket
+---   data_buffered : read socket data in `|channel-buffered|` mode.
+---   rpc     : If set, `|msgpack-rpc|` will be used to communicate
 ---       over the socket.
 --- Returns:
 ---   - The channel ID on success (greater than zero)
@@ -8558,13 +9398,14 @@ function vim.fn.sockconnect(mode, address, opts) end
 
 --- Sort the items in {list} in-place.  Returns {list}.
 ---
---- If you want a list to remain unmodified make a copy first: >vim
+--- If you want a list to remain unmodified make a copy first:
+--- ```vim
 ---   let sortedlist = sort(copy(mylist))
----
---- <When {how} is omitted or is a string, then sort() uses the
+--- ```
+--- When {how} is omitted or is a string, then sort() uses the
 --- string representation of each item to sort on.  Numbers sort
---- after Strings, |Lists| after Numbers.  For sorting text in the
---- current buffer use |:sort|.
+--- after Strings, `|Lists|` after Numbers.  For sorting text in the
+--- current buffer use `|:sort|`.
 ---
 --- When {how} is given and it is 'i' then case is ignored.
 --- For backwards compatibility, the value one can be used to
@@ -8572,19 +9413,22 @@ function vim.fn.sockconnect(mode, address, opts) end
 ---
 --- When {how} is given and it is 'l' then the current collation
 --- locale is used for ordering. Implementation details: strcoll()
---- is used to compare strings. See |:language| check or set the
---- collation locale. |v:collate| can also be used to check the
+--- is used to compare strings. See `|:language|` check or set the
+--- collation locale. `|v:collate|` can also be used to check the
 --- current locale. Sorting using the locale typically ignores
---- case. Example: >vim
+--- case. Example:
+--- ```vim
 ---   " ö is sorted similarly to o with English locale.
 ---   language collate en_US.UTF8
 ---   echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
---- <  ['n', 'o', 'O', 'ö', 'p', 'z'] ~
---- >vim
+--- ```
+--- ['n', 'o', 'O', 'ö', 'p', 'z'] ~
+--- ```vim
 ---   " ö is sorted after z with Swedish locale.
 ---   language collate sv_SE.UTF8
 ---   echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
---- <  ['n', 'o', 'O', 'p', 'z', 'ö'] ~
+--- ```
+--- ['n', 'o', 'O', 'p', 'z', 'ö'] ~
 --- This does not work properly on Mac.
 ---
 --- When {how} is given and it is 'n' then all items will be
@@ -8599,14 +9443,14 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- When {how} is given and it is 'f' then all items will be
 --- sorted numerical. All values must be a Number or a Float.
 ---
---- When {how} is a |Funcref| or a function name, this function
+--- When {how} is a `|Funcref|` or a function name, this function
 --- is called to compare items.  The function is invoked with two
 --- items as argument and must return zero if they are equal, 1 or
 --- bigger if the first one sorts after the second one, -1 or
 --- smaller if the first one sorts before the second one.
 ---
 --- {dict} is for functions with the "dict" attribute.  It will be
---- used to set the local variable "self". |Dictionary-function|
+--- used to set the local variable "self". `|Dictionary-function|`
 ---
 --- The sort is stable, items which compare equal (as number or as
 --- string) will keep their relative position. E.g., when sorting
@@ -8614,19 +9458,24 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- same order as they were originally.
 ---
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   func MyCompare(i1, i2)
 ---      return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
 ---   endfunc
 ---   eval mylist->sort("MyCompare")
---- <A shorter compare version for this specific simple case, which
---- ignores overflow: >vim
+--- ```
+--- A shorter compare version for this specific simple case, which
+--- ignores overflow:
+--- ```vim
 ---   func MyCompare(i1, i2)
 ---      return a:i1 - a:i2
 ---   endfunc
---- <For a simple expression you can use a lambda: >vim
+--- ```
+--- For a simple expression you can use a lambda:
+--- ```vim
 ---   eval mylist->sort({i1, i2 -> i1 - i2})
---- <
+--- ```
 ---
 --- @param list any
 --- @param how? any
@@ -8640,6 +9489,7 @@ function vim.fn.sort(list, how, dict) end
 --- possible the {word} is returned unmodified.
 --- This can be used for making spelling suggestions.  Note that
 --- the method can be quite slow.
+---
 ---
 --- @param word any
 --- @return any
@@ -8661,18 +9511,21 @@ function vim.fn.soundfold(word) end
 ---   "rare"    rare word
 ---   "local"    word only valid in another region
 ---   "caps"    word should start with Capital
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo spellbadword("the quik brown fox")
---- <  ['quik', 'bad'] ~
+--- ```
+--- ['quik', 'bad'] ~
 ---
 --- The spelling information for the current window and the value
 --- of 'spelllang' are used.
+---
 ---
 --- @param sentence? any
 --- @return any
 function vim.fn.spellbadword(sentence) end
 
---- Return a |List| with spelling suggestions to replace {word}.
+--- Return a `|List|` with spelling suggestions to replace {word}.
 --- When {max} is given up to this number of suggestions are
 --- returned.  Otherwise up to 25 suggestions are returned.
 ---
@@ -8692,35 +9545,45 @@ function vim.fn.spellbadword(sentence) end
 --- The spelling information for the current window is used.  The
 --- values of 'spelllang' and 'spellsuggest' are used.
 ---
+---
 --- @param word any
 --- @param max? any
 --- @param capital? any
 --- @return any
 function vim.fn.spellsuggest(word, max, capital) end
 
---- Make a |List| out of {string}.  When {pattern} is omitted or
+--- Make a `|List|` out of {string}.  When {pattern} is omitted or
 --- empty each white-separated sequence of characters becomes an
 --- item.
 --- Otherwise the string is split where {pattern} matches,
 --- removing the matched characters. 'ignorecase' is not used
---- here, add \c to ignore case. |/\c|
+--- here, add \c to ignore case. `|/\c|`
 --- When the first or last item is empty it is omitted, unless the
 --- {keepempty} argument is given and it's non-zero.
 --- Other empty items are kept when {pattern} matches at least one
 --- character or when {keepempty} is non-zero.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let words = split(getline('.'), '\W\+')
---- <To split a string in individual characters: >vim
+--- ```
+--- To split a string in individual characters:
+--- ```vim
 ---   for c in split(mystring, '\zs') | endfor
---- <If you want to keep the separator you can also use '\zs' at
---- the end of the pattern: >vim
+--- ```
+--- If you want to keep the separator you can also use '\zs' at
+--- the end of the pattern:
+--- ```vim
 ---   echo split('abc:def:ghi', ':\zs')
---- < >
+--- ```
+--- ```
 ---   ['abc:', 'def:', 'ghi']
---- <
---- Splitting a table where the first element can be empty: >vim
+--- ```
+--- Splitting a table where the first element can be empty:
+--- ```vim
 ---   let items = split(line, ':', 1)
---- <The opposite function is |join()|.
+--- ```
+--- The opposite function is `|join()|`.
+---
 ---
 --- @param string string
 --- @param pattern? any
@@ -8729,22 +9592,27 @@ function vim.fn.spellsuggest(word, max, capital) end
 function vim.fn.split(string, pattern, keepempty) end
 
 --- Return the non-negative square root of Float {expr} as a
---- |Float|.
---- {expr} must evaluate to a |Float| or a |Number|.  When {expr}
+--- `|Float|`.
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.  When {expr}
 --- is negative the result is NaN (Not a Number).  Returns 0.0 if
---- {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo sqrt(100)
---- <  10.0 >vim
+--- ```
+--- 10.0
+--- ```vim
 ---   echo sqrt(-4.01)
---- <  str2float("nan")
+--- ```
+--- str2float("nan")
 --- NaN may be different, it depends on system libraries.
+---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.sqrt(expr) end
 
---- Initialize seed used by |rand()|:
+--- Initialize seed used by `|rand()|`:
 --- - If {expr} is not given, seed values are initialized by
 ---   reading from /dev/urandom, if possible, or using time(NULL)
 ---   a.k.a. epoch time otherwise; this only has second accuracy.
@@ -8752,11 +9620,12 @@ function vim.fn.sqrt(expr) end
 ---   initialize the seed values.  This is useful for testing or
 ---   when a predictable sequence is intended.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   let seed = srand()
 ---   let seed = srand(userinput)
 ---   echo rand(seed)
---- <
+--- ```
 ---
 --- @param expr? any
 --- @return any
@@ -8767,26 +9636,27 @@ function vim.fn.srand(expr) end
 --- work that may not always be safe.  Roughly this works like:
 --- - callback uses state() to check if work is safe to do.
 ---   Yes: then do it right away.
----   No:  add to work queue and add a |SafeState| autocommand.
+---   No:  add to work queue and add a `|SafeState|` autocommand.
 --- - When SafeState is triggered and executes your autocommand,
 ---   check with `state()` if the work can be done now, and if yes
 ---   remove it from the queue and execute.
 ---   Remove the autocommand if the queue is now empty.
---- Also see |mode()|.
+--- Also see `|mode()|`.
 ---
 --- When {what} is given only characters in this string will be
---- added.  E.g, this checks if the screen has scrolled: >vim
+--- added.  E.g, this checks if the screen has scrolled:
+--- ```vim
 ---   if state('s') == ''
 ---      " screen has not scrolled
---- <
+--- ```
 --- These characters indicate the state, generally indicating that
 --- something is busy:
 ---     m  halfway a mapping, :normal command, feedkeys() or
 ---   stuffed command
----     o  operator pending, e.g. after |d|
+---     o  operator pending, e.g. after `|d|`
 ---     a  Insert mode autocomplete active
 ---     x  executing an autocommand
----     S  not triggering SafeState, e.g. after |f| or a count
+---     S  not triggering SafeState, e.g. after `|f|` or a count
 ---     c  callback invoked, including timer (repeats for
 ---   recursiveness up to "ccc")
 ---     s  screen has scrolled for messages
@@ -8795,37 +9665,37 @@ function vim.fn.srand(expr) end
 --- @return any
 function vim.fn.state(what) end
 
---- With |--headless| this opens stdin and stdout as a |channel|.
---- May be called only once. See |channel-stdio|. stderr is not
---- handled by this function, see |v:stderr|.
+--- With `|--headless|` this opens stdin and stdout as a `|channel|`.
+--- May be called only once. See `|channel-stdio|`. stderr is not
+--- handled by this function, see `|v:stderr|`.
 ---
---- Close the stdio handles with |chanclose()|. Use |chansend()|
---- to send data to stdout, and |rpcrequest()| and |rpcnotify()|
+--- Close the stdio handles with `|chanclose()|`. Use `|chansend()|`
+--- to send data to stdout, and `|rpcrequest()|` and `|rpcnotify()|`
 --- to communicate over RPC.
 ---
 --- {opts} is a dictionary with these keys:
----   |on_stdin| : callback invoked when stdin is written to.
+---   `|on_stdin|` : callback invoked when stdin is written to.
 ---   on_print : callback invoked when Nvim needs to print a
 ---        message, with the message (whose type is string)
 ---        as sole argument.
----   stdin_buffered : read stdin in |channel-buffered| mode.
----   rpc      : If set, |msgpack-rpc| will be used to communicate
+---   stdin_buffered : read stdin in `|channel-buffered|` mode.
+---   rpc      : If set, `|msgpack-rpc|` will be used to communicate
 ---        over stdio
 --- Returns:
----   - |channel-id| on success (value is always 1)
+---   - `|channel-id|` on success (value is always 1)
 ---   - 0 on invalid arguments
 ---
 --- @param opts table
 --- @return any
 function vim.fn.stdioopen(opts) end
 
---- Returns |standard-path| locations of various default files and
+--- Returns `|standard-path|` locations of various default files and
 --- directories.
 ---
 --- {what}       Type    Description ~
 --- cache        String  Cache directory: arbitrary temporary
 ---                      storage for plugins, etc.
---- config       String  User configuration directory. |init.vim|
+--- config       String  User configuration directory. `|init.vim|`
 ---                      is stored here.
 --- config_dirs  List    Other configuration directories.
 --- data         String  User data directory.
@@ -8834,11 +9704,12 @@ function vim.fn.stdioopen(opts) end
 --- run          String  Run directory: temporary, local storage
 ---          for sockets, named pipes, etc.
 --- state        String  Session state directory: storage for file
----          drafts, swap, undo, |shada|.
+---          drafts, swap, undo, `|shada|`.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo stdpath("config")
---- <
+--- ```
 ---
 --- @param what 'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'
 --- @return string|string[]
@@ -8846,7 +9717,7 @@ function vim.fn.stdpath(what) end
 
 --- Convert String {string} to a Float.  This mostly works the
 --- same as when using a floating point number in an expression,
---- see |floating-point-format|.  But it's a bit more permissive.
+--- see `|floating-point-format|`.  But it's a bit more permissive.
 --- E.g., "1e40" is accepted, while in an expression you need to
 --- write "1.0e40".  The hexadecimal form "0x123" is also
 --- accepted, but not others, like binary or octal.
@@ -8857,10 +9728,12 @@ function vim.fn.stdpath(what) end
 --- The decimal point is always '.', no matter what the locale is
 --- set to.  A comma ends the number: "12,345.67" is converted to
 --- 12.0.  You can strip out thousands separators with
---- |substitute()|: >vim
+--- `|substitute()|`:
+--- ```vim
 ---   let f = str2float(substitute(text, ',', '', 'g'))
---- <
+--- ```
 --- Returns 0.0 if the conversion fails.
+---
 ---
 --- @param string string
 --- @param quoted? any
@@ -8868,15 +9741,19 @@ function vim.fn.stdpath(what) end
 function vim.fn.str2float(string, quoted) end
 
 --- Return a list containing the number values which represent
---- each character in String {string}.  Examples: >vim
+--- each character in String {string}.  Examples:
+--- ```vim
 ---   echo str2list(" ")    " returns [32]
 ---   echo str2list("ABC")    " returns [65, 66, 67]
---- <|list2str()| does the opposite.
+--- ```
+--- `|list2str()|` does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
---- With UTF-8 composing characters are handled properly: >vim
+--- With UTF-8 composing characters are handled properly:
+--- ```vim
 ---   echo str2list("á")    " returns [97, 769]
+--- ```
 ---
 --- @param string string
 --- @param utf8? any
@@ -8890,9 +9767,10 @@ function vim.fn.str2list(string, utf8) end
 ---
 --- When {base} is omitted base 10 is used.  This also means that
 --- a leading zero doesn't cause octal conversion to be used, as
---- with the default String to Number conversion.  Example: >vim
+--- with the default String to Number conversion.  Example:
+--- ```vim
 ---   let nr = str2nr('0123')
---- <
+--- ```
 --- When {base} is 16 a leading "0x" or "0X" is ignored.  With a
 --- different base the result will be zero. Similarly, when
 --- {base} is 8 a leading "0", "0o" or "0O" is ignored, and when
@@ -8901,6 +9779,7 @@ function vim.fn.str2list(string, utf8) end
 ---
 --- Returns 0 if {string} is empty or on error.
 ---
+---
 --- @param string string
 --- @param base? any
 --- @return any
@@ -8908,30 +9787,34 @@ function vim.fn.str2nr(string, base) end
 
 --- The result is a Number, which is the number of characters
 --- in String {string}.  Composing characters are ignored.
---- |strchars()| can count the number of characters, counting
+--- `|strchars()|` can count the number of characters, counting
 --- composing characters separately.
 ---
 --- Returns 0 if {string} is empty or on error.
 ---
---- Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+--- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strwidth()|`.
+---
 ---
 --- @param string string
 --- @return any
 function vim.fn.strcharlen(string) end
 
---- Like |strpart()| but using character index and length instead
+--- Like `|strpart()|` but using character index and length instead
 --- of byte index and length.
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
 --- When {skipcc} set to 1, Composing characters are ignored,
---- similar to  |slice()|.
+--- similar to  `|slice()|`.
 --- When a character index is used where a character does not
 --- exist it is omitted and counted as one character.  For
---- example: >vim
+--- example:
+--- ```vim
 ---   echo strcharpart('abc', -1, 2)
---- <results in 'a'.
+--- ```
+--- results in 'a'.
 ---
 --- Returns an empty string on error.
+---
 ---
 --- @param src any
 --- @param start any
@@ -8945,14 +9828,15 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
 --- When {skipcc} set to 1, Composing characters are ignored.
---- |strcharlen()| always does this.
+--- `|strcharlen()|` always does this.
 ---
 --- Returns zero on error.
 ---
---- Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+--- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strwidth()|`.
 ---
 --- {skipcc} is only available after 7.4.755.  For backward
---- compatibility, you can define a wrapper function: >vim
+--- compatibility, you can define a wrapper function:
+--- ```vim
 ---     if has("patch-7.4.755")
 ---       function s:strchars(str, skipcc)
 ---   return strchars(a:str, a:skipcc)
@@ -8966,7 +9850,7 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 ---   endif
 ---       endfunction
 ---     endif
---- <
+--- ```
 ---
 --- @param string string
 --- @param skipcc? any
@@ -8984,7 +9868,8 @@ function vim.fn.strchars(string, skipcc) end
 --- When {string} contains characters with East Asian Width Class
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
---- Also see |strlen()|, |strwidth()| and |strchars()|.
+--- Also see `|strlen()|`, `|strwidth()|` and `|strchars()|`.
+---
 ---
 --- @param string string
 --- @param col? integer
@@ -8997,15 +9882,17 @@ function vim.fn.strdisplaywidth(string, col) end
 --- {format} depends on your system, thus this is not portable!
 --- See the manual page of the C function strftime() for the
 --- format.  The maximum length of the result is 80 characters.
---- See also |localtime()|, |getftime()| and |strptime()|.
---- The language can be changed with the |:language| command.
---- Examples: >vim
+--- See also `|localtime()|`, `|getftime()|` and `|strptime()|`.
+--- The language can be changed with the `|:language|` command.
+--- Examples:
+--- ```vim
 ---   echo strftime("%c")       " Sun Apr 27 11:49:23 1997
 ---   echo strftime("%Y %b %d %X")     " 1997 Apr 27 11:53:25
 ---   echo strftime("%y%m%d %T")     " 970427 11:53:55
 ---   echo strftime("%H:%M")       " 11:55
 ---   echo strftime("%c", getftime("file.c"))
 ---            " Show mod time of file.c.
+--- ```
 ---
 --- @param format any
 --- @param time? any
@@ -9015,10 +9902,11 @@ function vim.fn.strftime(format, time) end
 --- Get a Number corresponding to the character at {index} in
 --- {str}.  This uses a zero-based character index, not a byte
 --- index.  Composing characters are considered separate
---- characters here.  Use |nr2char()| to convert the Number to a
+--- characters here.  Use `|nr2char()|` to convert the Number to a
 --- String.
 --- Returns -1 if {index} is invalid.
---- Also see |strcharpart()| and |strchars()|.
+--- Also see `|strcharpart()|` and `|strchars()|`.
+---
 ---
 --- @param str string
 --- @param index integer
@@ -9028,20 +9916,25 @@ function vim.fn.strgetchar(str, index) end
 --- The result is a Number, which gives the byte index in
 --- {haystack} of the first occurrence of the String {needle}.
 --- If {start} is specified, the search starts at index {start}.
---- This can be used to find a second match: >vim
+--- This can be used to find a second match:
+--- ```vim
 ---   let colon1 = stridx(line, ":")
 ---   let colon2 = stridx(line, ":", colon1 + 1)
---- <The search is done case-sensitive.
---- For pattern searches use |match()|.
+--- ```
+--- The search is done case-sensitive.
+--- For pattern searches use `|match()|`.
 --- -1 is returned if the {needle} does not occur in {haystack}.
---- See also |strridx()|.
---- Examples: >vim
+--- See also `|strridx()|`.
+--- Examples:
+--- ```vim
 ---   echo stridx("An Example", "Example")     " 3
 ---   echo stridx("Starting point", "Start")   " 0
 ---   echo stridx("Starting point", "start")   " -1
---- <        *strstr()* *strchr()*
+--- ```
+--- *strstr()* *strchr()*
 --- stridx() works similar to the C function strstr().  When used
 --- with a single character it works similar to strchr().
+---
 ---
 --- @param haystack string
 --- @param needle string
@@ -9051,7 +9944,7 @@ function vim.fn.stridx(haystack, needle, start) end
 
 --- Return {expr} converted to a String.  If {expr} is a Number,
 --- Float, String, Blob or a composition of them, then the result
---- can be parsed back with |eval()|.
+--- can be parsed back with `|eval()|`.
 ---   {expr} type  result ~
 ---   String    'string'
 ---   Number    123
@@ -9062,15 +9955,16 @@ function vim.fn.stridx(haystack, needle, start) end
 ---   List    [item, item]
 ---   Dictionary  `{key: value, key: value}`
 --- Note that in String values the ' character is doubled.
---- Also see |strtrans()|.
+--- Also see `|strtrans()|`.
 --- Note 2: Output format is mostly compatible with YAML, except
 --- for infinite and NaN floating-point values representations
---- which use |str2float()|.  Strings are also dumped literally,
+--- which use `|str2float()|`.  Strings are also dumped literally,
 --- only single quote is escaped, which does not allow using YAML
---- for parsing back binary strings.  |eval()| should always work for
+--- for parsing back binary strings.  `|eval()|` should always work for
 --- strings and floats though and this is the only official
---- method, use |msgpackdump()| or |json_encode()| if you need to
+--- method, use `|msgpackdump()|` or `|json_encode()|` if you need to
 --- share data with other application.
+---
 ---
 --- @param expr any
 --- @return string
@@ -9081,8 +9975,9 @@ function vim.fn.string(expr) end
 --- If the argument is a Number it is first converted to a String.
 --- For other types an error is given and zero is returned.
 --- If you want to count the number of multibyte characters use
---- |strchars()|.
---- Also see |len()|, |strdisplaywidth()| and |strwidth()|.
+--- `|strchars()|`.
+--- Also see `|len()|`, `|strdisplaywidth()|` and `|strwidth()|`.
+---
 ---
 --- @param string string
 --- @return integer
@@ -9095,22 +9990,25 @@ function vim.fn.strlen(string) end
 --- separately, thus "1" means one base character and any
 --- following composing characters).
 --- To count {start} as characters instead of bytes use
---- |strcharpart()|.
+--- `|strcharpart()|`.
 ---
 --- When bytes are selected which do not exist, this doesn't
 --- result in an error, the bytes are simply omitted.
 --- If {len} is missing, the copy continues from {start} till the
---- end of the {src}. >vim
+--- end of the {src}.
+--- ```vim
 ---   echo strpart("abcdefg", 3, 2)    " returns 'de'
 ---   echo strpart("abcdefg", -2, 4)   " returns 'ab'
 ---   echo strpart("abcdefg", 5, 4)    " returns 'fg'
 ---   echo strpart("abcdefg", 3)   " returns 'defg'
----
---- <Note: To get the first character, {start} must be 0.  For
---- example, to get the character under the cursor: >vim
+--- ```
+--- Note: To get the first character, {start} must be 0.  For
+--- example, to get the character under the cursor:
+--- ```vim
 ---   strpart(getline("."), col(".") - 1, 1, v:true)
---- <
+--- ```
 --- Returns an empty string on error.
+---
 ---
 --- @param src string
 --- @param start integer
@@ -9133,14 +10031,21 @@ function vim.fn.strpart(src, start, len, chars) end
 --- can try different {format} values until you get a non-zero
 --- result.
 ---
---- See also |strftime()|.
---- Examples: >vim
+--- See also `|strftime()|`.
+--- Examples:
+--- ```vim
 ---   echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
---- <  862156163 >vim
+--- ```
+--- 862156163
+--- ```vim
 ---   echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
---- <  Sun Apr 27 11:53:55 1997 >vim
+--- ```
+--- Sun Apr 27 11:53:55 1997
+--- ```vim
 ---   echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
---- <  Sun Apr 27 12:53:55 1997
+--- ```
+--- Sun Apr 27 12:53:55 1997
+---
 ---
 --- @param format string
 --- @param timestring string
@@ -9151,18 +10056,23 @@ function vim.fn.strptime(format, timestring) end
 --- {haystack} of the last occurrence of the String {needle}.
 --- When {start} is specified, matches beyond this index are
 --- ignored.  This can be used to find a match before a previous
---- match: >vim
+--- match:
+--- ```vim
 ---   let lastcomma = strridx(line, ",")
 ---   let comma2 = strridx(line, ",", lastcomma - 1)
---- <The search is done case-sensitive.
---- For pattern searches use |match()|.
+--- ```
+--- The search is done case-sensitive.
+--- For pattern searches use `|match()|`.
 --- -1 is returned if the {needle} does not occur in {haystack}.
 --- If the {needle} is empty the length of {haystack} is returned.
---- See also |stridx()|.  Examples: >vim
+--- See also `|stridx()|`.  Examples:
+--- ```vim
 ---   echo strridx("an angry armadillo", "an")       3
---- <          *strrchr()*
+--- ```
+--- *strrchr()*
 --- When used with a single character it works similar to the C
 --- function strrchr().
+---
 ---
 --- @param haystack string
 --- @param needle string
@@ -9171,13 +10081,16 @@ function vim.fn.strptime(format, timestring) end
 function vim.fn.strridx(haystack, needle, start) end
 
 --- The result is a String, which is {string} with all unprintable
---- characters translated into printable characters |'isprint'|.
---- Like they are shown in a window.  Example: >vim
----   echo strtrans(\@a)
---- <This displays a newline in register a as "^\@" instead of
+--- characters translated into printable characters `|'isprint'|`.
+--- Like they are shown in a window.  Example:
+--- ```vim
+---   echo strtrans(@a)
+--- ```
+--- This displays a newline in register a as "^@" instead of
 --- starting a new line.
 ---
 --- Returns an empty string on error.
+---
 ---
 --- @param string string
 --- @return string
@@ -9193,14 +10106,15 @@ function vim.fn.strtrans(string) end
 ---
 --- Returns zero on error.
 ---
---- Also see |strlen()| and |strcharlen()|.
---- Examples: >vim
+--- Also see `|strlen()|` and `|strcharlen()|`.
+--- Examples:
+--- ```vim
 ---     echo strutf16len('a')    " returns 1
 ---     echo strutf16len('©')    " returns 1
 ---     echo strutf16len('😊')    " returns 2
 ---     echo strutf16len('ą́')    " returns 1
 ---     echo strutf16len('ą́', v:true)  " returns 3
---- <
+--- ```
 ---
 --- @param string string
 --- @param countcc? 0|1
@@ -9209,30 +10123,31 @@ function vim.fn.strutf16len(string, countcc) end
 
 --- The result is a Number, which is the number of display cells
 --- String {string} occupies.  A Tab character is counted as one
---- cell, alternatively use |strdisplaywidth()|.
+--- cell, alternatively use `|strdisplaywidth()|`.
 --- When {string} contains characters with East Asian Width Class
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
---- Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
+--- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strchars()|`.
+---
 ---
 --- @param string string
 --- @return integer
 function vim.fn.strwidth(string) end
 
---- Only for an expression in a |:substitute| command or
+--- Only for an expression in a `|:substitute|` command or
 --- substitute() function.
 --- Returns the {nr}th submatch of the matched text.  When {nr}
 --- is 0 the whole matched text is returned.
 --- Note that a NL in the string can stand for a line break of a
 --- multi-line match or a NUL character in the text.
---- Also see |sub-replace-expression|.
+--- Also see `|sub-replace-expression|`.
 ---
 --- If {list} is present and non-zero then submatch() returns
---- a list of strings, similar to |getline()| with two arguments.
+--- a list of strings, similar to `|getline()|` with two arguments.
 --- NL characters in the text represent NUL characters in the
 --- text.
---- Only returns more than one item for |:substitute|, inside
---- |substitute()| this list will always contain one or zero
+--- Only returns more than one item for `|:substitute|`, inside
+--- `|substitute()|` this list will always contain one or zero
 --- items, since there are no real line breaks.
 ---
 --- When substitute() is used recursively only the submatches in
@@ -9240,11 +10155,14 @@ function vim.fn.strwidth(string) end
 ---
 --- Returns an empty string or list on error.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   s/\d\+/\=submatch(0) + 1/
 ---   echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
---- <This finds the first number in the line and adds one to it.
+--- ```
+--- This finds the first number in the line and adds one to it.
 --- A line break is included as a newline character.
+---
 ---
 --- @param nr integer
 --- @param list? integer
@@ -9259,39 +10177,48 @@ function vim.fn.submatch(nr, list) end
 --- This works like the ":substitute" command (without any flags).
 --- But the matching with {pat} is always done like the 'magic'
 --- option is set and 'cpoptions' is empty (to make scripts
---- portable).  'ignorecase' is still relevant, use |/\c| or |/\C|
+--- portable).  'ignorecase' is still relevant, use `|/\c|` or `|/\C|`
 --- if you want to ignore or match case and ignore 'ignorecase'.
---- 'smartcase' is not used.  See |string-match| for how {pat} is
+--- 'smartcase' is not used.  See `|string-match|` for how {pat} is
 --- used.
 ---
 --- A "~" in {sub} is not replaced with the previous {sub}.
 --- Note that some codes in {sub} have a special meaning
---- |sub-replace-special|.  For example, to replace something with
+--- `|sub-replace-special|`.  For example, to replace something with
 --- "\n" (two characters), use "\\\\n" or '\\n'.
 ---
 --- When {pat} does not match in {string}, {string} is returned
 --- unmodified.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let &path = substitute(&path, ",\\=[^,]*$", "", "")
---- <This removes the last component of the 'path' option. >vim
+--- ```
+--- This removes the last component of the 'path' option.
+--- ```vim
 ---   echo substitute("testing", ".*", "\\U\\0", "")
---- <results in "TESTING".
+--- ```
+--- results in "TESTING".
 ---
 --- When {sub} starts with "\=", the remainder is interpreted as
---- an expression. See |sub-replace-expression|.  Example: >vim
+--- an expression. See `|sub-replace-expression|`.  Example:
+--- ```vim
 ---   echo substitute(s, '%\(\x\x\)',
 ---      \ '\=nr2char("0x" .. submatch(1))', 'g')
----
---- <When {sub} is a Funcref that function is called, with one
---- optional argument.  Example: >vim
+--- ```
+--- When {sub} is a Funcref that function is called, with one
+--- optional argument.  Example:
+--- ```vim
 ---    echo substitute(s, '%\(\x\x\)', SubNr, 'g')
---- <The optional argument is a list which contains the whole
+--- ```
+--- The optional argument is a list which contains the whole
 --- matched string and up to nine submatches, like what
---- |submatch()| returns.  Example: >vim
+--- `|submatch()|` returns.  Example:
+--- ```vim
 ---    echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
+--- ```
+--- Returns an empty string on error.
 ---
---- <Returns an empty string on error.
 ---
 --- @param string string
 --- @param pat string
@@ -9301,14 +10228,16 @@ function vim.fn.submatch(nr, list) end
 function vim.fn.substitute(string, pat, sub, flags) end
 
 --- Returns a list of swap file names, like what "vim -r" shows.
---- See the |-r| command argument.  The 'directory' option is used
+--- See the `|-r|` command argument.  The 'directory' option is used
 --- for the directories to inspect.  If you only want to get a
 --- list of swap files in the current directory then temporarily
---- set 'directory' to a dot: >vim
+--- set 'directory' to a dot:
+--- ```vim
 ---   let save_dir = &directory
 ---   let &directory = '.'
 ---   let swapfiles = swapfilelist()
 ---   let &directory = save_dir
+--- ```
 ---
 --- @return string[]
 function vim.fn.swapfilelist() end
@@ -9330,15 +10259,17 @@ function vim.fn.swapfilelist() end
 ---   Not a swap file: does not contain correct block ID
 ---   Magic number mismatch: Info in first block is invalid
 ---
+---
 --- @param fname string
 --- @return any
 function vim.fn.swapinfo(fname) end
 
 --- The result is the swap file path of the buffer {buf}.
---- For the use of {buf}, see |bufname()| above.
+--- For the use of {buf}, see `|bufname()|` above.
 --- If buffer {buf} is the current buffer, the result is equal to
---- |:swapname| (unless there is no swap file).
+--- `|:swapname|` (unless there is no swap file).
 --- If buffer {buf} has no swap file, returns an empty string.
+---
 ---
 --- @param buf integer|string
 --- @return string
@@ -9346,18 +10277,18 @@ function vim.fn.swapname(buf) end
 
 --- The result is a Number, which is the syntax ID at the position
 --- {lnum} and {col} in the current window.
---- The syntax ID can be used with |synIDattr()| and
---- |synIDtrans()| to obtain syntax information about text.
+--- The syntax ID can be used with `|synIDattr()|` and
+--- `|synIDtrans()|` to obtain syntax information about text.
 ---
 --- {col} is 1 for the leftmost column, {lnum} is 1 for the first
 --- line.  'synmaxcol' applies, in a longer line zero is returned.
 --- Note that when the position is after the last character,
 --- that's where the cursor can be in Insert mode, synID() returns
---- zero.  {lnum} is used like with |getline()|.
+--- zero.  {lnum} is used like with `|getline()|`.
 ---
---- When {trans} is |TRUE|, transparent items are reduced to the
+--- When {trans} is `|TRUE|`, transparent items are reduced to the
 --- item that they reveal.  This is useful when wanting to know
---- the effective color.  When {trans} is |FALSE|, the transparent
+--- the effective color.  When {trans} is `|FALSE|`, the transparent
 --- item is returned.  This is useful when wanting to know which
 --- syntax item is effective (e.g. inside parens).
 --- Warning: This function can be very slow.  Best speed is
@@ -9365,9 +10296,10 @@ function vim.fn.swapname(buf) end
 ---
 --- Returns zero on error.
 ---
---- Example (echoes the name of the syntax item under the cursor): >vim
+--- Example (echoes the name of the syntax item under the cursor):
+--- ```vim
 ---   echo synIDattr(synID(line("."), col("."), 1), "name")
---- <
+--- ```
 ---
 --- @param lnum integer
 --- @param col integer
@@ -9390,8 +10322,8 @@ function vim.fn.synID(lnum, col, trans) end
 ---     term: empty string)
 --- "bg"    background color (as with "fg")
 --- "font"    font name (only available in the GUI)
----     |highlight-font|
---- "sp"    special color (as with "fg") |guisp|
+---     `|highlight-font|`
+--- "sp"    special color (as with "fg") `|guisp|`
 --- "fg#"    like "fg", but for the GUI and the GUI is
 ---     running the name in "#RRGGBB" form
 --- "bg#"    like "fg#" for "bg"
@@ -9413,12 +10345,14 @@ function vim.fn.synID(lnum, col, trans) end
 --- Returns an empty string on error.
 ---
 --- Example (echoes the color of the syntax item under the
---- cursor): >vim
+--- cursor):
+--- ```vim
 ---   echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
---- <
---- Can also be used as a |method|: >vim
+--- ```
+--- Can also be used as a `|method|`:
+--- ```vim
 ---   echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
---- <
+--- ```
 ---
 --- @param synID integer
 --- @param what string
@@ -9433,14 +10367,15 @@ function vim.fn.synIDattr(synID, what, mode) end
 ---
 --- Returns zero on error.
 ---
+---
 --- @param synID integer
 --- @return integer
 function vim.fn.synIDtrans(synID) end
 
---- The result is a |List| with currently three items:
+--- The result is a `|List|` with currently three items:
 --- 1. The first item in the list is 0 if the character at the
 ---    position {lnum} and {col} is not part of a concealable
----    region, 1 if it is.  {lnum} is used like with |getline()|.
+---    region, 1 if it is.  {lnum} is used like with `|getline()|`.
 --- 2. The second item in the list is a string. If the first item
 ---    is 1, the second item contains the text which will be
 ---    displayed in place of the concealed text, depending on the
@@ -9466,20 +10401,22 @@ function vim.fn.synIDtrans(synID) end
 --- @return {[1]: integer, [2]: string, [3]: integer}[]
 function vim.fn.synconcealed(lnum, col) end
 
---- Return a |List|, which is the stack of syntax items at the
+--- Return a `|List|`, which is the stack of syntax items at the
 --- position {lnum} and {col} in the current window.  {lnum} is
---- used like with |getline()|.  Each item in the List is an ID
---- like what |synID()| returns.
+--- used like with `|getline()|`.  Each item in the List is an ID
+--- like what `|synID()|` returns.
 --- The first item in the List is the outer region, following are
---- items contained in that one.  The last one is what |synID()|
+--- items contained in that one.  The last one is what `|synID()|`
 --- returns, unless not the whole item is highlighted or it is a
 --- transparent item.
 --- This function is useful for debugging a syntax file.
---- Example that shows the syntax stack under the cursor: >vim
+--- Example that shows the syntax stack under the cursor:
+--- ```vim
 ---   for id in synstack(line("."), col("."))
 ---      echo synIDattr(id, "name")
 ---   endfor
---- <When the position specified with {lnum} and {col} is invalid
+--- ```
+--- When the position specified with {lnum} and {col} is invalid
 --- an empty list is returned.  The position just after the last
 --- character in a line and the first column in an empty line are
 --- valid positions.
@@ -9489,29 +10426,31 @@ function vim.fn.synconcealed(lnum, col) end
 --- @return integer[]
 function vim.fn.synstack(lnum, col) end
 
---- Note: Prefer |vim.system()| in Lua.
+--- Note: Prefer `|vim.system()|` in Lua.
 ---
---- Gets the output of {cmd} as a |string| (|systemlist()| returns
---- a |List|) and sets |v:shell_error| to the error code.
---- {cmd} is treated as in |jobstart()|:
+--- Gets the output of {cmd} as a `|string|` (`|systemlist()|` returns
+--- a `|List|`) and sets `|v:shell_error|` to the error code.
+--- {cmd} is treated as in `|jobstart()|`:
 --- If {cmd} is a List it runs directly (no 'shell').
---- If {cmd} is a String it runs in the 'shell', like this: >vim
+--- If {cmd} is a String it runs in the 'shell', like this:
+--- ```vim
 ---   call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
----
---- <Not to be used for interactive commands.
+--- ```
+--- Not to be used for interactive commands.
 ---
 --- Result is a String, filtered to avoid platform-specific quirks:
 --- - <CR><NL> is replaced with <NL>
 --- - NUL characters are replaced with SOH (0x01)
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---     echo system(['ls', expand('%:h')])
----
---- <If {input} is a string it is written to a pipe and passed as
+--- ```
+--- If {input} is a string it is written to a pipe and passed as
 --- stdin to the command.  The string is written as-is, line
 --- separators are not changed.
---- If {input} is a |List| it is written to the pipe as
---- |writefile()| does with {binary} set to "b" (i.e. with
+--- If {input} is a `|List|` it is written to the pipe as
+--- `|writefile()|` does with {binary} set to "b" (i.e. with
 --- a newline between each list item, and newlines inside list
 --- items converted to NULs).
 --- When {input} is given and is a valid buffer id, the content of
@@ -9519,41 +10458,49 @@ function vim.fn.synstack(lnum, col) end
 --- terminated by NL (and NUL where the text has NL).
 ---             *E5677*
 --- Note: system() cannot write to or read from backgrounded ("&")
---- shell commands, e.g.: >vim
+--- shell commands, e.g.:
+--- ```vim
 ---     echo system("cat - &", "foo")
---- <which is equivalent to: >
+--- ```
+--- which is equivalent to:
+--- ```
 ---     $ echo foo | bash -c 'cat - &'
---- <The pipes are disconnected (unless overridden by shell
+--- ```
+--- The pipes are disconnected (unless overridden by shell
 --- redirection syntax) before input can reach it. Use
---- |jobstart()| instead.
+--- `|jobstart()|` instead.
 ---
---- Note: Use |shellescape()| or |::S| with |expand()| or
---- |fnamemodify()| to escape special characters in a command
+--- Note: Use `|shellescape()|` or `|::S|` with `|expand()|` or
+--- `|fnamemodify()|` to escape special characters in a command
 --- argument. 'shellquote' and 'shellxquote' must be properly
---- configured. Example: >vim
+--- configured. Example:
+--- ```vim
 ---     echo system('ls '..shellescape(expand('%:h')))
 ---     echo system('ls '..expand('%:h:S'))
+--- ```
+--- Unlike ":!cmd" there is no automatic check for changed files.
+--- Use `|:checktime|` to force a check.
 ---
---- <Unlike ":!cmd" there is no automatic check for changed files.
---- Use |:checktime| to force a check.
 ---
 --- @param cmd string|string[]
 --- @param input? string|string[]|integer
 --- @return string
 function vim.fn.system(cmd, input) end
 
---- Same as |system()|, but returns a |List| with lines (parts of
+--- Same as `|system()|`, but returns a `|List|` with lines (parts of
 --- output separated by NL) with NULs transformed into NLs. Output
---- is the same as |readfile()| will output with {binary} argument
+--- is the same as `|readfile()|` will output with {binary} argument
 --- set to "b", except that a final newline is not preserved,
 --- unless {keepempty} is non-zero.
 --- Note that on MS-Windows you may get trailing CR characters.
 ---
 --- To see the difference between "echo hello" and "echo -n hello"
---- use |system()| and |split()|: >vim
+--- use `|system()|` and `|split()|`:
+--- ```vim
 ---   echo split(system('echo hello'), '\n', 1)
---- <
+--- ```
 --- Returns an empty string on error.
+---
 ---
 --- @param cmd string|string[]
 --- @param input? string|string[]|integer
@@ -9561,17 +10508,20 @@ function vim.fn.system(cmd, input) end
 --- @return string[]
 function vim.fn.systemlist(cmd, input, keepempty) end
 
---- The result is a |List|, where each item is the number of the
+--- The result is a `|List|`, where each item is the number of the
 --- buffer associated with each window in the current tab page.
 --- {arg} specifies the number of the tab page to be used. When
 --- omitted the current tab page is used.
 --- When {arg} is invalid the number zero is returned.
---- To get a list of all buffers in all tabs use this: >vim
+--- To get a list of all buffers in all tabs use this:
+--- ```vim
 ---   let buflist = []
 ---   for i in range(tabpagenr('$'))
 ---      call extend(buflist, tabpagebuflist(i + 1))
 ---   endfor
---- <Note that a buffer may appear in more than one window.
+--- ```
+--- Note that a buffer may appear in more than one window.
+---
 ---
 --- @param arg? any
 --- @return any
@@ -9584,9 +10534,9 @@ function vim.fn.tabpagebuflist(arg) end
 ---   $  the number of the last tab page (the tab page
 ---     count).
 ---   #  the number of the last accessed tab page
----     (where |g<Tab>| goes to).  If there is no
+---     (where `|g<Tab>|` goes to).  If there is no
 ---     previous tab page, 0 is returned.
---- The number can be used with the |:tab| command.
+--- The number can be used with the `|:tab|` command.
 ---
 --- Returns zero on error.
 ---
@@ -9594,33 +10544,36 @@ function vim.fn.tabpagebuflist(arg) end
 --- @return integer
 function vim.fn.tabpagenr(arg) end
 
---- Like |winnr()| but for tab page {tabarg}.
+--- Like `|winnr()|` but for tab page {tabarg}.
 --- {tabarg} specifies the number of tab page to be used.
---- {arg} is used like with |winnr()|:
+--- {arg} is used like with `|winnr()|`:
 --- - When omitted the current window number is returned.  This is
 ---   the window which will be used when going to this tab page.
 --- - When "$" the number of windows is returned.
 --- - When "#" the previous window nr is returned.
---- Useful examples: >vim
+--- Useful examples:
+--- ```vim
 ---     tabpagewinnr(1)      " current window of tab page 1
 ---     tabpagewinnr(4, '$')    " number of windows in tab page 4
---- <When {tabarg} is invalid zero is returned.
+--- ```
+--- When {tabarg} is invalid zero is returned.
+---
 ---
 --- @param tabarg integer
 --- @param arg? '$'|'#'
 --- @return integer
 function vim.fn.tabpagewinnr(tabarg, arg) end
 
---- Returns a |List| with the file names used to search for tags
+--- Returns a `|List|` with the file names used to search for tags
 --- for the current buffer.  This is the 'tags' option expanded.
 ---
 --- @return string[]
 function vim.fn.tagfiles() end
 
---- Returns a |List| of tags matching the regular expression {expr}.
+--- Returns a `|List|` of tags matching the regular expression {expr}.
 ---
 --- If {filename} is passed it is used to prioritize the results
---- in the same way that |:tselect| does. See |tag-priority|.
+--- in the same way that `|:tselect|` does. See `|tag-priority|`.
 --- {filename} should be the full path of the file.
 ---
 --- Each list item is a dictionary with at least the following
@@ -9637,7 +10590,7 @@ function vim.fn.tagfiles() end
 ---       using a tags file generated by
 ---       Universal/Exuberant ctags or hdrtag.
 ---   static    A file specific tag.  Refer to
----       |static-tag| for more information.
+---       `|static-tag|` for more information.
 --- More entries may be present, depending on the content of the
 --- tags file: access, implementation, inherits and signature.
 --- Refer to the ctags documentation for information about these
@@ -9652,69 +10605,81 @@ function vim.fn.tagfiles() end
 ---
 --- To get an exact tag match, the anchors '^' and '$' should be
 --- used in {expr}.  This also make the function work faster.
---- Refer to |tag-regexp| for more information about the tag
+--- Refer to `|tag-regexp|` for more information about the tag
 --- search regular expression pattern.
 ---
---- Refer to |'tags'| for information about how the tags file is
---- located by Vim. Refer to |tags-file-format| for the format of
+--- Refer to `|'tags'|` for information about how the tags file is
+--- located by Vim. Refer to `|tags-file-format|` for the format of
 --- the tags file generated by the different ctags tools.
+---
 ---
 --- @param expr any
 --- @param filename? string
 --- @return any
 function vim.fn.taglist(expr, filename) end
 
---- Return the tangent of {expr}, measured in radians, as a |Float|
+--- Return the tangent of {expr}, measured in radians, as a `|Float|`
 --- in the range [-inf, inf].
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo tan(10)
---- <  0.648361 >vim
+--- ```
+--- 0.648361
+--- ```vim
 ---   echo tan(-4.01)
---- <  -1.181502
+--- ```
+--- -1.181502
+---
 ---
 --- @param expr number
 --- @return number
 function vim.fn.tan(expr) end
 
---- Return the hyperbolic tangent of {expr} as a |Float| in the
+--- Return the hyperbolic tangent of {expr} as a `|Float|` in the
 --- range [-1, 1].
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo tanh(0.5)
---- <  0.462117 >vim
+--- ```
+--- 0.462117
+--- ```vim
 ---   echo tanh(-1)
---- <  -0.761594
+--- ```
+--- -0.761594
+---
 ---
 --- @param expr number
 --- @return number
 function vim.fn.tanh(expr) end
 
 --- Generates a (non-existent) filename located in the Nvim root
---- |tempdir|. Scripts can use the filename as a temporary file.
---- Example: >vim
+--- `|tempdir|`. Scripts can use the filename as a temporary file.
+--- Example:
+--- ```vim
 ---   let tmpfile = tempname()
 ---   exe "redir > " .. tmpfile
---- <
+--- ```
 ---
 --- @return string
 function vim.fn.tempname() end
 
 --- Spawns {cmd} in a new pseudo-terminal session connected
 --- to the current (unmodified) buffer. Parameters and behavior
---- are the same as |jobstart()| except "pty", "width", "height",
+--- are the same as `|jobstart()|` except "pty", "width", "height",
 --- and "TERM" are ignored: "height" and "width" are taken from
 --- the current window. Note that termopen() implies a "pty" arg
 --- to jobstart(), and thus has the implications documented at
---- |jobstart()|.
+--- `|jobstart()|`.
 ---
 --- Returns the same values as jobstart().
 ---
---- Terminal environment is initialized as in |jobstart-env|,
+--- Terminal environment is initialized as in `|jobstart-env|`,
 --- except $TERM is set to "xterm-256color". Full behavior is
---- described in |terminal|.
+--- described in `|terminal|`.
 ---
 --- @param cmd any
 --- @param opts? table
@@ -9727,13 +10692,14 @@ function vim.fn.termopen(cmd, opts) end
 --- returned.
 --- When {id} is omitted information about all timers is returned.
 ---
---- For each timer the information is stored in a |Dictionary| with
+--- For each timer the information is stored in a `|Dictionary|` with
 --- these items:
 ---     "id"      the timer ID
 ---     "time"      time the timer was started with
 ---     "repeat"      number of times the timer will still fire;
 ---         -1 means forever
 ---     "callback"      the callback
+---
 ---
 --- @param id? any
 --- @return any
@@ -9749,7 +10715,8 @@ function vim.fn.timer_info(id) end
 ---
 --- If {paused} evaluates to a non-zero Number or a non-empty
 --- String, then the timer is paused, otherwise it is unpaused.
---- See |non-zero-arg|.
+--- See `|non-zero-arg|`.
+---
 ---
 --- @param timer any
 --- @param paused any
@@ -9765,7 +10732,7 @@ function vim.fn.timer_pause(timer, paused) end
 --- the main loop.
 ---
 --- {callback} is the function to call.  It can be the name of a
---- function or a |Funcref|.  It is called with one argument, which
+--- function or a `|Funcref|`.  It is called with one argument, which
 --- is the timer ID.  The callback is only invoked when Vim is
 --- waiting for input.
 ---
@@ -9777,13 +10744,16 @@ function vim.fn.timer_pause(timer, paused) end
 ---
 --- Returns -1 on error.
 ---
---- Example: >vim
+--- Example:
+--- ```vim
 ---   func MyHandler(timer)
 ---     echo 'Handler called'
 ---   endfunc
 ---   let timer = timer_start(500, 'MyHandler',
 ---     \ {'repeat': 3})
---- <This invokes MyHandler() three times at 500 msec intervals.
+--- ```
+--- This invokes MyHandler() three times at 500 msec intervals.
+---
 ---
 --- @param time any
 --- @param callback any
@@ -9794,6 +10764,7 @@ function vim.fn.timer_start(time, callback, options) end
 --- Stop a timer.  The timer callback will no longer be invoked.
 --- {timer} is an ID returned by timer_start(), thus it must be a
 --- Number.  If {timer} does not exist there is no error.
+---
 ---
 --- @param timer any
 --- @return any
@@ -9807,16 +10778,18 @@ function vim.fn.timer_stop(timer) end
 function vim.fn.timer_stopall() end
 
 --- The result is a copy of the String given, with all uppercase
---- characters turned into lowercase (just like applying |gu| to
+--- characters turned into lowercase (just like applying `|gu|` to
 --- the string).  Returns an empty string on error.
+---
 ---
 --- @param expr any
 --- @return string
 function vim.fn.tolower(expr) end
 
 --- The result is a copy of the String given, with all lowercase
---- characters turned into uppercase (just like applying |gU| to
+--- characters turned into uppercase (just like applying `|gU|` to
 --- the string).  Returns an empty string on error.
+---
 ---
 --- @param expr any
 --- @return string
@@ -9831,11 +10804,16 @@ function vim.fn.toupper(expr) end
 ---
 --- Returns an empty string on error.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo tr("hello there", "ht", "HT")
---- <returns "Hello THere" >vim
+--- ```
+--- returns "Hello THere"
+--- ```vim
 ---   echo tr("<blob>", "<>", "{}")
---- <returns "{blob}"
+--- ```
+--- returns "{blob}"
+---
 ---
 --- @param src string
 --- @param fromstr string
@@ -9860,15 +10838,24 @@ function vim.fn.tr(src, fromstr, tostr) end
 --- This function deals with multibyte characters properly.
 --- Returns an empty string on error.
 ---
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo trim("   some text ")
---- <returns "some text" >vim
+--- ```
+--- returns "some text"
+--- ```vim
 ---   echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
---- <returns "RESERVE_TAIL" >vim
+--- ```
+--- returns "RESERVE_TAIL"
+--- ```vim
 ---   echo trim("rm<Xrm<>X>rrm", "rm<>")
---- <returns "Xrm<>X" (characters in the middle are not removed) >vim
+--- ```
+--- returns "Xrm<>X" (characters in the middle are not removed)
+--- ```vim
 ---   echo trim("  vim  ", " ", 2)
---- <returns "  vim"
+--- ```
+--- returns "  vim"
+---
 ---
 --- @param text any
 --- @param mask? string
@@ -9877,16 +10864,23 @@ function vim.fn.tr(src, fromstr, tostr) end
 function vim.fn.trim(text, mask, dir) end
 
 --- Return the largest integral value with magnitude less than or
---- equal to {expr} as a |Float| (truncate towards zero).
---- {expr} must evaluate to a |Float| or a |Number|.
---- Returns 0.0 if {expr} is not a |Float| or a |Number|.
---- Examples: >vim
+--- equal to {expr} as a `|Float|` (truncate towards zero).
+--- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Examples:
+--- ```vim
 ---   echo trunc(1.456)
---- <  1.0  >vim
+--- ```
+--- 1.0
+--- ```vim
 ---   echo trunc(-5.456)
---- <  -5.0  >vim
+--- ```
+--- -5.0
+--- ```vim
 ---   echo trunc(4.0)
---- <  4.0
+--- ```
+--- 4.0
+---
 ---
 --- @param expr any
 --- @return integer
@@ -9895,16 +10889,17 @@ function vim.fn.trunc(expr) end
 --- The result is a Number representing the type of {expr}.
 --- Instead of using the number directly, it is better to use the
 --- v:t_ variable that has the value:
----   Number:      0  |v:t_number|
----   String:      1  |v:t_string|
----   Funcref:    2  |v:t_func|
----   List:      3  |v:t_list|
----   Dictionary: 4  |v:t_dict|
----   Float:      5  |v:t_float|
----   Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
----   Null:      7  (|v:null|)
----   Blob:     10  |v:t_blob|
---- For backward compatibility, this method can be used: >vim
+---   Number:      0  `|v:t_number|`
+---   String:      1  `|v:t_string|`
+---   Funcref:    2  `|v:t_func|`
+---   List:      3  `|v:t_list|`
+---   Dictionary: 4  `|v:t_dict|`
+---   Float:      5  `|v:t_float|`
+---   Boolean:    6  `|v:t_bool|` (`|v:false|` and `|v:true|`)
+---   Null:      7  (`|v:null|`)
+---   Blob:     10  `|v:t_blob|`
+--- For backward compatibility, this method can be used:
+--- ```vim
 ---   if type(myvar) == type(0) | endif
 ---   if type(myvar) == type("") | endif
 ---   if type(myvar) == type(function("tr")) | endif
@@ -9912,11 +10907,16 @@ function vim.fn.trunc(expr) end
 ---   if type(myvar) == type({}) | endif
 ---   if type(myvar) == type(0.0) | endif
 ---   if type(myvar) == type(v:true) | endif
---- <In place of checking for |v:null| type it is better to check
---- for |v:null| directly as it is the only value of this type: >vim
+--- ```
+--- In place of checking for `|v:null|` type it is better to check
+--- for `|v:null|` directly as it is the only value of this type:
+--- ```vim
 ---   if myvar is v:null | endif
---- <To check if the v:t_ variables exist use this: >vim
+--- ```
+--- To check if the v:t_ variables exist use this:
+--- ```vim
 ---   if exists('v:t_number') | endif
+--- ```
 ---
 --- @param expr any
 --- @return integer
@@ -9930,7 +10930,8 @@ function vim.fn.type(expr) end
 --- is used internally.
 --- If {name} is empty undofile() returns an empty string, since a
 --- buffer without a file name will not write an undo file.
---- Useful in combination with |:wundo| and |:rundo|.
+--- Useful in combination with `|:wundo|` and `|:rundo|`.
+---
 ---
 --- @param name string
 --- @return string
@@ -9943,8 +10944,8 @@ function vim.fn.undofile(name) end
 ---   "seq_cur"  The sequence number of the current position in
 ---     the undo tree.  This differs from "seq_last"
 ---     when some changes were undone.
----   "time_cur"  Time last used for |:earlier| and related
----     commands.  Use |strftime()| to convert to
+---   "time_cur"  Time last used for `|:earlier|` and related
+---     commands.  Use `|strftime()|` to convert to
 ---     something readable.
 ---   "save_last"  Number of the last file write.  Zero when no
 ---     write yet.
@@ -9952,16 +10953,16 @@ function vim.fn.undofile(name) end
 ---     tree.
 ---   "synced"  Non-zero when the last undo block was synced.
 ---     This happens when waiting from input from the
----     user.  See |undo-blocks|.
+---     user.  See `|undo-blocks|`.
 ---   "entries"  A list of dictionaries with information about
 ---     undo blocks.
 ---
 --- The first item in the "entries" list is the oldest undo item.
---- Each List item is a |Dictionary| with these items:
+--- Each List item is a `|Dictionary|` with these items:
 ---   "seq"    Undo sequence number.  Same as what appears in
----     |:undolist|.
+---     `|:undolist|`.
 ---   "time"  Timestamp when the change happened.  Use
----     |strftime()| to convert to something readable.
+---     `|strftime()|` to convert to something readable.
 ---   "newhead"  Only appears in the item that is the last one
 ---     that was added.  This marks the last change
 ---     and where further changes will be added.
@@ -9985,12 +10986,15 @@ function vim.fn.undotree(buf) end
 
 --- Remove second and succeeding copies of repeated adjacent
 --- {list} items in-place.  Returns {list}.  If you want a list
---- to remain unmodified make a copy first: >vim
+--- to remain unmodified make a copy first:
+--- ```vim
 ---   let newlist = uniq(copy(mylist))
---- <The default compare function uses the string representation of
---- each item.  For the use of {func} and {dict} see |sort()|.
+--- ```
+--- The default compare function uses the string representation of
+--- each item.  For the use of {func} and {dict} see `|sort()|`.
 ---
---- Returns zero if {list} is not a |List|.
+--- Returns zero if {list} is not a `|List|`.
+---
 ---
 --- @param list any
 --- @param func? any
@@ -9998,7 +11002,7 @@ function vim.fn.undotree(buf) end
 --- @return any[]|0
 function vim.fn.uniq(list, func, dict) end
 
---- Same as |charidx()| but returns the UTF-16 code unit index of
+--- Same as `|charidx()|` but returns the UTF-16 code unit index of
 --- the byte at {idx} in {string} (after converting it to UTF-16).
 ---
 --- When {charidx} is present and TRUE, {idx} is used as the
@@ -10011,11 +11015,12 @@ function vim.fn.uniq(list, func, dict) end
 --- than {idx} bytes in {string}. If there are exactly {idx} bytes
 --- the length of the string in UTF-16 code units is returned.
 ---
---- See |byteidx()| and |byteidxcomp()| for getting the byte index
---- from the UTF-16 index and |charidx()| for getting the
+--- See `|byteidx()|` and `|byteidxcomp()|` for getting the byte index
+--- from the UTF-16 index and `|charidx()|` for getting the
 --- character index from the UTF-16 index.
---- Refer to |string-offset-encoding| for more information.
---- Examples: >vim
+--- Refer to `|string-offset-encoding|` for more information.
+--- Examples:
+--- ```vim
 ---   echo utf16idx('a😊😊', 3)  " returns 2
 ---   echo utf16idx('a😊😊', 7)  " returns 4
 ---   echo utf16idx('a😊😊', 1, 0, 1)  " returns 2
@@ -10023,7 +11028,7 @@ function vim.fn.uniq(list, func, dict) end
 ---   echo utf16idx('aą́c', 6)    " returns 2
 ---   echo utf16idx('aą́c', 6, 1)  " returns 4
 ---   echo utf16idx('a😊😊', 9)  " returns -1
---- <
+--- ```
 ---
 --- @param string string
 --- @param idx integer
@@ -10032,9 +11037,10 @@ function vim.fn.uniq(list, func, dict) end
 --- @return integer
 function vim.fn.utf16idx(string, idx, countcc, charidx) end
 
---- Return a |List| with all the values of {dict}.  The |List| is
---- in arbitrary order.  Also see |items()| and |keys()|.
---- Returns zero if {dict} is not a |Dict|.
+--- Return a `|List|` with all the values of {dict}.  The `|List|` is
+--- in arbitrary order.  Also see `|items()|` and `|keys()|`.
+--- Returns zero if {dict} is not a `|Dict|`.
+---
 ---
 --- @param dict any
 --- @return any
@@ -10046,10 +11052,10 @@ function vim.fn.values(dict) end
 --- would be of unlimited width.  When there is a <Tab> at the
 --- position, the returned Number will be the column at the end of
 --- the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
---- set to 8, it returns 8. |conceal| is ignored.
---- For the byte position use |col()|.
+--- set to 8, it returns 8. `|conceal|` is ignored.
+--- For the byte position use `|col()|`.
 ---
---- For the use of {expr} see |col()|.
+--- For the use of {expr} see `|col()|`.
 ---
 --- When 'virtualedit' is used {expr} can be [lnum, col, off],
 --- where "off" is the offset in screen columns from the start of
@@ -10057,7 +11063,7 @@ function vim.fn.values(dict) end
 --- last character.  When "off" is omitted zero is used.  When
 --- Virtual editing is active in the current mode, a position
 --- beyond the end of the line can be returned.  Also see
---- |'virtualedit'|
+--- `|'virtualedit'|`
 ---
 --- The accepted positions are:
 ---     .      the cursor position
@@ -10068,7 +11074,7 @@ function vim.fn.values(dict) end
 ---       returned)
 ---     v       In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
+---       returns the cursor position.  Differs from `|'<|` in
 ---       that it's updated right away.
 ---
 --- If {list} is present and non-zero then virtcol() returns a
@@ -10079,7 +11085,8 @@ function vim.fn.values(dict) end
 --- that window instead of the current window.
 ---
 --- Note that only marks in the current file can be used.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   " With text "foo^Lbar" and cursor on the "^L":
 ---
 ---   echo virtcol(".")  " returns 5
@@ -10089,10 +11096,13 @@ function vim.fn.values(dict) end
 ---   " With text "    there", with 't at 'h':
 ---
 ---   echo virtcol("'t")  " returns 6
---- <The first column is 1.  0 or [0, 0] is returned for an error.
+--- ```
+--- The first column is 1.  0 or [0, 0] is returned for an error.
 --- A more advanced example that echoes the maximum length of
---- all lines: >vim
+--- all lines:
+--- ```vim
 ---     echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+--- ```
 ---
 --- @param expr any
 --- @param list? any
@@ -10114,12 +11124,13 @@ function vim.fn.virtcol(expr, list, winid) end
 --- byte in the character is returned.
 ---
 --- The {winid} argument can be the window number or the
---- |window-ID|. If this is zero, then the current window is used.
+--- `|window-ID|`. If this is zero, then the current window is used.
 ---
 --- Returns -1 if the window {winid} doesn't exist or the buffer
 --- line {lnum} or virtual column {col} is invalid.
 ---
---- See also |screenpos()|, |virtcol()| and |col()|.
+--- See also `|screenpos()|`, `|virtcol()|` and `|col()|`.
+---
 ---
 --- @param winid integer
 --- @param lnum integer
@@ -10133,23 +11144,25 @@ function vim.fn.virtcol2col(winid, lnum, col) end
 --- "V", or "<CTRL-V>" (a single CTRL-V character) for
 --- character-wise, line-wise, or block-wise Visual mode
 --- respectively.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   exe "normal " .. visualmode()
---- <This enters the same Visual mode as before.  It is also useful
+--- ```
+--- This enters the same Visual mode as before.  It is also useful
 --- in scripts if you wish to act differently depending on the
 --- Visual mode that was used.
---- If Visual mode is active, use |mode()| to get the Visual mode
---- (e.g., in a |:vmap|).
+--- If Visual mode is active, use `|mode()|` to get the Visual mode
+--- (e.g., in a `|:vmap|`).
 --- If {expr} is supplied and it evaluates to a non-zero Number or
 --- a non-empty String, then the Visual mode will be cleared and
---- the old value is returned.  See |non-zero-arg|.
+--- the old value is returned.  See `|non-zero-arg|`.
 ---
 --- @param expr? any
 --- @return any
 function vim.fn.visualmode(expr) end
 
---- Waits until {condition} evaluates to |TRUE|, where {condition}
---- is a |Funcref| or |string| containing an expression.
+--- Waits until {condition} evaluates to `|TRUE|`, where {condition}
+--- is a `|Funcref|` or `|string|` containing an expression.
 ---
 --- {timeout} is the maximum waiting time in milliseconds, -1
 --- means forever.
@@ -10160,7 +11173,7 @@ function vim.fn.visualmode(expr) end
 --- Returns a status integer:
 ---   0 if the condition was satisfied before timeout
 ---   -1 if the timeout was exceeded
----   -2 if the function was interrupted (by |CTRL-C|)
+---   -2 if the function was interrupted (by `|CTRL-C|`)
 ---   -3 if an error occurred
 ---
 --- @param timeout integer
@@ -10169,14 +11182,15 @@ function vim.fn.visualmode(expr) end
 --- @return any
 function vim.fn.wait(timeout, condition, interval) end
 
---- Returns |TRUE| when the wildmenu is active and |FALSE|
+--- Returns `|TRUE|` when the wildmenu is active and `|FALSE|`
 --- otherwise.  See 'wildmenu' and 'wildmode'.
 --- This can be used in mappings to handle the 'wildcharm' option
---- gracefully. (Makes only sense with |mapmode-c| mappings).
+--- gracefully. (Makes only sense with `|mapmode-c|` mappings).
 ---
---- For example to make <c-j> work like <down> in wildmode, use: >vim
+--- For example to make <c-j> work like <down> in wildmode, use:
+--- ```vim
 ---     cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
---- <
+--- ```
 --- (Note, this needs the 'wildcharm' option set appropriately).
 ---
 --- @return any
@@ -10187,13 +11201,16 @@ function vim.fn.wildmenumode() end
 --- without triggering autocommands or changing directory.  When
 --- executing {command} autocommands will be triggered, this may
 --- have unexpected side effects.  Use `:noautocmd` if needed.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   call win_execute(winid, 'syntax enable')
---- <Doing the same with `setwinvar()` would not trigger
+--- ```
+--- Doing the same with `setwinvar()` would not trigger
 --- autocommands and not actually show syntax highlighting.
 ---
 --- When window {id} does not exist then no error is given and
 --- an empty string is returned.
+---
 ---
 --- @param id any
 --- @param command any
@@ -10201,20 +11218,22 @@ function vim.fn.wildmenumode() end
 --- @return any
 function vim.fn.win_execute(id, command, silent) end
 
---- Returns a |List| with |window-ID|s for windows that contain
+--- Returns a `|List|` with `|window-ID|`s for windows that contain
 --- buffer {bufnr}.  When there is none the list is empty.
+---
 ---
 --- @param bufnr any
 --- @return integer[]
 function vim.fn.win_findbuf(bufnr) end
 
---- Get the |window-ID| for the specified window.
+--- Get the `|window-ID|` for the specified window.
 --- When {win} is missing use the current window.
 --- With {win} this is the window number.  The top window has
 --- number 1.
 --- Without {tab} use the current tab, otherwise the tab with
 --- number {tab}.  The first tab has number one.
 --- Return zero if the window cannot be found.
+---
 ---
 --- @param win? any
 --- @param tab? any
@@ -10224,19 +11243,20 @@ function vim.fn.win_getid(win, tab) end
 --- Return the type of the window:
 ---   "autocmd"  autocommand window. Temporary window
 ---       used to execute autocommands.
----   "command"  command-line window |cmdwin|
+---   "command"  command-line window `|cmdwin|`
 ---   (empty)    normal window
----   "loclist"  |location-list-window|
----   "popup"    floating window |api-floatwin|
----   "preview"  preview window |preview-window|
----   "quickfix"  |quickfix-window|
+---   "loclist"  `|location-list-window|`
+---   "popup"    floating window `|api-floatwin|`
+---   "preview"  preview window `|preview-window|`
+---   "quickfix"  `|quickfix-window|`
 ---   "unknown"  window {nr} not found
 ---
 --- When {nr} is omitted return the type of the current window.
 --- When {nr} is given return the type of this window by number or
---- |window-ID|.
+--- `|window-ID|`.
 ---
 --- Also see the 'buftype' option.
+---
 ---
 --- @param nr? integer
 --- @return 'autocmd'|'command'|''|'loclist'|'popup'|'preview'|'quickfix'|'unknown'
@@ -10246,6 +11266,7 @@ function vim.fn.win_gettype(nr) end
 --- tabpage.
 --- Return TRUE if successful, FALSE if the window cannot be found.
 ---
+---
 --- @param expr any
 --- @return 0|1
 function vim.fn.win_gotoid(expr) end
@@ -10254,6 +11275,7 @@ function vim.fn.win_gotoid(expr) end
 --- with ID {expr}: [tabnr, winnr].
 --- Return [0, 0] if the window cannot be found.
 ---
+---
 --- @param expr any
 --- @return any
 function vim.fn.win_id2tabwin(expr) end
@@ -10261,13 +11283,14 @@ function vim.fn.win_id2tabwin(expr) end
 --- Return the window number of window with ID {expr}.
 --- Return 0 if the window cannot be found in the current tabpage.
 ---
+---
 --- @param expr any
 --- @return any
 function vim.fn.win_id2win(expr) end
 
 --- Move window {nr}'s vertical separator (i.e., the right border)
 --- by {offset} columns, as if being dragged by the mouse. {nr}
---- can be a window number or |window-ID|. A positive {offset}
+--- can be a window number or `|window-ID|`. A positive {offset}
 --- moves right and a negative {offset} moves left. Moving a
 --- window's vertical separator will change the width of the
 --- window and the width of other windows adjacent to the vertical
@@ -10279,6 +11302,7 @@ function vim.fn.win_id2win(expr) end
 --- window, since it has no separator on the right.
 --- Only works for the current tab page. *E1308*
 ---
+---
 --- @param nr integer
 --- @param offset any
 --- @return any
@@ -10286,7 +11310,7 @@ function vim.fn.win_move_separator(nr, offset) end
 
 --- Move window {nr}'s status line (i.e., the bottom border) by
 --- {offset} rows, as if being dragged by the mouse. {nr} can be a
---- window number or |window-ID|. A positive {offset} moves down
+--- window number or `|window-ID|`. A positive {offset} moves down
 --- and a negative {offset} moves up. Moving a window's status
 --- line will change the height of the window and the height of
 --- other windows adjacent to the status line. The magnitude of
@@ -10294,6 +11318,7 @@ function vim.fn.win_move_separator(nr, offset) end
 --- of maintaining 'winminheight'). Returns TRUE if the window can
 --- be found and FALSE otherwise.
 --- Only works for the current tab page.
+---
 ---
 --- @param nr integer
 --- @param offset any
@@ -10303,10 +11328,11 @@ function vim.fn.win_move_statusline(nr, offset) end
 --- Return the screen position of window {nr} as a list with two
 --- numbers: [row, col].  The first window always has position
 --- [1, 1], unless there is a tabline, then it is [2, 1].
---- {nr} can be the window number or the |window-ID|.  Use zero
+--- {nr} can be the window number or the `|window-ID|`.  Use zero
 --- for the current window.
 --- Returns [0, 0] if the window cannot be found in the current
 --- tabpage.
+---
 ---
 --- @param nr integer
 --- @return any
@@ -10314,22 +11340,23 @@ function vim.fn.win_screenpos(nr) end
 
 --- Move the window {nr} to a new split of the window {target}.
 --- This is similar to moving to {target}, creating a new window
---- using |:split| but having the same contents as window {nr}, and
+--- using `|:split|` but having the same contents as window {nr}, and
 --- then closing {nr}.
 ---
---- Both {nr} and {target} can be window numbers or |window-ID|s.
+--- Both {nr} and {target} can be window numbers or `|window-ID|`s.
 --- Both must be in the current tab page.
 ---
 --- Returns zero for success, non-zero for failure.
 ---
---- {options} is a |Dictionary| with the following optional entries:
+--- {options} is a `|Dictionary|` with the following optional entries:
 ---   "vertical"  When TRUE, the split is created vertically,
----     like with |:vsplit|.
+---     like with `|:vsplit|`.
 ---   "rightbelow"  When TRUE, the split is made below or to the
 ---     right (if vertical).  When FALSE, it is done
 ---     above or to the left (if vertical).  When not
 ---     present, the values of 'splitbelow' and
 ---     'splitright' are used.
+---
 ---
 --- @param nr integer
 --- @param target any
@@ -10339,13 +11366,14 @@ function vim.fn.win_splitmove(nr, target, options) end
 
 --- The result is a Number, which is the number of the buffer
 --- associated with window {nr}.  {nr} can be the window number or
---- the |window-ID|.
+--- the `|window-ID|`.
 --- When {nr} is zero, the number of the buffer in the current
 --- window is returned.
 --- When window {nr} doesn't exist, -1 is returned.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   echo "The file in the current window is " .. bufname(winbufnr(0))
---- <
+--- ```
 ---
 --- @param nr integer
 --- @return integer
@@ -10367,13 +11395,15 @@ function vim.fn.wincol() end
 function vim.fn.windowsversion() end
 
 --- The result is a Number, which is the height of window {nr}.
---- {nr} can be the window number or the |window-ID|.
+--- {nr} can be the window number or the `|window-ID|`.
 --- When {nr} is zero, the height of the current window is
 --- returned.  When window {nr} doesn't exist, -1 is returned.
 --- An existing window always has a height of zero or more.
 --- This excludes any window toolbar line.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo "The current window has " .. winheight(0) .. " lines."
+--- ```
 ---
 --- @param nr integer
 --- @return integer
@@ -10386,34 +11416,44 @@ function vim.fn.winheight(nr) end
 --- with number {tabnr}. If the tabpage {tabnr} is not found,
 --- returns an empty list.
 ---
---- For a leaf window, it returns: >
+--- For a leaf window, it returns:
+--- ```
 ---   ["leaf", {winid}]
---- <
+--- ```
 --- For horizontally split windows, which form a column, it
---- returns: >
+--- returns:
+--- ```
 ---   ["col", [{nested list of windows}]]
---- <For vertically split windows, which form a row, it returns: >
+--- ```
+--- For vertically split windows, which form a row, it returns:
+--- ```
 ---   ["row", [{nested list of windows}]]
---- <
---- Example: >vim
+--- ```
+--- Example:
+--- ```vim
 ---   " Only one window in the tab page
 ---   echo winlayout()
---- < >
+--- ```
+--- ```
 ---   ['leaf', 1000]
---- < >vim
+--- ```
+--- ```vim
 ---   " Two horizontally split windows
 ---   echo winlayout()
---- < >
+--- ```
+--- ```
 ---   ['col', [['leaf', 1000], ['leaf', 1001]]]
---- < >vim
+--- ```
+--- ```vim
 ---   " The second tab page, with three horizontally split
 ---   " windows, with two vertically split windows in the
 ---   " middle window
 ---   echo winlayout(2)
---- < >
+--- ```
+--- ```
 ---   ['col', [['leaf', 1002], ['row', [['leaf', 1003],
 ---           ['leaf', 1001]]], ['leaf', 1000]]]
---- <
+--- ```
 ---
 --- @param tabnr? integer
 --- @return any
@@ -10436,50 +11476,54 @@ function vim.fn.winline() end
 ---   $  the number of the last window (the window
 ---     count).
 ---   #  the number of the last accessed window (where
----     |CTRL-W_p| goes to).  If there is no previous
+---     `|CTRL-W_p|` goes to).  If there is no previous
 ---     window or it is in another tab page 0 is
 ---     returned.
 ---   {N}j  the number of the Nth window below the
----     current window (where |CTRL-W_j| goes to).
+---     current window (where `|CTRL-W_j|` goes to).
 ---   {N}k  the number of the Nth window above the current
----     window (where |CTRL-W_k| goes to).
+---     window (where `|CTRL-W_k|` goes to).
 ---   {N}h  the number of the Nth window left of the
----     current window (where |CTRL-W_h| goes to).
+---     current window (where `|CTRL-W_h|` goes to).
 ---   {N}l  the number of the Nth window right of the
----     current window (where |CTRL-W_l| goes to).
---- The number can be used with |CTRL-W_w| and ":wincmd w"
---- |:wincmd|.
+---     current window (where `|CTRL-W_l|` goes to).
+--- The number can be used with `|CTRL-W_w|` and ":wincmd w"
+--- `|:wincmd|`.
 --- When {arg} is invalid an error is given and zero is returned.
---- Also see |tabpagewinnr()| and |win_getid()|.
---- Examples: >vim
+--- Also see `|tabpagewinnr()|` and `|win_getid()|`.
+--- Examples:
+--- ```vim
 ---   let window_count = winnr('$')
 ---   let prev_window = winnr('#')
 ---   let wnum = winnr('3k')
+--- ```
 ---
 --- @param arg? any
 --- @return any
 function vim.fn.winnr(arg) end
 
---- Returns a sequence of |:resize| commands that should restore
+--- Returns a sequence of `|:resize|` commands that should restore
 --- the current window sizes.  Only works properly when no windows
 --- are opened or closed and the current window and tab page is
 --- unchanged.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let cmd = winrestcmd()
 ---   call MessWithWindowSizes()
 ---   exe cmd
---- <
+--- ```
 ---
 --- @return any
 function vim.fn.winrestcmd() end
 
---- Uses the |Dictionary| returned by |winsaveview()| to restore
+--- Uses the `|Dictionary|` returned by `|winsaveview()|` to restore
 --- the view of the current window.
 --- Note: The {dict} does not have to contain all values, that are
---- returned by |winsaveview()|. If values are missing, those
---- settings won't be restored. So you can use: >vim
+--- returned by `|winsaveview()|`. If values are missing, those
+--- settings won't be restored. So you can use:
+--- ```vim
 ---     call winrestview({'curswant': 4})
---- <
+--- ```
 --- This will only set the curswant value (the column the cursor
 --- wants to move on vertical movements) of the cursor to column 5
 --- (yes, that is 5), while all other settings will remain the
@@ -10488,12 +11532,13 @@ function vim.fn.winrestcmd() end
 --- If you have changed the values the result is unpredictable.
 --- If the window size changed the result won't be the same.
 ---
+---
 --- @param dict vim.fn.winrestview.dict
 --- @return any
 function vim.fn.winrestview(dict) end
 
---- Returns a |Dictionary| that contains information to restore
---- the view of the current window.  Use |winrestview()| to
+--- Returns a `|Dictionary|` that contains information to restore
+--- the view of the current window.  Use `|winrestview()|` to
 --- restore the view.
 --- This is useful if you have a mapping that jumps around in the
 --- buffer and you want to go back to the original view.
@@ -10503,14 +11548,14 @@ function vim.fn.winrestview(dict) end
 --- The return value includes:
 ---   lnum    cursor line number
 ---   col    cursor column (Note: the first column
----       zero, as opposed to what |getcurpos()|
+---       zero, as opposed to what `|getcurpos()|`
 ---       returns)
 ---   coladd    cursor column offset for 'virtualedit'
 ---   curswant  column for vertical movement (Note:
 ---       the first column is zero, as opposed
----       to what |getcurpos()| returns).  After
----       |$| command it will be a very large
----       number equal to |v:maxcol|.
+---       to what `|getcurpos()|` returns).  After
+---       `|$|` command it will be a very large
+---       number equal to `|v:maxcol|`.
 ---   topline    first line in the window
 ---   topfill    filler lines, only in diff mode
 ---   leftcol    first column displayed; only used when
@@ -10522,17 +11567,20 @@ function vim.fn.winrestview(dict) end
 function vim.fn.winsaveview() end
 
 --- The result is a Number, which is the width of window {nr}.
---- {nr} can be the window number or the |window-ID|.
+--- {nr} can be the window number or the `|window-ID|`.
 --- When {nr} is zero, the width of the current window is
 --- returned.  When window {nr} doesn't exist, -1 is returned.
 --- An existing window always has a width of zero or more.
---- Examples: >vim
+--- Examples:
+--- ```vim
 ---   echo "The current window has " .. winwidth(0) .. " columns."
 ---   if winwidth(0) <= 50
 ---     50 wincmd |
 ---   endif
---- <For getting the terminal or screen size, see the 'columns'
+--- ```
+--- For getting the terminal or screen size, see the 'columns'
 --- option.
+---
 ---
 --- @param nr integer
 --- @return any
@@ -10540,7 +11588,7 @@ function vim.fn.winwidth(nr) end
 
 --- The result is a dictionary of byte/chars/word statistics for
 --- the current buffer.  This is the same info as provided by
---- |g_CTRL-G|
+--- `|g_CTRL-G|`
 --- The return value includes:
 ---   bytes    Number of bytes in the buffer
 ---   chars    Number of chars in the buffer
@@ -10561,14 +11609,14 @@ function vim.fn.winwidth(nr) end
 --- @return any
 function vim.fn.wordcount() end
 
---- When {object} is a |List| write it to file {fname}.  Each list
+--- When {object} is a `|List|` write it to file {fname}.  Each list
 --- item is separated with a NL.  Each list item must be a String
 --- or Number.
 --- All NL characters are replaced with a NUL character.
 --- Inserting CR characters needs to be done before passing {list}
 --- to writefile().
 ---
---- When {object} is a |Blob| write the bytes to file {fname}
+--- When {object} is a `|Blob|` write the bytes to file {fname}
 --- unmodified, also when binary mode is not specified.
 ---
 --- {flags} must be a String.  These characters are recognized:
@@ -10577,14 +11625,17 @@ function vim.fn.wordcount() end
 ---      last list item.  An empty item at the end does cause the
 ---      last line in the file to end in a NL.
 ---
---- 'a'  Append mode is used, lines are appended to the file: >vim
+--- 'a'  Append mode is used, lines are appended to the file:
+--- ```vim
 ---   call writefile(["foo"], "event.log", "a")
 ---   call writefile(["bar"], "event.log", "a")
---- <
+--- ```
 --- 'D'  Delete the file when the current function ends.  This
----      works like: >vim
+---      works like:
+--- ```vim
 ---   defer delete({fname})
---- <     Fails when not in a function.  Also see |:defer|.
+--- ```
+--- Fails when not in a function.  Also see `|:defer|`.
 ---
 --- 's'  fsync() is called after writing the file.  This flushes
 ---      the file to disk, if possible.  This takes more time but
@@ -10601,10 +11652,12 @@ function vim.fn.wordcount() end
 --- error message if the file can't be created or when writing
 --- fails.
 ---
---- Also see |readfile()|.
---- To copy a file byte for byte: >vim
+--- Also see `|readfile()|`.
+--- To copy a file byte for byte:
+--- ```vim
 ---   let fl = readfile("foo", "b")
 ---   call writefile(fl, "foocopy", "b")
+--- ```
 ---
 --- @param object any
 --- @param fname string
@@ -10615,9 +11668,10 @@ function vim.fn.writefile(object, fname, flags) end
 --- Bitwise XOR on the two arguments.  The arguments are converted
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `and()` and `or()`.
---- Example: >vim
+--- Example:
+--- ```vim
 ---   let bits = xor(bits, 0x80)
---- <
+--- ```
 ---
 --- @param expr any
 --- @param expr1 any

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4,8 +4,8 @@
 error('Cannot require a meta file')
 
 --- Return the absolute value of {expr}.  When {expr} evaluates to
---- a `|Float|` abs() returns a `|Float|`.  When {expr} can be
---- converted to a `|Number|` abs() returns a `|Number|`.  Otherwise
+--- a [Float](help://Float) abs() returns a [Float](help://Float).  When {expr} can be
+--- converted to a [Number](help://Number) abs() returns a [Number](help://Number).  Otherwise
 --- abs() gives an error message and returns -1.
 --- Examples:
 --- ```vim
@@ -27,11 +27,11 @@ error('Cannot require a meta file')
 function vim.fn.abs(expr) end
 
 --- Return the arc cosine of {expr} measured in radians, as a
---- `|Float|` in the range of [0, pi].
---- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
+--- [Float](help://Float) in the range of [0, pi].
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number) in the range
 --- [-1, 1].
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
---- 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo acos(0)
@@ -47,17 +47,17 @@ function vim.fn.abs(expr) end
 --- @return number
 function vim.fn.acos(expr) end
 
---- Append the item {expr} to `|List|` or `|Blob|` {object}.  Returns
---- the resulting `|List|` or `|Blob|`.  Examples:
+--- Append the item {expr} to [List](help://List) or [Blob](help://Blob) {object}.  Returns
+--- the resulting [List](help://List) or [Blob](help://Blob).  Examples:
 --- ```vim
 ---   let alist = add([1, 2, 3], item)
 ---   call add(mylist, "woodstock")
 --- ```
---- Note that when {expr} is a `|List|` it is appended as a single
---- item.  Use `|extend()|` to concatenate `|Lists|`.
---- When {object} is a `|Blob|` then {expr} must be a number.
---- Use `|insert()|` to add an item at another position.
---- Returns 1 if {object} is not a `|List|` or a `|Blob|`.
+--- Note that when {expr} is a [List](help://List) it is appended as a single
+--- item.  Use [extend()](help://extend()) to concatenate [Lists](help://Lists).
+--- When {object} is a [Blob](help://Blob) then {expr} must be a number.
+--- Use [insert()](help://insert()) to add an item at another position.
+--- Returns 1 if {object} is not a [List](help://List) or a [Blob](help://Blob).
 ---
 ---
 --- @param object any
@@ -78,7 +78,7 @@ function vim.fn.add(object, expr) end
 --- @return integer
 vim.fn['and'] = function(expr, expr1) end
 
---- Returns Dictionary of `|api-metadata|`.
+--- Returns Dictionary of [api-metadata](help://api-metadata).
 ---
 --- View it in a nice human-readable format:
 --- ```vim
@@ -88,13 +88,13 @@ vim.fn['and'] = function(expr, expr1) end
 --- @return table
 function vim.fn.api_info() end
 
---- When {text} is a `|List|`: Append each item of the `|List|` as a
+--- When {text} is a [List](help://List): Append each item of the [List](help://List) as a
 --- text line below line {lnum} in the current buffer.
 --- Otherwise append {text} as one text line below line {lnum} in
 --- the current buffer.
 --- Any type of item is accepted and converted to a String.
 --- {lnum} can be zero to insert a line before the first one.
---- {lnum} is used like with `|getline()|`.
+--- {lnum} is used like with [getline()](help://getline()).
 --- Returns 1 for failure ({lnum} out of range or out of memory),
 --- 0 for success.  When {text} is an empty list zero is returned,
 --- no matter the value of {lnum}.  Example:
@@ -108,15 +108,15 @@ function vim.fn.api_info() end
 --- @return 0|1
 function vim.fn.append(lnum, text) end
 
---- Like `|append()|` but append the text in buffer {expr}.
+--- Like [append()](help://append()) but append the text in buffer {expr}.
 ---
 --- This function works only for loaded buffers. First call
---- `|bufload()|` if needed.
+--- [bufload()](help://bufload()) if needed.
 ---
---- For the use of {buf}, see `|bufname()|`.
+--- For the use of {buf}, see [bufname()](help://bufname()).
 ---
 --- {lnum} is the line number to append below.  Note that using
---- `|line()|` would use the current buffer, not the one appending
+--- [line()](help://line()) would use the current buffer, not the one appending
 --- to.  Use "$" to append at the end of the buffer.  Other string
 --- values are not supported.
 ---
@@ -138,7 +138,7 @@ function vim.fn.append(lnum, text) end
 function vim.fn.appendbufline(buf, lnum, text) end
 
 --- The result is the number of files in the argument list.  See
---- `|arglist|`.
+--- [arglist](help://arglist).
 --- If {winid} is not supplied, the argument list of the current
 --- window is used.
 --- If {winid} is -1, the global argument list is used.
@@ -151,21 +151,21 @@ function vim.fn.appendbufline(buf, lnum, text) end
 function vim.fn.argc(winid) end
 
 --- The result is the current index in the argument list.  0 is
---- the first file.  argc() - 1 is the last one.  See `|arglist|`.
+--- the first file.  argc() - 1 is the last one.  See [arglist](help://arglist).
 ---
 --- @return integer
 function vim.fn.argidx() end
 
 --- Return the argument list ID.  This is a number which
 --- identifies the argument list being used.  Zero is used for the
---- global argument list.  See `|arglist|`.
+--- global argument list.  See [arglist](help://arglist).
 --- Returns -1 if the arguments are invalid.
 ---
 --- Without arguments use the current window.
 --- With {winnr} only use this window in the current tab page.
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.
---- {winnr} can be the window number or the `|window-ID|`.
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -173,7 +173,7 @@ function vim.fn.argidx() end
 function vim.fn.arglistid(winnr, tabnr) end
 
 --- The result is the {nr}th file in the argument list.  See
---- `|arglist|`.  "argv(0)" is the first one.  Example:
+--- [arglist](help://arglist).  "argv(0)" is the first one.  Example:
 --- ```vim
 ---   let i = 0
 ---   while i < argc()
@@ -182,11 +182,11 @@ function vim.fn.arglistid(winnr, tabnr) end
 ---     let i = i + 1
 ---   endwhile
 --- ```
---- Without the {nr} argument, or when {nr} is -1, a `|List|` with
---- the whole `|arglist|` is returned.
+--- Without the {nr} argument, or when {nr} is -1, a [List](help://List) with
+--- the whole [arglist](help://arglist) is returned.
 ---
---- The {winid} argument specifies the window ID, see `|argc()|`.
---- For the Vim command line arguments see `|v:argv|`.
+--- The {winid} argument specifies the window ID, see [argc()](help://argc()).
+--- For the Vim command line arguments see [v:argv](help://v:argv).
 ---
 --- Returns an empty string if {nr}th argument is not present in
 --- the argument list.  Returns an empty List if the {winid}
@@ -197,12 +197,12 @@ function vim.fn.arglistid(winnr, tabnr) end
 --- @return string|string[]
 function vim.fn.argv(nr, winid) end
 
---- Return the arc sine of {expr} measured in radians, as a `|Float|`
+--- Return the arc sine of {expr} measured in radians, as a [Float](help://Float)
 --- in the range of [-pi/2, pi/2].
---- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number) in the range
 --- [-1, 1].
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
---- 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo asin(0.8)
@@ -218,10 +218,10 @@ function vim.fn.argv(nr, winid) end
 --- @return number
 function vim.fn.asin(expr) end
 
---- Run {cmd} and add an error message to `|v:errors|` if it does
+--- Run {cmd} and add an error message to [v:errors](help://v:errors) if it does
 --- NOT produce a beep or visual bell.
---- Also see `|assert_fails()|`, `|assert_nobeep()|` and
---- `|assert-return|`.
+--- Also see [assert_fails()](help://assert_fails()), [assert_nobeep()](help://assert_nobeep()) and
+--- [assert-return](help://assert-return).
 ---
 ---
 --- @param cmd any
@@ -229,8 +229,8 @@ function vim.fn.asin(expr) end
 function vim.fn.assert_beeps(cmd) end
 
 --- When {expected} and {actual} are not equal an error message is
---- added to `|v:errors|` and 1 is returned.  Otherwise zero is
---- returned. `|assert-return|`
+--- added to [v:errors](help://v:errors) and 1 is returned.  Otherwise zero is
+--- returned. [assert-return](help://assert-return)
 --- The error is in the form "Expected {expected} but got
 --- {actual}".  When {msg} is present it is prefixed to that.
 ---
@@ -242,7 +242,7 @@ function vim.fn.assert_beeps(cmd) end
 --- ```vim
 ---   assert_equal('foo', 'bar')
 --- ```
---- Will result in a string to be added to `|v:errors|`:
+--- Will result in a string to be added to [v:errors](help://v:errors):
 ---   test.vim line 12: Expected 'foo' but got 'bar' ~
 ---
 ---
@@ -253,8 +253,8 @@ function vim.fn.assert_beeps(cmd) end
 function vim.fn.assert_equal(expected, actual, msg) end
 
 --- When the files {fname-one} and {fname-two} do not contain
---- exactly the same text an error message is added to `|v:errors|`.
---- Also see `|assert-return|`.
+--- exactly the same text an error message is added to [v:errors](help://v:errors).
+--- Also see [assert-return](help://assert-return).
 --- When {fname-one} or {fname-two} does not exist the error will
 --- mention that.
 ---
@@ -263,7 +263,7 @@ function vim.fn.assert_equal(expected, actual, msg) end
 function vim.fn.assert_equalfile() end
 
 --- When v:exception does not contain the string {error} an error
---- message is added to `|v:errors|`.  Also see `|assert-return|`.
+--- message is added to [v:errors](help://v:errors).  Also see [assert-return](help://assert-return).
 --- This can be used to assert that a command throws an exception.
 --- Using the error number, followed by a colon, avoids problems
 --- with translations:
@@ -281,9 +281,9 @@ function vim.fn.assert_equalfile() end
 --- @return 0|1
 function vim.fn.assert_exception(error, msg) end
 
---- Run {cmd} and add an error message to `|v:errors|` if it does
+--- Run {cmd} and add an error message to [v:errors](help://v:errors) if it does
 --- NOT produce an error or when {error} is not found in the
---- error message.  Also see `|assert-return|`.
+--- error message.  Also see [assert-return](help://assert-return).
 ---
 --- When {error} is a string it must be found literally in the
 --- first reported error. Most often this will be the error code,
@@ -291,7 +291,7 @@ function vim.fn.assert_exception(error, msg) end
 --- ```vim
 ---   assert_fails('bad cmd', 'E987:')
 --- ```
---- When {error} is a `|List|` with one or two strings, these are
+--- When {error} is a [List](help://List) with one or two strings, these are
 --- used as patterns.  The first pattern is matched against the
 --- first reported error:
 --- ```vim
@@ -316,7 +316,7 @@ function vim.fn.assert_exception(error, msg) end
 --- {lnum} is located in.
 ---
 --- Note that beeping is not considered an error, and some failing
---- commands only beep.  Use `|assert_beeps()|` for those.
+--- commands only beep.  Use [assert_beeps()](help://assert_beeps()) for those.
 ---
 ---
 --- @param cmd any
@@ -328,10 +328,10 @@ function vim.fn.assert_exception(error, msg) end
 function vim.fn.assert_fails(cmd, error, msg, lnum, context) end
 
 --- When {actual} is not false an error message is added to
---- `|v:errors|`, like with `|assert_equal()|`.
+--- [v:errors](help://v:errors), like with [assert_equal()](help://assert_equal()).
 --- The error is in the form "Expected False but got {actual}".
 --- When {msg} is present it is prepended to that.
---- Also see `|assert-return|`.
+--- Also see [assert-return](help://assert-return).
 ---
 --- A value is false when it is zero. When {actual} is not a
 --- number the assert fails.
@@ -342,9 +342,9 @@ function vim.fn.assert_fails(cmd, error, msg, lnum, context) end
 --- @return 0|1
 function vim.fn.assert_false(actual, msg) end
 
---- This asserts number and `|Float|` values.  When {actual}  is lower
+--- This asserts number and [Float](help://Float) values.  When {actual}  is lower
 --- than {lower} or higher than {upper} an error message is added
---- to `|v:errors|`.  Also see `|assert-return|`.
+--- to [v:errors](help://v:errors).  Also see [assert-return](help://assert-return).
 --- The error is in the form "Expected range {lower} - {upper},
 --- but got {actual}".  When {msg} is present it is prefixed to
 --- that.
@@ -357,11 +357,11 @@ function vim.fn.assert_false(actual, msg) end
 function vim.fn.assert_inrange(lower, upper, actual, msg) end
 
 --- When {pattern} does not match {actual} an error message is
---- added to `|v:errors|`.  Also see `|assert-return|`.
+--- added to [v:errors](help://v:errors).  Also see [assert-return](help://assert-return).
 --- The error is in the form "Pattern {pattern} does not match
 --- {actual}".  When {msg} is present it is prefixed to that.
 ---
---- {pattern} is used as with `|expr-=~|`: The matching is always done
+--- {pattern} is used as with [expr-=~](help://expr-=~): The matching is always done
 --- like 'magic' was set and 'cpoptions' is empty, no matter what
 --- the actual value of 'magic' or 'cpoptions' is.
 ---
@@ -373,7 +373,7 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- ```vim
 ---   assert_match('^f.*o$', 'foobar')
 --- ```
---- Will result in a string to be added to `|v:errors|`:
+--- Will result in a string to be added to [v:errors](help://v:errors):
 ---   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 ---
 ---
@@ -383,9 +383,9 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- @return 0|1
 function vim.fn.assert_match(pattern, actual, msg) end
 
---- Run {cmd} and add an error message to `|v:errors|` if it
+--- Run {cmd} and add an error message to [v:errors](help://v:errors) if it
 --- produces a beep or visual bell.
---- Also see `|assert_beeps()|`.
+--- Also see [assert_beeps()](help://assert_beeps()).
 ---
 ---
 --- @param cmd any
@@ -393,8 +393,8 @@ function vim.fn.assert_match(pattern, actual, msg) end
 function vim.fn.assert_nobeep(cmd) end
 
 --- The opposite of `assert_equal()`: add an error message to
---- `|v:errors|` when {expected} and {actual} are equal.
---- Also see `|assert-return|`.
+--- [v:errors](help://v:errors) when {expected} and {actual} are equal.
+--- Also see [assert-return](help://assert-return).
 ---
 ---
 --- @param expected any
@@ -404,8 +404,8 @@ function vim.fn.assert_nobeep(cmd) end
 function vim.fn.assert_notequal(expected, actual, msg) end
 
 --- The opposite of `assert_match()`: add an error message to
---- `|v:errors|` when {pattern} matches {actual}.
---- Also see `|assert-return|`.
+--- [v:errors](help://v:errors) when {pattern} matches {actual}.
+--- Also see [assert-return](help://assert-return).
 ---
 ---
 --- @param pattern any
@@ -423,10 +423,10 @@ function vim.fn.assert_notmatch(pattern, actual, msg) end
 function vim.fn.assert_report(msg) end
 
 --- When {actual} is not true an error message is added to
---- `|v:errors|`, like with `|assert_equal()|`.
---- Also see `|assert-return|`.
---- A value is `|TRUE|` when it is a non-zero number or `|v:true|`.
---- When {actual} is not a number or `|v:true|` the assert fails.
+--- [v:errors](help://v:errors), like with [assert_equal()](help://assert_equal()).
+--- Also see [assert-return](help://assert-return).
+--- A value is [TRUE](help://TRUE) when it is a non-zero number or [v:true](help://v:true).
+--- When {actual} is not a number or [v:true](help://v:true) the assert fails.
 --- When {msg} is given it precedes the default message.
 ---
 ---
@@ -436,9 +436,9 @@ function vim.fn.assert_report(msg) end
 function vim.fn.assert_true(actual, msg) end
 
 --- Return the principal value of the arc tangent of {expr}, in
---- the range [-pi/2, +pi/2] radians, as a `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- the range [-pi/2, +pi/2] radians, as a [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo atan(100)
@@ -455,10 +455,10 @@ function vim.fn.assert_true(actual, msg) end
 function vim.fn.atan(expr) end
 
 --- Return the arc tangent of {expr1} / {expr2}, measured in
---- radians, as a `|Float|` in the range [-pi, pi].
---- {expr1} and {expr2} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr1} or {expr2} is not a `|Float|` or a
---- `|Number|`.
+--- radians, as a [Float](help://Float) in the range [-pi, pi].
+--- {expr1} and {expr2} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr1} or {expr2} is not a [Float](help://Float) or a
+--- [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo atan2(-1, 1)
@@ -481,7 +481,7 @@ function vim.fn.atan2(expr1, expr2) end
 ---   blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
 ---   blob2list(0z)    " returns []
 --- ```
---- Returns an empty List on error.  `|list2blob()|` does the
+--- Returns an empty List on error.  [list2blob()](help://list2blob()) does the
 --- opposite.
 ---
 ---
@@ -490,9 +490,9 @@ function vim.fn.atan2(expr1, expr2) end
 function vim.fn.blob2list(blob) end
 
 --- Put up a file requester.  This only works when "has("browse")"
---- returns `|TRUE|` (only in some GUI versions).
+--- returns [TRUE](help://TRUE) (only in some GUI versions).
 --- The input fields are:
----     {save}  when `|TRUE|`, select file to write
+---     {save}  when [TRUE](help://TRUE), select file to write
 ---     {title}  title for the requester
 ---     {initdir}  directory to start browsing in
 ---     {default}  default file name
@@ -507,7 +507,7 @@ function vim.fn.blob2list(blob) end
 function vim.fn.browse(save, title, initdir, default) end
 
 --- Put up a directory requester.  This only works when
---- "has("browse")" returns `|TRUE|` (only in some GUI versions).
+--- "has("browse")" returns [TRUE](help://TRUE) (only in some GUI versions).
 --- On systems where a directory browser is not supported a file
 --- browser is used.  In that case: select a file in the directory
 --- to be used.
@@ -541,7 +541,7 @@ function vim.fn.browsedir(title, initdir) end
 --- @return integer
 function vim.fn.bufadd(name) end
 
---- The result is a Number, which is `|TRUE|` if a buffer called
+--- The result is a Number, which is [TRUE](help://TRUE) if a buffer called
 --- {buf} exists.
 --- If the {buf} argument is a number, buffer numbers are used.
 --- Number zero is the alternate buffer for the current window.
@@ -554,10 +554,10 @@ function vim.fn.bufadd(name) end
 --- - A URL name.
 --- Unlisted buffers will be found.
 --- Note that help files are listed by their short name in the
---- output of `|:buffers|`, but bufexists() requires using their
+--- output of [:buffers](help://:buffers), but bufexists() requires using their
 --- long name to be able to find them.
 --- bufexists() may report a buffer exists, but to use the name
---- with a `|:buffer|` command you may need to use `|expand()|`.  Esp
+--- with a [:buffer](help://:buffer) command you may need to use [expand()](help://expand()).  Esp
 --- for MS-Windows 8.3 names in the form "c:\DOCUME~1"
 --- Use "bufexists(0)" to test for the existence of an alternate
 --- file name.
@@ -568,29 +568,29 @@ function vim.fn.bufadd(name) end
 function vim.fn.bufexists(buf) end
 
 --- @deprecated
---- Obsolete name for `|bufexists()|`.
+--- Obsolete name for [bufexists()](help://bufexists()).
 ---
 --- @param ... any
 --- @return 0|1
 function vim.fn.buffer_exists(...) end
 
 --- @deprecated
---- Obsolete name for `|bufname()|`.
+--- Obsolete name for [bufname()](help://bufname()).
 ---
 --- @param ... any
 --- @return string
 function vim.fn.buffer_name(...) end
 
 --- @deprecated
---- Obsolete name for `|bufnr()|`.
+--- Obsolete name for [bufnr()](help://bufnr()).
 ---
 --- @param ... any
 --- @return integer
 function vim.fn.buffer_number(...) end
 
---- The result is a Number, which is `|TRUE|` if a buffer called
+--- The result is a Number, which is [TRUE](help://TRUE) if a buffer called
 --- {buf} exists and is listed (has the 'buflisted' option set).
---- The {buf} argument is used like with `|bufexists()|`.
+--- The {buf} argument is used like with [bufexists()](help://bufexists()).
 ---
 ---
 --- @param buf any
@@ -604,15 +604,15 @@ function vim.fn.buflisted(buf) end
 --- file then no file is read (e.g., when 'buftype' is "nofile").
 --- If there is an existing swap file for the file of the buffer,
 --- there will be no dialog, the buffer will be loaded anyway.
---- The {buf} argument is used like with `|bufexists()|`.
+--- The {buf} argument is used like with [bufexists()](help://bufexists()).
 ---
 ---
 --- @param buf any
 function vim.fn.bufload(buf) end
 
---- The result is a Number, which is `|TRUE|` if a buffer called
+--- The result is a Number, which is [TRUE](help://TRUE) if a buffer called
 --- {buf} exists and is loaded (shown in a window or hidden).
---- The {buf} argument is used like with `|bufexists()|`.
+--- The {buf} argument is used like with [bufexists()](help://bufexists()).
 ---
 ---
 --- @param buf any
@@ -625,7 +625,7 @@ function vim.fn.bufloaded(buf) end
 --- If {buf} is omitted the current buffer is used.
 --- If {buf} is a Number, that buffer number's name is given.
 --- Number zero is the alternate buffer for the current window.
---- If {buf} is a String, it is used as a `|file-pattern|` to match
+--- If {buf} is a String, it is used as a [file-pattern](help://file-pattern) to match
 --- with the buffer names.  This is always done like 'magic' is
 --- set and 'cpoptions' is empty.  When there is more than one
 --- match an empty string is returned.
@@ -657,7 +657,7 @@ function vim.fn.bufloaded(buf) end
 function vim.fn.bufname(buf) end
 
 --- The result is the number of a buffer, as it is displayed by
---- the `:ls` command.  For the use of {buf}, see `|bufname()|`
+--- the `:ls` command.  For the use of {buf}, see [bufname()](help://bufname())
 --- above.
 --- If the buffer doesn't exist, -1 is returned.  Or, if the
 --- {create} argument is present and TRUE, a new, unlisted,
@@ -677,15 +677,15 @@ function vim.fn.bufname(buf) end
 --- @return integer
 function vim.fn.bufnr(buf, create) end
 
---- The result is a Number, which is the `|window-ID|` of the first
+--- The result is a Number, which is the [window-ID](help://window-ID) of the first
 --- window associated with buffer {buf}.  For the use of {buf},
---- see `|bufname()|` above.  If buffer {buf} doesn't exist or
+--- see [bufname()](help://bufname()) above.  If buffer {buf} doesn't exist or
 --- there is no such window, -1 is returned.  Example:
 --- ```vim
 ---
 ---   echo "A window containing buffer 1 is " .. (bufwinid(1))
 --- ```
---- Only deals with the current tab page.  See `|win_findbuf()|` for
+--- Only deals with the current tab page.  See [win_findbuf()](help://win_findbuf()) for
 --- finding more.
 ---
 ---
@@ -693,16 +693,16 @@ function vim.fn.bufnr(buf, create) end
 --- @return integer
 function vim.fn.bufwinid(buf) end
 
---- Like `|bufwinid()|` but return the window number instead of the
---- `|window-ID|`.
+--- Like [bufwinid()](help://bufwinid()) but return the window number instead of the
+--- [window-ID](help://window-ID).
 --- If buffer {buf} doesn't exist or there is no such window, -1
 --- is returned.  Example:
 --- ```vim
 ---
 ---   echo "A window containing buffer 1 is " .. (bufwinnr(1))
 --- ```
---- The number can be used with `|CTRL-W_w|` and ":wincmd w"
---- `|:wincmd|`.
+--- The number can be used with [CTRL-W_w](help://CTRL-W_w) and ":wincmd w"
+--- [:wincmd](help://:wincmd).
 ---
 ---
 --- @param buf any
@@ -714,7 +714,7 @@ function vim.fn.bufwinnr(buf) end
 --- end-of-line character, depending on the 'fileformat' option
 --- for the current buffer.  The first character has byte count
 --- one.
---- Also see `|line2byte()|`, `|go|` and `|:goto|`.
+--- Also see [line2byte()](help://line2byte()), [go](help://go) and [:goto](help://:goto).
 ---
 --- Returns -1 if the {byte} value is invalid.
 ---
@@ -730,7 +730,7 @@ function vim.fn.byte2line(byte) end
 --- equal to {nr}.
 --- Composing characters are not counted separately, their byte
 --- length is added to the preceding base character.  See
---- `|byteidxcomp()|` below for counting composing characters
+--- [byteidxcomp()](help://byteidxcomp()) below for counting composing characters
 --- separately.
 --- When {utf16} is present and TRUE, {nr} is used as the UTF-16
 --- index in the String {expr} instead of as the character index.
@@ -738,7 +738,7 @@ function vim.fn.byte2line(byte) end
 --- with 16-bit words.  If the specified UTF-16 index is in the
 --- middle of a character (e.g. in a 4-byte character), then the
 --- byte index of the first byte in the character is returned.
---- Refer to `|string-offset-encoding|` for more information.
+--- Refer to [string-offset-encoding](help://string-offset-encoding) for more information.
 --- Example :
 --- ```vim
 ---   echo matchstr(str, ".", byteidx(str, 3))
@@ -749,12 +749,12 @@ function vim.fn.byte2line(byte) end
 ---   let s = strpart(str, byteidx(str, 3))
 ---   echo strpart(s, 0, byteidx(s, 1))
 --- ```
---- Also see `|strgetchar()|` and `|strcharpart()|`.
+--- Also see [strgetchar()](help://strgetchar()) and [strcharpart()](help://strcharpart()).
 ---
 --- If there are less than {nr} characters -1 is returned.
 --- If there are exactly {nr} characters the length of the string
 --- in bytes is returned.
---- See `|charidx()|` and `|utf16idx()|` for getting the character and
+--- See [charidx()](help://charidx()) and [utf16idx()](help://utf16idx()) for getting the character and
 --- UTF-16 index respectively from the byte index.
 --- Examples:
 --- ```vim
@@ -788,13 +788,13 @@ function vim.fn.byteidx(expr, nr, utf16) end
 --- @return integer
 function vim.fn.byteidxcomp(expr, nr, utf16) end
 
---- Call function {func} with the items in `|List|` {arglist} as
+--- Call function {func} with the items in [List](help://List) {arglist} as
 --- arguments.
---- {func} can either be a `|Funcref|` or the name of a function.
+--- {func} can either be a [Funcref](help://Funcref) or the name of a function.
 --- a:firstline and a:lastline are set to the cursor line.
 --- Returns the return value of the called function.
 --- {dict} is for functions with the "dict" attribute.  It will be
---- used to set the local variable "self". `|Dictionary-function|`
+--- used to set the local variable "self". [Dictionary-function](help://Dictionary-function)
 ---
 ---
 --- @param func any
@@ -804,8 +804,8 @@ function vim.fn.byteidxcomp(expr, nr, utf16) end
 function vim.fn.call(func, arglist, dict) end
 
 --- Return the smallest integral value greater than or equal to
---- {expr} as a `|Float|` (round up).
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
+--- {expr} as a [Float](help://Float) (round up).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo ceil(1.456)
@@ -820,7 +820,7 @@ function vim.fn.call(func, arglist, dict) end
 --- ```
 --- 4.0
 ---
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 ---
 ---
 --- @param expr any
@@ -842,8 +842,8 @@ function vim.fn.ceil(expr) end
 function vim.fn.chanclose(id, stream) end
 
 --- Return the number of the most recent change.  This is the same
---- number as what is displayed with `|:undolist|` and can be used
---- with the `|:undo|` command.
+--- number as what is displayed with [:undolist](help://:undolist) and can be used
+--- with the [:undo](help://:undo) command.
 --- When a change was made it is the number of that change.  After
 --- redo it is the number of the redone change.  After undo it is
 --- one less than the number of the undone change.
@@ -853,12 +853,12 @@ function vim.fn.chanclose(id, stream) end
 function vim.fn.changenr() end
 
 --- Send data to channel {id}. For a job, it writes it to the
---- stdin of the process. For the stdio channel `|channel-stdio|`,
+--- stdin of the process. For the stdio channel [channel-stdio](help://channel-stdio),
 --- it writes to Nvim's stdout.  Returns the number of bytes
 --- written if the write succeeded, 0 otherwise.
---- See `|channel-bytes|` for more information.
+--- See [channel-bytes](help://channel-bytes) for more information.
 ---
---- {data} may be a string, string convertible, `|Blob|`, or a list.
+--- {data} may be a string, string convertible, [Blob](help://Blob), or a list.
 --- If {data} is a list, the items will be joined by newlines; any
 --- newlines in an item will be sent as NUL. To send a final
 --- newline, include a final empty string. Example:
@@ -869,7 +869,7 @@ function vim.fn.changenr() end
 ---
 --- chansend() writes raw data, not RPC messages.  If the channel
 --- was created with `"rpc":v:true` then the channel expects RPC
---- messages, use `|rpcnotify()|` and `|rpcrequest()|` instead.
+--- messages, use [rpcnotify()](help://rpcnotify()) and [rpcrequest()](help://rpcrequest()) instead.
 ---
 --- @param id any
 --- @param data any
@@ -888,9 +888,9 @@ function vim.fn.chansend(id, data) end
 --- Non-ASCII characters are always treated as UTF-8 characters.
 --- {utf8} is ignored, it exists only for backwards-compatibility.
 --- A combining character is a separate character.
---- `|nr2char()|` does the opposite.
+--- [nr2char()](help://nr2char()) does the opposite.
 ---
---- Returns 0 if {string} is not a `|String|`.
+--- Returns 0 if {string} is not a [String](help://String).
 ---
 ---
 --- @param string string
@@ -906,13 +906,13 @@ function vim.fn.char2nr(string, utf8) end
 ---   3  emoji
 ---   other  specific Unicode class
 --- The class is used in patterns and word motions.
---- Returns 0 if {string} is not a `|String|`.
+--- Returns 0 if {string} is not a [String](help://String).
 ---
 --- @param string string
 --- @return 0|1|2|3|'other'
 function vim.fn.charclass(string) end
 
---- Same as `|col()|` but returns the character index of the column
+--- Same as [col()](help://col()) but returns the character index of the column
 --- position given with {expr} instead of the byte position.
 ---
 --- Example:
@@ -932,10 +932,10 @@ function vim.fn.charcol(expr, winid) end
 --- If there are no multibyte characters the returned value is
 --- equal to {idx}.
 ---
---- When {countcc} is omitted or `|FALSE|`, then composing characters
+--- When {countcc} is omitted or [FALSE](help://FALSE), then composing characters
 --- are not counted separately, their byte length is added to the
 --- preceding base character.
---- When {countcc} is `|TRUE|`, then composing characters are
+--- When {countcc} is [TRUE](help://TRUE), then composing characters are
 --- counted as separate characters.
 ---
 --- When {utf16} is present and TRUE, {idx} is used as the UTF-16
@@ -949,10 +949,10 @@ function vim.fn.charcol(expr, winid) end
 --- not a string, the second argument is not a number or when the
 --- third argument is present and is not zero or one.
 ---
---- See `|byteidx()|` and `|byteidxcomp()|` for getting the byte index
---- from the character index and `|utf16idx()|` for getting the
+--- See [byteidx()](help://byteidx()) and [byteidxcomp()](help://byteidxcomp()) for getting the byte index
+--- from the character index and [utf16idx()](help://utf16idx()) for getting the
 --- UTF-16 index from the character index.
---- Refer to `|string-offset-encoding|` for more information.
+--- Refer to [string-offset-encoding](help://string-offset-encoding) for more information.
 --- Examples:
 --- ```vim
 ---   echo charidx('áb́ć', 3)    " returns 1
@@ -972,9 +972,9 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 --- the directory change depends on the directory of the current
 --- window:
 ---   - If the current window has a window-local directory
----     (`|:lcd|`), then changes the window local directory.
+---     ([:lcd](help://:lcd)), then changes the window local directory.
 ---   - Otherwise, if the current tabpage has a local
----     directory (`|:tcd|`) then changes the tabpage local
+---     directory ([:tcd](help://:tcd)) then changes the tabpage local
 ---     directory.
 ---   - Otherwise, changes the global directory.
 --- {dir} must be a String.
@@ -998,9 +998,9 @@ function vim.fn.chdir(dir) end
 --- Get the amount of indent for line {lnum} according the C
 --- indenting rules, as with 'cindent'.
 --- The indent is counted in spaces, the value of 'tabstop' is
---- relevant.  {lnum} is used just like in `|getline()|`.
+--- relevant.  {lnum} is used just like in [getline()](help://getline()).
 --- When {lnum} is invalid -1 is returned.
---- See `|C-indenting|`.
+--- See [C-indenting](help://C-indenting).
 ---
 ---
 --- @param lnum integer
@@ -1008,7 +1008,7 @@ function vim.fn.chdir(dir) end
 function vim.fn.cindent(lnum) end
 
 --- Clears all matches previously defined for the current window
---- by `|matchadd()|` and the `|:match|` commands.
+--- by [matchadd()](help://matchadd()) and the [:match](help://:match) commands.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
 ---
@@ -1025,18 +1025,18 @@ function vim.fn.clearmatches(win) end
 ---       returned)
 ---     v       In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from `|'<|` in
+---       returns the cursor position.  Differs from ['<](help://'<) in
 ---       that it's updated right away.
---- Additionally {expr} can be [lnum, col]: a `|List|` with the line
+--- Additionally {expr} can be [lnum, col]: a [List](help://List) with the line
 --- and column number. Most useful when the column is "$", to get
 --- the last column of a specific line.  When "lnum" or "col" is
 --- out of range then col() returns zero.
 --- With the optional {winid} argument the values are obtained for
 --- that window instead of the current window.
---- To get the line number use `|line()|`.  To get both use
---- `|getpos()|`.
---- For the screen column position use `|virtcol()|`.  For the
---- character position use `|charcol()|`.
+--- To get the line number use [line()](help://line()).  To get both use
+--- [getpos()](help://getpos()).
+--- For the screen column position use [virtcol()](help://virtcol()).  For the
+--- character position use [charcol()](help://charcol()).
 --- Note that only marks in the current file can be used.
 --- Examples:
 --- ```vim
@@ -1064,21 +1064,21 @@ function vim.fn.col(expr, winid) end
 
 --- Set the matches for Insert mode completion.
 --- Can only be used in Insert mode.  You need to use a mapping
---- with CTRL-R = (see `|i_CTRL-R|`).  It does not work after CTRL-O
+--- with CTRL-R = (see [i_CTRL-R](help://i_CTRL-R)).  It does not work after CTRL-O
 --- or with an expression mapping.
 --- {startcol} is the byte offset in the line where the completed
 --- text start.  The text up to the cursor is the original text
 --- that will be replaced by the matches.  Use col('.') for an
 --- empty string.  "col('.') - 1" will replace one character by a
 --- match.
---- {matches} must be a `|List|`.  Each `|List|` item is one match.
---- See `|complete-items|` for the kind of items that are possible.
+--- {matches} must be a [List](help://List).  Each [List](help://List) item is one match.
+--- See [complete-items](help://complete-items) for the kind of items that are possible.
 --- "longest" in 'completeopt' is ignored.
 --- Note that the after calling this function you need to avoid
 --- inserting anything that would cause completion to stop.
 --- The match can be selected with CTRL-N and CTRL-P as usual with
 --- Insert mode completion.  The popup menu will appear if
---- specified, see `|ins-completion-menu|`.
+--- specified, see [ins-completion-menu](help://ins-completion-menu).
 --- Example:
 --- ```vim
 ---   inoremap <F5> <C-R>=ListMonths()<CR>
@@ -1103,7 +1103,7 @@ function vim.fn.complete(startcol, matches) end
 --- Returns 0 for failure (empty string or out of memory),
 --- 1 when the match was added, 2 when the match was already in
 --- the list.
---- See `|complete-functions|` for an explanation of {expr}.  It is
+--- See [complete-functions](help://complete-functions) for an explanation of {expr}.  It is
 --- the same as one item in the list that 'omnifunc' would return.
 ---
 ---
@@ -1113,7 +1113,7 @@ function vim.fn.complete_add(expr) end
 
 --- Check for a key typed while looking for completion matches.
 --- This is to be used when looking for matches takes some time.
---- Returns `|TRUE|` when searching for matches is to be aborted,
+--- Returns [TRUE](help://TRUE) when searching for matches is to be aborted,
 --- zero otherwise.
 --- Only to be used by the function specified with the
 --- 'completefunc' option.
@@ -1121,17 +1121,17 @@ function vim.fn.complete_add(expr) end
 --- @return 0|1
 function vim.fn.complete_check() end
 
---- Returns a `|Dictionary|` with information about Insert mode
---- completion.  See `|ins-completion|`.
+--- Returns a [Dictionary](help://Dictionary) with information about Insert mode
+--- completion.  See [ins-completion](help://ins-completion).
 --- The items are:
 ---    mode    Current completion mode name string.
----     See `|complete_info_mode|` for the values.
----    pum_visible  `|TRUE|` if popup menu is visible.
----     See `|pumvisible()|`.
+---     See [complete_info_mode](help://complete_info_mode) for the values.
+---    pum_visible  [TRUE](help://TRUE) if popup menu is visible.
+---     See [pumvisible()](help://pumvisible()).
 ---    items  List of completion matches.  Each item is a
 ---     dictionary containing the entries "word",
 ---     "abbr", "menu", "kind", "info" and "user_data".
----     See `|complete-items|`.
+---     See [complete-items](help://complete-items).
 ---    selected  Selected item index.  First index is zero.
 ---     Index is -1 if no item is selected (showing
 ---     typed text only, or the last completion after
@@ -1142,22 +1142,22 @@ function vim.fn.complete_check() end
 ---           *complete_info_mode*
 --- mode values are:
 ---    ""         Not in completion mode
----    "keyword"       Keyword completion `|i_CTRL-X_CTRL-N|`
----    "ctrl_x"       Just pressed CTRL-X `|i_CTRL-X|`
----    "scroll"       Scrolling with `|i_CTRL-X_CTRL-E|` or
----          `|i_CTRL-X_CTRL-Y|`
----    "whole_line"       Whole lines `|i_CTRL-X_CTRL-L|`
----    "files"       File names `|i_CTRL-X_CTRL-F|`
----    "tags"       Tags `|i_CTRL-X_CTRL-]|`
----    "path_defines"    Definition completion `|i_CTRL-X_CTRL-D|`
----    "path_patterns"   Include completion `|i_CTRL-X_CTRL-I|`
----    "dictionary"       Dictionary `|i_CTRL-X_CTRL-K|`
----    "thesaurus"       Thesaurus `|i_CTRL-X_CTRL-T|`
----    "cmdline"       Vim Command line `|i_CTRL-X_CTRL-V|`
----    "function"       User defined completion `|i_CTRL-X_CTRL-U|`
----    "omni"       Omni completion `|i_CTRL-X_CTRL-O|`
----    "spell"       Spelling suggestions `|i_CTRL-X_s|`
----    "eval"       `|complete()|` completion
+---    "keyword"       Keyword completion [i_CTRL-X_CTRL-N](help://i_CTRL-X_CTRL-N)
+---    "ctrl_x"       Just pressed CTRL-X [i_CTRL-X](help://i_CTRL-X)
+---    "scroll"       Scrolling with [i_CTRL-X_CTRL-E](help://i_CTRL-X_CTRL-E) or
+---          [i_CTRL-X_CTRL-Y](help://i_CTRL-X_CTRL-Y)
+---    "whole_line"       Whole lines [i_CTRL-X_CTRL-L](help://i_CTRL-X_CTRL-L)
+---    "files"       File names [i_CTRL-X_CTRL-F](help://i_CTRL-X_CTRL-F)
+---    "tags"       Tags [i_CTRL-X_CTRL-]](help://i_CTRL-X_CTRL-])
+---    "path_defines"    Definition completion [i_CTRL-X_CTRL-D](help://i_CTRL-X_CTRL-D)
+---    "path_patterns"   Include completion [i_CTRL-X_CTRL-I](help://i_CTRL-X_CTRL-I)
+---    "dictionary"       Dictionary [i_CTRL-X_CTRL-K](help://i_CTRL-X_CTRL-K)
+---    "thesaurus"       Thesaurus [i_CTRL-X_CTRL-T](help://i_CTRL-X_CTRL-T)
+---    "cmdline"       Vim Command line [i_CTRL-X_CTRL-V](help://i_CTRL-X_CTRL-V)
+---    "function"       User defined completion [i_CTRL-X_CTRL-U](help://i_CTRL-X_CTRL-U)
+---    "omni"       Omni completion [i_CTRL-X_CTRL-O](help://i_CTRL-X_CTRL-O)
+---    "spell"       Spelling suggestions [i_CTRL-X_s](help://i_CTRL-X_s)
+---    "eval"       [complete()](help://complete()) completion
 ---    "unknown"       Other internal modes
 ---
 --- If the optional {what} list argument is supplied, then only
@@ -1165,10 +1165,10 @@ function vim.fn.complete_check() end
 --- {what} are silently ignored.
 ---
 --- To get the position and size of the popup menu, see
---- `|pum_getpos()|`. It's also available in `|v:event|` during the
---- `|CompleteChanged|` event.
+--- [pum_getpos()](help://pum_getpos()). It's also available in [v:event](help://v:event) during the
+--- [CompleteChanged](help://CompleteChanged) event.
 ---
---- Returns an empty `|Dictionary|` on error.
+--- Returns an empty [Dictionary](help://Dictionary) on error.
 ---
 --- Examples:
 --- ```vim
@@ -1251,20 +1251,20 @@ function vim.fn.confirm(msg, choices, default, type) end
 
 --- Make a copy of {expr}.  For Numbers and Strings this isn't
 --- different from using {expr} directly.
---- When {expr} is a `|List|` a shallow copy is created.  This means
---- that the original `|List|` can be changed without changing the
+--- When {expr} is a [List](help://List) a shallow copy is created.  This means
+--- that the original [List](help://List) can be changed without changing the
 --- copy, and vice versa.  But the items are identical, thus
---- changing an item changes the contents of both `|Lists|`.
---- A `|Dictionary|` is copied in a similar way as a `|List|`.
---- Also see `|deepcopy()|`.
+--- changing an item changes the contents of both [Lists](help://Lists).
+--- A [Dictionary](help://Dictionary) is copied in a similar way as a [List](help://List).
+--- Also see [deepcopy()](help://deepcopy()).
 ---
 --- @param expr any
 --- @return any
 function vim.fn.copy(expr) end
 
---- Return the cosine of {expr}, measured in radians, as a `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Return the cosine of {expr}, measured in radians, as a [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo cos(100)
@@ -1280,10 +1280,10 @@ function vim.fn.copy(expr) end
 --- @return number
 function vim.fn.cos(expr) end
 
---- Return the hyperbolic cosine of {expr} as a `|Float|` in the range
+--- Return the hyperbolic cosine of {expr} as a [Float](help://Float) in the range
 --- [1, inf].
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo cosh(0.5)
@@ -1300,12 +1300,12 @@ function vim.fn.cos(expr) end
 function vim.fn.cosh(expr) end
 
 --- Return the number of times an item with value {expr} appears
---- in `|String|`, `|List|` or `|Dictionary|` {comp}.
+--- in [String](help://String), [List](help://List) or [Dictionary](help://Dictionary) {comp}.
 ---
 --- If {start} is given then start with the item with this index.
---- {start} can only be used with a `|List|`.
+--- {start} can only be used with a [List](help://List).
 ---
---- When {ic} is given and it's `|TRUE|` then case is ignored.
+--- When {ic} is given and it's [TRUE](help://TRUE) then case is ignored.
 ---
 --- When {comp} is a string then the number of not overlapping
 --- occurrences of {expr} is returned. Zero is returned when
@@ -1319,33 +1319,33 @@ function vim.fn.cosh(expr) end
 --- @return integer
 function vim.fn.count(comp, expr, ic, start) end
 
---- Returns a `|Dictionary|` representing the `|context|` at {index}
---- from the top of the `|context-stack|` (see `|context-dict|`).
+--- Returns a [Dictionary](help://Dictionary) representing the [context](help://context) at {index}
+--- from the top of the [context-stack](help://context-stack) (see [context-dict](help://context-dict)).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
 --- @param index? any
 --- @return table
 function vim.fn.ctxget(index) end
 
---- Pops and restores the `|context|` at the top of the
---- `|context-stack|`.
+--- Pops and restores the [context](help://context) at the top of the
+--- [context-stack](help://context-stack).
 ---
 --- @return any
 function vim.fn.ctxpop() end
 
---- Pushes the current editor state (`|context|`) on the
---- `|context-stack|`.
---- If {types} is given and is a `|List|` of `|String|`s, it specifies
---- which `|context-types|` to include in the pushed context.
+--- Pushes the current editor state ([context](help://context)) on the
+--- [context-stack](help://context-stack).
+--- If {types} is given and is a [List](help://List) of [String](help://String)s, it specifies
+--- which [context-types](help://context-types) to include in the pushed context.
 --- Otherwise, all context types are included.
 ---
 --- @param types? any
 --- @return any
 function vim.fn.ctxpush(types) end
 
---- Sets the `|context|` at {index} from the top of the
---- `|context-stack|` to that represented by {context}.
---- {context} is a Dictionary with context data (`|context-dict|`).
+--- Sets the [context](help://context) at {index} from the top of the
+--- [context-stack](help://context-stack) to that represented by {context}.
+--- {context} is a Dictionary with context data ([context-dict](help://context-dict)).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
 --- @param context any
@@ -1353,7 +1353,7 @@ function vim.fn.ctxpush(types) end
 --- @return any
 function vim.fn.ctxset(context, index) end
 
---- Returns the size of the `|context-stack|`.
+--- Returns the size of the [context-stack](help://context-stack).
 ---
 --- @return any
 function vim.fn.ctxsize() end
@@ -1367,19 +1367,19 @@ function vim.fn.cursor(lnum, col, off) end
 --- Positions the cursor at the column (byte count) {col} in the
 --- line {lnum}.  The first column is one.
 ---
---- When there is one argument {list} this is used as a `|List|`
+--- When there is one argument {list} this is used as a [List](help://List)
 --- with two, three or four item:
 ---   [{lnum}, {col}]
 ---   [{lnum}, {col}, {off}]
 ---   [{lnum}, {col}, {off}, {curswant}]
---- This is like the return value of `|getpos()|` or `|getcurpos()|`,
+--- This is like the return value of [getpos()](help://getpos()) or [getcurpos()](help://getcurpos()),
 --- but without the first item.
 ---
 --- To position the cursor using {col} as the character count, use
---- `|setcursorcharpos()|`.
+--- [setcursorcharpos()](help://setcursorcharpos()).
 ---
 --- Does not change the jumplist.
---- {lnum} is used like with `|getline()|`, except that if {lnum} is
+--- {lnum} is used like with [getline()](help://getline()), except that if {lnum} is
 --- zero, the cursor will stay in the current line.
 --- If {lnum} is greater than the number of lines in the buffer,
 --- the cursor will be positioned at the last line in the buffer.
@@ -1402,11 +1402,11 @@ function vim.fn.cursor(list) end
 
 --- Specifically used to interrupt a program being debugged.  It
 --- will cause process {pid} to get a SIGTRAP.  Behavior for other
---- processes is undefined. See `|terminal-debug|`.
+--- processes is undefined. See [terminal-debug](help://terminal-debug).
 --- (Sends a SIGINT to a process {pid} other than MS-Windows)
 ---
---- Returns `|TRUE|` if successfully interrupted the program.
---- Otherwise returns `|FALSE|`.
+--- Returns [TRUE](help://TRUE) if successfully interrupted the program.
+--- Otherwise returns [FALSE](help://FALSE).
 ---
 ---
 --- @param pid any
@@ -1415,22 +1415,22 @@ function vim.fn.debugbreak(pid) end
 
 --- Make a copy of {expr}.  For Numbers and Strings this isn't
 --- different from using {expr} directly.
---- When {expr} is a `|List|` a full copy is created.  This means
---- that the original `|List|` can be changed without changing the
---- copy, and vice versa.  When an item is a `|List|`, a copy for it
+--- When {expr} is a [List](help://List) a full copy is created.  This means
+--- that the original [List](help://List) can be changed without changing the
+--- copy, and vice versa.  When an item is a [List](help://List), a copy for it
 --- is made, recursively.  Thus changing an item in the copy does
---- not change the contents of the original `|List|`.
+--- not change the contents of the original [List](help://List).
 ---
---- When {noref} is omitted or zero a contained `|List|` or
---- `|Dictionary|` is only copied once.  All references point to
+--- When {noref} is omitted or zero a contained [List](help://List) or
+--- [Dictionary](help://Dictionary) is only copied once.  All references point to
 --- this single copy.  With {noref} set to 1 every occurrence of a
---- `|List|` or `|Dictionary|` results in a new copy.  This also means
+--- [List](help://List) or [Dictionary](help://Dictionary) results in a new copy.  This also means
 --- that a cyclic reference causes deepcopy() to fail.
 ---             *E724*
 --- Nesting is possible up to 100 levels.  When there is an item
 --- that refers back to a higher level making a deep copy with
 --- {noref} set to 1 will fail.
---- Also see `|copy()|`.
+--- Also see [copy()](help://copy()).
 ---
 ---
 --- @param expr any
@@ -1467,12 +1467,12 @@ function vim.fn.delete(fname, flags) end
 --- On success 0 is returned, on failure 1 is returned.
 ---
 --- This function works only for loaded buffers. First call
---- `|bufload()|` if needed.
+--- [bufload()](help://bufload()) if needed.
 ---
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 ---
---- {first} and {last} are used like with `|getline()|`. Note that
---- when using `|line()|` this refers to the current buffer. Use "$"
+--- {first} and {last} are used like with [getline()](help://getline()). Note that
+--- when using [line()](help://line()) this refers to the current buffer. Use "$"
 --- to refer to the last line in buffer {buf}.
 ---
 ---
@@ -1528,8 +1528,8 @@ function vim.fn.deletebufline(buf, first, last) end
 --- @return any
 function vim.fn.dictwatcheradd(dict, pattern, callback) end
 
---- Removes a watcher added  with `|dictwatcheradd()|`. All three
---- arguments must match the ones passed to `|dictwatcheradd()|` in
+--- Removes a watcher added  with [dictwatcheradd()](help://dictwatcheradd()). All three
+--- arguments must match the ones passed to [dictwatcheradd()](help://dictwatcheradd()) in
 --- order for the watcher to be successfully deleted.
 ---
 --- @param dict any
@@ -1538,11 +1538,11 @@ function vim.fn.dictwatcheradd(dict, pattern, callback) end
 --- @return any
 function vim.fn.dictwatcherdel(dict, pattern, callback) end
 
---- Returns `|TRUE|` when autocommands are being executed and the
+--- Returns [TRUE](help://TRUE) when autocommands are being executed and the
 --- FileType event has been triggered at least once.  Can be used
 --- to avoid triggering the FileType event again in the scripts
---- that detect the file type. `|FileType|`
---- Returns `|FALSE|` when `:setf FALLBACK` was used.
+--- that detect the file type. [FileType](help://FileType)
+--- Returns [FALSE](help://FALSE) when `:setf FALLBACK` was used.
 --- When editing another file, the counter is reset, thus this
 --- really checks if the FileType event has been triggered for the
 --- current buffer.  This allows an autocommand that starts
@@ -1556,7 +1556,7 @@ function vim.fn.did_filetype() end
 --- These are the lines that were inserted at this point in
 --- another diff'ed window.  These filler lines are shown in the
 --- display but don't exist in the buffer.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- Returns 0 if the current window is not in diff mode.
 ---
@@ -1568,11 +1568,11 @@ function vim.fn.diff_filler(lnum) end
 --- Returns the highlight ID for diff mode at line {lnum} column
 --- {col} (byte index).  When the current line does not have a
 --- diff change zero is returned.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- {col} is 1 for the leftmost column, {lnum} is 1 for the first
 --- line.
---- The highlight ID can be used with `|synIDattr()|` to obtain
+--- The highlight ID can be used with [synIDattr()](help://synIDattr()) to obtain
 --- syntax information about the highlighting.
 ---
 ---
@@ -1586,7 +1586,7 @@ function vim.fn.diff_hlID(lnum, col) end
 --- characters, or the digraph of {chars} does not exist, an error
 --- is given and an empty string is returned.
 ---
---- Also see `|digraph_getlist()|`.
+--- Also see [digraph_getlist()](help://digraph_getlist()).
 ---
 --- Examples:
 --- ```vim
@@ -1606,7 +1606,7 @@ function vim.fn.digraph_get(chars) end
 --- and it is TRUE, return all digraphs, including the default
 --- digraphs.  Otherwise, return only user-defined digraphs.
 ---
---- Also see `|digraph_get()|`.
+--- Also see [digraph_get()](help://digraph_get()).
 ---
 --- Examples:
 --- ```vim
@@ -1625,20 +1625,20 @@ function vim.fn.digraph_getlist(listall) end
 --- with two characters.  {digraph} is a string with one UTF-8
 --- encoded character.  *E1215*
 --- Be careful, composing characters are NOT ignored.  This
---- function is similar to `|:digraphs|` command, but useful to add
+--- function is similar to [:digraphs](help://:digraphs) command, but useful to add
 --- digraphs start with a white space.
 ---
---- The function result is v:true if `|digraph|` is registered.  If
+--- The function result is v:true if [digraph](help://digraph) is registered.  If
 --- this fails an error message is given and v:false is returned.
 ---
 --- If you want to define multiple digraphs at once, you can use
---- `|digraph_setlist()|`.
+--- [digraph_setlist()](help://digraph_setlist()).
 ---
 --- Example:
 --- ```vim
 ---   call digraph_set('  ', 'あ')
 --- ```
---- Can be used as a `|method|`:
+--- Can be used as a [method](help://method):
 --- ```vim
 ---   GetString()->digraph_set('あ')
 --- ```
@@ -1648,10 +1648,10 @@ function vim.fn.digraph_getlist(listall) end
 --- @return any
 function vim.fn.digraph_set(chars, digraph) end
 
---- Similar to `|digraph_set()|` but this function can add multiple
+--- Similar to [digraph_set()](help://digraph_set()) but this function can add multiple
 --- digraphs at once.  {digraphlist} is a list composed of lists,
 --- where each list contains two strings with {chars} and
---- {digraph} as in `|digraph_set()|`. *E1216*
+--- {digraph} as in [digraph_set()](help://digraph_set()). *E1216*
 --- Example:
 --- ```vim
 ---     call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
@@ -1665,7 +1665,7 @@ function vim.fn.digraph_set(chars, digraph) end
 --- Except that the function returns after the first error,
 --- following digraphs will not be added.
 ---
---- Can be used as a `|method|`:
+--- Can be used as a [method](help://method):
 --- ```vim
 ---     GetList()->digraph_setlist()
 --- ```
@@ -1675,12 +1675,12 @@ function vim.fn.digraph_set(chars, digraph) end
 function vim.fn.digraph_setlist(digraphlist) end
 
 --- Return the Number 1 if {expr} is empty, zero otherwise.
---- - A `|List|` or `|Dictionary|` is empty when it does not have any
+--- - A [List](help://List) or [Dictionary](help://Dictionary) is empty when it does not have any
 ---   items.
---- - A `|String|` is empty when its length is zero.
---- - A `|Number|` and `|Float|` are empty when their value is zero.
---- - `|v:false|` and `|v:null|` are empty, `|v:true|` is not.
---- - A `|Blob|` is empty when its length is zero.
+--- - A [String](help://String) is empty when its length is zero.
+--- - A [Number](help://Number) and [Float](help://Float) are empty when their value is zero.
+--- - [v:false](help://v:false) and [v:null](help://v:null) are empty, [v:true](help://v:true) is not.
+--- - A [Blob](help://Blob) is empty when its length is zero.
 ---
 ---
 --- @param expr any
@@ -1710,7 +1710,7 @@ function vim.fn.environ() end
 --- ```
 ---   c:\\program\ files\\vim
 --- ```
---- Also see `|shellescape()|` and `|fnameescape()|`.
+--- Also see [shellescape()](help://shellescape()) and [fnameescape()](help://fnameescape()).
 ---
 ---
 --- @param string string
@@ -1719,9 +1719,9 @@ function vim.fn.environ() end
 function vim.fn.escape(string, chars) end
 
 --- Evaluate {string} and return the result.  Especially useful to
---- turn the result of `|string()|` back into the original value.
+--- turn the result of [string()](help://string()) back into the original value.
 --- This works for Numbers, Floats, Strings, Blobs and composites
---- of them.  Also works for `|Funcref|`s that refer to existing
+--- of them.  Also works for [Funcref](help://Funcref)s that refer to existing
 --- functions.
 ---
 ---
@@ -1752,12 +1752,12 @@ function vim.fn.eventhandler() end
 --- On MS-Windows it only checks if the file exists and is not a
 --- directory, not if it's really executable.
 --- On Windows an executable in the same directory as Vim is
---- always found (it is added to $PATH at `|startup|`).
+--- always found (it is added to $PATH at [startup](help://startup)).
 --- The result is a Number:
 ---   1  exists
 ---   0  does not exist
 ---   -1  not implemented on this system
---- `|exepath()|` can be used to get the full path of an executable.
+--- [exepath()](help://exepath()) can be used to get the full path of an executable.
 ---
 ---
 --- @param expr any
@@ -1765,8 +1765,8 @@ function vim.fn.eventhandler() end
 function vim.fn.executable(expr) end
 
 --- Execute {command} and capture its output.
---- If {command} is a `|String|`, returns {command} output.
---- If {command} is a `|List|`, returns concatenated outputs.
+--- If {command} is a [String](help://String), returns {command} output.
+--- If {command} is a [List](help://List), returns concatenated outputs.
 --- Line continuations in {command} are not recognized.
 --- Examples:
 --- ```vim
@@ -1789,7 +1789,7 @@ function vim.fn.executable(expr) end
 --- ```vim
 ---   execute('args')->split("\n")
 --- ```
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 --- Note: If nested, an outer execute() will not observe output of
 --- the inner calls.
 --- Note: Text attributes (highlights) are not captured.
@@ -1805,24 +1805,24 @@ function vim.fn.execute(command, silent) end
 --- Returns the full path of {expr} if it is an executable and
 --- given as a (partial or full) path or is found in $PATH.
 --- Returns empty string otherwise.
---- If {expr} starts with "./" the `|current-directory|` is used.
+--- If {expr} starts with "./" the [current-directory](help://current-directory) is used.
 ---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.exepath(expr) end
 
---- The result is a Number, which is `|TRUE|` if {expr} is
+--- The result is a Number, which is [TRUE](help://TRUE) if {expr} is
 --- defined, zero otherwise.
 ---
---- For checking for a supported feature use `|has()|`.
---- For checking if a file exists use `|filereadable()|`.
+--- For checking for a supported feature use [has()](help://has()).
+--- For checking if a file exists use [filereadable()](help://filereadable()).
 ---
 --- The {expr} argument is a string, which contains one of these:
 ---   varname    internal variable (see
----   dict.key  `|internal-variables|`).  Also works
----   list[i]    for `|curly-braces-names|`, `|Dictionary|`
----       entries, `|List|` items, etc.
+---   dict.key  [internal-variables](help://internal-variables)).  Also works
+---   list[i]    for [curly-braces-names](help://curly-braces-names), [Dictionary](help://Dictionary)
+---       entries, [List](help://List) items, etc.
 ---       Beware that evaluating an index may
 ---       cause an error message for an invalid
 ---       expression.  E.g.:
@@ -1842,20 +1842,20 @@ function vim.fn.exepath(expr) end
 ---   $ENVNAME  environment variable (could also be
 ---       done by comparing with an empty
 ---       string)
----   `*funcname`  built-in function (see `|functions|`)
+---   `*funcname`  built-in function (see [functions](help://functions))
 ---       or user defined function (see
----       `|user-function|`). Also works for a
+---       [user-function](help://user-function)). Also works for a
 ---       variable that is a Funcref.
 ---   :cmdname  Ex command: built-in command, user
----       command or command modifier `|:command|`.
+---       command or command modifier [:command](help://:command).
 ---       Returns:
 ---       1  for match with start of a command
 ---       2  full match with a command
 ---       3  matches several user commands
 ---       To check for a supported command
 ---       always check the return value to be 2.
----   :2match    The `|:2match|` command.
----   :3match    The `|:3match|` command (but you
+---   :2match    The [:2match](help://:2match) command.
+---   :3match    The [:3match](help://:3match) command (but you
 ---       probably should not use it, it is
 ---       reserved for internal usage)
 ---   #event    autocommand defined for this event
@@ -1915,10 +1915,10 @@ function vim.fn.exepath(expr) end
 --- @return 0|1
 function vim.fn.exists(expr) end
 
---- Return the exponential of {expr} as a `|Float|` in the range
+--- Return the exponential of {expr} as a [Float](help://Float) in the range
 --- [0, inf].
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo exp(2)
@@ -1937,7 +1937,7 @@ function vim.fn.exp(expr) end
 --- Expand wildcards and the following special keywords in
 --- {string}.  'wildignorecase' applies.
 ---
---- If {list} is given and it is `|TRUE|`, a List will be returned.
+--- If {list} is given and it is [TRUE](help://TRUE), a List will be returned.
 --- Otherwise the result is a String and when there are several
 --- matches, they are separated by <NL> characters.
 ---
@@ -1946,7 +1946,7 @@ function vim.fn.exp(expr) end
 --- not start with '%', '#' or '<', see below.
 ---
 --- When {string} starts with '%', '#' or '<', the expansion is
---- done like for the `|cmdline-special|` variables with their
+--- done like for the [cmdline-special](help://cmdline-special) variables with their
 --- associated modifiers.  Here is a short overview:
 ---
 ---   %    current file name
@@ -1963,7 +1963,7 @@ function vim.fn.exp(expr) end
 ---   <sflnum>  script file line number, also when in
 ---       a function
 ---   <SID>    "<SNR>123_"  where "123" is the
----       current script ID  `|<SID>|`
+---       current script ID  [<SID>](help://<SID>)
 ---   <script>  sourced script file, or script file
 ---       where the current function was defined
 ---   <stack>    call stack
@@ -1999,7 +1999,7 @@ function vim.fn.exp(expr) end
 ---   echo expand(expand("<cfile>"))
 --- ```
 --- There cannot be white space between the variables and the
---- following modifier.  The `|fnamemodify()|` function can be used
+--- following modifier.  The [fnamemodify()](help://fnamemodify()) function can be used
 --- to modify normal file names.
 ---
 --- When using '%' or '#', and the current or alternate file name
@@ -2013,7 +2013,7 @@ function vim.fn.exp(expr) end
 --- When {string} does not start with '%', '#' or '<', it is
 --- expanded like a file name is expanded on the command line.
 --- 'suffixes' and 'wildignore' are used, unless the optional
---- {nosuf} argument is given and it is `|TRUE|`.
+--- {nosuf} argument is given and it is [TRUE](help://TRUE).
 --- Names for non-existing files are included.  The "**" item can
 --- be used to search in a directory tree.  For example, to find
 --- all "README" files in the current directory and below:
@@ -2023,13 +2023,13 @@ function vim.fn.exp(expr) end
 --- expand() can also be used to expand variables and environment
 --- variables that are only known in a shell.  But this can be
 --- slow, because a shell may be used to do the expansion.  See
---- `|expr-env-expand|`.
+--- [expr-env-expand](help://expr-env-expand).
 --- The expanded variable is still handled like a list of file
 --- names.  When an environment variable cannot be expanded, it is
 --- left unchanged.  Thus ":echo expand('$FOOBAR')" results in
 --- "$FOOBAR".
 ---
---- See `|glob()|` for finding existing files.  See `|system()|` for
+--- See [glob()](help://glob()) for finding existing files.  See [system()](help://system()) for
 --- getting the raw output of an external command.
 ---
 ---
@@ -2041,7 +2041,7 @@ function vim.fn.expand(string, nosuf, list) end
 
 --- Expand special items in String {string} like what is done for
 --- an Ex command such as `:edit`.  This expands special keywords,
---- like with `|expand()|`, and environment variables, anywhere in
+--- like with [expand()](help://expand()), and environment variables, anywhere in
 --- {string}.  "~user" and "~/path" are only expanded at the
 --- start.
 ---
@@ -2070,10 +2070,10 @@ function vim.fn.expand(string, nosuf, list) end
 --- @return any
 function vim.fn.expandcmd(string, options) end
 
---- {expr1} and {expr2} must be both `|Lists|` or both
---- `|Dictionaries|`.
+--- {expr1} and {expr2} must be both [Lists](help://Lists) or both
+--- [Dictionaries](help://Dictionaries).
 ---
---- If they are `|Lists|`: Append {expr2} to {expr1}.
+--- If they are [Lists](help://Lists): Append {expr2} to {expr1}.
 --- If {expr3} is given insert the items of {expr2} before the
 --- item with index {expr3} in {expr1}.  When {expr3} is zero
 --- insert before the first item.  When {expr3} is equal to
@@ -2087,12 +2087,12 @@ function vim.fn.expandcmd(string, options) end
 --- items copied is equal to the original length of the List.
 --- E.g., when {expr3} is 1 you get N new copies of the first item
 --- (where N is the original length of the List).
---- Use `|add()|` to concatenate one item to a list.  To concatenate
+--- Use [add()](help://add()) to concatenate one item to a list.  To concatenate
 --- two lists into a new list use the + operator:
 --- ```vim
 ---   let newlist = [1, 2, 3] + [4, 5]
 --- ```
---- If they are `|Dictionaries|`:
+--- If they are [Dictionaries](help://Dictionaries):
 --- Add all entries from {expr2} to {expr1}.
 --- If a key exists in both {expr1} and {expr2} then {expr3} is
 --- used to decide what to do:
@@ -2115,7 +2115,7 @@ function vim.fn.expandcmd(string, options) end
 --- @return any
 function vim.fn.extend(expr1, expr2, expr3) end
 
---- Like `|extend()|` but instead of adding items to {expr1} a new
+--- Like [extend()](help://extend()) but instead of adding items to {expr1} a new
 --- List or Dictionary is created and returned.  {expr1} remains
 --- unchanged.
 ---
@@ -2138,10 +2138,10 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 --- {string}.
 ---
 --- To include special keys into {string}, use double-quotes
---- and "\..." notation `|expr-quote|`. For example,
+--- and "\..." notation [expr-quote](help://expr-quote). For example,
 --- feedkeys("\<CR>") simulates pressing of the <Enter> key. But
 --- feedkeys('\<CR>') pushes 5 characters.
---- The `|<Ignore>|` keycode may be used to exit the
+--- The [<Ignore>](help://<Ignore>) keycode may be used to exit the
 --- wait-for-character without doing anything.
 ---
 --- {mode} is a String, which can contain these character flags:
@@ -2176,18 +2176,18 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 function vim.fn.feedkeys(string, mode) end
 
 --- @deprecated
---- Obsolete name for `|filereadable()|`.
+--- Obsolete name for [filereadable()](help://filereadable()).
 ---
 --- @param file string
 --- @return any
 function vim.fn.file_readable(file) end
 
---- The result is a Number, which is `|TRUE|` when a file with the
+--- The result is a Number, which is [TRUE](help://TRUE) when a file with the
 --- name {file} exists, and can be read.  If {file} doesn't exist,
---- or is a directory, the result is `|FALSE|`.  {file} is any
+--- or is a directory, the result is [FALSE](help://FALSE).  {file} is any
 --- expression, which is used as a String.
 --- If you don't care about the file being readable you can use
---- `|glob()|`.
+--- [glob()](help://glob()).
 --- {file} is used as-is, you may want to expand wildcards first:
 --- ```vim
 ---   echo filereadable('~/.vimrc')
@@ -2216,19 +2216,19 @@ function vim.fn.filereadable(file) end
 --- @return 0|1
 function vim.fn.filewritable(file) end
 
---- {expr1} must be a `|List|`, `|String|`, `|Blob|` or `|Dictionary|`.
+--- {expr1} must be a [List](help://List), [String](help://String), [Blob](help://Blob) or [Dictionary](help://Dictionary).
 --- For each item in {expr1} evaluate {expr2} and when the result
---- is zero or false remove the item from the `|List|` or
---- `|Dictionary|`.  Similarly for each byte in a `|Blob|` and each
---- character in a `|String|`.
+--- is zero or false remove the item from the [List](help://List) or
+--- [Dictionary](help://Dictionary).  Similarly for each byte in a [Blob](help://Blob) and each
+--- character in a [String](help://String).
 ---
---- {expr2} must be a `|string|` or `|Funcref|`.
+--- {expr2} must be a [string](help://string) or [Funcref](help://Funcref).
 ---
---- If {expr2} is a `|string|`, inside {expr2} `|v:val|` has the value
---- of the current item.  For a `|Dictionary|` `|v:key|` has the key
---- of the current item and for a `|List|` `|v:key|` has the index of
---- the current item.  For a `|Blob|` `|v:key|` has the index of the
---- current byte. For a `|String|` `|v:key|` has the index of the
+--- If {expr2} is a [string](help://string), inside {expr2} [v:val](help://v:val) has the value
+--- of the current item.  For a [Dictionary](help://Dictionary) [v:key](help://v:key) has the key
+--- of the current item and for a [List](help://List) [v:key](help://v:key) has the index of
+--- the current item.  For a [Blob](help://Blob) [v:key](help://v:key) has the index of the
+--- current byte. For a [String](help://String) [v:key](help://v:key) has the index of the
 --- current character.
 --- Examples:
 --- ```vim
@@ -2242,16 +2242,16 @@ function vim.fn.filewritable(file) end
 --- ```vim
 ---   call filter(var, 0)
 --- ```
---- Removes all the items, thus clears the `|List|` or `|Dictionary|`.
+--- Removes all the items, thus clears the [List](help://List) or [Dictionary](help://Dictionary).
 ---
 --- Note that {expr2} is the result of expression and is then
 --- used as an expression again.  Often it is good to use a
---- `|literal-string|` to avoid having to double backslashes.
+--- [literal-string](help://literal-string) to avoid having to double backslashes.
 ---
---- If {expr2} is a `|Funcref|` it must take two arguments:
+--- If {expr2} is a [Funcref](help://Funcref) it must take two arguments:
 ---   1. the key or the index of the current item.
 ---   2. the value of the current item.
---- The function must return `|TRUE|` if the item should be kept.
+--- The function must return [TRUE](help://TRUE) if the item should be kept.
 --- Example that keeps the odd items of a list:
 --- ```vim
 ---   func Odd(idx, val)
@@ -2259,7 +2259,7 @@ function vim.fn.filewritable(file) end
 ---   endfunc
 ---   call filter(mylist, function('Odd'))
 --- ```
---- It is shorter when using a `|lambda|`:
+--- It is shorter when using a [lambda](help://lambda):
 --- ```vim
 ---   call filter(myList, {idx, val -> idx * val <= 42})
 --- ```
@@ -2267,14 +2267,14 @@ function vim.fn.filewritable(file) end
 --- ```vim
 ---   call filter(myList, {idx -> idx % 2 == 1})
 --- ```
---- For a `|List|` and a `|Dictionary|` the operation is done
+--- For a [List](help://List) and a [Dictionary](help://Dictionary) the operation is done
 --- in-place.  If you want it to remain unmodified make a copy
 --- first:
 --- ```vim
 ---   let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 --- ```
---- Returns {expr1}, the `|List|` or `|Dictionary|` that was filtered,
---- or a new `|Blob|` or `|String|`.
+--- Returns {expr1}, the [List](help://List) or [Dictionary](help://Dictionary) that was filtered,
+--- or a new [Blob](help://Blob) or [String](help://String).
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
 --- When {expr2} is a Funcref errors inside a function are ignored,
@@ -2287,7 +2287,7 @@ function vim.fn.filewritable(file) end
 function vim.fn.filter(expr1, expr2) end
 
 --- Find directory {name} in {path}.  Supports both downwards and
---- upwards recursive directory searches.  See `|file-searching|`
+--- upwards recursive directory searches.  See [file-searching](help://file-searching)
 --- for the syntax of {path}.
 ---
 --- Returns the path of the first found match.  When the found
@@ -2297,7 +2297,7 @@ function vim.fn.filter(expr1, expr2) end
 ---
 --- If the optional {count} is given, find {count}'s occurrence of
 --- {name} in {path} instead of the first one.
---- When {count} is negative return all the matches in a `|List|`.
+--- When {count} is negative return all the matches in a [List](help://List).
 ---
 --- Returns an empty string if the directory is not found.
 ---
@@ -2310,7 +2310,7 @@ function vim.fn.filter(expr1, expr2) end
 --- @return any
 function vim.fn.finddir(name, path, count) end
 
---- Just like `|finddir()|`, but find a file instead of a directory.
+--- Just like [finddir()](help://finddir()), but find a file instead of a directory.
 --- Uses 'suffixesadd'.
 --- Example:
 --- ```vim
@@ -2327,9 +2327,9 @@ function vim.fn.finddir(name, path, count) end
 function vim.fn.findfile(name, path, count) end
 
 --- Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
---- the result is a `|List|` without nesting, as if {maxdepth} is
+--- the result is a [List](help://List) without nesting, as if {maxdepth} is
 --- a very large number.
---- The {list} is changed in place, use `|flattennew()|` if you do
+--- The {list} is changed in place, use [flattennew()](help://flattennew()) if you do
 --- not want that.
 ---             *E900*
 --- {maxdepth} means how deep in nested lists changes are made.
@@ -2354,7 +2354,7 @@ function vim.fn.findfile(name, path, count) end
 --- @return any[]|0
 function vim.fn.flatten(list, maxdepth) end
 
---- Like `|flatten()|` but first make a copy of {list}.
+--- Like [flatten()](help://flatten()) but first make a copy of {list}.
 ---
 --- @param list any
 --- @param maxdepth? any
@@ -2363,9 +2363,9 @@ function vim.fn.flattennew(list, maxdepth) end
 
 --- Convert {expr} to a Number by omitting the part after the
 --- decimal point.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0 if {expr} is not a `|Float|` or a `|Number|`.
---- When the value of {expr} is out of range for a `|Number|` the
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
+--- When the value of {expr} is out of range for a [Number](help://Number) the
 --- result is truncated to 0x7fffffff or -0x7fffffff (or when
 --- 64-bit Number support is enabled, 0x7fffffffffffffff or
 --- -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
@@ -2398,9 +2398,9 @@ function vim.fn.flattennew(list, maxdepth) end
 function vim.fn.float2nr(expr) end
 
 --- Return the largest integral value less than or equal to
---- {expr} as a `|Float|` (round down).
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} as a [Float](help://Float) (round down).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo floor(1.856)
@@ -2425,10 +2425,10 @@ function vim.fn.floor(expr) end
 --- for some integer i such that if {expr2} is non-zero, the
 --- result has the same sign as {expr1} and magnitude less than
 --- the magnitude of {expr2}.  If {expr2} is zero, the value
---- returned is zero.  The value returned is a `|Float|`.
---- {expr1} and {expr2} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr1} or {expr2} is not a `|Float|` or a
---- `|Number|`.
+--- returned is zero.  The value returned is a [Float](help://Float).
+--- {expr1} and {expr2} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr1} or {expr2} is not a [Float](help://Float) or a
+--- [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo fmod(12.33, 1.22)
@@ -2451,8 +2451,8 @@ function vim.fn.fmod(expr1, expr2) end
 --- For most systems the characters escaped are
 --- " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
 --- appears in a filename, it depends on the value of 'isfname'.
---- A leading '+' and '>' is also escaped (special after `|:edit|`
---- and `|:write|`).  And a "-" by itself (special after `|:cd|`).
+--- A leading '+' and '>' is also escaped (special after [:edit](help://:edit)
+--- and [:write](help://:write)).  And a "-" by itself (special after [:cd](help://:cd)).
 --- Returns an empty string on error.
 --- Example:
 --- ```vim
@@ -2470,7 +2470,7 @@ function vim.fn.fnameescape(string) end
 
 --- Modify file name {fname} according to {mods}.  {mods} is a
 --- string of characters like it is used for file names on the
---- command line.  See `|filename-modifiers|`.
+--- command line.  See [filename-modifiers](help://filename-modifiers).
 --- Example:
 --- ```vim
 ---   echo fnamemodify("main.c", ":p:h")
@@ -2486,7 +2486,7 @@ function vim.fn.fnameescape(string) end
 --- expand('%:h') without a buffer name, which returns an empty
 --- string.
 --- Note: Environment variables don't work in {fname}, use
---- `|expand()|` first then.
+--- [expand()](help://expand()) first then.
 ---
 ---
 --- @param fname string
@@ -2497,7 +2497,7 @@ function vim.fn.fnamemodify(fname, mods) end
 --- The result is a Number.  If the line {lnum} is in a closed
 --- fold, the result is the number of the first line in that fold.
 --- If the line {lnum} is not in a closed fold, -1 is returned.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 ---
 ---
@@ -2508,7 +2508,7 @@ function vim.fn.foldclosed(lnum) end
 --- The result is a Number.  If the line {lnum} is in a closed
 --- fold, the result is the number of the last line in that fold.
 --- If the line {lnum} is not in a closed fold, -1 is returned.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 ---
 ---
@@ -2524,7 +2524,7 @@ function vim.fn.foldclosedend(lnum) end
 --- returned for lines where folds are still to be updated and the
 --- foldlevel is unknown.  As a special case the level of the
 --- previous line is usually available.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 ---
 ---
@@ -2535,7 +2535,7 @@ function vim.fn.foldlevel(lnum) end
 --- Returns a String, to be displayed for a closed fold.  This is
 --- the default function used for the 'foldtext' option and should
 --- only be called from evaluating 'foldtext'.  It uses the
---- `|v:foldstart|`, `|v:foldend|` and `|v:folddashes|` variables.
+--- [v:foldstart](help://v:foldstart), [v:foldend](help://v:foldend) and [v:folddashes](help://v:folddashes) variables.
 --- The returned string looks like this:
 --- ```
 ---   +-- 45 lines: abcdef
@@ -2557,7 +2557,7 @@ function vim.fn.foldtext() end
 --- {lnum}.  Evaluates 'foldtext' in the appropriate context.
 --- When there is no closed fold at {lnum} an empty string is
 --- returned.
---- {lnum} is used like with `|getline()|`.  Thus "." is the current
+--- {lnum} is used like with [getline()](help://getline()).  Thus "." is the current
 --- line, "'m" mark m, etc.
 --- Useful when exporting folded text, e.g., to HTML.
 ---
@@ -2567,7 +2567,7 @@ function vim.fn.foldtext() end
 function vim.fn.foldtextresult(lnum) end
 
 --- Get the full command name from a short abbreviated command
---- name; see `|20.2|` for details on command abbreviations.
+--- name; see [20.2](help://20.2) for details on command abbreviations.
 ---
 --- The string argument {name} may start with a `:` and can
 --- include a [range], these are skipped and not returned.
@@ -2582,14 +2582,14 @@ function vim.fn.foldtextresult(lnum) end
 --- @return string
 function vim.fn.fullcommand(name) end
 
---- Just like `|function()|`, but the returned Funcref will lookup
+--- Just like [function()](help://function()), but the returned Funcref will lookup
 --- the function by reference, not by name.  This matters when the
 --- function {name} is redefined later.
 ---
---- Unlike `|function()|`, {name} must be an existing user function.
+--- Unlike [function()](help://function()), {name} must be an existing user function.
 --- It only works for an autoloaded function if it has already
 --- been loaded (to avoid mistakenly loading the autoload script
---- when only intending to use the function name, use `|function()|`
+--- when only intending to use the function name, use [function()](help://function())
 --- instead). {name} cannot be a builtin function.
 --- Returns 0 on error.
 ---
@@ -2600,7 +2600,7 @@ function vim.fn.fullcommand(name) end
 --- @return any
 function vim.fn.funcref(name, arglist, dict) end
 
---- Return a `|Funcref|` variable that refers to function {name}.
+--- Return a [Funcref](help://Funcref) variable that refers to function {name}.
 --- {name} can be the name of a user defined function or an
 --- internal function.
 ---
@@ -2612,7 +2612,7 @@ function vim.fn.funcref(name, arglist, dict) end
 ---   let Broken = function(dict.Func, [arg], dict)
 --- ```
 --- When using the Funcref the function will be found by {name},
---- also when it was redefined later. Use `|funcref()|` to keep the
+--- also when it was redefined later. Use [funcref()](help://funcref()) to keep the
 --- same function.
 ---
 --- When {arglist} or {dict} is present this creates a partial.
@@ -2620,7 +2620,7 @@ function vim.fn.funcref(name, arglist, dict) end
 --- the Funcref and will be used when the Funcref is called.
 ---
 --- The arguments are passed to the function in front of other
---- arguments, but after any argument from `|method|`.  Example:
+--- arguments, but after any argument from [method](help://method).  Example:
 --- ```vim
 ---   func Callback(arg1, arg2, name)
 ---   "...
@@ -2633,7 +2633,7 @@ function vim.fn.funcref(name, arglist, dict) end
 --- ```vim
 ---   call Callback('one', 'two', 'name')
 --- ```
---- With a `|method|`:
+--- With a [method](help://method):
 --- ```vim
 ---   func Callback(one, two, three)
 ---   "...
@@ -2704,15 +2704,15 @@ function vim.fn.funcref(name, arglist, dict) end
 --- @return any
 vim.fn['function'] = function(name, arglist, dict) end
 
---- Cleanup unused `|Lists|` and `|Dictionaries|` that have circular
+--- Cleanup unused [Lists](help://Lists) and [Dictionaries](help://Dictionaries) that have circular
 --- references.
 ---
 --- There is hardly ever a need to invoke this function, as it is
 --- automatically done when Vim runs out of memory or is waiting
 --- for the user to press a key after 'updatetime'.  Items without
 --- circular references are always freed when they become unused.
---- This is useful if you have deleted a very big `|List|` and/or
---- `|Dictionary|` with circular references in a script that runs
+--- This is useful if you have deleted a very big [List](help://List) and/or
+--- [Dictionary](help://Dictionary) with circular references in a script that runs
 --- for a long time.
 ---
 --- When the optional {atexit} argument is one, garbage
@@ -2727,7 +2727,7 @@ vim.fn['function'] = function(name, arglist, dict) end
 --- @return any
 function vim.fn.garbagecollect(atexit) end
 
---- Get item {idx} from `|List|` {list}.  When this item is not
+--- Get item {idx} from [List](help://List) {list}.  When this item is not
 --- available return {default}.  Return zero when {default} is
 --- omitted.
 ---
@@ -2737,7 +2737,7 @@ function vim.fn.garbagecollect(atexit) end
 --- @return any
 function vim.fn.get(list, idx, default) end
 
---- Get byte {idx} from `|Blob|` {blob}.  When this byte is not
+--- Get byte {idx} from [Blob](help://Blob) {blob}.  When this byte is not
 --- available return {default}.  Return -1 when {default} is
 --- omitted.
 ---
@@ -2747,7 +2747,7 @@ function vim.fn.get(list, idx, default) end
 --- @return any
 function vim.fn.get(blob, idx, default) end
 
---- Get item with key {key} from `|Dictionary|` {dict}.  When this
+--- Get item with key {key} from [Dictionary](help://Dictionary) {dict}.  When this
 --- item is not available return {default}.  Return zero when
 --- {default} is omitted.  Useful example:
 --- ```vim
@@ -2784,7 +2784,7 @@ function vim.fn.getbufinfo(buf) end
 --- Without an argument information about all the buffers is
 --- returned.
 ---
---- When the argument is a `|Dictionary|` only the buffers matching
+--- When the argument is a [Dictionary](help://Dictionary) only the buffers matching
 --- the specified criteria are returned.  The following keys can
 --- be specified in {dict}:
 ---   buflisted  include only listed buffers.
@@ -2792,7 +2792,7 @@ function vim.fn.getbufinfo(buf) end
 ---   bufmodified  include only modified buffers.
 ---
 --- Otherwise, {buf} specifies a particular buffer to return
---- information for.  For the use of {buf}, see `|bufname()|`
+--- information for.  For the use of {buf}, see [bufname()](help://bufname())
 --- above.  If the buffer is found the returned List has one item.
 --- Otherwise the result is an empty list.
 ---
@@ -2803,7 +2803,7 @@ function vim.fn.getbufinfo(buf) end
 ---   changedtick  Number of changes made to the buffer.
 ---   hidden    TRUE if the buffer is hidden.
 ---   lastused  Timestamp in seconds, like
----       `|localtime()|`, when the buffer was
+---       [localtime()](help://localtime()), when the buffer was
 ---       last used.
 ---   listed    TRUE if the buffer is listed.
 ---   lnum    Line number used for the buffer when
@@ -2812,7 +2812,7 @@ function vim.fn.getbufinfo(buf) end
 ---       displayed in the window in the past.
 ---       If you want the line number of the
 ---       last known cursor position in a given
----       window, use `|line()|`:
+---       window, use [line()](help://line()):
 --- ```vim
 ---         echo line('.', {winid})
 --- ```
@@ -2828,7 +2828,7 @@ function vim.fn.getbufinfo(buf) end
 ---           name  sign name
 ---   variables  A reference to the dictionary with
 ---       buffer-local variables.
----   windows    List of `|window-ID|`s that display this
+---   windows    List of [window-ID](help://window-ID)s that display this
 ---       buffer
 ---
 --- Examples:
@@ -2851,26 +2851,26 @@ function vim.fn.getbufinfo(buf) end
 --- @return vim.fn.getbufinfo.ret.item[]
 function vim.fn.getbufinfo(dict) end
 
---- Return a `|List|` with the lines starting from {lnum} to {end}
+--- Return a [List](help://List) with the lines starting from {lnum} to {end}
 --- (inclusive) in the buffer {buf}.  If {end} is omitted, a
---- `|List|` with only the line {lnum} is returned.  See
+--- [List](help://List) with only the line {lnum} is returned.  See
 --- `getbufoneline()` for only getting the line.
 ---
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 ---
 --- For {lnum} and {end} "$" can be used for the last line of the
 --- buffer.  Otherwise a number must be used.
 ---
 --- When {lnum} is smaller than 1 or bigger than the number of
---- lines in the buffer, an empty `|List|` is returned.
+--- lines in the buffer, an empty [List](help://List) is returned.
 ---
 --- When {end} is greater than the number of lines in the buffer,
 --- it is treated as {end} is set to the number of lines in the
---- buffer.  When {end} is before {lnum} an empty `|List|` is
+--- buffer.  When {end} is before {lnum} an empty [List](help://List) is
 --- returned.
 ---
 --- This function works only for loaded buffers.  For unloaded and
---- non-existing buffers, an empty `|List|` is returned.
+--- non-existing buffers, an empty [List](help://List) is returned.
 ---
 --- Example:
 --- ```vim
@@ -2895,16 +2895,16 @@ function vim.fn.getbufoneline(buf, lnum) end
 --- {varname} in buffer {buf}.  Note that the name without "b:"
 --- must be used.
 --- The {varname} argument is a string.
---- When {varname} is empty returns a `|Dictionary|` with all the
+--- When {varname} is empty returns a [Dictionary](help://Dictionary) with all the
 --- buffer-local variables.
---- When {varname} is equal to "&" returns a `|Dictionary|` with all
+--- When {varname} is equal to "&" returns a [Dictionary](help://Dictionary) with all
 --- the buffer-local options.
 --- Otherwise, when {varname} starts with "&" returns the value of
 --- a buffer-local option.
 --- This also works for a global or buffer-local option, but it
 --- doesn't work for a global variable, window-local variable or
 --- window-local option.
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 --- When the buffer or variable doesn't exist {def} or an empty
 --- string is returned, there is no error message.
 --- Examples:
@@ -2919,16 +2919,16 @@ function vim.fn.getbufoneline(buf, lnum) end
 --- @return any
 function vim.fn.getbufvar(buf, varname, def) end
 
---- Returns a `|List|` of cell widths of character ranges overridden
---- by `|setcellwidths()|`.  The format is equal to the argument of
---- `|setcellwidths()|`.  If no character ranges have their cell
+--- Returns a [List](help://List) of cell widths of character ranges overridden
+--- by [setcellwidths()](help://setcellwidths()).  The format is equal to the argument of
+--- [setcellwidths()](help://setcellwidths()).  If no character ranges have their cell
 --- widths overridden, an empty List is returned.
 ---
 --- @return any
 function vim.fn.getcellwidths() end
 
---- Returns the `|changelist|` for the buffer {buf}. For the use
---- of {buf}, see `|bufname()|` above. If buffer {buf} doesn't
+--- Returns the [changelist](help://changelist) for the buffer {buf}. For the use
+--- of {buf}, see [bufname()](help://bufname()) above. If buffer {buf} doesn't
 --- exist, an empty list is returned.
 ---
 --- The returned list contains two entries: a list with the change
@@ -2953,11 +2953,11 @@ function vim.fn.getchangelist(buf) end
 ---   Return zero otherwise.
 --- If [expr] is 1, only check if a character is available, it is
 ---   not consumed.  Return zero if no character available.
---- If you prefer always getting a string use `|getcharstr()|`.
+--- If you prefer always getting a string use [getcharstr()](help://getcharstr()).
 ---
 --- Without [expr] and when [expr] is 0 a whole character or
 --- special key is returned.  If it is a single character, the
---- result is a Number.  Use `|nr2char()|` to convert it to a String.
+--- result is a Number.  Use [nr2char()](help://nr2char()) to convert it to a String.
 --- Otherwise a String is returned with the encoded character.
 --- For a special key it's a String with a sequence of bytes
 --- starting with 0x80 (decimal: 128).  This is the same value as
@@ -2976,9 +2976,11 @@ function vim.fn.getchangelist(buf) end
 --- Use getcharmod() to obtain any additional modifiers.
 ---
 --- When the user clicks a mouse button, the mouse event will be
---- returned.  The position can then be found in `|v:mouse_col|,
---- |v:mouse_lnum|`, `|v:mouse_winid|` and `|v:mouse_win|.
---- |getmousepos()|` can also be used.  Mouse move events will be
+--- returned.  The position can then be found in [v:mouse_col|,
+--- |v:mouse_lnum](help://v:mouse_col|,
+--- |v:mouse_lnum), [v:mouse_winid](help://v:mouse_winid) and [v:mouse_win|.
+--- |getmousepos()](help://v:mouse_win|.
+--- |getmousepos()) can also be used.  Mouse move events will be
 --- ignored.
 --- This example positions the mouse as it would normally happen:
 --- ```vim
@@ -3036,11 +3038,11 @@ function vim.fn.getchar() end
 --- @return integer
 function vim.fn.getcharmod() end
 
---- Get the position for String {expr}. Same as `|getpos()|` but the
+--- Get the position for String {expr}. Same as [getpos()](help://getpos()) but the
 --- column number in the returned List is a character index
 --- instead of a byte index.
---- If `|getpos()|` returns a very large column number, equal to
---- `|v:maxcol|`, then getcharpos() will return the character index
+--- If [getpos()](help://getpos()) returns a very large column number, equal to
+--- [v:maxcol](help://v:maxcol), then getcharpos() will return the character index
 --- of the last character.
 ---
 --- Example:
@@ -3058,22 +3060,22 @@ function vim.fn.getcharpos(expr) end
 --- with the following entries:
 ---
 ---     char  character previously used for a character
----     search (`|t|`, `|f|`, `|T|`, or `|F|`); empty string
+---     search ([t](help://t), [f](help://f), [T](help://T), or [F](help://F)); empty string
 ---     if no character search has been performed
 ---     forward  direction of character search; 1 for forward,
 ---     0 for backward
----     until  type of character search; 1 for a `|t|` or `|T|`
----     character search, 0 for an `|f|` or `|F|`
+---     until  type of character search; 1 for a [t](help://t) or [T](help://T)
+---     character search, 0 for an [f](help://f) or [F](help://F)
 ---     character search
 ---
---- This can be useful to always have `|;|` and `|,|` search
+--- This can be useful to always have [;](help://;) and [,](help://,) search
 --- forward/backward regardless of the direction of the previous
 --- character search:
 --- ```vim
 ---   nnoremap <expr> ; getcharsearch().forward ? ';' : ','
 ---   nnoremap <expr> , getcharsearch().forward ? ',' : ';'
 --- ```
---- Also see `|setcharsearch()|`.
+--- Also see [setcharsearch()](help://setcharsearch()).
 ---
 --- @return table[]
 function vim.fn.getcharsearch() end
@@ -3086,7 +3088,7 @@ function vim.fn.getcharsearch() end
 --- If [expr] is 1 or true, only check if a character is
 ---   available, it is not consumed.  Return an empty string
 ---   if no character is available.
---- Otherwise this works like `|getchar()|`, except that a number
+--- Otherwise this works like [getchar()](help://getchar()), except that a number
 --- result is converted to a string.
 ---
 --- @return string
@@ -3094,26 +3096,26 @@ function vim.fn.getcharstr() end
 
 --- Return the type of the current command-line completion.
 --- Only works when the command line is being edited, thus
---- requires use of `|c_CTRL-\_e|` or `|c_CTRL-R_=|`.
---- See `|:command-completion|` for the return string.
---- Also see `|getcmdtype()|`, `|setcmdpos()|`, `|getcmdline()|` and
---- `|setcmdline()|`.
+--- requires use of [c_CTRL-\_e](help://c_CTRL-\_e) or [c_CTRL-R_=](help://c_CTRL-R_=).
+--- See [:command-completion](help://:command-completion) for the return string.
+--- Also see [getcmdtype()](help://getcmdtype()), [setcmdpos()](help://setcmdpos()), [getcmdline()](help://getcmdline()) and
+--- [setcmdline()](help://setcmdline()).
 --- Returns an empty string when completion is not defined.
 ---
 --- @return string
 function vim.fn.getcmdcompltype() end
 
 --- Return the current command-line.  Only works when the command
---- line is being edited, thus requires use of `|c_CTRL-\_e|` or
---- `|c_CTRL-R_=|`.
+--- line is being edited, thus requires use of [c_CTRL-\_e](help://c_CTRL-\_e) or
+--- [c_CTRL-R_=](help://c_CTRL-R_=).
 --- Example:
 --- ```vim
 ---   cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
 --- ```
---- Also see `|getcmdtype()|`, `|getcmdpos()|`, `|setcmdpos()|` and
---- `|setcmdline()|`.
+--- Also see [getcmdtype()](help://getcmdtype()), [getcmdpos()](help://getcmdpos()), [setcmdpos()](help://setcmdpos()) and
+--- [setcmdline()](help://setcmdline()).
 --- Returns an empty string when entering a password or using
---- `|inputsecret()|`.
+--- [inputsecret()](help://inputsecret()).
 ---
 --- @return string
 function vim.fn.getcmdline() end
@@ -3121,22 +3123,22 @@ function vim.fn.getcmdline() end
 --- Return the position of the cursor in the command line as a
 --- byte count.  The first column is 1.
 --- Only works when editing the command line, thus requires use of
---- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
+--- [c_CTRL-\_e](help://c_CTRL-\_e) or [c_CTRL-R_=](help://c_CTRL-R_=) or an expression mapping.
 --- Returns 0 otherwise.
---- Also see `|getcmdtype()|`, `|setcmdpos()|`, `|getcmdline()|` and
---- `|setcmdline()|`.
+--- Also see [getcmdtype()](help://getcmdtype()), [setcmdpos()](help://setcmdpos()), [getcmdline()](help://getcmdline()) and
+--- [setcmdline()](help://setcmdline()).
 ---
 --- @return integer
 function vim.fn.getcmdpos() end
 
 --- Return the screen position of the cursor in the command line
 --- as a byte count.  The first column is 1.
---- Instead of `|getcmdpos()|`, it adds the prompt position.
+--- Instead of [getcmdpos()](help://getcmdpos()), it adds the prompt position.
 --- Only works when editing the command line, thus requires use of
---- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
+--- [c_CTRL-\_e](help://c_CTRL-\_e) or [c_CTRL-R_=](help://c_CTRL-R_=) or an expression mapping.
 --- Returns 0 otherwise.
---- Also see `|getcmdpos()|`, `|setcmdpos()|`, `|getcmdline()|` and
---- `|setcmdline()|`.
+--- Also see [getcmdpos()](help://getcmdpos()), [setcmdpos()](help://setcmdpos()), [getcmdline()](help://getcmdline()) and
+--- [setcmdline()](help://setcmdline()).
 ---
 --- @return any
 function vim.fn.getcmdscreenpos() end
@@ -3144,22 +3146,22 @@ function vim.fn.getcmdscreenpos() end
 --- Return the current command-line type. Possible return values
 --- are:
 ---     :  normal Ex command
----     >  debug mode command `|debug-mode|`
+---     >  debug mode command [debug-mode](help://debug-mode)
 ---     /  forward search command
 ---     ?  backward search command
----     @  `|input()|` command
----     `-`  `|:insert|` or `|:append|` command
----     =  `|i_CTRL-R_=|`
+---     @  [input()](help://input()) command
+---     `-`  [:insert](help://:insert) or [:append](help://:append) command
+---     =  [i_CTRL-R_=](help://i_CTRL-R_=)
 --- Only works when editing the command line, thus requires use of
---- `|c_CTRL-\_e|` or `|c_CTRL-R_=|` or an expression mapping.
+--- [c_CTRL-\_e](help://c_CTRL-\_e) or [c_CTRL-R_=](help://c_CTRL-R_=) or an expression mapping.
 --- Returns an empty string otherwise.
---- Also see `|getcmdpos()|`, `|setcmdpos()|` and `|getcmdline()|`.
+--- Also see [getcmdpos()](help://getcmdpos()), [setcmdpos()](help://setcmdpos()) and [getcmdline()](help://getcmdline()).
 ---
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
 function vim.fn.getcmdtype() end
 
---- Return the current `|command-line-window|` type. Possible return
---- values are the same as `|getcmdtype()|`. Returns an empty string
+--- Return the current [command-line-window](help://command-line-window) type. Possible return
+--- values are the same as [getcmdtype()](help://getcmdtype()). Returns an empty string
 --- when not in the command-line window.
 ---
 --- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
@@ -3172,38 +3174,38 @@ function vim.fn.getcmdwintype() end
 --- arglist    file names in argument list
 --- augroup    autocmd groups
 --- buffer    buffer names
---- breakpoint  `|:breakadd|` and `|:breakdel|` suboptions
---- cmdline    `|cmdline-completion|` result
+--- breakpoint  [:breakadd](help://:breakadd) and [:breakdel](help://:breakdel) suboptions
+--- cmdline    [cmdline-completion](help://cmdline-completion) result
 --- color    color schemes
 --- command    Ex command
 --- compiler  compilers
 --- custom,{func}  custom completion, defined via {func}
 --- customlist,{func} custom completion, defined via {func}
---- diff_buffer  `|:diffget|` and `|:diffput|` completion
+--- diff_buffer  [:diffget](help://:diffget) and [:diffput](help://:diffput) completion
 --- dir    directory names
 --- environment  environment variable names
 --- event    autocommand events
 --- expression  Vim expression
 --- file    file and directory names
---- file_in_path  file and directory names in `|'path'|`
---- filetype  filetype names `|'filetype'|`
+--- file_in_path  file and directory names in ['path'](help://'path')
+--- filetype  filetype names ['filetype'](help://'filetype')
 --- function  function name
 --- help    help subjects
 --- highlight  highlight groups
---- history    `|:history|` suboptions
+--- history    [:history](help://:history) suboptions
 --- locale    locale names (as output of locale -a)
 --- mapclear  buffer argument
 --- mapping    mapping name
 --- menu    menus
---- messages  `|:messages|` suboptions
+--- messages  [:messages](help://:messages) suboptions
 --- option    options
---- packadd    optional package `|pack-add|` names
---- runtime    `|:runtime|` completion
---- scriptnames  sourced script names `|:scriptnames|`
+--- packadd    optional package [pack-add](help://pack-add) names
+--- runtime    [:runtime](help://:runtime) completion
+--- scriptnames  sourced script names [:scriptnames](help://:scriptnames)
 --- shellcmd  Shell command
---- sign    `|:sign|` suboptions
---- syntax    syntax file names `|'syntax'|`
---- syntime    `|:syntime|` suboptions
+--- sign    [:sign](help://:sign) suboptions
+--- syntax    syntax file names ['syntax'](help://'syntax')
+--- syntime    [:syntime](help://:syntime) suboptions
 --- tag    tags
 --- tag_listfiles  tags, file names
 --- user    user names
@@ -3211,7 +3213,7 @@ function vim.fn.getcmdwintype() end
 ---
 --- If {pat} is an empty string, then all the matches are
 --- returned.  Otherwise only items matching {pat} are returned.
---- See `|wildcards|` for the use of special characters in {pat}.
+--- See [wildcards](help://wildcards) for the use of special characters in {pat}.
 ---
 --- If the optional {filtered} flag is set to 1, then 'wildignore'
 --- is applied to filter the results.  Otherwise all the matches
@@ -3224,7 +3226,7 @@ function vim.fn.getcmdwintype() end
 --- If you do not want this you can make 'wildoptions' empty
 --- before calling getcompletion() and restore it afterwards.
 ---
---- If {type} is "cmdline", then the `|cmdline-completion|` result is
+--- If {type} is "cmdline", then the [cmdline-completion](help://cmdline-completion) result is
 --- returned.  For example, to complete the possible values after
 --- a ":call" command:
 --- ```vim
@@ -3244,15 +3246,15 @@ function vim.fn.getcompletion(pat, type, filtered) end
 --- includes an extra "curswant" item in the list:
 ---     [0, lnum, col, off, curswant] ~
 --- The "curswant" number is the preferred column when moving the
---- cursor vertically.  After `|$|` command it will be a very large
---- number equal to `|v:maxcol|`.  Also see `|getcursorcharpos()|` and
---- `|getpos()|`.
+--- cursor vertically.  After [$](help://$) command it will be a very large
+--- number equal to [v:maxcol](help://v:maxcol).  Also see [getcursorcharpos()](help://getcursorcharpos()) and
+--- [getpos()](help://getpos()).
 --- The first "bufnum" item is always zero. The byte position of
 --- the cursor is returned in "col". To get the character
---- position, use `|getcursorcharpos()|`.
+--- position, use [getcursorcharpos()](help://getcursorcharpos()).
 ---
 --- The optional {winid} argument can specify the window.  It can
---- be the window number or the `|window-ID|`.  The last known
+--- be the window number or the [window-ID](help://window-ID).  The last known
 --- cursor position is returned, this may be invalid for the
 --- current value of the buffer if it is not the current window.
 --- If {winid} is invalid a list with zeroes is returned.
@@ -3264,14 +3266,14 @@ function vim.fn.getcompletion(pat, type, filtered) end
 ---   call setpos('.', save_cursor)
 --- ```
 --- Note that this only works within the window.  See
---- `|winrestview()|` for restoring more state.
+--- [winrestview()](help://winrestview()) for restoring more state.
 ---
 ---
 --- @param winid? integer
 --- @return any
 function vim.fn.getcurpos(winid) end
 
---- Same as `|getcurpos()|` but the column number in the returned
+--- Same as [getcurpos()](help://getcurpos()) but the column number in the returned
 --- List is a character index instead of a byte index.
 ---
 --- Example:
@@ -3286,7 +3288,7 @@ function vim.fn.getcurpos(winid) end
 function vim.fn.getcursorcharpos(winid) end
 
 --- With no arguments, returns the name of the effective
---- `|current-directory|`. With {winnr} or {tabnr} the working
+--- [current-directory](help://current-directory). With {winnr} or {tabnr} the working
 --- directory of that scope is returned, and 'autochdir' is
 --- ignored.
 --- Tabs and windows are identified by their respective numbers,
@@ -3297,10 +3299,10 @@ function vim.fn.getcursorcharpos(winid) end
 ---   getcwd(0, 0)
 --- ```
 --- If {winnr} is -1 it is ignored, only the tab is resolved.
---- {winnr} can be the window number or the `|window-ID|`.
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 --- If both {winnr} and {tabnr} are -1 the global working
 --- directory is returned.
---- Throw error if the arguments are invalid. `|E5000|` `|E5001|` `|E5002|`
+--- Throw error if the arguments are invalid. [E5000](help://E5000) [E5001](help://E5001) [E5002](help://E5002)
 ---
 ---
 --- @param winnr? integer
@@ -3313,9 +3315,9 @@ function vim.fn.getcwd(winnr, tabnr) end
 --- ```vim
 ---   myHome = getenv('HOME')
 --- ```
---- When the variable does not exist `|v:null|` is returned.  That
+--- When the variable does not exist [v:null](help://v:null) is returned.  That
 --- is different from a variable set to an empty string.
---- See also `|expr-env|`.
+--- See also [expr-env](help://expr-env).
 ---
 ---
 --- @param name string
@@ -3324,13 +3326,13 @@ function vim.fn.getenv(name) end
 
 --- Without an argument returns the name of the normal font being
 --- used.  Like what is used for the Normal highlight group
---- `|hl-Normal|`.
+--- [hl-Normal](help://hl-Normal).
 --- With an argument a check is done whether String {name} is a
 --- valid font name.  If not then an empty string is returned.
 --- Otherwise the actual font name is returned, or {name} if the
 --- GUI does not support obtaining the real name.
 --- Only works when the GUI is running, thus not in your vimrc or
---- gvimrc file.  Use the `|GUIEnter|` autocommand to use this
+--- gvimrc file.  Use the [GUIEnter](help://GUIEnter) autocommand to use this
 --- function just after the GUI has started.
 ---
 --- @param name? string
@@ -3353,7 +3355,7 @@ function vim.fn.getfontname(name) end
 --- This will hopefully (from a security point of view) display
 --- the string "rw-r--r--" or even "rw-------".
 ---
---- For setting permissions use `|setfperm()|`.
+--- For setting permissions use [setfperm()](help://setfperm()).
 ---
 --- @param fname string
 --- @return string
@@ -3374,7 +3376,7 @@ function vim.fn.getfsize(fname) end
 --- The result is a Number, which is the last modification time of
 --- the given file {fname}.  The value is measured as seconds
 --- since 1st Jan 1970, and may be passed to strftime().  See also
---- `|localtime()|` and `|strftime()|`.
+--- [localtime()](help://localtime()) and [strftime()](help://strftime()).
 --- If the file {fname} can't be found -1 is returned.
 ---
 ---
@@ -3408,11 +3410,11 @@ function vim.fn.getftime(fname) end
 --- @return 'file'|'dir'|'link'|'bdev'|'cdev'|'socket'|'fifo'|'other'
 function vim.fn.getftype(fname) end
 
---- Returns the `|jumplist|` for the specified window.
+--- Returns the [jumplist](help://jumplist) for the specified window.
 ---
 --- Without arguments use the current window.
 --- With {winnr} only use this window in the current tab page.
---- {winnr} can also be a `|window-ID|`.
+--- {winnr} can also be a [window-ID](help://window-ID).
 --- With {winnr} and {tabnr} use the window in the specified tab
 --- page.  If {winnr} or {tabnr} is invalid, an empty list is
 --- returned.
@@ -3439,7 +3441,7 @@ function vim.fn.getjumplist(winnr, tabnr) end
 ---   getline(1)
 --- ```
 --- When {lnum} is a String that doesn't start with a
---- digit, `|line()|` is called to translate the String into a Number.
+--- digit, [line()](help://line()) is called to translate the String into a Number.
 --- To get the line under the cursor:
 --- ```vim
 ---   getline(".")
@@ -3447,53 +3449,53 @@ function vim.fn.getjumplist(winnr, tabnr) end
 --- When {lnum} is a number smaller than 1 or bigger than the
 --- number of lines in the buffer, an empty string is returned.
 ---
---- When {end} is given the result is a `|List|` where each item is
+--- When {end} is given the result is a [List](help://List) where each item is
 --- a line from the current buffer in the range {lnum} to {end},
 --- including line {end}.
 --- {end} is used in the same way as {lnum}.
 --- Non-existing lines are silently omitted.
---- When {end} is before {lnum} an empty `|List|` is returned.
+--- When {end} is before {lnum} an empty [List](help://List) is returned.
 --- Example:
 --- ```vim
 ---   let start = line('.')
 ---   let end = search("^$") - 1
 ---   let lines = getline(start, end)
 --- ```
---- To get lines from another buffer see `|getbufline()|` and
---- `|getbufoneline()|`
+--- To get lines from another buffer see [getbufline()](help://getbufline()) and
+--- [getbufoneline()](help://getbufoneline())
 ---
 --- @param lnum integer
 --- @param end_? any
 --- @return string|string[]
 function vim.fn.getline(lnum, end_) end
 
---- Returns a `|List|` with all the entries in the location list for
---- window {nr}.  {nr} can be the window number or the `|window-ID|`.
+--- Returns a [List](help://List) with all the entries in the location list for
+--- window {nr}.  {nr} can be the window number or the [window-ID](help://window-ID).
 --- When {nr} is zero the current window is used.
 ---
 --- For a location list window, the displayed location list is
 --- returned.  For an invalid window number {nr}, an empty list is
---- returned. Otherwise, same as `|getqflist()|`.
+--- returned. Otherwise, same as [getqflist()](help://getqflist()).
 ---
 --- If the optional {what} dictionary argument is supplied, then
 --- returns the items listed in {what} as a dictionary. Refer to
---- `|getqflist()|` for the supported items in {what}.
+--- [getqflist()](help://getqflist()) for the supported items in {what}.
 ---
---- In addition to the items supported by `|getqflist()|` in {what},
---- the following item is supported by `|getloclist()|`:
+--- In addition to the items supported by [getqflist()](help://getqflist()) in {what},
+--- the following item is supported by [getloclist()](help://getloclist()):
 ---
 ---   filewinid  id of the window used to display files
 ---       from the location list. This field is
 ---       applicable only when called from a
 ---       location list window. See
----       `|location-list-file-window|` for more
+---       [location-list-file-window](help://location-list-file-window) for more
 ---       details.
 ---
---- Returns a `|Dictionary|` with default values if there is no
+--- Returns a [Dictionary](help://Dictionary) with default values if there is no
 --- location list for the window {nr}.
 --- Returns an empty Dictionary if window {nr} does not exist.
 ---
---- Examples (See also `|getqflist-examples|`):
+--- Examples (See also [getqflist-examples](help://getqflist-examples)):
 --- ```vim
 ---   echo getloclist(3, {'all': 0})
 ---   echo getloclist(5, {'filewinid': 0})
@@ -3504,22 +3506,22 @@ function vim.fn.getline(lnum, end_) end
 --- @return any
 function vim.fn.getloclist(nr, what) end
 
---- Without the {buf} argument returns a `|List|` with information
---- about all the global marks. `|mark|`
+--- Without the {buf} argument returns a [List](help://List) with information
+--- about all the global marks. [mark](help://mark)
 ---
 --- If the optional {buf} argument is specified, returns the
 --- local marks defined in buffer {buf}.  For the use of {buf},
---- see `|bufname()|`.  If {buf} is invalid, an empty list is
+--- see [bufname()](help://bufname()).  If {buf} is invalid, an empty list is
 --- returned.
 ---
---- Each item in the returned List is a `|Dict|` with the following:
+--- Each item in the returned List is a [Dict](help://Dict) with the following:
 ---     mark   name of the mark prefixed by "'"
----     pos     a `|List|` with the position of the mark:
+---     pos     a [List](help://List) with the position of the mark:
 ---     [bufnum, lnum, col, off]
----      Refer to `|getpos()|` for more information.
+---      Refer to [getpos()](help://getpos()) for more information.
 ---     file   file name
 ---
---- Refer to `|getpos()|` for getting information about a specific
+--- Refer to [getpos()](help://getpos()) for getting information about a specific
 --- mark.
 ---
 ---
@@ -3527,11 +3529,11 @@ function vim.fn.getloclist(nr, what) end
 --- @return any
 function vim.fn.getmarklist(buf) end
 
---- Returns a `|List|` with all matches previously defined for the
---- current window by `|matchadd()|` and the `|:match|` commands.
---- `|getmatches()|` is useful in combination with `|setmatches()|`,
---- as `|setmatches()|` can restore a list of matches saved by
---- `|getmatches()|`.
+--- Returns a [List](help://List) with all matches previously defined for the
+--- current window by [matchadd()](help://matchadd()) and the [:match](help://:match) commands.
+--- [getmatches()](help://getmatches()) is useful in combination with [setmatches()](help://setmatches()),
+--- as [setmatches()](help://setmatches()) can restore a list of matches saved by
+--- [getmatches()](help://getmatches()).
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.  If {win} is invalid,
 --- an empty list is returned.
@@ -3569,7 +3571,7 @@ function vim.fn.getmarklist(buf) end
 --- @return any
 function vim.fn.getmatches(win) end
 
---- Returns a `|Dictionary|` with the last known position of the
+--- Returns a [Dictionary](help://Dictionary) with the last known position of the
 --- mouse.  This can be used in a mapping for a mouse click.  The
 --- items are:
 ---   screenrow  screen row
@@ -3596,8 +3598,9 @@ function vim.fn.getmatches(win) end
 --- If the mouse is over a focusable floating window then that
 --- window is used.
 ---
---- When using `|getchar()|` the Vim variables `|v:mouse_lnum|,
---- |v:mouse_col|` and `|v:mouse_winid|` also provide these values.
+--- When using [getchar()](help://getchar()) the Vim variables [v:mouse_lnum|,
+--- |v:mouse_col](help://v:mouse_lnum|,
+--- |v:mouse_col) and [v:mouse_winid](help://v:mouse_winid) also provide these values.
 ---
 --- @return vim.fn.getmousepos.ret
 function vim.fn.getmousepos() end
@@ -3609,9 +3612,9 @@ function vim.fn.getmousepos() end
 function vim.fn.getpid() end
 
 --- Get the position for String {expr}.  For possible values of
---- {expr} see `|line()|`.  For getting the cursor position see
---- `|getcurpos()|`.
---- The result is a `|List|` with four numbers:
+--- {expr} see [line()](help://line()).  For getting the cursor position see
+--- [getcurpos()](help://getcurpos()).
+--- The result is a [List](help://List) with four numbers:
 ---     [bufnum, lnum, col, off]
 --- "bufnum" is zero, unless a mark like '0 or 'A is used, then it
 --- is the buffer number of the mark.
@@ -3623,11 +3626,11 @@ function vim.fn.getpid() end
 --- character.
 --- Note that for '< and '> Visual mode matters: when it is "V"
 --- (visual line mode) the column of '< is zero and the column of
---- '> is a large number equal to `|v:maxcol|`.
+--- '> is a large number equal to [v:maxcol](help://v:maxcol).
 --- The column number in the returned List is the byte position
 --- within the line. To get the character position in the line,
---- use `|getcharpos()|`.
---- A very large column number equal to `|v:maxcol|` can be returned,
+--- use [getcharpos()](help://getcharpos()).
+--- A very large column number equal to [v:maxcol](help://v:maxcol) can be returned,
 --- in which case it means "after the end of the line".
 --- If {expr} is invalid, returns a list with all zeros.
 --- This can be used to save and restore the position of a mark:
@@ -3636,14 +3639,14 @@ function vim.fn.getpid() end
 ---   " ...
 ---   call setpos("'a", save_a_mark)
 --- ```
---- Also see `|getcharpos()|`, `|getcurpos()|` and `|setpos()|`.
+--- Also see [getcharpos()](help://getcharpos()), [getcurpos()](help://getcurpos()) and [setpos()](help://setpos()).
 ---
 ---
 --- @param expr string
 --- @return integer[]
 function vim.fn.getpos(expr) end
 
---- Returns a `|List|` with all the current quickfix errors.  Each
+--- Returns a [List](help://List) with all the current quickfix errors.  Each
 --- list item is a dictionary with these entries:
 ---   bufnr  number of buffer that has the file name, use
 ---     bufname() to get the name
@@ -3653,13 +3656,13 @@ function vim.fn.getpos(expr) end
 ---     end of line number if the item is multiline
 ---   col  column number (first column is 1)
 ---   end_col  end of column number if the item has range
----   vcol  `|TRUE|`: "col" is visual column
----     `|FALSE|`: "col" is byte index
+---   vcol  [TRUE](help://TRUE): "col" is visual column
+---     [FALSE](help://FALSE): "col" is byte index
 ---   nr  error number
 ---   pattern  search pattern used to locate the error
 ---   text  description of the error
 ---   type  type of the error, 'E', '1', etc.
----   valid  `|TRUE|`: recognized error message
+---   valid  [TRUE](help://TRUE): recognized error message
 ---   user_data
 ---     custom data associated with the item, can be
 ---     any type.
@@ -3682,32 +3685,32 @@ function vim.fn.getpos(expr) end
 --- returns only the items listed in {what} as a dictionary. The
 --- following string items are supported in {what}:
 ---   changedtick  get the total number of changes made
----       to the list `|quickfix-changedtick|`
----   context  get the `|quickfix-context|`
+---       to the list [quickfix-changedtick](help://quickfix-changedtick)
+---   context  get the [quickfix-context](help://quickfix-context)
 ---   efm  errorformat to use when parsing "lines". If
 ---     not present, then the 'errorformat' option
 ---     value is used.
 ---   id  get information for the quickfix list with
----     `|quickfix-ID|`; zero means the id for the
+---     [quickfix-ID](help://quickfix-ID); zero means the id for the
 ---     current list or the list specified by "nr"
 ---   idx  get information for the quickfix entry at this
 ---     index in the list specified by "id" or "nr".
 ---     If set to zero, then uses the current entry.
----     See `|quickfix-index|`
+---     See [quickfix-index](help://quickfix-index)
 ---   items  quickfix list entries
 ---   lines  parse a list of lines using 'efm' and return
----     the resulting entries.  Only a `|List|` type is
+---     the resulting entries.  Only a [List](help://List) type is
 ---     accepted.  The current quickfix list is not
----     modified. See `|quickfix-parse|`.
+---     modified. See [quickfix-parse](help://quickfix-parse).
 ---   nr  get information for this quickfix list; zero
 ---     means the current quickfix list and "$" means
 ---     the last quickfix list
 ---   qfbufnr number of the buffer displayed in the quickfix
 ---     window. Returns 0 if the quickfix buffer is
----     not present. See `|quickfix-buffer|`.
+---     not present. See [quickfix-buffer](help://quickfix-buffer).
 ---   size  number of entries in the quickfix list
----   title  get the list title `|quickfix-title|`
----   winid  get the quickfix `|window-ID|`
+---   title  get the list title [quickfix-title](help://quickfix-title)
+---   winid  get the quickfix [window-ID](help://window-ID)
 ---   all  all of the above quickfix properties
 --- Non-string items in {what} are ignored. To get the value of a
 --- particular item, set it to zero.
@@ -3723,10 +3726,10 @@ function vim.fn.getpos(expr) end
 ---
 --- The returned dictionary contains the following entries:
 ---   changedtick  total number of changes made to the
----       list `|quickfix-changedtick|`
----   context  quickfix list context. See `|quickfix-context|`
+---       list [quickfix-changedtick](help://quickfix-changedtick)
+---   context  quickfix list context. See [quickfix-context](help://quickfix-context)
 ---     If not present, set to "".
----   id  quickfix list ID `|quickfix-ID|`. If not
+---   id  quickfix list ID [quickfix-ID](help://quickfix-ID). If not
 ---     present, set to 0.
 ---   idx  index of the quickfix entry in the list. If not
 ---     present, set to 0.
@@ -3739,9 +3742,9 @@ function vim.fn.getpos(expr) end
 ---     present, set to 0.
 ---   title  quickfix list title text. If not present, set
 ---     to "".
----   winid  quickfix `|window-ID|`. If not present, set to 0
+---   winid  quickfix [window-ID](help://window-ID). If not present, set to 0
 ---
---- Examples (See also `|getqflist-examples|`):
+--- Examples (See also [getqflist-examples](help://getqflist-examples)):
 --- ```vim
 ---   echo getqflist({'all': 1})
 ---   echo getqflist({'nr': 2, 'title': 1})
@@ -3764,17 +3767,17 @@ function vim.fn.getqflist(what) end
 --- getreg('=') returns the last evaluated value of the expression
 --- register.  (For use in maps.)
 --- getreg('=', 1) returns the expression itself, so that it can
---- be restored with `|setreg()|`.  For other registers the extra
+--- be restored with [setreg()](help://setreg()).  For other registers the extra
 --- argument is ignored, thus you can always give it.
 ---
---- If {list} is present and `|TRUE|`, the result type is changed
---- to `|List|`. Each list item is one text line. Use it if you care
+--- If {list} is present and [TRUE](help://TRUE), the result type is changed
+--- to [List](help://List). Each list item is one text line. Use it if you care
 --- about zero bytes possibly present inside register: without
 --- third argument both NLs and zero bytes are represented as NLs
---- (see `|NL-used-for-Nul|`).
+--- (see [NL-used-for-Nul](help://NL-used-for-Nul)).
 --- When the register was not set an empty list is returned.
 ---
---- If {regname} is not specified, `|v:register|` is used.
+--- If {regname} is not specified, [v:register](help://v:register) is used.
 ---
 ---
 --- @param regname? string
@@ -3788,13 +3791,13 @@ function vim.fn.getreg(regname, list) end
 ---       {regname}, like
 ---       getreg({regname}, 1, 1).
 ---   regtype    the type of register {regname}, as in
----       `|getregtype()|`.
+---       [getregtype()](help://getregtype()).
 ---   isunnamed  Boolean flag, v:true if this register
 ---       is currently pointed to by the unnamed
 ---       register.
 ---   points_to  for the unnamed register, gives the
 ---       single letter name of the register
----       currently pointed to (see `|quotequote|`).
+---       currently pointed to (see [quotequote](help://quotequote)).
 ---       For example, after deleting a line
 ---       with `dd`, this field will be "1",
 ---       which is the register that got the
@@ -3802,8 +3805,8 @@ function vim.fn.getreg(regname, list) end
 ---
 --- The {regname} argument is a string.  If {regname} is invalid
 --- or not set, an empty Dictionary will be returned.
---- If {regname} is not specified, `|v:register|` is used.
---- The returned Dictionary can be passed to `|setreg()|`.
+--- If {regname} is not specified, [v:register](help://v:register) is used.
+--- The returned Dictionary can be passed to [setreg()](help://setreg()).
 ---
 ---
 --- @param regname? string
@@ -3812,20 +3815,20 @@ function vim.fn.getreginfo(regname) end
 
 --- The result is a String, which is type of register {regname}.
 --- The value will be one of:
----     "v"      for `|charwise|` text
----     "V"      for `|linewise|` text
----     "<CTRL-V>{width}"  for `|blockwise-visual|` text
+---     "v"      for [charwise](help://charwise) text
+---     "V"      for [linewise](help://linewise) text
+---     "<CTRL-V>{width}"  for [blockwise-visual](help://blockwise-visual) text
 ---     ""      for an empty or unknown register
 --- <CTRL-V> is one character with value 0x16.
 --- The {regname} argument is a string.  If {regname} is not
---- specified, `|v:register|` is used.
+--- specified, [v:register](help://v:register) is used.
 ---
 ---
 --- @param regname? string
 --- @return string
 function vim.fn.getregtype(regname) end
 
---- Returns a `|List|` with information about all the sourced Vim
+--- Returns a [List](help://List) with information about all the sourced Vim
 --- scripts in the order they were sourced, like what
 --- `:scriptnames` shows.
 ---
@@ -3835,11 +3838,11 @@ function vim.fn.getregtype(regname) end
 ---     and "sid" is not specified, information about
 ---     scripts with a name that match the pattern
 ---     "name" are returned.
----     sid    Script ID `|<SID>|`.  If specified, only
+---     sid    Script ID [<SID>](help://<SID>).  If specified, only
 ---     information about the script with ID "sid" is
 ---     returned and "name" is ignored.
 ---
---- Each item in the returned List is a `|Dict|` with the following
+--- Each item in the returned List is a [Dict](help://Dict) with the following
 --- items:
 ---     autoload  Always set to FALSE.
 ---     functions   List of script-local function names defined in
@@ -3847,7 +3850,7 @@ function vim.fn.getregtype(regname) end
 ---     script is specified using the "sid" item in
 ---     {opts}.
 ---     name  Vim script file name.
----     sid    Script ID `|<SID>|`.
+---     sid    Script ID [<SID>](help://<SID>).
 ---     variables   A dictionary with the script-local variables.
 ---     Present only when a particular script is
 ---     specified using the "sid" item in {opts}.
@@ -3867,16 +3870,16 @@ function vim.fn.getregtype(regname) end
 function vim.fn.getscriptinfo(opts) end
 
 --- If {tabnr} is not specified, then information about all the
---- tab pages is returned as a `|List|`. Each List item is a
---- `|Dictionary|`.  Otherwise, {tabnr} specifies the tab page
+--- tab pages is returned as a [List](help://List). Each List item is a
+--- [Dictionary](help://Dictionary).  Otherwise, {tabnr} specifies the tab page
 --- number and information about that one is returned.  If the tab
 --- page does not exist an empty List is returned.
 ---
---- Each List item is a `|Dictionary|` with the following entries:
+--- Each List item is a [Dictionary](help://Dictionary) with the following entries:
 ---   tabnr    tab page number.
 ---   variables  a reference to the dictionary with
 ---       tabpage-local variables
----   windows    List of `|window-ID|`s in the tab page.
+---   windows    List of [window-ID](help://window-ID)s in the tab page.
 ---
 ---
 --- @param tabnr? integer
@@ -3884,7 +3887,7 @@ function vim.fn.getscriptinfo(opts) end
 function vim.fn.gettabinfo(tabnr) end
 
 --- Get the value of a tab-local variable {varname} in tab page
---- {tabnr}. `|t:var|`
+--- {tabnr}. [t:var](help://t:var)
 --- Tabs are numbered starting with one.
 --- The {varname} argument is a string.  When {varname} is empty a
 --- dictionary with all tab-local variables is returned.
@@ -3904,13 +3907,13 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 --- The {varname} argument is a string.  When {varname} is empty a
 --- dictionary with all window-local variables is returned.
 --- When {varname} is equal to "&" get the values of all
---- window-local options in a `|Dictionary|`.
+--- window-local options in a [Dictionary](help://Dictionary).
 --- Otherwise, when {varname} starts with "&" get the value of a
 --- window-local option.
 --- Note that {varname} must be the name without "w:".
 --- Tabs are numbered starting with one.  For the current tabpage
---- use `|getwinvar()|`.
---- {winnr} can be the window number or the `|window-ID|`.
+--- use [getwinvar()](help://getwinvar()).
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 --- When {winnr} is zero the current window is used.
 --- This also works for a global option, buffer-local option and
 --- window-local option, but it doesn't work for a global variable
@@ -3935,7 +3938,7 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 
 --- The result is a Dict, which is the tag stack of window {winnr}.
---- {winnr} can be the window number or the `|window-ID|`.
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 --- When {winnr} is not specified, the current window is used.
 --- When window {winnr} doesn't exist, an empty Dict is returned.
 ---
@@ -3952,14 +3955,14 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 --- entries:
 ---   bufnr    buffer number of the current jump
 ---   from    cursor position before the tag jump.
----       See `|getpos()|` for the format of the
+---       See [getpos()](help://getpos()) for the format of the
 ---       returned list.
 ---   matchnr    current matching tag number. Used when
 ---       multiple matching tags are found for a
 ---       name.
 ---   tagname    name of the tag
 ---
---- See `|tagstack|` for more information about the tag stack.
+--- See [tagstack](help://tagstack) for more information about the tag stack.
 ---
 ---
 --- @param winnr? integer
@@ -3980,16 +3983,16 @@ function vim.fn.gettagstack(winnr) end
 --- @return any
 function vim.fn.gettext(text) end
 
---- Returns information about windows as a `|List|` with Dictionaries.
+--- Returns information about windows as a [List](help://List) with Dictionaries.
 ---
 --- If {winid} is given Information about the window with that ID
---- is returned, as a `|List|` with one item.  If the window does not
+--- is returned, as a [List](help://List) with one item.  If the window does not
 --- exist the result is an empty list.
 ---
 --- Without {winid} information about all the windows in all the
 --- tab pages is returned.
 ---
---- Each List item is a `|Dictionary|` with the following entries:
+--- Each List item is a [Dictionary](help://Dictionary) with the following entries:
 ---   botline    last complete displayed buffer line
 ---   bufnr    number of buffer in the window
 ---   height    window height (excluding winbar)
@@ -4004,22 +4007,22 @@ function vim.fn.gettext(text) end
 ---   winbar    1 if the window has a toolbar, 0
 ---       otherwise
 ---   wincol    leftmost screen column of the window;
----       "col" from `|win_screenpos()|`
+---       "col" from [win_screenpos()](help://win_screenpos())
 ---   textoff    number of columns occupied by any
 ---       'foldcolumn', 'signcolumn' and line
 ---       number in front of the text
----   winid    `|window-ID|`
+---   winid    [window-ID](help://window-ID)
 ---   winnr    window number
 ---   winrow    topmost screen line of the window;
----       "row" from `|win_screenpos()|`
+---       "row" from [win_screenpos()](help://win_screenpos())
 ---
 ---
 --- @param winid? integer
 --- @return vim.fn.getwininfo.ret.item[]
 function vim.fn.getwininfo(winid) end
 
---- The result is a `|List|` with two numbers, the result of
---- `|getwinposx()|` and `|getwinposy()|` combined:
+--- The result is a [List](help://List) with two numbers, the result of
+--- [getwinposx()](help://getwinposx()) and [getwinposy()](help://getwinposy()) combined:
 ---   [x-pos, y-pos]
 --- {timeout} can be used to specify how long to wait in msec for
 --- a response from the terminal.  When omitted 100 msec is used.
@@ -4059,7 +4062,7 @@ function vim.fn.getwinposx() end
 --- @return integer
 function vim.fn.getwinposy() end
 
---- Like `|gettabwinvar()|` for the current tabpage.
+--- Like [gettabwinvar()](help://gettabwinvar()) for the current tabpage.
 --- Examples:
 --- ```vim
 ---   let list_is_on = getwinvar(2, '&list')
@@ -4072,16 +4075,16 @@ function vim.fn.getwinposy() end
 --- @return any
 function vim.fn.getwinvar(winnr, varname, def) end
 
---- Expand the file wildcards in {expr}.  See `|wildcards|` for the
+--- Expand the file wildcards in {expr}.  See [wildcards](help://wildcards) for the
 --- use of special characters.
 ---
---- Unless the optional {nosuf} argument is given and is `|TRUE|`,
+--- Unless the optional {nosuf} argument is given and is [TRUE](help://TRUE),
 --- the 'suffixes' and 'wildignore' options apply: Names matching
 --- one of the patterns in 'wildignore' will be skipped and
 --- 'suffixes' affect the ordering of matches.
 --- 'wildignorecase' always applies.
 ---
---- When {list} is present and it is `|TRUE|` the result is a `|List|`
+--- When {list} is present and it is [TRUE](help://TRUE) the result is a [List](help://List)
 --- with all matching files. The advantage of using a List is,
 --- you also get filenames containing newlines correctly.
 --- Otherwise the result is a String and when there are several
@@ -4089,13 +4092,13 @@ function vim.fn.getwinvar(winnr, varname, def) end
 ---
 --- If the expansion fails, the result is an empty String or List.
 ---
---- You can also use `|readdir()|` if you need to do complicated
+--- You can also use [readdir()](help://readdir()) if you need to do complicated
 --- things, such as limiting the number of matches.
 ---
 --- A name for a non-existing file is not included.  A symbolic
 --- link is only included if it points to an existing file.
 --- However, when the {alllinks} argument is present and it is
---- `|TRUE|` then all symbolic links are included.
+--- [TRUE](help://TRUE) then all symbolic links are included.
 ---
 --- For most systems backticks can be used to get files names from
 --- any external command.  Example:
@@ -4106,8 +4109,8 @@ function vim.fn.getwinvar(winnr, varname, def) end
 --- The result of the program inside the backticks should be one
 --- item per line.  Spaces inside an item are allowed.
 ---
---- See `|expand()|` for expanding special Vim variables.  See
---- `|system()|` for getting the raw output of an external command.
+--- See [expand()](help://expand()) for expanding special Vim variables.  See
+--- [system()](help://system()) for getting the raw output of an external command.
 ---
 ---
 --- @param expr any
@@ -4148,19 +4151,19 @@ function vim.fn.glob2regpat(string) end
 --- ```
 --- {path} is a comma-separated list of directory names.  Each
 --- directory name is prepended to {expr} and expanded like with
---- `|glob()|`.  A path separator is inserted when needed.
+--- [glob()](help://glob()).  A path separator is inserted when needed.
 --- To add a comma inside a directory name escape it with a
 --- backslash.  Note that on MS-Windows a directory may have a
 --- trailing backslash, remove it if you put a comma after it.
 --- If the expansion fails for one of the directories, there is no
 --- error message.
 ---
---- Unless the optional {nosuf} argument is given and is `|TRUE|`,
+--- Unless the optional {nosuf} argument is given and is [TRUE](help://TRUE),
 --- the 'suffixes' and 'wildignore' options apply: Names matching
 --- one of the patterns in 'wildignore' will be skipped and
 --- 'suffixes' affect the ordering of matches.
 ---
---- When {list} is present and it is `|TRUE|` the result is a `|List|`
+--- When {list} is present and it is [TRUE](help://TRUE) the result is a [List](help://List)
 --- with all matching files. The advantage of using a List is, you
 --- also get filenames containing newlines correctly. Otherwise
 --- the result is a String and when there are several matches,
@@ -4168,7 +4171,7 @@ function vim.fn.glob2regpat(string) end
 --- ```vim
 ---   echo globpath(&rtp, "syntax/c.vim", 0, 1)
 --- ```
---- {allinks} is used as with `|glob()|`.
+--- {allinks} is used as with [glob()](help://glob()).
 ---
 --- The "**" item can be used to search in a directory tree.
 --- For example, to find all "README.txt" files in the directories
@@ -4190,14 +4193,14 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 
 --- Returns 1 if {feature} is supported, 0 otherwise.  The
 --- {feature} argument is a feature name like "nvim-0.2.1" or
---- "win32", see below.  See also `|exists()|`.
+--- "win32", see below.  See also [exists()](help://exists()).
 ---
---- To get the system name use `|vim.uv|`.os_uname() in Lua:
+--- To get the system name use [vim.uv](help://vim.uv).os_uname() in Lua:
 --- ```lua
 ---   print(vim.uv.os_uname().sysname)
 --- ```
 --- If the code has a syntax error then Vimscript may skip the
---- rest of the line.  Put `|:if|` and `|:endif|` on separate lines to
+--- rest of the line.  Put [:if](help://:if) and [:endif](help://:endif) on separate lines to
 --- avoid the syntax error:
 --- ```vim
 ---   if has('feature')
@@ -4206,7 +4209,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- ```
 --- Vim's compile-time feature-names (prefixed with "+") are not
 --- recognized because Nvim is always compiled with all possible
---- features. `|feature-compile|`
+--- features. [feature-compile](help://feature-compile)
 ---
 --- Feature names can be:
 --- 1.  Nvim version. For example the "nvim-0.2.1" feature means
@@ -4225,30 +4228,30 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- ```
 --- *feature-list*
 ---     List of supported pseudo-feature names:
----   acl    `|ACL|` support.
+---   acl    [ACL](help://ACL) support.
 ---   bsd    BSD system (not macOS, use "mac" for that).
----   clipboard  `|clipboard|` provider is available.
+---   clipboard  [clipboard](help://clipboard) provider is available.
 ---   fname_case  Case in file names matters (for Darwin and MS-Windows
 ---       this is not present).
 ---   gui_running  Nvim has a GUI.
----   iconv    Can use `|iconv()|` for conversion.
+---   iconv    Can use [iconv()](help://iconv()) for conversion.
 ---   linux    Linux system.
 ---   mac    MacOS system.
 ---   nvim    This is Nvim.
----   python3    Legacy Vim `|python3|` interface. `|has-python|`
----   pythonx    Legacy Vim `|python_x|` interface. `|has-pythonx|`
+---   python3    Legacy Vim [python3](help://python3) interface. [has-python](help://has-python)
+---   pythonx    Legacy Vim [python_x](help://python_x) interface. [has-pythonx](help://has-pythonx)
 ---   sun    SunOS system.
 ---   ttyin    input is a terminal (tty).
 ---   ttyout    output is a terminal (tty).
 ---   unix    Unix system.
----   *vim_starting*  True during `|startup|`.
+---   *vim_starting*  True during [startup](help://startup).
 ---   win32    Windows system (32 or 64 bit).
 ---   win64    Windows system (64 bit).
 ---   wsl    WSL (Windows Subsystem for Linux) system.
 ---
 ---           *has-patch*
 --- 3.  Vim patch. For example the "patch123" feature means that
----     Vim patch 123 at the current `|v:version|` was included:
+---     Vim patch 123 at the current [v:version](help://v:version) was included:
 --- ```vim
 ---   if v:version > 602 || v:version == 602 && has("patch148")
 ---     " ...
@@ -4266,7 +4269,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- @return 0|1
 function vim.fn.has(feature) end
 
---- The result is a Number, which is TRUE if `|Dictionary|` {dict}
+--- The result is a Number, which is TRUE if [Dictionary](help://Dictionary) {dict}
 --- has an entry with key {key}.  FALSE otherwise. The {key}
 --- argument is a string.
 ---
@@ -4277,8 +4280,8 @@ function vim.fn.has(feature) end
 function vim.fn.has_key(dict, key) end
 
 --- The result is a Number, which is 1 when the window has set a
---- local path via `|:lcd|` or when {winnr} is -1 and the tabpage
---- has set a local path via `|:tcd|`, otherwise 0.
+--- local path via [:lcd](help://:lcd) or when {winnr} is -1 and the tabpage
+--- has set a local path via [:tcd](help://:tcd), otherwise 0.
 ---
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing argument implies 0.
@@ -4290,9 +4293,9 @@ function vim.fn.has_key(dict, key) end
 --- ```
 --- With {winnr} use that window in the current tabpage.
 --- With {winnr} and {tabnr} use the window in that tabpage.
---- {winnr} can be the window number or the `|window-ID|`.
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 --- If {winnr} is -1 it is ignored, only the tab is resolved.
---- Throw error if the arguments are invalid. `|E5000|` `|E5001|` `|E5002|`
+--- Throw error if the arguments are invalid. [E5000](help://E5000) [E5001](help://E5001) [E5002](help://E5002)
 ---
 ---
 --- @param winnr? integer
@@ -4305,7 +4308,7 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 --- mapped to) and this mapping exists in one of the modes
 --- indicated by {mode}.
 --- The arguments {what} and {mode} are strings.
---- When {abbr} is there and it is `|TRUE|` use abbreviations
+--- When {abbr} is there and it is [TRUE](help://TRUE) use abbreviations
 --- instead of mappings.  Don't forget to specify Insert and/or
 --- Command-line mode.
 --- Both the global mappings and the mappings local to the current
@@ -4340,14 +4343,14 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 function vim.fn.hasmapto(what, mode, abbr) end
 
 --- @deprecated
---- Obsolete name for `|hlID()|`.
+--- Obsolete name for [hlID()](help://hlID()).
 ---
 --- @param name string
 --- @return any
 function vim.fn.highlightID(name) end
 
 --- @deprecated
---- Obsolete name for `|hlexists()|`.
+--- Obsolete name for [hlexists()](help://hlexists()).
 ---
 --- @param name string
 --- @return any
@@ -4373,7 +4376,7 @@ function vim.fn.highlight_exists(name) end
 ---   call histadd("input", strftime("%Y %b %d"))
 ---   let date=input("Enter date: ")
 --- ```
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 ---
 --- @param history any
@@ -4381,15 +4384,15 @@ function vim.fn.highlight_exists(name) end
 --- @return 0|1
 function vim.fn.histadd(history, item) end
 
---- Clear {history}, i.e. delete all its entries.  See `|hist-names|`
+--- Clear {history}, i.e. delete all its entries.  See [hist-names](help://hist-names)
 --- for the possible values of {history}.
 ---
 --- If the parameter {item} evaluates to a String, it is used as a
 --- regular expression.  All entries matching that expression will
 --- be removed from the history (if there are any).
---- Upper/lowercase must match, unless "\c" is used `|/\c|`.
+--- Upper/lowercase must match, unless "\c" is used [/\c](help:///\c).
 --- If {item} evaluates to a Number, it will be interpreted as
---- an index, see `|:history-indexing|`.  The respective entry will
+--- an index, see [:history-indexing](help://:history-indexing).  The respective entry will
 --- be removed if it exists.
 ---
 --- The result is TRUE for a successful operation, otherwise FALSE
@@ -4423,8 +4426,8 @@ function vim.fn.histadd(history, item) end
 function vim.fn.histdel(history, item) end
 
 --- The result is a String, the entry with Number {index} from
---- {history}.  See `|hist-names|` for the possible values of
---- {history}, and `|:history-indexing|` for {index}.  If there is
+--- {history}.  See [hist-names](help://hist-names) for the possible values of
+--- {history}, and [:history-indexing](help://:history-indexing) for {index}.  If there is
 --- no such entry, an empty String is returned.  When {index} is
 --- omitted, the most recent item from the history is used.
 ---
@@ -4434,7 +4437,7 @@ function vim.fn.histdel(history, item) end
 ---   execute '/' .. histget("search", -2)
 --- ```
 --- Define an Ex command ":H {num}" that supports re-execution of
---- the {num}th entry from the output of `|:history|`.
+--- the {num}th entry from the output of [:history](help://:history).
 --- ```vim
 ---   command -nargs=1 H execute histget("cmd", 0+<args>)
 --- ```
@@ -4445,7 +4448,7 @@ function vim.fn.histdel(history, item) end
 function vim.fn.histget(history, index) end
 
 --- The result is the Number of the current entry in {history}.
---- See `|hist-names|` for the possible values of {history}.
+--- See [hist-names](help://hist-names) for the possible values of {history}.
 --- If an error occurred, -1 is returned.
 ---
 --- Example:
@@ -4507,8 +4510,8 @@ function vim.fn.hostname() end
 --- @return any
 function vim.fn.iconv(string, from, to) end
 
---- Returns a `|String|` which is a unique identifier of the
---- container type (`|List|`, `|Dict|`, `|Blob|` and `|Partial|`). It is
+--- Returns a [String](help://String) which is a unique identifier of the
+--- container type ([List](help://List), [Dict](help://Dict), [Blob](help://Blob) and [Partial](help://Partial)). It is
 --- guaranteed that for the mentioned types `id(v1) ==# id(v2)`
 --- returns true iff `type(v1) == type(v2) && v1 is v2`.
 --- Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
@@ -4530,7 +4533,7 @@ function vim.fn.id(expr) end
 --- The result is a Number, which is indent of line {lnum} in the
 --- current buffer.  The indent is counted in spaces, the value
 --- of 'tabstop' is relevant.  {lnum} is used just like in
---- `|getline()|`.
+--- [getline()](help://getline()).
 --- When {lnum} is invalid -1 is returned.
 ---
 ---
@@ -4539,22 +4542,22 @@ function vim.fn.id(expr) end
 function vim.fn.indent(lnum) end
 
 --- Find {expr} in {object} and return its index.  See
---- `|indexof()|` for using a lambda to select the item.
+--- [indexof()](help://indexof()) for using a lambda to select the item.
 ---
---- If {object} is a `|List|` return the lowest index where the item
+--- If {object} is a [List](help://List) return the lowest index where the item
 --- has a value equal to {expr}.  There is no automatic
 --- conversion, so the String "4" is different from the Number 4.
 --- And the Number 4 is different from the Float 4.0.  The value
 --- of 'ignorecase' is not used here, case matters as indicated by
 --- the {ic} argument.
 ---
---- If {object} is a `|Blob|` return the lowest index where the byte
+--- If {object} is a [Blob](help://Blob) return the lowest index where the byte
 --- value is equal to {expr}.
 ---
 --- If {start} is given then start looking at the item with index
 --- {start} (may be negative for an item relative to the end).
 ---
---- When {ic} is given and it is `|TRUE|`, ignore case.  Otherwise
+--- When {ic} is given and it is [TRUE](help://TRUE), ignore case.  Otherwise
 --- case must match.
 ---
 --- -1 is returned when {expr} is not found in {object}.
@@ -4574,28 +4577,28 @@ function vim.fn.indent(lnum) end
 function vim.fn.index(object, expr, start, ic) end
 
 --- Returns the index of an item in {object} where {expr} is
---- v:true.  {object} must be a `|List|` or a `|Blob|`.
+--- v:true.  {object} must be a [List](help://List) or a [Blob](help://Blob).
 ---
---- If {object} is a `|List|`, evaluate {expr} for each item in the
+--- If {object} is a [List](help://List), evaluate {expr} for each item in the
 --- List until the expression is v:true and return the index of
 --- this item.
 ---
---- If {object} is a `|Blob|` evaluate {expr} for each byte in the
+--- If {object} is a [Blob](help://Blob) evaluate {expr} for each byte in the
 --- Blob until the expression is v:true and return the index of
 --- this byte.
 ---
---- {expr} must be a `|string|` or `|Funcref|`.
+--- {expr} must be a [string](help://string) or [Funcref](help://Funcref).
 ---
---- If {expr} is a `|string|`: If {object} is a `|List|`, inside
---- {expr} `|v:key|` has the index of the current List item and
---- `|v:val|` has the value of the item.  If {object} is a `|Blob|`,
---- inside {expr} `|v:key|` has the index of the current byte and
---- `|v:val|` has the byte value.
+--- If {expr} is a [string](help://string): If {object} is a [List](help://List), inside
+--- {expr} [v:key](help://v:key) has the index of the current List item and
+--- [v:val](help://v:val) has the value of the item.  If {object} is a [Blob](help://Blob),
+--- inside {expr} [v:key](help://v:key) has the index of the current byte and
+--- [v:val](help://v:val) has the byte value.
 ---
---- If {expr} is a `|Funcref|` it must take two arguments:
+--- If {expr} is a [Funcref](help://Funcref) it must take two arguments:
 ---   1. the key or the index of the current item.
 ---   2. the value of the current item.
---- The function must return `|TRUE|` if the item is found and the
+--- The function must return [TRUE](help://TRUE) if the item is found and the
 --- search should stop.
 ---
 --- The optional argument {opts} is a Dict and supports the
@@ -4639,9 +4642,9 @@ function vim.fn.input(prompt, text, completion) end
 --- completion    nothing  Same as {completion} in the first form.
 --- cancelreturn  ""       The value returned when the dialog is
 ---                        cancelled.
---- highlight     nothing  Highlight handler: `|Funcref|`.
+--- highlight     nothing  Highlight handler: [Funcref](help://Funcref).
 ---
---- The highlighting set with `|:echohl|` is used for the prompt.
+--- The highlighting set with [:echohl](help://:echohl) is used for the prompt.
 --- The input is entered just like a command-line, with the same
 --- editing commands and mappings.  There is a separate history
 --- for lines typed for input().
@@ -4661,7 +4664,7 @@ function vim.fn.input(prompt, text, completion) end
 --- completion supported for the input.  Without it completion is
 --- not performed.  The supported completion types are the same as
 --- that can be supplied to a user-defined command using the
---- "-complete=" argument.  Refer to `|:command-completion|` for
+--- "-complete=" argument.  Refer to [:command-completion](help://:command-completion) for
 --- more information.  Example:
 --- ```vim
 ---   let fname = input("File: ", "", "file")
@@ -4674,7 +4677,7 @@ function vim.fn.input(prompt, text, completion) end
 --- where
 ---   hl_start_col is the first highlighted column,
 ---   hl_end_col is the last highlighted column (+ 1!),
----   hl_group is `|:hi|` group used for highlighting.
+---   hl_group is [:hi](help://:hi) group used for highlighting.
 ---             *E5403* *E5404* *E5405* *E5406*
 --- Both hl_start_col and hl_end_col + 1 must point to the start
 --- of the multibyte character (highlighting must not break
@@ -4713,7 +4716,7 @@ function vim.fn.input(prompt, text, completion) end
 --- displayed input string, before command-line is redrawn.  It is
 --- expected that function is pure for the duration of one input()
 --- call, i.e. it produces the same output for the same input, so
---- output may be memoized.  Function is run like under `|:silent|`
+--- output may be memoized.  Function is run like under [:silent](help://:silent)
 --- modifier. If the function causes any errors, it will be
 --- skipped for the duration of the current input() call.
 ---
@@ -4725,10 +4728,10 @@ function vim.fn.input(prompt, text, completion) end
 --- Note: When input() is called from within a mapping it will
 --- consume remaining characters from that mapping, because a
 --- mapping is handled like the characters were typed.
---- Use `|inputsave()|` before input() and `|inputrestore()|`
+--- Use [inputsave()](help://inputsave()) before input() and [inputrestore()](help://inputrestore())
 --- after input() to avoid that.  Another solution is to avoid
 --- that further characters follow in the mapping, e.g., by using
---- `|:execute|` or `|:normal|`.
+--- [:execute](help://:execute) or [:normal](help://:normal).
 ---
 --- Example with a mapping:
 --- ```vim
@@ -4745,13 +4748,13 @@ function vim.fn.input(prompt, text, completion) end
 function vim.fn.input(opts) end
 
 --- @deprecated
---- Use `|input()|` instead.
+--- Use [input()](help://input()) instead.
 ---
 --- @param ... any
 --- @return any
 function vim.fn.inputdialog(...) end
 
---- {textlist} must be a `|List|` of strings.  This `|List|` is
+--- {textlist} must be a [List](help://List) of strings.  This [List](help://List) is
 --- displayed, one string per line.  The user will be prompted to
 --- enter a number, which is returned.
 --- The user can also select an item by clicking on it with the
@@ -4773,7 +4776,7 @@ function vim.fn.inputdialog(...) end
 --- @return any
 function vim.fn.inputlist(textlist) end
 
---- Restore typeahead that was saved with a previous `|inputsave()|`.
+--- Restore typeahead that was saved with a previous [inputsave()](help://inputsave()).
 --- Should be called the same number of times inputsave() is
 --- called.  Calling it more often is harmless though.
 --- Returns TRUE when there is nothing to restore, FALSE otherwise.
@@ -4791,12 +4794,12 @@ function vim.fn.inputrestore() end
 --- @return any
 function vim.fn.inputsave() end
 
---- This function acts much like the `|input()|` function with but
+--- This function acts much like the [input()](help://input()) function with but
 --- two exceptions:
 --- a) the user's response will be displayed as a sequence of
 --- asterisks ("*") thereby keeping the entry secret, and
 --- b) the user's response will not be recorded on the input
---- `|history|` stack.
+--- [history](help://history) stack.
 --- The result is a String, which is whatever the user actually
 --- typed on the command-line in response to the issued prompt.
 --- NOTE: Command-line completion is not supported.
@@ -4807,23 +4810,23 @@ function vim.fn.inputsave() end
 --- @return any
 function vim.fn.inputsecret(prompt, text) end
 
---- When {object} is a `|List|` or a `|Blob|` insert {item} at the start
+--- When {object} is a [List](help://List) or a [Blob](help://Blob) insert {item} at the start
 --- of it.
 ---
 --- If {idx} is specified insert {item} before the item with index
 --- {idx}.  If {idx} is zero it goes before the first item, just
 --- like omitting {idx}.  A negative {idx} is also possible, see
---- `|list-index|`.  -1 inserts just before the last item.
+--- [list-index](help://list-index).  -1 inserts just before the last item.
 ---
---- Returns the resulting `|List|` or `|Blob|`.  Examples:
+--- Returns the resulting [List](help://List) or [Blob](help://Blob).  Examples:
 --- ```vim
 ---   let mylist = insert([2, 3, 5], 1)
 ---   call insert(mylist, 4, -1)
 ---   call insert(mylist, 6, len(mylist))
 --- ```
---- The last example can be done simpler with `|add()|`.
---- Note that when {item} is a `|List|` it is inserted as a single
---- item.  Use `|extend()|` to concatenate `|Lists|`.
+--- The last example can be done simpler with [add()](help://add()).
+--- Note that when {item} is a [List](help://List) it is inserted as a single
+--- item.  Use [extend()](help://extend()) to concatenate [Lists](help://Lists).
 ---
 ---
 --- @param object any
@@ -4859,9 +4862,9 @@ function vim.fn.interrupt() end
 --- @return any
 function vim.fn.invert(expr) end
 
---- The result is a Number, which is `|TRUE|` when a directory
+--- The result is a Number, which is [TRUE](help://TRUE) when a directory
 --- with the name {directory} exists.  If {directory} doesn't
---- exist, or isn't a directory, the result is `|FALSE|`.  {directory}
+--- exist, or isn't a directory, the result is [FALSE](help://FALSE).  {directory}
 --- is any expression, which is used as a String.
 ---
 ---
@@ -4885,10 +4888,10 @@ function vim.fn.isdirectory(directory) end
 --- @return 1|0|-1
 function vim.fn.isinf(expr) end
 
---- The result is a Number, which is `|TRUE|` when {expr} is the
+--- The result is a Number, which is [TRUE](help://TRUE) when {expr} is the
 --- name of a locked variable.
 --- The string argument {expr} must be the name of a variable,
---- `|List|` item or `|Dictionary|` entry, not the variable itself!
+--- [List](help://List) item or [Dictionary](help://Dictionary) entry, not the variable itself!
 --- Example:
 --- ```vim
 ---   let alist = [0, ['a', 'b'], 2, 3]
@@ -4897,14 +4900,14 @@ function vim.fn.isinf(expr) end
 ---   echo islocked('alist[1]')  " 0
 --- ```
 --- When {expr} is a variable that does not exist you get an error
---- message.  Use `|exists()|` to check for existence.
+--- message.  Use [exists()](help://exists()) to check for existence.
 ---
 ---
 --- @param expr any
 --- @return 0|1
 function vim.fn.islocked(expr) end
 
---- Return `|TRUE|` if {expr} is a float with value NaN.
+--- Return [TRUE](help://TRUE) if {expr} is a float with value NaN.
 --- ```vim
 ---   echo isnan(0.0 / 0.0)
 --- ```
@@ -4915,10 +4918,10 @@ function vim.fn.islocked(expr) end
 --- @return 0|1
 function vim.fn.isnan(expr) end
 
---- Return a `|List|` with all the key-value pairs of {dict}.  Each
---- `|List|` item is a list with two items: the key of a {dict}
---- entry and the value of this entry.  The `|List|` is in arbitrary
---- order.  Also see `|keys()|` and `|values()|`.
+--- Return a [List](help://List) with all the key-value pairs of {dict}.  Each
+--- [List](help://List) item is a list with two items: the key of a {dict}
+--- entry and the value of this entry.  The [List](help://List) is in arbitrary
+--- order.  Also see [keys()](help://keys()) and [values()](help://values()).
 --- Example:
 --- ```vim
 ---   for [key, value] in items(mydict)
@@ -4931,19 +4934,19 @@ function vim.fn.isnan(expr) end
 function vim.fn.items(dict) end
 
 --- @deprecated
---- Obsolete name for `|chanclose()|`
+--- Obsolete name for [chanclose()](help://chanclose())
 ---
 --- @param ... any
 --- @return any
 function vim.fn.jobclose(...) end
 
---- Return the PID (process id) of `|job-id|` {job}.
+--- Return the PID (process id) of [job-id](help://job-id) {job}.
 ---
 --- @param job any
 --- @return integer
 function vim.fn.jobpid(job) end
 
---- Resize the pseudo terminal window of `|job-id|` {job} to {width}
+--- Resize the pseudo terminal window of [job-id](help://job-id) {job} to {width}
 --- columns and {height} rows.
 --- Fails if the job was not started with `"pty":v:true`.
 ---
@@ -4954,13 +4957,13 @@ function vim.fn.jobpid(job) end
 function vim.fn.jobresize(job, width, height) end
 
 --- @deprecated
---- Obsolete name for `|chansend()|`
+--- Obsolete name for [chansend()](help://chansend())
 ---
 --- @param ... any
 --- @return any
 function vim.fn.jobsend(...) end
 
---- Note: Prefer `|vim.system()|` in Lua (unless using the `pty` option).
+--- Note: Prefer [vim.system()](help://vim.system()) in Lua (unless using the `pty` option).
 ---
 --- Spawns {cmd} as a job.
 --- If {cmd} is a List it runs directly (no 'shell').
@@ -4968,20 +4971,20 @@ function vim.fn.jobsend(...) end
 --- ```vim
 ---   call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
 --- ```
---- (See `|shell-unquoting|` for details.)
+--- (See [shell-unquoting](help://shell-unquoting) for details.)
 ---
 --- Example:
 --- ```vim
 ---   call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
 --- ```
---- Returns `|job-id|` on success, 0 on invalid arguments (or job
+--- Returns [job-id](help://job-id) on success, 0 on invalid arguments (or job
 --- table is full), -1 if {cmd}[0] or 'shell' is not executable.
---- The returned job-id is a valid `|channel-id|` representing the
---- job's stdio streams. Use `|chansend()|` (or `|rpcnotify()|` and
---- `|rpcrequest()|` if "rpc" was enabled) to send data to stdin and
---- `|chanclose()|` to close the streams without stopping the job.
+--- The returned job-id is a valid [channel-id](help://channel-id) representing the
+--- job's stdio streams. Use [chansend()](help://chansend()) (or [rpcnotify()](help://rpcnotify()) and
+--- [rpcrequest()](help://rpcrequest()) if "rpc" was enabled) to send data to stdin and
+--- [chanclose()](help://chanclose()) to close the streams without stopping the job.
 ---
---- See `|job-control|` and `|RPC|`.
+--- See [job-control](help://job-control) and [RPC](help://RPC).
 ---
 --- NOTE: on Windows if {cmd} is a List:
 ---   - cmd[0] must be an executable (not a "built-in"). If it is
@@ -4999,7 +5002,7 @@ function vim.fn.jobsend(...) end
 ---
 ---           *jobstart-env*
 --- The job environment is initialized as follows:
----   $NVIM                is set to `|v:servername|` of the parent Nvim
+---   $NVIM                is set to [v:servername](help://v:servername) of the parent Nvim
 ---   $NVIM_LISTEN_ADDRESS is unset
 ---   $NVIM_LOG_FILE       is unset
 ---   $VIM                 is unset
@@ -5010,19 +5013,19 @@ function vim.fn.jobsend(...) end
 --- {opts} is a dictionary with these keys:
 ---   clear_env:  (boolean) `env` defines the job environment
 ---         exactly, instead of merging current environment.
----   cwd:        (string, default=`|current-directory|`) Working
+---   cwd:        (string, default=[current-directory](help://current-directory)) Working
 ---         directory of the job.
 ---   detach:     (boolean) Detach the job process: it will not be
 ---         killed when Nvim exits. If the process exits
 ---         before Nvim, `on_exit` will be invoked.
 ---   env:        (dict) Map of environment variable name:value
 ---         pairs extending (or replace with "clear_env")
----         the current environment. `|jobstart-env|`
+---         the current environment. [jobstart-env](help://jobstart-env)
 ---   height:     (number) Height of the `pty` terminal.
----   `|on_exit|`:    (function) Callback invoked when the job exits.
----   `|on_stdout|`:  (function) Callback invoked when the job emits
+---   [on_exit](help://on_exit):    (function) Callback invoked when the job exits.
+---   [on_stdout](help://on_stdout):  (function) Callback invoked when the job emits
 ---         stdout data.
----   `|on_stderr|`:  (function) Callback invoked when the job emits
+---   [on_stderr](help://on_stderr):  (function) Callback invoked when the job emits
 ---         stderr data.
 ---   overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
 ---         stdio passed to the child process. Only on
@@ -5030,38 +5033,38 @@ function vim.fn.jobsend(...) end
 ---   pty:        (boolean) Connect the job to a new pseudo
 ---         terminal, and its streams to the master file
 ---         descriptor. `on_stdout` receives all output,
----         `on_stderr` is ignored. `|terminal-start|`
----   rpc:        (boolean) Use `|msgpack-rpc|` to communicate with
+---         `on_stderr` is ignored. [terminal-start](help://terminal-start)
+---   rpc:        (boolean) Use [msgpack-rpc](help://msgpack-rpc) to communicate with
 ---         the job over stdio. Then `on_stdout` is ignored,
 ---         but `on_stderr` can still be used.
 ---   stderr_buffered: (boolean) Collect data until EOF (stream closed)
----         before invoking `on_stderr`. `|channel-buffered|`
+---         before invoking `on_stderr`. [channel-buffered](help://channel-buffered)
 ---   stdout_buffered: (boolean) Collect data until EOF (stream
----         closed) before invoking `on_stdout`. `|channel-buffered|`
+---         closed) before invoking `on_stdout`. [channel-buffered](help://channel-buffered)
 ---   stdin:      (string) Either "pipe" (default) to connect the
 ---         job's stdin to a channel or "null" to disconnect
 ---         stdin.
 ---   width:      (number) Width of the `pty` terminal.
 ---
---- {opts} is passed as `|self|` dictionary to the callback; the
+--- {opts} is passed as [self](help://self) dictionary to the callback; the
 --- caller may set other keys to pass application-specific data.
 ---
 --- Returns:
----   - `|channel-id|` on success
+---   - [channel-id](help://channel-id) on success
 ---   - 0 on invalid arguments
 ---   - -1 if {cmd}[0] is not executable.
---- See also `|job-control|`, `|channel|`, `|msgpack-rpc|`.
+--- See also [job-control](help://job-control), [channel](help://channel), [msgpack-rpc](help://msgpack-rpc).
 ---
 --- @param cmd any
 --- @param opts? table
 --- @return any
 function vim.fn.jobstart(cmd, opts) end
 
---- Stop `|job-id|` {id} by sending SIGTERM to the job process. If
+--- Stop [job-id](help://job-id) {id} by sending SIGTERM to the job process. If
 --- the process does not terminate after a timeout then SIGKILL
---- will be sent. When the job terminates its `|on_exit|` handler
+--- will be sent. When the job terminates its [on_exit](help://on_exit) handler
 --- (if any) will be invoked.
---- See `|job-control|`.
+--- See [job-control](help://job-control).
 ---
 --- Returns 1 for valid job id, 0 for invalid id, including jobs have
 --- exited or stopped.
@@ -5070,9 +5073,9 @@ function vim.fn.jobstart(cmd, opts) end
 --- @return any
 function vim.fn.jobstop(id) end
 
---- Waits for jobs and their `|on_exit|` handlers to complete.
+--- Waits for jobs and their [on_exit](help://on_exit) handlers to complete.
 ---
---- {jobs} is a List of `|job-id|`s to wait for.
+--- {jobs} is a List of [job-id](help://job-id)s to wait for.
 --- {timeout} is the maximum waiting time in milliseconds. If
 --- omitted or -1, wait forever.
 ---
@@ -5081,14 +5084,14 @@ function vim.fn.jobstop(id) end
 ---   let running = jobwait([{job-id}], 0)[0] == -1
 --- ```
 --- During jobwait() callbacks for jobs not in the {jobs} list may
---- be invoked. The screen will not redraw unless `|:redraw|` is
+--- be invoked. The screen will not redraw unless [:redraw](help://:redraw) is
 --- invoked by a callback.
 ---
 --- Returns a list of len({jobs}) integers, where each integer is
 --- the status of the corresponding job:
 ---   Exit-code, if the job exited
 ---   -1 if the timeout was exceeded
----   -2 if the job was interrupted (by `|CTRL-C|`)
+---   -2 if the job was interrupted (by [CTRL-C](help://CTRL-C))
 ---   -3 if the job-id is invalid
 ---
 --- @param jobs any
@@ -5104,9 +5107,9 @@ function vim.fn.jobwait(jobs, timeout) end
 --- ```vim
 ---   let lines = join(mylist, "\n") .. "\n"
 --- ```
---- String items are used as-is.  `|Lists|` and `|Dictionaries|` are
---- converted into a string like with `|string()|`.
---- The opposite function is `|split()|`.
+--- String items are used as-is.  [Lists](help://Lists) and [Dictionaries](help://Dictionaries) are
+--- converted into a string like with [string()](help://string()).
+--- The opposite function is [split()](help://split()).
 ---
 ---
 --- @param list any
@@ -5114,10 +5117,10 @@ function vim.fn.jobwait(jobs, timeout) end
 --- @return any
 function vim.fn.join(list, sep) end
 
---- Convert {expr} from JSON object.  Accepts `|readfile()|`-style
+--- Convert {expr} from JSON object.  Accepts [readfile()](help://readfile())-style
 --- list as the input, as well as regular string.  May output any
 --- Vim value. In the following cases it will output
---- `|msgpack-special-dict|`:
+--- [msgpack-special-dict](help://msgpack-special-dict):
 --- 1. Dictionary contains duplicate key.
 --- 2. Dictionary contains empty key.
 --- 3. String contains NUL byte.  Two special dictionaries: for
@@ -5135,23 +5138,23 @@ function vim.fn.join(list, sep) end
 function vim.fn.json_decode(expr) end
 
 --- Convert {expr} into a JSON string.  Accepts
---- `|msgpack-special-dict|` as the input.  Will not convert
---- `|Funcref|`s, mappings with non-string keys (can be created as
---- `|msgpack-special-dict|`), values with self-referencing
+--- [msgpack-special-dict](help://msgpack-special-dict) as the input.  Will not convert
+--- [Funcref](help://Funcref)s, mappings with non-string keys (can be created as
+--- [msgpack-special-dict](help://msgpack-special-dict)), values with self-referencing
 --- containers, strings which contain non-UTF-8 characters,
 --- pseudo-UTF-8 strings which contain codepoints reserved for
 --- surrogate pairs (such strings are not valid UTF-8 strings).
 --- Non-printable characters are converted into "\u1234" escapes
 --- or special escapes like "\t", other are dumped as-is.
---- `|Blob|`s are converted to arrays of the individual bytes.
+--- [Blob](help://Blob)s are converted to arrays of the individual bytes.
 ---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.json_encode(expr) end
 
---- Return a `|List|` with all the keys of {dict}.  The `|List|` is in
---- arbitrary order.  Also see `|items()|` and `|values()|`.
+--- Return a [List](help://List) with all the keys of {dict}.  The [List](help://List) is in
+--- arbitrary order.  Also see [items()](help://items()) and [values()](help://values()).
 ---
 ---
 --- @param dict any
@@ -5159,7 +5162,7 @@ function vim.fn.json_encode(expr) end
 function vim.fn.keys(dict) end
 
 --- Turn the internal byte representation of keys into a form that
---- can be used for `|:map|`.  E.g.
+--- can be used for [:map](help://:map).  E.g.
 --- ```vim
 ---   let xx = "\<C-Home>"
 ---   echo keytrans(xx)
@@ -5179,12 +5182,12 @@ function vim.fn.last_buffer_nr() end
 
 --- The result is a Number, which is the length of the argument.
 --- When {expr} is a String or a Number the length in bytes is
---- used, as with `|strlen()|`.
---- When {expr} is a `|List|` the number of items in the `|List|` is
+--- used, as with [strlen()](help://strlen()).
+--- When {expr} is a [List](help://List) the number of items in the [List](help://List) is
 --- returned.
---- When {expr} is a `|Blob|` the number of bytes is returned.
---- When {expr} is a `|Dictionary|` the number of entries in the
---- `|Dictionary|` is returned.
+--- When {expr} is a [Blob](help://Blob) the number of bytes is returned.
+--- When {expr} is a [Dictionary](help://Dictionary) the number of entries in the
+--- [Dictionary](help://Dictionary) is returned.
 --- Otherwise an error is given and returns zero.
 ---
 ---
@@ -5241,7 +5244,7 @@ function vim.fn.len(expr) end
 --- @return any
 function vim.fn.libcall(libname, funcname, argument) end
 
---- Just like `|libcall()|`, but used for a function that returns an
+--- Just like [libcall()](help://libcall()), but used for a function that returns an
 --- int instead of a string.
 --- Examples:
 --- ```vim
@@ -5269,12 +5272,12 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 ---       less than "w0" if no lines are visible)
 ---     v      In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from `|'<|` in
+---       returns the cursor position.  Differs from ['<](help://'<) in
 ---       that it's updated right away.
 --- Note that a mark in another file can be used.  The line number
 --- then applies to another buffer.
---- To get the column number use `|col()|`.  To get both use
---- `|getpos()|`.
+--- To get the column number use [col()](help://col()).  To get both use
+--- [getpos()](help://getpos()).
 --- With the optional {winid} argument the values are obtained for
 --- that window instead of the current window.
 --- Returns 0 for invalid values of {expr} and {winid}.
@@ -5286,7 +5289,7 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 ---   echo line("'" .. marker)  " line number of mark marker
 --- ```
 --- To jump to the last known position when opening a file see
---- `|last-position-jump|`.
+--- [last-position-jump](help://last-position-jump).
 ---
 ---
 --- @param expr any
@@ -5305,8 +5308,8 @@ function vim.fn.line(expr, winid) end
 --- ```
 --- This is the buffer size plus one.  If 'fileencoding' is empty
 --- it is the file size plus one.  {lnum} is used like with
---- `|getline()|`.  When {lnum} is invalid -1 is returned.
---- Also see `|byte2line()|`, `|go|` and `|:goto|`.
+--- [getline()](help://getline()).  When {lnum} is invalid -1 is returned.
+--- Also see [byte2line()](help://byte2line()), [go](help://go) and [:goto](help://:goto).
 ---
 ---
 --- @param lnum integer
@@ -5316,7 +5319,7 @@ function vim.fn.line2byte(lnum) end
 --- Get the amount of indent for line {lnum} according the lisp
 --- indenting rules, as with 'lisp'.
 --- The indent is counted in spaces, the value of 'tabstop' is
---- relevant.  {lnum} is used just like in `|getline()|`.
+--- relevant.  {lnum} is used just like in [getline()](help://getline()).
 --- When {lnum} is invalid, -1 is returned.
 ---
 ---
@@ -5333,7 +5336,7 @@ function vim.fn.lispindent(lnum) end
 --- Returns an empty Blob on error.  If one of the numbers is
 --- negative or more than 255 error *E1239* is given.
 ---
---- `|blob2list()|` does the opposite.
+--- [blob2list()](help://blob2list()) does the opposite.
 ---
 ---
 --- @param list any
@@ -5350,7 +5353,7 @@ function vim.fn.list2blob(list) end
 --- ```vim
 ---   echo join(map(list, {nr, val -> nr2char(val)}), '')
 --- ```
---- `|str2list()|` does the opposite.
+--- [str2list()](help://str2list()) does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
@@ -5367,15 +5370,15 @@ function vim.fn.list2blob(list) end
 function vim.fn.list2str(list, utf8) end
 
 --- Return the current time, measured as seconds since 1st Jan
---- 1970.  See also `|strftime()|`, `|strptime()|` and `|getftime()|`.
+--- 1970.  See also [strftime()](help://strftime()), [strptime()](help://strptime()) and [getftime()](help://getftime()).
 ---
 --- @return any
 function vim.fn.localtime() end
 
---- Return the natural logarithm (base e) of {expr} as a `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|` in the range
+--- Return the natural logarithm (base e) of {expr} as a [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number) in the range
 --- (0, inf].
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo log(10)
@@ -5391,9 +5394,9 @@ function vim.fn.localtime() end
 --- @return any
 function vim.fn.log(expr) end
 
---- Return the logarithm of Float {expr} to base 10 as a `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Return the logarithm of Float {expr} to base 10 as a [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo log10(1000)
@@ -5409,22 +5412,22 @@ function vim.fn.log(expr) end
 --- @return any
 function vim.fn.log10(expr) end
 
---- {expr1} must be a `|List|`, `|String|`, `|Blob|` or `|Dictionary|`.
---- When {expr1} is a `|List||` or `|Dictionary|`, replace each
+--- {expr1} must be a [List](help://List), [String](help://String), [Blob](help://Blob) or [Dictionary](help://Dictionary).
+--- When {expr1} is a [List|](help://List|) or [Dictionary](help://Dictionary), replace each
 --- item in {expr1} with the result of evaluating {expr2}.
---- For a `|Blob|` each byte is replaced.
---- For a `|String|`, each character, including composing
+--- For a [Blob](help://Blob) each byte is replaced.
+--- For a [String](help://String), each character, including composing
 --- characters, is replaced.
---- If the item type changes you may want to use `|mapnew()|` to
+--- If the item type changes you may want to use [mapnew()](help://mapnew()) to
 --- create a new List or Dictionary.
 ---
---- {expr2} must be a `|String|` or `|Funcref|`.
+--- {expr2} must be a [String](help://String) or [Funcref](help://Funcref).
 ---
---- If {expr2} is a `|String|`, inside {expr2} `|v:val|` has the value
---- of the current item.  For a `|Dictionary|` `|v:key|` has the key
---- of the current item and for a `|List|` `|v:key|` has the index of
---- the current item.  For a `|Blob|` `|v:key|` has the index of the
---- current byte. For a `|String|` `|v:key|` has the index of the
+--- If {expr2} is a [String](help://String), inside {expr2} [v:val](help://v:val) has the value
+--- of the current item.  For a [Dictionary](help://Dictionary) [v:key](help://v:key) has the key
+--- of the current item and for a [List](help://List) [v:key](help://v:key) has the index of
+--- the current item.  For a [Blob](help://Blob) [v:key](help://v:key) has the index of the
+--- current byte. For a [String](help://String) [v:key](help://v:key) has the index of the
 --- current character.
 --- Example:
 --- ```vim
@@ -5434,10 +5437,10 @@ function vim.fn.log10(expr) end
 ---
 --- Note that {expr2} is the result of an expression and is then
 --- used as an expression again.  Often it is good to use a
---- `|literal-string|` to avoid having to double backslashes.  You
+--- [literal-string](help://literal-string) to avoid having to double backslashes.  You
 --- still have to double ' quotes
 ---
---- If {expr2} is a `|Funcref|` it is called with two arguments:
+--- If {expr2} is a [Funcref](help://Funcref) it is called with two arguments:
 ---   1. The key or the index of the current item.
 ---   2. the value of the current item.
 --- The function must return the new value of the item. Example
@@ -5448,7 +5451,7 @@ function vim.fn.log10(expr) end
 ---   endfunc
 ---   call map(myDict, function('KeyValue'))
 --- ```
---- It is shorter when using a `|lambda|`:
+--- It is shorter when using a [lambda](help://lambda):
 --- ```vim
 ---   call map(myDict, {key, val -> key .. '-' .. val})
 --- ```
@@ -5460,13 +5463,13 @@ function vim.fn.log10(expr) end
 --- ```vim
 ---   call map(myDict, {_, val -> 'item: ' .. val})
 --- ```
---- The operation is done in-place for a `|List|` and `|Dictionary|`.
+--- The operation is done in-place for a [List](help://List) and [Dictionary](help://Dictionary).
 --- If you want it to remain unmodified make a copy first:
 --- ```vim
 ---   let tlist = map(copy(mylist), ' v:val .. "\t"')
 --- ```
---- Returns {expr1}, the `|List|` or `|Dictionary|` that was filtered,
---- or a new `|Blob|` or `|String|`.
+--- Returns {expr1}, the [List](help://List) or [Dictionary](help://Dictionary) that was filtered,
+--- or a new [Blob](help://Blob) or [String](help://String).
 --- When an error is encountered while evaluating {expr2} no
 --- further items in {expr1} are processed.
 --- When {expr2} is a Funcref errors inside a function are ignored,
@@ -5499,15 +5502,15 @@ function vim.fn.map(expr1, expr2) end
 ---   "c"  Cmd-line
 ---   "s"  Select
 ---   "x"  Visual
----   "l"  langmap `|language-mapping|`
+---   "l"  langmap [language-mapping](help://language-mapping)
 ---   "t"  Terminal
 ---   ""  Normal, Visual and Operator-pending
 --- When {mode} is omitted, the modes for "" are used.
 ---
---- When {abbr} is there and it is `|TRUE|` use abbreviations
+--- When {abbr} is there and it is [TRUE](help://TRUE) use abbreviations
 --- instead of mappings.
 ---
---- When {dict} is there and it is `|TRUE|` return a dictionary
+--- When {dict} is there and it is [TRUE](help://TRUE) return a dictionary
 --- containing all the information of the mapping with the
 --- following items:
 ---   "lhs"       The {lhs} of the mapping as it would be typed
@@ -5515,25 +5518,25 @@ function vim.fn.map(expr1, expr2) end
 ---   "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
 ---         form, only present when it differs from "lhsraw"
 ---   "rhs"       The {rhs} of the mapping as typed.
----   "silent"   1 for a `|:map-silent|` mapping, else 0.
+---   "silent"   1 for a [:map-silent](help://:map-silent) mapping, else 0.
 ---   "noremap"  1 if the {rhs} of the mapping is not remappable.
 ---   "script"   1 if mapping was defined with <script>.
----   "expr"     1 for an expression mapping (`|:map-<expr>|`).
----   "buffer"   1 for a buffer local mapping (`|:map-local|`).
+---   "expr"     1 for an expression mapping ([:map-<expr>](help://:map-<expr>)).
+---   "buffer"   1 for a buffer local mapping ([:map-local](help://:map-local)).
 ---   "mode"     Modes for which the mapping is defined. In
 ---        addition to the modes mentioned above, these
 ---        characters will be used:
 ---        " "     Normal, Visual and Operator-pending
 ---        "!"     Insert and Commandline mode
----          (`|mapmode-ic|`)
+---          ([mapmode-ic](help://mapmode-ic))
 ---   "sid"       The script local ID, used for <sid> mappings
----        (`|<SID>|`).  Negative for special contexts.
+---        ([<SID>](help://<SID>)).  Negative for special contexts.
 ---   "lnum"     The line number in "sid", zero if unknown.
 ---   "nowait"   Do not wait for other, longer mappings.
----        (`|:map-<nowait>|`).
+---        ([:map-<nowait>](help://:map-<nowait>)).
 ---
 --- The dictionary can be used to restore a mapping with
---- `|mapset()|`.
+--- [mapset()](help://mapset()).
 ---
 --- The mappings local to the current buffer are checked first,
 --- then the global mappings.
@@ -5551,7 +5554,7 @@ function vim.fn.map(expr1, expr2) end
 function vim.fn.maparg(name, mode, abbr, dict) end
 
 --- Check if there is a mapping that matches with {name} in mode
---- {mode}.  See `|maparg()|` for {mode} and special names in
+--- {mode}.  See [maparg()](help://maparg()) for {mode} and special names in
 --- {name}.
 --- When {abbr} is there and it is non-zero use abbreviations
 --- instead of mappings.
@@ -5591,19 +5594,19 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 --- @return any
 function vim.fn.mapcheck(name, mode, abbr) end
 
---- Like `|map()|` but instead of replacing items in {expr1} a new
+--- Like [map()](help://map()) but instead of replacing items in {expr1} a new
 --- List or Dictionary is created and returned.  {expr1} remains
 --- unchanged.  Items can still be changed by {expr2}, if you
---- don't want that use `|deepcopy()|` first.
+--- don't want that use [deepcopy()](help://deepcopy()) first.
 ---
 --- @param expr1 any
 --- @param expr2 any
 --- @return any
 function vim.fn.mapnew(expr1, expr2) end
 
---- Restore a mapping from a dictionary returned by `|maparg()|`.
+--- Restore a mapping from a dictionary returned by [maparg()](help://maparg()).
 --- {mode} and {abbr} should be the same as for the call to
---- `|maparg()|`. *E460*
+--- [maparg()](help://maparg()). *E460*
 --- {mode} is used to define the mode in which the mapping is set,
 --- not the "mode" entry in {dict}.
 --- Example for saving and restoring a mapping:
@@ -5623,24 +5626,24 @@ function vim.fn.mapnew(expr1, expr2) end
 --- @return any
 function vim.fn.mapset(mode, abbr, dict) end
 
---- When {expr} is a `|List|` then this returns the index of the
+--- When {expr} is a [List](help://List) then this returns the index of the
 --- first item where {pat} matches.  Each item is used as a
---- String, `|Lists|` and `|Dictionaries|` are used as echoed.
+--- String, [Lists](help://Lists) and [Dictionaries](help://Dictionaries) are used as echoed.
 ---
 --- Otherwise, {expr} is used as a String.  The result is a
 --- Number, which gives the index (byte offset) in {expr} where
 --- {pat} matches.
 ---
---- A match at the first character or `|List|` item returns zero.
+--- A match at the first character or [List](help://List) item returns zero.
 --- If there is no match -1 is returned.
 ---
---- For getting submatches see `|matchlist()|`.
+--- For getting submatches see [matchlist()](help://matchlist()).
 --- Example:
 --- ```vim
 ---   echo match("testing", "ing")  " results in 4
 ---   echo match([1, 'x'], '\a')  " results in 1
 --- ```
---- See `|string-match|` for how {pat} is used.
+--- See [string-match](help://string-match) for how {pat} is used.
 ---             *strpbrk()*
 --- Vim doesn't have a strpbrk() function.  But you can do:
 --- ```vim
@@ -5653,7 +5656,7 @@ function vim.fn.mapset(mode, abbr, dict) end
 ---   let idx = match(haystack, '\cneedle')
 --- ```
 --- If {start} is given, the search starts from byte index
---- {start} in a String or item {start} in a `|List|`.
+--- {start} in a String or item {start} in a [List](help://List).
 --- The result, however, is still the index counted from the
 --- first character/item.  Example:
 --- ```vim
@@ -5676,7 +5679,7 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- For a String, if {start} < 0, it will be set to 0.  For a list
 --- the index is counted from the end.
 --- If {start} is out of range ({start} > strlen({expr}) for a
---- String or {start} > len({expr}) for a `|List|`) -1 is returned.
+--- String or {start} > len({expr}) for a [List](help://List)) -1 is returned.
 ---
 --- When {count} is given use the {count}th match.  When a match
 --- is found in a String the search for the next one starts one
@@ -5684,11 +5687,11 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- ```vim
 ---   echo match("testing", "..", 0, 2)
 --- ```
---- In a `|List|` the search continues in the next item.
+--- In a [List](help://List) the search continues in the next item.
 --- Note that when {count} is added the way {start} works changes,
 --- see above.
 ---
---- See `|pattern|` for the patterns that are accepted.
+--- See [pattern](help://pattern) for the patterns that are accepted.
 --- The 'ignorecase' option is used to set the ignore-caseness of
 --- the pattern.  'smartcase' is NOT used.  The matching is always
 --- done like 'magic' is set and 'cpoptions' is empty.
@@ -5708,7 +5711,7 @@ function vim.fn.match(expr, pat, start, count) end
 --- Defines a pattern to be highlighted in the current window (a
 --- "match").  It will be highlighted with {group}.  Returns an
 --- identification number (ID), which can be used to delete the
---- match using `|matchdelete()|`.  The ID is bound to the window.
+--- match using [matchdelete()](help://matchdelete()).  The ID is bound to the window.
 --- Matching is case sensitive and magic, unless case sensitivity
 --- or magicness are explicitly overridden in {pattern}.  The
 --- 'magic', 'smartcase' and 'ignorecase' options are not used.
@@ -5730,25 +5733,25 @@ function vim.fn.match(expr, pat, start, count) end
 --- match ID.  If a specified ID is already taken, an error
 --- message will appear and the match will not be added.  An ID
 --- is specified as a positive integer (zero excluded).  IDs 1, 2
---- and 3 are reserved for `|:match|`, `|:2match|` and `|:3match|`,
---- respectively.  3 is reserved for use by the `|matchparen|`
+--- and 3 are reserved for [:match](help://:match), [:2match](help://:2match) and [:3match](help://:3match),
+--- respectively.  3 is reserved for use by the [matchparen](help://matchparen)
 --- plugin.
---- If the {id} argument is not specified or -1, `|matchadd()|`
+--- If the {id} argument is not specified or -1, [matchadd()](help://matchadd())
 --- automatically chooses a free ID, which is at least 1000.
 ---
 --- The optional {dict} argument allows for further custom
 --- values. Currently this is used to specify a match specific
---- conceal character that will be shown for `|hl-Conceal|`
+--- conceal character that will be shown for [hl-Conceal](help://hl-Conceal)
 --- highlighted matches. The dict can have the following members:
 ---
 ---   conceal      Special character to show instead of the
----         match (only for `|hl-Conceal|` highlighted
----         matches, see `|:syn-cchar|`)
+---         match (only for [hl-Conceal](help://hl-Conceal) highlighted
+---         matches, see [:syn-cchar](help://:syn-cchar))
 ---   window      Instead of the current window use the
 ---         window with this number or window ID.
 ---
 --- The number of matches is not limited, as it is the case with
---- the `|:match|` commands.
+--- the [:match](help://:match) commands.
 ---
 --- Returns -1 on error.
 ---
@@ -5761,9 +5764,9 @@ function vim.fn.match(expr, pat, start, count) end
 --- ```vim
 ---   call matchdelete(m)
 --- ```
---- A list of matches defined by `|matchadd()|` and `|:match|` are
---- available from `|getmatches()|`.  All matches can be deleted in
---- one operation by `|clearmatches()|`.
+--- A list of matches defined by [matchadd()](help://matchadd()) and [:match](help://:match) are
+--- available from [getmatches()](help://getmatches()).  All matches can be deleted in
+--- one operation by [clearmatches()](help://clearmatches()).
 ---
 ---
 --- @param group any
@@ -5774,8 +5777,8 @@ function vim.fn.match(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchadd(group, pattern, priority, id, dict) end
 
---- Same as `|matchadd()|`, but requires a list of positions {pos}
---- instead of a pattern. This command is faster than `|matchadd()|`
+--- Same as [matchadd()](help://matchadd()), but requires a list of positions {pos}
+--- instead of a pattern. This command is faster than [matchadd()](help://matchadd())
 --- because it does not require to handle regular expressions and
 --- sets buffer line boundaries to redraw screen. It is supposed
 --- to be used when fast match additions and deletions are
@@ -5790,7 +5793,7 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- - A list with two numbers, e.g., [23, 11]. The first number is
 ---   the line number, the second one is the column number (first
 ---   column is 1, the value must correspond to the byte index as
----   `|col()|` would return).  The character at this position will
+---   [col()](help://col()) would return).  The character at this position will
 ---   be highlighted.
 --- - A list with three numbers, e.g., [23, 11, 3]. As above, but
 ---   the third number gives the length of the highlight in bytes.
@@ -5810,8 +5813,8 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- ```vim
 ---   call matchdelete(m)
 --- ```
---- Matches added by `|matchaddpos()|` are returned by
---- `|getmatches()|`.
+--- Matches added by [matchaddpos()](help://matchaddpos()) are returned by
+--- [getmatches()](help://getmatches()).
 ---
 ---
 --- @param group any
@@ -5822,26 +5825,27 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- @return any
 function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 
---- Selects the {nr} match item, as set with a `|:match|,
---- |:2match|` or `|:3match|` command.
---- Return a `|List|` with two elements:
+--- Selects the {nr} match item, as set with a [:match|,
+--- |:2match](help://:match|,
+--- |:2match) or [:3match](help://:3match) command.
+--- Return a [List](help://List) with two elements:
 ---   The name of the highlight group used
 ---   The pattern used.
---- When {nr} is not 1, 2 or 3 returns an empty `|List|`.
+--- When {nr} is not 1, 2 or 3 returns an empty [List](help://List).
 --- When there is no match item set returns ['', ''].
---- This is useful to save and restore a `|:match|`.
---- Highlighting matches using the `|:match|` commands are limited
---- to three matches. `|matchadd()|` does not have this limitation.
+--- This is useful to save and restore a [:match](help://:match).
+--- Highlighting matches using the [:match](help://:match) commands are limited
+--- to three matches. [matchadd()](help://matchadd()) does not have this limitation.
 ---
 ---
 --- @param nr integer
 --- @return any
 function vim.fn.matcharg(nr) end
 
---- Deletes a match with ID {id} previously defined by `|matchadd()|`
---- or one of the `|:match|` commands.  Returns 0 if successful,
---- otherwise -1.  See example for `|matchadd()|`.  All matches can
---- be deleted in one operation by `|clearmatches()|`.
+--- Deletes a match with ID {id} previously defined by [matchadd()](help://matchadd())
+--- or one of the [:match](help://:match) commands.  Returns 0 if successful,
+--- otherwise -1.  See example for [matchadd()](help://matchadd()).  All matches can
+--- be deleted in one operation by [clearmatches()](help://clearmatches()).
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
 ---
@@ -5851,7 +5855,7 @@ function vim.fn.matcharg(nr) end
 --- @return any
 function vim.fn.matchdelete(id, win) end
 
---- Same as `|match()|`, but return the index of first character
+--- Same as [match()](help://match()), but return the index of first character
 --- after the match.  Example:
 --- ```vim
 ---   echo matchend("testing", "ing")
@@ -5866,7 +5870,7 @@ function vim.fn.matchdelete(id, win) end
 --- ```
 --- Except that -1 is returned when there are no matches.
 ---
---- The {start}, if given, has the same meaning as for `|match()|`.
+--- The {start}, if given, has the same meaning as for [match()](help://match()).
 --- ```vim
 ---   echo matchend("testing", "ing", 2)
 --- ```
@@ -5875,7 +5879,7 @@ function vim.fn.matchdelete(id, win) end
 ---   echo matchend("testing", "ing", 5)
 --- ```
 --- result is "-1".
---- When {expr} is a `|List|` the result is equal to `|match()|`.
+--- When {expr} is a [List](help://List) the result is equal to [match()](help://match()).
 ---
 ---
 --- @param expr any
@@ -5885,7 +5889,7 @@ function vim.fn.matchdelete(id, win) end
 --- @return any
 function vim.fn.matchend(expr, pat, start, count) end
 
---- If {list} is a list of strings, then returns a `|List|` with all
+--- If {list} is a list of strings, then returns a [List](help://List) with all
 --- the strings in {list} that fuzzy match {str}. The strings in
 --- the returned list are sorted based on the matching score.
 ---
@@ -5902,7 +5906,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 ---     key    Key of the item which is fuzzy matched against
 ---     {str}. The value of this item should be a
 ---     string.
----     text_cb  `|Funcref|` that will be called for every item
+---     text_cb  [Funcref](help://Funcref) that will be called for every item
 ---     in {list} to get the text for fuzzy matching.
 ---     This should accept a dictionary item as the
 ---     argument and return the text for that item to
@@ -5922,7 +5926,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- When {limit} is given, matchfuzzy() will find up to this
 --- number of matches in {list} and return them in sorted order.
 ---
---- Refer to `|fuzzy-matching|` for more information about fuzzy
+--- Refer to [fuzzy-matching](help://fuzzy-matching) for more information about fuzzy
 --- matching strings.
 ---
 --- Example:
@@ -5969,10 +5973,10 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchfuzzy(list, str, dict) end
 
---- Same as `|matchfuzzy()|`, but returns the list of matched
+--- Same as [matchfuzzy()](help://matchfuzzy()), but returns the list of matched
 --- strings, the list of character positions where characters
 --- in {str} matches and a list of matching scores.  You can
---- use `|byteidx()|` to convert a character position to a byte
+--- use [byteidx()](help://byteidx()) to convert a character position to a byte
 --- position.
 ---
 --- If {str} matches multiple times in a string, then only the
@@ -6002,10 +6006,10 @@ function vim.fn.matchfuzzy(list, str, dict) end
 --- @return any
 function vim.fn.matchfuzzypos(list, str, dict) end
 
---- Same as `|match()|`, but return a `|List|`.  The first item in the
+--- Same as [match()](help://match()), but return a [List](help://List).  The first item in the
 --- list is the matched string, same as what matchstr() would
 --- return.  Following items are submatches, like "\1", "\2", etc.
---- in `|:substitute|`.  When an optional submatch didn't match an
+--- in [:substitute](help://:substitute).  When an optional submatch didn't match an
 --- empty string is used.  Example:
 --- ```vim
 ---   echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
@@ -6023,13 +6027,13 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 --- @return any
 function vim.fn.matchlist(expr, pat, start, count) end
 
---- Same as `|match()|`, but return the matched string.  Example:
+--- Same as [match()](help://match()), but return the matched string.  Example:
 --- ```vim
 ---   echo matchstr("testing", "ing")
 --- ```
 --- results in "ing".
 --- When there is no match "" is returned.
---- The {start}, if given, has the same meaning as for `|match()|`.
+--- The {start}, if given, has the same meaning as for [match()](help://match()).
 --- ```vim
 ---   echo matchstr("testing", "ing", 2)
 --- ```
@@ -6038,7 +6042,7 @@ function vim.fn.matchlist(expr, pat, start, count) end
 ---   echo matchstr("testing", "ing", 5)
 --- ```
 --- result is "".
---- When {expr} is a `|List|` then the matching item is returned.
+--- When {expr} is a [List](help://List) then the matching item is returned.
 --- The type isn't changed, it's not necessarily a String.
 ---
 ---
@@ -6049,14 +6053,14 @@ function vim.fn.matchlist(expr, pat, start, count) end
 --- @return any
 function vim.fn.matchstr(expr, pat, start, count) end
 
---- Same as `|matchstr()|`, but return the matched string, the start
+--- Same as [matchstr()](help://matchstr()), but return the matched string, the start
 --- position and the end position of the match.  Example:
 --- ```vim
 ---   echo matchstrpos("testing", "ing")
 --- ```
 --- results in ["ing", 4, 7].
 --- When there is no match ["", -1, -1] is returned.
---- The {start}, if given, has the same meaning as for `|match()|`.
+--- The {start}, if given, has the same meaning as for [match()](help://match()).
 --- ```vim
 ---   echo matchstrpos("testing", "ing", 2)
 --- ```
@@ -6065,7 +6069,7 @@ function vim.fn.matchstr(expr, pat, start, count) end
 ---   echo matchstrpos("testing", "ing", 5)
 --- ```
 --- result is ["", -1, -1].
---- When {expr} is a `|List|` then the matching item, the index
+--- When {expr} is a [List](help://List) then the matching item, the index
 --- of first item where {pat} matches, the start position and the
 --- end position of the match are returned.
 --- ```vim
@@ -6086,19 +6090,19 @@ function vim.fn.matchstrpos(expr, pat, start, count) end
 --- ```vim
 ---   echo max([apples, pears, oranges])
 --- ```
---- {expr} can be a `|List|` or a `|Dictionary|`.  For a Dictionary,
+--- {expr} can be a [List](help://List) or a [Dictionary](help://Dictionary).  For a Dictionary,
 --- it returns the maximum of all values in the Dictionary.
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
----                 an error.  An empty `|List|` or `|Dictionary|` results in zero.
+---                 an error.  An empty [List](help://List) or [Dictionary](help://Dictionary) results in zero.
 ---
 ---
 --- @param expr any
 --- @return any
 function vim.fn.max(expr) end
 
---- Returns a `|List|` of `|Dictionaries|` describing `|menus|` (defined
---- by `|:menu|`, `|:amenu|`, …), including `|hidden-menus|`.
+--- Returns a [List](help://List) of [Dictionaries](help://Dictionaries) describing [menus](help://menus) (defined
+--- by [:menu](help://:menu), [:amenu](help://:amenu), …), including [hidden-menus](help://hidden-menus).
 ---
 --- {path} matches a menu by name, or all menus if {path} is an
 --- empty string.  Example:
@@ -6106,8 +6110,8 @@ function vim.fn.max(expr) end
 ---   echo menu_get('File','')
 ---   echo menu_get('')
 --- ```
---- {modes} is a string of zero or more modes (see `|maparg()|` or
---- `|creating-menus|` for the list of modes). "a" means "all".
+--- {modes} is a string of zero or more modes (see [maparg()](help://maparg()) or
+--- [creating-menus](help://creating-menus) for the list of modes). "a" means "all".
 ---
 --- Example:
 --- ```vim
@@ -6167,13 +6171,13 @@ function vim.fn.menu_get(path, modes) end
 ---   "!"  Insert and Cmd-line
 --- When {mode} is omitted, the modes for "" are used.
 ---
---- Returns a `|Dictionary|` containing the following items:
----   accel    menu item accelerator text `|menu-text|`
+--- Returns a [Dictionary](help://Dictionary) containing the following items:
+---   accel    menu item accelerator text [menu-text](help://menu-text)
 ---   display  display name (name without '&')
 ---   enabled  v:true if this menu item is enabled
----     Refer to `|:menu-enable|`
+---     Refer to [:menu-enable](help://:menu-enable)
 ---   icon    name of the icon file (for toolbar)
----     `|toolbar-icon|`
+---     [toolbar-icon](help://toolbar-icon)
 ---   iconidx  index of a built-in icon
 ---   modes    modes for which the menu is defined. In
 ---     addition to the modes mentioned above, these
@@ -6182,19 +6186,19 @@ function vim.fn.menu_get(path, modes) end
 ---   name    menu item name.
 ---   noremenu  v:true if the {rhs} of the menu item is not
 ---     remappable else v:false.
----   priority  menu order priority `|menu-priority|`
+---   priority  menu order priority [menu-priority](help://menu-priority)
 ---   rhs    right-hand-side of the menu item. The returned
 ---     string has special characters translated like
 ---     in the output of the ":menu" command listing.
 ---     When the {rhs} of a menu item is empty, then
 ---     "<Nop>" is returned.
 ---   script  v:true if script-local remapping of {rhs} is
----     allowed else v:false.  See `|:menu-script|`.
+---     allowed else v:false.  See [:menu-script](help://:menu-script).
 ---   shortcut  shortcut key (character after '&' in
----     the menu name) `|menu-shortcut|`
+---     the menu name) [menu-shortcut](help://menu-shortcut)
 ---   silent  v:true if the menu item is created
----     with <silent> argument `|:menu-silent|`
----   submenus  `|List|` containing the names of
+---     with <silent> argument [:menu-silent](help://:menu-silent)
+---   submenus  [List](help://List) containing the names of
 ---     all the submenus.  Present only if the menu
 ---     item has submenus.
 ---
@@ -6229,11 +6233,11 @@ function vim.fn.menu_info(name, mode) end
 --- ```vim
 ---   echo min([apples, pears, oranges])
 --- ```
---- {expr} can be a `|List|` or a `|Dictionary|`.  For a Dictionary,
+--- {expr} can be a [List](help://List) or a [Dictionary](help://Dictionary).  For a Dictionary,
 --- it returns the minimum of all values in the Dictionary.
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
---- an error.  An empty `|List|` or `|Dictionary|` results in zero.
+--- an error.  An empty [List](help://List) or [Dictionary](help://Dictionary) results in zero.
 ---
 ---
 --- @param expr any
@@ -6280,7 +6284,7 @@ function vim.fn.min(expr) end
 --- ```vim
 ---   call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 --- ```
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 --- If you try to create an existing directory with {flags} set to
 --- "p" mkdir() will silently exit.
@@ -6298,45 +6302,45 @@ function vim.fn.mkdir(name, flags, prot) end
 
 --- Return a string that indicates the current mode.
 --- If [expr] is supplied and it evaluates to a non-zero Number or
---- a non-empty String (`|non-zero-arg|`), then the full mode is
+--- a non-empty String ([non-zero-arg](help://non-zero-arg)), then the full mode is
 --- returned, otherwise only the first letter is returned.
---- Also see `|state()|`.
+--- Also see [state()](help://state()).
 ---
 ---    n      Normal
 ---    no      Operator-pending
----    nov      Operator-pending (forced charwise `|o_v|`)
----    noV      Operator-pending (forced linewise `|o_V|`)
----    noCTRL-V Operator-pending (forced blockwise `|o_CTRL-V|`)
+---    nov      Operator-pending (forced charwise [o_v](help://o_v))
+---    noV      Operator-pending (forced linewise [o_V](help://o_V))
+---    noCTRL-V Operator-pending (forced blockwise [o_CTRL-V](help://o_CTRL-V))
 ---     CTRL-V is one character
----    niI      Normal using `|i_CTRL-O|` in `|Insert-mode|`
----    niR      Normal using `|i_CTRL-O|` in `|Replace-mode|`
----    niV      Normal using `|i_CTRL-O|` in `|Virtual-Replace-mode|`
----    nt      Normal in `|terminal-emulator|` (insert goes to
+---    niI      Normal using [i_CTRL-O](help://i_CTRL-O) in [Insert-mode](help://Insert-mode)
+---    niR      Normal using [i_CTRL-O](help://i_CTRL-O) in [Replace-mode](help://Replace-mode)
+---    niV      Normal using [i_CTRL-O](help://i_CTRL-O) in [Virtual-Replace-mode](help://Virtual-Replace-mode)
+---    nt      Normal in [terminal-emulator](help://terminal-emulator) (insert goes to
 ---     Terminal mode)
----    ntT      Normal using `|t_CTRL-\_CTRL-O|` in `|Terminal-mode|`
+---    ntT      Normal using [t_CTRL-\_CTRL-O](help://t_CTRL-\_CTRL-O) in [Terminal-mode](help://Terminal-mode)
 ---    v      Visual by character
----    vs      Visual by character using `|v_CTRL-O|` in Select mode
+---    vs      Visual by character using [v_CTRL-O](help://v_CTRL-O) in Select mode
 ---    V      Visual by line
----    Vs      Visual by line using `|v_CTRL-O|` in Select mode
+---    Vs      Visual by line using [v_CTRL-O](help://v_CTRL-O) in Select mode
 ---    CTRL-V   Visual blockwise
----    CTRL-Vs  Visual blockwise using `|v_CTRL-O|` in Select mode
+---    CTRL-Vs  Visual blockwise using [v_CTRL-O](help://v_CTRL-O) in Select mode
 ---    s      Select by character
 ---    S      Select by line
 ---    CTRL-S   Select blockwise
 ---    i      Insert
----    ic      Insert mode completion `|compl-generic|`
----    ix      Insert mode `|i_CTRL-X|` completion
----    R      Replace `|R|`
----    Rc      Replace mode completion `|compl-generic|`
----    Rx      Replace mode `|i_CTRL-X|` completion
----    Rv      Virtual Replace `|gR|`
----    Rvc      Virtual Replace mode completion `|compl-generic|`
----    Rvx      Virtual Replace mode `|i_CTRL-X|` completion
+---    ic      Insert mode completion [compl-generic](help://compl-generic)
+---    ix      Insert mode [i_CTRL-X](help://i_CTRL-X) completion
+---    R      Replace [R](help://R)
+---    Rc      Replace mode completion [compl-generic](help://compl-generic)
+---    Rx      Replace mode [i_CTRL-X](help://i_CTRL-X) completion
+---    Rv      Virtual Replace [gR](help://gR)
+---    Rvc      Virtual Replace mode completion [compl-generic](help://compl-generic)
+---    Rvx      Virtual Replace mode [i_CTRL-X](help://i_CTRL-X) completion
 ---    c      Command-line editing
----    cv      Vim Ex mode `|gQ|`
+---    cv      Vim Ex mode [gQ](help://gQ)
 ---    r      Hit-enter prompt
 ---    rm      The -- more -- prompt
----    r?      A `|:confirm|` query of some sort
+---    r?      A [:confirm](help://:confirm) query of some sort
 ---    !      Shell or external command is executing
 ---    t      Terminal mode: keys go to the job
 ---
@@ -6345,19 +6349,19 @@ function vim.fn.mkdir(name, flags, prot) end
 --- Note that in the future more modes and more specific modes may
 --- be added. It's better not to compare the whole string but only
 --- the leading character(s).
---- Also see `|visualmode()|`.
+--- Also see [visualmode()](help://visualmode()).
 ---
 ---
 --- @return any
 function vim.fn.mode() end
 
 --- Convert a list of Vimscript objects to msgpack. Returned value is a
---- `|readfile()|`-style list. When {type} contains "B", a `|Blob|` is
+--- [readfile()](help://readfile())-style list. When {type} contains "B", a [Blob](help://Blob) is
 --- returned instead. Example:
 --- ```vim
 ---   call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
 --- ```
---- or, using a `|Blob|`:
+--- or, using a [Blob](help://Blob):
 --- ```vim
 ---   call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
 --- ```
@@ -6366,18 +6370,18 @@ function vim.fn.mode() end
 --- messagepack).
 ---
 --- Limitations:        *E5004* *E5005*
---- 1. `|Funcref|`s cannot be dumped.
+--- 1. [Funcref](help://Funcref)s cannot be dumped.
 --- 2. Containers that reference themselves cannot be dumped.
 --- 3. Dictionary keys are always dumped as STR strings.
---- 4. Other strings and `|Blob|`s are always dumped as BIN strings.
---- 5. Points 3. and 4. do not apply to `|msgpack-special-dict|`s.
+--- 4. Other strings and [Blob](help://Blob)s are always dumped as BIN strings.
+--- 5. Points 3. and 4. do not apply to [msgpack-special-dict](help://msgpack-special-dict)s.
 ---
 --- @param list any
 --- @param type? any
 --- @return any
 function vim.fn.msgpackdump(list, type) end
 
---- Convert a `|readfile()|`-style list or a `|Blob|` to a list of
+--- Convert a [readfile()](help://readfile())-style list or a [Blob](help://Blob) to a list of
 --- Vimscript objects.
 --- Example:
 --- ```vim
@@ -6391,28 +6395,28 @@ function vim.fn.msgpackdump(list, type) end
 --- Limitations:
 --- 1. Mapping ordering is not preserved unless messagepack
 ---    mapping is dumped using generic mapping
----    (`|msgpack-special-map|`).
+---    ([msgpack-special-map](help://msgpack-special-map)).
 --- 2. Since the parser aims to preserve all data untouched
 ---    (except for 1.) some strings are parsed to
----    `|msgpack-special-dict|` format which is not convenient to
+---    [msgpack-special-dict](help://msgpack-special-dict) format which is not convenient to
 ---    use.
 ---           *msgpack-special-dict*
 --- Some messagepack strings may be parsed to special
 --- dictionaries. Special dictionaries are dictionaries which
 ---
 --- 1. Contain exactly two keys: `_TYPE` and `_VAL`.
---- 2. `_TYPE` key is one of the types found in `|v:msgpack_types|`
+--- 2. `_TYPE` key is one of the types found in [v:msgpack_types](help://v:msgpack_types)
 ---    variable.
 --- 3. Value for `_VAL` has the following format (Key column
----    contains name of the key from `|v:msgpack_types|`):
+---    contains name of the key from [v:msgpack_types](help://v:msgpack_types)):
 ---
 --- Key  Value ~
 --- nil  Zero, ignored when dumping.  Not returned by
----   `|msgpackparse()|` since `|v:null|` was introduced.
+---   [msgpackparse()](help://msgpackparse()) since [v:null](help://v:null) was introduced.
 --- boolean  One or zero.  When dumping it is only checked that
----   value is a `|Number|`.  Not returned by `|msgpackparse()|`
----   since `|v:true|` and `|v:false|` were introduced.
---- integer  `|List|` with four numbers: sign (-1 or 1), highest two
+---   value is a [Number](help://Number).  Not returned by [msgpackparse()](help://msgpackparse())
+---   since [v:true](help://v:true) and [v:false](help://v:false) were introduced.
+--- integer  [List](help://List) with four numbers: sign (-1 or 1), highest two
 ---   bits, number with bits from 62nd to 31st, lowest 31
 ---   bits. I.e. to get actual number one will need to use
 ---   code like
@@ -6422,37 +6426,37 @@ function vim.fn.msgpackdump(list, type) end
 ---                & _VAL[3])
 --- ```
 --- Special dictionary with this type will appear in
----   `|msgpackparse()|` output under one of the following
+---   [msgpackparse()](help://msgpackparse()) output under one of the following
 ---   circumstances:
----   1. `|Number|` is 32-bit and value is either above
+---   1. [Number](help://Number) is 32-bit and value is either above
 ---      INT32_MAX or below INT32_MIN.
----   2. `|Number|` is 64-bit and value is above INT64_MAX. It
+---   2. [Number](help://Number) is 64-bit and value is above INT64_MAX. It
 ---      cannot possibly be below INT64_MIN because msgpack
 ---      C parser does not support such values.
---- float  `|Float|`. This value cannot possibly appear in
----   `|msgpackparse()|` output.
---- string  `|readfile()|`-style list of strings. This value will
----   appear in `|msgpackparse()|` output if string contains
+--- float  [Float](help://Float). This value cannot possibly appear in
+---   [msgpackparse()](help://msgpackparse()) output.
+--- string  [readfile()](help://readfile())-style list of strings. This value will
+---   appear in [msgpackparse()](help://msgpackparse()) output if string contains
 ---   zero byte or if string is a mapping key and mapping is
 ---   being represented as special dictionary for other
 ---   reasons.
---- binary  `|String|`, or `|Blob|` if binary string contains zero
----   byte. This value cannot appear in `|msgpackparse()|`
+--- binary  [String](help://String), or [Blob](help://Blob) if binary string contains zero
+---   byte. This value cannot appear in [msgpackparse()](help://msgpackparse())
 ---   output since blobs were introduced.
---- array  `|List|`. This value cannot appear in `|msgpackparse()|`
+--- array  [List](help://List). This value cannot appear in [msgpackparse()](help://msgpackparse())
 ---   output.
 ---           *msgpack-special-map*
---- map  `|List|` of `|List|`s with two items (key and value) each.
----   This value will appear in `|msgpackparse()|` output if
+--- map  [List](help://List) of [List](help://List)s with two items (key and value) each.
+---   This value will appear in [msgpackparse()](help://msgpackparse()) output if
 ---   parsed mapping contains one of the following keys:
 ---   1. Any key that is not a string (including keys which
 ---      are binary strings).
 ---   2. String with NUL byte inside.
 ---   3. Duplicate key.
 ---   4. Empty key.
---- ext  `|List|` with two values: first is a signed integer
+--- ext  [List](help://List) with two values: first is a signed integer
 ---   representing extension type. Second is
----   `|readfile()|`-style list of strings.
+---   [readfile()](help://readfile())-style list of strings.
 ---
 --- @param data any
 --- @return any
@@ -6465,8 +6469,8 @@ function vim.fn.msgpackparse(data) end
 --- ```
 --- When {lnum} is invalid or there is no non-blank line at or
 --- below it, zero is returned.
---- {lnum} is used like with `|getline()|`.
---- See also `|prevnonblank()|`.
+--- {lnum} is used like with [getline()](help://getline()).
+--- See also [prevnonblank()](help://prevnonblank()).
 ---
 ---
 --- @param lnum integer
@@ -6535,12 +6539,12 @@ vim.fn['or'] = function(expr, expr1) end
 --- @return any
 function vim.fn.pathshorten(path, len) end
 
---- Evaluate `|perl|` expression {expr} and return its result
+--- Evaluate [perl](help://perl) expression {expr} and return its result
 --- converted to Vim data structures.
 --- Numbers and strings are returned as they are (strings are
 --- copied though).
---- Lists are represented as Vim `|List|` type.
---- Dictionaries are represented as Vim `|Dictionary|` type,
+--- Lists are represented as Vim [List](help://List) type.
+--- Dictionaries are represented as Vim [Dictionary](help://Dictionary) type,
 --- non-string keys result in error.
 ---
 --- Note: If you want an array or hash, {expr} must return a
@@ -6556,9 +6560,9 @@ function vim.fn.pathshorten(path, len) end
 --- @return any
 function vim.fn.perleval(expr) end
 
---- Return the power of {x} to the exponent {y} as a `|Float|`.
---- {x} and {y} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {x} or {y} is not a `|Float|` or a `|Number|`.
+--- Return the power of {x} to the exponent {y} as a [Float](help://Float).
+--- {x} and {y} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {x} or {y} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo pow(3, 3)
@@ -6586,8 +6590,8 @@ function vim.fn.pow(x, y) end
 --- ```
 --- When {lnum} is invalid or there is no non-blank line at or
 --- above it, zero is returned.
---- {lnum} is used like with `|getline()|`.
---- Also see `|nextnonblank()|`.
+--- {lnum} is used like with [getline()](help://getline()).
+--- Also see [nextnonblank()](help://nextnonblank()).
 ---
 ---
 --- @param lnum integer
@@ -6602,7 +6606,7 @@ function vim.fn.prevnonblank(lnum) end
 --- May result in:
 ---   "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 ---
---- When used as a `|method|` the base is passed as the second
+--- When used as a [method](help://method) the base is passed as the second
 --- argument:
 --- ```vim
 ---   Compute()->printf("result: %d")
@@ -6719,7 +6723,7 @@ function vim.fn.prevnonblank(lnum) end
 --- argument specifier, and a '*' is used to indicate that a
 --- number argument is to be used to specify the width or
 --- precision, the argument(s) to be used must also be specified
---- using a {n$} positional argument specifier. See `|printf-$|`.
+--- using a {n$} positional argument specifier. See [printf-$](help://printf-$).
 ---
 --- The conversion specifiers and their meanings are:
 ---
@@ -6783,7 +6787,7 @@ function vim.fn.prevnonblank(lnum) end
 --- ```
 --- 12.12
 ---   Note that roundoff depends on the system libraries.
----   Use `|round()|` when in doubt.
+---   Use [round()](help://round()) when in doubt.
 ---
 ---           *printf-e* *printf-E*
 --- e E  The Float argument is converted into a string of the
@@ -6964,7 +6968,7 @@ function vim.fn.prevnonblank(lnum) end
 function vim.fn.printf(fmt, expr1) end
 
 --- Returns the effective prompt text for buffer {buf}.  {buf} can
---- be a buffer name or number.  See `|prompt-buffer|`.
+--- be a buffer name or number.  See [prompt-buffer](help://prompt-buffer).
 ---
 --- If the buffer doesn't exist or isn't a prompt buffer, an empty
 --- string is returned.
@@ -7039,23 +7043,23 @@ function vim.fn.prompt_setinterrupt(buf, expr) end
 --- @return any
 function vim.fn.prompt_setprompt(buf, text) end
 
---- If the popup menu (see `|ins-completion-menu|`) is not visible,
---- returns an empty `|Dictionary|`, otherwise, returns a
---- `|Dictionary|` with the following keys:
+--- If the popup menu (see [ins-completion-menu](help://ins-completion-menu)) is not visible,
+--- returns an empty [Dictionary](help://Dictionary), otherwise, returns a
+--- [Dictionary](help://Dictionary) with the following keys:
 ---   height    nr of items visible
 ---   width    screen cells
 ---   row    top screen row (0 first row)
 ---   col    leftmost screen column (0 first col)
 ---   size    total nr of items
----   scrollbar  `|TRUE|` if scrollbar is visible
+---   scrollbar  [TRUE](help://TRUE) if scrollbar is visible
 ---
---- The values are the same as in `|v:event|` during `|CompleteChanged|`.
+--- The values are the same as in [v:event](help://v:event) during [CompleteChanged](help://CompleteChanged).
 ---
 --- @return any
 function vim.fn.pum_getpos() end
 
 --- Returns non-zero when the popup menu is visible, zero
---- otherwise.  See `|ins-completion-menu|`.
+--- otherwise.  See [ins-completion-menu](help://ins-completion-menu).
 --- This can be used to avoid some things that would remove the
 --- popup menu.
 ---
@@ -7067,8 +7071,8 @@ function vim.fn.pumvisible() end
 --- Numbers and strings are returned as they are (strings are
 --- copied though, Unicode strings are additionally converted to
 --- UTF-8).
---- Lists are represented as Vim `|List|` type.
---- Dictionaries are represented as Vim `|Dictionary|` type with
+--- Lists are represented as Vim [List](help://List) type.
+--- Dictionaries are represented as Vim [Dictionary](help://Dictionary) type with
 --- keys converted to strings.
 ---
 ---
@@ -7080,8 +7084,8 @@ function vim.fn.py3eval(expr) end
 --- converted to Vim data structures.
 --- Numbers and strings are returned as they are (strings are
 --- copied though).
---- Lists are represented as Vim `|List|` type.
---- Dictionaries are represented as Vim `|Dictionary|` type,
+--- Lists are represented as Vim [List](help://List) type.
+--- Dictionaries are represented as Vim [Dictionary](help://Dictionary) type,
 --- non-string keys result in error.
 ---
 ---
@@ -7091,8 +7095,8 @@ function vim.fn.pyeval(expr) end
 
 --- Evaluate Python expression {expr} and return its result
 --- converted to Vim data structures.
---- Uses Python 2 or 3, see `|python_x|` and 'pyxversion'.
---- See also: `|pyeval()|`, `|py3eval()|`
+--- Uses Python 2 or 3, see [python_x](help://python_x) and 'pyxversion'.
+--- See also: [pyeval()](help://pyeval()), [py3eval()](help://py3eval())
 ---
 ---
 --- @param expr any
@@ -7102,7 +7106,7 @@ function vim.fn.pyxeval(expr) end
 --- Return a pseudo-random Number generated with an xoshiro128**
 --- algorithm using seed {expr}.  The returned number is 32 bits,
 --- also on 64 bits systems, for consistency.
---- {expr} can be initialized by `|srand()|` and will be updated by
+--- {expr} can be initialized by [srand()](help://srand()) and will be updated by
 --- rand().  If {expr} is omitted, an internal seed value is used
 --- and updated.
 --- Returns -1 if {expr} is invalid.
@@ -7119,7 +7123,7 @@ function vim.fn.pyxeval(expr) end
 --- @return any
 function vim.fn.rand(expr) end
 
---- Returns a `|List|` with Numbers:
+--- Returns a [List](help://List) with Numbers:
 --- - If only {expr} is specified: [0, 1, ..., {expr} - 1]
 --- - If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
 --- - If {stride} is specified: [{expr}, {expr} + {stride}, ...,
@@ -7144,7 +7148,7 @@ function vim.fn.rand(expr) end
 --- @return any
 function vim.fn.range(expr, max, stride) end
 
---- Read file {fname} in binary mode and return a `|Blob|`.
+--- Read file {fname} in binary mode and return a [Blob](help://Blob).
 --- If {offset} is specified, read the file from the specified
 --- offset.  If it is a negative value, it is used as an offset
 --- from the end of the file.  E.g., to read the last 12 bytes:
@@ -7166,12 +7170,12 @@ function vim.fn.range(expr, max, stride) end
 ---   echo readblob('/dev/ttyS0', 0, 10)
 --- ```
 --- When the file can't be opened an error message is given and
---- the result is an empty `|Blob|`.
+--- the result is an empty [Blob](help://Blob).
 --- When the offset is beyond the end of the file the result is an
 --- empty blob.
 --- When trying to read more bytes than are available the result
 --- is truncated.
---- Also see `|readfile()|` and `|writefile()|`.
+--- Also see [readfile()](help://readfile()) and [writefile()](help://writefile()).
 ---
 --- @param fname string
 --- @param offset? any
@@ -7180,7 +7184,7 @@ function vim.fn.range(expr, max, stride) end
 function vim.fn.readblob(fname, offset, size) end
 
 --- Return a list with file and directory names in {directory}.
---- You can also use `|glob()|` if you don't need to do complicated
+--- You can also use [glob()](help://glob()) if you don't need to do complicated
 --- things, such as limiting the number of matches.
 ---
 --- When {expr} is omitted all entries are included.
@@ -7191,7 +7195,7 @@ function vim.fn.readblob(fname, offset, size) end
 ---   added to the list.
 ---   If {expr} results in 1 then this entry will be added
 ---   to the list.
---- Each time {expr} is evaluated `|v:val|` is set to the entry name.
+--- Each time {expr} is evaluated [v:val](help://v:val) is set to the entry name.
 --- When {expr} is a function the name is passed as the argument.
 --- For example, to get a list of files ending in ".txt":
 --- ```vim
@@ -7218,7 +7222,7 @@ function vim.fn.readblob(fname, offset, size) end
 --- @return any
 function vim.fn.readdir(directory, expr) end
 
---- Read file {fname} and return a `|List|`, each line of the file
+--- Read file {fname} and return a [List](help://List), each line of the file
 --- as an item.  Lines are broken at NL characters.  Macintosh
 --- files separated with CR will result in a single long line
 --- (unless a NL appears somewhere).
@@ -7245,12 +7249,12 @@ function vim.fn.readdir(directory, expr) end
 --- Note that without {max} the whole file is read into memory.
 --- Also note that there is no recognition of encoding.  Read a
 --- file into a buffer if you need to.
---- Deprecated (use `|readblob()|` instead): When {type} contains
---- "B" a `|Blob|` is returned with the binary data of the file
+--- Deprecated (use [readblob()](help://readblob()) instead): When {type} contains
+--- "B" a [Blob](help://Blob) is returned with the binary data of the file
 --- unmodified.
 --- When the file can't be opened an error message is given and
 --- the result is an empty list.
---- Also see `|writefile()|`.
+--- Also see [writefile()](help://writefile()).
 ---
 ---
 --- @param fname string
@@ -7260,7 +7264,7 @@ function vim.fn.readdir(directory, expr) end
 function vim.fn.readfile(fname, type, max) end
 
 --- {func} is called for every item in {object}, which can be a
---- `|String|`, `|List|` or a `|Blob|`.  {func} is called with two
+--- [String](help://String), [List](help://List) or a [Blob](help://Blob).  {func} is called with two
 --- arguments: the result so far and current item.  After
 --- processing all items the result is returned.
 ---
@@ -7285,20 +7289,20 @@ function vim.fn.reduce(object, func, initial) end
 
 --- Returns the single letter name of the register being executed.
 --- Returns an empty string when no register is being executed.
---- See `|@|`.
+--- See [@](help://@).
 ---
 --- @return any
 function vim.fn.reg_executing() end
 
 --- Returns the single letter name of the last recorded register.
 --- Returns an empty string when nothing was recorded yet.
---- See `|q|` and `|Q|`.
+--- See [q](help://q) and [Q](help://Q).
 ---
 --- @return any
 function vim.fn.reg_recorded() end
 
 --- Returns the single letter name of the register being recorded.
---- Returns an empty string when not recording.  See `|q|`.
+--- Returns an empty string when not recording.  See [q](help://q).
 ---
 --- @return any
 function vim.fn.reg_recording() end
@@ -7312,12 +7316,12 @@ function vim.fn.reltime(start) end
 
 --- Return an item that represents a time value.  The item is a
 --- list with items that depend on the system.
---- The item can be passed to `|reltimestr()|` to convert it to a
---- string or `|reltimefloat()|` to convert to a Float.
+--- The item can be passed to [reltimestr()](help://reltimestr()) to convert it to a
+--- string or [reltimefloat()](help://reltimefloat()) to convert to a Float.
 ---
 --- Without an argument it returns the current "relative time", an
 --- implementation-defined value meaningful only when used as an
---- argument to `|reltime()|`, `|reltimestr()|` and `|reltimefloat()|`.
+--- argument to [reltime()](help://reltime()), [reltimestr()](help://reltimestr()) and [reltimefloat()](help://reltimefloat()).
 ---
 --- With one argument it returns the time passed since the time
 --- specified in the argument.
@@ -7327,7 +7331,7 @@ function vim.fn.reltime(start) end
 --- The {start} and {end} arguments must be values returned by
 --- reltime().  Returns zero on error.
 ---
---- Note: `|localtime()|` returns the current (non-relative) time.
+--- Note: [localtime()](help://localtime()) returns the current (non-relative) time.
 ---
 --- @param start? any
 --- @param end_? any
@@ -7341,7 +7345,7 @@ function vim.fn.reltime(start, end_) end
 ---   call MyFunction()
 ---   let seconds = reltimefloat(reltime(start))
 --- See the note of reltimestr() about overhead.
---- Also see `|profiling|`.
+--- Also see [profiling](help://profiling).
 --- If there is an error an empty string is returned
 ---
 ---
@@ -7363,7 +7367,7 @@ function vim.fn.reltimefloat(time) end
 --- ```vim
 ---   echo split(reltimestr(reltime(start)))[0]
 --- ```
---- Also see `|profiling|`.
+--- Also see [profiling](help://profiling).
 --- If there is an error an empty string is returned
 ---
 ---
@@ -7376,20 +7380,20 @@ function vim.fn.reltimestr(time) end
 --- @return any
 function vim.fn.remove(list, idx) end
 
---- Without {end}: Remove the item at {idx} from `|List|` {list} and
+--- Without {end}: Remove the item at {idx} from [List](help://List) {list} and
 --- return the item.
 --- With {end}: Remove items from {idx} to {end} (inclusive) and
---- return a `|List|` with these items.  When {idx} points to the same
+--- return a [List](help://List) with these items.  When {idx} points to the same
 --- item as {end} a list with one item is returned.  When {end}
 --- points to an item before {idx} this is an error.
---- See `|list-index|` for possible values of {idx} and {end}.
+--- See [list-index](help://list-index) for possible values of {idx} and {end}.
 --- Returns zero on error.
 --- Example:
 --- ```vim
 ---   echo "last item: " .. remove(mylist, -1)
 ---   call remove(mylist, 0, 9)
 --- ```
---- Use `|delete()|` to remove a file.
+--- Use [delete()](help://delete()) to remove a file.
 ---
 ---
 --- @param list any
@@ -7403,11 +7407,11 @@ function vim.fn.remove(list, idx, end_) end
 --- @return any
 function vim.fn.remove(blob, idx) end
 
---- Without {end}: Remove the byte at {idx} from `|Blob|` {blob} and
+--- Without {end}: Remove the byte at {idx} from [Blob](help://Blob) {blob} and
 --- return the byte.
 --- With {end}: Remove bytes from {idx} to {end} (inclusive) and
---- return a `|Blob|` with these bytes.  When {idx} points to the same
---- byte as {end} a `|Blob|` with one byte is returned.  When {end}
+--- return a [Blob](help://Blob) with these bytes.  When {idx} points to the same
+--- byte as {end} a [Blob](help://Blob) with one byte is returned.  When {end}
 --- points to a byte before {idx} this is an error.
 --- Returns zero on error.
 --- Example:
@@ -7440,7 +7444,7 @@ function vim.fn.remove(dict, key) end
 --- result is a Number, which is 0 if the file was renamed
 --- successfully, and non-zero when the renaming failed.
 --- NOTE: If {to} exists it is overwritten without warning.
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 ---
 --- @param from any
@@ -7454,7 +7458,7 @@ function vim.fn.rename(from, to) end
 ---   let separator = repeat('-', 80)
 --- ```
 --- When {count} is zero or negative the result is empty.
---- When {expr} is a `|List|` or a `|Blob|` the result is {expr}
+--- When {expr} is a [List](help://List) or a [Blob](help://Blob) the result is {expr}
 --- concatenated {count} times.  Example:
 --- ```vim
 ---   let longlist = repeat(['a', 'b'], 3)
@@ -7474,7 +7478,7 @@ vim.fn['repeat'] = function(expr, count) end
 --- To cope with link cycles, resolving of symbolic links is
 --- stopped after 100 iterations.
 --- On other systems, return the simplified {filename}.
---- The simplification step is done as by `|simplify()|`.
+--- The simplification step is done as by [simplify()](help://simplify()).
 --- resolve() keeps a leading path component specifying the
 --- current directory (provided the result is still a relative
 --- path name) and also keeps a trailing path separator.
@@ -7485,7 +7489,7 @@ vim.fn['repeat'] = function(expr, count) end
 function vim.fn.resolve(filename) end
 
 --- Reverse the order of items in {object}.  {object} can be a
---- `|List|`, a `|Blob|` or a `|String|`.  For a List and a Blob the
+--- [List](help://List), a [Blob](help://Blob) or a [String](help://String).  For a List and a Blob the
 --- items are reversed in-place and {object} is returned.
 --- For a String a new String is returned.
 --- Returns zero if {object} is not a List, Blob or a String.
@@ -7500,10 +7504,10 @@ function vim.fn.resolve(filename) end
 function vim.fn.reverse(object) end
 
 --- Round off {expr} to the nearest integral value and return it
---- as a `|Float|`.  If {expr} lies halfway between two integral
+--- as a [Float](help://Float).  If {expr} lies halfway between two integral
 --- values, then use the larger one (away from zero).
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo round(0.456)
@@ -7523,7 +7527,7 @@ function vim.fn.reverse(object) end
 --- @return any
 function vim.fn.round(expr) end
 
---- Sends {event} to {channel} via `|RPC|` and returns immediately.
+--- Sends {event} to {channel} via [RPC](help://RPC) and returns immediately.
 --- If {channel} is 0, the event is broadcast to all channels.
 --- Example:
 --- ```vim
@@ -7537,7 +7541,7 @@ function vim.fn.round(expr) end
 function vim.fn.rpcnotify(channel, event, args) end
 
 --- Sends a request to {channel} to invoke {method} via
---- `|RPC|` and blocks until a response is received.
+--- [RPC](help://RPC) and blocks until a response is received.
 --- Example:
 --- ```vim
 ---   let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
@@ -7564,7 +7568,7 @@ function vim.fn.rpcrequest(channel, method, args) end
 function vim.fn.rpcstart(prog, argv) end
 
 --- @deprecated
---- Use `|jobstop()|` instead to stop any job, or
+--- Use [jobstop()](help://jobstop()) instead to stop any job, or
 --- `chanclose(id, "rpc")` to close RPC communication
 --- without stopping the job. Use chanclose(id) to close
 --- any socket.
@@ -7577,8 +7581,8 @@ function vim.fn.rpcstop(...) end
 --- converted to Vim data structures.
 --- Numbers, floats and strings are returned as they are (strings
 --- are copied though).
---- Arrays are represented as Vim `|List|` type.
---- Hashes are represented as Vim `|Dictionary|` type.
+--- Arrays are represented as Vim [List](help://List) type.
+--- Hashes are represented as Vim [Dictionary](help://Dictionary) type.
 --- Other objects are represented as strings resulted from their
 --- "Object#to_s" method.
 ---
@@ -7587,7 +7591,7 @@ function vim.fn.rpcstop(...) end
 --- @return any
 function vim.fn.rubyeval(expr) end
 
---- Like `|screenchar()|`, but return the attribute.  This is a rather
+--- Like [screenchar()](help://screenchar()), but return the attribute.  This is a rather
 --- arbitrary number that can only be used to compare to the
 --- attribute at other positions.
 --- Returns -1 when row or col is out of range.
@@ -7613,8 +7617,8 @@ function vim.fn.screenattr(row, col) end
 --- @return any
 function vim.fn.screenchar(row, col) end
 
---- The result is a `|List|` of Numbers.  The first number is the same
---- as what `|screenchar()|` returns.  Further numbers are
+--- The result is a [List](help://List) of Numbers.  The first number is the same
+--- as what [screenchar()](help://screenchar()) returns.  Further numbers are
 --- composing characters on top of the base character.
 --- This is mainly to be used for testing.
 --- Returns an empty List when row or col is out of range.
@@ -7658,10 +7662,10 @@ function vim.fn.screencol() end
 --- The "curscol" value is where the cursor would be placed.  For
 --- a Tab it would be the same as "endcol", while for a double
 --- width character it would be the same as "col".
---- The `|conceal|` feature is ignored here, the column numbers are
+--- The [conceal](help://conceal) feature is ignored here, the column numbers are
 --- as if 'conceallevel' is zero.  You can set the cursor to the
---- right position and use `|screencol()|` to get the value with
---- `|conceal|` taken into account.
+--- right position and use [screencol()](help://screencol()) to get the value with
+--- [conceal](help://conceal) taken into account.
 --- If the position is in a closed fold the screen position of the
 --- first character is returned, {col} is not used.
 --- Returns an empty Dict if {winid} is invalid.
@@ -7676,16 +7680,16 @@ function vim.fn.screenpos(winid, lnum, col) end
 --- The result is a Number, which is the current screen row of the
 --- cursor.  The top line has number one.
 --- This function is mainly used for testing.
---- Alternatively you can use `|winline()|`.
+--- Alternatively you can use [winline()](help://winline()).
 ---
---- Note: Same restrictions as with `|screencol()|`.
+--- Note: Same restrictions as with [screencol()](help://screencol()).
 ---
 --- @return any
 function vim.fn.screenrow() end
 
 --- The result is a String that contains the base character and
 --- any composing characters at position [row, col] on the screen.
---- This is like `|screenchars()|` but returning a String with the
+--- This is like [screenchars()](help://screenchars()) but returning a String with the
 --- characters.
 --- This is mainly to be used for testing.
 --- Returns an empty String when row or col is out of range.
@@ -7697,7 +7701,7 @@ function vim.fn.screenrow() end
 function vim.fn.screenstring(row, col) end
 
 --- Search for regexp pattern {pattern}.  The search starts at the
---- cursor position (you can use `|cursor()|` to set it).
+--- cursor position (you can use [cursor()](help://cursor()) to set it).
 ---
 --- When a match has been found its line number is returned.
 --- If there is no match a 0 is returned and the cursor doesn't
@@ -7726,8 +7730,8 @@ function vim.fn.screenstring(row, col) end
 --- skipped.  When the 'c' flag is present in 'cpo' the next
 --- search starts after the match.  Without the 'c' flag the next
 --- search starts one column after the start of the match.  This
---- matters for overlapping matches.  See `|cpo-c|`.  You can also
---- insert "\ze" to change where the match ends, see  `|/\ze|`.
+--- matters for overlapping matches.  See [cpo-c](help://cpo-c).  You can also
+--- insert "\ze" to change where the match ends, see  [/\ze](help:///\ze).
 ---
 --- When searching backwards and the 'z' flag is given then the
 --- search starts in column zero, thus no match in the current
@@ -7764,7 +7768,7 @@ function vim.fn.screenstring(row, col) end
 --- With the 'p' flag the returned value is one more than the
 --- first sub-match in \(\).  One if none of them matched but the
 --- whole pattern did match.
---- To get the column number too use `|searchpos()|`.
+--- To get the column number too use [searchpos()](help://searchpos()).
 ---
 --- The cursor will be positioned at the match, unless the 'n'
 --- flag is used.
@@ -7788,7 +7792,7 @@ function vim.fn.screenstring(row, col) end
 --- ```
 --- Example for using some flags:
 --- ```vim
----     echo search('\<if\`|\(else\)\|`\(endif\)', 'ncpe')
+---     echo search('\<if\[\(else\)\](help://\(else\)\)\(endif\)', 'ncpe')
 --- ```
 --- This will search for the keywords "if", "else", and "endif"
 --- under or after the cursor.  Because of the 'p' flag, it
@@ -7814,25 +7818,25 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- without the "S" flag in 'shortmess'.  This works even if
 --- 'shortmess' does contain the "S" flag.
 ---
---- This returns a `|Dictionary|`. The dictionary is empty if the
+--- This returns a [Dictionary](help://Dictionary). The dictionary is empty if the
 --- previous pattern was not set and "pattern" was not specified.
 ---
 ---   key    type    meaning ~
----   current  `|Number|`  current position of match;
+---   current  [Number](help://Number)  current position of match;
 ---         0 if the cursor position is
 ---         before the first match
----   exact_match  `|Boolean|`  1 if "current" is matched on
+---   exact_match  [Boolean](help://Boolean)  1 if "current" is matched on
 ---         "pos", otherwise 0
----   total    `|Number|`  total count of matches found
----   incomplete  `|Number|`  0: search was fully completed
+---   total    [Number](help://Number)  total count of matches found
+---   incomplete  [Number](help://Number)  0: search was fully completed
 ---         1: recomputing was timed out
 ---         2: max count exceeded
 ---
 --- For {options} see further down.
 ---
---- To get the last search count when `|n|` or `|N|` was pressed, call
+--- To get the last search count when [n](help://n) or [N](help://N) was pressed, call
 --- this function with `recompute: 0` . This sometimes returns
---- wrong information because `|n|` and `|N|`'s maximum count is 99.
+--- wrong information because [n](help://n) and [N](help://N)'s maximum count is 99.
 --- If it exceeded 99 the result must be max count + 1 (100). If
 --- you want to get correct information, specify `recompute: 1`:
 --- ```vim
@@ -7874,7 +7878,7 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " \   '%{v:hlsearch ? LastSearchCount() : ""}'
 --- ```
 --- You can also update the search count, which can be useful in a
---- `|CursorMoved|` or `|CursorMovedI|` autocommand:
+--- [CursorMoved](help://CursorMoved) or [CursorMovedI](help://CursorMovedI) autocommand:
 --- ```vim
 ---
 ---   autocmd CursorMoved,CursorMovedI *
@@ -7900,40 +7904,40 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---   " search again
 ---   call searchcount()
 --- ```
---- {options} must be a `|Dictionary|`. It can contain:
+--- {options} must be a [Dictionary](help://Dictionary). It can contain:
 ---   key    type    meaning ~
----   recompute  `|Boolean|`  if `|TRUE|`, recompute the count
----         like `|n|` or `|N|` was executed.
+---   recompute  [Boolean](help://Boolean)  if [TRUE](help://TRUE), recompute the count
+---         like [n](help://n) or [N](help://N) was executed.
 ---         otherwise returns the last
----         computed result (when `|n|` or
----         `|N|` was used when "S" is not
+---         computed result (when [n](help://n) or
+---         [N](help://N) was used when "S" is not
 ---         in 'shortmess', or this
 ---         function was called).
----         (default: `|TRUE|`)
----   pattern  `|String|`  recompute if this was given
----         and different with `|@/|`.
+---         (default: [TRUE](help://TRUE))
+---   pattern  [String](help://String)  recompute if this was given
+---         and different with [@/](help://@/).
 ---         this works as same as the
 ---         below command is executed
 ---         before calling this function
 --- ```vim
 ---           let @/ = pattern
 --- ```
---- (default: `|@/|`)
----   timeout  `|Number|`  0 or negative number is no
+--- (default: [@/](help://@/))
+---   timeout  [Number](help://Number)  0 or negative number is no
 ---         timeout. timeout milliseconds
 ---         for recomputing the result
 ---         (default: 0)
----   maxcount  `|Number|`  0 or negative number is no
+---   maxcount  [Number](help://Number)  0 or negative number is no
 ---         limit. max count of matched
 ---         text while recomputing the
 ---         result.  if search exceeded
 ---         total count, "total" value
 ---         becomes `maxcount + 1`
 ---         (default: 0)
----   pos    `|List|`    `[lnum, col, off]` value
+---   pos    [List](help://List)    `[lnum, col, off]` value
 ---         when recomputing the result.
 ---         this changes "current" result
----         value. see `|cursor()|`, `|getpos()|`
+---         value. see [cursor()](help://cursor()), [getpos()](help://getpos())
 ---         (default: cursor's position)
 ---
 ---
@@ -7943,8 +7947,8 @@ function vim.fn.searchcount(options) end
 
 --- Search for the declaration of {name}.
 ---
---- With a non-zero {global} argument it works like `|gD|`, find
---- first match in the file.  Otherwise it works like `|gd|`, find
+--- With a non-zero {global} argument it works like [gD](help://gD), find
+--- first match in the file.  Otherwise it works like [gd](help://gd), find
 --- first match in the function.
 ---
 --- With a non-zero {thisblock} argument matches in a {} block
@@ -7976,7 +7980,7 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- returned and the cursor doesn't move.  No error message is
 --- given.
 ---
---- {start}, {middle} and {end} are patterns, see `|pattern|`.  They
+--- {start}, {middle} and {end} are patterns, see [pattern](help://pattern).  They
 --- must not contain \( \) pairs.  Use of \%( \) is allowed.  When
 --- {middle} is not empty, it is found when searching from either
 --- direction, but only when not in a nested start-end pair.  A
@@ -7987,7 +7991,7 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- By leaving {middle} empty the "else" is skipped.
 ---
 --- {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
---- `|search()|`.  Additionally:
+--- [search()](help://search()).  Additionally:
 --- 'r'  Repeat until no more matches found; will find the
 ---   outer pair.  Implies the 'W' flag.
 --- 'm'  Return number of matches instead of line number with
@@ -8006,7 +8010,7 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- {skip} can be a string, a lambda, a funcref or a partial.
 --- Anything else makes the function fail.
 ---
---- For {stopline} and {timeout} see `|search()|`.
+--- For {stopline} and {timeout} see [search()](help://search()).
 ---
 --- The value of 'ignorecase' is used.  'magic' is ignored, the
 --- patterns are used like it's on.
@@ -8060,8 +8064,8 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- @return any
 function vim.fn.searchpair() end
 
---- Same as `|searchpair()|`, but returns a `|List|` with the line and
---- column position of the match. The first element of the `|List|`
+--- Same as [searchpair()](help://searchpair()), but returns a [List](help://List) with the line and
+--- column position of the match. The first element of the [List](help://List)
 --- is the line number and the second element is the byte index of
 --- the column position of the match.  If no match is found,
 --- returns [0, 0].
@@ -8069,13 +8073,13 @@ function vim.fn.searchpair() end
 ---
 ---   let [lnum,col] = searchpairpos('{', '', '}', 'n')
 --- ```
---- See `|match-parens|` for a bigger and more useful example.
+--- See [match-parens](help://match-parens) for a bigger and more useful example.
 ---
 --- @return any
 function vim.fn.searchpairpos() end
 
---- Same as `|search()|`, but returns a `|List|` with the line and
---- column position of the match. The first element of the `|List|`
+--- Same as [search()](help://search()), but returns a [List](help://List) with the line and
+--- column position of the match. The first element of the [List](help://List)
 --- is the line number and the second element is the byte index of
 --- the column position of the match. If no match is found,
 --- returns [0, 0].
@@ -8084,12 +8088,12 @@ function vim.fn.searchpairpos() end
 ---   let [lnum, col] = searchpos('mypattern', 'n')
 --- ```
 --- When the 'p' flag is given then there is an extra item with
---- the sub-pattern match number `|search()-sub-match|`.  Example:
+--- the sub-pattern match number [search()-sub-match](help://search()-sub-match).  Example:
 --- ```vim
 ---   let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
 --- ```
 --- In this example "submatch" is 2 when a lowercase letter is
---- found `|/\l|`, 3 when an uppercase letter is found `|/\u|`.
+--- found [/\l](help:///\l), 3 when an uppercase letter is found [/\u](help:///\u).
 ---
 ---
 --- @param pattern any
@@ -8101,7 +8105,7 @@ function vim.fn.searchpairpos() end
 function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 
 --- Returns a list of server addresses, or empty if all servers
---- were stopped. `|serverstart()|` `|serverstop()|`
+--- were stopped. [serverstart()](help://serverstart()) [serverstop()](help://serverstop())
 --- Example:
 --- ```vim
 ---   echo serverlist()
@@ -8111,7 +8115,7 @@ function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 function vim.fn.serverlist() end
 
 --- Opens a socket or named pipe at {address} and listens for
---- `|RPC|` messages. Clients can send `|API|` commands to the
+--- [RPC](help://RPC) messages. Clients can send [API](help://API) commands to the
 --- returned address to control Nvim.
 ---
 --- Returns the address string (which may differ from the
@@ -8156,29 +8160,29 @@ function vim.fn.serverstart(address) end
 
 --- Closes the pipe or socket at {address}.
 --- Returns TRUE if {address} is valid, else FALSE.
---- If `|v:servername|` is stopped it is set to the next available
---- address in `|serverlist()|`.
+--- If [v:servername](help://v:servername) is stopped it is set to the next available
+--- address in [serverlist()](help://serverlist()).
 ---
 --- @param address any
 --- @return any
 function vim.fn.serverstop(address) end
 
 --- Set line {lnum} to {text} in buffer {buf}.  This works like
---- `|setline()|` for the specified buffer.
+--- [setline()](help://setline()) for the specified buffer.
 ---
 --- This function works only for loaded buffers. First call
---- `|bufload()|` if needed.
+--- [bufload()](help://bufload()) if needed.
 ---
---- To insert lines use `|appendbufline()|`.
+--- To insert lines use [appendbufline()](help://appendbufline()).
 ---
 --- {text} can be a string to set one line, or a List of strings
 --- to set multiple lines.  If the List extends below the last
 --- line then those lines are added.  If the List is empty then
 --- nothing is changed and zero is returned.
 ---
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 ---
---- {lnum} is used like with `|setline()|`.
+--- {lnum} is used like with [setline()](help://setline()).
 --- Use "$" to refer to the last line in buffer {buf}.
 --- When {lnum} is just below the last line the {text} will be
 --- added below the last line.
@@ -8199,7 +8203,7 @@ function vim.fn.setbufline(buf, lnum, text) end
 --- This also works for a global or local window option, but it
 --- doesn't work for a global or local window variable.
 --- For a local window option the global value is unchanged.
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 --- The {varname} argument is a string.
 --- Note that the variable name without "b:" must be used.
 --- Examples:
@@ -8207,7 +8211,7 @@ function vim.fn.setbufline(buf, lnum, text) end
 ---   call setbufvar(1, "&mod", 1)
 ---   call setbufvar("todo", "myvar", "foobar")
 --- ```
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 ---
 --- @param buf any
@@ -8255,7 +8259,7 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- @return any
 function vim.fn.setcellwidths(list) end
 
---- Same as `|setpos()|` but uses the specified column number as the
+--- Same as [setpos()](help://setpos()) but uses the specified column number as the
 --- character index instead of the byte index in the line.
 ---
 --- Example:
@@ -8279,12 +8283,12 @@ function vim.fn.setcharpos(expr, list) end
 --- which contains one or more of the following entries:
 ---
 ---     char  character which will be used for a subsequent
----     `|,|` or `|;|` command; an empty string clears the
+---     [,](help://,) or [;](help://;) command; an empty string clears the
 ---     character search
 ---     forward  direction of character search; 1 for forward,
 ---     0 for backward
----     until  type of character search; 1 for a `|t|` or `|T|`
----     character search, 0 for an `|f|` or `|F|`
+---     until  type of character search; 1 for a [t](help://t) or [T](help://T)
+---     character search, 0 for an [f](help://f) or [F](help://F)
 ---     character search
 ---
 --- This can be useful to save/restore a user's character search
@@ -8294,7 +8298,7 @@ function vim.fn.setcharpos(expr, list) end
 ---   " Perform a command which clobbers user's search
 ---   call setcharsearch(prevsearch)
 --- ```
---- Also see `|getcharsearch()|`.
+--- Also see [getcharsearch()](help://getcharsearch()).
 ---
 ---
 --- @param dict any
@@ -8315,12 +8319,12 @@ function vim.fn.setcmdline(str, pos) end
 
 --- Set the cursor position in the command line to byte position
 --- {pos}.  The first position is 1.
---- Use `|getcmdpos()|` to obtain the current position.
+--- Use [getcmdpos()](help://getcmdpos()) to obtain the current position.
 --- Only works while editing the command line, thus you must use
---- `|c_CTRL-\_e|`, `|c_CTRL-R_=|` or `|c_CTRL-R_CTRL-R|` with '='.  For
---- `|c_CTRL-\_e|` and `|c_CTRL-R_CTRL-R|` with '=' the position is
+--- [c_CTRL-\_e](help://c_CTRL-\_e), [c_CTRL-R_=](help://c_CTRL-R_=) or [c_CTRL-R_CTRL-R](help://c_CTRL-R_CTRL-R) with '='.  For
+--- [c_CTRL-\_e](help://c_CTRL-\_e) and [c_CTRL-R_CTRL-R](help://c_CTRL-R_CTRL-R) with '=' the position is
 --- set after the command line is set to the expression.  For
---- `|c_CTRL-R_=|` it is set after evaluating the expression but
+--- [c_CTRL-R_=](help://c_CTRL-R_=) it is set after evaluating the expression but
 --- before inserting the resulting text.
 --- When the number is too big the cursor is put at the end of the
 --- line.  A number smaller than one has undefined results.
@@ -8338,7 +8342,7 @@ function vim.fn.setcmdpos(pos) end
 --- @return any
 function vim.fn.setcursorcharpos(lnum, col, off) end
 
---- Same as `|cursor()|` but uses the specified column number as the
+--- Same as [cursor()](help://cursor()) but uses the specified column number as the
 --- character index instead of the byte index in the line.
 ---
 --- Example:
@@ -8361,8 +8365,8 @@ function vim.fn.setcursorcharpos(list) end
 --- ```vim
 ---   call setenv('HOME', '/home/myhome')
 --- ```
---- When {val} is `|v:null|` the environment variable is deleted.
---- See also `|expr-env|`.
+--- When {val} is [v:null](help://v:null) the environment variable is deleted.
+--- See also [expr-env](help://expr-env).
 ---
 ---
 --- @param name string
@@ -8384,7 +8388,7 @@ function vim.fn.setenv(name, val) end
 ---
 --- Returns non-zero for success, zero for failure.
 ---
---- To read permissions see `|getfperm()|`.
+--- To read permissions see [getfperm()](help://getfperm()).
 ---
 --- @param fname string
 --- @param mode string
@@ -8392,10 +8396,10 @@ function vim.fn.setenv(name, val) end
 function vim.fn.setfperm(fname, mode) end
 
 --- Set line {lnum} of the current buffer to {text}.  To insert
---- lines use `|append()|`. To set lines in another buffer use
---- `|setbufline()|`.
+--- lines use [append()](help://append()). To set lines in another buffer use
+--- [setbufline()](help://setbufline()).
 ---
---- {lnum} is used like with `|getline()|`.
+--- {lnum} is used like with [getline()](help://getline()).
 --- When {lnum} is just below the last line the {text} will be
 --- added below the last line.
 --- {text} can be any type or a List of any type, each item is
@@ -8409,7 +8413,7 @@ function vim.fn.setfperm(fname, mode) end
 --- ```vim
 ---   call setline(5, strftime("%c"))
 --- ```
---- When {text} is a `|List|` then line {lnum} and following lines
+--- When {text} is a [List](help://List) then line {lnum} and following lines
 --- will be set to the items in the list.  Example:
 --- ```vim
 ---   call setline(5, ['aaa', 'bbb', 'ccc'])
@@ -8429,18 +8433,18 @@ function vim.fn.setfperm(fname, mode) end
 function vim.fn.setline(lnum, text) end
 
 --- Create or replace or add to the location list for window {nr}.
---- {nr} can be the window number or the `|window-ID|`.
+--- {nr} can be the window number or the [window-ID](help://window-ID).
 --- When {nr} is zero the current window is used.
 ---
 --- For a location list window, the displayed location list is
 --- modified.  For an invalid window number {nr}, -1 is returned.
---- Otherwise, same as `|setqflist()|`.
---- Also see `|location-list|`.
+--- Otherwise, same as [setqflist()](help://setqflist()).
+--- Also see [location-list](help://location-list).
 ---
---- For {action} see `|setqflist-action|`.
+--- For {action} see [setqflist-action](help://setqflist-action).
 ---
 --- If the optional {what} dictionary argument is supplied, then
---- only the items listed in {what} are set. Refer to `|setqflist()|`
+--- only the items listed in {what} are set. Refer to [setqflist()](help://setqflist())
 --- for the list of supported keys in {what}.
 ---
 ---
@@ -8451,10 +8455,10 @@ function vim.fn.setline(lnum, text) end
 --- @return any
 function vim.fn.setloclist(nr, list, action, what) end
 
---- Restores a list of matches saved by `|getmatches()|` for the
+--- Restores a list of matches saved by [getmatches()](help://getmatches()) for the
 --- current window.  Returns 0 if successful, otherwise -1.  All
 --- current matches are cleared before the list is restored.  See
---- example for `|getmatches()|`.
+--- example for [getmatches()](help://getmatches()).
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
 ---
@@ -8468,14 +8472,14 @@ function vim.fn.setmatches(list, win) end
 ---   .  the cursor
 ---   'x  mark x
 ---
---- {list} must be a `|List|` with four or five numbers:
+--- {list} must be a [List](help://List) with four or five numbers:
 ---     [bufnum, lnum, col, off]
 ---     [bufnum, lnum, col, off, curswant]
 ---
 --- "bufnum" is the buffer number.  Zero can be used for the
 --- current buffer.  When setting an uppercase mark "bufnum" is
 --- used for the mark position.  For other marks it specifies the
---- buffer to set the mark in.  You can use the `|bufnr()|` function
+--- buffer to set the mark in.  You can use the [bufnr()](help://bufnr()) function
 --- to turn a file name into a buffer number.
 --- For setting the cursor and the ' mark "bufnum" is ignored,
 --- since these are associated with a window, not a buffer.
@@ -8484,7 +8488,7 @@ function vim.fn.setmatches(list, win) end
 --- "lnum" and "col" are the position in the buffer.  The first
 --- column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
 --- smaller than 1 then 1 is used. To use the character count
---- instead of the byte count, use `|setcharpos()|`.
+--- instead of the byte count, use [setcharpos()](help://setcharpos()).
 ---
 --- The "off" number is only used when 'virtualedit' is set. Then
 --- it is the offset in screen columns from the start of the
@@ -8504,13 +8508,13 @@ function vim.fn.setmatches(list, win) end
 --- Returns 0 when the position could be set, -1 otherwise.
 --- An error message is given if {expr} is invalid.
 ---
---- Also see `|setcharpos()|`, `|getpos()|` and `|getcurpos()|`.
+--- Also see [setcharpos()](help://setcharpos()), [getpos()](help://getpos()) and [getcurpos()](help://getcurpos()).
 ---
 --- This does not restore the preferred column for moving
---- vertically; if you set the cursor position with this, `|j|` and
---- `|k|` motions will jump to previous columns!  Use `|cursor()|` to
+--- vertically; if you set the cursor position with this, [j](help://j) and
+--- [k](help://k) motions will jump to previous columns!  Use [cursor()](help://cursor()) to
 --- also set the preferred column.  Also see the "curswant" key in
---- `|winrestview()|`.
+--- [winrestview()](help://winrestview()).
 ---
 ---
 --- @param expr any
@@ -8564,7 +8568,7 @@ function vim.fn.setpos(expr, list) end
 --- If you supply an empty {list}, the quickfix list will be
 --- cleared.
 --- Note that the list is not exactly the same as what
---- `|getqflist()|` returns.
+--- [getqflist()](help://getqflist()) returns.
 ---
 --- {action} values:    *setqflist-action* *E927*
 --- 'a'  The items from {list} are added to the existing
@@ -8587,22 +8591,22 @@ function vim.fn.setpos(expr, list) end
 --- set "nr" in {what} to "$".
 ---
 --- The following items can be specified in dictionary {what}:
----     context  quickfix list context. See `|quickfix-context|`
+---     context  quickfix list context. See [quickfix-context](help://quickfix-context)
 ---     efm    errorformat to use when parsing text from
 ---     "lines". If this is not present, then the
 ---     'errorformat' option value is used.
----     See `|quickfix-parse|`
----     id    quickfix list identifier `|quickfix-ID|`
+---     See [quickfix-parse](help://quickfix-parse)
+---     id    quickfix list identifier [quickfix-ID](help://quickfix-ID)
 ---     idx    index of the current entry in the quickfix
 ---     list specified by "id" or "nr". If set to '$',
 ---     then the last entry in the list is set as the
----     current entry.  See `|quickfix-index|`
+---     current entry.  See [quickfix-index](help://quickfix-index)
 ---     items  list of quickfix entries. Same as the {list}
 ---     argument.
 ---     lines  use 'errorformat' to parse a list of lines and
 ---     add the resulting entries to the quickfix list
----     {nr} or {id}.  Only a `|List|` value is supported.
----     See `|quickfix-parse|`
+---     {nr} or {id}.  Only a [List](help://List) value is supported.
+---     See [quickfix-parse](help://quickfix-parse)
 ---     nr    list number in the quickfix stack; zero
 ---     means the current quickfix list and "$" means
 ---     the last quickfix list.
@@ -8610,9 +8614,9 @@ function vim.fn.setpos(expr, list) end
 ---     function to get the text to display in the
 ---     quickfix window.  The value can be the name of
 ---     a function or a funcref or a lambda.  Refer to
----     `|quickfix-window-function|` for an explanation
+---     [quickfix-window-function](help://quickfix-window-function) for an explanation
 ---     of how to write the function and an example.
----     title  quickfix list title text. See `|quickfix-title|`
+---     title  quickfix list title text. See [quickfix-title](help://quickfix-title)
 --- Unsupported keys in {what} are ignored.
 --- If the "nr" item is not present, then the current quickfix list
 --- is modified. When creating a new quickfix list, "nr" can be
@@ -8621,7 +8625,7 @@ function vim.fn.setpos(expr, list) end
 --- list is modified, "id" should be used instead of "nr" to
 --- specify the list.
 ---
---- Examples (See also `|setqflist-examples|`):
+--- Examples (See also [setqflist-examples](help://setqflist-examples)):
 --- ```vim
 ---    call setqflist([], 'r', {'title': 'My search'})
 ---    call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
@@ -8644,15 +8648,15 @@ function vim.fn.setqflist(list, action, what) end
 --- If {regname} is "" or "@", the unnamed register '"' is used.
 --- The {regname} argument is a string.
 ---
---- {value} may be any value returned by `|getreg()|` or
---- `|getreginfo()|`, including a `|List|` or `|Dict|`.
+--- {value} may be any value returned by [getreg()](help://getreg()) or
+--- [getreginfo()](help://getreginfo()), including a [List](help://List) or [Dict](help://Dict).
 --- If {options} contains "a" or {regname} is upper case,
 --- then the value is appended.
 ---
 --- {options} can also contain a register type specification:
----     "c" or "v"        `|charwise|` mode
----     "l" or "V"        `|linewise|` mode
----     "b" or "<CTRL-V>" `|blockwise-visual|` mode
+---     "c" or "v"        [charwise](help://charwise) mode
+---     "l" or "V"        [linewise](help://linewise) mode
+---     "b" or "<CTRL-V>" [blockwise-visual](help://blockwise-visual) mode
 --- If a number immediately follows "b" or "<CTRL-V>" then this is
 --- used as the width of the selection - if it is not specified
 --- then the width of the block is set to the number of characters
@@ -8667,7 +8671,7 @@ function vim.fn.setqflist(list, action, what) end
 --- Returns zero for success, non-zero for failure.
 ---
 ---           *E883*
---- Note: you may not use `|List|` containing more than one item to
+--- Note: you may not use [List](help://List) containing more than one item to
 ---       set search and expression registers. Lists containing no
 ---       items act like empty strings.
 ---
@@ -8692,9 +8696,9 @@ function vim.fn.setqflist(list, action, what) end
 ---   call setreg('a', var_a, var_amode)
 --- ```
 --- Note: you may not reliably restore register value
---- without using the third argument to `|getreg()|` as without it
+--- without using the third argument to [getreg()](help://getreg()) as without it
 --- newlines are represented as newlines AND Nul bytes are
---- represented as newlines as well, see `|NL-used-for-Nul|`.
+--- represented as newlines as well, see [NL-used-for-Nul](help://NL-used-for-Nul).
 ---
 --- You can also change the type of a register by appending
 --- nothing:
@@ -8709,11 +8713,11 @@ function vim.fn.setqflist(list, action, what) end
 function vim.fn.setreg(regname, value, options) end
 
 --- Set tab-local variable {varname} to {val} in tab page {tabnr}.
---- `|t:var|`
+--- [t:var](help://t:var)
 --- The {varname} argument is a string.
 --- Note that the variable name without "t:" must be used.
 --- Tabs are numbered starting with one.
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 ---
 --- @param tabnr integer
@@ -8725,8 +8729,8 @@ function vim.fn.settabvar(tabnr, varname, val) end
 --- Set option or local variable {varname} in window {winnr} to
 --- {val}.
 --- Tabs are numbered starting with one.  For the current tabpage
---- use `|setwinvar()|`.
---- {winnr} can be the window number or the `|window-ID|`.
+--- use [setwinvar()](help://setwinvar()).
+--- {winnr} can be the window number or the [window-ID](help://window-ID).
 --- When {winnr} is zero the current window is used.
 --- This also works for a global or local buffer option, but it
 --- doesn't work for a global or local buffer variable.
@@ -8737,7 +8741,7 @@ function vim.fn.settabvar(tabnr, varname, val) end
 ---   call settabwinvar(1, 1, "&list", 0)
 ---   call settabwinvar(3, 2, "myvar", "foobar")
 --- ```
---- This function is not available in the `|sandbox|`.
+--- This function is not available in the [sandbox](help://sandbox).
 ---
 ---
 --- @param tabnr integer
@@ -8748,10 +8752,10 @@ function vim.fn.settabvar(tabnr, varname, val) end
 function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 
 --- Modify the tag stack of the window {nr} using {dict}.
---- {nr} can be the window number or the `|window-ID|`.
+--- {nr} can be the window number or the [window-ID](help://window-ID).
 ---
 --- For a list of supported items in {dict}, refer to
---- `|gettagstack()|`. "curidx" takes effect before changing the tag
+--- [gettagstack()](help://gettagstack()). "curidx" takes effect before changing the tag
 --- stack.
 ---           *E962*
 --- How the tag stack is modified depends on the {action}
@@ -8769,7 +8773,7 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 ---
 --- Returns zero for success, -1 for failure.
 ---
---- Examples (for more examples see `|tagstack-examples|`):
+--- Examples (for more examples see [tagstack-examples](help://tagstack-examples)):
 ---     Empty the tag stack of window 3:
 --- ```vim
 ---   call settagstack(3, {'items' : []})
@@ -8788,7 +8792,7 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 --- @return any
 function vim.fn.settagstack(nr, dict, action) end
 
---- Like `|settabwinvar()|` for the current tab page.
+--- Like [settabwinvar()](help://settabwinvar()) for the current tab page.
 --- Examples:
 --- ```vim
 ---   call setwinvar(1, "&list", 0)
@@ -8816,32 +8820,32 @@ function vim.fn.sha256(string) end
 --- Otherwise encloses {string} in single-quotes and replaces all
 --- "'" with "'\''".
 ---
---- If {special} is a `|non-zero-arg|`:
+--- If {special} is a [non-zero-arg](help://non-zero-arg):
 --- - Special items such as "!", "%", "#" and "<cword>" will be
 ---   preceded by a backslash. The backslash will be removed again
----   by the `|:!|` command.
+---   by the [:!](help://:!) command.
 --- - The <NL> character is escaped.
 ---
 --- If 'shell' contains "csh" in the tail:
 --- - The "!" character will be escaped. This is because csh and
 ---   tcsh use "!" for history replacement even in single-quotes.
 --- - The <NL> character is escaped (twice if {special} is
----   a `|non-zero-arg|`).
+---   a [non-zero-arg](help://non-zero-arg)).
 ---
 --- If 'shell' contains "fish" in the tail, the "\" character will
 --- be escaped because in fish it is used as an escape character
 --- inside single quotes.
 ---
---- Example of use with a `|:!|` command:
+--- Example of use with a [:!](help://:!) command:
 --- ```vim
 ---     exe '!dir ' .. shellescape(expand('<cfile>'), 1)
 --- ```
 --- This results in a directory listing for the file under the
---- cursor.  Example of use with `|system()|`:
+--- cursor.  Example of use with [system()](help://system()):
 --- ```vim
 ---     call system("chmod +w -- " .. shellescape(expand("%")))
 --- ```
---- See also `|::S|`.
+--- See also [::S](help://::S).
 ---
 ---
 --- @param string string
@@ -8882,7 +8886,7 @@ function vim.fn.shiftwidth(col) end
 function vim.fn.sign_define(name, dict) end
 
 --- Define a new sign named {name} or modify the attributes of an
---- existing sign.  This is similar to the `|:sign-define|` command.
+--- existing sign.  This is similar to the [:sign-define](help://:sign-define) command.
 ---
 --- Prefix {name} with a unique text to avoid name collisions.
 --- There is no {group} like with placing signs.
@@ -8932,7 +8936,7 @@ function vim.fn.sign_define(name, dict) end
 function vim.fn.sign_define(list) end
 
 --- Get a list of defined signs and their attributes.
---- This is similar to the `|:sign-list|` command.
+--- This is similar to the [:sign-list](help://:sign-list) command.
 ---
 --- If the {name} is not supplied, then a list of all the defined
 --- signs is returned. Otherwise the attribute of the specified
@@ -8972,22 +8976,22 @@ function vim.fn.sign_define(list) end
 function vim.fn.sign_getdefined(name) end
 
 --- Return a list of signs placed in a buffer or all the buffers.
---- This is similar to the `|:sign-place-list|` command.
+--- This is similar to the [:sign-place-list](help://:sign-place-list) command.
 ---
 --- If the optional buffer name {buf} is specified, then only the
 --- list of signs placed in that buffer is returned.  For the use
---- of {buf}, see `|bufname()|`. The optional {dict} can contain
+--- of {buf}, see [bufname()](help://bufname()). The optional {dict} can contain
 --- the following entries:
 ---    group  select only signs in this group
 ---    id    select sign with this identifier
 ---    lnum    select signs placed in this line. For the use
----     of {lnum}, see `|line()|`.
+---     of {lnum}, see [line()](help://line()).
 --- If {group} is "*", then signs in all the groups including the
 --- global group are returned. If {group} is not supplied or is an
 --- empty string, then only signs in the global group are
 --- returned.  If no arguments are supplied, then signs in the
 --- global group placed in all the buffers are returned.
---- See `|sign-group|`.
+--- See [sign-group](help://sign-group).
 ---
 --- Each list item in the returned value is a dictionary with the
 --- following entries:
@@ -9039,10 +9043,10 @@ function vim.fn.sign_getplaced(buf, dict) end
 
 --- Open the buffer {buf} or jump to the window that contains
 --- {buf} and position the cursor at sign {id} in group {group}.
---- This is similar to the `|:sign-jump|` command.
+--- This is similar to the [:sign-jump](help://:sign-jump) command.
 ---
 --- If {group} is an empty string, then the global group is used.
---- For the use of {buf}, see `|bufname()|`.
+--- For the use of {buf}, see [bufname()](help://bufname()).
 ---
 --- Returns the line number of the sign. Returns -1 if the
 --- arguments are invalid.
@@ -9061,25 +9065,25 @@ function vim.fn.sign_jump(id, group, buf) end
 
 --- Place the sign defined as {name} at line {lnum} in file or
 --- buffer {buf} and assign {id} and {group} to sign.  This is
---- similar to the `|:sign-place|` command.
+--- similar to the [:sign-place](help://:sign-place) command.
 ---
 --- If the sign identifier {id} is zero, then a new identifier is
 --- allocated.  Otherwise the specified number is used. {group} is
 --- the sign group name. To use the global sign group, use an
 --- empty string.  {group} functions as a namespace for {id}, thus
---- two groups can use the same IDs. Refer to `|sign-identifier|`
---- and `|sign-group|` for more information.
+--- two groups can use the same IDs. Refer to [sign-identifier](help://sign-identifier)
+--- and [sign-group](help://sign-group) for more information.
 ---
 --- {name} refers to a defined sign.
 --- {buf} refers to a buffer name or number. For the accepted
---- values, see `|bufname()|`.
+--- values, see [bufname()](help://bufname()).
 ---
 --- The optional {dict} argument supports the following entries:
 ---   lnum    line number in the file or buffer
 ---       {buf} where the sign is to be placed.
----       For the accepted values, see `|line()|`.
+---       For the accepted values, see [line()](help://line()).
 ---   priority  priority of the sign. See
----       `|sign-priority|` for more information.
+---       [sign-priority](help://sign-priority) for more information.
 ---
 --- If the optional {dict} is not specified, then it modifies the
 --- placed sign {id} in group {group} to use the defined sign
@@ -9117,30 +9121,30 @@ function vim.fn.sign_jump(id, group, buf) end
 function vim.fn.sign_place(id, group, name, buf, dict) end
 
 --- Place one or more signs.  This is similar to the
---- `|sign_place()|` function.  The {list} argument specifies the
+--- [sign_place()](help://sign_place()) function.  The {list} argument specifies the
 --- List of signs to place. Each list item is a dict with the
 --- following sign attributes:
 ---     buffer  Buffer name or number. For the accepted
----     values, see `|bufname()|`.
+---     values, see [bufname()](help://bufname()).
 ---     group  Sign group. {group} functions as a namespace
 ---     for {id}, thus two groups can use the same
 ---     IDs. If not specified or set to an empty
 ---     string, then the global group is used.   See
----     `|sign-group|` for more information.
+---     [sign-group](help://sign-group) for more information.
 ---     id    Sign identifier. If not specified or zero,
 ---     then a new unique identifier is allocated.
 ---     Otherwise the specified number is used. See
----     `|sign-identifier|` for more information.
+---     [sign-identifier](help://sign-identifier) for more information.
 ---     lnum  Line number in the buffer where the sign is to
 ---     be placed. For the accepted values, see
----     `|line()|`.
----     name  Name of the sign to place. See `|sign_define()|`
+---     [line()](help://line()).
+---     name  Name of the sign to place. See [sign_define()](help://sign_define())
 ---     for more information.
 ---     priority  Priority of the sign. When multiple signs are
 ---     placed on a line, the sign with the highest
 ---     priority is used. If not specified, the
 ---     default value of 10 is used. See
----     `|sign-priority|` for more information.
+---     [sign-priority](help://sign-priority) for more information.
 ---
 --- If {id} refers to an existing sign, then the existing sign is
 --- modified to use the specified {name} and/or {priority}.
@@ -9184,7 +9188,7 @@ function vim.fn.sign_placelist(list) end
 function vim.fn.sign_undefine(name) end
 
 --- Deletes a previously defined sign {name}. This is similar to
---- the `|:sign-undefine|` command. If {name} is not supplied, then
+--- the [:sign-undefine](help://:sign-undefine) command. If {name} is not supplied, then
 --- deletes all the defined signs.
 ---
 --- The one argument {list} can be used to undefine a list of
@@ -9211,7 +9215,7 @@ function vim.fn.sign_undefine(name) end
 function vim.fn.sign_undefine(list) end
 
 --- Remove a previously placed sign in one or more buffers.  This
---- is similar to the `|:sign-unplace|` command.
+--- is similar to the [:sign-unplace](help://:sign-unplace) command.
 ---
 --- {group} is the sign group name. To use the global sign group,
 --- use an empty string.  If {group} is set to "*", then all the
@@ -9219,7 +9223,7 @@ function vim.fn.sign_undefine(list) end
 --- The signs in {group} are selected based on the entries in
 --- {dict}.  The following optional entries in {dict} are
 --- supported:
----   buffer  buffer name or number. See `|bufname()|`.
+---   buffer  buffer name or number. See [bufname()](help://bufname()).
 ---   id  sign identifier
 --- If {dict} is not supplied, then all the signs in {group} are
 --- removed.
@@ -9259,12 +9263,12 @@ function vim.fn.sign_undefine(list) end
 function vim.fn.sign_unplace(group, dict) end
 
 --- Remove previously placed signs from one or more buffers.  This
---- is similar to the `|sign_unplace()|` function.
+--- is similar to the [sign_unplace()](help://sign_unplace()) function.
 ---
 --- The {list} argument specifies the List of signs to remove.
 --- Each list item is a dict with the following sign attributes:
 ---     buffer  buffer name or number. For the accepted
----     values, see `|bufname()|`. If not specified,
+---     values, see [bufname()](help://bufname()). If not specified,
 ---     then the specified sign is removed from all
 ---     the buffers.
 ---     group  sign group name. If not specified or set to an
@@ -9307,16 +9311,16 @@ function vim.fn.sign_unplacelist(list) end
 --- a searchable directory or does not exist.  On Unix, it is also
 --- removed when "dir" is a symbolic link within the same
 --- directory.  In order to resolve all the involved symbolic
---- links before simplifying the path name, use `|resolve()|`.
+--- links before simplifying the path name, use [resolve()](help://resolve()).
 ---
 ---
 --- @param filename any
 --- @return any
 function vim.fn.simplify(filename) end
 
---- Return the sine of {expr}, measured in radians, as a `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- Return the sine of {expr}, measured in radians, as a [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo sin(100)
@@ -9332,10 +9336,10 @@ function vim.fn.simplify(filename) end
 --- @return any
 function vim.fn.sin(expr) end
 
---- Return the hyperbolic sine of {expr} as a `|Float|` in the range
+--- Return the hyperbolic sine of {expr} as a [Float](help://Float) in the range
 --- [-inf, inf].
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo sinh(0.5)
@@ -9351,7 +9355,7 @@ function vim.fn.sin(expr) end
 --- @return any
 function vim.fn.sinh(expr) end
 
---- Similar to using a `|slice|` "expr[start : end]", but "end" is
+--- Similar to using a [slice](help://slice) "expr[start : end]", but "end" is
 --- used exclusive.  And for a string the indexes are used as
 --- character indexes instead of byte indexes.
 --- Also, composing characters are not counted.
@@ -9373,18 +9377,18 @@ function vim.fn.slice(expr, start, end_) end
 --- should be an ip adderess or host name, and port the port
 --- number.
 ---
---- For "pipe" mode, see `|luv-pipe-handle|`. For "tcp" mode, see
---- `|luv-tcp-handle|`.
+--- For "pipe" mode, see [luv-pipe-handle](help://luv-pipe-handle). For "tcp" mode, see
+--- [luv-tcp-handle](help://luv-tcp-handle).
 ---
---- Returns a `|channel|` ID. Close the socket with `|chanclose()|`.
---- Use `|chansend()|` to send data over a bytes socket, and
---- `|rpcrequest()|` and `|rpcnotify()|` to communicate with a RPC
+--- Returns a [channel](help://channel) ID. Close the socket with [chanclose()](help://chanclose()).
+--- Use [chansend()](help://chansend()) to send data over a bytes socket, and
+--- [rpcrequest()](help://rpcrequest()) and [rpcnotify()](help://rpcnotify()) to communicate with a RPC
 --- socket.
 ---
 --- {opts} is an optional dictionary with these keys:
----   `|on_data|` : callback invoked when data was read from socket
----   data_buffered : read socket data in `|channel-buffered|` mode.
----   rpc     : If set, `|msgpack-rpc|` will be used to communicate
+---   [on_data](help://on_data) : callback invoked when data was read from socket
+---   data_buffered : read socket data in [channel-buffered](help://channel-buffered) mode.
+---   rpc     : If set, [msgpack-rpc](help://msgpack-rpc) will be used to communicate
 ---       over the socket.
 --- Returns:
 ---   - The channel ID on success (greater than zero)
@@ -9404,8 +9408,8 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- ```
 --- When {how} is omitted or is a string, then sort() uses the
 --- string representation of each item to sort on.  Numbers sort
---- after Strings, `|Lists|` after Numbers.  For sorting text in the
---- current buffer use `|:sort|`.
+--- after Strings, [Lists](help://Lists) after Numbers.  For sorting text in the
+--- current buffer use [:sort](help://:sort).
 ---
 --- When {how} is given and it is 'i' then case is ignored.
 --- For backwards compatibility, the value one can be used to
@@ -9413,8 +9417,8 @@ function vim.fn.sockconnect(mode, address, opts) end
 ---
 --- When {how} is given and it is 'l' then the current collation
 --- locale is used for ordering. Implementation details: strcoll()
---- is used to compare strings. See `|:language|` check or set the
---- collation locale. `|v:collate|` can also be used to check the
+--- is used to compare strings. See [:language](help://:language) check or set the
+--- collation locale. [v:collate](help://v:collate) can also be used to check the
 --- current locale. Sorting using the locale typically ignores
 --- case. Example:
 --- ```vim
@@ -9443,14 +9447,14 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- When {how} is given and it is 'f' then all items will be
 --- sorted numerical. All values must be a Number or a Float.
 ---
---- When {how} is a `|Funcref|` or a function name, this function
+--- When {how} is a [Funcref](help://Funcref) or a function name, this function
 --- is called to compare items.  The function is invoked with two
 --- items as argument and must return zero if they are equal, 1 or
 --- bigger if the first one sorts after the second one, -1 or
 --- smaller if the first one sorts before the second one.
 ---
 --- {dict} is for functions with the "dict" attribute.  It will be
---- used to set the local variable "self". `|Dictionary-function|`
+--- used to set the local variable "self". [Dictionary-function](help://Dictionary-function)
 ---
 --- The sort is stable, items which compare equal (as number or as
 --- string) will keep their relative position. E.g., when sorting
@@ -9525,7 +9529,7 @@ function vim.fn.soundfold(word) end
 --- @return any
 function vim.fn.spellbadword(sentence) end
 
---- Return a `|List|` with spelling suggestions to replace {word}.
+--- Return a [List](help://List) with spelling suggestions to replace {word}.
 --- When {max} is given up to this number of suggestions are
 --- returned.  Otherwise up to 25 suggestions are returned.
 ---
@@ -9552,12 +9556,12 @@ function vim.fn.spellbadword(sentence) end
 --- @return any
 function vim.fn.spellsuggest(word, max, capital) end
 
---- Make a `|List|` out of {string}.  When {pattern} is omitted or
+--- Make a [List](help://List) out of {string}.  When {pattern} is omitted or
 --- empty each white-separated sequence of characters becomes an
 --- item.
 --- Otherwise the string is split where {pattern} matches,
 --- removing the matched characters. 'ignorecase' is not used
---- here, add \c to ignore case. `|/\c|`
+--- here, add \c to ignore case. [/\c](help:///\c)
 --- When the first or last item is empty it is omitted, unless the
 --- {keepempty} argument is given and it's non-zero.
 --- Other empty items are kept when {pattern} matches at least one
@@ -9582,7 +9586,7 @@ function vim.fn.spellsuggest(word, max, capital) end
 --- ```vim
 ---   let items = split(line, ':', 1)
 --- ```
---- The opposite function is `|join()|`.
+--- The opposite function is [join()](help://join()).
 ---
 ---
 --- @param string string
@@ -9592,10 +9596,10 @@ function vim.fn.spellsuggest(word, max, capital) end
 function vim.fn.split(string, pattern, keepempty) end
 
 --- Return the non-negative square root of Float {expr} as a
---- `|Float|`.
---- {expr} must evaluate to a `|Float|` or a `|Number|`.  When {expr}
+--- [Float](help://Float).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).  When {expr}
 --- is negative the result is NaN (Not a Number).  Returns 0.0 if
---- {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo sqrt(100)
@@ -9612,7 +9616,7 @@ function vim.fn.split(string, pattern, keepempty) end
 --- @return any
 function vim.fn.sqrt(expr) end
 
---- Initialize seed used by `|rand()|`:
+--- Initialize seed used by [rand()](help://rand()):
 --- - If {expr} is not given, seed values are initialized by
 ---   reading from /dev/urandom, if possible, or using time(NULL)
 ---   a.k.a. epoch time otherwise; this only has second accuracy.
@@ -9636,12 +9640,12 @@ function vim.fn.srand(expr) end
 --- work that may not always be safe.  Roughly this works like:
 --- - callback uses state() to check if work is safe to do.
 ---   Yes: then do it right away.
----   No:  add to work queue and add a `|SafeState|` autocommand.
+---   No:  add to work queue and add a [SafeState](help://SafeState) autocommand.
 --- - When SafeState is triggered and executes your autocommand,
 ---   check with `state()` if the work can be done now, and if yes
 ---   remove it from the queue and execute.
 ---   Remove the autocommand if the queue is now empty.
---- Also see `|mode()|`.
+--- Also see [mode()](help://mode()).
 ---
 --- When {what} is given only characters in this string will be
 --- added.  E.g, this checks if the screen has scrolled:
@@ -9653,10 +9657,10 @@ function vim.fn.srand(expr) end
 --- something is busy:
 ---     m  halfway a mapping, :normal command, feedkeys() or
 ---   stuffed command
----     o  operator pending, e.g. after `|d|`
+---     o  operator pending, e.g. after [d](help://d)
 ---     a  Insert mode autocomplete active
 ---     x  executing an autocommand
----     S  not triggering SafeState, e.g. after `|f|` or a count
+---     S  not triggering SafeState, e.g. after [f](help://f) or a count
 ---     c  callback invoked, including timer (repeats for
 ---   recursiveness up to "ccc")
 ---     s  screen has scrolled for messages
@@ -9665,37 +9669,37 @@ function vim.fn.srand(expr) end
 --- @return any
 function vim.fn.state(what) end
 
---- With `|--headless|` this opens stdin and stdout as a `|channel|`.
---- May be called only once. See `|channel-stdio|`. stderr is not
---- handled by this function, see `|v:stderr|`.
+--- With [--headless](help://--headless) this opens stdin and stdout as a [channel](help://channel).
+--- May be called only once. See [channel-stdio](help://channel-stdio). stderr is not
+--- handled by this function, see [v:stderr](help://v:stderr).
 ---
---- Close the stdio handles with `|chanclose()|`. Use `|chansend()|`
---- to send data to stdout, and `|rpcrequest()|` and `|rpcnotify()|`
+--- Close the stdio handles with [chanclose()](help://chanclose()). Use [chansend()](help://chansend())
+--- to send data to stdout, and [rpcrequest()](help://rpcrequest()) and [rpcnotify()](help://rpcnotify())
 --- to communicate over RPC.
 ---
 --- {opts} is a dictionary with these keys:
----   `|on_stdin|` : callback invoked when stdin is written to.
+---   [on_stdin](help://on_stdin) : callback invoked when stdin is written to.
 ---   on_print : callback invoked when Nvim needs to print a
 ---        message, with the message (whose type is string)
 ---        as sole argument.
----   stdin_buffered : read stdin in `|channel-buffered|` mode.
----   rpc      : If set, `|msgpack-rpc|` will be used to communicate
+---   stdin_buffered : read stdin in [channel-buffered](help://channel-buffered) mode.
+---   rpc      : If set, [msgpack-rpc](help://msgpack-rpc) will be used to communicate
 ---        over stdio
 --- Returns:
----   - `|channel-id|` on success (value is always 1)
+---   - [channel-id](help://channel-id) on success (value is always 1)
 ---   - 0 on invalid arguments
 ---
 --- @param opts table
 --- @return any
 function vim.fn.stdioopen(opts) end
 
---- Returns `|standard-path|` locations of various default files and
+--- Returns [standard-path](help://standard-path) locations of various default files and
 --- directories.
 ---
 --- {what}       Type    Description ~
 --- cache        String  Cache directory: arbitrary temporary
 ---                      storage for plugins, etc.
---- config       String  User configuration directory. `|init.vim|`
+--- config       String  User configuration directory. [init.vim](help://init.vim)
 ---                      is stored here.
 --- config_dirs  List    Other configuration directories.
 --- data         String  User data directory.
@@ -9704,7 +9708,7 @@ function vim.fn.stdioopen(opts) end
 --- run          String  Run directory: temporary, local storage
 ---          for sockets, named pipes, etc.
 --- state        String  Session state directory: storage for file
----          drafts, swap, undo, `|shada|`.
+---          drafts, swap, undo, [shada](help://shada).
 ---
 --- Example:
 --- ```vim
@@ -9717,7 +9721,7 @@ function vim.fn.stdpath(what) end
 
 --- Convert String {string} to a Float.  This mostly works the
 --- same as when using a floating point number in an expression,
---- see `|floating-point-format|`.  But it's a bit more permissive.
+--- see [floating-point-format](help://floating-point-format).  But it's a bit more permissive.
 --- E.g., "1e40" is accepted, while in an expression you need to
 --- write "1.0e40".  The hexadecimal form "0x123" is also
 --- accepted, but not others, like binary or octal.
@@ -9728,7 +9732,7 @@ function vim.fn.stdpath(what) end
 --- The decimal point is always '.', no matter what the locale is
 --- set to.  A comma ends the number: "12,345.67" is converted to
 --- 12.0.  You can strip out thousands separators with
---- `|substitute()|`:
+--- [substitute()](help://substitute()):
 --- ```vim
 ---   let f = str2float(substitute(text, ',', '', 'g'))
 --- ```
@@ -9746,7 +9750,7 @@ function vim.fn.str2float(string, quoted) end
 ---   echo str2list(" ")    " returns [32]
 ---   echo str2list("ABC")    " returns [65, 66, 67]
 --- ```
---- `|list2str()|` does the opposite.
+--- [list2str()](help://list2str()) does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
@@ -9787,24 +9791,24 @@ function vim.fn.str2nr(string, base) end
 
 --- The result is a Number, which is the number of characters
 --- in String {string}.  Composing characters are ignored.
---- `|strchars()|` can count the number of characters, counting
+--- [strchars()](help://strchars()) can count the number of characters, counting
 --- composing characters separately.
 ---
 --- Returns 0 if {string} is empty or on error.
 ---
---- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strwidth()|`.
+--- Also see [strlen()](help://strlen()), [strdisplaywidth()](help://strdisplaywidth()) and [strwidth()](help://strwidth()).
 ---
 ---
 --- @param string string
 --- @return any
 function vim.fn.strcharlen(string) end
 
---- Like `|strpart()|` but using character index and length instead
+--- Like [strpart()](help://strpart()) but using character index and length instead
 --- of byte index and length.
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
 --- When {skipcc} set to 1, Composing characters are ignored,
---- similar to  `|slice()|`.
+--- similar to  [slice()](help://slice()).
 --- When a character index is used where a character does not
 --- exist it is omitted and counted as one character.  For
 --- example:
@@ -9828,11 +9832,11 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
 --- When {skipcc} set to 1, Composing characters are ignored.
---- `|strcharlen()|` always does this.
+--- [strcharlen()](help://strcharlen()) always does this.
 ---
 --- Returns zero on error.
 ---
---- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strwidth()|`.
+--- Also see [strlen()](help://strlen()), [strdisplaywidth()](help://strdisplaywidth()) and [strwidth()](help://strwidth()).
 ---
 --- {skipcc} is only available after 7.4.755.  For backward
 --- compatibility, you can define a wrapper function:
@@ -9868,7 +9872,7 @@ function vim.fn.strchars(string, skipcc) end
 --- When {string} contains characters with East Asian Width Class
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
---- Also see `|strlen()|`, `|strwidth()|` and `|strchars()|`.
+--- Also see [strlen()](help://strlen()), [strwidth()](help://strwidth()) and [strchars()](help://strchars()).
 ---
 ---
 --- @param string string
@@ -9882,8 +9886,8 @@ function vim.fn.strdisplaywidth(string, col) end
 --- {format} depends on your system, thus this is not portable!
 --- See the manual page of the C function strftime() for the
 --- format.  The maximum length of the result is 80 characters.
---- See also `|localtime()|`, `|getftime()|` and `|strptime()|`.
---- The language can be changed with the `|:language|` command.
+--- See also [localtime()](help://localtime()), [getftime()](help://getftime()) and [strptime()](help://strptime()).
+--- The language can be changed with the [:language](help://:language) command.
 --- Examples:
 --- ```vim
 ---   echo strftime("%c")       " Sun Apr 27 11:49:23 1997
@@ -9902,10 +9906,10 @@ function vim.fn.strftime(format, time) end
 --- Get a Number corresponding to the character at {index} in
 --- {str}.  This uses a zero-based character index, not a byte
 --- index.  Composing characters are considered separate
---- characters here.  Use `|nr2char()|` to convert the Number to a
+--- characters here.  Use [nr2char()](help://nr2char()) to convert the Number to a
 --- String.
 --- Returns -1 if {index} is invalid.
---- Also see `|strcharpart()|` and `|strchars()|`.
+--- Also see [strcharpart()](help://strcharpart()) and [strchars()](help://strchars()).
 ---
 ---
 --- @param str string
@@ -9922,9 +9926,9 @@ function vim.fn.strgetchar(str, index) end
 ---   let colon2 = stridx(line, ":", colon1 + 1)
 --- ```
 --- The search is done case-sensitive.
---- For pattern searches use `|match()|`.
+--- For pattern searches use [match()](help://match()).
 --- -1 is returned if the {needle} does not occur in {haystack}.
---- See also `|strridx()|`.
+--- See also [strridx()](help://strridx()).
 --- Examples:
 --- ```vim
 ---   echo stridx("An Example", "Example")     " 3
@@ -9944,7 +9948,7 @@ function vim.fn.stridx(haystack, needle, start) end
 
 --- Return {expr} converted to a String.  If {expr} is a Number,
 --- Float, String, Blob or a composition of them, then the result
---- can be parsed back with `|eval()|`.
+--- can be parsed back with [eval()](help://eval()).
 ---   {expr} type  result ~
 ---   String    'string'
 ---   Number    123
@@ -9955,14 +9959,14 @@ function vim.fn.stridx(haystack, needle, start) end
 ---   List    [item, item]
 ---   Dictionary  `{key: value, key: value}`
 --- Note that in String values the ' character is doubled.
---- Also see `|strtrans()|`.
+--- Also see [strtrans()](help://strtrans()).
 --- Note 2: Output format is mostly compatible with YAML, except
 --- for infinite and NaN floating-point values representations
---- which use `|str2float()|`.  Strings are also dumped literally,
+--- which use [str2float()](help://str2float()).  Strings are also dumped literally,
 --- only single quote is escaped, which does not allow using YAML
---- for parsing back binary strings.  `|eval()|` should always work for
+--- for parsing back binary strings.  [eval()](help://eval()) should always work for
 --- strings and floats though and this is the only official
---- method, use `|msgpackdump()|` or `|json_encode()|` if you need to
+--- method, use [msgpackdump()](help://msgpackdump()) or [json_encode()](help://json_encode()) if you need to
 --- share data with other application.
 ---
 ---
@@ -9975,8 +9979,8 @@ function vim.fn.string(expr) end
 --- If the argument is a Number it is first converted to a String.
 --- For other types an error is given and zero is returned.
 --- If you want to count the number of multibyte characters use
---- `|strchars()|`.
---- Also see `|len()|`, `|strdisplaywidth()|` and `|strwidth()|`.
+--- [strchars()](help://strchars()).
+--- Also see [len()](help://len()), [strdisplaywidth()](help://strdisplaywidth()) and [strwidth()](help://strwidth()).
 ---
 ---
 --- @param string string
@@ -9990,7 +9994,7 @@ function vim.fn.strlen(string) end
 --- separately, thus "1" means one base character and any
 --- following composing characters).
 --- To count {start} as characters instead of bytes use
---- `|strcharpart()|`.
+--- [strcharpart()](help://strcharpart()).
 ---
 --- When bytes are selected which do not exist, this doesn't
 --- result in an error, the bytes are simply omitted.
@@ -10031,7 +10035,7 @@ function vim.fn.strpart(src, start, len, chars) end
 --- can try different {format} values until you get a non-zero
 --- result.
 ---
---- See also `|strftime()|`.
+--- See also [strftime()](help://strftime()).
 --- Examples:
 --- ```vim
 ---   echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
@@ -10062,10 +10066,10 @@ function vim.fn.strptime(format, timestring) end
 ---   let comma2 = strridx(line, ",", lastcomma - 1)
 --- ```
 --- The search is done case-sensitive.
---- For pattern searches use `|match()|`.
+--- For pattern searches use [match()](help://match()).
 --- -1 is returned if the {needle} does not occur in {haystack}.
 --- If the {needle} is empty the length of {haystack} is returned.
---- See also `|stridx()|`.  Examples:
+--- See also [stridx()](help://stridx()).  Examples:
 --- ```vim
 ---   echo strridx("an angry armadillo", "an")       3
 --- ```
@@ -10081,7 +10085,7 @@ function vim.fn.strptime(format, timestring) end
 function vim.fn.strridx(haystack, needle, start) end
 
 --- The result is a String, which is {string} with all unprintable
---- characters translated into printable characters `|'isprint'|`.
+--- characters translated into printable characters ['isprint'](help://'isprint').
 --- Like they are shown in a window.  Example:
 --- ```vim
 ---   echo strtrans(@a)
@@ -10106,7 +10110,7 @@ function vim.fn.strtrans(string) end
 ---
 --- Returns zero on error.
 ---
---- Also see `|strlen()|` and `|strcharlen()|`.
+--- Also see [strlen()](help://strlen()) and [strcharlen()](help://strcharlen()).
 --- Examples:
 --- ```vim
 ---     echo strutf16len('a')    " returns 1
@@ -10123,31 +10127,31 @@ function vim.fn.strutf16len(string, countcc) end
 
 --- The result is a Number, which is the number of display cells
 --- String {string} occupies.  A Tab character is counted as one
---- cell, alternatively use `|strdisplaywidth()|`.
+--- cell, alternatively use [strdisplaywidth()](help://strdisplaywidth()).
 --- When {string} contains characters with East Asian Width Class
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
---- Also see `|strlen()|`, `|strdisplaywidth()|` and `|strchars()|`.
+--- Also see [strlen()](help://strlen()), [strdisplaywidth()](help://strdisplaywidth()) and [strchars()](help://strchars()).
 ---
 ---
 --- @param string string
 --- @return integer
 function vim.fn.strwidth(string) end
 
---- Only for an expression in a `|:substitute|` command or
+--- Only for an expression in a [:substitute](help://:substitute) command or
 --- substitute() function.
 --- Returns the {nr}th submatch of the matched text.  When {nr}
 --- is 0 the whole matched text is returned.
 --- Note that a NL in the string can stand for a line break of a
 --- multi-line match or a NUL character in the text.
---- Also see `|sub-replace-expression|`.
+--- Also see [sub-replace-expression](help://sub-replace-expression).
 ---
 --- If {list} is present and non-zero then submatch() returns
---- a list of strings, similar to `|getline()|` with two arguments.
+--- a list of strings, similar to [getline()](help://getline()) with two arguments.
 --- NL characters in the text represent NUL characters in the
 --- text.
---- Only returns more than one item for `|:substitute|`, inside
---- `|substitute()|` this list will always contain one or zero
+--- Only returns more than one item for [:substitute](help://:substitute), inside
+--- [substitute()](help://substitute()) this list will always contain one or zero
 --- items, since there are no real line breaks.
 ---
 --- When substitute() is used recursively only the submatches in
@@ -10177,14 +10181,14 @@ function vim.fn.submatch(nr, list) end
 --- This works like the ":substitute" command (without any flags).
 --- But the matching with {pat} is always done like the 'magic'
 --- option is set and 'cpoptions' is empty (to make scripts
---- portable).  'ignorecase' is still relevant, use `|/\c|` or `|/\C|`
+--- portable).  'ignorecase' is still relevant, use [/\c](help:///\c) or [/\C](help:///\C)
 --- if you want to ignore or match case and ignore 'ignorecase'.
---- 'smartcase' is not used.  See `|string-match|` for how {pat} is
+--- 'smartcase' is not used.  See [string-match](help://string-match) for how {pat} is
 --- used.
 ---
 --- A "~" in {sub} is not replaced with the previous {sub}.
 --- Note that some codes in {sub} have a special meaning
---- `|sub-replace-special|`.  For example, to replace something with
+--- [sub-replace-special](help://sub-replace-special).  For example, to replace something with
 --- "\n" (two characters), use "\\\\n" or '\\n'.
 ---
 --- When {pat} does not match in {string}, {string} is returned
@@ -10201,7 +10205,7 @@ function vim.fn.submatch(nr, list) end
 --- results in "TESTING".
 ---
 --- When {sub} starts with "\=", the remainder is interpreted as
---- an expression. See `|sub-replace-expression|`.  Example:
+--- an expression. See [sub-replace-expression](help://sub-replace-expression).  Example:
 --- ```vim
 ---   echo substitute(s, '%\(\x\x\)',
 ---      \ '\=nr2char("0x" .. submatch(1))', 'g')
@@ -10213,7 +10217,7 @@ function vim.fn.submatch(nr, list) end
 --- ```
 --- The optional argument is a list which contains the whole
 --- matched string and up to nine submatches, like what
---- `|submatch()|` returns.  Example:
+--- [submatch()](help://submatch()) returns.  Example:
 --- ```vim
 ---    echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
 --- ```
@@ -10228,7 +10232,7 @@ function vim.fn.submatch(nr, list) end
 function vim.fn.substitute(string, pat, sub, flags) end
 
 --- Returns a list of swap file names, like what "vim -r" shows.
---- See the `|-r|` command argument.  The 'directory' option is used
+--- See the [-r](help://-r) command argument.  The 'directory' option is used
 --- for the directories to inspect.  If you only want to get a
 --- list of swap files in the current directory then temporarily
 --- set 'directory' to a dot:
@@ -10265,9 +10269,9 @@ function vim.fn.swapfilelist() end
 function vim.fn.swapinfo(fname) end
 
 --- The result is the swap file path of the buffer {buf}.
---- For the use of {buf}, see `|bufname()|` above.
+--- For the use of {buf}, see [bufname()](help://bufname()) above.
 --- If buffer {buf} is the current buffer, the result is equal to
---- `|:swapname|` (unless there is no swap file).
+--- [:swapname](help://:swapname) (unless there is no swap file).
 --- If buffer {buf} has no swap file, returns an empty string.
 ---
 ---
@@ -10277,18 +10281,18 @@ function vim.fn.swapname(buf) end
 
 --- The result is a Number, which is the syntax ID at the position
 --- {lnum} and {col} in the current window.
---- The syntax ID can be used with `|synIDattr()|` and
---- `|synIDtrans()|` to obtain syntax information about text.
+--- The syntax ID can be used with [synIDattr()](help://synIDattr()) and
+--- [synIDtrans()](help://synIDtrans()) to obtain syntax information about text.
 ---
 --- {col} is 1 for the leftmost column, {lnum} is 1 for the first
 --- line.  'synmaxcol' applies, in a longer line zero is returned.
 --- Note that when the position is after the last character,
 --- that's where the cursor can be in Insert mode, synID() returns
---- zero.  {lnum} is used like with `|getline()|`.
+--- zero.  {lnum} is used like with [getline()](help://getline()).
 ---
---- When {trans} is `|TRUE|`, transparent items are reduced to the
+--- When {trans} is [TRUE](help://TRUE), transparent items are reduced to the
 --- item that they reveal.  This is useful when wanting to know
---- the effective color.  When {trans} is `|FALSE|`, the transparent
+--- the effective color.  When {trans} is [FALSE](help://FALSE), the transparent
 --- item is returned.  This is useful when wanting to know which
 --- syntax item is effective (e.g. inside parens).
 --- Warning: This function can be very slow.  Best speed is
@@ -10322,8 +10326,8 @@ function vim.fn.synID(lnum, col, trans) end
 ---     term: empty string)
 --- "bg"    background color (as with "fg")
 --- "font"    font name (only available in the GUI)
----     `|highlight-font|`
---- "sp"    special color (as with "fg") `|guisp|`
+---     [highlight-font](help://highlight-font)
+--- "sp"    special color (as with "fg") [guisp](help://guisp)
 --- "fg#"    like "fg", but for the GUI and the GUI is
 ---     running the name in "#RRGGBB" form
 --- "bg#"    like "fg#" for "bg"
@@ -10349,7 +10353,7 @@ function vim.fn.synID(lnum, col, trans) end
 --- ```vim
 ---   echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
 --- ```
---- Can also be used as a `|method|`:
+--- Can also be used as a [method](help://method):
 --- ```vim
 ---   echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
 --- ```
@@ -10372,10 +10376,10 @@ function vim.fn.synIDattr(synID, what, mode) end
 --- @return integer
 function vim.fn.synIDtrans(synID) end
 
---- The result is a `|List|` with currently three items:
+--- The result is a [List](help://List) with currently three items:
 --- 1. The first item in the list is 0 if the character at the
 ---    position {lnum} and {col} is not part of a concealable
----    region, 1 if it is.  {lnum} is used like with `|getline()|`.
+---    region, 1 if it is.  {lnum} is used like with [getline()](help://getline()).
 --- 2. The second item in the list is a string. If the first item
 ---    is 1, the second item contains the text which will be
 ---    displayed in place of the concealed text, depending on the
@@ -10401,12 +10405,12 @@ function vim.fn.synIDtrans(synID) end
 --- @return {[1]: integer, [2]: string, [3]: integer}[]
 function vim.fn.synconcealed(lnum, col) end
 
---- Return a `|List|`, which is the stack of syntax items at the
+--- Return a [List](help://List), which is the stack of syntax items at the
 --- position {lnum} and {col} in the current window.  {lnum} is
---- used like with `|getline()|`.  Each item in the List is an ID
---- like what `|synID()|` returns.
+--- used like with [getline()](help://getline()).  Each item in the List is an ID
+--- like what [synID()](help://synID()) returns.
 --- The first item in the List is the outer region, following are
---- items contained in that one.  The last one is what `|synID()|`
+--- items contained in that one.  The last one is what [synID()](help://synID())
 --- returns, unless not the whole item is highlighted or it is a
 --- transparent item.
 --- This function is useful for debugging a syntax file.
@@ -10426,11 +10430,11 @@ function vim.fn.synconcealed(lnum, col) end
 --- @return integer[]
 function vim.fn.synstack(lnum, col) end
 
---- Note: Prefer `|vim.system()|` in Lua.
+--- Note: Prefer [vim.system()](help://vim.system()) in Lua.
 ---
---- Gets the output of {cmd} as a `|string|` (`|systemlist()|` returns
---- a `|List|`) and sets `|v:shell_error|` to the error code.
---- {cmd} is treated as in `|jobstart()|`:
+--- Gets the output of {cmd} as a [string](help://string) ([systemlist()](help://systemlist()) returns
+--- a [List](help://List)) and sets [v:shell_error](help://v:shell_error) to the error code.
+--- {cmd} is treated as in [jobstart()](help://jobstart()):
 --- If {cmd} is a List it runs directly (no 'shell').
 --- If {cmd} is a String it runs in the 'shell', like this:
 --- ```vim
@@ -10449,8 +10453,8 @@ function vim.fn.synstack(lnum, col) end
 --- If {input} is a string it is written to a pipe and passed as
 --- stdin to the command.  The string is written as-is, line
 --- separators are not changed.
---- If {input} is a `|List|` it is written to the pipe as
---- `|writefile()|` does with {binary} set to "b" (i.e. with
+--- If {input} is a [List](help://List) it is written to the pipe as
+--- [writefile()](help://writefile()) does with {binary} set to "b" (i.e. with
 --- a newline between each list item, and newlines inside list
 --- items converted to NULs).
 --- When {input} is given and is a valid buffer id, the content of
@@ -10468,10 +10472,10 @@ function vim.fn.synstack(lnum, col) end
 --- ```
 --- The pipes are disconnected (unless overridden by shell
 --- redirection syntax) before input can reach it. Use
---- `|jobstart()|` instead.
+--- [jobstart()](help://jobstart()) instead.
 ---
---- Note: Use `|shellescape()|` or `|::S|` with `|expand()|` or
---- `|fnamemodify()|` to escape special characters in a command
+--- Note: Use [shellescape()](help://shellescape()) or [::S](help://::S) with [expand()](help://expand()) or
+--- [fnamemodify()](help://fnamemodify()) to escape special characters in a command
 --- argument. 'shellquote' and 'shellxquote' must be properly
 --- configured. Example:
 --- ```vim
@@ -10479,7 +10483,7 @@ function vim.fn.synstack(lnum, col) end
 ---     echo system('ls '..expand('%:h:S'))
 --- ```
 --- Unlike ":!cmd" there is no automatic check for changed files.
---- Use `|:checktime|` to force a check.
+--- Use [:checktime](help://:checktime) to force a check.
 ---
 ---
 --- @param cmd string|string[]
@@ -10487,15 +10491,15 @@ function vim.fn.synstack(lnum, col) end
 --- @return string
 function vim.fn.system(cmd, input) end
 
---- Same as `|system()|`, but returns a `|List|` with lines (parts of
+--- Same as [system()](help://system()), but returns a [List](help://List) with lines (parts of
 --- output separated by NL) with NULs transformed into NLs. Output
---- is the same as `|readfile()|` will output with {binary} argument
+--- is the same as [readfile()](help://readfile()) will output with {binary} argument
 --- set to "b", except that a final newline is not preserved,
 --- unless {keepempty} is non-zero.
 --- Note that on MS-Windows you may get trailing CR characters.
 ---
 --- To see the difference between "echo hello" and "echo -n hello"
---- use `|system()|` and `|split()|`:
+--- use [system()](help://system()) and [split()](help://split()):
 --- ```vim
 ---   echo split(system('echo hello'), '\n', 1)
 --- ```
@@ -10508,7 +10512,7 @@ function vim.fn.system(cmd, input) end
 --- @return string[]
 function vim.fn.systemlist(cmd, input, keepempty) end
 
---- The result is a `|List|`, where each item is the number of the
+--- The result is a [List](help://List), where each item is the number of the
 --- buffer associated with each window in the current tab page.
 --- {arg} specifies the number of the tab page to be used. When
 --- omitted the current tab page is used.
@@ -10534,9 +10538,9 @@ function vim.fn.tabpagebuflist(arg) end
 ---   $  the number of the last tab page (the tab page
 ---     count).
 ---   #  the number of the last accessed tab page
----     (where `|g<Tab>|` goes to).  If there is no
+---     (where [g<Tab>](help://g<Tab>) goes to).  If there is no
 ---     previous tab page, 0 is returned.
---- The number can be used with the `|:tab|` command.
+--- The number can be used with the [:tab](help://:tab) command.
 ---
 --- Returns zero on error.
 ---
@@ -10544,9 +10548,9 @@ function vim.fn.tabpagebuflist(arg) end
 --- @return integer
 function vim.fn.tabpagenr(arg) end
 
---- Like `|winnr()|` but for tab page {tabarg}.
+--- Like [winnr()](help://winnr()) but for tab page {tabarg}.
 --- {tabarg} specifies the number of tab page to be used.
---- {arg} is used like with `|winnr()|`:
+--- {arg} is used like with [winnr()](help://winnr()):
 --- - When omitted the current window number is returned.  This is
 ---   the window which will be used when going to this tab page.
 --- - When "$" the number of windows is returned.
@@ -10564,16 +10568,16 @@ function vim.fn.tabpagenr(arg) end
 --- @return integer
 function vim.fn.tabpagewinnr(tabarg, arg) end
 
---- Returns a `|List|` with the file names used to search for tags
+--- Returns a [List](help://List) with the file names used to search for tags
 --- for the current buffer.  This is the 'tags' option expanded.
 ---
 --- @return string[]
 function vim.fn.tagfiles() end
 
---- Returns a `|List|` of tags matching the regular expression {expr}.
+--- Returns a [List](help://List) of tags matching the regular expression {expr}.
 ---
 --- If {filename} is passed it is used to prioritize the results
---- in the same way that `|:tselect|` does. See `|tag-priority|`.
+--- in the same way that [:tselect](help://:tselect) does. See [tag-priority](help://tag-priority).
 --- {filename} should be the full path of the file.
 ---
 --- Each list item is a dictionary with at least the following
@@ -10590,7 +10594,7 @@ function vim.fn.tagfiles() end
 ---       using a tags file generated by
 ---       Universal/Exuberant ctags or hdrtag.
 ---   static    A file specific tag.  Refer to
----       `|static-tag|` for more information.
+---       [static-tag](help://static-tag) for more information.
 --- More entries may be present, depending on the content of the
 --- tags file: access, implementation, inherits and signature.
 --- Refer to the ctags documentation for information about these
@@ -10605,11 +10609,11 @@ function vim.fn.tagfiles() end
 ---
 --- To get an exact tag match, the anchors '^' and '$' should be
 --- used in {expr}.  This also make the function work faster.
---- Refer to `|tag-regexp|` for more information about the tag
+--- Refer to [tag-regexp](help://tag-regexp) for more information about the tag
 --- search regular expression pattern.
 ---
---- Refer to `|'tags'|` for information about how the tags file is
---- located by Vim. Refer to `|tags-file-format|` for the format of
+--- Refer to ['tags'](help://'tags') for information about how the tags file is
+--- located by Vim. Refer to [tags-file-format](help://tags-file-format) for the format of
 --- the tags file generated by the different ctags tools.
 ---
 ---
@@ -10618,10 +10622,10 @@ function vim.fn.tagfiles() end
 --- @return any
 function vim.fn.taglist(expr, filename) end
 
---- Return the tangent of {expr}, measured in radians, as a `|Float|`
+--- Return the tangent of {expr}, measured in radians, as a [Float](help://Float)
 --- in the range [-inf, inf].
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo tan(10)
@@ -10637,10 +10641,10 @@ function vim.fn.taglist(expr, filename) end
 --- @return number
 function vim.fn.tan(expr) end
 
---- Return the hyperbolic tangent of {expr} as a `|Float|` in the
+--- Return the hyperbolic tangent of {expr} as a [Float](help://Float) in the
 --- range [-1, 1].
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo tanh(0.5)
@@ -10657,7 +10661,7 @@ function vim.fn.tan(expr) end
 function vim.fn.tanh(expr) end
 
 --- Generates a (non-existent) filename located in the Nvim root
---- `|tempdir|`. Scripts can use the filename as a temporary file.
+--- [tempdir](help://tempdir). Scripts can use the filename as a temporary file.
 --- Example:
 --- ```vim
 ---   let tmpfile = tempname()
@@ -10669,17 +10673,17 @@ function vim.fn.tempname() end
 
 --- Spawns {cmd} in a new pseudo-terminal session connected
 --- to the current (unmodified) buffer. Parameters and behavior
---- are the same as `|jobstart()|` except "pty", "width", "height",
+--- are the same as [jobstart()](help://jobstart()) except "pty", "width", "height",
 --- and "TERM" are ignored: "height" and "width" are taken from
 --- the current window. Note that termopen() implies a "pty" arg
 --- to jobstart(), and thus has the implications documented at
---- `|jobstart()|`.
+--- [jobstart()](help://jobstart()).
 ---
 --- Returns the same values as jobstart().
 ---
---- Terminal environment is initialized as in `|jobstart-env|`,
+--- Terminal environment is initialized as in [jobstart-env](help://jobstart-env),
 --- except $TERM is set to "xterm-256color". Full behavior is
---- described in `|terminal|`.
+--- described in [terminal](help://terminal).
 ---
 --- @param cmd any
 --- @param opts? table
@@ -10692,7 +10696,7 @@ function vim.fn.termopen(cmd, opts) end
 --- returned.
 --- When {id} is omitted information about all timers is returned.
 ---
---- For each timer the information is stored in a `|Dictionary|` with
+--- For each timer the information is stored in a [Dictionary](help://Dictionary) with
 --- these items:
 ---     "id"      the timer ID
 ---     "time"      time the timer was started with
@@ -10715,7 +10719,7 @@ function vim.fn.timer_info(id) end
 ---
 --- If {paused} evaluates to a non-zero Number or a non-empty
 --- String, then the timer is paused, otherwise it is unpaused.
---- See `|non-zero-arg|`.
+--- See [non-zero-arg](help://non-zero-arg).
 ---
 ---
 --- @param timer any
@@ -10732,7 +10736,7 @@ function vim.fn.timer_pause(timer, paused) end
 --- the main loop.
 ---
 --- {callback} is the function to call.  It can be the name of a
---- function or a `|Funcref|`.  It is called with one argument, which
+--- function or a [Funcref](help://Funcref).  It is called with one argument, which
 --- is the timer ID.  The callback is only invoked when Vim is
 --- waiting for input.
 ---
@@ -10778,7 +10782,7 @@ function vim.fn.timer_stop(timer) end
 function vim.fn.timer_stopall() end
 
 --- The result is a copy of the String given, with all uppercase
---- characters turned into lowercase (just like applying `|gu|` to
+--- characters turned into lowercase (just like applying [gu](help://gu) to
 --- the string).  Returns an empty string on error.
 ---
 ---
@@ -10787,7 +10791,7 @@ function vim.fn.timer_stopall() end
 function vim.fn.tolower(expr) end
 
 --- The result is a copy of the String given, with all lowercase
---- characters turned into uppercase (just like applying `|gU|` to
+--- characters turned into uppercase (just like applying [gU](help://gU) to
 --- the string).  Returns an empty string on error.
 ---
 ---
@@ -10864,9 +10868,9 @@ function vim.fn.tr(src, fromstr, tostr) end
 function vim.fn.trim(text, mask, dir) end
 
 --- Return the largest integral value with magnitude less than or
---- equal to {expr} as a `|Float|` (truncate towards zero).
---- {expr} must evaluate to a `|Float|` or a `|Number|`.
---- Returns 0.0 if {expr} is not a `|Float|` or a `|Number|`.
+--- equal to {expr} as a [Float](help://Float) (truncate towards zero).
+--- {expr} must evaluate to a [Float](help://Float) or a [Number](help://Number).
+--- Returns 0.0 if {expr} is not a [Float](help://Float) or a [Number](help://Number).
 --- Examples:
 --- ```vim
 ---   echo trunc(1.456)
@@ -10889,15 +10893,15 @@ function vim.fn.trunc(expr) end
 --- The result is a Number representing the type of {expr}.
 --- Instead of using the number directly, it is better to use the
 --- v:t_ variable that has the value:
----   Number:      0  `|v:t_number|`
----   String:      1  `|v:t_string|`
----   Funcref:    2  `|v:t_func|`
----   List:      3  `|v:t_list|`
----   Dictionary: 4  `|v:t_dict|`
----   Float:      5  `|v:t_float|`
----   Boolean:    6  `|v:t_bool|` (`|v:false|` and `|v:true|`)
----   Null:      7  (`|v:null|`)
----   Blob:     10  `|v:t_blob|`
+---   Number:      0  [v:t_number](help://v:t_number)
+---   String:      1  [v:t_string](help://v:t_string)
+---   Funcref:    2  [v:t_func](help://v:t_func)
+---   List:      3  [v:t_list](help://v:t_list)
+---   Dictionary: 4  [v:t_dict](help://v:t_dict)
+---   Float:      5  [v:t_float](help://v:t_float)
+---   Boolean:    6  [v:t_bool](help://v:t_bool) ([v:false](help://v:false) and [v:true](help://v:true))
+---   Null:      7  ([v:null](help://v:null))
+---   Blob:     10  [v:t_blob](help://v:t_blob)
 --- For backward compatibility, this method can be used:
 --- ```vim
 ---   if type(myvar) == type(0) | endif
@@ -10908,8 +10912,8 @@ function vim.fn.trunc(expr) end
 ---   if type(myvar) == type(0.0) | endif
 ---   if type(myvar) == type(v:true) | endif
 --- ```
---- In place of checking for `|v:null|` type it is better to check
---- for `|v:null|` directly as it is the only value of this type:
+--- In place of checking for [v:null](help://v:null) type it is better to check
+--- for [v:null](help://v:null) directly as it is the only value of this type:
 --- ```vim
 ---   if myvar is v:null | endif
 --- ```
@@ -10930,7 +10934,7 @@ function vim.fn.type(expr) end
 --- is used internally.
 --- If {name} is empty undofile() returns an empty string, since a
 --- buffer without a file name will not write an undo file.
---- Useful in combination with `|:wundo|` and `|:rundo|`.
+--- Useful in combination with [:wundo](help://:wundo) and [:rundo](help://:rundo).
 ---
 ---
 --- @param name string
@@ -10944,8 +10948,8 @@ function vim.fn.undofile(name) end
 ---   "seq_cur"  The sequence number of the current position in
 ---     the undo tree.  This differs from "seq_last"
 ---     when some changes were undone.
----   "time_cur"  Time last used for `|:earlier|` and related
----     commands.  Use `|strftime()|` to convert to
+---   "time_cur"  Time last used for [:earlier](help://:earlier) and related
+---     commands.  Use [strftime()](help://strftime()) to convert to
 ---     something readable.
 ---   "save_last"  Number of the last file write.  Zero when no
 ---     write yet.
@@ -10953,16 +10957,16 @@ function vim.fn.undofile(name) end
 ---     tree.
 ---   "synced"  Non-zero when the last undo block was synced.
 ---     This happens when waiting from input from the
----     user.  See `|undo-blocks|`.
+---     user.  See [undo-blocks](help://undo-blocks).
 ---   "entries"  A list of dictionaries with information about
 ---     undo blocks.
 ---
 --- The first item in the "entries" list is the oldest undo item.
---- Each List item is a `|Dictionary|` with these items:
+--- Each List item is a [Dictionary](help://Dictionary) with these items:
 ---   "seq"    Undo sequence number.  Same as what appears in
----     `|:undolist|`.
+---     [:undolist](help://:undolist).
 ---   "time"  Timestamp when the change happened.  Use
----     `|strftime()|` to convert to something readable.
+---     [strftime()](help://strftime()) to convert to something readable.
 ---   "newhead"  Only appears in the item that is the last one
 ---     that was added.  This marks the last change
 ---     and where further changes will be added.
@@ -10991,9 +10995,9 @@ function vim.fn.undotree(buf) end
 ---   let newlist = uniq(copy(mylist))
 --- ```
 --- The default compare function uses the string representation of
---- each item.  For the use of {func} and {dict} see `|sort()|`.
+--- each item.  For the use of {func} and {dict} see [sort()](help://sort()).
 ---
---- Returns zero if {list} is not a `|List|`.
+--- Returns zero if {list} is not a [List](help://List).
 ---
 ---
 --- @param list any
@@ -11002,7 +11006,7 @@ function vim.fn.undotree(buf) end
 --- @return any[]|0
 function vim.fn.uniq(list, func, dict) end
 
---- Same as `|charidx()|` but returns the UTF-16 code unit index of
+--- Same as [charidx()](help://charidx()) but returns the UTF-16 code unit index of
 --- the byte at {idx} in {string} (after converting it to UTF-16).
 ---
 --- When {charidx} is present and TRUE, {idx} is used as the
@@ -11015,10 +11019,10 @@ function vim.fn.uniq(list, func, dict) end
 --- than {idx} bytes in {string}. If there are exactly {idx} bytes
 --- the length of the string in UTF-16 code units is returned.
 ---
---- See `|byteidx()|` and `|byteidxcomp()|` for getting the byte index
---- from the UTF-16 index and `|charidx()|` for getting the
+--- See [byteidx()](help://byteidx()) and [byteidxcomp()](help://byteidxcomp()) for getting the byte index
+--- from the UTF-16 index and [charidx()](help://charidx()) for getting the
 --- character index from the UTF-16 index.
---- Refer to `|string-offset-encoding|` for more information.
+--- Refer to [string-offset-encoding](help://string-offset-encoding) for more information.
 --- Examples:
 --- ```vim
 ---   echo utf16idx('a😊😊', 3)  " returns 2
@@ -11037,9 +11041,9 @@ function vim.fn.uniq(list, func, dict) end
 --- @return integer
 function vim.fn.utf16idx(string, idx, countcc, charidx) end
 
---- Return a `|List|` with all the values of {dict}.  The `|List|` is
---- in arbitrary order.  Also see `|items()|` and `|keys()|`.
---- Returns zero if {dict} is not a `|Dict|`.
+--- Return a [List](help://List) with all the values of {dict}.  The [List](help://List) is
+--- in arbitrary order.  Also see [items()](help://items()) and [keys()](help://keys()).
+--- Returns zero if {dict} is not a [Dict](help://Dict).
 ---
 ---
 --- @param dict any
@@ -11052,10 +11056,10 @@ function vim.fn.values(dict) end
 --- would be of unlimited width.  When there is a <Tab> at the
 --- position, the returned Number will be the column at the end of
 --- the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
---- set to 8, it returns 8. `|conceal|` is ignored.
---- For the byte position use `|col()|`.
+--- set to 8, it returns 8. [conceal](help://conceal) is ignored.
+--- For the byte position use [col()](help://col()).
 ---
---- For the use of {expr} see `|col()|`.
+--- For the use of {expr} see [col()](help://col()).
 ---
 --- When 'virtualedit' is used {expr} can be [lnum, col, off],
 --- where "off" is the offset in screen columns from the start of
@@ -11063,7 +11067,7 @@ function vim.fn.values(dict) end
 --- last character.  When "off" is omitted zero is used.  When
 --- Virtual editing is active in the current mode, a position
 --- beyond the end of the line can be returned.  Also see
---- `|'virtualedit'|`
+--- ['virtualedit'](help://'virtualedit')
 ---
 --- The accepted positions are:
 ---     .      the cursor position
@@ -11074,7 +11078,7 @@ function vim.fn.values(dict) end
 ---       returned)
 ---     v       In Visual mode: the start of the Visual area (the
 ---       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from `|'<|` in
+---       returns the cursor position.  Differs from ['<](help://'<) in
 ---       that it's updated right away.
 ---
 --- If {list} is present and non-zero then virtcol() returns a
@@ -11124,12 +11128,12 @@ function vim.fn.virtcol(expr, list, winid) end
 --- byte in the character is returned.
 ---
 --- The {winid} argument can be the window number or the
---- `|window-ID|`. If this is zero, then the current window is used.
+--- [window-ID](help://window-ID). If this is zero, then the current window is used.
 ---
 --- Returns -1 if the window {winid} doesn't exist or the buffer
 --- line {lnum} or virtual column {col} is invalid.
 ---
---- See also `|screenpos()|`, `|virtcol()|` and `|col()|`.
+--- See also [screenpos()](help://screenpos()), [virtcol()](help://virtcol()) and [col()](help://col()).
 ---
 ---
 --- @param winid integer
@@ -11151,18 +11155,18 @@ function vim.fn.virtcol2col(winid, lnum, col) end
 --- This enters the same Visual mode as before.  It is also useful
 --- in scripts if you wish to act differently depending on the
 --- Visual mode that was used.
---- If Visual mode is active, use `|mode()|` to get the Visual mode
---- (e.g., in a `|:vmap|`).
+--- If Visual mode is active, use [mode()](help://mode()) to get the Visual mode
+--- (e.g., in a [:vmap](help://:vmap)).
 --- If {expr} is supplied and it evaluates to a non-zero Number or
 --- a non-empty String, then the Visual mode will be cleared and
---- the old value is returned.  See `|non-zero-arg|`.
+--- the old value is returned.  See [non-zero-arg](help://non-zero-arg).
 ---
 --- @param expr? any
 --- @return any
 function vim.fn.visualmode(expr) end
 
---- Waits until {condition} evaluates to `|TRUE|`, where {condition}
---- is a `|Funcref|` or `|string|` containing an expression.
+--- Waits until {condition} evaluates to [TRUE](help://TRUE), where {condition}
+--- is a [Funcref](help://Funcref) or [string](help://string) containing an expression.
 ---
 --- {timeout} is the maximum waiting time in milliseconds, -1
 --- means forever.
@@ -11173,7 +11177,7 @@ function vim.fn.visualmode(expr) end
 --- Returns a status integer:
 ---   0 if the condition was satisfied before timeout
 ---   -1 if the timeout was exceeded
----   -2 if the function was interrupted (by `|CTRL-C|`)
+---   -2 if the function was interrupted (by [CTRL-C](help://CTRL-C))
 ---   -3 if an error occurred
 ---
 --- @param timeout integer
@@ -11182,10 +11186,10 @@ function vim.fn.visualmode(expr) end
 --- @return any
 function vim.fn.wait(timeout, condition, interval) end
 
---- Returns `|TRUE|` when the wildmenu is active and `|FALSE|`
+--- Returns [TRUE](help://TRUE) when the wildmenu is active and [FALSE](help://FALSE)
 --- otherwise.  See 'wildmenu' and 'wildmode'.
 --- This can be used in mappings to handle the 'wildcharm' option
---- gracefully. (Makes only sense with `|mapmode-c|` mappings).
+--- gracefully. (Makes only sense with [mapmode-c](help://mapmode-c) mappings).
 ---
 --- For example to make <c-j> work like <down> in wildmode, use:
 --- ```vim
@@ -11218,7 +11222,7 @@ function vim.fn.wildmenumode() end
 --- @return any
 function vim.fn.win_execute(id, command, silent) end
 
---- Returns a `|List|` with `|window-ID|`s for windows that contain
+--- Returns a [List](help://List) with [window-ID](help://window-ID)s for windows that contain
 --- buffer {bufnr}.  When there is none the list is empty.
 ---
 ---
@@ -11226,7 +11230,7 @@ function vim.fn.win_execute(id, command, silent) end
 --- @return integer[]
 function vim.fn.win_findbuf(bufnr) end
 
---- Get the `|window-ID|` for the specified window.
+--- Get the [window-ID](help://window-ID) for the specified window.
 --- When {win} is missing use the current window.
 --- With {win} this is the window number.  The top window has
 --- number 1.
@@ -11243,17 +11247,17 @@ function vim.fn.win_getid(win, tab) end
 --- Return the type of the window:
 ---   "autocmd"  autocommand window. Temporary window
 ---       used to execute autocommands.
----   "command"  command-line window `|cmdwin|`
+---   "command"  command-line window [cmdwin](help://cmdwin)
 ---   (empty)    normal window
----   "loclist"  `|location-list-window|`
----   "popup"    floating window `|api-floatwin|`
----   "preview"  preview window `|preview-window|`
----   "quickfix"  `|quickfix-window|`
+---   "loclist"  [location-list-window](help://location-list-window)
+---   "popup"    floating window [api-floatwin](help://api-floatwin)
+---   "preview"  preview window [preview-window](help://preview-window)
+---   "quickfix"  [quickfix-window](help://quickfix-window)
 ---   "unknown"  window {nr} not found
 ---
 --- When {nr} is omitted return the type of the current window.
 --- When {nr} is given return the type of this window by number or
---- `|window-ID|`.
+--- [window-ID](help://window-ID).
 ---
 --- Also see the 'buftype' option.
 ---
@@ -11290,7 +11294,7 @@ function vim.fn.win_id2win(expr) end
 
 --- Move window {nr}'s vertical separator (i.e., the right border)
 --- by {offset} columns, as if being dragged by the mouse. {nr}
---- can be a window number or `|window-ID|`. A positive {offset}
+--- can be a window number or [window-ID](help://window-ID). A positive {offset}
 --- moves right and a negative {offset} moves left. Moving a
 --- window's vertical separator will change the width of the
 --- window and the width of other windows adjacent to the vertical
@@ -11310,7 +11314,7 @@ function vim.fn.win_move_separator(nr, offset) end
 
 --- Move window {nr}'s status line (i.e., the bottom border) by
 --- {offset} rows, as if being dragged by the mouse. {nr} can be a
---- window number or `|window-ID|`. A positive {offset} moves down
+--- window number or [window-ID](help://window-ID). A positive {offset} moves down
 --- and a negative {offset} moves up. Moving a window's status
 --- line will change the height of the window and the height of
 --- other windows adjacent to the status line. The magnitude of
@@ -11328,7 +11332,7 @@ function vim.fn.win_move_statusline(nr, offset) end
 --- Return the screen position of window {nr} as a list with two
 --- numbers: [row, col].  The first window always has position
 --- [1, 1], unless there is a tabline, then it is [2, 1].
---- {nr} can be the window number or the `|window-ID|`.  Use zero
+--- {nr} can be the window number or the [window-ID](help://window-ID).  Use zero
 --- for the current window.
 --- Returns [0, 0] if the window cannot be found in the current
 --- tabpage.
@@ -11340,17 +11344,17 @@ function vim.fn.win_screenpos(nr) end
 
 --- Move the window {nr} to a new split of the window {target}.
 --- This is similar to moving to {target}, creating a new window
---- using `|:split|` but having the same contents as window {nr}, and
+--- using [:split](help://:split) but having the same contents as window {nr}, and
 --- then closing {nr}.
 ---
---- Both {nr} and {target} can be window numbers or `|window-ID|`s.
+--- Both {nr} and {target} can be window numbers or [window-ID](help://window-ID)s.
 --- Both must be in the current tab page.
 ---
 --- Returns zero for success, non-zero for failure.
 ---
---- {options} is a `|Dictionary|` with the following optional entries:
+--- {options} is a [Dictionary](help://Dictionary) with the following optional entries:
 ---   "vertical"  When TRUE, the split is created vertically,
----     like with `|:vsplit|`.
+---     like with [:vsplit](help://:vsplit).
 ---   "rightbelow"  When TRUE, the split is made below or to the
 ---     right (if vertical).  When FALSE, it is done
 ---     above or to the left (if vertical).  When not
@@ -11366,7 +11370,7 @@ function vim.fn.win_splitmove(nr, target, options) end
 
 --- The result is a Number, which is the number of the buffer
 --- associated with window {nr}.  {nr} can be the window number or
---- the `|window-ID|`.
+--- the [window-ID](help://window-ID).
 --- When {nr} is zero, the number of the buffer in the current
 --- window is returned.
 --- When window {nr} doesn't exist, -1 is returned.
@@ -11395,7 +11399,7 @@ function vim.fn.wincol() end
 function vim.fn.windowsversion() end
 
 --- The result is a Number, which is the height of window {nr}.
---- {nr} can be the window number or the `|window-ID|`.
+--- {nr} can be the window number or the [window-ID](help://window-ID).
 --- When {nr} is zero, the height of the current window is
 --- returned.  When window {nr} doesn't exist, -1 is returned.
 --- An existing window always has a height of zero or more.
@@ -11476,21 +11480,21 @@ function vim.fn.winline() end
 ---   $  the number of the last window (the window
 ---     count).
 ---   #  the number of the last accessed window (where
----     `|CTRL-W_p|` goes to).  If there is no previous
+---     [CTRL-W_p](help://CTRL-W_p) goes to).  If there is no previous
 ---     window or it is in another tab page 0 is
 ---     returned.
 ---   {N}j  the number of the Nth window below the
----     current window (where `|CTRL-W_j|` goes to).
+---     current window (where [CTRL-W_j](help://CTRL-W_j) goes to).
 ---   {N}k  the number of the Nth window above the current
----     window (where `|CTRL-W_k|` goes to).
+---     window (where [CTRL-W_k](help://CTRL-W_k) goes to).
 ---   {N}h  the number of the Nth window left of the
----     current window (where `|CTRL-W_h|` goes to).
+---     current window (where [CTRL-W_h](help://CTRL-W_h) goes to).
 ---   {N}l  the number of the Nth window right of the
----     current window (where `|CTRL-W_l|` goes to).
---- The number can be used with `|CTRL-W_w|` and ":wincmd w"
---- `|:wincmd|`.
+---     current window (where [CTRL-W_l](help://CTRL-W_l) goes to).
+--- The number can be used with [CTRL-W_w](help://CTRL-W_w) and ":wincmd w"
+--- [:wincmd](help://:wincmd).
 --- When {arg} is invalid an error is given and zero is returned.
---- Also see `|tabpagewinnr()|` and `|win_getid()|`.
+--- Also see [tabpagewinnr()](help://tabpagewinnr()) and [win_getid()](help://win_getid()).
 --- Examples:
 --- ```vim
 ---   let window_count = winnr('$')
@@ -11502,7 +11506,7 @@ function vim.fn.winline() end
 --- @return any
 function vim.fn.winnr(arg) end
 
---- Returns a sequence of `|:resize|` commands that should restore
+--- Returns a sequence of [:resize](help://:resize) commands that should restore
 --- the current window sizes.  Only works properly when no windows
 --- are opened or closed and the current window and tab page is
 --- unchanged.
@@ -11516,10 +11520,10 @@ function vim.fn.winnr(arg) end
 --- @return any
 function vim.fn.winrestcmd() end
 
---- Uses the `|Dictionary|` returned by `|winsaveview()|` to restore
+--- Uses the [Dictionary](help://Dictionary) returned by [winsaveview()](help://winsaveview()) to restore
 --- the view of the current window.
 --- Note: The {dict} does not have to contain all values, that are
---- returned by `|winsaveview()|`. If values are missing, those
+--- returned by [winsaveview()](help://winsaveview()). If values are missing, those
 --- settings won't be restored. So you can use:
 --- ```vim
 ---     call winrestview({'curswant': 4})
@@ -11537,8 +11541,8 @@ function vim.fn.winrestcmd() end
 --- @return any
 function vim.fn.winrestview(dict) end
 
---- Returns a `|Dictionary|` that contains information to restore
---- the view of the current window.  Use `|winrestview()|` to
+--- Returns a [Dictionary](help://Dictionary) that contains information to restore
+--- the view of the current window.  Use [winrestview()](help://winrestview()) to
 --- restore the view.
 --- This is useful if you have a mapping that jumps around in the
 --- buffer and you want to go back to the original view.
@@ -11548,14 +11552,14 @@ function vim.fn.winrestview(dict) end
 --- The return value includes:
 ---   lnum    cursor line number
 ---   col    cursor column (Note: the first column
----       zero, as opposed to what `|getcurpos()|`
+---       zero, as opposed to what [getcurpos()](help://getcurpos())
 ---       returns)
 ---   coladd    cursor column offset for 'virtualedit'
 ---   curswant  column for vertical movement (Note:
 ---       the first column is zero, as opposed
----       to what `|getcurpos()|` returns).  After
----       `|$|` command it will be a very large
----       number equal to `|v:maxcol|`.
+---       to what [getcurpos()](help://getcurpos()) returns).  After
+---       [$](help://$) command it will be a very large
+---       number equal to [v:maxcol](help://v:maxcol).
 ---   topline    first line in the window
 ---   topfill    filler lines, only in diff mode
 ---   leftcol    first column displayed; only used when
@@ -11567,7 +11571,7 @@ function vim.fn.winrestview(dict) end
 function vim.fn.winsaveview() end
 
 --- The result is a Number, which is the width of window {nr}.
---- {nr} can be the window number or the `|window-ID|`.
+--- {nr} can be the window number or the [window-ID](help://window-ID).
 --- When {nr} is zero, the width of the current window is
 --- returned.  When window {nr} doesn't exist, -1 is returned.
 --- An existing window always has a width of zero or more.
@@ -11588,7 +11592,7 @@ function vim.fn.winwidth(nr) end
 
 --- The result is a dictionary of byte/chars/word statistics for
 --- the current buffer.  This is the same info as provided by
---- `|g_CTRL-G|`
+--- [g_CTRL-G](help://g_CTRL-G)
 --- The return value includes:
 ---   bytes    Number of bytes in the buffer
 ---   chars    Number of chars in the buffer
@@ -11609,14 +11613,14 @@ function vim.fn.winwidth(nr) end
 --- @return any
 function vim.fn.wordcount() end
 
---- When {object} is a `|List|` write it to file {fname}.  Each list
+--- When {object} is a [List](help://List) write it to file {fname}.  Each list
 --- item is separated with a NL.  Each list item must be a String
 --- or Number.
 --- All NL characters are replaced with a NUL character.
 --- Inserting CR characters needs to be done before passing {list}
 --- to writefile().
 ---
---- When {object} is a `|Blob|` write the bytes to file {fname}
+--- When {object} is a [Blob](help://Blob) write the bytes to file {fname}
 --- unmodified, also when binary mode is not specified.
 ---
 --- {flags} must be a String.  These characters are recognized:
@@ -11635,7 +11639,7 @@ function vim.fn.wordcount() end
 --- ```vim
 ---   defer delete({fname})
 --- ```
---- Fails when not in a function.  Also see `|:defer|`.
+--- Fails when not in a function.  Also see [:defer](help://:defer).
 ---
 --- 's'  fsync() is called after writing the file.  This flushes
 ---      the file to disk, if possible.  This takes more time but
@@ -11652,7 +11656,7 @@ function vim.fn.wordcount() end
 --- error message if the file can't be created or when writing
 --- fails.
 ---
---- Also see `|readfile()|`.
+--- Also see [readfile()](help://readfile()).
 --- To copy a file byte for byte:
 --- ```vim
 ---   let fl = readfile("foo", "b")

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -129,7 +129,16 @@ function M.open(path)
     path = { path, 'string' },
   })
   local is_uri = path:match('%w+:')
-  if not is_uri then
+  if is_uri then
+    local help = path:match('^help://(.+)$')
+    if help then
+      local ok, err = pcall(vim.cmd.help, help)
+      return {
+        code = ok and 0 or 1,
+        stderr = not ok and err or nil,
+      }
+    end
+  else
     path = vim.fn.expand(path)
   end
 

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -211,7 +211,7 @@ local function get_api_meta()
   return ret
 end
 
----@param text string
+--- @param text string
 local function fix_indent(text)
   local lines = vim.split(text, "\n")
   local indent = 100
@@ -225,7 +225,7 @@ local function fix_indent(text)
       end
     end
   end
-  if indent and indent > 0 then
+  if indent > 0 then
     for l, line in ipairs(lines) do
       lines[l] = line:gsub("^" .. ("\t"):rep(indent), ""):gsub("\t", "  ")
     end
@@ -233,8 +233,8 @@ local function fix_indent(text)
   return table.concat(lines, "\n")
 end
 
----@param text string
----@param str string?
+--- @param text string
+--- @param str string?
 local function indent(text, str)
   str = str or "  "
   local lines = vim.split(text, "\n")
@@ -254,10 +254,10 @@ end
 local function norm_text(x)
   local input = x
   x = fix_indent(x)
-  x = x:gsub('|([^ ]+)|', '`|%1|`')
+  x = x:gsub('|([^ ]+)|', '[%1](help://%1)')
   local lines = vim.split(x, '\n')
-  local block ---@type number?
-  local before, lang ---@type string?, string?
+  local block --- @type number?
+  local before, lang --- @type string?, string?
   for l, line in ipairs(lines) do
     if block then
       local after = line:match("^%s*<%s*(.*)%s*$")
@@ -273,7 +273,7 @@ local function norm_text(x)
     else
       before, lang = line:match("^(.*)%s*>([a-z]*)%s*$")
       -- don't match tags
-      if line:find("<[a-zA-Z%-_]+>%s*$") then before = nil end
+      if line:find("<[%a%-_]+>%s*$") then before = nil end
       block = before and l or nil
     end
   end


### PR DESCRIPTION
Added some improvements to the lua meta doc gen:

* [x] fix indentation for params. This ensures param descriptions are not interpreted as a markdown code block
* [x] better support for vim code blocks
* [x] generate markdown code blocks for `vimfn`
* [x] render help tags as markdown links like `[helptag](help://helptag)` instead of just `tag`  (useful with `<gx>`)
* [x] added support for help links to `vim.ui.open()` 