### PR TITLE
build: add utf8proc as dependency

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -37,6 +37,7 @@ option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_TS "Use the bundled treesitter runtime." ${USE_BUNDLED})
 option(USE_BUNDLED_TS_PARSERS "Use the bundled treesitter parsers." ${USE_BUNDLED})
 option(USE_BUNDLED_UNIBILIUM "Use the bundled unibilium." ${USE_BUNDLED})
+option(USE_BUNDLED_UTF8PROC "Use the bundled utf8proc library." ${USE_BUNDLED})
 if(USE_BUNDLED AND MSVC)
   option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." ON)
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." ON)
@@ -138,6 +139,10 @@ endif()
 
 if(USE_BUNDLED_TS)
   include(BuildTreesitter)
+endif()
+
+if(USE_BUNDLED_UTF8PROC)
+  include(BuildUTF8proc)
 endif()
 
 if(WIN32)

--- a/cmake.deps/CMakePresets.json
+++ b/cmake.deps/CMakePresets.json
@@ -17,7 +17,8 @@
       "cacheVariables": {
         "USE_BUNDLED":"OFF",
         "USE_BUNDLED_LIBVTERM":"ON",
-        "USE_BUNDLED_TS":"ON"
+        "USE_BUNDLED_TS":"ON",
+        "USE_BUNDLED_UTF8PROC":"ON"
       },
       "inherits": ["base"]
     }

--- a/cmake.deps/cmake/BuildUTF8proc.cmake
+++ b/cmake.deps/cmake/BuildUTF8proc.cmake
@@ -1,0 +1,5 @@
+get_externalproject_options(utf8proc ${DEPS_IGNORE_SHA})
+ExternalProject_Add(utf8proc
+  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/utf8proc
+  CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+  ${EXTERNALPROJECT_OPTIONS})

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -41,6 +41,9 @@ GETTEXT_SHA256 66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c
 LIBICONV_URL https://github.com/neovim/deps/raw/b9bf36eb31f27e8136d907da38fa23518927737e/opt/libiconv-1.17.tar.gz
 LIBICONV_SHA256 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
 
+UTF8PROC_URL https://github.com/JuliaStrings/utf8proc/archive/v2.9.0.tar.gz
+UTF8PROC_SHA256 18c1626e9fc5a2e192311e36b3010bfc698078f692888940f1fa150547abb0c1
+
 TREESITTER_C_URL https://github.com/tree-sitter/tree-sitter-c/archive/v0.21.3.tar.gz
 TREESITTER_C_SHA256 75a3780df6114cd37496761c4a7c9fd900c78bee3a2707f590d78c0ca3a24368
 TREESITTER_LUA_URL https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.1.0.tar.gz

--- a/cmake/FindUTF8proc.cmake
+++ b/cmake/FindUTF8proc.cmake
@@ -1,0 +1,12 @@
+find_path2(UTF8PROC_INCLUDE_DIR utf8proc.h)
+find_library2(UTF8PROC_LIBRARY NAMES utf8proc utf8proc_static)
+find_package_handle_standard_args(UTF8proc DEFAULT_MSG
+  UTF8PROC_LIBRARY UTF8PROC_INCLUDE_DIR)
+mark_as_advanced(UTF8PROC_LIBRARY UTF8PROC_INCLUDE_DIR)
+
+add_library(utf8proc INTERFACE)
+target_include_directories(utf8proc SYSTEM BEFORE INTERFACE ${UTF8PROC_INCLUDE_DIR})
+target_link_libraries(utf8proc INTERFACE ${UTF8PROC_LIBRARY})
+
+#TODO(dundargoc): this is a hack that should ideally be hardcoded into the utf8proc project via configure_command
+target_compile_definitions(utf8proc INTERFACE "UTF8PROC_STATIC")

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Lpeg REQUIRED)
 find_package(Msgpack 1.0.0 REQUIRED)
 find_package(Treesitter 0.22.6 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
+find_package(UTF8proc REQUIRED)
 
 target_link_libraries(main_lib INTERFACE
   iconv
@@ -42,7 +43,8 @@ target_link_libraries(main_lib INTERFACE
   lpeg
   msgpack
   treesitter
-  unibilium)
+  unibilium
+  utf8proc)
 target_link_libraries(nlua0 PUBLIC lpeg)
 
 if(ENABLE_LIBINTL)

--- a/src/nvim/generators/gen_unicode_tables.lua
+++ b/src/nvim/generators/gen_unicode_tables.lua
@@ -5,13 +5,13 @@
 --    (A) east asian width respectively.
 -- 2. combining table: same as the above, but characters inside are combining
 --    characters (i.e. have general categories equal to Mn, Mc or Me).
--- 3. foldCase, toLower and toUpper tables used to convert characters to
---    folded/lower/upper variants. In these tables first two values are
+-- 3. foldCase table used to convert characters to
+--    folded variants. In this table first two values are
 --    character ranges: like in previous tables they are sorted and must be
 --    non-overlapping. Third value means step inside the range: e.g. if it is
 --    2 then interval applies only to first, third, fifth, … character in range.
 --    Fourth value is number that should be added to the codepoint to yield
---    folded/lower/upper codepoint.
+--    folded codepoint.
 -- 4. emoji_wide and emoji_all tables: sorted lists of non-overlapping closed
 --    intervals of Emoji characters.  emoji_wide contains all the characters
 --    which don't have ambiguous or double width, and emoji_all has all Emojis.
@@ -127,13 +127,6 @@ local build_convert_table = function(ut_fp, props, cond_func, nl_index, table_na
     ut_fp:write(make_range(start, end_, step, add))
   end
   ut_fp:write('};\n')
-end
-
-local build_case_table = function(ut_fp, dataprops, table_name, index)
-  local cond_func = function(p)
-    return p[index] ~= ''
-  end
-  return build_convert_table(ut_fp, dataprops, cond_func, index, 'to' .. table_name)
 end
 
 local build_fold_table = function(ut_fp, foldprops)
@@ -296,8 +289,6 @@ ud_fp:close()
 
 local ut_fp = io.open(utf_tables_fname, 'w')
 
-build_case_table(ut_fp, dataprops, 'Lower', 14)
-build_case_table(ut_fp, dataprops, 'Upper', 13)
 build_combining_table(ut_fp, dataprops)
 
 local cf_fp = io.open(casefolding_fname, 'r')

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <utf8proc.h>
 #include <uv.h>
 #include <wctype.h>
 
@@ -1346,8 +1347,7 @@ int mb_toupper(int a)
     return TOUPPER_LOC(a);
   }
 
-  // For any other characters use the above mapping table.
-  return utf_convert(a, toUpper, ARRAY_SIZE(toUpper));
+  return utf8proc_toupper(a);
 }
 
 bool mb_islower(int a)
@@ -1374,8 +1374,7 @@ int mb_tolower(int a)
     return TOLOWER_LOC(a);
   }
 
-  // For any other characters use the above mapping table.
-  return utf_convert(a, toLower, ARRAY_SIZE(toLower));
+  return utf8proc_tolower(a);
 }
 
 bool mb_isupper(int a)


### PR DESCRIPTION
utf8proc contains all the data which is currently in
unicode_tables.generated.h internally, but in quite a different format.
Ideally unicode_tables.generated.h should be removed as well so we rely
solely on utf8proc. We want to avoid a situation where the possibility
of unicode mismatch occurs, e.g a distro using both unicode 12 and
unicode 13.