### PR TITLE
feat(treesitter): highlight help files by default

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -266,6 +266,7 @@ The following changes to existing APIs or features add new behavior.
       vim.g.query_lint_on = {}
 <
   • Enabled treesitter highlighting for treesitter query files.
+  • Enabled treesitter highlighting for help files.
 
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
   by default.

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -1,3 +1,7 @@
+-- use treesitter over syntax (for highlighted code blocks)
+vim.treesitter.start()
+
+-- add custom highlights for list in `:h highlight-groups`
 if vim.endswith(vim.fs.normalize(vim.api.nvim_buf_get_name(0)), '/doc/syntax.txt') then
   require('vim.vimhelp').highlight_groups()
 end

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -120,6 +120,8 @@ lang mess C
 
 " Nvim: append runtime from build dir, which contains the generated doc/tags.
 let &runtimepath ..= ',' .. expand($BUILD_DIR) .. '/runtime/'
+" Nvim: append libdir from build dir, which contains the bundled TS parsers.
+let &runtimepath ..= ',' .. expand($BUILD_DIR) .. '/lib/nvim/'
 
 let s:t_bold = &t_md
 let s:t_normal = &t_me


### PR DESCRIPTION
I think it's safe to enable this by default for 0.10 so everyone can appreciate our shiny syntax-highlighted code blocks.

**Question:** Do we want to provide an opt-out?