### PR TITLE
fix(health): fix node provider health check warning call

### DIFF
--- a/runtime/lua/provider/health.lua
+++ b/runtime/lua/provider/health.lua
@@ -806,11 +806,11 @@ local function node()
       .. current_npm
       .. ' latest: '
       .. latest_npm
-    warn(message({
+    warn(message, {
       'Run in shell: npm install -g neovim',
       'Run in shell (if you use yarn): yarn global add neovim',
       'Run in shell (if you use pnpm): pnpm install -g neovim',
-    }))
+    })
   else
     ok('Latest "neovim" npm/yarn/pnpm package is installed: ' .. current_npm)
   end


### PR DESCRIPTION
This pull request is a minor fix for the Node provider health check; Instead of giving a warning when the 'neovim' npm package is out-of-date, it would show an error because it was misusing the message string, treating it as a function.

I've changed it so that it correctly passes the message as an argument to the `warn` function followed by the advice list.

**Note:** An open pull request, #23007, might cause this change to be lost due to the new file being created there. This PR is a tiny change, though, so adding it to that PR should be easy, and then we can get rid of this one 🙂