### PR TITLE
fix(api): crash after nvim_win_set_config title/footer validation error

### DIFF
--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -906,4 +906,38 @@ describe('API/win', function()
       eq(footer, cfg.footer)
     end)
   end)
+
+  describe('set_config', function()
+    it('no crash with invalid title', function ()
+      local win = meths.open_win(0, true, {
+        width = 10,
+        height = 10,
+        relative = "editor",
+        row = 10,
+        col = 10,
+        title = { { "test" } },
+        border = "single",
+      })
+      eq("title/footer cannot be an empty array",
+          pcall_err(meths.win_set_config, win, {title = {}}))
+      command("redraw!")
+      assert_alive()
+    end)
+
+    it('no crash with invalid footer', function ()
+      local win = meths.open_win(0, true, {
+        width = 10,
+        height = 10,
+        relative = "editor",
+        row = 10,
+        col = 10,
+        footer = { { "test" } },
+        border = "single",
+      })
+      eq("title/footer cannot be an empty array",
+          pcall_err(meths.win_set_config, win, {footer = {}}))
+      command("redraw!")
+      assert_alive()
+    end)
+  end)
 end)


### PR DESCRIPTION
This PR will fix the following crash.

```
./build/bin/nvim --headless --clean +"luafile ./minimal.lua"
Error detected while processing command line:
E5113: Error while calling lua chunk: ./minimal.lua:13: title cannot be an empty array
stack traceback:
        [C]: in function 'nvim_win_set_config'
        ./minimal.lua:13: in main chunkSegmentation fault (core dumped)
```

minimal.lua
```lua
local window = vim.api.nvim_open_win(0, true, {
  width = 10,
  height = 10,
  relative = "editor",
  row = 10,
  col = 10,
  focusable = true,
  external = false,
  style = "minimal",
  footer = { { "test" } },
  border = "single",
})
vim.api.nvim_win_set_config(window, {
  footer = {},
})
```

<details>
<summary>backtrace</summary>

version: NVIM v0.10.0-dev-1859+g5ed55ff14

