### PR TITLE
Change log level to DEBUG instead of WARN when unknown tag is found in diagnostic

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -89,7 +89,7 @@ local function tags_lsp_to_vim(diagnostic, client_id)
       tags = tags or {}
       tags.deprecated = true
     else
-      log.info('Unknown DiagnosticTag %d from LSP client %d', tag, client_id)
+      log.info(string.format('Unknown DiagnosticTag %d from LSP client %d', tag, client_id))
     end
   end
   return tags

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -90,7 +90,7 @@ local function tags_lsp_to_vim(diagnostic, client_id)
     else
       vim.notify_once(
         string.format('Unknown DiagnosticTag %d from LSP client %d', tag, client_id),
-        vim.log.levels.WARN
+        vim.log.levels.DEBUG
       )
     end
   end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -2,6 +2,7 @@
 
 local util = require('vim.lsp.util')
 local protocol = require('vim.lsp.protocol')
+local log = require('vim.lsp.log')
 local ms = protocol.Methods
 
 local api = vim.api
@@ -88,10 +89,7 @@ local function tags_lsp_to_vim(diagnostic, client_id)
       tags = tags or {}
       tags.deprecated = true
     else
-      vim.notify_once(
-        string.format('Unknown DiagnosticTag %d from LSP client %d', tag, client_id),
-        vim.log.levels.DEBUG
-      )
+      log.info('Unknown DiagnosticTag %d from LSP client %d', tag, client_id)
     end
   end
   return tags


### PR DESCRIPTION
LSP client should ignore unknown enumeration values for enum types (like `DiagnosticTag`) [according to the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#enumerations). This `WARN` every time an unknown tag is found is very annoying :(.