### PR TITLE
perf(column): only invalidate lines affected by added sign

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -706,9 +706,10 @@ struct file_buffer {
 
   struct {
     int size;                   // last calculated number of sign columns
-    bool valid;                 // calculated sign columns is valid
+    int max;                    // maximum value size is valid for.
     linenr_T sentinel;          // a line number which is holding up the signcolumn
-    int max;                    // Maximum value size is valid for.
+    linenr_T invalid_top;       // first invalid line number that needs to be checked
+    linenr_T invalid_bot;       // last invalid line number that needs to be checked
   } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -607,10 +607,12 @@ int update_screen(void)
     }
 
     // Reset 'statuscolumn' if there is no dedicated signcolumn but it is invalid.
-    if (*wp->w_p_stc != NUL && !wp->w_buffer->b_signcols.valid && wp->w_minscwidth <= SCL_NO) {
+    if (*wp->w_p_stc != NUL && wp->w_minscwidth <= SCL_NO
+        && (wp->w_buffer->b_signcols.invalid_bot || !wp->w_buffer->b_signcols.sentinel)) {
       wp->w_nrwidth_line_count = 0;
       wp->w_valid &= ~VALID_WCOL;
       wp->w_redr_type = UPD_NOT_VALID;
+      wp->w_buffer->b_signcols.invalid_bot = 0;
     }
   }
 
@@ -619,11 +621,6 @@ int update_screen(void)
   screen_search_hl.rm.regprog = NULL;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    // Validate b_signcols if there is no dedicated signcolumn but 'statuscolumn' is set.
-    if (*wp->w_p_stc != NUL && wp->w_minscwidth <= SCL_NO) {
-      buf_signcols(wp->w_buffer, 0);
-    }
-
     if (wp->w_redr_type == UPD_CLEAR && wp->w_floating && wp->w_grid_alloc.chars) {
       grid_invalidate(&wp->w_grid_alloc);
       wp->w_redr_type = UPD_NOT_VALID;
@@ -1214,6 +1211,7 @@ static void redraw_win_signcol(win_T *wp)
   wp->w_scwidth = win_signcol_count(wp);
   if (wp->w_scwidth != scwidth) {
     changed_line_abv_curs_win(wp);
+    redraw_later(wp, UPD_NOT_VALID);
   }
 }
 

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -467,6 +467,27 @@ describe('Signs', function()
         {0:~                                                    }|
                                                              |
       ]])
+      -- should not increase size because sign with existing id is moved
+      command('sign place 4 line=1 name=pietSearch buffer=1')
+      screen:expect_unchanged()
+      command('sign unplace 4')
+      screen:expect([[
+        {1:>>>>>>}{6:  1 }a                                          |
+        {2:      }{6:  2 }b                                          |
+        {2:      }{6:  3 }c                                          |
+        {2:      }{6:  4 }^                                           |
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+        {0:~                                                    }|
+                                                             |
+      ]])
+      command('sign place 4 line=1 name=pietSearch buffer=1')
       -- should keep the column at maximum size when signs are
       -- exceeding the maximum
       command('sign place 5 line=1 name=pietSearch buffer=1')


### PR DESCRIPTION
Only feasible when a sign is added. When a sign at the sentinel line is removed we still need to invalidate the entire buffer. This cannot be avoided unless we start keeping track of all lines that hold up the signcolumn.

Perhaps the common case in between redraws will contain both added and removed signs. Despite that, this PR does still reduce the amount of lines checked in `make functionaltest` by ~16%, which mostly tests small buffers. For actual files it will result in a greater reduction in lines checked.

Also only do a `UPD_NOT_VALID` redraw when the signcolumn actually changed in size.