### PR TITLE
fix(extmarks): restore old position before revalidating

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -389,15 +389,15 @@ void extmark_apply_undo(ExtmarkUndoObject undo_info, bool undo)
   } else if (undo_info.type == kExtmarkSavePos) {
     ExtmarkSavePos pos = undo_info.data.savepos;
     if (undo) {
+      if (pos.old_row >= 0) {
+        extmark_setraw(curbuf, pos.mark, pos.old_row, pos.old_col);
+      }
       if (pos.invalidated) {
         MarkTreeIter itr[1] = { 0 };
         MTKey mark = marktree_lookup(curbuf->b_marktree, pos.mark, itr);
         mt_itr_rawkey(itr).flags &= (uint16_t) ~MT_FLAG_INVALID;
         MTPos end = marktree_get_altpos(curbuf->b_marktree, mark, itr);
         buf_put_decor(curbuf, mt_decor(mark), mark.pos.row, end.row < 0 ? mark.pos.row : end.row);
-      }
-      if (pos.old_row >= 0) {
-        extmark_setraw(curbuf, pos.mark, pos.old_row, pos.old_col);
       }
       // Redo
     } else {

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1628,26 +1628,27 @@ describe('API/extmarks', function()
     screen = Screen.new(40, 6)
     screen:attach()
     feed('dd6iaaa bbb ccc<CR><ESC>gg')
-    set_extmark(ns, 1, 0, 0, { invalidate = true, sign_text = 'S1' })
-    set_extmark(ns, 2, 1, 0, { invalidate = true, sign_text = 'S2' })
+    meths.set_option_value('signcolumn', 'auto:2', {})
+    set_extmark(ns, 1, 0, 0, { invalidate = true, sign_text = 'S1', end_row = 1 })
+    set_extmark(ns, 2, 1, 0, { invalidate = true, sign_text = 'S2', end_row = 2 })
     -- mark with invalidate is removed
-    command('d')
+    command('d2')
     screen:expect([[
       S2^aaa bbb ccc                           |
         aaa bbb ccc                           |
         aaa bbb ccc                           |
         aaa bbb ccc                           |
-        aaa bbb ccc                           |
+                                              |
                                               |
     ]])
     -- mark is restored with undo_restore == true
     command('silent undo')
     screen:expect([[
-      S1^aaa bbb ccc                           |
-      S2aaa bbb ccc                           |
-        aaa bbb ccc                           |
-        aaa bbb ccc                           |
-        aaa bbb ccc                           |
+      S1  ^aaa bbb ccc                         |
+      S1S2aaa bbb ccc                         |
+      S2  aaa bbb ccc                         |
+          aaa bbb ccc                         |
+          aaa bbb ccc                         |
                                               |
     ]])
     -- mark is deleted with undo_restore == false


### PR DESCRIPTION
Problem:  Invalidated decor is put back in buffer with incorrect range.
Solution: Restore original mark position before revalidating and adding to buffer.