### PR TITLE
build: use stylua with add_glob_target

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -1,7 +1,7 @@
+/build
+/runtime/lua/coxpcall.lua
+/runtime/lua/vim/_meta
+/runtime/lua/vim/re.lua
 /scripts
 /src
 /test
-/build
-/runtime/lua/vim/re.lua
-/runtime/lua/vim/_meta/options.lua
-/runtime/lua/coxpcall.lua

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,16 @@ add_glob_target(
   TOUCH_STRATEGY SINGLE)
 add_dependencies(lintlua-luacheck lua-dev-deps)
 
-# Don't use add_glob_target as .styluaignore won't be respected.
-# https://github.com/JohnnyMorganz/StyLua/issues/751
-add_custom_target(lintlua-stylua
-  COMMAND ${STYLUA_PRG} --color=always --check .
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+add_glob_target(
+  TARGET lintlua-stylua
+  COMMAND ${STYLUA_PRG}
+  FLAGS --color=always --check --respect-ignores
+  GLOB_DIRS runtime/
+  GLOB_PAT *.lua
+  EXCLUDE
+    /runtime/lua/vim/_meta
+  TOUCH_STRATEGY SINGLE)
+
 add_custom_target(lintlua)
 add_dependencies(lintlua lintlua-luacheck lintlua-stylua)
 


### PR DESCRIPTION
stylua version 0.19.0 has added the flag `--respect-ignores` which
unbreaks stylua when used with add_glob_target.

See eecddd24164c3c4a250aec25dbd760b283849981 for more context.