### PR TITLE
vim-patch:9.0.1892: CI: no FreeBSD 14 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ freebsd_task:
   name: FreeBSD
   only_if: $BRANCH != "master"
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-14-0
   timeout_in: 30m
   install_script:
     - pkg install -y cmake gmake ninja unzip wget gettext python git


### PR DESCRIPTION
#### vim-patch:9.0.1892: CI: no FreeBSD 14 support

Problem:  CI: no FreeBSD 14 support
Solution: Drop support for FreeBSD 12, add FreeBSD 14

closes: vim/vim#13059

https://github.com/vim/vim/commit/24a95f42b8469944a1e74838438ac8f1d86f9450

Co-authored-by: Philip H <47042125+pheiduck@users.noreply.github.com>

N/A patches cirrus:

vim-patch:8.2.4853: CI with FreeBSD is a bit outdated
vim-patch:8.2.4889: CI only tests with FreeBSD 12
vim-patch:9.0.0580: no CI running for MacOS on M1
vim-patch:9.0.0596: CI on Mac M1 has the channel feature disabled
vim-patch:9.0.0668: CI on Mac M1 only uses clang
vim-patch:9.0.0676: CI on Mac M1 with gcc actually uses clang
vim-patch:9.0.1024: CI doesn't use the latest FreeBSD version
vim-patch:9.0.1904: Cirrus-CI fails because we have used all credits
vim-patch:9.0.1912: Cirrus-CI running out of credits
vim-patch:9.0.1979: Cirrus CI disabled

N/A patches github actions:

vim-patch:ed37d9b3241a
vim-patch:8.2.3450: coveralls action fails
vim-patch:8.2.3488: issue template is not easy to use
vim-patch:8.2.3500: Github CI fails to install clang
vim-patch:8.2.3785: running CI on MacOS with gcc is not useful
vim-patch:4e30b5c3bc83
vim-patch:9a4ec5a62632
vim-patch:8.2.3821: ASAN test run fails
vim-patch:8.2.3827: huntr badge does not really fit in the list
vim-patch:8.2.3891: github CI: workflows may overlap
vim-patch:8.2.4061: codecov bash script is deprecated
vim-patch:8.2.4092: MacOS CI: unnecessarily doing "Install packages"
vim-patch:8.2.4096: Linux CI: unnecessarily installing packages
vim-patch:8.2.4222: MS-Windows: clumsy way to suppress progress on CI
vim-patch:8.2.4268: CI log output is long
vim-patch:8.2.4342: CI will soon switch to other windows version
vim-patch:8.2.4351: no coverage is measured on MS-Windows CI
vim-patch:8.2.4353: CI does not use the latest Lua and Python
vim-patch:8.2.4377: CI steps for Windows are a bit unorganized
vim-patch:8.2.4433: CI: cannot see interface versions for MS-Windows
vim-patch:8.2.4743: clang 14 is available on CI
vim-patch:8.2.4764: CI uses an older gcc version
vim-patch:8.2.4768: CI: codecov upload sometimes does not work
vim-patch:8.2.4816: still using older codecov app in some places of CI
vim-patch:8.2.4856: MinGW compiler complains about unknown escape sequence
vim-patch:8.2.4986: some github actions are outdated
vim-patch:8.2.5052: CI checkout step title is a bit cryptic
vim-patch:8.2.5086: CI runs on Windows 2019
vim-patch:8.2.5119: CI uses cache v2
vim-patch:9.0.0264: CI still runs on Ubuntu 18.04
vim-patch:9.0.0267: Coverity workflow still uses Ubuntu 18.04
vim-patch:9.0.0277: Coverity CI: update-alternatives not needed with Ubuntu 20.04
vim-patch:9.0.0302: CI for Coverity is bothered by deprecation warnings
vim-patch:9.0.0305: CI lists useless deprecation warnings
vim-patch:9.0.0401: CI uses older clang version
vim-patch:9.0.0421: MS-Windows makefiles are inconsistently named
vim-patch:9.0.0536: CI: codecov action update available
vim-patch:9.0.0570: CI for Windows is still using codecov action 3.1.0
vim-patch:9.0.0573: outdated dependencies go unnoticed
vim-patch:9.0.0593: CI actions have too many permissions
vim-patch:9.0.0704: CI runs "tiny" and "small" builds, which are the same
vim-patch:9.0.0755: huge build on macos always fails on CI
vim-patch:9.0.0759: huge build on macos does not use Perl
vim-patch:9.0.0773: huge build on macos uses dynamic Perl
vim-patch:9.0.0847: CI: not totally clear what MS-Windows version is used
vim-patch:9.0.0937: forked repositories send out useless email
vim-patch:9.0.0941: CI failures in sound dummy
vim-patch:9.0.0946: CI: Error in Coverity flow is not reported
vim-patch:9.0.1071: Codecov action version is too specific
vim-patch:9.0.1114: CI does not use the latest Python version
vim-patch:9.0.1253: CI adds repository unnecessarily
vim-patch:9.0.1289: a newer version of clang can be used for CI
vim-patch:9.0.1384: setting HOMEBREW_NO_AUTO_UPDATE is not needed with version 4
vim-patch:9.0.1473: CI does not run sound tests
vim-patch:9.0.1474: CI runs with old version of Ubuntu and tools
vim-patch:9.0.1536: CI: sound dummy stopped working
vim-patch:9.0.1541: CI: sound dummy is disabled
vim-patch:9.0.1547: Coveralls workflow on CI is commented out
vim-patch:9.0.1548: CI: check in sound-dummy module may throw an error
vim-patch:9.0.1552: CI: sound-dummy module is not installed
vim-patch:9.0.1553: CI: using slightly outdated gcc version
vim-patch:9.0.1562: mixing package managers is not a good idea
vim-patch:9.0.1646: CI: codecov may take a very long time to run
vim-patch:9.0.1681: Build Failure with Perl 5.38
vim-patch:8f5a8d8a8bdc
vim-patch:9.0.1713: Github CI fails to load snd-dummy kernel module
vim-patch:9.0.1733: CI: cannot cache linux-modules-extra
vim-patch:9.0.1736: Github Actions times out after 20 minutes
vim-patch:9.0.1748: CI: cannot label issues automatically
vim-patch:9.0.1751: CI: labeler configuration not found
vim-patch:9.0.1764: CI: label should not be set on all yml files
vim-patch:9180633e6892
vim-patch:9.0.1819: Github CI too complex
vim-patch:213c32318419
vim-patch:9.0.1903: CI fails because snd-dummy modules missing
vim-patch:9.0.1943: CI not run with clang-17
vim-patch:9.0.1954: CI: change netrw label in labeller bot
vim-patch:198734897ead
vim-patch:50f3ec2898a4
vim-patch:4b0018feca3a
vim-patch:cb5e7a2026d3
vim-patch:f1952d9fa8ef
vim-patch:9cc95aa0d8f5
vim-patch:a40e1687e757
vim-patch:c1c3b83816c8
vim-patch:1760331ae317
vim-patch:a02fe3480f8e

