### PR TITLE
vim-patch:9.0.2100: CI: test_termdebug fails

### DIFF
--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -940,7 +940,7 @@ void format_lines(linenr_T line_count, bool avoid_fex)
   // length of a line to force formatting: 3 * 'tw'
   const int max_len = comp_textwidth(true) * 3;
 
-  // check for 'q', '2' and '1' in 'formatoptions'
+  // check for 'q', '2', 'n' and 'w' in 'formatoptions'
   const bool do_comments = has_format_option(FO_Q_COMS);  // format comments
   int do_comments_list = 0;  // format comments with 'n' or '2'
   const bool do_second_indent = has_format_option(FO_Q_SECOND);

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -97,16 +97,22 @@ func Test_termdebug_basic()
     bw!
   endif
   set columns=160
+  let winw = winwidth(0)
   Var
-  call assert_equal(winnr(), winnr('$') - 1)
-  call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
-  let cn += 1
-  bw!
+  if winwidth(0) < winw
+    call assert_equal(winnr(), winnr('$') - 1)
+    call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
+    let cn += 1
+    bw!
+  endif
+  let winw = winwidth(0)
   Asm
-  call assert_equal(winnr(), winnr('$') - 1)
-  call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
-  let cn += 1
-  bw!
+  if winwidth(0) < winw
+    call assert_equal(winnr(), winnr('$') - 1)
+    call assert_equal(winlayout(), ['col', [['leaf', 1002], ['leaf', 1001], ['row', [['leaf', 1003 + cn], ['leaf', 1000]]]]])
+    let cn += 1
+    bw!
+  endif
   set columns&
 
   wincmd t


### PR DESCRIPTION
#### vim-patch:9.0.2100: CI: test_termdebug fails

Problem:  CI: test_termdebug fails
Solution: only test for a changed winlayout, if the window
          width actually changed

Also, include an unrelated comment (which doesn't warrant its own patch
number)

https://github.com/vim/vim/commit/305127f9f2f6058b4ec071041a2c98f76114a9b0

Co-authored-by: Christian Brabandt <cb@256bit.org>