### PR TITLE
fix(eval): use no_ff instead of ffdos as condition

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3907,7 +3907,7 @@ int ml_find_line_or_offset(buf_T *buf, linenr_T lnum, int *offp, bool no_ff)
       || lnum < 0) {
     // memline is currently empty. Although if it is loaded,
     // it behaves like there is one empty line.
-    if (!ffdos && buf->b_ml.ml_mfp && (lnum == 1 || lnum == 2)) {
+    if (no_ff && buf->b_ml.ml_mfp && (lnum == 1 || lnum == 2)) {
       return lnum - 1;
     }
     return -1;

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -1876,6 +1876,7 @@ describe('api/buf', function()
     it('works in empty buffer', function()
       eq(0, get_offset(0))
       eq(1, get_offset(1))
+      eq(-1, funcs.line2byte('$'))
     end)
 
     it('works in buffer with one line inserted', function()


### PR DESCRIPTION
Problem: line2byte behavior is changed after commit b051b13. It no
longer return `-1` on empty buffer.

Solution: use `no_ff` instead of `!ff_dos` as condition. Then
compatible behavior of line2byte() is restored.


Fix #25369 