### PR TITLE
feat(extmarks): add sign name to extmark "details" array

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6998,11 +6998,11 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 		similar to the |:sign-place| command.
 
 		If the sign identifier {id} is zero, then a new identifier is
-		allocated.  Otherwise the specified number is used. {group} is
-		the sign group name. To use the global sign group, use an
-		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs. Refer to |sign-identifier|
-		and |sign-group| for more information.
+		allocated (first available id in a buffer).  Otherwise the
+		specified number is used. {group} is the sign group name. To use
+		the global sign group, use an empty string.  {group} functions
+		as a namespace for {id}, thus two groups can use the same IDs.
+		Refer to |sign-identifier| and |sign-group| for more information.
 
 		{name} refers to a defined sign.
 		{buf} refers to a buffer name or number. For the accepted

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -53,9 +53,9 @@ If 'cursorline' is enabled, then the CursorLineSign highlight group is used
 Each placed sign is identified by a number called the sign identifier. This
 identifier is used to jump to the sign or to remove the sign. The identifier
 is assigned when placing the sign using the |:sign-place| command or the
-|sign_place()| function. Each sign identifier should be a unique number.
-Placing the same identifier twice will move the previously placed sign. The
-|sign_place()| function can be called with a zero sign identifier to allocate
+|sign_place()| function. Each sign identifier should be a unique number (per
+buffer). Placing the same identifier twice will move the previously placed sign.
+The |sign_place()| function can be called with a zero sign identifier to allocate
 the next available identifier.
 
 							*sign-group*

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -1022,6 +1022,10 @@ void decor_to_dict_legacy(Dictionary *dict, DecorInline decor, bool hl_name)
       PUT(*dict, "sign_text", CSTR_TO_OBJ(sh_sign.text.ptr));
     }
 
+    if (sh_sign.sign_name) {
+      PUT(*dict, "sign_name", CSTR_TO_OBJ(sh_sign.sign_name));
+    }
+
     // uncrustify:off
 
     struct { char *name; const int val; } hls[] = {

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1582,6 +1582,23 @@ describe('API/extmarks', function()
       priority = 4096,
       right_gravity = true,
     } }, get_extmark_by_id(ns, marks[3], { details = true }))
+    curbufmeths.clear_namespace(ns, 0, -1)
+    -- legacy sign mark includes sign name
+    command('sign define sign1 text=s1 texthl=Title linehl=LineNR numhl=Normal culhl=CursorLine')
+    command('sign place 1 name=sign1 line=1')
+    eq({ {1, 0, 0, {
+      cursorline_hl_group = 'CursorLine',
+      invalidate = true,
+      line_hl_group = 'LineNr',
+      ns_id = 0,
+      number_hl_group = 'Normal',
+      priority = 10,
+      right_gravity = true,
+      sign_hl_group = 'Title',
+      sign_name = 'sign1',
+      sign_text = 's1',
+      undo_restore = false
+    } } }, get_extmarks(-1, 0, -1, { details = true }))
   end)
 
   it('can get marks from anonymous namespaces', function()


### PR DESCRIPTION
Problem:  Unable to identify legacy signs when fetching extmarks with
          `nvim_buf_get_extmarks()`.
Solution: Add "sign_name" to the extmark detail array.

Add some misc. changes as follow-up to #25724

Close #24467