### PR TITLE
vim-patch:9.0.2133: Cannot detect overstrike mode in Cmdline mode

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4850,7 +4850,9 @@ mode([expr])                                                            *mode()*
 		   Rvc	    Virtual Replace mode completion |compl-generic|
 		   Rvx	    Virtual Replace mode |i_CTRL-X| completion
 		   c	    Command-line editing
+		   cr	    Command-line while in overstrike mode |c_<Insert>|
 		   cv	    Vim Ex mode |gQ|
+		   cvr	    Vim Ex while in overstrike mode |c_<Insert>|
 		   r	    Hit-enter prompt
 		   rm	    The -- more -- prompt
 		   r?	    A |:confirm| query of some sort

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -5812,7 +5812,9 @@ function vim.fn.mkdir(name, flags, prot) end
 ---    Rvc      Virtual Replace mode completion |compl-generic|
 ---    Rvx      Virtual Replace mode |i_CTRL-X| completion
 ---    c      Command-line editing
+---    cr      Command-line while in overstrike mode |c_<Insert>|
 ---    cv      Vim Ex mode |gQ|
+---    cvr      Vim Ex while in overstrike mode |c_<Insert>|
 ---    r      Hit-enter prompt
 ---    rm      The -- more -- prompt
 ---    r?      A |:confirm| query of some sort

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7038,7 +7038,9 @@ M.funcs = {
          Rvc	    Virtual Replace mode completion |compl-generic|
          Rvx	    Virtual Replace mode |i_CTRL-X| completion
          c	    Command-line editing
+         cr	    Command-line while in overstrike mode |c_<Insert>|
          cv	    Vim Ex mode |gQ|
+         cvr	    Vim Ex while in overstrike mode |c_<Insert>|
          r	    Hit-enter prompt
          rm	    The -- more -- prompt
          r?	    A |:confirm| query of some sort

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1835,8 +1835,10 @@ static int command_line_handle_key(CommandLineState *s)
   case K_INS:
   case K_KINS:
     ccline.overstrike = !ccline.overstrike;
-
     ui_cursor_shape();                // may show different cursor shape
+    may_trigger_modechanged();
+    status_redraw_curbuf();
+    redraw_statuslines();
     return command_line_not_changed(s);
 
   case Ctrl_HAT:

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -8,6 +8,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/event/defs.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/ex_getln.h"
 #include "nvim/getchar.h"
 #include "nvim/globals.h"
 #include "nvim/insexpand.h"
@@ -209,6 +210,9 @@ void get_mode(char *buf)
     buf[i++] = 'c';
     if (exmode_active) {
       buf[i++] = 'v';
+    }
+    if ((State & MODE_CMDLINE) && cmdline_overstrike()) {
+      buf[i++] = 'r';
     }
   } else if (State & MODE_TERMINAL) {
     buf[i++] = 't';

--- a/test/functional/editor/mode_cmdline_spec.lua
+++ b/test/functional/editor/mode_cmdline_spec.lua
@@ -1,9 +1,11 @@
 -- Cmdline-mode tests.
 
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear, insert, funcs, eq, feed =
   helpers.clear, helpers.insert, helpers.funcs, helpers.eq, helpers.feed
 local eval = helpers.eval
+local command = helpers.command
 local meths = helpers.meths
 
 describe('cmdline', function()
@@ -41,6 +43,30 @@ describe('cmdline', function()
     feed(':"<C-S-V><C-J><C-S-V><C-@><C-S-V><C-[><C-S-V><C-S-M><C-S-V><M-C-I><C-S-V><C-D-J><CR>')
 
     eq('"<C-J><C-@><C-[><C-S-M><M-C-I><C-D-J>', eval('@:'))
+  end)
+
+  it('redraws statusline when toggling overstrike', function()
+    local screen = Screen.new(60, 4)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {reverse = true, bold = true},  -- StatusLine
+    })
+    screen:attach()
+    command('set laststatus=2 statusline=%!mode(1)')
+    feed(':')
+    screen:expect{grid=[[
+                                                                  |
+      {0:~                                                           }|
+      {1:c                                                           }|
+      :^                                                           |
+    ]]}
+    feed('<Insert>')
+    screen:expect{grid=[[
+                                                                  |
+      {0:~                                                           }|
+      {1:cr                                                          }|
+      :^                                                           |
+    ]]}
   end)
 
   describe('history', function()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -798,8 +798,12 @@ func Test_mode()
 
   call feedkeys(":echo \<C-R>=Save_mode()\<C-U>\<CR>", 'xt')
   call assert_equal('c-c', g:current_modes)
+  call feedkeys(":\<insert>\<C-r>=Save_mode()\<CR>",'xt')
+  call assert_equal("c-cr", g:current_modes)
   call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
   call assert_equal('c-cv', g:current_modes)
+  call feedkeys("gQ\<insert>\<C-r>=Save_mode()\<CR>",'xt')
+  call assert_equal("c-cvr", g:current_modes)
   " call feedkeys("Qcall Save_mode()\<CR>vi\<CR>", 'xt')
   " call assert_equal('c-ce', g:current_modes)
   " How to test Ex mode?
@@ -817,6 +821,18 @@ func Test_mode()
   call assert_equal('n-niR', g:current_modes)
   execute "normal! gR\<C-o>g@l\<Esc>"
   call assert_equal('n-niV', g:current_modes)
+  " Test statusline updates for overstike mode
+  if CanRunVimInTerminal()
+    let buf = RunVimInTerminal('', {'rows': 12})
+    call term_sendkeys(buf, ":set laststatus=2 statusline=%!mode(1)\<CR>")
+    call term_sendkeys(buf, ":")
+    call TermWait(buf)
+    call VerifyScreenDump(buf, 'Test_mode_1', {})
+    call term_sendkeys(buf, "\<insert>")
+    call TermWait(buf)
+    call VerifyScreenDump(buf, 'Test_mode_2', {})
+    call StopVimInTerminal(buf)
+  endif
 
   if has('terminal')
     term


### PR DESCRIPTION
#### vim-patch:9.0.2133: Cannot detect overstrike mode in Cmdline mode

Problem:  Cannot detect overstrike mode in Cmdline mode
Solution: Make mode() return "cr" for overstrike

closes: vim/vim#13569

https://github.com/vim/vim/commit/d1c3ef1f47c87d1da056c56564e1985fe6f2931d

Co-authored-by: Sam-programs <None>