### PR TITLE
refactor(sign): store 'signcolumn' width range when it is set

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1206,6 +1206,8 @@ struct window_S {
   int w_nrwidth;                    // width of 'number' and 'relativenumber'
                                     // column being used
   int w_scwidth;                    // width of 'signcolumn'
+  int w_minscwidth;                 // minimum width or SCL_NO/SCL_NUM
+  int w_maxscwidth;                 // maximum width or SCL_NO/SCL_NUM
 
   // === end of cached values ===
 

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -442,7 +442,9 @@ void decor_redraw_signs(win_T *wp, buf_T *buf, int row, SignTextAttrs sattrs[], 
                         int *cul_id, int *num_id)
 {
   MarkTreeIter itr[1];
-  if (!buf->b_signs || !marktree_itr_get_overlap(buf->b_marktree, row, 0, itr)) {
+  if (!buf->b_signs
+      || wp->w_minscwidth == SCL_NO
+      || !marktree_itr_get_overlap(buf->b_marktree, row, 0, itr)) {
     return;
   }
 
@@ -471,7 +473,7 @@ void decor_redraw_signs(win_T *wp, buf_T *buf, int row, SignTextAttrs sattrs[], 
   }
 
   if (kv_size(signs)) {
-    int width = (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u') ? 1 : wp->w_scwidth;
+    int width = wp->w_minscwidth == SCL_NUM ? 1 : wp->w_scwidth;
     int idx = MIN(width, num_text) - 1;
     qsort((void *)&kv_A(signs, 0), kv_size(signs), sizeof(MTKey), sign_cmp);
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -561,7 +561,7 @@ static void handle_lnum_col(win_T *wp, winlinevars_T *wlv, int sign_num_attr, in
       && !((has_cpo_n && !wp->w_p_bri) && wp->w_skipcol > 0 && wlv->lnum == wp->w_topline)) {
     // If 'signcolumn' is set to 'number' and a sign is present in "lnum",
     // then display the sign instead of the line number.
-    if (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u' && wlv->sattrs[0].text) {
+    if (wp->w_minscwidth == SCL_NUM && wlv->sattrs[0].text) {
       get_sign_display_info(true, wp, wlv, 0, sign_cul_attr);
     } else {
       // Draw the line number (empty space after wrapping).

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -606,7 +606,7 @@ int update_screen(void)
     }
 
     // Reset 'statuscolumn' if there is no dedicated signcolumn but it is invalid.
-    if (*wp->w_p_stc != NUL && !wp->w_buffer->b_signcols.valid && win_no_signcol(wp)) {
+    if (*wp->w_p_stc != NUL && !wp->w_buffer->b_signcols.valid && wp->w_minscwidth <= SCL_NO) {
       wp->w_nrwidth_line_count = 0;
       wp->w_valid &= ~VALID_WCOL;
       wp->w_redr_type = UPD_NOT_VALID;
@@ -619,7 +619,7 @@ int update_screen(void)
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     // Validate b_signcols if there is no dedicated signcolumn but 'statuscolumn' is set.
-    if (*wp->w_p_stc != NUL && win_no_signcol(wp)) {
+    if (*wp->w_p_stc != NUL && wp->w_minscwidth <= SCL_NO) {
       buf_signcols(wp->w_buffer, 0);
     }
 
@@ -2632,8 +2632,7 @@ int number_width(win_T *wp)
 
   // If 'signcolumn' is set to 'number' and there is a sign to display, then
   // the minimal width for the number column is 2.
-  if (n < 2 && wp->w_buffer->b_signs_with_text
-      && (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u')) {
+  if (n < 2 && wp->w_buffer->b_signs_with_text && wp->w_minscwidth == SCL_NUM) {
     n = 2;
   }
 

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -947,3 +947,6 @@ enum {
 #define MAX_NUMBERWIDTH 20      // used for 'numberwidth' and 'statuscolumn'
 
 #define TABSTOP_MAX 9999
+
+#define SCL_NO  -1  // 'signcolumn' set to "no"
+#define SCL_NUM -2  // 'signcolumn' set to "number"


### PR DESCRIPTION
Problem:  Minimum and maximum signcolumn width is determined each redraw.
Solution: Determine and store 'signcolumn' range when option is set.