### PR TITLE
fix(treesitter): make InspectTree correctly handle nested injections

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -101,18 +101,23 @@ function TSTreeView:new(bufnr, lang)
   -- the root in the child tree to the {injections} table.
   local root = parser:parse(true)[1]:root()
   local injections = {} ---@type table<integer,table>
-  for _, child in pairs(parser:children()) do
-    child:for_each_tree(function(tree, ltree)
-      local r = tree:root()
-      local node = root:named_descendant_for_range(r:range())
-      if node then
-        injections[node:id()] = {
-          lang = ltree:lang(),
-          root = r,
-        }
-      end
-    end)
-  end
+
+  parser:for_each_tree(function(parent_tree, parent_ltree)
+    local parent = parent_tree:root()
+    for _, child in pairs(parent_ltree:children()) do
+      child:for_each_tree(function(tree, ltree)
+        local r = tree:root()
+        local node = assert(parent:named_descendant_for_range(r:range()))
+        local id = node:id()
+        if not injections[id] or r:byte_length() > injections[id].root:byte_length() then
+          injections[id] = {
+            lang = ltree:lang(),
+            root = r,
+          }
+        end
+      end)
+    end
+  end)
 
   local nodes = traverse(root, 0, parser:lang(), injections, {})
 


### PR DESCRIPTION
**Problem**: `:InspectTree` doesn't correctly handle nested injections

Using nvim-treesitter, we can have a codeblock of
```html
<script> 
const x = html`<ge></ge>`
</script>
```
that will be rendered as the image: ![image](https://github.com/neovim/neovim/assets/29790821/c95be05a-9dc6-4f8e-8770-fab951c3fcb9)


This was because of the codeblock below https://github.com/neovim/neovim/blob/315c711700a87fe3fa546906ab39557ebba19baf/runtime/lua/vim/treesitter/dev.lua#L104-L115

When we check for an injection, we only consider it to be a child of the root tree, and didn't check whether it was a child of another injection tree.

**Solution**: During initial creation of `TSTreeView`, Iterate over all root trees to get their injections, not just the root tree. For each overlapping tree of a parent tree, Keep the injection tree with the biggest range as the child.

Potential issues:
- The old nvim-treesitter-playground implementation has all injections for a range shown, should this be followed?
- How exactly can we find the tree with the biggest range? I used to try `child:trees()[1]:root()`, but this sometimes break while messing with a large enough file. Because of that, I opted for iterating every injected tree of a child, which is sometimes unnecessary.

fixes #26084 

| Before | After |
| - | - |
| ![image](https://github.com/neovim/neovim/assets/29790821/c95be05a-9dc6-4f8e-8770-fab951c3fcb9) | ![image](https://github.com/neovim/neovim/assets/29790821/9490c294-3c35-44e2-9059-3fbd1a96f46f) |