### PR TITLE
refactor(encoding): remove redundant vim_isprintc_strict

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -534,7 +534,7 @@ char *transchar_buf(const buf_T *buf, int c)
   }
 
   if ((!chartab_initialized && (c >= ' ' && c <= '~'))
-      || ((c <= 0xFF) && vim_isprintc_strict(c))) {
+      || ((c <= 0xFF) && vim_isprintc(c))) {
     // printable character
     transchar_charbuf[i] = (uint8_t)c;
     transchar_charbuf[i + 1] = NUL;
@@ -870,25 +870,9 @@ bool vim_isfilec_or_wc(int c)
 }
 
 /// Check that "c" is a printable character.
-/// Assume characters above 0x100 are printable for double-byte encodings.
 ///
 /// @param  c  character to check
 bool vim_isprintc(int c)
-  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
-{
-  if (c >= 0x100) {
-    return utf_printable(c);
-  }
-  return c > 0 && (g_chartab[c] & CT_PRINT_CHAR);
-}
-
-/// Strict version of vim_isprintc(c), don't return true if "c" is the head
-/// byte of a double-byte character.
-///
-/// @param  c  character to check
-///
-/// @return true if "c" is a printable character.
-bool vim_isprintc_strict(int c)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (c >= 0x100) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -155,7 +155,7 @@ void do_ascii(exarg_T *eap)
                       ? NL  // NL is stored as CR.
                       : c);
     char buf1[20];
-    if (vim_isprintc_strict(c) && (c < ' ' || c > '~')) {
+    if (vim_isprintc(c) && (c < ' ' || c > '~')) {
       char buf3[7];
       transchar_nonprint(curbuf, buf3, c);
       vim_snprintf(buf1, sizeof(buf1), "  <%s>", buf3);

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3881,7 +3881,7 @@ static char *get_syn_options(char *arg, syn_opt_arg_T *opt, int *conceal_char, i
       // cchar=?
       *conceal_char = utf_ptr2char(arg + 6);
       arg += utfc_ptr2len(arg + 6) - 1;
-      if (!vim_isprintc_strict(*conceal_char)) {
+      if (!vim_isprintc(*conceal_char)) {
         emsg(_(e_invalid_cchar_value));
         return NULL;
       }


### PR DESCRIPTION
This function is identical to vim_isprintc when encoding=utf-8 is used. As this is the only internal encoding nvim supports, it is now redundant.

ref #2905