### PR TITLE
fix(terminal): never propagate $COLORTERM from outer env

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3898,12 +3898,13 @@ static void f_jobresize(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_number = 1;
 }
 
-static const char *ignored_env_vars[] = {
+static const char *pty_ignored_env_vars[] = {
 #ifndef MSWIN
   "COLUMNS",
   "LINES",
   "TERMCAP",
   "COLORFGBG",
+  "COLORTERM",
 #endif
   NULL
 };
@@ -3943,9 +3944,9 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
       // child process.  We're removing them here so the user can still decide
       // they want to explicitly set them.
       for (size_t i = 0;
-           i < ARRAY_SIZE(ignored_env_vars) && ignored_env_vars[i];
+           i < ARRAY_SIZE(pty_ignored_env_vars) && pty_ignored_env_vars[i];
            i++) {
-        dictitem_T *dv = tv_dict_find(env, ignored_env_vars[i], -1);
+        dictitem_T *dv = tv_dict_find(env, pty_ignored_env_vars[i], -1);
         if (dv) {
           tv_dict_item_remove(env, dv);
         }
@@ -3953,10 +3954,6 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
 #ifndef MSWIN
       // Set COLORTERM to "truecolor" if termguicolors is set
       if (p_tgc) {
-        dictitem_T *dv = tv_dict_find(env, S_LEN("COLORTERM"));
-        if (dv) {
-          tv_dict_item_remove(env, dv);
-        }
         tv_dict_add_str(env, S_LEN("COLORTERM"), "truecolor");
       }
 #endif

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -38,8 +38,6 @@ module.nvim_argv = {
   '--cmd', module.nvim_set,
   -- Remove default mappings.
   '--cmd', 'mapclear | mapclear!',
-  -- Unset $COLORTERM so that it won't propagate to :terminal when 'notermguicolors'.
-  '--cmd', 'unlet $COLORTERM',
   -- Make screentest work after changing to the new default color scheme
   -- Source 'vim' color scheme without side effects
   -- TODO: rewrite tests

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2213,8 +2213,6 @@ describe("TUI 't_Co' (terminal colors)", function()
 
   local function assert_term_colors(term, colorterm, maxcolors)
     clear({env={TERM=term}, args={}})
-    -- Allow overriding $COLORTERM in :terminal
-    command('set notermguicolors')
     screen = thelpers.setup_child_nvim({
       '-u', 'NONE',
       '-i', 'NONE',


### PR DESCRIPTION
If $COLORTERM is "truecolor" but the user sets 'notermguicolors',
propagating $COLORTERM to :terminal usually doesn't work well.
