### PR TITLE
fix(treesitter): keep parser valid when highighting

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -136,7 +136,7 @@ function TSHighlighter.new(tree, opts)
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
 
-  self.tree:parse()
+  self.tree:parse(true)
 
   return self
 end

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -476,6 +476,31 @@ describe('treesitter highlighting (C)', function()
     screen:expect{grid=injection_grid_expected_c}
   end)
 
+  it('keeps parser in a valid state with injections present', function()
+    insert([[
+      # Heading
+
+      ```lua
+      local question = {}
+      local answer = 42
+      ```
+    ]])
+    exec_lua [[
+      vim.o.ft = "markdown"
+      vim.treesitter.start()
+    ]]
+
+    eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+
+    -- modify injection
+    feed([[Gkkdd]])
+
+    -- modify outer lang
+    feed([[GO<cr>A text]])
+
+    eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+  end)
+
   it("supports injecting by ft name in metadata['injection.language']", function()
     insert(injection_text_c)
 


### PR DESCRIPTION
Currently, at the end of initialization, highlighter calls `:parse` on the passed parser. However, with no argument passed, if injections are detected, the tree remains in an invalid state.

This commit passes `true` as an argument to initial parse, which ends up keeping the tree in a valid state throughout its lifetime.

By doing this, other plugins are now able to fetch a buffer parser with `vim.treesitter.get_parser()`, attach "on_changedtree" listener and let highlighter handle parsing without implementing own potentially overlapping re-validation logic.

PS: This is a regression introduced with `languagetree:parse()` arguments handling. Stable release keeps parser valid already.