### PR TITLE
feat(treesitter): add `#if?` predicate for conditional queries

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -237,6 +237,14 @@ The following predicates are built in:
         This is the recommended way to check if the node matches one of many
         keywords, as it has been optimized for this.
 
+    `if?`                                            *treesitter-predicate-of?*
+        Apply the pattern if the specified variable is truthy. If the
+        corresponding buffer variable is not `nil`, use its value; otherwise
+        the global variable is checked). For example, the following pattern is
+        only applied if `vim.g.identifier-foo` is `true` and
+        `vim.b.identifier-foo` is not `false`: >query
+            ((identifier) @foo (#if? "identifier-foo"))
+<
     `has-ancestor?`                        *treesitter-predicate-has-ancestor?*
         Match any of the given node types against all ancestors of a node: >query
             ((identifier) @variable.builtin

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -240,7 +240,7 @@ The following predicates are built in:
     `if?`                                            *treesitter-predicate-of?*
         Apply the pattern if the specified variable is truthy. If the
         corresponding buffer variable is not `nil`, use its value; otherwise
-        the global variable is checked). For example, the following pattern is
+        the global variable is checked. For example, the following pattern is
         only applied if `vim.g.identifier-foo` is `true` and
         `vim.b.identifier-foo` is not `false`: >query
             ((identifier) @foo (#if? "identifier-foo"))

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -370,6 +370,14 @@ local predicate_handlers = {
     return string_set[node_text]
   end,
 
+  ['if?'] = function(_, bufnr, _, predicate)
+    local var = predicate[2]
+    if vim.b[bufnr][var] ~= nil then
+      return vim.b[bufnr][var]
+    end
+    return vim.g[var]
+  end,
+
   ['has-ancestor?'] = function(match, _, _, predicate)
     local node = match[predicate[2]]
     if not node then

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -487,7 +487,7 @@ end]]
     return list
     ]]
 
-    eq({ 'any-of?', 'contains?', 'eq?', 'has-ancestor?', 'has-parent?', 'is-main?', 'lua-match?', 'match?', 'vim-match?' }, res_list)
+    eq({ 'any-of?', 'contains?', 'eq?', 'has-ancestor?', 'has-parent?', 'if?', 'is-main?', 'lua-match?', 'match?', 'vim-match?' }, res_list)
   end)
 
   it('allows to set simple ranges', function()


### PR DESCRIPTION
### Problem 

There is no way to control queries at runtime, meaning controversial conceals or expensive injections have to be left to user config (and are not possible to conditionally enable). This is a regression over legacy syntax, which gates some features behind configuration variables.

### Solution

 Add an `#if?` predicate that can be used to gate patterns behind a configuration variable, where buffer variables take precedence. For example, the pattern
```lisp
((identifier) @foo (#if? "identifier-foo"))
```
is only applied if
1. `vim.b.identifier-foo` is truthy or
2. `vim.g.identifier-foo` is truthy and `vim.b.identifier-foo` is not falsy.


### Open question

 Should these variables be scoped, e.g., `vim.b.treesitter.identifier-foo`, or be part of a single dict (`vim.g.treesitter`)? If so, what color should that shed be?
