### PR TITLE
vim-patch:7b7cda67a124

### DIFF
--- a/runtime/ftplugin/debchangelog.vim
+++ b/runtime/ftplugin/debchangelog.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
 " Former Maintainers:   Michael Piefel <piefel@informatik.hu-berlin.de>
 "                       Stefano Zacchiroli <zack@debian.org>
-" Last Change:  2023 Jan 16
+" Last Change:  2023 Aug 18
 " License:      Vim License
 " URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/debchangelog.vim
 

--- a/runtime/ftplugin/debsources.vim
+++ b/runtime/ftplugin/debsources.vim
@@ -1,0 +1,16 @@
+" Language:     Debian sources.list
+" Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
+" Last Change:  2023 Aug 30
+" License:      Vim License
+" URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/debsources.vim
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin=1
+
+setlocal comments=:#
+setlocal commentstring=#%s
+setlocal formatoptions-=t
+
+let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions<'

--- a/runtime/syntax/deb822sources.vim
+++ b/runtime/syntax/deb822sources.vim
@@ -1,0 +1,63 @@
+" Vim syntax file
+" Language:     Debian deb822-format source list file
+" Maintainer:   Debian Vim Maintainers
+" Last Change: 2023 May 25
+" URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/deb822sources.vim
+
+" Standard syntax initialization
+if exists('b:current_syntax')
+  finish
+endif
+
+" case insensitive
+syn case ignore
+
+" Comments are matched from the first character of a line to the end-of-line
+syn region deb822sourcesComment start="^#" end="$"
+
+" A bunch of useful keywords
+syn match deb822sourcesType               /\(deb-src\|deb\)/
+syn match deb822sourcesFreeComponent      /\(main\|universe\)/
+syn match deb822sourcesNonFreeComponent   /\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)/
+
+" Include Debian versioning information
+runtime! syntax/shared/debversions.vim
+
+exe 'syn match deb822sourcesSupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedSupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
+exe 'syn match deb822sourcesUnsupportedSuites contained + *\([[:alnum:]_./]*\)\<\('. join(g:debSharedUnsupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
+
+unlet g:debSharedSupportedVersions
+unlet g:debSharedUnsupportedVersions
+
+syn region deb822sourcesSuites start="\(^Suites: *\)\@<=" end="$" contains=deb822sourcesSupportedSuites,deb822sourcesUnsupportedSuites oneline
+
+syn keyword deb822sourcesForce contained force
+syn keyword deb822sourcesYesNo contained yes no
+
+" Match uri's
+syn match deb822sourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorrent://\|\(cdrom\|copy\|file\):\)[^' 	<>"]\+'
+
+syn match deb822sourcesEntryField            "^\%(Types\|URIs\|Suites\|Components\): *"
+syn match deb822sourcesOptionField           "^\%(Signed-By\|Check-Valid-Until\|Valid-Until-Min\|Valid-Until-Max\|Date-Max-Future\|InRelease-Path\): *"
+syn match deb822sourcesMultiValueOptionField "^\%(Architectures\|Languages\|Targets\)\%(-Add\|-Remove\)\?: *"
+
+syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\): *" end="$" contains=deb822sourcesYesNo oneline
+syn region deb822sourcesStrictField matchgroup=deb822sourcesForceBooleanOptionField start="^\%(By-Hash\): *" end="$" contains=deb822sourcesForce,deb822sourcesYesNo oneline
+
+hi def link deb822sourcesComment                 Comment
+hi def link deb822sourcesEntryField              Keyword
+hi def link deb822sourcesOptionField             Special
+hi def link deb822sourcesMultiValueOptionField   Special
+hi def link deb822sourcesBooleanOptionField      Special
+hi def link deb822sourcesForceBooleanOptionField Special
+hi def link deb822sourcesStrictField             Error
+hi def link deb822sourcesType                    Identifier
+hi def link deb822sourcesFreeComponent           Identifier
+hi def link deb822sourcesNonFreeComponent        Identifier
+hi def link deb822sourcesForce                   Identifier
+hi def link deb822sourcesYesNo                   Identifier
+hi def link deb822sourcesUri                     Constant
+hi def link deb822sourcesSupportedSuites         Type
+hi def link deb822sourcesUnsupportedSuites       WarningMsg
+
+let b:current_syntax = 'deb822sources'

--- a/runtime/syntax/debchangelog.vim
+++ b/runtime/syntax/debchangelog.vim
@@ -3,7 +3,7 @@
 " Maintainer:  Debian Vim Maintainers
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2023 Jan 16
+" Last Change: 2023 Oct 11
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debchangelog.vim
 
 " Standard syntax initialization
