### PR TITLE
docs: mention col_end index exclusivity in nvim_buf_add_highlight()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2516,8 +2516,8 @@ nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line}, {col_start},
       • {hl_group}   Name of the highlight group to use
       • {line}       Line to highlight (zero-indexed)
       • {col_start}  Start of (byte-indexed) column range to highlight
-      • {col_end}    End of (byte-indexed) column range to highlight, or -1 to
-                     highlight to end of line
+      • {col_end}    End of (byte-indexed) column range to highlight
+                     (exclusive), or -1 to highlight to end of line
 
     Return: ~
         The ns_id that was used

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -124,8 +124,8 @@ function vim.api.nvim__unpack(str) end
 --- @param hl_group string Name of the highlight group to use
 --- @param line integer Line to highlight (zero-indexed)
 --- @param col_start integer Start of (byte-indexed) column range to highlight
---- @param col_end integer End of (byte-indexed) column range to highlight, or -1 to
----                  highlight to end of line
+--- @param col_end integer End of (byte-indexed) column range to highlight
+---                  (exclusive), or -1 to highlight to end of line
 --- @return integer
 function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start, col_end) end
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -915,7 +915,7 @@ uint32_t src2ns(Integer *src_id)
 /// @param hl_group   Name of the highlight group to use
 /// @param line       Line to highlight (zero-indexed)
 /// @param col_start  Start of (byte-indexed) column range to highlight
-/// @param col_end    End of (byte-indexed) column range to highlight,
+/// @param col_end    End of (byte-indexed) column range to highlight (exclusive),
 ///                   or -1 to highlight to end of line
 /// @param[out] err   Error details, if any
 /// @return The ns_id that was used


### PR DESCRIPTION
I believe since `nvim_buf_add_highlight` uses `extmark_set` function, the col_end index should be documented as **exclusive** in a similar fashion to how is documented on the [nvim_buf_set_extmark](https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L464C14-L464C14) function. 