### PR TITLE
vim-patch:596a9f29c83a

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5276,96 +5276,96 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 		having a different word order, positional arguments may be
 		used to indicate this. For instance: >vim
 
-			#, c-format
-			msgid "%s returning %s"
-			msgstr "waarde %2$s komt terug van %1$s"
+		    #, c-format
+		    msgid "%s returning %s"
+		    msgstr "waarde %2$s komt terug van %1$s"
 <
-		In this example, the sentence has its 2 string arguments reversed
-		in the output. >vim
+		In this example, the sentence has its 2 string arguments
+		reversed in the output. >vim
 
-			echo printf(
-				"In The Netherlands, vim's creator's name is: %1$s %2$s",
-				"Bram", "Moolenaar")
-<			In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+		    echo printf(
+			"In The Netherlands, vim's creator's name is: %1$s %2$s",
+			"Bram", "Moolenaar")
+<		    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
-			echo printf(
-				"In Belgium, vim's creator's name is: %2$s %1$s",
-				"Bram", "Moolenaar")
-<			In Belgium, vim's creator's name is: Moolenaar Bram
+		    echo printf(
+			"In Belgium, vim's creator's name is: %2$s %1$s",
+			"Bram", "Moolenaar")
+<		    In Belgium, vim's creator's name is: Moolenaar Bram
 
 		Width (and precision) can be specified using the '*' specifier.
 		In this case, you must specify the field width position in the
 		argument list. >vim
 
-			echo printf("%1$*2$.*3$d", 1, 2, 3)
-<			001 >vim
-			echo printf("%2$*3$.*1$d", 1, 2, 3)
-<			  2 >vim
-			echo printf("%3$*1$.*2$d", 1, 2, 3)
-<			03 >vim
-			echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-<			1.414
+		    echo printf("%1$*2$.*3$d", 1, 2, 3)
+<		    001 >vim
+		    echo printf("%2$*3$.*1$d", 1, 2, 3)
+<		      2 >vim
+		    echo printf("%3$*1$.*2$d", 1, 2, 3)
+<		    03 >vim
+		    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+<		    1.414
 
 		You can mix specifying the width and/or precision directly
 		and via positional arguments: >vim
 
-			echo printf("%1$4.*2$f", 1.4142135, 6)
-<			1.414214 >vim
-			echo printf("%1$*2$.4f", 1.4142135, 6)
-<			1.4142 >vim
-			echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-<			  1.41
+		    echo printf("%1$4.*2$f", 1.4142135, 6)
+<		    1.414214 >vim
+		    echo printf("%1$*2$.4f", 1.4142135, 6)
+<		    1.4142 >vim
+		    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+<		      1.41
 
 							*E1500*
 		You cannot mix positional and non-positional arguments: >vim
-			echo printf("%s%1$s", "One", "Two")
-<			E1500: Cannot mix positional and non-positional
-			arguments: %s%1$s
+		    echo printf("%s%1$s", "One", "Two")
+<		    E1500: Cannot mix positional and non-positional arguments:
+		    %s%1$s
 
 							*E1501*
 		You cannot skip a positional argument in a format string: >vim
-			echo printf("%3$s%1$s", "One", "Two", "Three")
-<			E1501: format argument 2 unused in $-style
-			format: %3$s%1$s
+		    echo printf("%3$s%1$s", "One", "Two", "Three")
+<		    E1501: format argument 2 unused in $-style format:
+		    %3$s%1$s
 
 							*E1502*
 		You can re-use a [field-width] (or [precision]) argument: >vim
-			echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-<			1 at width 2 is: 01
+		    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+<		    1 at width 2 is: 01
 
 		However, you can't use it as a different type: >vim
-			echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-<			E1502: Positional argument 2 used as field
-			width reused as different type: long int/int
+		    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+<		    E1502: Positional argument 2 used as field width reused as
+		    different type: long int/int
 
 							*E1503*
 		When a positional argument is used, but not the correct number
 		or arguments is given, an error is raised: >vim
-			echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-<			E1503: Positional argument 3 out of bounds:
-			%1$d at width %2$d is: %01$*2$.*3$d
+		    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+<		    E1503: Positional argument 3 out of bounds: %1$d at width
+		    %2$d is: %01$*2$.*3$d
 
 		Only the first error is reported: >vim
