### PR TITLE
feat(treesitter): add `tsmatchlimit` options

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -199,6 +199,9 @@ The following new APIs and features were added.
   • Improved error messages for query parsing.
   • |vim.treesitter.foldtext()| applies treesitter highlighting to
     foldtext.
+  • |vim.go.tsmatchlimit| and |vim.bo.tsmatchlimit| now allows for adjustment of
+    the maximum number of treesitter nodes matches when a cursor query is
+    executed.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6646,6 +6646,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	NOTE: Use of special characters in 'titlestring' may cause the display
 	to be garbled (e.g., when it contains a CR or NL character).
 
+						*'tsmatchlimit'* *'tsml'*
+'tsmatchlimit' 'tsml'	number	(default 256)
+			global or local to buffer |global-local|
+	This option determines the maximum number of treesitter nodes matched
+	when a cursor query is executed. Higher values allow for deeper matches
+	at the expense of query execution time, while lower values can be used
+	to speed up the execution time.
+
+	The default value is 256. Maximum is 64000 and minimum is 32.
+
 					*'ttimeout'* *'nottimeout'*
 'ttimeout'		boolean	(default on)
 			global

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7131,6 +7131,21 @@ vim.go.titleold = vim.o.titleold
 vim.o.titlestring = ""
 vim.go.titlestring = vim.o.titlestring
 
+--- This option determines the maximum number of treesitter nodes matched
+--- when a cursor query is executed. Higher values allow for deeper matches
+--- at the expense of query execution time, while lower values can be used
+--- to speed up the execution time.
+---
+--- The default value is 256. Maximum is 64000 and minimum is 32.
+---
+--- @type integer
+vim.o.tsmatchlimit = 256
+vim.o.tsml = vim.o.tsmatchlimit
+vim.bo.tsmatchlimit = vim.o.tsmatchlimit
+vim.bo.tsml = vim.bo.tsmatchlimit
+vim.go.tsmatchlimit = vim.o.tsmatchlimit
+vim.go.tsml = vim.go.tsmatchlimit
+
 --- This option and 'ttimeoutlen' determine the behavior when part of a
 --- key code sequence has been received by the `TUI`.
 ---

--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -34,20 +34,22 @@
 local TSNode = {}
 
 ---@param query userdata
+---@param bufnr integer
 ---@param captures true
 ---@param start? integer
 ---@param end_? integer
 ---@param opts? table
 ---@return fun(): integer, TSNode, any
-function TSNode:_rawquery(query, captures, start, end_, opts) end
+function TSNode:_rawquery(query, bufnr, captures, start, end_, opts) end
 
 ---@param query userdata
+---@param bufnr integer
 ---@param captures false
 ---@param start? integer
 ---@param end_? integer
 ---@param opts? table
 ---@return fun(): string, any
-function TSNode:_rawquery(query, captures, start, end_, opts) end
+function TSNode:_rawquery(query, bufnr, captures, start, end_, opts) end
 
 ---@alias TSLoggerCallback fun(logtype: 'parse'|'lex', msg: string)
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -692,10 +692,14 @@ function Query:iter_captures(node, source, start, stop)
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
   end
+  local bufnr = source --[[@as integer]]
+  if type(source) == 'string' then
+    bufnr = api.nvim_get_current_buf()
+  end
 
   start, stop = value_or_node_range(start, stop, node)
 
-  local raw_iter = node:_rawquery(self.query, true, start, stop)
+  local raw_iter = node:_rawquery(self.query, bufnr, true, start, stop)
   local function iter(end_line)
     local capture, captured_node, match = raw_iter()
     local metadata = {}
@@ -754,10 +758,14 @@ function Query:iter_matches(node, source, start, stop, opts)
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
   end
+  local bufnr = source --[[@as integer]]
+  if type(source) == 'string' then
+    bufnr = api.nvim_get_current_buf()
+  end
 
   start, stop = value_or_node_range(start, stop, node)
 
-  local raw_iter = node:_rawquery(self.query, false, start, stop, opts)
+  local raw_iter = node:_rawquery(self.query, bufnr, false, start, stop, opts)
   ---@cast raw_iter fun(): string, any
   local function iter()
     local pattern, match = raw_iter()

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2029,6 +2029,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_tfu);
   callback_free(&buf->b_tfu_cb);
   clear_string_option(&buf->b_p_dict);
