### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -1,17 +1,30 @@
-vim9script
+" Vim runtime support library,
+" runs the vim9 script version or legacy script version
+" on demand (mostly for Neovim compatability)
+"
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Nov 04
 
-# Vim runtime support library
-#
-# Maintainer:	The Vim Project <https://github.com/vim/vim>
-# Last Change:	2023 Oct 25
 
-export def IsSafeExecutable(filetype: string, executable: string): bool
-  var cwd = getcwd()
-  return get(g:, filetype .. '_exec', get(g:, 'plugin_exec', 0))
-    && (fnamemodify(exepath(executable), ':p:h') !=# cwd
-        || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1
-            && cwd != '.'))
-enddef
+" enable the zip and gzip plugin by default, if not set
+if !exists('g:zip_exec')
+  let g:zip_exec = 1
+endif
 
-# Uncomment this line to check for compilation errors early
-# defcompile
+if !exists('g:gzip_exec')
+  let g:gzip_exec = 1
+endif
+
+if !exists(":def")
+    function dist#vim#IsSafeExecutable(filetype, executable)
+    let cwd = getcwd()
+    return get(g:, a:filetype .. '_exec', get(g:, 'plugin_exec', 0)) &&
+          \ (fnamemodify(exepath(a:executable), ':p:h') !=# cwd
+          \ || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1 &&
+          \  cwd != '.'))
+    endfunction
+else
+    def dist#vim#IsSafeExecutable(filetype: string, executable: string): bool
+      return dist#vim9#IsSafeExecutable(filetype, executable)
+    enddef
+endif

--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -15,16 +15,18 @@ if !exists('g:gzip_exec')
   let g:gzip_exec = 1
 endif
 
-if !exists(":def")
-    function dist#vim#IsSafeExecutable(filetype, executable)
+if !has('vim9script')
+  function dist#vim#IsSafeExecutable(filetype, executable)
     let cwd = getcwd()
     return get(g:, a:filetype .. '_exec', get(g:, 'plugin_exec', 0)) &&
           \ (fnamemodify(exepath(a:executable), ':p:h') !=# cwd
           \ || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1 &&
           \  cwd != '.'))
-    endfunction
-else
-    def dist#vim#IsSafeExecutable(filetype: string, executable: string): bool
-      return dist#vim9#IsSafeExecutable(filetype, executable)
-    enddef
+  endfunction
+
+  finish
 endif
+
+def dist#vim#IsSafeExecutable(filetype: string, executable: string): bool
+  return dist#vim9#IsSafeExecutable(filetype, executable)
+enddef

--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -1,0 +1,17 @@
+vim9script
+
+# Vim runtime support library
+#
+# Maintainer:	The Vim Project <https://github.com/vim/vim>
+# Last Change:	2023 Oct 25
+
+export def IsSafeExecutable(filetype: string, executable: string): bool
+  var cwd = getcwd()
+  return get(g:, filetype .. '_exec', get(g:, 'plugin_exec', 0))
+    && (fnamemodify(exepath(executable), ':p:h') !=# cwd
+        || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1
+            && cwd != '.'))
+enddef
+
+# Uncomment this line to check for compilation errors early
+# defcompile

--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -11,10 +11,7 @@ fun s:check(cmd)
   let name = substitute(a:cmd, '\(\S*\).*', '\1', '')
   if !exists("s:have_" . name)
     " safety check, don't execute anything from the current directory
-    let s:tmp_cwd = getcwd()
-    let f = (fnamemodify(exepath(name), ":p:h") !=# s:tmp_cwd
-          \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
-    unlet s:tmp_cwd
+    let f = dist#vim#IsSafeExecutable('gzip', name)
     if !f
       echoerr "Warning: NOT executing " .. name .. " from current directory!"
     endif

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -57,14 +57,10 @@ if !exists("g:zip_extractcmd")
  let g:zip_extractcmd= g:zip_unzipcmd
 endif
 
-let s:tmp_cwd = getcwd()
-if (fnamemodify(exepath(g:zip_unzipcmd), ":p:h") ==# getcwd()
-          \ && (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) == -1 || s:tmp_cwd == '.'))
- unlet s:tmp_cwd
+if !dist#vim#IsSafeExecutable('zip', g:zip_unzipcmd)
  echoerr "Warning: NOT executing " .. g:zip_unzipcmd .. " from current directory!"
  finish
 endif
