### PR TITLE
refactor(grid): implement rightleftcmd as a post-processing step

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -715,12 +715,8 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   ExpandInit(&s->xpc);
   ccline.xpc = &s->xpc;
 
-  if (curwin->w_p_rl && *curwin->w_p_rlc == 's'
-      && (s->firstc == '/' || s->firstc == '?')) {
-    cmdmsg_rl = true;
-  } else {
-    cmdmsg_rl = false;
-  }
+  cmdmsg_rl = (curwin->w_p_rl && *curwin->w_p_rlc == 's'
+               && (s->firstc == '/' || s->firstc == '?'));
 
   msg_grid_validate();
 
@@ -1564,11 +1560,7 @@ static int command_line_erase_chars(CommandLineState *s)
 
     XFREE_CLEAR(ccline.cmdbuff);        // no commandline to return
     if (!cmd_silent && !ui_has(kUICmdline)) {
-      if (cmdmsg_rl) {
-        msg_col = Columns;
-      } else {
-        msg_col = 0;
-      }
+      msg_col = 0;
       msg_putchar(' ');                             // delete ':'
     }
     s->is_state.search_start = s->is_state.save_cursor;
@@ -2664,7 +2656,7 @@ static int command_line_changed(CommandLineState *s)
     }
   }
 
-  if (cmdmsg_rl || (p_arshape && !p_tbidi)) {
+  if (p_arshape && !p_tbidi) {
     // Always redraw the whole command line to fix shaping and
     // right-left typing.  Not efficient, but it works.
     // Do it only when there are no characters left to read
@@ -3863,18 +3855,10 @@ void cursorcmd(void)
     return;
   }
 
-  if (cmdmsg_rl) {
-    msg_row = cmdline_row + (ccline.cmdspos / (Columns - 1));
-    msg_col = Columns - (ccline.cmdspos % (Columns - 1)) - 1;
-    if (msg_row <= 0) {
-      msg_row = Rows - 1;
-    }
-  } else {
-    msg_row = cmdline_row + (ccline.cmdspos / Columns);
-    msg_col = ccline.cmdspos % Columns;
-    if (msg_row >= Rows) {
-      msg_row = Rows - 1;
-    }
+  msg_row = cmdline_row + (ccline.cmdspos / Columns);
+  msg_col = ccline.cmdspos % Columns;
+  if (msg_row >= Rows) {
+    msg_row = Rows - 1;
   }
 
   msg_cursor_goto(msg_row, msg_col);
@@ -3886,11 +3870,7 @@ void gotocmdline(bool clr)
     return;
   }
   msg_start();
-  if (cmdmsg_rl) {
-    msg_col = Columns - 1;
-  } else {
-    msg_col = 0;  // always start in column 0
-  }
+  msg_col = 0;  // always start in column 0
   if (clr) {  // clear the bottom line(s)
     msg_clr_eos();  // will reset clear_cmdline
   }

--- a/src/nvim/grid.h
+++ b/src/nvim/grid.h
@@ -29,6 +29,7 @@ EXTERN bool resizing_screen INIT( = 0);
 EXTERN schar_T *linebuf_char INIT( = NULL);
 EXTERN sattr_T *linebuf_attr INIT( = NULL);
 EXTERN colnr_T *linebuf_vcol INIT( = NULL);
+EXTERN char *linebuf_scratch INIT( = NULL);
 
 // Low-level functions to manipulate individual character cells on the
 // screen grid.

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -16,7 +16,9 @@
 // otherwise it must be a UTF-8 string of length maximum 4 (no NUL when n=4)
 
 typedef uint32_t schar_T;
-typedef int sattr_T;
+typedef int32_t sattr_T;
+// must be at least as big as the biggest of schar_T, sattr_T, col_T
+typedef int32_t sscratch_T;
 
 enum {
   kZIndexDefaultGrid = 0,

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -537,22 +537,18 @@ void spell_suggest(int count)
   } else {
     // When 'rightleft' is set the list is drawn right-left.
     cmdmsg_rl = curwin->w_p_rl;
-    if (cmdmsg_rl) {
-      msg_col = Columns - 1;
-    }
 
     // List the suggestions.
     msg_start();
     msg_row = Rows - 1;         // for when 'cmdheight' > 1
     lines_left = Rows;          // avoid more prompt
-    vim_snprintf(IObuff, IOSIZE, _("Change \"%.*s\" to:"),
-                 sug.su_badlen, sug.su_badptr);
-    if (cmdmsg_rl && strncmp(IObuff, "Change", 6) == 0) {
+    char *fmt = _("Change \"%.*s\" to:");
+    if (cmdmsg_rl && strncmp(fmt, "Change", 6) == 0) {
       // And now the rabbit from the high hat: Avoid showing the
       // untranslated message rightleft.
-      vim_snprintf(IObuff, IOSIZE, ":ot \"%.*s\" egnahC",
-                   sug.su_badlen, sug.su_badptr);
+      fmt = ":ot \"%.*s\" egnahC";
     }
+    vim_snprintf(IObuff, IOSIZE, fmt, sug.su_badlen, sug.su_badptr);
     msg_puts(IObuff);
     msg_clr_eos();
     msg_putchar('\n');

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -24,6 +24,7 @@ local function new_screen(opt)
     [7] = {bold = true, foreground = Screen.colors.Brown},
     [8] = {background = Screen.colors.LightGrey},
     [9] = {bold = true},
+    [10] = {background = Screen.colors.Yellow1};
   })
   return screen
 end
@@ -770,6 +771,84 @@ describe('cmdline redraw', function()
       {3:[Command Line]                          }|
       :^abc                                    |
     ]])
+  end)
+
+  it('with rightleftcmd', function()
+    command('set rightleft rightleftcmd=search shortmess+=s')
+    meths.buf_set_lines(0, 0, -1, true, {"let's rock!"})
+    screen:expect{grid=[[
+                    !kcor s'te^l|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                               |
+    ]]}
+
+    feed '/'
+    screen:expect{grid=[[
+                    !kcor s'tel|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                             ^ /|
+    ]]}
+
+    feed "let's"
+    -- note: cursor looks off but looks alright in real use
+    -- when rendered as a block so it touches the end of the text
+    screen:expect{grid=[[
+                    !kcor {2:s'tel}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                        ^ s'tel/|
+    ]]}
+
+    -- cursor movement
+    feed "<space>"
+    screen:expect{grid=[[
+                    !kcor{2: s'tel}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                       ^  s'tel/|
+    ]]}
+
+    feed "rock"
+    screen:expect{grid=[[
+                    !{2:kcor s'tel}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                   ^ kcor s'tel/|
+    ]]}
+
+    feed "<right>"
+    screen:expect{grid=[[
+                    !{2:kcor s'tel}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                    ^kcor s'tel/|
+    ]]}
+
+    feed "<left>"
+    screen:expect{grid=[[
+                    !{2:kcor s'tel}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+                   ^ kcor s'tel/|
+    ]]}
+
+    feed "<cr>"
+    screen:expect{grid=[[
+                    !{10:kcor s'te^l}|
+      {1:                        ~}|
+      {1:                        ~}|
+      {1:                        ~}|
+      kcor s'tel/              |
+    ]]}
   end)
 end)
 


### PR DESCRIPTION
Previously, `'rightleftcmd'` was implemented by having all code which would affect `msg_col` or output screen cells be conditional on `cmdmsg_rl`. This change removes all that and instead implements rightleft as a mirroring post-processing step.