-			echo printf("%01$*2$.*3$d %4$d", 1, 2)
-<			E1503: Positional argument 3 out of bounds:
-			%01$*2$.*3$d %4$d
+		    echo printf("%01$*2$.*3$d %4$d", 1, 2)
+<		    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+		    %4$d
 
 							*E1504*
 		A positional argument can be used more than once: >vim
-			echo printf("%1$s %2$s %1$s", "One", "Two")
-<			One Two One
+		    echo printf("%1$s %2$s %1$s", "One", "Two")
+<		    One Two One
 
 		However, you can't use a different type the second time: >vim
-			echo printf("%1$s %2$s %1$d", "One", "Two")
-<			E1504: Positional argument 1 type used
-			inconsistently: int/string
+		    echo printf("%1$s %2$s %1$d", "One", "Two")
+<		    E1504: Positional argument 1 type used inconsistently:
+		    int/string
 
 							*E1505*
 		Various other errors that lead to a format string being
 		wrongly formatted lead to: >vim
-			echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-<			E1505: Invalid format specifier:
-			%1$d at width %2$d is: %01$*2$.3$d
+		    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+<		    E1505: Invalid format specifier: %1$d at width %2$d is:
+		    %01$*2$.3$d
 
 							*E1507*
 		This internal error indicates that the logic to parse a

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6261,96 +6261,96 @@ function vim.fn.prevnonblank(lnum) end
 --- having a different word order, positional arguments may be
 --- used to indicate this. For instance: >vim
 ---
----   #, c-format
----   msgid "%s returning %s"
----   msgstr "waarde %2$s komt terug van %1$s"
+---     #, c-format
+---     msgid "%s returning %s"
+---     msgstr "waarde %2$s komt terug van %1$s"
 --- <
---- In this example, the sentence has its 2 string arguments reversed
---- in the output. >vim
+--- In this example, the sentence has its 2 string arguments
+--- reversed in the output. >vim
 ---
----   echo printf(
----     "In The Netherlands, vim's creator's name is: %1$s %2$s",
----     "Bram", "Moolenaar")
---- <  In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+---     echo printf(
+---   "In The Netherlands, vim's creator's name is: %1$s %2$s",
+---   "Bram", "Moolenaar")
+--- <    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 ---
----   echo printf(
----     "In Belgium, vim's creator's name is: %2$s %1$s",
----     "Bram", "Moolenaar")
---- <  In Belgium, vim's creator's name is: Moolenaar Bram
+---     echo printf(
+---   "In Belgium, vim's creator's name is: %2$s %1$s",
+---   "Bram", "Moolenaar")
+--- <    In Belgium, vim's creator's name is: Moolenaar Bram
 ---
 --- Width (and precision) can be specified using the '*' specifier.
 --- In this case, you must specify the field width position in the
 --- argument list. >vim
 ---
----   echo printf("%1$*2$.*3$d", 1, 2, 3)
---- <  001 >vim
----   echo printf("%2$*3$.*1$d", 1, 2, 3)
---- <    2 >vim
----   echo printf("%3$*1$.*2$d", 1, 2, 3)
---- <  03 >vim
----   echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
---- <  1.414
+---     echo printf("%1$*2$.*3$d", 1, 2, 3)
+--- <    001 >vim
+---     echo printf("%2$*3$.*1$d", 1, 2, 3)
+--- <      2 >vim
+---     echo printf("%3$*1$.*2$d", 1, 2, 3)
+--- <    03 >vim
+---     echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+--- <    1.414
 ---
 --- You can mix specifying the width and/or precision directly
 --- and via positional arguments: >vim
 ---
----   echo printf("%1$4.*2$f", 1.4142135, 6)
---- <  1.414214 >vim
----   echo printf("%1$*2$.4f", 1.4142135, 6)
---- <  1.4142 >vim
----   echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
---- <    1.41
+---     echo printf("%1$4.*2$f", 1.4142135, 6)
+--- <    1.414214 >vim
+---     echo printf("%1$*2$.4f", 1.4142135, 6)
+--- <    1.4142 >vim
+---     echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+--- <      1.41
 ---
 ---           *E1500*
 --- You cannot mix positional and non-positional arguments: >vim
----   echo printf("%s%1$s", "One", "Two")
---- <  E1500: Cannot mix positional and non-positional
----   arguments: %s%1$s
+---     echo printf("%s%1$s", "One", "Two")
+--- <    E1500: Cannot mix positional and non-positional arguments:
+---     %s%1$s
 ---
 ---           *E1501*
 --- You cannot skip a positional argument in a format string: >vim
