### PR TITLE
refactor: enable formatting for ternaries

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -379,8 +379,8 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     goto end;
   });
   const char *fullname = IS_USER_CMDIDX(ea.cmdidx)
-    ? get_user_command_name(ea.useridx, ea.cmdidx)
-    : get_command_name(NULL, ea.cmdidx);
+                         ? get_user_command_name(ea.useridx, ea.cmdidx)
+                         : get_command_name(NULL, ea.cmdidx);
   VALIDATE(strncmp(fullname, cmdname, strlen(cmdname)) == 0, "Invalid command: \"%s\"", cmdname, {
     goto end;
   });
@@ -836,8 +836,8 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
     offset += eap->arglens[i];
   }
   // If there isn't an argument, make eap->arg point to end of cmdline.
-  eap->arg = argc > 0 ? eap->args[0] :
-             cmdline.items + cmdline.size - 1;  // Subtract 1 to account for NUL
+  eap->arg = argc > 0 ? eap->args[0]
+                      : cmdline.items + cmdline.size - 1;  // Subtract 1 to account for NUL
 
   // Finally, make cmdlinep point to the cmdline string.
   *cmdlinep = cmdline.items;

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -689,8 +689,9 @@ static void set_option_to(uint64_t channel_id, void *to, OptReqScope req_scope, 
 
   // For global-win-local options -> setlocal
   // For        win-local options -> setglobal and setlocal (opt_flags == 0)
-  const int opt_flags = (req_scope == kOptReqWin && !(flags & SOPT_GLOBAL)) ? 0 :
-                        (req_scope == kOptReqGlobal) ? OPT_GLOBAL : OPT_LOCAL;
+  const int opt_flags = (req_scope == kOptReqWin && !(flags & SOPT_GLOBAL))
+                        ? 0
+                        : (req_scope == kOptReqGlobal) ? OPT_GLOBAL : OPT_LOCAL;
 
   WITH_SCRIPT_CONTEXT(channel_id, {
     set_option_value_for(name.data, optval, opt_flags, req_scope, to, err);

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -88,9 +88,9 @@ static int validate_option_value_args(Dict(option) *opts, char *name, int *scope
     int req_flags = *req_scope == kOptReqBuf ? SOPT_BUF : SOPT_WIN;
     if (!(flags & req_flags)) {
       char *tgt = *req_scope & kOptReqBuf ? "buf" : "win";
-      char *global = flags & SOPT_GLOBAL ? "global ": "";
-      char *req = flags & SOPT_BUF ? "buffer-local " :
-                  flags & SOPT_WIN ? "window-local " : "";
+      char *global = flags & SOPT_GLOBAL ? "global " : "";
+      char *req = flags & SOPT_BUF ? "buffer-local "
+                                   : flags & SOPT_WIN ? "window-local " : "";
 
       api_set_error(err, kErrorTypeValidation, "'%s' cannot be passed for %s%soption '%s'",
                     tgt, global, req, name);
@@ -495,7 +495,7 @@ OptVal get_option_value_strict(char *name, OptReqScope req_scope, void *from, Er
   switchwin_T switchwin;
   aco_save_T aco;
   void *ctx = req_scope == kOptReqWin ? (void *)&switchwin
-                                    : (req_scope == kOptReqBuf ? (void *)&aco : NULL);
+                                      : (req_scope == kOptReqBuf ? (void *)&aco : NULL);
   bool switched = switch_option_context(ctx, req_scope, from, err);
   if (ERROR_SET(err)) {
     return retv;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1301,9 +1301,9 @@ void nvim_subscribe(uint64_t channel_id, String event)
 void nvim_unsubscribe(uint64_t channel_id, String event)
   FUNC_API_SINCE(1) FUNC_API_REMOTE_ONLY
 {
-  size_t length = (event.size < METHOD_MAXLEN ?
-                   event.size :
-                   METHOD_MAXLEN);
+  size_t length = (event.size < METHOD_MAXLEN
+                   ? event.size
+                   : METHOD_MAXLEN);
   char e[METHOD_MAXLEN + 1];
   memcpy(e, event.data, length);
   e[length] = NUL;
@@ -2235,8 +2235,9 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
     maxwidth = (int)opts->maxwidth;
   } else {
     maxwidth = statuscol_lnum ? win_col_off(wp)
-               : (opts->use_tabline
-                  || (!opts->use_winbar && global_stl_height() > 0)) ? Columns : wp->w_width;
+                              : (opts->use_tabline
+                                 || (!opts->use_winbar
+                                     && global_stl_height() > 0)) ? Columns : wp->w_width;
   }
 
   char buf[MAXPATHL];

--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -858,8 +858,8 @@ static void arg_all_close_unused_windows(arg_all_state_T *aall)
     for (win_T *wp = lastwin->w_floating ? lastwin : firstwin; wp != NULL; wp = wpnext) {
       int i;
       wpnext = wp->w_floating
-        ? wp->w_prev->w_floating ? wp->w_prev : firstwin
-        : (wp->w_next == NULL || wp->w_next->w_floating) ? NULL : wp->w_next;
+               ? wp->w_prev->w_floating ? wp->w_prev : firstwin
+               : (wp->w_next == NULL || wp->w_next->w_floating) ? NULL : wp->w_next;
       buf_T *buf = wp->w_buffer;
       if (buf->b_ffname == NULL
           || (!aall->keep_tabs

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -423,8 +423,8 @@ bool bufref_valid(bufref_T *bufref)
   FUNC_ATTR_PURE
 {
   return bufref->br_buf_free_count == buf_free_count
-    ? true
-    : buf_valid(bufref->br_buf) && bufref->br_fnum == bufref->br_buf->b_fnum;
+         ? true
+         : buf_valid(bufref->br_buf) && bufref->br_fnum == bufref->br_buf->b_fnum;
 }
 
 /// Check that "buf" points to a valid buffer in the buffer list.
@@ -2777,7 +2777,7 @@ void buflist_list(exarg_T *eap)
   for (;
        buf != NULL && !got_int;
        buf = buflist_data != NULL
-       ? (++p < buflist_data + buflist.ga_len ? *p : NULL) : buf->b_next) {
+             ? (++p < buflist_data + buflist.ga_len ? *p : NULL) : buf->b_next) {
     const bool is_terminal = buf->terminal;
     const bool job_running = buf->terminal && terminal_running(buf->terminal);
 
@@ -2811,8 +2811,8 @@ void buflist_list(exarg_T *eap)
     }
 
     const int changed_char = (buf->b_flags & BF_READERR)
-      ? 'x'
-      : (bufIsChanged(buf) ? '+' : ' ');
+                             ? 'x'
+                             : (bufIsChanged(buf) ? '+' : ' ');
     int ro_char = !MODIFIABLE(buf) ? '-' : (buf->b_p_ro ? '=' : ' ');
     if (buf->terminal) {
       ro_char = channel_job_running((uint64_t)buf->b_p_channel) ? 'R' : 'F';
@@ -3592,8 +3592,8 @@ void ex_buffer_all(exarg_T *eap)
     // Try to close floating windows first
     for (wp = lastwin->w_floating ? lastwin : firstwin; wp != NULL; wp = wpnext) {
       wpnext = wp->w_floating
-        ? wp->w_prev->w_floating ? wp->w_prev : firstwin
-        : (wp->w_next == NULL || wp->w_next->w_floating) ? NULL : wp->w_next;
+               ? wp->w_prev->w_floating ? wp->w_prev : firstwin
+               : (wp->w_next == NULL || wp->w_next->w_floating) ? NULL : wp->w_next;
       if ((wp->w_buffer->b_nwindows > 1
            || wp->w_floating
            || ((cmdmod.cmod_split & WSP_VERT)

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -586,8 +586,8 @@ void f_histnr(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   const char *const histname = tv_get_string_chk(&argvars[0]);
   HistoryType i = histname == NULL
-    ? HIST_INVALID
-    : get_histtype(histname, strlen(histname), false);
+                  ? HIST_INVALID
+                  : get_histtype(histname, strlen(histname), false);
   if (i != HIST_INVALID) {
     i = get_history_idx(i);
   }

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -477,7 +477,7 @@ static void get_sign_display_info(bool nrcol, win_T *wp, winlinevars_T *wlv, int
     wlv->p_extra = wlv->extra;
     wlv->c_extra = NUL;
     wlv->char_attr = (use_cursor_line_highlight(wp, wlv->lnum) && sign_cul_attr)
-                   ? sign_cul_attr : sattr.hl_id ? syn_id2attr(sattr.hl_id) : 0;
+                     ? sign_cul_attr : sattr.hl_id ? syn_id2attr(sattr.hl_id) : 0;
   } else {
     wlv->c_extra = ' ';
     wlv->n_extra = nrcol ? number_width(wp) + 1 : SIGN_WIDTH;
@@ -1806,9 +1806,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
         // Overlay CursorLine onto diff-mode highlight.
         if (wlv.cul_attr) {
           wlv.line_attr = 0 != wlv.line_attr_lowprio  // Low-priority CursorLine
-            ? hl_combine_attr(hl_combine_attr(wlv.cul_attr, wlv.line_attr),
-                              hl_get_underline())
-            : hl_combine_attr(wlv.line_attr, wlv.cul_attr);
+                          ? hl_combine_attr(hl_combine_attr(wlv.cul_attr, wlv.line_attr),
+                                            hl_get_underline())
+                          : hl_combine_attr(wlv.line_attr, wlv.cul_attr);
         }
       }
 
@@ -1905,8 +1905,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
           if (wlv.cul_attr) {
             multi_attr = 0 != wlv.line_attr_lowprio
-              ? hl_combine_attr(wlv.cul_attr, multi_attr)
-              : hl_combine_attr(multi_attr, wlv.cul_attr);
+                         ? hl_combine_attr(wlv.cul_attr, multi_attr)
+                         : hl_combine_attr(multi_attr, wlv.cul_attr);
           }
         } else {
           wlv.n_extra -= mb_l;
@@ -2068,8 +2068,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           if (!attr_pri) {
             if (wlv.cul_attr) {
               wlv.char_attr = 0 != wlv.line_attr_lowprio
-                ? hl_combine_attr(wlv.cul_attr, decor_attr)
-                : hl_combine_attr(decor_attr, wlv.cul_attr);
+                              ? hl_combine_attr(wlv.cul_attr, decor_attr)
+                              : hl_combine_attr(decor_attr, wlv.cul_attr);
             } else {
               wlv.char_attr = decor_attr;
             }
@@ -2358,7 +2358,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
           if (wp->w_p_list) {
             mb_c = (wlv.n_extra == 0 && wp->w_p_lcs_chars.tab3)
-                    ? wp->w_p_lcs_chars.tab3 : wp->w_p_lcs_chars.tab1;
+                   ? wp->w_p_lcs_chars.tab3 : wp->w_p_lcs_chars.tab1;
             if (wp->w_p_lbr && wlv.p_extra != NULL && *wlv.p_extra != NUL) {
               wlv.c_extra = NUL;  // using p_extra from above
             } else {

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2250,8 +2250,8 @@ static void win_update(win_T *wp, DecorProviders *providers)
       // When lines are folded, display one line for all of them.
       // Otherwise, display normally (can be several display lines when
       // 'wrap' is on).
-      foldinfo_T foldinfo = wp->w_p_cul && lnum == wp->w_cursor.lnum ?
-                            cursorline_fi : fold_info(wp, lnum);
+      foldinfo_T foldinfo = wp->w_p_cul && lnum == wp->w_cursor.lnum
+                            ? cursorline_fi : fold_info(wp, lnum);
 
       if (foldinfo.fi_lines == 0
           && idx < wp->w_lines_valid
@@ -2312,8 +2312,8 @@ static void win_update(win_T *wp, DecorProviders *providers)
       if (wp->w_p_rnu && wp->w_last_cursor_lnum_rnu != wp->w_cursor.lnum) {
         // 'relativenumber' set and cursor moved vertically: The
         // text doesn't need to be drawn, but the number column does.
-        foldinfo_T info = wp->w_p_cul && lnum == wp->w_cursor.lnum ?
-                          cursorline_fi : fold_info(wp, lnum);
+        foldinfo_T info = wp->w_p_cul && lnum == wp->w_cursor.lnum
+                          ? cursorline_fi : fold_info(wp, lnum);
         (void)win_line(wp, lnum, srow, wp->w_grid.rows, true, &spv, info, &line_providers);
       }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2479,8 +2479,8 @@ int oneright(void)
 
     // Adjust for multi-wide char (excluding TAB)
     ptr = get_cursor_pos_ptr();
-    coladvance(getviscol() + ((*ptr != TAB && vim_isprintc(utf_ptr2char(ptr))) ?
-                              ptr2cells(ptr) : 1));
+    coladvance(getviscol() + ((*ptr != TAB && vim_isprintc(utf_ptr2char(ptr)))
+                              ? ptr2cells(ptr) : 1));
     curwin->w_set_curswant = true;
     // Return OK if the cursor moved, FAIL otherwise (at window edge).
     return (prevpos.col != curwin->w_cursor.col
@@ -3550,8 +3550,9 @@ static bool ins_start_select(int c)
 // <Insert> key in Insert mode: toggle insert/replace mode.
 static void ins_insert(int replaceState)
 {
-  set_vim_var_string(VV_INSERTMODE, ((State & REPLACE_FLAG) ? "i" :
-                                     replaceState == MODE_VREPLACE ? "v" : "r"), 1);
+  set_vim_var_string(VV_INSERTMODE, ((State & REPLACE_FLAG)
+                                     ? "i"
+                                     : replaceState == MODE_VREPLACE ? "v" : "r"), 1);
   ins_apply_autocmds(EVENT_INSERTCHANGE);
   if (State & REPLACE_FLAG) {
     State = MODE_INSERT | (State & MODE_LANGMAP);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2439,7 +2439,7 @@ int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
     }
     *arg = skipwhite(*arg + 1);
     evalarg_used->eval_flags = (op_falsy ? !result : result)
-                                  ? orig_flags : (orig_flags & ~EVAL_EVALUATE);
+                               ? orig_flags : (orig_flags & ~EVAL_EVALUATE);
     typval_T var2;
     if (eval1(arg, &var2, evalarg_used) == FAIL) {
       evalarg_used->eval_flags = orig_flags;
@@ -7352,7 +7352,7 @@ char *set_cmdarg(exarg_T *eap, char *oldarg)
                   newval_len - xlen,
                   " ++ff=%s",
                   eap->force_ff == 'u' ? "unix"
-                  : eap->force_ff == 'd' ? "dos" : "mac");
+                                       : eap->force_ff == 'd' ? "dos" : "mac");
     if (rc < 0) {
       goto error;
     }
@@ -8086,10 +8086,10 @@ void ex_execute(exarg_T *eap)
 
     if (!eap->skip) {
       const char *const argstr = eap->cmdidx == CMD_execute
-        ? tv_get_string(&rettv)
-        : rettv.v_type == VAR_STRING
-        ? encode_tv2echo(&rettv, NULL)
-        : encode_tv2string(&rettv, NULL);
+                                 ? tv_get_string(&rettv)
+                                 : rettv.v_type == VAR_STRING
+                                 ? encode_tv2echo(&rettv, NULL)
+                                 : encode_tv2string(&rettv, NULL);
       const size_t len = strlen(argstr);
       ga_grow(&ga, (int)len + 2);
       if (!GA_EMPTY(&ga)) {
@@ -8879,8 +8879,8 @@ bool eval_has_provider(const char *feat)
   }
 
   bool ok = (tv.v_type == VAR_NUMBER)
-    ? 2 == tv.vval.v_number  // Value of 2 means "loaded and working".
-    : false;
+            ? 2 == tv.vval.v_number  // Value of 2 means "loaded and working".
+            : false;
 
   if (ok) {
     // Call() must be defined if provider claims to be working.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2897,8 +2897,8 @@ static void f_wait(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   int timeout = (int)argvars[0].vval.v_number;
   typval_T expr = argvars[1];
   int interval = argvars[2].v_type == VAR_NUMBER
-    ? (int)argvars[2].vval.v_number
-    : 200;  // Default.
+                 ? (int)argvars[2].vval.v_number
+                 : 200;  // Default.
   TimeWatcher *tw = xmalloc(sizeof(TimeWatcher));
 
   // Start dummy timer.
@@ -5712,11 +5712,11 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
         // Find the two bytes before the 0xbf.  If p is at buf, or buf + 1,
         // these may be in the "prev" string.
         char back1 = p >= buf + 1 ? p[-1]
-                                    : prevlen >= 1 ? prev[prevlen - 1] : NUL;
+                                  : prevlen >= 1 ? prev[prevlen - 1] : NUL;
         char back2 = p >= buf + 2 ? p[-2]
-                                    : p == buf + 1 && prevlen >= 1 ? prev[prevlen - 1]
-                                                                   : prevlen >=
-                     2 ? prev[prevlen - 2] : NUL;
+                                  : (p == buf + 1 && prevlen >= 1
+                                     ? prev[prevlen - 1]
+                                     : prevlen >= 2 ? prev[prevlen - 2] : NUL);
 
         if ((uint8_t)back2 == 0xef && (uint8_t)back1 == 0xbb) {
           char *dest = p - 2;
@@ -7914,10 +7914,11 @@ static void f_spellbadword(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
   tv_list_alloc_ret(rettv, 2);
   tv_list_append_string(rettv->vval.v_list, word, (ssize_t)len);
   tv_list_append_string(rettv->vval.v_list,
-                        (attr == HLF_SPB ? "bad" :
-                         attr == HLF_SPR ? "rare" :
-                         attr == HLF_SPL ? "local" :
-                         attr == HLF_SPC ? "caps" : NULL), -1);
+                        (attr == HLF_SPB
+                         ? "bad" : (attr == HLF_SPR
+                                    ? "rare" : (attr == HLF_SPL
+                                                ? "local" : (attr == HLF_SPC
+                                                             ? "caps" : NULL)))), -1);
 }
 
 /// "spellsuggest()" function
@@ -8410,8 +8411,8 @@ static void f_synconcealed(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
       cchar = syn_get_sub_char();
       if (cchar == NUL && curwin->w_p_cole == 1) {
         cchar = (curwin->w_p_lcs_chars.conceal == NUL)
-          ? ' '
-          : curwin->w_p_lcs_chars.conceal;
+                ? ' '
+                : curwin->w_p_lcs_chars.conceal;
       }
       if (cchar != NUL) {
         utf_char2bytes(cchar, str);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2446,7 +2446,7 @@ void ex_function(exarg_T *eap)
           p = theline;
         } else if (is_heredoc) {
           p = skipwhite(theline) == theline
-            ? theline : theline + strlen(heredoc_trimmed);
+              ? theline : theline + strlen(heredoc_trimmed);
         } else {
           p = theline + strlen(heredoc_trimmed);
         }
@@ -3573,8 +3573,8 @@ void make_partial(dict_T *const selfdict, typval_T *const rettv)
     fp = rettv->vval.v_partial->pt_func;
   } else {
     char *fname = rettv->v_type == VAR_FUNC || rettv->v_type == VAR_STRING
-                                      ? rettv->vval.v_string
-                                      : rettv->vval.v_partial->pt_name;
+                  ? rettv->vval.v_string
+                  : rettv->vval.v_partial->pt_name;
     // Translate "s:func" to the stored function name.
     fname = fname_trans_sid(fname, fname_buf, &tofree, &error);
     fp = find_func(fname);

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -71,8 +71,8 @@ int libuv_process_spawn(LibuvProcess *uvproc)
     uvproc->uvstdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
 #ifdef MSWIN
     // pipe must be readable for IOCP to work on Windows.
-    uvproc->uvstdio[1].flags |= proc->overlapped ?
-                                (UV_READABLE_PIPE | UV_OVERLAPPED_PIPE) : 0;
+    uvproc->uvstdio[1].flags |= proc->overlapped
+                                ? (UV_READABLE_PIPE | UV_OVERLAPPED_PIPE) : 0;
 #endif
     uvproc->uvstdio[1].data.stream = (uv_stream_t *)(&proc->out.uv.pipe);
   }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -397,10 +397,10 @@ static int sort_compare(const void *s1, const void *s2)
       result = l1.st_u.num.is_number - l2.st_u.num.is_number;
     } else {
       result = l1.st_u.num.value == l2.st_u.num.value
-        ? 0
-        : l1.st_u.num.value > l2.st_u.num.value
-          ? 1
-          : -1;
+               ? 0
+               : l1.st_u.num.value > l2.st_u.num.value
+               ? 1
+               : -1;
     }
   } else if (sort_flt) {
     result = l1.st_u.value_flt == l2.st_u.value_flt
@@ -1365,7 +1365,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 
   if (itmp != NULL) {
     len += is_pwsh ? strlen(itmp) + sizeof("& { Get-Content " " | & " " }") - 1 + 6  // +6: #20530
-                    : strlen(itmp) + sizeof(" { " " < " " } ") - 1;
+                   : strlen(itmp) + sizeof(" { " " < " " } ") - 1;
   }
   if (otmp != NULL) {
     len += strlen(otmp) + strlen(p_srr) + 2;  // two extra spaces ("  "),
@@ -1389,7 +1389,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
     // redirecting input and/or output.
     if (itmp != NULL || otmp != NULL) {
       char *fmt = is_fish_shell ? "begin; %s; end"
-        : "(%s)";
+                                : "(%s)";
       vim_snprintf(buf, len, fmt, cmd);
     } else {
       xstrlcpy(buf, cmd, len);
@@ -4283,15 +4283,15 @@ bool do_sub_msg(bool count_only)
     }
 
     char *msg_single = count_only
-                     ? NGETTEXT("%" PRId64 " match on %" PRId64 " line",
-                                "%" PRId64 " matches on %" PRId64 " line", sub_nsubs)
-                     : NGETTEXT("%" PRId64 " substitution on %" PRId64 " line",
-                                "%" PRId64 " substitutions on %" PRId64 " line", sub_nsubs);
+                       ? NGETTEXT("%" PRId64 " match on %" PRId64 " line",
+                                  "%" PRId64 " matches on %" PRId64 " line", sub_nsubs)
+                       : NGETTEXT("%" PRId64 " substitution on %" PRId64 " line",
+                                  "%" PRId64 " substitutions on %" PRId64 " line", sub_nsubs);
     char *msg_plural = count_only
-                     ? NGETTEXT("%" PRId64 " match on %" PRId64 " lines",
-                                "%" PRId64 " matches on %" PRId64 " lines", sub_nsubs)
-                     : NGETTEXT("%" PRId64 " substitution on %" PRId64 " lines",
-                                "%" PRId64 " substitutions on %" PRId64 " lines", sub_nsubs);
+                       ? NGETTEXT("%" PRId64 " match on %" PRId64 " lines",
+                                  "%" PRId64 " matches on %" PRId64 " lines", sub_nsubs)
+                       : NGETTEXT("%" PRId64 " substitution on %" PRId64 " lines",
+                                  "%" PRId64 " substitutions on %" PRId64 " lines", sub_nsubs);
     vim_snprintf_add(msg_buf, sizeof(msg_buf),
                      NGETTEXT(msg_single, msg_plural, sub_nlines),
                      (int64_t)sub_nsubs, (int64_t)sub_nlines);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2755,7 +2755,7 @@ int parse_cmd_address(exarg_T *eap, const char **errormsg, bool silent)
           if (IS_USER_CMDIDX(eap->cmdidx)) {
             eap->line1 = 1;
             eap->line2 = eap->addr_type == ADDR_WINDOWS
-                ? LAST_WIN_NR : LAST_TAB_NR;
+                         ? LAST_WIN_NR : LAST_TAB_NR;
           } else {
             // there is no Vim command which uses '%' and
             // ADDR_WINDOWS or ADDR_TABS
@@ -5209,8 +5209,8 @@ static void ex_tabs(exarg_T *eap)
   msg_scroll = true;
 
   win_T *lastused_win = valid_tabpage(lastused_tabpage)
-    ? lastused_tabpage->tp_curwin
-    : NULL;
+                        ? lastused_tabpage->tp_curwin
+                        : NULL;
 
   FOR_ALL_TABS(tp) {
     if (got_int) {

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -1658,8 +1658,9 @@ void ex_endtry(exarg_T *eap)
 
   if (!skip) {
     report_resume_pending(pending,
-                          (pending == CSTP_RETURN) ? rettv :
-                          (pending & CSTP_THROW) ? (void *)current_exception : NULL);
+                          (pending == CSTP_RETURN)
+                          ? rettv
+                          : (pending & CSTP_THROW) ? (void *)current_exception : NULL);
     switch (pending) {
     case CSTP_NONE:
       break;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -479,16 +479,17 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
       goto theend;
     }
 #if defined(UNIX) && defined(EOVERFLOW)
-    filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]") :
+    filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]")
+                                               :
                               // libuv only returns -errno
                               // in Unix and in Windows
                               // open() does not set
                               // EOVERFLOW
-                              (fd == -EOVERFLOW) ? _("[File too big]") :
-                              _("[Permission Denied]")), 0);
+                              (fd == -EOVERFLOW) ? _("[File too big]")
+                                                 : _("[Permission Denied]")), 0);
 #else
-    filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]") :
-                              _("[Permission Denied]")), 0);
+    filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]")
+                                               : _("[Permission Denied]")), 0);
 #endif
     curbuf->b_p_ro = true;                  // must use "w!" now
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -426,8 +426,8 @@ EXTERN win_T *prevwin INIT( = NULL);  // previous window
   FOR_ALL_WINDOWS_IN_TAB(wp, tp)
 
 #define FOR_ALL_WINDOWS_IN_TAB(wp, tp) \
-  for (win_T *wp = ((tp) == curtab) \
-       ? firstwin : (tp)->tp_firstwin; wp != NULL; wp = wp->w_next)
+  for (win_T *wp = ((tp) == curtab) ? firstwin : (tp)->tp_firstwin; \
+       wp != NULL; wp = wp->w_next)
 
 EXTERN win_T *curwin;        // currently active window
 

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -378,12 +378,12 @@ int grid_line_puts(int col, const char *text, int textlen, int attr)
   while (col < max_col && (len < 0 || (int)(ptr - text) < len) && *ptr != NUL) {
     // check if this is the first byte of a multibyte
     int mbyte_blen = len > 0
-      ? utfc_ptr2len_len(ptr, (int)((text + len) - ptr))
-      : utfc_ptr2len(ptr);
+                     ? utfc_ptr2len_len(ptr, (int)((text + len) - ptr))
+                     : utfc_ptr2len(ptr);
     int firstc;
     schar_T schar = len >= 0
-      ? utfc_ptr2schar_len(ptr, (int)((text + len) - ptr), &firstc)
-      : utfc_ptr2schar(ptr, &firstc);
+                    ? utfc_ptr2schar_len(ptr, (int)((text + len) - ptr), &firstc)
+                    : utfc_ptr2schar(ptr, &firstc);
     int mbyte_cells = utf_char2cells(firstc);
     if (mbyte_cells > 2) {
       mbyte_cells = 1;

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -347,15 +347,15 @@ static void hash_may_resize(hashtab_T *ht, size_t minitems)
   // so that copying is possible.
   hashitem_T temparray[HT_INIT_SIZE];
   hashitem_T *oldarray = keep_smallarray
-    ? memcpy(temparray, ht->ht_smallarray, sizeof(temparray))
-    : ht->ht_array;
+                         ? memcpy(temparray, ht->ht_smallarray, sizeof(temparray))
+                         : ht->ht_array;
 
   if (newarray_is_small) {
     CLEAR_FIELD(ht->ht_smallarray);
   }
   hashitem_T *newarray = newarray_is_small
-    ? ht->ht_smallarray
-    : xcalloc(newsize, sizeof(hashitem_T));
+                         ? ht->ht_smallarray
+                         : xcalloc(newsize, sizeof(hashitem_T));
 
   // Move all the items from the old array to the new one, placing them in
   // the right spot. The new array won't have any removed items, thus this

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -888,7 +888,7 @@ int get_breakindent_win(win_T *wp, char *line)
     // always leave at least bri_min characters on the left,
     // if text width is sufficient
     bri = (eff_wwidth - wp->w_briopt_min < 0)
-      ? 0 : eff_wwidth - wp->w_briopt_min;
+          ? 0 : eff_wwidth - wp->w_briopt_min;
   }
 
   return bri;

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2967,11 +2967,11 @@ static void get_next_dict_tsr_completion(int compl_type, char *dict, int dict_f)
   if (thesaurus_func_complete(compl_type)) {
     expand_by_function(compl_type, compl_pattern);
   } else {
-    ins_compl_dictionaries(dict != NULL ? dict
+    ins_compl_dictionaries(dict != NULL
+                           ? dict
                            : (compl_type == CTRL_X_THESAURUS
                               ? (*curbuf->b_p_tsr == NUL ? p_tsr : curbuf->b_p_tsr)
-                              : (*curbuf->b_p_dict ==
-                                 NUL ? p_dict : curbuf->b_p_dict)),
+                              : (*curbuf->b_p_dict == NUL ? p_dict : curbuf->b_p_dict)),
                            compl_pattern,
                            dict != NULL ? dict_f : 0,
                            compl_type == CTRL_X_THESAURUS);
@@ -3427,8 +3427,8 @@ static int ins_compl_get_exp(pos_T *ini)
     // just been made cyclic then we have to move compl_curr_match to the
     // next or previous entry (if any) -- Acevedo
     compl_curr_match = compl_dir_forward()
-                        ? compl_old_match->cp_next
-                        : compl_old_match->cp_prev;
+                       ? compl_old_match->cp_next
+                       : compl_old_match->cp_prev;
     if (compl_curr_match == NULL) {
       compl_curr_match = compl_old_match;
     }

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -339,13 +339,13 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
 
   // Print the log message.
   int rv = (line_num == -1 || func_name == NULL)
-    ? fprintf(log_file, "%s %s.%03d %-10s %s",
-              log_levels[log_level], date_time, millis, name,
-              (context == NULL ? "?:" : context))
-                               : fprintf(log_file, "%s %s.%03d %-10s %s%s:%d: ",
-                                         log_levels[log_level], date_time, millis, name,
-                                         (context == NULL ? "" : context),
-                                         func_name, line_num);
+           ? fprintf(log_file, "%s %s.%03d %-10s %s",
+                     log_levels[log_level], date_time, millis, name,
+                     (context == NULL ? "?:" : context))
+           : fprintf(log_file, "%s %s.%03d %-10s %s%s:%d: ",
+                     log_levels[log_level], date_time, millis, name,
+                     (context == NULL ? "" : context),
+                     func_name, line_num);
   if (name[0] == '?') {
     // No v:servername yet. Clear `name` so that the next log can try again.
     name[0] = '\0';

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -450,7 +450,7 @@ static int nlua_wait(lua_State *lstate)
   }
 
   MultiQueue *loop_events = fast_only || in_fast_callback > 0
-    ? main_loop.fast_events : main_loop.events;
+                            ? main_loop.fast_events : main_loop.events;
 
   TimeWatcher *tw = xmalloc(sizeof(TimeWatcher));
 
@@ -474,8 +474,8 @@ static int nlua_wait(lua_State *lstate)
                             (int)timeout,
                             got_int || (is_function ? nlua_wait_condition(lstate,
                                                                           &pcall_status,
-                                                                          &callback_result) :
-                                        false));
+                                                                          &callback_result)
+                                                    : false));
 
   // Stop dummy timer
   time_watcher_stop(tw);

--- a/src/nvim/lua/spell.c
+++ b/src/nvim/lua/spell.c
@@ -65,11 +65,11 @@ int nlua_spell_check(lua_State *lstate)
       lua_pushlstring(lstate, str, len);
       lua_rawseti(lstate, -2, 1);
 
-      result = attr == HLF_SPB ? "bad" :
-               attr == HLF_SPR ? "rare" :
-               attr == HLF_SPL ? "local" :
-               attr == HLF_SPC ? "caps" :
-               NULL;
+      result = attr == HLF_SPB
+               ? "bad" : (attr == HLF_SPR
+                          ? "rare" : (attr == HLF_SPL
+                                      ? "local" : (attr == HLF_SPC
+                                                   ? "caps" : NULL)));
 
       assert(result != NULL);
 

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -192,11 +192,11 @@ static bool check_xdiff_opt(ObjectType actType, ObjectType expType, const char *
 {
   if (actType != expType) {
     const char *type_str =
-      expType == kObjectTypeString ? "string" :
-      expType == kObjectTypeInteger ? "integer" :
-      expType == kObjectTypeBoolean ? "boolean" :
-      expType == kObjectTypeLuaRef ? "function" :
-      "NA";
+      expType == kObjectTypeString
+      ? "string" : (expType == kObjectTypeInteger
+                    ? "integer" : (expType == kObjectTypeBoolean
+                                   ? "boolean" : (expType == kObjectTypeLuaRef
+                                                  ? "function" : "NA")));
 
     api_set_error(err, kErrorTypeValidation, "%s is not a %s", name,
                   type_str);

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -579,8 +579,8 @@ static int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev,
   mapblock_T **abbr_table = args->buffer ? &buf->b_first_abbr : &first_abbr;
 
   // For ":noremap" don't remap, otherwise do remap.
-  int noremap = args->script ? REMAP_SCRIPT :
-                maptype == MAPTYPE_NOREMAP ? REMAP_NONE : REMAP_YES;
+  int noremap = args->script ? REMAP_SCRIPT
+                             : maptype == MAPTYPE_NOREMAP ? REMAP_NONE : REMAP_YES;
 
   const bool has_lhs = (args->lhs[0] != NUL);
   const bool has_rhs = args->rhs_lua != LUA_NOREF || (args->rhs[0] != NUL) || args->rhs_is_noop;
@@ -1521,8 +1521,8 @@ bool check_abbr(int c, char *ptr, int col, int mincol)
       mp2 = NULL;
     }
     for (; mp;
-         mp->m_next == NULL ? (mp = mp2, mp2 = NULL) :
-         (mp = mp->m_next)) {
+         mp->m_next == NULL ? (mp = mp2, mp2 = NULL)
+                            : (mp = mp->m_next)) {
       int qlen = mp->m_keylen;
       char *q = mp->m_keys;
       int match;
@@ -2621,7 +2621,7 @@ static void do_exmap(exarg_T *eap, int isabbrev)
   int mode = get_map_mode(&cmdp, eap->forceit || isabbrev);
 
   switch (do_map((*cmdp == 'n') ? MAPTYPE_NOREMAP
-                 : (*cmdp == 'u') ? MAPTYPE_UNMAP : MAPTYPE_MAP,
+                                : (*cmdp == 'u') ? MAPTYPE_UNMAP : MAPTYPE_MAP,
                  eap->arg, mode, isabbrev)) {
   case 1:
     emsg(_(e_invarg));

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -933,8 +933,8 @@ void ex_delmarks(exarg_T *eap)
           from = (uint8_t)(*p);
           to = (uint8_t)p[2];
           if (!(lower ? ASCII_ISLOWER(p[2])
-                : (digit ? ascii_isdigit(p[2])
-                   : ASCII_ISUPPER(p[2])))
+                      : (digit ? ascii_isdigit(p[2])
+                               : ASCII_ISUPPER(p[2])))
               || to < from) {
             semsg(_(e_invarg2), p);
             return;
@@ -1516,9 +1516,9 @@ const void *mark_global_iter(const void *const iter, char *const name, xfmark_T 
     return NULL;
   }
   size_t iter_off = (size_t)(iter_mark - &(namedfm[0]));
-  *name = (char)(iter_off < NMARKS ?
-                 'A' + (char)iter_off :
-                 '0' + (char)(iter_off - NMARKS));
+  *name = (char)(iter_off < NMARKS
+                 ? 'A' + (char)iter_off
+                 : '0' + (char)(iter_off - NMARKS));
   *fm = *iter_mark;
   while ((size_t)(++iter_mark - &(namedfm[0])) < ARRAY_SIZE(namedfm)) {
     if (iter_mark->fmark.mark.lnum) {
@@ -1580,11 +1580,15 @@ const void *mark_buffer_iter(const void *const iter, const buf_T *const buf, cha
   FUNC_ATTR_NONNULL_ARG(2, 3, 4) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   *name = NUL;
-  char mark_name = (char)(iter == NULL ? NUL :
-                          iter == &(buf->b_last_cursor) ? '"' :
-                          iter == &(buf->b_last_insert) ? '^' :
-                          iter == &(buf->b_last_change) ? '.' :
-                          'a' + (char)((const fmark_T *)iter - &(buf->b_namedm[0])));
+  char mark_name = (char)(iter == NULL
+                          ? NUL
+                          : (iter == &(buf->b_last_cursor)
+                             ? '"'
+                             : (iter == &(buf->b_last_insert)
+                                ? '^'
+                                : (iter == &(buf->b_last_change)
+                                   ? '.'
+                                   : 'a' + (const fmark_T *)iter - &(buf->b_namedm[0])))));
   const fmark_T *iter_mark = next_buffer_mark(buf, &mark_name);
   while (iter_mark != NULL && iter_mark->mark.lnum == 0) {
     iter_mark = next_buffer_mark(buf, &mark_name);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3437,9 +3437,9 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
                                name,
                                process_running
                                ? _("&Open Read-Only\n&Edit anyway\n&Recover"
-                                   "\n&Quit\n&Abort") :
-                               _("&Open Read-Only\n&Edit anyway\n&Recover"
-                                 "\n&Delete it\n&Quit\n&Abort"),
+                                   "\n&Quit\n&Abort")
+                               : _("&Open Read-Only\n&Edit anyway\n&Recover"
+                                   "\n&Delete it\n&Quit\n&Abort"),
                                1, NULL, false);
 
             if (process_running && choice >= 4) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -757,8 +757,8 @@ void validate_cursor_col(void)
 // fold column and sign column (these don't move when scrolling horizontally).
 int win_col_off(win_T *wp)
 {
-  return ((wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc != NUL) ?
-          (number_width(wp) + (*wp->w_p_stc == NUL)) : 0)
+  return ((wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc != NUL)
+          ? (number_width(wp) + (*wp->w_p_stc == NUL)) : 0)
          + ((cmdwin_type == 0 || wp != curwin) ? 0 : 1)
          + win_fdccol_count(wp) + (win_signcol_count(wp) * SIGN_WIDTH);
 }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -337,8 +337,8 @@ static void parse_msgpack(Channel *channel)
       arena_mem_free(arena_finish(&p->arena));
     } else if (p->type == kMessageTypeResponse) {
       ChannelCallFrame *frame = channel->rpc.client_type == kClientTypeMsgpackRpc
-        ? find_call_frame(&channel->rpc, p->request_id)
-        : kv_last(channel->rpc.call_stack);
+                                ? find_call_frame(&channel->rpc, p->request_id)
+                                : kv_last(channel->rpc.call_stack);
       if (frame == NULL || p->request_id != frame->request_id) {
         char buf[256];
         snprintf(buf, sizeof(buf),

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -472,8 +472,8 @@ msgpack_object *msgpack_rpc_method(msgpack_object *req)
 {
   msgpack_object *obj = req->via.array.ptr
                         + (msgpack_rpc_is_notification(req) ? 1 : 2);
-  return obj->type == MSGPACK_OBJECT_STR || obj->type == MSGPACK_OBJECT_BIN ?
-         obj : NULL;
+  return obj->type == MSGPACK_OBJECT_STR || obj->type == MSGPACK_OBJECT_BIN
+         ? obj : NULL;
 }
 
 msgpack_object *msgpack_rpc_args(msgpack_object *req)

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -68,8 +68,8 @@ static void close_socket_watcher(SocketWatcher **watcher)
 static void set_vservername(garray_T *srvs)
 {
   char *default_server = (srvs->ga_len > 0)
-    ? ((SocketWatcher **)srvs->ga_data)[0]->addr
-    : NULL;
+                         ? ((SocketWatcher **)srvs->ga_data)[0]->addr
+                         : NULL;
   set_vim_var_string(VV_SEND_SERVER, default_server, -1);
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2613,9 +2613,9 @@ void scroll_redraw(int up, linenr_T count)
   int prev_topfill = curwin->w_topfill;
   linenr_T prev_lnum = curwin->w_cursor.lnum;
 
-  bool moved = up ?
-               scrollup(count, true) :
-               scrolldown(count, true);
+  bool moved = up
+               ? scrollup(count, true)
+               : scrolldown(count, true);
 
   if (get_scrolloff_value(curwin) > 0) {
     // Adjust the cursor position for 'scrolloff'.  Mark w_topline as
@@ -4225,9 +4225,9 @@ static void nv_brackets(cmdarg_T *cap)
                             ? FIND_DEFINE
                             : FIND_ANY),
                            cap->count1,
-                           (isupper(cap->nchar) ? ACTION_SHOW_ALL :
-                            islower(cap->nchar) ? ACTION_SHOW :
-                            ACTION_GOTO),
+                           (isupper(cap->nchar) ? ACTION_SHOW_ALL
+                                                : islower(cap->nchar) ? ACTION_SHOW
+                                                                      : ACTION_GOTO),
                            (cap->cmdchar == ']'
                             ? curwin->w_cursor.lnum + 1
                             : 1),
@@ -6463,7 +6463,7 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
 
   if (fix_indent) {
     dir = (cap->cmdchar == ']' && cap->nchar == 'p')
-      ? FORWARD : BACKWARD;
+          ? FORWARD : BACKWARD;
     flags |= PUT_FIXINDENT;
   } else {
     dir = (cap->cmdchar == 'P'

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -451,8 +451,8 @@ static void shift_block(oparg_T *oap, int amount)
     const colnr_T block_space_width = non_white_col - oap->start_vcol;
     // We will shift by "total" or "block_space_width", whichever is less.
     const colnr_T shift_amount = block_space_width < total
-        ? block_space_width
-        : total;
+                                 ? block_space_width
+                                 : total;
     // The column to which we will shift the text.
     const colnr_T destination_col = non_white_col - shift_amount;
 
@@ -688,8 +688,8 @@ void op_reindent(oparg_T *oap, Indenter how)
   // there is no change still need to remove the Visual highlighting.
   if (last_changed != 0) {
     changed_lines(curbuf, first_changed, 0,
-                  oap->is_VIsual ? start_lnum + oap->line_count :
-                  last_changed + 1, 0, true);
+                  oap->is_VIsual ? start_lnum + oap->line_count
+                                 : last_changed + 1, 0, true);
   } else if (oap->is_VIsual) {
     redraw_curbuf_later(UPD_INVERTED);
   }
@@ -2067,8 +2067,8 @@ void op_tilde(oparg_T *oap)
     } else {
       while (true) {
         did_change |= swapchars(oap->op_type, &pos,
-                                pos.lnum == oap->end.lnum ? oap->end.col + 1 :
-                                (int)strlen(ml_get_pos(&pos)));
+                                pos.lnum == oap->end.lnum ? oap->end.col + 1
+                                                          : (int)strlen(ml_get_pos(&pos)));
         if (ltoreq(oap->end, pos) || inc(&pos) == -1) {
           break;
         }
@@ -2913,8 +2913,9 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
     bool non_linewise_vis = (VIsual_active && VIsual_mode != 'V');
 
     // PUT_LINE has special handling below which means we use 'i' to start.
-    char command_start_char = non_linewise_vis ? 'c' :
-                              (flags & PUT_LINE ? 'i' : (dir == FORWARD ? 'a' : 'i'));
+    char command_start_char = non_linewise_vis
+                              ? 'c'
+                              : (flags & PUT_LINE ? 'i' : (dir == FORWARD ? 'a' : 'i'));
 
     // To avoid 'autoindent' on linewise puts, create a new line with `:put _`.
     if (flags & PUT_LINE) {
@@ -3125,8 +3126,8 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
     }
     // In an empty buffer the empty line is going to be replaced, include
     // it in the saved lines.
-    if ((buf_is_empty(curbuf) ?
-         u_save(0, 2) : u_save(lnum - 1, lnum)) == FAIL) {
+    if ((buf_is_empty(curbuf)
+         ? u_save(0, 2) : u_save(lnum - 1, lnum)) == FAIL) {
       goto end;
     }
     if (dir == FORWARD) {
@@ -6201,8 +6202,8 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
           break;
         }
         op_reindent(oap,
-                    *curbuf->b_p_inde != NUL ? get_expr_indent :
-                    get_c_indent);
+                    *curbuf->b_p_inde != NUL ? get_expr_indent
+                                             : get_c_indent);
         break;
       }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -618,12 +618,12 @@ void set_init_3(void)
   // set, but only if they have not been set before.
   int idx_srr = findoption("srr");
   int do_srr = (idx_srr < 0)
-    ? false
-    : !(options[idx_srr].flags & P_WAS_SET);
+               ? false
+               : !(options[idx_srr].flags & P_WAS_SET);
   int idx_sp = findoption("sp");
   int do_sp = (idx_sp < 0)
-    ? false
-    : !(options[idx_sp].flags & P_WAS_SET);
+              ? false
+              : !(options[idx_sp].flags & P_WAS_SET);
 
   size_t len = 0;
   char *p = (char *)invocation_path_tail(p_sh, &len);
@@ -1645,8 +1645,8 @@ static char *option_expand(int opt_idx, char *val)
   // For 'spellsuggest' expand after "file:".
   expand_env_esc(val, NameBuff, MAXPATHL,
                  (char **)options[opt_idx].var == &p_tags, false,
-                 (char **)options[opt_idx].var == &p_sps ? "file:" :
-                 NULL);
+                 (char **)options[opt_idx].var == &p_sps ? "file:"
+                                                         : NULL);
   if (strcmp(NameBuff, val) == 0) {   // they are the same
     return NULL;
   }
@@ -2281,8 +2281,8 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
           xfree(buf->b_p_vsts_nopaste);
         }
         buf->b_p_vsts_nopaste = buf->b_p_vsts && buf->b_p_vsts != empty_string_option
-                                    ? xstrdup(buf->b_p_vsts)
-                                    : NULL;
+                                ? xstrdup(buf->b_p_vsts)
+                                : NULL;
       }
 
       // save global options

--- a/src/nvim/os/dl.c
+++ b/src/nvim/os/dl.c
@@ -72,7 +72,7 @@ bool os_libcall(const char *libname, const char *funcname, const char *argv, int
 
     // assume that ptr values of NULL, 1 or -1 are illegal
     *str_out = (res && (intptr_t)res != 1 && (intptr_t)res != -1)
-        ? xstrdup(res) : NULL;
+               ? xstrdup(res) : NULL;
   } else {
     str_int_fn sfn = (str_int_fn)fn;
     int_int_fn ifn = (int_int_fn)fn;

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -27,7 +27,7 @@ static garray_T ga_users = GA_EMPTY_INIT_VALUE;
 static void add_user(garray_T *users, char *user, bool need_copy)
 {
   char *user_copy = (user != NULL && need_copy)
-    ? xstrdup(user) : user;
+                    ? xstrdup(user) : user;
 
   if (user_copy == NULL || *user_copy == NUL) {
     if (need_copy) {

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -971,8 +971,8 @@ int64_t win_text_height(win_T *const wp, const linenr_T start_lnum, const int64_
     const int64_t row_off = end_vcol == 0
                             ? 0
                             : (end_vcol <= width1 || width2 <= 0)
-                              ? 1
-                              : 1 + (end_vcol - width1 + width2 - 1) / width2;
+                            ? 1
+                            : 1 + (end_vcol - width1 + width2 - 1) / width2;
     height_sum_nofill += MIN(row_off, height_cur_nofill);
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -821,7 +821,7 @@ retry:
       }
 
       state->growbufsiz = (2 * state->growbufsiz < LINE_MAXLEN)
-        ? 2 * state->growbufsiz : LINE_MAXLEN;
+                          ? 2 * state->growbufsiz : LINE_MAXLEN;
       state->growbuf = xrealloc(state->growbuf, state->growbufsiz);
     }
 
@@ -858,7 +858,7 @@ retry:
         state->linebuf = line;
         state->growbuf = line;
         state->growbufsiz = state->linelen < LINE_MAXLEN
-          ? state->linelen : LINE_MAXLEN;
+                            ? state->linelen : LINE_MAXLEN;
       }
     }
   }

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -5109,9 +5109,9 @@ static uint8_t *reg(int paren, int *flagp)
   }
 
   // Make a closing node, and hook it on the end.
-  ender = regnode(paren == REG_ZPAREN ? ZCLOSE + parno :
-                  paren == REG_PAREN ? MCLOSE + parno :
-                  paren == REG_NPAREN ? NCLOSE : END);
+  ender = regnode(paren == REG_ZPAREN ? ZCLOSE + parno
+                                      : paren == REG_PAREN ? MCLOSE + parno
+                                                           : paren == REG_NPAREN ? NCLOSE : END);
   regtail(ret, ender);
 
   // Hook the tails of the branches to the closing node.
@@ -5985,8 +5985,8 @@ static bool regmatch(uint8_t *scan, proftime_T *tm, int *timed_out)
             pos = &fm->mark;
             const colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
                                     && pos->col == MAXCOL
-              ? (colnr_T)strlen(reg_getline(pos->lnum - rex.reg_firstlnum))
-              : pos->col;
+                                    ? (colnr_T)strlen(reg_getline(pos->lnum - rex.reg_firstlnum))
+                                    : pos->col;
 
             if (pos->lnum == rex.lnum + rex.reg_firstlnum
                 ? (pos_col == (colnr_T)(rex.input - rex.line)
@@ -10064,8 +10064,8 @@ static int nfa_regatom(void)
             n = curwin->w_cursor.lnum;
           }
           // \%{n}l  \%{n}<l  \%{n}>l
-          EMIT(cmp == '<' ? NFA_LNUM_LT :
-               cmp == '>' ? NFA_LNUM_GT : NFA_LNUM);
+          EMIT(cmp == '<' ? NFA_LNUM_LT
+                          : cmp == '>' ? NFA_LNUM_GT : NFA_LNUM);
           if (save_prev_at_start) {
             at_start = true;
           }
@@ -10075,8 +10075,8 @@ static int nfa_regatom(void)
             n++;
           }
           // \%{n}c  \%{n}<c  \%{n}>c
-          EMIT(cmp == '<' ? NFA_COL_LT :
-               cmp == '>' ? NFA_COL_GT : NFA_COL);
+          EMIT(cmp == '<' ? NFA_COL_LT
+                          : cmp == '>' ? NFA_COL_GT : NFA_COL);
         } else {
           if (cur) {
             colnr_T vcol = 0;
@@ -10084,8 +10084,8 @@ static int nfa_regatom(void)
             n = ++vcol;
           }
           // \%{n}v  \%{n}<v  \%{n}>v
-          EMIT(cmp == '<' ? NFA_VCOL_LT :
-               cmp == '>' ? NFA_VCOL_GT : NFA_VCOL);
+          EMIT(cmp == '<' ? NFA_VCOL_LT
+                          : cmp == '>' ? NFA_VCOL_GT : NFA_VCOL);
           limit = INT32_MAX / MB_MAXBYTES;
         }
         if (n >= limit) {
@@ -10096,8 +10096,8 @@ static int nfa_regatom(void)
         break;
       } else if (c == '\'' && n == 0) {
         // \%'m  \%<'m  \%>'m
-        EMIT(cmp == '<' ? NFA_MARK_LT :
-             cmp == '>' ? NFA_MARK_GT : NFA_MARK);
+        EMIT(cmp == '<' ? NFA_MARK_LT
+                        : cmp == '>' ? NFA_MARK_GT : NFA_MARK);
         EMIT(getchr());
         break;
       }
@@ -10271,7 +10271,7 @@ collection:
 
           if (*regparse == 'n') {
             startc = (reg_string || emit_range || regparse[1] == '-')
-              ? NL : NFA_NEWL;
+                     ? NL : NFA_NEWL;
           } else if (*regparse == 'd'
                      || *regparse == 'o'
                      || *regparse == 'x'
@@ -14435,9 +14435,9 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
               }
             }
           } else if (state->c < 0 ? check_char_class(state->c, curc)
-                     : (curc == state->c
-                        || (rex.reg_ic
-                            && utf_fold(curc) == utf_fold(state->c)))) {
+                                  : (curc == state->c
+                                     || (rex.reg_ic
+                                         && utf_fold(curc) == utf_fold(state->c)))) {
             result = result_if_matched;
             break;
           }
@@ -14780,18 +14780,18 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
           pos_T *pos = &fm->mark;
           const colnr_T pos_col = pos->lnum == rex.lnum + rex.reg_firstlnum
                                   && pos->col == MAXCOL
-            ? (colnr_T)strlen(reg_getline(pos->lnum - rex.reg_firstlnum))
-            : pos->col;
+                                  ? (colnr_T)strlen(reg_getline(pos->lnum - rex.reg_firstlnum))
+                                  : pos->col;
 
           result = pos->lnum == rex.lnum + rex.reg_firstlnum
-            ? (pos_col == (colnr_T)(rex.input - rex.line)
-               ? t->state->c == NFA_MARK
-               : (pos_col < (colnr_T)(rex.input - rex.line)
-                  ? t->state->c == NFA_MARK_GT
-                  : t->state->c == NFA_MARK_LT))
-            : (pos->lnum < rex.lnum + rex.reg_firstlnum
-               ? t->state->c == NFA_MARK_GT
-               : t->state->c == NFA_MARK_LT);
+                   ? (pos_col == (colnr_T)(rex.input - rex.line)
+                      ? t->state->c == NFA_MARK
+                      : (pos_col < (colnr_T)(rex.input - rex.line)
+                         ? t->state->c == NFA_MARK_GT
+                         : t->state->c == NFA_MARK_LT))
+                   : (pos->lnum < rex.lnum + rex.reg_firstlnum
+                      ? t->state->c == NFA_MARK_GT
+                      : t->state->c == NFA_MARK_LT);
           if (result) {
             add_here = true;
             add_state = t->state->out;

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -152,8 +152,8 @@ char *estack_sfile(estack_arg_T which)
                                        ? &entry->es_info.ufunc->uf_script_ctx
                                        : &entry->es_info.aucmd->script_ctx);
         return def_ctx->sc_sid > 0
-                ? xstrdup((SCRIPT_ITEM(def_ctx->sc_sid)->sn_name))
-                : NULL;
+               ? xstrdup((SCRIPT_ITEM(def_ctx->sc_sid)->sn_name))
+               : NULL;
       } else if (entry->es_type == ETYPE_SCRIPT) {
         return xstrdup(entry->es_name);
       }
@@ -186,8 +186,8 @@ char *estack_sfile(estack_arg_T which)
       len += strlen(type_name);
       ga_grow(&ga, (int)len);
       linenr_T lnum = idx == exestack.ga_len - 1
-        ? which == ESTACK_STACK ? SOURCING_LNUM : 0
-        : entry->es_lnum;
+                      ? which == ESTACK_STACK ? SOURCING_LNUM : 0
+                      : entry->es_lnum;
       char *dots = idx == exestack.ga_len - 1 ? "" : "..";
       if (lnum == 0) {
         // For the bottom entry of <sfile>: do not add the line number,
@@ -1657,11 +1657,11 @@ char *runtimepath_default(bool clean_arg)
 {
   size_t rtp_size = 0;
   char *const data_home = clean_arg
-    ? NULL
-    : stdpaths_get_xdg_var(kXDGDataHome);
+                          ? NULL
+                          : stdpaths_get_xdg_var(kXDGDataHome);
   char *const config_home = clean_arg
-    ? NULL
-    : stdpaths_get_xdg_var(kXDGConfigHome);
+                            ? NULL
+                            : stdpaths_get_xdg_var(kXDGConfigHome);
   char *const vimruntime = vim_getenv("VIMRUNTIME");
   char *const libdir = get_lib_dir();
   char *const data_dirs = stdpaths_get_xdg_var(kXDGDataDirs);
@@ -2415,8 +2415,8 @@ linenr_T get_sourced_lnum(LineGetter fgetline, void *cookie)
   FUNC_ATTR_PURE
 {
   return fgetline == getsourceline
-        ? ((struct source_cookie *)cookie)->sourcing_lnum
-        : SOURCING_LNUM;
+         ? ((struct source_cookie *)cookie)->sourcing_lnum
+         : SOURCING_LNUM;
 }
 
 /// Return a List of script-local functions defined in the script with id "sid".

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1480,7 +1480,7 @@ int search_for_exact_line(buf_T *buf, pos_T *pos, Direction dir, char *pat)
       // Expanding lines or words.
       assert(ins_compl_len() >= 0);
       if ((p_ic ? mb_strnicmp(p, pat, (size_t)ins_compl_len())
-           : strncmp(p, pat, (size_t)ins_compl_len())) == 0) {
+                : strncmp(p, pat, (size_t)ins_compl_len())) == 0) {
         return OK;
       }
     }
@@ -3627,7 +3627,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
     if (incl_regmatch.regprog != NULL
         && vim_regexec(&incl_regmatch, line, 0)) {
       char *p_fname = (curr_fname == curbuf->b_fname)
-                        ? curbuf->b_ffname : curr_fname;
+                      ? curbuf->b_ffname : curr_fname;
 
       if (inc_opt != NULL && strstr(inc_opt, "\\zs") != NULL) {
         // Use text from '\zs' to '\ze' (or end) of 'include'.

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1611,8 +1611,8 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
                              // finally, additional data:
                              + (
                                 entry.data.search_pattern.additional_data
-              ? entry.data.search_pattern.additional_data->dv_hashtab.ht_used
-              : 0));
+                                ? entry.data.search_pattern.additional_data->dv_hashtab.ht_used
+                                : 0));
     msgpack_pack_map(spacker, entry_map_size);
     PACK_STATIC_STR(SEARCH_KEY_PAT);
     PACK_BIN(cstr_as_string(entry.data.search_pattern.pat));
@@ -1645,8 +1645,8 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
                              // Additional entries, if any:
                              + (
                                 entry.data.filemark.additional_data == NULL
-              ? 0
-              : entry.data.filemark.additional_data->dv_hashtab.ht_used));
+                                ? 0
+                                : entry.data.filemark.additional_data->dv_hashtab.ht_used));
     msgpack_pack_map(spacker, entry_map_size);
     PACK_STATIC_STR(KEY_FILE);
     PACK_BIN(cstr_as_string(entry.data.filemark.fname));
@@ -1718,9 +1718,9 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
                                + (
                                   entry.data.buffer_list.buffers[i].additional_data
                                   == NULL
-                ? 0
-                : (entry.data.buffer_list.buffers[i].additional_data
-                   ->dv_hashtab.ht_used)));
+                                  ? 0
+                                  : (entry.data.buffer_list.buffers[i].additional_data
+                                     ->dv_hashtab.ht_used)));
       msgpack_pack_map(spacker, entry_map_size);
       PACK_STATIC_STR(KEY_FILE);
       PACK_BIN(cstr_as_string(entry.data.buffer_list.buffers[i].fname));
@@ -2346,8 +2346,8 @@ static inline void add_search_pattern(PossiblyFreedShadaEntry *const ret_pse,
                                 : pat.off.line),
             .place_cursor_at_end = (
                                     is_substitute_pattern
-                ? defaults.data.search_pattern.place_cursor_at_end
-                : pat.off.end),
+                                    ? defaults.data.search_pattern.place_cursor_at_end
+                                    : pat.off.end),
             .offset = (is_substitute_pattern
                        ? defaults.data.search_pattern.offset
                        : pat.off.off),

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -149,8 +149,8 @@ int sign_cmp(const void *p1, const void *p2)
   int n = s1->pos.row - s2->pos.row;
 
   return n ? n : (n = s2->decor_full->priority - s1->decor_full->priority)
-           ? n : (n = (int)(s2->id - s1->id))
-           ? n : (s2->decor_full->sign_add_id - s1->decor_full->sign_add_id);
+         ? n : (n = (int)(s2->id - s1->id))
+         ? n : (s2->decor_full->sign_add_id - s1->decor_full->sign_add_id);
 }
 
 /// Delete the specified signs

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2488,8 +2488,8 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
                 // Not found, add a new condition.
                 idx = spin->si_prefcond.ga_len;
                 char **pp = GA_APPEND_VIA_PTR(char *, &spin->si_prefcond);
-                *pp = (aff_entry->ae_cond == NULL) ?
-                      NULL : getroom_save(spin, aff_entry->ae_cond);
+                *pp = (aff_entry->ae_cond == NULL)
+                      ? NULL : getroom_save(spin, aff_entry->ae_cond);
               }
 
               // Add the prefix to the prefix tree.
@@ -2608,7 +2608,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
             // when "to" is "_" it means empty
             add_fromto(spin, &spin->si_sal, items[1],
                        strcmp(items[2], "_") == 0 ? ""
-                       : items[2]);
+                                                  : items[2]);
           }
         }
       } else if (is_aff_rule(items, itemcnt, "SOFOFROM", 2)
@@ -5368,8 +5368,9 @@ static void spell_message(const spellinfo_T *spin, char *str)
 void ex_spell(exarg_T *eap)
 {
   spell_add_word(eap->arg, (int)strlen(eap->arg),
-                 eap->cmdidx == CMD_spellwrong ? SPELL_ADD_BAD :
-                 eap->cmdidx == CMD_spellrare ? SPELL_ADD_RARE : SPELL_ADD_GOOD,
+                 eap->cmdidx == CMD_spellwrong
+                 ? SPELL_ADD_BAD
+                 : eap->cmdidx == CMD_spellrare ? SPELL_ADD_RARE : SPELL_ADD_GOOD,
                  eap->forceit ? 0 : (int)eap->line2,
                  eap->cmdidx == CMD_spellundo);
 }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1387,7 +1387,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
         xstrlcpy(NameBuff, buf_spname(wp->w_buffer), MAXPATHL);
       } else {
         char *t = (opt == STL_FULLPATH) ? wp->w_buffer->b_ffname
-                                          : wp->w_buffer->b_fname;
+                                        : wp->w_buffer->b_fname;
         home_replace(wp->w_buffer, t, NameBuff, MAXPATHL, true);
       }
       trans_characters(NameBuff, MAXPATHL);
