### PR TITLE
feat(breakindent): add `cul` option to 'breakindentopt'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1093,6 +1093,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		sbr	    Display the 'showbreak' value before applying the
 			    additional indent.
 			    (default: off)
+		cul	    Highlight the visual indent with CursorLine.
+			    (default: off)
 		list:{n}    Adds an additional indent for lines that match a
 			    numbered or bulleted list (using the
 			    'formatlistpat' setting).

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -555,6 +555,8 @@ vim.wo.bri = vim.wo.breakindent
 --- 	sbr	    Display the 'showbreak' value before applying the
 --- 		    additional indent.
 --- 		    (default: off)
+--- 	cul	    Highlight the visual indent with CursorLine.
+--- 		    (default: off)
 --- 	list:{n}    Adds an additional indent for lines that match a
 --- 		    numbered or bulleted list (using the
 --- 		    'formatlistpat' setting).

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1265,6 +1265,7 @@ struct window_S {
   int w_briopt_min;                 // minimum width for breakindent
   int w_briopt_shift;               // additional shift for breakindent
   bool w_briopt_sbr;                // sbr in 'briopt'
+  bool w_briopt_cul;                // cul in 'briopt'
   int w_briopt_list;                // additional indent for lists
   int w_briopt_vcol;                // indent for specific column
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -779,6 +779,9 @@ static void handle_breakindent(win_T *wp, winlinevars_T *wlv)
       if (wlv->diff_hlf != (hlf_T)0) {
         wlv->char_attr = win_hl_attr(wp, (int)wlv->diff_hlf);
       }
+      else if (wlv->cul_attr && wp->w_briopt_cul) {
+        wlv->char_attr = win_hl_attr(wp, HLF_CUL);
+      }
       wlv->p_extra = NULL;
       wlv->c_extra = ' ';
       wlv->c_final = NUL;

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -753,6 +753,7 @@ bool briopt_check(win_T *wp)
   int bri_shift = 0;
   int bri_min = 20;
   bool bri_sbr = false;
+  bool bri_cul = false;
   int bri_list = 0;
   int bri_vcol = 0;
 
@@ -769,6 +770,9 @@ bool briopt_check(win_T *wp)
     } else if (strncmp(p, "sbr", 3) == 0) {
       p += 3;
       bri_sbr = true;
+    } else if (strncmp(p, "cul", 3) == 0) {
+      p += 3;
+      bri_cul = true;
     } else if (strncmp(p, "list:", 5) == 0) {
       p += 5;
       bri_list = (int)getdigits(&p, false, 0);
@@ -787,6 +791,7 @@ bool briopt_check(win_T *wp)
   wp->w_briopt_shift = bri_shift;
   wp->w_briopt_min = bri_min;
   wp->w_briopt_sbr = bri_sbr;
+  wp->w_briopt_cul = bri_cul;
   wp->w_briopt_list = bri_list;
   wp->w_briopt_vcol = bri_vcol;
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -76,7 +76,7 @@ static char *(p_bo_values[]) = { "all", "backspace", "cursor", "complete", "copy
                                  "esc", "ex", "hangul", "lang", "mess", "showmatch", "operator",
                                  "register", "shell", "spell", "wildmode", NULL };
 // Note: Keep this in sync with briopt_check()
-static char *(p_briopt_values[]) = { "shift:", "min:", "sbr", "list:", "column:", NULL };
+static char *(p_briopt_values[]) = { "shift:", "min:", "sbr", "cul", "list:", "column:", NULL };
 // Note: Keep this in sync with diffopt_changed()
 static char *(p_dip_values[]) = { "filler", "context:", "iblank", "icase",
                                   "iwhite", "iwhiteall", "iwhiteeol", "horizontal", "vertical",


### PR DESCRIPTION
This pull request adds an option to 'breakindentopt' which allows the visually generated indent to be highlighted via `CursorLine`. This is to make the cursor line more visually appealing alongside `breakindent`.

With `:set linebreak breakindent breakindentopt=shift:8`:
<img width="752" alt="Screenshot 2023-11-01 at 11 47 06 am" src="https://github.com/neovim/neovim/assets/83528263/2ea30d7a-6906-47da-9ec5-3b4dff957076">

With `:set linebreak breakindent breakindentopt=shift:8,cul`:
<img width="748" alt="Screenshot 2023-11-01 at 11 47 27 am" src="https://github.com/neovim/neovim/assets/83528263/d1efea4a-401e-4f69-899e-632a909f9f89">

I have also provided documentation within the help pages and lua comments.
