### PR TITLE
docs: clarify on_bytes arguments

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2099,11 +2099,15 @@ nvim_buf_attach({buffer}, {send_buffer}, {*opts})          *nvim_buf_attach()*
                          • start column of the changed text
                          • byte offset of the changed text (from the start of
                            the buffer)
-                         • old end row of the changed text
-                         • old end column of the changed text
+                         • old end row of the changed text (offset from start
+                           row)
+                         • old end column of the changed text (if old end row
+                           = 0, offset from start column)
                          • old end byte length of the changed text
-                         • new end row of the changed text
-                         • new end column of the changed text
+                         • new end row of the changed text (offset from start
+                           row)
+                         • new end column of the changed text (if new end row
+                           = 0, offset from start column)
                          • new end byte length of the changed text
 
                        • on_changedtick: Lua callback invoked on changedtick

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -173,11 +173,15 @@ function vim.api.nvim_buf_add_highlight(buffer, ns_id, hl_group, line, col_start
 ---                      • start column of the changed text
 ---                      • byte offset of the changed text (from the start of
 ---                        the buffer)
----                      • old end row of the changed text
----                      • old end column of the changed text
+---                      • old end row of the changed text (offset from start
+---                        row)
+---                      • old end column of the changed text (if old end row
+---                        = 0, offset from start column)
 ---                      • old end byte length of the changed text
----                      • new end row of the changed text
----                      • new end column of the changed text
+---                      • new end row of the changed text (offset from start
+---                        row)
+---                      • new end column of the changed text (if new end row
+---                        = 0, offset from start column)
 ---                      • new end byte length of the changed text
 ---
 ---                    • on_changedtick: Lua callback invoked on changedtick

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -127,11 +127,13 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 ///               - start column of the changed text
 ///               - byte offset of the changed text (from the start of
 ///                   the buffer)
-///               - old end row of the changed text
+///               - old end row of the changed text (offset from start row)
 ///               - old end column of the changed text
+///                 (if old end row = 0, offset from start column)
 ///               - old end byte length of the changed text
-///               - new end row of the changed text
+///               - new end row of the changed text (offset from start row)
 ///               - new end column of the changed text
+///                 (if new end row = 0, offset from start column)
 ///               - new end byte length of the changed text
 ///             - on_changedtick: Lua callback invoked on changedtick
 ///               increment without text change. Args:


### PR DESCRIPTION
I found it surprising that the end row/columns are not absolute indices. Fixed the documentation based on the comment from `extmark_splice()`.