### PR TITLE
Backport to release-0.9

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7296,7 +7296,9 @@ static void ex_terminal(exarg_T *eap)
     char shell_argv[512] = { 0 };
 
     while (*p != NULL) {
-      snprintf(tempstring, sizeof(tempstring), ",\"%s\"", *p);
+      char *escaped = vim_strsave_escaped(*p, "\"\\");
+      snprintf(tempstring, sizeof(tempstring), ",\"%s\"", escaped);
+      xfree(escaped);
       xstrlcat(shell_argv, tempstring, sizeof(shell_argv));
       p++;
     }

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -141,7 +141,13 @@ describe(':terminal', function()
   end)
 end)
 
-describe(':terminal (with fake shell)', function()
+local function test_terminal_with_fake_shell(backslash)
+  -- shell-test.c is a fake shell that prints its arguments and exits.
+  local shell_path = testprg('shell-test')
+  if backslash then
+    shell_path = shell_path:gsub('/', [[\]])
+  end
+
   local screen
 
   before_each(function()
@@ -149,7 +155,7 @@ describe(':terminal (with fake shell)', function()
     screen = Screen.new(50, 4)
     screen:attach({rgb=false})
     -- shell-test.c is a fake shell that prints its arguments and exits.
-    nvim('set_option', 'shell', testprg('shell-test'))
+    nvim('set_option', 'shell', shell_path)
     nvim('set_option', 'shellcmdflag', 'EXE')
   end)
 
@@ -183,7 +189,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("with no argument, but 'shell' has arguments, acts like termopen()", function()
-    nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
+    nvim('set_option', 'shell', shell_path ..' -t jeff')
     terminal_with_fake_shell()
     screen:expect([[
       ^jeff $                                            |
@@ -205,7 +211,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("executes a given command through the shell, when 'shell' has arguments", function()
-    nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
+    nvim('set_option', 'shell', shell_path ..' -t jeff')
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell('echo hi')
     screen:expect([[
@@ -297,4 +303,13 @@ describe(':terminal (with fake shell)', function()
       terminal]])
     end
   end)
+end
+
+describe(':terminal (with fake shell)', function()
+  test_terminal_with_fake_shell(false)
+  if is_os('win') then
+    describe("when 'shell' uses backslashes", function()
+      test_terminal_with_fake_shell(true)
+    end)
+  end
 end)


### PR DESCRIPTION
- fix(terminal): make backslashes in 'shell' work on Windows
- test: :terminal when 'shell' uses backslashes
