### PR TITLE
refactor(api): complete conversion from `Dictionary` to `Dict(opts)`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1006,7 +1006,7 @@ nvim_get_keymap({mode})                                    *nvim_get_keymap()*
         Array of |maparg()|-like dictionaries describing mappings. The
         "buffer" key is always zero.
 
-nvim_get_mark({name}, {opts})                                *nvim_get_mark()*
+nvim_get_mark({name}, {*opts})                               *nvim_get_mark()*
     Returns a `(row, col, buffer, buffername)` tuple representing the position
     of the uppercase/file named mark. "End of line" column position is
     returned as |v:maxcol| (big number). See |mark-motions|.
@@ -1204,7 +1204,7 @@ nvim_notify({msg}, {log_level}, {opts})                        *nvim_notify()*
       • {log_level}  The log level
       • {opts}       Reserved for future use.
 
-nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
+nvim_open_term({buffer}, {*opts})                           *nvim_open_term()*
     Open a terminal instance in a buffer
 
     By default (and currently the only option) the terminal will not be
@@ -1305,7 +1305,7 @@ nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
       • cpoptions
 
                                                 *nvim_select_popupmenu_item()*
-nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
+nvim_select_popupmenu_item({item}, {insert}, {finish}, {*opts})
     Selects an item in the completion popup menu.
 
     If neither |ins-completion| nor |cmdline-completion| popup menu is active
@@ -1878,7 +1878,7 @@ nvim_get_commands({*opts})                               *nvim_get_commands()*
     See also: ~
       • |nvim_get_all_options_info()|
 
-nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
+nvim_parse_cmd({str}, {*opts})                              *nvim_parse_cmd()*
     Parse command line.
 
     Doesn't check the validity of command arguments.
@@ -2057,7 +2057,7 @@ affected.
 You can use |nvim_buf_is_loaded()| or |nvim_buf_line_count()| to check
 whether a buffer is loaded.
 
-nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
+nvim_buf_attach({buffer}, {send_buffer}, {*opts})          *nvim_buf_attach()*
     Activates buffer-update events on a channel, or as Lua callbacks.
 
     Example (Lua): capture buffer updates in a global `events` variable (use
@@ -2193,7 +2193,7 @@ nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
       • {buffer}  Buffer handle, or 0 for current buffer
       • {name}    Variable name
 
-nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
+nvim_buf_delete({buffer}, {*opts})                         *nvim_buf_delete()*
     Deletes the buffer. See |:bwipeout|
 
     Attributes: ~
@@ -2310,7 +2310,7 @@ nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
 
                                                          *nvim_buf_get_text()*
 nvim_buf_get_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
-                  {opts})
+                  {*opts})
     Gets a range from the buffer.
 
     This differs from |nvim_buf_get_lines()| in that it allows retrieving only
@@ -2412,7 +2412,7 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
       • |nvim_buf_set_text()|
 
                                                          *nvim_buf_set_mark()*
-nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
+nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {*opts})
     Sets a named mark in the given buffer, all marks are allowed
     file/uppercase, visual, last change, etc. See |mark-motions|.
 
@@ -2553,7 +2553,7 @@ nvim_buf_del_extmark({buffer}, {ns_id}, {id})         *nvim_buf_del_extmark()*
         true if the extmark was found, else false
 
                                                 *nvim_buf_get_extmark_by_id()*
-nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {opts})
+nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {*opts})
     Gets the position (0-indexed) of an |extmark|.
 
     Parameters: ~

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -151,7 +151,7 @@ function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start
 ---                    `nvim_buf_lines_event`. Else the first notification
 ---                    will be `nvim_buf_changedtick_event`. Not for Lua
 ---                    callbacks.
---- @param opts table<string,function> Optional parameters.
+--- @param opts vim.api.keyset.buf_attach Optional parameters.
 ---                    • on_lines: Lua callback invoked on change. Return `true` to detach. Args:
 ---                      • the string "lines"
 ---                      • buffer handle
@@ -284,7 +284,7 @@ function vim.api.nvim_buf_del_var(buffer, name) end
 --- Deletes the buffer. See `:bwipeout`
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
---- @param opts table<string,any> Optional parameters. Keys:
+--- @param opts vim.api.keyset.buf_delete Optional parameters. Keys:
 ---               • force: Force deletion and ignore unsaved changes.
 ---               • unload: Unloaded only, do not delete. See `:bunload`
 function vim.api.nvim_buf_delete(buffer, opts) end
