### PR TITLE
vim-patch:9.0.{0137,0336,0525}

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2447,7 +2447,7 @@ function Test_dirchanged_auto()
   set acd
   cd ..
   call assert_equal([], s:li)
-  exe 'edit ' . s:dir_foo . '/Xfile'
+  exe 'edit ' . s:dir_foo . '/Xautofile'
   call assert_equal(s:dir_foo, getcwd())
   let expected = ["pre cd " .. s:dir_foo, "auto:", s:dir_foo]
   call assert_equal(expected, s:li)
@@ -3124,7 +3124,7 @@ func Test_FileChangedRO_winclose()
 
   augroup FileChangedROTest
     au!
-    autocmd FileChangedRO * edit Xfile
+    autocmd FileChangedRO * edit Xrofile
   augroup END
   new
   set readonly
@@ -3200,13 +3200,13 @@ endfunc
 " Test for passing invalid arguments to autocmd
 func Test_autocmd_invalid_args()
   " Additional character after * for event
-  call assert_fails('autocmd *a Xfile set ff=unix', 'E215:')
+  call assert_fails('autocmd *a Xinvfile set ff=unix', 'E215:')
   augroup Test
   augroup END
   " Invalid autocmd event
-  call assert_fails('autocmd Bufabc Xfile set ft=vim', 'E216:')
+  call assert_fails('autocmd Bufabc Xinvfile set ft=vim', 'E216:')
   " Invalid autocmd event in a autocmd group
-  call assert_fails('autocmd Test Bufabc Xfile set ft=vim', 'E216:')
+  call assert_fails('autocmd Test Bufabc Xinvfile set ft=vim', 'E216:')
   augroup! Test
   " Execute all autocmds
   call assert_fails('doautocmd * BufEnter', 'E217:')
@@ -3217,9 +3217,9 @@ endfunc
 
 " Test for deep nesting of autocmds
 func Test_autocmd_deep_nesting()
-  autocmd BufEnter Xfile doautocmd BufEnter Xfile
-  call assert_fails('doautocmd BufEnter Xfile', 'E218:')
-  autocmd! BufEnter Xfile
+  autocmd BufEnter Xdeepfile doautocmd BufEnter Xdeepfile
+  call assert_fails('doautocmd BufEnter Xdeepfile', 'E218:')
+  autocmd! BufEnter Xdeepfile
 endfunc
 
 " Tests for SigUSR1 autocmd event, which is only available on posix systems.

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -134,7 +134,7 @@ func Test_bdelete_cmd()
   call assert_fails('bdelete \)', 'E55:')
 
   " Deleting a unlisted and unloaded buffer
-  edit Xfile1
+  edit Xbdelfile1
   let bnr = bufnr()
   set nobuflisted
   enew
@@ -310,8 +310,8 @@ endfunc
 " Test for trying to load a buffer with text locked
 " <C-\>e in the command line is used to lock the text
 func Test_load_buf_with_text_locked()
-  new Xfile1
-  edit Xfile2
+  new Xlockfile1
+  edit Xlockfile2
   let cmd = ":\<C-\>eexecute(\"normal \<C-O>\")\<CR>\<C-C>"
   call assert_fails("call feedkeys(cmd, 'xt')", 'E565:')
   %bw!

--- a/test/old/testdir/test_changelist.vim
+++ b/test/old/testdir/test_changelist.vim
@@ -37,13 +37,13 @@ endfunc
 
 " Tests for the getchangelist() function
 func Test_changelist_index()
-  edit Xfile1.txt
+  edit Xgclfile1.txt
   exe "normal iabc\<C-G>u\ndef\<C-G>u\nghi"
   call assert_equal(3, getchangelist('%')[1])
   " Move one step back in the changelist.
   normal 2g;
 
-  hide edit Xfile2.txt
+  hide edit Xgclfile2.txt
   exe "normal iabcd\<C-G>u\ndefg\<C-G>u\nghij"
   call assert_equal(3, getchangelist('%')[1])
   " Move to the beginning of the changelist.
@@ -54,8 +54,8 @@ func Test_changelist_index()
   call assert_equal(1, getchangelist('#')[1])
 
   bwipe!
-  call delete('Xfile1.txt')
-  call delete('Xfile2.txt')
+  call delete('Xgclfile1.txt')
+  call delete('Xgclfile2.txt')
 endfunc
 
 func Test_getchangelist()
@@ -64,10 +64,10 @@ func Test_getchangelist()
   call assert_equal([], 10->getchangelist())
   call assert_equal([[], 0], getchangelist())
 
-  call writefile(['line1', 'line2', 'line3'], 'Xfile1.txt')
-  call writefile(['line1', 'line2', 'line3'], 'Xfile2.txt')
+  call writefile(['line1', 'line2', 'line3'], 'Xclistfile1.txt')
+  call writefile(['line1', 'line2', 'line3'], 'Xclistfile2.txt')
 
-  edit Xfile1.txt
+  edit Xclistfile1.txt
   let buf_1 = bufnr()
   exe "normal 1Goline\<C-G>u1.1"
   exe "normal 3Goline\<C-G>u2.1"
@@ -79,7 +79,7 @@ func Test_getchangelist()
 	      \ {'lnum' : 6, 'col' : 4, 'coladd' : 0}], 2],
 	      \ getchangelist('%'))
 
-  hide edit Xfile2.txt
+  hide edit Xclistfile2.txt
   let buf_2 = bufnr()
   exe "normal 1GOline\<C-G>u1.0"
   exe "normal 2Goline\<C-G>u2.0"
@@ -100,8 +100,8 @@ func Test_getchangelist()
 	      \ getchangelist(buf_2))
 
   bwipe!
-  call delete('Xfile1.txt')
-  call delete('Xfile2.txt')
+  call delete('Xclistfile1.txt')
+  call delete('Xclistfile2.txt')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_clientserver.vim
+++ b/test/old/testdir/test_clientserver.vim
@@ -130,9 +130,9 @@ func Test_client_server()
 
     " Run a separate instance to send a command to the server
     call remote_expr(name, 'execute("only")')
-    call system(cmd .. ' --remote-send ":new Xfile<CR>"')
+    call system(cmd .. ' --remote-send ":new Xclientfile<CR>"')
     call assert_equal('2', remote_expr(name, 'winnr("$")'))
-    call assert_equal('Xfile', remote_expr(name, 'winbufnr(1)->bufname()'))
+    call assert_equal('Xclientfile', remote_expr(name, 'winbufnr(1)->bufname()'))
     call remote_expr(name, 'execute("only")')
 
     " Invoke a remote-expr. On MS-Windows, the returned value has a carriage
@@ -141,24 +141,24 @@ func Test_client_server()
     call assert_equal(['4'], split(l, "\n"))
 
     " Edit multiple files using --remote
