### PR TITLE
fix(lsp): lsp.buf.definition() handles responses from multiple servers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -210,6 +210,7 @@ The following new APIs and features were added.
     the original LSP `Location` or `LocationLink`.
   • Added support for connecting to servers using named pipes (Windows) or
     unix domain sockets (Unix) via |vim.lsp.rpc.domain_socket_connect()|.
+  • |vim.lsp.buf.definition()| handles responses from multiple clients.
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -122,9 +122,6 @@ function M.definition(options)
       return options.on_list({
         title = title,
         items = items,
-        -- FIXME currently passing nil as items can come from multiple clients
-        -- need a better way to attribute items to context
-        context = nil,
       })
     end
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -87,9 +87,9 @@ function M.definition(options)
     local total_items = 0
     for client_id, v in pairs(results) do
       if v.error == nil and v.result ~= nil then
-        -- first check for Location | LocationLink because
+        -- first check for Location because
         -- tbl_islist returns `false` for empty lists
-        if v.result.uri or v.result.targetUri then
+        if v.result.uri then
           local client = vim.lsp.get_client_by_id(client_id)
           local items = util.locations_to_items({ v.result }, client.offset_encoding)
           total_items = total_items + #items

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -82,6 +82,7 @@ function M.definition(options)
 
   ---@param results table<integer, {error: lsp.ResponseError, result: lsp.Location|lsp.Location[]|lsp.LocationLink[]|nil}>
   local function handler(results)
+    ---@type table<integer, vim.lsp.util.LocationItem[]>
     local client_id_to_items = {}
     local total_items = 0
     for client_id, v in pairs(results) do

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -108,6 +108,7 @@ function M.definition(options)
 
     local items = {}
 
+    -- luacheck: ignore 512
     for _, v in pairs(client_id_to_items) do
       for _, v2 in ipairs(v) do
         table.insert(items, v2)

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -106,20 +106,6 @@ function M.definition(options)
       return
     end
 
-    -- jump to the only response
-    if total_items == 1 then
-      for client_id, _ in pairs(client_id_to_items) do
-        local client = vim.lsp.get_client_by_id(client_id)
-
-        local loc = results[client_id].result
-        if vim.tbl_islist(loc) then
-          loc = loc[1]
-        end
-
-        return util.jump_to_location(loc, client.offset_encoding, options.reuse_win)
-      end
-    end
-
     local items = {}
 
     for _, v in pairs(client_id_to_items) do
@@ -138,6 +124,20 @@ function M.definition(options)
         -- need a better way to attribute items to context
         context = nil,
       })
+    end
+
+    -- jump to the only response
+    if total_items == 1 then
+      for client_id, _ in pairs(client_id_to_items) do
+        local client = vim.lsp.get_client_by_id(client_id)
+
+        local loc = results[client_id].result
+        if vim.tbl_islist(loc) then
+          loc = loc[1]
+        end
+
+        return util.jump_to_location(loc, client.offset_encoding, options.reuse_win)
+      end
     end
 
     vim.fn.setqflist({}, ' ', { title = title, items = items })


### PR DESCRIPTION
Resolves #22318 when vim.lsp.buf.definition() subsequently jumps to multiple locations if more than one server responds.

Motivation: In case of multiple servers supporting the same lsp method, neovim should merge the results and handle them the same way it currently handles multiple results from a single server. This can reduce confusion by removing jumping to multiple locations without the user's action. In comparison vscode merges responses from its plugins/lsp servers and presents them to the user in a single picker. This is also partially solved in [lspsaga](https://nvimdev.github.io/lspsaga/definition/), where in `peek_definition` every result in opened in a separate float. 

I am uncertain whether this is the best place to handle the entire thing and open for feedback. As of opening this PR is in incomplete state as there are no tests or documentation. I did not go any further as I am not sure what would be a good way to pass multiple contexts in case the option `on_list` is set.

In the future the same approach can be applied to other methods such as `type_definition`, `declaration`, `implementation`, and the general idea of merging results from multiple servers for `hover`.