@@ -307,7 +307,7 @@ function vim.api.nvim_buf_get_commands(buffer, opts) end
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param ns_id integer Namespace id from `nvim_create_namespace()`
 --- @param id integer Extmark id
---- @param opts table<string,any> Optional parameters. Keys:
+--- @param opts vim.api.keyset.get_extmark Optional parameters. Keys:
 ---               • details: Whether to include the details dict
 ---               • hl_name: Whether to include highlight group name instead
 ---                 of id, true if omitted
@@ -440,7 +440,7 @@ function vim.api.nvim_buf_get_option(buffer, name) end
 --- @param start_col integer Starting column (byte offset) on first line
 --- @param end_row integer Last line index, inclusive
 --- @param end_col integer Ending column (byte offset) on last line, exclusive
---- @param opts table<string,any> Optional parameters. Currently unused.
+--- @param opts vim.api.keyset.empty Optional parameters. Currently unused.
 --- @return string[]
 function vim.api.nvim_buf_get_text(buffer, start_row, start_col, end_row, end_col, opts) end
 
@@ -626,7 +626,7 @@ function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replac
 --- @param name string Mark name
 --- @param line integer Line number
 --- @param col integer Column/row number
---- @param opts table<string,any> Optional parameters. Reserved for future use.
+--- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 --- @return boolean
 function vim.api.nvim_buf_set_mark(buffer, name, line, col, opts) end
 
@@ -675,7 +675,7 @@ function vim.api.nvim_buf_set_var(buffer, name, value) end
 --- @param src_id integer
 --- @param line integer
 --- @param chunks any[]
---- @param opts table<string,any>
+--- @param opts vim.api.keyset.empty
 --- @return integer
 function vim.api.nvim_buf_set_virtual_text(buffer, src_id, line, chunks, opts) end
 
@@ -1241,7 +1241,7 @@ function vim.api.nvim_get_keymap(mode) end
 --- Marks are (1,0)-indexed. `api-indexing`
 ---
 --- @param name string Mark name
---- @param opts table<string,any> Optional parameters. Reserved for future use.
+--- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 --- @return any[]
 function vim.api.nvim_get_mark(name, opts) end
 
@@ -1439,7 +1439,7 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- virtual terminal having the intended size.
 ---
 --- @param buffer integer the buffer to use (expected to be empty)
---- @param opts table<string,function> Optional parameters.
+--- @param opts vim.api.keyset.open_term Optional parameters.
 ---               • on_input: Lua callback for input sent, i e keypresses in
 ---                 terminal mode. Note: keypresses are sent raw as they would
 ---                 be to the pty master end. For instance, a carriage return
@@ -1602,7 +1602,7 @@ function vim.api.nvim_out_write(str) end
 --- Doesn't check the validity of command arguments.
 ---
 --- @param str string Command line string to parse. Cannot contain "\n".
---- @param opts table<string,any> Optional parameters. Reserved for future use.
+--- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 --- @return table<string,any>
 function vim.api.nvim_parse_cmd(str, opts) end
 
@@ -1685,7 +1685,7 @@ function vim.api.nvim_replace_termcodes(str, from_part, do_lt, special) end
 ---               inserted in the buffer. Ignored for `cmdline-completion`.
 --- @param finish boolean Finish the completion and dismiss the popup menu. Implies
 ---               {insert}.
---- @param opts table<string,any> Optional parameters. Reserved for future use.
+--- @param opts vim.api.keyset.empty Optional parameters. Reserved for future use.
 function vim.api.nvim_select_popupmenu_item(item, insert, finish, opts) end
 
 --- Sets the current buffer.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -3,6 +3,19 @@
 -- DO NOT EDIT
 error('Cannot require a meta file')
 
+--- @class vim.api.keyset.buf_attach
+--- @field on_lines? function
+--- @field on_bytes? function
+--- @field on_changedtick? function
+--- @field on_detach? function
+--- @field on_reload? function
+--- @field utf_sizes? boolean
+--- @field preview? boolean
+
+--- @class vim.api.keyset.buf_delete
+--- @field force? boolean
+--- @field unload? boolean
+
 --- @class vim.api.keyset.clear_autocmds
 --- @field buffer? integer
 --- @field event? any
