### PR TITLE
build: cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,24 +282,24 @@ endif()
 ExternalProject_Add(uncrustify
   URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.78.1.tar.gz
   URL_HASH SHA256=ecaf4c0adca14c36dfffa30bc28e69865115ecd602c90eb16a8cddccb41caad2
-  DOWNLOAD_NO_PROGRESS TRUE
   DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/uncrustify
   CMAKE_ARGS ${DEPS_CMAKE_ARGS}
   CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS}
-  EXCLUDE_FROM_ALL TRUE)
+  EXCLUDE_FROM_ALL TRUE
+  ${EXTERNALPROJECT_OPTIONS})
 
 option(USE_BUNDLED_BUSTED "Use bundled busted" ON)
 if(USE_BUNDLED_BUSTED)
   ExternalProject_Add(lua-dev-deps
     URL https://github.com/neovim/deps/raw/5a1f71cceb24990a0b15fd9a472a5f549f019248/opt/lua-dev-deps.tar.gz
     URL_HASH SHA256=27db2495f5eddc7fc191701ec9b291486853530c6125609d3197d03481e8d5a2
-    DOWNLOAD_NO_PROGRESS TRUE
     DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/lua-dev-deps
     SOURCE_DIR ${DEPS_SHARE_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
-    EXCLUDE_FROM_ALL TRUE)
+    EXCLUDE_FROM_ALL TRUE
+    ${EXTERNALPROJECT_OPTIONS})
 else()
   add_custom_target(lua-dev-deps)
 endif()

--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -170,7 +170,7 @@ function(append_target_expression)
   set(VERSION_STRING "${VERSION_STRING} ${TARGET_EXPRESSION} " PARENT_SCOPE)
 endfunction()
 append_target_expression(PROPERTY COMPILE_OPTIONS)
-append_target_expression(PROPERTY LINK_FLAGS) # TODO(dundargoc): Replace/complement with LINK_OPTIONS when minimum version is 3.13+
+append_target_expression(PROPERTY LINK_OPTIONS)
 append_target_expression(PREFIX "-D" PROPERTY COMPILE_DEFINITIONS)
 append_target_expression(PREFIX "-I" PROPERTY INCLUDE_DIRECTORIES)
 string(REPLACE "  " " " VERSION_STRING "${VERSION_STRING}") # Remove duplicate whitespace

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -34,18 +34,16 @@ set(DEPS_INCLUDE_FLAGS "-I${DEPS_INSTALL_DIR}/include -I${DEPS_INSTALL_DIR}/incl
 
 option(USE_BUNDLED "Use bundled dependencies." ON)
 
-option(USE_BUNDLED_UNIBILIUM "Use the bundled unibilium." ${USE_BUNDLED})
-option(USE_BUNDLED_LIBVTERM "Use the bundled libvterm." ${USE_BUNDLED})
 option(USE_BUNDLED_LIBUV "Use the bundled libuv." ${USE_BUNDLED})
-option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
+option(USE_BUNDLED_LIBVTERM "Use the bundled libvterm." ${USE_BUNDLED})
+option(USE_BUNDLED_LPEG "Use the bundled lpeg." ${USE_BUNDLED})
+option(USE_BUNDLED_LUA "Use the bundled version of lua." OFF)
 option(USE_BUNDLED_LUAJIT "Use the bundled version of luajit." ${USE_BUNDLED})
 option(USE_BUNDLED_LUV "Use the bundled version of luv." ${USE_BUNDLED})
-option(USE_BUNDLED_LPEG "Use the bundled lpeg." ${USE_BUNDLED})
-#XXX(tarruda): Lua is only used for debugging the functional test client, don't
-# build it unless explicitly requested
-option(USE_BUNDLED_LUA "Use the bundled version of lua." OFF)
-option(USE_BUNDLED_TS_PARSERS "Use the bundled treesitter parsers." ${USE_BUNDLED})
+option(USE_BUNDLED_MSGPACK "Use the bundled msgpack." ${USE_BUNDLED})
 option(USE_BUNDLED_TS "Use the bundled treesitter runtime." ${USE_BUNDLED})
+option(USE_BUNDLED_TS_PARSERS "Use the bundled treesitter parsers." ${USE_BUNDLED})
+option(USE_BUNDLED_UNIBILIUM "Use the bundled unibilium." ${USE_BUNDLED})
 
 if(USE_BUNDLED AND MSVC)
   option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." ON)

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -7,10 +7,6 @@ function(BuildLuajit)
     "TARGET"
     "CONFIGURE_COMMAND;BUILD_COMMAND;INSTALL_COMMAND;DEPENDS"
     ${ARGN})
