### PR TITLE
refactor(tui): use synchronized updates around actual TUI buffer flush

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -42,9 +42,6 @@
 # include "nvim/os/tty.h"
 #endif
 
-// Space reserved in two output buffers to make the cursor normal or invisible
-// when flushing. No existing terminal will require 32 bytes to do that.
-#define CNORM_COMMAND_MAX_SIZE 32
 #define OUTBUF_SIZE 0xffff
 
 #define TOO_MANY_EVENTS 1000000
@@ -76,7 +73,6 @@ struct TUIData {
   size_t bufpos;
   TermInput input;
   uv_loop_t write_loop;
-  bool dirty;  ///< whether there has been drawing since the last tui_flush()
   unibi_term *ut;
   char *term;  ///< value of $TERM
   union {
@@ -901,8 +897,6 @@ static void print_cell_at_pos(TUIData *tui, int row, int col, UCell *cell, bool 
     return;
   }
 
-  tui_set_dirty(tui);
-
   cursor_goto(tui, row, col);
 
   char buf[MAX_SCHAR_SIZE];
@@ -927,8 +921,6 @@ static void print_cell_at_pos(TUIData *tui, int row, int col, UCell *cell, bool 
 static void clear_region(TUIData *tui, int top, int bot, int left, int right, int attr_id)
 {
   UGrid *grid = &tui->grid;
-
-  tui_set_dirty(tui);
 
   update_attrs(tui, attr_id);
 
@@ -1247,8 +1239,6 @@ void tui_grid_scroll(TUIData *tui, Integer g, Integer startrow, Integer endrow, 
                                 || tui->can_set_left_right_margin)));
 
   if (can_scroll) {
-    tui_set_dirty(tui);
-
     // Change terminal scroll region and move cursor to the top
     if (!tui->scroll_region_is_full_screen) {
       set_scroll_region(tui, top, bot, left, right);
@@ -1318,48 +1308,6 @@ void tui_default_colors_set(TUIData *tui, Integer rgb_fg, Integer rgb_bg, Intege
   invalidate(tui, 0, tui->grid.height, 0, tui->grid.width);
 }
 
-static void tui_set_dirty(TUIData *tui)
-  FUNC_ATTR_NONNULL_ALL
-{
-  if (!tui->dirty) {
-    tui->dirty = true;
-    tui_flush_start(tui);
-  }
-}
-
-/// Begin flushing the TUI. If 'termsync' is set and the terminal supports synchronized updates,
-/// begin a synchronized update. Otherwise, hide the cursor to avoid cursor jumping.
-static void tui_flush_start(TUIData *tui)
-  FUNC_ATTR_NONNULL_ALL
-{
-  if (tui->sync_output && tui->unibi_ext.sync != -1) {
-    UNIBI_SET_NUM_VAR(tui->params[0], 1);
-    unibi_out_ext(tui, tui->unibi_ext.sync);
-  } else if (!tui->is_invisible) {
-    unibi_out(tui, unibi_cursor_invisible);
-    tui->is_invisible = true;
-  }
-}
-
-/// Finish flushing the TUI. If 'termsync' is set and the terminal supports synchronized updates,
-/// end a synchronized update. Otherwise, make the cursor visible again.
-static void tui_flush_end(TUIData *tui)
-  FUNC_ATTR_NONNULL_ALL
-{
-  if (tui->sync_output && tui->unibi_ext.sync != -1) {
-    UNIBI_SET_NUM_VAR(tui->params[0], 0);
-    unibi_out_ext(tui, tui->unibi_ext.sync);
-  }
-  bool should_invisible = tui->busy || tui->want_invisible;
-  if (tui->is_invisible && !should_invisible) {
-    unibi_out(tui, unibi_cursor_normal);
-    tui->is_invisible = false;
-  } else if (!tui->is_invisible && should_invisible) {
-    unibi_out(tui, unibi_cursor_invisible);
-    tui->is_invisible = true;
-  }
-}
-
 void tui_flush(TUIData *tui)
 {
   UGrid *grid = &tui->grid;
@@ -1375,8 +1323,6 @@ void tui_flush(TUIData *tui)
     loop_purge(tui->loop);
     tui_busy_stop(tui);  // avoid hidden cursor
   }
-
-  tui_set_dirty(tui);
 
   while (kv_size(tui->invalid_regions)) {
     Rect r = kv_pop(tui->invalid_regions);
@@ -1405,10 +1351,7 @@ void tui_flush(TUIData *tui)
 
   cursor_goto(tui, tui->row, tui->col);
 
-  assert(tui->dirty);
-  tui_flush_end(tui);
   flush_buf(tui);
-  tui->dirty = false;
 }
 
 /// Dumps termcap info to the messages area, if 'verbose' >= 3.
@@ -2312,23 +2255,93 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
   }
 }
 
+/// Write the sequence to begin flushing output to `buf`.
+/// If 'termsync' is set and the terminal supports synchronized output, begin synchronized update.
+/// Otherwise, hide the cursor to avoid cursor jumping.
+///
+/// @param buf  the buffer to write the sequence to
+/// @param len  the length of `buf`
+static size_t flush_buf_start(TUIData *tui, char *buf, size_t len)
+  FUNC_ATTR_NONNULL_ALL
+{
+  const char *str = NULL;
+
+  if (tui->sync_output && tui->unibi_ext.sync != -1) {
+    UNIBI_SET_NUM_VAR(tui->params[0], 1);
+    str = unibi_get_ext_str(tui->ut, (size_t)tui->unibi_ext.sync);
+  } else if (!tui->is_invisible) {
+    str = unibi_get_str(tui->ut, unibi_cursor_invisible);
+    tui->is_invisible = true;
+  }
+
+  if (str == NULL) {
+    return 0;
+  }
+
+  return unibi_run(str, tui->params, buf, len);
+}
+
+/// Write the sequence to end flushing output to `buf`.
+/// If 'termsync' is set and the terminal supports synchronized output, end synchronized update.
+/// Otherwise, make the cursor visible again.
+///
+/// @param buf  the buffer to write the sequence to
+/// @param len  the length of `buf`
+static size_t flush_buf_end(TUIData *tui, char *buf, size_t len)
+  FUNC_ATTR_NONNULL_ALL
+{
+  size_t offset = 0;
+  if (tui->sync_output && tui->unibi_ext.sync != -1) {
+    UNIBI_SET_NUM_VAR(tui->params[0], 0);
+    const char *str = unibi_get_ext_str(tui->ut, (size_t)tui->unibi_ext.sync);
+    offset = unibi_run(str, tui->params, buf, len);
+  }
+
+  const char *str = NULL;
+  bool should_invisible = tui->busy || tui->want_invisible;
+  if (tui->is_invisible && !should_invisible) {
+    str = unibi_get_str(tui->ut, unibi_cursor_normal);
+    tui->is_invisible = false;
+  } else if (!tui->is_invisible && should_invisible) {
+    str = unibi_get_str(tui->ut, unibi_cursor_invisible);
+    tui->is_invisible = true;
+  }
+
+  if (str != NULL) {
+    assert(len >= offset);
+    offset += unibi_run(str, tui->params, buf + offset, len - offset);
+  }
+
+  return offset;
+}
+
 static void flush_buf(TUIData *tui)
 {
   uv_write_t req;
-  uv_buf_t buf;
+  uv_buf_t bufs[3];
+  char pre[32];
+  char post[32];
 
   if (tui->bufpos <= 0) {
     return;
   }
 
-  buf.base = tui->buf;
-  buf.len = UV_BUF_LEN(tui->bufpos);
+  bufs[0].base = pre;
+  bufs[0].len = UV_BUF_LEN(flush_buf_start(tui, pre, sizeof(pre)));
+
+  bufs[1].base = tui->buf;
+  bufs[1].len = UV_BUF_LEN(tui->bufpos);
+
+  bufs[2].base = post;
+  bufs[2].len = UV_BUF_LEN(flush_buf_end(tui, post, sizeof(post)));
 
   if (tui->screenshot) {
-    fwrite(buf.base, buf.len, 1, tui->screenshot);
+    for (size_t i = 0; i < ARRAY_SIZE(bufs); i++) {
+      fwrite(bufs[i].base, bufs[i].len, 1, tui->screenshot);
+    }
   } else {
     int ret
-      = uv_write(&req, (uv_stream_t *)&tui->output_handle, &buf, 1, NULL);
+      = uv_write(&req, (uv_stream_t *)&tui->output_handle, bufs, ARRAY_SIZE(bufs), NULL);
     if (ret) {
       ELOG("uv_write failed: %s", uv_strerror(ret));
     }

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1671,10 +1671,9 @@ describe('TUI', function()
     -- Use full screen message so that redrawing afterwards is more deterministic.
     child_session:notify('nvim_command', 'intro')
     screen:expect({any = 'Nvim'})
-    -- Hiding the cursor needs 6 bytes.
     -- Going to top-left corner needs 3 bytes.
     -- Setting underline attribute needs 9 bytes.
-    -- The whole line needs 6 + 3 + 9 + 65513 + 3 = 65534 bytes.
+    -- The whole line needs 3 + 9 + 65513 + 3 = 65528 bytes.
     -- The cursor_address that comes after will overflow the 65535-byte buffer.
     local line = ('a'):rep(65513) .. '℃'
     child_session:notify('nvim_exec_lua', [[


### PR DESCRIPTION
Rather than writing the synchronized update begin and end sequences into the TUI's internal buffer (where it is later flushed to the TTY), write these sequences directly to the TTY before and after the TUI's internal buffer is itself flushed to the TTY.

This guarantees that a synchronized update is always used when we are actually sending data to the TTY. This means we do not need to keep track of the TUI's "dirty" state (any sequences which affect the TUI state will be written in the TUI's internal buffer, which is now guaranteed to only ever be written when a synchronized update is active).

---

I've double checked this change against both https://github.com/neovim/neovim/issues/26422 and https://github.com/neovim/neovim/issues/26054 and as far as I can tell it still resolves both.

There has been a lot of churn around this change, so I want to outline why I think this is the best approach (lots of text incoming).

In the original implementation in https://github.com/neovim/neovim/pull/25871 we wrote the "begin synchronized update" (BSU) and "end synchronized update" (ESU) sequences in `tui_flush`, before and after iterating through the list of invalid regions which needed to be redrawn. These sequences were written into the same internal buffer (`tui->buf`) that the actual output data was written into. Importantly, this does not actually write any bytes to the tty (unless the internal buffer gets full). At the end of `tui_flush`, we call `flush_buf`, which actually flushes the internal buffer to the TTY.

This gets a little confusing because there are two uses of the term "flush". In `tui_flush`, we flush the TUI's grid state into its internal buffer. In `flush_buf`, we flush the internal buffer to the TTY.

The first issue caused by https://github.com/neovim/neovim/pull/25871 was https://github.com/neovim/neovim/issues/26054. This happened because `flush_buf` was itself "bracketing" the flush to the TTY by first hiding the cursor, then flushing the internal buffer, then making the cursor visible again. However, when the internal buffer itself contained the BSU sequence, the cursor hiding was synchronized by the terminal which made the invisible state just long enough to be perceptible. The fix in https://github.com/neovim/neovim/pull/26055 was to remove this "bracketing" in `flush_buf` and instead move the cursor visibility management out into `tui_flush`. Now, _all_ escape sequences that are written to the TTY go into the TUI's internal buffer, and `flush_buf` simply flushes out that buffer to the TTY without doing any "bracketing".

In picture form:

**Before**:

    ┌───────────────┐  ────────────────┐
    │  Hide cursor  │                  │
    ├───────────────┤  ─┐              │
    │      BSU      │   │              │
    ├───────────────┤   │              │
    │ Grid updates  │   ├─ tui_flush   ├─ flush_buf
    ├───────────────┤   │              │
    │      ESU      │   │              │
    ├───────────────┤  ─┘              │
    │  Show cursor  │                  │
    └───────────────┘  ────────────────┘

**After**:

    ┌───────────────────┐  ─┐
    │ BSU / Hide cursor │   │
    ├───────────────────┤   │
    │    Grid updates   │   ├─ tui_flush
    ├───────────────────┤   │
    │ ESU / Show cursor │   │
    └───────────────────┘  ─┘

The next issue was https://github.com/neovim/neovim/issues/26422. This occurred because data gets written into the TUI's internal buffer outside of `tui_flush`, and so ends up being written to the TTY before the BSU sequence does.

    ┌───────────────────┐
    │Other screen update│  ─── print_cell_at_pos, cursor_goto, etc
    ├───────────────────┤  ─┐
    │ BSU / Hide cursor │   │
    ├───────────────────┤   │
    │    Grid updates   │   ├─ tui_flush
    ├───────────────────┤   │
    │ ESU / Show cursor │   │
    └───────────────────┘  ─┘

In these scenarios (usually when the cursor is moved), the BSU sequence that was written in `tui_flush` would cause whatever screen state changes happened _before_ `tui_flush` to be "locked" while the synchronized update was active. This caused the flickering effect in #26422.

@zeertzjq addressed this in https://github.com/neovim/neovim/pull/26463 by ensuring a BSU sequence was written anytime the screen state was modified. This was done by tracking the "dirty" state of the screen through a new flag.


    ┌───────────────────┐
    │Other screen update│  ─── print_cell_at_pos, cursor_goto, etc. Sets "dirty" flag and writes BSU to buffer
    ├───────────────────┤  ─┐
    │ BSU / Hide cursor │   │  ← only if dirty flag not already set
    ├───────────────────┤   │
    │    Grid updates   │   ├─ tui_flush
    ├───────────────────┤   │
    │ ESU / Show cursor │   │  ← clear dirty flag
    └───────────────────┘  ─┘

This works but requires us to manually track when the TUI becomes dirty so that we can write a BSU sequence at the appropriate place.

That finally brings us to this PR. This PR brings back the "bracketing" that was removed in #26055, but instead of bracketing the TUI flush with cursor hide/show sequences, it brackets it with the BSU/ESU sequence if 'termsync' is enabled and available.

    ┌─────────────────────┐  ───────────────┐
    │  BSU / Hide cursor  │                 │
    ├─────────────────────┤                 │
    │     Grid updates    │  ── tui_flush   ├─ flush_buf
    ├─────────────────────┤                 │
    │  ESU / Show cursor  │                 │
    └─────────────────────┘  ───────────────┘

Essentially this means that *any time* the TUI writes actual bytes to the TTY, we are using BSU/ESU (if enabled) or hiding/showing the cursor. This means we don't have to track the dirty state of the TUI, because if the screen state is being modified at all, it will only occur _during_ a synchronized update, which guarantees that a synchronized update does not begin halfway through some screen state modification.

In #26055, I wrote:

>There is no need to hide the cursor every time we write bytes to the TTY, only at the beginning of a full TUI "flush" event.

I can only say that now with the benefit of hindsight and further understanding I disagree with my past self. #26422 demonstrated that the screen state can be modified outside of a full TUI flush (`tui_flush`), so it is unsufficient to only manage cursor visibility/synchronized updates then.
