### PR TITLE
Diagnostic sign fixups

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -445,6 +445,12 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                              signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
                            })
 <
+                       • numhl: (table) A table mapping |diagnostic-severity|
+                         to the highlight group used for the line number where
+                         the sign is placed.
+                       • linehl: (table) A table mapping |diagnostic-severity|
+                         to the highlight group used for the whole line the
+                         sign is placed in.
 
                      • float: Options for floating windows. See
                        |vim.diagnostic.open_float()|.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -441,9 +441,9 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                          warnings, information, and hints, respectively.
                          Example: >lua
 
-                         vim.diagnostic.config({
-                           sign = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
-                         })
+                           vim.diagnostic.config({
+                             signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
+                           })
 <
 
                      • float: Options for floating windows. See

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -602,6 +602,10 @@ end
 ---                         signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
 ---                       })
 ---                   </pre>
+---                * numhl: (table) A table mapping |diagnostic-severity| to the highlight
+---                group used for the line number where the sign is placed.
+---                * linehl: (table) A table mapping |diagnostic-severity| to the highlight group
+---                used for the whole line the sign is placed in.
 ---       - float: Options for floating windows. See |vim.diagnostic.open_float()|.
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,
 ---                           diagnostics are updated on InsertLeave)
@@ -885,11 +889,16 @@ M.handlers.signs = {
       end
     end
 
+    local numhl = opts.signs.numhl or {}
+    local linehl = opts.signs.linehl or {}
+
     for _, diagnostic in ipairs(diagnostics) do
       if api.nvim_buf_is_loaded(diagnostic.bufnr) then
         api.nvim_buf_set_extmark(bufnr, ns.user_data.sign_ns, diagnostic.lnum, 0, {
           sign_text = text[diagnostic.severity] or text[M.severity[diagnostic.severity]] or 'U',
           sign_hl_group = sign_highlight_map[diagnostic.severity],
+          number_hl_group = numhl[diagnostic.severity],
+          line_hl_group = linehl[diagnostic.severity],
           priority = get_priority(diagnostic.severity),
         })
       end

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -598,9 +598,9 @@ end
 ---                to display in the sign column. The default is to use "E", "W", "I", and "H"
 ---                for errors, warnings, information, and hints, respectively. Example:
 ---                   <pre>lua
----                     vim.diagnostic.config({
----                       sign = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
----                     })
+---                       vim.diagnostic.config({
+---                         signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
+---                       })
 ---                   </pre>
 ---       - float: Options for floating windows. See |vim.diagnostic.open_float()|.
 ---       - update_in_insert: (default false) Update diagnostics in Insert mode (if false,

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -897,7 +897,7 @@ M.handlers.signs = {
   end,
   hide = function(namespace, bufnr)
     local ns = M.get_namespace(namespace)
-    if ns.user_data.sign_group and api.nvim_buf_is_valid(bufnr) then
+    if ns.user_data.sign_ns and api.nvim_buf_is_valid(bufnr) then
       api.nvim_buf_clear_namespace(bufnr, ns.user_data.sign_ns, 0, -1)
     end
   end,

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1495,32 +1495,47 @@ end)
       ]])
     end)
 
-    it('sets signs', function()
-      local result = exec_lua [[
-        vim.diagnostic.config({
-          signs = true,
-        })
+    it('sets and clears signs #26193 #26555', function()
+      do
+        local result = exec_lua [[
+          vim.diagnostic.config({
+            signs = true,
+          })
 
-        local diagnostics = {
-          make_error('Error', 1, 1, 1, 2),
-          make_warning('Warning', 3, 3, 3, 3),
-        }
+          local diagnostics = {
+            make_error('Error', 1, 1, 1, 2),
+            make_warning('Warning', 3, 3, 3, 3),
+          }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
 
-        local ns = vim.diagnostic.get_namespace(diagnostic_ns)
-        local sign_ns = ns.user_data.sign_ns
+          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local sign_ns = ns.user_data.sign_ns
 
-        local signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
-        local result = {}
-        for _, s in ipairs(signs) do
-          result[#result + 1] = { lnum = s[2] + 1, name = s[4].sign_hl_group }
-        end
-        return result
-      ]]
+          local signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
+          local result = {}
+          for _, s in ipairs(signs) do
+            result[#result + 1] = { lnum = s[2] + 1, name = s[4].sign_hl_group }
+          end
+          return result
+        ]]
 
-      eq({2, 'DiagnosticSignError'}, {result[1].lnum, result[1].name})
-      eq({4, 'DiagnosticSignWarn'}, {result[2].lnum, result[2].name})
+        eq({2, 'DiagnosticSignError'}, {result[1].lnum, result[1].name})
+        eq({4, 'DiagnosticSignWarn'}, {result[2].lnum, result[2].name})
+      end
+
+      do
+        local result = exec_lua [[
+          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {})
+
+          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local sign_ns = ns.user_data.sign_ns
+
+          return vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
+        ]]
+
+        eq({}, result)
+      end
     end)
   end)
 


### PR DESCRIPTION
* Fixes a regression introduced by https://github.com/neovim/neovim/pull/26193.
* Fix a typo in the doc example
* Allow setting `numhl` and `linehl` highlight groups (ref https://github.com/neovim/neovim/pull/26193#issuecomment-1854156710).

cc @glepnir
