### PR TITLE
fix: use BEL to terminate OSC 11 request

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -297,7 +297,7 @@ do
       end,
     })
 
-    io.stdout:write('\027]11;?\027\\')
+    io.stdout:write('\027]11;?\007')
 
     timer:start(1000, 0, function()
       -- No response received. Delete the autocommand


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/26295

Now that libtermkey is vendored we can be confident that all versions of Neovim (regardless of how they are built) will be able to handle a BEL in the response.

Why change? Well, _some_ terminals send an incorrect ST response when we use ST in the request. Those terminals have fixed that bug, but haven't released the fix yet (and even when they do, it may take a while for distributions to update, if they do at all). So using BEL circumvents that issue.

Note that the old C implementation used BEL as well.