### PR TITLE
vim-patch:9.0.2050: Vim9: crash with deferred function call and exception

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3297,21 +3297,16 @@ static void handle_defer_one(funccall_T *funccal)
     dr->dr_name = NULL;
 
     // If the deferred function is called after an exception, then only the
-    // first statement in the function will be executed.  Save and restore
-    // the try/catch/throw exception state.
-    const int save_trylevel = trylevel;
-    const bool save_did_throw = did_throw;
-    const bool save_need_rethrow = need_rethrow;
-
-    trylevel = 0;
-    did_throw = false;
-    need_rethrow = false;
+    // first statement in the function will be executed (because of the
+    // exception).  So save and restore the try/catch/throw exception
+    // state.
+    exception_state_T estate;
+    exception_state_save(&estate);
+    exception_state_clear();
 
     call_func(name, -1, &rettv, dr->dr_argcount, dr->dr_argvars, &funcexe);
 
-    trylevel = save_trylevel;
-    did_throw = save_did_throw;
-    need_rethrow = save_need_rethrow;
+    exception_state_restore(&estate);
 
     tv_clear(&rettv);
     xfree(name);

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -661,6 +661,35 @@ static void finish_exception(except_T *excp)
   discard_exception(excp, true);
 }
 
+/// Save the current exception state in "estate"
+void exception_state_save(exception_state_T *estate)
+{
+  estate->estate_current_exception = current_exception;
+  estate->estate_did_throw = did_throw;
+  estate->estate_need_rethrow = need_rethrow;
+  estate->estate_trylevel = trylevel;
+}
+
+/// Restore the current exception state from "estate"
+void exception_state_restore(exception_state_T *estate)
+{
+  if (current_exception == NULL) {
+    current_exception = estate->estate_current_exception;
+  }
+  did_throw |= estate->estate_did_throw;
+  need_rethrow |= estate->estate_need_rethrow;
+  trylevel |= estate->estate_trylevel;
+}
+
+/// Clear the current exception state
+void exception_state_clear(void)
+{
+  current_exception = NULL;
+  did_throw = false;
+  need_rethrow = false;
+  trylevel = 0;
+}
+
 // Flags specifying the message displayed by report_pending.
 #define RP_MAKE         0
 #define RP_RESUME       1

--- a/src/nvim/ex_eval_defs.h
+++ b/src/nvim/ex_eval_defs.h
@@ -118,4 +118,14 @@ struct cleanup_stuff {
   except_T *exception;  ///< exception value
 };
 
+/// Exception state that is saved and restored when calling timer callback
+/// functions and deferred functions.
+typedef struct exception_state_S exception_state_T;
+struct exception_state_S {
+  except_T *estate_current_exception;
+  bool estate_did_throw;
+  bool estate_need_rethrow;
+  int estate_trylevel;
+};
+
 #endif  // NVIM_EX_EVAL_DEFS_H

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -796,11 +796,21 @@ endfunc
 " Test for calling a deferred function after an exception
 func Test_defer_after_exception()
   let g:callTrace = []
+  func Bar()
+    let g:callTrace += [1]
+    throw 'InnerException'
+  endfunc
+
   func Defer()
-    let g:callTrace += ['a']
-    let g:callTrace += ['b']
-    let g:callTrace += ['c']
-    let g:callTrace += ['d']
+    let g:callTrace += [2]
+    let g:callTrace += [3]
+    try
+      call Bar()
+    catch /InnerException/
+      let g:callTrace += [4]
+    endtry
+    let g:callTrace += [5]
+    let g:callTrace += [6]
   endfunc
 
   func Foo()
@@ -811,9 +821,9 @@ func Test_defer_after_exception()
   try
     call Foo()
   catch /TestException/
-    let g:callTrace += ['e']
+    let g:callTrace += [7]
   endtry
-  call assert_equal(['a', 'b', 'c', 'd', 'e'], g:callTrace)
+  call assert_equal([2, 3, 1, 4, 5, 6, 7], g:callTrace)
 
   delfunc Defer
   delfunc Foo


### PR DESCRIPTION
#### vim-patch:9.0.2050: Vim9: crash with deferred function call and exception

Problem:  Vim9: crash with deferred function call and exception
Solution: Save and restore exception state

Crash when a deferred function is called after an exception and another
exception is thrown

closes: vim/vim#13376

https://github.com/vim/vim/commit/c59c1e0d88651a71ece7366e418f1253abbe2a28

The change in check_due_timer() is N/A as Nvim calls timer callbacks on
the main loop.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>