### PR TITLE
refactor: only reload colorscheme if &bg changed

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -774,7 +774,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |:hi-normal| if you want to set the background color explicitly.
 						*g:colors_name*
 	When a color scheme is loaded (the "g:colors_name" variable is set)
-	setting 'background' will cause the color scheme to be reloaded.  If
+	changing 'background' will cause the color scheme to be reloaded.  If
 	the color scheme adjusts to the value of 'background' this will work.
 	However, if the color scheme sets 'background' itself the effect may
 	be undone.  First delete the "g:colors_name" variable when needed.
@@ -784,13 +784,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		:if $TERM ==# "xterm"
 		:  set background=dark
 		:endif
-<	When this option is set, the default settings for the highlight groups
+<	When this option is changed, the default settings for the highlight groups
 	will change.  To use other settings, place ":highlight" commands AFTER
 	the setting of the 'background' option.
-	This option is also used in the "$VIMRUNTIME/syntax/syntax.vim" file
-	to select the colors for syntax highlighting.  After changing this
-	option, you must load syntax.vim again to see the result.  This can be
-	done with ":syntax on".
 
 						*'backspace'* *'bs'*
 'backspace' 'bs'	string	(default "indent,eol,start")

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -297,6 +297,8 @@ Options:
   global-local string options work.
 
   'autoread'    works in the terminal (if it supports "focus" events)
+  'background'  colorscheme is only reloaded if value is changed, not every
+                time it is set
   'cpoptions'   flags: |cpo-_|
   'diffopt'     "linematch" feature
   'exrc'        searches for ".nvim.lua", ".nvimrc", or ".exrc" files. The

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -191,7 +191,7 @@ vim.go.awa = vim.go.autowriteall
 --- See `:hi-normal` if you want to set the background color explicitly.
 --- 					*g:colors_name*
 --- When a color scheme is loaded (the "g:colors_name" variable is set)
---- setting 'background' will cause the color scheme to be reloaded.  If
+--- changing 'background' will cause the color scheme to be reloaded.  If
 --- the color scheme adjusts to the value of 'background' this will work.
 --- However, if the color scheme sets 'background' itself the effect may
 --- be undone.  First delete the "g:colors_name" variable when needed.
@@ -203,13 +203,9 @@ vim.go.awa = vim.go.autowriteall
 --- 	:  set background=dark
 --- 	:endif
 --- ```
---- When this option is set, the default settings for the highlight groups
+--- When this option is changed, the default settings for the highlight groups
 --- will change.  To use other settings, place ":highlight" commands AFTER
 --- the setting of the 'background' option.
---- This option is also used in the "$VIMRUNTIME/syntax/syntax.vim" file
---- to select the colors for syntax highlighting.  After changing this
---- option, you must load syntax.vim again to see the result.  This can be
---- done with ":syntax on".
 ---
 --- @type string
 vim.o.background = "dark"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -316,7 +316,7 @@ return {
         See |:hi-normal| if you want to set the background color explicitly.
         					*g:colors_name*
         When a color scheme is loaded (the "g:colors_name" variable is set)
-        setting 'background' will cause the color scheme to be reloaded.  If
+        changing 'background' will cause the color scheme to be reloaded.  If
         the color scheme adjusts to the value of 'background' this will work.
         However, if the color scheme sets 'background' itself the effect may
         be undone.  First delete the "g:colors_name" variable when needed.
@@ -326,13 +326,9 @@ return {
         	:if $TERM ==# "xterm"
         	:  set background=dark
         	:endif
-        <	When this option is set, the default settings for the highlight groups
+        <	When this option is changed, the default settings for the highlight groups
         will change.  To use other settings, place ":highlight" commands AFTER
         the setting of the 'background' option.
-        This option is also used in the "$VIMRUNTIME/syntax/syntax.vim" file
-        to select the colors for syntax highlighting.  After changing this
-        option, you must load syntax.vim again to see the result.  This can be
-        done with ":syntax on".
       ]=],
       expand_cb = 'expand_set_background',
       full_name = 'background',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -663,10 +663,15 @@ int expand_set_ambiwidth(optexpand_T *args, int *numMatches, char ***matches)
 }
 
 /// The 'background' option is changed.
-const char *did_set_background(optset_T *args FUNC_ATTR_UNUSED)
+const char *did_set_background(optset_T *args)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
     return e_invarg;
+  }
+
+  if (args->os_oldval.string.data[0] == *p_bg) {
+    // Value was not changed
+    return NULL;
   }
 
   int dark = (*p_bg == 'd');


### PR DESCRIPTION
Currently, setting &bg at all re-initializes highlights and reloads the active colorscheme, even if the actual value of &bg has not changed. With https://github.com/neovim/neovim/pull/26595 this causes a regression since &bg is set unconditionally based on the value detected from the terminal.

Instead, only reload the colorscheme if the actual value of &bg has changed.
