### PR TITLE
ci: add optional CI that can be triggered manually

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -1,0 +1,34 @@
+name: optional
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  s390x:
+    if: ${{ github.event.label.name == 'ci-s390x' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [functionaltest, oldtest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - uses: docker://multiarch/ubuntu-core:s390x-focal
+        with:
+          args: >
+            bash -c
+            "
+            apt-get -y update &&
+            DEBIAN_FRONTEND=noninteractive apt-get -y install attr build-essential cmake curl gettext libattr1-dev ninja-build unzip locales-all cpanminus git &&
+            git clone --depth=1 https://github.com/neovim/neovim.git &&
+            cd neovim &&
+            cmake -S cmake.deps -B .deps -G Ninja -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON &&
+            cmake --build .deps &&
+            cmake -B build -G Ninja -D PREFER_LUA=ON &&
+            make ${{ matrix.test }}
+            "


### PR DESCRIPTION
These are meant for expensive or situational tests that may not be
suitable to run each time, but can occasionally be useful.

Currently only add testing for s390x. The job is enabled by adding the
ci-s390x label in github.
