### PR TITLE
vim-patch:9.0.2065: EXPAND flag set for filetype option

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2797,7 +2797,6 @@ return {
         'S' flag in 'cpoptions'.
         Only normal file name characters can be used, `/\*?[|<>` are illegal.
       ]=],
-      expand = true,
       full_name = 'filetype',
       noglob = true,
       normal_fname_chars = true,


### PR DESCRIPTION
#### vim-patch:9.0.2065: EXPAND flag set for filetype option

Problem:  EXPAND flag set for filetype option
Solution: Remove P_EXPAND flag from the 'filetype' option

Remove P_EXPAND flag from the 'filetype' option

Problem:  P_EXPAND flag is erroneously set for 'filetype' option
Solution: Remove the P_EXPAND flag

This flag is used by string options that accept file path values.  See
:help set_env.

This appears to have been included in d5e8c92 and resulted from an
incorrect implementation of 'filetype' completion.

See vim/vim#12900 for a small discussion.

related: vim/vim#12900
closes: vim/vim#13416

https://github.com/vim/vim/commit/3932072ab435eb171ab55b2a2c0185358cd0d7bf

Co-authored-by: Doug Kearns <dougkearns@gmail.com>