### PR TITLE
vim-patch:9.0.2071

### DIFF
--- a/runtime/ftplugin/objdump.vim
+++ b/runtime/ftplugin/objdump.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin file
+" Language:     Objdump
+" Maintainer:   Colin Kennedy <colinvfx@gmail.com>
+" Last Change:  2023 October 25
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setlocal cms<"
+
+setlocal commentstring=#\ %s

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -716,6 +716,7 @@ local extension = {
   nsi = 'nsis',
   nsh = 'nsis',
   obj = 'obj',
+  objdump = 'objdump',
   obl = 'obse',
   obse = 'obse',
   oblivion = 'obse',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -455,6 +455,7 @@ func s:GetFilenameChecks() abort
     \ 'nsis': ['file.nsi', 'file.nsh'],
     \ 'nu': ['env.nu', 'config.nu'],
     \ 'obj': ['file.obj'],
+    \ 'objdump': ['file.objdump', 'file.cppobjdump'],
     \ 'obse': ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],
     \ 'ocaml': ['file.ml', 'file.mli', 'file.mll', 'file.mly', '.ocamlinit', 'file.mlt', 'file.mlp', 'file.mlip', 'file.mli.cppo', 'file.ml.cppo'],
     \ 'occam': ['file.occ'],


### PR DESCRIPTION
#### vim-patch:9.0.2071: objdump files not recognized

Problem:  objdump files not recognized
Solution: detect *.objdump files, add a filetype plugin

Added the objdump file/text format

closes: vim/vim#13425

https://github.com/vim/vim/commit/10407df7a95d0311c7d2eb920d3b72020db5b301

Co-authored-by: Colin Kennedy <colinvfx@gmail.com>