### PR TITLE
vim-patch:fea96c00e55a

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -84,8 +84,8 @@ if !exists("no_plugin_maps") && !exists("no_vim_maps")
   vnoremap <silent><buffer> ][ m':<C-U>exe "normal! gv"<Bar>call search('^\s*end\(f\%[unction]\\|def\)\>', "W")<CR>
 
   " Move around comments
-  nnoremap <silent><buffer> ]" :call search('^\(\s*".*\n\)\@<!\(\s*"\)', "W")<CR>
-  vnoremap <silent><buffer> ]" :<C-U>exe "normal! gv"<Bar>call search('^\(\s*".*\n\)\@<!\(\s*"\)', "W")<CR>
+  nnoremap <silent><buffer> ]" :call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
+  vnoremap <silent><buffer> ]" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\@<!\%(^\s*"\)', "W")<CR>
   nnoremap <silent><buffer> [" :call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
   vnoremap <silent><buffer> [" :<C-U>exe "normal! gv"<Bar>call search('\%(^\s*".*\n\)\%(^\s*"\)\@!', "bW")<CR>
 endif


### PR DESCRIPTION
runtime(vim): Update ftplugin - comment motions (vim/vim#13412)

Fix the pattern used by comment-motion mappings to match the start of a
block comment.

Block-comment start lines were being ignored if the previous line
contained a double-quote character anywhere in the line.  Line comments
should only be ignored if the previous line is a full-line comment and,
therefore, part of the current block comment.

https://github.com/vim/vim/commit/fea96c00e55a71e3007907ff4f7ad513bb9ff0eb

Co-authored-by: dkearns <dougkearns@gmail.com>