-    call system(cmd .. ' --remote Xfile1 Xfile2 Xfile3')
-    call assert_match(".*Xfile1\n.*Xfile2\n.*Xfile3\n", remote_expr(name, 'argv()'))
+    call system(cmd .. ' --remote Xclientfile1 Xclientfile2 Xclientfile3')
+    call assert_match(".*Xclientfile1\n.*Xclientfile2\n.*Xclientfile3\n", remote_expr(name, 'argv()'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit files in separate tab pages
-    call system(cmd .. ' --remote-tab Xfile1 Xfile2 Xfile3')
+    call system(cmd .. ' --remote-tab Xclientfile1 Xclientfile2 Xclientfile3')
     call WaitForAssert({-> assert_equal('3', remote_expr(name, 'tabpagenr("$")'))})
-    call assert_match('.*\<Xfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
+    call assert_match('.*\<Xclientfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit a file using --remote-wait
     eval name->remote_send(":source $VIMRUNTIME/plugin/rrhelper.vim\<CR>")
-    call system(cmd .. ' --remote-wait +enew Xfile1')
-    call assert_match('.*\<Xfile1', remote_expr(name, 'bufname("#")'))
+    call system(cmd .. ' --remote-wait +enew Xclientfile1')
+    call assert_match('.*\<Xclientfile1', remote_expr(name, 'bufname("#")'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit files using --remote-tab-wait
-    call system(cmd .. ' --remote-tabwait +tabonly\|enew Xfile1 Xfile2')
+    call system(cmd .. ' --remote-tabwait +tabonly\|enew Xclientfile1 Xclientfile2')
     call assert_equal('1', remote_expr(name, 'tabpagenr("$")'))
     eval name->remote_send(":%bw!\<CR>")
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1126,14 +1126,14 @@ func Test_cmdline_complete_various()
   call assert_equal("\"sI \<C-A>", @:)
 
   " completion for :write command
-  call mkdir('Xdir')
-  call writefile(['one'], 'Xdir/Xfile1')
+  call mkdir('Xcwdir')
+  call writefile(['one'], 'Xcwdir/Xfile1')
   let save_cwd = getcwd()
-  cd Xdir
+  cd Xcwdir
   call feedkeys(":w >> \<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"w >> Xfile1", @:)
   call chdir(save_cwd)
-  call delete('Xdir', 'rf')
+  call delete('Xcwdir', 'rf')
 
   " completion for :w ! and :r ! commands
   call feedkeys(":w !invalid_xyz_cmd\<C-A>\<C-B>\"\<CR>", 'xt')
@@ -1190,12 +1190,12 @@ func Test_cmdline_complete_various()
   call assert_equal("\"doautocmd BufNew,BufEnter", @:)
 
   " completion of file name in :doautocmd
-  call writefile([], 'Xfile1')
-  call writefile([], 'Xfile2')
-  call feedkeys(":doautocmd BufEnter Xfi\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal("\"doautocmd BufEnter Xfile1 Xfile2", @:)
-  call delete('Xfile1')
-  call delete('Xfile2')
+  call writefile([], 'Xvarfile1')
+  call writefile([], 'Xvarfile2')
+  call feedkeys(":doautocmd BufEnter Xvarfi\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"doautocmd BufEnter Xvarfile1 Xvarfile2", @:)
+  call delete('Xvarfile1')
+  call delete('Xvarfile2')
 
   " completion for the :augroup command
   augroup XTest.test
@@ -2010,17 +2010,17 @@ endfunc
 
 " Test for using ~ for home directory in cmdline completion matches
 func Test_cmdline_expand_home()
-  call mkdir('Xdir')
-  call writefile([], 'Xdir/Xfile1')
-  call writefile([], 'Xdir/Xfile2')
-  cd Xdir
+  call mkdir('Xexpdir')
+  call writefile([], 'Xexpdir/Xfile1')
+  call writefile([], 'Xexpdir/Xfile2')
+  cd Xexpdir
   let save_HOME = $HOME
   let $HOME = getcwd()
   call feedkeys(":e ~/\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"e ~/Xfile1 ~/Xfile2', @:)
   let $HOME = save_HOME
   cd ..
-  call delete('Xdir', 'rf')
+  call delete('Xexpdir', 'rf')
 endfunc
 
 " Test for using CTRL-\ CTRL-G in the command line to go back to normal mode
@@ -2138,6 +2138,29 @@ func Test_wildmode()
   " set encoding=latin1
   " call Wildmode_tests()
   let &encoding = save_encoding
+endfunc
+
+func Test_custom_complete_autoload()
+  call mkdir('Xcustdir/autoload', 'p')
+  let save_rtp = &rtp
+  exe 'set rtp=' .. getcwd() .. '/Xcustdir'
+  let lines =<< trim END
+      func vim8#Complete(a, c, p)
+        return "oneA\noneB\noneC"
+      endfunc
+  END
+  call writefile(lines, 'Xcustdir/autoload/vim8.vim')
+
+  command -nargs=1 -complete=custom,vim8#Complete MyCmd
+  set nowildmenu
+  set wildmode=full,list
+  call feedkeys(":MyCmd \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd oneA oneB oneC', @:)
+
+  let &rtp = save_rtp
+  set wildmode& wildmenu&
+  delcommand MyCmd
+  call delete('Xcustdir', 'rf')
 endfunc
 
 " Test for interrupting the command-line completion
@@ -2470,31 +2493,31 @@ endfunc
 
 " Test for the 'suffixes' option
 func Test_suffixes_opt()
-  call writefile([], 'Xfile')
-  call writefile([], 'Xfile.c')
-  call writefile([], 'Xfile.o')
+  call writefile([], 'Xsuffile')
+  call writefile([], 'Xsuffile.c')
+  call writefile([], 'Xsuffile.o')
   set suffixes=
-  call feedkeys(":e Xfi*\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile Xfile.c Xfile.o', @:)
-  call feedkeys(":e Xfi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile.c', @:)
+  call feedkeys(":e Xsuffi*\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile Xsuffile.c Xsuffile.o', @:)
+  call feedkeys(":e Xsuffi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile.c', @:)
   set suffixes=.c
-  call feedkeys(":e Xfi*\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile Xfile.o Xfile.c', @:)
-  call feedkeys(":e Xfi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile.o', @:)
+  call feedkeys(":e Xsuffi*\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile Xsuffile.o Xsuffile.c', @:)
+  call feedkeys(":e Xsuffi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile.o', @:)
   set suffixes=,,
-  call feedkeys(":e Xfi*\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile.c Xfile.o Xfile', @:)
-  call feedkeys(":e Xfi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"e Xfile.o', @:)
+  call feedkeys(":e Xsuffi*\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile.c Xsuffile.o Xsuffile', @:)
+  call feedkeys(":e Xsuffi*\<Tab>\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xsuffile.o', @:)
   set suffixes&
   " Test for getcompletion() with different patterns
-  call assert_equal(['Xfile', 'Xfile.c', 'Xfile.o'], getcompletion('Xfile', 'file'))
-  call assert_equal(['Xfile'], getcompletion('Xfile$', 'file'))
-  call delete('Xfile')
-  call delete('Xfile.c')
-  call delete('Xfile.o')
+  call assert_equal(['Xsuffile', 'Xsuffile.c', 'Xsuffile.o'], getcompletion('Xsuffile', 'file'))
+  call assert_equal(['Xsuffile'], getcompletion('Xsuffile$', 'file'))
+  call delete('Xsuffile')
+  call delete('Xsuffile.c')
+  call delete('Xsuffile.o')
 endfunc
 
 " Test for using a popup menu for the command line completion matches

--- a/test/old/testdir/test_cpoptions.vim
+++ b/test/old/testdir/test_cpoptions.vim
@@ -31,17 +31,17 @@ func Test_cpo_A()
   " Wipe out all the buffers, so that the alternate file is empty
   edit Xfoo | %bw
   set cpo-=A
-  new Xfile1
-  write Xfile2
+  new XcpoAfile1
+  write XcpoAfile2
   call assert_equal('', @#)
   %bw
-  call delete('Xfile2')
-  new Xfile1
+  call delete('XcpoAfile2')
+  new XcpoAfile1
   set cpo+=A
-  write Xfile2
-  call assert_equal('Xfile2', @#)
+  write XcpoAfile2
+  call assert_equal('XcpoAfile2', @#)
   close!
-  call delete('Xfile2')
+  call delete('XcpoAfile2')
   let &cpo = save_cpo
 endfunc
 

--- a/test/old/testdir/test_debugger.vim
+++ b/test/old/testdir/test_debugger.vim
@@ -81,10 +81,10 @@ func Test_Debugger()
           endfor
         enddef
   END
-  call writefile(lines, 'Xtest.vim')
+  call writefile(lines, 'XtestDebug.vim', 'D')
 
   " Start Vim in a terminal
-  let buf = RunVimInTerminal('-S Xtest.vim', {})
+  let buf = RunVimInTerminal('-S XtestDebug.vim', {})
 
   " Start the Vim debugger
   call RunDbgCmd(buf, ':debug echo Foo()', ['cmd: echo Foo()'])
@@ -344,19 +344,18 @@ func Test_Debugger_breakadd()
 	let var3 = 30
 	let var4 = 40
   END
-  call writefile(lines, 'Xtest.vim')
+  call writefile(lines, 'XdebugBreakadd.vim', 'D')
 
   " Start Vim in a terminal
-  let buf = RunVimInTerminal('Xtest.vim', {})
-  call RunDbgCmd(buf, ':breakadd file 2 Xtest.vim')
+  let buf = RunVimInTerminal('XdebugBreakadd.vim', {})
+  call RunDbgCmd(buf, ':breakadd file 2 XdebugBreakadd.vim')
   call RunDbgCmd(buf, ':4 | breakadd here')
-  call RunDbgCmd(buf, ':source Xtest.vim', ['line 2: let var2 = 20'])
+  call RunDbgCmd(buf, ':source XdebugBreakadd.vim', ['line 2: let var2 = 20'])
   call RunDbgCmd(buf, 'cont', ['line 4: let var4 = 40'])
   call RunDbgCmd(buf, 'cont')
 
   call StopVimInTerminal(buf)
 
-  call delete('Xtest.vim')
   %bw!
 
   call assert_fails('breakadd here', 'E32:')
@@ -371,31 +370,30 @@ func Test_Debugger_breakadd_expr()
   let lines =<< trim END
     let g:Xtest_var += 1
   END
-  call writefile(lines, 'Xtest.vim')
+  call writefile(lines, 'XdebugBreakExpr.vim', 'D')
 
   " Start Vim in a terminal
-  let buf = RunVimInTerminal('Xtest.vim', {})
+  let buf = RunVimInTerminal('XdebugBreakExpr.vim', {})
   call RunDbgCmd(buf, ':let g:Xtest_var = 10')
   call RunDbgCmd(buf, ':breakadd expr g:Xtest_var')
   call RunDbgCmd(buf, ':source %')
-  let expected =<< eval trim END
+  let expected =<< trim eval END
     Oldval = "10"
     Newval = "11"
-    {fnamemodify('Xtest.vim', ':p')}
+    {fnamemodify('XdebugBreakExpr.vim', ':p')}
     line 1: let g:Xtest_var += 1
   END
   call RunDbgCmd(buf, ':source %', expected)
   call RunDbgCmd(buf, 'cont')
-  let expected =<< eval trim END
+  let expected =<< trim eval END
     Oldval = "11"
     Newval = "12"
-    {fnamemodify('Xtest.vim', ':p')}
+    {fnamemodify('XdebugBreakExpr.vim', ':p')}
     line 1: let g:Xtest_var += 1
   END
   call RunDbgCmd(buf, ':source %', expected)
 
   call StopVimInTerminal(buf)
-  call delete('Xtest.vim')
 endfunc
 
 func Test_Backtrace_Through_Source()
@@ -415,7 +413,7 @@ func Test_Backtrace_Through_Source()
       call CallAFunction()
     endfunc
   END
-  call writefile(file1, 'Xtest1.vim')
+  call writefile(file1, 'Xtest1.vim', 'D')
 
   let file2 =<< trim END
     func DoAThing()
@@ -428,7 +426,7 @@ func Test_Backtrace_Through_Source()
 
     call File2Function()
   END
-  call writefile(file2, 'Xtest2.vim')
+  call writefile(file2, 'Xtest2.vim', 'D')
 
   let buf = RunVimInTerminal('-S Xtest1.vim', {})
 
@@ -570,8 +568,6 @@ func Test_Backtrace_Through_Source()
         \ 'line 1: call DoAThing()'])
 
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
 endfunc
 
 func Test_Backtrace_Autocmd()
@@ -593,7 +589,7 @@ func Test_Backtrace_Autocmd()
 
     au User TestGlobalFunction :call GlobalFunction() | echo "Done"
   END
-  call writefile(file1, 'Xtest1.vim')
+  call writefile(file1, 'Xtest1.vim', 'D')
 
   let file2 =<< trim END
     func DoAThing()
@@ -606,7 +602,7 @@ func Test_Backtrace_Autocmd()
 
     call File2Function()
   END
-  call writefile(file2, 'Xtest2.vim')
+  call writefile(file2, 'Xtest2.vim', 'D')
 
   let buf = RunVimInTerminal('-S Xtest1.vim', {})
 
@@ -826,8 +822,6 @@ func Test_Backtrace_Autocmd()
         \ 'cmd: echo "Done"'])
 
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
 endfunc
 
 func Test_Backtrace_CmdLine()
@@ -849,7 +843,7 @@ func Test_Backtrace_CmdLine()
 
     au User TestGlobalFunction :call GlobalFunction() | echo "Done"
   END
-  call writefile(file1, 'Xtest1.vim')
+  call writefile(file1, 'Xtest1.vim', 'D')
 
   let file2 =<< trim END
     func DoAThing()
@@ -862,7 +856,7 @@ func Test_Backtrace_CmdLine()
 
     call File2Function()
   END
-  call writefile(file2, 'Xtest2.vim')
+  call writefile(file2, 'Xtest2.vim', 'D')
 
   let buf = RunVimInTerminal(
         \ '-S Xtest1.vim -c "debug call GlobalFunction()"',
@@ -888,8 +882,6 @@ func Test_Backtrace_CmdLine()
         \ 'line 1: call CallAFunction()'])
 
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
 endfunc
 
 func Test_Backtrace_DefFunction()
@@ -915,7 +907,7 @@ func Test_Backtrace_DefFunction()
 
     defcompile
   END
-  call writefile(file1, 'Xtest1.vim')
+  call writefile(file1, 'Xtest1.vim', 'D')
 
   let file2 =<< trim END
     vim9script
@@ -933,7 +925,7 @@ func Test_Backtrace_DefFunction()
     defcompile
     File2Function()
   END
-  call writefile(file2, 'Xtest2.vim')
+  call writefile(file2, 'Xtest2.vim', 'D')
 
   let buf = RunVimInTerminal('-S Xtest1.vim', {})
 
@@ -984,8 +976,6 @@ func Test_Backtrace_DefFunction()
         \ #{match: 'pattern'})
 
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
 endfunc
 
 func Test_DefFunction_expr()
@@ -1000,14 +990,13 @@ func Test_DefFunction_expr()
       enddef
       defcompile
   END
-  call writefile(file3, 'Xtest3.vim')
+  call writefile(file3, 'Xtest3.vim', 'D')
   let buf = RunVimInTerminal('-S Xtest3.vim', {})
 
   call RunDbgCmd(buf, ':breakadd expr g:someVar')
   call RunDbgCmd(buf, ':call g:ChangeVar()', ['Oldval = "''foo''"', 'Newval = "''bar''"', 'function ChangeVar', 'line 2: echo "changed"'])
 
   call StopVimInTerminal(buf)
-  call delete('Xtest3.vim')
 endfunc
 
 func Test_debug_def_and_legacy_function()
@@ -1037,7 +1026,7 @@ func Test_debug_def_and_legacy_function()
 
     breakadd func 2 g:SomeFunc
   END
-  call writefile(file, 'XtestDebug.vim')
+  call writefile(file, 'XtestDebug.vim', 'D')
 
   let buf = RunVimInTerminal('-S XtestDebug.vim', {})
 
@@ -1054,7 +1043,6 @@ func Test_debug_def_and_legacy_function()
   call RunDbgCmd(buf, 'cont')
 
   call StopVimInTerminal(buf)
-  call delete('XtestDebug.vim')
 endfunc
 
 func Test_debug_def_function()
@@ -1111,7 +1099,7 @@ func Test_debug_def_function()
            | eval 2 + 3
     enddef
   END
-  call writefile(file, 'Xtest.vim')
+  call writefile(file, 'Xtest.vim', 'D')
 
   let buf = RunVimInTerminal('-S Xtest.vim', {})
 
@@ -1178,7 +1166,6 @@ func Test_debug_def_function()
 
   call RunDbgCmd(buf, 'cont')
   call StopVimInTerminal(buf)
-  call delete('Xtest.vim')
 endfunc
 
 func Test_debug_def_function_with_lambda()
@@ -1193,7 +1180,7 @@ func Test_debug_def_function_with_lambda()
      enddef
      breakadd func 2 g:Func
   END
-  call writefile(lines, 'XtestLambda.vim')
+  call writefile(lines, 'XtestLambda.vim', 'D')
 
   let buf = RunVimInTerminal('-S XtestLambda.vim', {})
 
@@ -1206,7 +1193,6 @@ func Test_debug_def_function_with_lambda()
 
   call RunDbgCmd(buf, 'cont')
   call StopVimInTerminal(buf)
-  call delete('XtestLambda.vim')
 endfunc
 
 func Test_debug_backtrace_level()
@@ -1225,7 +1211,7 @@ func Test_debug_backtrace_level()
 
     call s:File1Func( 'arg1' )
   END
-  call writefile(lines, 'Xtest1.vim')
+  call writefile(lines, 'Xtest1.vim', 'D')
 
   let lines =<< trim END
     let s:file2_var = 'file2'
@@ -1238,7 +1224,7 @@ func Test_debug_backtrace_level()
 
     call s:File2Func( 'arg2' )
   END
-  call writefile(lines, 'Xtest2.vim')
+  call writefile(lines, 'Xtest2.vim', 'D')
 
   let file1 = getcwd() .. '/Xtest1.vim'
   let file2 = getcwd() .. '/Xtest2.vim'
@@ -1399,8 +1385,6 @@ func Test_debug_backtrace_level()
 
   call RunDbgCmd(buf, 'cont')
   call StopVimInTerminal(buf)
-  call delete('Xtest1.vim')
-  call delete('Xtest2.vim')
 endfunc
 
 " Test for setting a breakpoint on a :endif where the :if condition is false

--- a/test/old/testdir/test_debugger.vim
+++ b/test/old/testdir/test_debugger.vim
@@ -366,6 +366,8 @@ endfunc
 " Test for expression breakpoint set using ":breakadd expr <expr>"
 func Test_Debugger_breakadd_expr()
   CheckRunVimInTerminal
+  CheckCWD
+
   let lines =<< trim END
     let g:Xtest_var += 1
   END

--- a/test/old/testdir/test_delete.vim
+++ b/test/old/testdir/test_delete.vim
@@ -3,103 +3,103 @@
 source check.vim
 
 func Test_file_delete()
-  split Xfile
+  split Xfdelfile
   call setline(1, ['a', 'b'])
   wq
-  call assert_equal(['a', 'b'], readfile('Xfile'))
-  call assert_equal(0, delete('Xfile'))
-  call assert_fails('call readfile("Xfile")', 'E484:')
-  call assert_equal(-1, delete('Xfile'))
-  bwipe Xfile
+  call assert_equal(['a', 'b'], readfile('Xfdelfile'))
+  call assert_equal(0, delete('Xfdelfile'))
+  call assert_fails('call readfile("Xfdelfile")', 'E484:')
+  call assert_equal(-1, delete('Xfdelfile'))
+  bwipe Xfdelfile
 endfunc
 
 func Test_dir_delete()
-  call mkdir('Xdir1')
-  call assert_true(isdirectory('Xdir1'))
-  call assert_equal(0, delete('Xdir1', 'd'))
-  call assert_false(isdirectory('Xdir1'))
-  call assert_equal(-1, delete('Xdir1', 'd'))
+  call mkdir('Xdirdel')
+  call assert_true(isdirectory('Xdirdel'))
+  call assert_equal(0, delete('Xdirdel', 'd'))
+  call assert_false(isdirectory('Xdirdel'))
+  call assert_equal(-1, delete('Xdirdel', 'd'))
 endfunc
 
 func Test_recursive_delete()
-  call mkdir('Xdir1')
-  call mkdir('Xdir1/subdir')
-  call mkdir('Xdir1/empty')
-  split Xdir1/Xfile
+  call mkdir('Xrecdel')
+  call mkdir('Xrecdel/subdir')
+  call mkdir('Xrecdel/empty')
+  split Xrecdel/Xfile
   call setline(1, ['a', 'b'])
   w
-  w Xdir1/subdir/Xfile
+  w Xrecdel/subdir/Xfile
   close
-  call assert_true(isdirectory('Xdir1'))
-  call assert_equal(['a', 'b'], readfile('Xdir1/Xfile'))
-  call assert_true(isdirectory('Xdir1/subdir'))
-  call assert_equal(['a', 'b'], readfile('Xdir1/subdir/Xfile'))
-  call assert_true('Xdir1/empty'->isdirectory())
-  call assert_equal(0, delete('Xdir1', 'rf'))
-  call assert_false(isdirectory('Xdir1'))
-  call assert_equal(-1, delete('Xdir1', 'd'))
-  bwipe Xdir1/Xfile
-  bwipe Xdir1/subdir/Xfile
+  call assert_true(isdirectory('Xrecdel'))
+  call assert_equal(['a', 'b'], readfile('Xrecdel/Xfile'))
+  call assert_true(isdirectory('Xrecdel/subdir'))
+  call assert_equal(['a', 'b'], readfile('Xrecdel/subdir/Xfile'))
+  call assert_true('Xrecdel/empty'->isdirectory())
+  call assert_equal(0, delete('Xrecdel', 'rf'))
+  call assert_false(isdirectory('Xrecdel'))
+  call assert_equal(-1, delete('Xrecdel', 'd'))
+  bwipe Xrecdel/Xfile
+  bwipe Xrecdel/subdir/Xfile
 endfunc
 
 func Test_symlink_delete()
   CheckUnix
-  split Xfile
+  split Xslfile
   call setline(1, ['a', 'b'])
   wq
-  silent !ln -s Xfile Xlink
+  silent !ln -s Xslfile Xdellink
   " Delete the link, not the file
-  call assert_equal(0, delete('Xlink'))
-  call assert_equal(-1, delete('Xlink'))
-  call assert_equal(0, delete('Xfile'))
-  bwipe Xfile
+  call assert_equal(0, delete('Xdellink'))
+  call assert_equal(-1, delete('Xdellink'))
+  call assert_equal(0, delete('Xslfile'))
+  bwipe Xslfile
 endfunc
 
 func Test_symlink_dir_delete()
   CheckUnix
-  call mkdir('Xdir1')
-  silent !ln -s Xdir1 Xlink
-  call assert_true(isdirectory('Xdir1'))
-  call assert_true(isdirectory('Xlink'))
+  call mkdir('Xsymdir')
+  silent !ln -s Xsymdir Xdirlink
+  call assert_true(isdirectory('Xsymdir'))
+  call assert_true(isdirectory('Xdirlink'))
   " Delete the link, not the directory
-  call assert_equal(0, delete('Xlink'))
-  call assert_equal(-1, delete('Xlink'))
-  call assert_equal(0, delete('Xdir1', 'd'))
+  call assert_equal(0, delete('Xdirlink'))
+  call assert_equal(-1, delete('Xdirlink'))
+  call assert_equal(0, delete('Xsymdir', 'd'))
 endfunc
 
 func Test_symlink_recursive_delete()
   CheckUnix
-  call mkdir('Xdir3')
-  call mkdir('Xdir3/subdir')
-  call mkdir('Xdir4')
-  split Xdir3/Xfile
+  call mkdir('Xrecdir3')
+  call mkdir('Xrecdir3/subdir')
+  call mkdir('Xrecdir4')
+  split Xrecdir3/Xfile
   call setline(1, ['a', 'b'])
   w
-  w Xdir3/subdir/Xfile
-  w Xdir4/Xfile
+  w Xrecdir3/subdir/Xfile
+  w Xrecdir4/Xfile
   close
-  silent !ln -s ../Xdir4 Xdir3/Xlink
+  silent !ln -s ../Xrecdir4 Xrecdir3/Xreclink
 
-  call assert_true(isdirectory('Xdir3'))
-  call assert_equal(['a', 'b'], readfile('Xdir3/Xfile'))
-  call assert_true(isdirectory('Xdir3/subdir'))
-  call assert_equal(['a', 'b'], readfile('Xdir3/subdir/Xfile'))
-  call assert_true(isdirectory('Xdir4'))
-  call assert_true(isdirectory('Xdir3/Xlink'))
-  call assert_equal(['a', 'b'], readfile('Xdir4/Xfile'))
+  call assert_true(isdirectory('Xrecdir3'))
+  call assert_equal(['a', 'b'], readfile('Xrecdir3/Xfile'))
+  call assert_true(isdirectory('Xrecdir3/subdir'))
+  call assert_equal(['a', 'b'], readfile('Xrecdir3/subdir/Xfile'))
+  call assert_true(isdirectory('Xrecdir4'))
+  call assert_true(isdirectory('Xrecdir3/Xreclink'))
+  call assert_equal(['a', 'b'], readfile('Xrecdir4/Xfile'))
 
-  call assert_equal(0, delete('Xdir3', 'rf'))
-  call assert_false(isdirectory('Xdir3'))
-  call assert_equal(-1, delete('Xdir3', 'd'))
+  call assert_equal(0, delete('Xrecdir3', 'rf'))
+  call assert_false(isdirectory('Xrecdir3'))
+  call assert_equal(-1, delete('Xrecdir3', 'd'))
   " symlink is deleted, not the directory it points to
-  call assert_true(isdirectory('Xdir4'))
-  call assert_equal(['a', 'b'], readfile('Xdir4/Xfile'))
-  call assert_equal(0, delete('Xdir4/Xfile'))
-  call assert_equal(0, delete('Xdir4', 'd'))
+  call assert_true(isdirectory('Xrecdir4'))
+  call assert_equal(['a', 'b'], readfile('Xrecdir4/Xfile'))
+  call assert_equal(0, delete('Xrecdir4/Xfile'))
+  call assert_equal(0, delete('Xrecdir4', 'd'))
 
-  bwipe Xdir3/Xfile
-  bwipe Xdir3/subdir/Xfile
-  bwipe Xdir4/Xfile
+  bwipe Xrecdir3/Xfile
+  bwipe Xrecdir3/subdir/Xfile
+  bwipe Xrecdir4/Xfile
 endfunc
 
 func Test_delete_errors()

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -822,12 +822,13 @@ func Test_diff_lastline()
 endfunc
 
 func WriteDiffFiles(buf, list1, list2)
-  call writefile(a:list1, 'Xfile1')
-  call writefile(a:list2, 'Xfile2')
+  call writefile(a:list1, 'Xdifile1')
+  call writefile(a:list2, 'Xdifile2')
   if a:buf
     call term_sendkeys(a:buf, ":checktime\<CR>")
   endif
 endfunc
+
 " Verify a screendump with both the internal and external diff.
 func VerifyBoth(buf, dumpfile, extra)
   " trailing : for leaving the cursor on the command line
@@ -877,12 +878,12 @@ func Test_diff_screen()
   call writefile(lines, 'XdiffSetup')
 
   " clean up already existing swap files, just in case
-  call delete('.Xfile1.swp')
-  call delete('.Xfile2.swp')
+  call delete('.Xdifile1.swp')
+  call delete('.Xdifile2.swp')
 
   " Test 1: Add a line in beginning of file 2
   call WriteDiffFiles(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-  let buf = RunVimInTerminal('-d -S XdiffSetup Xfile1 Xfile2', {})
+  let buf = RunVimInTerminal('-d -S XdiffSetup Xdifile1 Xdifile2', {})
   " Set autoread mode, so that Vim won't complain once we re-write the test
   " files
   call term_sendkeys(buf, ":set autoread\<CR>\<c-w>w:set autoread\<CR>\<c-w>w")
@@ -1000,8 +1001,8 @@ func Test_diff_screen()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xfile1')
-  call delete('Xfile2')
+  call delete('Xdifile1')
+  call delete('Xdifile2')
   call delete('XdiffSetup')
 endfunc
 
@@ -1495,9 +1496,9 @@ endfunc
 " for the issue fixed by patch 6.2.317)
 func Test_diff_foldinvert()
   %bw!
-  edit Xfile1
-  new Xfile2
-  new Xfile3
+  edit Xdoffile1
+  new Xdoffile2
+  new Xdoffile3
   windo diffthis
   " open a non-diff window
   botright new

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -875,7 +875,7 @@ func Test_diff_screen()
         set diffexpr=
       endfunc
   END
-  call writefile(lines, 'XdiffSetup')
+  call writefile(lines, 'XdiffSetup', 'D')
 
   " clean up already existing swap files, just in case
   call delete('.Xdifile1.swp')
@@ -1003,7 +1003,6 @@ func Test_diff_screen()
   call StopVimInTerminal(buf)
   call delete('Xdifile1')
   call delete('Xdifile2')
-  call delete('XdiffSetup')
 endfunc
 
 func Test_diff_with_scroll_and_change()
@@ -1017,7 +1016,7 @@ func Test_diff_with_scroll_and_change()
 	wincmd h
 	exe "normal Gl5\<C-E>"
   END
-  call writefile(lines, 'Xtest_scroll_change')
+  call writefile(lines, 'Xtest_scroll_change', 'D')
   let buf = RunVimInTerminal('-S Xtest_scroll_change', {})
 
   call VerifyScreenDump(buf, 'Test_diff_scroll_change_01', {})
@@ -1030,7 +1029,6 @@ func Test_diff_with_scroll_and_change()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_scroll_change')
 endfunc
 
 func Test_diff_with_cursorline()
@@ -1044,7 +1042,7 @@ func Test_diff_with_cursorline()
 	\ 'call setline(1, ["bee","foo","foo","baz"])',
 	\ 'windo diffthis',
 	\ '2wincmd w',
-	\ ], 'Xtest_diff_cursorline')
+	\ ], 'Xtest_diff_cursorline', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_cursorline', {})
 
   call VerifyScreenDump(buf, 'Test_diff_with_cursorline_01', {})
@@ -1055,7 +1053,6 @@ func Test_diff_with_cursorline()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_cursorline')
 endfunc
 
 func Test_diff_with_cursorline_number()
@@ -1072,7 +1069,7 @@ func Test_diff_with_cursorline_number()
       windo diffthis
       1wincmd w
   END
-  call writefile(lines, 'Xtest_diff_cursorline_number')
+  call writefile(lines, 'Xtest_diff_cursorline_number', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_cursorline_number', {})
 
   call VerifyScreenDump(buf, 'Test_diff_with_cursorline_number_01', {})
@@ -1081,7 +1078,6 @@ func Test_diff_with_cursorline_number()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_cursorline_number')
 endfunc
 
 func Test_diff_with_cursorline_breakindent()
@@ -1098,7 +1094,7 @@ func Test_diff_with_cursorline_breakindent()
 	\ 'exe "norm 20Abee\<Esc>j20Afoo\<Esc>j20Afoo\<Esc>j20Abaz\<Esc>"',
 	\ 'windo diffthis',
 	\ '2wincmd w',
-	\ ], 'Xtest_diff_cursorline_breakindent')
+	\ ], 'Xtest_diff_cursorline_breakindent', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_cursorline_breakindent', {})
 
   call term_sendkeys(buf, "gg0")
@@ -1112,7 +1108,6 @@ func Test_diff_with_cursorline_breakindent()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_cursorline_breakindent')
 endfunc
 
 func Test_diff_with_syntax()
@@ -1125,7 +1120,7 @@ func Test_diff_with_syntax()
 	   return 5;
 	}
   END
-  call writefile(lines, 'Xprogram1.c')
+  call writefile(lines, 'Xprogram1.c', 'D')
   let lines =<< trim END
   	void doSomething() {
 	   int x = 0;
@@ -1133,22 +1128,19 @@ func Test_diff_with_syntax()
 	   return 5;
 	}
   END
-  call writefile(lines, 'Xprogram2.c')
+  call writefile(lines, 'Xprogram2.c', 'D')
 
   let lines =<< trim END
   	edit Xprogram1.c
 	diffsplit Xprogram2.c
   END
-  call writefile(lines, 'Xtest_diff_syntax')
+  call writefile(lines, 'Xtest_diff_syntax', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_syntax', {})
 
   call VerifyScreenDump(buf, 'Test_diff_syntax_1', {})
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_syntax')
-  call delete('Xprogram1.c')
-  call delete('Xprogram2.c')
 endfunc
 
 func Test_diff_of_diff()
@@ -1160,7 +1152,9 @@ func Test_diff_of_diff()
 	\ 'vnew',
 	\ 'call setline(1, ["aa","bb","cc"])',
 	\ 'windo diffthis',
-	\ ], 'Xtest_diff_diff')
+	\ '1wincmd w',
+	\ 'setlocal number',
+	\ ], 'Xtest_diff_diff', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_diff', {})
 
   call VerifyScreenDump(buf, 'Test_diff_of_diff_01', {})
@@ -1170,7 +1164,6 @@ func Test_diff_of_diff()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_diff')
 endfunc
 
 func CloseoffSetup()
@@ -1252,8 +1245,8 @@ func Test_patchexpr()
   endfunc
   set patchexpr=TPatch()
 
-  call writefile(['input file'], 'Xinput')
-  call writefile(['diff file'], 'Xdiff')
+  call writefile(['input file'], 'Xinput', 'D')
+  call writefile(['diff file'], 'Xdiff', 'D')
   %bwipe!
   edit Xinput
   diffpatch Xdiff
@@ -1270,8 +1263,6 @@ func Test_patchexpr()
   set patchexpr=<SID>NewPatchExpr()
   call assert_equal(expand('<SID>') .. 'NewPatchExpr()', &patchexpr)
 
-  call delete('Xinput')
-  call delete('Xdiff')
   set patchexpr&
   delfunc TPatch
   delfunc s:NewPatchExpr
@@ -1291,7 +1282,7 @@ func Test_diff_rnu()
     windo diffthis
     setlocal number rnu foldcolumn=0
   END
-  call writefile(content, 'Xtest_diff_rnu')
+  call writefile(content, 'Xtest_diff_rnu', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_rnu', {})
 
   call VerifyScreenDump(buf, 'Test_diff_rnu_01', {})
@@ -1303,7 +1294,6 @@ func Test_diff_rnu()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_rnu')
 endfunc
 
 func Test_diff_multilineconceal()
@@ -1351,7 +1341,7 @@ func Test_diff_filler_cursorcolumn()
     norm! gg0
     redraw!
   END
-  call writefile(content, 'Xtest_diff_cuc')
+  call writefile(content, 'Xtest_diff_cuc', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_cuc', {})
 
   call VerifyScreenDump(buf, 'Test_diff_cuc_01', {})
@@ -1368,7 +1358,6 @@ func Test_diff_filler_cursorcolumn()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_cuc')
 endfunc
 
 " Test for adding/removing lines inside diff chunks, between diff chunks
@@ -1467,7 +1456,7 @@ func Test_diff_binary()
     norm! gg0
     redraw!
   END
-  call writefile(content, 'Xtest_diff_bin')
+  call writefile(content, 'Xtest_diff_bin', 'D')
   let buf = RunVimInTerminal('-S Xtest_diff_bin', {})
 
   " Test using internal diff
@@ -1488,7 +1477,6 @@ func Test_diff_binary()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_diff_bin')
   set diffopt&vim
 endfunc
 
@@ -1558,7 +1546,7 @@ func Test_diff_scroll()
       // containing
       // four lines
   END
-  call writefile(left, 'Xleft')
+  call writefile(left, 'Xleft', 'D')
   let right =<< trim END
       line 1
       line 2
@@ -1594,7 +1582,7 @@ func Test_diff_scroll()
       // containing
       // four lines
   END
-  call writefile(right, 'Xright')
+  call writefile(right, 'Xright', 'D')
   let buf = RunVimInTerminal('-d Xleft Xright', {'rows': 12})
   call term_sendkeys(buf, "\<C-W>\<C-W>jjjj")
   call VerifyScreenDump(buf, 'Test_diff_scroll_1', {})
@@ -1602,8 +1590,6 @@ func Test_diff_scroll()
   call VerifyScreenDump(buf, 'Test_diff_scroll_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xleft')
-  call delete('Xright')
 endfunc
 
 " This was scrolling too many lines.

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -456,9 +456,7 @@ func Test_digraphs_output()
 endfunc
 
 func Test_loadkeymap()
-  if !has('keymap')
-    return
-  endif
+  CheckFeature keymap
   new
   set keymap=czech
   set iminsert=0
@@ -498,13 +496,10 @@ endfunc
 
 " Test for error in a keymap file
 func Test_loadkeymap_error()
-  if !has('keymap')
-    return
-  endif
+  CheckFeature keymap
   call assert_fails('loadkeymap', 'E105:')
-  call writefile(['loadkeymap', 'a'], 'Xkeymap')
+  call writefile(['loadkeymap', 'a'], 'Xkeymap', 'D')
   call assert_fails('source Xkeymap', 'E791:')
-  call delete('Xkeymap')
 endfunc
 
 " Test for the characters displayed on the screen when entering a digraph

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -79,7 +79,7 @@ func Test_scroll_without_region()
     set t_cs=
     set laststatus=2
   END
-  call writefile(lines, 'Xtestscroll')
+  call writefile(lines, 'Xtestscroll', 'D')
   let buf = RunVimInTerminal('-S Xtestscroll', #{rows: 10})
 
   call VerifyScreenDump(buf, 'Test_scroll_no_region_1', {})
@@ -103,11 +103,9 @@ func Test_scroll_without_region()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtestscroll')
 endfunc
 
 func Test_display_listchars_precedes()
-  set fillchars+=vert:\|
   call NewWindow(10, 10)
   " Need a physical line that wraps over the complete
   " window size
@@ -174,14 +172,13 @@ func Test_scroll_CursorLineNr_update()
     exe ":norm! o\<esc>110ia\<esc>"
   END
   let filename = 'Xdrawscreen'
-  call writefile(lines, filename)
+  call writefile(lines, filename, 'D')
   let buf = RunVimInTerminal('-S '.filename, #{rows: 5, cols: 50})
   call term_sendkeys(buf, "k")
   call VerifyScreenDump(buf, 'Test_winline_rnu', {})
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete(filename)
 endfunc
 
 " check a long file name does not result in the hit-enter prompt
@@ -189,28 +186,27 @@ func Test_edit_long_file_name()
   CheckScreendump
 
   let longName = 'x'->repeat(min([&columns, 255]))
-  call writefile([], longName)
+  call writefile([], longName, 'D')
   let buf = RunVimInTerminal('-N -u NONE ' .. longName, #{rows: 8})
 
   call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete(longName)
 endfunc
 
 func Test_unprintable_fileformats()
   CheckScreendump
 
-  call writefile(["unix\r", "two"], 'Xunix.txt')
-  call writefile(["mac\r", "two"], 'Xmac.txt')
+  call writefile(["unix\r", "two"], 'Xunix.txt', 'D')
+  call writefile(["mac\r", "two"], 'Xmac.txt', 'D')
   let lines =<< trim END
     edit Xunix.txt
     split Xmac.txt
     edit ++ff=mac
   END
   let filename = 'Xunprintable'
-  call writefile(lines, filename)
+  call writefile(lines, filename, 'D')
   let buf = RunVimInTerminal('-S '.filename, #{rows: 9, cols: 50})
   call VerifyScreenDump(buf, 'Test_display_unprintable_01', {})
   call term_sendkeys(buf, "\<C-W>\<C-W>\<C-L>")
@@ -218,9 +214,6 @@ func Test_unprintable_fileformats()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xunix.txt')
-  call delete('Xmac.txt')
-  call delete(filename)
 endfunc
 
 " Test for scrolling that modifies buffer during visual block
@@ -299,19 +292,18 @@ func Test_display_scroll_update_visual()
       call sign_place(2, 'bar', 'foo', bufnr(), { 'lnum': 1 })
       autocmd CursorMoved * if getcurpos()[1] == 2 | call sign_unplace('bar', { 'id': 1 }) | endif
   END
-  call writefile(lines, 'XupdateVisual.vim')
+  call writefile(lines, 'XupdateVisual.vim', 'D')
 
   let buf = RunVimInTerminal('-S XupdateVisual.vim', #{rows: 8, cols: 60})
   call term_sendkeys(buf, "VG7kk")
   call VerifyScreenDump(buf, 'Test_display_scroll_update_visual', {})
 
   call StopVimInTerminal(buf)
-  call delete('XupdateVisual.vim')
 endfunc
 
 " Test for 'eob' (EndOfBuffer) item in 'fillchars'
 func Test_eob_fillchars()
-  " default value (skipped)
+  " default value
   " call assert_match('eob:\~', &fillchars)
   " invalid values
   call assert_fails(':set fillchars=eob:', 'E474:')
@@ -405,7 +397,7 @@ func Test_local_fillchars()
       call setline(1, ['window 4']->repeat(3))
       setlocal fillchars=stl:4,stlnc:d,vert:>,eob:o
   END
-  call writefile(lines, 'Xdisplayfillchars')
+  call writefile(lines, 'Xdisplayfillchars', 'D')
   let buf = RunVimInTerminal('-S Xdisplayfillchars', #{rows: 12})
   call VerifyScreenDump(buf, 'Test_display_fillchars_1', {})
 
@@ -413,7 +405,6 @@ func Test_local_fillchars()
   call VerifyScreenDump(buf, 'Test_display_fillchars_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xdisplayfillchars')
 endfunc
 
 func Test_display_linebreak_breakat()

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -446,31 +446,31 @@ endfunc
 " terminal.
 func Test_autoindent_remove_indent()
   CheckRunVimInTerminal
-  let buf = RunVimInTerminal('-N Xfile', {'rows': 6, 'cols' : 20})
+  let buf = RunVimInTerminal('-N Xarifile', {'rows': 6, 'cols' : 20})
   call TermWait(buf)
   call term_sendkeys(buf, ":set autoindent\n")
   " leaving insert mode in a new line with indent added by autoindent, should
   " remove the indent.
   call term_sendkeys(buf, "i\<Tab>foo\<CR>\<Esc>")
-  " Need to delay for sometime, otherwise the code in getchar.c will not be
+  " Need to delay for some time, otherwise the code in getchar.c will not be
   " exercised.
   call TermWait(buf, 50)
   " when a line is wrapped and the cursor is at the start of the second line,
   " leaving insert mode, should move the cursor back to the first line.
   call term_sendkeys(buf, "o" .. repeat('x', 20) .. "\<Esc>")
-  " Need to delay for sometime, otherwise the code in getchar.c will not be
+  " Need to delay for some time, otherwise the code in getchar.c will not be
   " exercised.
   call TermWait(buf, 50)
   call term_sendkeys(buf, ":w\n")
   call TermWait(buf)
   call StopVimInTerminal(buf)
-  call assert_equal(["\tfoo", '', repeat('x', 20)], readfile('Xfile'))
-  call delete('Xfile')
+  call assert_equal(["\tfoo", '', repeat('x', 20)], readfile('Xarifile'))
+  call delete('Xarifile')
 endfunc
 
 func Test_edit_CR()
   " Test for <CR> in insert mode
-  " basically only in quickfix mode ist tested, the rest
+  " basically only in quickfix mode it's tested, the rest
   " has been taken care of by other tests
   CheckFeature quickfix
   botright new
@@ -1518,12 +1518,10 @@ func Test_edit_rightleft()
 endfunc
 
 func Test_edit_complete_very_long_name()
-  if !has('unix')
-    " Long directory names only work on Unix.
-    return
-  endif
+  " Long directory names only work on Unix.
+  CheckUnix
 
-  let dirname = getcwd() . "/Xdir"
+  let dirname = getcwd() . "/Xlongdir"
   let longdirname = dirname . repeat('/' . repeat('d', 255), 4)
   try
     call mkdir(longdirname, 'p')
@@ -1561,7 +1559,7 @@ func Test_edit_complete_very_long_name()
   let longfilename = longdirname . '/' . repeat('a', 255)
   call writefile(['Totum', 'Table'], longfilename)
   new
-  exe "next Xfile " . longfilename
+  exe "next Xnofile " . longfilename
   exe "normal iT\<C-N>"
 
   bwipe!
@@ -1760,7 +1758,7 @@ endfunc
 " Test for editing a directory
 func Test_edit_is_a_directory()
   CheckEnglish
-  let dirname = getcwd() . "/Xdir"
+  let dirname = getcwd() . "/Xeditdir"
   call mkdir(dirname, 'p')
 
   new
@@ -1785,19 +1783,19 @@ endfunc
 " Test for editing a file using invalid file encoding
 func Test_edit_invalid_encoding()
   CheckEnglish
-  call writefile([], 'Xfile')
+  call writefile([], 'Xinvfile')
   redir => msg
-  new ++enc=axbyc Xfile
+  new ++enc=axbyc Xinvfile
   redir END
   call assert_match('\[NOT converted\]', msg)
-  call delete('Xfile')
+  call delete('Xinvfile')
   close!
 endfunc
 
 " Test for the "charconvert" option
 func Test_edit_charconvert()
   CheckEnglish
-  call writefile(['one', 'two'], 'Xfile')
+  call writefile(['one', 'two'], 'Xccfile')
 
   " set 'charconvert' to a non-existing function
   set charconvert=NonExitingFunc()
@@ -1805,7 +1803,7 @@ func Test_edit_charconvert()
   let caught_e117 = v:false
   try
     redir => msg
-    edit ++enc=axbyc Xfile
+    edit ++enc=axbyc Xccfile
   catch /E117:/
     let caught_e117 = v:true
   finally
@@ -1823,7 +1821,7 @@ func Test_edit_charconvert()
   set charconvert=Cconv1()
   new
   redir => msg
-  edit ++enc=axbyc Xfile
+  edit ++enc=axbyc Xccfile
   redir END
   call assert_equal(['one', 'two'], getline(1, '$'))
   call assert_match("can't read output of 'charconvert'", msg)
@@ -1838,10 +1836,10 @@ func Test_edit_charconvert()
     call writefile(data, v:fname_out)
   endfunc
   set charconvert=Cconv2()
-  new Xfile
-  write ++enc=ucase Xfile1
-  call assert_equal(['ONE', 'TWO'], readfile('Xfile1'))
-  call delete('Xfile1')
+  new Xccfile
+  write ++enc=ucase Xccfile1
+  call assert_equal(['ONE', 'TWO'], readfile('Xccfile1'))
+  call delete('Xccfile1')
   close!
   delfunc Cconv2
   set charconvert&
@@ -1852,13 +1850,13 @@ func Test_edit_charconvert()
   endfunc
   set charconvert=Cconv3()
   new
-  call assert_fails('edit ++enc=lcase Xfile', 'E202:')
+  call assert_fails('edit ++enc=lcase Xccfile', 'E202:')
   call assert_equal([''], getline(1, '$'))
   close!
   delfunc Cconv3
   set charconvert&
 
-  call delete('Xfile')
+  call delete('Xccfile')
 endfunc
 
 " Test for editing a file without read permission
@@ -1866,17 +1864,17 @@ func Test_edit_file_no_read_perm()
   CheckUnix
   CheckNotRoot
 
-  call writefile(['one', 'two'], 'Xfile')
-  call setfperm('Xfile', '-w-------')
+  call writefile(['one', 'two'], 'Xnrpfile')
+  call setfperm('Xnrpfile', '-w-------')
   new
   redir => msg
-  edit Xfile
+  edit Xnrpfile
   redir END
   call assert_equal(1, &readonly)
   call assert_equal([''], getline(1, '$'))
   call assert_match('\[Permission Denied\]', msg)
   close!
-  call delete('Xfile')
+  call delete('Xnrpfile')
 endfunc
 
 " Using :edit without leaving 'insertmode' should not cause Insert mode to be

--- a/test/old/testdir/test_help_tagjump.vim
+++ b/test/old/testdir/test_help_tagjump.vim
@@ -185,14 +185,14 @@ let s:langs = ['en', 'ab', 'ja']
 
 func s:doc_config_setup()
   let s:helpfile_save = &helpfile
-  let &helpfile="Xdir1/doc-en/doc/testdoc.txt"
+  let &helpfile="Xdocdir1/doc-en/doc/testdoc.txt"
   let s:rtp_save = &rtp
-  let &rtp="Xdir1/doc-en"
+  let &rtp="Xdocdir1/doc-en"
   if has('multi_lang')
     let s:helplang_save=&helplang
   endif
 
-  call delete('Xdir1', 'rf')
+  call delete('Xdocdir1', 'rf')
 
   for lang in s:langs
     if lang ==# 'en'
@@ -202,7 +202,7 @@ func s:doc_config_setup()
       let tagfname = 'tags-' . lang
       let docfname = 'testdoc.' . lang . 'x'
     endif
-    let docdir = "Xdir1/doc-" . lang . "/doc"
+    let docdir = "Xdocdir1/doc-" . lang . "/doc"
     call mkdir(docdir, "p")
     call writefile(["\t*test-char*", "\t*test-col*"], docdir . '/' . docfname)
     call writefile(["test-char\t" . docfname . "\t/*test-char*",
@@ -212,7 +212,7 @@ func s:doc_config_setup()
 endfunc
 
 func s:doc_config_teardown()
-  call delete('Xdir1', 'rf')
+  call delete('Xdocdir1', 'rf')
 
   let &helpfile = s:helpfile_save
   let &rtp = s:rtp_save
@@ -244,7 +244,7 @@ func Test_help_complete()
       call assert_equal(['test-col', 'test-char'], list)
 
       " 'helplang=' and help file lang is 'en' and 'ab'
-      set rtp+=Xdir1/doc-ab
+      set rtp+=Xdocdir1/doc-ab
       set helplang=
       let list = s:get_help_compl_list("test")
       call assert_equal(sort(['test-col@en', 'test-col@ab',
@@ -257,7 +257,7 @@ func Test_help_complete()
             \             'test-char', 'test-char@en']), sort(list))
 
       " 'helplang=' and help file lang is 'en', 'ab' and 'ja'
-      set rtp+=Xdir1/doc-ja
+      set rtp+=Xdocdir1/doc-ja
       set helplang=
       let list = s:get_help_compl_list("test")
       call assert_equal(sort(['test-col@en', 'test-col@ab',
@@ -300,8 +300,8 @@ func Test_help_respect_current_file_lang()
         helpclose
       endfunc
 
-      set rtp+=Xdir1/doc-ab
-      set rtp+=Xdir1/doc-ja
+      set rtp+=Xdocdir1/doc-ab
+      set rtp+=Xdocdir1/doc-ja
 
       set helplang=ab
       call s:check_help_file_ext('test-char', 'abx')


### PR DESCRIPTION
#### vim-patch:9.0.0137: debugger test may fail when $CWD is very long

Problem:    Debugger test may fail when $CWD is very long.
Solution:   Skip the test if the directory name is too long. (James McCoy,
            closes vim/vim#10837)

https://github.com/vim/vim/commit/db7a88db8b52508d3df6d5947f7c4f3ef05d5f62

Co-authored-by: James McCoy <jamessan@jamessan.com>


#### vim-patch:9.0.0336: tests are flaky because of using a common file name

Problem:    Tests are flaky because of using a common file name.
Solution:   Rename files and directories to be more unique.

https://github.com/vim/vim/commit/61abe7d8f827ec31f098e8abcdf58846b956ef16

Cherry-pick Test_custom_complete_autoload() from patch 8.2.4584.
Cherry-pick test_delete.vim & test_edit.vim changes from patch 9.0.0323.
Cherry-pick test_edit.vim changes from patch 8.2.3637.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0525: manually deleting temp test files

Problem:    Manually deleting temp test files.
Solution:   Add the 'D' flag to writefile().

https://github.com/vim/vim/commit/5917341f65d4fc669b9d15343ccdb00c160201da

Co-authored-by: Bram Moolenaar <Bram@vim.org>