### PR TITLE
fix(diagnostic): show diagnostics following a text edit

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -535,6 +535,10 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
   if fix_eol then
     api.nvim_buf_set_lines(bufnr, -2, -1, false, {})
   end
+
+  -- Show diagnostics in case nvim_buf_set_lines/text() invalidated diagnostic extmarks but did
+  -- not trigger 'textDocument/publishDiagnostics'.
+  vim.diagnostic.show(nil, bufnr, nil, {})
 end
 
 -- local valid_windows_path_characters = "[^<>:\"/\\|?*]"


### PR DESCRIPTION
Problem:  vim.lsp.util.apply_text_edits() may invalidate diagnostic
          extmarks without triggering 'textDocument/publishDiagnostics'.
Solution: Re-validate diagnostic extmarks by calling vim.diagnostic.show()
          manually after a text edit.

Fix #26296