### PR TITLE
fix(event-loop): flush UI when no input is available

### DIFF
--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -59,6 +59,8 @@ getkey:
     if (vpeekc() != NUL || typebuf.tb_len > 0) {
       key = safe_vgetc();
     } else if (!multiqueue_empty(main_loop.events)) {
+      // No input available and processing events may take time, flush now.
+      ui_flush();
       // Event was made available after the last multiqueue_process_events call
       key = K_EVENT;
     } else {


### PR DESCRIPTION
Fix #25642
Fix #25727

Problem:  With lots of events, UI flush may be delayed for too long.
Solution: Flush UI when no input is available.This still flushes less
          frequently than before #25629, when a flush also happens when
          typeahead buffer is empty but input is available.
