### PR TITLE
feat(lsp): support textDocument/semanticTokens/range

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1736,7 +1736,10 @@ function lsp.start_client(config)
     -- on_attach and LspAttach callbacks the ability to schedule wrap the
     -- opt-out (deleting the semanticTokensProvider from capabilities)
     vim.schedule(function()
-      if vim.tbl_get(client.server_capabilities, 'semanticTokensProvider', 'full') then
+      if
+        vim.tbl_get(client.server_capabilities, 'semanticTokensProvider', 'full')
+        or vim.tbl_get(client.server_capabilities, 'semanticTokensProvider', 'range')
+      then
         semantic_tokens.start(bufnr, client.id)
       end
     end)


### PR DESCRIPTION
Resolves https://github.com/neovim/neovim/issues/23026 and addresses servers not implementing `textDocument/semanticTokens/full` (i.e. https://github.com/dotnet/roslyn/issues/70536)

My intentions were both to provide a basic implementation of range according to the suggestions in the lsp spec (listed the paragraph above [here](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens_rangeRequest)) for improving response times when a user opens a file and on edits, and to allow for servers not implementing full or full/delta to just have the entire document requested through range.

Requesting the entire document through range may be a bad idea on some servers, but I was unsure whether I should disable semantic token full (or range spanning the whole document, same idea) requests entirely for slower servers and only update on scroll, or if I should just leave it as is, because of the behavior not being already present.

As for testing, I am unsure if the existing tests for semantic tokens are adequate or if I should add more, given my lack of familiarity with testing. Feedback would be appreciated.

Edit: Those failing tests don't look right (I could swear I ran testing earlier on my system, not sure what happened there), I'll look into those soon