### PR TITLE
Revert "docs: adjust help-tag-right CSS for HTML"

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -967,16 +967,13 @@ local function gen_css(fname)
     /* Tag pseudo-header common in :help docs. */
     .help-tag-right {
       color: var(--tag-color);
-      background-color: inherit;
-      display: flex;
-      justify-content: right;
-      margin-top: 1.5em;
-      margin-bottom: 1em;
+      margin-left: auto;
+      margin-right: 0;
+      float: right;
     }
     .help-tag a,
     .help-tag-right a {
       color: inherit;
-      background-color: var(--accent-bg-color);
     }
     .help-tag a:not(:hover),
     .help-tag-right a:not(:hover) {


### PR DESCRIPTION
The style change is mostly a regression.

Reverts neovim/neovim#25858