### PR TITLE
build: make the vimdoc generation depend on the nvim target

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -913,7 +913,10 @@ glob_wrapper(LUA_SOURCES
 add_custom_command(
   OUTPUT ${VIMDOC_FILES}
   COMMAND ${PROJECT_SOURCE_DIR}/scripts/gen_vimdoc.py
-  DEPENDS ${API_SOURCES} ${LUA_SOURCES}
+  DEPENDS
+    nvim
+    ${API_SOURCES}
+    ${LUA_SOURCES}
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
The gen_vimdoc.py script uses the nvim executable, so the executable
must be built before running the script.
