### PR TITLE
fix(treesitter): Don't invalidate parser when discovering injections

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -508,7 +508,6 @@ function LanguageTree:add_child(lang)
   end
 
   self._children[lang] = child
-  self:invalidate()
   self:_do_callback('child_added', self._children[lang])
 
   return self._children[lang]
@@ -524,7 +523,6 @@ function LanguageTree:remove_child(lang)
   if child then
     self._children[lang] = nil
     child:destroy()
-    self:invalidate()
     self:_do_callback('child_removed', child)
   end
 end


### PR DESCRIPTION
When parsing with a range, languagetree looks up injections and adds them if needed. This explicitly invalidates parser, making `is_valid` report `false` both when including and excluding children.

This is an attempt to describe desired<sup>*</sup> behaviour of `is_valid` in tests, with what ended up being a single line change to satisfy them.

--------------

<sup>*</sup> "Not surprising" could be a better description.