### PR TITLE
vim-patch:partial:5985879e3c36

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2919,7 +2919,7 @@ getscriptinfo([{opts}])                                        *getscriptinfo()*
 				Note that this is a copy, the value of
 				script-local variables cannot be changed using
 				this dictionary.
-		    version	Vimscript version, always 1
+		    version	Vim script version, always 1
 
 		Examples: >vim
 			echo getscriptinfo({'name': 'myscript'})

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -89,7 +89,7 @@ Nvim development is funded separately from Vim:
 ==============================================================================
 Credits							*credits*
 
-Most of Vim was written by Bram Moolenaar <Bram@vim.org> |Bram-Moolenaar|
+Most of Vim was written by Bram Moolenaar <Bram@vim.org> |Bram-Moolenaar|.
 
 Parts of the documentation come from several Vi manuals, written by:
 	W.N. Joy

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -423,8 +423,9 @@ If there is no g:termdebug_config you can use: >vim
 Any value greater than 1 will set the Asm window height to that value.
 
 						*termdebug_variables_window*
-If you want the Var window shown by default, set the flag to 1.
-the "variables_window_height" entry can be used to set the window height: >vim
+If you want the Var window shown by default, set the "variables_window" flag
+to 1.  The "variables_window_height" entry can be used to set the window
+height: >vim
 	let g:termdebug_config['variables_window'] = 1
 	let g:termdebug_config['variables_window_height'] = 15
 If there is no g:termdebug_config you can use: >vim

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -52,7 +52,7 @@ achieve special effects.  These options come in three forms:
 			  'lines'
 			Warning: This may have a lot of side effects.
 
-						*:set-args* *:set=* *E487* *E521*
+					    *:set-args* *:set=* *E487* *E521*
 :se[t] {option}={value}		or
 :se[t] {option}:{value}
 			Set string or number option to {value}.
@@ -6224,7 +6224,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option controls the behavior when switching between buffers.
 	This option is checked, when
 	- jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
-	  etc.)
+	  etc.).
 	- jumping to a tag using the |:stag| command.
 	- opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
 	- jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6614,7 +6614,7 @@ vim.bo.swf = vim.bo.swapfile
 --- This option controls the behavior when switching between buffers.
 --- This option is checked, when
 --- - jumping to errors with the `quickfix` commands (`:cc`, `:cn`, `:cp`,
----   etc.)
+---   etc.).
 --- - jumping to a tag using the `:stag` command.
 --- - opening a file using the `CTRL-W_f` or `CTRL-W_F` command.
 --- - jumping to a buffer using a buffer split command (e.g.  `:sbuffer`,

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3507,7 +3507,7 @@ function vim.fn.getregtype(regname) end
 ---     Note that this is a copy, the value of
 ---     script-local variables cannot be changed using
 ---     this dictionary.
----     version  Vimscript version, always 1
+---     version  Vim script version, always 1
 ---
 --- Examples: >vim
 ---   echo getscriptinfo({'name': 'myscript'})

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4335,7 +4335,7 @@ M.funcs = {
       		Note that this is a copy, the value of
       		script-local variables cannot be changed using
       		this dictionary.
-          version	Vimscript version, always 1
+          version	Vim script version, always 1
 
       Examples: >vim
       	echo getscriptinfo({'name': 'myscript'})

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8367,7 +8367,7 @@ return {
         This option controls the behavior when switching between buffers.
         This option is checked, when
         - jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
-          etc.)
+          etc.).
         - jumping to a tag using the |:stag| command.
         - opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
         - jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,


### PR DESCRIPTION
#### vim-patch:partial:5985879e3c36

runtime(doc): Fix typos in several documents (vim/vim#13420)

* Fix typos in several documents
* Update runtime/doc/terminal.txt

https://github.com/vim/vim/commit/5985879e3c36383155f84649fa42d06813a1893e

Skip runtime/doc/indent.txt: not ported yet

Co-authored-by: h_east <h.east.727@gmail.com>
Co-authored-by: K.Takata <kentkt@csc.jp>