### PR TITLE
feat(providers): support Slackadays/Clipboard as a clipboard provider

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -156,6 +156,12 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'tmux'
+  elseif executable('cb')
+    let s:copy['+'] = ['cb', 'copy']
+    let s:paste['+'] = ['cb', 'paste']
+    let s:copy['*'] = s:copy['+']
+    let s:paste['*'] = s:paste['+']
+    return 'cb'
   endif
 
   let s:err = 'clipboard: No clipboard tool. :help clipboard'

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -242,6 +242,8 @@ The following new APIs and features were added.
   clipboard is now bundled by default and will be automatically enabled under
   certain conditions. |clipboard-osc52|
 
+• Added cb as a clipboard provider |provider-clipboard|
+
 • The 'termsync' option asks the terminal emulator to buffer screen updates
   until the redraw cycle is complete. Requires support from the terminal.
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -196,6 +196,7 @@ registers. Nvim looks for these clipboard tools, in order of priority:
   - win32yank (Windows)
   - termux (via termux-clipboard-set, termux-clipboard-set)
   - tmux (if $TMUX is set)
+  - cb https://github.com/Slackadays/Clipboard
 
 								 *g:clipboard*
 To configure a custom clipboard tool, set g:clipboard to a dictionary.


### PR DESCRIPTION
Adds support for `cb` ([Slackadays/Clipboard](https://github.com/Slackadays/Clipboard)) as a clipboard provider.