### PR TITLE
feat(extmarks): add "undo_restore" flag to opt out of undo-restoring

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -270,6 +270,9 @@ The following changes to existing APIs or features add new behavior.
   In addition, |nvim_buf_get_extmarks()| has gained an "overlap" option to
   return such ranges even if they started before the specified position.
 
+• Extmarks can opt-out of precise undo tracking using the new "undo_restore"
+  flag to |nvim_buf_set_extmark()|
+
 • LSP hover and signature help now use Treesitter for highlighting of Markdown
   content.
   Note that syntax highlighting of code examples requires a matching parser

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -172,8 +172,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
   decor.virt_text_width = width;
   decor.priority = 0;
 
-  extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, &decor, true,
-              false, kExtmarkNoUndo, NULL);
+  extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, &decor, true, false, false, NULL);
   return src_id;
 }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -166,6 +166,10 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
       PUT(dict, "end_right_gravity", BOOLEAN_OBJ(extmark->end_right_gravity));
     }
 
+    if (extmark->no_undo) {
+      PUT(dict, "undo_restore", BOOLEAN_OBJ(false));
+    }
+
     const Decoration *decor = &extmark->decor;
     if (decor->hl_id) {
       PUT(dict, "hl_group", hl_group_name(decor->hl_id, hl_name));
@@ -519,6 +523,9 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                   the extmark end position (if it exists) will be shifted
 ///                   in when new text is inserted (true for right, false
 ///                   for left). Defaults to false.
+///               - undo_restore : Restore the exact position of the mark
+///                   if text around the mark was deleted and then restored by undo.
+///                   Defaults to true.
 ///               - priority: a priority value for the highlight group or sign
 ///                   attribute. For example treesitter highlighting uses a
 ///                   value of 100.
@@ -825,7 +832,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
     extmark_set(buf, (uint32_t)ns_id, &id, (int)line, (colnr_T)col, line2, col2,
                 has_decor ? &decor : NULL, right_gravity, end_right_gravity,
-                kExtmarkNoUndo, err);
+                !GET_BOOL_OR_TRUE(opts, set_extmark, undo_restore), err);
     if (ERROR_SET(err)) {
       goto error;
     }
@@ -952,7 +959,7 @@ Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, In
   extmark_set(buf, ns, NULL,
               (int)line, (colnr_T)col_start,
               end_line, (colnr_T)col_end,
-              &decor, true, false, kExtmarkNoUndo, NULL);
+              &decor, true, false, false, NULL);
   return ns_id;
 }
 

--- a/src/nvim/api/keysets.h
+++ b/src/nvim/api/keysets.h
@@ -48,6 +48,7 @@ typedef struct {
   String conceal;
   Boolean spell;
   Boolean ui_watched;
+  Boolean undo_restore;
 } Dict(set_extmark);
 
 typedef struct {

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -66,7 +66,7 @@ void bufhl_add_hl_pos_offset(buf_T *buf, int src_id, int hl_id, lpos_T pos_start
     }
     extmark_set(buf, (uint32_t)src_id, NULL,
                 (int)lnum - 1, hl_start, (int)lnum - 1 + end_off, hl_end,
-                &decor, true, false, kExtmarkNoUndo, NULL);
+                &decor, true, false, true, NULL);
   }
 }
 

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -25,6 +25,7 @@ typedef struct {
   colnr_T end_col;
   bool right_gravity;
   bool end_right_gravity;
+  bool no_undo;
   Decoration decor;  // TODO(bfredl): CHONKY
 } ExtmarkInfo;
 

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -2007,7 +2007,7 @@ void marktree_put_test(MarkTree *b, uint32_t ns, uint32_t id, int row, int col, 
                        int end_row, int end_col, bool end_right)
 {
   MTKey key = { { row, col }, ns, id, 0,
-                mt_flags(right_gravity, 0), 0, NULL };
+                mt_flags(right_gravity, 0, false), 0, NULL };
   marktree_put(b, key, end_row, end_col, end_right);
 }
 

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -77,18 +77,18 @@ typedef struct {
 // orphaned: the other side of this paired mark was deleted. this mark must be deleted very soon!
 #define MT_FLAG_ORPHANED (((uint16_t)1) << 3)
 #define MT_FLAG_HL_EOL (((uint16_t)1) << 4)
+#define MT_FLAG_NO_UNDO (((uint16_t)1) << 5)
 
 #define DECOR_LEVELS 4
-#define MT_FLAG_DECOR_OFFSET 5
+#define MT_FLAG_DECOR_OFFSET 6
 #define MT_FLAG_DECOR_MASK (((uint16_t)(DECOR_LEVELS - 1)) << MT_FLAG_DECOR_OFFSET)
-
-// next flag is (((uint16_t)1) << 6)
 
 // These _must_ be last to preserve ordering of marks
 #define MT_FLAG_RIGHT_GRAVITY (((uint16_t)1) << 14)
 #define MT_FLAG_LAST (((uint16_t)1) << 15)
 
-#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_RIGHT_GRAVITY | MT_FLAG_HL_EOL)
+#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_RIGHT_GRAVITY | \
+                               MT_FLAG_NO_UNDO | MT_FLAG_HL_EOL)
 
 // this is defined so that start and end of the same range have adjacent ids
 #define MARKTREE_END_FLAG ((uint64_t)1)
@@ -127,16 +127,22 @@ static inline bool mt_right(MTKey key)
   return key.flags & MT_FLAG_RIGHT_GRAVITY;
 }
 
+static inline bool mt_no_undo(MTKey key)
+{
+  return key.flags & MT_FLAG_NO_UNDO;
+}
+
 static inline uint8_t marktree_decor_level(MTKey key)
 {
   return (uint8_t)((key.flags&MT_FLAG_DECOR_MASK) >> MT_FLAG_DECOR_OFFSET);
 }
 
-static inline uint16_t mt_flags(bool right_gravity, uint8_t decor_level)
+static inline uint16_t mt_flags(bool right_gravity, uint8_t decor_level, bool no_undo)
 {
   assert(decor_level < DECOR_LEVELS);
   return (uint16_t)((right_gravity ? MT_FLAG_RIGHT_GRAVITY : 0)
-                    | (decor_level << MT_FLAG_DECOR_OFFSET));
+                    | (decor_level << MT_FLAG_DECOR_OFFSET)
+                    | (no_undo ? MT_FLAG_NO_UNDO : 0));
 }
 
 typedef kvec_withinit_t(uint64_t, 4) Intersection;


### PR DESCRIPTION
It is a  design goal of extmarks that they allow precise tracking of changes accross undo/redo, including restore the exact positions after a do/undo or undo/redo cycle. However this behaviour is not useful for all usecases. Many plugins don't keep mark around for long after text changes, but uses them more like a cache until some external source (like LSP semantic highlights) has fully updated to changed text and then will explicitly readjust all extmark decorations.

Add a "no_undo_restore" flag as an opt-out.

Ref discussion in https://github.com/neovim/neovim/pull/25767#issuecomment-1790502818