### PR TITLE
ci: skip api-doc workflow on draft PRs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -2,6 +2,7 @@
 name: Autogenerate API docs and types
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/nvim/api/*.[ch]'
       - 'src/nvim/eval.lua'
@@ -11,6 +12,7 @@ on:
 jobs:
   regen-api-docs-and-types:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Checking the documentation generation is mostly useful towards the end
of a pull request like with the lintcommit workflow.
