### PR TITLE
build: enable ASAN for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,12 +157,6 @@ if((ENABLE_ASAN_UBSAN AND ENABLE_MSAN)
   message(FATAL_ERROR "Sanitizers cannot be enabled simultaneously")
 endif()
 
-if(ENABLE_ASAN_UBSAN OR ENABLE_MSAN OR ENABLE_TSAN)
-  if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_C_COMPILER_ID MATCHES "GNU")
-    message(FATAL_ERROR "Sanitizers are only supported for Clang and GCC")
-  endif()
-endif()
-
 # Place targets in bin/ or lib/ for all build configurations
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,8 @@ Each pull request must pass the automated builds on [Cirrus CI] and [GitHub Acti
 - If any tests fail, the build will fail. See [test/README.md#running-tests][run-tests] to run tests locally.
 - CI runs [ASan] and other analyzers.
     - To run valgrind locally: `VALGRIND=1 make test`
-    - To run Clang ASan/UBSan locally: `CC=clang make CMAKE_FLAGS="-DENABLE_ASAN_UBSAN=ON"`
+    - To run ASan/UBSan locally: `CC=clang make CMAKE_FLAGS="-DENABLE_ASAN_UBSAN=ON"`.
+      Note that MSVC requires Release or RelWithDebInfo build type to work properly.
 - The [lint](#lint) build checks modified lines _and their immediate
   neighbors_, to encourage incrementally updating the legacy style to meet our
   [style](#style). (See [#3174][3174] for background.)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -764,17 +764,20 @@ target_link_libraries(libnvim PRIVATE main_lib PUBLIC libuv)
 
 if(ENABLE_ASAN_UBSAN)
   message(STATUS "Enabling address sanitizer and undefined behavior sanitizer for nvim.")
-  if(CI_BUILD)
-    # Try to recover from all sanitize issues so we get reports about all failures
-    target_compile_options(nvim PRIVATE -fsanitize-recover=all)
-  else()
-    target_compile_options(nvim PRIVATE -fno-sanitize-recover=all)
+  if(NOT MSVC)
+    if(CI_BUILD)
+      # Try to recover from all sanitize issues so we get reports about all failures
+      target_compile_options(nvim PRIVATE -fsanitize-recover=all)
+    else()
+      target_compile_options(nvim PRIVATE -fno-sanitize-recover=all)
+    endif()
+    target_compile_options(nvim PRIVATE
+      -fno-omit-frame-pointer
+      -fno-optimize-sibling-calls
+      -fsanitize=undefined)
   endif()
-  target_compile_options(nvim PRIVATE
-    -fno-omit-frame-pointer
-    -fno-optimize-sibling-calls
-    -fsanitize=address
-    -fsanitize=undefined)
+
+  target_compile_options(nvim PRIVATE -fsanitize=address)
   target_link_libraries(nvim PRIVATE -fsanitize=address -fsanitize=undefined)
   target_compile_definitions(nvim PRIVATE ENABLE_ASAN_UBSAN)
 elseif(ENABLE_MSAN)


### PR DESCRIPTION
It is enabled with ENABLE_ASAN_UBSAN like other compilers. Technically
it only enables ASAN as UBSAN is not available, meaning to make the
variable names fully correct we'd need to separate it into two checks:
ENABLE_ASAN and ENABLE_UBSAN, but the convenience of combining them into
the same flag outweighs the theoretical correctness.

Also note in CONTRIBUTING.md that debug builds in ASAN is not supported.
Technically it is the debug runtime that is not supported, which cmake
automatically enables when using the debug build type. However, neovim
can't be built with debug builds without linking to the debug runtime
since the third party libraries has likely been linked to the debug
runtime if it was built with debug build type. This technicality is
likely uninteresting to the potential developer and it's easier to just
say to use a release build type.