### PR TITLE
docs: remove mentions of scan-build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you want to help but don't know where to start, here are some
 low-risk/isolated tasks:
 
 - Try a [complexity:low] issue.
-- Fix bugs found by [Clang](#clang-scan-build) or [Coverity](#coverity).
+- Fix bugs found by [Coverity](#coverity).
 - [Merge a Vim patch] (requires strong familiarity with Vim)
   - NOTE: read the above link before sending improvements to "runtime files" (anything in `runtime/`).
     - Vimscript and documentation files are (mostly) maintained by [Vim](https://github.com/vim/vim), not Nvim.
@@ -131,21 +131,6 @@ Each pull request must pass the automated builds on [Cirrus CI] and [GitHub Acti
 - CI for FreeBSD runs on [Cirrus CI].
 - To see CI results faster in your PR, you can temporarily set `TEST_FILE` in
   [test.yml](https://github.com/neovim/neovim/blob/e35b9020b16985eee26e942f9a3f6b045bc3809b/.github/workflows/test.yml#L29).
-
-### Clang scan-build
-
-View the [Clang report] to see potential bugs found by the Clang
-[scan-build](https://clang-analyzer.llvm.org/scan-build.html) analyzer.
-
-- Search the Neovim commit history to find examples:
-  ```bash
-  git log --oneline --no-merges --grep clang
-  ```
-- To verify a fix locally, run `scan-build` like this:
-  ```bash
-  rm -rf build/
-  scan-build --use-analyzer=/usr/bin/clang make
-  ```
 
 ### Coverity
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 </h1>
 
 [![Coverity Scan analysis](https://scan.coverity.com/projects/2227/badge.svg)](https://scan.coverity.com/projects/2227)
-[![Clang analysis](https://neovim.io/doc/reports/clang/badge.svg)](https://neovim.io/doc/reports/clang)
 [![Packages](https://repology.org/badge/tiny-repos/neovim.svg)](https://repology.org/metapackage/neovim)
 [![Debian CI](https://badges.debian.net/badges/debian/testing/neovim/version.svg)](https://buildd.debian.org/neovim)
 [![Downloads](https://img.shields.io/github/downloads/neovim/neovim/total.svg?maxAge=2592001)](https://github.com/neovim/neovim/releases/)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -833,9 +833,12 @@ add_glob_target(
   FLAGS --quiet
   EXCLUDE ${EXCLUDE_CLANG_TIDY})
 
-# These are the same warnings as https://neovim.io/doc/reports/clang/. The
-# checks we ignore are meant to be removed eventually, but we can only do so
-# after we properly fix the problems without breaking CI.
+# The checks we ignore are meant to be removed eventually, but we can only
+# enable each warning after we fix all instances of that specific warning as to
+# not break CI.
+if(APPLE)
+  string(APPEND CLANG_ANALYZER_IGNORE "-clang-analyzer-core.NonNullParamChecker,")
+endif()
 add_glob_target(
   TARGET clang-analyzer
   COMMAND ${CLANG_TIDY_PRG}
@@ -849,6 +852,7 @@ add_glob_target(
   -clang-analyzer-core.uninitialized.Assign,
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.strcpy,
+  ${CLANG_ANALYZER_IGNORE}
   '
   EXCLUDE ${EXCLUDE_CLANG_TIDY})
 


### PR DESCRIPTION
These same checks are already checked by the clang-analyzer job, so this
duplication is not necessary.