### PR TITLE
fix(swap): remove swap exist action check

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3398,9 +3398,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
 
           // If there is a SwapExists autocommand and we can handle the
           // response, trigger it.  It may return 0 to ask the user anyway.
-          if (choice == 0
-              && swap_exists_action != SEA_NONE
-              && has_autocmd(EVENT_SWAPEXISTS, buf_fname, buf)) {
+          if (choice == 0 && has_autocmd(EVENT_SWAPEXISTS, buf_fname, buf)) {
             choice = do_swapexists(buf, fname);
           }
 


### PR DESCRIPTION
because the `swap_exists_action` init to none so this condition not trigger default swapexist autcomd handler. now we have a default handler for swapexist this action check seems like redundant. (or change swap_exists_action init value to SEA_DIALOG).

Fix  #26137