### PR TITLE
vim-patch:9.0.2103: recursive callback may cause issues on some archs

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -127,6 +127,8 @@ This happens when an Ex command executes an Ex command that executes an Ex
 command, etc.  The limit is 200 or the value of 'maxfuncdepth', whatever is
 larger.  When it's more there probably is an endless loop.  Probably a
 |:execute| or |:source| command is involved.
+Can also happen with a recursive callback function (|channel-callback|).
+A limit of 20 is used here.
 
 							*E254*  >
   Cannot allocate color {name}

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4026,7 +4026,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
-	Also used for maximum depth of callback functions.
 
 					*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4037,7 +4037,6 @@ vim.go.mat = vim.go.matchtime
 --- Increasing this limit above 200 also changes the maximum for Ex
 --- command recursion, see `E169`.
 --- See also `:function`.
---- Also used for maximum depth of callback functions.
 ---
 --- @type integer
 vim.o.maxfuncdepth = 100

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -87,6 +87,8 @@
 
 #define DICT_MAXNEST 100        // maximum nesting of lists and dicts
 
+#define MAX_CALLBACK_DEPTH 20
+
 static const char *e_missbrac = N_("E111: Missing ']'");
 static const char *e_list_end = N_("E697: Missing end of List ']': %s");
 static const char e_cannot_slice_dictionary[]
@@ -6061,7 +6063,7 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
                    typval_T *const rettv)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (callback_depth > p_mfd) {
+  if (callback_depth > MAX_CALLBACK_DEPTH) {
     emsg(_(e_command_too_recursive));
     return false;
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5155,7 +5155,6 @@ return {
         Increasing this limit above 200 also changes the maximum for Ex
         command recursion, see |E169|.
         See also |:function|.
-        Also used for maximum depth of callback functions.
       ]=],
       full_name = 'maxfuncdepth',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:9.0.2103: recursive callback may cause issues on some archs

Problem:  recursive callback may cause issues on some archs
Solution: Decrease the limit drastically to 20

Recursive callback limit causes problems on some architectures

Since commit 47510f3d6598a1218958c03ed11337a43b73f48d we have a test
that causes a recursive popup callback function to be executed. However
it seems the current limit of 'maxfuncdepth' option value is still too
recursive for some 32bit architectures (e.g. 32bit ARM).

So instead of allowing a default limit of 100 (default value for
'maxfuncdepth'), let's reduce this limit to 20. I don't think there is a
use case where one would need such a high recursive callback limit and a
limit of 20 seems reasonable (although it is currently hard-coded).

closes: vim/vim#13502

https://github.com/vim/vim/commit/2076463e383901cef44685aaf4b63e4306444f9e

Co-authored-by: Christian Brabandt <cb@256bit.org>