### PR TITLE
vim-patch:e06f2b498ccc

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -425,7 +425,7 @@ Note that when 'nrformats' includes "octal", decimal numbers with leading
 zeros cause mistakes, because they can be confused with octal numbers.
 
 Note similarly, when 'nrformats' includes "bin", binary numbers with a leading
-'0x' or '0X' can be interpreted as hexadecimal rather than binary since '0b'
+'0b' or '0B' can be interpreted as hexadecimal rather than binary since '0b'
 are valid hexadecimal digits.
 
 When the number under the cursor is too big to fit into 64 bits, it will be


### PR DESCRIPTION
#### vim-patch:e06f2b498ccc

runtime(doc): fix typo in change.txt

https://github.com/vim/vim/commit/e06f2b498ccca921f34a1bec4464f042a5a2cabd

Co-authored-by: Christian Brabandt <cb@256bit.org>