### PR TITLE
docs: undeprecate gdefault

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -171,7 +171,6 @@ NORMAL COMMANDS
 OPTIONS
 - *cpo-<* *:menu-<special>* *:menu-special* *:map-<special>* *:map-special*
   `<>` notation is always enabled.
-- 'gdefault'		Enables the |:substitute| flag 'g' by default.
 - *'fe'*		'fenc'+'enc' before Vim 6.0; no longer used.
 - *'highlight'* *'hl'*	Names of builtin |highlight-groups| cannot be changed.
 - *'langnoremap'*	Deprecated alias to 'nolangremap'.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2827,10 +2827,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:s///g		  subst. one	  subst. all
 		:s///gg		  subst. all	  subst. one
 
-	DEPRECATED: Setting this option may break plugins that are not aware
-	of this option.  Also, many users get confused that adding the /g flag
-	has the opposite effect of that it normally does.
-
 						*'grepformat'* *'gfm'*
 'grepformat' 'gfm'	string	(default "%f:%l:%m,%f:%l%m,%f  %l%m")
 			global


### PR DESCRIPTION
The reasoning given for its deprecation is underwhelming, and does not
hold up to scrutiny.

- "Setting this option may break plugins that are not aware of this
  option."

Given that this option has not been removed, and that gdefault is widely
in use, then in this hypothetical scenario the plugin author has either
already fixed problems related to gdefault due to user report, or they
are not aware that their plugin is broken. Either way, deprecating it
effectively does nothing as people use it regardless of its deprecation
status.

- "Also, many users get confused that adding the /g flag has the
  opposite effect of that it normally does."

This is a strange objection as it's not on by default. Is the
implication that the user somehow unwittingly sets the option and then
get confused by its behavior? Or that a system administrator enables it
by default which affects unaware users? If so, what makes gdefault any
more surprising than a multitude of other options?

If there are other, more compelling, arguments for its deprecation then
those should be used instead.
