### PR TITLE
fix(oldtest): always use a 64-bit int for swapfile block number

### DIFF
--- a/test/old/testdir/test_recover.vim
+++ b/test/old/testdir/test_recover.vim
@@ -266,7 +266,7 @@ func Test_recover_corrupted_swap_file()
 
   " set the block number in a pointer entry to a negative number
   let b = copy(save_b)
-  if system_64bit
+  if v:true  " Nvim changed this field from a long to an int64_t
     let b[4104:4111] = little_endian ? 0z00000000.00000080 : 0z80000000.00000000
   else
     let b[4104:4107] = little_endian ? 0z00000080 : 0z80000000


### PR DESCRIPTION
09d4133 changed blocknr_T from long to int64_t, so pe_bnum is now always 64-bit.  This was an incompatible change in the swapfile format for 32-bit systems, but there have been no complaints in the past 9 years so just adjust the test.