### PR TITLE
refactor(diagnostic): use named namespaces

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -877,7 +877,8 @@ M.handlers.signs = {
 
     local ns = M.get_namespace(namespace)
     if not ns.user_data.sign_ns then
-      ns.user_data.sign_ns = api.nvim_create_namespace('')
+      ns.user_data.sign_ns =
+        api.nvim_create_namespace(string.format('%s/diagnostic/signs', ns.name))
     end
 
     local text = {}
@@ -938,7 +939,8 @@ M.handlers.underline = {
 
     local ns = M.get_namespace(namespace)
     if not ns.user_data.underline_ns then
-      ns.user_data.underline_ns = api.nvim_create_namespace('')
+      ns.user_data.underline_ns =
+        api.nvim_create_namespace(string.format('%s/diagnostic/underline', ns.name))
     end
 
     local underline_ns = ns.user_data.underline_ns
@@ -1020,7 +1022,8 @@ M.handlers.virtual_text = {
 
     local ns = M.get_namespace(namespace)
     if not ns.user_data.virt_text_ns then
-      ns.user_data.virt_text_ns = api.nvim_create_namespace('')
+      ns.user_data.virt_text_ns =
+        api.nvim_create_namespace(string.format('%s/diagnostic/virtual_text', ns.name))
     end
 
     local virt_text_ns = ns.user_data.virt_text_ns


### PR DESCRIPTION
Anonymous namespaces are more difficult to extend or hook into since
they do not appear in the output of nvim_get_namespaces(). Use named
namespaces instead.
