### PR TITLE
revert: "memory: Free buffers after freeing variables"

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2643,7 +2643,6 @@ int number_width(win_T *wp)
 /// Set must_redraw only if not already set to a higher value.
 /// e.g. if must_redraw is UPD_CLEAR, type UPD_NOT_VALID will do nothing.
 void redraw_later(win_T *wp, int type)
-  FUNC_ATTR_NONNULL_ALL
 {
   if (!exiting && wp->w_redr_type < type) {
     wp->w_redr_type = type;

--- a/test/functional/vimscript/eval_spec.lua
+++ b/test/functional/vimscript/eval_spec.lua
@@ -15,6 +15,7 @@ local Screen = require('test.functional.ui.screen')
 local mkdir = helpers.mkdir
 local clear = helpers.clear
 local eq = helpers.eq
+local exec = helpers.exec
 local exc_exec = helpers.exc_exec
 local exec_lua = helpers.exec_lua
 local exec_capture = helpers.exec_capture
@@ -28,6 +29,7 @@ local pcall_err = helpers.pcall_err
 local assert_alive = helpers.assert_alive
 local poke_eventloop = helpers.poke_eventloop
 local feed = helpers.feed
+local expect_exit = helpers.expect_exit
 
 describe('Up to MAX_FUNC_ARGS arguments are handled by', function()
   local max_func_args = 20  -- from eval.h
@@ -311,4 +313,15 @@ it('no double-free in garbage collection #16287', function()
   command('source Xgarbagecollect.vim')
   sleep(10)
   assert_alive()
+end)
+
+it('no heap-use-after-free with EXITFREE and partial as prompt callback', function()
+  clear()
+  exec([[
+    func PromptCallback(text)
+    endfunc
+    setlocal buftype=prompt
+    call prompt_setcallback('', funcref('PromptCallback'))
+  ]])
+  expect_exit(command, 'qall!')
 end)


### PR DESCRIPTION
This reverts commit fe30d8ccef17fff23676b8670dfec86444e2cb32.

The original commit intends to prevent heap-use-after-free with EXITFREE
caused by `changedtick_di`, which is no longer a problem.

Freeing buffers after freeing variables will cause heap-use-after-free
with EXITFREE when a partial is used as prompt callback.