### PR TITLE
vim-patch:ff0baca86523

### DIFF
--- a/runtime/syntax/cpp.vim
+++ b/runtime/syntax/cpp.vim
@@ -2,7 +2,7 @@
 " Language:	C++
 " Current Maintainer:	vim-jp (https://github.com/vim-jp/vim-cpp)
 " Previous Maintainer:	Ken Shan <ccshan@post.harvard.edu>
-" Last Change:	2021 Aug 23
+" Last Change:	2023 Dec 08
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -15,6 +15,7 @@ let b:filetype_in_cpp_family = 1
 " Read the C syntax to start with
 runtime! syntax/c.vim
 unlet b:current_syntax
+unlet b:filetype_in_cpp_family
 
 " C++ extensions
 syn keyword cppStatement	new delete this friend using

--- a/runtime/syntax/squirrel.vim
+++ b/runtime/syntax/squirrel.vim
@@ -2,7 +2,7 @@
 " Language: squirrel
 " Current Maintainer: Matt Dunford (zenmatic@gmail.com)
 " URL: https://github.com/zenmatic/vim-syntax-squirrel
-" Last Change:	2021 Nov 28
+" Last Change:	2023 Dec 08
 
 " http://squirrel-lang.org/
 
@@ -17,6 +17,7 @@ let b:filetype_in_cpp_family = 1
 " Read the C syntax to start with
 runtime! syntax/c.vim
 unlet b:current_syntax
+unlet b:filetype_in_cpp_family
 
 " squirrel extensions
 syn keyword squirrelStatement	delete this in yield resume base clone


### PR DESCRIPTION
#### vim-patch:ff0baca86523

runtime(syntax): unlet b:filetype_in_cpp_family for cpp & squirrel

Update runtime/syntax/cpp.vim and runtime/syntax/squirrel.vim to unlet
b:filetype_in_cpp_family as it remains set even after updating the ft of
a file manually or through a modeline, not allowing c specific keywords
to be highlighted.

Since the variable b:filetype_in_cpp_family is only used by the c.vim
syntax script, unlet it directly after sourcing the c.vim runtime file
instead of at the end of the script.

Also update the last Change Header for both files.

closes: vim/vim#13650

https://github.com/vim/vim/commit/ff0baca86523f1e8c6ea593ec0ef2f9860f001d0

Co-authored-by: laburnumT <laburnumtec@gmail.com>