### PR TITLE
fix(lua): correct return value for on_key with no arguments

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -650,7 +650,7 @@ local on_key_cbs = {}
 ---if on_key() is called without arguments.
 function vim.on_key(fn, ns_id)
   if fn == nil and ns_id == nil then
-    return #on_key_cbs
+    return vim.tbl_count(on_key_cbs)
   end
 
   vim.validate({

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2438,6 +2438,12 @@ describe('lua stdlib', function()
     end)
 
     it('allows removing on_key listeners', function()
+      -- Create some unused namespaces
+      meths.create_namespace('unused1')
+      meths.create_namespace('unused2')
+      meths.create_namespace('unused3')
+      meths.create_namespace('unused4')
+
       insert([[hello world]])
 
       exec_lua [[


### PR DESCRIPTION
For some reason, it uses `#` to get the count in the table `on_key_cbs` even though it is not an array.

This pull simply replaces `#` with `vim.tbl_count` to get the correct count of values in `on_key_cbs`.