### PR TITLE
build(deps): bump libiconv to 1.17

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -41,8 +41,8 @@ WIN32YANK_X86_64_SHA256 247c9a05b94387a884b49d3db13f806b1677dfc38020f955f719be69
 GETTEXT_URL https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.1.tar.gz
 GETTEXT_SHA256 66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c
 
-LIBICONV_URL https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz
-LIBICONV_SHA256 ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
+LIBICONV_URL https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz
+LIBICONV_SHA256 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
 
 TREESITTER_C_URL https://github.com/tree-sitter/tree-sitter-c/archive/v0.20.6.tar.gz
 TREESITTER_C_SHA256 44989072e1a9cd3d8f16e9cc3e726af50de6d3017f1231bdf3303b8cc007424e


### PR DESCRIPTION
new license (LGPL 2.1), adds EBCDIC encodings
