### PR TITLE
build: fix universal mac builds

### DIFF
--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -18,7 +18,7 @@ function(BuildLuajit)
   ExternalProject_Add(${_luajit_TARGET}
     URL ${LUAJIT_URL}
     URL_HASH SHA256=${LUAJIT_SHA256}
-    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luajit
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/${_luajit_TARGET}
     CONFIGURE_COMMAND "${_luajit_CONFIGURE_COMMAND}"
     BUILD_IN_SOURCE 1
     BUILD_COMMAND "${_luajit_BUILD_COMMAND}"


### PR DESCRIPTION
Cmake 3.28+ will fail if two projects download the same file to prevent
scheduling problems. This can be circumvented by downloading luajit to a
unique location for each target. This is theoretically non-optimal since
we need to download the same file three times for universal builds, but
universal builds are rare and the convenience of this method outweighs
setting up the dependencies optimally. This fixes the currently broken
release workflow for mac.

Closes https://github.com/neovim/neovim/issues/26526.