### PR TITLE
refactor: use non-obsolete POSIX permission bits

### DIFF
--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -748,7 +748,7 @@ static bool mf_do_open(memfile_T *mfp, char *fname, int flags)
     emsg(_("E300: Swap file already exists (symlink attack?)"));
   } else {
     // try to open the file
-    mfp->mf_fd = os_open(mfp->mf_fname, flags | O_NOFOLLOW, S_IREAD | S_IWRITE);
+    mfp->mf_fd = os_open(mfp->mf_fname, flags | O_NOFOLLOW, S_IRUSR | S_IWUSR);
   }
 
   // If the file cannot be opened, use memory only


### PR DESCRIPTION
S_IREAD is deprecated in favor of S_IRUSR and S_IWRITE is deprecated in
favor of S_IWUSR.
