### PR TITLE
vim-patch:a9058440b7b9

### DIFF
--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -3,9 +3,9 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainers: Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 "			Claudio Fleiner <claudio@fleiner.com>
-" Last Change:		2023 Feb 20
+" Last Change:		2023 Nov 28
 
-" Please check :help html.vim for some comments and a description of the options
+" See :help html.vim for some comments and a description of the options
 
 " quit when a syntax file was already loaded
 if !exists("main_syntax")
@@ -28,7 +28,6 @@ syn case ignore
 " mark illegal characters
 syn match htmlError "[<>&]"
 
-
 " tags
 syn region  htmlString	 contained start=+"+ end=+"+ contains=htmlSpecialChar,javaScriptExpression,@htmlPreproc
 syn region  htmlString	 contained start=+'+ end=+'+ contains=htmlSpecialChar,javaScriptExpression,@htmlPreproc
@@ -38,7 +37,6 @@ syn region  htmlTag		   start=+<[^/]+   end=+>+ fold contains=htmlTagN,htmlStrin
 syn match   htmlTagN	 contained +<\s*[-a-zA-Z0-9]\++hs=s+1 contains=htmlTagName,htmlSpecialTagName,@htmlTagNameCluster
 syn match   htmlTagN	 contained +</\s*[-a-zA-Z0-9]\++hs=s+2 contains=htmlTagName,htmlSpecialTagName,@htmlTagNameCluster
 syn match   htmlTagError contained "[^>]<"ms=s+1
-
 
 " tag names
 syn keyword htmlTagName contained address applet area a base basefont
@@ -61,7 +59,7 @@ syn keyword htmlTagName contained article aside audio bdi canvas data
 syn keyword htmlTagName contained datalist details dialog embed figcaption
 syn keyword htmlTagName contained figure footer header hgroup keygen main
 syn keyword htmlTagName contained mark menuitem meter nav output picture
-syn keyword htmlTagName contained progress rb rp rt rtc ruby section
+syn keyword htmlTagName contained progress rb rp rt rtc ruby search section
 syn keyword htmlTagName contained slot source summary template time track
 syn keyword htmlTagName contained video wbr
 
@@ -88,18 +86,71 @@ syn keyword htmlArg contained size src start target text type url
 syn keyword htmlArg contained usemap ismap valign value vlink vspace width wrap
 syn match   htmlArg contained "\<\%(http-equiv\|href\|title\)="me=e-1
 
-" aria attributes
-exe 'syn match htmlArg contained "\<aria-\%(' . join([
-    \ 'activedescendant', 'atomic', 'autocomplete', 'busy', 'checked', 'colcount',
-    \ 'colindex', 'colspan', 'controls', 'current', 'describedby', 'details',
-    \ 'disabled', 'dropeffect', 'errormessage', 'expanded', 'flowto', 'grabbed',
-    \ 'haspopup', 'hidden', 'invalid', 'keyshortcuts', 'label', 'labelledby', 'level',
-    \ 'live', 'modal', 'multiline', 'multiselectable', 'orientation', 'owns',
-    \ 'placeholder', 'posinset', 'pressed', 'readonly', 'relevant', 'required',
-    \ 'roledescription', 'rowcount', 'rowindex', 'rowspan', 'selected', 'setsize',
-    \ 'sort', 'valuemax', 'valuemin', 'valuenow', 'valuetext'
-    \ ], '\|') . '\)\>"'
 syn keyword htmlArg contained role
+
+" ARIA attributes {{{1
+let s:aria =<< trim END
+  activedescendant
+  atomic
+  autocomplete
+  braillelabel
+  brailleroledescription
+  busy
+  checked
+  colcount
+  colindex
+  colindextext
+  colspan
+  controls
+  current
+  describedby
+  description
+  details
+  disabled
+  errormessage
+  expanded
+  flowto
+  haspopup
+  hidden
+  invalid
+  keyshortcuts
+  label
+  labelledby
+  level
+  live
+  modal
+  multiline
+  multiselectable
+  orientation
+  owns
+  placeholder
+  posinset
+  pressed
+  readonly
+  relevant
+  required
+  roledescription
+  rowcount
+  rowindex
+  rowindextext
+  rowspan
+  selected
+  setsize
+  sort
+  valuemax
+  valuemin
+  valuenow
+  valuetext
+END
+let s:aria_deprecated =<< trim END
+  dropeffect
+  grabbed
+END
+
+call extend(s:aria, s:aria_deprecated)
+exe 'syn match htmlArg contained "\%#=1\<aria-\%(' .. s:aria->join('\|') .. '\)\>"'
+unlet s:aria s:aria_deprecated
+" }}}
 
 " Netscape extensions
 syn keyword htmlTagName contained frame noframes frameset nobr blink
@@ -321,9 +372,9 @@ if !exists("html_no_rendering")
     hi def htmlUnderlineItalic	   term=italic,underline cterm=italic,underline gui=italic,underline
     hi def htmlItalic		   term=italic cterm=italic gui=italic
     if v:version > 800 || v:version == 800 && has("patch1038")
-	hi def htmlStrike	       term=strikethrough cterm=strikethrough gui=strikethrough
+      hi def htmlStrike	term=strikethrough cterm=strikethrough gui=strikethrough
     else
-	hi def htmlStrike	       term=underline cterm=underline gui=underline
+      hi def htmlStrike	term=underline cterm=underline gui=underline
     endif
   endif
 endif
@@ -356,4 +407,5 @@ endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-" vim: ts=8
+
+" vim: nowrap sw=2 sts=2 ts=8 noet fdm=marker:


### PR DESCRIPTION
runtime(html): Update syntax file (vim/vim#13591)

Add missing search element and update ARIA attribute list.

Add a very basic test file to check all elements are matched.

https://github.com/vim/vim/commit/a9058440b7b9d7f5d0027c8cd44366e9200ca241

Co-authored-by: dkearns <dougkearns@gmail.com>
