### PR TITLE
fix(context): don't crash on invalid arg to nvim_load_context

### DIFF
--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -261,7 +261,9 @@ Object vim_to_object(typval_T *obj)
 /// @param obj  Object to convert from.
 /// @param tv   Conversion result is placed here. On failure member v_type is
 ///             set to VAR_UNKNOWN (no allocation was made for this variable).
-/// returns     true if conversion is successful, otherwise false.
+/// @param err  Error object.
+///
+/// @returns    true if conversion is successful, otherwise false.
 bool object_to_vim(Object obj, typval_T *tv, Error *err)
 {
   tv->v_type = VAR_UNKNOWN;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1402,7 +1402,7 @@ Dictionary nvim_get_context(Dict(context) *opts, Error *err)
 /// Sets the current editor state from the given |context| map.
 ///
 /// @param  dict  |Context| map.
-Object nvim_load_context(Dictionary dict)
+Object nvim_load_context(Dictionary dict, Error *err)
   FUNC_API_SINCE(6)
 {
   Context ctx = CONTEXT_INIT;
@@ -1410,8 +1410,8 @@ Object nvim_load_context(Dictionary dict)
   int save_did_emsg = did_emsg;
   did_emsg = false;
 
-  ctx_from_dict(dict, &ctx);
-  if (!did_emsg) {
+  ctx_from_dict(dict, &ctx, err);
+  if (!ERROR_SET(err)) {
     ctx_restore(&ctx, kCtxAll);
   }
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -224,6 +224,7 @@ void channel_create_event(Channel *chan, const char *ext_source)
   // TODO(bfredl): do the conversion in one step. Also would be nice
   // to pretty print top level dict in defined order
   (void)object_to_vim(DICTIONARY_OBJ(info), &tv, NULL);
+  assert(tv.v_type == VAR_DICT);
   char *str = encode_tv2json(&tv, NULL);
   ILOG("new channel %" PRIu64 " (%s) : %s", chan->id, source, str);
   xfree(str);
@@ -849,6 +850,7 @@ static void set_info_event(void **argv)
   Dictionary info = channel_info(chan->id);
   typval_T retval;
   (void)object_to_vim(DICTIONARY_OBJ(info), &retval, NULL);
+  assert(retval.v_type == VAR_DICT);
   tv_dict_add_dict(dict, S_LEN("info"), retval.vval.v_dict);
   tv_dict_set_keys_readonly(dict);
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1979,6 +1979,13 @@ describe('API', function()
       nvim('load_context', ctx)
       eq({1, 2 ,3}, eval('[g:one, g:Two, g:THREE]'))
     end)
+
+    it('errors when context dictionary is invalid', function()
+      eq('E474: Failed to convert list to msgpack string buffer',
+         pcall_err(nvim, 'load_context', { regs = { {} } }))
+      eq("Empty dictionary keys aren't allowed",
+         pcall_err(nvim, 'load_context', { regs = { { [''] = '' } } }))
+    end)
   end)
 
   describe('nvim_replace_termcodes', function()

--- a/test/functional/vimscript/ctx_functions_spec.lua
+++ b/test/functional/vimscript/ctx_functions_spec.lua
@@ -375,6 +375,12 @@ describe('context functions', function()
       eq(outofbounds, pcall_err(call, 'ctxset', {dummy = 1}, 0))
     end)
 
+    it('errors when context dictionary is invalid', function()
+      call('ctxpush')
+      eq('Vim:E474: Failed to convert list to msgpack string buffer',
+         pcall_err(call, 'ctxset', { regs = { {} } }))
+    end)
+
     it('sets context dictionary at index in context stack', function()
       nvim('set_var', 'one', 1)
       nvim('set_var', 'Two', 2)


### PR DESCRIPTION
Note: The crash happens in the second test case when using uninitialized
memory, and therefore doesn't happen with ASAN.
