### PR TITLE
refactor(options): replace `p_force_(on|off)` with `immutable`

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -143,9 +143,13 @@ local function dump_option(i, o)
   end
   if o.varname then
     w('    .var=&' .. o.varname)
+  -- Immutable options should directly point to the default value
+  elseif o.immutable then
+    w(('    .var=&options[%u].def_val'):format(i - 1))
   elseif #o.scope == 1 and o.scope[1] == 'window' then
     w('    .var=VAR_WIN')
   end
+  w('    .immutable=' .. (o.immutable and 'true' or 'false'))
   if #o.scope == 1 and o.scope[1] == 'global' then
     w('    .indir=PV_NONE')
   else

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -46,6 +46,7 @@ typedef struct vimoption {
                      ///< local option: indirect option index
                      ///< callback function to invoke after an option is modified to validate and
                      ///< apply the new value.
+  bool immutable;    ///< option value cannot be changed from the default value.
 
   /// callback function to invoke after an option is modified to validate and
   /// apply the new value.

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -456,7 +456,6 @@ EXTERN unsigned dy_flags;
 #define DY_UHEX                 0x004
 // legacy flag, not used
 #define DY_MSGSEP               0x008
-EXTERN int p_ed;                ///< 'edcompatible'
 EXTERN char *p_ead;             ///< 'eadirection'
 EXTERN int p_emoji;             ///< 'emoji'
 EXTERN int p_ea;                ///< 'equalalways'
@@ -785,9 +784,6 @@ EXTERN int p_wa;                ///< 'writeany'
 EXTERN int p_wb;                ///< 'writebackup'
 EXTERN OptInt p_wd;             ///< 'writedelay'
 EXTERN int p_cdh;               ///< 'cdhome'
-
-EXTERN int p_force_on;          ///< options that cannot be turned off.
-EXTERN int p_force_off;         ///< options that cannot be turned on.
 
 /// "indir" values for buffer-local options.
 /// These need to be defined globally, so that the BV_COUNT can be used with

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6,6 +6,7 @@
 --- @field varname? string
 --- @field pv_name? string
 --- @field type 'bool'|'number'|'string'
+--- @field immutable? boolean
 --- @field list? 'comma'|'onecomma'|'commacolon'|'onecommacolon'|'flags'|'flagscomma'
 --- @field scope vim.option_scope[]
 --- @field deny_duplicates? boolean
@@ -1341,7 +1342,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'cpt',
@@ -2299,7 +2300,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'emo',
@@ -3885,7 +3886,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'hkp',
@@ -3894,7 +3895,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'hls',
@@ -4292,7 +4293,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'isf',
@@ -6042,7 +6043,7 @@ return {
       scope = { 'global' },
       short_desc = N_('enable prompt in Ex mode'),
       type = 'bool',
-      varname = 'p_force_on',
+      immutable = true,
     },
     {
       abbreviation = 'pb',
@@ -6299,7 +6300,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_on',
+      immutable = true,
     },
     {
       defaults = { if_true = 2 },
@@ -8824,7 +8825,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_off',
+      immutable = true,
     },
     {
       abbreviation = 'tw',
@@ -9069,7 +9070,7 @@ return {
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'bool',
-      varname = 'p_force_on',
+      immutable = true,
     },
     {
       abbreviation = 'udir',


### PR DESCRIPTION
Problem: We use the `p_force_on` and `p_force_off` variables to check if a variable is immutable and what its default value is. This is not only hacky and unintuitive, but also is limited to only boolean options.

Solution: Replace `p_force_on` and `p_force_off` with an `immutable` property for options, which indicates if an option is immutable. Immutable options cannot be changed from their default value.

Ref: #25672.