### PR TITLE
refactor: remove __clang_analyzer__ macro

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -671,9 +671,7 @@ static void cat_func_name(char *buf, size_t buflen, ufunc_T *fp)
 /// Add a number variable "name" to dict "dp" with value "nr".
 static void add_nr_var(dict_T *dp, dictitem_T *v, char *name, varnumber_T nr)
 {
-#ifndef __clang_analyzer__
   STRCPY(v->di_key, name);
-#endif
   v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
   hash_add(&dp->dv_hashtab, v->di_key);
   v->di_tv.v_type = VAR_NUMBER;
@@ -976,10 +974,8 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     // Set l:self to "selfdict".  Use "name" to avoid a warning from
     // some compiler that checks the destination size.
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
-#ifndef __clang_analyzer__
     name = (char *)v->di_key;
     STRCPY(name, "self");
-#endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_vars.dv_hashtab, v->di_key);
     v->di_tv.v_type = VAR_DICT;
@@ -1002,10 +998,8 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     // Use "name" to avoid a warning from some compiler that checks the
     // destination size.
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
-#ifndef __clang_analyzer__
     name = (char *)v->di_key;
     STRCPY(name, "000");
-#endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_avars.dv_hashtab, v->di_key);
     v->di_tv.v_type = VAR_LIST;


### PR DESCRIPTION
It is less intrusive to silence the warning with a comment instead of a
macro if needed.