### PR TITLE
fix: only attempt to close timer if not already closing

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -254,8 +254,6 @@ do
       callback = function(args)
         if vim.api.nvim_get_option_info2('background', {}).was_set then
           -- Don't do anything if 'background' is already set
-          timer:stop()
-          timer:close()
           return true
         end
 
@@ -274,9 +272,6 @@ do
             end
           end
 
-          timer:stop()
-          timer:close()
-
           return true
         end
       end,
@@ -290,7 +285,10 @@ do
         -- Suppress error if autocommand has already been deleted
         pcall(vim.api.nvim_del_autocmd, id)
       end)
-      timer:close()
+
+      if not timer:is_closing() then
+        timer:close()
+      end
     end)
   end
 end


### PR DESCRIPTION
This fixes an error that can occur in certain pathological cases when the autocommand fires at just the right time such that it attempts to close the timer after the timer has already exited, but before the scheduled callback has fired.

We now let the timer continue to run even when the autocommand deletes itself to avoid having to repeat the cleanup code multiple times. There is no harm in letting the timer execute if the autocommand does not exist, as the pcall will catch the error.
