### PR TITLE
build: various cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,8 +247,6 @@ add_glob_target(
   FLAGS -x -a
   GLOB_DIRS scripts
   GLOB_PAT *.sh
-  EXCLUDE
-    scripts/pvscheck.sh
   TOUCH_STRATEGY SINGLE)
 
 add_custom_target(lintcommit
@@ -294,7 +292,7 @@ ExternalProject_Add(uncrustify
   CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS}
   EXCLUDE_FROM_ALL TRUE)
 
-option(USE_BUNDLED_BUSTED "Use bundled luarocks" ON)
+option(USE_BUNDLED_BUSTED "Use bundled busted" ON)
 if(USE_BUNDLED_BUSTED)
   ExternalProject_Add(lua-dev-deps
     URL https://github.com/neovim/deps/raw/5a1f71cceb24990a0b15fd9a472a5f549f019248/opt/lua-dev-deps.tar.gz

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -9,8 +9,8 @@ endif()
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DIR}/../cmake")
 
-include(ExternalProject)
 include(CheckCCompilerFlag)
+include(ExternalProject)
 include(FindPackageHandleStandardArgs)
 
 include(Deps)

--- a/cmake.deps/cmake/BuildLua.cmake
+++ b/cmake.deps/cmake/BuildLua.cmake
@@ -40,8 +40,6 @@ set(LUA_CONFIGURE_COMMAND
       -i ${DEPS_BUILD_DIR}/src/lua/src/luaconf.h)
 set(LUA_INSTALL_TOP_ARG "INSTALL_TOP=${DEPS_INSTALL_DIR}")
 
-message(STATUS "Lua target is ${LUA_TARGET}")
-
 ExternalProject_Add(lua
   URL ${LUA_URL}
   URL_HASH SHA256=${LUA_SHA256}

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.47.0.tar.gz
 LIBUV_SHA256 d50af7e6d72526db137e66fad812421c8a1cae09d146b0ec2bb9a22c5f23ba93
 
-MSGPACK_URL https://github.com/msgpack/msgpack-c/releases/download/c-6.0.0/msgpack-c-6.0.0.tar.gz
-MSGPACK_SHA256 3654f5e2c652dc52e0a993e270bb57d5702b262703f03771c152bba51602aeba
+MSGPACK_URL https://github.com/msgpack/msgpack-c/archive/c-6.0.0.tar.gz
+MSGPACK_SHA256 af6f3cf25edb220aa2140b09bb5bdd73ddf00938194bd94ebe5c92090cccb466
 
 LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/43d0a19158ceabaa51b0462c1ebc97612b420a2e.tar.gz
 LUAJIT_SHA256 4fefa19bc5600928fb13c928bf5325eaa1c78f2c1738a8ac9552154ef178bb9a

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -91,7 +91,7 @@ if(MSVC)
   target_compile_options(main_lib INTERFACE -W3)
 
   # Disable warnings that give too many false positives.
-  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003 -wd4715 -wd4003)
+  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003 -wd4715)
   target_compile_definitions(main_lib INTERFACE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
 
   target_sources(main_lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/os/nvim.manifest)
@@ -420,7 +420,10 @@ if(APPLE AND CMAKE_OSX_SYSROOT)
   list(APPEND gen_cflags "-isysroot")
   list(APPEND gen_cflags "${CMAKE_OSX_SYSROOT}")
 endif()
-set(gen_cflags ${gen_cflags} -O2)
+if(MSVC)
+  list(APPEND gen_cflags -wd4003)
+endif()
+list(APPEND gen_cflags -O2)
 
 set(NVIM_VERSION_GIT_H ${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef_git.h)
 add_custom_target(update_version_stamp
@@ -857,15 +860,16 @@ add_glob_target(
     tui/terminfo_defs.h)
 
 set(UNCRUSTIFY_PRG ${DEPS_BIN_DIR}/uncrustify)
+set(UNCRUSTIFY_CONFIG ${PROJECT_SOURCE_DIR}/src/uncrustify.cfg)
+
+add_custom_target(uncrustify_update_config
+  ${UNCRUSTIFY_PRG} -c ${UNCRUSTIFY_CONFIG} --update-config-with-doc -o ${UNCRUSTIFY_CONFIG})
+
 add_glob_target(
   TARGET lintc-uncrustify
   COMMAND ${UNCRUSTIFY_PRG}
-  FLAGS -c "${PROJECT_SOURCE_DIR}/src/uncrustify.cfg" -q --check
+  FLAGS -c ${UNCRUSTIFY_CONFIG} -q --check
   FILES ${LINT_NVIM_SOURCES})
-add_dependencies(lintc-uncrustify uncrustify)
-
-add_custom_target(lintc)
-add_dependencies(lintc lintc-clint lintc-uncrustify lintc-clang-tidy)
 
 add_custom_target(formatc
   COMMAND ${CMAKE_COMMAND}
@@ -873,7 +877,13 @@ add_custom_target(formatc
     -D LANG=c
     -P ${PROJECT_SOURCE_DIR}/cmake/Format.cmake
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-add_dependencies(formatc uncrustify)
+
+add_dependencies(lintc-uncrustify uncrustify_update_config)
+add_dependencies(formatc uncrustify_update_config)
+add_dependencies(uncrustify_update_config uncrustify)
+
+add_custom_target(lintc)
+add_dependencies(lintc lintc-clint lintc-uncrustify lintc-clang-tidy)
 
 add_custom_target(generated-sources DEPENDS
   ${NVIM_GENERATED_FOR_SOURCES}

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -359,7 +359,7 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '(' and ')' of 'for' statements.
-sp_inside_for                   = ignore   # ignore/add/remove/force/not_defined
+sp_inside_for                   = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '(' of 'for' statements.
 #
@@ -3663,5 +3663,5 @@ set CLASS_COLON                  REAL_FATTR_CONST
 set CLASS_COLON                  REAL_FATTR_NONNULL_ALL
 set CLASS_COLON                  REAL_FATTR_PURE
 set CLASS_COLON                  REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 131
+# option(s) with 'not default' value: 132
 #


### PR DESCRIPTION
- Correct MSVC warning suppression. The C4003 warning is issued during
  file generation and not for the actual source files.
- Remove non-existent "scripts/pvscheck.sh" file from `lintsh` target.
- Remove spaces inside for loops with uncrustify.
- Point dependencies to use a git tag rather than releases, as releases
  might have changes that deviate from the actual source code.
- Automatically update uncrustify config before formatting or linting.
