### PR TITLE
refactor(options): remove option type macros

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -346,6 +346,9 @@ The following changes to existing APIs or features add new behavior.
 
 • Added "force_crlf" option field in |nvim_open_term()|.
 
+• Attempting to set an invalid keycode option (e.g. `set t_foo=123`) no longer
+  gives an error.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -59,7 +59,7 @@ local LUA_KEYWORDS = {
 }
 
 local OPTION_TYPES = {
-  bool = 'boolean',
+  boolean = 'boolean',
   number = 'integer',
   string = 'string',
 }
@@ -603,7 +603,7 @@ local function build_option_tags(opt)
   local tags = { opt.full_name }
 
   tags[#tags + 1] = opt.abbreviation
-  if opt.type == 'bool' then
+  if opt.type == 'boolean' then
     for i = 1, #tags do
       tags[#tags + 1] = 'no' .. tags[i]
     end
@@ -642,7 +642,7 @@ local function render_option_doc(_f, opt, write)
     name_str = string.format("'%s'", opt.full_name)
   end
 
-  local otype = opt.type == 'bool' and 'boolean' or opt.type
+  local otype = opt.type == 'boolean' and 'boolean' or opt.type
   if opt.defaults.doc or opt.defaults.if_true ~= nil or opt.defaults.meta ~= nil then
     local v = render_option_default(opt.defaults, true)
     local pad = string.rep('\t', math.max(1, math.ceil((24 - #name_str) / 8)))

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -13,6 +13,7 @@
 #include "nvim/hashtab_defs.h"
 #include "nvim/macros_defs.h"
 #include "nvim/mbyte_defs.h"  // IWYU pragma: keep
+#include "nvim/option_defs.h"  // IWYU pragma: keep
 #include "nvim/os/fileio_defs.h"  // IWYU pragma: keep
 #include "nvim/os/stdpaths_defs.h"  // IWYU pragma: keep
 #include "nvim/vim_defs.h"  // IWYU pragma: keep

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -761,11 +761,12 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
 
   // Find the end of the name.
   char *arg_end = NULL;
+  OptIndex opt_idx;
   int scope;
-  char *const p = (char *)find_option_end((const char **)&arg, &scope);
-  if (p == NULL
-      || (endchars != NULL
-          && vim_strchr(endchars, (uint8_t)(*skipwhite(p))) == NULL)) {
+
+  char *const p = (char *)find_option_var_end((const char **)&arg, &opt_idx, &scope);
+
+  if (p == NULL || (endchars != NULL && vim_strchr(endchars, (uint8_t)(*skipwhite(p))) == NULL)) {
     emsg(_(e_letunexp));
     return NULL;
   }
@@ -774,8 +775,6 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
   *p = NUL;
 
   bool is_tty_opt = is_tty_option(arg);
-  OptIndex opt_idx = is_tty_opt ? kOptInvalid : findoption(arg);
-  uint32_t opt_p_flags = get_option_flags(opt_idx);
   bool hidden = is_option_hidden(opt_idx);
   OptVal curval = is_tty_opt ? get_tty_option(arg) : get_option_value(opt_idx, scope);
   OptVal newval = NIL_OPTVAL;
@@ -792,7 +791,7 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
   }
 
   bool error;
-  newval = tv_to_optval(tv, arg, opt_p_flags, &error);
+  newval = tv_to_optval(tv, opt_idx, arg, &error);
   if (error) {
     goto theend;
   }
@@ -1849,22 +1848,27 @@ static void getwinvar(typval_T *argvars, typval_T *rettv, int off)
 ///
 /// @return  Typval converted to OptVal. Must be freed by caller.
 ///          Returns NIL_OPTVAL for invalid option name.
-static OptVal tv_to_optval(typval_T *tv, const char *option, uint32_t flags, bool *error)
+///
+/// TODO(famiu): Refactor this to support multitype options.
+static OptVal tv_to_optval(typval_T *tv, OptIndex opt_idx, const char *option, bool *error)
 {
   OptVal value = NIL_OPTVAL;
   char nbuf[NUMBUFLEN];
   bool err = false;
+  const bool is_tty_opt = is_tty_option(option);
+  const bool option_has_bool = !is_tty_opt && option_has_type(opt_idx, kOptValTypeBoolean);
+  const bool option_has_num = !is_tty_opt && option_has_type(opt_idx, kOptValTypeNumber);
+  const bool option_has_str = is_tty_opt || option_has_type(opt_idx, kOptValTypeString);
 
-  if ((flags & P_FUNC) && tv_is_func(*tv)) {
+  if (!is_tty_opt && (get_option(opt_idx)->flags & P_FUNC) && tv_is_func(*tv)) {
     // If the option can be set to a function reference or a lambda
     // and the passed value is a function reference, then convert it to
     // the name (string) of the function reference.
     char *strval = encode_tv2string(tv, NULL);
     err = strval == NULL;
     value = CSTR_AS_OPTVAL(strval);
-  } else if (flags & (P_NUM | P_BOOL)) {
-    varnumber_T n = (flags & P_NUM) ? tv_get_number_chk(tv, &err)
-                                    : tv_get_bool_chk(tv, &err);
+  } else if (option_has_bool || option_has_num) {
+    varnumber_T n = option_has_num ? tv_get_number_chk(tv, &err) : tv_get_bool_chk(tv, &err);
     // This could be either "0" or a string that's not a number.
     // So we need to check if it's actually a number.
     if (!err && tv->v_type == VAR_STRING && n == 0) {
@@ -1877,14 +1881,14 @@ static OptVal tv_to_optval(typval_T *tv, const char *option, uint32_t flags, boo
         semsg(_("E521: Number required: &%s = '%s'"), option, tv->vval.v_string);
       }
     }
-    value = (flags & P_NUM) ? NUMBER_OPTVAL((OptInt)n) : BOOLEAN_OPTVAL(TRISTATE_FROM_INT(n));
-  } else if ((flags & P_STRING) || is_tty_option(option)) {
+    value = option_has_num ? NUMBER_OPTVAL((OptInt)n) : BOOLEAN_OPTVAL(TRISTATE_FROM_INT(n));
+  } else if (option_has_str) {
     // Avoid setting string option to a boolean or a special value.
     if (tv->v_type != VAR_BOOL && tv->v_type != VAR_SPECIAL) {
       const char *strval = tv_get_string_buf_chk(tv, nbuf);
       err = strval == NULL;
       value = CSTR_TO_OPTVAL(strval);
-    } else if (flags & P_STRING) {
+    } else if (!is_tty_opt) {
       err = true;
       emsg(_(e_stringreq));
     }
@@ -1900,10 +1904,12 @@ static OptVal tv_to_optval(typval_T *tv, const char *option, uint32_t flags, boo
 
 /// Convert an option value to typval.
 ///
-/// @param[in]  value  Option value to convert.
+/// @param[in]  value    Option value to convert.
+/// @param      numbool  Whether to convert boolean values to number.
+///                      Used for backwards compatibility.
 ///
 /// @return  OptVal converted to typval.
-typval_T optval_as_tv(OptVal value)
+typval_T optval_as_tv(OptVal value, bool numbool)
 {
   typval_T rettv = { .v_type = VAR_SPECIAL, .vval = { .v_special = kSpecialVarNull } };
 
@@ -1911,19 +1917,16 @@ typval_T optval_as_tv(OptVal value)
   case kOptValTypeNil:
     break;
   case kOptValTypeBoolean:
-    switch (value.data.boolean) {
-    case kTrue:
-      rettv.v_type = VAR_BOOL;
-      rettv.vval.v_bool = kBoolVarTrue;
-      break;
-    case kFalse:
-      rettv.v_type = VAR_BOOL;
-      rettv.vval.v_bool = kBoolVarFalse;
-      break;
-    case kNone:
-      break;  // return v:null for None boolean value
+    if (value.data.boolean != kNone) {
+      if (numbool) {
+        rettv.v_type = VAR_NUMBER;
+        rettv.vval.v_number = value.data.boolean == kTrue;
+      } else {
+        rettv.v_type = VAR_BOOL;
+        rettv.vval.v_bool = value.data.boolean == kTrue;
+      }
     }
-    break;
+    break;  // return v:null for None boolean value.
   case kOptValTypeNumber:
     rettv.v_type = VAR_NUMBER;
     rettv.vval.v_number = value.data.number;
@@ -1947,8 +1950,7 @@ static void set_option_from_tv(const char *varname, typval_T *varp)
   }
 
   bool error = false;
-  uint32_t opt_p_flags = get_option_flags(opt_idx);
-  OptVal value = tv_to_optval(varp, varname, opt_p_flags, &error);
+  OptVal value = tv_to_optval(varp, opt_idx, varname, &error);
 
   if (!error) {
     const char *errmsg = set_option_value_handle_tty(varname, opt_idx, value, OPT_LOCAL);

--- a/src/nvim/math.c
+++ b/src/nvim/math.c
@@ -40,3 +40,29 @@ int xisnan(double d)
 {
   return FP_NAN == xfpclassify(d);
 }
+
+/// Count trailing zeroes at the end of bit field.
+int xctz(uint64_t x)
+{
+  // If x == 0, that means all bits are zeroes.
+  if (x == 0) {
+    return 8 * sizeof(x);
+  }
+
+  // Use compiler builtin if possible.
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 4))
+  return __builtin_ctzll(x);
+#else
+  int count = 0;
+  // Set x's trailing zeroes to ones and zero the rest.
+  x = (x ^ (x - 1)) >> 1;
+
+  // Increment count until there are just zero bits remaining.
+  while (x) {
+    count++;
+    x >>= 1;
+  }
+
+  return count;
+#endif
+}

--- a/src/nvim/math.h
+++ b/src/nvim/math.h
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
+
+/// Check if number is a power of two
+static inline bool is_power_of_two(uint64_t x)
+{
+  return x != 0 && ((x & (x - 1)) == 0);
+}
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "math.h.generated.h"
 #endif

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -515,6 +515,13 @@ bool strequal(const char *a, const char *b)
   return (a == NULL && b == NULL) || (a && b && strcmp(a, b) == 0);
 }
 
+/// Returns true if first `n` characters of strings `a` and `b` are equal. Arguments may be NULL.
+bool strnequal(const char *a, const char *b, size_t n)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return (a == NULL && b == NULL) || (a && b && strncmp(a, b, n) == 0);
+}
+
 // Avoid repeating the error message many times (they take 1 second each).
 // Did_outofmem_msg is reset when a character is read.
 void do_outofmem_msg(size_t size)

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -8,6 +8,7 @@
 #include "nvim/cmdexpand_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
+#include "nvim/math.h"
 #include "nvim/option_defs.h"  // IWYU pragma: export
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
@@ -38,17 +39,16 @@ typedef enum {
 #define VAR_WIN ((char *)-1)
 
 typedef struct vimoption {
-  char *fullname;    ///< full option name
-  char *shortname;   ///< permissible abbreviation
-  uint32_t flags;    ///< see above
-  void *var;         ///< global option: pointer to variable;
-                     ///< window-local option: VAR_WIN;
-                     ///< buffer-local option: global value
-  idopt_T indir;     ///< global option: PV_NONE;
-                     ///< local option: indirect option index
-                     ///< callback function to invoke after an option is modified to validate and
-                     ///< apply the new value.
-  bool immutable;    ///< option value cannot be changed from the default value.
+  char *fullname;           ///< full option name
+  char *shortname;          ///< permissible abbreviation
+  uint32_t flags;           ///< see above
+  OptTypeFlags type_flags;  ///< option type flags, see OptValType
+  void *var;                ///< global option: pointer to variable;
+                            ///< window-local option: VAR_WIN;
+                            ///< buffer-local option: global value
+  idopt_T indir;            ///< global option: PV_NONE;
+                            ///< local option: indirect option index
+  bool immutable;           ///< option value cannot be changed from the default value.
 
   /// callback function to invoke after an option is modified to validate and
   /// apply the new value.
@@ -85,7 +85,7 @@ typedef enum {
   OPT_ONECOLUMN = 0x40,   ///< list options one per line
   OPT_NO_REDRAW = 0x80,   ///< ignore redraw flags on option
   OPT_SKIPRTP   = 0x100,  ///< "skiprtp" in 'sessionoptions'
-} OptionFlags;
+} OptionSetFlags;
 
 /// Return value from get_option_attrs().
 enum {
@@ -93,6 +93,22 @@ enum {
   SOPT_WIN    = 0x02,  ///< Option has window-local value
   SOPT_BUF    = 0x04,  ///< Option has buffer-local value
 };
+
+/// Get name of OptValType as a string.
+static inline const char *optval_type_get_name(const OptValType type)
+{
+  switch (type) {
+  case kOptValTypeNil:
+    return "nil";
+  case kOptValTypeBoolean:
+    return "boolean";
+  case kOptValTypeNumber:
+    return "number";
+  case kOptValTypeString:
+    return "string";
+  }
+  UNREACHABLE;
+}
 
 // OptVal helper macros.
 #define NIL_OPTVAL ((OptVal) { .type = kOptValTypeNil })
@@ -108,3 +124,24 @@ enum {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.h.generated.h"
 #endif
+
+/// Check if option supports a specific type.
+static inline bool option_has_type(OptIndex opt_idx, OptValType type)
+{
+  // Ensure that type flags variable can hold all types.
+  STATIC_ASSERT(kOptValTypeSize <= sizeof(OptTypeFlags) * 8,
+                "Option type_flags cannot fit all option types");
+  // Ensure that the type is valid before accessing type_flags.
+  assert(type > kOptValTypeNil && type < kOptValTypeSize);
+  // Bitshift 1 by the value of type to get the type's corresponding flag, and check if it's set in
+  // the type_flags bit_field.
+  return get_option(opt_idx)->type_flags & (1 << type);
+}
+
+/// Check if option is multitype (supports multiple types).
+static inline bool option_is_multitype(OptIndex opt_idx)
+{
+  const OptTypeFlags type_flags = get_option(opt_idx)->type_flags;
+  assert(type_flags != 0);
+  return !is_power_of_two(type_flags);
+}

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -8,13 +8,20 @@
 #include "nvim/regexp_defs.h"
 #include "nvim/types_defs.h"
 
-/// Option value type
+/// Option value type.
+/// These types are also used as type flags by using the type value as an index for the type_flags
+/// bit field (@see option_has_type()).
 typedef enum {
-  kOptValTypeNil = 0,
+  kOptValTypeNil = -1,  // Make sure Nil can't be bitshifted and used as an option type flag.
   kOptValTypeBoolean,
   kOptValTypeNumber,
   kOptValTypeString,
 } OptValType;
+
+/// Always update this whenever a new option type is added.
+#define kOptValTypeSize (kOptValTypeString + 1)
+
+typedef uint32_t OptTypeFlags;
 
 typedef union {
   // boolean options are actually tri-states because they have a third "None" value.

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -6,55 +6,49 @@
 // option_vars.h: definition of global variables for settable options
 
 // Option Flags
-#define P_BOOL         0x01U        ///< the option is boolean
-#define P_NUM          0x02U        ///< the option is numeric
-#define P_STRING       0x04U        ///< the option is a string
-#define P_ALLOCED      0x08U        ///< the string option is in allocated memory,
+#define P_ALLOCED      0x01U        ///< the option is in allocated memory,
                                     ///< must use free_string_option() when
                                     ///< assigning new value. Not set if default is
                                     ///< the same.
-#define P_EXPAND       0x10U        ///< environment expansion.  NOTE: P_EXPAND can
+#define P_EXPAND       0x02U        ///< environment expansion.  NOTE: P_EXPAND can
                                     ///< never be used for local or hidden options
-#define P_NO_DEF_EXP   0x20U        ///< do not expand default value
-#define P_NODEFAULT    0x40U        ///< don't set to default value
-#define P_DEF_ALLOCED  0x80U        ///< default value is in allocated memory, must
+#define P_NO_DEF_EXP   0x04U        ///< do not expand default value
+#define P_NODEFAULT    0x08U        ///< don't set to default value
+#define P_DEF_ALLOCED  0x10U        ///< default value is in allocated memory, must
                                     ///< use free() when assigning new value
-#define P_WAS_SET      0x100U       ///< option has been set/reset
-#define P_NO_MKRC      0x200U       ///< don't include in :mkvimrc output
+#define P_WAS_SET      0x20U        ///< option has been set/reset
+#define P_NO_MKRC      0x40U        ///< don't include in :mkvimrc output
 
 // when option changed, what to display:
-#define P_UI_OPTION    0x400U       ///< send option to remote UI
-#define P_RTABL        0x800U       ///< redraw tabline
-#define P_RSTAT        0x1000U      ///< redraw status lines
-#define P_RWIN         0x2000U      ///< redraw current window and recompute text
-#define P_RBUF         0x4000U      ///< redraw current buffer and recompute text
-#define P_RALL         0x6000U      ///< redraw all windows
-#define P_RCLR         0x7000U      ///< clear and redraw all
+#define P_UI_OPTION    0x80U        ///< send option to remote UI
+#define P_RTABL        0x100U       ///< redraw tabline
+#define P_RSTAT        0x200U       ///< redraw status lines
+#define P_RWIN         0x400U       ///< redraw current window and recompute text
+#define P_RBUF         0x800U       ///< redraw current buffer and recompute text
+#define P_RALL         0xC00U       ///< redraw all windows
+#define P_RCLR         0xE00U       ///< clear and redraw all
 
-#define P_COMMA        0x8000U      ///< comma separated list
-#define P_ONECOMMA     0x18000U     ///< P_COMMA and cannot have two consecutive
+#define P_COMMA        0x1000U      ///< comma separated list
+#define P_ONECOMMA     0x3000U      ///< P_COMMA and cannot have two consecutive
                                     ///< commas
-#define P_NODUP        0x20000U     ///< don't allow duplicate strings
-#define P_FLAGLIST     0x40000U     ///< list of single-char flags
+#define P_NODUP        0x4000U      ///< don't allow duplicate strings
+#define P_FLAGLIST     0x8000U      ///< list of single-char flags
 
-#define P_SECURE       0x80000U     ///< cannot change in modeline or secure mode
-#define P_GETTEXT      0x100000U    ///< expand default value with _()
-#define P_NOGLOB       0x200000U    ///< do not use local value for global vimrc
-#define P_NFNAME       0x400000U    ///< only normal file name chars allowed
-#define P_INSECURE     0x800000U    ///< option was set from a modeline
-#define P_PRI_MKRC     0x1000000U   ///< priority for :mkvimrc (setting option
+#define P_SECURE       0x10000U     ///< cannot change in modeline or secure mode
+#define P_GETTEXT      0x20000U     ///< expand default value with _()
+#define P_NOGLOB       0x40000U     ///< do not use local value for global vimrc
+#define P_NFNAME       0x80000U     ///< only normal file name chars allowed
+#define P_INSECURE     0x100000U    ///< option was set from a modeline
+#define P_PRI_MKRC     0x200000U    ///< priority for :mkvimrc (setting option
                                     ///< has side effects)
-#define P_NO_ML        0x2000000U   ///< not allowed in modeline
-#define P_CURSWANT     0x4000000U   ///< update curswant required; not needed
+#define P_NO_ML        0x400000U    ///< not allowed in modeline
+#define P_CURSWANT     0x800000U    ///< update curswant required; not needed
                                     ///< when there is a redraw flag
-#define P_NDNAME       0x8000000U   ///< only normal dir name chars allowed
-#define P_RWINONLY     0x10000000U  ///< only redraw current window
-#define P_MLE          0x20000000U  ///< under control of 'modelineexpr'
-#define P_FUNC         0x40000000U  ///< accept a function reference or a lambda
-#define P_COLON        0x80000000U  ///< values use colons to create sublists
-// Warning: Currently we have used all 32 bits for option flags, and adding more
-//          flags will overflow it. Adding another flag will need to change how
-//          it's stored first.
+#define P_NDNAME       0x1000000U   ///< only normal dir name chars allowed
+#define P_RWINONLY     0x2000000U   ///< only redraw current window
+#define P_MLE          0x4000000U   ///< under control of 'modelineexpr'
+#define P_FUNC         0x8000000U   ///< accept a function reference or a lambda
+#define P_COLON        0x10000000U  ///< values use colons to create sublists
 
 #define HIGHLIGHT_INIT \
   "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText,d:Directory,e:ErrorMsg," \

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5,7 +5,7 @@
 --- @field short_desc? string|fun(): string
 --- @field varname? string
 --- @field pv_name? string
---- @field type 'bool'|'number'|'string'
+--- @field type 'boolean'|'number'|'string'
 --- @field immutable? boolean
 --- @field list? 'comma'|'onecomma'|'commacolon'|'onecommacolon'|'flags'|'flagscomma'
 --- @field scope vim.option_scope[]
@@ -105,7 +105,7 @@ return {
       full_name = 'allowrevins',
       scope = { 'global' },
       short_desc = N_('allow CTRL-_ in Insert and Command-line mode'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ari',
     },
     {
@@ -176,7 +176,7 @@ return {
       redraw = { 'curswant' },
       scope = { 'window' },
       short_desc = N_('Arabic as a default second language'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'arshape',
@@ -199,7 +199,7 @@ return {
       redraw = { 'all_windows', 'ui_option' },
       scope = { 'global' },
       short_desc = N_('do shaping for Arabic characters'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_arshape',
     },
     {
@@ -217,7 +217,7 @@ return {
       full_name = 'autochdir',
       scope = { 'global' },
       short_desc = N_('change directory to the file in the current window'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_acd',
     },
     {
@@ -239,7 +239,7 @@ return {
       full_name = 'autoindent',
       scope = { 'buffer' },
       short_desc = N_('take indent for new line from previous line'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ai',
     },
     {
@@ -259,7 +259,7 @@ return {
       full_name = 'autoread',
       scope = { 'global', 'buffer' },
       short_desc = N_('autom. read file when changed outside of Vim'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ar',
     },
     {
@@ -284,7 +284,7 @@ return {
       full_name = 'autowrite',
       scope = { 'global' },
       short_desc = N_('automatically write file if changed'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_aw',
     },
     {
@@ -299,7 +299,7 @@ return {
       full_name = 'autowriteall',
       scope = { 'global' },
       short_desc = N_("as 'autowrite', but works with more commands"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_awa',
     },
     {
@@ -387,7 +387,7 @@ return {
       full_name = 'backup',
       scope = { 'global' },
       short_desc = N_('keep backup file after overwriting a file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_bk',
     },
     {
@@ -671,7 +671,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('read/write/edit file in binary mode'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_bin',
     },
     {
@@ -699,7 +699,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('a Byte Order Mark to the file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_bomb',
     },
     {
@@ -733,7 +733,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('wrapped line repeats indent'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'briopt',
@@ -848,7 +848,7 @@ return {
       scope = { 'buffer' },
       short_desc = N_('whether the buffer shows up in the buffer list'),
       tags = { 'E85' },
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_bl',
     },
     {
@@ -950,7 +950,7 @@ return {
       scope = { 'global' },
       secure = true,
       short_desc = N_(':cd without argument goes to the home directory'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_cdh',
     },
     {
@@ -1088,7 +1088,7 @@ return {
       full_name = 'cindent',
       scope = { 'buffer' },
       short_desc = N_('do C program indenting'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_cin',
     },
     {
@@ -1341,7 +1341,7 @@ return {
       full_name = 'compatible',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -1558,7 +1558,7 @@ return {
       full_name = 'confirm',
       scope = { 'global' },
       short_desc = N_('ask what to do about unsaved/read-only files'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_confirm',
     },
     {
@@ -1578,7 +1578,7 @@ return {
       full_name = 'copyindent',
       scope = { 'buffer' },
       short_desc = N_("make 'autoindent' use existing indent structure"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ci',
     },
     {
@@ -1843,7 +1843,7 @@ return {
       pv_name = 'p_crbind',
       scope = { 'window' },
       short_desc = N_('move cursor in window as it moves in other windows'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'cuc',
@@ -1862,7 +1862,7 @@ return {
       redraw = { 'current_window_only' },
       scope = { 'window' },
       short_desc = N_('highlight the screen column of the cursor'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'cul',
@@ -1877,7 +1877,7 @@ return {
       redraw = { 'current_window_only' },
       scope = { 'window' },
       short_desc = N_('highlight the screen line of the cursor'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'culopt',
@@ -1978,7 +1978,7 @@ return {
       full_name = 'delcombine',
       scope = { 'global' },
       short_desc = N_('delete combining characters on their own'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_deco',
     },
     {
@@ -2030,7 +2030,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('diff mode for the current window'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'dex',
@@ -2183,7 +2183,7 @@ return {
       full_name = 'digraph',
       scope = { 'global' },
       short_desc = N_('enable the entering of digraphs in Insert mode'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_dg',
     },
     {
@@ -2299,7 +2299,7 @@ return {
       full_name = 'edcompatible',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -2317,7 +2317,7 @@ return {
       redraw = { 'all_windows', 'ui_option' },
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_emoji',
     },
     {
@@ -2354,7 +2354,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('write CTRL-Z for last line in file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_eof',
     },
     {
@@ -2380,7 +2380,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('write <EOL> for last line in file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_eol',
     },
     {
@@ -2406,7 +2406,7 @@ return {
       full_name = 'equalalways',
       scope = { 'global' },
       short_desc = N_('windows are automatically made the same size'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ea',
     },
     {
@@ -2442,7 +2442,7 @@ return {
       full_name = 'errorbells',
       scope = { 'global' },
       short_desc = N_('ring the bell for error messages'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_eb',
     },
     {
@@ -2517,7 +2517,7 @@ return {
       full_name = 'expandtab',
       scope = { 'buffer' },
       short_desc = N_('use spaces when <Tab> is inserted'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_et',
     },
     {
@@ -2539,7 +2539,7 @@ return {
       scope = { 'global' },
       secure = true,
       short_desc = N_('read .nvimrc and .exrc in the current directory'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_exrc',
     },
     {
@@ -2769,7 +2769,7 @@ return {
       full_name = 'fileignorecase',
       scope = { 'global' },
       short_desc = N_('ignore case when using file names'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_fic',
     },
     {
@@ -2901,7 +2901,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('make sure last line in file has <EOL>'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_fixeol',
     },
     {
@@ -2960,7 +2960,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('set to display all folds open'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'fde',
@@ -3329,7 +3329,7 @@ return {
       scope = { 'global' },
       secure = true,
       short_desc = N_('whether to invoke fsync() after file write'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_fs',
     },
     {
@@ -3353,7 +3353,7 @@ return {
       full_name = 'gdefault',
       scope = { 'global' },
       short_desc = N_('the ":substitute" flag \'g\' is default on'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_gd',
     },
     {
@@ -3849,7 +3849,7 @@ return {
       full_name = 'hidden',
       scope = { 'global' },
       short_desc = N_("don't unload buffer when it is |abandon|ed"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_hid',
     },
     {
@@ -3885,7 +3885,7 @@ return {
       full_name = 'hkmap',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -3894,7 +3894,7 @@ return {
       full_name = 'hkmapp',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -3926,7 +3926,7 @@ return {
       redraw = { 'all_windows' },
       scope = { 'global' },
       short_desc = N_('highlight matches with last search pattern'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_hls',
     },
     {
@@ -3945,7 +3945,7 @@ return {
       full_name = 'icon',
       scope = { 'global' },
       short_desc = N_('Vim set the text of the window icon'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_icon',
     },
     {
@@ -3981,7 +3981,7 @@ return {
       full_name = 'ignorecase',
       scope = { 'global' },
       short_desc = N_('ignore case in search patterns'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ic',
     },
     {
@@ -3998,7 +3998,7 @@ return {
       full_name = 'imcmdline',
       scope = { 'global' },
       short_desc = N_('use IM when starting to edit a command line'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'imd',
@@ -4016,7 +4016,7 @@ return {
       full_name = 'imdisable',
       scope = { 'global' },
       short_desc = N_('do not use the IM in any mode'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'imi',
@@ -4195,7 +4195,7 @@ return {
       full_name = 'incsearch',
       scope = { 'global' },
       short_desc = N_('highlight match while typing search pattern'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_is',
     },
     {
@@ -4283,7 +4283,7 @@ return {
       full_name = 'infercase',
       scope = { 'buffer' },
       short_desc = N_('adjust case of match for keyword completion'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_inf',
     },
     {
@@ -4292,7 +4292,7 @@ return {
       full_name = 'insertmode',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -4469,7 +4469,7 @@ return {
       full_name = 'joinspaces',
       scope = { 'global' },
       short_desc = N_('two spaces after a period with a join command'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_js',
     },
     {
@@ -4664,7 +4664,7 @@ return {
       full_name = 'langnoremap',
       scope = { 'global' },
       short_desc = N_("do not apply 'langmap' to mapped characters"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_lnr',
     },
     {
@@ -4679,7 +4679,7 @@ return {
       full_name = 'langremap',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_lrm',
     },
     {
@@ -4718,7 +4718,7 @@ return {
       full_name = 'lazyredraw',
       scope = { 'global' },
       short_desc = N_("don't redraw while executing macros"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_lz',
     },
     {
@@ -4739,7 +4739,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('wrap long lines at a blank'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       defaults = {
@@ -4802,7 +4802,7 @@ return {
       full_name = 'lisp',
       scope = { 'buffer' },
       short_desc = N_('indenting for Lisp'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_lisp',
     },
     {
@@ -4868,7 +4868,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('<Tab> and <EOL>'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'lcs',
@@ -4996,7 +4996,7 @@ return {
       full_name = 'loadplugins',
       scope = { 'global' },
       short_desc = N_('load plugin scripts when starting up'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_lpl',
     },
     {
@@ -5013,7 +5013,7 @@ return {
       full_name = 'magic',
       scope = { 'global' },
       short_desc = N_('special characters in search patterns'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_magic',
     },
     {
@@ -5280,7 +5280,7 @@ return {
       full_name = 'modeline',
       scope = { 'buffer' },
       short_desc = N_('recognize modelines at start or end of file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ml',
     },
     {
@@ -5297,7 +5297,7 @@ return {
       scope = { 'global' },
       secure = true,
       short_desc = N_('allow some options to be set in modeline'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_mle',
     },
     {
@@ -5329,7 +5329,7 @@ return {
       scope = { 'buffer' },
       short_desc = N_('changes to the text are not possible'),
       tags = { 'E21' },
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ma',
     },
     {
@@ -5364,7 +5364,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('buffer has been modified'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_mod',
     },
     {
@@ -5377,7 +5377,7 @@ return {
       full_name = 'more',
       scope = { 'global' },
       short_desc = N_('listings when the whole screen is filled'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_more',
     },
     {
@@ -5443,7 +5443,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('keyboard focus follows the mouse'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_mousef',
     },
     {
@@ -5459,7 +5459,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('hide mouse pointer while typing'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_mh',
     },
     {
@@ -5536,7 +5536,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('deliver mouse move events to input queue'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_mousemev',
     },
     {
@@ -5733,7 +5733,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('print the line number in front of each line'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'nuw',
@@ -5797,7 +5797,7 @@ return {
       full_name = 'opendevice',
       scope = { 'global' },
       short_desc = N_('allow reading/writing devices on MS-Windows'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'opfunc',
@@ -5864,7 +5864,7 @@ return {
       pri_mkrc = true,
       scope = { 'global' },
       short_desc = N_('pasting text'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_paste',
     },
     {
@@ -6004,7 +6004,7 @@ return {
       full_name = 'preserveindent',
       scope = { 'buffer' },
       short_desc = N_('preserve the indent structure when reindenting'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_pi',
     },
     {
@@ -6035,14 +6035,14 @@ return {
       scope = { 'window' },
       short_desc = N_('identifies the preview window'),
       tags = { 'E590' },
-      type = 'bool',
+      type = 'boolean',
     },
     {
       defaults = { if_true = true },
       full_name = 'prompt',
       scope = { 'global' },
       short_desc = N_('enable prompt in Ex mode'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -6176,7 +6176,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('disallow writing the buffer'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ro',
     },
     {
@@ -6292,14 +6292,14 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('show relative line number in front of each line'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       defaults = { if_true = true },
       full_name = 'remap',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -6328,7 +6328,7 @@ return {
       full_name = 'revins',
       scope = { 'global' },
       short_desc = N_('inserting characters will work backwards'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ri',
     },
     {
@@ -6349,7 +6349,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('window is right-to-left oriented'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'rlc',
@@ -6403,7 +6403,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'global' },
       short_desc = N_('show cursor line and column in the status line'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ru',
     },
     {
@@ -6598,7 +6598,7 @@ return {
       pv_name = 'p_scbind',
       scope = { 'window' },
       short_desc = N_('scroll in window as other windows scroll'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'sj',
@@ -6700,7 +6700,7 @@ return {
       scope = { 'global' },
       secure = true,
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_secure',
     },
     {
@@ -7184,7 +7184,7 @@ return {
       full_name = 'shellslash',
       scope = { 'global' },
       short_desc = N_('use forward slash for shell file names'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ssl',
     },
     {
@@ -7205,7 +7205,7 @@ return {
       full_name = 'shelltemp',
       scope = { 'global' },
       short_desc = N_('whether to use a temp file for shell commands'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_stmp',
     },
     {
@@ -7262,7 +7262,7 @@ return {
       full_name = 'shiftround',
       scope = { 'global' },
       short_desc = N_('round indent to multiple of shiftwidth'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sr',
     },
     {
@@ -7394,7 +7394,7 @@ return {
       full_name = 'showcmd',
       scope = { 'global' },
       short_desc = N_('show (partial) command in status line'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sc',
     },
     {
@@ -7437,7 +7437,7 @@ return {
       full_name = 'showfulltag',
       scope = { 'global' },
       short_desc = N_('show full tag pattern when completing tag'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sft',
     },
     {
@@ -7463,7 +7463,7 @@ return {
       full_name = 'showmatch',
       scope = { 'global' },
       short_desc = N_('briefly jump to matching bracket if insert one'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sm',
     },
     {
@@ -7477,7 +7477,7 @@ return {
       full_name = 'showmode',
       scope = { 'global' },
       short_desc = N_('message on status line to show current mode'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_smd',
     },
     {
@@ -7592,7 +7592,7 @@ return {
       full_name = 'smartcase',
       scope = { 'global' },
       short_desc = N_('no ignore case when pattern has uppercase'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_scs',
     },
     {
@@ -7622,7 +7622,7 @@ return {
       full_name = 'smartindent',
       scope = { 'buffer' },
       short_desc = N_('smart autoindenting for C programs'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_si',
     },
     {
@@ -7643,7 +7643,7 @@ return {
       full_name = 'smarttab',
       scope = { 'global' },
       short_desc = N_("use 'shiftwidth' when inserting <Tab>"),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sta',
     },
     {
@@ -7665,7 +7665,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_("scroll by screen lines when 'wrap' is set"),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'sts',
@@ -7704,7 +7704,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('spell checking'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'spc',
@@ -7935,7 +7935,7 @@ return {
       full_name = 'splitbelow',
       scope = { 'global' },
       short_desc = N_('new window from split is below the current one'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sb',
     },
     {
@@ -7973,7 +7973,7 @@ return {
       full_name = 'splitright',
       scope = { 'global' },
       short_desc = N_('new window is put right of the current one'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_spr',
     },
     {
@@ -7994,7 +7994,7 @@ return {
       full_name = 'startofline',
       scope = { 'global' },
       short_desc = N_('commands move cursor to first non-blank in line'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_sol',
       vim = false,
     },
@@ -8356,7 +8356,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'buffer' },
       short_desc = N_('whether to use a swapfile for a buffer'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_swf',
     },
     {
@@ -8610,7 +8610,7 @@ return {
       full_name = 'tagbsearch',
       scope = { 'global' },
       short_desc = N_('use binary searching in tags files'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_tbs',
     },
     {
@@ -8677,7 +8677,7 @@ return {
       full_name = 'tagrelative',
       scope = { 'global' },
       short_desc = N_('file names in tag file are relative'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_tr',
     },
     {
@@ -8727,7 +8727,7 @@ return {
       full_name = 'tagstack',
       scope = { 'global' },
       short_desc = N_('push tags onto the tag stack'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_tgst',
     },
     {
@@ -8746,7 +8746,7 @@ return {
       full_name = 'termbidi',
       scope = { 'global' },
       short_desc = N_('terminal takes care of bi-directionality'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_tbidi',
     },
     {
@@ -8773,7 +8773,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('Terminal true color support'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_tgc',
     },
     {
@@ -8820,7 +8820,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('synchronize redraw output with the host terminal'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_termsync',
     },
     {
@@ -8828,7 +8828,7 @@ return {
       full_name = 'terse',
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -8910,7 +8910,7 @@ return {
       full_name = 'tildeop',
       scope = { 'global' },
       short_desc = N_('tilde command "~" behaves like an operator'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_to',
     },
     {
@@ -8925,7 +8925,7 @@ return {
       full_name = 'timeout',
       scope = { 'global' },
       short_desc = N_('time out on mappings and key codes'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_timeout',
     },
     {
@@ -8959,7 +8959,7 @@ return {
       full_name = 'title',
       scope = { 'global' },
       short_desc = N_('Vim set the title of the window'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_title',
     },
     {
@@ -9048,7 +9048,7 @@ return {
       redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('out on mappings'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ttimeout',
     },
     {
@@ -9073,7 +9073,7 @@ return {
       no_mkrc = true,
       scope = { 'global' },
       short_desc = N_('No description'),
-      type = 'bool',
+      type = 'boolean',
       immutable = true,
     },
     {
@@ -9129,7 +9129,7 @@ return {
       full_name = 'undofile',
       scope = { 'buffer' },
       short_desc = N_('save undo information in a file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_udf',
     },
     {
@@ -9441,7 +9441,7 @@ return {
       full_name = 'visualbell',
       scope = { 'global' },
       short_desc = N_('use visual bell instead of beeping'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_vb',
     },
     {
@@ -9453,7 +9453,7 @@ return {
       full_name = 'warn',
       scope = { 'global' },
       short_desc = N_('for shell command when buffer was changed'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_warn',
     },
     {
@@ -9578,7 +9578,7 @@ return {
       full_name = 'wildignorecase',
       scope = { 'global' },
       short_desc = N_('ignore case when completing file names'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_wic',
     },
     {
@@ -9626,7 +9626,7 @@ return {
       full_name = 'wildmenu',
       scope = { 'global' },
       short_desc = N_('use menu for command line completion'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_wmnu',
     },
     {
@@ -9829,7 +9829,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'window' },
       short_desc = N_('keep window height when opening/closing windows'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'wfw',
@@ -9843,7 +9843,7 @@ return {
       redraw = { 'statuslines' },
       scope = { 'window' },
       short_desc = N_('keep window width when opening/closing windows'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'wh',
@@ -9996,7 +9996,7 @@ return {
       redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('lines wrap and continue on the next line'),
-      type = 'bool',
+      type = 'boolean',
     },
     {
       abbreviation = 'wm',
@@ -10027,7 +10027,7 @@ return {
       scope = { 'global' },
       short_desc = N_('searches wrap around the end of the file'),
       tags = { 'E384', 'E385' },
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_ws',
     },
     {
@@ -10042,7 +10042,7 @@ return {
       full_name = 'write',
       scope = { 'global' },
       short_desc = N_('to a file is allowed'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_write',
     },
     {
@@ -10054,7 +10054,7 @@ return {
       full_name = 'writeany',
       scope = { 'global' },
       short_desc = N_('write to file with no need for "!" override'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_wa',
     },
     {
@@ -10077,7 +10077,7 @@ return {
       full_name = 'writebackup',
       scope = { 'global' },
       short_desc = N_('make a backup before overwriting a file'),
-      type = 'bool',
+      type = 'boolean',
       varname = 'p_wb',
     },
     {

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1478,9 +1478,9 @@ describe('API', function()
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 42}))
       eq("Invalid 'value': expected valid option type, got Array",
         pcall_err(nvim, 'set_option_value', 'scrolloff', {}, {}))
-      eq("Invalid value for option 'scrolloff': expected Number, got Boolean true",
+      eq("Invalid value for option 'scrolloff': expected number, got boolean true",
         pcall_err(nvim, 'set_option_value', 'scrolloff', true, {}))
-      eq("Invalid value for option 'scrolloff': expected Number, got String \"wrong\"",
+      eq("Invalid value for option 'scrolloff': expected number, got string \"wrong\"",
         pcall_err(nvim, 'set_option_value', 'scrolloff', 'wrong', {}))
     end)
 

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -813,7 +813,7 @@ func Test_set_option_errors()
   call assert_fails('set winwidth=9 winminwidth=10', 'E592:')
   set winwidth& winminwidth&
   call assert_fails("set showbreak=\x01", 'E595:')
-  call assert_fails('set t_foo=', 'E846:')
+  " call assert_fails('set t_foo=', 'E846:')
   call assert_fails('set tabstop??', 'E488:')
   call assert_fails('set wrapscan!!', 'E488:')
   call assert_fails('set tabstop&&', 'E488:')
@@ -1446,8 +1446,10 @@ endfunc
 
 " Test for setting keycodes using set
 func Test_opt_set_keycode()
-  call assert_fails('set <t_k1=l', 'E474:')
-  call assert_fails('set <Home=l', 'E474:')
+  " call assert_fails('set <t_k1=l', 'E474:')
+  " call assert_fails('set <Home=l', 'E474:')
+  call assert_fails('set <t_k1=l', 'E518:')
+  call assert_fails('set <Home=l', 'E518:')
   set <t_k9>=abcd
   " call assert_equal('abcd', &t_k9)
   set <t_k9>&


### PR DESCRIPTION
Problem: We have `P_(BOOL|NUM|STRING)` macros to represent an option's type, which is redundant because `OptValType` can already do that. The current implementation of option type flags is also too limited to allow adding multitype options in the future.

Solution: Remove `P_(BOOL|NUM|STRING)` and replace it with a new `type_flags` attribute in `vimoption_T`. Also do some groundwork for adding multitype options in the future.

Side-effects: Attempting to set an invalid keycode option (e.g. `set t_foo=123`) no longer gives an error.

It is an eventual goal to replace all (at least most) of the `option_has_type` checks with switch statements, but that is for much later. In a follow-up PR, we can also work on removing the `is_tty_option` checks by giving TTY options their own option index.