### PR TITLE
PVS fixes

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -383,7 +383,7 @@ run_analysis() {(
       --sourcetree-root . || true
 
   rm -rf PVS-studio.{xml,err,tsk,html.d}
-  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V002,V011,V1028,V1042,V1051,V1074"
+  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V002,V011,V601,V1028,V1042,V1051,V1074"
   plog-converter $plog_args --renderTypes xml       --output PVS-studio.xml
   plog-converter $plog_args --renderTypes errorfile --output PVS-studio.err
   plog-converter $plog_args --renderTypes tasklist  --output PVS-studio.tsk

--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -374,6 +374,8 @@ run_analysis() {(
       --lic-file PVS-Studio.lic \
       --threads "$(get_jobs_num)" \
       --exclude-path src/cjson \
+      --exclude-path src/klib \
+      --exclude-path src/mpack \
       --exclude-path src/xdiff \
       --exclude-path build \
       --output-file PVS-studio.log \

--- a/src/nvim/base64.c
+++ b/src/nvim/base64.c
@@ -1,3 +1,6 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -169,10 +169,8 @@ static void wildescape(expand_T *xp, const char *str, int numfiles, char **files
       } else if (xp->xp_backslash & XP_BS_COMMA) {
         if (vim_strchr(files[i], ',') != NULL) {
           p = vim_strsave_escaped(files[i], ",");
-          if (p != NULL) {
-            xfree(files[i]);
-            files[i] = p;
-          }
+          xfree(files[i]);
+          files[i] = p;
         }
       }
 #ifdef BACKSLASH_IN_FILENAME

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -259,7 +259,7 @@ void terminal_open(Terminal **termpp, buf_T *buf, TerminalOptions opts)
 
   aucmd_restbuf(&aco);
 
-  if (*termpp == NULL) {
+  if (*termpp == NULL) {  // -V547
     return;  // Terminal has already been destroyed.
   }
 


### PR DESCRIPTION
- build(PVS): exclude mpack and klib as they are external dependencies

- build(PVS): suppress warning V601

See https://pvs-studio.com/en/docs/warnings/v601/

- fix(PVS/V009): add top-level message

- fix(PVS/V547): expression 'p != NULL' is always true

- fix(PVS/V547): expression '* termpp == NULL' is always false