### PR TITLE
fix(log): increase size of buffer for nvim instance name

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -295,7 +295,7 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
   FUNC_ATTR_PRINTF(7, 0)
 {
   // Name of the Nvim instance that produced the log.
-  static char name[16] = { 0 };
+  static char name[32] = { 0 };
 
   static const char *log_levels[] = {
     [LOGLVL_DBG] = "DBG",


### PR DESCRIPTION
16 bytes is not enough room for existing usage of the buffer by the
tests, so the name may get truncated and cause log_spec test to fail:

    FAILED   test/functional/core/log_spec.lua @ 30: log messages are formatted with name or test id
    test/helpers.lua:146: retry() attempts: 51
    test/helpers.lua:155: Pattern "%.%d+%.%d/c +server_init:%d+: test log message" not found in log (last 100 lines): Xtest_logging:
        ERR 2023-11-24T23:36:34.252 T1274.2445945.0 server_init:57: test log message
        ERR 2023-11-24T23:36:34.275 T1274.2445945.0 server_init:57: test log message