### PR TITLE
vim-patch:9.0.2101: CI: test_termdebug may still fail

### DIFF
--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -97,6 +97,7 @@ func Test_termdebug_basic()
     bw!
   endif
   set columns=160
+  call Nterm_wait(gdb_buf)
   let winw = winwidth(0)
   Var
   if winwidth(0) < winw
@@ -114,11 +115,9 @@ func Test_termdebug_basic()
     bw!
   endif
   set columns&
+  call Nterm_wait(gdb_buf)
 
   wincmd t
-  " Nvim: stop GDB process and process pending events
-  call chanclose(&channel)
-  call wait(0, '0')
   quit!
   redraw!
   call WaitForAssert({-> assert_equal(1, winnr('$'))})


### PR DESCRIPTION
#### vim-patch:9.0.2101: CI: test_termdebug may still fail

Problem:  CI: test_termdebug may still fail
Solution: use term_wait() to make it more robust

closes: vim/vim#13529

https://github.com/vim/vim/commit/fdbadea4b60e5e1a0bf192dc5ee04d8ab06f4399

Co-authored-by: shane.xb.qian <shane.qian@foxmail.com>