### PR TITLE
build: various cmake fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: clang-tidy
-        run: cmake --build build --target clang-tidy
+        run: cmake --build build --target lintc-clang-tidy
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: uncrustify

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ add_custom_target(lintcommit
 add_dependencies(lintcommit nvim)
 
 add_custom_target(lint)
-add_dependencies(lint clang-tidy lintc lintlua lintsh lintcommit)
+add_dependencies(lint lintc lintlua lintsh lintcommit)
 
 # Format
 add_custom_target(formatlua

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ functionaltest-lua: | nvim
 	$(BUILD_TOOL) -C build functionaltest
 
 FORMAT=formatc formatlua format
-LINT=lintlua lintsh lintc clang-tidy clang-analyzer lintcommit lint
+LINT=lintlua lintsh lintc clang-analyzer lintcommit lint
 TEST=functionaltest unittest
 generated-sources benchmark $(FORMAT) $(LINT) $(TEST) doc: | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@

--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -4,6 +4,7 @@ include(CheckFunctionExists)
 include(CheckIncludeFiles)
 include(CheckCSourceRuns)
 include(CheckCSourceCompiles)
+include(TestBigEndian)
 
 check_c_source_compiles("
 #include <execinfo.h>
@@ -130,31 +131,8 @@ endif()
 if("${HAVE_BE64TOH_MACROS}" OR "${HAVE_BE64TOH_FUNC}")
   set(HAVE_BE64TOH 1)
 endif()
-if (NOT "${HAVE_BE64TOH}")
-  if (NOT "${CMAKE_CROSSCOMPILING}")
-    # It is safe to make ORDER_BIG_ENDIAN not defined if
-    # - HAVE_BE64TOH is true. In this case be64toh will be used unconditionally in
-    #   any case and ORDER_BIG_ENDIAN will not be examined.
-    # - CMAKE_CROSSCOMPILING *and* HAVE_BE64TOH are both false. In this case
-    #   be64toh function which uses cycle and arithmetic operations is used which
-    #   will work regardless of endianness. Function is sub-optimal though.
-    check_c_source_runs("
-      ${SI}
-      ${MS}
-        char *s = (char *) &i;
-        return (
-          s[0] == 0x01
-          && s[1] == 0x02
-          && s[2] == 0x03
-          && s[3] == 0x04
-          && s[4] == 0x05
-          && s[5] == 0x06
-          && s[6] == 0x07
-          && s[7] == 0x08) ? 0 : 1;
-      ${ME}"
-      ORDER_BIG_ENDIAN)
-  endif()
-endif()
+
+test_big_endian(ORDER_BIG_ENDIAN)
 
 configure_file (
   "${PROJECT_SOURCE_DIR}/cmake.config/config.h.in"

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -13,8 +13,8 @@ include(ExternalProject)
 include(CheckCCompilerFlag)
 
 include(Deps)
-include(Util)
 include(Find)
+include(Util)
 
 set_default_buildtype()
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/cmake.deps/cmake/LibtermkeyCMakeLists.txt
+++ b/cmake.deps/cmake/LibtermkeyCMakeLists.txt
@@ -13,16 +13,15 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/termkey.h.in)
   string(REPLACE "@@VERSION_MINOR@@" "${TERMKEY_VERSION_MINOR}" TERMKEY_TEXT "${TERMKEY_TEXT}")
   file(WRITE termkey.h "${TERMKEY_TEXT}")
 endif()
-add_definitions(-D _CRT_SECURE_NO_WARNINGS)
-add_definitions(-DHAVE_UNIBILIUM)
-
-include_directories(${PROJECT_BINARY_DIR}/t)
-include_directories(SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
 
 add_library(termkey termkey.c driver-csi.c driver-ti.c)
+
+target_compile_definitions(termkey PRIVATE _CRT_SECURE_NO_WARNINGS HAVE_UNIBILIUM)
+target_include_directories(termkey PRIVATE SYSTEM ${UNIBILIUM_INCLUDE_DIRS})
+
 set_target_properties(termkey PROPERTIES
   PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/termkey.h)
-target_link_libraries(termkey ${UNIBILIUM_LIBRARIES})
+target_link_libraries(termkey PRIVATE ${UNIBILIUM_LIBRARIES})
 
 include(GNUInstallDirs)
 install(TARGETS termkey

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -7,7 +7,8 @@ if(TARGET libuv::uv_a)
   target_link_libraries(libuv INTERFACE libuv::uv_a)
   mark_as_advanced(libuv_DIR)
 else()
-  # Fall back to find module for older libuv versions that don't provide config file
+  # Fall back to find module for libuv versions older than v1.45.0 which don't
+  # provide a config file
   find_package(Libuv 1.28.0 REQUIRED MODULE)
   target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIR})
   target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})
@@ -90,7 +91,7 @@ if(MSVC)
   target_compile_options(main_lib INTERFACE -W3)
 
   # Disable warnings that give too many false positives.
-  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003 -wd4715)
+  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003 -wd4715 -wd4003)
   target_compile_definitions(main_lib INTERFACE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
 
   target_sources(main_lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/os/nvim.manifest)
@@ -812,7 +813,7 @@ else()
     os/os_win_console.h)
 endif()
 add_glob_target(
-  TARGET clang-tidy
+  TARGET lintc-clang-tidy
   COMMAND ${CLANG_TIDY_PRG}
   FILES ${NVIM_SOURCES} ${NVIM_HEADERS}
   FLAGS --quiet
@@ -841,7 +842,7 @@ add_glob_target(
 add_custom_target(copy_compile_commands
   COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR}/compile_commands.json)
 add_dependencies(copy_compile_commands nvim)
-add_dependencies(clang-tidy copy_compile_commands)
+add_dependencies(lintc-clang-tidy copy_compile_commands)
 add_dependencies(clang-analyzer copy_compile_commands)
 
 if(CI_BUILD)
@@ -866,7 +867,7 @@ add_glob_target(
 add_dependencies(lintc-uncrustify uncrustify)
 
 add_custom_target(lintc)
-add_dependencies(lintc lintc-clint lintc-uncrustify)
+add_dependencies(lintc lintc-clint lintc-uncrustify lintc-clang-tidy)
 
 add_custom_target(formatc
   COMMAND ${CMAKE_COMMAND}

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -46,12 +46,6 @@ typedef enum {
 
 typedef struct Decoration Decoration;
 
-#ifndef ORDER_BIG_ENDIAN
-# if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
-#  define ORDER_BIG_ENDIAN
-# endif
-#endif
-
 typedef int64_t OptInt;
 
 #endif  // NVIM_TYPES_H


### PR DESCRIPTION
- silence false warnings on MSVC
- merge `clang-tidy` cmake target into `lintc` and remove the
  corresponding make target
- use cmake's built-in endianness detection