### PR TITLE
vim-patch:8.2.3695: confusing error for missing key

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3735,7 +3735,11 @@ static int eval_index_inner(typval_T *rettv, bool is_range, typval_T *var1, typv
     dictitem_T *const item = tv_dict_find(rettv->vval.v_dict, key, keylen);
 
     if (item == NULL && verbose) {
-      semsg(_(e_dictkey), key);
+      if (keylen > 0) {
+        semsg(_(e_dictkey_len), keylen, key);
+      } else {
+        semsg(_(e_dictkey), key);
+      }
     }
     if (item == NULL || tv_is_luafunc(&item->di_tv)) {
       return FAIL;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -887,6 +887,7 @@ EXTERN const char e_invalblob[] INIT(= N_("E978: Invalid operation for Blob"));
 EXTERN const char e_toomanyarg[] INIT(= N_("E118: Too many arguments for function: %s"));
 EXTERN const char e_toofewarg[] INIT(= N_("E119: Not enough arguments for function: %s"));
 EXTERN const char e_dictkey[] INIT(= N_("E716: Key not present in Dictionary: \"%s\""));
+EXTERN const char e_dictkey_len[] INIT(= N_("E716: Key not present in Dictionary: \"%.*s\""));
 EXTERN const char e_listreq[] INIT(= N_("E714: List required"));
 EXTERN const char e_listblobreq[] INIT(= N_("E897: List or Blob required"));
 EXTERN const char e_listdictarg[] INIT(= N_("E712: Argument of %s must be a List or Dictionary"));

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -115,7 +115,7 @@ lua_State *get_global_lstate(void)
 /// Convert lua error into a Vim error message
 ///
 /// @param  lstate  Lua interpreter state.
-/// @param[in]  msg  Message base, must contain one `%*s`.
+/// @param[in]  msg  Message base, must contain one `%.*s`.
 void nlua_error(lua_State *const lstate, const char *const msg)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -456,6 +456,25 @@ func Test_dict_func_remove()
   call CheckLegacyAndVim9Failure(lines, 'E716:')
 
   let lines =<< trim END
+      let d = {'a-b': 55}
+      echo d.a-b
+  END
+  call CheckScriptFailure(lines, 'E716: Key not present in Dictionary: "a"')
+
+  let lines =<< trim END
+      vim9script
+      var d = {'a-b': 55}
+      echo d.a-b
+  END
+  call CheckScriptFailure(lines, 'E716: Key not present in Dictionary: "a"')
+
+  let lines =<< trim END
+      var d = {'a-b': 55}
+      echo d.a-b
+  END
+  call CheckDefFailure(lines, 'E1004: White space required before and after ''-''')
+
+  let lines =<< trim END
       let d = {1: 'a', 3: 'c'}
       call remove(d, [])
   END


### PR DESCRIPTION
#### vim-patch:8.2.3695: confusing error for missing key

Problem:    Confusing error for missing key.
Solution:   Use the actualy key for the error.

https://github.com/vim/vim/commit/5c1ec439f0a69e9aa7ece9bbb7d916f48f58be1e

Co-authored-by: Bram Moolenaar <Bram@vim.org>