### PR TITLE
fix(clipboard): fix interoperability between macOS and Linux through pbcopy/pbpaste

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -145,6 +145,13 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'termux-clipboard'
+  elseif executable('pbcopy') && executable('pbpaste') 
+    let s:copy['+'] = ['pbcopy']
+    let s:paste['+'] = ['pbpaste']
+    let s:copy['*'] = s:copy['+']
+    let s:paste['*'] = s:paste['+']
+    let s:cache_enabled = 0
+    return 'pbcopy'
   elseif !empty($TMUX) && executable('tmux')
     let tmux_v = v:lua.vim.version.parse(system(['tmux', '-V']))
     if !empty(tmux_v) && !v:lua.vim.version.lt(tmux_v, [3,2,0])

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -195,6 +195,7 @@ registers. Nvim looks for these clipboard tools, in order of priority:
   - doitclient (for SSH) https://www.chiark.greenend.org.uk/~sgtatham/doit/
   - win32yank (Windows)
   - termux (via termux-clipboard-set, termux-clipboard-set)
+  - pbcopy, pbpaste
   - tmux (if $TMUX is set)
 
 								 *g:clipboard*


### PR DESCRIPTION
Currently, the pbcopy/pbpaste provider is only enabled on macOS. It might be too conservative since a container or a virtual machine (which are different platforms like Linux) may use the pbcopy/pbpaste of the host macOS. It's exactly the case when using OrbStack.
For compatibility consideration, I don't remove the old check and choose to append a new check after the if chain.