-  if(NOT _luajit_CONFIGURE_COMMAND AND NOT _luajit_BUILD_COMMAND
-        AND NOT _luajit_INSTALL_COMMAND)
-    message(FATAL_ERROR "Must pass at least one of CONFIGURE_COMMAND, BUILD_COMMAND, INSTALL_COMMAND")
-  endif()
   if(NOT _luajit_TARGET)
     set(_luajit_TARGET "luajit")
   endif()

--- a/cmake.deps/cmake/BuildTreesitter.cmake
+++ b/cmake.deps/cmake/BuildTreesitter.cmake
@@ -2,7 +2,6 @@ ExternalProject_Add(treesitter
   URL ${TREESITTER_URL}
   URL_HASH SHA256=${TREESITTER_SHA256}
   DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/treesitter
-  INSTALL_DIR ${DEPS_INSTALL_DIR}
   PATCH_COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TreesitterCMakeLists.txt
     ${DEPS_BUILD_DIR}/src/treesitter/CMakeLists.txt

--- a/cmake.deps/cmake/MarkdownParserCMakeLists.txt
+++ b/cmake.deps/cmake/MarkdownParserCMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 project(${PARSERLANG} C)
 
 add_compile_options(-w)
-set(CMAKE_C_STANDARD 99)
 
 add_library(markdown MODULE
 tree-sitter-markdown/src/parser.c

--- a/cmake/FindLibintl.cmake
+++ b/cmake/FindLibintl.cmake
@@ -78,3 +78,9 @@ endif()
 find_package_handle_standard_args(Libintl DEFAULT_MSG
   ${REQUIRED_VARIABLES})
 mark_as_advanced(LIBINTL_LIBRARY LIBINTL_INCLUDE_DIR)
+
+add_library(libintl INTERFACE)
+target_include_directories(libintl SYSTEM BEFORE INTERFACE ${LIBINTL_INCLUDE_DIR})
+if (LIBINTL_LIBRARY)
+  target_link_libraries(libintl INTERFACE ${LIBINTL_LIBRARY})
+endif()

--- a/cmake/FindLibuv.cmake
+++ b/cmake/FindLibuv.cmake
@@ -61,3 +61,7 @@ find_package_handle_standard_args(Libuv DEFAULT_MSG
                                   LIBUV_LIBRARY LIBUV_INCLUDE_DIR)
 
 mark_as_advanced(LIBUV_INCLUDE_DIR LIBUV_LIBRARY)
+
+add_library(libuv INTERFACE)
+target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIR})
+target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -32,10 +32,6 @@ if(IS_ABSOLUTE ${TEST_PATH})
   file(RELATIVE_PATH TEST_PATH "${WORKING_DIR}" "${TEST_PATH}")
 endif()
 
-if(BUSTED_OUTPUT_TYPE STREQUAL junit)
-  set(EXTRA_ARGS OUTPUT_FILE ${BUILD_DIR}/${TEST_TYPE}test-junit.xml)
-endif()
-
 set(BUSTED_ARGS $ENV{BUSTED_ARGS})
 separate_arguments(BUSTED_ARGS)
 
@@ -72,7 +68,7 @@ endif()
 execute_process(
   # Note: because of "-ll" (low-level interpreter mode), some modules like
   # _editor.lua are not loaded.
-  COMMAND ${NVIM_PRG} -ll ${WORKING_DIR}/test/lua_runner.lua ${DEPS_INSTALL_DIR} busted -v -o test.busted.outputHandlers.${BUSTED_OUTPUT_TYPE}
+  COMMAND ${NVIM_PRG} -ll ${WORKING_DIR}/test/lua_runner.lua ${DEPS_INSTALL_DIR} busted -v -o test.busted.outputHandlers.nvim
     --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua
     --lpath=${WORKING_DIR}/runtime/lua/?.lua

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -5,8 +5,6 @@ set(GENERATED_HELP_TAGS ${GENERATED_RUNTIME_DIR}/doc/tags)
 set(GENERATED_PACKAGE_DIR ${GENERATED_RUNTIME_DIR}/pack/dist/opt)
 set(FUNCS_DATA ${PROJECT_BINARY_DIR}/funcs_data.mpack)
 
-file(MAKE_DIRECTORY ${GENERATED_RUNTIME_DIR})
-file(MAKE_DIRECTORY ${GENERATED_RUNTIME_DIR}/syntax)
 file(MAKE_DIRECTORY ${GENERATED_RUNTIME_DIR}/syntax/vim)
 
 get_directory_property(LUA_GEN DIRECTORY ${PROJECT_SOURCE_DIR}/src/nvim DEFINITION LUA_GEN)
@@ -76,7 +74,6 @@ add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
     nvim_runtime_deps
   WORKING_DIRECTORY "${GENERATED_RUNTIME_DIR}"
 )
