### PR TITLE
vim-patch:9.0.2079: Not all Dart files detected

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1655,6 +1655,7 @@ local patterns_hashbang = {
   ['^crystal\\>'] = { 'crystal', { vim_regex = true } },
   ['^\\%(rexx\\|regina\\)\\>'] = { 'rexx', { vim_regex = true } },
   ['^janet\\>'] = { 'janet', { vim_regex = true } },
+  ['^dart\\>'] = { 'dart', { vim_regex = true } },
 }
 
 ---@private

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -865,7 +865,8 @@ let s:script_checks = {
       \ 'crystal': [['#!/path/crystal']],
       \ 'rexx': [['#!/path/rexx'],
       \          ['#!/path/regina']],
-      \ 'janet': [['#!/path/janet']],
+      \ 'janet':  [['#!/path/janet']],
+      \ 'dart':   [['#!/path/dart']],
       \ }
 
 " Various forms of "env" optional arguments.


### PR DESCRIPTION
Problem:  Not all Dart files detected
Solution: Add shebang filetype detection for Dart

closes: vim/vim#13449

https://github.com/vim/vim/commit/c1c177a47bfe1b9a524ede2743a689e461668d14

Co-authored-by: Doug Kearns <dougkearns@gmail.com>
