### PR TITLE
vim-patch:9a775b4a2ae6

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5268,7 +5268,8 @@ fun! s:NetrwBrowseUpDir(islocal)
    endif
    call s:RestorePosn(s:netrw_posn)
    let curdir= substitute(curdir,'^.*[\/]','','')
-   call search('\<'.curdir.'/','wc')
+   let curdir= '\<'. escape(curdir, '~'). '/'
+   call search(curdir,'wc')
   endif
 "  call Dret("s:NetrwBrowseUpDir")
 endfun


### PR DESCRIPTION
#### vim-patch:9a775b4a2ae6

runtime(netrw): escape curdir in BrowseUpDir (vim/vim#13681)

https://github.com/vim/vim/commit/9a775b4a2ae658e61f9d6582de72ea7a1b241aaa

Co-authored-by: Christian Brabandt <cb@256bit.org>