### PR TITLE
fix(lsp): fix omnicomplete in middle of the line

### DIFF
--- a/runtime/lua/vim/lsp/_completion.lua
+++ b/runtime/lua/vim/lsp/_completion.lua
@@ -137,6 +137,7 @@ end
 function M._convert_results(
   line,
   lnum,
+  cursor_col,
   client_start_boundary,
   server_start_boundary,
   result,
@@ -164,7 +165,7 @@ function M._convert_results(
   elseif curstartbyte ~= nil and curstartbyte ~= server_start_boundary then
     server_start_boundary = client_start_boundary
   end
-  local prefix = line:sub((server_start_boundary or client_start_boundary) + 1)
+  local prefix = line:sub((server_start_boundary or client_start_boundary) + 1, cursor_col)
   local matches = M._lsp_to_complete_items(result, prefix)
   return matches, server_start_boundary
 end
@@ -212,6 +213,7 @@ function M.omnifunc(findstart, base)
         matches, server_start_boundary = M._convert_results(
           line,
           lnum,
+          cursor_col,
           client_start_boundary,
           server_start_boundary,
           result,


### PR DESCRIPTION
I experienced that no results were displayed from lsp server when I tried to autocomplete from the middle of a line.

I tracked down _completion.lua `M._lsp_to_complete_items` function, where the matches_prefix didn't match to anything, because the prefix was always the whole line and not stopped at the cursor.

I found that the prefix `M.convert_results function`:
```lua
local prefix = line:sub((server_start_boundary or client_start_boundary) + 1)
```

Probably it's a regression from 5e5f5174e3faa862a9bc353aa7da41487911140b

Until that commit we had a logic like this:
```lua
local prefix = startbyte and line:sub(startbyte + 1) or line_to_cursor:sub(word_boundary)
```

So in case of `startbyte` was falsy, we had a different logic and used the `line_to_cursor` instead if line.

To fix the issue, I pass the `cursor_column` to the `M._convert_results` function. Then when we construct the prefix we use it as the last character index. So the prefix will start at the word boundary and ends at the cursor.

I choose to pass the cursor_column instead of the line, so the `_convert_results` function holds the logic and it's testable