----   echo printf("%3$s%1$s", "One", "Two", "Three")
---- <  E1501: format argument 2 unused in $-style
----   format: %3$s%1$s
+---     echo printf("%3$s%1$s", "One", "Two", "Three")
+--- <    E1501: format argument 2 unused in $-style format:
+---     %3$s%1$s
 ---
 ---           *E1502*
 --- You can re-use a [field-width] (or [precision]) argument: >vim
----   echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
---- <  1 at width 2 is: 01
+---     echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+--- <    1 at width 2 is: 01
 ---
 --- However, you can't use it as a different type: >vim
----   echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
---- <  E1502: Positional argument 2 used as field
----   width reused as different type: long int/int
+---     echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+--- <    E1502: Positional argument 2 used as field width reused as
+---     different type: long int/int
 ---
 ---           *E1503*
 --- When a positional argument is used, but not the correct number
 --- or arguments is given, an error is raised: >vim
----   echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
---- <  E1503: Positional argument 3 out of bounds:
----   %1$d at width %2$d is: %01$*2$.*3$d
+---     echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+--- <    E1503: Positional argument 3 out of bounds: %1$d at width
+---     %2$d is: %01$*2$.*3$d
 ---
 --- Only the first error is reported: >vim
----   echo printf("%01$*2$.*3$d %4$d", 1, 2)
---- <  E1503: Positional argument 3 out of bounds:
----   %01$*2$.*3$d %4$d
+---     echo printf("%01$*2$.*3$d %4$d", 1, 2)
+--- <    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+---     %4$d
 ---
 ---           *E1504*
 --- A positional argument can be used more than once: >vim
----   echo printf("%1$s %2$s %1$s", "One", "Two")
---- <  One Two One
+---     echo printf("%1$s %2$s %1$s", "One", "Two")
+--- <    One Two One
 ---
 --- However, you can't use a different type the second time: >vim
----   echo printf("%1$s %2$s %1$d", "One", "Two")
---- <  E1504: Positional argument 1 type used
----   inconsistently: int/string
+---     echo printf("%1$s %2$s %1$d", "One", "Two")
+--- <    E1504: Positional argument 1 type used inconsistently:
+---     int/string
 ---
 ---           *E1505*
 --- Various other errors that lead to a format string being
 --- wrongly formatted lead to: >vim
