### PR TITLE
fix(termcap): escape escapes in passthrough sequence

### DIFF
--- a/runtime/lua/vim/termcap.lua
+++ b/runtime/lua/vim/termcap.lua
@@ -53,7 +53,7 @@ function M.query(caps, cb)
 
   -- If running in tmux, wrap with the passthrough sequence
   if os.getenv('TMUX') then
-    query = string.format('\027Ptmux;\027%s\027\\', query)
+    query = string.format('\027Ptmux;%s\027\\', query:gsub('\027', '\027\027'))
   end
 
   io.stdout:write(query)


### PR DESCRIPTION
When using the tmux passthrough sequence any escape characters in the
inner sequence must be escaped by adding another escape character.

Fixes: https://github.com/neovim/neovim/issues/26288
