### PR TITLE
feat(highlight): tweak default color scheme

### DIFF
--- a/runtime/colors/default.vim
+++ b/runtime/colors/default.vim
@@ -2,12 +2,7 @@
 " Maintainer:	The Neovim Project <https://github.com/neovim/neovim>
 " Last Change:	2023 Dec 01
 
-" This is the default color scheme.
-
-" Set 'background' back to the default. The value can't always be estimated
-" and is then guessed.
-hi clear Normal
-set bg&
+" This is the default color scheme. See `:help dev_theme`.
 
 " Remove all existing highlighting and set the defaults.
 hi clear

--- a/runtime/colors/vim.vim
+++ b/runtime/colors/vim.vim
@@ -14,8 +14,8 @@ let g:colors_name = 'vim'
 
 " General
 hi Conceal      guifg=LightGrey guibg=DarkGrey guisp=NONE gui=NONE         ctermfg=LightGrey ctermbg=DarkGrey cterm=NONE
-hi Cursor       guifg=bg        guibg=fg       guisp=NONE gui=NONE         ctermfg=bg        ctermbg=fg       cterm=NONE
-hi lCursor      guifg=bg        guibg=fg       guisp=NONE gui=NONE         ctermfg=bg        ctermbg=fg       cterm=NONE
+hi Cursor       guifg=bg        guibg=fg       guisp=NONE gui=NONE         ctermfg=NONE      ctermbg=NONE     cterm=NONE
+hi lCursor      guifg=bg        guibg=fg       guisp=NONE gui=NONE         ctermfg=NONE      ctermbg=NONE     cterm=NONE
 hi DiffText     guifg=NONE      guibg=Red      guisp=NONE gui=bold         ctermfg=NONE      ctermbg=Red      cterm=bold
 hi ErrorMsg     guifg=White     guibg=Red      guisp=NONE gui=NONE         ctermfg=White     ctermbg=DarkRed  cterm=NONE
 hi IncSearch    guifg=NONE      guibg=NONE     guisp=NONE gui=reverse      ctermfg=NONE      ctermbg=NONE     cterm=reverse
@@ -214,7 +214,7 @@ if &background ==# 'light'
   hi SpellRare    guifg=NONE      guibg=NONE         guisp=Magenta  gui=undercurl ctermfg=NONE        ctermbg=LightMagenta cterm=NONE
   hi TabLine      guifg=NONE      guibg=LightGrey    guisp=NONE     gui=underline ctermfg=black       ctermbg=LightGrey    cterm=underline
   hi Title        guifg=Magenta   guibg=NONE         guisp=NONE     gui=bold      ctermfg=DarkMagenta ctermbg=NONE         cterm=NONE
-  hi Visual       guifg=NONE      guibg=LightGrey    guisp=NONE     gui=NONE      ctermfg=NONE        ctermbg=NONE         cterm=NONE
+  hi Visual       guifg=NONE      guibg=LightGrey    guisp=NONE     gui=NONE      ctermfg=NONE        ctermbg=LightGrey    cterm=NONE
   hi WarningMsg   guifg=Red       guibg=NONE         guisp=NONE     gui=NONE      ctermfg=DarkRed     ctermbg=NONE         cterm=NONE
   hi Comment      guifg=Blue      guibg=NONE         guisp=NONE     gui=NONE      ctermfg=DarkBlue    ctermbg=NONE         cterm=NONE      term=bold
   hi Constant     guifg=Magenta   guibg=NONE         guisp=NONE     gui=NONE      ctermfg=DarkRed     ctermbg=NONE         cterm=NONE      term=underline
@@ -253,7 +253,7 @@ else
   hi SpellRare    guifg=NONE     guibg=NONE        guisp=Magenta gui=undercurl ctermfg=NONE         ctermbg=Magenta     cterm=NONE
   hi TabLine      guifg=NONE     guibg=DarkGrey    guisp=NONE    gui=underline ctermfg=white        ctermbg=DarkGrey    cterm=underline
   hi Title        guifg=Magenta  guibg=NONE        guisp=NONE    gui=bold      ctermfg=LightMagenta ctermbg=NONE        cterm=NONE
-  hi Visual       guifg=NONE     guibg=DarkGrey    guisp=NONE    gui=NONE      ctermfg=NONE         ctermbg=NONE        cterm=NONE
+  hi Visual       guifg=NONE     guibg=DarkGrey    guisp=NONE    gui=NONE      ctermfg=NONE         ctermbg=DarkGrey    cterm=NONE
   hi WarningMsg   guifg=Red      guibg=NONE        guisp=NONE    gui=NONE      ctermfg=LightRed     ctermbg=NONE        cterm=NONE
   hi Comment      guifg=#80a0ff  guibg=NONE        guisp=NONE    gui=NONE      ctermfg=Cyan         ctermbg=NONE        cterm=NONE      term=bold
   hi Constant     guifg=#ffa0a0  guibg=NONE        guisp=NONE    gui=NONE      ctermfg=Magenta      ctermbg=NONE        cterm=NONE      term=underline

--- a/runtime/doc/dev_theme.txt
+++ b/runtime/doc/dev_theme.txt
@@ -18,8 +18,8 @@ Design
 - Be "Neovim branded", i.e. have mostly "green-blue" feel plus one or two
   colors reserved for very occasional user attention.
 
-- Be extra minimal for 'notermguicolors' (256 colors) while allowing a bit
-  more shades when 'termguicolors' is set (true colors).
+- Be oriented for 'termguicolors' (true colors) while being extra minimal for
+  'notermguicolors' (16 colors) as fallback.
 
 - Be accessible, i.e. have high enough contrast ratio (as defined in
   https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef).
@@ -49,8 +49,7 @@ Palettes
 - Each palette has the following colors (descriptions are for dark background;
   reverse for light one):
 
-    - Four shades of "colored" greys for general UI. In 256 colors they are
-      exact greys; in true colors they are shades of "cold" grey.
+    - Four shades of colored "cold" greys for general UI.
 
         - Dark ones (from darkest to lightest) are reserved as background for
           |hl-NormalFloat| (considered as "black"), |hl-Normal| (background),
@@ -67,8 +66,17 @@ Palettes
   (which is used for |hl-Normal|) as possible. They should have (reasonably)
   different hues to make them visually separable.
 
-- Each palette color should have a 256 colors variant with closest color
-  computed based on the perceptually uniform distance measure.
+- For 16 colors:
+
+    - Greys are not used and are replaced with the foreground and background
+      colors of the terminal emulator.
+
+    - Non-grey colors fall back to terminal colors as ordered in ANSI codes
+      (https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit),
+      that is red (1, 9), green (2, 10), yellow (3, 11), blue (4, 12),
+      magenta (5, 13), cyan (6, 14).
+      To increase contrast, colors 1-6 are used for light background and 9-14
+      for dark background.
 
 
 ==============================================================================
@@ -91,13 +99,23 @@ Use:
 - Red to generally mean high user attention, i.e. errors; in particular for
   |hl-ErrorMsg|, |hl-DiffDelete|, |hl-DiagnosticError|.
 
-- Yellow very sparingly only with true colors to mean mild user attention,
-  i.e. warnings. That is, |hl-DiagnosticWarn| and |hl-WarningMsg|.
+- Yellow very sparingly to mean mild user attention, i.e. warnings. That is,
+  |hl-DiagnosticWarn| and |hl-WarningMsg|.
 
-- Blue very sparingly only with true colors as |hl-DiagnosticHint| and some
-  additional important syntax group (like `Identifier`).
+- Blue very sparingly as |hl-DiagnosticHint| and some additional important
+  syntax group (like `Identifier`).
 
 - Magenta very carefully (if at all).
+
+In case of 16 colors:
+
+- Rely on the assumption "Background color can be used as background; other
+  colors can be used as foreground". This means that in any
+  foreground/background combination there should be background and one
+  non-background color.
+
+- Use 0 (black) or 15 (bright white) as foreground for non-grey background,
+  depending on whether normal background is light or dark.
 
 
  vim:tw=78:ts=8:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -92,8 +92,21 @@ The following changes may require adaptations in user config or plugins.
   • Legacy and extmark signs are displayed and listed with the same priority:
       line number -> priority -> sign id -> recently placed
 
-• Default color scheme has been updated to be "Neovim branded" and accessible.
+• Default color scheme has been updated to be "Nvim branded" and accessible.
   Use `:colorscheme vim` to revert to the old legacy color scheme.
