### PR TITLE
fix(textformat): remove unnecessary changed_bytes()

### DIFF
--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -16,7 +16,7 @@ struct funccal_entry;
 
 // From user function to hashitem and back.
 #define UF2HIKEY(fp) ((fp)->uf_name)
-#define HIKEY2UF(p)  ((ufunc_T *)(p - offsetof(ufunc_T, uf_name)))
+#define HIKEY2UF(p)  ((ufunc_T *)((p) - offsetof(ufunc_T, uf_name)))
 #define HI2UF(hi)    HIKEY2UF((hi)->hi_key)
 
 // flags used in uf_flags

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1569,7 +1569,7 @@ int op_delete(oparg_T *oap)
         curwin->w_cursor.coladd = 0;
       }
 
-      // n == number of chars deleted
+      // "n" == number of chars deleted
       // If we delete a TAB, it may be replaced by several characters.
       // Thus the number of characters may increase!
       n = bd.textlen - bd.startspaces - bd.endspaces;
@@ -4025,8 +4025,9 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
     comments = xcalloc(count, sizeof(*comments));
   }
 
-  // Don't move anything, just compute the final line length
+  // Don't move anything yet, just compute the final line length
   // and setup the array of space strings lengths
+  // This loops forward over joined lines.
   for (t = 0; t < (linenr_T)count; t++) {
     curr_start = ml_get(curwin->w_cursor.lnum + t);
     curr = curr_start;
@@ -4107,6 +4108,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
   *cend = 0;
 
   // Move affected lines to the new long one.
+  // This loops backwards over the joined lines, including the original line.
   //
   // Move marks from each deleted line to the joined line, adjusting the
   // column.  This is not Vi compatible, but Vi deletes the marks, thus that

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -420,7 +420,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
             for (int i = 0; i < padding; i++) {
               ins_str(" ");
             }
-            changed_bytes(curwin->w_cursor.lnum, leader_len);
           } else {
             (void)set_indent(second_indent, SIN_CHANGED);
           }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2981,7 +2981,7 @@ void u_clearall(buf_T *buf)
   buf->b_u_line_lnum = 0;
 }
 
-/// save the line "lnum" for the "U" command
+/// Save the line "lnum" for the "U" command.
 void u_saveline(buf_T *buf, linenr_T lnum)
 {
   if (lnum == buf->b_u_line_lnum) {      // line is already saved


### PR DESCRIPTION
This was removed from Vim in patch 8.1.0681.
