### PR TITLE
build: remove git requirement

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -57,11 +57,6 @@ endif()
 
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
 
-find_package(Git)
-if(NOT Git_FOUND)
-  message(FATAL_ERROR "Git is required to apply patches.")
-endif()
-
 # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
 # fall back to local system version. Needs to be done here and in top-level CMakeLists.txt.
 if(APPLE)


### PR DESCRIPTION
We do not have any patches that we use at the moment, so git is not
needed right now. Futhermore, we've become more strict with not adding
patches, which makes it pretty safe to remove this for the time being.