### PR TITLE
build: use built nvim artifact to generate eval files

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -15,10 +15,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
-          version: nightly
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
@@ -35,7 +31,6 @@ jobs:
       - name: FAIL, PR has not committed doc changes
         if: ${{ steps.docs.outputs.UPDATED_DOCS != 0 }}
         run: |
-          echo "Job failed, run ./scripts/gen_vimdoc.py and/or ./scripts/gen_vimfn_types.lua"
-          echo "and commit your doc changes"
+          echo "Job failed, run 'make doc' and commit your doc changes."
           echo "The doc generation produces the following changes:"
           git diff --color --exit-code

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -18,12 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          sudo apt-get update
           ./.github/scripts/install_deps.sh
-          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y doxygen python3 python3-msgpack
+          sudo apt-get install -y doxygen python3-msgpack
+      - uses: ./.github/actions/cache
 
       - name: Generate docs
-        id: docs
         run: |
           make doc
           printf 'UPDATED_DOCS=%s\n' $([ -z "$(git diff)" ]; echo $?) >> $GITHUB_OUTPUT

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -1,4 +1,3 @@
-#!/usr/bin/env -S nvim -l
 -- Generator for various vimdoc and Lua type files
 
 local DEP_API_METADATA = 'build/api_metadata.mpack'

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -928,7 +928,8 @@ set(GEN_EVAL_FILES
 
 add_custom_command(
   OUTPUT ${GEN_EVAL_FILES}
-  COMMAND ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
+  COMMAND nvim
+  ARGS -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
   DEPENDS
     ${API_METADATA}
     ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -928,8 +928,7 @@ set(GEN_EVAL_FILES
 
 add_custom_command(
   OUTPUT ${GEN_EVAL_FILES}
-  COMMAND nvim
-  ARGS -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
+  COMMAND nvim -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
   DEPENDS
     ${API_METADATA}
     ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -928,7 +928,7 @@ set(GEN_EVAL_FILES
 
 add_custom_command(
   OUTPUT ${GEN_EVAL_FILES}
-  COMMAND nvim -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
+  COMMAND $<TARGET_FILE:nvim> -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
   DEPENDS
     ${API_METADATA}
     ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua


### PR DESCRIPTION
In cases where the generated files depend on changes to Nvim itself, generating the files with an older version of Nvim will fail because those changes are not present in the older version.

For example, if a new option is added then the generator script should be run with the version of Nvim that contains the new option, or else the generation will fail.