+
+  Here is a list of Nvim specific highlight groups which are now defined in
+  a meaningfully different way and might need an update:
+  • |hl-FloatBorder| is linked to |hl-NormalFloat| instead of |hl-WinSeparator|.
+  • |hl-NormalFloat| is not linked to |hl-Pmenu|.
+  • |hl-WinBar| is linked to |hl-StatusLine|.
+  • |hl-WinBarNC| is linked to |hl-StatusLineNC| instead of |hl-WinBar|.
+  • |hl-WinSeparator| is linked to |hl-Normal| instead of |hl-VertSplit|.
+
+  This also might result into some color schemes looking differently due to
+  them relying on an implicit assumptions about how highlight groups are
+  defined by default. To account for this, define all attributes of highlight
+  groups explicitly or use `:colorscheme vim` to restore previous definitions.
 
 • 'termguicolors' is enabled by default when Nvim is able to determine that
   the host terminal emulator supports 24-bit color.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5136,6 +5136,18 @@ guisp={color-name}					*guisp*
 	    Black	White
 	    Orange	Purple		Violet
 
+	Colors which define Nvim's default color scheme:
+	    NvimDarkBlue    NvimLightBlue
+	    NvimDarkCyan    NvimLightCyan
+	    NvimDarkGreen   NvimLightGreen
+	    NvimDarkGrey1   NvimLightGrey1
+	    NvimDarkGrey2   NvimLightGrey2
+	    NvimDarkGrey3   NvimLightGrey3
+	    NvimDarkGrey4   NvimLightGrey4
+	    NvimDarkMagenta NvimLightMagenta
+	    NvimDarkRed     NvimLightRed
+	    NvimDarkYellow  NvimLightYellow
+
 	You can also specify a color by its RGB (red, green, blue) values.
 	The format is "#rrggbb", where
 		"rr"	is the Red value

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -30,8 +30,10 @@ Defaults					            *nvim-defaults*
   ":filetype off" to |init.vim|.
 - Syntax highlighting is enabled by default. This can be disabled by adding
   ":syntax off" to |init.vim|.
