### PR TITLE
build: remove config-specific find_package search for libuv

### DIFF
--- a/cmake/FindLibuv.cmake
+++ b/cmake/FindLibuv.cmake
@@ -1,5 +1,5 @@
 find_path2(LIBUV_INCLUDE_DIR uv.h)
-find_library2(LIBUV_LIBRARY NAMES uv_a uv)
+find_library2(LIBUV_LIBRARY NAMES uv_a uv libuv)
 
 set(LIBUV_LIBRARIES ${LIBUV_LIBRARY})
 
@@ -41,10 +41,12 @@ endif()
 if(WIN32)
   # check_library_exists() does not work for Win32 API calls in X86 due to name
   # mangling calling conventions
-  list(APPEND LIBUV_LIBRARIES iphlpapi)
-  list(APPEND LIBUV_LIBRARIES psapi)
-  list(APPEND LIBUV_LIBRARIES userenv)
-  list(APPEND LIBUV_LIBRARIES ws2_32)
+  list(APPEND LIBUV_LIBRARIES
+    iphlpapi
+    psapi
+    userenv
+    ws2_32
+    dbghelp)
 endif()
 
 find_package(Threads)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -11,17 +11,9 @@ set_target_properties(nvim
 #-------------------------------------------------------------------------------
 
 add_library(libuv INTERFACE)
-find_package(libuv CONFIG QUIET)
-if(TARGET libuv::uv_a)
-  target_link_libraries(libuv INTERFACE libuv::uv_a)
-  mark_as_advanced(libuv_DIR)
-else()
-  # Fall back to find module for libuv versions older than v1.45.0 which don't
-  # provide a config file
-  find_package(Libuv 1.28.0 REQUIRED MODULE)
-  target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIR})
-  target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})
-endif()
+find_package(Libuv 1.28.0 REQUIRED)
+target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIR})
+target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})
 
 add_library(nlua0 MODULE)
 if(WIN32)


### PR DESCRIPTION
Having two separate find_package calls makes it harder to maintain.
