### PR TITLE
feat(event): add VisualChanged autocmd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1116,6 +1116,10 @@ VimResized			After the Vim window was resized, thus 'lines'
 VimResume			After Nvim resumes from |suspend| state.
 							*VimSuspend*
 VimSuspend			Before Nvim enters |suspend| state.
+							*VisualChanged*
+VisualChanged			When Visual mode starts, visual mode changes
+				to another visual mode, selection changes,
+				cursor moves while in visual mode.
 							*WinClosed*
 WinClosed			When closing a window, just before it is
 				removed from the window layout.  The pattern

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -125,6 +125,7 @@ EVENTS
 
 • |CompleteDone| now sets the `reason` key in `v:event` which specifies the reason
   for completion being done.
+• Added |VisualChanged| autocommand that fires when the visual selection changes
 
 LSP
 

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -127,6 +127,7 @@ return {
     'VimResized', -- after Vim window was resized
     'VimResume', -- after Nvim is resumed
     'VimSuspend', -- before Nvim is suspended
+    'VisualChanged', -- when visual selection was changed
     'WinClosed', -- after closing a window
     'WinEnter', -- after entering a window
     'WinLeave', -- before leaving a window

--- a/test/functional/autocmd/visualchanged_spec.lua
+++ b/test/functional/autocmd/visualchanged_spec.lua
@@ -1,0 +1,82 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local eq = t.eq
+local clear = n.clear
+local source = n.source
+local feed = n.feed
+local insert = n.insert
+local eval = n.eval
+local api = n.api
+
+describe('VisualChanged', function()
+  before_each(function()
+    clear()
+    insert [[
+      Hello
+      Hello
+      Hello]]
+
+    api.nvim_win_set_cursor(0, { 1, 0 })
+
+    source [[
+      let g:visual_count = 0
+      au VisualChanged * let g:visual_count += 1
+    ]]
+  end)
+
+  local function count()
+    return eval('g:visual_count')
+  end
+
+  it('fires when visual mode changes or starts', function()
+    feed 'v'
+    eq(1, count())
+
+    feed 'iw'
+    eq(2, count())
+
+    feed 'V'
+    eq(3, count())
+
+    feed '<c-v>'
+    eq(4, count())
+
+    feed 'v'
+    eq(5, count())
+
+    feed '<esc>v'
+    eq(6, count())
+
+    feed '<esc>V'
+    eq(7, count())
+
+    feed '<esc><c-v>'
+    eq(8, count())
+  end)
+
+  it('fires when visual area changes or cursor moves', function()
+    feed 'v'
+    eq(1, count())
+
+    feed 'iw'
+    eq(2, count())
+
+    feed 'Vj0'
+    eq(5, count())
+
+    feed '<esc>Vjl'
+    eq(8, count())
+
+    feed '<esc>gg<c-v>ejh'
+    eq(12, count())
+  end)
+
+  it('works with gv', function()
+    feed 'vjl'
+    eq(3, count())
+
+    feed '<esc>Ggv'
+    eq(4, count())
+  end)
+end)


### PR DESCRIPTION
Fires when Visual mode starts, visual mode changes to another visual mode, selection changes, cursor moves while in visual mode.
Close #19708.
