### PR TITLE
vim-patch:17dca3cb97cd

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5171,9 +5171,9 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 <		This limits the length of the text used from "line" to
 		"width" bytes.
 
-		If the argument to be formatted is specified using a posional
-		argument specifier, and a '*' is used to indicate that a
-		number argument is to be used to specify the width or
+		If the argument to be formatted is specified using a
+		positional argument specifier, and a '*' is used to indicate
+		that a number argument is to be used to specify the width or
 		precision, the argument(s) to be used must also be specified
 		using a {n$} positional argument specifier. See |printf-$|.
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6156,9 +6156,9 @@ function vim.fn.prevnonblank(lnum) end
 --- <This limits the length of the text used from "line" to
 --- "width" bytes.
 ---
---- If the argument to be formatted is specified using a posional
---- argument specifier, and a '*' is used to indicate that a
---- number argument is to be used to specify the width or
+--- If the argument to be formatted is specified using a
+--- positional argument specifier, and a '*' is used to indicate
+--- that a number argument is to be used to specify the width or
 --- precision, the argument(s) to be used must also be specified
 --- using a {n$} positional argument specifier. See |printf-$|.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7443,9 +7443,9 @@ M.funcs = {
       <This limits the length of the text used from "line" to
       "width" bytes.
 
-      If the argument to be formatted is specified using a posional
-      argument specifier, and a '*' is used to indicate that a
-      number argument is to be used to specify the width or
+      If the argument to be formatted is specified using a
+      positional argument specifier, and a '*' is used to indicate
+      that a number argument is to be used to specify the width or
       precision, the argument(s) to be used must also be specified
       using a {n$} positional argument specifier. See |printf-$|.
 


### PR DESCRIPTION
#### vim-patch:17dca3cb97cd

runtime(doc): grammar & typo fixes

closes: vim/vim#13654

https://github.com/vim/vim/commit/17dca3cb97cdd7835e334b990565c8c0b93b1284

Co-authored-by: Dominique Pellé <dominique.pelle@tomtom.com>