@@ -74,6 +87,8 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.echo_opts
 --- @field verbose? boolean
 
+--- @class vim.api.keyset.empty
+
 --- @class vim.api.keyset.eval_statusline
 --- @field winid? integer
 --- @field maxwidth? integer
@@ -123,6 +138,10 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.get_commands
 --- @field builtin? boolean
+
+--- @class vim.api.keyset.get_extmark
+--- @field details? boolean
+--- @field hl_name? boolean
 
 --- @class vim.api.keyset.get_extmarks
 --- @field limit? integer
@@ -195,6 +214,9 @@ error('Cannot require a meta file')
 --- @field callback? function
 --- @field desc? string
 --- @field replace_keycodes? boolean
+
+--- @class vim.api.keyset.open_term
+--- @field on_input? function
 
 --- @class vim.api.keyset.option
 --- @field scope? string

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -94,14 +94,10 @@
 ///               - "belowright": |:belowright|.
 ///               - "topleft": |:topleft|.
 ///               - "botright": |:botright|.
-Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
+Dictionary nvim_parse_cmd(String str, Dict(empty) *opts, Error *err)
   FUNC_API_SINCE(10) FUNC_API_FAST
 {
   Dictionary result = ARRAY_DICT_INIT;
-
-  VALIDATE((opts.size == 0), "%s", "opts dict isn't empty", {
-    return result;
-  });
 
   // Parse command line
   exarg_T ea;

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -126,7 +126,7 @@ void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, 
 /// @param[out] err   Error details, if any
 /// @return The ns_id that was used
 Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, Array chunks,
-                                  Dictionary opts, Error *err)
+                                  Dict(empty) *opts, Error *err)
   FUNC_API_SINCE(5)
   FUNC_API_DEPRECATED_SINCE(8)
 {
@@ -137,11 +137,6 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
 
   if (line < 0 || line >= MAXLNUM) {
     api_set_error(err, kErrorTypeValidation, "Line number outside range");
-    return 0;
-  }
-
-  if (opts.size > 0) {
-    api_set_error(err, kErrorTypeValidation, "opts dict isn't empty");
     return 0;
   }
 

--- a/src/nvim/api/deprecated.h
+++ b/src/nvim/api/deprecated.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>  // IWYU pragma: keep
 
+#include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -187,7 +187,7 @@ static Array extmark_to_array(MTPair extmark, bool id, bool add_dict, bool hl_na
 /// @return 0-indexed (row, col) tuple or empty list () if extmark id was
 /// absent
 ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
-                                            Integer id, Dictionary opts,
+                                            Integer id, Dict(get_extmark) *opts,
                                             Error *err)
   FUNC_API_SINCE(7)
 {
@@ -203,27 +203,9 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
     return rv;
   });
 
