### PR TITLE
fix(inccommand): don't preview when in ex mode

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2633,6 +2633,7 @@ static int command_line_changed(CommandLineState *s)
   if (s->firstc == ':'
       && current_sctx.sc_sid == 0    // only if interactive
       && *p_icm != NUL       // 'inccommand' is set
+      && !exmode_active      // not in ex mode
       && curbuf->b_p_ma      // buffer is modifiable
       && cmdline_star == 0   // not typing a password
       && !vpeekc_any()

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1097,3 +1097,25 @@ describe('user session', function()
     eq(1, eval('g:lua_session'))
   end)
 end)
+
+describe('inccommand on ex mode', function()
+  it('should not preview', function()
+    clear()
+    local screen
+    screen = Screen.new(60, 10)
+    screen:attach()
+    local id = funcs.termopen({ nvim_prog, '-u', 'NONE', '-c', 'set termguicolors', '-E', 'test/README.md' }, {
+      env = { VIMRUNTIME = os.getenv('VIMRUNTIME') }
+    })
+    funcs.chansend(id, '%s/N')
+    screen:expect{grid=[[
+      {1:^                                                            }|
+      {1:                                                            }|*6
+      {1:Entering Ex mode.  Type "visual" to go to Normal mode.      }|
+      {1::%s/N                                                       }|
+                                                                  |
+    ]], attr_ids={
+      [1] = {background = Screen.colors.NvimDarkGrey2, foreground = Screen.colors.NvimLightGrey2};
+    }}
+  end)
+end)


### PR DESCRIPTION
Probelem: inccommand has default value, when run substitute in exmode will show preview.

Solution: check if its in exmode.

Fix #26056