### PR TITLE
vim-patch:partial:8.0.1592,8.1.{0870,partial:1218,1581,2276,2373},8.2.{2112,4850}

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -324,9 +324,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
   // when 'viewoptions' contains "cursor".
   do_cursor = (flagp == &ssop_flags || *flagp & SSOP_CURSOR);
 
-  //
   // Local argument list.
-  //
   if (wp->w_alist == &global_alist) {
     PUTLINE_FAIL("argglobal");
   } else {
@@ -419,21 +417,17 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
     }
   }
 
-  //
   // Local mappings and abbreviations.
-  //
   if ((*flagp & (SSOP_OPTIONS | SSOP_LOCALOPTIONS))
       && makemap(fd, wp->w_buffer) == FAIL) {
     return FAIL;
   }
 
-  //
   // Local options.  Need to go to the window temporarily.
   // Store only local values when using ":mkview" and when ":mksession" is
   // used and 'sessionoptions' doesn't include "nvim/options".
   // Some folding options are always stored when "folds" is included,
   // otherwise the folds would not be restored correctly.
-  //
   save_curwin = curwin;
   curwin = wp;
   curbuf = curwin->w_buffer;
@@ -451,9 +445,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
     return FAIL;
   }
 
-  //
   // Save Folds when 'buftype' is empty and for help files.
-  //
   if ((*flagp & SSOP_FOLDS)
       && wp->w_buffer->b_ffname != NULL
       && (bt_normal(wp->w_buffer)
@@ -463,9 +455,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
     }
   }
 
-  //
   // Set the cursor after creating folds, since that moves the cursor.
-  //
   if (do_cursor) {
     // Restore the cursor line in the file and relatively in the
     // window.  Don't use "G", it changes the jumplist.
@@ -516,10 +506,8 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
     }
   }
 
-  //
   // Local directory, if the current flag is not view options or the "curdir"
   // option is included.
-  //
   if (wp->w_localdir != NULL
       && (flagp != &vop_flags || (*flagp & SSOP_CURDIR))) {
     if (fputs("lcd ", fd) < 0
@@ -574,9 +562,7 @@ static int makeopens(FILE *fd, char *dirnow)
     return FAIL;
   }
 
-  //
   // Now a :cd command to the session directory or the current directory
-  //
   if (ssop_flags & SSOP_SESDIR) {
     PUTLINE_FAIL("exe \"cd \" . escape(expand(\"<sfile>:p:h\"), ' ')");
   } else if (ssop_flags & SSOP_CURDIR) {
@@ -658,11 +644,9 @@ static int makeopens(FILE *fd, char *dirnow)
     restore_stal = true;
   }
 
-  //
   // For each tab:
   // - Put windows for each tab, when "tabpages" is in 'sessionoptions'.
   // - Don't use goto_tabpage(), it may change CWD and trigger autocommands.
-  //
   tab_firstwin = firstwin;      // First window in tab page "tabnr".
   tab_topframe = topframe;
   if ((ssop_flags & SSOP_TABPAGES)) {
@@ -703,11 +687,9 @@ static int makeopens(FILE *fd, char *dirnow)
       }
     }
 
-    //
     // Before creating the window layout, try loading one file.  If this
     // is aborted we don't end up with a number of useless windows.
     // This may have side effects! (e.g., compressed or network file).
