### PR TITLE
vim-patch:d3e277f279ed

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1442,10 +1442,11 @@ Finally, these constructs are unique to Perl:
 		Just like |:match| above, but set a separate match.  Thus
 		there can be three matches active at the same time.  The match
 		with the lowest number has priority if several match at the
-		same position.
-		The ":3match" command is used by the |matchparen| plugin.  You
-		are suggested to use ":match" for manual matching and
-		":2match" for another plugin.
+		same position.  It uses the match id 3.
+		The ":3match" command is used by (older Vims) |matchparen|
+		plugin. You are suggested to use ":match" for manual matching
+		and ":2match" for another plugin or even better make use of
+		the more flexible |matchadd()| (and similar) functions instead.
 
 ==============================================================================
 11. Fuzzy matching					*fuzzy-matching*


### PR DESCRIPTION
#### vim-patch:d3e277f279ed

matchparen: do not use hard-coded match id (vim/vim#13393)

* matchparen: do not use hard-coded match id

Instead of using the hard-coded match id 3, which may also be used by
other plugins, let the matchparen plugin use whatever ids are
automatically returned when calling matchaddpos().

For backwards-compatibility, keep the `:3match` call, which will still
use the hard-coded id 3 (as mentioned in :h :3match).

closes: vim/vim#13381

https://github.com/vim/vim/commit/d3e277f279ed628809eb6857ea3ebcfca566ca2a

Co-authored-by: Christian Brabandt <cb@256bit.org>