### PR TITLE
vim-patch:9.0.2116: No test for defining sign without attribute

### DIFF
--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -194,6 +194,11 @@ func Test_sign()
   sign undefine Sign3
   call assert_fails("sign place 41 line=3 name=Sign1 buffer=" .
 			  \ bufnr('%'), 'E155:')
+
+  " Defining a sign without attributes is allowed.
+  sign define Sign1
+  call assert_equal([{'name': 'Sign1'}], sign_getdefined())
+  sign undefine Sign1
 endfunc
 
 func Test_sign_many_bytes()


### PR DESCRIPTION
Problem:  No test for defining sign without attribute
Solution: Add test for defining sign without attributes

https://github.com/vim/vim/commit/e670d17342ea05af253b0452afb980397fa143be