### PR TITLE
fix(screenpos): Prevent crash by handling negative column

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -953,7 +953,7 @@ EXTERN const char e_highlight_group_name_invalid_char[] INIT(= N_("E5248: Invali
 
 EXTERN const char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
 
-EXTERN const char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line number: %ld"));
+EXTERN const char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line number: %lld"));
 
 EXTERN const char e_stray_closing_curly_str[]
 INIT(= N_("E1278: Stray '}' without a matching '{': %s"));

--- a/test/functional/vimscript/screenpos_spec.lua
+++ b/test/functional/vimscript/screenpos_spec.lua
@@ -70,4 +70,8 @@ describe('screenpos() function', function()
     eq({row = 1, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
     eq({row = 2, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
   end)
+
+  it('handles negative column values', function()
+    eq({ row = 1, col = 1, endcol = 1, curscol = 1 }, funcs.screenpos(0, 1, -2000000000))
+  end)
 end)


### PR DESCRIPTION
I was working on improving performance of [`f_screenpos()`](https://github.com/neovim/neovim/blob/096211a87b1649e9a7408ce159072a6236195eea/src/nvim/move.c#L1109) which corresponds to vim's [`screenpos()`](https://neovim.io/doc/user/builtin.html#screenpos()) function (which as it turns out can be made much faster in some cases with a simple change), and noticed that the user-provided column value wasn't validated. I called the function with `call screenpos(0, 1, -999999999)` to see what the result would be for a negative column value, and Neovim crashed with access violation. 

What happens is that `f_screenpos()` calls [`textpos2screenpos()`](https://github.com/neovim/neovim/blob/096211a87b1649e9a7408ce159072a6236195eea/src/nvim/move.c#L1037) with position that contains the negative column value. `textpos2screenpos()` passes that position to [`getvcol()`](https://github.com/neovim/neovim/blob/096211a87b1649e9a7408ce159072a6236195eea/src/nvim/plines.c#L480), which calls [`utf_head_off()`](https://github.com/neovim/neovim/blob/096211a87b1649e9a7408ce159072a6236195eea/src/nvim/mbyte.c#L1535) with a an out of bounds pointer obtained by adding the column to the start of the line, and `utf_head_off()` reads the value from that pointer, causing a crash.

Additionally, line numbers below 1 weren't handled as well, but this didn't cause any issues as `textpos2screenpos` checked if the line number is in the correct range. I don't think anyone relies on negative line numbers producing the results that they produce.

This PR adds logic to clamp the column between 0 and MAXCOL and give an error if the line number is below 0.