### PR TITLE
vim-patch: mark N/A 8.1 patches

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -218,11 +218,12 @@ preprocess_patch() {
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/src/testdir/\<\%('"${na_src_testdir}"'\)\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
 
   # Remove testdir/test_*.vim files
-  local na_src_testdir='balloon.*\|behave\.vim\|channel.*\|crypt\.vim\|cscope\.vim\|gui.*\|hardcopy\.vim\|job_fails\.vim\|json\.vim\|mzscheme\.vim\|netbeans.*\|paste\.vim\|popupwin.*\|python2\.vim\|pyx2\.vim\|restricted\.vim\|shortpathname\.vim\|tcl\.vim\|terminal.*\|xxd\.vim'
+  local na_src_testdir='balloon.*\|behave\.vim\|channel.*\|crypt\.vim\|cscope\.vim\|gui.*\|hardcopy\.vim\|job_fails\.vim\|json\.vim\|listener\.vim\|mzscheme\.vim\|netbeans.*\|paste\.vim\|popupwin.*\|python2\.vim\|pyx2\.vim\|restricted\.vim\|shortpathname\.vim\|sound\.vim\|tcl\.vim\|terminal.*\|xxd\.vim'
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/src/testdir/\<test_\%('"${na_src_testdir}"'\)\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
 
-  # Remove version.c #7555
-  2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/src/\<\%(version\.c\)\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
+  # Remove N/A src/*.[ch] files: sound.c, version.c
+  local na_src_c='sound\|version'
+  2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/src/\<\%('"${na_src_c}"'\)\.[ch]\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
 
   # Remove some *.po files. #5622
   local na_po='sjiscorr\.c\|ja\.sjis\.po\|ko\.po\|pl\.cp1250\.po\|pl\.po\|ru\.cp1251\.po\|uk\.cp1251\.po\|zh_CN\.cp936\.po\|zh_CN\.po\|zh_TW\.po'

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2433,7 +2433,7 @@ static const int included_patches[] = {
   52,
   51,
   // 50,
-  // 49,
+  49,
   48,
   47,
   46,


### PR DESCRIPTION
# Problem:
Numerous Vim 8.1 patches are listed by `vim-patch.sh -l`.

# Solution:
Mark the following patches as N/A:

N/A various:
- obviated by $NVIM env var:
    - [vim-patch:8.1.0049](https://github.com/vim/vim/commit/d7a137fb0d980545dd567bee9c24cf7b9c3a2eae) shell cannot tell running in a terminal window
    - [vim-patch:8.1.0050](https://github.com/vim/vim/commit/493359eb3b10377d5c3524e91d911809b8ac7a76) $VIM_TERMINAL is also set when not in a terminal window
- Nvim handles STOP signal via libuv:
    - [vim-patch:8.1.0304](https://github.com/vim/vim/commit/2e31048c304fb94d6255667783edfe9f4d5894c2) no redraw when using a STOP signal on Vim and then CONT
    - [vim-patch:8.1.0312](https://github.com/vim/vim/commit/8e82c057ffb86cec3210ad8a22ad3f21d52e0953) wrong type for flags used in signal handlers
- [vim-patch:8.1.0072](https://github.com/vim/vim/commit/dcdeaaf1505b96aa7a31ccd4becc92c32119bdda) use of 'termwinkey' is inconsistent
    - 'termwinkey' is not supported by Nvim:
- [vim-patch:8.1.0367](https://github.com/vim/vim/commit/84d9390480548c8d711dd772cb162a91d0bb3c30) getchar(1) no longer processes pending messages
    - Nvim does not have `parse_queued_messages`:
- [vim-patch:8.1.1396](https://github.com/vim/vim/commit/193ffd1d9f4f4d5412ce8d7a46bb2f89d47a56da) 'wincolor' does not apply to lines below the buffer
- [vim-patch:8.1.1502](https://github.com/vim/vim/commit/427f5b66ce0abe19daed9291b1693f6e8aae6552) cannot play any sound
- [vim-patch:8.1.1515](https://github.com/vim/vim/commit/82febc16e4ed54b5af0ff503b02b9fd1af75711b) memory leak reported for sound when build with EXITFREE
- N/A platform patches:
    - [vim-patch:8.1.1103](https://github.com/vim/vim/commit/0eb035c974c47e65d32439b48e5a056b370ad429) MS-Windows: old API calls are no longer needed
- N/A Lua patches:
    - [vim-patch:8.1.1019](https://github.com/vim/vim/commit/4eefe47ea4b6bf958617e924f52bc7a409cfb0ed) Lua: may garbage collect function reference in use


Nvim has extmarks instead of textprops:
- [vim-patch:8.1.0579](https://github.com/vim/vim/commit/98aefe7c3250bb5d4153b994f878594d1745424e) cannot attach properties to text
- [vim-patch:8.1.0582](https://github.com/vim/vim/commit/fb95e212a2696e5b1c8b5e6b2984af59fa7ead6f) text properties are not enabled
- [vim-patch:8.1.0634](https://github.com/vim/vim/commit/e3d31b02a56710e64ef0c1eb6ac5afcc57cb4890) text properties cannot cross line boundaries
- [vim-patch:8.1.0638](https://github.com/vim/vim/commit/48f88ac85be8446a42a03cec45264eac21f9eba8) text property highlighting is off by one column
- [vim-patch:8.1.0639](https://github.com/vim/vim/commit/8cf734e024af56707a1165bcdfee42364695ec8e) text properties test fails on MS-Windows
- [vim-patch:8.1.0643](https://github.com/vim/vim/commit/00b1e041654e8a38fb6b81218a037e1dc94e0943) computing byte offset wrong
- [vim-patch:8.1.0654](https://github.com/vim/vim/commit/c1a9bc1a7284bd0e60f9bddfef6a4ee733bfc838) when deleting a line text property flags are not adjusted
- [vim-patch:8.1.0655](https://github.com/vim/vim/commit/b56ac049ea6ca77a0a9b0a415bac5e82ae60b842) when appending a line text property flags are not added
- [vim-patch:8.1.0663](https://github.com/vim/vim/commit/8caa10a8ec6e398fd67c30b8a2bf20638d3c6c0a) text property display wrong when 'number' is set
- [vim-patch:8.1.0665](https://github.com/vim/vim/commit/c6d86dccc4edff8627e309fb23dc8f810ef36b28) text property display wrong when 'spell' is set
- [vim-patch:8.1.0667](https://github.com/vim/vim/commit/2f21fa8743404289f1410ba49dd711a622f45d81) textprop test leaves file behind
- [vim-patch:8.1.0675](https://github.com/vim/vim/commit/b9c67a51c15481d9257e5c26581d17780e9808d5) text property column in screen columns is not practical
- [vim-patch:8.1.0676](https://github.com/vim/vim/commit/5e53ac00a2a3ead7b52ef56c61ccce823186bd2f) textprop screendump test fails
- [vim-patch:8.1.0681](https://github.com/vim/vim/commit/33c8ca923ed6d5638fa98afabb2e25b5056dd47b) text properties as not adjusted for deleted text
- [vim-patch:8.1.0682](https://github.com/vim/vim/commit/196d157f12cf0476d97f78834155fc67d6b161de) text properties not adjusted when backspacing replaced text
- [vim-patch:8.1.0688](https://github.com/vim/vim/commit/ccae4672fd622f2feac8322be71b6e43e68dc4fc) text properties are not restored by undo
- [vim-patch:8.1.0689](https://github.com/vim/vim/commit/7f1664e392388fd38c8b154389167ad1bdedff66) undo with text properties not tested
- [vim-patch:8.1.0690](https://github.com/vim/vim/commit/21b5038e02306ce2fd438249055eed372befe51f) setline() and setbufline() do not clear text properties
- [vim-patch:8.1.0691](https://github.com/vim/vim/commit/4164bb204e97a2ff3d6c43cba779bdff9e853892) text properties are not adjusted for :substitute
- [vim-patch:8.1.0694](https://github.com/vim/vim/commit/4614f53e0f853b513963d1a639398348a571ecf1) when using text props may free memory that is not allocated
- [vim-patch:8.1.0703](https://github.com/vim/vim/commit/8aef43b66cf280c79a75d81f43ce5223b9044e63) compiler warnings with 64-bit compiler
- [vim-patch:8.1.0707](https://github.com/vim/vim/commit/663bc89bbb8158bd0888f7d7228b2dbc6bbd4802) text property columns are not adjusted for changed indent
- [vim-patch:8.1.0970](https://github.com/vim/vim/commit/ed79d1e348c40e2432802423bf22e4f7b536bf8a) text properties test fails when 'encoding' is not utf-8
- [vim-patch:8.1.1035](https://github.com/vim/vim/commit/0a2f578e22de7e4d82075578afdd5fc2d2dd8134) prop_remove() second argument is not optional
- [vim-patch:8.1.1276](https://github.com/vim/vim/commit/de24a8701328b1cce7cad0ee11b415369b482420) cannot combine text properties with syntax highlighting
- [vim-patch:8.1.1278](https://github.com/vim/vim/commit/58187f1c8a7095dbe0237a8208fa7f7bc899f246) missing change for "combine" field
- [vim-patch:8.1.1333](https://github.com/vim/vim/commit/45dd07f10af9bea86f8df77e92788209e209fdab) text properties don't always move after changes
- [vim-patch:8.1.1337](https://github.com/vim/vim/commit/5c65e6a062dfc7d20931fa1f73d03b1714a4d5e1) get empty text prop when splitting line just after text prop
- [vim-patch:8.1.1341](https://github.com/vim/vim/commit/80e737cc6ab6b68948f6765348b6881be861b200) text properties are lost when joining lines
- [vim-patch:8.1.1343](https://github.com/vim/vim/commit/8055d17388736421d875dd4933c4c93d49a2ab58) text properties not adjusted for Visual block mode delete
- [vim-patch:8.1.1340](https://github.com/vim/vim/commit/bfd451283f8c37926f4b0aa22b74b534bd84e482) attributes from 'cursorline' overwrite textprop
- [vim-patch:8.1.1351](https://github.com/vim/vim/commit/338dfdad3844ebb1ce1d56c421d1f698c086eb0c) text property wrong after :substitute
- [vim-patch:8.1.1359](https://github.com/vim/vim/commit/f3333b02f34526da46cdae608f7e2d869bb8c654) text property wrong after :substitute with backslash
- [vim-patch:8.1.1387](https://github.com/vim/vim/commit/d79eef2eb1f24b53206c4e55b80a4634f548c429) calling prop_add() in an empty buffer doesn't work
- [vim-patch:8.1.1388](https://github.com/vim/vim/commit/f0884c5f3f5a25481d1e16f0979aa978a6690bb1) errors when calling prop_remove() for an unloaded buffer
- [vim-patch:8.1.1463](https://github.com/vim/vim/commit/277e79adc4d2b62556ce8a3720684e4b3e1e6d42) gcc warns for uninitialized variable

N/A Nvim has buf_attach instead of "listeners":
- [vim-patch:8.1.1320](https://github.com/vim/vim/commit/6d2399bd1053b367e13cc2b8991d3ff0bf724c7c) it is not possible to track changes to a buffer
- [vim-patch:8.1.1321](https://github.com/vim/vim/commit/a334772967de25764ed7b11d768e8b977818d0c6) no docs or tests for listener functions
- [vim-patch:8.1.1326](https://github.com/vim/vim/commit/8aad88d8de256e58f04054eb7230c9613e26502f) no test for listener with partial
- [vim-patch:8.1.1328](https://github.com/vim/vim/commit/bc4fd43160739efb93c39589dcc9ffd5d5a951d0) no test for listener with undo operation
- [vim-patch:8.1.1332](https://github.com/vim/vim/commit/fe1ade0a78a70a4c7ddaebb6964497f037f4997a) cannot flush listeners without redrawing, mix of changes
- [vim-patch:8.1.1335](https://github.com/vim/vim/commit/dda4144d39a9d685b8dda830978e7410bd372c40) listener callback is called after inserting text
- [vim-patch:8.1.1419](https://github.com/vim/vim/commit/68a4b04a8d2471adf9de595745437c7cf20b98d8) listener callbacks may be called recursively
- [vim-patch:8.1.1486](https://github.com/vim/vim/commit/125370459178b0ca3acc98edca774c390c9b9fa4) a listener change is merged even when it adds a line

N/A build issues:
- [vim-patch:8.1.0601](https://github.com/vim/vim/commit/4efe73b478d3ba689078da502fd96f45204ff1f5) a few compiler warnings
- [vim-patch:8.1.0612](https://github.com/vim/vim/commit/9d302ad4e31b4e20ce0b3af700f43edb6f5e6036) cannot use two global runtime dirs with configure
- [vim-patch:8.1.0684](https://github.com/vim/vim/commit/4b7214ea7834c72188f4a7b0b76b49b81fef7d27) warnings from 64-bit compiler
- [vim-patch:8.1.1344](https://github.com/vim/vim/commit/0d3cb73012332964e7a81d7afd1c21d393f45566) Coverity complains about possibly using a NULL pointer
- [vim-patch:8.1.1376](https://github.com/vim/vim/commit/e2ad826f431b2f8dd1b235c219282cc3961f7188) warnings for size_t/int mixups
- [vim-patch:8.1.1414](https://github.com/vim/vim/commit/c799fe206e61f2e2c1231bc46cbe4bb354f3da69) alloc() returning "char_u *" causes a lot of type casts
- [vim-patch:8.1.1508](https://github.com/vim/vim/commit/541faf7a73448bbed9e8d129f2001fb34e39b7b1) sound keeps failing on Travis
- [vim-patch:8.1.1494](https://github.com/vim/vim/commit/6c009a39744b49393464567266a3fa3562f08ee2) build failure

N/A terminal / job control patches:
- [vim-patch:8.1.0761](https://github.com/vim/vim/commit/e299bbdf6e7edd633501b7a0e11c349c703c361b) default value for brief_wait is wrong
- [vim-patch:8.1.0824](https://github.com/vim/vim/commit/1ecc5e4a995ade68ae216bb56f6ac9bd5c0b7e4b) SunOS/Solaris has a problem with ttys
- [vim-patch:8.1.0845](https://github.com/vim/vim/commit/2a4857a1fcf1d188e5b985ac21bcfc532eddde94) having job_status() free the job causes problems
- [vim-patch:8.1.0870](https://github.com/vim/vim/commit/aa5df7e3127dff6b7336df0903f5c569a40eb174) Vim doesn't use the new ConPTY support in Windows 10
- [vim-patch:8.1.0880](https://github.com/vim/vim/commit/c6ddce3f2cf6daa3a545405373b661f8a9bccad9) MS-Windows: inconsistent selection of winpty/conpty
- [vim-patch:8.1.0890](https://github.com/vim/vim/commit/593864817a08f9b719a093ef4fd8d4d35132ab86) pty allocation wrong if using file for out channel
- [vim-patch:8.1.0906](https://github.com/vim/vim/commit/e1ed53f3f95786c744d4b6c85bda4f476f67cc91) using clumsy way to get console window handle
- [vim-patch:8.1.0909](https://github.com/vim/vim/commit/d9ef1b8d77f304c83241f807c17ffa26c9033778) MS-Windows: using ConPTY even though it is not stable
- [vim-patch:8.1.0928](https://github.com/vim/vim/commit/d634024b90c7ae6ff08c1970646f1bca91f5611f) stray log function call
- [vim-patch:8.1.0940](https://github.com/vim/vim/commit/78d21dae9c3a39efb30316d3e38dce120bc1abbd) MS-Windows console resizing not handled properly
- [vim-patch:8.1.1028](https://github.com/vim/vim/commit/9029b918f902c01e8f46441155ec2f01690929f9) MS-Windows: memory leak when creating terminal fails
- [vim-patch:8.1.1265](https://github.com/vim/vim/commit/bedf091a951bdcd5f9f13839c0aaf2e395a635f6) when GPM mouse support is enabled double clicks do not work
- [vim-patch:8.1.1267](https://github.com/vim/vim/commit/4b8366b56edbf4f3efcaeedbaba491c49c5788ca) cannot check if GPM mouse support is working

N/A encoding patches:
- [vim-patch:8.1.0879](https://github.com/vim/vim/commit/0036201a1a096913840d3df8ff08eb58eaae90a6) MS-Windows: temp name encoding can be wrong
- [vim-patch:8.1.0895](https://github.com/vim/vim/commit/ec0f50a35e207e01ff54cef954313030e3ab42a6) MS-Windows: dealing with temp name encoding not quite right
- [vim-patch:8.1.0918](https://github.com/vim/vim/commit/9b5c1fcdeae75f82a2083fafbbf75ab220f6ac1e) MS-Windows: startup messages are not converted
- [vim-patch:8.1.1090](https://github.com/vim/vim/commit/2d04a91d691ae1ea0c3bf9fc522c3fddc2c9746a) MS-Windows: modify_fname() has problems with some 'encoding'

N/A Nvim has floating windows instead of popup window:
- [vim-patch:8.1.1329](https://github.com/vim/vim/commit/957f85d54ebd5a3bd0d930de9603190f0876f977) plans for popup window support are spread out
- [vim-patch:8.1.1364](https://github.com/vim/vim/commit/5c017b2de28d19dfa4af58b8973e32f31bb1477e) design for popup window support needs more details
- [vim-patch:8.1.1391](https://github.com/vim/vim/commit/4d784b21d14fc66e98a2b07f70343cdd4acd62aa) no popup window support
- [vim-patch:8.1.1400](https://github.com/vim/vim/commit/9c27b1c6d140ca824a78654c1cb70a43a69b4ec6) using global pointer for tab-local popups is clumsy
- [vim-patch:8.1.1399](https://github.com/vim/vim/commit/ec58384afa0dc1678afd7b8d19b4645ac2f73f42) popup windows not adjusted when switching tabs
- [vim-patch:8.1.0062](https://github.com/vim/vim/commit/491ac28d5f91505519c623ebc1a9ab08834bf367) popup menu broken if a callback changes the window layout
- [vim-patch:8.1.1405](https://github.com/vim/vim/commit/20c023aee0ceafac9431fb8ab8d169747b5140dd) "highlight" option of popup windows not supported
- [vim-patch:8.1.1406](https://github.com/vim/vim/commit/2cd0dce898995a2b05f7285a70efec3f67f579f5) popup_hide() and popup_show() not implemented yet
- [vim-patch:8.1.1407](https://github.com/vim/vim/commit/7a8d0278bd6bd57e04f61183cb8e2969cf148e3f) popup_create() does not support text properties
- [vim-patch:8.1.1410](https://github.com/vim/vim/commit/60cdb3004abe683e5e8851fa6c5d67b337df4443) popup_move() is not implemented yet
- [vim-patch:8.1.1402](https://github.com/vim/vim/commit/51fe3b14f63da2b985bcd7b4c50fbe34ae84ea48) "timer" option of popup windows not supported
- [vim-patch:8.1.1408](https://github.com/vim/vim/commit/bf0ecb2cb63fb710198d6be742ae4f00fdd2f948) PFL_HIDDEN conflicts with system header file
- [vim-patch:8.1.1420](https://github.com/vim/vim/commit/88c4e1f06905983870175a473683e81312d14c64) popup window size only uses first line length
- [vim-patch:8.1.1421](https://github.com/vim/vim/commit/1714696600f2859f897f4ffb33cedb5de09eded3) drawing "~" line in popup window
- [vim-patch:8.1.1422](https://github.com/vim/vim/commit/8c2a600f72ca930841a5f4f7eac22884238afaf3) popup_getoptions() not implemented yet
- [vim-patch:8.1.1423](https://github.com/vim/vim/commit/cacc6a5c986fbc716bf53b6916f076dd7b388142) popup windows use options from current window and buffer
- [vim-patch:8.1.1426](https://github.com/vim/vim/commit/b42301247d85d60b64c2cc23f5cdf30da2342827) no test for syntax highlight in popup window
- [vim-patch:8.1.1427](https://github.com/vim/vim/commit/54fabd4b5e373c7f1d794d24d27a30a8bac84da1) popup window screenshot test fails
- [vim-patch:8.1.1428](https://github.com/vim/vim/commit/cc31ad9f9b601d53926b96586bd6b40602d57951) popup_atcursor() not implemented yet
- [vim-patch:8.1.1429](https://github.com/vim/vim/commit/ac1f1bc222b7de3cb2d3f1f2aa076f11c75e69de) "pos" option of popup window not supported yet
- [vim-patch:8.1.1430](https://github.com/vim/vim/commit/402502d0e4019ca97330eff40b9fb13736304896) popup window option "wrap" not supported
- [vim-patch:8.1.1431](https://github.com/vim/vim/commit/c6896e20f8e7e8d9fe0fd1ad333aae1130d714e1) popup window listed as "Scratch"
- [vim-patch:8.1.1432](https://github.com/vim/vim/commit/ccd6e3471df5250611a78489384a91c65fcc43c4) can't build with eval feature
- [vim-patch:8.1.1438](https://github.com/vim/vim/commit/815b76bff618c07226653e11f29c4d3c5640b63a) some commands cause trouble in a popup window
- [vim-patch:8.1.1441](https://github.com/vim/vim/commit/bf0eff0b724ebf4951f7ca82e6c648451f9f0c01) popup window filter not yet implemented
- [vim-patch:8.1.1442](https://github.com/vim/vim/commit/8caaf82569a6bfec2b575997b3a84e5623eff12d) popup windows not considered when the Vim window is resized
- [vim-patch:8.1.1443](https://github.com/vim/vim/commit/2fd8e35e16e502c98045c4b4e09a91eca840fb97) popup window padding and border not implemented yet
- [vim-patch:8.1.1444](https://github.com/vim/vim/commit/3bfd04e672ea47e371595e50a92ddfb2223f6e3d) not using double line characters for popup border
- [vim-patch:8.1.1445](https://github.com/vim/vim/commit/790498b509443f96f39431d2bc87b777efbe250f) popup window border highlight not implemented yet
- [vim-patch:8.1.1446](https://github.com/vim/vim/commit/9eaac896501bcd6abdd430a90293eae8101df24a) popup window callback not implemented yet
- [vim-patch:8.1.1447](https://github.com/vim/vim/commit/7b29dd850752b975baef47b66c590f5e978ad847) not allowed to create an empty popup
- [vim-patch:8.1.1448](https://github.com/vim/vim/commit/988c43310a8dcfad9fbacd110b50ba220227d19a) statusline is sometimes drawn on top of popup
- [vim-patch:8.1.1449](https://github.com/vim/vim/commit/042fb4b449bb5d8494698803e766dfd288b458cf) popup text truncated at end of screen
- [vim-patch:8.1.1450](https://github.com/vim/vim/commit/399d898ac1e6e587088b5bdd6e36eca4998bc1eb) popup window positioning wrong when using padding or borders
- [vim-patch:8.1.1451](https://github.com/vim/vim/commit/ca2f7037c1a53bdbb6f5dc0a2f92d50020e062cc) CTRL-L does not clear screen with a popup window
- [vim-patch:8.1.1452](https://github.com/vim/vim/commit/b0ebbda06cf1a4a7c40cb274529c4c53de534e32) line and col property of popup windows not properly checked
- [vim-patch:8.1.1453](https://github.com/vim/vim/commit/3397f74ac2ac27f1eef48e950c3c8eeb0338fe55) popup window "moved" property not implemented yet
- [vim-patch:8.1.1455](https://github.com/vim/vim/commit/1762731f2039d78fc8ddd785c3d3b52e5968c0f1) popup_atcursor() not completely implemented
- [vim-patch:8.1.1459](https://github.com/vim/vim/commit/3f6aeba18b3e29da98ab9326e66d287a997d98d1) popup window border looks bad when 'ambiwidth' is "double"
- [vim-patch:8.1.1460](https://github.com/vim/vim/commit/02e15072be08ef4ae03d673fc95ed6234e749e1c) popup window border characters may be wrong
- [vim-patch:8.1.1416](https://github.com/vim/vim/commit/bc133543b8b0ebb1d8624e37d840b739eb00f3f3) popup_getposition() not implemented yet
- [vim-patch:8.1.1493](https://github.com/vim/vim/commit/33796b39b9f00b42ca57fa00dbbb52316d9d38ff) redrawing with popups is slow and causes flicker
- [vim-patch:8.1.1496](https://github.com/vim/vim/commit/acc682bd7ca66b74b42de7a5fb5d3ef37897926f) popup window height is not recomputed
- [vim-patch:8.1.1499](https://github.com/vim/vim/commit/24a5ac5d4dbc4dc5d6d2b7e4dda6612dd9233f5d) ruler not updated after popup window was removed
- [vim-patch:8.1.1511](https://github.com/vim/vim/commit/ac2450a9a863f02a5e749f2b7058157cbf76edf8) matches in a popup window are not displayed properly
- [vim-patch:8.1.1513](https://github.com/vim/vim/commit/3ff5f0f05d437a6b3eaf3caa5dc2762b49314617) all popup functionality is in functions, except :popupclear
- [vim-patch:8.1.1517](https://github.com/vim/vim/commit/4c063a0dab57be7bd7aad4b8434feff3db5f1057) when a popup changes all windows are redrawn
- [vim-patch:8.1.1518](https://github.com/vim/vim/commit/202d982b36d87cf91d992bd7e30d3223bdc72cd9) crash when setting 'columns' while a popup is visible
- [vim-patch:8.1.1520](https://github.com/vim/vim/commit/451d4b5b7c7262631cd1f5057c75d6f5f5772fb1) popup windows are ignored when dealing with mouse position
- ~~[vim-patch:8.1.1521](https://github.com/vim/vim/commit/7c7f01e2b260c75d9996ca9ab621119eafe13a63) when a popup window is closed the buffer remains~~
- [vim-patch:8.1.1522](https://github.com/vim/vim/commit/68d48f40a4da79547b53e3164b658812e154d411) poup_notification() not implemented yet
- [vim-patch:8.1.1495](https://github.com/vim/vim/commit/1748c7f77ea864c669b7e5cfb2be0c34ce45e36e) memory access error
- [vim-patch:8.1.1497](https://github.com/vim/vim/commit/aef5c62a6fff7654bb8df7b9359e811f7a6e428f) accessing memory beyond allocated space

N/A already applied:
- [vim-patch:8.1.1226](https://github.com/vim/vim/commit/6c60f47fb9251e686217d51cf81847e14d0dd26d) {not in Vi} remarks get in the way of useful help text
- [vim-patch:8.1.1280](https://github.com/vim/vim/commit/25c9c680ec4dfbb51f4ef21c3460a48d3c67ffc8) remarks about functionality not in Vi clutters the help