### PR TITLE
vim-patch:9.0.2168: Moving tabpages on :drop may cause an endless loop

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -851,6 +851,9 @@ static void arg_all_close_unused_windows(arg_all_state_T *aall)
   if (aall->had_tab > 0) {
     goto_tabpage_tp(first_tabpage, true, true);
   }
+
+  // moving tabpages around in an autocommand may cause an endless loop
+  tabpage_move_disallowed++;
   while (true) {
     win_T *wpnext = NULL;
     tabpage_T *tpnext = curtab->tp_next;
@@ -950,6 +953,7 @@ static void arg_all_close_unused_windows(arg_all_state_T *aall)
     }
     goto_tabpage_tp(tpnext, true, true);
   }
+  tabpage_move_disallowed--;
 }
 
 /// Open up to "count" windows for the files in the argument list "aall->alist".

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -28,8 +28,8 @@ EXTERN win_T *last_cursormoved_win INIT( = NULL);
 EXTERN pos_T last_cursormoved INIT( = { 0, 0, 0 });
 
 EXTERN bool autocmd_busy INIT( = false);     ///< Is apply_autocmds() busy?
-EXTERN int autocmd_no_enter INIT( = false);  ///< *Enter autocmds disabled
-EXTERN int autocmd_no_leave INIT( = false);  ///< *Leave autocmds disabled
+EXTERN int autocmd_no_enter INIT( = false);  ///< Buf/WinEnter autocmds disabled
+EXTERN int autocmd_no_leave INIT( = false);  ///< Buf/WinLeave autocmds disabled
 EXTERN bool did_filetype INIT( = false);     ///< FileType event found
 /// value for did_filetype when starting to execute autocommands
 EXTERN bool keep_filetype INIT( = false);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4426,6 +4426,10 @@ void tabpage_move(int nr)
     return;
   }
 
+  if (tabpage_move_disallowed) {
+    return;
+  }
+
   int n = 1;
   tabpage_T *tp;
 

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -43,6 +43,8 @@ enum {
   LOWEST_WIN_ID = 1000,
 };
 
+EXTERN int tabpage_move_disallowed INIT( = 0);  ///< moving tabpages around disallowed
+
 /// Set to true if 'cmdheight' was explicitly set to 0.
 EXTERN bool p_ch_was_zero INIT( = false);
 

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -905,4 +905,23 @@ func Test_tabpage_last_line()
   bwipe!
 endfunc
 
+" this was causing an endless loop
+func Test_tabpage_drop_tabmove()
+  augroup TestTabpageTabmove
+    au!
+    autocmd! TabEnter * :if tabpagenr() > 1 | tabmove - | endif
+  augroup end
+  $tab drop XTab_99.log
+  $tab drop XTab_98.log
+  $tab drop XTab_97.log
+
+  autocmd! TestTabpageTabmove
+  augroup! TestTabpageTabmove
+
+  " clean up
+  bwipe!
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2168: Moving tabpages on :drop may cause an endless loop

Problem:  Moving tabpages on :drop may cause an endless loop
Solution: Disallow moving tabpages on :drop when cleaning up the arglist
          first

Moving tabpages during drop command may cause an endless loop

When executing a :tab drop command, Vim will close all windows not in
the argument list. This triggers various autocommands. If a user has
created an 'au Tabenter * :tabmove -' autocommand, this can cause Vim to
end up in an endless loop, when trying to iterate over all tabs (which
would trigger the tabmove autocommand, which will change the tpnext
pointer, etc).

So instead of blocking all autocommands before we actually try to edit
the given file, lets simply disallow to move tabpages around. Otherwise,
we may change the expected number of events triggered during a :drop
command, which users may rely on (there is actually a test, that expects
various TabLeave/TabEnter autocommands) and would therefore be a
backwards incompatible change.

Don't make this an error, as this could trigger several times during the
drop command, but silently ignore the :tabmove command in this case (and
it should in fact finally trigger successfully when loading the given
file in a new tab). So let's just be quiet here instead.

closes: vim/vim#13686

https://github.com/vim/vim/commit/df12e39b8b9dd39056e22b452276622cb7b617fd

Co-authored-by: Christian Brabandt <cb@256bit.org>