### PR TITLE
fix(lua): crash in nlua_error

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -135,8 +135,8 @@ static void nlua_error(lua_State *const lstate, const char *const msg)
   }
 
   if (in_script) {
-    os_errmsg(str);
-    os_errmsg("\n");
+    fprintf(stderr, msg, (int)len, str);
+    fprintf(stderr, "\n");
   } else {
     msg_ext_set_kind("lua_error");
     semsg_multiline(msg, (int)len, str);


### PR DESCRIPTION
Backport fix hidden in bd4ff0b88, by actually using the `msg` parameter,
rather than trying to print a potentially null `str`.