### PR TITLE
feat(api): add 'flush' option to nvim_echo

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -760,6 +760,8 @@ nvim_echo({chunks}, {history}, {*opts})                          *nvim_echo()*
                      option if Nvim was invoked with -V3log_file, the message
                      will be redirected to the log_file and suppressed from
                      direct output.
+                   • flush: Flush the message to be displayed immediately in
+                     the UI, without waiting for a redraw
 
 nvim_err_write({str})                                       *nvim_err_write()*
     Writes a message to the Vim error buffer. Does not append "\n", the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -211,6 +211,9 @@ The following new APIs and features were added.
 • A clipboard provider which uses OSC 52 to copy the selection to the system
   clipboard is now bundled by default. |clipboard-osc52|
 
+• Added a "flush" option to |nvim_echo()| to cause messages to be displayed
+  immediately without waiting for a redraw.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1005,6 +1005,8 @@ function vim.api.nvim_del_var(name) end
 ---                  option if Nvim was invoked with -V3log_file, the message
 ---                  will be redirected to the log_file and suppressed from
 ---                  direct output.
+---                • flush: Flush the message to be displayed immediately in
+---                  the UI, without waiting for a redraw
 function vim.api.nvim_echo(chunks, history, opts) end
 
 --- Writes a message to the Vim error buffer. Does not append "\n", the

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -73,6 +73,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.echo_opts
 --- @field verbose? boolean
+--- @field flush? boolean
 
 --- @class vim.api.keyset.eval_statusline
 --- @field winid? integer

--- a/src/nvim/api/keysets.h
+++ b/src/nvim/api/keysets.h
@@ -309,6 +309,7 @@ typedef struct {
 
 typedef struct {
   Boolean verbose;
+  Boolean flush;
 } Dict(echo_opts);
 
 typedef struct {

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -738,6 +738,8 @@ void nvim_set_vvar(String name, Object value, Error *err)
 ///          - verbose: Message was printed as a result of 'verbose' option
 ///            if Nvim was invoked with -V3log_file, the message will be
 ///            redirected to the log_file and suppressed from direct output.
+///          - flush: Flush the message to be displayed immediately in the UI, without waiting for a
+///                   redraw
 void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
   FUNC_API_SINCE(7)
 {
@@ -755,6 +757,10 @@ void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
   if (opts->verbose) {
     verbose_leave();
     verbose_stop();  // flush now
+  }
+
+  if (opts->flush) {
+    ui_flush();
   }
 
   if (history) {


### PR DESCRIPTION
This causes the echoed message to be printed to the UI right away, without waiting for a redraw.

This can be done today by forcing a redraw after each call to `nvim_echo` with `vim.cmd.redraw()`, so maybe this isn't strictly necessary, but in my opinion it is clearer/more straightforward to allow `nvim_echo` to flush itself.

Demo:

Save the following script to `echo.lua`:

```lua
vim.api.nvim_echo({{'A'}}, false, {})

vim.wait(1000)

vim.api.nvim_echo({{'B'}}, false, {})

vim.wait(1000)

vim.api.nvim_echo({{'C'}}, false, {})

vim.wait(1000)

vim.api.nvim_echo({{'D'}}, false, {})
```

Running this without this PR waits for 3 seconds, and then prints:

```
A
B
C
D
```

all at once.

Now modify the script to add `flush = true` to the `opts` table and run it with the changes in this PR. Now, each character appears after 1s.
