### PR TITLE
fix(terminal): assign channel to terminal earlier

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1034,9 +1034,12 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   topts.write_cb = term_write;
   topts.resize_cb = term_resize;
   topts.close_cb = term_close;
-  Terminal *term = terminal_open(buf, topts);
-  terminal_check_size(term);
-  chan->term = term;
+  channel_incref(chan);
+  terminal_open(&chan->term, buf, topts);
+  if (chan->term != NULL) {
+    terminal_check_size(chan->term);
+  }
+  channel_decref(chan);
   return (Integer)chan->id;
 }
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -786,9 +786,8 @@ void channel_terminal_open(buf_T *buf, Channel *chan)
   topts.resize_cb = term_resize;
   topts.close_cb = term_close;
   buf->b_p_channel = (OptInt)chan->id;  // 'channel' option
-  Terminal *term = terminal_open(buf, topts);
-  chan->term = term;
   channel_incref(chan);
+  terminal_open(&chan->term, buf, topts);
 }
 
 static void term_write(char *buf, size_t size, void *data)

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8637,8 +8637,10 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
                INTEGER_OBJ(pid), false, false, &err);
   api_clear_error(&err);
 
+  channel_incref(chan);
   channel_terminal_open(curbuf, chan);
   channel_create_event(chan, NULL);
+  channel_decref(chan);
 }
 
 /// "timer_info([timer])" function

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -22,7 +22,6 @@ describe('autocmd TermClose', function()
     command('set shellcmdflag=EXE shellredir= shellpipe= shellquote= shellxquote=')
   end)
 
-
   local function test_termclose_delete_own_buf()
     -- The terminal process needs to keep running so that TermClose isn't triggered immediately.
     nvim('set_option_value', 'shell', string.format('"%s" INTERACT', testprg('shell-test')), {})


### PR DESCRIPTION
Fix #19408
