### PR TITLE
vim-patch:2f54c13292af

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1798,7 +1798,7 @@ local patterns_text = {
   function(lines)
     if
       -- inaccurate fast match first, then use accurate slow match
-      (lines[1]:find('execve%(') and lines[1]:find('^[0-9:%.]* *execve%('))
+      (lines[1]:find('execve%(') and lines[1]:find('^[0-9:%. ]*execve%('))
       or lines[1]:find('^__libc_start_main')
     then
       return 'strace'


### PR DESCRIPTION
runtime(script.vim): make strace ft check less strict (vim/vim#13482)

Strace output, depending on parameters (-ttf this time), can dump both
times and pid:
  1038  07:14:20.959262 execve("./e.py", ["./e.py"], 0x7ffca1422840 /* 51 vars */) = 0 <0.000150>

So loose the regexp matching this, so that the above is matched too.

Fixes vim/vim#13481.

https://github.com/vim/vim/commit/2f54c13292af053ec00c18e5fded87b1bc602822

Co-authored-by: Jiri Slaby <jirislaby@gmail.com>
Co-authored-by: Jiri Slaby (SUSE) <jirislaby@kernel.org>