-unlet s:tmp_cwd
 
 " ----------------
 "  Functions: {{{1

--- a/runtime/ftplugin/awk.vim
+++ b/runtime/ftplugin/awk.vim
@@ -37,8 +37,8 @@ if exists("g:awk_is_gawk")
     let b:undo_ftplugin .= " | setl fp<"
   endif
 
-  " Disabled by default for security reasons.  
-  if get(g:, 'awk_exec', get(g:, 'plugin_exec', 0))
+  " Disabled by default for security reasons.
+  if dist#vim#IsSafeExecutable('awk', 'gawk')
     let path = system("gawk 'BEGIN { printf ENVIRON[\"AWKPATH\"] }'")
     let path = substitute(path, '^\.\=:\|:\.\=$\|:\.\=:', ',,', 'g') " POSIX cwd
     let path = substitute(path, ':', ',', 'g')

--- a/runtime/ftplugin/changelog.vim
+++ b/runtime/ftplugin/changelog.vim
@@ -57,8 +57,8 @@ if &filetype == 'changelog'
     endif
     let s:default_login = 'unknown'
 
-    " Disabled by default for security reasons.  
-    if get(g:, 'changelog_exec', get(g:, 'plugin_exec', 0))
+    " Disabled by default for security reasons.
+    if dist#vim#IsSafeExecutable('changelog', 'whoami')
       let login = s:login()
     else
       let login = s:default_login

--- a/runtime/ftplugin/perl.vim
+++ b/runtime/ftplugin/perl.vim
@@ -56,12 +56,8 @@ endif
 
 " Set this once, globally.
 if !exists("perlpath")
-    let s:tmp_cwd = getcwd()
     " safety check: don't execute perl binary by default
-    if executable("perl") && get(g:, 'perl_exec', get(g:, 'plugin_exec', 0))
-        \ && (fnamemodify(exepath("perl"), ":p:h") != s:tmp_cwd
-        \ || (index(split($PATH, has("win32") ? ';' : ':'), s:tmp_cwd) != -1
-        \ && s:tmp_cwd != '.'))
+    if dist#vim#IsSafeExecutable('perl', 'perl')
       try
 	if &shellxquote != '"'
 	    let perlpath = system('perl -e "print join(q/,/,@INC)"')
@@ -77,7 +73,6 @@ if !exists("perlpath")
 	" current directory and the directory of the current file.
 	let perlpath = ".,,"
     endif
-    unlet! s:tmp_cwd
 endif
 
 " Append perlpath to the existing path value, if it is set.  Since we don't

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -41,16 +41,13 @@ let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 
 " Safety check: don't execute zig from current directory
 if !exists('g:zig_std_dir') && exists('*json_decode') &&
-    \  executable('zig') && get(g:, 'zig_exec', get(g:, 'plugin_exec', 0))
-    \ && (fnamemodify(exepath("zig"), ":p:h") != s:tmp_cwd
-    \ || (index(split($PATH,has("win32")? ';' : ':'), s:tmp_cwd) != -1 && s:tmp_cwd != '.'))
+    \  executable('zig') && dist#vim#IsSafeExecutable('zig', 'zig')
     silent let s:env = system('zig env')
     if v:shell_error == 0
         let g:zig_std_dir = json_decode(s:env)['std_dir']
     endif
     unlet! s:env
 endif
-unlet! s:tmp_cwd
 
 if exists('g:zig_std_dir')
     let &l:path = g:zig_std_dir . ',' . &l:path


### PR DESCRIPTION
- vim-patch:cd8a3eaf5348
- vim-patch:4f174f0de90b (omit conditional `vim9.vim` file)


We may want to squash-merge these as cd8a3eaf5348 by itself is broken on Neovim?