### PR TITLE
docs: minor update (API)

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -112,7 +112,9 @@ Basic types ~
   Dictionary (msgpack: map)
   Object
 <
-  Note: empty Array is accepted as a valid argument for Dictionary parameter.
+  Note: 
+    - An empty Array is accepted as a valid argument for Dictionary parameter.
+    - There is no Function type, so API functions cannot return Lua functions.
 
 Special types (msgpack EXT) ~
 


### PR DESCRIPTION
I am not sure if this is the best wording, but I thought it would make sense to add a comment about the lack of a `Function` type in the API. 

(This showed up in the discussion in #26531.)