### PR TITLE
vim-patch:8.1.0970: text properties test fails when 'encoding' is not utf-8

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -84,7 +84,9 @@ source setup.vim
 set nocp viminfo+=nviminfo
 
 " Use utf-8 by default, instead of whatever the system default happens to be.
-" Individual tests can overrule this at the top of the file.
+" Individual tests can overrule this at the top of the file and use
+" g:orig_encoding if needed.
+let g:orig_encoding = &encoding
 set encoding=utf-8
 
 " REDIR_TEST_TO_NULL has a very permissive SwapExists autocommand which is for


### PR DESCRIPTION
#### vim-patch:8.1.0970: text properties test fails when 'encoding' is not utf-8

Problem:    Text properties test fails when 'encoding' is not utf-8.
Solution:   Compare with original value of 'encoding'. (Christian Brabandt)

https://github.com/vim/vim/commit/ed79d1e348c40e2432802423bf22e4f7b536bf8a

Co-authored-by: Bram Moolenaar <Bram@vim.org>