### PR TITLE
vim-patch:1b08d2cd0789

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2774,8 +2774,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'formatoptions' 'fo'	string	(default "tcqj")
 			local to buffer
 	This is a sequence of letters which describes how automatic
-	formatting is to be done.  See |fo-table|.  Commas can be inserted for
-	readability.
+	formatting is to be done.
+	See |fo-table| for possible values and |gq| for how to format text.
+	Commas can be inserted for readability.
 	To avoid problems with flags that are added in the future, use the
 	"+=" and "-=" feature of ":set" |add-option-flags|.
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2528,8 +2528,9 @@ vim.bo.formatlistpat = vim.o.formatlistpat
 vim.bo.flp = vim.bo.formatlistpat
 
 --- This is a sequence of letters which describes how automatic
---- formatting is to be done.  See `fo-table`.  Commas can be inserted for
---- readability.
+--- formatting is to be done.
+--- See `fo-table` for possible values and `gq` for how to format text.
+--- Commas can be inserted for readability.
 --- To avoid problems with flags that are added in the future, use the
 --- "+=" and "-=" feature of ":set" `add-option-flags`.
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3246,8 +3246,9 @@ return {
       defaults = { if_true = macros('DFLT_FO_VIM') },
       desc = [=[
         This is a sequence of letters which describes how automatic
-        formatting is to be done.  See |fo-table|.  Commas can be inserted for
-        readability.
+        formatting is to be done.
+        See |fo-table| for possible values and |gq| for how to format text.
+        Commas can be inserted for readability.
         To avoid problems with flags that are added in the future, use the
         "+=" and "-=" feature of ":set" |add-option-flags|.
       ]=],


### PR DESCRIPTION
#### vim-patch:1b08d2cd0789

runtime(doc): clarify when formatoptions applies

https://github.com/vim/vim/commit/1b08d2cd0789fd9aaae148a64ff46342730022d7

Co-authored-by: Christian Brabandt <cb@256bit.org>