### PR TITLE
vim-patch:8.1.1583: set_ref_in_list() only sets ref in items

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4711,7 +4711,7 @@ bool set_ref_in_ht(hashtab_T *ht, int copyID, list_stack_T **list_stack)
 /// @param ht_stack      Used to add hashtabs to be marked. Can be NULL.
 ///
 /// @returns             true if setting references failed somehow.
-bool set_ref_in_list(list_T *l, int copyID, ht_stack_T **ht_stack)
+bool set_ref_in_list_items(list_T *l, int copyID, ht_stack_T **ht_stack)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   bool abort = false;
@@ -4788,7 +4788,7 @@ bool set_ref_in_item(typval_T *tv, int copyID, ht_stack_T **ht_stack, list_stack
       // Didn't see this list yet.
       ll->lv_copyID = copyID;
       if (list_stack == NULL) {
-        abort = set_ref_in_list(ll, copyID, ht_stack);
+        abort = set_ref_in_list_items(ll, copyID, ht_stack);
       } else {
         list_stack_T *const newitem = xmalloc(sizeof(list_stack_T));
         newitem->list = ll;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3818,7 +3818,7 @@ bool set_ref_in_previous_funccal(int copyID)
     fc->fc_copyID = copyID + 1;
     if (set_ref_in_ht(&fc->fc_l_vars.dv_hashtab, copyID + 1, NULL)
         || set_ref_in_ht(&fc->fc_l_avars.dv_hashtab, copyID + 1, NULL)
-        || set_ref_in_list(&fc->fc_l_varlist, copyID + 1, NULL)) {
+        || set_ref_in_list_items(&fc->fc_l_varlist, copyID + 1, NULL)) {
       return true;
     }
   }
@@ -3831,7 +3831,7 @@ static bool set_ref_in_funccal(funccall_T *fc, int copyID)
     fc->fc_copyID = copyID;
     if (set_ref_in_ht(&fc->fc_l_vars.dv_hashtab, copyID, NULL)
         || set_ref_in_ht(&fc->fc_l_avars.dv_hashtab, copyID, NULL)
-        || set_ref_in_list(&fc->fc_l_varlist, copyID, NULL)
+        || set_ref_in_list_items(&fc->fc_l_varlist, copyID, NULL)
         || set_ref_in_func(NULL, fc->fc_func, copyID)) {
       return true;
     }

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2604,7 +2604,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
       case VAR_LIST: {
         list_T *l = vartv.vval.v_list;
         int copyID = get_copyID();
-        if (!set_ref_in_list(l, copyID, NULL)
+        if (!set_ref_in_list_items(l, copyID, NULL)
             && copyID == l->lv_copyID) {
           tv_clear(&vartv);
           continue;


### PR DESCRIPTION
#### vim-patch:8.1.1583: set_ref_in_list() only sets ref in items

Problem:    Set_ref_in_list() only sets ref in items.
Solution:   Rename to set_ref_in_list_items() to avoid confusion.

https://github.com/vim/vim/commit/7be3ab25891fec711d8a2d9d242711a9155852b6

Omit set_ref_in_list() and set_ref_in_dict(): only used in popup window,
if_pyth and if_lua.

Co-authored-by: Bram Moolenaar <Bram@vim.org>