### PR TITLE
fix(tui): use uv_timer_t instead of TimeWatcher for input

### DIFF
--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -6,7 +6,6 @@
 
 #include "nvim/event/loop.h"
 #include "nvim/event/stream.h"
-#include "nvim/event/time.h"
 #include "nvim/rbuffer_defs.h"
 #include "nvim/tui/input_defs.h"  // IWYU pragma: export
 #include "nvim/tui/tui.h"
@@ -33,7 +32,7 @@ typedef struct {
   OptInt ttimeoutlen;
   TermKey *tk;
   TermKey_Terminfo_Getstr_Hook *tk_ti_hook_fn;  ///< libtermkey terminfo hook
-  TimeWatcher timer_handle;
+  uv_timer_t timer_handle;
   Loop *loop;
   Stream read_stream;
   RBuffer *key_buffer;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -170,8 +170,7 @@ void tui_start(TUIData **tui_p, int *width, int *height, char **term, bool *rgb)
 
   uv_timer_init(&tui->loop->uv, &tui->startup_delay_timer);
   tui->startup_delay_timer.data = tui;
-  uv_timer_start(&tui->startup_delay_timer, after_startup_cb,
-                 100, 0);
+  uv_timer_start(&tui->startup_delay_timer, after_startup_cb, 100, 0);
 
   *tui_p = tui;
   loop_poll_events(&main_loop, 1);


### PR DESCRIPTION
Avoid scheduling on main loop.
Fix #26425
