### PR TITLE
vim-patch:9.0.{2074,2077}: Completion menu may be wrong

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2315,17 +2315,72 @@ func Test_complete_info_index()
   " Ensure 'index' in complete_info() is coherent with the 'items' array.
 
   set completeopt=menu,preview
-  " Search forward.
+  " Search forward
   call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
   call feedkeys("Go\<C-X>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("bbb", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ccc", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ddd", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("eee", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " Search forward: unselected item
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal(-1 , g:compl_info['selected'])
 
-  " Search backward.
+  " Search backward
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
   call feedkeys("Go\<C-X>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("eee", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ddd", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("ccc", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("bbb", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " search backwards: unselected item
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal(-1 , g:compl_info['selected'])
+
+  " switch direction: forwards, then backwards
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " switch direction: forwards, then backwards, then forwards again
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-P>\<C-P>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+
+  " switch direction: backwards, then forwards
+  call feedkeys("Go\<C-X>\<C-P>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  " switch direction: backwards, then forwards, then backwards again
+  call feedkeys("Go\<C-X>\<C-P>\<C-P>\<C-N>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
 
   " Add 'noselect', check that 'selected' is -1 when nothing is selected.
   set completeopt+=noselect
@@ -2336,6 +2391,16 @@ func Test_complete_info_index()
   " Search backward.
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(-1, g:compl_info['selected'])
+
+  " Check if index out of range
+  " https://github.com/vim/vim/pull/12971
+  call feedkeys("Go\<C-X>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(0, g:compl_info['selected'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word']) 
+  call assert_equal(6 , len(g:compl_info['items']))
 
   set completeopt&
   bwipe!

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2399,7 +2399,7 @@ func Test_complete_info_index()
   call assert_equal(6 , len(g:compl_info['items']))
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
   call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
-  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word']) 
+  call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
   call assert_equal(6 , len(g:compl_info['items']))
 
   set completeopt&


### PR DESCRIPTION
#### vim-patch:9.0.2074: Completion menu may be wrong

Problem:  Completion menu may be wrong
Solution: Check for the original direction of the completion menu,
          add more tests, make it work with 'noselect'

completion: move in right direction when  filling completion_info()

When moving through the insert completion menu and switching directions,
we need to make sure we start at the correct position in the list and
move correctly forward/backwards through it, so that we do not skip
entries and the selected item points to the correct entry in the list
of completion entries generated by the completion_info() function.

The general case is this:

1) CTRL-X CTRL-N, we will traverse the list starting from
   compl_first_match and then go forwards (using the cp->next pointer)
   through the list (skipping the very first entry, which has the
   CP_ORIGINAL_TEXT flag set (since that is the empty/non-selected entry

2) CTRL-X CTRL-P, we will traverse the list starting from
   compl_first_match (which now points to the last entry). The previous
   entry will have the CP_ORIGINAL_TEXT flag set, so we need to start
   traversing the list from the second prev pointer.

There are in fact 2 special cases after starting the completion menu
with CTRL-X:

3)  CTRL-N and then going backwards by pressing CTRL-P again.
    compl_first_match will point to the same entry as in step 1 above,
    but since compl_dir_foward() has been switched by pressing CTRL-P
    to backwards we need to pretend to be in still in case 1 and still
    traverse the list in forward direction using the cp_next pointer

4)  CTRL-P and then going forwards by pressing CTRL-N again.
    compl_first_match will point to the same entry as in step 2 above,
    but since compl_dir_foward() has been switched by pressing CTRL-N
    to forwards we need to pretend to be in still in case 2 and still
    traverse the list in backward direction using the cp_prev pointer

For the 'noselect' case however, this is slightly different again. When
going backwards, we only need to go one cp_prev pointer back. And
resting of the direction works again slightly different. So we need to
take the noselect option into account when deciding in which direction
to iterate through the list of matches.

related: vim/vim#13402
related: vim/vim#12971
closes: vim/vim#13408

https://github.com/vim/vim/commit/daef8c74375141974d61b85199b383017644978c

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.2077: CI fails because of trailing whitespace in test

Problem:  CI fails because of trailing whitespace in test
Solution: Remove it

https://github.com/vim/vim/commit/87ca5e86fa0ef305f3d39cc4261b622f21417f7f

Co-authored-by: Christian Brabandt <cb@256bit.org>