+  buf->b_p_tsml = -1;
   clear_string_option(&buf->b_p_tsr);
   clear_string_option(&buf->b_p_qe);
   buf->b_p_ar = -1;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "nvim/types_defs.h"
+
 typedef struct file_buffer buf_T;
 
 /// Reference to a buffer that stores the value of buf_free_count.
@@ -615,6 +617,7 @@ struct file_buffer {
   char *b_p_tc;                 ///< 'tagcase' local value
   unsigned b_tc_flags;          ///< flags for 'tagcase'
   char *b_p_dict;               ///< 'dictionary' local value
+  OptInt b_p_tsml;              ///< 'tsmatchlimit' local value
   char *b_p_tsr;                ///< 'thesaurus' local value
   char *b_p_tsrfu;              ///< 'thesaurusfunc' local value
   Callback b_tsrfu_cb;          ///< 'thesaurusfunc' callback

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1456,7 +1456,11 @@ static int node_rawquery(lua_State *L)
 
   handle_T bufnr = (handle_T)lua_tointeger(L, 3);
   buf_T *buf;
-  buf = handle_get_buffer(bufnr);
+  if (bufnr == 0) {
+    buf = curbuf;
+  } else {
+    buf = handle_get_buffer(bufnr);
+  }
 
   if (!buf) {
     // is this the correct way to do this?

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2882,6 +2882,10 @@ static const char *validate_num_option(const OptInt *pp, OptInt *valuep)
     if (value < 0) {
       return e_positive;
     }
+  } else if (pp == &p_tsml) {
+    if (value < 32 || value > 64000) {
+      return e_invarg;
+    }
   } else if (pp == &p_hi) {
     if (value < 0) {
       return e_positive;
@@ -4378,6 +4382,8 @@ void *get_varp_scope_from(vimoption_T *p, int scope, buf_T *buf, win_T *win)
       return &(win->w_p_lcs);
     case PV_VE:
       return &(win->w_p_ve);
+    case PV_TSML:
+      return &(buf->b_p_tsml);
     }
     return NULL;     // "cannot happen"
   }
@@ -4465,6 +4471,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return *win->w_p_lcs != NUL ? &(win->w_p_lcs) : p->var;
   case PV_VE:
     return *win->w_p_ve != NUL ? &win->w_p_ve : p->var;
+  case PV_TSML:
+    return buf->b_p_tsml >= 0 ? &(buf->b_p_tsml) : p->var;
 
   case PV_ARAB:
     return &(win->w_p_arab);
@@ -5104,6 +5112,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_inex = xstrdup(p_inex);
       COPY_OPT_SCTX(buf, BV_INEX);
       buf->b_p_dict = empty_string_option;
+      buf->b_p_tsml = -1;
       buf->b_p_tsr = empty_string_option;
       buf->b_p_tsrfu = empty_string_option;
       buf->b_p_qe = xstrdup(p_qe);

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -727,6 +727,7 @@ EXTERN char *p_titleold;        ///< 'titleold'
 EXTERN char *p_titlestring;     ///< 'titlestring'
 EXTERN char *p_tsr;             ///< 'thesaurus'
 EXTERN int p_tgc;               ///< 'termguicolors'
+EXTERN OptInt p_tsml;              ///< 'tsmatchlimit'
 EXTERN int p_ttimeout;          ///< 'ttimeout'
 EXTERN OptInt p_ttm;            ///< 'ttimeoutlen'
 EXTERN char *p_udir;            ///< 'undodir'
@@ -867,6 +868,7 @@ enum {
   BV_SWF,
   BV_TFU,
   BV_TSRFU,
+  BV_TSML,
   BV_TAGS,
   BV_TC,
   BV_TS,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9044,7 +9044,7 @@ return {
       scope = { 'global', 'buffer' },
       short_desc = N_('maximum number of nodes in treesitter matches for each query'),
       type = 'number',
-      redraw = { 'ui_option', 'current_buffer' },
+      redraw = { 'current_buffer' },
       varname = 'p_tsml',
     },
     {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9030,6 +9030,24 @@ return {
       varname = 'p_titlestring',
     },
     {
+      abbreviation = 'tsml',
+      defaults = { if_true = 256 },
+      desc = [=[
+        This option determines the maximum number of treesitter nodes matched
+        when a cursor query is executed. Higher values allow for deeper matches
+        at the expense of query execution time, while lower values can be used
+        to speed up the execution time.
+
+        The default value is 256. Maximum is 64000 and minimum is 32.
+      ]=],
+      full_name = 'tsmatchlimit',
+      scope = { 'global', 'buffer' },
+      short_desc = N_('maximum number of nodes in treesitter matches for each query'),
+      type = 'number',
+      redraw = { 'ui_option', 'current_buffer' },
+      varname = 'p_tsml',
+    },
+    {
       defaults = { if_true = true },
       desc = [=[
         This option and 'ttimeoutlen' determine the behavior when part of a

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -24,6 +24,7 @@ describe('UI receives option updates', function()
       showtabline=1,
       termguicolors=false,
       termsync=true,
+      tsmatchlimit = 256,
       ttimeout=true,
       ttimeoutlen=50,
       verbose=0,

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -301,7 +301,7 @@ func Test_set_completion()
 
   " Expand abbreviation of options.
   call feedkeys(":set ts\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set tabstop thesaurus thesaurusfunc', @:)
+  call assert_equal('"set tabstop thesaurus thesaurusfunc tsmatchlimit', @:)
 
   " Expand current value
   call feedkeys(":set suffixes=\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
This pull request is trying to continue work along the lines of #16008, but it gives both a global and a buffer local option (`vim.go.tsmatchlimit` and `vim.bo.tsmatchlimit`). A similar discussion about a different way of setting up treesitter can be found in #15260, where it was discussed if we should make something like `vim.treesitter.config(...)` (similar to `vim.diagnostics.config(...)`).

The current code is only a draft for now (I have almost no experience in working with C or the neovim code base), but it works as intended.

## Problem

The main goal of this pull request is fixing the problem of highlighting a deep tree with something like `rainbow-delimiters` as described in #26325. 

As identified in that issue the main problem is that a value of 256 in
```c
ts_query_cursor_set_match_limit(cursor, 256);
```
is not always high enough. (Note: This value has been raised once already from 64 to 256.)

Of course this problem could be fixed by raising the limit once again, but it was specifically chosen to be relatively low for performance reasons (discussed in #22055 where there is also discussion about maybe introducing a timeout for the query instead). Therefore it might be better to allow users to adjust this value themselves, especially since this would also allow for trying to lower the value if you run into treesitter performance issues. 

Furthermore, a global value for this match limit is not really a good idea, since users might have different preferences depending on e.g. the language they are working in or the file size of the file they are editing (really anything that can effect treesitter highlighting and performance). Thus it makes sense to allow for local adjustment to the match limit value.

## Solution

Expose `vim.go.tsmatchlimit` and `vim.bo.tsmatchlimit` for setting this value globally or locally (within a buffer). 

For example I have so far mainly run into problems with the match limit of 256 in `:InspectTree`, so something like the following allows for increasing the match limit there and lowering it elsewhere:
 
```lua
vim.go.tsmatchlimit = 32 -- mainly to make the difference clearer
vim.api.nvim_create_autocmd("FileType", {
	group = augroup,
	pattern = "*",
	callback = function(args)
		local lang = vim.treesitter.language.get_lang(args.match)
		if lang == 'query' then
			vim.bo.tsmatchlimit = 2048
		end
	end,
})
```

(Of course you could target this better than just looking at the language, but this is fine for an example.)

Here is the start of my `:InspectTree` with `vim.go.tsmatchlimit = 32` without the auto command:
<img width="288" alt="Screenshot 2023-12-13 at 23 39 21" src="https://github.com/neovim/neovim/assets/7075380/a0ea977b-bcb8-4b46-be85-143417e99f06">

And with the above auto command:
<img width="287" alt="Screenshot 2023-12-13 at 23 39 49" src="https://github.com/neovim/neovim/assets/7075380/4e294261-3bf2-4efd-92bb-e9e8678f94f2">

You can see that a match limit of 32 (and even 256 in this case) is too low for `rainbow-delimiters` to allow capturing the outer `section`. 

An alternative solution would be to allow changing the value via `vim.treesitter.config(...)`, which I think could also work fine. In general I would just like a way of adjusting the value. 

As a side note: I get very weird errors when using small values for the `tsmatchlimit` (like 1, 2 or 4 for example), where some key presses jump outside the neovim window and into my terminal shell prompt. Is there anything in neovim that expects the value to always be at least 32? (Or some other number >4?)