### PR TITLE
fix(loader): supply correct library-name for modules containing "."

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -188,7 +188,14 @@ end
 function Loader.loader_lib(modname)
   local sysname = uv.os_uname().sysname:lower() or ''
   local is_win = sysname:find('win', 1, true) and not sysname:find('darwin', 1, true)
-  local ret = M.find(modname, { patterns = is_win and { '.dll' } or { '.so' } })[1]
+  -- strip first dot (if it exists) and all characters after it to get
+  -- the library-name from the modname.
+  -- (see https://www.lua.org/manual/5.1/manual.html#pdf-require)
+  local dot_at = modname:find('.', 1, true)
+  local ret = M.find(
+    modname:sub(1, dot_at and (dot_at - 1)),
+    { patterns = is_win and { '.dll' } or { '.so' } }
+  )[1]
   ---@type function?, string?
   if ret then
     -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -2,6 +2,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 
 local exec_lua = helpers.exec_lua
+local exec = helpers.exec
 local command = helpers.command
 local eq = helpers.eq
 
@@ -52,5 +53,52 @@ describe('vim.loader', function()
     vim.uv.fs_utime(tmp2, 0, 0)
     eq(1, exec_lua('return loadfile(...)()', tmp1))
     eq(2, exec_lua('return loadfile(...)()', tmp2))
+  end)
+
+  it('handles "." in modname for dynamic library correctly (#26308)', function()
+    exec_lua [[
+      vim.loader.enable()
+    ]]
+
+    local tmpdir = helpers.tmpname()
+    -- make sure tmpdir is empty.
+    assert(os.remove(tmpdir))
+
+    -- mkdir_p does not work on windows => create separately.
+    assert(helpers.mkdir(tmpdir))
+    assert(helpers.mkdir(tmpdir .. '/lua'))
+
+    -- Create file for mimicking lua-library.
+    -- Content does not matter, append/write does not matter (file is empty at this point).
+    helpers.write_file(tmpdir .. '/lua/foo.' .. (helpers.is_os('win') and 'dll' or 'so'), '', false)
+
+    exec('set rtp+=' .. tmpdir)
+    -- Call the function responsible for resolving the `require` of a dynamic library directly.
+    -- The reason for skipping over `require` itself is that observing the correct behaviour
+    -- (file is found and loadlib attempted) with it would require a valid library with the correct
+    -- luaopen_foo_bar-symbol, which is more cumbersome than just placing an empty file at the
+    -- correct location, which is all we need to see different behaviour with the loader-internal
+    -- function.
+    local ok, err_msg = pcall(exec_lua, [[ return package.loaders[3]('foo.bar') ]])
+
+    -- Make sure the module is found.
+    -- (loading the module fails at a later stage, but we can check for just that).
+    eq(false, ok)
+
+    -- make sure there is an error loading it, and not something else.
+    if helpers.is_os('win') then
+      eq(true, err_msg:match('not a valid Win32 application') ~= nil)
+    elseif helpers.is_os('mac') then
+      eq(true, err_msg:match('lua/foo.so, 0x0006') ~= nil)
+    elseif helpers.is_os('freebsd') then
+      eq(true, err_msg:match('foo.so: invalid file format') ~= nil)
+    else
+      eq(true, err_msg:match('foo.so: file too short') ~= nil)
+    end
+
+    -- Verify different behaviour for unavailable (as in not found) library.
+    ok, err_msg = pcall(exec_lua, [[ return package.loaders[3]('foobar12345$') ]])
+    eq(true, ok)
+    eq('\ncache_loader_lib: module foobar12345$ not found', err_msg)
   end)
 end)


### PR DESCRIPTION
Noticed this when trying to `require` a C-library which uses namespacing:
`require("foo.bar")` should search for "foo.so", but the current code in `loader_lib` looks for "foo.bar.so".