### PR TITLE
vim-patch:9.0.2095: statusline may look different than expected

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2521,10 +2521,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	default to single-byte alternatives.
 
 	Example: >
-	    :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
-<	This is similar to the default, except that these characters will also
-	be used when there is highlighting.
-
+	    :set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
+<
 	For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
 	single-byte and multibyte characters are supported.  But double-width
 	characters are not supported.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -550,10 +550,6 @@ Vimscript compatibility:
   `shell_error` does not alias to |v:shell_error|
   `this_session` does not alias to |v:this_session|
 
-UI/Display:
-  'statusline' always uses the "stl" and "stlnc" fields of 'fillchars', even
-  if they are the same and |hl-StatusLine| and |hl-StatusLineNC| are equal.
-
 Working directory (Vim implemented some of these after Nvim):
 - |DirChanged| and |DirChangedPre| can be triggered when switching to another
   window or tab.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2217,10 +2217,8 @@ vim.bo.ft = vim.bo.filetype
 ---
 --- Example:
 --- ```
----     :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
+---     :set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
 --- ```
---- This is similar to the default, except that these characters will also
---- be used when there is highlighting.
 ---
 --- For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
 --- single-byte and multibyte characters are supported.  But double-width

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2851,10 +2851,8 @@ return {
         default to single-byte alternatives.
 
         Example: >
-            :set fillchars=stl:^,stlnc:=,vert:│,fold:·,diff:-
-        <	This is similar to the default, except that these characters will also
-        be used when there is highlighting.
-
+            :set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
+        <
         For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
         single-byte and multibyte characters are supported.  But double-width
         characters are not supported.

--- a/test/old/testdir/test_modeline.vim
+++ b/test/old/testdir/test_modeline.vim
@@ -172,6 +172,8 @@ func Test_modeline_colon()
 endfunc
 
 func s:modeline_fails(what, text, error)
+  " Don't use CheckOption(), it would skip the whole test
+  " just for a single un-supported option
   if !exists('+' .. a:what)
     return
   endif

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -617,4 +617,25 @@ func Test_statusline_showcmd()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_statusline_highlight_group_cleared()
+  CheckScreendump
+
+  " the laststatus option is there to prevent
+  " the code-style test from complaining about
+  " trailing whitespace
+  let lines =<< trim END
+    set fillchars=stl:\ ,stlnc:\  laststatus=2
+    split
+    hi clear StatusLine
+    hi clear StatusLineNC
+  END
+  call writefile(lines, 'XTest_statusline_stl', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_statusline_stl', {})
+
+  call VerifyScreenDump(buf, 'Test_statusline_stl_1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2095: statusline may look different than expected

Problem:  statusline may look different than expected
Solution: do not check for highlighting of stl and stlnc characters

statusline fillchar may be different than expected

If the highlighting group for the statusline for the current window
|hl-StatusLine| or the non-current window |hl-StatusLineNC| are cleared
(or do not differ from each other), than Vim will use the hard-coded
fallback values '^' (for the non-current windows) or '=' (for the
current window).  I believe this was done, to make sure the statusline
will always be visible and be distinguishable from the rest of the
window.

However, this may be unexpected, if a user explicitly defined those
fillchar characters just to notice that those values are then not used
by Vim.

So, let's assume users know what they are doing and just always return
the configured stl and stlnc values.  And if they want the statusline to
be non-distinguishable from the rest of the window space, so be it.  It
is their responsibility and Vim shall not know better what to use.

closes: vim/vim#13488

https://github.com/vim/vim/commit/6a650bf696f1df3214b3d788947447c5bbf1a77d

Co-authored-by: Christian Brabandt <cb@256bit.org>