-- Default color scheme has been updated. This can be reversed by adding
-  ":colorscheme vim" to |init.vim|.
+- Default color scheme has been updated. This can result in color schemes
+  looking differently due to them relying on how highlight groups are defined
+  by default. Add ":colorscheme vim" to |init.vim| or your color scheme file to
+  restore the old default links and colors.
 
 - 'autoindent' is enabled
 - 'autoread' is enabled (works in all UIs, including terminal)

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -135,24 +135,29 @@ static const char e_missing_argument_str[]
 // they still work when the runtime files can't be found.
 
 static const char *highlight_init_both[] = {
-  "Cursor            guibg=fg      guifg=bg",
+  "Cursor            guifg=bg      guibg=fg",
   "CursorLineNr      gui=bold      cterm=bold",
-  "QuickFixLine      gui=bold      cterm=bold",
   "RedrawDebugNormal gui=reverse   cterm=reverse",
   "TabLineSel        gui=bold      cterm=bold",
   "TermCursor        gui=reverse   cterm=reverse",
   "Title             gui=bold      cterm=bold",
+  "Todo              gui=bold      cterm=bold",
   "Underlined        gui=underline cterm=underline",
-  "lCursor           guibg=fg      guifg=bg",
+  "lCursor           guifg=bg      guibg=fg",
+
+  "Constant   guifg=NONE",
+  "Operator   guifg=NONE",
+  "PreProc    guifg=NONE",
+  "Type       guifg=NONE",
+  "Delimiter  guifg=NONE",
 
   // UI
-  "default link CurSearch      Search",
   "default link CursorIM       Cursor",
   "default link CursorLineFold FoldColumn",
   "default link CursorLineSign SignColumn",
   "default link EndOfBuffer    NonText",
   "default link FloatBorder    NormalFloat",
-  "default link FloatFooter    Title",
+  "default link FloatFooter    FloatTitle",
   "default link FloatTitle     Title",
   "default link FoldColumn     SignColumn",
   "default link IncSearch      Search",
@@ -167,6 +172,7 @@ static const char *highlight_init_both[] = {
   "default link PmenuKindSel   PmenuSel",
   "default link PmenuSbar      Pmenu",
   "default link Substitute     Search",
+  "default link TabLine        StatusLine",
   "default link TabLineFill    TabLine",
   "default link TermCursorNC   NONE",
   "default link VertSplit      WinSeparator",
@@ -203,6 +209,11 @@ static const char *highlight_init_both[] = {
   "default link SnippetTabstop Visual",
 
   // Diagnostic
+  "default link DiagnosticFloatingError    DiagnosticError",
+  "default link DiagnosticFloatingWarn     DiagnosticWarn",
+  "default link DiagnosticFloatingInfo     DiagnosticInfo",
+  "default link DiagnosticFloatingHint     DiagnosticHint",
+  "default link DiagnosticFloatingOk       DiagnosticOk",
   "default link DiagnosticVirtualTextError DiagnosticError",
   "default link DiagnosticVirtualTextWarn  DiagnosticWarn",
   "default link DiagnosticVirtualTextInfo  DiagnosticInfo",
@@ -293,162 +304,138 @@ static const char *highlight_init_both[] = {
 
 // Default colors only used with a light background.
 static const char *highlight_init_light[] = {
-  "Normal guifg=NvimDarkGrey2 ctermfg=234 guibg=NvimLightGrey2 ctermbg=253",
+  "Normal guifg=NvimDarkGrey2 guibg=NvimLightGrey2 ctermfg=NONE ctermbg=NONE",
 
   // UI
-  "ColorColumn          guibg=NvimLightGrey4 ctermbg=247",
-  "Conceal              guifg=NvimLightGrey4 ctermfg=247",
-  "CursorColumn         guibg=NvimLightGrey3 ctermbg=251",
-  "CursorLine           guibg=NvimLightGrey3 ctermbg=251",
-  "DiffAdd              guifg=NvimDarkGrey1  ctermfg=232   guibg=NvimLightGreen  ctermbg=158",
-  "DiffChange           guifg=NvimDarkGrey1  ctermfg=232   guibg=NvimLightGrey4  ctermbg=247",
-  "DiffDelete           guifg=NvimDarkRed    ctermfg=52    gui=bold              cterm=bold",
-  "DiffText             guifg=NvimDarkGrey1  ctermfg=232   guibg=NvimLightCyan   ctermbg=123",
-  "Directory            guifg=NvimDarkCyan   ctermfg=30",
-  "ErrorMsg             guifg=NvimDarkRed    ctermfg=52",
-  "FloatShadow          guibg=NvimLightGrey1 ctermbg=255   blend=80",
-  "FloatShadowThrough   guibg=NvimLightGrey1 ctermbg=255   blend=100",
-  "Folded               guifg=NvimDarkGrey4  ctermfg=239   guibg=NvimLightGrey3  ctermbg=251",
-  "LineNr               guifg=NvimLightGrey4 ctermfg=247",
-  "MatchParen           guibg=NvimLightGrey4 ctermbg=247   gui=bold              cterm=bold",
-  "ModeMsg              guifg=NvimDarkGreen  ctermfg=22",
-  "MoreMsg              guifg=NvimDarkCyan   ctermfg=30",
-  "NonText              guifg=NvimLightGrey4 ctermfg=247",
-  "NormalFloat          guifg=NvimDarkGrey2  ctermfg=234   guibg=NvimLightGrey1  ctermbg=255",
-  "Pmenu                guifg=NvimDarkGrey2  ctermfg=234   guibg=NvimLightGrey3  ctermbg=251",
-  "PmenuSel             guifg=NvimLightGrey3 ctermfg=251   guibg=NvimDarkGrey2   ctermbg=234 blend=0",
-  "PmenuThumb           guibg=NvimLightGrey4 ctermbg=247",
-  "Question             guifg=NvimDarkCyan   ctermfg=30",
-  "RedrawDebugClear     guibg=NvimLightCyan  ctermbg=123",
-  "RedrawDebugComposed  guibg=NvimLightGreen ctermbg=158",
-  "RedrawDebugRecompose guibg=NvimLightRed   ctermbg=217",
-  "Search               guifg=NvimDarkGrey1  ctermfg=232   guibg=NvimLightYellow ctermbg=222",
-  "SignColumn           guifg=NvimLightGrey4 ctermfg=247",
-  "SpecialKey           guifg=NvimLightGrey4 ctermfg=247",
-  "SpellBad             guisp=NvimDarkRed    gui=undercurl cterm=undercurl",
-  "SpellCap             guisp=NvimDarkYellow gui=undercurl cterm=undercurl",
-  "SpellLocal           guisp=NvimDarkGreen  gui=undercurl cterm=undercurl",
-  "SpellRare            guisp=NvimDarkCyan   gui=undercurl cterm=undercurl",
-  "StatusLine           guifg=NvimDarkGrey3  ctermfg=236   guibg=NvimLightGrey1  ctermbg=255",
-  "StatusLineNC         guifg=NvimDarkGrey4  ctermfg=239   guibg=NvimLightGrey1  ctermbg=255",
-  "TabLine              guifg=NvimDarkGrey3  ctermfg=236   guibg=NvimLightGrey1  ctermbg=255",
-  "Visual               guibg=NvimLightGrey4 ctermbg=247",
-  "WarningMsg           guifg=NvimDarkYellow ctermfg=52",  // In 256 colors fall back to red
+  "ColorColumn                               guibg=NvimLightGrey4            cterm=reverse",
+  "Conceal              guifg=NvimLightGrey4",
+  "CurSearch            guifg=NvimLightGrey1 guibg=NvimDarkYellow            ctermfg=15 ctermbg=3",
+  "CursorColumn                              guibg=NvimLightGrey3",
+  "CursorLine                                guibg=NvimLightGrey3",
+  "DiffAdd              guifg=NvimDarkGrey1  guibg=NvimLightGreen            ctermfg=15 ctermbg=2",
+  "DiffChange           guifg=NvimDarkGrey1  guibg=NvimLightGrey4",
+  "DiffDelete           guifg=NvimDarkRed                          gui=bold  ctermfg=1 cterm=bold",
+  "DiffText             guifg=NvimDarkGrey1  guibg=NvimLightCyan             ctermfg=15 ctermbg=6",
+  "Directory            guifg=NvimDarkCyan                                   ctermfg=6",
+  "ErrorMsg             guifg=NvimDarkRed                                    ctermfg=1",
+  "FloatShadow                               guibg=NvimLightGrey4            ctermbg=0 blend=80",
+  "FloatShadowThrough                        guibg=NvimLightGrey4            ctermbg=0 blend=100",
+  "Folded               guifg=NvimDarkGrey4  guibg=NvimLightGrey3",
+  "LineNr               guifg=NvimLightGrey4",
+  "MatchParen                                guibg=NvimLightGrey4  gui=bold  cterm=bold,underline",
+  "ModeMsg              guifg=NvimDarkGreen                                  ctermfg=2",
+  "MoreMsg              guifg=NvimDarkCyan                                   ctermfg=6",
+  "NonText              guifg=NvimLightGrey4",
+  "NormalFloat                               guibg=NvimLightGrey1",
+  "Pmenu                                     guibg=NvimLightGrey3            cterm=reverse",
+  "PmenuSel             guifg=NvimLightGrey3 guibg=NvimDarkGrey2             cterm=reverse,underline blend=0",
+  "PmenuThumb                                guibg=NvimLightGrey4",
+  "Question             guifg=NvimDarkCyan                                   ctermfg=6",
+  "QuickFixLine         guifg=NvimDarkCyan                                   ctermfg=6",
+  "RedrawDebugClear                          guibg=NvimLightYellow           ctermfg=15 ctermbg=3",
+  "RedrawDebugComposed                       guibg=NvimLightGreen            ctermfg=15 ctermbg=2",
+  "RedrawDebugRecompose                      guibg=NvimLightRed              ctermfg=15 ctermbg=1",
+  "Search               guifg=NvimDarkGrey1  guibg=NvimLightYellow           ctermfg=15 ctermbg=3",
+  "SignColumn           guifg=NvimLightGrey4",
+  "SpecialKey           guifg=NvimLightGrey4",
+  "SpellBad             guisp=NvimDarkRed    gui=undercurl                   cterm=undercurl",
+  "SpellCap             guisp=NvimDarkYellow gui=undercurl                   cterm=undercurl",
+  "SpellLocal           guisp=NvimDarkGreen  gui=undercurl                   cterm=undercurl",
+  "SpellRare            guisp=NvimDarkCyan   gui=undercurl                   cterm=undercurl",
+  "StatusLine           guifg=NvimDarkGrey3  guibg=NvimLightGrey1            cterm=reverse",
+  "StatusLineNC         guifg=NvimDarkGrey4  guibg=NvimLightGrey1            cterm=bold",
+  "Visual                                    guibg=NvimLightGrey4            ctermfg=15 ctermbg=0",
+  "WarningMsg           guifg=NvimDarkYellow                                 ctermfg=3",
 
   // Syntax
-  "Comment    guifg=NvimDarkGrey4 ctermfg=239",
-  "Constant   guifg=NvimDarkGrey2 ctermfg=234",
-  "String     guifg=NvimDarkGreen ctermfg=22",
-  "Identifier guifg=NvimDarkBlue  ctermfg=NONE",  // No fallback in 256 colors to reduce noise
-  "Function   guifg=NvimDarkCyan  ctermfg=30",
-  "Statement  guifg=NvimDarkGrey2 ctermfg=234 gui=bold           cterm=bold",
-  "Operator   guifg=NvimDarkGrey2 ctermfg=234",
-  "PreProc    guifg=NvimDarkGrey2 ctermfg=234",
-  "Type       guifg=NvimDarkGrey2 ctermfg=234",
-  "Special    guifg=NvimDarkGrey2 ctermfg=234",
-  "Delimiter  guifg=NvimDarkGrey2 ctermfg=234",
-  "Error      guifg=NvimDarkGrey1 ctermfg=232 guibg=NvimLightRed ctermbg=217",
-  "Todo       guifg=NvimDarkGrey1 ctermfg=232 gui=bold           cterm=bold",
+  "Comment    guifg=NvimDarkGrey4",
+  "String     guifg=NvimDarkGreen                    ctermfg=2",
+  "Identifier guifg=NvimDarkBlue                     ctermfg=4",
+  "Function   guifg=NvimDarkCyan                     ctermfg=6",
+  "Statement  gui=bold                               cterm=bold",
+  "Special    guifg=NvimDarkCyan                     ctermfg=6",
+  "Error      guifg=NvimDarkGrey1 guibg=NvimLightRed ctermfg=15 ctermbg=1",
 
   // Diagnostic
-  "DiagnosticError          guifg=NvimDarkRed    ctermfg=52",
-  "DiagnosticWarn           guifg=NvimDarkYellow ctermfg=52",  // In 256 colors fall back to red
-  "DiagnosticInfo           guifg=NvimDarkCyan   ctermfg=30",
-  "DiagnosticHint           guifg=NvimDarkBlue   ctermfg=30",  // In 256 colors fall back to cyan
-  "DiagnosticOk             guifg=NvimDarkGreen  ctermfg=22",
+  "DiagnosticError          guifg=NvimDarkRed                      ctermfg=1",
+  "DiagnosticWarn           guifg=NvimDarkYellow                   ctermfg=3",
+  "DiagnosticInfo           guifg=NvimDarkCyan                     ctermfg=6",
+  "DiagnosticHint           guifg=NvimDarkBlue                     ctermfg=4",
+  "DiagnosticOk             guifg=NvimDarkGreen                    ctermfg=2",
   "DiagnosticUnderlineError guisp=NvimDarkRed    gui=underline     cterm=underline",
   "DiagnosticUnderlineWarn  guisp=NvimDarkYellow gui=underline     cterm=underline",
   "DiagnosticUnderlineInfo  guisp=NvimDarkCyan   gui=underline     cterm=underline",
-  "DiagnosticUnderlineHint  guisp=NvimDarkBlue   gui=underline     cterm=underline",  // In 256 colors fall back to cyan
+  "DiagnosticUnderlineHint  guisp=NvimDarkBlue   gui=underline     cterm=underline",
   "DiagnosticUnderlineOk    guisp=NvimDarkGreen  gui=underline     cterm=underline",
-  "DiagnosticFloatingError  guifg=NvimDarkRed    ctermfg=52        guibg=NvimLightGrey1 ctermbg=255",
-  //  In 256 colors fall back to red
-  "DiagnosticFloatingWarn   guifg=NvimDarkYellow ctermfg=52        guibg=NvimLightGrey1 ctermbg=255",
-  "DiagnosticFloatingInfo   guifg=NvimDarkCyan   ctermfg=30        guibg=NvimLightGrey1 ctermbg=255",
-  // In 256 colors fall back to cyan
-  "DiagnosticFloatingHint   guifg=NvimDarkBlue   ctermfg=30        guibg=NvimLightGrey1 ctermbg=255",
-  "DiagnosticFloatingOk     guifg=NvimDarkGreen  ctermfg=22        guibg=NvimLightGrey1 ctermbg=255",
   "DiagnosticDeprecated     guisp=NvimDarkRed    gui=strikethrough cterm=strikethrough",
   NULL
 };
 
 // Default colors only used with a dark background.
 static const char *highlight_init_dark[] = {
-  "Normal guifg=NvimLightGrey2 ctermfg=253 guibg=NvimDarkGrey2 ctermbg=234",
+  "Normal guifg=NvimLightGrey2 guibg=NvimDarkGrey2 ctermfg=NONE ctermbg=NONE",
 
   // UI
-  "ColorColumn          guibg=NvimDarkGrey4   ctermbg=239",
-  "Conceal              guifg=NvimDarkGrey4   ctermfg=239",
-  "CursorColumn         guibg=NvimDarkGrey3   ctermbg=236",
-  "CursorLine           guibg=NvimDarkGrey3   ctermbg=236",
-  "DiffAdd              guifg=NvimLightGrey1  ctermfg=255   guibg=NvimDarkGreen  ctermbg=22",
-  "DiffChange           guifg=NvimLightGrey1  ctermfg=255   guibg=NvimDarkGrey4  ctermbg=239",
-  "DiffDelete           guifg=NvimLightRed    ctermfg=217   gui=bold             cterm=bold",
-  "DiffText             guifg=NvimLightGrey1  ctermfg=255   guibg=NvimDarkCyan   ctermbg=30",
-  "Directory            guifg=NvimLightCyan   ctermfg=123",
-  "ErrorMsg             guifg=NvimLightRed    ctermfg=217",
-  "FloatShadow          guibg=NvimDarkGrey1   ctermbg=232   blend=80",
-  "FloatShadowThrough   guibg=NvimDarkGrey1   ctermbg=232   blend=100",
-  "Folded               guifg=NvimLightGrey4  ctermfg=247   guibg=NvimDarkGrey3  ctermbg=236",
-  "LineNr               guifg=NvimDarkGrey4   ctermfg=239",
-  "MatchParen           guibg=NvimDarkGrey4   ctermbg=239   gui=bold             cterm=bold",
-  "ModeMsg              guifg=NvimLightGreen  ctermfg=158",
-  "MoreMsg              guifg=NvimLightCyan   ctermfg=123",
-  "NonText              guifg=NvimDarkGrey4   ctermfg=239",
-  "NormalFloat          guifg=NvimLightGrey2  ctermfg=253   guibg=NvimDarkGrey1  ctermbg=232",
-  "Pmenu                guifg=NvimLightGrey2  ctermfg=253   guibg=NvimDarkGrey3  ctermbg=236",
-  "PmenuSel             guifg=NvimDarkGrey3   ctermfg=236   guibg=NvimLightGrey2 ctermbg=253 blend=0",
-  "PmenuThumb           guibg=NvimDarkGrey4   ctermbg=239",
-  "Question             guifg=NvimLightCyan   ctermfg=123",
-  "RedrawDebugClear     guibg=NvimDarkCyan    ctermbg=30",
-  "RedrawDebugComposed  guibg=NvimDarkGreen   ctermbg=22",
-  "RedrawDebugRecompose guibg=NvimDarkRed     ctermbg=52",
-  "Search               guifg=NvimLightGrey1  ctermfg=255   guibg=NvimDarkYellow ctermbg=58",
-  "SignColumn           guifg=NvimDarkGrey4   ctermfg=239",
-  "SpecialKey           guifg=NvimDarkGrey4   ctermfg=239",
-  "SpellBad             guisp=NvimLightRed    gui=undercurl cterm=undercurl",
-  "SpellCap             guisp=NvimLightYellow gui=undercurl cterm=undercurl",
-  "SpellLocal           guisp=NvimLightGreen  gui=undercurl cterm=undercurl",
-  "SpellRare            guisp=NvimLightCyan   gui=undercurl cterm=undercurl",
-  "StatusLine           guifg=NvimLightGrey3  ctermfg=251   guibg=NvimDarkGrey1  ctermbg=232",
-  "StatusLineNC         guifg=NvimLightGrey4  ctermfg=247   guibg=NvimDarkGrey1  ctermbg=232",
-  "TabLine              guifg=NvimLightGrey3  ctermfg=251   guibg=NvimDarkGrey1  ctermbg=232",
-  "Visual               guibg=NvimDarkGrey4   ctermbg=239",
-  "WarningMsg           guifg=NvimLightYellow ctermfg=217",  // In 256 colors fall back to red
+  "ColorColumn                                guibg=NvimDarkGrey4           cterm=reverse",
+  "Conceal              guifg=NvimDarkGrey4",
+  "CurSearch            guifg=NvimDarkGrey1   guibg=NvimLightYellow         ctermfg=0 ctermbg=11",
+  "CursorColumn                               guibg=NvimDarkGrey3",
+  "CursorLine                                 guibg=NvimDarkGrey3",
+  "DiffAdd              guifg=NvimLightGrey1  guibg=NvimDarkGreen           ctermfg=0 ctermbg=10",
+  "DiffChange           guifg=NvimLightGrey1  guibg=NvimDarkGrey4",
+  "DiffDelete           guifg=NvimLightRed                         gui=bold ctermfg=9 cterm=bold",
+  "DiffText             guifg=NvimLightGrey1  guibg=NvimDarkCyan            ctermfg=0 ctermbg=14",
+  "Directory            guifg=NvimLightCyan                                 ctermfg=14",
+  "ErrorMsg             guifg=NvimLightRed                                  ctermfg=9",
+  "FloatShadow                                guibg=NvimDarkGrey4           ctermbg=0 blend=80",
+  "FloatShadowThrough                         guibg=NvimDarkGrey4           ctermbg=0 blend=100",
+  "Folded               guifg=NvimLightGrey4  guibg=NvimDarkGrey3",
+  "LineNr               guifg=NvimDarkGrey4",
+  "MatchParen                                 guibg=NvimDarkGrey4  gui=bold cterm=bold,underline",
+  "ModeMsg              guifg=NvimLightGreen                                ctermfg=10",
+  "MoreMsg              guifg=NvimLightCyan                                 ctermfg=14",
+  "NonText              guifg=NvimDarkGrey4",
+  "NormalFloat                                guibg=NvimDarkGrey1",
+  "Pmenu                                      guibg=NvimDarkGrey3           cterm=reverse",
+  "PmenuSel             guifg=NvimDarkGrey3   guibg=NvimLightGrey2          cterm=reverse,underline blend=0",
+  "PmenuThumb                                 guibg=NvimDarkGrey4",
+  "Question             guifg=NvimLightCyan                                 ctermfg=14",
+  "QuickFixLine         guifg=NvimLightCyan                                 ctermfg=14",
+  "RedrawDebugClear                           guibg=NvimDarkYellow          ctermfg=0 ctermbg=11",
+  "RedrawDebugComposed                        guibg=NvimDarkGreen           ctermfg=0 ctermbg=10",
+  "RedrawDebugRecompose                       guibg=NvimDarkRed             ctermfg=0 ctermbg=9",
+  "Search               guifg=NvimLightGrey1  guibg=NvimDarkYellow          ctermfg=0 ctermbg=11",
+  "SignColumn           guifg=NvimDarkGrey4",
+  "SpecialKey           guifg=NvimDarkGrey4",
+  "SpellBad             guisp=NvimLightRed    gui=undercurl                 cterm=undercurl",
+  "SpellCap             guisp=NvimLightYellow gui=undercurl                 cterm=undercurl",
+  "SpellLocal           guisp=NvimLightGreen  gui=undercurl                 cterm=undercurl",
+  "SpellRare            guisp=NvimLightCyan   gui=undercurl                 cterm=undercurl",
+  "StatusLine           guifg=NvimLightGrey3  guibg=NvimDarkGrey1           cterm=reverse",
+  "StatusLineNC         guifg=NvimLightGrey4  guibg=NvimDarkGrey1           cterm=bold",
+  "Visual                                     guibg=NvimDarkGrey4           ctermfg=0 ctermbg=15",
+  "WarningMsg           guifg=NvimLightYellow                               ctermfg=11",
 
   // Syntax
-  "Comment    guifg=NvimLightGrey4   ctermfg=247",
-  "Constant   guifg=NvimLightGrey2   ctermfg=253",
-  "String     guifg=NvimLightGreen   ctermfg=158",
-  "Identifier guifg=NvimLightBlue    ctermfg=NONE",  // No fallback in 256 colors to reduce noise
-  "Function   guifg=NvimLightCyan    ctermfg=123",
-  "Statement  guifg=NvimLightGrey2   ctermfg=253 gui=bold          cterm=bold",
-  "Operator   guifg=NvimLightGrey2   ctermfg=253",
-  "PreProc    guifg=NvimLightGrey2   ctermfg=253",
-  "Type       guifg=NvimLightGrey2   ctermfg=253",
-  "Special    guifg=NvimLightGrey2   ctermfg=253",
-  "Delimiter  guifg=NvimLightGrey2   ctermfg=253",
-  "Error      guifg=NvimLightGrey1   ctermfg=255 guibg=NvimDarkRed ctermbg=52",
-  "Todo       guifg=NvimLightGrey1   ctermfg=255 gui=bold          cterm=bold",
+  "Comment    guifg=NvimLightGrey4",
+  "String     guifg=NvimLightGreen                   ctermfg=10",
+  "Identifier guifg=NvimLightBlue                    ctermfg=12",
+  "Function   guifg=NvimLightCyan                    ctermfg=14",
+  "Statement  gui=bold                               cterm=bold",
+  "Special    guifg=NvimLightCyan                    ctermfg=14",
+  "Error      guifg=NvimLightGrey1 guibg=NvimDarkRed ctermfg=0 ctermbg=9",
 
   // Diagnostic
-  "DiagnosticError          guifg=NvimLightRed    ctermfg=217",
-  "DiagnosticWarn           guifg=NvimLightYellow ctermfg=217",  // In 256 colors fall back to red
-  "DiagnosticInfo           guifg=NvimLightCyan   ctermfg=123",
-  "DiagnosticHint           guifg=NvimLightBlue   ctermfg=123",  // In 256 colors fall back to cyan
-  "DiagnosticOk             guifg=NvimLightGreen  ctermfg=158",
+  "DiagnosticError          guifg=NvimLightRed                      ctermfg=9",
+  "DiagnosticWarn           guifg=NvimLightYellow                   ctermfg=11",
+  "DiagnosticInfo           guifg=NvimLightCyan                     ctermfg=14",
+  "DiagnosticHint           guifg=NvimLightBlue                     ctermfg=12",
+  "DiagnosticOk             guifg=NvimLightGreen                    ctermfg=10",
   "DiagnosticUnderlineError guisp=NvimLightRed    gui=underline     cterm=underline",
-  "DiagnosticUnderlineWarn  guisp=NvimLightYellow gui=underline     cterm=underline",  // In 256 colors fall back to red
+  "DiagnosticUnderlineWarn  guisp=NvimLightYellow gui=underline     cterm=underline",
   "DiagnosticUnderlineInfo  guisp=NvimLightCyan   gui=underline     cterm=underline",
   "DiagnosticUnderlineHint  guisp=NvimLightBlue   gui=underline     cterm=underline",
   "DiagnosticUnderlineOk    guisp=NvimLightGreen  gui=underline     cterm=underline",
-  "DiagnosticFloatingError  guifg=NvimLightRed    ctermfg=217       guibg=NvimDarkGrey1 ctermbg=232",
-  // In 256 colors fall back to red
-  "DiagnosticFloatingWarn   guifg=NvimLightYellow ctermfg=217       guibg=NvimDarkGrey1 ctermbg=232",
-  "DiagnosticFloatingInfo   guifg=NvimLightCyan   ctermfg=123       guibg=NvimDarkGrey1 ctermbg=232",
-  // In 256 colors fall back to cyan
-  "DiagnosticFloatingHint   guifg=NvimLightBlue   ctermfg=123       guibg=NvimDarkGrey1 ctermbg=232",
-  "DiagnosticFloatingOk     guifg=NvimLightGreen  ctermfg=158       guibg=NvimDarkGrey1 ctermbg=232",
   "DiagnosticDeprecated     guisp=NvimLightRed    gui=strikethrough cterm=strikethrough",
   NULL
 };
@@ -718,22 +705,6 @@ void init_highlight(bool both, bool reset)
                                  : highlight_init_dark);
   for (size_t i = 0; pp[i] != NULL; i++) {
     do_highlight(pp[i], reset, true);
-  }
-
-  // Reverse looks ugly, but grey may not work for 8 colors.  Thus let it
-  // depend on the number of colors available.
-  // With 8 colors brown is equal to yellow, need to use black for Search fg
-  // to avoid Statement highlighted text disappears.
-  // Clear the attributes, needed when changing the t_Co value.
-  if (t_colors > 8) {
-    do_highlight((*p_bg == 'l'
-                  ? "Visual cterm=NONE ctermbg=LightGrey"
-                  : "Visual cterm=NONE ctermbg=DarkGrey"), false, true);
-  } else {
-    do_highlight("Visual cterm=reverse ctermbg=NONE", false, true);
-    if (*p_bg == 'l') {
-      do_highlight("Search ctermfg=black", false, true);
-    }
   }
 
   syn_init_cmdline_highlight(false, false);
@@ -2890,26 +2861,26 @@ color_name_table_T color_name_table[] = {
   // Default Neovim palettes.
   // Dark/light palette is used for background in dark/light color scheme and
   // for foreground in light/dark color scheme.
-  { "NvimDarkBlue", RGB_(0x00, 0x50, 0x78) },      // cterm=24
-  { "NvimDarkCyan", RGB_(0x00, 0x76, 0x76) },      // cterm=30
-  { "NvimDarkGreen", RGB_(0x01, 0x58, 0x25) },     // cterm=22
-  { "NvimDarkGrey1", RGB_(0x0a, 0x0b, 0x10) },     // cterm=232
-  { "NvimDarkGrey2", RGB_(0x1c, 0x1d, 0x23) },     // cterm=234
-  { "NvimDarkGrey3", RGB_(0x2c, 0x2e, 0x33) },     // cterm=236
-  { "NvimDarkGrey4", RGB_(0x4f, 0x52, 0x58) },     // cterm=239
-  { "NvimDarkMagenta", RGB_(0x4c, 0x00, 0x49) },   // cterm=53
-  { "NvimDarkRed", RGB_(0x5e, 0x00, 0x09) },       // cterm=52
-  { "NvimDarkYellow", RGB_(0x6e, 0x56, 0x00) },    // cterm=58
-  { "NvimLightBlue", RGB_(0x9f, 0xd8, 0xff) },     // cterm=153
-  { "NvimLightCyan", RGB_(0x83, 0xef, 0xef) },     // cterm=123
-  { "NvimLightGreen", RGB_(0xaa, 0xed, 0xb7) },    // cterm=158
-  { "NvimLightGrey1", RGB_(0xeb, 0xee, 0xf5) },    // cterm=255
-  { "NvimLightGrey2", RGB_(0xd7, 0xda, 0xe1) },    // cterm=253
-  { "NvimLightGrey3", RGB_(0xc4, 0xc6, 0xcd) },    // cterm=251
-  { "NvimLightGrey4", RGB_(0x9b, 0x9e, 0xa4) },    // cterm=247
-  { "NvimLightMagenta", RGB_(0xff, 0xc3, 0xfa) },  // cterm=189
-  { "NvimLightRed", RGB_(0xff, 0xbc, 0xb5) },      // cterm=217
-  { "NvimLightYellow", RGB_(0xf4, 0xd8, 0x8c) },   // cterm=222
+  { "NvimDarkBlue", RGB_(0x00, 0x4c, 0x73) },
+  { "NvimDarkCyan", RGB_(0x00, 0x73, 0x73) },
+  { "NvimDarkGreen", RGB_(0x00, 0x55, 0x23) },
+  { "NvimDarkGrey1", RGB_(0x07, 0x08, 0x0d) },
+  { "NvimDarkGrey2", RGB_(0x14, 0x16, 0x1b) },
+  { "NvimDarkGrey3", RGB_(0x2c, 0x2e, 0x33) },
+  { "NvimDarkGrey4", RGB_(0x4f, 0x52, 0x58) },
+  { "NvimDarkMagenta", RGB_(0x47, 0x00, 0x45) },
+  { "NvimDarkRed", RGB_(0x59, 0x00, 0x08) },
+  { "NvimDarkYellow", RGB_(0x6b, 0x53, 0x00) },
+  { "NvimLightBlue", RGB_(0xa6, 0xdb, 0xff) },
+  { "NvimLightCyan", RGB_(0x8c, 0xf8, 0xf7) },
+  { "NvimLightGreen", RGB_(0xb3, 0xf6, 0xc0) },
+  { "NvimLightGrey1", RGB_(0xee, 0xf1, 0xf8) },
+  { "NvimLightGrey2", RGB_(0xe0, 0xe2, 0xea) },
+  { "NvimLightGrey3", RGB_(0xc4, 0xc6, 0xcd) },
+  { "NvimLightGrey4", RGB_(0x9b, 0x9e, 0xa4) },
+  { "NvimLightMagenta", RGB_(0xff, 0xca, 0xff) },
+  { "NvimLightRed", RGB_(0xff, 0xc0, 0xb9) },
+  { "NvimLightYellow", RGB_(0xfc, 0xe0, 0x94) },
   { "OldLace", RGB_(0xfd, 0xf5, 0xe6) },
   { "Olive", RGB_(0x80, 0x80, 0x00) },
   { "OliveDrab", RGB_(0x6b, 0x8e, 0x23) },

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -72,15 +72,12 @@ describe('command-line option', function()
         env = { VIMRUNTIME = os.getenv('VIMRUNTIME') }
       })
       screen:expect([[
-        {1:^                                        }|
-        {2:~                                       }|*4
-        {3:[No Name]             0,0-1          All}|
-        {1:                                        }|
-                                                |
+        ^                                        |
+        ~                                       |*4
+        {1:[No Name]             0,0-1          All}|
+                                                |*2
       ]], {
-        [1] = {bg_indexed = true, foreground = Screen.colors.Grey91, background = tonumber('0x161616'), fg_indexed = true},
-        [2] = {bg_indexed = true, foreground = Screen.colors.Gray30, background = tonumber('0x161616'), fg_indexed = true},
-        [3] = {bg_indexed = true, foreground = tonumber('0xd2d2d2'), background = Screen.colors.Black , fg_indexed = true},
+        [1] = {reverse = true};
       })
       feed('i:cq<CR>')
       screen:expect([[

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -168,17 +168,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     })
     screen:set_default_attr_ids({
       [1] = {foreground = 253, background = 11};
+      [2] = {reverse = true};
       [3] = {bold = true},
-      [16] = {background = 234, foreground = 253};
-      [17] = {reverse = true, background = 234, foreground = 253};
+      [4] = {background = 11};
     })
     -- Also check for real cursor position, as it is used for stuff like input methods
     screen._handle_busy_start = function() end
     screen._handle_busy_stop = function() end
     screen:expect([[
-      {16:                                                                      }|*4
-      {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-      {16::}{17:^ }{16:                                                                    }|
+                                                                            |*4
+      Entering Ex mode.  Type "visual" to go to Normal mode.                |
+      :{2:^ }                                                                    |
       {3:-- TERMINAL --}                                                        |
     ]])
   end
@@ -193,17 +193,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::aaaaaaaa}{17:^ }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaaaa{2:^ }                                                            |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 9}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::aaaaaaa^a}{1: }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaaa^a{4: }                                                            |
                                                                               |
       ]])
       eq({6, 8}, eval('nvim_win_get_cursor(0)'))
