### PR TITLE
fix(lsp): increase LSP progress ringbuf size

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1320,7 +1320,7 @@ function lsp.start_client(config)
     --- - lsp.WorkDoneProgressBegin,
     --- - lsp.WorkDoneProgressReport (extended with title from Begin)
     --- - lsp.WorkDoneProgressEnd    (extended with title from Begin)
-    progress = vim.ringbuf(50),
+    progress = vim.ringbuf(1024),
 
     --- @type lsp.ServerCapabilities
     server_capabilities = {},


### PR DESCRIPTION
In https://github.com/j-hui/fidget.nvim/issues/167, we discovered that Neovim's progress ringbuf size is too small to accommodate huge bursts of messages from LSP servers. Notably, for large Rust projects, rust-analyzer blasts so many messages that later progress messages overwrite earlier completion messages. For LSP progress plugins like [fidget.nvim](https://github.com/j-hui/fidget.nvim), those tasks whose completion messages are overwritten seem to run forever.

This PR is very simple, it just bumps the LSP progress ringbuf size from 50 to 1024. I'm not actually sure whether this is the "right" solution---but it is the simplest---so I'm just filing this as a draft PR to start a discussion.

Alternative solutions I can think of are:
1. grow the of the `ringbuf` using an autocmd callback listening for the `LspAttach` event, as I suggest [here](https://github.com/j-hui/fidget.nvim/issues/167#issuecomment-1816705057)
2. change Fidget to be purely event-driven and check the ringbuf on every `LspProgress` event (as described [here](https://github.com/j-hui/fidget.nvim/issues/167#issuecomment-1813604877)), instead of the current heartbeat-driven execution model
3. patch rust-analyzer to rate-limit its progress messages

I've provided alternative 1 as [a convenience option in Fidget](https://github.com/j-hui/fidget.nvim/commit/5be956d940d3ebeb7ea04289382117876c68ce13), but I'm wondering if it makes sense for Neovim's default to be large enough to accommodate these bursts.

I'm also fine with alternative 2, though I do hope to maintain Fidget's periodic polling model since it has made [other features really easy to implement](https://github.com/j-hui/fidget.nvim/issues/73#issuecomment-1806638776).

Alternative 3 seems like it could involve a lot of work, and put additional burden on LSP servers.