### PR TITLE
ci: fix mac release

### DIFF
--- a/.github/scripts/build_universal_macos.sh
+++ b/.github/scripts/build_universal_macos.sh
@@ -1,5 +1,29 @@
 #!/bin/bash -e
 
+# NOTE: the following code is deceptive as without it the mac release will work
+# on arm, but not on intel. Not only that, but it will only not work on intel
+# if gettext isn't already installed with homebrew.
+echo "Provision universal libintl"
+GETTEXT_PREFIX="$(brew --prefix gettext)"
+printf 'GETTEXT_PREFIX=%s\n' "$GETTEXT_PREFIX" >> $GITHUB_ENV
+bottle_tag="arm64_sonoma"
+brew fetch --bottle-tag="$bottle_tag" gettext
+cd "$(mktemp -d)"
+tar xf "$(brew --cache)"/**/*gettext*${bottle_tag}*.tar.gz
+lipo gettext/*/lib/libintl.a "${GETTEXT_PREFIX}/lib/libintl.a" -create -output libintl.a
+mv -f libintl.a /usr/local/lib/
+
+echo "Ensure static linkage to libintl"
+# We're about to mangle `gettext`, so let's remove any potentially broken
+# installs (e.g. curl, git) as those could interfere with our build.
+brew uninstall --ignore-dependencies $(brew uses --installed --recursive gettext)
+brew unlink gettext
+ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/bin"/* /usr/local/bin/
+ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/include"/* /usr/local/include/
+rm -f "$GETTEXT_PREFIX"
+
+echo "Build release"
+cd "$GITHUB_WORKSPACE"
 MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
 export MACOSX_DEPLOYMENT_TARGET
 cmake -S cmake.deps -B .deps -G Ninja \


### PR DESCRIPTION
Partially reverts commit 753adcc66cb2210e292e67500142f3d9f1b45543.

The gettext hack is needed for mac release to work on intel without
already having it installed in homebrew.