@@ -212,17 +212,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::aaaaaa}{17:^a}{16:a                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaaa{2:^a}a                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 7}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::aaaaa^a}{1:a}{16:a                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :aaaaa^a{4:a}a                                                             |
                                                                               |
       ]])
       eq({6, 6}, eval('nvim_win_get_cursor(0)'))
@@ -231,17 +231,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::a}{17:^a}{16:aaaaaa                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :a{2:^a}aaaaaa                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 2}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::^a}{1:a}{16:aaaaaa                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^a{4:a}aaaaaa                                                             |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -256,17 +256,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µµµµµµµµ}{17:^ }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµµµ{2:^ }                                                            |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 17}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µµµµµµµ^µ}{1: }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµµ^µ{4: }                                                            |
                                                                               |
       ]])
       eq({6, 15}, eval('nvim_win_get_cursor(0)'))
@@ -275,17 +275,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µµµµµµ}{17:^µ}{16:µ                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµµ{2:^µ}µ                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 13}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µµµµµ^µ}{1:µ}{16:µ                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µµµµµ^µ{4:µ}µ                                                             |
                                                                               |
       ]])
       eq({6, 11}, eval('nvim_win_get_cursor(0)'))
@@ -294,17 +294,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ}{17:^µ}{16:µµµµµµ                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ{2:^µ}µµµµµµ                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 3}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::^µ}{1:µ}{16:µµµµµµ                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^µ{4:µ}µµµµµµ                                                             |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -321,17 +321,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳}{17:^ }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{2:^ }                                                            |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 33}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳}{1: }{16:                                                            }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{4: }                                                            |
                                                                               |
       ]])
       eq({6, 29}, eval('nvim_win_get_cursor(0)'))