-
 
 # TODO: This doesn't work. wait for "nvim -l" to land?
 add_custom_target(doc_html

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -10,11 +10,6 @@ set_target_properties(nvim
 # Dependencies
 #-------------------------------------------------------------------------------
 
-add_library(libuv INTERFACE)
-find_package(Libuv 1.28.0 REQUIRED)
-target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIR})
-target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})
-
 add_library(nlua0 MODULE)
 if(WIN32)
   target_compile_definitions(nlua0 PUBLIC LUA_BUILD_AS_DLL LUA_LIB)
@@ -23,32 +18,30 @@ elseif(APPLE)
   target_link_options(nlua0 PRIVATE -undefined dynamic_lookup)
 endif()
 
+# TODO(dundargoc): unittest stops working if I create an pseudo-imported
+# library "luv" as with the other dependencies. Figure out why and fix.
 find_package(Luv 1.43.0 REQUIRED)
 target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUV_INCLUDE_DIR})
 target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})
 
 find_package(Iconv REQUIRED)
-find_package(Lpeg REQUIRED)
+find_package(Libintl REQUIRED) # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
+find_package(Libuv 1.28.0 REQUIRED)
 find_package(Libvterm 0.3.3 REQUIRED)
+find_package(Lpeg REQUIRED)
 find_package(Msgpack 1.0.0 REQUIRED)
 find_package(Treesitter 0.20.8 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 
 target_link_libraries(main_lib INTERFACE
   iconv
+  libintl
   libvterm
+  lpeg
   msgpack
   treesitter
-  unibilium
-  lpeg)
+  unibilium)
 target_link_libraries(nlua0 PUBLIC lpeg)
-
-# Libintl (not Intl) selects our FindLibintl.cmake script. #8464
-find_package(Libintl REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBINTL_INCLUDE_DIR})
-if (LIBINTL_LIBRARY)
-  target_link_libraries(main_lib INTERFACE ${LIBINTL_LIBRARY})
-endif()
 
 target_compile_definitions(main_lib INTERFACE HAVE_UNIBILIUM)
 
@@ -218,7 +211,9 @@ if(ENABLE_ASAN_UBSAN)
   target_compile_options(nvim PRIVATE -fsanitize=address)
   target_link_libraries(nvim PRIVATE -fsanitize=address -fsanitize=undefined)
   target_compile_definitions(nvim PRIVATE ENABLE_ASAN_UBSAN)
-elseif(ENABLE_MSAN)
+endif()
+
+if(ENABLE_MSAN)
   message(STATUS "Enabling memory sanitizer for nvim.")
   target_compile_options(nvim PRIVATE
     -fsanitize=memory
@@ -226,7 +221,9 @@ elseif(ENABLE_MSAN)
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls)
   target_link_libraries(nvim PRIVATE -fsanitize=memory -fsanitize-memory-track-origins)
-elseif(ENABLE_TSAN)
+endif()
+
+if(ENABLE_TSAN)
   message(STATUS "Enabling thread sanitizer for nvim.")
   target_compile_options(nvim PRIVATE -fsanitize=thread -fPIE)
   target_link_libraries(nvim PRIVATE -fsanitize=thread)
@@ -244,11 +241,7 @@ endif()
 
 option(ENABLE_IWYU "Run include-what-you-use with the compiler." OFF)
 if(ENABLE_IWYU)
-  find_program(IWYU_PRG NAMES include-what-you-use iwyu)
-  if(NOT IWYU_PRG)
-    message(FATAL_ERROR "ENABLE_IWYU is ON but include-what-you-use is not found!")
-  endif()
-
+  find_program(IWYU_PRG NAMES include-what-you-use iwyu REQUIRED)
   set(iwyu_flags "${IWYU_PRG};")
   string(APPEND iwyu_flags "-Xiwyu;--no_default_mappings;")
   string(APPEND iwyu_flags "-Xiwyu;--no_fwd_decls;")
@@ -260,26 +253,11 @@ endif()
 
 option(ENABLE_COMPILER_SUGGESTIONS "Enable -Wsuggest compiler warnings" OFF)
 if(ENABLE_COMPILER_SUGGESTIONS)
