### PR TITLE
ci: install perl provider on mac

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,10 +161,8 @@ jobs:
           npm install -g neovim
           npm link neovim
 
-          if [[ $RUNNER_OS != macOS ]]; then
-            sudo cpanm -n Neovim::Ext || cat "$HOME/.cpanm/build.log"
-            perl -W -e 'use Neovim::Ext; print $Neovim::Ext::VERSION'
-          fi
+          sudo cpanm -n Neovim::Ext || cat "$HOME/.cpanm/build.log"
+          perl -W -e 'use Neovim::Ext; print $Neovim::Ext::VERSION'
 
       - uses: ./.github/actions/cache
 


### PR DESCRIPTION
Perl provider installation was previously disabled on mac due to a
version conflict in 79bf5074499ae06788762ec49d12af6175b01d15. It is no
longer present, so we enable it.