### PR TITLE
fix(quickfix): check if delete failed in `qf_fill_buffer()`

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4135,7 +4135,12 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
 
     // delete all existing lines
     while ((curbuf->b_ml.ml_flags & ML_EMPTY) == 0) {
-      (void)ml_delete((linenr_T)1, false);
+      // If deletion fails, this loop may run forever, so
+      // signal error and return.
+      if (ml_delete((linenr_T)1, false) == FAIL) {
+        internal_error("qf_fill_buffer()");
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
This prevents neovim from hanging in the situation described in #25402 (also see https://github.com/neovim/neovim/issues/25402#issuecomment-1766133906).

I'm unsure on how to write a test for this since the reproduction steps require quite a few things, and I haven't found a more minimal example that triggers the same problem.

Fix #25402