### PR TITLE
build: disable UnusedIncludes from clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,4 @@
 CompileFlags:
   CompilationDatabase: build/       # Search build/ directory for compile_commands.json
+Diagnostics:
+  UnusedIncludes: None


### PR DESCRIPTION
Include Cleaner is enabled by default since clangd 17 and gives
incorrect suggestions.