----   echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
---- <  E1505: Invalid format specifier:
----   %1$d at width %2$d is: %01$*2$.3$d
+---     echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+--- <    E1505: Invalid format specifier: %1$d at width %2$d is:
+---     %01$*2$.3$d
 ---
 ---           *E1507*
 --- This internal error indicates that the logic to parse a

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7548,96 +7548,96 @@ M.funcs = {
       having a different word order, positional arguments may be
       used to indicate this. For instance: >vim
 
-      	#, c-format
-      	msgid "%s returning %s"
-      	msgstr "waarde %2$s komt terug van %1$s"
+          #, c-format
+          msgid "%s returning %s"
+          msgstr "waarde %2$s komt terug van %1$s"
       <
-      In this example, the sentence has its 2 string arguments reversed
-      in the output. >vim
+      In this example, the sentence has its 2 string arguments
+      reversed in the output. >vim
 
-      	echo printf(
-      		"In The Netherlands, vim's creator's name is: %1$s %2$s",
-      		"Bram", "Moolenaar")
-      <	In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+          echo printf(
+      	"In The Netherlands, vim's creator's name is: %1$s %2$s",
+      	"Bram", "Moolenaar")
+      <    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
-      	echo printf(
-      		"In Belgium, vim's creator's name is: %2$s %1$s",
-      		"Bram", "Moolenaar")
-      <	In Belgium, vim's creator's name is: Moolenaar Bram
+          echo printf(
+      	"In Belgium, vim's creator's name is: %2$s %1$s",
+      	"Bram", "Moolenaar")
+      <    In Belgium, vim's creator's name is: Moolenaar Bram
 
       Width (and precision) can be specified using the '*' specifier.
       In this case, you must specify the field width position in the
       argument list. >vim
 
-      	echo printf("%1$*2$.*3$d", 1, 2, 3)
-      <	001 >vim
-      	echo printf("%2$*3$.*1$d", 1, 2, 3)
-      <	  2 >vim
-      	echo printf("%3$*1$.*2$d", 1, 2, 3)
-      <	03 >vim
-      	echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-      <	1.414
+          echo printf("%1$*2$.*3$d", 1, 2, 3)
+      <    001 >vim
+          echo printf("%2$*3$.*1$d", 1, 2, 3)
+      <      2 >vim
+          echo printf("%3$*1$.*2$d", 1, 2, 3)
+      <    03 >vim
+          echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+      <    1.414
 
       You can mix specifying the width and/or precision directly
       and via positional arguments: >vim
 
-      	echo printf("%1$4.*2$f", 1.4142135, 6)
-      <	1.414214 >vim
-      	echo printf("%1$*2$.4f", 1.4142135, 6)
-      <	1.4142 >vim
-      	echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-      <	  1.41
+          echo printf("%1$4.*2$f", 1.4142135, 6)
+      <    1.414214 >vim
+          echo printf("%1$*2$.4f", 1.4142135, 6)
+      <    1.4142 >vim
+          echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+      <      1.41
 
       					*E1500*
       You cannot mix positional and non-positional arguments: >vim
-      	echo printf("%s%1$s", "One", "Two")
-      <	E1500: Cannot mix positional and non-positional
-      	arguments: %s%1$s
+          echo printf("%s%1$s", "One", "Two")
+      <    E1500: Cannot mix positional and non-positional arguments:
+          %s%1$s
 
       					*E1501*
       You cannot skip a positional argument in a format string: >vim
-      	echo printf("%3$s%1$s", "One", "Two", "Three")
-      <	E1501: format argument 2 unused in $-style
-      	format: %3$s%1$s
+          echo printf("%3$s%1$s", "One", "Two", "Three")
+      <    E1501: format argument 2 unused in $-style format:
+          %3$s%1$s
 
       					*E1502*
       You can re-use a [field-width] (or [precision]) argument: >vim
-      	echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-      <	1 at width 2 is: 01
+          echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+      <    1 at width 2 is: 01
 
       However, you can't use it as a different type: >vim
-      	echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-      <	E1502: Positional argument 2 used as field
-      	width reused as different type: long int/int
+          echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+      <    E1502: Positional argument 2 used as field width reused as
+          different type: long int/int
 
       					*E1503*
       When a positional argument is used, but not the correct number
       or arguments is given, an error is raised: >vim
-      	echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-      <	E1503: Positional argument 3 out of bounds:
-      	%1$d at width %2$d is: %01$*2$.*3$d
+          echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+      <    E1503: Positional argument 3 out of bounds: %1$d at width
+          %2$d is: %01$*2$.*3$d
 
       Only the first error is reported: >vim
-      	echo printf("%01$*2$.*3$d %4$d", 1, 2)
-      <	E1503: Positional argument 3 out of bounds:
-      	%01$*2$.*3$d %4$d
+          echo printf("%01$*2$.*3$d %4$d", 1, 2)
+      <    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+          %4$d
 
       					*E1504*
       A positional argument can be used more than once: >vim
-      	echo printf("%1$s %2$s %1$s", "One", "Two")
-      <	One Two One
+          echo printf("%1$s %2$s %1$s", "One", "Two")
+      <    One Two One
 
       However, you can't use a different type the second time: >vim
-      	echo printf("%1$s %2$s %1$d", "One", "Two")
-      <	E1504: Positional argument 1 type used
-      	inconsistently: int/string
+          echo printf("%1$s %2$s %1$d", "One", "Two")
+      <    E1504: Positional argument 1 type used inconsistently:
+          int/string
 
       					*E1505*
       Various other errors that lead to a format string being
       wrongly formatted lead to: >vim
-      	echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-      <	E1505: Invalid format specifier:
-      	%1$d at width %2$d is: %01$*2$.3$d
+          echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+      <    E1505: Invalid format specifier: %1$d at width %2$d is:
+          %01$*2$.3$d
 
       					*E1507*
       This internal error indicates that the logic to parse a


### PR DESCRIPTION
#### vim-patch:596a9f29c83a

runtime(doc): Fix whitespace and formatting of some help files (vim/vim#13549)

https://github.com/vim/vim/commit/596a9f29c83af85ace1a2702c88591851ad14df8

N/A patch:
vim-patch:aabca259fa48

Co-authored-by: h_east <h.east.727@gmail.com>