### PR TITLE
fix(defaults): set 'fsync'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2796,7 +2796,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 					*'fsync'* *'fs'* *'nofsync'* *'nofs'*
-'fsync' 'fs'		boolean	(default off)
+'fsync' 'fs'		boolean	(default on)
 			global
 	When on, the OS function fsync() will be called after saving a file
 	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -47,7 +47,6 @@ Defaults					            *nvim-defaults*
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·,foldsep:│"
 - 'formatoptions' defaults to "tcqj"
-- 'fsync' is disabled
 - 'hidden' is enabled
 - 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is enabled

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3307,7 +3307,7 @@ return {
     },
     {
       abbreviation = 'fs',
-      defaults = { if_true = false },
+      defaults = { if_true = true },
       desc = [=[
         When on, the OS function fsync() will be called after saving a file
         (|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -51,6 +51,7 @@ describe('fileio', function()
 
   it('fsync() codepaths #8304', function()
     clear({ args={ '-i', 'Xtest_startup_shada',
+                   '--cmd', 'set nofsync',
                    '--cmd', 'set directory=Xtest_startup_swapdir' } })
 
     -- These cases ALWAYS force fsync (regardless of 'fsync' option):


### PR DESCRIPTION
Fix the longstanding #9888 bug by enabling fsync by default and reverting commit 9139bf81cf which introduced the bug.