### PR TITLE
vim-patch:9.0.2125: File info disappears when 'cmdheight' has decreased

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1395,7 +1395,11 @@ void msg_ext_set_kind(const char *msg_kind)
 /// Prepare for outputting characters in the command line.
 void msg_start(void)
 {
-  int did_return = false;
+  bool did_return = false;
+
+  if (msg_row < cmdline_row) {
+    msg_row = cmdline_row;
+  }
 
   if (!msg_silent) {
     XFREE_CLEAR(keep_msg);              // don't display old message now

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -727,6 +727,46 @@ describe('messages', function()
     ]])
   end)
 
+  -- oldtest: Test_fileinfo_tabpage_cmdheight()
+  it("fileinfo works when 'cmdheight' has just decreased", function()
+    screen = Screen.new(40, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue};  -- NonText
+      [1] = {bold = true};  -- TabLineSel
+      [2] = {underline = true, background = Screen.colors.LightGrey};  -- TabLine
+      [3] = {reverse = true};  -- TabLineFill
+    })
+    screen:attach()
+
+    exec([[
+      set shortmess-=o
+      set shortmess-=O
+      set shortmess-=F
+      tabnew
+      set cmdheight=2
+    ]])
+    command('mode')  -- FIXME: bottom is invalid after scrolling
+    screen:expect([[
+      {2: [No Name] }{1: [No Name] }{3:                 }{2:X}|
+      ^                                        |
+      {0:~                                       }|
+      {0:~                                       }|
+                                              |
+                                              |
+    ]])
+
+    feed(':tabprev | edit Xfileinfo.txt<CR>')
+    screen:expect([[
+      {1: Xfileinfo.txt }{2: [No Name] }{3:             }{2:X}|
+      ^                                        |
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
+      "Xfileinfo.txt" [New]                   |
+    ]])
+    assert_alive()
+  end)
+
   -- oldtest: Test_fileinfo_after_echo()
   it('fileinfo does not overwrite echo message vim-patch:8.2.4156', function()
     screen = Screen.new(40, 6)
@@ -734,6 +774,7 @@ describe('messages', function()
       [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
     })
     screen:attach()
+
     exec([[
       set shortmess-=F
 
@@ -747,6 +788,7 @@ describe('messages', function()
 
       autocmd CursorHold * buf b.txt | w | echo "'b' written"
     ]])
+
     command('set updatetime=50')
     feed('0$')
     screen:expect([[

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -485,6 +485,29 @@ func Test_echo_string_partial()
   call assert_equal("function('CountSpaces', [{'ccccccccccc': ['ab', 'cd'], 'aaaaaaaaaaa': v:false, 'bbbbbbbbbbbb': ''}])", string(function('CountSpaces', [#{aaaaaaaaaaa: v:false, bbbbbbbbbbbb: '', ccccccccccc: ['ab', 'cd']}])))
 endfunc
 
+" Test that fileinfo is shown properly when 'cmdheight' has just decreased
+" due to switching tabpage and 'shortmess' doesn't contain 'o' or 'O'.
+func Test_fileinfo_tabpage_cmdheight()
+  CheckRunVimInTerminal
+
+  let content =<< trim END
+    set shortmess-=o
+    set shortmess-=O
+    set shortmess-=F
+    tabnew
+    set cmdheight=2
+    tabprev
+    edit Xfileinfo.txt
+  END
+
+  call writefile(content, 'Xtest_fileinfo_tabpage_cmdheight', 'D')
+  let buf = RunVimInTerminal('-S Xtest_fileinfo_tabpage_cmdheight', #{rows: 6})
+  call WaitForAssert({-> assert_match('^"Xfileinfo.txt" \[New\]', term_getline(buf, 6))})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " Message output was previously overwritten by the fileinfo display, shown
 " when switching buffers. If a buffer is switched to, then a message if
 " echoed, we should show the message, rather than overwriting it with


### PR DESCRIPTION
Fix #26150

#### vim-patch:9.0.2125: File info disappears when 'cmdheight' has decreased

Problem:  File info disappears immediately when 'cmdheight' has just
          decreased due to switching tabpage and 'shortmess' doesn't
          contain 'o' or 'O'.
Solution: Make sure msg_row isn't smaller than cmdline_row.

closes: vim/vim#13561

https://github.com/vim/vim/commit/40ed6711bd385051021691980e8ce16375b4b510