### PR TITLE
refactor(defaults): always set options, even if value hasn't changed

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -189,9 +189,7 @@ if tty then
     -- Wait until Nvim is finished starting to set the option to ensure the
     -- OptionSet event fires.
     if vim.v.vim_did_enter == 1 then
-      if vim.o[option] ~= value then
-        vim.o[option] = value
-      end
+      vim.o[option] = value
     else
       vim.api.nvim_create_autocmd('VimEnter', {
         once = true,


### PR DESCRIPTION
Comparing against the old value before setting matched the [original C implementation](https://github.com/neovim/neovim/blob/48bcc7b9710d6db619b05254ea87f4087cdd9764/src/nvim/option.c#L3188), but there is no reason to use this restriction. In particular, this inhibits using OptionSet to determine when the option was set. If users need to handle a case where the option _changed_, it is easy to do so in an OptionSet autocommand using v:option_new and v:option_old (and friends).
