### PR TITLE
vim-patch:2dd613f57bf1

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -537,9 +537,9 @@ If there is no g:termdebug_config you can use: >vim
 
 Change default signs ~
 							*termdebug_signs*
-Termdebug uses the last two characters of the breakpoint ID in the
-signcolumn to represent breakpoints. For example, breakpoint ID 133
-will be displayed as `33`.
+Termdebug uses the hex number of the breakpoint ID in the signcolumn to
+represent breakpoints. if it is greater than "0xFF", then it will be displayed
+as "F+", due to we really only have two screen cells for the sign.
 
 If you want to customize the breakpoint signs: >vim
 	let g:termdebug_config['sign'] = '>>'

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1781,9 +1781,9 @@ func s:CreateBreakpoint(id, subid, enabled)
       let label = get(g:termdebug_config, 'sign', '')
     endif
     if label == ''
-      let label = substitute(nr, '\..*', '', '')
-      if strlen(label) > 2
-        let label = strpart(label, strlen(label) - 2)
+      let label = printf('%02X', a:id)
+      if a:id > 255
+        let label = 'F+'
       endif
     endif
     call sign_define('debugBreakpoint' .. nr,

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -81,6 +81,32 @@ func Test_termdebug_basic()
         \  'priority': 110, 'group': 'TermDebug'}],
         \ sign_getplaced('', #{group: 'TermDebug'})[0].signs)})
   Continue
+  call Nterm_wait(gdb_buf)
+
+  let i = 2
+  while i <= 258
+    Break
+    call Nterm_wait(gdb_buf)
+    if i == 2
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '02')})
+    endif
+    if i == 10
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '0A')})
+    endif
+    if i == 168
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint168.0')[0].text, 'A8')})
+    endif
+    if i == 255
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint255.0')[0].text, 'FF')})
+    endif
+    if i == 256
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint256.0')[0].text, 'F+')})
+    endif
+    if i == 258
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint258.0')[0].text, 'F+')})
+    endif
+    let i += 1
+  endwhile
 
   let cn = 0
   " 60 is approx spaceBuffer * 3


### PR DESCRIPTION
#### vim-patch:2dd613f57bf1

runtime(termdebug): improve the breakpoint sign label (vim/vim#13525)

// related vim/vim#12589
// that should be the last chat (I) with Bram, r.i.p

https://github.com/vim/vim/commit/2dd613f57bf17eb8ff050bcb5510eb0279f5c9ab

Co-authored-by: Shane-XB-Qian <shane.qian@foxmail.com>