### PR TITLE
refactor(api): redundant `ml_mfp` check

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -356,12 +356,10 @@ void nvim_buf_set_lines(uint64_t channel_id, Buffer buffer, Integer start, Integ
     return;
   }
 
-  // load buffer first if it's not loaded
-  if (buf->b_ml.ml_mfp == NULL) {
-    if (!buf_ensure_loaded(buf)) {
-      api_set_error(err, kErrorTypeException, "Failed to load buffer");
-      return;
-    }
+  // Load buffer if necessary. #22670
+  if (!buf_ensure_loaded(buf)) {
+    api_set_error(err, kErrorTypeException, "Failed to load buffer");
+    return;
   }
 
   bool oob = false;
@@ -538,12 +536,10 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     return;
   }
 
-  // load buffer first if it's not loaded
-  if (buf->b_ml.ml_mfp == NULL) {
-    if (!buf_ensure_loaded(buf)) {
-      api_set_error(err, kErrorTypeException, "Failed to load buffer");
-      return;
-    }
+  // Load buffer if necessary. #22670
+  if (!buf_ensure_loaded(buf)) {
+    api_set_error(err, kErrorTypeException, "Failed to load buffer");
+    return;
   }
 
   bool oob = false;


### PR DESCRIPTION
buf_ensure_loaded already checks `(buf->b_ml.ml_mfp != NULL)`. #25823

---

TODO:
- [#10070](https://github.com/neovim/neovim/issues/10070) [#13201](https://github.com/neovim/neovim/issues/13201) All buffer-related API functions except `nvim_buf_is_loaded` (and `nvim_buf_is_valid`?) should always call `buf_ensure_loaded`. Because the _common case_ is that plugins expect the buffer to "just work"—and for the uncomon, performance-sensitive case, the script can check `nvim_buf_is_loaded` to avoid implicitly loading a buffer.
- Update documentation to clarify the above semantics.