### PR TITLE
build(IWYU): remove arabic_defs.h

### DIFF
--- a/cmake.config/iwyu/mapping.imp
+++ b/cmake.config/iwyu/mapping.imp
@@ -195,7 +195,6 @@
   # headers on the left, it will use the headers on the right if possible. This
   # isn't explicitly mentioned in the IWYU docs, this is just my interpretation
   # of its behavior.
-  { include: [ '"nvim/arabic_defs.h"', public, '"nvim/arabic.h"', public ] },
   { include: [ '"nvim/arglist_defs.h"', public, '"nvim/arglist.h"', public ] },
   { include: [ '"nvim/buffer_defs.h"', public, '"nvim/buffer.h"', public ] },
   { include: [ '"nvim/cmdexpand_defs.h"', public, '"nvim/cmdexpand.h"', public ] },

--- a/src/nvim/arabic.h
+++ b/src/nvim/arabic.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "nvim/arabic_defs.h"
+#define ARABIC_CHAR(ch)            (((ch) & 0xFF00) == 0x0600)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "arabic.h.generated.h"

--- a/src/nvim/arabic_defs.h
+++ b/src/nvim/arabic_defs.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define ARABIC_CHAR(ch)            (((ch) & 0xFF00) == 0x0600)


### PR DESCRIPTION
A _defs header is only needed if it's included by multiple files.
