### PR TITLE
vim-patch:9.0.2097: No support for cypher files

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -333,6 +333,7 @@ local extension = {
   pld = 'cupl',
   si = 'cuplsim',
   cyn = 'cynpp',
+  cypher = 'cypher',
   dart = 'dart',
   drt = 'dart',
   ds = 'datascript',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -176,6 +176,7 @@ func s:GetFilenameChecks() abort
     \ 'cvs': ['cvs123'],
     \ 'cvsrc': ['.cvsrc'],
     \ 'cynpp': ['file.cyn'],
+    \ 'cypher': ['file.cypher'],
     \ 'd': ['file.d'],
     \ 'dart': ['file.dart', 'file.drt'],
     \ 'datascript': ['file.ds'],


### PR DESCRIPTION
Problem:  No support for cypher files
Solution: Add cypher filetype detection

Cypher query language support to work with (mostly) graph databases.

Already existing lsp support in Neovim's nvim-lspconfig:
https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cypher_ls

closes: vim/vim#13516

https://github.com/vim/vim/commit/8f0fe20ff1a13b468fdfaf85c434475f75c7a615

Co-authored-by: Gerrit Meier <meistermeier@gmail.com>
