### PR TITLE
vim-patch:9.0.2059: outstanding exceptions may be skipped

### DIFF
--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -410,7 +410,8 @@ Any return value of the deferred function is discarded.  The function cannot
 be followed by anything, such as "->func" or ".member".  Currently `:defer
 GetArg()->TheFunc()` does not work, it may work in a later version.
 
-Errors are reported but do not cause aborting execution of deferred functions.
+Errors are reported but do not cause aborting execution of deferred functions
+or altering execution outside of deferred functions.
 
 No range is accepted.  The function can be a partial with extra arguments, but
 not with a dictionary. *E1300*

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -668,17 +668,21 @@ void exception_state_save(exception_state_T *estate)
   estate->estate_did_throw = did_throw;
   estate->estate_need_rethrow = need_rethrow;
   estate->estate_trylevel = trylevel;
+  estate->estate_did_emsg = did_emsg;
 }
 
 /// Restore the current exception state from "estate"
 void exception_state_restore(exception_state_T *estate)
 {
-  if (current_exception == NULL) {
-    current_exception = estate->estate_current_exception;
+  // Handle any outstanding exceptions before restoring the state
+  if (did_throw) {
+    handle_did_throw();
   }
-  did_throw |= estate->estate_did_throw;
-  need_rethrow |= estate->estate_need_rethrow;
-  trylevel |= estate->estate_trylevel;
+  current_exception = estate->estate_current_exception;
+  did_throw = estate->estate_did_throw;
+  need_rethrow = estate->estate_need_rethrow;
+  trylevel = estate->estate_trylevel;
+  did_emsg = estate->estate_did_emsg;
 }
 
 /// Clear the current exception state
@@ -688,6 +692,7 @@ void exception_state_clear(void)
   did_throw = false;
   need_rethrow = false;
   trylevel = 0;
+  did_emsg = 0;
 }
 
 // Flags specifying the message displayed by report_pending.

--- a/src/nvim/ex_eval_defs.h
+++ b/src/nvim/ex_eval_defs.h
@@ -126,6 +126,7 @@ struct exception_state_S {
   bool estate_did_throw;
   bool estate_need_rethrow;
   int estate_trylevel;
+  int estate_did_emsg;
 };
 
 #endif  // NVIM_EX_EVAL_DEFS_H


### PR DESCRIPTION
#### vim-patch:9.0.2059: outstanding exceptions may be skipped

Problem:  outstanding exceptions may be skipped
Solution: When restoring exception state, process remaining outstanding
          exceptions

closes: vim/vim#13386

https://github.com/vim/vim/commit/0ab500dede4edd8d5aee7ddc63444537be527871

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>