### PR TITLE
vim-patch:9.0.2126: unused assignments when checking 'listchars'

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2871,9 +2871,6 @@ static const char *set_chars_option(win_T *wp, const char *value, const bool is_
     } else {
       wp->w_p_fcs_chars = fcs_chars;
     }
-  } else if (is_listchars) {
-    xfree(lcs_chars.multispace);
-    xfree(lcs_chars.leadmultispace);
   }
 
   return NULL;          // no error

--- a/test/old/testdir/test_listchars.vim
+++ b/test/old/testdir/test_listchars.vim
@@ -265,6 +265,11 @@ func Test_listchars()
   call Check_listchars(expected, 5, 12)
   call assert_equal(expected, split(execute("%list"), "\n"))
 
+  " Changing the value of 'ambiwidth' twice shouldn't cause double-free when
+  " "leadmultispace" is specified.
+  set ambiwidth=double
+  set ambiwidth&
+
   " Test leadmultispace and lead and space
   normal ggdG
   set listchars=eol:$  " Accommodate Nvim default


### PR DESCRIPTION
Fix #26160

#### vim-patch:9.0.2126: unused assignments when checking 'listchars'

Problem:  Unused assignments when checking the value of 'listchars'.
Solution: Loop only once when just checking the value.  Add a test to
          check that this change doesn't cause double-free.

closes: vim/vim#13559

https://github.com/vim/vim/commit/00624a2fa08d04bdded240d474e9cfdc193dbe10