### PR TITLE
vim-patch:61e984e212ed

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -439,9 +439,8 @@ CTRL-T		When 'incsearch' is set, entering a search pattern for "/" or
 		keyboard T is above G.
 
 The 'wildchar' option defaults to <Tab> (CTRL-E when in Vi compatible mode; in
-a previous version <Esc> was used).  In the pattern standard wildcards "*" and
-'?' are accepted when matching file names.  "*" matches any string, '?'
-matches exactly one character.
+a previous version <Esc> was used).  In the pattern standard |wildcards| are
+accepted when matching file names.
 
 When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,


### PR DESCRIPTION
#### vim-patch:61e984e212ed

runtime(doc): link cmdline completion to to |wildcards| and fix typos (vim/vim#13636)

The docs for cmdline completion doesn't mention that [abc] is considered
a wildcard, and |wildcards| contains more detailed information, so just
link to it.

Also fix some typos in other help files.

https://github.com/vim/vim/commit/61e984e212ed19774e088868c30c2d03c4e5a0cf