### PR TITLE
docs(editorconfig): add missing indent_size description 

### DIFF
--- a/runtime/doc/editorconfig.txt
+++ b/runtime/doc/editorconfig.txt
@@ -49,6 +49,8 @@ indent_size             A number indicating the size of a single indent.
                         Alternatively, use the value "tab" to use the value of
                         the tab_width property. Sets the 'shiftwidth' and
                         'softtabstop' options.
+                        If this value is not "tab" and the tab_width property
+                        is not set, 'tabstop' is also set to this value.
 
                                            *editorconfig_insert_final_newline*
 insert_final_newline    "true" or "false" to ensure the file always has a


### PR DESCRIPTION
The specifications for this part were not written in the documentation, so I have added this description.
https://github.com/neovim/neovim/blob/71e954ad303eec25b67541f3a99392446f6de8b3/runtime/lua/editorconfig.lua#L67-L69

Corresponding editorconfig doc

https://editorconfig.org/

> This defaults to the value of indent_size and doesn't usually need to be specified.