### PR TITLE
feat(extmarks): add 'invalidate' property

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2707,6 +2707,12 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                     the extmark end position (if it exists) will be shifted in
                     when new text is inserted (true for right, false for
                     left). Defaults to false.
+                  • undo_restore : Restore the exact position of the mark if
+                    text around the mark was deleted and then restored by
+                    undo. Defaults to true.
+                  • invalidate : boolean that indicates whether to hide the
+                    extmark if the entirety of its range is deleted. If
+                    "undo_restore" is false, the extmark is deleted instead.
                   • priority: a priority value for the highlight group or sign
                     attribute. For example treesitter highlighting uses a
                     value of 100.
@@ -2777,7 +2783,7 @@ nvim_set_decoration_provider({ns_id}, {*opts})
     |nvim_buf_set_extmark()| can be called to add marks on a per-window or
     per-lines basis. Use the `ephemeral` key to only use the mark for the
     current screen redraw (the callback will be called again for the next
-    redraw ).
+    redraw).
 
     Note: this function should not be called often. Rather, the callbacks
     themselves can be used to throttle unneeded callbacks. the `on_start`

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -273,6 +273,9 @@ The following changes to existing APIs or features add new behavior.
 • Extmarks can opt-out of precise undo tracking using the new "undo_restore"
   flag to |nvim_buf_set_extmark()|
 
+• Extmarks can be automatically hidden or removed using the new "invalidate"
+  flag to |nvim_buf_set_extmark()|
+
 • LSP hover and signature help now use Treesitter for highlighting of Markdown
   content.
   Note that syntax highlighting of code examples requires a matching parser

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -554,6 +554,12 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---                 the extmark end position (if it exists) will be shifted in
 ---                 when new text is inserted (true for right, false for
 ---                 left). Defaults to false.
+---               • undo_restore : Restore the exact position of the mark if
+---                 text around the mark was deleted and then restored by
+---                 undo. Defaults to true.
+---               • invalidate : boolean that indicates whether to hide the
+---                 extmark if the entirety of its range is deleted. If
+---                 "undo_restore" is false, the extmark is deleted instead.
 ---               • priority: a priority value for the highlight group or sign
 ---                 attribute. For example treesitter highlighting uses a
 ---                 value of 100.
@@ -1812,7 +1818,7 @@ function vim.api.nvim_set_current_win(window) end
 --- `nvim_buf_set_extmark()` can be called to add marks on a per-window or
 --- per-lines basis. Use the `ephemeral` key to only use the mark for the
 --- current screen redraw (the callback will be called again for the next
---- redraw ).
+--- redraw).
 --- Note: this function should not be called often. Rather, the callbacks
 --- themselves can be used to throttle unneeded callbacks. the `on_start`
 --- callback can return `false` to disable the provider until the next redraw.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -227,6 +227,7 @@ error('Cannot require a meta file')
 --- @field virt_text_hide? boolean
 --- @field hl_eol? boolean
 --- @field hl_mode? string
+--- @field invalidate? boolean
 --- @field ephemeral? boolean
 --- @field priority? integer
 --- @field right_gravity? boolean
@@ -243,6 +244,7 @@ error('Cannot require a meta file')
 --- @field conceal? string
 --- @field spell? boolean
 --- @field ui_watched? boolean
+--- @field undo_restore? boolean
 
 --- @class vim.api.keyset.user_command
 --- @field addr? any

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -172,7 +172,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
   decor.virt_text_width = width;
   decor.priority = 0;
 
-  extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, &decor, true, false, false, NULL);
+  extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, &decor, true, false, false, false, NULL);
   return src_id;
 }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -170,6 +170,13 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
       PUT(dict, "undo_restore", BOOLEAN_OBJ(false));
     }
 
+    if (extmark->invalidate) {
+      PUT(dict, "invalidate", BOOLEAN_OBJ(true));
+    }
+    if (extmark->invalid) {
+      PUT(dict, "invalid", BOOLEAN_OBJ(true));
+    }
+
     const Decoration *decor = &extmark->decor;
     if (decor->hl_id) {
       PUT(dict, "hl_group", hl_group_name(decor->hl_id, hl_name));
@@ -526,6 +533,9 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///               - undo_restore : Restore the exact position of the mark
 ///                   if text around the mark was deleted and then restored by undo.
 ///                   Defaults to true.
+///               - invalidate : boolean that indicates whether to hide the
+///                   extmark if the entirety of its range is deleted. If
+///                   "undo_restore" is false, the extmark is deleted instead.
 ///               - priority: a priority value for the highlight group or sign
 ///                   attribute. For example treesitter highlighting uses a
 ///                   value of 100.
@@ -759,8 +769,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     goto error;
   });
 
