### PR TITLE
fix(change): update fold after on_bytes

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1839,11 +1839,11 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
     curwin->w_cursor.lnum = old_cursor.lnum + 1;
   }
   if (did_append) {
-    changed_lines(curbuf, curwin->w_cursor.lnum, 0, curwin->w_cursor.lnum, 1, true);
     // bail out and just get the final length of the line we just manipulated
     bcount_t extra = (bcount_t)strlen(ml_get(curwin->w_cursor.lnum));
     extmark_splice(curbuf, (int)curwin->w_cursor.lnum - 1, 0,
                    0, 0, 0, 1, 0, 1 + extra, kExtmarkUndo);
+    changed_lines(curbuf, curwin->w_cursor.lnum, 0, curwin->w_cursor.lnum, 1, true);
   }
   curbuf_splice_pending--;
 

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -418,7 +418,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
         -- meths.set_option_value('autoindent', true, {})
         feed 'Go'
         check_events {
-          { "test1", "bytes", 1, 4, 7, 0, 114, 0, 0, 0, 1, 0, 1 };
+          { "test1", "bytes", 1, 3, 7, 0, 114, 0, 0, 0, 1, 0, 1 };
         }
         feed '<cr>'
         check_events {
@@ -431,7 +431,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
         meths.set_option_value('autoindent', true, {})
         feed 'Go'
         check_events {
-          { "test1", "bytes", 1, 4, 7, 0, 114, 0, 0, 0, 1, 0, 5 };
+          { "test1", "bytes", 1, 3, 7, 0, 114, 0, 0, 0, 1, 0, 5 };
         }
         feed '<cr>'
         check_events {
@@ -476,7 +476,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
       feed 'ggo' -- goto first line to continue testing
       check_events {
-        { "test1", "bytes", 1, 6, 1, 0, 11, 0, 0, 0, 1, 0, 4 };
+        { "test1", "bytes", 1, 5, 1, 0, 11, 0, 0, 0, 1, 0, 4 };
       }
 
       feed '<CR>'


### PR DESCRIPTION
Problem:
With vim.treesitter.foldexpr, `o`-ing two lines above a folded region opens the fold. This does not happen with legacy foldexprs. For example, make a markdown file with the following text, enable treesitter fold, and follow the instruction in the text.

    put cursor on this line and type zoo<Esc>
    initially folded, revealed by zo
    # then this fold will be opened
    initially folded, revealed by o<Esc>

Analysis:
* `o` updates folds first (done in `changed_lines`), evaluating foldexpr, and then invokes `on_bytes` (done in `extmark_splice`).
* Treesitter fold allocates the foldinfo for added lines (`add_range`) on `on_bytes`.
* Therefore, when treesitter foldexpr is invoked while running `o`, it sees outdated foldinfo.

Solution:
`extmark_splice`, and then `changed_lines`. This seems to be the standard order in other places, e.g., `nvim_buf_set_lines`.