### PR TITLE
vim-patch:9.0.{2044,2045}

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3296,7 +3296,22 @@ static void handle_defer_one(funccall_T *funccal)
     char *name = dr->dr_name;
     dr->dr_name = NULL;
 
+    // If the deferred function is called after an exception, then only the
+    // first statement in the function will be executed.  Save and restore
+    // the try/catch/throw exception state.
+    const int save_trylevel = trylevel;
+    const bool save_did_throw = did_throw;
+    const bool save_need_rethrow = need_rethrow;
+
+    trylevel = 0;
+    did_throw = false;
+    need_rethrow = false;
+
     call_func(name, -1, &rettv, dr->dr_argcount, dr->dr_argvars, &funcexe);
+
+    trylevel = save_trylevel;
+    did_throw = save_did_throw;
+    need_rethrow = save_need_rethrow;
 
     tv_clear(&rettv);
     xfree(name);

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -793,5 +793,31 @@ func Test_defer_wrong_arguments()
   call v9.CheckScriptFailure(lines, 'E1013: Argument 1: type mismatch, expected string but got number')
 endfunc
 
+" Test for calling a deferred function after an exception
+func Test_defer_after_exception()
+  let g:callTrace = []
+  func Defer()
+    let g:callTrace += ['a']
+    let g:callTrace += ['b']
+    let g:callTrace += ['c']
+    let g:callTrace += ['d']
+  endfunc
+
+  func Foo()
+    defer Defer()
+    throw "TestException"
+  endfunc
+
+  try
+    call Foo()
+  catch /TestException/
+    let g:callTrace += ['e']
+  endtry
+  call assert_equal(['a', 'b', 'c', 'd', 'e'], g:callTrace)
+
+  delfunc Defer
+  delfunc Foo
+  unlet g:callTrace
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2044: Vim9: exceptions confuse defered functions

Problem:  Vim9: exceptions confuse defered functions
Solution: save and restore exception state when calling defered
          functions

closes: vim/vim#13372

https://github.com/vim/vim/commit/0672595fd50e9ae668676a40e28ebf66d7f52392

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.2045: tests: checking for swap files takes time

Problem:  tests: checking for swap files takes time
Solution: don't check for swap files  when test has been skipped

Check for swap files takes a considerable about of time, so don't do
that for skipped tests to avoid wasting time.

closes: vim/vim#13371

https://github.com/vim/vim/commit/a0e1f06f04da3444e278ddf47e2ea3d5857a7dec