### PR TITLE
fix(build): include FindPackageHandleStandardArgs

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DI
 
 include(ExternalProject)
 include(CheckCCompilerFlag)
+include(FindPackageHandleStandardArgs)
 
 include(Deps)
 include(Find)


### PR DESCRIPTION
Building `cmake.deps` with `cmake 3.27.7` fails without this.
I'm not sure if it has anything to do with disabling the bundled luajit.

#### Command

```bash
  cmake -S cmake.deps \
        -B .deps \
        -GNinja \
        -DCMAKE_BUILD_TYPE=Release \
        -DUSE_BUNDLED_LUAJIT=OFF \
        -DUSE_BUNDLED_LIBUV=OFF \
        -DUSE_BUNDLED_TS_PARSERS=OFF
```

#### Error

```
CMake Error at cmake/FindLuajit.cmake:14 (find_package_handle_standard_args):
  Unknown CMake command "find_package_handle_standard_args".
Call Stack (most recent call first):
  cmake/BuildLuv.cmake:13 (find_package)
  CMakeLists.txt:123 (include)
```