### PR TITLE
vim-patch:a390e984db20

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -163,7 +163,7 @@ syn cluster shIdList	contains=shArithmetic,shCommandSub,shCommandSubBQ,shWrapLin
 syn cluster shIfList	contains=@shLoopList,shDblBrace,shDblParen,shFunctionKey,shFunctionOne,shFunctionTwo
 syn cluster shLoopList	contains=@shCaseList,@shErrorList,shCaseEsac,shConditional,shDblBrace,shExpr,shFor,shIf,shOption,shSet,shTest,shTestOpr,shTouch
 if exists("b:is_kornshell") || exists("b:is_bash")
- syn cluster shLoopoList	add=shForPP
+ syn cluster shLoopList	add=shForPP,shDblParen
 endif
 syn cluster shPPSLeftList	contains=shAlias,shArithmetic,shCmdParenRegion,shCommandSub,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shHereDoc,shNumber,shOperator,shOption,shPosnParm,shHereString,shRedir,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
 syn cluster shPPSRightList	contains=shDeref,shDerefSimple,shEscape,shPosnParm


### PR DESCRIPTION
runtime(sh): add shDblParen to shLoopList for bash (vim/vim#13445)

add shDblParen to shLoopList to correctly highlight
arithmetic expressions for Bash and Ksh

This should allow code such as:

```bash
declare -i i j
for i in foo bar
do ((j = 1 << j))
done
```

https://github.com/vim/vim/commit/a390e984db20575dc726b4e0ebf95582265df8e7

Co-authored-by: Lucien Grondin <grondilu@yahoo.fr>
