### PR TITLE
fix(treesitter): use proper query syntax for inspector

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -77,8 +77,9 @@ local function traverse(node, depth, lang, injections, tree)
 
     traverse(child, depth + 1, lang, injections, tree)
 
-    -- Add closing parens to final child
-    tree[#tree].text = string.format('%s)', tree[#tree].text)
+    if named then
+      tree[#tree].text = string.format('%s)', tree[#tree].text)
+    end
   end
 
   return tree


### PR DESCRIPTION
Use actual Tree-sitter query syntax for the inspector window. This makes parsing with the query parser work correctly and more reliably.

In particular this means that nested nodes are grouped within parentheses (like all lisps).