@@ -17,34 +17,19 @@ syn case ignore
 let s:urgency='urgency=\(low\|medium\|high\|emergency\|critical\)\( [^[:space:],][^,]*\)\='
 let s:binNMU='binary-only=yes'
 
-let s:cpo = &cpo
-set cpo-=C
-let s:supported = [
-      \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
-      \ 'buster', 'bullseye', 'bookworm', 'trixie', 'forky',
-      \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'kinetic', 'lunar',
-      \ 'devel'
-      \ ]
-let s:unsupported = [
-      \ 'frozen', 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
-      \ 'woody', 'sarge', 'etch', 'lenny', 'squeeze', 'wheezy',
-      \ 'jessie', 'stretch',
-      \
-      \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
-      \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
-      \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
-      \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan', 'hirsute', 'impish', 'groovy'
-      \ ]
-let &cpo=s:cpo
+" Include Debian versioning information
+runtime! syntax/shared/debversions.vim
+
+exe 'syn match debchangelogTarget	contained "\%( \%('.join(g:debSharedSupportedVersions, '\|').'\)\>[-[:alnum:]]*\)\+"'
+exe 'syn match debchangelogUnsupportedTarget	contained "\%( \%('.join(g:debSharedUnsupportedVersions, '\|').'\)\>[-[:alnum:]]*\)\+"'
+
+unlet g:debSharedSupportedVersions
+unlet g:debSharedUnsupportedVersions
 
 " Define some common expressions we can use later on
 syn match debchangelogName	contained "^[[:alnum:]][[:alnum:].+-]\+ "
 exe 'syn match debchangelogFirstKV	contained "; \('.s:urgency.'\|'.s:binNMU.'\)"'
 exe 'syn match debchangelogOtherKV	contained ", \('.s:urgency.'\|'.s:binNMU.'\)"'
-exe 'syn match debchangelogTarget	contained "\%( \%('.join(s:supported, '\|').'\)\>[-[:alnum:]]*\)\+"'
-exe 'syn match debchangelogUnsupportedTarget	contained "\%( \%('.join(s:unsupported, '\|').'\)\>[-[:alnum:]]*\)\+"'
 syn match debchangelogUnreleased	contained / UNRELEASED/
 syn match debchangelogVersion	contained "(.\{-})"
 syn match debchangelogCloses	contained "closes:\_s*\(bug\)\=#\=\_s\=\d\+\(,\_s*\(bug\)\=#\=\_s\=\d\+\)*"
@@ -58,19 +43,19 @@ syn region debchangelogFooter start="^ [^ ]" end="$" contains=debchangelogEmail 
 syn region debchangelogEntry start="^  " end="$" contains=debchangelogCloses,debchangelogLP oneline
 
 " Associate our matches and regions with pretty colours
-hi def link debchangelogHeader  Error
-hi def link debchangelogFooter  Identifier
-hi def link debchangelogEntry   Normal
-hi def link debchangelogCloses  Statement
-hi def link debchangelogLP      Statement
-hi def link debchangelogFirstKV Identifier
-hi def link debchangelogOtherKV Identifier
-hi def link debchangelogName    Comment
-hi def link debchangelogVersion Identifier
-hi def link debchangelogTarget  Identifier
-hi def link debchangelogUnsupportedTarget  Identifier
+hi def link debchangelogHeader     Error
+hi def link debchangelogFooter     Identifier
+hi def link debchangelogEntry      Normal
+hi def link debchangelogCloses     Statement
+hi def link debchangelogLP         Statement
+hi def link debchangelogFirstKV    Identifier
+hi def link debchangelogOtherKV    Identifier
+hi def link debchangelogName       Comment
+hi def link debchangelogVersion    Identifier
 hi def link debchangelogUnreleased WarningMsg
-hi def link debchangelogEmail   Special
+hi def link debchangelogEmail      Special
+hi def link debchangelogTarget     Identifier
+hi def link debchangelogUnsupportedTarget Identifier
 
 let b:current_syntax = 'debchangelog'
 

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,7 +2,7 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2023 Feb 06
+" Last Change: 2023 Oct 11
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debsources.vim
 
 " Standard syntax initialization
