### PR TITLE
refactor(defaults): defer setting 'termguicolors' until after VimEnter

### DIFF
--- a/runtime/lua/vim/termcap.lua
+++ b/runtime/lua/vim/termcap.lua
@@ -34,6 +34,7 @@ function M.query(caps, cb)
   local timer = assert(vim.uv.new_timer())
 
   local id = vim.api.nvim_create_autocmd('TermResponse', {
+    nested = true,
     callback = function(args)
       local resp = args.data ---@type string
       local k, rest = resp:match('^\027P1%+r(%x+)(.*)$')


### PR DESCRIPTION
This ensures that any OptionSet autocommands will fire when the value is changed.
