### PR TITLE
fix(termcap): only call callback for requested capabilities

### DIFF
--- a/runtime/lua/vim/termcap.lua
+++ b/runtime/lua/vim/termcap.lua
@@ -39,6 +39,12 @@ function M.query(caps, cb)
       local k, rest = resp:match('^\027P1%+r(%x+)(.*)$')
       if k and rest then
         local cap = vim.text.hexdecode(k)
+        if not pending[cap] then
+          -- Received a response for a capability we didn't request. This can happen if there are
+          -- multiple concurrent XTGETTCAP requests
+          return
+        end
+
         local seq ---@type string?
         if rest:match('^=%x+$') then
           seq = vim.text


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/26545

If multiple XTGETTCAP requests are active at once (for example, for requesting the Ms capability and truecolor capabilities), then the TermResponse autocommand may fire for capabilities that were not requested. Instead, make sure that the provided callback is only called for capabilities that were actually requested.
