### PR TITLE
vim-patch:9.0.2145: wrong scrolling in insert mode with smoothscroll

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2644,6 +2644,8 @@ int number_width(win_T *wp)
 /// e.g. if must_redraw is UPD_CLEAR, type UPD_NOT_VALID will do nothing.
 void redraw_later(win_T *wp, int type)
 {
+  // curwin may have been set to NULL when exiting
+  assert(wp != NULL || exiting);
   if (!exiting && wp->w_redr_type < type) {
     wp->w_redr_type = type;
     if (type >= UPD_NOT_VALID) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -444,8 +444,11 @@ static int insert_check(VimState *state)
   // is detected when the cursor column is smaller after inserting something.
   // Don't do this when the topline changed already, it has already been
   // adjusted (by insertchar() calling open_line())).
+  // Also don't do this when 'smoothscroll' is set, as the window should then
+  // be scrolled by screen lines.
   if (curbuf->b_mod_set
       && curwin->w_p_wrap
+      && !curwin->w_p_sms
       && !s->did_backspace
       && curwin->w_topline == s->old_topline
       && curwin->w_topfill == s->old_topfill) {

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1096,6 +1096,26 @@ describe('smoothscroll', function()
     ]])
   end)
 
+  it('works in Insert mode at bottom of window', function()
+    screen:try_resize(40, 9)
+    exec([[
+      call setline(1, repeat([repeat('A very long line ...', 10)], 5))
+      set wrap smoothscroll scrolloff=0
+    ]])
+    feed('Go123456789<CR>')
+    screen:expect([[
+      <<<ery long line ...A very long line ...|
+      A very long line ...A very long line ...|
+      A very long line ...A very long line ...|
+      A very long line ...A very long line ...|
+      A very long line ...A very long line ...|
+      A very long line ...A very long line ...|
+      123456789                               |
+      ^                                        |
+      -- INSERT --                            |
+    ]])
+  end)
+
   it('<<< marker shows with tabline, winbar and splits', function()
     screen:try_resize(40, 12)
     exec([[

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -923,7 +923,7 @@ func Test_smoothscroll_cursor_top()
       exe "norm G3\<C-E>k"
   END
   call writefile(lines, 'XSmoothScrollCursorTop', 'D')
-  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols:40})
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols: 40})
   call VerifyScreenDump(buf, 'Test_smoothscroll_cursor_top', {})
 
   call StopVimInTerminal(buf)
@@ -942,8 +942,23 @@ func Test_smoothscroll_crash()
       exe "norm! 0\<c-e>"
   END
   call writefile(lines, 'XSmoothScrollCrash', 'D')
-  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCrash', #{rows: 12, cols:40})
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCrash', #{rows: 12, cols: 40})
   call term_sendkeys(buf, "2\<C-E>\<C-L>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_insert_bottom()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, repeat([repeat('A very long line ...', 10)], 5))
+    set wrap smoothscroll scrolloff=0
+  END
+  call writefile(lines, 'XSmoothScrollInsertBottom', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInsertBottom', #{rows: 9, cols: 40})
+  call term_sendkeys(buf, "Go123456789\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_insert_bottom', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.2145: wrong scrolling in insert mode with smoothscroll

Problem:  Wrong scrolling in Insert mode with 'smoothscroll' at the
          bottom of the window.
Solution: Don't use set_topline() when 'smoothscroll' is set.

closes: vim/vim#13613

https://github.com/vim/vim/commit/5b4d1fcbf06757bae32a894871b9a649c84eba7f