### PR TITLE
fix(completion): make sure the buffer name is valid

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3334,7 +3334,7 @@ static bool get_next_completion_match(int type, ins_compl_next_state_T *st, pos_
 static void get_next_bufname_token(void)
 {
   FOR_ALL_BUFFERS(b) {
-    if (b->b_p_bl) {
+    if (b->b_p_bl && b->b_sfname != NULL) {
       char *start = get_past_head(b->b_sfname);
       char *current = start;
       char *p = (char *)path_next_component(start);

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1237,7 +1237,7 @@ describe('completion', function()
       bufname = 'C:\\foo\\bar.txt'
       hidden = 'C:\\fooA\\.hidden'
     end
-    command('set complete+=f | edit '.. bufname ..' | edit '..hidden)
+    command('set complete+=f | edit '..bufname..' | edit '..hidden..' | enew')
     feed('i<C-n>')
 
     screen:expect{grid=[[


### PR DESCRIPTION
Problem:
crash from
  set complete+=f
  open a empty buffer
  C-N

Solution:
make sure the buffer name is valid.

regression from ae4ca4edf89ece433b61e8bf92c412298b58d9ea