### PR TITLE
perf(column): keep track of number of lines that hold up the 'signcolumn'

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2189,7 +2189,6 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
       int cul_id = 0;
       int num_id = 0;
       linenr_T lnum = statuscol_lnum;
-      wp->w_scwidth = win_signcol_count(wp);
       decor_redraw_signs(wp, wp->w_buffer, lnum - 1, sattrs, &line_id, &cul_id, &num_id);
 
       statuscol.sattrs = sattrs;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -703,11 +703,10 @@ struct file_buffer {
                                 // may use a different synblock_T.
 
   struct {
-    int size;                   // last calculated number of sign columns
-    int max;                    // maximum value size is valid for.
-    linenr_T sentinel;          // a line number which is holding up the signcolumn
-    linenr_T invalid_top;       // first invalid line number that needs to be checked
-    linenr_T invalid_bot;       // last invalid line number that needs to be checked
+    int max;                         // maximum number of signs on a single line
+    int max_count;                   // number of lines with max number of signs
+    bool resized;                    // whether max changed at start of redraw
+    Map(int, SignRange) invalid[1];  // map of invalid ranges to be checked
   } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -67,18 +67,18 @@ void extmark_set(buf_T *buf, uint32_t ns_id, uint32_t *idp, int row, colnr_T col
       } else {
         assert(marktree_itr_valid(itr));
         if (old_mark.pos.row == row && old_mark.pos.col == col) {
+          // not paired: we can revise in place
           if (mt_decor_any(old_mark)) {
+            mt_itr_rawkey(itr).flags &= (uint16_t) ~MT_FLAG_DECOR_SIGNTEXT;
             buf_decor_remove(buf, row, row, mt_decor(old_mark), true);
           }
-
-          // not paired: we can revise in place
           mt_itr_rawkey(itr).flags &= (uint16_t) ~MT_FLAG_EXTERNAL_MASK;
           mt_itr_rawkey(itr).flags |= flags;
           mt_itr_rawkey(itr).decor_data = decor.data;
           goto revised;
         }
-        buf_decor_remove(buf, old_mark.pos.row, old_mark.pos.row, mt_decor(old_mark), true);
         marktree_del_itr(buf->b_marktree, itr, false);
+        buf_decor_remove(buf, old_mark.pos.row, old_mark.pos.row, mt_decor(old_mark), true);
       }
     } else {
       *ns = MAX(*ns, id);
@@ -513,20 +513,6 @@ void extmark_splice_impl(buf_T *buf, int start_row, colnr_T start_col, bcount_t 
     u_header_T *uhp = u_force_get_undo_header(buf);
     extmark_undo_vec_t *uvp = uhp ? &uhp->uh_extmark : NULL;
     extmark_splice_delete(buf, start_row, start_col, end_row, end_col, uvp, false, undo);
-  }
-
-  // Move the signcolumn sentinel line
-  if (buf->b_signs_with_text && buf->b_signcols.sentinel) {
-    linenr_T se_lnum = buf->b_signcols.sentinel;
-    if (se_lnum >= start_row) {
-      if (old_row != 0 && se_lnum > old_row + start_row) {
-        buf->b_signcols.sentinel += new_row - old_row;
-      } else if (new_row == 0) {
-        buf->b_signcols.sentinel = 0;
-      } else {
-        buf->b_signcols.sentinel += new_row;
-      }
-    }
   }
 
   marktree_splice(buf->b_marktree, (int32_t)start_row, start_col,

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -111,6 +111,9 @@ void mh_clear(MapHash *h)
 #define VAL_NAME(x) quasiquote(x, String)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
+#define VAL_NAME(x) quasiquote(x, SignRange)
+#include "nvim/map_value_impl.c.h"
+#undef VAL_NAME
 #undef KEY_NAME
 
 #define KEY_NAME(x) x##ptr_t

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -48,6 +48,7 @@ static const uint64_t value_init_uint64_t = 0;
 static const int64_t value_init_int64_t = 0;
 static const String value_init_String = STRING_INIT;
 static const ColorItem value_init_ColorItem = COLOR_ITEM_INITIALIZER;
+static const SignRange value_init_SignRange = SIGNRANGE_INIT;
 
 // layer 0: type non-specific code
 
@@ -150,6 +151,7 @@ KEY_DECLS(uint32_t)
 KEY_DECLS(String)
 KEY_DECLS(HlEntry)
 KEY_DECLS(ColorKey)
+KEY_DECLS(SignRange)
 
 MAP_DECLS(int, int)
 MAP_DECLS(int, ptr_t)
@@ -166,6 +168,7 @@ MAP_DECLS(uint32_t, uint32_t)
 MAP_DECLS(String, int)
 MAP_DECLS(int, String)
 MAP_DECLS(ColorKey, ColorItem)
+MAP_DECLS(int, SignRange)
 
 #define set_has(T, set, key) set_has_##T(set, key)
 #define set_put(T, set, key) set_put_##T(set, key, NULL)

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -760,7 +760,7 @@ int win_col_off(win_T *wp)
   return ((wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc != NUL)
           ? (number_width(wp) + (*wp->w_p_stc == NUL)) : 0)
          + ((cmdwin_type == 0 || wp != curwin) ? 0 : 1)
-         + win_fdccol_count(wp) + (win_signcol_count(wp) * SIGN_WIDTH);
+         + win_fdccol_count(wp) + (wp->w_scwidth * SIGN_WIDTH);
 }
 
 int curwin_col_off(void)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6172,20 +6172,6 @@ bool fish_like_shell(void)
   return strstr(path_tail(p_sh), "fish") != NULL;
 }
 
