### PR TITLE
refactor(options): remove SOPT type enums

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -400,7 +400,7 @@ int get_option_attrs(char *name)
   vimoption_T *opt = get_option(opt_idx);
 
   if (is_tty_option(opt->fullname)) {
-    return SOPT_STRING | SOPT_GLOBAL;
+    return SOPT_GLOBAL;
   }
 
   // Hidden option
@@ -409,14 +409,6 @@ int get_option_attrs(char *name)
   }
 
   int attrs = 0;
-
-  if (opt->flags & P_BOOL) {
-    attrs |= SOPT_BOOL;
-  } else if (opt->flags & P_NUM) {
-    attrs |= SOPT_NUM;
-  } else if (opt->flags & P_STRING) {
-    attrs |= SOPT_STRING;
-  }
 
   if (opt->indir == PV_NONE || (opt->indir & PV_BOTH)) {
     attrs |= SOPT_GLOBAL;

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -89,12 +89,9 @@ typedef enum {
 
 /// Return value from get_option_value_strict
 enum {
-  SOPT_BOOL   = 0x01,  ///< Boolean option
-  SOPT_NUM    = 0x02,  ///< Number option
-  SOPT_STRING = 0x04,  ///< String option
-  SOPT_GLOBAL = 0x08,  ///< Option has global value
-  SOPT_WIN    = 0x10,  ///< Option has window-local value
-  SOPT_BUF    = 0x20,  ///< Option has buffer-local value
+  SOPT_GLOBAL = 0x01,  ///< Option has global value
+  SOPT_WIN    = 0x02,  ///< Option has window-local value
+  SOPT_BUF    = 0x04,  ///< Option has buffer-local value
 };
 
 // OptVal helper macros.


### PR DESCRIPTION
Problem: SOPT type enums (`SOPT_NUM`, `SOPT_BOOL`, `SOPT_STRING`) are no longer used anywhere.

Solution: Remove them.