N/A patches build system:

vim-patch:8.2.0591: MS-Windows: should always support IPv6
vim-patch:8.2.3507: generating proto files may fail
vim-patch:8.2.3565: Makefile dependencies are outdated
vim-patch:8.2.3863: various build flags accidentally enabled
vim-patch:8.2.4130: MS-Windows: MSVC build may have libraries duplicated
vim-patch:8.2.4220: MS-Windows: some old compiler support remains
vim-patch:8.2.4244: MS-Windows: warning from MSVC on debug build
vim-patch:8.2.4271: MS-Windows: cannot build with Ruby 3.1.0
vim-patch:8.2.4284: old mac resources files are no longer used
vim-patch:8.2.4423: "make nvcmdidxs" fails
vim-patch:8.2.4491: MS-Windows makefile dependencies are outdated
vim-patch:8.2.4517: MS-Windows: cannot specify location of sodium library
vim-patch:8.2.4524: MS-Windows: cannot build with some sodium libraries
vim-patch:8.2.4596: installing tutor binary may fail
vim-patch:8.2.5031: cannot easily run the benchmarks
vim-patch:8.2.5090: MS-Windows: vim.def is no longer used
vim-patch:8.2.5101: MS-Windows with MinGW: $CC may be "cc" instead of "gcc"
vim-patch:8.2.5153: "make uninstall" does not remove colors/lists
vim-patch:8.2.5171: dependencies and proto files are outdated
vim-patch:9.0.0029: the bitmaps/vim.ico file is not in the distribution
vim-patch:9.0.0241: "make install" does not install shared syntax file
vim-patch:9.0.0242: "make install" still fails
vim-patch:9.0.0477: missing dependency may cause crashes on incomplete build
vim-patch:9.0.0542: MSVC build still has support for 2012 edition
vim-patch:9.0.0588: MorphOS build is broken
vim-patch:9.0.0594: Makefile error message causes a shell error
vim-patch:9.0.0857: selecting MSVC 2017 does not set $PLATFORM
vim-patch:9.0.0879: unnecessary nesting in makefile
vim-patch:9.0.1342: MS-Windows: linking may fail with space in directory name
vim-patch:9.0.1486: parallel make might not work
vim-patch:9.0.1630: "make clean" at the toplevel fails
vim-patch:9.0.1739: Leftover files in libvterm
vim-patch:9.0.1823: Autoconf 2.69 too old
vim-patch:9.0.1839: No Makefile rule to build cscope database
vim-patch:9.0.2028: confusing build dependencies