### PR TITLE
test: fileio_spec is unreliable/flaky

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -672,7 +672,7 @@ EXTERN bool must_redraw_pum INIT( = false);  // redraw pum. NB: must_redraw
 
 EXTERN bool need_highlight_changed INIT( = true);
 
-EXTERN FILE *scriptout INIT( = NULL);  ///< Stream to write script to.
+EXTERN FILE *scriptout INIT( = NULL);  ///< Write input to this file ("nvim -w").
 
 // Note that even when handling SIGINT, volatile is not necessary because the
 // callback is not called directly from the signal handlers.

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -149,9 +149,9 @@ end
 --- Retries for 1 second in case of filesystem delay.
 ---
 ---@param pat (string) Lua pattern to match lines in the log file
----@param logfile (string) Full path to log file (default=$NVIM_LOG_FILE)
----@param nrlines (number) Search up to this many log lines
----@param inverse (boolean) Assert that the pattern does NOT match.
+---@param logfile? (string) Full path to log file (default=$NVIM_LOG_FILE)
+---@param nrlines? (number) Search up to this many log lines
+---@param inverse? (boolean) Assert that the pattern does NOT match.
 function module.assert_log(pat, logfile, nrlines, inverse)
   logfile = logfile or os.getenv('NVIM_LOG_FILE') or '.nvimlog'
   assert(logfile ~= nil, 'no logfile')


### PR DESCRIPTION
## Problem:
CI sometimes fails. Something is triggering an extra `fsync()`.

    FAILED   test/functional/core/fileio_spec.lua @ 52: fileio fsync() codepaths #8304
    test/functional/core/fileio_spec.lua:87: Expected objects to be the same.
    Passed in:
    (number) 3
    Expected:
    (number) 2
    stack traceback:
            test/functional/core/fileio_spec.lua:87: in function <test/functional/core/fileio_spec.lua:52>

## Solution:
Relax the assertion to `fsync >= 2` instead of exactly 2.

(Note this is not a behavior change: the next assertion has always checked `fsync == 4`, it's just that the intermediate 3rd fsync was never explicitly asserted.)


