### PR TITLE
vim-patch:9.0.2148: Vim does not detect pacman.log file

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1394,6 +1394,7 @@ local filename = {
   octaverc = 'octave',
   ['octave.conf'] = 'octave',
   opam = 'opam',
+  ['pacman.log'] = 'pacmanlog',
   ['/etc/pam.conf'] = 'pamconf',
   ['pam_env.conf'] = 'pamenv',
   ['.pam_environment'] = 'pamenv',

--- a/runtime/syntax/pacmanlog.vim
+++ b/runtime/syntax/pacmanlog.vim
@@ -1,0 +1,41 @@
+" Vim syntax file
+" Language: pacman.log
+" Maintainer: Ronan Pigott <ronan@rjp.ie>
+" Last Change: 2023 Dec 04
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn sync maxlines=1
+syn region pacmanlogMsg start='\S' end='$' keepend contains=pacmanlogTransaction,pacmanlogALPMMsg
+syn region pacmanlogTag start='\['hs=s+1 end='\]'he=e-1 keepend nextgroup=pacmanlogMsg
+syn region pacmanlogTime start='^\['hs=s+1 end='\]'he=e-1 keepend nextgroup=pacmanlogTag
+
+syn match pacmanlogPackageName '\v[a-z0-9@_+.-]+' contained skipwhite nextgroup=pacmanlogPackageVersion
+syn match pacmanlogPackageVersion '(.*)' contained
+
+syn match pacmanlogTransaction 'transaction \v(started|completed)$' contained
+syn match pacmanlogInstalled   '\v(re)?installed' contained nextgroup=pacmanlogPackageName
+syn match pacmanlogUpgraded    'upgraded'         contained nextgroup=pacmanlogPackageName
+syn match pacmanlogDowngraded  'downgraded'       contained nextgroup=pacmanlogPackageName
+syn match pacmanlogRemoved     'removed'          contained nextgroup=pacmanlogPackageName
+syn match pacmanlogWarning     'warning:.*$'      contained
+
+syn region pacmanlogALPMMsg start='\v(\[ALPM\] )@<=(transaction|(re)?installed|upgraded|downgraded|removed|warning)>' end='$' contained
+	\ contains=pacmanlogTransaction,pacmanlogInstalled,pacmanlogUpgraded,pacmanlogDowngraded,pacmanlogRemoved,pacmanlogWarning,pacmanlogPackageName,pacmanlogPackgeVersion
+
+hi def link pacmanlogTime String
+hi def link pacmanlogTag  Type
+
+hi def link pacmanlogTransaction Special
+hi def link pacmanlogInstalled   Identifier
+hi def link pacmanlogRemoved     Repeat
+hi def link pacmanlogUpgraded    pacmanlogInstalled
+hi def link pacmanlogDowngraded  pacmanlogRemoved
+hi def link pacmanlogWarning     WarningMsg
+
+hi def link pacmanlogPackageName    Normal
+hi def link pacmanlogPackageVersion Comment
+
+let b:current_syntax = "pacmanlog"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -471,6 +471,7 @@ func s:GetFilenameChecks() abort
     \ 'opl': ['file.OPL', 'file.OPl', 'file.OpL', 'file.Opl', 'file.oPL', 'file.oPl', 'file.opL', 'file.opl'],
     \ 'ora': ['file.ora'],
     \ 'org': ['file.org', 'file.org_archive'],
+    \ 'pacmanlog': ['pacman.log'],
     \ 'pamconf': ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],
     \ 'pamenv': ['/etc/security/pam_env.conf', '/home/user/.pam_environment', '.pam_environment', 'pam_env.conf'],
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],


### PR DESCRIPTION
Problem:  Vim does not detect pacman.log file
Solution: Detect pacmanlogs and add syntax highlighting

pacman.log is a filetype common to Arch Liux and related distributions.
Add some simple syntax highlighting for the pacmanlog filetype.

closes: vim/vim#13618

https://github.com/vim/vim/commit/1e5d66408ef85c750a5af03bbf5cc19b5de7a6bc

Co-authored-by: Ronan Pigott <ronan@rjp.ie>
