### PR TITLE
feat(decoration): allow conceal_char to be a composing char

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -645,6 +645,10 @@ nvim__inspect_cell({grid}, {row}, {col})                *nvim__inspect_cell()*
     NB: if your UI doesn't use hlstate, this will not return hlstate first
     time.
 
+nvim__invalidate_glyph_cache()                *nvim__invalidate_glyph_cache()*
+    For testing. The condition in schar_cache_clear_if_full is hard to reach,
+    so this function can be used to force a cache clear in a test.
+
 nvim__stats()                                                  *nvim__stats()*
     Gets internal stats.
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -80,6 +80,9 @@ function vim.api.nvim__id_float(flt) end
 function vim.api.nvim__inspect_cell(grid, row, col) end
 
 --- @private
+--- For testing. The condition in schar_cache_clear_if_full is hard to reach,
+--- so this function can be used to force a cache clear in a test.
+---
 function vim.api.nvim__invalidate_glyph_cache() end
 
 --- @private

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -18,6 +18,7 @@
 #include "nvim/drawscreen.h"
 #include "nvim/extmark.h"
 #include "nvim/func_attr.h"
+#include "nvim/grid.h"
 #include "nvim/highlight_group.h"
 #include "nvim/marktree.h"
 #include "nvim/mbyte.h"
@@ -503,7 +504,6 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   DecorVirtText virt_text = DECOR_VIRT_TEXT_INIT;
   DecorVirtText virt_lines = DECOR_VIRT_LINES_INIT;
   bool has_hl = false;