-  bool end_right_gravity = opts->end_right_gravity;
-
   size_t len = 0;
 
   if (!HAS_KEY(opts, set_extmark, spell)) {
@@ -823,7 +831,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   // TODO(bfredl): synergize these two branches even more
   if (opts->ephemeral && decor_state.win && decor_state.win->w_buffer == buf) {
-    decor_add_ephemeral((int)line, (int)col, line2, col2, &decor, (uint64_t)ns_id, id);
+    decor_push_ephemeral((int)line, (int)col, line2, col2, &decor, (uint64_t)ns_id, id);
   } else {
     if (opts->ephemeral) {
       api_set_error(err, kErrorTypeException, "not yet implemented");
@@ -831,8 +839,9 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
 
     extmark_set(buf, (uint32_t)ns_id, &id, (int)line, (colnr_T)col, line2, col2,
-                has_decor ? &decor : NULL, right_gravity, end_right_gravity,
-                !GET_BOOL_OR_TRUE(opts, set_extmark, undo_restore), err);
+                has_decor ? &decor : NULL, right_gravity, opts->end_right_gravity,
+                !GET_BOOL_OR_TRUE(opts, set_extmark, undo_restore),
+                opts->invalidate, err);
     if (ERROR_SET(err)) {
       goto error;
     }
@@ -959,7 +968,7 @@ Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, In
   extmark_set(buf, ns, NULL,
               (int)line, (colnr_T)col_start,
               end_line, (colnr_T)col_end,
-              &decor, true, false, false, NULL);
+              &decor, true, false, false, false, NULL);
   return ns_id;
 }
 
@@ -1010,7 +1019,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 /// redrawn buffer. |nvim_buf_set_extmark()| can be called to add marks
 /// on a per-window or per-lines basis. Use the `ephemeral` key to only
 /// use the mark for the current screen redraw (the callback will be called
-/// again for the next redraw ).
+/// again for the next redraw).
 ///
 /// Note: this function should not be called often. Rather, the callbacks
 /// themselves can be used to throttle unneeded callbacks. the `on_start`

--- a/src/nvim/api/keysets.h
+++ b/src/nvim/api/keysets.h
@@ -32,6 +32,7 @@ typedef struct {
   Boolean virt_text_hide;
   Boolean hl_eol;
   String hl_mode;
+  Boolean invalidate;
   Boolean ephemeral;
   Integer priority;
   Boolean right_gravity;

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -25,9 +25,13 @@ typedef struct {
   colnr_T end_col;
   bool right_gravity;
   bool end_right_gravity;
+  bool invalidate;
+  bool invalid;
   bool no_undo;
   Decoration decor;  // TODO(bfredl): CHONKY
 } ExtmarkInfo;
+#define EXTMARKINFO_INIT { 0, 0, -1, -1, -1, -1, false, false, false, false, false, \
+                           DECORATION_INIT };
 
 typedef kvec_t(ExtmarkInfo) ExtmarkInfoArray;
 