```

warning: Can't open file anon_inode:[io_uring] which was expanded to anon_inode:[io_uring] during file-backed mapping note processing

warning: Can't open file anon_inode:[io_uring] which was expanded to anon_inode:[io_uring] during file-backed mapping note processing

warning: Can't open file anon_inode:[io_uring] which was expanded to anon_inode:[io_uring] during file-backed mapping note processing

warning: Can't open file anon_inode:[io_uring] which was expanded to anon_inode:[io_uring] during file-backed mapping note processing
[New LWP 27792]
[New LWP 27793]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/home/notomo/workspace/neovim/build/bin/nvim --headless --clean +luafile ./mini'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00005563b9b1408b in grid_line_puts (col=1, text=0x5566ecaa9c44 <error: Cannot access memory at address 0x5566ecaa9c44>, textlen=-1, attr=0) at /home/notomo/workspace/neovim/src/nvim/grid.c:385
385	  while (col < max_col && (len < 0 || (int)(ptr - text) < len) && *ptr != NUL) {
[Current thread is 1 (Thread 0x7fcdf3b21bc0 (LWP 27792))]

Thread 2 (LWP 27793):
#0  0x0000000000000000 in ?? ()
No symbol table info available.
Backtrace stopped: Cannot access memory at address 0x0

Thread 1 (Thread 0x7fcdf3b21bc0 (LWP 27792)):
#0  0x00005563b9b1408b in grid_line_puts (col=1, text=0x5566ecaa9c44 <error: Cannot access memory at address 0x5566ecaa9c44>, textlen=-1, attr=0) at /home/notomo/workspace/neovim/src/nvim/grid.c:385
        ptr = 0x5566ecaa9c44 <error: Cannot access memory at address 0x5566ecaa9c44>
        len = -1
        start_col = 1
        max_col = 12
#1  0x00005563b9a43745 in win_redr_bordertext (wp=0x5563ba91b760, vt=..., col=1) at /home/notomo/workspace/neovim/src/nvim/drawscreen.c:714
        attr = 0
        text = 0x5566ecaa9c44 <error: Cannot access memory at address 0x5566ecaa9c44>
        i = 1
#2  0x00005563b9a3db48 in win_redr_border (wp=0x5563ba91b760) at /home/notomo/workspace/neovim/src/nvim/drawscreen.c:799
        footer_col = 1
        grid = 0x5563ba91ded8
        chars = {9213154, 8426722, 9475298, 8557794, 9999586, 8426722, 9737442, 8557794}
        attrs = 0x5563ba91e0b8
        adj = 0x5563ba91b920
        irow = 10
        icol = 10
#3  0x00005563b9a3d2b3 in update_screen () at /home/notomo/workspace/neovim/src/nvim/drawscreen.c:624
        wp = 0x5563ba91b760
        did_intro = false
        is_stl_global = false
        type = 40
        hl_changed = true
        providers = {size = 0, capacity = 4, items = 0x7ffe4fcd9e08, init_array = {0x5563ba91b760, 0x7ffe4fcd9e30, 0x5563b9a42293 <show_cursor_info_later+547>, 0x101cd9e30}}
        did_one = true
#4  0x00005563b9bc7236 in normal_redraw (s=0x7ffe4fcd9ee8) at /home/notomo/workspace/neovim/src/nvim/normal.c:1347
No locals.
#5  0x00005563b9bc6bb9 in normal_check (state=0x7ffe4fcd9ee8) at /home/notomo/workspace/neovim/src/nvim/normal.c:1443
        s = 0x7ffe4fcd9ee8
#6  0x00005563b9cb0da7 in state_enter (s=0x7ffe4fcd9ee8) at /home/notomo/workspace/neovim/src/nvim/state.c:36
        check_result = 32766
        key = 1338875600
        keyname = 0x5563b9bb832c <normal_state_init+28> "H\213E\370H\215\r", <incomplete sequence \347>
        execute_result = 16777216
#7  0x00005563b9bb82d4 in normal_enter (cmdwin=false, noexmode=false) at /home/notomo/workspace/neovim/src/nvim/normal.c:508
        state = {state = {check = 0x5563b9bc6a50 <normal_check>, execute = 0x5563b9bbba70 <normal_execute>}, command_finished = false, ctrl_w = false, need_flushbuf = false, set_prevcount = false, previous_got_int = false, cmdwin = false, noexmode = false, toplevel = true, oa = {op_type = 0, regname = 0, motion_type = kMTCharWise, motion_force = 0, use_reg_one = false, inclusive = false, end_adjusted = false, start = {lnum = 0, col = 0, coladd = 0}, end = {lnum = 0, col = 0, coladd = 0}, cursor_start = {lnum = 0, col = 0, coladd = 0}, line_count = 0, empty = false, is_VIsual = false, start_vcol = 0, end_vcol = 0, prev_opcount = 0, prev_count0 = 0, excl_tr_ws = false}, ca = {oap = 0x0, prechar = 0, cmdchar = 0, nchar = 0, ncharC1 = 0, ncharC2 = 0, extra_char = 0, opcount = 0, count0 = 0, count1 = 0, arg = 0, retval = 0, searchbuf = 0x0}, mapped_len = 0, old_mapped_len = 0, idx = 0, c = 0, old_col = 0, old_pos = {lnum = 0, col = 0, coladd = 0}}
        prev_oap = 0x0
#8  0x00005563b996d91d in main (argc=4, argv=0x7ffe4fcda308) at /home/notomo/workspace/neovim/src/nvim/main.c:638
        fname = 0x0
        params = {argc = 4, argv = 0x7ffe4fcda308, use_vimrc = 0x5563b9ea50da "NONE", clean = true, n_commands = 1, commands = {0x7ffe4fcdbc5b "luafile ./minimal.lua", 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, cmds_tofree = "\000\000\000\000\000\000\000\000\000", n_pre_commands = 0, pre_commands = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, luaf = 0x0, lua_arg0 = -1, edit_type = 0, tagname = 0x0, use_ef = 0x0, input_istext = false, no_swap_file = 0, use_debug_break_level = -1, window_count = 1, window_layout = 0, diff_mode = 0, listen_addr = 0x0, remote = 0, server_addr = 0x0, scriptin = 0x0, scriptout = 0x0, scriptout_append = false, had_stdin_file = false}
        cwd = 0x0
        has_term = true
        use_builtin_ui = false
        remote_ui = false
        use_remote_ui = false
        listen_and_embed = false
        vimrc_none = true
```

</details>
