### PR TITLE
fix(osc52): enable OSC 52 by default in tmux sessions

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -268,7 +268,6 @@ does as long as all of the following are true:
   • |g:clipboard| is unset
   • 'clipboard' is not set to "unnamed" or "unnamedplus"
   • $SSH_TTY is set
-  • $TMUX is unset
 
 If any of the above conditions are not met then the OSC 52 clipboard provider
 will not be used by default and Nvim will fall back to discovering a

--- a/runtime/plugin/osc52.lua
+++ b/runtime/plugin/osc52.lua
@@ -2,18 +2,17 @@ local tty = vim.iter(vim.api.nvim_list_uis()):any(function(ui)
   return ui.chan == 1 and ui.stdout_tty
 end)
 
-if
-  not tty
-  or vim.g.clipboard ~= nil
-  or vim.o.clipboard ~= ''
-  or not os.getenv('SSH_TTY')
-  or os.getenv('TMUX')
-then
+if not tty or vim.g.clipboard ~= nil or vim.o.clipboard ~= '' or not os.getenv('SSH_TTY') then
   return
 end
 
 require('vim.termcap').query('Ms', function(cap, seq)
   assert(cap == 'Ms')
+
+  -- Check 'clipboard' and g:clipboard again to avoid a race condition
+  if vim.o.clipboard ~= '' or vim.g.clipboard ~= nil then
+    return
+  end
 
   -- If the terminal reports a sequence other than OSC 52 for the Ms capability
   -- then ignore it. We only support OSC 52 (for now)


### PR DESCRIPTION
tmux has a set-clipboard option which, when set to 'on', allows
applications to set the system clipboard using the usual OSC 52 escape
sequence.

Ref: https://github.com/neovim/neovim/pull/26064#issuecomment-1815117138