### PR TITLE
build: update libtermkey commit

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -13,8 +13,8 @@ LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 UNIBILIUM_URL https://github.com/neovim/unibilium/archive/d72c3598e7ac5d1ebf86ee268b8b4ed95c0fa628.tar.gz
 UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b9536655596797487
 
-LIBTERMKEY_URL https://github.com/neovim/libtermkey/archive/v0.22.tar.gz
-LIBTERMKEY_SHA256 81cac2b685c9ada4ead4ea788fb69ff74fc1947ad188ed0264c646fe12b496ba
+LIBTERMKEY_URL https://github.com/neovim/libtermkey/archive/dcb198a85c520ce38450a5970c97f8ff03b50f0e.tar.gz
+LIBTERMKEY_SHA256 5eb3e50af54312817bd56fa63b9f8dbd12ec11cedbcf8a7aa0fd79950cc83259
 
 LIBVTERM_URL https://github.com/neovim/libvterm/archive/v0.3.3.tar.gz
 LIBVTERM_SHA256 0babe3ab42c354925dadede90d352f054aa9c4ae6842ea803a20c9741e172e56


### PR DESCRIPTION
The new commit includes the following patches:

https://github.com/neovim/libtermkey/commit/bf544610f5bd1a4e049b9ba0f94d2a588d1312ce
https://github.com/neovim/libtermkey/commit/dcb198a85c520ce38450a5970c97f8ff03b50f0e

Fixes https://github.com/neovim/neovim/issues/26038.