### PR TITLE
refactor(options): split `get_option_value()` into smaller functions

### DIFF
--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -138,7 +138,7 @@ bool ctx_restore(Context *ctx, const int flags)
     free_ctx = true;
   }
 
-  OptVal op_shada = get_option_value("shada", NULL, OPT_GLOBAL, NULL);
+  OptVal op_shada = get_option_value(findoption("shada"), OPT_GLOBAL);
   set_option_value("shada", STATIC_CSTR_AS_OPTVAL("!,'100,%"), OPT_GLOBAL);
 
   if (flags & kCtxRegs) {

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -773,11 +773,14 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
   const char c1 = *p;
   *p = NUL;
 
-  uint32_t opt_p_flags;
-  bool hidden;
-  OptVal curval = get_option_value(arg, &opt_p_flags, scope, &hidden);
+  bool is_tty_opt = is_tty_option(arg);
+  int opt_idx = is_tty_opt ? -1 : findoption(arg);
+  uint32_t opt_p_flags = get_option_flags(opt_idx);
+  bool hidden = is_option_hidden(opt_idx);
+  OptVal curval = is_tty_opt ? get_tty_option(arg) : get_option_value(opt_idx, scope);
   OptVal newval = NIL_OPTVAL;
-  if (curval.type == kOptValTypeNil && arg[0] != 't' && arg[1] != '_') {
+
+  if (curval.type == kOptValTypeNil) {
     semsg(_(e_unknown_option2), arg);
     goto theend;
   }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3218,7 +3218,7 @@ void ex_spelldump(exarg_T *eap)
   if (no_spell_checking(curwin)) {
     return;
   }
-  OptVal spl = get_option_value("spl", NULL, OPT_LOCAL, NULL);
+  OptVal spl = get_option_value(findoption("spl"), OPT_LOCAL);
 
   // Create a new empty buffer in a new window.
   do_cmdline_cmd("new");


### PR DESCRIPTION
Problem: Currently, `get_option_value()` returns 3 separate things: The actual value of the option, whether the option is hidden, and the option flags. This makes the function difficult to refactor, modify or otherwise reason about.

Solution: Split `get_option_value()` into 3 functions, each with a single purpose. This also affects `get_option_value_for()`.