### PR TITLE
fix(defaults): set 'fsync'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2765,7 +2765,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 					*'fsync'* *'fs'* *'nofsync'* *'nofs'*
-'fsync' 'fs'		boolean	(default off)
+'fsync' 'fs'		boolean	(default on)
 			global
 	When on, the OS function fsync() will be called after saving a file
 	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -42,7 +42,6 @@ Defaults					            *nvim-defaults*
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·,sep:│"
 - 'formatoptions' defaults to "tcqj"
-- 'fsync' is disabled
 - 'hidden' is enabled
 - 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is enabled

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -942,7 +942,7 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_fs',
-      defaults={if_true=false}
+      defaults={if_true=true}
     },
     {
       full_name='gdefault', abbreviation='gd',

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -50,6 +50,7 @@ describe('fileio', function()
 
   it('fsync() codepaths #8304', function()
     clear({ args={ '-i', 'Xtest_startup_shada',
+                   '--cmd', 'set nofsync',
                    '--cmd', 'set directory=Xtest_startup_swapdir' } })
 
     -- These cases ALWAYS force fsync (regardless of 'fsync' option):


### PR DESCRIPTION
backport https://github.com/neovim/neovim/pull/26034

Problem:
'nofsync' may lose data if the system has a hard shutdown. #9888

Solution:
Change default to 'fsync'. This may be revisited in the future when 'nofsync' can be made safer.