### PR TITLE
vim-patch:9.0.2102: matchparen highlight not cleared in completion mode

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -26,6 +26,7 @@ augroup matchparen
   autocmd! WinLeave,BufLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()
+    autocmd! TextChangedP * call s:Remove_Matches()
   endif
 augroup END
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1241,9 +1241,6 @@ void ins_compl_show_pum(void)
     return;
   }
 
-  // Dirty hard-coded hack: remove any matchparen highlighting.
-  do_cmdline_cmd("if exists('g:loaded_matchparen')|3match none|endif");
-
   // Update the screen before drawing the popup menu over it.
   update_screen();
 

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -9,34 +9,6 @@ local command = helpers.command
 describe('display', function()
   before_each(clear)
 
-  -- oldtest: Test_visual_block_scroll()
-  it('redraws properly after scrolling with matchparen loaded and scrolloff=1', function()
-    local screen = Screen.new(30, 7)
-    screen:attach()
-    screen:set_default_attr_ids({
-      [1] = {bold = true},
-      [2] = {background = Screen.colors.LightGrey},
-    })
-
-    exec([[
-      source $VIMRUNTIME/plugin/matchparen.vim
-      set scrolloff=1
-      call setline(1, ['a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'])
-      call cursor(5, 1)
-    ]])
-
-    feed('V<c-d><c-d>')
-    screen:expect([[
-      {2:{}                             |
-      {2:}}                             |
-      {2:{}                             |
-      {2:f}                             |
-      ^g                             |
-      }                             |
-      {1:-- VISUAL LINE --}             |
-    ]])
-  end)
-
   -- oldtest: Test_display_scroll_at_topline()
   it('scroll when modified at topline vim-patch:8.2.1488', function()
     local screen = Screen.new(20, 4)
@@ -84,51 +56,6 @@ describe('display', function()
       {3:  }foo                                                       |
       {1:-- VISUAL LINE --}                                           |
     ]])
-  end)
-
-  -- oldtest: Test_matchparen_clear_highlight()
-  it('matchparen highlight is cleared when switching buffer', function()
-    local screen = Screen.new(20, 5)
-    screen:set_default_attr_ids({
-      [0] = {bold = true, foreground = Screen.colors.Blue},
-      [1] = {background = Screen.colors.Cyan},
-    })
-    screen:attach()
-
-    local screen1 = [[
-      {1:^()}                  |
-      {0:~                   }|
-      {0:~                   }|
-      {0:~                   }|
-                          |
-    ]]
-    local screen2 = [[
-      ^aa                  |
-      {0:~                   }|
-      {0:~                   }|
-      {0:~                   }|
-                          |
-    ]]
-
-    exec([[
-      source $VIMRUNTIME/plugin/matchparen.vim
-      set hidden
-      call setline(1, ['()'])
-      normal 0
-    ]])
-    screen:expect(screen1)
-
-    exec([[
-      enew
-      exe "normal iaa\<Esc>0"
-    ]])
-    screen:expect(screen2)
-
-    feed('<C-^>')
-    screen:expect(screen1)
-
-    feed('<C-^>')
-    screen:expect(screen2)
   end)
 
   local function run_test_display_lastline(euro)

--- a/test/functional/legacy/matchparen_spec.lua
+++ b/test/functional/legacy/matchparen_spec.lua
@@ -1,0 +1,116 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local exec = helpers.exec
+local feed = helpers.feed
+
+describe('matchparen', function()
+  before_each(clear)
+
+  -- oldtest: Test_visual_block_scroll()
+  it('redraws properly after scrolling with scrolloff=1', function()
+    local screen = Screen.new(30, 7)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true},
+      [2] = {background = Screen.colors.LightGrey},
+    })
+
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set scrolloff=1
+      call setline(1, ['a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'])
+      call cursor(5, 1)
+    ]])
+
+    feed('V<c-d><c-d>')
+    screen:expect([[
+      {2:{}                             |
+      {2:}}                             |
+      {2:{}                             |
+      {2:f}                             |
+      ^g                             |
+      }                             |
+      {1:-- VISUAL LINE --}             |
+    ]])
+  end)
+
+  -- oldtest: Test_matchparen_clear_highlight()
+  it('matchparen highlight is cleared when switching buffer', function()
+    local screen = Screen.new(20, 5)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {background = Screen.colors.Cyan},
+    })
+    screen:attach()
+
+    local screen1 = [[
+      {1:^()}                  |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+                          |
+    ]]
+    local screen2 = [[
+      ^aa                  |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+                          |
+    ]]
+
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set hidden
+      call setline(1, ['()'])
+      normal 0
+    ]])
+    screen:expect(screen1)
+
+    exec([[
+      enew
+      exe "normal iaa\<Esc>0"
+    ]])
+    screen:expect(screen2)
+
+    feed('<C-^>')
+    screen:expect(screen1)
+
+    feed('<C-^>')
+    screen:expect(screen2)
+  end)
+
+  -- oldtest: Test_matchparen_pum_clear()
+  it('is cleared when completion popup is shown', function()
+    local screen = Screen.new(30, 9)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue};
+      [1] = {background = Screen.colors.Plum1};
+      [2] = {background = Screen.colors.Grey};
+      [3] = {bold = true};
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen};
+    })
+
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set completeopt=menuone
+      call setline(1, ['aa', 'aaa', 'aaaa', '(a)'])
+      call cursor(4, 3)
+    ]])
+
+    feed('i<C-X><C-N><C-N>')
+    screen:expect{grid=[[
+      aa                            |
+      aaa                           |
+      aaaa                          |
+      (aaa^)                         |
+      {1: aa             }{0:              }|
+      {2: aaa            }{0:              }|
+      {1: aaaa           }{0:              }|
+      {0:~                             }|
+      {3:-- }{4:match 2 of 3}               |
+    ]]}
+  end)
+end)

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -216,59 +216,6 @@ func Test_unprintable_fileformats()
   call StopVimInTerminal(buf)
 endfunc
 
