### PR TITLE
ci: disable libintl on mac release

### DIFF
--- a/.github/scripts/build_universal_macos.sh
+++ b/.github/scripts/build_universal_macos.sh
@@ -12,6 +12,7 @@ cmake -B build -G Ninja \
   -D CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
   -D CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
   -D CMAKE_OSX_ARCHITECTURES=arm64\;x86_64 \
+  -D ENABLE_LIBINTL=OFF \
   -D CMAKE_FIND_FRAMEWORK=NEVER
 cmake --build build
 # Make sure we build everything for M1 as well

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if (MINGW)
 else()
   option(ENABLE_LTO "enable link time optimization" ON)
 endif()
+option(ENABLE_LIBINTL "enable libintl" ON)
 
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -25,7 +25,6 @@ target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUV_INCLUDE_DIR})
 target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})
 
 find_package(Iconv REQUIRED)
-find_package(Libintl REQUIRED) # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
 find_package(Libuv 1.28.0 REQUIRED)
 find_package(Libvterm 0.3.3 REQUIRED)
 find_package(Lpeg REQUIRED)
@@ -35,13 +34,17 @@ find_package(Unibilium 2.0 REQUIRED)
 
 target_link_libraries(main_lib INTERFACE
   iconv
-  libintl
   libvterm
   lpeg
   msgpack
   treesitter
   unibilium)
 target_link_libraries(nlua0 PUBLIC lpeg)
+
+if(ENABLE_LIBINTL)
+  find_package(Libintl REQUIRED) # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
+  target_link_libraries(main_lib INTERFACE libintl)
+endif()
 
 target_compile_definitions(main_lib INTERFACE HAVE_UNIBILIUM)
 


### PR DESCRIPTION
The releases doesn't work on intel mac as libintl isn't available on the
system.
