### PR TITLE
refactor: move float_relative_str[] to nvim_win_get_config()

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -311,6 +311,9 @@ static Dictionary config_put_bordertext(Dictionary config, FloatConfig *fconfig,
 Dictionary nvim_win_get_config(Window window, Error *err)
   FUNC_API_SINCE(6)
 {
+  /// Keep in sync with FloatRelative in buffer_defs.h
+  static const char *const float_relative_str[] = { "editor", "win", "cursor", "mouse" };
+
   Dictionary rv = ARRAY_DICT_INIT;
 
   win_T *wp = find_window_by_handle(window, err);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -902,7 +902,7 @@ enum {
   kFloatAnchorSouth = 2,
 };
 
-/// Keep in sync with float_relative_str in winfloat.h
+/// Keep in sync with float_relative_str[] in nvim_win_get_config()
 typedef enum {
   kFloatRelativeEditor = 0,
   kFloatRelativeWindow = 1,

--- a/src/nvim/winfloat.h
+++ b/src/nvim/winfloat.h
@@ -10,10 +10,6 @@
 /// SE -> kFloatAnchorSouth | kFloatAnchorEast
 EXTERN const char *const float_anchor_str[] INIT( = { "NW", "NE", "SW", "SE" });
 
-/// Keep in sync with FloatRelative in buffer_defs.h
-EXTERN const char *const float_relative_str[]
-INIT( = { "editor", "win", "cursor", "mouse" });
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "winfloat.h.generated.h"
 #endif


### PR DESCRIPTION
It's only used in one place, as it's usually conveyed as non-string.