### PR TITLE
ci: work around flaky python3 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,13 @@ jobs:
       - name: Create log dir
         run: mkdir -p "$LOG_DIR"
 
+      # FIXME(dundargoc): this workaround is needed for macos as the python3
+      # provider tests suddenly started to become extremely flaky, and this
+      # removes the flakiness for some reason.
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - if: ${{ matrix.test != 'unittest' }}
         name: Set up interpreter packages
         run: |


### PR DESCRIPTION
Python3 provider tests suddenly became extremely flaky on macos for
unknown reasons. For some reason, installing python with the
setup-python action over using the default python fixes the flakiness.
Use this workaround for the time being to unblock CI while we figure out
the root cause.