### PR TITLE
fix(man): set the nested flag for the BufReadCmd autocommand

### DIFF
--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -29,6 +29,7 @@ local augroup = vim.api.nvim_create_augroup('man', {})
 vim.api.nvim_create_autocmd('BufReadCmd', {
   group = augroup,
   pattern = 'man://*',
+  nested = true,
   callback = function(params)
     require('man').read_page(vim.fn.matchstr(params.match, 'man://\\zs.*'))
   end,


### PR DESCRIPTION
The nested flag must be set so that other autocommands can fire while
the BufReadCmd is still executing.
