### PR TITLE
docs(lsp): don't say inlay_hint.enable toggles

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -357,7 +357,7 @@ function M.is_enabled(bufnr)
   return bufstates[bufnr] and bufstates[bufnr].enabled or false
 end
 
---- Enable/disable/toggle inlay hints for a buffer
+--- Enable/disable inlay hints for a buffer
 ---
 --- @param bufnr (integer|nil) Buffer handle, or 0 or nil for current
 --- @param enable (boolean|nil) true/nil to enable, false to disable


### PR DESCRIPTION
It doesn't since 448907f65d6709fa234d8366053e33311a01bdb9 (https://github.com/neovim/neovim/pull/25512).