### PR TITLE
docs: document TSNode:byte_length()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -165,6 +165,10 @@ TSNode:named_descendant_for_range({start_row}, {start_col}, {end_row}, {end_col}
 TSNode:equal({node})
     Check if {node} refers to the same node within the same tree.
 
+                                                        *TSNode:byte_length()*
+TSNode:byte_length()
+    Return the number of bytes spanned by this node.
+
 ==============================================================================
 TREESITTER QUERIES                                          *treesitter-query*
 

--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -1,7 +1,7 @@
 ---@meta
 
 ---@class TSNode: userdata
----@field id fun(self: TSNode): integer
+---@field id fun(self: TSNode): string
 ---@field tree fun(self: TSNode): TSTree
 ---@field range fun(self: TSNode, include_bytes: false?): integer, integer, integer, integer
 ---@field range fun(self: TSNode, include_bytes: true): integer, integer, integer, integer, integer, integer
@@ -30,6 +30,7 @@
 ---@field equal fun(self: TSNode, other: TSNode): boolean
 ---@field iter_children fun(self: TSNode): fun(): TSNode, string
 ---@field field fun(self: TSNode, name: string): TSNode[]
+---@field byte_length fun(self: TSNode): integer
 local TSNode = {}
 
 ---@param query userdata

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -24,6 +24,10 @@ local TSTreeView = {}
 ---@field lang string Source language of this node
 ---@field root TSNode
 
+---@class TSP.Injection
+---@field lang string Source language of this injection
+---@field root TSNode Root node of the injection
+
 --- Traverse all child nodes starting at {node}.
 ---
 --- This is a recursive function. The {depth} parameter indicates the current recursion level.
@@ -39,8 +43,8 @@ local TSTreeView = {}
 ---@param node TSNode Starting node to begin traversal |tsnode|
 ---@param depth integer Current recursion depth
 ---@param lang string Language of the tree currently being traversed
----@param injections table<integer,TSP.Node> Mapping of node ids to root nodes of injected language trees (see
----                        explanation above)
+---@param injections table<string, TSP.Injection> Mapping of node ids to root nodes
+---                  of injected language trees (see explanation above)
 ---@param tree TSP.Node[] Output table containing a list of tables each representing a node in the tree
 local function traverse(node, depth, lang, injections, tree)
   local injection = injections[node:id()]
@@ -104,7 +108,7 @@ function TSTreeView:new(bufnr, lang)
   -- the primary tree that contains that root. Add a mapping from the node in the primary tree to
   -- the root in the child tree to the {injections} table.
   local root = parser:parse(true)[1]:root()
-  local injections = {} ---@type table<integer,table>
+  local injections = {} ---@type table<string, TSP.Injection>
 
   parser:for_each_tree(function(parent_tree, parent_ltree)
     local parent = parent_tree:root()


### PR DESCRIPTION
Also update the type annotation of TSNode:id(), which returns a string,
not an integer.
