### PR TITLE
vim-patch:9.0.2112: [security]: overflow in shift_line

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -290,13 +290,13 @@ void op_shift(oparg_T *oap, int curs_top, int amount)
 /// @param call_changed_bytes  call changed_bytes()
 void shift_line(int left, int round, int amount, int call_changed_bytes)
 {
-  const int sw_val = get_sw_value_indent(curbuf);
+  const int64_t sw_val = get_sw_value_indent(curbuf);
 
-  int count = get_indent();  // get current indent
+  int64_t count = get_indent();  // get current indent
 
   if (round) {  // round off indent
-    int i = count / sw_val;  // number of 'shiftwidth' rounded down
-    int j = count % sw_val;  // extra spaces
+    int64_t i = count / sw_val;  // number of 'shiftwidth' rounded down
+    int64_t j = count % sw_val;  // extra spaces
     if (j && left) {  // first remove extra spaces
       amount--;
     }
@@ -316,15 +316,19 @@ void shift_line(int left, int round, int amount, int call_changed_bytes)
         count = 0;
       }
     } else {
-      count += sw_val * amount;
+      if (sw_val * amount > INT_MAX - count) {
+        count = INT_MAX;
+      } else {
+        count += sw_val * amount;
+      }
     }
   }
 
   // Set new indent
   if (State & VREPLACE_FLAG) {
-    change_indent(INDENT_SET, count, false, NUL, call_changed_bytes);
+    change_indent(INDENT_SET, (int)count, false, NUL, call_changed_bytes);
   } else {
-    (void)set_indent(count, call_changed_bytes ? SIN_CHANGED : 0);
+    (void)set_indent((int)count, call_changed_bytes ? SIN_CHANGED : 0);
   }
 }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -316,12 +316,12 @@ void shift_line(int left, int round, int amount, int call_changed_bytes)
         count = 0;
       }
     } else {
-      if (sw_val * amount > INT_MAX - count) {
-        count = INT_MAX;
-      } else {
-        count += sw_val * amount;
-      }
+      count += sw_val * amount;
     }
+  }
+
+  if (count > INT_MAX) {
+    count = INT_MAX;
   }
 
   // Set new indent

--- a/test/old/testdir/test_indent.vim
+++ b/test/old/testdir/test_indent.vim
@@ -276,4 +276,15 @@ func Test_formatting_keeps_first_line_indent()
   bwipe!
 endfunc
 
+" Test for indenting with large amount, causes overflow
+func Test_indent_overflow_count()
+  new
+  setl sw=8
+  call setline(1, "abc")
+  norm! V2147483647>
+  " indents by INT_MAX
+  call assert_equal(2147483647, indent(1))
+  close!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
- vim-patch:9.0.2112: [security]: overflow in shift_line

Problem:  [security]: overflow in shift_line
Solution: allow a max indent of INT_MAX

[security]: overflow in shift_line

When shifting lines in operator pending mode and using a very large
value, we may overflow the size of integer. Fix this by using a long
variable, testing if the result would be larger than INT_MAX and if so,
indent by INT_MAX value.

Special case: We cannot use long here, since on 32bit architectures (or
on Windows?), it typically cannot take larger values than a plain int,
so we have to use long long count, decide whether the resulting
multiplication of the shiftwidth value * amount is larger than INT_MAX
and if so, we will store INT_MAX as possible larges value in the long
long count variable.

Then we can safely cast it back to int when calling the functions to set
the indent (set_indent() or change_indent()). So this should be safe.

Add a test that when using a huge value in operator pending mode for
shifting, we will shift by INT_MAX

closes: vim/vim#13535

https://github.com/vim/vim/commit/6bf131888a3d1de62bbfa8a7ea03c0ddccfd496e

Co-authored-by: Christian Brabandt <cb@256bit.org>

- vim-patch:9.0.2113: Coverity warns for another overflow in shift_line()

Problem:  Coverity warns for another overflow in shift_line()
Solution: Test for INT_MAX after the if condition, cast integer values
          to (long long) before multiplying.

https://github.com/vim/vim/commit/22a97fc241361aa91bda84e5344d5b7c0cda3e81

Co-authored-by: Christian Brabandt <cb@256bit.org>