### PR TITLE
fix: Remove nested for_each_tree in TSTreeView

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -87,17 +87,17 @@ function TSTreeView:new(bufnr, lang)
   parser:for_each_tree(function(parent_tree, parent_ltree)
     local parent = parent_tree:root()
     for _, child in pairs(parent_ltree:children()) do
-      child:for_each_tree(function(tree, ltree)
+      for _, tree in pairs(child:trees()) do
         local r = tree:root()
         local node = assert(parent:named_descendant_for_range(r:range()))
         local id = node:id()
         if not injections[id] or r:byte_length() > injections[id].root:byte_length() then
           injections[id] = {
-            lang = ltree:lang(),
+            lang = child:lang(),
             root = r,
           }
         end
-      end)
+      end
     end
   end)
 


### PR DESCRIPTION
**Problem**:
`LanguageTree:for_each_tree` calls itself for child nodes, so when we calls `for_each_tree` inside `for_each_tree`, this quickly leads to exponential tree calls.

**Solution**:
Use `pairs(child:trees())` directly in this case, as we don't need the extra callback for each children, this is already handled from the outer `for_each_tree` call

My previous PR #26085 reintroduces a regression that was patched out before. This is a fixup to it

cc @gpanders 