### PR TITLE
vim-patch:2103a56eab5a

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -485,7 +485,7 @@ SHIFTING LINES LEFT OR RIGHT				*shift-left-right*
 			lines to [indent] (default 0).
 
 							*:>*
-:[range]> [flags]	Shift {count} [range] lines one 'shiftwidth' right.
+:[range]> [flags]	Shift [range] lines one 'shiftwidth' right.
 			Repeat '>' for shifting multiple 'shiftwidth's.
 			See |ex-flags| for [flags].
 


### PR DESCRIPTION
#### vim-patch:2103a56eab5a

runtime(doc): remove non-existent parameter in shift-command (vim/vim#13626)

The variant with the {count} parameter is explained in the next item.

https://github.com/vim/vim/commit/2103a56eab5a935f3c14c6e0b1610ff16fc8678f

N/A patches:
vim-patch:9.0.2150: Using int for errbuflen in option funcs
vim-patch:3f7855a6123c

Co-authored-by: Roy Orbitson <Roy-Orbison@users.noreply.github.com>