### PR TITLE
Update help-tag-right CSS for HTML docs

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -975,13 +975,16 @@ local function gen_css(fname)
     /* Tag pseudo-header common in :help docs. */
     .help-tag-right {
       color: var(--tag-color);
-      margin-left: auto;
-      margin-right: 0;
-      float: right;
+      background-color: inherit;
+      display: flex;
+      justify-content: right;
+      margin-top: 1.5em;
+      margin-bottom: 1em;
     }
     .help-tag a,
     .help-tag-right a {
       color: inherit;
+      background-color: var(--accent-bg-color);
     }
     .help-tag a:not(:hover),
     .help-tag-right a:not(:hover) {


### PR DESCRIPTION
Updates `help-tag-right` elements putting them on their own line to prevent confusing layout and act more like mini-headers.

Before:
<img width="1017" alt="Screenshot 2023-10-31 at 1 14 24 PM" src="https://github.com/neovim/neovim/assets/4392850/e1ab6b26-eb41-49a6-8217-be4080f3c444">

After:
<img width="1017" alt="Screenshot 2023-10-31 at 1 14 19 PM" src="https://github.com/neovim/neovim/assets/4392850/e1c3dc3f-c21c-4f5b-98e7-ceb637fd4067">
