### PR TITLE
test: set 'termguicolors' in outer Nvim instance

### DIFF
--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -28,17 +28,18 @@ module.nvim_prog = (
 )
 -- Default settings for the test session.
 module.nvim_set = (
-  'set shortmess+=IS background=light noswapfile noautoindent startofline'
+  'set shortmess+=IS background=light termguicolors noswapfile noautoindent startofline'
   ..' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
-  ..' belloff= wildoptions-=pum joinspaces noshowcmd noruler nomore redrawdebug=invalid'
-  ..' notermguicolors')
+  ..' belloff= wildoptions-=pum joinspaces noshowcmd noruler nomore redrawdebug=invalid')
 module.nvim_argv = {
   module.nvim_prog, '-u', 'NONE', '-i', 'NONE',
   -- XXX: find treesitter parsers.
   '--cmd', runtime_set,
   '--cmd', module.nvim_set,
-  '--cmd', 'mapclear',
-  '--cmd', 'mapclear!',
+  -- Remove default mappings.
+  '--cmd', 'mapclear | mapclear!',
+  -- Unset $COLORTERM so that it won't propagate to :terminal when 'notermguicolors'.
+  '--cmd', 'unlet $COLORTERM',
   -- Make screentest work after changing to the new default color scheme
   -- Source 'vim' color scheme without side effects
   -- TODO: rewrite tests

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -15,7 +15,7 @@ describe('api', function()
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', helpers.nvim_set,
+      '--cmd', helpers.nvim_set .. ' notermguicolors',
     })
   end)
   after_each(function()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -143,7 +143,7 @@ it(':terminal highlight has lower precedence than editor #9964', function()
   screen:attach({rgb=true})
   -- Child nvim process in :terminal (with cterm colors).
   funcs.termopen({
-    nvim_prog_abs(), '-n', '-u', 'NORC', '-i', 'NONE', '--cmd', nvim_set,
+    nvim_prog_abs(), '-n', '-u', 'NORC', '-i', 'NONE', '--cmd', nvim_set .. ' notermguicolors',
     '+hi Normal ctermfg=Blue ctermbg=Yellow',
     '+norm! ichild nvim',
     '+norm! oline 2',

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -43,7 +43,7 @@ describe('TUI', function()
       '--listen', child_server,
       '-u', 'NONE',
       '-i', 'NONE',
-      '--cmd', string.format('%s laststatus=2 background=dark', nvim_set),
+      '--cmd', nvim_set .. ' notermguicolors laststatus=2 background=dark',
       '--cmd', 'colorscheme vim'
     })
     screen:expect([[
@@ -2213,11 +2213,13 @@ describe("TUI 't_Co' (terminal colors)", function()
 
   local function assert_term_colors(term, colorterm, maxcolors)
     clear({env={TERM=term}, args={}})
+    -- Allow overriding $COLORTERM in :terminal
+    command('set notermguicolors')
     screen = thelpers.setup_child_nvim({
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', nvim_set,
+      '--cmd', nvim_set .. ' notermguicolors',
     }, {
       env = {
         LANG = 'C',
@@ -2495,7 +2497,7 @@ describe("TUI 'term' option", function()
     screen = thelpers.setup_child_nvim({
       '-u', 'NONE',
       '-i', 'NONE',
-      '--cmd', nvim_set,
+      '--cmd', nvim_set .. ' notermguicolors',
     }, {
       env = {
         LANG = 'C',
@@ -2555,7 +2557,7 @@ describe("TUI", function()
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', nvim_set,
+      '--cmd', nvim_set .. ' notermguicolors',
       extra_args,
     }, {
       env = {
@@ -2753,7 +2755,7 @@ describe("TUI as a client", function()
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', string.format('%s laststatus=2 background=dark', nvim_set),
+      '--cmd', nvim_set .. ' notermguicolors laststatus=2 background=dark',
     })
 
     feed_data("iHello, World")
@@ -2819,6 +2821,7 @@ describe("TUI as a client", function()
     set_session(server)
     local server_pipe = meths.get_vvar('servername')
     server:request('nvim_input', 'iHalloj!<Esc>')
+    server:request('nvim_command', 'set notermguicolors')
 
     set_session(client_super)
     local screen_client = thelpers.setup_child_nvim({
@@ -2887,7 +2890,7 @@ describe("TUI as a client", function()
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', string.format('%s laststatus=2 background=dark', nvim_set),
+      '--cmd', nvim_set .. ' notermguicolors laststatus=2 background=dark',
     })
     screen_server:expect{grid=[[
       {1: }                                                 |

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -9,7 +9,7 @@ local eval = helpers.eval
 describe('UI receives option updates', function()
   local screen
 
-  local function reset(opts, ...)
+  local function reset(screen_opts, clear_opts)
     local defaults = {
       ambiwidth='single',
       arabicshape=true,
@@ -38,9 +38,12 @@ describe('UI receives option updates', function()
       ext_termcolors=false,
     }
 
-    clear(...)
+    clear_opts = shallowcopy(clear_opts or {})
+    clear_opts.args_rm = clear_opts.args_rm or {}
+    table.insert(clear_opts.args_rm or {}, '--cmd')
+    clear(clear_opts)
     screen = Screen.new(20,5)
-    screen:attach(opts)
+    screen:attach(screen_opts)
     -- NB: UI test suite can be run in both "linegrid" and legacy grid mode.
     -- In both cases check that the received value is the one requested.
     defaults.ext_linegrid = screen._options.ext_linegrid or false

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -25,7 +25,7 @@ describe("shell command :!", function()
       '-u', 'NONE',
       '-i', 'NONE',
       '--cmd', 'colorscheme vim',
-      '--cmd', helpers.nvim_set,
+      '--cmd', helpers.nvim_set .. ' notermguicolors',
     })
     screen:expect([[
       {1: }                                                 |


### PR DESCRIPTION
Currently, the value of $COLORTERM in :terminal in tests depends on
outer environment because of 'notermguicolors'.

If $COLORTERM is not set in :terminal, an inner Nvim instance will try
to detect 'termguicolors' support, which may interfere with tests.

So set 'termguicolors' in outer Nvim instance unless $COLORTERM needs to
be overridden, and unset it in inner Nvim instance when running TUI.