### PR TITLE
fix(lsp): error if dialog appears during "buf.definition()" mapping

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1071,7 +1071,14 @@ function M.show_document(location, offset_encoding, opts)
     --- Jump to new location (adjusting for encoding of characters)
     local row = range.start.line
     local col = get_line_byte_from_position(bufnr, range.start, offset_encoding)
-    api.nvim_win_set_cursor(win, { row + 1, col })
+    local ok, err = pcall(api.nvim_win_set_cursor, win, { row + 1, col })
+    if not ok then
+      vim.notify(
+        string.format('[LSP] failed to jump (dialog pending?): %s', err),
+        vim.log.levels.WARN
+      )
+      return false
+    end
     api.nvim_win_call(win, function()
       -- Open folds under the cursor
       vim.cmd('normal! zv')


### PR DESCRIPTION
# Problem:
`vim.lsp.buf.definition()` (executed from a keybinding) throws an error if prompt is shown while opening a file (specifically the "E325: ATTENTION" swapfile prompt).

    Error executing vim.schedule lua callback: …/runtime/lua/vim/lsp/util.lua:1074:
    Cursor position outside buffer
    stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        …/runtime/lua/vim/lsp/util.lua:1074: in function 'jump_to_location'
        …/runtime/lua/vim/lsp/handlers.lua:423: in function 'handler'
        …/runtime/lua/vim/lsp.lua:1517: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>

## Steps to reproduce

1. create an unrecovered swapfile, e.g. by:
   ```
   nvim src/nvim/main.c`
   x
   :exe '!kill -9' getpid()
   ```
2. start `nvim` again
3. create a mapping for `vim.lsp.buf.definition()`:
   ```
   nnoremap <buffer> gd :lua vim.lsp.buf.definition()<cr>
   ```
4. visit `src/nvim/buffer.c` and use the `gd` mapping on `getout` here: https://github.com/neovim/neovim/blob/a4c852c677ce5e411561da5f1566de7e7359096c/src/nvim/buffer.c#L243
5. above error will occur

# Solution:
Handle `nvim_win_set_cursor` failure.
Didn't bother adding a test assuming #25272 will obviate this.