### PR TITLE
fix(rplugin): dont create data dir if it's a broken symlink

### DIFF
--- a/runtime/plugin/rplugin.vim
+++ b/runtime/plugin/rplugin.vim
@@ -14,7 +14,9 @@ function! s:GetManifestPath() abort
   let dest = stdpath('data')
   if !empty(dest)
     if !isdirectory(dest)
-      call mkdir(dest, 'p', 0700)
+      if getftype(dest) != "link"
+        call mkdir(dest, 'p', 0700)
+      endif
     endif
     let manifest_base = dest
   endif


### PR DESCRIPTION
Checking if it's non-empty and not a directory gets us quite far, but not all the way. While a working symlink would trigger the earlier checks, a broken symlink does not.

This PR fixes the special case where `~/.local/share/nvim` already exists but is a broken symlink. Thus, it fixes the following error on startup:

```
E739: Cannot create directory /home/samuel/.local/share/nvim: file already exists
```

**Test coverage**: I ran all the tests using `make test`. One unittest failed, but it fails on `master` as well.
  <details><summary>Unittest results</summary>
  <p>
  
  ```
  ======== 732 tests from 35 test files ran. (37245.00 ms total)
  PASSED   730 tests.
  SKIPPED  1 test, listed below:
  SKIPPED  test/unit/eval/typval_spec.lua @ 2189: typval.c dict extend() disallows overriding builtin or user functions: 
  here be the dragons
  ERROR    1 error, listed below:
  ERROR    test/unit/helpers.lua @ 776: path.c vim_FullName fails and uses filename if given filename contains non-existing directory
  test/unit/helpers.lua:750: test/unit/helpers.lua:734: (string) '
  test/unit/path_spec.lua:420: Expected objects to be the same.
  Passed in:
  (string) '/tmp/neovim/test.file'
  Expected:
  (string) 'non_existing_dir/test.file''
  exit code: 256
  
  stack traceback:
  	test/unit/helpers.lua:750: in function 'itp_parent'
	test/unit/helpers.lua:786: in function <test/unit/helpers.lua:776>
  
  
   1 SKIPPED TEST
   1 ERROR
  ```
  
  </p>
  </details> 

**No new test**: I looked for existing tests for rplugin.vim, but couldn't find any. That is the reason this change isn't accompanied by a new test.