@@ -21,41 +21,27 @@ syn match debsourcesNonFreeComponent   /\(contrib\|non-free-firmware\|non-free\|
 " Match comments
 syn match debsourcesComment        /#.*/  contains=@Spell
 
-let s:cpo = &cpo
-set cpo-=C
-let s:supported = [
-      \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
-      \ 'buster', 'bullseye', 'bookworm', 'trixie', 'forky',
-      \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'kinetic', 'lunar',
-      \ 'devel'
-      \ ]
-let s:unsupported = [
-      \ 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
-      \ 'woody', 'sarge', 'etch', 'lenny', 'squeeze', 'wheezy',
-      \ 'jessie', 'stretch',
-      \
-      \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
-      \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
-      \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
-      \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
-      \ 'disco', 'eoan', 'hirsute', 'impish', 'groovy'
-      \ ]
-let &cpo=s:cpo
+" Include Debian versioning information
+runtime! syntax/shared/debversions.vim
+
+exe 'syn match debsourcesDistrKeyword   +\([[:alnum:]_./]*\)\<\('. join(g:debSharedSupportedVersions, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
+exe 'syn match debsourcesUnsupportedDistrKeyword +\([[:alnum:]_./]*\)\<\('. join(g:debSharedUnsupportedVersions, '\|') .'\)\>\([-[:alnum:]_./]*\)+'
+
+unlet g:debSharedSupportedVersions
+unlet g:debSharedUnsupportedVersions
 
 " Match uri's
 syn match debsourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorrent://\|\(cdrom\|copy\|file\):\)[^' 	<>"]\+'
-exe 'syn match debsourcesDistrKeyword   +\([[:alnum:]_./]*\)\<\('. join(s:supported, '\|'). '\)\>\([-[:alnum:]_./]*\)+'
-exe 'syn match debsourcesUnsupportedDistrKeyword +\([[:alnum:]_./]*\)\<\('. join(s:unsupported, '\|') .'\)\>\([-[:alnum:]_./]*\)+'
+syn region debsourcesLine start="^" end="$" contains=debsourcesType,debsourcesFreeComponent,debsourcesNonFreeComponent,debsourcesComment,debsourcesUri,debsourcesDistrKeyword,debsourcesUnsupportedDistrKeyword oneline
+
 
 " Associate our matches and regions with pretty colours
-hi def link debsourcesLine                    Error
 hi def link debsourcesType                    Statement
 hi def link debsourcesFreeComponent           Statement
 hi def link debsourcesNonFreeComponent        Statement
-hi def link debsourcesDistrKeyword            Type
-hi def link debsourcesUnsupportedDistrKeyword WarningMsg
 hi def link debsourcesComment                 Comment
 hi def link debsourcesUri                     Constant
+hi def link debsourcesDistrKeyword            Type
+hi def link debsourcesUnsupportedDistrKeyword WarningMsg
 
 let b:current_syntax = 'debsources'

--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,0 +1,29 @@
+" Vim syntax file
+" Language:     Debian version information
+" Maintainer:   Debian Vim Maintainers
+" Last Change: 2023 Oct 11
+" URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
+
+let s:cpo = &cpo
+set cpo-=C
+
+let g:debSharedSupportedVersions = [
+      \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
+      \ 'bullseye', 'bookworm', 'trixie', 'forky',
+      \
+      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'lunar', 'mantic',
+      \ 'devel'
+      \ ]
+let g:debSharedUnsupportedVersions = [
+      \ 'buzz', 'rex', 'bo', 'hamm', 'slink', 'potato',
+      \ 'woody', 'sarge', 'etch', 'lenny', 'squeeze', 'wheezy',
+      \ 'jessie', 'stretch', 'buster',
+      \
+      \ 'warty', 'hoary', 'breezy', 'dapper', 'edgy', 'feisty',
+      \ 'gutsy', 'hardy', 'intrepid', 'jaunty', 'karmic', 'lucid',
+      \ 'maverick', 'natty', 'oneiric', 'precise', 'quantal', 'raring', 'saucy',
+      \ 'utopic', 'vivid', 'wily', 'yakkety', 'zesty', 'artful', 'cosmic',
+      \ 'disco', 'eoan', 'hirsute', 'impish', 'kinetic', 'groovy'
+      \ ]
+
+let &cpo=s:cpo


### PR DESCRIPTION
runtime(debian): update debian related runtime files (vim/vim#13423)

* Update Debian runtime files

Add mantic as a supported Ubuntu release and move buster/kinetic to
unsupported.

Add syntax highlighting for deb822sources filetype.

Add debsources ftplugin to set relevant comment options.

Move common version information to shared/debversions.vim

Closes vim/vim#11934

* Add myself as codeowner for Debian-related runtime files

---------

https://github.com/vim/vim/commit/7b7cda67a1246874520b280277d9b1447e1a7ef5

Co-authored-by: James McCoy <jamessan@jamessan.com>
Co-authored-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
Co-authored-by: James Addison <jay@jp-hosting.net>
Co-authored-by: Viktor Szépe <viktor@szepe.net>
Co-authored-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
Co-authored-by: James Addison <jay@jp-hosting.net>
Co-authored-by: Viktor Szépe <viktor@szepe.net>
