### PR TITLE
vim-patch:9.0.2159: screenpos() may crash with neg. column

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1125,6 +1125,9 @@ void f_screenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     semsg(_(e_invalid_line_number_nr), pos.lnum);
     return;
   }
+  if (pos.col < 0) {
+    pos.col = 0;
+  }
   int row = 0;
   int scol = 0, ccol = 0, ecol = 0;
   textpos2screenpos(wp, &pos, &row, &scol, &ccol, &ecol, false);

--- a/test/old/testdir/test_cursor_func.vim
+++ b/test/old/testdir/test_cursor_func.vim
@@ -206,6 +206,11 @@ func Test_screenpos()
   call assert_equal(#{col: 1, row: 2, endcol: 1, curscol: 1}, screenpos(win_getid(), 1, 1))
   " nunmenu WinBar.TEST
   setlocal winbar&
+  call assert_equal(#{col: 1, row: 1, endcol: 1, curscol: 1}, screenpos(win_getid(), 1, 1))
+
+  call assert_equal(#{col: 0, row: 0, endcol: 0, curscol: 0}, screenpos(0, 0, 1))
+  call assert_equal(#{col: 0, row: 0, endcol: 0, curscol: 0}, screenpos(0, -1, 1))
+  call assert_equal(#{col: 1, row: 1, endcol: 1, curscol: 1}, screenpos(0, 1, -v:maxcol))
 endfunc
 
 func Test_screenpos_fold()


### PR DESCRIPTION
#### vim-patch:9.0.2159: screenpos() may crash with neg. column

Problem:  screenpos() may crash with neg. column
Solution: validate and correct column

closes: vim/vim#13669

https://github.com/vim/vim/commit/ec54af4e26952d954a4cc009f62c80ea01445d30