### PR TITLE
test: skip failing watch file tests on freebsd

### DIFF
--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -99,6 +99,7 @@ describe('vim._watch', function()
 
   describe('poll', function()
     it('detects file changes', function()
+      skip(is_os('bsd'), "bsd only reports rename on folders if file inside change")
       local root_dir = vim.uv.fs_mkdtemp(vim.fs.dirname(helpers.tmpname()) .. '/nvim_XXXXXXXXXX')
 
       local result = exec_lua(

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4026,6 +4026,7 @@ describe('LSP', function()
 
   describe('vim.lsp._watchfiles', function()
     it('sends notifications when files change', function()
+      skip(is_os('bsd'), "bsd only reports rename on folders if file inside change")
       local root_dir = helpers.tmpname()
       os.remove(root_dir)
       mkdir(root_dir)


### PR DESCRIPTION
Quick fix as follow up to https://github.com/neovim/neovim/pull/26108

kqueue only reports events on a watched folder itself, not for files
created within. So the approach the PR took doesn't work on FreeBSD.

We'll either need to add manual file tracking (to check _which_ file changed within a folder on a event), bring back the polling version for FreeBSD, or disable LSP file watching on FreeBSD
