### PR TITLE
vim-patch:cf40409e7d17

### DIFF
--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: nginx.conf
 " Maintainer: Chris Aumann <me@chr4.org>
-" Last Change: Jan 25, 2023
+" Last Change: Nov 25, 2023
 
 if exists("b:current_syntax")
   finish
@@ -260,6 +260,7 @@ syn keyword ngxDirective hls_forward_args
 syn keyword ngxDirective hls_fragment
 syn keyword ngxDirective hls_mp4_buffer_size
 syn keyword ngxDirective hls_mp4_max_buffer_size
+syn keyword ngxDirective http2
 syn keyword ngxDirective http2_chunk_size
 syn keyword ngxDirective http2_body_preread_size
 syn keyword ngxDirective http2_idle_timeout
@@ -271,6 +272,7 @@ syn keyword ngxDirective http2_push
 syn keyword ngxDirective http2_push_preload
 syn keyword ngxDirective http2_recv_buffer_size
 syn keyword ngxDirective http2_recv_timeout
+syn keyword ngxDirective http3
 syn keyword ngxDirective http3_hq
 syn keyword ngxDirective http3_max_concurrent_pushes
 syn keyword ngxDirective http3_max_concurrent_streams


### PR DESCRIPTION
runtime(nginx): add additional nginx keywords (vim/vim#13581)

* Add support for missing keywords to the nginx syntax plugin

This adds support for several keywords from
- the built-in HTTP/2 module,
- the built-in SSL module,
- the built-in uWSGI module,
- the experimental QUIC branch,
- the third-party SSL CT module,
- the third-party dynamic TLS records patch.

Co-Author: ObserverOfTime <chronobserver@disroot.org>

* Add missing http2/ http3 keywords to nginx plugin

https://github.com/vim/vim/commit/cf40409e7d17ddadaa697188788753c761479ef8

Co-authored-by: Chris Aumann <me@chr4.org>
Co-authored-by: Christian Brabandt <cb@256bit.org>
