### PR TITLE
docs(api): add User autocmd example

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3363,6 +3363,13 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
         })
 <
 
+    Example using a User autocommand: >lua
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "MyPlugin",
+          command = "echo 'got MyPlugin event'",
+        })
+<
+
     Note: `pattern` is NOT automatically expanded (unlike with |:autocmd|),
     thus names like "$HOME" and "~" must be expanded explicitly: >lua
         pattern = vim.fn.expand("~") .. "/some/path/*.py"

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -823,6 +823,15 @@ function vim.api.nvim_create_augroup(name, opts) end
 ---     })
 --- ```
 ---
+--- Example using a User autocommand:
+---
+--- ```lua
+---     vim.api.nvim_create_autocmd("User", {
+---       pattern = "MyPlugin",
+---       command = "echo 'got MyPlugin event'",
+---     })
+--- ```
+---
 --- Note: `pattern` is NOT automatically expanded (unlike with `:autocmd`),
 --- thus names like "$HOME" and "~" must be expanded explicitly:
 ---

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -361,6 +361,15 @@ cleanup:
 /// })
 /// ```
 ///
+/// Example using a User autocommand:
+///
+/// ```lua
+/// vim.api.nvim_create_autocmd("User", {
+///   pattern = "MyPlugin",
+///   command = "echo 'got MyPlugin event'",
+/// })
+/// ```
+///
 /// Note: `pattern` is NOT automatically expanded (unlike with |:autocmd|), thus names like "$HOME"
 /// and "~" must be expanded explicitly:
 ///


### PR DESCRIPTION
It's a common misconception about vimscript that the User autocmd is special, and many people (previously myself included) don't realize that the event name given to the autocommand is just a regular pattern.

To eliminate this misconception, and to make it clear how to make a User autocommand, an example is added to illustrate that the event name is  just a regular pattern.

I am very much open to bikeshedding over phrasing in general and what the example looks like, it was adapted from the `User` event example in the vimscript documentation.