-  String conceal_char_large = STRING_INIT;
 
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {
@@ -593,10 +593,11 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     has_hl = true;
     String c = opts->conceal;
     if (c.size > 0) {
-      if (c.size <= 4) {
-        memcpy(hl.conceal_char, c.data, c.size + (c.size < 4 ? 1 : 0));
-      } else {
-        conceal_char_large = c;
+      int ch;
+      hl.conceal_char = utfc_ptr2schar_len(c.data, (int)c.size, &ch);
+      if (!hl.conceal_char || !vim_isprintc(ch)) {
+        api_set_error(err, kErrorTypeValidation, "conceal char has to be printable");
+        goto error;
       }
     }
   }
@@ -777,7 +778,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
     }
     if (has_hl) {
-      DecorSignHighlight sh = decor_sh_from_inline(hl, conceal_char_large);
+      DecorSignHighlight sh = decor_sh_from_inline(hl);
       decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
     }
     if (sign.flags & kSHIsSign) {
@@ -815,9 +816,9 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
 
     DecorInline decor = DECOR_INLINE_INIT;
-    if (decor_alloc || decor_indexed != DECOR_ID_INVALID || conceal_char_large.size) {
+    if (decor_alloc || decor_indexed != DECOR_ID_INVALID || schar_high(hl.conceal_char)) {
       if (has_hl) {
-        DecorSignHighlight sh = decor_sh_from_inline(hl, conceal_char_large);
+        DecorSignHighlight sh = decor_sh_from_inline(hl);
         sh.next = decor_indexed;
         decor_indexed = decor_put_sh(sh);
       }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1999,9 +1999,12 @@ void nvim__screenshot(String path)
   ui_call_screenshot(path);
 }
 
+/// For testing. The condition in schar_cache_clear_if_full is hard to
+/// reach, so this function can be used to force a cache clear in a test.
 void nvim__invalidate_glyph_cache(void)
 {
-  schar_cache_clear_force();
+  schar_cache_clear();
+  must_redraw = UPD_CLEAR;
 }
 
 Object nvim__unpack(String str, Error *err)

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -67,7 +67,7 @@ typedef struct {
   int eol_col;
 
   int conceal;
-  int conceal_char;
+  schar_T conceal_char;
   int conceal_attr;
 
   TriState spell;

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "klib/kvec.h"
+#include "nvim/types_defs.h"
 
 #define DECOR_ID_INVALID UINT32_MAX
 
@@ -42,29 +43,24 @@ enum {
   kSHSpellOn = 16,
   kSHSpellOff = 32,
   kSHConceal = 64,
-  kSHConcealAlloc = 128,
 };
 
 typedef struct {
   uint16_t flags;
   DecorPriority priority;
   int hl_id;
-  char conceal_char[4];
+  schar_T conceal_char;
 } DecorHighlightInline;
 
-#define DECOR_HIGHLIGHT_INLINE_INIT { 0, DECOR_PRIORITY_BASE, 0, { 0 } }
+#define DECOR_HIGHLIGHT_INLINE_INIT { 0, DECOR_PRIORITY_BASE, 0,  0 }
 typedef struct {
   uint16_t flags;
   DecorPriority priority;
   int hl_id;  // if sign: highlight of sign text
-  // TODO(bfredl): Later this should be schar_T[2], but then it needs to handle
-  // invalidations of the cache
+  // TODO(bfredl): Later signs should use sc[2] as well.
   union {
-    // for now:
-    // 1. sign is always allocated (drawline.c expects a `char *` for a sign)
-    // 2. conceal char is allocated if larger than 8 bytes.
-    char *ptr;  // sign or conceal text
-    char data[8];
+    char *ptr;  // sign
+    schar_T sc[2];  // conceal text (only sc[0] used)
   } text;
   // NOTE: if more functionality is added to a Highlight these should be overloaded
   // or restructured

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2459,6 +2459,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           && ((syntax_flags & HL_CONCEAL) != 0 || has_match_conc > 0 || decor_conceal > 0)
           && !(lnum_in_visual_area && vim_strchr(wp->w_p_cocu, 'v') == NULL)) {
         wlv.char_attr = conceal_attr;
+        bool is_conceal_char = false;
         if (((prev_syntax_id != syntax_seqnr && (syntax_flags & HL_CONCEAL) != 0)
              || has_match_conc > 1 || decor_conceal > 1)
             && (syn_get_sub_char() != NUL
@@ -2471,7 +2472,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           if (has_match_conc && match_conc) {
             mb_c = match_conc;
           } else if (decor_conceal && decor_state.conceal_char) {
-            mb_c = decor_state.conceal_char;
+            mb_schar = decor_state.conceal_char;
+            mb_c = schar_get_first_codepoint(mb_schar);
+            is_conceal_char = true;
             if (decor_state.conceal_attr) {
               wlv.char_attr = decor_state.conceal_attr;
             }
@@ -2499,7 +2502,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           is_concealing = true;
           wlv.skip_cells = 1;
         }
-        mb_schar = schar_from_char(mb_c);
+        if (!is_conceal_char) {
+          mb_schar = schar_from_char(mb_c);
+        }
       } else {
         prev_syntax_id = 0;
         is_concealing = false;

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -11,14 +11,6 @@
 // ensures we can fit all composed chars which did fit before.
 #define MAX_SCHAR_SIZE 32
 
-// if data[0] is 0xFF, then data[1..4] is a 24-bit index (in machine endianness)
-// otherwise it must be a UTF-8 string of length maximum 4 (no NUL when n=4)
-
-typedef uint32_t schar_T;
-typedef int32_t sattr_T;
-// must be at least as big as the biggest of schar_T, sattr_T, col_T
-typedef int32_t sscratch_T;
-
 enum {
   kZIndexDefaultGrid = 0,
   kZIndexFloatDefault = 50,

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -6,8 +6,12 @@
 // dummy to pass an ACL to a function
 typedef void *vim_acl_T;
 
-// Can hold one decoded UTF-8 character.
-typedef uint32_t u8char_T;
+// if data[0] is 0xFF, then data[1..4] is a 24-bit index (in machine endianness)
+// otherwise it must be a UTF-8 string of length maximum 4 (no NUL when n=4)
+typedef uint32_t schar_T;
+typedef int32_t sattr_T;
+// must be at least as big as the biggest of schar_T, sattr_T, colnr_T
+typedef int32_t sscratch_T;
 
 // Opaque handle used by API clients to refer to various objects in vim
 typedef int handle_T;


### PR DESCRIPTION
decor->text.str pointer must go. This removes it for conceal char, in preparation for a larger PR which will also handle the sign case.

By actually allowing composing chars for a conceal chars, this becomes a feature and not just a refactor, as a bonus.