@@ -1586,9 +1586,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
     case STL_OFFSET: {
       int l = ml_find_line_or_offset(wp->w_buffer, wp->w_cursor.lnum, NULL,
                                      false);
-      num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) || l < 0 ?
-            0 : l + 1 + ((State & MODE_INSERT) == 0 && empty_line ?
-                         0 : (int)wp->w_cursor.col);
+      num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) || l < 0
+            ? 0 : l + 1 + ((State & MODE_INSERT) == 0 && empty_line
+                           ? 0 : (int)wp->w_cursor.col);
       break;
     }
     case STL_BYTEVAL_X:
@@ -1654,8 +1654,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
         if (!fold) {
           SignTextAttrs *sattr = virtnum ? NULL : &stcp->sattrs[i];
           p = sattr && sattr->text ? sattr->text : "  ";
-          stl_items[curitem].minwid = -(sattr && sattr->text ? stcp->sign_cul_id ? stcp->sign_cul_id
-                                        : sattr->hl_id : (stcp->use_cul ? HLF_CLS : HLF_SC) + 1);
+          stl_items[curitem].minwid = -(sattr && sattr->text
+                                        ? (stcp->sign_cul_id ? stcp->sign_cul_id : sattr->hl_id)
+                                        : (stcp->use_cul ? HLF_CLS : HLF_SC) + 1);
         }
         stl_items[curitem].type = Highlight;
         stl_items[curitem].start = out_p + buflen;

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -915,8 +915,8 @@ static int adjust_types(const char ***ap_types, int arg, int *num_posarg, const 
 {
   if (*ap_types == NULL || *num_posarg < arg) {
     const char **new_types = *ap_types == NULL
-      ? xcalloc(sizeof(const char *), (size_t)arg)
-      : xrealloc(*ap_types, (size_t)arg * sizeof(const char *));
+                             ? xcalloc(sizeof(const char *), (size_t)arg)
+                             : xrealloc(*ap_types, (size_t)arg * sizeof(const char *));
 
     for (int idx = *num_posarg; idx < arg; idx++) {
       new_types[idx] = NULL;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3719,9 +3719,9 @@ static void add_keyword(char *const name, const int id, const int flags,
 {
   char name_folded[MAXKEYWLEN + 1];
   const char *const name_ic = (curwin->w_s->b_syn_ic)
-      ? str_foldcase(name, (int)strlen(name), name_folded,
-                     sizeof(name_folded))
-      : name;
+                              ? str_foldcase(name, (int)strlen(name), name_folded,
+                                             sizeof(name_folded))
+                              : name;
 
   keyentry_T *const kp = xmalloc(offsetof(keyentry_T, keyword) + strlen(name_ic) + 1);
   STRCPY(kp->keyword, name_ic);
@@ -3737,8 +3737,8 @@ static void add_keyword(char *const name, const int id, const int flags,
 
   const hash_T hash = hash_hash(kp->keyword);
   hashtab_T *const ht = (curwin->w_s->b_syn_ic)
-      ? &curwin->w_s->b_keywtab_ic
-      : &curwin->w_s->b_keywtab;
+                        ? &curwin->w_s->b_keywtab_ic
+                        : &curwin->w_s->b_keywtab;
   hashitem_T *const hi = hash_lookup(ht, kp->keyword,
                                      strlen(kp->keyword), hash);
 
@@ -4385,8 +4385,8 @@ static void syn_cmd_region(exarg_T *eap, int syncing)
             SYN_ITEMS(curwin->w_s)[idx] = *(ppp->pp_synp);
             SYN_ITEMS(curwin->w_s)[idx].sp_syncing = syncing;
             SYN_ITEMS(curwin->w_s)[idx].sp_type =
-              (item == ITEM_START) ? SPTYPE_START :
-              (item == ITEM_SKIP) ? SPTYPE_SKIP : SPTYPE_END;
+              (item == ITEM_START) ? SPTYPE_START
+                                   : (item == ITEM_SKIP) ? SPTYPE_SKIP : SPTYPE_END;
             SYN_ITEMS(curwin->w_s)[idx].sp_flags |= syn_opt_arg.flags;
             SYN_ITEMS(curwin->w_s)[idx].sp_syn.id = (int16_t)syn_id;
             SYN_ITEMS(curwin->w_s)[idx].sp_syn.inc_tag =

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -390,8 +390,8 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
 
       new_tag = true;
     } else {
-      if (g_do_tagpreview != 0 ? ptag_entry.tagname == NULL :
-          tagstacklen == 0) {
+      if (g_do_tagpreview != 0 ? ptag_entry.tagname == NULL
+                               : tagstacklen == 0) {
         // empty stack
         emsg(_(e_tag_stack_empty));
         goto end_do_tag;
@@ -2307,11 +2307,12 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
   int verbose = (flags & TAG_VERBOSE);
   int save_p_ic = p_ic;
 
+  // uncrustify:off
+
   // Change the value of 'ignorecase' according to 'tagcase' for the
   // duration of this function.
   switch (curbuf->b_tc_flags ? curbuf->b_tc_flags : tc_flags) {
-  case TC_FOLLOWIC:
-    break;
+  case TC_FOLLOWIC: break;
   case TC_IGNORE:
     p_ic = true;
     break;
@@ -2327,6 +2328,8 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
   default:
     abort();
   }
+
+  // uncrustify:on
 
   int help_save = curbuf->b_help;
 
@@ -3208,7 +3211,7 @@ int expand_tags(int tagnames, char *pat, int *num_file, char ***file)
       memmove(name_buf, t_p.tagname, len);
       name_buf[len++] = 0;
       name_buf[len++] = (t_p.tagkind != NULL && *t_p.tagkind)
-                                                   ? *t_p.tagkind : 'f';
+                        ? *t_p.tagkind : 'f';
       name_buf[len++] = 0;
       memmove((*file)[i] + len, t_p.fname, (size_t)(t_p.fname_end - t_p.fname));
       (*file)[i][len + (size_t)(t_p.fname_end - t_p.fname)] = 0;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -725,8 +725,8 @@ static void tinput_read_cb(Stream *stream, RBuffer *buf, size_t count_, void *da
   if (rbuffer_size(input->read_stream.buffer)) {
     // If 'ttimeout' is not set, start the timer with a timeout of 0 to process
     // the next input.
-    int64_t ms = input->ttimeout ?
-                 (input->ttimeoutlen >= 0 ? input->ttimeoutlen : 0) : 0;
+    int64_t ms = input->ttimeout
+                 ? (input->ttimeoutlen >= 0 ? input->ttimeoutlen : 0) : 0;
     // Stop the current timer if already running
     time_watcher_stop(&input->timer_handle);
     time_watcher_start(&input->timer_handle, tinput_timer_cb, (uint32_t)ms, 0);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -334,7 +334,7 @@ static void terminfo_start(TUIData *tui)
                  || os_getenv("KONSOLE_DBUS_SESSION");
   const char *konsolev_env = os_getenv("KONSOLE_VERSION");
   int konsolev = konsolev_env ? (int)strtol(konsolev_env, NULL, 10)
-                               : (konsole ? 1 : 0);
+                              : (konsole ? 1 : 0);
 
   patch_terminfo_bugs(tui, term, colorterm, vtev, konsolev, iterm_env, nsterm);
   augment_terminfo(tui, term, vtev, konsolev, iterm_env, nsterm);
@@ -792,11 +792,15 @@ static void cursor_goto(TUIData *tui, int row, int col)
   if (grid->row == -1) {
     goto safe_move;
   }
-  if (0 == col ? col != grid->col :
-      row != grid->row ? false :
-      1 == col ? 2 < grid->col && cheap_to_print(tui, grid->row, 0, col) :
-      2 == col ? 5 < grid->col && cheap_to_print(tui, grid->row, 0, col) :
-      false) {
+  if (0 == col
+      ? col != grid->col
+      : (row != grid->row
+         ? false
+         : (1 == col
+            ? (2 < grid->col && cheap_to_print(tui, grid->row, 0, col))
+            : (2 == col
+               ? (5 < grid->col && cheap_to_print(tui, grid->row, 0, col))
+               : false)))) {
     // Motion to left margin from anywhere else, or CR + printing chars is
     // even less expensive than using BSes or CUB.
     unibi_out(tui, unibi_carriage_return);
@@ -2226,9 +2230,9 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
                                                                   "\x1b[?2004l");
   // For urxvt send BOTH xterm and old urxvt sequences. #8695
   tui->unibi_ext.enable_focus_reporting = (int)unibi_add_ext_str(ut, "ext.enable_focus",
-                                                                 rxvt ?
-                                                                 "\x1b[?1004h\x1b]777;focus;on\x7" :
-                                                                 "\x1b[?1004h");
+                                                                 rxvt
+                                                                 ? "\x1b[?1004h\x1b]777;focus;on\x7"
+                                                                 : "\x1b[?1004h");
   tui->unibi_ext.disable_focus_reporting =
     (int)unibi_add_ext_str(ut, "ext.disable_focus",
                            rxvt ? "\x1b[?1004l\x1b]777;focus;off\x7" : "\x1b[?1004l");

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1824,8 +1824,8 @@ bool u_undo_and_forget(int count, bool do_buf_event)
   if (curbuf->b_u_curhead) {
     to_forget->uh_alt_next.ptr = NULL;
     curbuf->b_u_curhead->uh_alt_prev.ptr = to_forget->uh_alt_prev.ptr;
-    curbuf->b_u_seq_cur = curbuf->b_u_curhead->uh_next.ptr ?
-                          curbuf->b_u_curhead->uh_next.ptr->uh_seq : 0;
+    curbuf->b_u_seq_cur = curbuf->b_u_curhead->uh_next.ptr
+                          ? curbuf->b_u_curhead->uh_next.ptr->uh_seq : 0;
   } else if (curbuf->b_u_newhead) {
     curbuf->b_u_seq_cur = curbuf->b_u_newhead->uh_seq;
   }
@@ -2039,9 +2039,9 @@ void undo_time(int step, bool sec, bool file, bool absolute)
 
     while (uhp != NULL) {
       uhp->uh_walk = mark;
-      int val = dosec ? (int)(uhp->uh_time) :
-                dofile ? uhp->uh_save_nr
-                        : uhp->uh_seq;
+      int val = dosec ? (int)(uhp->uh_time)
+                      : dofile ? uhp->uh_save_nr
+                               : uhp->uh_seq;
 
       if (round == 1 && !(dofile && val == 0)) {
         // Remember the header that is closest to the target.
@@ -2049,7 +2049,7 @@ void undo_time(int step, bool sec, bool file, bool absolute)
         // "b_u_seq_cur").  When the timestamp is equal find the
         // highest/lowest sequence number.
         if ((step < 0 ? uhp->uh_seq <= curbuf->b_u_seq_cur
-             : uhp->uh_seq > curbuf->b_u_seq_cur)
+                      : uhp->uh_seq > curbuf->b_u_seq_cur)
             && ((dosec && val == closest)
                 ? (step < 0
                    ? uhp->uh_seq < closest_seq
@@ -2505,8 +2505,8 @@ static void u_undoredo(int undo, bool do_buf_event)
   if (undo) {
     // We are below the previous undo.  However, to make ":earlier 1s"
     // work we compute this as being just above the just undone change.
-    curbuf->b_u_seq_cur = curhead->uh_next.ptr ?
-                          curhead->uh_next.ptr->uh_seq : 0;
+    curbuf->b_u_seq_cur = curhead->uh_next.ptr
+                          ? curhead->uh_next.ptr->uh_seq : 0;
   }
 
   // Remember where we are for ":earlier 1f" and ":later 1f".

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1532,10 +1532,13 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
   case ct_RANGE:
   case ct_COUNT: {
     char num_buf[20];
-    int64_t num = (type == ct_LINE1) ? eap->line1 :
-                  (type == ct_LINE2) ? eap->line2 :
-                  (type == ct_RANGE) ? eap->addr_count :
-                  (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
+    int64_t num = type == ct_LINE1
+                  ? eap->line1
+                  : (type == ct_LINE2
+                     ? eap->line2
+                     : (type == ct_RANGE
+                        ? eap->addr_count
+                        : (eap->addr_count > 0 ? eap->line2 : cmd->uc_def)));
     size_t num_len;
 
     snprintf(num_buf, sizeof(num_buf), "%" PRId64, num);

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -1268,8 +1268,8 @@ static bool viml_pexpr_handle_bop(const ParserState *const pstate, ExprASTStack 
   const ExprOpAssociativity bop_node_ass = (
                                             (bop_node->type == kExprNodeCall
                                              || bop_node->type == kExprNodeSubscript)
-      ? kEOpAssLeft
-      : node_ass(*bop_node));
+                                            ? kEOpAssLeft
+                                            : node_ass(*bop_node));
 #endif
   do {
     ExprASTNode **new_top_node_p = kv_last(*ast_stack);
@@ -2202,8 +2202,8 @@ viml_pexpr_parse_process_token:
         cur_node->data.opt.ident_len = 0;
         cur_node->data.opt.scope = (
                                     cur_token.len == 3
-              ? (ExprOptScope)pline.data[cur_token.start.col + 1]
-              : kExprOptScopeUnspecified);
+                                    ? (ExprOptScope)pline.data[cur_token.start.col + 1]
+                                    : kExprOptScopeUnspecified);
       } else {
         cur_node->data.opt.ident = cur_token.data.opt.name;
         cur_node->data.opt.ident_len = cur_token.data.opt.len;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3983,7 +3983,7 @@ int win_new_tabpage(int after, char *filename)
   }
 
   newtp->tp_localdir = old_curtab->tp_localdir
-    ? xstrdup(old_curtab->tp_localdir) : NULL;
+                       ? xstrdup(old_curtab->tp_localdir) : NULL;
 
   curtab = newtp;
 

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -972,7 +972,7 @@ sp_after_oc_property            = ignore   # ignore/add/remove/force/not_defined
 sp_after_oc_synchronized        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the ':' in 'b ? t : f'.
-sp_cond_colon                   = ignore   # ignore/add/remove/force/not_defined
+sp_cond_colon                   = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space before the ':' in 'b ? t : f'.
 #
@@ -1610,7 +1610,7 @@ indent_using_block              = true     # true/false
 # 0: Off (default)
 # 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
-indent_ternary_operator         = 0        # unsigned number
+indent_ternary_operator         = 2        # unsigned number
 
 # Whether to indent the statements inside ternary operator.
 indent_inside_ternary_operator  = false    # true/false
@@ -2570,7 +2570,7 @@ pos_compare                     = ignore   # ignore/break/force/lead/trail/join/
 
 # The position of conditional operators, as in the '?' and ':' of
 # 'expr ? stmt : stmt', in wrapped expressions.
-pos_conditional                 = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+pos_conditional                 = lead     # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 # The position of the comma in wrapped expressions.
 pos_comma                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
@@ -3731,5 +3731,5 @@ set CLASS_COLON                  REAL_FATTR_CONST
 set CLASS_COLON                  REAL_FATTR_NONNULL_ALL
 set CLASS_COLON                  REAL_FATTR_PURE
 set CLASS_COLON                  REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 132
+# option(s) with 'not default' value: 135
 #


### PR DESCRIPTION
This requires removing the "Inner expression should be aligned" rule
from clint as it prevents essentially any formatting regarding ternary
operators.