### PR TITLE
build(lint): remove unnecessary clint.py rules

### DIFF
--- a/src/nvim/api/extmark.h
+++ b/src/nvim/api/extmark.h
@@ -8,8 +8,8 @@
 #include "nvim/map.h"
 #include "nvim/types.h"
 
-EXTERN Map(String, int) namespace_ids INIT(= MAP_INIT);
-EXTERN handle_T next_namespace_id INIT(= 1);
+EXTERN Map(String, int) namespace_ids INIT( = MAP_INIT);
+EXTERN handle_T next_namespace_id INIT( = 1);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/extmark.h.generated.h"

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -128,9 +128,9 @@
 #define api_free_window(value)
 #define api_free_tabpage(value)
 
-EXTERN PMap(int) buffer_handles INIT(= MAP_INIT);
-EXTERN PMap(int) window_handles INIT(= MAP_INIT);
-EXTERN PMap(int) tabpage_handles INIT(= MAP_INIT);
+EXTERN PMap(int) buffer_handles INIT( = MAP_INIT);
+EXTERN PMap(int) window_handles INIT( = MAP_INIT);
+EXTERN PMap(int) tabpage_handles INIT( = MAP_INIT);
 
 #define handle_get_buffer(h) pmap_get(int)(&buffer_handles, (h))
 #define handle_get_window(h) pmap_get(int)(&window_handles, (h))

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2197,8 +2197,8 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
     }
     if (statuscol_lnum) {
       HlPriId line = { 0 };
-      HlPriId cul  = { 0 };
-      HlPriId num  = { 0 };
+      HlPriId cul = { 0 };
+      HlPriId num = { 0 };
       linenr_T lnum = statuscol_lnum;
       int num_signs = buf_get_signattrs(wp->w_buffer, lnum, sattrs, &num, &line, &cul);
       decor_redraw_signs(wp->w_buffer, lnum - 1, &num_signs, sattrs, &num, &line, &cul);

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -79,12 +79,12 @@ typedef kvec_t(AutoCmd) AutoCmdVec;
 //
 // Relying on this value requires one to reset it prior calling
 // apply_autocmds_group.
-EXTERN bool au_did_filetype INIT(= false);
+EXTERN bool au_did_filetype INIT( = false);
 
 /// For CursorMoved event
-EXTERN win_T *last_cursormoved_win INIT(= NULL);
+EXTERN win_T *last_cursormoved_win INIT( = NULL);
 /// For CursorMoved event, only used when last_cursormoved_win == curwin
-EXTERN pos_T last_cursormoved INIT(= { 0, 0, 0 });
+EXTERN pos_T last_cursormoved INIT( = { 0, 0, 0 });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "autocmd.h.generated.h"

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -69,8 +69,8 @@ enum bfa_values {
   BFA_IGNORE_ABORT = 8,  // do not abort for aborting()
 };
 
-EXTERN char *msg_loclist INIT(= N_("[Location List]"));
-EXTERN char *msg_qflist INIT(= N_("[Quickfix List]"));
+EXTERN char *msg_loclist INIT( = N_("[Location List]"));
+EXTERN char *msg_qflist INIT( = N_("[Quickfix List]"));
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "buffer.h.generated.h"

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -361,7 +361,7 @@ typedef struct {
 #define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF, LUA_NOREF, \
                                     LUA_NOREF, LUA_NOREF, false, false }
 
-EXTERN int curbuf_splice_pending INIT(= 0);
+EXTERN int curbuf_splice_pending INIT( = 0);
 
 #define BUF_HAS_QF_ENTRY 1
 #define BUF_HAS_LL_ENTRY 2
@@ -913,7 +913,7 @@ enum {
 // NE -> kFloatAnchorEast
 // SW -> kFloatAnchorSouth
 // SE -> kFloatAnchorSouth | kFloatAnchorEast
-EXTERN const char *const float_anchor_str[] INIT(= { "NW", "NE", "SW", "SE" });
+EXTERN const char *const float_anchor_str[] INIT( = { "NW", "NE", "SW", "SE" });
 
 typedef enum {
   kFloatRelativeEditor = 0,
@@ -922,8 +922,8 @@ typedef enum {
   kFloatRelativeMouse = 3,
 } FloatRelative;
 
-EXTERN const char *const float_relative_str[] INIT(= { "editor", "win",
-                                                       "cursor", "mouse" });
+EXTERN const char *const float_relative_str[] INIT( = { "editor", "win",
+                                                        "cursor", "mouse" });
 
 typedef enum {
   kWinStyleUnused = 0,

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -818,7 +818,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
     while (*dirp) {
       // Isolate one directory name, using an entry in 'bdir'.
       size_t dir_len = copy_option_part(&dirp, IObuff, IOSIZE, ",");
-      char *p  = IObuff + dir_len;
+      char *p = IObuff + dir_len;
       bool trailing_pathseps = after_pathsep(IObuff, p) && p[-1] == p[-2];
       if (trailing_pathseps) {
         IObuff[dir_len - 2] = NUL;

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -108,9 +108,9 @@ struct Channel {
   bool callback_scheduled;
 };
 
-EXTERN PMap(uint64_t) channels INIT(= MAP_INIT);
+EXTERN PMap(uint64_t) channels INIT( = MAP_INIT);
 
-EXTERN Callback on_print INIT(= CALLBACK_INIT);
+EXTERN Callback on_print INIT( = CALLBACK_INIT);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "channel.h.generated.h"

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -26,8 +26,8 @@ typedef enum {
   kVTInline,
 } VirtTextPos;
 
-EXTERN const char *const virt_text_pos_str[] INIT(= { "eol", "overlay", "win_col", "right_align",
-                                                      "inline" });
+EXTERN const char *const virt_text_pos_str[] INIT( = { "eol", "overlay", "win_col", "right_align",
+                                                       "inline" });
 
 typedef enum {
   kHlModeUnknown,
@@ -36,7 +36,7 @@ typedef enum {
   kHlModeBlend,
 } HlMode;
 
-EXTERN const char *const hl_mode_str[] INIT(= { "", "replace", "combine", "blend" });
+EXTERN const char *const hl_mode_str[] INIT( = { "", "replace", "combine", "blend" });
 
 #define VIRTTEXT_EMPTY ((VirtText)KV_INITIAL_VALUE)
 
@@ -114,7 +114,7 @@ typedef struct {
   bool running_on_lines;
 } DecorState;
 
-EXTERN DecorState decor_state INIT(= { 0 });
+EXTERN DecorState decor_state INIT( = { 0 });
 
 static inline bool decor_has_sign(Decoration *decor)
 {

--- a/src/nvim/decoration_provider.h
+++ b/src/nvim/decoration_provider.h
@@ -29,7 +29,7 @@ typedef struct {
 
 typedef kvec_withinit_t(DecorProvider *, 4) DecorProviders;
 
-EXTERN bool provider_active INIT(= false);
+EXTERN bool provider_active INIT( = false);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "decoration_provider.h.generated.h"

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2950,7 +2950,7 @@ void ex_diffgetput(exarg_T *eap)
   }
 
   const int idx_from = eap->cmdidx == CMD_diffget ? idx_other : idx_cur;
-  const int idx_to   = eap->cmdidx == CMD_diffget ? idx_cur : idx_other;
+  const int idx_to = eap->cmdidx == CMD_diffget ? idx_cur : idx_other;
 
   // May give the warning for a changed buffer here, which can trigger the
   // FileChangedRO autocommand, which may do nasty things and mess
@@ -3505,10 +3505,10 @@ static int xdiff_out(int start_a, int count_a, int start_b, int count_b, void *p
 {
   diffout_T *dout = (diffout_T *)priv;
   GA_APPEND(diffhunk_T, &(dout->dout_ga), ((diffhunk_T){
-    .lnum_orig  = (linenr_T)start_a + 1,
+    .lnum_orig = (linenr_T)start_a + 1,
     .count_orig = count_a,
-    .lnum_new   = (linenr_T)start_b + 1,
-    .count_new  = count_b,
+    .lnum_new = (linenr_T)start_b + 1,
+    .count_new = count_b,
   }));
   return 0;
 }

--- a/src/nvim/diff.h
+++ b/src/nvim/diff.h
@@ -8,11 +8,11 @@
 #include "nvim/pos.h"
 
 // Value set from 'diffopt'.
-EXTERN int diff_context INIT(= 6);  // context for folds
-EXTERN int diff_foldcolumn INIT(= 2);  // 'foldcolumn' for diff mode
-EXTERN bool diff_need_scrollbind INIT(= false);
+EXTERN int diff_context INIT( = 6);  // context for folds
+EXTERN int diff_foldcolumn INIT( = 2);  // 'foldcolumn' for diff mode
+EXTERN bool diff_need_scrollbind INIT( = false);
 
-EXTERN bool need_diff_redraw INIT(= false);  // need to call diff_redraw()
+EXTERN bool need_diff_redraw INIT( = false);  // need to call diff_redraw()
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "diff.h.generated.h"

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1171,14 +1171,14 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
   int left_curline_col = 0;
   int right_curline_col = 0;
 
-  int match_conc      = 0;              ///< cchar for match functions
-  bool on_last_col    = false;
-  int syntax_flags    = 0;
-  int syntax_seqnr    = 0;
-  int prev_syntax_id  = 0;
-  int conceal_attr    = win_hl_attr(wp, HLF_CONCEAL);
-  bool is_concealing  = false;
-  int did_wcol        = false;
+  int match_conc = 0;              ///< cchar for match functions
+  bool on_last_col = false;
+  int syntax_flags = 0;
+  int syntax_seqnr = 0;
+  int prev_syntax_id = 0;
+  int conceal_attr = win_hl_attr(wp, HLF_CONCEAL);
+  bool is_concealing = false;
+  int did_wcol = false;
   int old_boguscols = 0;
 #define VCOL_HLC (wlv.vcol - wlv.vcol_off)
 #define FIX_FOR_BOGUSCOLS \

--- a/src/nvim/drawline.h
+++ b/src/nvim/drawline.h
@@ -20,9 +20,9 @@ typedef struct {
   int win_row;
   int win_col;
 } WinExtmark;
-EXTERN kvec_t(WinExtmark) win_extmark_arr INIT(= KV_INITIAL_VALUE);
+EXTERN kvec_t(WinExtmark) win_extmark_arr INIT( = KV_INITIAL_VALUE);
 
-EXTERN bool conceal_cursor_used INIT(= false);
+EXTERN bool conceal_cursor_used INIT( = false);
 
 // Spell checking variables passed from win_update() to win_line().
 typedef struct {

--- a/src/nvim/drawscreen.h
+++ b/src/nvim/drawscreen.h
@@ -21,9 +21,9 @@ enum {
 
 /// While redrawing the screen this flag is set.  It means the screen size
 /// ('lines' and 'rows') must not be changed.
-EXTERN bool updating_screen INIT(= 0);
+EXTERN bool updating_screen INIT( = 0);
 
-EXTERN match_T screen_search_hl INIT(= { 0 });       // used for 'hlsearch' highlight matching
+EXTERN match_T screen_search_hl INIT( = { 0 });       // used for 'hlsearch' highlight matching
 
 #define W_ENDCOL(wp)   ((wp)->w_wincol + (wp)->w_width)
 #define W_ENDROW(wp)   ((wp)->w_winrow + (wp)->w_height)

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -277,7 +277,7 @@ enum {
 };
 
 /// Passed to an eval() function to enable evaluation.
-EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL, NULL, NULL });
+EXTERN evalarg_T EVALARG_EVALUATE INIT( = { EVAL_EVALUATE, NULL, NULL, NULL });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval.h.generated.h"

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2502,7 +2502,7 @@ static void f_getcwd(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     [kCdScopeTabpage] = 0,  // Number of tab to look at.
   };
 
-  char *cwd  = NULL;    // Current working directory to print
+  char *cwd = NULL;    // Current working directory to print
   char *from = NULL;    // The original string to copy
 
   tabpage_T *tp = curtab;  // The tabpage to look at.
@@ -3281,7 +3281,7 @@ static void f_haslocaldir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     [kCdScopeTabpage] = 0,  // Number of tab to look at.
   };
 
-  tabpage_T *tp  = curtab;  // The tabpage to look at.
+  tabpage_T *tp = curtab;  // The tabpage to look at.
   win_T *win = curwin;  // The window to look at.
 
   rettv->v_type = VAR_NUMBER;
@@ -5258,7 +5258,7 @@ static void f_prompt_setinterrupt(typval_T *argvars, typval_T *rettv, EvalFuncDa
   }
 
   callback_free(&buf->b_prompt_interrupt);
-  buf->b_prompt_interrupt= interrupt_callback;
+  buf->b_prompt_interrupt = interrupt_callback;
 }
 
 /// "prompt_getprompt({buffer})" function
@@ -5589,9 +5589,9 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
   char buf[(IOSIZE/256) * 256];    // rounded to avoid odd + 1
   int io_size = sizeof(buf);
   char *prev = NULL;               // previously read bytes, if any
-  ptrdiff_t prevlen  = 0;               // length of data in prev
+  ptrdiff_t prevlen = 0;               // length of data in prev
   ptrdiff_t prevsize = 0;               // size of prev buffer
-  int64_t maxline  = MAXLNUM;
+  int64_t maxline = MAXLNUM;
   off_T offset = 0;
   off_T size = -1;
 
@@ -5651,7 +5651,7 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
          p < buf + readlen || (readlen <= 0 && (prevlen > 0 || binary));
          p++) {
       if (readlen <= 0 || *p == '\n') {
-        char *s  = NULL;
+        char *s = NULL;
         size_t len = (size_t)(p - start);
 
         // Finished a line.  Remove CRs before NL.
@@ -5754,7 +5754,7 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
           prevsize = p - start;
         } else {
           ptrdiff_t grow50pc = (prevsize * 3) / 2;
-          ptrdiff_t growmin  = (p - start) * 2 + prevlen;
+          ptrdiff_t growmin = (p - start) * 2 + prevlen;
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
         prev = xrealloc(prev, (size_t)prevsize);

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3964,13 +3964,13 @@ bool tv_check_str_or_nr(const typval_T *const tv)
 #define FUNC_ERROR "E703: Using a Funcref as a Number"
 
 static const char *const num_errors[] = {
-  [VAR_PARTIAL]= N_(FUNC_ERROR),
-  [VAR_FUNC]= N_(FUNC_ERROR),
-  [VAR_LIST]= N_("E745: Using a List as a Number"),
-  [VAR_DICT]= N_("E728: Using a Dictionary as a Number"),
-  [VAR_FLOAT]= N_("E805: Using a Float as a Number"),
-  [VAR_BLOB]= N_("E974: Using a Blob as a Number"),
-  [VAR_UNKNOWN]= N_("E685: using an invalid value as a Number"),
+  [VAR_PARTIAL] = N_(FUNC_ERROR),
+  [VAR_FUNC] = N_(FUNC_ERROR),
+  [VAR_LIST] = N_("E745: Using a List as a Number"),
+  [VAR_DICT] = N_("E728: Using a Dictionary as a Number"),
+  [VAR_FLOAT] = N_("E805: Using a Float as a Number"),
+  [VAR_BLOB] = N_("E974: Using a Blob as a Number"),
+  [VAR_UNKNOWN] = N_("E685: using an invalid value as a Number"),
 };
 
 #undef FUNC_ERROR
@@ -4009,12 +4009,12 @@ bool tv_check_num(const typval_T *const tv)
 #define FUNC_ERROR "E729: Using a Funcref as a String"
 
 static const char *const str_errors[] = {
-  [VAR_PARTIAL]= N_(FUNC_ERROR),
-  [VAR_FUNC]= N_(FUNC_ERROR),
-  [VAR_LIST]= N_("E730: Using a List as a String"),
-  [VAR_DICT]= N_("E731: Using a Dictionary as a String"),
-  [VAR_BLOB]= N_("E976: Using a Blob as a String"),
-  [VAR_UNKNOWN]= e_using_invalid_value_as_string,
+  [VAR_PARTIAL] = N_(FUNC_ERROR),
+  [VAR_FUNC] = N_(FUNC_ERROR),
+  [VAR_LIST] = N_("E730: Using a List as a String"),
+  [VAR_DICT] = N_("E731: Using a Dictionary as a String"),
+  [VAR_BLOB] = N_("E976: Using a Blob as a String"),
+  [VAR_UNKNOWN] = e_using_invalid_value_as_string,
 };
 
 #undef FUNC_ERROR

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -485,8 +485,8 @@ static inline bool tv_is_func(const typval_T tv)
 
 #ifdef UNIT_TESTING
 // Do not use enum constants, see commit message.
-EXTERN const size_t kTVCstring INIT(= TV_CSTRING);
-EXTERN const size_t kTVTranslate INIT(= TV_TRANSLATE);
+EXTERN const size_t kTVCstring INIT( = TV_CSTRING);
+EXTERN const size_t kTVTranslate INIT( = TV_TRANSLATE);
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -224,7 +224,7 @@ bool socket_connect(Loop *loop, Stream *stream, bool is_tcp, const char *address
 
     const struct addrinfo hints = { .ai_family = AF_UNSPEC,
                                     .ai_socktype = SOCK_STREAM,
-                                    .ai_flags  = AI_NUMERICSERV };
+                                    .ai_flags = AI_NUMERICSERV };
     int retval = uv_getaddrinfo(&loop->uv, &addr_req, NULL,
                                 addr, host_end + 1, &hints);
     if (retval != 0) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3341,7 +3341,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
   int which_pat;
   char *cmd = eap->arg;
   linenr_T first_line = 0;  // first changed line
-  linenr_T last_line= 0;    // below last changed line AFTER the change
+  linenr_T last_line = 0;    // below last changed line AFTER the change
   linenr_T old_line_count = curbuf->b_ml.ml_line_count;
   char *sub_firstline;    // allocated copy of first sub line
   bool endcolumn = false;   // cursor in last column when done
@@ -3601,7 +3601,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
       while (true) {
         SubResult current_match = {
           .start = { 0, 0 },
-          .end   = { 0, 0 },
+          .end = { 0, 0 },
           .pre_match = 0,
         };
         // lnum is where the match start, but maybe not the pattern match,
@@ -3905,7 +3905,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
           if (current_match.end.lnum == 0) {
             current_match.end.lnum = sub_firstlnum + (linenr_T)nmatch - 1;
           }
-          current_match.end.col  = regmatch.endpos[0].col;
+          current_match.end.col = regmatch.endpos[0].col;
 
           ADJUST_SUB_FIRSTLNUM();
           lnum += (linenr_T)nmatch - 1;
@@ -4636,7 +4636,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
 
     if (cmdpreview_buf) {
       lpos_T p_start = { 0, match.start.col };  // match starts here in preview
-      lpos_T p_end   = { 0, match.end.col };    // ... and ends here
+      lpos_T p_end = { 0, match.end.col };    // ... and ends here
 
       // You Might Gonna Need It
       buf_ensure_loaded(cmdpreview_buf);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -159,19 +159,28 @@ static char dollar_command[2] = { '$', 0 };
 
 static void save_dbg_stuff(struct dbg_stuff *dsp)
 {
-  dsp->trylevel       = trylevel;             trylevel = 0;
-  dsp->force_abort    = force_abort;          force_abort = false;
-  dsp->caught_stack   = caught_stack;         caught_stack = NULL;
-  dsp->vv_exception   = v_exception(NULL);
-  dsp->vv_throwpoint  = v_throwpoint(NULL);
+  dsp->trylevel = trylevel;
+  trylevel = 0;
+  dsp->force_abort = force_abort;
+  force_abort = false;
+  dsp->caught_stack = caught_stack;
+  caught_stack = NULL;
+  dsp->vv_exception = v_exception(NULL);
+  dsp->vv_throwpoint = v_throwpoint(NULL);
 
   // Necessary for debugging an inactive ":catch", ":finally", ":endtry".
-  dsp->did_emsg       = did_emsg;             did_emsg     = false;
-  dsp->got_int        = got_int;              got_int      = false;
-  dsp->did_throw      = did_throw;            did_throw    = false;
-  dsp->need_rethrow   = need_rethrow;         need_rethrow = false;
-  dsp->check_cstack   = check_cstack;         check_cstack = false;
-  dsp->current_exception = current_exception; current_exception = NULL;
+  dsp->did_emsg = did_emsg;
+  did_emsg = false;
+  dsp->got_int = got_int;
+  got_int = false;
+  dsp->did_throw = did_throw;
+  did_throw = false;
+  dsp->need_rethrow = need_rethrow;
+  need_rethrow = false;
+  dsp->check_cstack = check_cstack;
+  check_cstack = false;
+  dsp->current_exception = current_exception;
+  current_exception = NULL;
 }
 
 static void restore_dbg_stuff(struct dbg_stuff *dsp)

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -14,7 +14,7 @@
 #include "nvim/pos.h"
 #include "nvim/types.h"
 
-EXTERN int extmark_splice_pending INIT(= 0);
+EXTERN int extmark_splice_pending INIT( = 0);
 
 typedef struct {
   uint64_t ns_id;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1119,12 +1119,12 @@ static ff_stack_T *ff_create_stack_element(char *fix_part, char *wc_part, int le
 {
   ff_stack_T *stack = xmalloc(sizeof(ff_stack_T));
 
-  stack->ffs_prev          = NULL;
-  stack->ffs_filearray     = NULL;
+  stack->ffs_prev = NULL;
+  stack->ffs_filearray = NULL;
   stack->ffs_filearray_size = 0;
-  stack->ffs_filearray_cur  = 0;
-  stack->ffs_stage         = 0;
-  stack->ffs_level         = level;
+  stack->ffs_filearray_cur = 0;
+  stack->ffs_stage = 0;
+  stack->ffs_level = level;
   stack->ffs_star_star_empty = star_star_empty;
 
   // the following saves NULL pointer checks in vim_findfile

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1783,7 +1783,7 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
       current_sctx = saved_sctx;
     }
     last_lnum = lnum;
-    last_wp   = wp;
+    last_wp = wp;
     set_vim_var_string(VV_FOLDDASHES, NULL, -1);
 
     if (!did_emsg && save_did_emsg) {

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -10,7 +10,7 @@
 #include "nvim/pos.h"
 #include "nvim/types.h"
 
-EXTERN int disable_fold_update INIT(= 0);
+EXTERN int disable_fold_update INIT( = 0);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "fold.h.generated.h"

--- a/src/nvim/func_attr.h
+++ b/src/nvim/func_attr.h
@@ -125,7 +125,7 @@
 #  define REAL_FATTR_NONNULL_ALL __attribute__((nonnull))
 #  define REAL_FATTR_NONNULL_ARG(...) __attribute__((nonnull(__VA_ARGS__)))
 #  define REAL_FATTR_NORETURN __attribute__((noreturn))
-#  define REAL_FATTR_PRINTF(x, y) __attribute__((format (printf, x, y)))
+#  define REAL_FATTR_PRINTF(x, y) __attribute__((format(printf, x, y)))
 
 #  if NVIM_HAS_ATTRIBUTE(returns_nonnull)
 #   define REAL_FATTR_NONNULL_RET __attribute__((returns_nonnull))

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -92,7 +92,7 @@ EXTERN struct nvim_stats_s {
   int64_t fsync;
   int64_t redraw;
   int16_t log_skip;  // How many logs were tried and skipped before log_init.
-} g_stats INIT(= { 0, 0, 0 });
+} g_stats INIT( = { 0, 0, 0 });
 
 // Values for "starting".
 #define NO_SCREEN       2       // no screen updating yet
@@ -106,8 +106,8 @@ EXTERN struct nvim_stats_s {
 // up).
 #define DFLT_COLS       80              // default value for 'columns'
 #define DFLT_ROWS       24              // default value for 'lines'
-EXTERN int Rows INIT(= DFLT_ROWS);     // nr of rows in the screen
-EXTERN int Columns INIT(= DFLT_COLS);  // nr of columns in the screen
+EXTERN int Rows INIT( = DFLT_ROWS);     // nr of rows in the screen
+EXTERN int Columns INIT( = DFLT_COLS);  // nr of columns in the screen
 
 // We use 64-bit file functions here, if available.  E.g. ftello() returns
 // off_t instead of long, which helps if long is 32 bit and off_t is 64 bit.
@@ -139,11 +139,11 @@ typedef off_t off_T;
 
 // When vgetc() is called, it sets mod_mask to the set of modifiers that are
 // held down based on the MOD_MASK_* symbols that are read first.
-EXTERN int mod_mask INIT(= 0);  // current key modifiers
+EXTERN int mod_mask INIT( = 0);  // current key modifiers
 
 // The value of "mod_mask" and the unmodified character before calling merge_modifiers().
-EXTERN int vgetc_mod_mask INIT(= 0);
-EXTERN int vgetc_char INIT(= 0);
+EXTERN int vgetc_mod_mask INIT( = 0);
+EXTERN int vgetc_char INIT( = 0);
 
 // Cmdline_row is the row where the command line starts, just below the
 // last window.
@@ -154,65 +154,65 @@ EXTERN int vgetc_char INIT(= 0);
 // update_screen().
 EXTERN int cmdline_row;
 
-EXTERN bool redraw_cmdline INIT(= false);          // cmdline must be redrawn
-EXTERN bool redraw_mode INIT(= false);             // mode must be redrawn
-EXTERN bool clear_cmdline INIT(= false);           // cmdline must be cleared
-EXTERN bool mode_displayed INIT(= false);          // mode is being displayed
-EXTERN int cmdline_star INIT(= false);             // cmdline is encrypted
-EXTERN bool redrawing_cmdline INIT(= false);       // cmdline is being redrawn
-EXTERN bool cmdline_was_last_drawn INIT(= false);  // cmdline was last drawn
+EXTERN bool redraw_cmdline INIT( = false);          // cmdline must be redrawn
+EXTERN bool redraw_mode INIT( = false);             // mode must be redrawn
+EXTERN bool clear_cmdline INIT( = false);           // cmdline must be cleared
+EXTERN bool mode_displayed INIT( = false);          // mode is being displayed
+EXTERN int cmdline_star INIT( = false);             // cmdline is encrypted
+EXTERN bool redrawing_cmdline INIT( = false);       // cmdline is being redrawn
+EXTERN bool cmdline_was_last_drawn INIT( = false);  // cmdline was last drawn
 
-EXTERN bool exec_from_reg INIT(= false);         // executing register
+EXTERN bool exec_from_reg INIT( = false);         // executing register
 
 // When '$' is included in 'cpoptions' option set:
 // When a change command is given that deletes only part of a line, a dollar
 // is put at the end of the changed text. dollar_vcol is set to the virtual
 // column of this '$'.  -1 is used to indicate no $ is being displayed.
-EXTERN colnr_T dollar_vcol INIT(= -1);
+EXTERN colnr_T dollar_vcol INIT( = -1);
 
 // Variables for Insert mode completion.
 
-EXTERN char *edit_submode INIT(= NULL);         // msg for CTRL-X submode
-EXTERN char *edit_submode_pre INIT(= NULL);     // prepended to edit_submode
-EXTERN char *edit_submode_extra INIT(= NULL);   // appended to edit_submode
+EXTERN char *edit_submode INIT( = NULL);         // msg for CTRL-X submode
+EXTERN char *edit_submode_pre INIT( = NULL);     // prepended to edit_submode
+EXTERN char *edit_submode_extra INIT( = NULL);   // appended to edit_submode
 EXTERN hlf_T edit_submode_highl;                // highl. method for extra info
 
 // state for putting characters in the message area
-EXTERN bool cmdmsg_rl INIT(= false);  // cmdline is drawn right to left
+EXTERN bool cmdmsg_rl INIT( = false);  // cmdline is drawn right to left
 EXTERN int msg_col;
 EXTERN int msg_row;
 EXTERN int msg_scrolled;        // Number of screen lines that windows have
                                 // scrolled because of printing messages.
 // when true don't set need_wait_return in msg_puts_attr()
 // when msg_scrolled is non-zero
-EXTERN bool msg_scrolled_ign INIT(= false);
+EXTERN bool msg_scrolled_ign INIT( = false);
 // Whether the screen is damaged due to scrolling. Sometimes msg_scrolled
 // is reset before the screen is redrawn, so we need to keep track of this.
-EXTERN bool msg_did_scroll INIT(= false);
+EXTERN bool msg_did_scroll INIT( = false);
 
-EXTERN char *keep_msg INIT(= NULL);         // msg to be shown after redraw
-EXTERN int keep_msg_attr INIT(= 0);         // highlight attr for keep_msg
-EXTERN bool need_fileinfo INIT(= false);    // do fileinfo() after redraw
-EXTERN int msg_scroll INIT(= false);        // msg_start() will scroll
-EXTERN bool msg_didout INIT(= false);       // msg_outstr() was used in line
-EXTERN bool msg_didany INIT(= false);       // msg_outstr() was used at all
-EXTERN bool msg_nowait INIT(= false);       // don't wait for this msg
-EXTERN int emsg_off INIT(= 0);              // don't display errors for now,
-                                            // unless 'debug' is set.
-EXTERN bool info_message INIT(= false);     // printing informative message
-EXTERN bool msg_hist_off INIT(= false);     // don't add messages to history
-EXTERN bool need_clr_eos INIT(= false);     // need to clear text before
-                                            // displaying a message.
-EXTERN int emsg_skip INIT(= 0);             // don't display errors for
-                                            // expression that is skipped
-EXTERN bool emsg_severe INIT(= false);      // use message of next of several
-                                            //  emsg() calls for throw
+EXTERN char *keep_msg INIT( = NULL);         // msg to be shown after redraw
+EXTERN int keep_msg_attr INIT( = 0);         // highlight attr for keep_msg
+EXTERN bool need_fileinfo INIT( = false);    // do fileinfo() after redraw
+EXTERN int msg_scroll INIT( = false);        // msg_start() will scroll
+EXTERN bool msg_didout INIT( = false);       // msg_outstr() was used in line
+EXTERN bool msg_didany INIT( = false);       // msg_outstr() was used at all
+EXTERN bool msg_nowait INIT( = false);       // don't wait for this msg
+EXTERN int emsg_off INIT( = 0);              // don't display errors for now,
+                                             // unless 'debug' is set.
+EXTERN bool info_message INIT( = false);     // printing informative message
+EXTERN bool msg_hist_off INIT( = false);     // don't add messages to history
+EXTERN bool need_clr_eos INIT( = false);     // need to clear text before
+                                             // displaying a message.
+EXTERN int emsg_skip INIT( = 0);             // don't display errors for
+                                             // expression that is skipped
+EXTERN bool emsg_severe INIT( = false);      // use message of next of several
+                                             //  emsg() calls for throw
 // used by assert_fails()
-EXTERN char *emsg_assert_fails_msg INIT(= NULL);
-EXTERN long emsg_assert_fails_lnum INIT(= 0);
-EXTERN char *emsg_assert_fails_context INIT(= NULL);
+EXTERN char *emsg_assert_fails_msg INIT( = NULL);
+EXTERN long emsg_assert_fails_lnum INIT( = 0);
+EXTERN char *emsg_assert_fails_context INIT( = NULL);
 
-EXTERN bool did_endif INIT(= false);        // just had ":endif"
+EXTERN bool did_endif INIT( = false);        // just had ":endif"
 EXTERN dict_T vimvardict;                   // Dictionary with v: variables
 EXTERN dict_T globvardict;                  // Dictionary with g: variables
 /// g: value
@@ -223,39 +223,39 @@ EXTERN bool called_vim_beep;                // set if vim_beep() is called
 EXTERN bool did_emsg_syntax;                // did_emsg set because of a
                                             // syntax error
 EXTERN int called_emsg;                     // always incremented by emsg()
-EXTERN int ex_exitval INIT(= 0);            // exit value for ex mode
-EXTERN bool emsg_on_display INIT(= false);  // there is an error message
-EXTERN bool rc_did_emsg INIT(= false);      // vim_regcomp() called emsg()
+EXTERN int ex_exitval INIT( = 0);            // exit value for ex mode
+EXTERN bool emsg_on_display INIT( = false);  // there is an error message
+EXTERN bool rc_did_emsg INIT( = false);      // vim_regcomp() called emsg()
 
-EXTERN int no_wait_return INIT(= 0);         // don't wait for return for now
-EXTERN bool need_wait_return INIT(= false);  // need to wait for return later
-EXTERN bool did_wait_return INIT(= false);   // wait_return() was used and
-                                             // nothing written since then
-EXTERN bool need_maketitle INIT(= true);     // call maketitle() soon
+EXTERN int no_wait_return INIT( = 0);         // don't wait for return for now
+EXTERN bool need_wait_return INIT( = false);  // need to wait for return later
+EXTERN bool did_wait_return INIT( = false);   // wait_return() was used and
+                                              // nothing written since then
+EXTERN bool need_maketitle INIT( = true);     // call maketitle() soon
 
-EXTERN bool quit_more INIT(= false);        // 'q' hit at "--more--" msg
-EXTERN int vgetc_busy INIT(= 0);            // when inside vgetc() then > 0
+EXTERN bool quit_more INIT( = false);        // 'q' hit at "--more--" msg
+EXTERN int vgetc_busy INIT( = 0);            // when inside vgetc() then > 0
 
-EXTERN bool didset_vim INIT(= false);         // did set $VIM ourselves
-EXTERN bool didset_vimruntime INIT(= false);  // idem for $VIMRUNTIME
+EXTERN bool didset_vim INIT( = false);         // did set $VIM ourselves
+EXTERN bool didset_vimruntime INIT( = false);  // idem for $VIMRUNTIME
 
 /// Lines left before a "more" message.  Ex mode needs to be able to reset this
 /// after you type something.
-EXTERN int lines_left INIT(= -1);           // lines left for listing
-EXTERN bool msg_no_more INIT(= false);      // don't use more prompt, truncate
-                                            // messages
+EXTERN int lines_left INIT( = -1);           // lines left for listing
+EXTERN bool msg_no_more INIT( = false);      // don't use more prompt, truncate
+                                             // messages
 
-EXTERN int ex_nesting_level INIT(= 0);          // nesting level
-EXTERN int debug_break_level INIT(= -1);        // break below this level
-EXTERN bool debug_did_msg INIT(= false);        // did "debug mode" message
-EXTERN int debug_tick INIT(= 0);                // breakpoint change count
-EXTERN int debug_backtrace_level INIT(= 0);     // breakpoint backtrace level
+EXTERN int ex_nesting_level INIT( = 0);          // nesting level
+EXTERN int debug_break_level INIT( = -1);        // break below this level
+EXTERN bool debug_did_msg INIT( = false);        // did "debug mode" message
+EXTERN int debug_tick INIT( = 0);                // breakpoint change count
+EXTERN int debug_backtrace_level INIT( = 0);     // breakpoint backtrace level
 
 // Values for "do_profiling".
 #define PROF_NONE       0       ///< profiling not started
 #define PROF_YES        1       ///< profiling busy
 #define PROF_PAUSED     2       ///< profiling paused
-EXTERN int do_profiling INIT(= PROF_NONE);      ///< PROF_ values
+EXTERN int do_profiling INIT( = PROF_NONE);      ///< PROF_ values
 
 /// Exception currently being thrown.  Used to pass an exception to a different
 /// cstack.  Also used for discarding an exception before it is caught or made
@@ -264,19 +264,19 @@ EXTERN except_T *current_exception;
 
 /// An exception is being thrown.  Reset when the exception is caught or as
 /// long as it is pending in a finally clause.
-EXTERN bool did_throw INIT(= false);
+EXTERN bool did_throw INIT( = false);
 
 /// Set when a throw that cannot be handled in do_cmdline() must be propagated
 /// to the cstack of the previously called do_cmdline().
-EXTERN bool need_rethrow INIT(= false);
+EXTERN bool need_rethrow INIT( = false);
 
 /// Set when a ":finish" or ":return" that cannot be handled in do_cmdline()
 /// must be propagated to the cstack of the previously called do_cmdline().
-EXTERN bool check_cstack INIT(= false);
+EXTERN bool check_cstack INIT( = false);
 
 /// Number of nested try conditionals (across function calls and ":source"
 /// commands).
-EXTERN int trylevel INIT(= 0);
+EXTERN int trylevel INIT( = 0);
 
 /// When "force_abort" is true, always skip commands after an error message,
 /// even after the outermost ":endif", ":endwhile" or ":endfor" or for a
@@ -284,7 +284,7 @@ EXTERN int trylevel INIT(= 0);
 /// non-zero (and ":silent!" was not used) or an exception is being thrown at
 /// the time an error is detected.  It is set to false when "trylevel" gets
 /// zero again and there was no error or interrupt or throw.
-EXTERN bool force_abort INIT(= false);
+EXTERN bool force_abort INIT( = false);
 
 /// "msg_list" points to a variable in the stack of do_cmdline() which keeps
 /// the list of arguments of several emsg() calls, one of which is to be
@@ -294,19 +294,19 @@ EXTERN bool force_abort INIT(= false);
 /// same as the "msg" field of that element, but can be identical to the "msg"
 /// field of a later list element, when the "emsg_severe" flag was set when the
 /// emsg() call was made.
-EXTERN msglist_T **msg_list INIT(= NULL);
+EXTERN msglist_T **msg_list INIT( = NULL);
 
 /// When set, don't convert an error to an exception.  Used when displaying the
 /// interrupt message or reporting an exception that is still uncaught at the
 /// top level (which has already been discarded then).  Also used for the error
 /// message when no exception can be thrown.
-EXTERN bool suppress_errthrow INIT(= false);
+EXTERN bool suppress_errthrow INIT( = false);
 
 /// The stack of all caught and not finished exceptions.  The exception on the
 /// top of the stack is the one got by evaluation of v:exception.  The complete
 /// stack of all caught and pending exceptions is embedded in the various
 /// cstacks; the pending exceptions, however, are not on the caught stack.
-EXTERN except_T *caught_stack INIT(= NULL);
+EXTERN except_T *caught_stack INIT( = NULL);
 
 ///
 /// Garbage collection can only take place when we are sure there are no Lists
@@ -316,9 +316,9 @@ EXTERN except_T *caught_stack INIT(= NULL);
 /// we do garbage collection before waiting for a char at the toplevel.
 /// "garbage_collect_at_exit" indicates garbagecollect(1) was called.
 ///
-EXTERN bool may_garbage_collect INIT(= false);
-EXTERN bool want_garbage_collect INIT(= false);
-EXTERN bool garbage_collect_at_exit INIT(= false);
+EXTERN bool may_garbage_collect INIT( = false);
+EXTERN bool want_garbage_collect INIT( = false);
+EXTERN bool garbage_collect_at_exit INIT( = false);
 
 // Special values for current_SID.
 #define SID_MODELINE    (-1)      // when using a modeline
@@ -333,11 +333,11 @@ EXTERN bool garbage_collect_at_exit INIT(= false);
 #define SID_STR         (-10)     // for sourcing a string with no script item
 
 // Script CTX being sourced or was sourced to define the current function.
-EXTERN sctx_T current_sctx INIT(= { 0, 0, 0 });
+EXTERN sctx_T current_sctx INIT( = { 0, 0, 0 });
 // ID of the current channel making a client API call
-EXTERN uint64_t current_channel_id INIT(= 0);
+EXTERN uint64_t current_channel_id INIT( = 0);
 
-EXTERN bool did_source_packages INIT(= false);
+EXTERN bool did_source_packages INIT( = false);
 
 // Scope information for the code that indirectly triggered the current
 // provider function call
@@ -349,73 +349,73 @@ EXTERN struct caller_scope {
   int autocmd_bufnr;
   void *funccalp;
 } provider_caller_scope;
-EXTERN int provider_call_nesting INIT(= 0);
+EXTERN int provider_call_nesting INIT( = 0);
 
-EXTERN int t_colors INIT(= 256);                // int value of T_CCO
+EXTERN int t_colors INIT( = 256);                // int value of T_CCO
 
 // Flags to indicate an additional string for highlight name completion.
-EXTERN int include_none INIT(= 0);     // when 1 include "None"
-EXTERN int include_default INIT(= 0);  // when 1 include "default"
-EXTERN int include_link INIT(= 0);     // when 2 include "link" and "clear"
+EXTERN int include_none INIT( = 0);     // when 1 include "None"
+EXTERN int include_default INIT( = 0);  // when 1 include "default"
+EXTERN int include_link INIT( = 0);     // when 2 include "link" and "clear"
 
 // When highlight_match is true, highlight a match, starting at the cursor
 // position.  Search_match_lines is the number of lines after the match (0 for
 // a match within one line), search_match_endcol the column number of the
 // character just after the match in the last line.
-EXTERN bool highlight_match INIT(= false);         // show search match pos
+EXTERN bool highlight_match INIT( = false);         // show search match pos
 EXTERN linenr_T search_match_lines;                // lines of matched string
 EXTERN colnr_T search_match_endcol;                // col nr of match end
-EXTERN linenr_T search_first_line INIT(= 0);       // for :{FIRST},{last}s/pat
-EXTERN linenr_T search_last_line INIT(= MAXLNUM);  // for :{first},{LAST}s/pat
+EXTERN linenr_T search_first_line INIT( = 0);       // for :{FIRST},{last}s/pat
+EXTERN linenr_T search_last_line INIT( = MAXLNUM);  // for :{first},{LAST}s/pat
 
-EXTERN bool no_smartcase INIT(= false);          // don't use 'smartcase' once
+EXTERN bool no_smartcase INIT( = false);          // don't use 'smartcase' once
 
-EXTERN bool need_check_timestamps INIT(= false);  // need to check file
-                                                  // timestamps asap
-EXTERN bool did_check_timestamps INIT(= false);   // did check timestamps
-                                                  // recently
-EXTERN int no_check_timestamps INIT(= 0);         // Don't check timestamps
+EXTERN bool need_check_timestamps INIT( = false);  // need to check file
+                                                   // timestamps asap
+EXTERN bool did_check_timestamps INIT( = false);   // did check timestamps
+                                                   // recently
+EXTERN int no_check_timestamps INIT( = 0);         // Don't check timestamps
 
-EXTERN bool autocmd_busy INIT(= false);          // Is apply_autocmds() busy?
-EXTERN int autocmd_no_enter INIT(= false);       // *Enter autocmds disabled
-EXTERN int autocmd_no_leave INIT(= false);       // *Leave autocmds disabled
+EXTERN bool autocmd_busy INIT( = false);          // Is apply_autocmds() busy?
+EXTERN int autocmd_no_enter INIT( = false);       // *Enter autocmds disabled
+EXTERN int autocmd_no_leave INIT( = false);       // *Leave autocmds disabled
 EXTERN int modified_was_set;                     // did ":set modified"
-EXTERN bool did_filetype INIT(= false);          // FileType event found
+EXTERN bool did_filetype INIT( = false);          // FileType event found
 // value for did_filetype when starting to execute autocommands
-EXTERN bool keep_filetype INIT(= false);
+EXTERN bool keep_filetype INIT( = false);
 
 // When deleting the current buffer, another one must be loaded.
 // If we know which one is preferred, au_new_curbuf is set to it.
-EXTERN bufref_T au_new_curbuf INIT(= { NULL, 0, 0 });
+EXTERN bufref_T au_new_curbuf INIT( = { NULL, 0, 0 });
 
 // When deleting a buffer/window and autocmd_busy is true, do not free the
 // buffer/window. but link it in the list starting with
 // au_pending_free_buf/ap_pending_free_win, using b_next/w_next.
 // Free the buffer/window when autocmd_busy is being set to false.
-EXTERN buf_T *au_pending_free_buf INIT(= NULL);
-EXTERN win_T *au_pending_free_win INIT(= NULL);
+EXTERN buf_T *au_pending_free_buf INIT( = NULL);
+EXTERN win_T *au_pending_free_win INIT( = NULL);
 
 // Mouse coordinates, set by handle_mouse_event()
 EXTERN int mouse_grid;
 EXTERN int mouse_row;
 EXTERN int mouse_col;
-EXTERN bool mouse_past_bottom INIT(= false);  // mouse below last line
-EXTERN bool mouse_past_eol INIT(= false);     // mouse right of line
-EXTERN int mouse_dragging INIT(= 0);          // extending Visual area with
-                                              // mouse dragging
+EXTERN bool mouse_past_bottom INIT( = false);  // mouse below last line
+EXTERN bool mouse_past_eol INIT( = false);     // mouse right of line
+EXTERN int mouse_dragging INIT( = 0);          // extending Visual area with
+                                               // mouse dragging
 
 // The root of the menu hierarchy.
-EXTERN vimmenu_T *root_menu INIT(= NULL);
+EXTERN vimmenu_T *root_menu INIT( = NULL);
 // While defining the system menu, sys_menu is true.  This avoids
 // overruling of menus that the user already defined.
-EXTERN bool sys_menu INIT(= false);
+EXTERN bool sys_menu INIT( = false);
 
 // All windows are linked in a list. firstwin points to the first entry,
 // lastwin to the last entry (can be the same as firstwin) and curwin to the
 // currently active window.
 EXTERN win_T *firstwin;              // first window
 EXTERN win_T *lastwin;               // last window
-EXTERN win_T *prevwin INIT(= NULL);  // previous window
+EXTERN win_T *prevwin INIT( = NULL);  // previous window
 #define ONE_WINDOW (firstwin == lastwin)
 #define FOR_ALL_FRAMES(frp, first_frame) \
   for ((frp) = first_frame; (frp) != NULL; (frp) = (frp)->fr_next)  // NOLINT
@@ -442,7 +442,7 @@ typedef struct {
 /// When executing autocommands for a buffer that is not in any window, a
 /// special window is created to handle the side effects.  When autocommands
 /// nest we may need more than one.
-EXTERN kvec_t(aucmdwin_T) aucmd_win_vec INIT(= KV_INITIAL_VALUE);
+EXTERN kvec_t(aucmdwin_T) aucmd_win_vec INIT( = KV_INITIAL_VALUE);
 #define aucmd_win (aucmd_win_vec.items)
 #define AUCMD_WIN_COUNT ((int)aucmd_win_vec.size)
 
@@ -456,16 +456,16 @@ EXTERN frame_T *topframe;      // top of the window frame tree
 EXTERN tabpage_T *first_tabpage;
 EXTERN tabpage_T *curtab;
 EXTERN tabpage_T *lastused_tabpage;
-EXTERN bool redraw_tabline INIT(= false);  // need to redraw tabline
+EXTERN bool redraw_tabline INIT( = false);  // need to redraw tabline
 
 // Iterates over all tabs in the tab list
 #define FOR_ALL_TABS(tp) for (tabpage_T *(tp) = first_tabpage; (tp) != NULL; (tp) = (tp)->tp_next)
 
 // All buffers are linked in a list. 'firstbuf' points to the first entry,
 // 'lastbuf' to the last entry and 'curbuf' to the currently active buffer.
-EXTERN buf_T    *firstbuf INIT(= NULL);  // first buffer
-EXTERN buf_T *lastbuf INIT(= NULL);   // last buffer
-EXTERN buf_T *curbuf INIT(= NULL);    // currently active buffer
+EXTERN buf_T    *firstbuf INIT( = NULL);  // first buffer
+EXTERN buf_T *lastbuf INIT( = NULL);   // last buffer
+EXTERN buf_T *curbuf INIT( = NULL);    // currently active buffer
 
 // Iterates over all buffers in the buffer list.
 #define FOR_ALL_BUFFERS(buf) \
@@ -483,9 +483,9 @@ EXTERN buf_T *curbuf INIT(= NULL);    // currently active buffer
 // List of files being edited (global argument list).  curwin->w_alist points
 // to this when the window is using the global argument list.
 EXTERN alist_T global_alist;    // global argument list
-EXTERN int max_alist_id INIT(= 0);     ///< the previous argument list id
-EXTERN bool arg_had_last INIT(= false);     // accessed last file in
-                                            // global_alist
+EXTERN int max_alist_id INIT( = 0);     ///< the previous argument list id
+EXTERN bool arg_had_last INIT( = false);     // accessed last file in
+                                             // global_alist
 
 EXTERN int ru_col;              // column for ruler
 EXTERN int ru_wid;              // 'rulerfmt' width of ruler when non-zero
@@ -495,61 +495,61 @@ EXTERN int sc_col;              // column for shown command
 // updating).
 
 // First NO_SCREEN, then NO_BUFFERS, then 0 when startup finished.
-EXTERN int starting INIT(= NO_SCREEN);
+EXTERN int starting INIT( = NO_SCREEN);
 // true when planning to exit. Might keep running if there is a changed buffer.
-EXTERN bool exiting INIT(= false);
+EXTERN bool exiting INIT( = false);
 // internal value of v:dying
-EXTERN int v_dying INIT(= 0);
+EXTERN int v_dying INIT( = 0);
 // is stdin a terminal?
-EXTERN bool stdin_isatty INIT(= true);
+EXTERN bool stdin_isatty INIT( = true);
 // is stdout a terminal?
-EXTERN bool stdout_isatty INIT(= true);
+EXTERN bool stdout_isatty INIT( = true);
 // is stderr a terminal?
-EXTERN bool stderr_isatty INIT(= true);
+EXTERN bool stderr_isatty INIT( = true);
 
 /// filedesc set by embedder for reading first buffer like `cmd | nvim -`
-EXTERN int stdin_fd INIT(= -1);
+EXTERN int stdin_fd INIT( = -1);
 
 // true when doing full-screen output, otherwise only writing some messages.
-EXTERN bool full_screen INIT(= false);
+EXTERN bool full_screen INIT( = false);
 
 /// Non-zero when only "safe" commands are allowed
-EXTERN int secure INIT(= 0);
+EXTERN int secure INIT( = 0);
 
 /// Non-zero when changing text and jumping to another window or editing another buffer is not
 /// allowed.
-EXTERN int textlock INIT(= 0);
+EXTERN int textlock INIT( = 0);
 
 /// Non-zero when no buffer name can be changed, no buffer can be deleted and
 /// current directory can't be changed. Used for SwapExists et al.
-EXTERN int allbuf_lock INIT(= 0);
+EXTERN int allbuf_lock INIT( = 0);
 
 /// Non-zero when evaluating an expression in a "sandbox".  Several things are
 /// not allowed then.
-EXTERN int sandbox INIT(= 0);
+EXTERN int sandbox INIT( = 0);
 
 /// Batch-mode: "-es", "-Es", "-l" commandline argument was given.
-EXTERN bool silent_mode INIT(= false);
+EXTERN bool silent_mode INIT( = false);
 
 /// Start position of active Visual selection.
 EXTERN pos_T VIsual;
 /// Whether Visual mode is active.
-EXTERN bool VIsual_active INIT(= false);
+EXTERN bool VIsual_active INIT( = false);
 /// Whether Select mode is active.
-EXTERN bool VIsual_select INIT(= false);
+EXTERN bool VIsual_select INIT( = false);
 /// Register name for Select mode
-EXTERN int VIsual_select_reg INIT(= 0);
+EXTERN int VIsual_select_reg INIT( = 0);
 /// Restart Select mode when next cmd finished
-EXTERN int restart_VIsual_select INIT(= 0);
+EXTERN int restart_VIsual_select INIT( = 0);
 /// Whether to restart the selection after a Select-mode mapping or menu.
 EXTERN int VIsual_reselect;
 /// Type of Visual mode.
-EXTERN int VIsual_mode INIT(= 'v');
+EXTERN int VIsual_mode INIT( = 'v');
 /// true when redoing Visual.
-EXTERN bool redo_VIsual_busy INIT(= false);
+EXTERN bool redo_VIsual_busy INIT( = false);
 
 // The Visual area is remembered for reselection.
-EXTERN int resel_VIsual_mode INIT(= NUL);       // 'v', 'V', or Ctrl-V
+EXTERN int resel_VIsual_mode INIT( = NUL);       // 'v', 'V', or Ctrl-V
 EXTERN linenr_T resel_VIsual_line_count;        // number of lines
 EXTERN colnr_T resel_VIsual_vcol;               // nr of cols or end col
 
@@ -561,40 +561,40 @@ EXTERN pos_T where_paste_started;
 // <RETURN> or <ESC> is typed. It is set when an auto-indent is done, and
 // reset when any other editing is done on the line. If an <ESC> or <RETURN>
 // is received, and did_ai is true, the line is truncated.
-EXTERN bool did_ai INIT(= false);
+EXTERN bool did_ai INIT( = false);
 
 // Column of first char after autoindent.  0 when no autoindent done.  Used
 // when 'backspace' is 0, to avoid backspacing over autoindent.
-EXTERN colnr_T ai_col INIT(= 0);
+EXTERN colnr_T ai_col INIT( = 0);
 
 // This is a character which will end a start-middle-end comment when typed as
 // the first character on a new line.  It is taken from the last character of
 // the "end" comment leader when the COM_AUTO_END flag is given for that
 // comment end in 'comments'.  It is only valid when did_ai is true.
-EXTERN int end_comment_pending INIT(= NUL);
+EXTERN int end_comment_pending INIT( = NUL);
 
 // This flag is set after a ":syncbind" to let the check_scrollbind() function
 // know that it should not attempt to perform scrollbinding due to the scroll
 // that was a result of the ":syncbind." (Otherwise, check_scrollbind() will
 // undo some of the work done by ":syncbind.")  -ralston
-EXTERN bool did_syncbind INIT(= false);
+EXTERN bool did_syncbind INIT( = false);
 
 // This flag is set when a smart indent has been performed. When the next typed
 // character is a '{' the inserted tab will be deleted again.
-EXTERN bool did_si INIT(= false);
+EXTERN bool did_si INIT( = false);
 
 // This flag is set after an auto indent. If the next typed character is a '}'
 // one indent will be removed.
-EXTERN bool can_si INIT(= false);
+EXTERN bool can_si INIT( = false);
 
 // This flag is set after an "O" command. If the next typed character is a '{'
 // one indent will be removed.
-EXTERN bool can_si_back INIT(= false);
+EXTERN bool can_si_back INIT( = false);
 
-EXTERN int old_indent INIT(= 0);  ///< for ^^D command in insert mode
+EXTERN int old_indent INIT( = 0);  ///< for ^^D command in insert mode
 
 // w_cursor before formatting text.
-EXTERN pos_T saved_cursor INIT(= { 0, 0, 0 });
+EXTERN pos_T saved_cursor INIT( = { 0, 0, 0 });
 
 // Stuff for insert mode.
 EXTERN pos_T Insstart;                  // This is where the latest
@@ -606,11 +606,11 @@ EXTERN pos_T Insstart;                  // This is where the latest
 EXTERN pos_T Insstart_orig;
 
 // Stuff for MODE_VREPLACE state.
-EXTERN linenr_T orig_line_count INIT(= 0);       // Line count when "gR" started
-EXTERN int vr_lines_changed INIT(= 0);      // #Lines changed by "gR" so far
+EXTERN linenr_T orig_line_count INIT( = 0);       // Line count when "gR" started
+EXTERN int vr_lines_changed INIT( = 0);      // #Lines changed by "gR" so far
 
 // increase around internal delete/replace
-EXTERN int inhibit_delete_count INIT(= 0);
+EXTERN int inhibit_delete_count INIT( = 0);
 
 // These flags are set based upon 'fileencoding'.
 // The characters are internally stored as UTF-8
@@ -627,7 +627,7 @@ EXTERN int inhibit_delete_count INIT(= 0);
 #define DBCS_DEBUG     (-1)
 
 /// Encoding used when 'fencs' is set to "default"
-EXTERN char *fenc_default INIT(= NULL);
+EXTERN char *fenc_default INIT( = NULL);
 
 /// "State" is the main state of Vim.
 /// There are other variables that modify the state:
@@ -636,60 +636,60 @@ EXTERN char *fenc_default INIT(= NULL);
 ///                    before typing the motion command.
 ///    motion_force:   Last motion_force from do_pending_operator()
 ///    debug_mode:     Debug mode
-EXTERN int State INIT(= MODE_NORMAL);
+EXTERN int State INIT( = MODE_NORMAL);
 
-EXTERN bool debug_mode INIT(= false);
-EXTERN bool finish_op INIT(= false);    // true while an operator is pending
-EXTERN int opcount INIT(= 0);           // count for pending operator
-EXTERN int motion_force INIT(= 0);      // motion force for pending operator
+EXTERN bool debug_mode INIT( = false);
+EXTERN bool finish_op INIT( = false);    // true while an operator is pending
+EXTERN int opcount INIT( = 0);           // count for pending operator
+EXTERN int motion_force INIT( = 0);      // motion force for pending operator
 
 // Ex Mode (Q) state
-EXTERN bool exmode_active INIT(= false);  // true if Ex mode is active
+EXTERN bool exmode_active INIT( = false);  // true if Ex mode is active
 
 /// Flag set when normal_check() should return 0 when entering Ex mode.
-EXTERN bool pending_exmode_active INIT(= false);
+EXTERN bool pending_exmode_active INIT( = false);
 
-EXTERN bool ex_no_reprint INIT(= false);   // No need to print after z or p.
+EXTERN bool ex_no_reprint INIT( = false);   // No need to print after z or p.
 
 // 'inccommand' command preview state
-EXTERN bool cmdpreview INIT(= false);
+EXTERN bool cmdpreview INIT( = false);
 
-EXTERN int reg_recording INIT(= 0);     // register for recording  or zero
-EXTERN int reg_executing INIT(= 0);     // register being executed or zero
+EXTERN int reg_recording INIT( = 0);     // register for recording  or zero
+EXTERN int reg_executing INIT( = 0);     // register being executed or zero
 // Flag set when peeking a character and found the end of executed register
-EXTERN bool pending_end_reg_executing INIT(= false);
-EXTERN int reg_recorded INIT(= 0);      // last recorded register or zero
+EXTERN bool pending_end_reg_executing INIT( = false);
+EXTERN int reg_recorded INIT( = 0);      // last recorded register or zero
 
-EXTERN int no_mapping INIT(= false);    // currently no mapping allowed
-EXTERN int no_zero_mapping INIT(= 0);   // mapping zero not allowed
-EXTERN int allow_keys INIT(= false);    // allow key codes when no_mapping is set
-EXTERN int no_u_sync INIT(= 0);         // Don't call u_sync()
-EXTERN int u_sync_once INIT(= 0);       // Call u_sync() once when evaluating
-                                        // an expression.
+EXTERN int no_mapping INIT( = false);    // currently no mapping allowed
+EXTERN int no_zero_mapping INIT( = 0);   // mapping zero not allowed
+EXTERN int allow_keys INIT( = false);    // allow key codes when no_mapping is set
+EXTERN int no_u_sync INIT( = 0);         // Don't call u_sync()
+EXTERN int u_sync_once INIT( = 0);       // Call u_sync() once when evaluating
+                                         // an expression.
 
-EXTERN bool force_restart_edit INIT(= false);  // force restart_edit after
-                                               // ex_normal returns
-EXTERN int restart_edit INIT(= 0);      // call edit when next cmd finished
+EXTERN bool force_restart_edit INIT( = false);  // force restart_edit after
+                                                // ex_normal returns
+EXTERN int restart_edit INIT( = 0);      // call edit when next cmd finished
 EXTERN int arrow_used;                  // Normally false, set to true after
                                         // hitting cursor key in insert mode.
                                         // Used by vgetorpeek() to decide when
                                         // to call u_sync()
-EXTERN bool ins_at_eol INIT(= false);   // put cursor after eol when
-                                        // restarting edit after CTRL-O
+EXTERN bool ins_at_eol INIT( = false);   // put cursor after eol when
+                                         // restarting edit after CTRL-O
 
-EXTERN bool no_abbr INIT(= true);       // true when no abbreviations loaded
+EXTERN bool no_abbr INIT( = true);       // true when no abbreviations loaded
 
-EXTERN int mapped_ctrl_c INIT(= 0);  // Modes where CTRL-C is mapped.
-EXTERN bool ctrl_c_interrupts INIT(= true);  // CTRL-C sets got_int
+EXTERN int mapped_ctrl_c INIT( = 0);  // Modes where CTRL-C is mapped.
+EXTERN bool ctrl_c_interrupts INIT( = true);  // CTRL-C sets got_int
 
 EXTERN cmdmod_T cmdmod;                 // Ex command modifiers
 
-EXTERN int msg_silent INIT(= 0);         // don't print messages
-EXTERN int emsg_silent INIT(= 0);        // don't print error messages
-EXTERN bool emsg_noredir INIT(= false);  // don't redirect error messages
-EXTERN bool cmd_silent INIT(= false);    // don't echo the command line
+EXTERN int msg_silent INIT( = 0);         // don't print messages
+EXTERN int emsg_silent INIT( = 0);        // don't print error messages
+EXTERN bool emsg_noredir INIT( = false);  // don't redirect error messages
+EXTERN bool cmd_silent INIT( = false);    // don't echo the command line
 
-EXTERN bool in_assert_fails INIT(= false);  // assert_fails() active
+EXTERN bool in_assert_fails INIT( = false);  // assert_fails() active
 
 // Values for swap_exists_action: what to do when swap file already exists
 #define SEA_NONE        0       // don't use dialog
@@ -697,8 +697,8 @@ EXTERN bool in_assert_fails INIT(= false);  // assert_fails() active
 #define SEA_QUIT        2       // quit editing the file
 #define SEA_RECOVER     3       // recover the file
 
-EXTERN int swap_exists_action INIT(= SEA_NONE);  ///< For dialog when swap file already exists.
-EXTERN bool swap_exists_did_quit INIT(= false);  ///< Selected "quit" at the dialog.
+EXTERN int swap_exists_action INIT( = SEA_NONE);  ///< For dialog when swap file already exists.
+EXTERN bool swap_exists_did_quit INIT( = false);  ///< Selected "quit" at the dialog.
 
 EXTERN char IObuff[IOSIZE];                 ///< Buffer for sprintf, I/O, etc.
 EXTERN char NameBuff[MAXPATHL];             ///< Buffer for expanding file names
@@ -712,100 +712,100 @@ EXTERN char os_buf[                         ///< Buffer for the os/ layer
 ];
 
 // When non-zero, postpone redrawing.
-EXTERN int RedrawingDisabled INIT(= 0);
+EXTERN int RedrawingDisabled INIT( = 0);
 
-EXTERN bool readonlymode INIT(= false);      // Set to true for "view"
-EXTERN bool recoverymode INIT(= false);      // Set to true for "-r" option
+EXTERN bool readonlymode INIT( = false);      // Set to true for "view"
+EXTERN bool recoverymode INIT( = false);      // Set to true for "-r" option
 
 // typeahead buffer
-EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
+EXTERN typebuf_T typebuf INIT( = { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
 
 /// Flag used to indicate that vgetorpeek() returned a char like Esc when the
 /// :normal argument was exhausted.
-EXTERN bool typebuf_was_empty INIT(= false);
+EXTERN bool typebuf_was_empty INIT( = false);
 
-EXTERN int ex_normal_busy INIT(= 0);      // recursiveness of ex_normal()
-EXTERN int expr_map_lock INIT(= 0);       // running expr mapping, prevent use of ex_normal() and text changes
-EXTERN bool ignore_script INIT(= false);  // ignore script input
+EXTERN int ex_normal_busy INIT( = 0);      // recursiveness of ex_normal()
+EXTERN int expr_map_lock INIT( = 0);       // running expr mapping, prevent use of ex_normal() and text changes
+EXTERN bool ignore_script INIT( = false);  // ignore script input
 EXTERN int stop_insert_mode;              // for ":stopinsert"
 EXTERN bool KeyTyped;                     // true if user typed current char
 EXTERN int KeyStuffed;                    // true if current char from stuffbuf
-EXTERN int maptick INIT(= 0);             // tick for each non-mapped char
+EXTERN int maptick INIT( = 0);             // tick for each non-mapped char
 
-EXTERN int must_redraw INIT(= 0);           // type of redraw necessary
-EXTERN bool skip_redraw INIT(= false);      // skip redraw once
-EXTERN bool do_redraw INIT(= false);        // extra redraw once
-EXTERN bool must_redraw_pum INIT(= false);  // redraw pum. NB: must_redraw
-                                            // should also be set.
+EXTERN int must_redraw INIT( = 0);           // type of redraw necessary
+EXTERN bool skip_redraw INIT( = false);      // skip redraw once
+EXTERN bool do_redraw INIT( = false);        // extra redraw once
+EXTERN bool must_redraw_pum INIT( = false);  // redraw pum. NB: must_redraw
+                                             // should also be set.
 
-EXTERN bool need_highlight_changed INIT(= true);
+EXTERN bool need_highlight_changed INIT( = true);
 
-EXTERN FILE *scriptout INIT(= NULL);  ///< Stream to write script to.
+EXTERN FILE *scriptout INIT( = NULL);  ///< Stream to write script to.
 
 // Note that even when handling SIGINT, volatile is not necessary because the
 // callback is not called directly from the signal handlers.
-EXTERN bool got_int INIT(= false);          // set to true when interrupt signal occurred
-EXTERN bool bangredo INIT(= false);         // set to true with ! command
+EXTERN bool got_int INIT( = false);          // set to true when interrupt signal occurred
+EXTERN bool bangredo INIT( = false);         // set to true with ! command
 EXTERN int searchcmdlen;                    // length of previous search cmd
-EXTERN int reg_do_extmatch INIT(= 0);       // Used when compiling regexp:
-                                            // REX_SET to allow \z\(...\),
-                                            // REX_USE to allow \z\1 et al.
+EXTERN int reg_do_extmatch INIT( = 0);       // Used when compiling regexp:
+                                             // REX_SET to allow \z\(...\),
+                                             // REX_USE to allow \z\1 et al.
 // Used by vim_regexec(): strings for \z\1...\z\9
-EXTERN reg_extmatch_T *re_extmatch_in INIT(= NULL);
+EXTERN reg_extmatch_T *re_extmatch_in INIT( = NULL);
 // Set by vim_regexec() to store \z\(...\) matches
-EXTERN reg_extmatch_T *re_extmatch_out INIT(= NULL);
+EXTERN reg_extmatch_T *re_extmatch_out INIT( = NULL);
 
-EXTERN bool did_outofmem_msg INIT(= false);  ///< set after out of memory msg
-EXTERN bool did_swapwrite_msg INIT(= false);  ///< set after swap write error msg
-EXTERN int global_busy INIT(= 0);           ///< set when :global is executing
-EXTERN bool listcmd_busy INIT(= false);     ///< set when :argdo, :windo or :bufdo is executing
-EXTERN bool need_start_insertmode INIT(= false);  ///< start insert mode soon
+EXTERN bool did_outofmem_msg INIT( = false);  ///< set after out of memory msg
+EXTERN bool did_swapwrite_msg INIT( = false);  ///< set after swap write error msg
+EXTERN int global_busy INIT( = 0);           ///< set when :global is executing
+EXTERN bool listcmd_busy INIT( = false);     ///< set when :argdo, :windo or :bufdo is executing
+EXTERN bool need_start_insertmode INIT( = false);  ///< start insert mode soon
 
 #define MODE_MAX_LENGTH 4       // max mode length returned in get_mode(),
                                 // including the terminating NUL
 
-EXTERN char last_mode[MODE_MAX_LENGTH] INIT(= "n");
-EXTERN char *last_cmdline INIT(= NULL);        // last command line (for ":)
-EXTERN char *repeat_cmdline INIT(= NULL);      // command line for "."
-EXTERN char *new_last_cmdline INIT(= NULL);    // new value for last_cmdline
-EXTERN char *autocmd_fname INIT(= NULL);       // fname for <afile> on cmdline
-EXTERN bool autocmd_fname_full INIT(= false);  // autocmd_fname is full path
-EXTERN int autocmd_bufnr INIT(= 0);            // fnum for <abuf> on cmdline
-EXTERN char *autocmd_match INIT(= NULL);       // name for <amatch> on cmdline
-EXTERN bool did_cursorhold INIT(= false);      // set when CursorHold t'gerd
+EXTERN char last_mode[MODE_MAX_LENGTH] INIT( = "n");
+EXTERN char *last_cmdline INIT( = NULL);        // last command line (for ":)
+EXTERN char *repeat_cmdline INIT( = NULL);      // command line for "."
+EXTERN char *new_last_cmdline INIT( = NULL);    // new value for last_cmdline
+EXTERN char *autocmd_fname INIT( = NULL);       // fname for <afile> on cmdline
+EXTERN bool autocmd_fname_full INIT( = false);  // autocmd_fname is full path
+EXTERN int autocmd_bufnr INIT( = 0);            // fnum for <abuf> on cmdline
+EXTERN char *autocmd_match INIT( = NULL);       // name for <amatch> on cmdline
+EXTERN bool did_cursorhold INIT( = false);      // set when CursorHold t'gerd
 
-EXTERN int postponed_split INIT(= 0);        // for CTRL-W CTRL-] command
-EXTERN int postponed_split_flags INIT(= 0);  // args for win_split()
-EXTERN int postponed_split_tab INIT(= 0);    // cmdmod.cmod_tab
-EXTERN int g_do_tagpreview INIT(= 0);  // for tag preview commands:
-                                       // height of preview window
-EXTERN bool g_tag_at_cursor INIT(= false);  // whether the tag command comes
-                                            // from the command line (0) or was
-                                            // invoked as a normal command (1)
+EXTERN int postponed_split INIT( = 0);        // for CTRL-W CTRL-] command
+EXTERN int postponed_split_flags INIT( = 0);  // args for win_split()
+EXTERN int postponed_split_tab INIT( = 0);    // cmdmod.cmod_tab
+EXTERN int g_do_tagpreview INIT( = 0);  // for tag preview commands:
+                                        // height of preview window
+EXTERN bool g_tag_at_cursor INIT( = false);  // whether the tag command comes
+                                             // from the command line (0) or was
+                                             // invoked as a normal command (1)
 
-EXTERN int replace_offset INIT(= 0);        // offset for replace_push()
+EXTERN int replace_offset INIT( = 0);        // offset for replace_push()
 
-EXTERN char *escape_chars INIT(= " \t\\\"|");  // need backslash in cmd line
+EXTERN char *escape_chars INIT( = " \t\\\"|");  // need backslash in cmd line
 
-EXTERN bool keep_help_flag INIT(= false);  // doing :ta from help file
+EXTERN bool keep_help_flag INIT( = false);  // doing :ta from help file
 
 // When a string option is NULL (which only happens in out-of-memory situations), it is set to
 // empty_string_option, to avoid having to check for NULL everywhere.
 //
 // TODO(famiu): Remove this when refcounted strings are used for string options.
-EXTERN char *empty_string_option INIT(= "");
+EXTERN char *empty_string_option INIT( = "");
 
-EXTERN bool redir_off INIT(= false);        // no redirection for a moment
-EXTERN FILE *redir_fd INIT(= NULL);         // message redirection file
-EXTERN int redir_reg INIT(= 0);             // message redirection register
-EXTERN int redir_vname INIT(= 0);           // message redirection variable
-EXTERN garray_T *capture_ga INIT(= NULL);   // captured output for execute()
+EXTERN bool redir_off INIT( = false);        // no redirection for a moment
+EXTERN FILE *redir_fd INIT( = NULL);         // message redirection file
+EXTERN int redir_reg INIT( = 0);             // message redirection register
+EXTERN int redir_vname INIT( = 0);           // message redirection variable
+EXTERN garray_T *capture_ga INIT( = NULL);   // captured output for execute()
 
 EXTERN uint8_t langmap_mapchar[256];     // mapping for language keys
 
-EXTERN int save_p_ls INIT(= -1);        // Save 'laststatus' setting
-EXTERN int save_p_wmh INIT(= -1);       // Save 'winminheight' setting
-EXTERN int wild_menu_showing INIT(= 0);
+EXTERN int save_p_ls INIT( = -1);        // Save 'laststatus' setting
+EXTERN int save_p_wmh INIT( = -1);       // Save 'winminheight' setting
+EXTERN int wild_menu_showing INIT( = 0);
 enum {
   WM_SHOWN = 1,     ///< wildmenu showing
   WM_SCROLLED = 2,  ///< wildmenu showing with scroll
@@ -815,20 +815,20 @@ enum {
 // When a window has a local directory, the absolute path of the global
 // current directory is stored here (in allocated memory).  If the current
 // directory is not a local directory, globaldir is NULL.
-EXTERN char *globaldir INIT(= NULL);
+EXTERN char *globaldir INIT( = NULL);
 
-EXTERN char *last_chdir_reason INIT(= NULL);
+EXTERN char *last_chdir_reason INIT( = NULL);
 
 // Whether 'keymodel' contains "stopsel" and "startsel".
-EXTERN bool km_stopsel INIT(= false);
-EXTERN bool km_startsel INIT(= false);
+EXTERN bool km_stopsel INIT( = false);
+EXTERN bool km_startsel INIT( = false);
 
-EXTERN int cmdwin_type INIT(= 0);    ///< type of cmdline window or 0
-EXTERN int cmdwin_result INIT(= 0);  ///< result of cmdline window or 0
-EXTERN int cmdwin_level INIT(= 0);   ///< cmdline recursion level
-EXTERN win_T *cmdwin_old_curwin INIT(= NULL);  ///< curwin before opening cmdline window or NULL
+EXTERN int cmdwin_type INIT( = 0);    ///< type of cmdline window or 0
+EXTERN int cmdwin_result INIT( = 0);  ///< result of cmdline window or 0
+EXTERN int cmdwin_level INIT( = 0);   ///< cmdline recursion level
+EXTERN win_T *cmdwin_old_curwin INIT( = NULL);  ///< curwin before opening cmdline window or NULL
 
-EXTERN char no_lines_msg[] INIT(= N_("--No lines in buffer--"));
+EXTERN char no_lines_msg[] INIT( = N_("--No lines in buffer--"));
 
 // When ":global" is used to number of substitutions and changed lines is
 // accumulated until it's finished.
@@ -842,30 +842,30 @@ EXTERN uint8_t wim_flags[4];
 // whether titlestring and iconstring contains statusline syntax
 #define STL_IN_ICON    1
 #define STL_IN_TITLE   2
-EXTERN int stl_syntax INIT(= 0);
+EXTERN int stl_syntax INIT( = 0);
 
 // don't use 'hlsearch' temporarily
-EXTERN bool no_hlsearch INIT(= false);
+EXTERN bool no_hlsearch INIT( = false);
 
-EXTERN bool typebuf_was_filled INIT(= false);     // received text from client
-                                                  // or from feedkeys()
+EXTERN bool typebuf_was_filled INIT( = false);     // received text from client
+                                                   // or from feedkeys()
 
 #ifdef BACKSLASH_IN_FILENAME
-EXTERN char psepc INIT(= '\\');            // normal path separator character
-EXTERN char psepcN INIT(= '/');            // abnormal path separator character
-EXTERN char pseps[2] INIT(= { '\\', 0 });  // normal path separator string
+EXTERN char psepc INIT( = '\\');            // normal path separator character
+EXTERN char psepcN INIT( = '/');            // abnormal path separator character
+EXTERN char pseps[2] INIT( = { '\\', 0 });  // normal path separator string
 #endif
 
 // Set to kTrue when an operator is being executed with virtual editing
 // kNone when no operator is being executed, kFalse otherwise.
-EXTERN TriState virtual_op INIT(= kNone);
+EXTERN TriState virtual_op INIT( = kNone);
 
 // Display tick, incremented for each call to update_screen()
-EXTERN disptick_T display_tick INIT(= 0);
+EXTERN disptick_T display_tick INIT( = 0);
 
 // Line in which spell checking wasn't highlighted because it touched the
 // cursor position in Insert mode.
-EXTERN linenr_T spell_redraw_lnum INIT(= 0);
+EXTERN linenr_T spell_redraw_lnum INIT( = 0);
 
 // uncrustify:off
 
@@ -1092,17 +1092,17 @@ typedef enum {
 } CdCause;
 
 // Only filled for Win32.
-EXTERN char windowsVersion[20] INIT(= { 0 });
+EXTERN char windowsVersion[20] INIT( = { 0 });
 
 /// While executing a regexp and set to OPTION_MAGIC_ON or OPTION_MAGIC_OFF this
 /// overrules p_magic.  Otherwise set to OPTION_MAGIC_NOT_SET.
-EXTERN optmagic_T magic_overruled INIT(= OPTION_MAGIC_NOT_SET);
+EXTERN optmagic_T magic_overruled INIT( = OPTION_MAGIC_NOT_SET);
 
 /// Skip win_fix_cursor() call for 'splitkeep' when cmdwin is closed.
-EXTERN bool skip_win_fix_cursor INIT(= false);
+EXTERN bool skip_win_fix_cursor INIT( = false);
 /// Skip win_fix_scroll() call for 'splitkeep' when closing tab page.
-EXTERN bool skip_win_fix_scroll INIT(= false);
+EXTERN bool skip_win_fix_scroll INIT( = false);
 /// Skip update_topline() call while executing win_fix_scroll().
-EXTERN bool skip_update_topline INIT(= false);
+EXTERN bool skip_update_topline INIT( = false);
 
 #endif  // NVIM_GLOBALS_H

--- a/src/nvim/grid.h
+++ b/src/nvim/grid.h
@@ -19,16 +19,16 @@
 ///
 /// Note: before the screen is initialized and when out of memory these can be
 /// NULL.
-EXTERN ScreenGrid default_grid INIT(= SCREEN_GRID_INIT);
+EXTERN ScreenGrid default_grid INIT( = SCREEN_GRID_INIT);
 
 #define DEFAULT_GRID_HANDLE 1  // handle for the default_grid
 
 /// While resizing the screen this flag is set.
-EXTERN bool resizing_screen INIT(= 0);
+EXTERN bool resizing_screen INIT( = 0);
 
-EXTERN schar_T *linebuf_char INIT(= NULL);
-EXTERN sattr_T *linebuf_attr INIT(= NULL);
-EXTERN colnr_T *linebuf_vcol INIT(= NULL);
+EXTERN schar_T *linebuf_char INIT( = NULL);
+EXTERN sattr_T *linebuf_attr INIT( = NULL);
+EXTERN colnr_T *linebuf_vcol INIT( = NULL);
 
 // Low-level functions to manipulate individual character cells on the
 // screen grid.

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -478,7 +478,7 @@ int hl_get_underline(void)
 /// Get attribute code for forwarded :terminal highlights.
 int hl_get_term_attr(HlAttrs *aep)
 {
-  return get_attr_entry((HlEntry){ .attr= *aep, .kind = kHlTerminal,
+  return get_attr_entry((HlEntry){ .attr = *aep, .kind = kHlTerminal,
                                    .id1 = 0, .id2 = 0 });
 }
 
@@ -842,7 +842,7 @@ void hlattrs2dict(Dictionary *hl, Dictionary *hl_attrs, HlAttrs ae, bool use_rgb
   hl_attrs = hl_attrs ? hl_attrs : hl;
   assert(hl->capacity >= HLATTRS_DICT_SIZE);  // at most 16 items
   assert(hl_attrs->capacity >= HLATTRS_DICT_SIZE);  // at most 16 items
-  int mask  = use_rgb ? ae.rgb_ae_attr : ae.cterm_ae_attr;
+  int mask = use_rgb ? ae.rgb_ae_attr : ae.cterm_ae_attr;
 
   if (mask & HL_INVERSE) {
     PUT_C(*hl_attrs, "reverse", BOOLEAN_OBJ(true));

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -127,7 +127,7 @@ typedef enum {
   HLF_COUNT,      // MUST be the last one
 } hlf_T;
 
-EXTERN const char *hlf_names[] INIT(= {
+EXTERN const char *hlf_names[] INIT( = {
   [HLF_8] = "SpecialKey",
   [HLF_EOB] = "EndOfBuffer",
   [HLF_TERM] = "TermCursor",
@@ -200,18 +200,18 @@ EXTERN int highlight_attr[HLF_COUNT + 1];     // Highl. attr for each context.
 EXTERN int highlight_attr_last[HLF_COUNT];  // copy for detecting changed groups
 EXTERN int highlight_user[9];                   // User[1-9] attributes
 EXTERN int highlight_stlnc[9];                  // On top of user
-EXTERN int cterm_normal_fg_color INIT(= 0);
-EXTERN int cterm_normal_bg_color INIT(= 0);
-EXTERN RgbValue normal_fg INIT(= -1);
-EXTERN RgbValue normal_bg INIT(= -1);
-EXTERN RgbValue normal_sp INIT(= -1);
+EXTERN int cterm_normal_fg_color INIT( = 0);
+EXTERN int cterm_normal_bg_color INIT( = 0);
+EXTERN RgbValue normal_fg INIT( = -1);
+EXTERN RgbValue normal_bg INIT( = -1);
+EXTERN RgbValue normal_sp INIT( = -1);
 
-EXTERN NS ns_hl_global INIT(= 0);  // global highlight namespace
-EXTERN NS ns_hl_win INIT(= -1);    // highlight namespace for the current window
-EXTERN NS ns_hl_fast INIT(= -1);   // highlight namespace specified in a fast callback
-EXTERN NS ns_hl_active INIT(= 0);  // currently active/cached namespace
+EXTERN NS ns_hl_global INIT( = 0);  // global highlight namespace
+EXTERN NS ns_hl_win INIT( = -1);    // highlight namespace for the current window
+EXTERN NS ns_hl_fast INIT( = -1);   // highlight namespace specified in a fast callback
+EXTERN NS ns_hl_active INIT( = 0);  // currently active/cached namespace
 
-EXTERN int *hl_attr_active INIT(= highlight_attr);
+EXTERN int *hl_attr_active INIT( = highlight_attr);
 
 typedef enum {
   kHlUnknown,

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -960,7 +960,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
 
     from_end = skiptowhite(from_start);
     to_start = skipwhite(from_end);
-    to_end   = skiptowhite(to_start);
+    to_end = skiptowhite(to_start);
 
     if (ends_excmd((uint8_t)(*from_start))
         || ends_excmd((uint8_t)(*to_start))) {

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -45,7 +45,7 @@ typedef struct {
 # include "lua/executor.h.generated.h"
 #endif
 
-EXTERN nlua_ref_state_t *nlua_global_refs INIT(= NULL);
-EXTERN bool nlua_disable_preload INIT(= false);
+EXTERN nlua_ref_state_t *nlua_global_refs INIT( = NULL);
+EXTERN bool nlua_disable_preload INIT( = false);
 
 #endif  // NVIM_LUA_EXECUTOR_H

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -515,7 +515,7 @@ static int nlua_iconv(lua_State *lstate)
   const char *str = lua_tolstring(lstate, 1, &str_len);
 
   char *from = enc_canonize(enc_skip((char *)lua_tolstring(lstate, 2, NULL)));
-  char *to   = enc_canonize(enc_skip((char *)lua_tolstring(lstate, 3, NULL)));
+  char *to = enc_canonize(enc_skip((char *)lua_tolstring(lstate, 3, NULL)));
 
   vimconv_T vimconv;
   vimconv.vc_type = CONV_NONE;

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -361,7 +361,7 @@ static int parser_tostring(lua_State *L)
 static const char *input_cb(void *payload, uint32_t byte_index, TSPoint position,
                             uint32_t *bytes_read)
 {
-  buf_T *bp  = payload;
+  buf_T *bp = payload;
 #define BUFSIZE 256
   static char buf[BUFSIZE];
 
@@ -1585,7 +1585,7 @@ static void query_err_string(const char *src, int error_offset, TSQueryError err
   do {
     const char *src_tmp = src + line_start;
     end_str = strchr(src_tmp, '\n');
-    int line_length  = end_str != NULL ? (int)(end_str - src_tmp) : (int)strlen(src_tmp);
+    int line_length = end_str != NULL ? (int)(end_str - src_tmp) : (int)strlen(src_tmp);
     int line_end = line_start + line_length;
     if (line_end > error_offset) {
       error_line = src_tmp;

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -367,18 +367,18 @@ int nlua_xdl_diff(lua_State *lstate)
     cfg.hunk_func = call_on_hunk_cb;
     priv = (hunkpriv_t) {
       .lstate = lstate,
-      .err    = &err,
+      .err = &err,
     };
     ecb.priv = &priv;
     break;
   case kNluaXdiffModeLocations:
     cfg.hunk_func = hunk_locations_cb;
     priv = (hunkpriv_t) {
-      .lstate    = lstate,
-      .ma        = &ma,
-      .mb        = &mb,
+      .lstate = lstate,
+      .ma = &ma,
+      .mb = &mb,
       .linematch = linematch,
-      .iwhite    = (params.flags & XDF_IGNORE_WHITESPACE) > 0
+      .iwhite = (params.flags & XDF_IGNORE_WHITESPACE) > 0
     };
     ecb.priv = &priv;
     lua_createtable(lstate, 0, 0);

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -78,8 +78,8 @@ static inline bool equal_ColorKey(ColorKey ae1, ColorKey ae2)
 // TODO(bfredl): this could be _less_ for the h->hash part as this is now small (4 bytes per value)
 #define UPPER_FILL 0.77
 
-#define roundup32(x) (--(x), (x)|= (x)>>1, (x)|= (x)>>2, (x)|= (x)>>4, (x)|= (x)>>8, \
-                      (x)|= (x)>>16, ++(x))
+#define roundup32(x) (--(x), (x) |= (x)>>1, (x) |= (x)>>2, (x) |= (x)>>4, (x) |= (x)>>8, \
+                      (x) |= (x)>>16, ++(x))
 
 // h->hash must either be NULL or an already valid pointer
 void mh_realloc(MapHash *h, uint32_t n_min_buckets)

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -981,13 +981,13 @@ void ex_delmarks(exarg_T *eap)
           clear_fmark(&curbuf->b_last_change, timestamp);
           break;
         case '[':
-          curbuf->b_op_start.lnum    = 0; break;
+          curbuf->b_op_start.lnum = 0; break;
         case ']':
-          curbuf->b_op_end.lnum      = 0; break;
+          curbuf->b_op_end.lnum = 0; break;
         case '<':
           curbuf->b_visual.vi_start.lnum = 0; break;
         case '>':
-          curbuf->b_visual.vi_end.lnum   = 0; break;
+          curbuf->b_visual.vi_end.lnum = 0; break;
         case ' ':
           break;
         default:

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -87,6 +87,6 @@ typedef struct xfilemark {
 #define INIT_XFMARK { INIT_FMARK, NULL }
 
 /// Global marks (marks with file number or name)
-EXTERN xfmark_T namedfm[NGLOBALMARKS] INIT(= { 0 });
+EXTERN xfmark_T namedfm[NGLOBALMARKS] INIT( = { 0 });
 
 #endif  // NVIM_MARK_DEFS_H

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3645,7 +3645,7 @@ static bool fnamecmp_ino(char *fname_c, char *fname_s, long ino_block0)
 /// Used for machine independency in block zero.
 static void long_to_char(long n, char *s_in)
 {
-  uint8_t *s= (uint8_t *)s_in;
+  uint8_t *s = (uint8_t *)s_in;
   s[0] = (uint8_t)(n & 0xff);
   n = (unsigned)n >> 8;
   s[1] = (uint8_t)(n & 0xff);

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -39,7 +39,7 @@ extern MemRealloc mem_realloc;
 extern bool entered_free_all_mem;
 #endif
 
-EXTERN size_t arena_alloc_count INIT(= 0);
+EXTERN size_t arena_alloc_count INIT( = 0);
 
 typedef struct consumed_blk {
   struct consumed_blk *prev;

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -49,12 +49,12 @@ extern MessageHistoryEntry *first_msg_hist;
 /// Last message
 extern MessageHistoryEntry *last_msg_hist;
 
-EXTERN bool msg_ext_need_clear INIT(= false);
+EXTERN bool msg_ext_need_clear INIT( = false);
 
 // allocated grid for messages. Used when display+=msgsep is set, or
 // ext_multigrid is active. See also the description at msg_scroll_flush()
-EXTERN ScreenGrid msg_grid INIT(= SCREEN_GRID_INIT);
-EXTERN int msg_grid_pos INIT(= 0);
+EXTERN ScreenGrid msg_grid INIT( = SCREEN_GRID_INIT);
+EXTERN int msg_grid_pos INIT( = 0);
 
 // "adjusted" message grid. This grid accepts positions relative to
 // default_grid. Internally it will be translated to a position on msg_grid
@@ -62,14 +62,14 @@ EXTERN int msg_grid_pos INIT(= 0);
 // for legacy (display-=msgsep) message scroll behavior.
 // // TODO(bfredl): refactor "internal" message logic, msg_row etc
 // to use the correct positions already.
-EXTERN ScreenGrid msg_grid_adj INIT(= SCREEN_GRID_INIT);
+EXTERN ScreenGrid msg_grid_adj INIT( = SCREEN_GRID_INIT);
 
 // value of msg_scrolled at latest msg_scroll_flush.
-EXTERN int msg_scrolled_at_flush INIT(= 0);
+EXTERN int msg_scrolled_at_flush INIT( = 0);
 
-EXTERN int msg_grid_scroll_discount INIT(= 0);
+EXTERN int msg_grid_scroll_discount INIT( = 0);
 
-EXTERN int msg_listdo_overwrite INIT(= 0);
+EXTERN int msg_listdo_overwrite INIT( = 0);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "message.h.generated.h"

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1119,8 +1119,8 @@ void f_screenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   pos_T pos = {
-    .lnum   = (linenr_T)tv_get_number(&argvars[1]),
-    .col    = (colnr_T)tv_get_number(&argvars[2]) - 1,
+    .lnum = (linenr_T)tv_get_number(&argvars[1]),
+    .col = (colnr_T)tv_get_number(&argvars[2]) - 1,
     .coladd = 0
   };
   if (pos.lnum > wp->w_buffer->b_ml.ml_line_count) {
@@ -2694,9 +2694,9 @@ void do_check_cursorbind(void)
   prev_curwin = curwin;
   prev_cursor = curwin->w_cursor;
 
-  linenr_T line    = curwin->w_cursor.lnum;
-  colnr_T col      = curwin->w_cursor.col;
-  colnr_T coladd   = curwin->w_cursor.coladd;
+  linenr_T line = curwin->w_cursor.lnum;
+  colnr_T col = curwin->w_cursor.col;
+  colnr_T coladd = curwin->w_cursor.coladd;
   colnr_T curswant = curwin->w_curswant;
   int set_curswant = curwin->w_set_curswant;
   win_T *old_curwin = curwin;

--- a/src/nvim/msgpack_rpc/channel.h
+++ b/src/nvim/msgpack_rpc/channel.h
@@ -17,7 +17,7 @@
 /// HACK: os/input.c drains this queue immediately before blocking for input.
 ///       Events on this queue are async-safe, but they need the resolved state
 ///       of os_inchar(), so they are processed "just-in-time".
-EXTERN MultiQueue *ch_before_blocking_events INIT(= NULL);
+EXTERN MultiQueue *ch_before_blocking_events INIT( = NULL);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "msgpack_rpc/channel.h.generated.h"

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -137,6 +137,6 @@ static inline bool is_literal_register(const int regname)
 # include "ops.h.generated.h"
 #endif
 
-EXTERN LuaRef repeat_luaref INIT(= LUA_NOREF);  ///< LuaRef for "."
+EXTERN LuaRef repeat_luaref INIT( = LUA_NOREF);  ///< LuaRef for "."
 
 #endif  // NVIM_OPS_H

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4681,7 +4681,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_ve = copy_option_val(from->wo_ve);
   to->wo_ve_flags = from->wo_ve_flags;
   to->wo_nuw = from->wo_nuw;
-  to->wo_rl  = from->wo_rl;
+  to->wo_rl = from->wo_rl;
   to->wo_rlc = copy_option_val(from->wo_rlc);
   to->wo_sbr = copy_option_val(from->wo_sbr);
   to->wo_stl = copy_option_val(from->wo_stl);

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -573,8 +573,8 @@ EXTERN int p_mousemev;          ///< 'mousemoveevent'
 EXTERN int p_mousef;            ///< 'mousefocus'
 EXTERN int p_mh;                ///< 'mousehide'
 EXTERN char *p_mousescroll;     ///< 'mousescroll'
-EXTERN OptInt p_mousescroll_vert INIT(= MOUSESCROLL_VERT_DFLT);
-EXTERN OptInt p_mousescroll_hor INIT(= MOUSESCROLL_HOR_DFLT);
+EXTERN OptInt p_mousescroll_vert INIT( = MOUSESCROLL_VERT_DFLT);
+EXTERN OptInt p_mousescroll_hor INIT( = MOUSESCROLL_HOR_DFLT);
 EXTERN OptInt p_mouset;         ///< 'mousetime'
 EXTERN int p_more;              ///< 'more'
 EXTERN char *p_nf;              ///< 'nrformats'

--- a/src/nvim/os/input.h
+++ b/src/nvim/os/input.h
@@ -8,7 +8,7 @@
 #include "nvim/event/multiqueue.h"
 #include "nvim/macros.h"
 
-EXTERN bool used_stdin INIT(= false);
+EXTERN bool used_stdin INIT( = false);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/input.h.generated.h"

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -14,9 +14,9 @@
 # define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE 0x00020016
 #endif
 
-HRESULT (WINAPI *pCreatePseudoConsole)(COORD, HANDLE, HANDLE, DWORD, HPCON *);
-HRESULT (WINAPI *pResizePseudoConsole)(HPCON, COORD);
-void (WINAPI *pClosePseudoConsole)(HPCON);
+HRESULT(WINAPI *pCreatePseudoConsole)(COORD, HANDLE, HANDLE, DWORD, HPCON *);
+HRESULT(WINAPI *pResizePseudoConsole)(HPCON, COORD);
+void(WINAPI *pClosePseudoConsole)(HPCON);
 
 bool os_has_conpty_working(void)
 {

--- a/src/nvim/os/pty_conpty_win.h
+++ b/src/nvim/os/pty_conpty_win.h
@@ -8,10 +8,10 @@
 # define HPCON VOID *
 #endif
 
-extern HRESULT (WINAPI *pCreatePseudoConsole)  // NOLINT(whitespace/parens)
+extern HRESULT(WINAPI *pCreatePseudoConsole)  // NOLINT(whitespace/parens)
   (COORD, HANDLE, HANDLE, DWORD, HPCON *);
-extern HRESULT (WINAPI *pResizePseudoConsole)(HPCON, COORD);
-extern void (WINAPI *pClosePseudoConsole)(HPCON);
+extern HRESULT(WINAPI *pResizePseudoConsole)(HPCON, COORD);
+extern void(WINAPI *pClosePseudoConsole)(HPCON);
 
 typedef struct conpty {
   HPCON pty;

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -335,21 +335,21 @@ static void init_termios(struct termios *termios) FUNC_ATTR_NONNULL_ALL
   termios->c_lflag |= ECHOKE;
 #endif
 
-  termios->c_cc[VINTR]    = 0x1f & 'C';
-  termios->c_cc[VQUIT]    = 0x1f & '\\';
-  termios->c_cc[VERASE]   = 0x7f;
-  termios->c_cc[VKILL]    = 0x1f & 'U';
-  termios->c_cc[VEOF]     = 0x1f & 'D';
-  termios->c_cc[VEOL]     = _POSIX_VDISABLE;
-  termios->c_cc[VEOL2]    = _POSIX_VDISABLE;
-  termios->c_cc[VSTART]   = 0x1f & 'Q';
-  termios->c_cc[VSTOP]    = 0x1f & 'S';
-  termios->c_cc[VSUSP]    = 0x1f & 'Z';
+  termios->c_cc[VINTR] = 0x1f & 'C';
+  termios->c_cc[VQUIT] = 0x1f & '\\';
+  termios->c_cc[VERASE] = 0x7f;
+  termios->c_cc[VKILL] = 0x1f & 'U';
+  termios->c_cc[VEOF] = 0x1f & 'D';
+  termios->c_cc[VEOL] = _POSIX_VDISABLE;
+  termios->c_cc[VEOL2] = _POSIX_VDISABLE;
+  termios->c_cc[VSTART] = 0x1f & 'Q';
+  termios->c_cc[VSTOP] = 0x1f & 'S';
+  termios->c_cc[VSUSP] = 0x1f & 'Z';
   termios->c_cc[VREPRINT] = 0x1f & 'R';
-  termios->c_cc[VWERASE]  = 0x1f & 'W';
-  termios->c_cc[VLNEXT]   = 0x1f & 'V';
-  termios->c_cc[VMIN]     = 1;
-  termios->c_cc[VTIME]    = 0;
+  termios->c_cc[VWERASE] = 0x1f & 'W';
+  termios->c_cc[VLNEXT] = 0x1f & 'V';
+  termios->c_cc[VMIN] = 1;
+  termios->c_cc[VTIME] = 0;
 }
 
 static int set_duplicating_descriptor(int fd, uv_pipe_t *pipe)

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1022,9 +1022,9 @@ static void system_data_cb(Stream *stream, RBuffer *buf, size_t count, void *dat
 ///          Returns the previous decision if size=0.
 static bool out_data_decide_throttle(size_t size)
 {
-  static uint64_t started     = 0;  // Start time of the current throttle.
-  static size_t received    = 0;  // Bytes observed since last throttle.
-  static size_t visit       = 0;  // "Pulse" count of the current throttle.
+  static uint64_t started = 0;  // Start time of the current throttle.
+  static size_t received = 0;  // Bytes observed since last throttle.
+  static size_t visit = 0;  // "Pulse" count of the current throttle.
   static char pulse_msg[] = { ' ', ' ', ' ', '\0' };
 
   if (!size) {
@@ -1104,7 +1104,7 @@ static void out_data_ring(char *output, size_t size)
     last_skipped_len = MAX_CHUNK_SIZE;
   } else if (size > 0) {
     // Length of the old data that can be kept.
-    size_t keep_len   = MIN(last_skipped_len, MAX_CHUNK_SIZE - size);
+    size_t keep_len = MIN(last_skipped_len, MAX_CHUNK_SIZE - size);
     size_t keep_start = last_skipped_len - keep_len;
     // Shift the kept part of the old data to the start.
     if (keep_start) {

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -16,7 +16,7 @@ typedef struct {
   char *pum_info;          // extra info
 } pumitem_T;
 
-EXTERN ScreenGrid pum_grid INIT(= SCREEN_GRID_INIT);
+EXTERN ScreenGrid pum_grid INIT( = SCREEN_GRID_INIT);
 
 /// state for pum_ext_select_item.
 EXTERN struct {

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -233,21 +233,21 @@ void profile_reset(void)
   for (int id = 1; id <= script_items.ga_len; id++) {
     scriptitem_T *si = SCRIPT_ITEM(id);
     if (si->sn_prof_on) {
-      si->sn_prof_on      = false;
-      si->sn_pr_force     = false;
-      si->sn_pr_child     = profile_zero();
-      si->sn_pr_nest      = 0;
-      si->sn_pr_count     = 0;
-      si->sn_pr_total     = profile_zero();
-      si->sn_pr_self      = profile_zero();
-      si->sn_pr_start     = profile_zero();
-      si->sn_pr_children  = profile_zero();
+      si->sn_prof_on = false;
+      si->sn_pr_force = false;
+      si->sn_pr_child = profile_zero();
+      si->sn_pr_nest = 0;
+      si->sn_pr_count = 0;
+      si->sn_pr_total = profile_zero();
+      si->sn_pr_self = profile_zero();
+      si->sn_pr_start = profile_zero();
+      si->sn_pr_children = profile_zero();
       ga_clear(&si->sn_prl_ga);
-      si->sn_prl_start    = profile_zero();
+      si->sn_prl_start = profile_zero();
       si->sn_prl_children = profile_zero();
-      si->sn_prl_wait     = profile_zero();
-      si->sn_prl_idx      = -1;
-      si->sn_prl_execed   = 0;
+      si->sn_prl_wait = profile_zero();
+      si->sn_prl_idx = -1;
+      si->sn_prl_execed = 0;
     }
   }
 
@@ -261,22 +261,22 @@ void profile_reset(void)
       todo--;
       ufunc_T *uf = HI2UF(hi);
       if (uf->uf_prof_initialized) {
-        uf->uf_profiling    = 0;
-        uf->uf_tm_count     = 0;
-        uf->uf_tm_total     = profile_zero();
-        uf->uf_tm_self      = profile_zero();
-        uf->uf_tm_children  = profile_zero();
+        uf->uf_profiling = 0;
+        uf->uf_tm_count = 0;
+        uf->uf_tm_total = profile_zero();
+        uf->uf_tm_self = profile_zero();
+        uf->uf_tm_children = profile_zero();
 
         for (int i = 0; i < uf->uf_lines.ga_len; i++) {
           uf->uf_tml_count[i] = 0;
           uf->uf_tml_total[i] = uf->uf_tml_self[i] = 0;
         }
 
-        uf->uf_tml_start    = profile_zero();
+        uf->uf_tml_start = profile_zero();
         uf->uf_tml_children = profile_zero();
-        uf->uf_tml_wait     = profile_zero();
-        uf->uf_tml_idx      = -1;
-        uf->uf_tml_execed   = 0;
+        uf->uf_tml_wait = profile_zero();
+        uf->uf_tml_idx = -1;
+        uf->uf_tml_execed = 0;
       }
     }
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1661,7 +1661,7 @@ static int qf_parse_multiline_pfx(int idx, qf_list_T *qfl, qffields_T *fields)
     }
     if (*fields->errmsg) {
       size_t textlen = strlen(qfprev->qf_text);
-      size_t errlen  = strlen(fields->errmsg);
+      size_t errlen = strlen(fields->errmsg);
       qfprev->qf_text = xrealloc(qfprev->qf_text, textlen + errlen + 2);
       qfprev->qf_text[textlen] = '\n';
       STRCPY(qfprev->qf_text + textlen + 1, fields->errmsg);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3434,12 +3434,12 @@ static nfa_state_T *alloc_state(int c, nfa_state_T *out, nfa_state_T *out1)
 
   s = &state_ptr[istate++];
 
-  s->c    = c;
-  s->out  = out;
+  s->c = c;
+  s->out = out;
   s->out1 = out1;
-  s->val  = 0;
+  s->val = 0;
 
-  s->id   = istate;
+  s->id = istate;
   s->lastlist[0] = 0;
   s->lastlist[1] = 0;
 
@@ -4053,7 +4053,7 @@ static nfa_state_T *post2nfa(int *postfix, int *end, int nfa_calc_size)
         if (zend == NULL) {
           goto theend;
         }
-        s1->out= skip;
+        s1->out = skip;
         patch(e.out, zend);
         PUSH(frag(s, list1(&skip->out)));
       } else {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -347,13 +347,13 @@ void restore_last_search_pattern(void)
 static void save_incsearch_state(void)
 {
   saved_search_match_endcol = search_match_endcol;
-  saved_search_match_lines  = search_match_lines;
+  saved_search_match_lines = search_match_lines;
 }
 
 static void restore_incsearch_state(void)
 {
   search_match_endcol = saved_search_match_endcol;
-  search_match_lines  = saved_search_match_lines;
+  search_match_lines = saved_search_match_lines;
 }
 
 char *last_search_pattern(void)
@@ -2467,7 +2467,7 @@ int current_search(int count, bool forward)
       } else {  // try again from end of buffer
                 // searching backwards, so set pos to last line and col
         pos.lnum = curwin->w_buffer->b_ml.ml_line_count;
-        pos.col  = (colnr_T)strlen(ml_get(curwin->w_buffer->b_ml.ml_line_count));
+        pos.col = (colnr_T)strlen(ml_get(curwin->w_buffer->b_ml.ml_line_count));
       }
     }
   }
@@ -2718,7 +2718,7 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, searchst
     pos_T endpos = { 0, 0, 0 };
     p_ws = false;
     if (timeout > 0) {
-      start  = profile_setlimit(timeout);
+      start = profile_setlimit(timeout);
     }
     while (!got_int && searchit(curwin, curbuf, &lastpos, &endpos,
                                 FORWARD, NULL, 1, SEARCH_KEEP, RE_LAST,

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -230,7 +230,7 @@ void sha256_finish(context_sha256_T *ctx, uint8_t digest[SHA256_SUM_SIZE])
   uint8_t msglen[8];
 
   high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);
-  low  = (ctx->total[0] <<  3);
+  low = (ctx->total[0] <<  3);
 
   PUT_UINT32(high, msglen, 0);
   PUT_UINT32(low,  msglen, 4);

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1505,7 +1505,7 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
     dict_T *const d = (src); \
     if (d != NULL) { \
       size_t todo = d->dv_hashtab.ht_used; \
-      for (const hashitem_T *hi= d->dv_hashtab.ht_array; todo; hi++) { \
+      for (const hashitem_T *hi = d->dv_hashtab.ht_array; todo; hi++) { \
         if (!HASHITEM_EMPTY(hi)) { \
           todo--; \
           dictitem_T *const di = TV_DICT_HI2DI(hi); \

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1954,12 +1954,12 @@ static int sign_define_from_dict(const char *name_arg, dict_T *dict)
     goto cleanup;
   }
   if (dict != NULL) {
-    icon   = tv_dict_get_string(dict, "icon", true);
+    icon = tv_dict_get_string(dict, "icon", true);
     linehl = tv_dict_get_string(dict, "linehl", true);
-    text   = tv_dict_get_string(dict, "text", true);
+    text = tv_dict_get_string(dict, "text", true);
     texthl = tv_dict_get_string(dict, "texthl", true);
-    culhl  = tv_dict_get_string(dict, "culhl", true);
-    numhl  = tv_dict_get_string(dict, "numhl", true);
+    culhl = tv_dict_get_string(dict, "culhl", true);
+    numhl = tv_dict_get_string(dict, "numhl", true);
   }
 
   if (sign_define_by_name(name, icon, linehl,

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -311,8 +311,8 @@ static int badword_captype(char *word, char *end)
   }
 
   // Count the number of UPPER and lower case letters.
-  int l= 0;
-  int u= 0;
+  int l = 0;
+  int u = 0;
   bool first = false;
   for (char *p = word; p < end; MB_PTR_ADV(p)) {
     int c = utf_ptr2char(p);

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -958,7 +958,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
 
     // Allocate one more, because the last element is used to indicate the
     // end of the list.
-    stl_hltab  = xmalloc(sizeof(stl_hlrec_t) * (stl_items_len + 1));
+    stl_hltab = xmalloc(sizeof(stl_hlrec_t) * (stl_items_len + 1));
     stl_tabtab = xmalloc(sizeof(StlClickRecord) * (stl_items_len + 1));
 
     stl_separator_locations = xmalloc(sizeof(int) * stl_items_len);
@@ -1017,7 +1017,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
   }
 
   int groupdepth = 0;
-  int evaldepth  = 0;
+  int evaldepth = 0;
 
   int curitem = 0;
   int foldsignitem = -1;
@@ -2030,7 +2030,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       // { Determine how many bytes to remove
       int trunc_len = 0;
       while (width >= maxwidth) {
-        width     -= ptr2cells(trunc_p + trunc_len);
+        width -= ptr2cells(trunc_p + trunc_len);
         trunc_len += utfc_ptr2len(trunc_p + trunc_len);
       }
       // }

--- a/src/nvim/statusline.h
+++ b/src/nvim/statusline.h
@@ -8,9 +8,9 @@
 #include "nvim/statusline_defs.h"
 
 /// Array defining what should be done when tabline is clicked
-EXTERN StlClickDefinition *tab_page_click_defs INIT(= NULL);
+EXTERN StlClickDefinition *tab_page_click_defs INIT( = NULL);
 /// Size of the tab_page_click_defs array
-EXTERN size_t tab_page_click_defs_size INIT(= 0);
+EXTERN size_t tab_page_click_defs_size INIT( = 0);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "statusline.h.generated.h"

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -511,7 +511,7 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
   int found_flags = 0;
   int found_match_idx = 0;
   linenr_T found_current_lnum = 0;
-  int found_current_col= 0;
+  int found_current_col = 0;
   lpos_T found_m_endpos;
   colnr_T prev_current_col;
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -160,13 +160,13 @@ struct terminal {
 };
 
 static VTermScreenCallbacks vterm_screen_callbacks = {
-  .damage      = term_damage,
-  .moverect    = term_moverect,
-  .movecursor  = term_movecursor,
+  .damage = term_damage,
+  .moverect = term_moverect,
+  .movecursor = term_movecursor,
   .settermprop = term_settermprop,
-  .bell        = term_bell,
+  .bell = term_bell,
   .sb_pushline = term_sb_push,  // Called before a line goes offscreen.
-  .sb_popline  = term_sb_pop,
+  .sb_popline = term_sb_pop,
 };
 
 static Set(ptr_t) invalidated_terminals = SET_INIT;

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -76,7 +76,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
   bool haveto_redraw = false;
   const bool fo_ins_blank = has_format_option(FO_INS_BLANK);
   const bool fo_multibyte = has_format_option(FO_MBYTE_BREAK);
-  const bool fo_rigor_tw  = has_format_option(FO_RIGOROUS_TW);
+  const bool fo_rigor_tw = has_format_option(FO_RIGOROUS_TW);
   const bool fo_white_par = has_format_option(FO_WHITE_PAR);
   bool first_line = true;
   colnr_T leader_len;
@@ -309,7 +309,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
             col = curwin->w_cursor.col;
 
             inc_cursor();
-            cc  = ncc;
+            cc = ncc;
             ncc = gchar_cursor();
             // handle insert
             ncc = (ncc != NUL) ? ncc : c;

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -30,7 +30,7 @@ typedef enum {
   kUIExtCount,
 } UIExtension;
 
-EXTERN const char *ui_ext_names[] INIT(= {
+EXTERN const char *ui_ext_names[] INIT( = {
   "ext_cmdline",
   "ext_popupmenu",
   "ext_tabline",

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -16,29 +16,29 @@ typedef struct {
 } UIClientHandler;
 
 // Temporary buffer for converting a single grid_line event
-EXTERN size_t grid_line_buf_size INIT(= 0);
-EXTERN schar_T *grid_line_buf_char INIT(= NULL);
-EXTERN sattr_T *grid_line_buf_attr INIT(= NULL);
+EXTERN size_t grid_line_buf_size INIT( = 0);
+EXTERN schar_T *grid_line_buf_char INIT( = NULL);
+EXTERN sattr_T *grid_line_buf_attr INIT( = NULL);
 
 // ID of the ui client channel. If zero, the client is not running.
-EXTERN uint64_t ui_client_channel_id INIT(= 0);
+EXTERN uint64_t ui_client_channel_id INIT( = 0);
 
 // exit status from embedded nvim process
-EXTERN int ui_client_exit_status INIT(= 0);
+EXTERN int ui_client_exit_status INIT( = 0);
 
 // TODO(bfredl): the current structure for how tui and ui_client.c communicate is a bit awkward.
 // This will be restructured as part of The UI Devirtualization Project.
 
 /// Whether ui client has sent nvim_ui_attach yet
-EXTERN bool ui_client_attached INIT(= false);
+EXTERN bool ui_client_attached INIT( = false);
 
 /// Whether ui client has gotten a response about the bg color of the terminal,
 /// kTrue=dark, kFalse=light, kNone=no response yet
-EXTERN TriState ui_client_bg_response INIT(= kNone);
+EXTERN TriState ui_client_bg_response INIT( = kNone);
 
 /// The ui client should forward its stdin to the nvim process
 /// by convention, this uses fd=3 (next free number after stdio)
-EXTERN bool ui_client_forward_stdin INIT(= false);
+EXTERN bool ui_client_forward_stdin INIT( = false);
 
 #define UI_CLIENT_STDIN_FD 3
 // uncrustify:off

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3447,20 +3447,20 @@ static frame_T *win_altframe(win_T *win, tabpage_T *tp)
   // By default the next window will get the space that was abandoned by this
   // window
   frame_T *target_fr = frp->fr_next;
-  frame_T *other_fr  = frp->fr_prev;
+  frame_T *other_fr = frp->fr_prev;
 
   // If this is part of a column of windows and 'splitbelow' is true then the
   // previous window will get the space.
   if (frp->fr_parent != NULL && frp->fr_parent->fr_layout == FR_COL && p_sb) {
     target_fr = frp->fr_prev;
-    other_fr  = frp->fr_next;
+    other_fr = frp->fr_next;
   }
 
   // If this is part of a row of windows, and 'splitright' is true then the
   // previous window will get the space.
   if (frp->fr_parent != NULL && frp->fr_parent->fr_layout == FR_ROW && p_spr) {
     target_fr = frp->fr_prev;
-    other_fr  = frp->fr_next;
+    other_fr = frp->fr_next;
   }
 
   // If 'wfh' or 'wfw' is set for the target and not for the alternate

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -33,7 +33,7 @@
 #define MIN_LINES       2       // minimal lines for screen
 
 // Set to true if 'cmdheight' was explicitly set to 0.
-EXTERN bool p_ch_was_zero INIT(= false);
+EXTERN bool p_ch_was_zero INIT( = false);
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "window.h.generated.h"
 #endif

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -84,7 +84,7 @@ sp_arith                        = ignore   # ignore/add/remove/force/not_defined
 sp_arith_additive               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment operator '=', '+=', etc.
-sp_assign                       = ignore   # ignore/add/remove/force/not_defined
+sp_assign                       = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space around '=' in C++11 lambda capture specifications.
 #
@@ -125,12 +125,12 @@ sp_before_assign                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space after assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_after_assign                 = force    # ignore/add/remove/force/not_defined
+sp_after_assign                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'enum {'.
 #
 # Default: add
-sp_enum_brace                   = add      # ignore/add/remove/force/not_defined
+sp_enum_brace                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'NS_ENUM ('.
 sp_enum_paren                   = ignore   # ignore/add/remove/force/not_defined
@@ -577,7 +577,7 @@ sp_decltype_paren               = ignore   # ignore/add/remove/force/not_defined
 sp_after_tag                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside enum '{' and '}'.
-sp_inside_braces_enum           = ignore   # ignore/add/remove/force/not_defined
+sp_inside_braces_enum           = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space inside struct/union '{' and '}'.
 sp_inside_braces_struct         = ignore   # ignore/add/remove/force/not_defined
@@ -678,7 +678,7 @@ sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force/not_defined
 sp_fparen_dbrace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function calls.
-sp_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
+sp_func_call_paren              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function calls without
 # parameters. If set to ignore (the default), sp_func_call_paren is used.
@@ -770,10 +770,10 @@ sp_macro                        = ignore   # ignore/add/remove/force/not_defined
 sp_macro_func                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'else' and '{' if on the same line.
-sp_else_brace                   = add      # ignore/add/remove/force/not_defined
+sp_else_brace                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'else' if on the same line.
-sp_brace_else                   = add      # ignore/add/remove/force/not_defined
+sp_brace_else                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and the name of a typedef on the same line.
 sp_brace_typedef                = force    # ignore/add/remove/force/not_defined
@@ -2139,7 +2139,7 @@ nl_define_macro                 = false    # true/false
 # Whether to alter newlines between consecutive parenthesis closes. The number
 # of closing parentheses in a line will depend on respective open parenthesis
 # lines.
-nl_squeeze_paren_close          = false    # true/false
+nl_squeeze_paren_close          = true     # true/false
 
 # Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and
 # '#endif'. Does not affect top-level #ifdefs.
@@ -3636,14 +3636,14 @@ set_numbering_for_html_output   = false    # true/false
 #       `macro-close END_MESSAGE_MAP`
 #
 #
-set CLASS_COLON                  FUNC_API_TEXTLOCK
-set CLASS_COLON                  FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 set CLASS_COLON                  FUNC_API_DEPRECATED_SINCE
 set CLASS_COLON                  FUNC_API_FAST
 set CLASS_COLON                  FUNC_API_LUA_ONLY
 set CLASS_COLON                  FUNC_API_NOEXPORT
 set CLASS_COLON                  FUNC_API_REMOTE_ONLY
 set CLASS_COLON                  FUNC_API_SINCE
+set CLASS_COLON                  FUNC_API_TEXTLOCK
+set CLASS_COLON                  FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 set CLASS_COLON                  FUNC_ATTR_ALWAYS_INLINE
 set CLASS_COLON                  FUNC_ATTR_CONST
 set CLASS_COLON                  FUNC_ATTR_MALLOC
@@ -3663,5 +3663,5 @@ set CLASS_COLON                  REAL_FATTR_CONST
 set CLASS_COLON                  REAL_FATTR_NONNULL_ALL
 set CLASS_COLON                  REAL_FATTR_PURE
 set CLASS_COLON                  REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 127
+# option(s) with 'not default' value: 131
 #


### PR DESCRIPTION
Uncrustify is the source of truth where possible.
Remove any redundant checks from clint.py.
