### PR TITLE
fix(treesitter): don't forcefully open folds

### DIFF
--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -536,11 +536,14 @@ static int nlua_iconv(lua_State *lstate)
   return 1;
 }
 
-// Like 'zx' but don't call newFoldLevel()
+// Update foldlevels (e.g., by evaluating 'foldexpr') for all lines in the current window without
+// invoking other side effects. Unlike `zx`, it does not close manually opened folds and does not
+// open folds under the cursor.
 static int nlua_foldupdate(lua_State *lstate)
 {
   curwin->w_foldinvalid = true;  // recompute folds
-  foldOpenCursor();
+  foldUpdate(curwin, 1, (linenr_T)MAXLNUM);
+  curwin->w_foldinvalid = false;
 
   return 0;
 }


### PR DESCRIPTION
Problem:
When `vim._foldupdate()` is invoked inside a scheduled callback, the cursor may have moved to a line with a closed fold, e.g., after `dd` on the line that is one line above a folded region. Then it opens the fold, which is unnecessary and distracting. Legacy foldexprs do not have this issue.

Solution:
Don't explicitly open folds on cursor.

Note:
This doesn't completely prevent spurious opening of folds. That is due to bugs in treesitter foldexpr algorithm, which should be addressed separately.