### PR TITLE
fix(terminal): ignore $VIM and $VIMRUNTIME in pty jobs

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3903,6 +3903,8 @@ static const char *pty_ignored_env_vars[] = {
   "COLORFGBG",
   "COLORTERM",
 #endif
+  "VIM",
+  "VIMRUNTIME",
   NULL
 };
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -866,7 +866,11 @@ describe('user config init', function()
 
         local screen = Screen.new(50, 8)
         screen:attach()
-        funcs.termopen({nvim_prog})
+        funcs.termopen({nvim_prog}, {
+          env = {
+            VIMRUNTIME = os.getenv('VIMRUNTIME'),
+          },
+        })
         screen:expect({ any = pesc('[i]gnore, (v)iew, (d)eny, (a)llow:') })
         -- `i` to enter Terminal mode, `a` to allow
         feed('ia')

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -127,7 +127,13 @@ end
 local function setup_child_nvim(args, opts)
   opts = opts or {}
   local argv = { nvim_prog, unpack(args) }
-  return screen_setup(0, argv, opts.cols, opts.env)
+
+  local env = opts.env or {}
+  if not env.VIMRUNTIME then
+    env.VIMRUNTIME = os.getenv('VIMRUNTIME')
+  end
+
+  return screen_setup(0, argv, opts.cols, env)
 end
 
 return {

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -147,6 +147,10 @@ it(':terminal highlight has lower precedence than editor #9964', function()
     '+hi Normal ctermfg=Blue ctermbg=Yellow',
     '+norm! ichild nvim',
     '+norm! oline 2',
+  }, {
+    env = {
+      VIMRUNTIME = os.getenv('VIMRUNTIME'),
+    },
   })
   screen:expect([[
     {N_child:^child nvim                    }|

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -376,6 +376,19 @@ function module.is_os(s)
   )
 end
 
+function module.is_arch(s)
+  local machine = luv.os_uname().machine
+  if s == 'arm64' or s == 'aarch64' then
+    return machine == 'arm64' or machine == 'aarch64'
+  end
+
+  if s == 'x86' or s == 'x86_64' or s == 'amd64' then
+    return machine == 'x86_64'
+  end
+
+  return machine == s
+end
+
 local function tmpdir_get()
   return os.getenv('TMPDIR') and os.getenv('TMPDIR') or os.getenv('TEMP')
 end

--- a/test/old/testdir/runnvim.vim
+++ b/test/old/testdir/runnvim.vim
@@ -7,6 +7,8 @@ function s:logger.on_exit(id, data, event)
   call add(self.d_events, [a:event, ['']])
 endfunction
 
+let s:logger.env = #{VIMRUNTIME: $VIMRUNTIME}
+
 " Replace non-printable chars by special sequence, or "<%x>".
 let s:escaped_char = {"\n": '\n', "\r": '\r', "\t": '\t'}
 function! s:escape_non_printable(char) abort


### PR DESCRIPTION
Fixes: #6764

Replaces: https://github.com/neovim/neovim/pull/18388
