### PR TITLE
vim-patch:ce3b0136c6d9

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -531,7 +531,7 @@ if exists("b:is_kornshell") || exists("b:is_posix")
 endif
 
 " sh ksh bash : ${var[... ]...}  array reference: {{{1
-syn region  shDerefVarArray   contained	matchgroup=shDeref start="\[" end="]"	contains=@shCommandSubList nextgroup=shDerefOp,shDerefOpError
+syn region  shDerefVarArray   contained	matchgroup=shDeref start="\[" end="]"	contains=@shCommandSubList nextgroup=shDerefOp,shDerefOpError,shDerefOffset
 
 " Special ${parameter OPERATOR word} handling: {{{1
 " sh ksh bash : ${parameter:-word}    word is default value


### PR DESCRIPTION
runtime(sh): Update sh syntax and add shDerefOffset to shDerefVarArray for bash (vim/vim#13480)

Add shDerefOffset to shDerefVarArray.

Example code:

```bash
declare -a a=({a..z})

echo "${a[@]:1:3}"
```

https://github.com/vim/vim/commit/ce3b0136c6d9d09af41969d3dc9634f115505a32

Co-authored-by: Lucien Grondin <grondilu@yahoo.fr>
