### PR TITLE
fix(lsp): advertise workspace.didChangeConfiguration capability (fixes #26026)

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -855,6 +855,9 @@ function protocol.make_client_capabilities()
         },
       },
       configuration = true,
+      didChangeConfiguration = {
+        dynamicRegistration = false,
+      },
       workspaceFolders = true,
       applyEdit = true,
       workspaceEdit = {


### PR DESCRIPTION
Fix #26026

This ensures the `workspace/didChangeConfiguration` notification sent after init is correctly handled by language servers that are strict about not handling notifications for capabilities that are not advertised.

### Tests

The test `tests.basic_check_capabilities` in `test/functional/fixtures/fake-lsp-server.lua` asserts that the capabilities received by a server match the capabilities defined in the client, so these tests immediately pass even with the changes made to `protocol.make_client_capabilities`.

I'd be happy to write a test that specifically asserts on the presence of this capability, but it does not appear that this is a standard pattern in the test suite (i.e. many other capabilities are not explicitly asserted on) - let me know if I should add such a test.

When running tests locally there are a variable number of failing tests (e.g. 3-5 tests) when both running on `master` and on this branch, suggesting there are tests susceptible to timing issues/race conditions etc. They are all in areas of functionality unrelated to this change, so hopefully all is good when the tests are run in CI.

### An Aside on Test Design

Although beyond the scope of this bug/PR, if the team is open to it, I'd be happy to amend the tests in `test/functional/fixtures/fake-lsp-server.lua` to store their own copy of the expected capabilities.  Asserting that the received capabilities match the capabilities defined within the client leaves the test suite exposed to the risk of not catching regressions where the capability set is accidentally modified (as the modified capability set will be compared with itself). Storing a separate copy of expected capabilities creates a 'check and balance' ensuring all changes are intentional, and provides an explicit definition of the capabilities expected/required by language servers as part of the test suite.