-  # Clang doesn't have -Wsuggest-attribute so check for each one.
-  check_c_compiler_flag(-Wsuggest-attribute=pure HAVE_WSUGGEST_ATTRIBUTE_PURE)
-  if(HAVE_WSUGGEST_ATTRIBUTE_PURE)
-    target_compile_options(main_lib INTERFACE -Wsuggest-attribute=pure)
-  endif()
-
-  check_c_compiler_flag(-Wsuggest-attribute=const HAVE_WSUGGEST_ATTRIBUTE_CONST)
-  if(HAVE_WSUGGEST_ATTRIBUTE_CONST)
-    target_compile_options(main_lib INTERFACE -Wsuggest-attribute=const)
-  endif()
-
-  check_c_compiler_flag(-Wsuggest-attribute=malloc HAVE_WSUGGEST_ATTRIBUTE_MALLOC)
-  if(HAVE_WSUGGEST_ATTRIBUTE_MALLOC)
-    target_compile_options(main_lib INTERFACE -Wsuggest-attribute=malloc)
-  endif()
-
-  check_c_compiler_flag(-Wsuggest-attribute=cold HAVE_WSUGGEST_ATTRIBUTE_COLD)
-  if(HAVE_WSUGGEST_ATTRIBUTE_COLD)
-    target_compile_options(main_lib INTERFACE -Wsuggest-attribute=cold)
-  endif()
+  target_compile_options(main_lib INTERFACE
+    -Wsuggest-attribute=cold
+    -Wsuggest-attribute=const
+    -Wsuggest-attribute=malloc
+    -Wsuggest-attribute=pure)
 endif()
 
 option(ENABLE_GCOV "Enable gcov support" OFF)
