### PR TITLE
feat(statuscolumn): always re-evaluate 'statuscolumn' for virtual lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3233,16 +3233,10 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
         wlv.need_showbreak = true;
       }
       if (statuscol.draw) {
-        if (wlv.row == startrow + wlv.filler_lines) {
-          statuscol.textp = NULL;  // re-evaluate for first non-filler line
-        } else if (vim_strchr(p_cpo, CPO_NUMCOL) && wlv.row > startrow + wlv.filler_lines) {
+        if (vim_strchr(p_cpo, CPO_NUMCOL) && wlv.row > startrow + wlv.filler_lines) {
           statuscol.draw = false;  // don't draw status column if "n" is in 'cpo'
-        } else if (wlv.row == startrow + wlv.filler_lines + 1) {
-          statuscol.textp = NULL;  // re-evaluate for first wrapped line
         } else {
-          // Draw the already built 'statuscolumn' on the next wrapped or filler line
-          statuscol.textp = statuscol.text;
-          statuscol.hlrecp = statuscol.hlrec;
+          statuscol.textp = NULL;  // re-evaluate with new v:virtnum
         }
       }
       wlv.filler_todo--;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -429,7 +429,7 @@ describe('statuscolumn', function()
       {1:buffer  0 5}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {1:wrapped 1 5}aaaaaaaa                                  |
       {1:virtual-2 5}virt_line                                 |
-      {1:virtual-2 5}virt_line above                           |
+      {1:virtual-1 5}virt_line above                           |
       {1:buffer  0 6}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {1:wrapped 1 6}aaaaaaaa                                  |
       {1:buffer  0 7}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
@@ -443,18 +443,18 @@ describe('statuscolumn', function()
     exec_lua([[
       vim.api.nvim_buf_set_extmark(0, ns, 15, 0, { virt_lines = {{{"END", ""}}} })
     ]])
-    feed('Gzz')
+    feed('GkJzz')
     screen:expect([[
+      {1:buffer  0 12}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 1 12}aaaaaaaaa                                |
       {1:buffer  0 13}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {1:wrapped 1 13}aaaaaaaaa                                |
       {1:buffer  0 14}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {1:wrapped 1 14}aaaaaaaaa                                |
-      {1:buffer  0 15}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      {1:wrapped 1 15}aaaaaaaaa                                |
-      {4:buffer  0 16}{5:^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
-      {4:wrapped 1 16}{5:aaaaaaaaa                                }|
-      {1:virtual-1 16}END                                      |
-      {0:~                                                    }|
+      {4:buffer  0 15}{5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {4:wrapped 1 15}{5:aaaaaaaaa^ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {4:wrapped 2 15}{5:aaaaaaaaaaaaaaaaaaa                      }|
+      {1:virtual-1 15}END                                      |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -467,18 +467,18 @@ describe('statuscolumn', function()
       vim.api.nvim_buf_set_extmark(0, ns, 14, 0, { virt_lines = {{{"virt_line2", ""}}} })
     ]])
     screen:expect([[
+      {1:buffer  0 12}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaa                                            |
       {1:buffer  0 13}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaa                                            |
       {1:buffer  0 14}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaa                                            |
-      {1:buffer  0 15}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      aaaaaaaaa                                            |
-      {1:virtual-2 15}virt_line1                               |
+      {4:buffer  0 15}{5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {5:aaaaaaaaa^ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {5:aaaaaaa                                              }|
+      {1:virtual-3 15}virt_line1                               |
       {1:virtual-2 15}virt_line2                               |
-      {4:buffer  0 16}{5:^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
-      {5:aaaaaaaaa                                            }|
-      {1:virtual-1 16}END                                      |
-      {0:~                                                    }|
+      {1:virtual-1 15}END                                      |
       {0:~                                                    }|
                                                            |
     ]])


### PR DESCRIPTION
Problem:  v:virtnum is less useful than it could be. 
Solution: Always re-evaluate 'statuscolumn', and update v:virtnum accordingly.