### PR TITLE
build: use neovim/libvterm instead of neovim/deps for libvterm

### DIFF
--- a/cmake.deps/cmake/LibvtermCMakeLists.txt
+++ b/cmake.deps/cmake/LibvtermCMakeLists.txt
@@ -7,6 +7,59 @@ if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 endif()
 
+set(DECDRAWING [[
+ static const struct StaticTableEncoding encoding_DECdrawing = {
+   { .decode = &decode_table },
+   {
+     [0x60] = 0x25C6,
+     [0x61] = 0x2592,
+     [0x62] = 0x2409,
+     [0x63] = 0x240C,
+     [0x64] = 0x240D,
+     [0x65] = 0x240A,
+     [0x66] = 0x00B0,
+     [0x67] = 0x00B1,
+     [0x68] = 0x2424,
+     [0x69] = 0x240B,
+     [0x6a] = 0x2518,
+     [0x6b] = 0x2510,
+     [0x6c] = 0x250C,
+     [0x6d] = 0x2514,
+     [0x6e] = 0x253C,
+     [0x6f] = 0x23BA,
+     [0x70] = 0x23BB,
+     [0x71] = 0x2500,
+     [0x72] = 0x23BC,
+     [0x73] = 0x23BD,
+     [0x74] = 0x251C,
+     [0x75] = 0x2524,
+     [0x76] = 0x2534,
+     [0x77] = 0x252C,
+     [0x78] = 0x2502,
+     [0x79] = 0x2A7D,
+     [0x7a] = 0x2A7E,
+     [0x7b] = 0x03C0,
+     [0x7c] = 0x2260,
+     [0x7d] = 0x00A3,
+     [0x7e] = 0x00B7,
+   }
+ };
+]]
+)
+
+set(UK [[
+ static const struct StaticTableEncoding encoding_uk = {
+   { .decode = &decode_table },
+   {
+     [0x23] = 0x00a3,
+   }
+ };
+]]
+)
+
+file(WRITE src/encoding/DECdrawing.inc "${DECDRAWING}")
+file(WRITE src/encoding/uk.inc "${UK}")
+
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_BINARY_DIR})
 

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -16,8 +16,8 @@ UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b953665559679748
 LIBTERMKEY_URL https://github.com/neovim/libtermkey/archive/v0.22.tar.gz
 LIBTERMKEY_SHA256 81cac2b685c9ada4ead4ea788fb69ff74fc1947ad188ed0264c646fe12b496ba
 
-LIBVTERM_URL https://github.com/neovim/deps/raw/12c9dcf1d823ac4acbccf494c93c4774a87db11d/opt/libvterm-0.3.3.tar.gz
-LIBVTERM_SHA256 09156f43dd2128bd347cbeebe50d9a571d32c64e0cf18d211197946aff7226e0
+LIBVTERM_URL https://github.com/neovim/libvterm/archive/v0.3.3.tar.gz
+LIBVTERM_SHA256 0babe3ab42c354925dadede90d352f054aa9c4ae6842ea803a20c9741e172e56
 
 LUV_URL https://github.com/luvit/luv/archive/dcd1a1cad5b05634a7691402d6ca2f214fb4ae76.tar.gz
 LUV_SHA256 b68c73ed233918da7e0b34b57c6bac0490e6c6f1b12c1051266b6ad9efa780d0


### PR DESCRIPTION
Using a mirror makes it easier to test patches as well as reducing
maintenance when a new version is released.
