### PR TITLE
refactor(api)!: redesign nvim_(get|set)_option_value

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1479,9 +1479,9 @@ describe('API', function()
     end)
 
     it('validation', function()
-      eq("Invalid 'scope': expected 'local' or 'global'",
+      eq("Invalid 'scope': expected 'local', 'global' or 'both'",
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 'bogus'}))
-      eq("Invalid 'scope': expected 'local' or 'global'",
+      eq("Invalid 'scope': expected 'local', 'global' or 'both'",
         pcall_err(nvim, 'set_option_value', 'scrolloff', 1, {scope = 'bogus'}))
       eq("Invalid 'scope': expected String, got Integer",
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 42}))


### PR DESCRIPTION
Problem: Currently, `nvim_(get|set)_option_value` can modify the local value forthe current buffer or window even when it's not explicitly specified.This is undesirable behavior for the API, as any changes to a localvalue should only happen when the intent to do so is explicitlyexpressed by the caller of the API function.

Solution: Make `nvim_(get|set)_option_value` always require window or buffer to be explicitly specified when a local value needs to be modified. Also change how default scope is picked to always prefer global scope by default whenever possible. Also add a `'both'` scope to set both the local and global scope.