### PR TITLE
vim-patch:7fbbd7fdc6df

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -399,18 +399,22 @@ Prompt mode can be used with: >vim
 If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_use_prompt = 1
 <
-						*termdebug_map_K*
-The K key is normally mapped to |:Evaluate|. If you do not want this use: >vim
+Mappings ~
+					*termdebug_map_K* *termdebug-mappings*
+The K key is normally mapped to |:Evaluate| unless there already exists a
+buffer local mapping to K |:map-local|.  If you do not want this use: >vim
 	let g:termdebug_config['map_K'] = 0
 If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_map_K = 0
 <
 						*termdebug_map_minus*
-The - key is normally mapped to |:Down|. If you do not want this use: >vim
+The - key is normally mapped to |:Down| unless there already exists a buffer
+local mapping to the - key.  If you do not want this use: >vim
 	let g:termdebug_config['map_minus'] = 0
 <
 						*termdebug_map_plus*
-The + key is normally mapped to |:Up|. If you do not want this use: >vim
+The + key is normally mapped to |:Up| unless there already exists a buffer
+local mapping to the + key.  If you do not want this use: >vim
 	let g:termdebug_config['map_plus'] = 0
 <
 						*termdebug_disasm_window*

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2023 Aug 23
+" Last Change: 2023 Nov 02
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -1024,7 +1024,9 @@ func s:InstallCommands()
   endif
   if map
     let s:k_map_saved = maparg('K', 'n', 0, 1)
-    nnoremap K :Evaluate<CR>
+    if !empty(s:k_map_saved) && !s:k_map_saved.buffer || empty(s:k_map_saved)
+      nnoremap K :Evaluate<CR>
+    endif
   endif
 
   let map = 1
@@ -1033,7 +1035,9 @@ func s:InstallCommands()
   endif
   if map
     let s:plus_map_saved = maparg('+', 'n', 0, 1)
-    nnoremap <expr> + $'<Cmd>{v:count1}Up<CR>'
+    if !empty(s:plus_map_saved) && !s:plus_map_saved.buffer || empty(s:plus_map_saved)
+      nnoremap <expr> + $'<Cmd>{v:count1}Up<CR>'
+    endif
   endif
 
   let map = 1
@@ -1042,7 +1046,9 @@ func s:InstallCommands()
   endif
   if map
     let s:minus_map_saved = maparg('-', 'n', 0, 1)
-    nnoremap <expr> - $'<Cmd>{v:count1}Down<CR>'
+    if !empty(s:minus_map_saved) && !s:minus_map_saved.buffer || empty(s:minus_map_saved)
+      nnoremap <expr> - $'<Cmd>{v:count1}Down<CR>'
+    endif
   endif
 
 
@@ -1108,29 +1114,32 @@ func s:DeleteCommands()
   delcommand Winbar
 
   if exists('s:k_map_saved')
-    if empty(s:k_map_saved)
+    if !empty(s:k_map_saved) && !s:k_map_saved.buffer
       nunmap K
-    else
       " call mapset(s:k_map_saved)
       call mapset('n', 0, s:k_map_saved)
+    elseif empty(s:k_map_saved)
+      nunmap K
     endif
     unlet s:k_map_saved
   endif
   if exists('s:plus_map_saved')
-    if empty(s:plus_map_saved)
+    if !empty(s:plus_map_saved) && !s:plus_map_saved.buffer
       nunmap +
-    else
       " call mapset(s:plus_map_saved)
       call mapset('n', 0, s:plus_map_saved)
+    elseif empty(s:plus_map_saved)
+      nunmap +
     endif
     unlet s:plus_map_saved
   endif
   if exists('s:minus_map_saved')
-    if empty(s:minus_map_saved)
+    if !empty(s:minus_map_saved) && !s:minus_map_saved.buffer
       nunmap -
-    else
       " call mapset(s:minus_map_saved)
       call mapset('n', 0, s:minus_map_saved)
+    elseif empty(s:minus_map_saved)
+      nunmap -
     endif
     unlet s:minus_map_saved
   endif
@@ -1926,3 +1935,5 @@ call s:InitAutocmd()
 
 let &cpo = s:keepcpo
 unlet s:keepcpo
+
+" vim: sw=2 sts=2 et

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -110,11 +110,87 @@ func Test_termdebug_basic()
   set columns&
 
   wincmd t
+  " Nvim: stop GDB process and process pending events
+  call chanclose(&channel)
+  call wait(0, '0')
   quit!
   redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
   call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
 
   call delete('XTD_basic')
+  %bw!
+endfunc
+
+func Test_termdebug_mapping()
+  %bw!
+  call assert_equal(maparg('K', 'n', 0, 1)->empty(), 1)
+  call assert_equal(maparg('-', 'n', 0, 1)->empty(), 1)
+  call assert_equal(maparg('+', 'n', 0, 1)->empty(), 1)
+  Termdebug
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  wincmd b
+  call assert_equal(maparg('K', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('-', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('+', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('K', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('-', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('+', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('K', 'n', 0, 1).rhs, ':Evaluate<CR>')
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+  call assert_equal(maparg('K', 'n', 0, 1)->empty(), 1)
+  call assert_equal(maparg('-', 'n', 0, 1)->empty(), 1)
+  call assert_equal(maparg('+', 'n', 0, 1)->empty(), 1)
+
+  %bw!
+  nnoremap K :echom "K"<cr>
+  nnoremap - :echom "-"<cr>
+  nnoremap + :echom "+"<cr>
+  Termdebug
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  wincmd b
+  call assert_equal(maparg('K', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('-', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('+', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('K', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('-', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('+', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('K', 'n', 0, 1).rhs, ':Evaluate<CR>')
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+  call assert_equal(maparg('K', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('-', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('+', 'n', 0, 1)->empty(), 0)
+  call assert_equal(maparg('K', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('-', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('+', 'n', 0, 1).buffer, 0)
+  call assert_equal(maparg('K', 'n', 0, 1).rhs, ':echom "K"<cr>')
+
+  %bw!
+  nnoremap <buffer> K :echom "bK"<cr>
+  nnoremap <buffer> - :echom "b-"<cr>
+  nnoremap <buffer> + :echom "b+"<cr>
+  Termdebug
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  wincmd b
+  call assert_equal(maparg('K', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('-', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('+', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('K', 'n', 0, 1).rhs, ':echom "bK"<cr>')
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+  call assert_equal(maparg('K', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('-', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('+', 'n', 0, 1).buffer, 1)
+  call assert_equal(maparg('K', 'n', 0, 1).rhs, ':echom "bK"<cr>')
+
   %bw!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:7fbbd7fdc6df

runtime(termdebug):  handle buffer-local mappings properly

closes: vim/vim#13475

https://github.com/vim/vim/commit/7fbbd7fdc6df9dc198b3735cfbe8dbe8afd646f9

Co-authored-by: shane.xb.qian <shane.qian@foxmail.com>