### PR TITLE
vim-patch:9.0.2070: [security] disallow setting env in restricted mode

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7436,6 +7436,13 @@ static void f_setenv(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   char valbuf[NUMBUFLEN];
   const char *name = tv_get_string_buf(&argvars[0], namebuf);
 
+  // seting an environment variable may be dangerous, e.g. you could
+  // setenv GCONV_PATH=/tmp and then have iconv() unexpectedly call
+  // a shell command using some shared library:
+  if (check_secure()) {
+    return;
+  }
+
   if (argvars[1].v_type == VAR_SPECIAL
       && argvars[1].vval.v_special == kSpecialVarNull) {
     vim_unsetenv_ext(name);


### PR DESCRIPTION
#### vim-patch:9.0.2070: [security] disallow setting env in restricted mode

Problem:  [security] disallow setting env in restricted mode
Solution: Setting environment variables in restricted mode could
          potentially be used to execute shell commands. Disallow this.

restricted mode: disable allow setting of environment variables

Setting environment variables in restricted mode, may have some unwanted
consequences. So, for example by setting $GCONV_PATH in restricted mode
and then calling the iconv() function, one may be able to execute some
unwanted payload, because the `iconv_open()` function internally uses
the `$GCONV_PATH` variable to find its conversion data.

So let's disable setting environment variables, even so this is no
complete protection, since we are not clearing the existing environment.
I tried a few ways but wasn't successful :(

One could also argue to disable the iconv() function completely in
restricted mode, but who knows what other API functions can be
influenced by setting some other unrelated environment variables.
So let's leave it as it is currently.

closes: vim/vim#13394
See: https://huntr.com/bounties/b0a2eda1-459c-4e36-98e6-0cc7d7faccfe/

https://github.com/vim/vim/commit/6b89dd6a7257a1e2e9c7ea070b407bc4674a5118

Co-authored-by: Christian Brabandt <cb@256bit.org>