### PR TITLE
Revert "fix(lua): do not schedule events if Nvim is exiting"

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -366,12 +366,6 @@ static void nlua_schedule_event(void **argv)
 static int nlua_schedule(lua_State *const lstate)
   FUNC_ATTR_NONNULL_ALL
 {
-  // If Nvim is exiting don't schedule tasks to run in the future. Any refs
-  // allocated here will not be cleaned up otherwise
-  if (exiting) {
-    return 0;
-  }
-
   if (lua_type(lstate, 1) != LUA_TFUNCTION) {
     lua_pushliteral(lstate, "vim.schedule: expected function");
     return lua_error(lstate);


### PR DESCRIPTION
This reverts commit 22eb2ba18336df6cd70a88f666818ee5d8ba92d2.

---

Running this to test in CI. Locally, I can't re-create the ASAN failure that this commit originally solved. If the ASAN error doesn't reappear we can consider reverting this change to fix https://github.com/neovim/neovim/issues/26077.