-/// Return the number of requested sign columns, based on current
-/// buffer signs and on user configuration.
-int win_signcol_count(win_T *wp)
-{
-  if (wp->w_minscwidth <= SCL_NO) {
-    return 0;
-  }
-
-  int needed_signcols = buf_signcols(wp->w_buffer, wp->w_maxscwidth);
-  int ret = MAX(wp->w_minscwidth, MIN(wp->w_maxscwidth, needed_signcols));
-  assert(ret <= SIGN_SHOW_MAX);
-  return ret;
-}
-
 /// Get window or buffer local options
 dict_T *get_winbuf_options(const int bufopt)
   FUNC_ATTR_WARN_UNUSED_RESULT

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2095,6 +2095,8 @@ const char *did_set_signcolumn(optset_T *args)
   if (check_signcolumn(win) != OK) {
     return e_invarg;
   }
+  int scwidth = win->w_minscwidth <= 0 ? 0 : MIN(win->w_maxscwidth, win->w_scwidth);
+  win->w_scwidth = MAX(win->w_minscwidth, scwidth);
   // When changing the 'signcolumn' to or from 'number', recompute the
   // width of the number column if 'number' or 'relativenumber' is set.
   if ((*oldval == 'n' && *(oldval + 1) == 'u') || win->w_minscwidth == SCL_NUM) {

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -761,7 +761,7 @@ int comp_textwidth(bool ff)
       textwidth -= 1;
     }
     textwidth -= win_fdccol_count(curwin);
-    textwidth -= win_signcol_count(curwin);
+    textwidth -= curwin->w_scwidth;
 
     if (curwin->w_p_nu || curwin->w_p_rnu) {
       textwidth -= 8;

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -48,3 +48,10 @@ typedef enum {
 #define TRISTATE_FROM_INT(val) ((val) == 0 ? kFalse : ((val) >= 1 ? kTrue : kNone))
 
 typedef int64_t OptInt;
+
+// Range entry for the "b_signcols.invalid" map in which the keys are the range start.
+typedef struct {
+  int end;  // End of the invalid range.
+  int add;  // Number of signs added in the invalid range, negative for deleted signs.
+} SignRange;
+#define SIGNRANGE_INIT { 0, 0 }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4644,7 +4644,6 @@ l5
       {2:~                                                 }|
                                                         |
     ]]}
-
   end)
 
   it('can add a single sign (with end row)', function()
@@ -4665,7 +4664,6 @@ l5
       {2:~                                                 }|
                                                         |
     ]]}
-
   end)
 
   it('can add a single sign and text highlight', function()
@@ -4707,7 +4705,6 @@ l5
       {2:~                                                 }|
                                                         |
     ]]}
-
   end)
 
   it('can add multiple signs (multiple extmarks)', function()
@@ -4867,7 +4864,6 @@ l5
       {2:~                                                 }|
                                                         |
     ]]}
-
   end)
 
   it('can add lots of signs', function()
@@ -4977,6 +4973,22 @@ l5
                           |
     ]]}
   end)
+
+  it('correct width when removing multiple signs from sentinel line', function()
+    screen:try_resize(20, 4)
+    insert(example_test3)
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1', end_row=3})
+    meths.buf_set_extmark(0, ns, 1, -1, {invalidate = true, sign_text='S2'})
+    meths.buf_set_extmark(0, ns, 1, -1, {invalidate = true, sign_text='S3'})
+    feed('2Gdd')
+
+    screen:expect{grid=[[
+      S1l1                |
+      S1^l3                |
+      S1l4                |
+                          |
+    ]]}
+  end)
 end)
 
 describe('decorations: virt_text', function()
@@ -5073,5 +5085,4 @@ describe('decorations: virt_text', function()
                                                         |
     ]]}
   end)
-
 end)


### PR DESCRIPTION
Problem:  The entire marktree needs to be traversed each time a sign is removed from the sentinel line.
Solution: Remove sentinel line and instead keep track of the number of lines that hold up the 'signcolumn' in "max_count". Adjust this number for added/removed signs, and set it to 0 when the maximum number of signs on a line changes. Only when "max_count" is decremented to 0 due to sign removal do we need to check the entire buffer.

Also replace "invalid_top" and "invalid_bot" with a map of invalid ranges, further reducing the number of lines to be checked.

Also improve tree traversal when counting the number of signs. Instead of looping over the to be checked range and counting the overlap for each row, keep track of the overlap in an array and add this to the count.