### PR TITLE
vim-patch:9.0.2081: smoothscroll may result in wrong cursor position

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2534,12 +2534,10 @@ static const char *did_set_showtabline(optset_T *args FUNC_ATTR_UNUSED)
 static const char *did_set_smoothscroll(optset_T *args FUNC_ATTR_UNUSED)
 {
   win_T *win = (win_T *)args->os_win;
-  if (win->w_p_sms) {
-    return NULL;
+  if (!win->w_p_sms) {
+    win->w_skipcol = 0;
   }
 
-  win->w_skipcol = 0;
-  changed_line_abv_curs_win(win);
   return NULL;
 }
 
@@ -2746,11 +2744,13 @@ static const char *did_set_winwidth(optset_T *args)
 static const char *did_set_wrap(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
-
-  // If 'wrap' is set, set w_leftcol to zero.
+  // Set w_leftcol or w_skipcol to zero.
   if (win->w_p_wrap) {
     win->w_leftcol = 0;
+  } else {
+    win->w_skipcol = 0;
   }
+
   return NULL;
 }
 /// Check the bounds of numeric options.

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2193,4 +2193,20 @@ func Test_binary_depending_options()
   call delete('Xoutput_bin')
 endfunc
 
+func Test_set_wrap()
+  " Unsetting 'wrap' when 'smoothscroll' is set does not result in incorrect
+  " cursor position.
+  set wrap smoothscroll scrolloff=5
+
+  call setline(1, ['', 'aaaa'->repeat(500)])
+  20 split
+  20 vsplit
+  norm 2G$
+  redraw
+  set nowrap
+  call assert_equal(2, winline())
+
+  set wrap& smoothscroll& scrolloff&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  With 'smoothscroll' set, "w_skipcol" is not reset when unsetting 'wrap'.
          Resulting in incorrect calculation of the cursor position.
Solution: Reset "w_skipcol" when unsetting 'wrap'.

fixes:  vim/vim#12970
closes: vim/vim#13439

https://github.com/vim/vim/commit/1bf1bf569b96d2f9b28e0cce0968ffbf2fb80aac