-" Test for scrolling that modifies buffer during visual block
-func Test_visual_block_scroll()
-  CheckScreendump
-
-  let lines =<< trim END
-    source $VIMRUNTIME/plugin/matchparen.vim
-    set scrolloff=1
-    call setline(1, ['a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'])
-    call cursor(5, 1)
-  END
-
-  let filename = 'Xvisualblockmodifiedscroll'
-  call writefile(lines, filename, 'D')
-
-  let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
-  call term_sendkeys(buf, "V\<C-D>\<C-D>")
-
-  call VerifyScreenDump(buf, 'Test_display_visual_block_scroll', {})
-
-  call StopVimInTerminal(buf)
-endfunc
-
-" Test for clearing paren highlight when switching buffers
-func Test_matchparen_clear_highlight()
-  CheckScreendump
-
-  let lines =<< trim END
-    source $VIMRUNTIME/plugin/matchparen.vim
-    set hidden
-    call setline(1, ['()'])
-    normal 0
-
-    func OtherBuffer()
-       enew
-       exe "normal iaa\<Esc>0"
-    endfunc
-  END
-  call writefile(lines, 'XMatchparenClear', 'D')
-  let buf = RunVimInTerminal('-S XMatchparenClear', #{rows: 5})
-  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
-
-  call term_sendkeys(buf, ":call OtherBuffer()\<CR>:\<Esc>")
-  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
-
-  call term_sendkeys(buf, "\<C-^>:\<Esc>")
-  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
-
-  call term_sendkeys(buf, "\<C-^>:\<Esc>")
-  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
-
-  call StopVimInTerminal(buf)
-endfunc
-
 func Test_display_scroll_at_topline()
   CheckScreendump
 

--- a/test/old/testdir/test_matchparen.vim
+++ b/test/old/testdir/test_matchparen.vim
@@ -1,0 +1,87 @@
+" Test for the matchparen plugin
+
+if !has('gui_running') && has('unix')
+  " set term=ansi
+endif
+
+source view_util.vim
+source check.vim
+source screendump.vim
+
+" Test for scrolling that modifies buffer during visual block
+func Test_visual_block_scroll()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set scrolloff=1
+    call setline(1, ['a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'])
+    call cursor(5, 1)
+  END
+
+  let filename = 'Xvisualblockmodifiedscroll'
+  call writefile(lines, filename, 'D')
+
+  let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
+  call term_sendkeys(buf, "V\<C-D>\<C-D>")
+
+  call VerifyScreenDump(buf, 'Test_display_visual_block_scroll', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+" Test for clearing paren highlight when switching buffers
+func Test_matchparen_clear_highlight()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set hidden
+    call setline(1, ['()'])
+    normal 0
+
+    func OtherBuffer()
+       enew
+       exe "normal iaa\<Esc>0"
+    endfunc
+  END
+  call writefile(lines, 'XMatchparenClear', 'D')
+  let buf = RunVimInTerminal('-S XMatchparenClear', #{rows: 5})
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, ":call OtherBuffer()\<CR>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+" Test for scrolling that modifies buffer during visual block
+func Test_matchparen_pum_clear()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set completeopt=menuone
+    call setline(1, ['aa', 'aaa', 'aaaa', '(a)'])
+    call cursor(4, 3)
+  END
+
+  let filename = 'Xmatchparen'
+  call writefile(lines, filename, 'D')
+
+  let buf = RunVimInTerminal('-S '.filename, #{rows: 10})
+  call term_sendkeys(buf, "i\<C-N>\<C-N>")
+
+  call VerifyScreenDump(buf, 'Test_matchparen_pum_clear_1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2102: matchparen highlight not cleared in completion mode

Problem:  matchparen highlight not cleared in completion mode
Solution: Clear matchparen highlighting in completion mode

Remove hard-coded hack in insexpand.c to clear the :3match before
displaying the completion menu.

Add a test for matchparen highlighting. While at it, move all test tests
related to the matchparen plugin into a separate test file.

closes: vim/vim#13524

https://github.com/vim/vim/commit/9588666360e94de3ff58d4bc79aa9148fbf5fc44

Co-authored-by: Christian Brabandt <cb@256bit.org>