### PR TITLE
vim-patch:8.2.4078: terminal test for current directory not used on FreeBSD

### DIFF
--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -1051,7 +1051,6 @@ func Test_map_cmdkey()
     call assert_equal('t', m)
     call assert_equal('t', mode(1))
     call StopShellInTerminal(buf)
-    call TermWait(buf)
     close!
     tunmap <F3>
   endif


### PR DESCRIPTION
#### vim-patch:8.2.4078: terminal test for current directory not used on FreeBSD

Problem:    Terminal test for current directory not used on FreeBSD.
Solution:   Make it work on FreeBSD. (Ozaki Kiichi, closes vim/vim#9516) Add
            TermWait() inside Run_shell_in_terminal() as a generic solution.

https://github.com/vim/vim/commit/ced2b38a560cc4f4ec983ed2cf4372ab62e1dbc1

Co-authored-by: Bram Moolenaar <Bram@vim.org>