@@ -67,6 +71,7 @@ typedef struct {
   colnr_T old_col;
   int row;
   colnr_T col;
+  bool invalidated;
 } ExtmarkSavePos;
 
 typedef enum {

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1146,9 +1146,14 @@ void marktree_revise(MarkTree *b, MarkTreeIter *itr, uint8_t decor_level, MTKey 
   // TODO(bfredl): clean up this mess and re-instantiate &= and |= forms
   // once we upgrade to a non-broken version of gcc in functionaltest-lua CI
   rawkey(itr).flags = (uint16_t)(rawkey(itr).flags & (uint16_t) ~MT_FLAG_DECOR_MASK);
+  rawkey(itr).flags = (uint16_t)(rawkey(itr).flags & (uint16_t) ~MT_FLAG_INVALID);
   rawkey(itr).flags = (uint16_t)(rawkey(itr).flags
                                  | (uint16_t)(decor_level << MT_FLAG_DECOR_OFFSET)
-                                 | (uint16_t)(key.flags & MT_FLAG_DECOR_MASK));
+                                 | (uint16_t)(key.flags & MT_FLAG_DECOR_MASK)
+                                 | (uint16_t)(key.flags & MT_FLAG_HL_EOL)
+                                 | (uint16_t)(key.flags & MT_FLAG_NO_UNDO)
+                                 | (uint16_t)(key.flags & MT_FLAG_INVALID)
+                                 | (uint16_t)(key.flags & MT_FLAG_INVALIDATE));
   rawkey(itr).decor_full = key.decor_full;
   rawkey(itr).hl_id = key.hl_id;
   rawkey(itr).priority = key.priority;
@@ -2006,8 +2011,8 @@ static void marktree_itr_fix_pos(MarkTree *b, MarkTreeIter *itr)
 void marktree_put_test(MarkTree *b, uint32_t ns, uint32_t id, int row, int col, bool right_gravity,
                        int end_row, int end_col, bool end_right)
 {
-  MTKey key = { { row, col }, ns, id, 0,
-                mt_flags(right_gravity, 0, false), 0, NULL };
+  uint16_t flags = mt_flags(right_gravity, false, false, false, 0);
+  MTKey key = { { row, col }, ns, id, 0, flags, 0, NULL };
   marktree_put(b, key, end_row, end_col, end_right);
 }
 

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -78,17 +78,19 @@ typedef struct {
 #define MT_FLAG_ORPHANED (((uint16_t)1) << 3)
 #define MT_FLAG_HL_EOL (((uint16_t)1) << 4)
 #define MT_FLAG_NO_UNDO (((uint16_t)1) << 5)
+#define MT_FLAG_INVALIDATE (((uint16_t)1) << 6)
+#define MT_FLAG_INVALID (((uint16_t)1) << 7)
 
 #define DECOR_LEVELS 4
-#define MT_FLAG_DECOR_OFFSET 6
+#define MT_FLAG_DECOR_OFFSET 8
 #define MT_FLAG_DECOR_MASK (((uint16_t)(DECOR_LEVELS - 1)) << MT_FLAG_DECOR_OFFSET)
 
 // These _must_ be last to preserve ordering of marks
 #define MT_FLAG_RIGHT_GRAVITY (((uint16_t)1) << 14)
 #define MT_FLAG_LAST (((uint16_t)1) << 15)
 
-#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_RIGHT_GRAVITY | \
-                               MT_FLAG_NO_UNDO | MT_FLAG_HL_EOL)
+#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_RIGHT_GRAVITY | MT_FLAG_HL_EOL \
+                               | MT_FLAG_NO_UNDO | MT_FLAG_INVALIDATE | MT_FLAG_INVALID)
 
 // this is defined so that start and end of the same range have adjacent ids
 #define MARKTREE_END_FLAG ((uint64_t)1)
@@ -132,17 +134,30 @@ static inline bool mt_no_undo(MTKey key)
   return key.flags & MT_FLAG_NO_UNDO;
 }
 
+static inline bool mt_invalidate(MTKey key)
+{
+  return key.flags & MT_FLAG_INVALIDATE;
+}
+
+static inline bool mt_invalid(MTKey key)
+{
+  return key.flags & MT_FLAG_INVALID;
+}
+
 static inline uint8_t marktree_decor_level(MTKey key)
 {
   return (uint8_t)((key.flags&MT_FLAG_DECOR_MASK) >> MT_FLAG_DECOR_OFFSET);
 }
 