@@ -340,17 +340,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ̳µ̳µ̳µ̳µ̳µ̳}{17:^µ̳}{16:µ̳                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳µ̳{2:^µ̳}µ̳                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 25}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ̳µ̳µ̳µ̳µ̳^µ̳}{1:µ̳}{16:µ̳                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳µ̳µ̳µ̳µ̳^µ̳{4:µ̳}µ̳                                                             |
                                                                               |
       ]])
       eq({6, 21}, eval('nvim_win_get_cursor(0)'))
@@ -359,17 +359,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::µ̳}{17:^µ̳}{16:µ̳µ̳µ̳µ̳µ̳µ̳                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :µ̳{2:^µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 5}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::^µ̳}{1:µ̳}{16:µ̳µ̳µ̳µ̳µ̳µ̳                                                             }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^µ̳{4:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -386,17 +386,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::哦哦哦哦哦哦哦哦}{17:^ }{16:                                                    }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦哦哦{2:^ }                                                    |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 25}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::哦哦哦哦哦哦哦^哦}{1: }{16:                                                    }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦哦^哦{4: }                                                    |
                                                                               |
       ]])
       eq({6, 22}, eval('nvim_win_get_cursor(0)'))
@@ -405,17 +405,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::哦哦哦哦哦哦}{17:^哦}{16:哦                                                     }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦哦{2:^哦}哦                                                     |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 19}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::哦哦哦哦哦^哦}{1:哦}{16:哦                                                     }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦哦哦哦哦^哦{4:哦}哦                                                     |
                                                                               |
       ]])
       eq({6, 16}, eval('nvim_win_get_cursor(0)'))