-    //
     for (wp = tab_firstwin; wp != NULL; wp = wp->w_next) {
       if (ses_do_win(wp)
           && wp->w_buffer->b_ffname != NULL
@@ -785,9 +767,19 @@ static int makeopens(FILE *fd, char *dirnow)
       return FAIL;
     }
 
-    //
+    // Restore the tab-local working directory if specified
+    // Do this before the windows, so that the window-local directory can
+    // override the tab-local directory.
+    if (tp != NULL && tp->tp_localdir != NULL && (ssop_flags & SSOP_CURDIR)) {
+      if (fputs("tcd ", fd) < 0
+          || ses_put_fname(fd, tp->tp_localdir, &ssop_flags) == FAIL
+          || put_eol(fd) == FAIL) {
+        return FAIL;
+      }
+      did_lcd = true;
+    }
+
     // Restore the view of the window (options, file, cursor, etc.).
-    //
     for (wp = tab_firstwin; wp != NULL; wp = wp->w_next) {
       if (!ses_do_win(wp)) {
         continue;
@@ -807,29 +799,15 @@ static int makeopens(FILE *fd, char *dirnow)
     // "tabedit".
     cur_arg_idx = next_arg_idx;
 
-    //
     // Restore cursor to the current window if it's not the first one.
-    //
     if (cnr > 1 && (fprintf(fd, "%dwincmd w\n", cnr) < 0)) {
       return FAIL;
     }
 
-    //
     // Restore window sizes again after jumping around in windows, because
     // the current window has a minimum size while others may not.
-    //
     if (nr > 1 && ses_winsizes(fd, restore_size, tab_firstwin) == FAIL) {
       return FAIL;
-    }
-
-    // Take care of tab-local working directories if applicable
-    if (tp->tp_localdir) {
-      if (fputs("if exists(':tcd') == 2 | tcd ", fd) < 0
-          || ses_put_fname(fd, tp->tp_localdir, &ssop_flags) == FAIL
-          || fputs(" | endif\n", fd) < 0) {
-        return FAIL;
-      }
-      did_lcd = true;
     }
 
     // Don't continue in another tab page when doing only the current one
@@ -848,9 +826,7 @@ static int makeopens(FILE *fd, char *dirnow)
     return FAIL;
   }
 
-  //
   // Wipe out an empty unnamed buffer we started in.
-  //
   if (fprintf(fd, "%s",
               "if exists('s:wipebuf') "
               "&& len(win_findbuf(s:wipebuf)) == 0 "
@@ -882,9 +858,7 @@ static int makeopens(FILE *fd, char *dirnow)
     PUTLINE_FAIL("let &winminwidth = s:save_winminwidth");
   }
 
-  //
   // Lastly, execute the x.vim file if it exists.
-  //
   if (fprintf(fd, "%s",
               "let s:sx = expand(\"<sfile>:p:r\").\"x.vim\"\n"
               "if filereadable(s:sx)\n"
@@ -999,9 +973,8 @@ void ex_mkrc(exarg_T *eap)
         char *dirnow;  // current directory
 
         dirnow = xmalloc(MAXPATHL);
-        //
+
         // Change to session file's dir.
-        //
         if (os_dirname(dirnow, MAXPATHL) == FAIL
             || os_chdir(dirnow) != 0) {
           *dirnow = NUL;

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2548,7 +2548,13 @@ func Test_Changed_FirstTime()
   let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
   call assert_equal('running', term_getstatus(buf))
   " Wait for the ruler (in the status line) to be shown.
-  call WaitForAssert({-> assert_match('\<All$', term_getline(buf, 3))})
+  " In ConPTY, there is additional character which is drawn up to the width of
+  " the screen.
+  if has('conpty')
+    call WaitForAssert({-> assert_match('\<All.*$', term_getline(buf, 3))})
+  else
+    call WaitForAssert({-> assert_match('\<All$', term_getline(buf, 3))})
+  endif
   " It's only adding autocmd, so that no event occurs.
   call term_sendkeys(buf, ":au! TextChanged <buffer> call writefile(['No'], 'Xchanged.txt')\<cr>")
   call term_sendkeys(buf, "\<C-\\>\<C-N>:qa!\<cr>")

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3028,6 +3028,8 @@ func Test_autocmd_CmdWinEnter()
 endfunc
 
 func Test_autocmd_was_using_freed_memory()
+  CheckFeature quickfix
+
   pedit xx
   n x
   augroup winenter

--- a/test/old/testdir/test_bufwintabinfo.vim
+++ b/test/old/testdir/test_bufwintabinfo.vim
@@ -1,6 +1,9 @@
 " Tests for the getbufinfo(), getwininfo() and gettabinfo() functions
+source check.vim
 
-function Test_getbufwintabinfo()
+func Test_getbufwintabinfo()
+  CheckFeature quickfix
+
   edit Xtestfile1
   edit Xtestfile2
   let buflist = getbufinfo()
@@ -109,7 +112,7 @@ function Test_getbufwintabinfo()
   call assert_true(winlist[2].quickfix)
   call assert_false(winlist[2].loclist)
   wincmd t | only
-endfunction
+endfunc
 
 function Test_get_buf_options()
   let opts = bufnr()->getbufvar('&')

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -1137,6 +1137,8 @@ func Test_edit_CTRL_V()
 endfunc
 
 func Test_edit_F1()
+  CheckFeature quickfix
+
   " Pressing <f1>
   new
   " call feedkeys(":set im\<cr>\<f1>\<c-l>", 'tnix')

--- a/test/old/testdir/test_execute_func.vim
+++ b/test/old/testdir/test_execute_func.vim
@@ -124,6 +124,8 @@ func Test_win_execute()
 endfunc
 
 func Test_win_execute_update_ruler()
+  CheckFeature quickfix
+
   enew
   call setline(1, range(500))
   20

--- a/test/old/testdir/test_filter_cmd.vim
+++ b/test/old/testdir/test_filter_cmd.vim
@@ -1,5 +1,7 @@
 " Test the :filter command modifier
 
+source check.vim
+
 func Test_filter()
   edit Xdoesnotmatch
   edit Xwillmatch
@@ -97,6 +99,8 @@ func Test_filter_cmd_with_filter()
 endfunction
 
 func Test_filter_commands()
+  CheckFeature quickfix
+
   let g:test_filter_a = 1
   let b:test_filter_b = 2
   let test_filter_c = 3

--- a/test/old/testdir/test_makeencoding.vim
+++ b/test/old/testdir/test_makeencoding.vim
@@ -1,7 +1,9 @@
 " Tests for 'makeencoding'.
 
 source shared.vim
+source check.vim
 
+CheckFeature quickfix
 let s:python = PythonProg()
 if s:python == ''
   throw 'Skipped: python program missing'

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -294,8 +294,8 @@ func Test_mksession_tcd_multiple_tabs()
   call assert_equal('Xtabdir3', fnamemodify(getcwd(-1, 3), ':t'))
   call assert_equal('Xtabdir3', fnamemodify(getcwd(1, 3), ':t'))
   call assert_equal('Xwindir3', fnamemodify(getcwd(2, 3), ':t'))
-  only | tabonly
-  exe 'cd ' . save_cwd
+  %bwipe
+  call chdir(save_cwd)
   call delete("Xtopdir", "rf")
 endfunc
 
@@ -781,6 +781,7 @@ endfunc
 
 " Test for changing directory to the session file directory
 func Test_mksession_sesdir()
+  let save_cwd = getcwd()
   call mkdir('Xproj')
   mksession! Xproj/Xtest_mks1.out
   set sessionoptions-=curdir
@@ -791,7 +792,8 @@ func Test_mksession_sesdir()
   call assert_equal('testdir', fnamemodify(getcwd(), ':t'))
   source Xproj/Xtest_mks2.out
   call assert_equal('Xproj', fnamemodify(getcwd(), ':t'))
-  cd ..
+  call chdir(save_cwd)
+  %bwipe
 
   set sessionoptions&
   call delete('Xproj', 'rf')

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -424,7 +424,7 @@ func Test_mksession_terminal_no_restore_cmdarg()
   let term_cmd = ''
   for line in lines
     if line =~ '^terminal'
-      call assert_report('session must not restore teminal')
+      call assert_report('session must not restore terminal')
     endif
   endfor
 
@@ -439,7 +439,7 @@ func Test_mksession_terminal_no_restore_funcarg()
   let term_cmd = ''
   for line in lines
     if line =~ '^terminal'
-      call assert_report('session must not restore teminal')
+      call assert_report('session must not restore terminal')
     endif
   endfor
 
@@ -455,7 +455,7 @@ func Test_mksession_terminal_no_restore_func()
   let term_cmd = ''
   for line in lines
     if line =~ '^terminal'
-      call assert_report('session must not restore teminal')
+      call assert_report('session must not restore terminal')
     endif
   endfor
 
@@ -471,7 +471,7 @@ func Test_mksession_terminal_no_ssop()
   let term_cmd = ''
   for line in lines
     if line =~ '^terminal'
-      call assert_report('session must not restore teminal')
+      call assert_report('session must not restore terminal')
     endif
   endfor
 

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -803,6 +803,35 @@ func Test_mksession_sesdir()
   call delete('Xproj', 'rf')
 endfunc
 
+" Test for saving and restoring the tab-local working directory when there is
+" only a single tab and 'tabpages' is not in 'sessionoptions'.
+func Test_mksession_tcd_single_tabs()
+  only | tabonly
+
+  let save_cwd = getcwd()
+  set sessionoptions-=tabpages
+  set sessionoptions+=curdir
+  call mkdir('Xtopdir1')
+  call mkdir('Xtopdir2')
+
+  " There are two tab pages, the current one has local cwd set to 'Xtopdir2'.
+  exec 'tcd ' .. save_cwd .. '/Xtopdir1'
+  tabnew
+  exec 'tcd ' .. save_cwd .. '/Xtopdir2'
+  mksession! Xtest_tcd_single
+
+  source Xtest_tcd_single
+  " call assert_equal(2, haslocaldir())
+  call assert_equal(1, haslocaldir(-1))
+  call assert_equal('Xtopdir2', fnamemodify(getcwd(-1, 0), ':t'))
+  %bwipe
+
+  set sessionoptions&
+  call chdir(save_cwd)
+  call delete('Xtopdir1', 'rf')
+  call delete('Xtopdir2', 'rf')
+endfunc
+
 " Test for storing the 'lines' and 'columns' settings
 func Test_mksession_resize()
   mksession! Xtest_mks1.out

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -398,6 +398,8 @@ endfunc
 if has('terminal')
 
 func Test_mksession_terminal_shell()
+  CheckFeature quickfix
+
   terminal
   mksession! Xtest_mks.out
   let lines = readfile('Xtest_mks.out')
@@ -479,8 +481,10 @@ func Test_mksession_terminal_no_ssop()
 endfunc
 
 func Test_mksession_terminal_restore_other()
+  CheckFeature quickfix
+
   terminal
-  call term_setrestore(bufnr('%'), 'other')
+  eval bufnr('%')->term_setrestore('other')
   mksession! Xtest_mks.out
   let lines = readfile('Xtest_mks.out')
   let term_cmd = ''

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -257,6 +257,48 @@ func Test_mksession_lcd_multiple_tabs()
   call delete('Xtest_mks.out')
 endfunc
 
+" Test for tabpage-local directory
+func Test_mksession_tcd_multiple_tabs()
+  let save_cwd = getcwd()
+  call mkdir('Xtopdir')
+  cd Xtopdir
+  call mkdir('Xtabdir1')
+  call mkdir('Xtabdir2')
+  call mkdir('Xtabdir3')
+  call mkdir('Xwindir1')
+  call mkdir('Xwindir2')
+  call mkdir('Xwindir3')
+  tcd Xtabdir1
+  botright new
+  wincmd t
+  lcd ../Xwindir1
+  tabnew
+  tcd ../Xtabdir2
+  botright new
+  lcd ../Xwindir2
+  tabnew
+  tcd ../Xtabdir3
+  botright new
+  lcd ../Xwindir3
+  tabfirst
+  1wincmd w
+  mksession! Xtest_mks.out
+  only | tabonly
+  source Xtest_mks.out
+  call assert_equal('Xtabdir1', fnamemodify(getcwd(-1, 1), ':t'))
+  call assert_equal('Xwindir1', fnamemodify(getcwd(1, 1), ':t'))
+  call assert_equal('Xtabdir1', fnamemodify(getcwd(2, 1), ':t'))
+  call assert_equal('Xtabdir2', fnamemodify(getcwd(-1, 2), ':t'))
+  call assert_equal('Xtabdir2', fnamemodify(getcwd(1, 2), ':t'))
+  call assert_equal('Xwindir2', fnamemodify(getcwd(2, 2), ':t'))
+  call assert_equal('Xtabdir3', fnamemodify(getcwd(-1, 3), ':t'))
+  call assert_equal('Xtabdir3', fnamemodify(getcwd(1, 3), ':t'))
+  call assert_equal('Xwindir3', fnamemodify(getcwd(2, 3), ':t'))
+  only | tabonly
+  exe 'cd ' . save_cwd
+  call delete("Xtopdir", "rf")
+endfunc
+
 func Test_mksession_blank_tabs()
   tabnew
   tabnew

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -353,6 +353,108 @@ func Test_mksession_blank_windows()
   call delete('Xtest_mks.out')
 endfunc
 
+if has('terminal')
+
+func Test_mksession_terminal_shell()
+  terminal
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      let term_cmd = line
+    elseif line =~ 'badd.*' . &shell
+      call assert_report('unexpected shell line: ' . line)
+    endif
+  endfor
+  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*$', term_cmd)
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_terminal_no_restore_cmdarg()
+  terminal ++norestore
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      call assert_report('session must not restore teminal')
+    endif
+  endfor
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_terminal_no_restore_funcarg()
+  call term_start(&shell, {'norestore': 1})
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      call assert_report('session must not restore teminal')
+    endif
+  endfor
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_terminal_no_restore_func()
+  terminal
+  call term_setrestore(bufnr('%'), 'NONE')
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      call assert_report('session must not restore teminal')
+    endif
+  endfor
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+endfunc
+
+func Test_mksession_terminal_no_ssop()
+  terminal
+  set sessionoptions-=terminal
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      call assert_report('session must not restore teminal')
+    endif
+  endfor
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+  set sessionoptions&
+endfunc
+
+func Test_mksession_terminal_restore_other()
+  terminal
+  call term_setrestore(bufnr('%'), 'other')
+  mksession! Xtest_mks.out
+  let lines = readfile('Xtest_mks.out')
+  let term_cmd = ''
+  for line in lines
+    if line =~ '^terminal'
+      let term_cmd = line
+    endif
+  endfor
+  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+ other', term_cmd)
+
+  call Stop_shell_in_terminal(bufnr('%'))
+  call delete('Xtest_mks.out')
+endfunc
+
+endif " has('terminal')
+
 func Test_mkview_open_folds()
   enew!
 

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -411,7 +411,7 @@ func Test_mksession_terminal_shell()
   endfor
   call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*.*$', term_cmd)
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -426,7 +426,7 @@ func Test_mksession_terminal_no_restore_cmdarg()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -441,7 +441,7 @@ func Test_mksession_terminal_no_restore_funcarg()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -457,7 +457,7 @@ func Test_mksession_terminal_no_restore_func()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 
@@ -473,7 +473,7 @@ func Test_mksession_terminal_no_ssop()
     endif
   endfor
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
   set sessionoptions&
 endfunc
@@ -491,7 +491,7 @@ func Test_mksession_terminal_restore_other()
   endfor
   call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+.*other', term_cmd)
 
-  call Stop_shell_in_terminal(bufnr('%'))
+  call StopShellInTerminal(bufnr('%'))
   call delete('Xtest_mks.out')
 endfunc
 

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -367,7 +367,7 @@ func Test_mksession_terminal_shell()
       call assert_report('unexpected shell line: ' . line)
     endif
   endfor
-  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*$', term_cmd)
+  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+\s*.*$', term_cmd)
 
   call Stop_shell_in_terminal(bufnr('%'))
   call delete('Xtest_mks.out')
@@ -447,7 +447,7 @@ func Test_mksession_terminal_restore_other()
       let term_cmd = line
     endif
   endfor
-  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+ other', term_cmd)
+  call assert_match('terminal ++curwin ++cols=\d\+ ++rows=\d\+.*other', term_cmd)
 
   call Stop_shell_in_terminal(bufnr('%'))
   call delete('Xtest_mks.out')

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -1923,6 +1923,8 @@ func Test_normal24_rot13()
 endfunc
 
 func Test_normal25_tag()
+  CheckFeature quickfix
+
   " Testing for CTRL-] g CTRL-] g]
   " CTRL-W g] CTRL-W CTRL-] CTRL-W g CTRL-]
   h

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -501,6 +501,8 @@ endfunc
 " Test that 'completefunc' on Scratch buffer with preview window works when
 " it's OK.
 func Test_completefunc_with_scratch_buffer()
+  CheckFeature quickfix
+
   new +setlocal\ buftype=nofile\ bufhidden=wipe\ noswapfile
   set completeopt+=preview
   setlocal completefunc=DummyCompleteFive
@@ -710,14 +712,13 @@ func Test_popup_and_window_resize()
 endfunc
 
 func Test_popup_and_preview_autocommand()
+  CheckFeature python
+  CheckFeature quickfix
+  if winheight(0) < 15
+    throw 'Skipped: window height insufficient'
+  endif
+
   " This used to crash Vim
-  if !has('python')
-    return
-  endif
-  let h = winheight(0)
-  if h < 15
-    return
-  endif
   new
   augroup MyBufAdd
     au!
@@ -821,9 +822,8 @@ func Test_balloon_split()
 endfunc
 
 func Test_popup_position()
-  if !CanRunVimInTerminal()
-    return
-  endif
+  CheckScreendump
+
   let lines =<< trim END
     123456789_123456789_123456789_a
     123456789_123456789_123456789_b

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -4,6 +4,8 @@ source screendump.vim
 source check.vim
 
 function Test_tabpage()
+  CheckFeature quickfix
+
   bw!
   " Simple test for opening and closing a tab page
   tabnew
@@ -273,6 +275,8 @@ function Test_tabpage_with_autocmd_tab_drop()
 endfunction
 
 function Test_tabpage_with_tab_modifier()
+  CheckFeature quickfix
+
   for n in range(4)
     tabedit
   endfor

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -508,6 +508,8 @@ func Test_equalalways_on_close()
 endfunc
 
 func Test_win_screenpos()
+  CheckFeature quickfix
+
   call assert_equal(1, winnr('$'))
   split
   vsplit


### PR DESCRIPTION
#### vim-patch:partial:8.0.1592: terminal windows in a session are not properly restored

Problem:    Terminal windows in a session are not properly restored.
Solution:   Add "terminal" in 'sessionoptions'.  When possible restore the
            command running in a terminal.

https://github.com/vim/vim/commit/4d8bac8bf593ff087517ff79090c2d224325aae6

Tests only. Nvim has no equivalent to "norestore" yet.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.0870: Vim doesn't use the new ConPTY support in Windows 10

Problem:    Vim doesn't use the new ConPTY support in Windows 10.
Solution:   Use ConPTY support, if available. (Nobuhiro Takasaki, closes vim/vim#3794)

https://github.com/vim/vim/commit/aa5df7e3127dff6b7336df0903f5c569a40eb174

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:partial:8.1.1218: cannot set a directory for a tab page

Problem:    Cannot set a directory for a tab page.
Solution:   Add the tab-local directory. (Yegappan Lakshmanan, closes vim/vim#4212)

https://github.com/vim/vim/commit/00aa069db8132851a91cfc5ca7f58ef945c75c73

Session-related changes only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1581: shared functions for testing are disorganised

Problem:    Shared functions for testing are disorganised.
Solution:   Group finctions in script files. (Ozaki Kiichi, closes vim/vim#4573)

https://github.com/vim/vim/commit/7a39dd7f00239059ce34660611589b26126a550c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.2276: MS-Windows: session test leaves files behind

Problem:    MS-Windows: session test leaves files behind.
Solution:   Wipe out buffers before deleting the directory. (closes vim/vim#5187)

https://github.com/vim/vim/commit/5bf46e978619ff602a7c63dd98e19de8248236b3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.2373: cannot build with +popupwin but without +quickfix

Problem:    Cannot build with +popupwin but without +quickfix. (John Marriott)
Solution:   Adjust #ifdefs.

https://github.com/vim/vim/commit/5a4c3082d7ab51b3d448a91578479c96c1ab0ad3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2112: running tests may leave some files behind

Problem:    Running tests may leave some files behind.
Solution:   Delete the right files.  Fix a few typos. (Dominique Pellé,
            closes vim/vim#7436

https://github.com/vim/vim/commit/ac665c24c97582a64ae2d151a812eca92c1ff2d6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4850: mksession mixes up "tabpages" and "curdir" arguments

Problem:    Mksession mixes up "tabpages" and "curdir" arguments.
Solution:   Correct logic for storing tabpage in session. (closes vim/vim#10312)

https://github.com/vim/vim/commit/d7c9564d8d24343f2e27205633032dd6ebe5232c

Co-authored-by: LemonBoy <thatlemon@gmail.com>