### PR TITLE
fix: setxattr error handling

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -795,6 +795,7 @@ void os_copy_xattr(const char *from_file, const char *to_file)
         case E2BIG:
           errmsg = e_xattr_e2big;
           goto error_exit;
+        case ENOTSUP:
         case EACCES:
         case EPERM:
           break;


### PR DESCRIPTION
ENOTSUP case is present in vim, but it's not included here.

It seems that this case was deleted in [#25478](https://github.com/neovim/neovim/pull/25478), whereas it was kept in the corresponding Vim patch https://github.com/vim/vim/commit/993b17569b5acffe2d8941d1709a55da4e439755