### PR TITLE
fix(diagnostic): virtual_text prefix function should have index and total

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -404,9 +404,12 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                          the beginning of the virtual text.
                        • prefix: (string or function) prepend diagnostic
                          message with prefix. If a function, it must have the
-                         signature (diagnostic) -> string, where {diagnostic}
-                         is of type |diagnostic-structure|. This can be used
-                         to render diagnostic symbols or error codes.
+                         signature (diagnostic, i, total) -> string, where
+                         {diagnostic} is of type |diagnostic-structure|, {i}
+                         is the index of the diagnostic being evaluated, and
+                         {total} is the total number of diagnostics for the
+                         line. This can be used to render diagnostic symbols
+                         or error codes.
                        • suffix: (string or function) Append diagnostic
                          message with suffix. If a function, it must have the
                          signature (diagnostic) -> string, where {diagnostic}

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -592,8 +592,10 @@ end
 ---                       * spacing: (number) Amount of empty spaces inserted at the beginning
 ---                                  of the virtual text.
 ---                       * prefix: (string or function) prepend diagnostic message with prefix.
----                                 If a function, it must have the signature (diagnostic) -> string,
----                                 where {diagnostic} is of type |diagnostic-structure|. This can be
+---                                 If a function, it must have the signature (diagnostic, i, total)
+---                                 -> string, where {diagnostic} is of type |diagnostic-structure|,
+---                                 {i} is the index of the diagnostic being evaluated, and {total}
+---                                 is the total number of diagnostics for the line. This can be
 ---                                 used to render diagnostic symbols or error codes.
 ---                       * suffix: (string or function) Append diagnostic message with suffix.
 ---                                 If a function, it must have the signature (diagnostic) ->
@@ -1072,7 +1074,7 @@ function M._get_virt_text_chunks(line_diags, opts)
   for i = 1, #line_diags do
     local resolved_prefix = prefix
     if type(prefix) == 'function' then
-      resolved_prefix = prefix(line_diags[i]) or ''
+      resolved_prefix = prefix(line_diags[i], i, #line_diags) or ''
     end
     table.insert(
       virt_texts,

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1237,7 +1237,7 @@ end)
         return prefix .. message
       ]])
 
-      eq('[err-code] Some error',  exec_lua [[
+      eq('[(1/1) err-code] Some error',  exec_lua [[
         local diagnostics = {
           make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
         }
@@ -1245,7 +1245,7 @@ end)
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
           underline = false,
           virtual_text = {
-            prefix = function(diag) return string.format('[%s]', diag.code) end,
+            prefix = function(diag, i, total) return string.format('[(%d/%d) %s]', i, total, diag.code) end,
             suffix = '',
           }
         })


### PR DESCRIPTION
The prefix option of the diagnostic virtual text can be a function,
but previously (#22965) it was only a function of diagnostic.

This function should also have additional parameters index and total,
more consistently and similarily as in the prefix function for
`vim.diagnostic.open_float()`.

These additional parameters will be useful when there are too many
number of diagnostics in a single line.

/cc @isaksamsten (the author of #22965)
