### PR TITLE
fix(column): invalidate a :moved region if it contains signs

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -150,7 +150,7 @@ static Array extmark_to_array(MTPair extmark, bool id, bool add_dict, bool hl_na
 
     PUT(dict, "right_gravity", BOOLEAN_OBJ(mt_right(start)));
 
-    if (extmark.end_pos.row >= 0) {
+    if (mt_paired(start)) {
       PUT(dict, "end_row", INTEGER_OBJ(extmark.end_pos.row));
       PUT(dict, "end_col", INTEGER_OBJ(extmark.end_pos.col));
       PUT(dict, "end_right_gravity", BOOLEAN_OBJ(extmark.end_right_gravity));

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -617,10 +617,6 @@ int decor_redraw_col(win_T *wp, int col, int win_col, bool hidden, DecorState *s
     }
 
     MTPos endpos = marktree_get_altpos(buf->b_marktree, mark, NULL);
-    if (endpos.row == -1) {
-      endpos = mark.pos;
-    }
-
     decor_range_add_from_inline(state, mark.pos.row, mark.pos.col, endpos.row, endpos.col,
                                 mt_decor(mark), false, mark.ns, mark.id);
 
@@ -846,8 +842,8 @@ static void buf_signcols_validate_range(buf_T *buf, int row1, int row2, int add)
     }
     // Increment overlap array for the start and range of a paired sign mark.
     if (!mt_invalid(mark) && !mt_end(mark) && (mark.flags & MT_FLAG_DECOR_SIGNTEXT)) {
-      MTPos end = marktree_get_altpos(buf->b_marktree, mark, NULL);
-      for (int i = currow; i <= MIN(row2, end.row < 0 ? currow : end.row); i++) {
+      int endrow = marktree_get_altpos(buf->b_marktree, mark, NULL).row;
+      for (int i = currow; i <= MIN(row2, endrow); i++) {
         overlap[i - row1]++;
       }
     }
@@ -887,7 +883,7 @@ int buf_signcols_validate(win_T *wp, buf_T *buf, bool stc_check)
   return buf->b_signcols.max;
 }
 
-static void buf_signcols_invalidate_range(buf_T *buf, int row1, int row2, int add)
+void buf_signcols_invalidate_range(buf_T *buf, int row1, int row2, int add)
 {
   if (!buf->b_signs_with_text) {
     buf->b_signcols.max = buf->b_signcols.max_count = 0;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -812,7 +812,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
          (int64_t)num_lines);
   }
 
-  extmark_move_region(curbuf, line1 - 1, 0, start_byte,
+  extmark_move_region(curwin, line1 - 1, 0, start_byte,
                       line2 - line1 + 1, 0, extent_byte,
                       dest + line_off, 0, dest_byte + byte_off,
                       kExtmarkUndo);

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2545,7 +2545,7 @@ static void restore_orig_extmarks(void)
 {
   for (long i = (int)kv_size(compl_orig_extmarks) - 1; i > -1; i--) {
     ExtmarkUndoObject undo_info = kv_A(compl_orig_extmarks, i);
-    extmark_apply_undo(undo_info, true);
+    extmark_apply_undo(curwin, undo_info, true);
   }
 }
 

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -4,6 +4,7 @@
 #include <stddef.h>  // IWYU pragma: keep
 #include <stdint.h>
 
+#include "nvim/buffer_defs.h"  // IWYU pragma: keep
 #include "nvim/decoration_defs.h"
 #include "nvim/marktree_defs.h"  // IWYU pragma: export
 #include "nvim/pos_defs.h"  // IWYU pragma: keep

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2420,13 +2420,13 @@ static void u_undoredo(bool undo, bool do_buf_event)
   if (undo) {
     for (int i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
       undo_info = kv_A(curhead->uh_extmark, i);
-      extmark_apply_undo(undo_info, undo);
+      extmark_apply_undo(curwin, undo_info, undo);
     }
     // redo
   } else {
     for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
       undo_info = kv_A(curhead->uh_extmark, i);
-      extmark_apply_undo(undo_info, undo);
+      extmark_apply_undo(curwin, undo_info, undo);
     }
   }
   if (curhead->uh_flags & UH_RELOAD) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4832,16 +4832,28 @@ l5
   it('correct width with multiple overlapping signs', function()
     screen:try_resize(20, 4)
     insert(example_test3)
-    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1', end_row=2})
-    meths.buf_set_extmark(0, ns, 1, -1, {sign_text='S2', end_row=2})
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1'})
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S2', end_row=2})
+    meths.buf_set_extmark(0, ns, 1, -1, {sign_text='S3', end_row=2})
     feed('gg')
 
+    local s1 = [[
+      S1S2^l1              |
+      S2S3l2              |
+      S2S3l3              |
+                          |
+    ]]
+    screen:expect{grid=s1}
+    -- Correct width when :move'ing a line with signs
+    command('move2')
     screen:expect{grid=[[
-      S1{1:  }^l1              |
-      S1S2l2              |
-      S1S2l3              |
+      S3{1:    }l2            |
+      S1S2S3^l1            |
+      {1:      }l3            |
                           |
     ]]}
+    command('move0')
+    screen:expect{grid=s1}
   end)
 end)
 


### PR DESCRIPTION
Problem:  'signcolumn' has incorrect "auto" width when moving
          a region with signs.
Solution: Invalidate the moved region in b_signcols.