### PR TITLE
fix: decoupled local options from cmdline's CTRL-W

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -476,6 +476,8 @@ coerced to strings. See |id()| for more details, currently it uses
 
 |CursorMoved| triggers when moving between windows.
 
+|c_CTRL-W| uses global 'iskeyword' instead of buffer-local
+
 Lua interface (|lua.txt|):
 
 - `:lua print("a\0b")` will print `a^@b`, like with `:echomsg "a\nb"` . In Vim

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1509,6 +1509,13 @@ static int command_line_erase_chars(CommandLineState *s)
         p = mb_prevptr(ccline.cmdbuff, p);
       }
 
+      char *save_p_isk = curbuf->b_p_isk;
+      curbuf->b_p_isk = p_isk;
+      int save_p_lisp = curbuf->b_p_lisp;
+      // init_chartab() uses 'lisp' to decide whether to add "-" to chartab[]
+      curbuf->b_p_lisp = p_lisp;
+      (void)init_chartab();
+
       int i = mb_get_class(p);
       while (p > ccline.cmdbuff && mb_get_class(p) == i) {
         p = mb_prevptr(ccline.cmdbuff, p);
@@ -1517,6 +1524,10 @@ static int command_line_erase_chars(CommandLineState *s)
       if (mb_get_class(p) != i) {
         p += utfc_ptr2len(p);
       }
+
+      curbuf->b_p_isk = save_p_isk;
+      curbuf->b_p_lisp = save_p_lisp;
+      (void)init_chartab();
     }
 
     ccline.cmdpos = (int)(p - ccline.cmdbuff);

--- a/test/functional/editor/mode_cmdline_spec.lua
+++ b/test/functional/editor/mode_cmdline_spec.lua
@@ -4,6 +4,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, insert, funcs, eq, feed =
   helpers.clear, helpers.insert, helpers.funcs, helpers.eq, helpers.feed
 local eval = helpers.eval
+local command = helpers.command
 local meths = helpers.meths
 
 describe('cmdline', function()
@@ -71,6 +72,27 @@ describe('cmdline', function()
       eq(1, funcs.histdel(':', -2))
       eq(1, funcs.histdel(':'))
       eq('', funcs.histget(':', -1))
+    end)
+  end)
+
+  describe('Ctrl-W', function()
+    it('local option lisp decoupled', function()
+      command('setlocal lisp')
+      feed(':-a<C-w>')
+      eq('-', funcs.getcmdline())
+      command('setlocal nolisp')
+      command('setglobal lisp')
+      feed('a<C-w>')
+      eq('', funcs.getcmdline())
+    end)
+    it('local option iskeyword decoupled', function()
+      command('setlocal iskeyword=_')
+      feed(':a_<C-w>')
+      eq('', funcs.getcmdline())
+      command('setlocal iskeyword&')
+      command('setglobal iskeyword=_')
+      feed('a_<C-w>')
+      eq('a', funcs.getcmdline())
     end)
   end)
 end)


### PR DESCRIPTION
Temporarily set the buffer options `'lisp'` and `'iskeyword'` to the global ones when enacting `CTRL-W` in the cmdline.

Fix #14141