### PR TITLE
vim-patch:9.0.2105: skipcol not reset when topline changed

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1816,7 +1816,9 @@ void scroll_cursor_top(int min_scroll, int always)
       }
     }
     check_topfill(curwin, false);
-    if (curwin->w_topline == curwin->w_cursor.lnum) {
+    if (curwin->w_topline != old_topline) {
+      reset_skipcol(curwin);
+    } else if (curwin->w_topline == curwin->w_cursor.lnum) {
       validate_virtcol();
       if (curwin->w_skipcol >= curwin->w_virtcol) {
         // TODO(vim): if the line doesn't fit may optimize w_skipcol instead

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -982,6 +982,31 @@ describe('smoothscroll', function()
     ]])
   end)
 
+  -- oldtest: Test_smoothscroll_cursor_top()
+  it('resets skipcol when scrolling cursor to top', function()
+    screen:try_resize(40, 12)
+    exec([[
+      set smoothscroll scrolloff=2
+      new | 11resize | wincmd j
+      call setline(1, ['line1', 'line2', 'line3'->repeat(20), 'line4'])
+      exe "norm G3\<C-E>k"
+    ]])
+    screen:expect([[
+                                              |
+      [No Name]                               |
+      line1                                   |
+      line2                                   |
+      ^line3line3line3line3line3line3line3line3|
+      line3line3line3line3line3line3line3line3|
+      line3line3line3line3                    |
+      line4                                   |
+      ~                                       |
+      ~                                       |
+      [No Name] [+]                           |
+                                              |
+    ]])
+  end)
+
   it("works with virt_lines above and below", function()
     screen:try_resize(55, 7)
     exec([=[

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -912,4 +912,21 @@ func Test_smoothscroll_zero_width_scroll_cursor_bot()
   call StopVimInTerminal(buf)
 endfunc
 
+" scroll_cursor_top() should reset skipcol when it changes topline
+func Test_smoothscroll_cursor_top()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll scrolloff=2
+      new | 11resize | wincmd j
+      call setline(1, ['line1', 'line2', 'line3'->repeat(20), 'line4'])
+      exe "norm G3\<C-E>k"
+  END
+  call writefile(lines, 'XSmoothScrollCursorTop', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols:40})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_cursor_top', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Skipcol is not reset when topline changed scrolling cursor to top
Solution: reset skipcol

closes: vim/vim#13528

https://github.com/vim/vim/commit/bb800a7907209f7d349f87b76b3b9ca30b416298