@@ -353,19 +331,19 @@ file(GLOB API_HEADERS CONFIGURE_DEPENDS api/*.h)
 list(REMOVE_ITEM API_HEADERS ${CMAKE_CURRENT_LIST_DIR}/api/ui_events.in.h)
 file(GLOB MSGPACK_RPC_HEADERS CONFIGURE_DEPENDS msgpack_rpc/*.h)
 
-target_include_directories(main_lib INTERFACE ${GENERATED_DIR})
-target_include_directories(main_lib INTERFACE ${CACHED_GENERATED_DIR})
-target_include_directories(main_lib INTERFACE ${GENERATED_INCLUDES_DIR})
-target_include_directories(main_lib INTERFACE "${PROJECT_BINARY_DIR}/cmake.config")
-target_include_directories(main_lib INTERFACE "${PROJECT_SOURCE_DIR}/src")
+target_include_directories(main_lib INTERFACE
+  ${GENERATED_DIR}
+  ${CACHED_GENERATED_DIR}
+  ${GENERATED_INCLUDES_DIR}
+  "${PROJECT_BINARY_DIR}/cmake.config"
+  "${PROJECT_SOURCE_DIR}/src")
 
-target_include_directories(nlua0 PUBLIC "${PROJECT_SOURCE_DIR}/src")
-target_include_directories(nlua0 PUBLIC "${PROJECT_BINARY_DIR}/cmake.config")
-target_include_directories(nlua0 PUBLIC ${GENERATED_INCLUDES_DIR})
+target_include_directories(nlua0 PUBLIC
+  "${PROJECT_SOURCE_DIR}/src"
+  "${PROJECT_BINARY_DIR}/cmake.config"
+  ${GENERATED_INCLUDES_DIR})
 
-file(MAKE_DIRECTORY ${TOUCHES_DIR})
-file(MAKE_DIRECTORY ${GENERATED_DIR})
-file(MAKE_DIRECTORY ${GENERATED_INCLUDES_DIR})
+file(MAKE_DIRECTORY ${TOUCHES_DIR} ${GENERATED_DIR} ${GENERATED_INCLUDES_DIR})
 
 file(GLOB NVIM_SOURCES CONFIGURE_DEPENDS *.c)
 file(GLOB NVIM_HEADERS CONFIGURE_DEPENDS *.h)
@@ -885,6 +863,10 @@ add_dependencies(uncrustify_update_config uncrustify)
 add_custom_target(lintc)
 add_dependencies(lintc lintc-clint lintc-uncrustify lintc-clang-tidy)
 
+#-------------------------------------------------------------------------------
+# Docs
+#-------------------------------------------------------------------------------
+
 add_custom_target(generated-sources DEPENDS
   ${NVIM_GENERATED_FOR_SOURCES}
   ${NVIM_GENERATED_FOR_HEADERS}
@@ -892,10 +874,6 @@ add_custom_target(generated-sources DEPENDS
 )
 
 add_subdirectory(po)
-
-#-------------------------------------------------------------------------------
-# Docs
-#-------------------------------------------------------------------------------
 
 set(VIMDOC_FILES
   ${NVIM_RUNTIME_DIR}/doc/api.mpack

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,31 +1,25 @@
 add_subdirectory(functional/fixtures)  # compile test programs
 get_directory_property(GENERATED_HELP_TAGS DIRECTORY ${PROJECT_SOURCE_DIR}/runtime DEFINITION GENERATED_HELP_TAGS)
 
-if(NOT BUSTED_OUTPUT_TYPE)
-  set(BUSTED_OUTPUT_TYPE "nvim")
-endif()
-
 get_target_property(TEST_INCLUDE_DIRS main_lib INTERFACE_INCLUDE_DIRECTORIES)
 
-set(UNITTEST_PREREQS nvim)
-set(FUNCTIONALTEST_PREREQS nvim printenv-test printargs-test shell-test pwsh-test streams-test tty-test ${GENERATED_HELP_TAGS})
-set(BENCHMARK_PREREQS nvim tty-test)
+set(TEST_OPTIONS
+      -D BUILD_DIR=${CMAKE_BINARY_DIR}
+      -D CIRRUS_CI=$ENV{CIRRUS_CI}
+      -D CI_BUILD=${CI_BUILD}
+      -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
+      -D NVIM_PRG=$<TARGET_FILE:nvim>
+      -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+      -D WORKING_DIR=${PROJECT_SOURCE_DIR})
 
 check_lua_module(${LUA_PRG} "ffi" LUA_HAS_FFI)
 if(LUA_HAS_FFI)
   add_custom_target(unittest
     COMMAND ${CMAKE_COMMAND}
-      -D NVIM_PRG=$<TARGET_FILE:nvim>
-      -D WORKING_DIR=${PROJECT_SOURCE_DIR}
-      -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
-      -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-      -D BUILD_DIR=${CMAKE_BINARY_DIR}
-      -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
       -D TEST_TYPE=unit
-      -D CIRRUS_CI=$ENV{CIRRUS_CI}
-      -D CI_BUILD=${CI_BUILD}
+      ${TEST_OPTIONS}
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
-    DEPENDS ${UNITTEST_PREREQS}
+    DEPENDS nvim
     USES_TERMINAL)
   add_dependencies(unittest lua-dev-deps)
 else()
@@ -38,32 +32,18 @@ configure_file(
 
 add_custom_target(functionaltest
   COMMAND ${CMAKE_COMMAND}
-    -D NVIM_PRG=$<TARGET_FILE:nvim>
-    -D WORKING_DIR=${PROJECT_SOURCE_DIR}
-    -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
-    -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-    -D BUILD_DIR=${CMAKE_BINARY_DIR}
-    -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
     -D TEST_TYPE=functional
-    -D CIRRUS_CI=$ENV{CIRRUS_CI}
-    -D CI_BUILD=${CI_BUILD}
+    ${TEST_OPTIONS}
     -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
-  DEPENDS ${FUNCTIONALTEST_PREREQS}
+  DEPENDS nvim printenv-test printargs-test shell-test pwsh-test streams-test tty-test ${GENERATED_HELP_TAGS}
   USES_TERMINAL)
 
 add_custom_target(benchmark
   COMMAND ${CMAKE_COMMAND}
-    -D NVIM_PRG=$<TARGET_FILE:nvim>
-    -D WORKING_DIR=${PROJECT_SOURCE_DIR}
-    -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
-    -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-    -D BUILD_DIR=${CMAKE_BINARY_DIR}
-    -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
     -D TEST_TYPE=benchmark
-    -D CIRRUS_CI=$ENV{CIRRUS_CI}
-    -D CI_BUILD=${CI_BUILD}
+    ${TEST_OPTIONS}
     -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
-  DEPENDS ${BENCHMARK_PREREQS}
+  DEPENDS nvim tty-test
   USES_TERMINAL)
 
 add_dependencies(functionaltest lua-dev-deps)


### PR DESCRIPTION
- add EXTERNALPROJECT_OPTIONS variable to main build
- use `REQUIRED` keyword for IWYU.
- remove check_c_compiler_flag checks when `ENABLE_COMPILER_SUGGESTIONS`
  is `ON`. If we explicitly enable it then we probably want it to give
  an error if it doesn't exist, rather than silently skip it.
- Move dependency interface libraries to their find module and use them
  as a pseudo-imported target.
- Remove BUSTED_OUTPUT_TYPE. It's not used and we can reintroduce it
  again if something similar is needed.
- Use LINK_OPTIONS intead of LINK_FLAGS when generating the `--version`
  output.