### PR TITLE
fix(snippet): expand TM_FILENAME_BASE to filename without any extensions

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -43,7 +43,7 @@ local function resolve_variable(var, default)
     return expand_or_default('%:t')
   elseif var == 'TM_FILENAME_BASE' then
     -- Not using '%:t:r' since we want to remove all extensions.
-    local filename_base = expand_or_default('%:t'):gsub('%.[^%.]*$', '')
+    local filename_base = expand_or_default('%:t'):gsub('%..*$', '')
     return filename_base
   elseif var == 'TM_DIRECTORY' then
     return expand_or_default('%:p:h:t')


### PR DESCRIPTION
Problem:
vim.snippet variable `TM_FILENAME_BASE` only removes last extension of filename.

Steps:
1. nvim --clean test.many.extensions.lua
2. `i`
3. `<C-o>`
4. `:lua vim.snippet.expand("${TM_FILENAME_BASE}")<CR>`

Result:
test.many.extensions

Solution:
Change replacement in snippet.lua
As the [specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax) says, `TM_FILENAME_BASE` should expand to the filename without any extensions.