### PR TITLE
vim-patch:8.2.4685: when a swap file is found for a popup there is no dialog

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -930,10 +930,14 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
 /// Go to another buffer.  Handles the result of the ATTENTION dialog.
 void goto_buffer(exarg_T *eap, int start, int dir, int count)
 {
+  const int save_sea = swap_exists_action;
+
   bufref_T old_curbuf;
   set_bufref(&old_curbuf, curbuf);
-  swap_exists_action = SEA_DIALOG;
 
+  if (swap_exists_action == SEA_NONE) {
+    swap_exists_action = SEA_DIALOG;
+  }
   (void)do_buffer(*eap->cmd == 's' ? DOBUF_SPLIT : DOBUF_GOTO,
                   start, dir, count, eap->forceit);
 
@@ -946,7 +950,7 @@ void goto_buffer(exarg_T *eap, int start, int dir, int count)
 
     // Quitting means closing the split window, nothing else.
     win_close(curwin, true, false);
-    swap_exists_action = SEA_NONE;
+    swap_exists_action = save_sea;
     swap_exists_did_quit = true;
 
     // Restore the error/interrupt/exception state if not discarded by a

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -298,7 +298,9 @@ void f_bufload(typval_T *argvars, typval_T *unused, EvalFuncData fptr)
   buf_T *buf = get_buf_arg(&argvars[0]);
 
   if (buf != NULL) {
-    swap_exists_action = SEA_NONE;
+    if (swap_exists_action != SEA_READONLY) {
+      swap_exists_action = SEA_NONE;
+    }
     buf_ensure_loaded(buf);
   }
 }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -684,6 +684,7 @@ EXTERN bool in_assert_fails INIT( = false);  // assert_fails() active
 #define SEA_DIALOG      1       // use dialog when possible
 #define SEA_QUIT        2       // quit editing the file
 #define SEA_RECOVER     3       // recover the file
+#define SEA_READONLY    4       // no dialog, mark buffer as read-only
 
 EXTERN int swap_exists_action INIT( = SEA_NONE);  ///< For dialog when swap file already exists.
 EXTERN bool swap_exists_did_quit INIT( = false);  ///< Selected "quit" at the dialog.


### PR DESCRIPTION
#### vim-patch:8.2.4685: when a swap file is found for a popup there is no dialog

Problem:    When a swap file is found for a popup there is no dialog and the
            buffer is loaded anyway.
Solution:   Silently load the buffer read-only.

https://github.com/vim/vim/commit/188639d75c363dffaf813e8e2209f7350ad1e871

Co-authored-by: Bram Moolenaar <Bram@vim.org>