@@ -424,17 +424,17 @@ describe('buffer cursor position is correct in terminal without number column', 
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::哦}{17:^哦}{16:哦哦哦哦哦哦                                                     }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :哦{2:^哦}哦哦哦哦哦哦                                                     |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 4}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {16:                                                                      }|*4
-        {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-        {16::^哦}{1:哦}{16:哦哦哦哦哦哦                                                     }|
+                                                                              |*4
+        Entering Ex mode.  Type "visual" to go to Normal mode.                |
+        :^哦{4:哦}哦哦哦哦哦哦                                                     |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -445,18 +445,18 @@ describe('buffer cursor position is correct in terminal without number column', 
     setup_ex_register('aaaaaaaa    ')
     feed('<C-R>r')
     screen:expect([[
-      {16:                                                                      }|*4
-      {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-      {16::aaaaaaaa    }{17:^ }{16:                                                        }|
+                                                                            |*4
+      Entering Ex mode.  Type "visual" to go to Normal mode.                |
+      :aaaaaaaa    {2:^ }                                                        |
       {3:-- TERMINAL --}                                                        |
     ]])
     matches('^:aaaaaaaa    [ ]*$', eval('nvim_get_current_line()'))
     eq({6, 13}, eval('nvim_win_get_cursor(0)'))
     feed([[<C-\><C-N>]])
     screen:expect([[
-      {16:                                                                      }|*4
-      {16:Entering Ex mode.  Type "visual" to go to Normal mode.                }|
-      {16::aaaaaaaa   ^ }{1: }{16:                                                        }|
+                                                                            |*4
+      Entering Ex mode.  Type "visual" to go to Normal mode.                |
+      :aaaaaaaa   ^ {4: }                                                        |
                                                                             |
     ]])
     eq({6, 12}, eval('nvim_win_get_cursor(0)'))
@@ -481,21 +481,21 @@ describe('buffer cursor position is correct in terminal with number column', fun
     })
     screen:set_default_attr_ids({
       [1] = {foreground = 253, background = 11};
+      [2] = {reverse = true};
       [3] = {bold = true},
+      [4] = {background = 11};
       [7] = {foreground = 130};
-      [16] = {background = 234, foreground = 253};
-      [17] = {reverse = true, background = 234, foreground = 253};
     })
     -- Also check for real cursor position, as it is used for stuff like input methods
     screen._handle_busy_start = function() end
     screen._handle_busy_stop = function() end
     screen:expect([[
-      {7:  1 }{16:                                                                  }|
-      {7:  2 }{16:                                                                  }|
-      {7:  3 }{16:                                                                  }|
-      {7:  4 }{16:                                                                  }|
-      {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-      {7:  6 }{16::}{17:^ }{16:                                                                }|
+      {7:  1 }                                                                  |
+      {7:  2 }                                                                  |
+      {7:  3 }                                                                  |
+      {7:  4 }                                                                  |
+      {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+      {7:  6 }:{2:^ }                                                                |
       {3:-- TERMINAL --}                                                        |
     ]])
   end
@@ -513,23 +513,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::aaaaaaaa}{17:^ }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaaaa{2:^ }                                                        |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 9}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::aaaaaaa^a}{1: }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaaa^a{4: }                                                        |
                                                                               |
       ]])
       eq({6, 8}, eval('nvim_win_get_cursor(0)'))
