### PR TITLE
build: suppress bugprone-reserved-identifier warnings

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2227,13 +2227,13 @@ static void check_swap_exists_action(void)
 }
 
 #ifdef ENABLE_ASAN_UBSAN
-const char *__ubsan_default_options(void);
+const char *__ubsan_default_options(void);  // NOLINT(bugprone-reserved-identifier)
 const char *__ubsan_default_options(void)
 {
   return "print_stacktrace=1";
 }
 
-const char *__asan_default_options(void);
+const char *__asan_default_options(void);  // NOLINT(bugprone-reserved-identifier)
 const char *__asan_default_options(void)
 {
   return "handle_abort=1,handle_sigill=1";


### PR DESCRIPTION
These are only used when running `make lintc` with ENABLE_ASAN_UBSAN
enabled, which is why it wasn't caught by CI.