### PR TITLE
ci: remove python workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,13 +127,6 @@ jobs:
       - name: Create log dir
         run: mkdir -p "$LOG_DIR"
 
-      # FIXME(dundargoc): this workaround is needed for macos as the python3
-      # provider tests suddenly started to become extremely flaky, and this
-      # removes the flakiness for some reason.
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
       - if: ${{ matrix.test != 'unittest' }}
         name: Set up interpreter packages
         run: |


### PR DESCRIPTION
The provider tests seems to work now without this workaround.