@@ -538,23 +538,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::aaaaaa}{17:^a}{16:a                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaaa{2:^a}a                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 7}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::aaaaa^a}{1:a}{16:a                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:aaaaa^a{4:a}a                                                         |
                                                                               |
       ]])
       eq({6, 6}, eval('nvim_win_get_cursor(0)'))
@@ -563,23 +563,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::a}{17:^a}{16:aaaaaa                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:a{2:^a}aaaaaa                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 2}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::^a}{1:a}{16:aaaaaa                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^a{4:a}aaaaaa                                                         |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -594,23 +594,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µµµµµµµµ}{17:^ }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµµµ{2:^ }                                                        |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 17}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µµµµµµµ^µ}{1: }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµµ^µ{4: }                                                        |
                                                                               |
       ]])
       eq({6, 15}, eval('nvim_win_get_cursor(0)'))
@@ -619,23 +619,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µµµµµµ}{17:^µ}{16:µ                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµµ{2:^µ}µ                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 13}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µµµµµ^µ}{1:µ}{16:µ                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µµµµµ^µ{4:µ}µ                                                         |
                                                                               |
       ]])
       eq({6, 11}, eval('nvim_win_get_cursor(0)'))
@@ -644,23 +644,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ}{17:^µ}{16:µµµµµµ                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ{2:^µ}µµµµµµ                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 3}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::^µ}{1:µ}{16:µµµµµµ                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^µ{4:µ}µµµµµµ                                                         |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -677,23 +677,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳}{17:^ }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{2:^ }                                                        |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 33}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳}{1: }{16:                                                        }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{4: }                                                        |
                                                                               |
       ]])
       eq({6, 29}, eval('nvim_win_get_cursor(0)'))
@@ -702,23 +702,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ̳µ̳µ̳µ̳µ̳µ̳}{17:^µ̳}{16:µ̳                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳{2:^µ̳}µ̳                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 25}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ̳µ̳µ̳µ̳µ̳^µ̳}{1:µ̳}{16:µ̳                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳µ̳µ̳µ̳µ̳^µ̳{4:µ̳}µ̳                                                         |
                                                                               |
       ]])
       eq({6, 21}, eval('nvim_win_get_cursor(0)'))
@@ -727,23 +727,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::µ̳}{17:^µ̳}{16:µ̳µ̳µ̳µ̳µ̳µ̳                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:µ̳{2:^µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 5}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::^µ̳}{1:µ̳}{16:µ̳µ̳µ̳µ̳µ̳µ̳                                                         }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^µ̳{4:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -760,23 +760,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('at the end', function()
       feed('<C-R>r')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::哦哦哦哦哦哦哦哦}{17:^ }{16:                                                }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦哦哦{2:^ }                                                |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 25}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::哦哦哦哦哦哦哦^哦}{1: }{16:                                                }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦哦^哦{4: }                                                |
                                                                               |
       ]])
       eq({6, 22}, eval('nvim_win_get_cursor(0)'))
@@ -785,23 +785,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the end', function()
       feed('<C-R>r<C-X><C-X>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::哦哦哦哦哦哦}{17:^哦}{16:哦                                                 }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦哦{2:^哦}哦                                                 |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 19}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::哦哦哦哦哦^哦}{1:哦}{16:哦                                                 }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦哦哦哦哦^哦{4:哦}哦                                                 |
                                                                               |
       ]])
       eq({6, 16}, eval('nvim_win_get_cursor(0)'))
