### PR TITLE
perf(column): map lines to number of attached signs

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -703,11 +703,9 @@ struct file_buffer {
                                 // may use a different synblock_T.
 
   struct {
-    int size;                   // last calculated number of sign columns
-    int max;                    // maximum value size is valid for.
-    linenr_T sentinel;          // a line number which is holding up the signcolumn
-    linenr_T invalid_top;       // first invalid line number that needs to be checked
-    linenr_T invalid_bot;       // last invalid line number that needs to be checked
+    int size;                   // number of signs holding up the signcolumn
+    bool valid;                 // whether size is currently valid
+    Map(int, int) lines;        // number of signs on a line
   } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -791,52 +791,6 @@ DecorSignHighlight *decor_find_sign(DecorInline decor)
   }
 }
 
-// Increase the signcolumn size and update the sentinel line if necessary for
-// the invalidated range.
-void decor_validate_signcols(buf_T *buf, int max)
-{
-  int signcols = 0;  // highest value of count
-  int currow = buf->b_signcols.invalid_top - 1;
-  // TODO(bfredl): only need to use marktree_itr_get_overlap once.
-  // then we can process both start and end events and update state for each row
-  for (; currow < buf->b_signcols.invalid_bot; currow++) {
-    MarkTreeIter itr[1];
-    if (!marktree_itr_get_overlap(buf->b_marktree, currow, 0, itr)) {
-      continue;
-    }
-
-    int count = 0;
-    MTPair pair;
-    while (marktree_itr_step_overlap(buf->b_marktree, itr, &pair)) {
-      if (!mt_invalid(pair.start) && (pair.start.flags & MT_FLAG_DECOR_SIGNTEXT)) {
-        count++;
-      }
-    }
-
-    while (itr->x) {
-      MTKey mark = marktree_itr_current(itr);
-      if (mark.pos.row != currow) {
-        break;
-      }
-      if (!mt_invalid(mark) && !mt_end(mark) && (mark.flags & MT_FLAG_DECOR_SIGNTEXT)) {
-        count++;
-      }
-      marktree_itr_next(buf->b_marktree, itr);
-    }
-
-    if (count > signcols) {
-      if (count >= buf->b_signcols.size) {
-        buf->b_signcols.size = count;
-        buf->b_signcols.sentinel = currow + 1;
-      }
-      if (count >= max) {
-        return;
-      }
-      signcols = count;
-    }
-  }
-}
-
 void decor_redraw_end(DecorState *state)
 {
   state->win = NULL;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2226,6 +2226,7 @@ static const char *did_set_number_relativenumber(optset_T *args)
     win->w_nrwidth_line_count = 0;
   }
   check_signcolumn(win);
+  win_redraw_signcols(win);
   return NULL;
 }
 
@@ -6177,8 +6178,7 @@ int win_signcol_count(win_T *wp)
     return 0;
   }
 
-  int needed_signcols = buf_signcols(wp->w_buffer, wp->w_maxscwidth);
-  int ret = MAX(wp->w_minscwidth, MIN(wp->w_maxscwidth, needed_signcols));
+  int ret = MAX(wp->w_minscwidth, MIN(wp->w_maxscwidth, wp->w_buffer->b_signcols.size));
   assert(ret <= SIGN_SHOW_MAX);
   return ret;
 }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -5,7 +5,7 @@
 
 #include "nvim/ascii_defs.h"
 #include "nvim/autocmd.h"
-#include "nvim/buffer_defs.h"
+#include "nvim/buffer.h"
 #include "nvim/charset.h"
 #include "nvim/cmdexpand.h"
 #include "nvim/cmdexpand_defs.h"
@@ -2100,6 +2100,7 @@ const char *did_set_signcolumn(optset_T *args)
   if ((*oldval == 'n' && *(oldval + 1) == 'u') || win->w_minscwidth == SCL_NUM) {
     win->w_nrwidth_line_count = 0;
   }
+  win_redraw_signcols(win);
   return NULL;
 }
 


### PR DESCRIPTION
Changes:
  - The "b_signcols" structure holds a mapping from line number to number of signs on that line (excluding 0 signs).
  - The "b_signcols" structure no longer needs to be invalidated when adding a sign, only when removing a sign from a sentinel line.
  - The "b_signcols" structure can be validated after such a sign removal by looping over the map and checking that it no longer holds any lines of size "b_signcols.size". This is instead of looping over all extmarks in a buffer and counting the signs.

Performance indication:
  `make functionaltest` just loops over 76 lines (and doesn't have to
  count the number of signs) instead of 220 lines (having to count the
  number of signs) after this change. In exchange for an (int, int) map
  that grows with the number lines with signs in a buffer.