### PR TITLE
vim-patch:9.0.2117: [security] use-after-free in qf_free_items

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3411,9 +3411,10 @@ static void qf_free_items(qf_list_T *qfl)
         // to avoid crashing when it's wrong.
         // TODO(vim): Avoid qf_count being incorrect.
         qfl->qf_count = 1;
+      } else {
+        qfl->qf_start = qfpnext;
       }
     }
-    qfl->qf_start = qfpnext;
     qfl->qf_count--;
   }
 


### PR DESCRIPTION
#### vim-patch:9.0.2117: [security] use-after-free in qf_free_items

Problem:  [security] use-after-free in qf_free_items
Solution: only access qfpnext, if it hasn't been freed

Coverity discovered a possible use-after-free in qf_free_items. When
freeing the qfline items, we may access freed memory, when qfp ==
qfpnext.

So only access qfpnext, when it hasn't been freed.

https://github.com/vim/vim/commit/567cae2630a51efddc07eacff3b38a295e1f5671

Co-authored-by: Christian Brabandt <cb@256bit.org>