@@ -810,23 +810,23 @@ describe('buffer cursor position is correct in terminal with number column', fun
     it('near the start', function()
       feed('<C-R>r<C-B><C-O>')
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::哦}{17:^哦}{16:哦哦哦哦哦哦                                                 }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:哦{2:^哦}哦哦哦哦哦哦                                                 |
         {3:-- TERMINAL --}                                                        |
       ]])
       eq({6, 4}, eval('nvim_win_get_cursor(0)'))
       feed([[<C-\><C-N>]])
       screen:expect([[
-        {7:  1 }{16:                                                                  }|
-        {7:  2 }{16:                                                                  }|
-        {7:  3 }{16:                                                                  }|
-        {7:  4 }{16:                                                                  }|
-        {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-        {7:  6 }{16::^哦}{1:哦}{16:哦哦哦哦哦哦                                                 }|
+        {7:  1 }                                                                  |
+        {7:  2 }                                                                  |
+        {7:  3 }                                                                  |
+        {7:  4 }                                                                  |
+        {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+        {7:  6 }:^哦{4:哦}哦哦哦哦哦哦                                                 |
                                                                               |
       ]])
       eq({6, 1}, eval('nvim_win_get_cursor(0)'))
@@ -837,24 +837,24 @@ describe('buffer cursor position is correct in terminal with number column', fun
     setup_ex_register('aaaaaaaa    ')
     feed('<C-R>r')
     screen:expect([[
-      {7:  1 }{16:                                                                  }|
-      {7:  2 }{16:                                                                  }|
-      {7:  3 }{16:                                                                  }|
-      {7:  4 }{16:                                                                  }|
-      {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-      {7:  6 }{16::aaaaaaaa    }{17:^ }{16:                                                    }|
+      {7:  1 }                                                                  |
+      {7:  2 }                                                                  |
+      {7:  3 }                                                                  |
+      {7:  4 }                                                                  |
+      {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+      {7:  6 }:aaaaaaaa    {2:^ }                                                    |
       {3:-- TERMINAL --}                                                        |
     ]])
     matches('^:aaaaaaaa    [ ]*$', eval('nvim_get_current_line()'))
     eq({6, 13}, eval('nvim_win_get_cursor(0)'))
     feed([[<C-\><C-N>]])
     screen:expect([[
-      {7:  1 }{16:                                                                  }|
-      {7:  2 }{16:                                                                  }|
-      {7:  3 }{16:                                                                  }|
-      {7:  4 }{16:                                                                  }|
-      {7:  5 }{16:Entering Ex mode.  Type "visual" to go to Normal mode.            }|
-      {7:  6 }{16::aaaaaaaa   ^ }{1: }{16:                                                    }|
+      {7:  1 }                                                                  |
+      {7:  2 }                                                                  |
+      {7:  3 }                                                                  |
+      {7:  4 }                                                                  |
+      {7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
+      {7:  6 }:aaaaaaaa   ^ {4: }                                                    |
                                                                             |
     ]])
     eq({6, 12}, eval('nvim_win_get_cursor(0)'))

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -213,7 +213,7 @@ describe('ui/cursor', function()
           m.hl_id = 64
           m.attr = {background = Screen.colors.DarkGray}
       end
-      if m.id_lm then m.id_lm = 69 end
+      if m.id_lm then m.id_lm = 70 end
     end
 
     -- Assert the new expectation.

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -29,9 +29,6 @@ local function test_embed(ext_linegrid)
       [6] = {foreground = Screen.colors.NvimDarkGrey3, background = Screen.colors.NvimLightGrey1};
       [7] = {foreground = Screen.colors.NvimDarkRed};
       [8] = {foreground = Screen.colors.NvimDarkCyan};
-      [9] = {foreground = Screen.colors.NvimLightGrey3, background = Screen.colors.NvimDarkGrey1};
-      [10] = {foreground = Screen.colors.NvimLightRed};
-      [11] = {foreground = Screen.colors.NvimLightCyan};
     })
   end
 
@@ -60,11 +57,11 @@ local function test_embed(ext_linegrid)
     startup('--cmd', 'echoerr "foo"', '--cmd', 'color default', '--cmd', 'echoerr "bar"')
     screen:expect([[
                                                                   |*3
-      {9:                                                            }|
+      {6:                                                            }|
       {7:Error detected while processing pre-vimrc command line:}     |
       {7:foo}                                                         |
-      {10:bar}                                                         |
-      {11:Press ENTER or type command to continue}^                     |
+      {7:bar}                                                         |
+      {8:Press ENTER or type command to continue}^                     |
     ]])
   end)
 


### PR DESCRIPTION
This is a follow up to #26334.

Related to #26369. Related to #26378.
Resolves #26385. Resolves #26389. Resolves #26468.

It mostly follows a list from the first task of #26369.

------

Here are the important points which might deserve extra attention during review:

1. Lightness values of `Nvim{Dark,Light}Grey1` (darkest/lightest) and `Nvim{Dark,Light}Grey2` (`Normal` highlight group) are made more extreme to increase contrast ratio. This makes background darker/lighter with foreground lighter/darker. This also prompted non-grey colors to shift a bit as they have lightness taken from `Normal` group.

    I **really** think that current values have the most possible compromise between "much contrast" and "not too much contrast" camps. All contrast ratio values passed previously (except objectively hard "saturated dark cyan") and now they pass even better (for example, `Comment` is now closer to passing with AAA than with AA).

1. `cterm` values are changed to use colors 0-6 and 9-15 to more utilize terminal colors and be treated more like "emergency exit" values (especially after #26407 is merged). Both dark/light variant use only 8 colors: one background, one foreground, and 6 colors (red, green, yellow, blue, magenta, cyan). Not using shades of grey (7 for dark-ish foreground and 8 for grey) allows a UI which is more robust towards terminal color palette not designed for these greys to be used together with non-grey colors.

    Currently the only assumption about terminal palette is that "Background color 0 can be used as background; foreground and colors can be used as foreground". This essentially limits the possible fg-bg color combinations to bg-{fg,red,green,yellow,blue,magenta,cyan} and fg-bg (inverted `Normal`).

    Most UI decisions are similar to ones from 'quiet' color scheme in case of only 16 colors available. Colors are translated from the corresponding `gui*` values: 9-14 for dark variant and 1-6 for light (to possibly have more contrast).

1. All highlight groups are reworked to follow "add attribute only if it is intended to be different". This includes two cases:
    - Add `guifg`/`ctermfg` if it is meant to have different foreground. For example, most "basic" syntax groups (`Constant`, `Operator`, `PreProc`, `Type`, `Delimiter`) are left without definition. This means that they will inherit the foreground, which is usually OK but can lead to not really good result inside markdown code blocks (falling back to `@text.literal` which links to `Comment`). @clason, this is probably better be addressed in tree-sitter highlight groups rework, correct?

    - Add `guibg`/`ctermbg` if it is meant to have different background. This resolves some issues with `DiagnosticFloating*`.

1. Specific highlight group decisions which might need discussion:

    1. `CurSearch` is changed to actually be different from `Search` (with antipodal lightness value of yellow as background). This adds another breaking behavior for color scheme authors, but seems to be worth having in default color scheme.

    1. `WinSeparator` was previously linked to a `VertSplit` for compatibility with Vim's color scheme. As `VertSplit` is deprecated since 0.8, I decided to revert the link. Even now I think it is a reasonable thing to do, but this might need extra discussion. Here are possible actions:
        - Leave the current `VertSplit -> WinSeparator -> Normal` linking dependency.
        - Revert to have `WinSeparator -> VertSplit -> Normal`.
        - Remove `VertSplit` entirely from default color scheme. Having it linked to `WinSeparator` is beneficial only to allow Neovim targeted color schemes work in Vim, which is rarely the case. So removing it completely might be reasonable here.

    1. As current default `EndOfBuffer` is already quite non intrusive, I don't think having it being separate from `Whitespace` adds benefit to address [this comment](https://github.com/neovim/neovim/issues/21694#issuecomment-1575756133). So nothing has changed here in this follow up.

    1. `PmenuSel` (current selection in pop-up menu) in the #26334 was changed to include `blend=0`. This is because if pop-up menu is transparent, current selection also amplifies the background text which makes it very uncomfortable to read. As this is a breaking change, it might be worth a discussion of whether this is necessary.

    1. `FloatShadow` and `FloatShadowThrough` are changed to have `Grey4` color implementing "soft shadow". This is mostly to make them visible with both dark and light color scheme variants.

    1. `FloatFooter` is changed to link to `FloatTitle` (instead of previous `Title`).

------

Information about new color scheme:

<details><summary>Palette</summary>

- `#004c73` (Dark blue)
- `#007373` (Dark cyan)
- `#005523` (Dark green)
- `#07080d` (Dark grey1)
- `#14161b` (Dark grey2)
- `#2c2e33` (Dark grey3)
- `#4f5258` (Dark grey4)
- `#470045` (Dark magenta)
- `#590008` (Dark red)
- `#6b5300` (Dark yellow)
- `#a6dbff` (Light blue)
- `#8cf8f7` (Light cyan)
- `#b3f6c0` (Light green)
- `#eef1f8` (Light grey1)
- `#e0e2ea` (Light grey2)
- `#c4c6cd` (Light grey3)
- `#9b9ea4` (Light grey4)
- `#ffcaff` (Light magenta)
- `#ffc0b9` (Light red)
- `#fce094` (Light yellow)

</details>

<details><summary>Contrast ratio values</summary>

`dark_*` are for dark color scheme, `ligth_*` - for light.

```
dark_blue         = 12.2
dark_comment      = 6.7
dark_comment_cur  = 5.1
dark_comment_vis  = 2.9
dark_cur_line     = 10.5
dark_cyan         = 14.6
dark_green        = 14.5
dark_magenta      = 13.1
dark_normal       = 14
dark_red          = 11.6
dark_visual       = 6.1
dark_yellow       = 14
light_blue        = 7.1
light_comment     = 6.1
light_comment_cur = 4.6
light_comment_vis = 2.9
light_cur_line    = 10.6
light_cyan        = 4.4
light_green       = 7
light_magenta     = 12
light_normal      = 14
light_red         = 11.4
light_visual      = 6.7
light_yellow      = 5.7
```

</details>

<details><summary>Screenshots</summary>

With `termguicolors`:

![default-cs2_dark_tgc](https://github.com/neovim/neovim/assets/24854248/5a730823-7579-49cf-bc1d-9c9e16cb488a)
![default-cs2_dark_tgc_diff](https://github.com/neovim/neovim/assets/24854248/5b56ca08-e193-4e26-97a7-1fe8e38586eb)
![default-cs2_light_tgc](https://github.com/neovim/neovim/assets/24854248/7a1939f0-2196-43fe-8c7c-04fd45056611)
![default-cs2_light_tgc_diff](https://github.com/neovim/neovim/assets/24854248/17337301-5116-4209-bb83-eaea87b63e18)

With `notermguicolors` and [VGA color palette](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit) (for popular terminal palettes it should look better):

![default-cs2_dark_notgc](https://github.com/neovim/neovim/assets/24854248/86cccdd6-a632-487a-8b8a-27da64921fed)
![default-cs2_dark_notgc_diff](https://github.com/neovim/neovim/assets/24854248/1cdb3785-3dae-4778-be4b-054be259b7da)
![default-cs2_light_notgc](https://github.com/neovim/neovim/assets/24854248/695c6c34-689e-452b-b485-2824b9a99540)
![default-cs2_light_notgc_diff](https://github.com/neovim/neovim/assets/24854248/91a3fa98-6ef3-4fcb-80ec-4c1e243c87fd)

</details>
