### PR TITLE
fix(lua): make vim.defer_fn() close timer before vim.schedule()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1559,7 +1559,7 @@ vim.defer_fn({fn}, {timeout})                                 *vim.defer_fn()*
     Defers calling {fn} until {timeout} ms passes.
 
     Use to do a one-shot timer that calls {fn} Note: The {fn} is
-    |vim.schedule_wrap()|ped automatically, so API functions are safe to call.
+    |vim.schedule()|d automatically, so API functions are safe to call.
 
     Parameters: ~
       • {fn}       (function) Callback to call once `timeout` expires

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -565,24 +565,24 @@ end
 --- Defers calling {fn} until {timeout} ms passes.
 ---
 --- Use to do a one-shot timer that calls {fn}
---- Note: The {fn} is |vim.schedule_wrap()|ped automatically, so API functions are
+--- Note: The {fn} is |vim.schedule()|d automatically, so API functions are
 --- safe to call.
 ---@param fn function Callback to call once `timeout` expires
 ---@param timeout integer Number of milliseconds to wait before calling `fn`
 ---@return table timer luv timer object
 function vim.defer_fn(fn, timeout)
   vim.validate({ fn = { fn, 'c', true } })
+
   local timer = vim.uv.new_timer()
   timer:start(
     timeout,
     0,
-    vim.schedule_wrap(function()
+    function()
       if not timer:is_closing() then
         timer:close()
       end
-
-      fn()
-    end)
+      vim.schedule(fn)
+    end
   )
 
   return timer

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -26,6 +26,7 @@ local rmdir = helpers.rmdir
 local write_file = helpers.write_file
 local poke_eventloop = helpers.poke_eventloop
 local assert_alive = helpers.assert_alive
+local expect_exit = helpers.expect_exit
 
 describe('lua stdlib', function()
   before_each(clear)
@@ -2386,6 +2387,18 @@ describe('lua stdlib', function()
     ]])
     exec_lua [[vim.wait(1000, function() return vim.g.test end)]]
     eq(true, exec_lua[[return vim.g.test]])
+  end)
+
+  it('vim.defer_fn does not leak memory or handles on exit #19727', function()
+    expect_exit(exec_lua, [[
+      vim.defer_fn(function()
+        vim.defer_fn(function()
+          vim.defer_fn(function()
+          end, 0)
+        end, 0)
+      end, 0)
+      vim.cmd('quit')
+    ]])
   end)
 
   describe('vim.region', function()


### PR DESCRIPTION
Problem:  If vim.schedule() fails (e.g. on exit), the timer may leak.
Solution: Close timer before vim.schedule().

Fix #19727