-static inline uint16_t mt_flags(bool right_gravity, uint8_t decor_level, bool no_undo)
+static inline uint16_t mt_flags(bool right_gravity, bool hl_eol, bool no_undo, bool invalidate,
+                                uint8_t decor_level)
 {
   assert(decor_level < DECOR_LEVELS);
   return (uint16_t)((right_gravity ? MT_FLAG_RIGHT_GRAVITY : 0)
-                    | (decor_level << MT_FLAG_DECOR_OFFSET)
-                    | (no_undo ? MT_FLAG_NO_UNDO : 0));
+                    | (hl_eol ? MT_FLAG_HL_EOL : 0)
+                    | (no_undo ? MT_FLAG_NO_UNDO : 0)
+                    | (invalidate ? MT_FLAG_INVALIDATE : 0)
+                    | (decor_level << MT_FLAG_DECOR_OFFSET));
 }
 
 typedef kvec_withinit_t(uint64_t, 4) Intersection;

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1599,11 +1599,69 @@ describe('API/extmarks', function()
     set_extmark(ns, 3, 0, 0, { sign_text = '>>' })
     set_extmark(ns, 4, 0, 0, { virt_text = {{'text', 'Normal'}}})
     set_extmark(ns, 5, 0, 0, { virt_lines = {{{ 'line', 'Normal' }}}})
-    eq(5, #get_extmarks(-1, 0, -1, { details = true }))
+    eq(5, #get_extmarks(-1, 0, -1, {}))
     eq({{ 2, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'highlight' }))
     eq({{ 3, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'sign' }))
     eq({{ 4, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'virt_text' }))
     eq({{ 5, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'virt_lines' }))
+  end)
+
+  it("invalidated marks are deleted", function()
+    screen = Screen.new(40, 6)
+    screen:attach()
+    feed('dd6iaaa bbb ccc<CR><ESC>gg')
+    set_extmark(ns, 1, 0, 0, { invalidate = true, sign_text = 'S1' })
+    set_extmark(ns, 2, 1, 0, { invalidate = true, sign_text = 'S2' })
+    -- mark with invalidate is removed
+    command('d')
+    screen:expect([[
+      S2^aaa bbb ccc                           |
+        aaa bbb ccc                           |
+        aaa bbb ccc                           |
+        aaa bbb ccc                           |
+        aaa bbb ccc                           |
+                                              |
+    ]])
+    -- mark is restored with undo_restore == true
+    command('silent undo')
+    screen:expect([[
+      S1^aaa bbb ccc                           |
+      S2aaa bbb ccc                           |
+        aaa bbb ccc                           |
+        aaa bbb ccc                           |
+        aaa bbb ccc                           |
+                                              |
+    ]])
+    -- mark is deleted with undo_restore == false
+    set_extmark(ns, 1, 0, 0, { invalidate = true, undo_restore = false, sign_text = 'S1' })
+    set_extmark(ns, 2, 1, 0, { invalidate = true, undo_restore = false, sign_text = 'S2' })
+    command('1d 2')
+    eq(0, #get_extmarks(-1, 0, -1, {}))
+    -- mark is not removed when deleting bytes before the range
+    set_extmark(ns, 3, 0, 4, { invalidate = true, undo_restore = false,
+                               hl_group = 'Error', end_col = 7 })
+    feed('dw')
+    eq(3, get_extmark_by_id(ns, 3, { details = true })[3].end_col)
+    -- mark is not removed when deleting bytes at the start of the range
+    feed('x')
+    eq(2, get_extmark_by_id(ns, 3, { details = true })[3].end_col)
+    -- mark is not removed when deleting bytes from the end of the range
+    feed('lx')
+    eq(1, get_extmark_by_id(ns, 3, { details = true})[3].end_col)
+    -- mark is not removed when deleting bytes beyond end of the range
+    feed('x')
+    eq(1, get_extmark_by_id(ns, 3, { details = true})[3].end_col)
+    -- mark is removed when all bytes in the range are deleted
+    feed('hx')
+    eq({}, get_extmark_by_id(ns, 3, {}))
+    -- multiline mark is not removed when start of its range is deleted
+    set_extmark(ns, 4, 1, 4, { undo_restore = false, invalidate = true,
+                               hl_group = 'Error', end_col = 7, end_row = 3 })
+    feed('ddDdd')
+    eq({0, 0}, get_extmark_by_id(ns, 4, {}))
+    -- multiline mark is removed when entirety of its range is deleted
+    feed('vj2ed')
+    eq({}, get_extmark_by_id(ns, 4, {}))
   end)
 end)
 


### PR DESCRIPTION
Problem:  No way to have extmarks automatically removed when the range it
          is attached to is deleted.
Solution: Add new 'invalidate' property that will remove marks when the
          start of its range is deleted.