### PR TITLE
fix(inccommand): save and restore '[ and '] marks

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -152,6 +152,8 @@ typedef struct cmdpreview_buf_info {
   buf_T *buf;
   OptInt save_b_p_ul;
   int save_b_changed;
+  pos_T save_b_op_start;
+  pos_T save_b_op_end;
   varnumber_T save_changedtick;
   CpUndoInfo undo_info;
 } CpBufInfo;
@@ -2360,6 +2362,8 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
       cp_bufinfo.buf = buf;
       cp_bufinfo.save_b_p_ul = buf->b_p_ul;
       cp_bufinfo.save_b_changed = buf->b_changed;
+      cp_bufinfo.save_b_op_start = buf->b_op_start;
+      cp_bufinfo.save_b_op_end = buf->b_op_end;
       cp_bufinfo.save_changedtick = buf_get_changedtick(buf);
       cmdpreview_save_undo(&cp_bufinfo.undo_info, buf);
       kv_push(cpinfo->buf_info, cp_bufinfo);
@@ -2437,6 +2441,9 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
 
     u_blockfree(buf);
     cmdpreview_restore_undo(&cp_bufinfo.undo_info, buf);
+
+    buf->b_op_start = cp_bufinfo.save_b_op_start;
+    buf->b_op_end = cp_bufinfo.save_b_op_end;
 
     if (cp_bufinfo.save_changedtick != buf_get_changedtick(buf)) {
       buf_set_changedtick(buf, cp_bufinfo.save_changedtick);

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -8,6 +8,7 @@ local feed_command = helpers.feed_command
 local expect = helpers.expect
 local feed = helpers.feed
 local insert = helpers.insert
+local funcs = helpers.funcs
 local meths = helpers.meths
 local neq = helpers.neq
 local ok = helpers.ok
@@ -151,6 +152,29 @@ describe(":substitute, 'inccommand' preserves", function()
       {13:Press ENTER or type command to}|
       {13: continue}^                     |
     ]])
+  end)
+
+  it("'[ and '] marks #26439", function()
+    local screen = Screen.new(30, 10)
+    common_setup(screen, 'nosplit', ('abc\ndef\n'):rep(50))
+
+    feed('ggyG')
+    local X = meths.get_vvar('maxcol')
+    eq({0, 1, 1, 0}, funcs.getpos("'["))
+    eq({0, 101, X, 0}, funcs.getpos("']"))
+
+    feed(":'[,']s/def/")
+    poke_eventloop()
+    eq({0, 1, 1, 0}, funcs.getpos("'["))
+    eq({0, 101, X, 0}, funcs.getpos("']"))
+
+    feed('DEF/g')
+    poke_eventloop()
+    eq({0, 1, 1, 0}, funcs.getpos("'["))
+    eq({0, 101, X, 0}, funcs.getpos("']"))
+
+    feed('<CR>')
+    expect(('abc\nDEF\n'):rep(50))
   end)
 
   for _, case in pairs{"", "split", "nosplit"} do


### PR DESCRIPTION
Undoing a change moves `'[` and `']` marks, so it is necessary to save and restore them.

Fix #26439
