### PR TITLE
vim-patch:9.0.2058: tests: avoid error when no swap files exist

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -177,7 +177,7 @@ endfunc
 for name in s:GetSwapFileList()
   call delete(name)
 endfor
-unlet name
+unlet! name
 
 
 " Invoked when a test takes too much time.


### PR DESCRIPTION
#### vim-patch:9.0.2058: tests: avoid error when no swap files exist

Problem:  tests: avoid error when no swap files exist
Solution: use unlet! so that no error message is reported
          in case the variable does not exists

When s:GetSwapFileList() does not find any swapfiles, it will return an
empty list []. This means, that the variable 'name' will not be
declared, cause the following unlet command to fail and causing a 1 sec
delay on running the tests.

So let's instead use the :unlet! command which simply skips reporting an
error when the variable given as parameter does not exists.

closes: vim/vim#13396

https://github.com/vim/vim/commit/a36acb7ac444a789440dc30e0f04d5427069face