### PR TITLE
refactor(drawline): avoid xmalloc/xfree cycles on each screenline

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -17,6 +17,7 @@
 #include "nvim/buffer_updates.h"
 #include "nvim/context.h"
 #include "nvim/decoration_provider.h"
+#include "nvim/drawline.h"
 #include "nvim/eval.h"
 #include "nvim/gettext.h"
 #include "nvim/globals.h"
@@ -818,6 +819,7 @@ void free_all_mem(void)
   check_quickfix_busy();
 
   decor_free_all_mem();
+  drawline_free_all_mem();
 
   ui_free_all_mem();
   nlua_free_all_mem();


### PR DESCRIPTION
not a big deal but the malloc theft police doesn't like that we do xmalloc/xfree for random stuff in `win_line()`. A `xfree()` still remains for API generated fold text.