### PR TITLE
vim-patch:8ebdbc9e6d80

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1214,6 +1214,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	current working directory to the |$HOME| directory like in Unix.
 	When off, those commands just print the current directory name.
 	On Unix this option has no effect.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 					*'cdpath'* *'cd'* *E344* *E346*
 'cdpath' 'cd'		string	(default equivalent to $CDPATH or ",,")
@@ -4095,7 +4097,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	If you have less than 512 Mbyte |:mkspell| may fail for some
 	languages, no matter what you set 'mkspellmem' to.
 
-	This option cannot be set from a |modeline| or in the |sandbox|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 				*'modeline'* *'ml'* *'nomodeline'* *'noml'*
 'modeline' 'ml'		boolean	(default on (off for root))
@@ -4475,6 +4478,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Directories used to find packages.
 	See |packages| and |packages-runtimepath|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'paragraphs'* *'para'*
 'paragraphs' 'para'	string	(default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
@@ -4487,6 +4492,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Expression which is evaluated to apply a patch to a file and generate
 	the resulting new version of the file.  See |diff-patchexpr|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 					*'patchmode'* *'pm'* *E205* *E206*
 'patchmode' 'pm'	string	(default "")
@@ -5382,6 +5389,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When 'shellxquote' is set to "(" then the characters listed in this
 	option will be escaped with a '^' character.  This makes it possible
 	to execute most external commands with cmd.exe.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'shellxquote'* *'sxq'*
 'shellxquote' 'sxq'	string	(default "", Windows: "\"")
@@ -6429,6 +6438,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function and an example.  The value can be the name of a function, a
 	|lambda| or a |Funcref|. See |option-value-function| for more
 	information.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'taglength'* *'tl'*
 'taglength' 'tl'	number	(default 0)
@@ -6817,6 +6828,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Setting 'verbosefile' to a new value is like making it empty first.
 	The difference with |:redir| is that verbose messages are not
 	displayed when 'verbosefile' is set.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
 						*'viewdir'* *'vdir'*
 'viewdir' 'vdir'	string	(default "$XDG_STATE_HOME/nvim/view//")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -694,6 +694,8 @@ vim.go.cmp = vim.go.casemap
 --- current working directory to the `$HOME` directory like in Unix.
 --- When off, those commands just print the current directory name.
 --- On Unix this option has no effect.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type boolean
 vim.o.cdhome = false
@@ -4122,7 +4124,8 @@ vim.go.mis = vim.go.menuitems
 --- If you have less than 512 Mbyte `:mkspell` may fail for some
 --- languages, no matter what you set 'mkspellmem' to.
 ---
---- This option cannot be set from a `modeline` or in the `sandbox`.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.mkspellmem = "460000,2000,500"
@@ -4567,6 +4570,8 @@ vim.go.opfunc = vim.go.operatorfunc
 
 --- Directories used to find packages.
 --- See `packages` and `packages-runtimepath`.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.packpath = "..."
@@ -4585,6 +4590,8 @@ vim.go.para = vim.go.paragraphs
 
 --- Expression which is evaluated to apply a patch to a file and generate
 --- the resulting new version of the file.  See `diff-patchexpr`.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.patchexpr = ""
@@ -5628,6 +5635,8 @@ vim.go.stmp = vim.go.shelltemp
 --- When 'shellxquote' is set to "(" then the characters listed in this
 --- option will be escaped with a '^' character.  This makes it possible
 --- to execute most external commands with cmd.exe.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.shellxescape = ""
@@ -6855,6 +6864,8 @@ vim.go.tc = vim.go.tagcase
 --- function and an example.  The value can be the name of a function, a
 --- `lambda` or a `Funcref`. See `option-value-function` for more
 --- information.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.tagfunc = ""
@@ -7340,6 +7351,8 @@ vim.go.vbs = vim.go.verbose
 --- Setting 'verbosefile' to a new value is like making it empty first.
 --- The difference with `:redir` is that verbose messages are not
 --- displayed when 'verbosefile' is set.
+--- This option cannot be set from a `modeline` or in the `sandbox`, for
+--- security reasons.
 ---
 --- @type string
 vim.o.verbosefile = ""

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -942,6 +942,8 @@ return {
         current working directory to the |$HOME| directory like in Unix.
         When off, those commands just print the current directory name.
         On Unix this option has no effect.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       full_name = 'cdhome',
       scope = { 'global' },
@@ -5254,7 +5256,8 @@ return {
         <	If you have less than 512 Mbyte |:mkspell| may fail for some
         languages, no matter what you set 'mkspellmem' to.
 
-        This option cannot be set from a |modeline| or in the |sandbox|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       expand = true,
       full_name = 'mkspellmem',
@@ -5830,6 +5833,8 @@ return {
       desc = [=[
         Directories used to find packages.
         See |packages| and |packages-runtimepath|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       expand = true,
       full_name = 'packpath',
@@ -5878,6 +5883,8 @@ return {
       desc = [=[
         Expression which is evaluated to apply a patch to a file and generate
         the resulting new version of the file.  See |diff-patchexpr|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       full_name = 'patchexpr',
       scope = { 'global' },
@@ -7256,6 +7263,8 @@ return {
         When 'shellxquote' is set to "(" then the characters listed in this
         option will be escaped with a '^' character.  This makes it possible
         to execute most external commands with cmd.exe.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       full_name = 'shellxescape',
       scope = { 'global' },
@@ -8464,6 +8473,8 @@ return {
         function and an example.  The value can be the name of a function, a
         |lambda| or a |Funcref|. See |option-value-function| for more
         information.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       full_name = 'tagfunc',
       func = true,
@@ -9297,6 +9308,8 @@ return {
         Setting 'verbosefile' to a new value is like making it empty first.
         The difference with |:redir| is that verbose messages are not
         displayed when 'verbosefile' is set.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
       ]=],
       expand = true,
       full_name = 'verbosefile',


### PR DESCRIPTION
#### vim-patch:8ebdbc9e6d80

runtime(doc): all secure options should note this restriction in the documentation (vim/vim#13448)

Problem:  Not all secure options document their status
Solution: Describe secure context :set restrictions in each help entry

https://github.com/vim/vim/commit/8ebdbc9e6d80b707c2b2d923e702dc86bf902923

Co-authored-by: dkearns <dougkearns@gmail.com>