### PR TITLE
vim-patch:9.0.2135: No test for mode() when executing Ex commands

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4850,9 +4850,9 @@ mode([expr])                                                            *mode()*
 		   Rvc	    Virtual Replace mode completion |compl-generic|
 		   Rvx	    Virtual Replace mode |i_CTRL-X| completion
 		   c	    Command-line editing
-		   cr	    Command-line while in overstrike mode |c_<Insert>|
+		   cr	    Command-line editing overstrike mode |c_<Insert>|
 		   cv	    Vim Ex mode |gQ|
-		   cvr	    Vim Ex while in overstrike mode |c_<Insert>|
+		   cvr	    Vim Ex mode while in overstrike mode |c_<Insert>|
 		   r	    Hit-enter prompt
 		   rm	    The -- more -- prompt
 		   r?	    A |:confirm| query of some sort

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -5812,9 +5812,9 @@ function vim.fn.mkdir(name, flags, prot) end
 ---    Rvc      Virtual Replace mode completion |compl-generic|
 ---    Rvx      Virtual Replace mode |i_CTRL-X| completion
 ---    c      Command-line editing
----    cr      Command-line while in overstrike mode |c_<Insert>|
+---    cr      Command-line editing overstrike mode |c_<Insert>|
 ---    cv      Vim Ex mode |gQ|
----    cvr      Vim Ex while in overstrike mode |c_<Insert>|
+---    cvr      Vim Ex mode while in overstrike mode |c_<Insert>|
 ---    r      Hit-enter prompt
 ---    rm      The -- more -- prompt
 ---    r?      A |:confirm| query of some sort

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7038,9 +7038,9 @@ M.funcs = {
          Rvc	    Virtual Replace mode completion |compl-generic|
          Rvx	    Virtual Replace mode |i_CTRL-X| completion
          c	    Command-line editing
-         cr	    Command-line while in overstrike mode |c_<Insert>|
+         cr	    Command-line editing overstrike mode |c_<Insert>|
          cv	    Vim Ex mode |gQ|
-         cvr	    Vim Ex while in overstrike mode |c_<Insert>|
+         cvr	    Vim Ex mode while in overstrike mode |c_<Insert>|
          r	    Hit-enter prompt
          rm	    The -- more -- prompt
          r?	    A |:confirm| query of some sort

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3656,8 +3656,6 @@ func Test_mode_changes()
   call assert_equal(len(g:mode_seq) - 1, g:index)
   call assert_equal(2, g:n_to_c)
   call assert_equal(2, g:c_to_n)
-  unlet g:n_to_c
-  unlet g:c_to_n
 
   let g:n_to_v = 0
   au ModeChanged n:v let g:n_to_v += 1
@@ -3668,8 +3666,10 @@ func Test_mode_changes()
   call assert_equal(len(g:mode_seq) - 1, g:index)
   call assert_equal(1, g:n_to_v)
   call assert_equal(1, g:v_to_n)
-  unlet g:n_to_v
-  unlet g:v_to_n
+
+  let g:mode_seq += ['c', 'cr', 'c', 'cr', 'n']
+  call feedkeys(":\<Insert>\<Insert>\<Insert>\<CR>", 'tnix')
+  call assert_equal(len(g:mode_seq) - 1, g:index)
 
   au! ModeChanged
   delfunc TestMode
@@ -3684,6 +3684,10 @@ func Test_mode_changes()
   unlet! g:i_to_n
   unlet! g:nori_to_any
   unlet! g:i_to_any
+  unlet! g:n_to_c
+  unlet! g:c_to_n
+  unlet! g:n_to_v
+  unlet! g:v_to_n
 endfunc
 
 func Test_recursive_ModeChanged()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -637,7 +637,7 @@ func Test_mode()
   " Only complete from the current buffer.
   set complete=.
 
-  inoremap <F2> <C-R>=Save_mode()<CR>
+  noremap! <F2> <C-R>=Save_mode()<CR>
   xnoremap <F2> <Cmd>call Save_mode()<CR>
 
   normal! 3G
@@ -796,17 +796,24 @@ func Test_mode()
   exe "normal g\<C-H>\<C-O>\<F2>\<Esc>"
   call assert_equal("\<C-V>-\<C-V>s", g:current_modes)
 
-  call feedkeys(":echo \<C-R>=Save_mode()\<C-U>\<CR>", 'xt')
+  call feedkeys(":\<F2>\<CR>", 'xt')
   call assert_equal('c-c', g:current_modes)
-  call feedkeys(":\<insert>\<C-r>=Save_mode()\<CR>",'xt')
+  call feedkeys(":\<Insert>\<F2>\<CR>", 'xt')
   call assert_equal("c-cr", g:current_modes)
-  call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
+  call feedkeys("gQ\<F2>vi\<CR>", 'xt')
   call assert_equal('c-cv', g:current_modes)
-  call feedkeys("gQ\<insert>\<C-r>=Save_mode()\<CR>",'xt')
+  call feedkeys("gQ\<Insert>\<F2>vi\<CR>", 'xt')
   call assert_equal("c-cvr", g:current_modes)
+
+  " Executing commands in Vim Ex mode should return "cv", never "cvr",
+  " as Cmdline editing has already ended.
+  call feedkeys("gQcall Save_mode()\<CR>vi\<CR>", 'xt')
+  call assert_equal('c-cv', g:current_modes)
+  call feedkeys("gQ\<Insert>call Save_mode()\<CR>vi\<CR>", 'xt')
+  call assert_equal('c-cv', g:current_modes)
+
   " call feedkeys("Qcall Save_mode()\<CR>vi\<CR>", 'xt')
   " call assert_equal('c-ce', g:current_modes)
-  " How to test Ex mode?
 
   " Test mode in operatorfunc (it used to be Operator-pending).
   set operatorfunc=OperatorFunc
@@ -821,14 +828,15 @@ func Test_mode()
   call assert_equal('n-niR', g:current_modes)
   execute "normal! gR\<C-o>g@l\<Esc>"
   call assert_equal('n-niV', g:current_modes)
-  " Test statusline updates for overstike mode
+
+  " Test statusline updates for overstrike mode
   if CanRunVimInTerminal()
     let buf = RunVimInTerminal('', {'rows': 12})
     call term_sendkeys(buf, ":set laststatus=2 statusline=%!mode(1)\<CR>")
     call term_sendkeys(buf, ":")
     call TermWait(buf)
     call VerifyScreenDump(buf, 'Test_mode_1', {})
-    call term_sendkeys(buf, "\<insert>")
+    call term_sendkeys(buf, "\<Insert>")
     call TermWait(buf)
     call VerifyScreenDump(buf, 'Test_mode_2', {})
     call StopVimInTerminal(buf)
@@ -843,7 +851,7 @@ func Test_mode()
   endif
 
   bwipe!
-  iunmap <F2>
+  unmap! <F2>
   xunmap <F2>
   set complete&
   set operatorfunc&


### PR DESCRIPTION
#### vim-patch:9.0.2135: No test for mode() when executing Ex commands

Problem:  No test for mode() when executing Ex commands
Solution: Add some test cases and simplify several other test cases.
          Also add a few more test cases for ModeChanged.

closes: vim/vim#13588

https://github.com/vim/vim/commit/fcaeb3d42b228e73c669b2fce78f1d3fe112769f