### PR TITLE
vim-patch:9.0.2090: complete_info() skips entries with 'noselect'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2735,7 +2735,8 @@ static int info_add_completion_info(list_T *li)
   // Skip the element with the CP_ORIGINAL_TEXT flag at the beginning, in case of
   // forward completion, or at the end, in case of backward completion.
   match = forward ? match->cp_next
-                  : (compl_no_select ? match->cp_prev : match->cp_prev->cp_prev);
+                  : (compl_no_select && match_at_original_text(match)
+                     ? match->cp_prev : match->cp_prev->cp_prev);
 
   while (match != NULL && !match_at_original_text(match)) {
     dict_T *di = tv_dict_alloc();

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2392,14 +2392,15 @@ func Test_complete_info_index()
   call feedkeys("Go\<C-X>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(-1, g:compl_info['selected'])
 
-  " Check if index out of range
-  " https://github.com/vim/vim/pull/12971
   call feedkeys("Go\<C-X>\<C-N>\<C-P>\<F5>\<Esc>_dd", 'tx')
   call assert_equal(0, g:compl_info['selected'])
   call assert_equal(6 , len(g:compl_info['items']))
   call assert_equal("fff", g:compl_info['items'][g:compl_info['selected']]['word'])
   call feedkeys("Go\<C-X>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<C-N>\<F5>\<Esc>_dd", 'tx')
   call assert_equal("aaa", g:compl_info['items'][g:compl_info['selected']]['word'])
+  call assert_equal(6 , len(g:compl_info['items']))
+  call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>_dd", 'tx')
+  call assert_equal(-1, g:compl_info['selected'])
   call assert_equal(6 , len(g:compl_info['items']))
 
   set completeopt&


### PR DESCRIPTION
#### vim-patch:9.0.2090: complete_info() skips entries with 'noselect'

Problem:  complete_info() skips entries with 'noselect'
Solution: Check, if first entry is at original text state

Unfortunately, Commit daef8c74375141974d61b85199b383017644978c
introduced a regression, that when ':set completeopt+=noselect' is set
and no completion item has been selected yet, it did not fill the
complete_info['items'] list.

This happened, because the current match item did not have the
CP_ORIGINAL_TEXT flag set and then the cp->prev pointer did point to the
original flag item, which caused the following while loop to not being
run but being skipped instead.

So when the 'noselect' is set, only start with to the previous selection
item, if the initial completion item has the CP_ORIGINAL_TEXT flag set,
else use the 2nd previous item instead.

closes: vim/vim#13452

https://github.com/vim/vim/commit/57f9ce1a0977da13e5923214086795ffa2d28ce1

Co-authored-by: Christian Brabandt <cb@256bit.org>