### PR TITLE
test: 'nofsync' with deadly signal

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -438,7 +438,7 @@ function module.connect(file_or_address)
   return Session.new(stream)
 end
 
--- Starts a new global Nvim session.
+-- Starts (and returns) a new global Nvim session.
 --
 -- Parameters are interpreted as startup args, OR a map with these keys:
 --    args:       List: Args appended to the default `nvim_argv` set.
@@ -452,6 +452,7 @@ end
 --    clear{args={'-e'}, args_rm={'-i'}, env={TERM=term}}
 function module.clear(...)
   module.set_session(module.spawn_argv(false, ...))
+  return module.get_session()
 end
 
 -- same params as clear, but does returns the session instead
@@ -943,7 +944,7 @@ function module.add_builddir_to_rtp()
   module.command(string.format([[set rtp+=%s/runtime]], module.test_build_dir))
 end
 
--- Kill process with given pid
+-- Kill (reap) a process by PID.
 function module.os_kill(pid)
   return os.execute((is_os('win')
     and 'taskkill /f /t /pid '..pid..' > nul'

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -12,7 +12,7 @@ describe('screen', function()
     helpers.nvim_prog,
     '-u', 'NONE',
     '-i', 'NONE',
-    '-N',
+    '-n',
     '--cmd', 'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
     '--cmd', 'colorscheme vim',
     '--embed',


### PR DESCRIPTION
Problem:
The test for 'nofsync' swapfile preservation on a deadly signal, does not actually assert anything.

followup to 1fd29a28841dee3d25ff079eb24fc160eb02cb3c

Solution:
- Check that swapfile contents are present after getting SIGTERM. 
- TODO: this doesn't really verify that 'fsync' was called; it still passes with this patch:

```diff
diff --git a/src/nvim/main.c b/src/nvim/main.c
index 216e39f3e81c..7a635520401d 100644
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -838,7 +838,7 @@ void preserve_exit(const char *errmsg)
       if (errmsg != NULL) {
         os_errmsg("Vim: preserving files...\r\n");
       }
-      ml_sync_all(false, false, true);  // preserve all swap files
+      ml_sync_all(false, false, false);  // preserve all swap files
       break;
     }
   }
```

However it correctly fails with this patch, at least:

```diff
diff --git a/src/nvim/main.c b/src/nvim/main.c
index 216e39f3e81c..f2306c310ddc 100644
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -838,7 +838,6 @@ void preserve_exit(const char *errmsg)
       if (errmsg != NULL) {
         os_errmsg("Vim: preserving files...\r\n");
       }
-      ml_sync_all(false, false, true);  // preserve all swap files
       break;
     }
   }
```