### PR TITLE
vim-patch:9.0.{1791,1808,1809,1811},ca48202b6f46

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -30,7 +30,7 @@ if [[ $os == Linux ]]; then
   fi
 
   if [[ -n $TEST ]]; then
-    sudo apt-get install -y locales-all cpanminus attr libattr1-dev
+    sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb
   fi
 elif [[ $os == Darwin ]]; then
   brew update --quiet

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -421,6 +421,9 @@ If you want the Asm window shown by default, set the "disasm_window" flag to
 If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_disasm_window = 15
 Any value greater than 1 will set the Asm window height to that value.
+If the current window has enough horizontal space, it will be vertically split
+and the Asm window will be shown side by side with the source code window (and
+the height option won't be used).
 
 						*termdebug_variables_window*
 If you want the Var window shown by default, set the "variables_window" flag
@@ -431,6 +434,9 @@ height: >vim
 If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_variables_window = 15
 Any value greater than 1 will set the Var window height to that value.
+If the current window has enough horizontal space, it will be vertically split
+and the Var window will be shown side by side with the source code window (and
+the height options won't be used).
 
 Communication ~
 						*termdebug-communication*

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -894,7 +894,9 @@ func s:ParseVarinfo(varinfo)
   let nameIdx = matchstrpos(a:varinfo, '{name="\([^"]*\)"')
   let dict['name'] = a:varinfo[nameIdx[1] + 7 : nameIdx[2] - 2]
   let typeIdx = matchstrpos(a:varinfo, ',type="\([^"]*\)"')
-  let dict['type'] = a:varinfo[typeIdx[1] + 7 : typeIdx[2] - 2]
+  " 'type' maybe is a url-like string,
+  " try to shorten it and show only the /tail
+  let dict['type'] = (a:varinfo[typeIdx[1] + 7 : typeIdx[2] - 2])->fnamemodify(':t')
   let valueIdx = matchstrpos(a:varinfo, ',value="\(.*\)"}')
   if valueIdx[1] == -1
     let dict['value'] = 'Complex value'
@@ -1556,8 +1558,15 @@ endfunc
 
 func s:GotoAsmwinOrCreateIt()
   if !win_gotoid(s:asmwin)
+    let mdf = ''
     if win_gotoid(s:sourcewin)
-      exe 'rightbelow new'
+      " 60 is approx spaceBuffer * 3
+      if winwidth(0) > (78 + 60)
+        let mdf = 'vert'
+        exe mdf .. ' ' .. 60 .. 'new'
+      else
+        exe 'rightbelow new'
+      endif
     else
       exe 'new'
     endif
@@ -1579,7 +1588,7 @@ func s:GotoAsmwinOrCreateIt()
       let s:asmbuf = bufnr('Termdebug-asm-listing')
     endif
 
-    if s:GetDisasmWindowHeight() > 0
+    if mdf != 'vert' && s:GetDisasmWindowHeight() > 0
       exe 'resize ' .. s:GetDisasmWindowHeight()
     endif
   endif
@@ -1619,8 +1628,15 @@ endfunc
 
 func s:GotoVariableswinOrCreateIt()
   if !win_gotoid(s:varwin)
+    let mdf = ''
     if win_gotoid(s:sourcewin)
-      exe 'rightbelow new'
+      " 60 is approx spaceBuffer * 3
+      if winwidth(0) > (78 + 60)
+        let mdf = 'vert'
+        exe mdf .. ' ' .. 60 .. 'new'
+      else
+        exe 'rightbelow new'
+      endif
     else
       exe 'new'
     endif
@@ -1641,7 +1657,7 @@ func s:GotoVariableswinOrCreateIt()
       let s:varbuf = bufnr('Termdebug-variables-listing')
     endif
 
-    if s:GetVariablesWindowHeight() > 0
+    if mdf != 'vert' && s:GetVariablesWindowHeight() > 0
       exe 'resize ' .. s:GetVariablesWindowHeight()
     endif
   endif

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -58,6 +58,11 @@ func Ntest_setmouse(row, col)
   endif
 endfunc
 
+" roughly equivalent to term_wait() in Vim
+func Nterm_wait(buf, time = 10)
+  execute $'sleep {a:time}m'
+endfunc
+
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -9,12 +9,12 @@ CheckExecutable gcc
 
 let g:GDB = exepath('gdb')
 if g:GDB->empty()
-  throw 'Skpped: gdb is not found in $PATH'
+  throw 'Skipped: gdb is not found in $PATH'
 endif
 
 let g:GCC = exepath('gcc')
 if g:GCC->empty()
-  throw 'Skpped: gcc is not found in $PATH'
+  throw 'Skipped: gcc is not found in $PATH'
 endif
 
 packadd termdebug

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -1,0 +1,91 @@
+" Test for the termdebug plugin
+
+source check.vim
+
+CheckUnix
+" CheckFeature terminal
+CheckExecutable gdb
+CheckExecutable gcc
+
+let g:GDB = exepath('gdb')
+if g:GDB->empty()
+  throw 'Skpped: gdb is not found in $PATH'
+endif
+
+let g:GCC = exepath('gcc')
+if g:GCC->empty()
+  throw 'Skpped: gcc is not found in $PATH'
+endif
+
+packadd termdebug
+
+func Test_termdebug_basic()
+  let lines =<< trim END
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int isprime(int n)
+    {
+      if (n <= 1)
+        return 0;
+
+      for (int i = 2; i <= n / 2; i++)
+        if (n % i == 0)
+          return 0;
+
+      return 1;
+    }
+
+    int main(int argc, char *argv[])
+    {
+      int n = 7;
+
+      printf("%d is %s prime\n", n, isprime(n) ? "a" : "not a");
+
+      return 0;
+    }
+  END
+  call writefile(lines, 'XTD_basic.c', 'D')
+  call system($'{g:GCC} -g -o XTD_basic XTD_basic.c')
+
+  edit XTD_basic.c
+  Termdebug ./XTD_basic
+  call assert_equal(3, winnr('$'))
+  let gdb_buf = winbufnr(1)
+  wincmd b
+  Break 9
+  call Nterm_wait(gdb_buf)
+  redraw!
+  call assert_equal([
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+  Run
+  call Nterm_wait(gdb_buf, 200)
+  redraw!
+  call assert_equal([
+        \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,
+        \  'group': 'TermDebug'},
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+  Finish
+  call Nterm_wait(gdb_buf)
+  redraw!
+  call assert_equal([
+        \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
+        \  'priority': 110, 'group': 'TermDebug'},
+        \ {'lnum': 20, 'id': 12, 'name': 'debugPC',
+        \  'priority': 110, 'group': 'TermDebug'}],
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+  Continue
+  wincmd t
+  quit!
+  redraw!
+  call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+
+  call delete('XTD_basic')
+  %bw!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -1,5 +1,6 @@
 " Test for the termdebug plugin
 
+source shared.vim
 source check.vim
 
 CheckUnix
@@ -50,7 +51,7 @@ func Test_termdebug_basic()
 
   edit XTD_basic.c
   Termdebug ./XTD_basic
-  call assert_equal(3, winnr('$'))
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
   let gdb_buf = winbufnr(1)
   wincmd b
   Break 9
@@ -63,21 +64,22 @@ func Test_termdebug_basic()
   Run
   call Nterm_wait(gdb_buf, 400)
   redraw!
-  call assert_equal([
+  call WaitForAssert({-> assert_equal([
         \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,
         \  'group': 'TermDebug'},
         \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+        "\ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs->reverse())})
   Finish
   call Nterm_wait(gdb_buf)
   redraw!
-  call assert_equal([
+  call WaitForAssert({-> assert_equal([
         \ {'lnum': 9, 'id': 1014, 'name': 'debugBreakpoint1.0',
         \  'priority': 110, 'group': 'TermDebug'},
         \ {'lnum': 20, 'id': 12, 'name': 'debugPC',
         \  'priority': 110, 'group': 'TermDebug'}],
-        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+        \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
   Continue
   wincmd t
   quit!

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -81,6 +81,34 @@ func Test_termdebug_basic()
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
   Continue
+
+  let cn = 0
+  " 60 is approx spaceBuffer * 3
+  if winwidth(0) <= 78 + 60
+    Var
+    call assert_equal(winnr(), winnr('$'))
+    call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['leaf', 1000], ['leaf', 1003 + cn]]])
+    let cn += 1
+    bw!
+    Asm
+    call assert_equal(winnr(), winnr('$'))
+    call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['leaf', 1000], ['leaf', 1003 + cn]]])
+    let cn += 1
+    bw!
+  endif
+  set columns=160
+  Var
+  call assert_equal(winnr(), winnr('$') - 1)
+  call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
+  let cn += 1
+  bw!
+  Asm
+  call assert_equal(winnr(), winnr('$') - 1)
+  call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
+  let cn += 1
+  bw!
+  set columns&
+
   wincmd t
   quit!
   redraw!

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -61,7 +61,7 @@ func Test_termdebug_basic()
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)
   Run
-  call Nterm_wait(gdb_buf, 200)
+  call Nterm_wait(gdb_buf, 400)
   redraw!
   call assert_equal([
         \ {'lnum': 9, 'id': 12, 'name': 'debugPC', 'priority': 110,


### PR DESCRIPTION
#### vim-patch:9.0.1791: No tests for the termdebug plugin

Problem:  No tests for the termdebug plugin
Solution: Add some simple tests for the termdebug plugin

closes: vim/vim#12927

https://github.com/vim/vim/commit/58f39d89a8adff51ab04893d1fd28e3767979f9f

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.1808: termdebug: Typo in termdebug test

Problem:  termdebug: Typo in termdebug test
Solution: fix the typos

https://github.com/vim/vim/commit/f2534434c99a2b0cea08b238df24979b3fdc9212

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1809: termdebug test flayk

Problem:  termdebug test flayk
Solution: wait slightly longer

https://github.com/vim/vim/commit/6c93c949298c1a6cb294a09b10d690cae357a8bf

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1811: still some issues with term_debug test

Problem:  still some issues with term_debug test
Solution: Use WaitForAssert()

closes: vim/vim#12936

https://github.com/vim/vim/commit/85c3a5bc265393c1b8b93d8b88b936d3b8b4aec7

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:ca48202b6f46

runtime(termdebug): improve window handling, shorten var types

closes vim/vim#13474

https://github.com/vim/vim/commit/ca48202b6f46cfb40a0d1d80033a2f3e8cb7b813

Co-authored-by: shane.xb.qian <shane.qian@foxmail.com>