-  bool details = false;
-  bool hl_name = true;
-  for (size_t i = 0; i < opts.size; i++) {
-    String k = opts.items[i].key;
-    Object *v = &opts.items[i].value;
-    if (strequal("details", k.data)) {
-      details = api_object_to_bool(*v, "details", false, err);
-      if (ERROR_SET(err)) {
-        return rv;
-      }
-    } else if (strequal("hl_name", k.data)) {
-      hl_name = api_object_to_bool(*v, "hl_name", false, err);
-      if (ERROR_SET(err)) {
-        return rv;
-      }
-    } else {
-      VALIDATE_S(false, "'opts' key", k.data, {
-        return rv;
-      });
-    }
-  }
+  bool details = opts->details;
+
+  bool hl_name = GET_BOOL_OR_TRUE(opts, get_extmark, hl_name);
 
   MTPair extmark = extmark_from_id(buf, (uint32_t)ns_id, (uint32_t)id);
   if (extmark.start.pos.row < 0) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -52,6 +52,12 @@ typedef struct {
 } Dict(set_extmark);
 
 typedef struct {
+  OptionalKeys is_set__get_extmark_;
+  Boolean details;
+  Boolean hl_name;
+} Dict(get_extmark);
+
+typedef struct {
   OptionalKeys is_set__get_extmarks_;
   Integer limit;
   Boolean details;
@@ -313,3 +319,29 @@ typedef struct {
 typedef struct {
   Boolean output;
 } Dict(exec_opts);
+
+typedef struct {
+  OptionalKeys is_set__buf_attach_;
+  LuaRef on_lines;
+  LuaRef on_bytes;
+  LuaRef on_changedtick;
+  LuaRef on_detach;
+  LuaRef on_reload;
+  Boolean utf_sizes;
+  Boolean preview;
+} Dict(buf_attach);
+
+typedef struct {
+  OptionalKeys is_set__buf_delete_;
+  Boolean force;
+  Boolean unload;
+} Dict(buf_delete);
+
+typedef struct {
+  OptionalKeys is_set__empty_;
+} Dict(empty);
+
+typedef struct {
+  OptionalKeys is_set__open_term_;
+  LuaRef on_input;
+} Dict(open_term);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -987,7 +987,7 @@ fail:
 ///                 ["input", term, bufnr, data]
 /// @param[out] err Error details, if any
 /// @return Channel id, or 0 on error
-Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
+Integer nvim_open_term(Buffer buffer, Dict(open_term) *opts, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
@@ -1002,19 +1002,10 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   }
 
   LuaRef cb = LUA_NOREF;
-  for (size_t i = 0; i < opts.size; i++) {
-    String k = opts.items[i].key;
-    Object *v = &opts.items[i].value;
-    if (strequal("on_input", k.data)) {
-      VALIDATE_T("on_input", kObjectTypeLuaRef, v->type, {
-        return 0;
-      });
-      cb = v->data.luaref;
-      v->data.luaref = LUA_NOREF;
-      break;
-    } else {
-      VALIDATE_S(false, "'opts' key", k.data, {});
-    }
+
+  if (HAS_KEY(opts, open_term, on_input)) {
+    cb = opts->on_input;
+    opts->on_input = LUA_NOREF;
   }
 
   TerminalOptions topts;
@@ -1940,14 +1931,10 @@ Object nvim_get_proc(Integer pid, Error *err)
 /// @param finish  Finish the completion and dismiss the popup menu. Implies {insert}.
 /// @param opts    Optional parameters. Reserved for future use.
 /// @param[out] err Error details, if any
-void nvim_select_popupmenu_item(Integer item, Boolean insert, Boolean finish, Dictionary opts,
+void nvim_select_popupmenu_item(Integer item, Boolean insert, Boolean finish, Dict(empty) *opts,
                                 Error *err)
   FUNC_API_SINCE(6)
 {
-  VALIDATE((opts.size == 0), "%s", "opts dict isn't empty", {
-    return;
-  });
-
   if (finish) {
     insert = true;
   }
@@ -2048,7 +2035,7 @@ Boolean nvim_del_mark(String name, Error *err)
 /// not set.
 /// @see |nvim_buf_set_mark()|
 /// @see |nvim_del_mark()|
-Array nvim_get_mark(String name, Dictionary opts, Error *err)
+Array nvim_get_mark(String name, Dict(empty) *opts, Error *err)
   FUNC_API_SINCE(8)
 {
   Array rv = ARRAY_DICT_INIT;

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -762,7 +762,7 @@ describe('API: buffer events:', function()
   it('returns a proper error on nonempty options dict', function()
     clear()
     local b = editoriginal(false)
-    eq("Invalid 'opts' key: 'builtin'", pcall_err(buffer, 'attach', b, false, {builtin="asfd"}))
+    eq("Invalid key: 'builtin'", pcall_err(buffer, 'attach', b, false, {builtin="asfd"}))
   end)
 
   it('nvim_buf_attach returns response after delay #8634', function()


### PR DESCRIPTION
### Problem

Most of the API functions accept optional arguments under a `Dict(<opts>) *opts` whose contents can be statically checked at compile time, *except* for a few functions that still take a `Dictionary opts`. These functions are:

- [x] `nvim_buf_attach`
- [x] `nvim_buf_delete`
- [x] `nvim_buf_get_extmark_by_id`
- [x] `nvim_buf_get_text`
- [x] `nvim_buf_set_mark`
- [x]  `nvim_buf_set_virtual_text`
- [x] `nvim_get_mark`
- [ ] `nvim_notify` (see https://github.com/neovim/neovim/pull/26365#discussion_r1414705427)
- [x] `nvim_open_term`
- [x] `nvim_parse_cmd`
- [x] `nvim_select_popupmenu_item`

### Solution

Refactor the remaining functions to accept `Dict(<opts>) *opts`.

cc @bfredl @lewis6991 