### PR TITLE
refactor(options): `get_option_value_strict()` and `SREQ_*`

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -26,8 +26,9 @@
 # include "api/options.c.generated.h"
 #endif
 
-static int validate_option_value_args(Dict(option) *opts, char *name, int *scope, int *opt_type,
-                                      void **from, char **filetype, Error *err)
+static int validate_option_value_args(Dict(option) *opts, char *name, int *scope,
+                                      OptReqScope *req_scope, void **from, char **filetype,
+                                      Error *err)
 {
 #define HAS_KEY_X(d, v) HAS_KEY(d, option, v)
   if (HAS_KEY_X(opts, scope)) {
@@ -42,14 +43,14 @@ static int validate_option_value_args(Dict(option) *opts, char *name, int *scope
     }
   }
 
-  *opt_type = SREQ_GLOBAL;
+  *req_scope = kOptReqGlobal;
 
   if (filetype != NULL && HAS_KEY_X(opts, filetype)) {
     *filetype = opts->filetype.data;
   }
 
   if (HAS_KEY_X(opts, win)) {
-    *opt_type = SREQ_WIN;
+    *req_scope = kOptReqWin;
     *from = find_window_by_handle(opts->win, err);
     if (ERROR_SET(err)) {
       return FAIL;
@@ -58,7 +59,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, int *scope
 
   if (HAS_KEY_X(opts, buf)) {
     *scope = OPT_LOCAL;
-    *opt_type = SREQ_BUF;
+    *req_scope = kOptReqBuf;
     *from = find_buffer_by_handle(opts->buf, err);
     if (ERROR_SET(err)) {
       return FAIL;
@@ -81,15 +82,15 @@ static int validate_option_value_args(Dict(option) *opts, char *name, int *scope
     return FAIL;
   });
 
-  int flags = get_option_value_strict(name, NULL, NULL, 0, NULL);
+  int flags = get_option_attrs(name);
   if (flags == 0) {
     // hidden or unknown option
     api_set_error(err, kErrorTypeValidation, "Unknown option '%s'", name);
-  } else if (*opt_type & (SREQ_BUF | SREQ_WIN)) {
+  } else if (*req_scope == kOptReqBuf || *req_scope == kOptReqWin) {
     // if 'buf' or 'win' is passed, make sure the option supports it
-    int req_flags = *opt_type & SREQ_BUF ? SOPT_BUF : SOPT_WIN;
+    int req_flags = *req_scope == kOptReqBuf ? SOPT_BUF : SOPT_WIN;
     if (!(flags & req_flags)) {
-      char *tgt = *opt_type & SREQ_BUF ? "buf" : "win";
+      char *tgt = *req_scope & kOptReqBuf ? "buf" : "win";
       char *global = flags & SOPT_GLOBAL ? "global ": "";
       char *req = flags & SOPT_BUF ? "buffer-local " :
                   flags & SOPT_WIN ? "window-local " : "";
@@ -158,11 +159,11 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   OptVal value = NIL_OPTVAL;
 
   int scope = 0;
-  int opt_type = SREQ_GLOBAL;
+  OptReqScope req_scope = kOptReqGlobal;
   void *from = NULL;
   char *filetype = NULL;
 
-  if (!validate_option_value_args(opts, name.data, &scope, &opt_type, &from, &filetype, err)) {
+  if (!validate_option_value_args(opts, name.data, &scope, &req_scope, &from, &filetype, err)) {
     goto err;
   }
 
@@ -179,7 +180,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   }
 
   bool hidden;
-  value = get_option_value_for(name.data, NULL, scope, &hidden, opt_type, from, err);
+  value = get_option_value_for(name.data, NULL, scope, &hidden, req_scope, from, err);
 
   if (ftbuf != NULL) {
     // restore curwin/curbuf and a few other things
@@ -222,9 +223,9 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
   FUNC_API_SINCE(9)
 {
   int scope = 0;
-  int opt_type = SREQ_GLOBAL;
+  OptReqScope req_scope = kOptReqGlobal;
   void *to = NULL;
-  if (!validate_option_value_args(opts, name.data, &scope, &opt_type, &to, NULL, err)) {
+  if (!validate_option_value_args(opts, name.data, &scope, &req_scope, &to, NULL, err)) {
     return;
   }
 
@@ -234,8 +235,8 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
   // - option is global or local to window (global-local)
   //
   // Then force scope to local since we don't want to change the global option
-  if (opt_type == SREQ_WIN && scope == 0) {
-    int flags = get_option_value_strict(name.data, NULL, NULL, opt_type, to);
+  if (req_scope == kOptReqWin && scope == 0) {
+    int flags = get_option_attrs(name.data);
     if (flags & SOPT_GLOBAL) {
       scope = OPT_LOCAL;
     }
@@ -245,15 +246,15 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
   OptVal optval = object_as_optval(value, &error);
 
   // Handle invalid option value type.
-  if (error) {
-    // Don't use `name` in the error message here, because `name` can be any String.
-    VALIDATE_EXP(false, "value", "Integer/Boolean/String", api_typename(value.type), {
-      return;
-    });
-  }
+  // Don't use `name` in the error message here, because `name` can be any String.
+  // No need to check if value type actually matches the types for the option, as set_option_value()
+  // already handles that.
+  VALIDATE_EXP(!error, "value", "valid option type", api_typename(value.type), {
+    return;
+  });
 
   WITH_SCRIPT_CONTEXT(channel_id, {
-    set_option_value_for(name.data, optval, scope, opt_type, to, err);
+    set_option_value_for(name.data, optval, scope, req_scope, to, err);
   });
 }
 
@@ -308,30 +309,31 @@ Dictionary nvim_get_option_info2(String name, Dict(option) *opts, Error *err)
   FUNC_API_SINCE(11)
 {
   int scope = 0;
-  int opt_type = SREQ_GLOBAL;
+  OptReqScope req_scope = kOptReqGlobal;
   void *from = NULL;
-  if (!validate_option_value_args(opts, name.data, &scope, &opt_type, &from, NULL, err)) {
+  if (!validate_option_value_args(opts, name.data, &scope, &req_scope, &from, NULL, err)) {
     return (Dictionary)ARRAY_DICT_INIT;
   }
 
-  buf_T *buf = (opt_type == SREQ_BUF) ? (buf_T *)from : curbuf;
-  win_T *win = (opt_type == SREQ_WIN) ? (win_T *)from : curwin;
+  buf_T *buf = (req_scope == kOptReqBuf) ? (buf_T *)from : curbuf;
+  win_T *win = (req_scope == kOptReqWin) ? (win_T *)from : curwin;
 
   return get_vimoption(name, scope, buf, win, err);
 }
 
 /// Switch current context to get/set option value for window/buffer.
 ///
-/// @param[out]  ctx       Current context. switchwin_T for window and aco_save_T for buffer.
-/// @param[in]   opt_type  Option type. See SREQ_* in option_defs.h.
-/// @param[in]   from      Target buffer/window.
-/// @param[out]  err       Error message, if any.
+/// @param[out]  ctx        Current context. switchwin_T for window and aco_save_T for buffer.
+/// @param       req_scope  Requested option scope. See OptReqScope in option.h.
+/// @param[in]   from       Target buffer/window.
+/// @param[out]  err        Error message, if any.
 ///
 /// @return  true if context was switched, false otherwise.
-static bool switch_option_context(void *const ctx, int opt_type, void *const from, Error *err)
+static bool switch_option_context(void *const ctx, OptReqScope req_scope, void *const from,
+                                  Error *err)
 {
-  switch (opt_type) {
-  case SREQ_WIN: {
+  switch (req_scope) {
+  case kOptReqWin: {
     win_T *const win = (win_T *)from;
     switchwin_T *const switchwin = (switchwin_T *)ctx;
 
@@ -351,7 +353,7 @@ static bool switch_option_context(void *const ctx, int opt_type, void *const fro
     }
     return true;
   }
-  case SREQ_BUF: {
+  case kOptReqBuf: {
     buf_T *const buf = (buf_T *)from;
     aco_save_T *const aco = (aco_save_T *)ctx;
 
@@ -361,51 +363,177 @@ static bool switch_option_context(void *const ctx, int opt_type, void *const fro
     aucmd_prepbuf(aco, buf);
     return true;
   }
-  case SREQ_GLOBAL:
+  case kOptReqGlobal:
     return false;
-  default:
-    abort();  // This should never happen.
   }
+  UNREACHABLE;
 }
 
 /// Restore context after getting/setting option for window/buffer. See switch_option_context() for
 /// params.
-static void restore_option_context(void *const ctx, const int opt_type)
+static void restore_option_context(void *const ctx, OptReqScope req_scope)
 {
-  switch (opt_type) {
-  case SREQ_WIN:
+  switch (req_scope) {
+  case kOptReqWin:
     restore_win_noblock((switchwin_T *)ctx, true);
     break;
-  case SREQ_BUF:
+  case kOptReqBuf:
     aucmd_restbuf((aco_save_T *)ctx);
     break;
-  case SREQ_GLOBAL:
+  case kOptReqGlobal:
     break;
-  default:
-    abort();  // This should never happen.
   }
+}
+
+/// Get attributes for an option.
+///
+/// @param  name  Option name.
+///
+/// @return  Option attributes.
+///          0 for hidden or unknown option.
+///          See SOPT_* in option_defs.h for other flags.
+int get_option_attrs(char *name)
+{
+  int opt_idx = findoption(name);
+
+  if (opt_idx < 0) {
+    return 0;
+  }
+
+  vimoption_T *opt = get_option(opt_idx);
+
+  if (is_tty_option(opt->fullname)) {
+    return SOPT_STRING | SOPT_GLOBAL;
+  }
+
+  // Hidden option
+  if (opt->var == NULL) {
+    return 0;
+  }
+
+  int attrs = 0;
+
+  if (opt->flags & P_BOOL) {
+    attrs |= SOPT_BOOL;
+  } else if (opt->flags & P_NUM) {
+    attrs |= SOPT_NUM;
+  } else if (opt->flags & P_STRING) {
+    attrs |= SOPT_STRING;
+  }
+
+  if (opt->indir == PV_NONE || (opt->indir & PV_BOTH)) {
+    attrs |= SOPT_GLOBAL;
+  }
+  if (opt->indir & PV_WIN) {
+    attrs |= SOPT_WIN;
+  } else if (opt->indir & PV_BUF) {
+    attrs |= SOPT_BUF;
+  }
+
+  return attrs;
+}
+
+/// Check if option has a value in the requested scope.
+///
+/// @param  name       Option name.
+/// @param  req_scope  Requested option scope. See OptReqScope in option.h.
+///
+/// @return  true if option has a value in the requested scope, false otherwise.
+static bool option_has_scope(char *name, OptReqScope req_scope)
+{
+  int opt_idx = findoption(name);
+
+  if (opt_idx < 0) {
+    return false;
+  }
+
+  vimoption_T *opt = get_option(opt_idx);
+
+  // Hidden option.
+  if (opt->var == NULL) {
+    return false;
+  }
+  // TTY option.
+  if (is_tty_option(opt->fullname)) {
+    return req_scope == kOptReqGlobal;
+  }
+
+  switch (req_scope) {
+  case kOptReqGlobal:
+    return opt->var != VAR_WIN;
+  case kOptReqBuf:
+    return opt->indir & PV_BUF;
+  case kOptReqWin:
+    return opt->indir & PV_WIN;
+  }
+  UNREACHABLE;
+}
+
+/// Get the option value in the requested scope.
+///
+/// @param       name       Option name.
+/// @param       req_scope  Requested option scope. See OptReqScope in option.h.
+/// @param[in]   from       Pointer to buffer or window for local option value.
+/// @param[out]  err        Error message, if any.
+///
+/// @return  Option value in the requested scope. Returns a Nil option value if option is not found,
+/// hidden or if it isn't present in the requested scope. (i.e. has no global, window-local or
+/// buffer-local value depending on opt_scope).
+OptVal get_option_value_strict(char *name, OptReqScope req_scope, void *from, Error *err)
+{
+  OptVal retv = NIL_OPTVAL;
+
+  if (!option_has_scope(name, req_scope)) {
+    return retv;
+  }
+  if (get_tty_option(name, &retv.data.string.data)) {
+    retv.type = kOptValTypeString;
+    return retv;
+  }
+
+  int opt_idx = findoption(name);
+  assert(opt_idx != 0);  // option_has_scope() already verifies if option name is valid.
+
+  vimoption_T *opt = get_option(opt_idx);
+  switchwin_T switchwin;
+  aco_save_T aco;
+  void *ctx = req_scope == kOptReqWin ? (void *)&switchwin
+                                    : (req_scope == kOptReqBuf ? (void *)&aco : NULL);
+  bool switched = switch_option_context(ctx, req_scope, from, err);
+  if (ERROR_SET(err)) {
+    return retv;
+  }
+
+  char *varp = get_varp_scope(opt, req_scope == kOptReqGlobal ? OPT_GLOBAL : OPT_LOCAL);
+  retv = optval_from_varp(opt_idx, varp);
+
+  if (switched) {
+    restore_option_context(ctx, req_scope);
+  }
+
+  return retv;
 }
 
 /// Get option value for buffer / window.
 ///
-/// @param[in]   name      Option name.
-/// @param[out]  flagsp    Set to the option flags (P_xxxx) (if not NULL).
-/// @param[in]   scope     Option scope (can be OPT_LOCAL, OPT_GLOBAL or a combination).
-/// @param[out]  hidden    Whether option is hidden.
-/// @param[in]   opt_type  Option type. See SREQ_* in option_defs.h.
-/// @param[in]   from      Target buffer/window.
-/// @param[out]  err       Error message, if any.
+/// @param[in]   name       Option name.
+/// @param[out]  flagsp     Set to the option flags (P_xxxx) (if not NULL).
+/// @param[in]   scope      Option scope (can be OPT_LOCAL, OPT_GLOBAL or a combination).
+/// @param[out]  hidden     Whether option is hidden.
+/// @param       req_scope  Requested option scope. See OptReqScope in option.h.
+/// @param[in]   from       Target buffer/window.
+/// @param[out]  err        Error message, if any.
 ///
 /// @return  Option value. Must be freed by caller.
 OptVal get_option_value_for(const char *const name, uint32_t *flagsp, int scope, bool *hidden,
-                            const int opt_type, void *const from, Error *err)
+                            const OptReqScope req_scope, void *const from, Error *err)
 {
   switchwin_T switchwin;
   aco_save_T aco;
-  void *ctx = opt_type == SREQ_WIN ? (void *)&switchwin
-                                   : (opt_type == SREQ_BUF ? (void *)&aco : NULL);
+  void *ctx = req_scope == kOptReqWin ? (void *)&switchwin
+                                      : (req_scope == kOptReqBuf ? (void *)&aco : NULL);
 
-  bool switched = switch_option_context(ctx, opt_type, from, err);
+  bool switched = switch_option_context(ctx, req_scope, from, err);
   if (ERROR_SET(err)) {
     return NIL_OPTVAL;
   }
@@ -413,7 +541,7 @@ OptVal get_option_value_for(const char *const name, uint32_t *flagsp, int scope,
   OptVal retv = get_option_value(name, flagsp, scope, hidden);
 
   if (switched) {
-    restore_option_context(ctx, opt_type);
+    restore_option_context(ctx, req_scope);
   }
 
   return retv;
@@ -421,21 +549,21 @@ OptVal get_option_value_for(const char *const name, uint32_t *flagsp, int scope,
 
 /// Set option value for buffer / window.
 ///
-/// @param[in]   name       Option name.
-/// @param[in]   value      Option value.
-/// @param[in]   opt_flags  Flags: OPT_LOCAL, OPT_GLOBAL, or 0 (both).
-/// @param[in]   opt_type   Option type. See SREQ_* in option_defs.h.
-/// @param[in]   from       Target buffer/window.
-/// @param[out]  err        Error message, if any.
+/// @param[in]   name        Option name.
+/// @param[in]   value       Option value.
+/// @param[in]   opt_flags   Flags: OPT_LOCAL, OPT_GLOBAL, or 0 (both).
+/// @param       req_scope   Requested option scope. See OptReqScope in option.h.
+/// @param[in]   from        Target buffer/window.
+/// @param[out]  err         Error message, if any.
 void set_option_value_for(const char *const name, OptVal value, const int opt_flags,
-                          const int opt_type, void *const from, Error *err)
+                          const OptReqScope req_scope, void *const from, Error *err)
 {
   switchwin_T switchwin;
   aco_save_T aco;
-  void *ctx = opt_type == SREQ_WIN ? (void *)&switchwin
-                                   : (opt_type == SREQ_BUF ? (void *)&aco : NULL);
+  void *ctx = req_scope == kOptReqWin ? (void *)&switchwin
+                                      : (req_scope == kOptReqBuf ? (void *)&aco : NULL);
 
-  bool switched = switch_option_context(ctx, opt_type, from, err);
+  bool switched = switch_option_context(ctx, req_scope, from, err);
   if (ERROR_SET(err)) {
     return;
   }
@@ -446,6 +574,6 @@ void set_option_value_for(const char *const name, OptVal value, const int opt_fl
   }
 
   if (switched) {
-    restore_option_context(ctx, opt_type);
+    restore_option_context(ctx, req_scope);
   }
 }

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -91,15 +91,14 @@ enum {
   SOPT_GLOBAL = 0x08,  ///< Option has global value
   SOPT_WIN    = 0x10,  ///< Option has window-local value
   SOPT_BUF    = 0x20,  ///< Option has buffer-local value
-  SOPT_UNSET  = 0x40,  ///< Option does not have local value set
 };
 
-/// Option types for various functions in option.c
-enum {
-  SREQ_GLOBAL = 0,  ///< Request global option value
-  SREQ_WIN    = 1,  ///< Request window-local option value
-  SREQ_BUF    = 2,  ///< Request buffer-local option value
-};
+/// Requested option scopes for various functions in option.c
+typedef enum {
+  kOptReqGlobal = 0,  ///< Request global option value
+  kOptReqWin    = 1,  ///< Request window-local option value
+  kOptReqBuf    = 2,  ///< Request buffer-local option value
+} OptReqScope;
 
 // OptVal helper macros.
 #define NIL_OPTVAL ((OptVal) { .type = kOptValTypeNil })

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1493,7 +1493,7 @@ describe('API', function()
         pcall_err(nvim, 'set_option_value', 'scrolloff', 1, {scope = 'bogus'}))
       eq("Invalid 'scope': expected String, got Integer",
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 42}))
-      eq("Invalid 'value': expected Integer/Boolean/String, got Array",
+      eq("Invalid 'value': expected valid option type, got Array",
         pcall_err(nvim, 'set_option_value', 'scrolloff', {}, {}))
       eq("Invalid value for option 'scrolloff': expected Number, got Boolean true",
         pcall_err(nvim, 'set_option_value', 'scrolloff', true, {}))


### PR DESCRIPTION
`SREQ_*` values are now actual typedef'd enums. `get_option_value_strict()` has also been refactored and split into two functions, `get_option_attrs()` for getting the option attributes, and `get_option_value_strict()` for getting the actual value. Moreover, it now returns an `OptVal`. Other miscellaneous refactors have also been made.

Ref: #25672 