### PR TITLE
refactor(diagnostic): set sign by using extmark

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -435,6 +435,16 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                          for signs. When {severity_sort} is used, the priority
                          of a sign is adjusted based on its severity.
                          Otherwise, all signs use the same priority.
+                       • text: (table) A table mapping |diagnostic-severity|
+                         to the sign text to display in the sign column. The
+                         default is to use "E", "W", "I", and "H" for errors,
+                         warnings, information, and hints, respectively.
+                         Example: >lua
+
+                         vim.diagnostic.config({
+                           sign = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
+                         })
+<
 
                      • float: Options for floating windows. See
                        |vim.diagnostic.open_float()|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -341,6 +341,9 @@ The following changes to existing APIs or features add new behavior.
 
 • Vimscript function |exists()| supports checking |v:lua| functions.
 
+• Diagnostic sign text is no longer configured with |sign_define()|.
+  Use |vim.diagnostic.config()| instead.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1080,9 +1080,19 @@ end)
             table.insert(virt_texts, (string.gsub(virt_text[i][2], "DiagnosticVirtualText", "")))
           end
 
+          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local sign_ns = ns.user_data.sign_ns
           local signs = {}
-          for _, v in ipairs(vim.fn.sign_getplaced(diagnostic_bufnr, {group = "*"})[1].signs) do
-            table.insert(signs, (string.gsub(v.name, "DiagnosticSign", "")))
+          local all_signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type = 'sign', details = true})
+          table.sort(all_signs, function(a, b)
+            return a[1] > b[1]
+          end)
+
+          for _, v in ipairs(all_signs) do
+            local s = v[4].sign_hl_group:gsub('DiagnosticSign', "")
+            if not vim.tbl_contains(signs, s) then
+              signs[#signs + 1] = s
+            end
           end
 
           return {virt_texts, signs}
@@ -1498,7 +1508,15 @@ end)
 
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
 
-        return vim.fn.sign_getplaced(diagnostic_bufnr, {group = '*'})[1].signs
+        local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+        local sign_ns = ns.user_data.sign_ns
+
+        local signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
+        local result = {}
+        for _, s in ipairs(signs) do
+          result[#result + 1] = { lnum = s[2] + 1, name = s[4].sign_hl_group }
+        end
+        return result
       ]]
 
       eq({2, 'DiagnosticSignError'}, {result[1].lnum, result[1].name})


### PR DESCRIPTION
after sign implementation refactor by using extmark, we can use `nvim_buf_set_extmark` to set diagnostic sign instead of get sign text from `sign_define`. now we can set sign text by using `vim.diagnostic.config`. like

```lua
  vim.diagnostic.config({
    signs = {
      --support diagnostic severity / diagnostic type name
      text = { [1] = 'e', ['WARN'] = 'w', ['HINT'] = 'h' },
    },
  })
```