### PR TITLE
build: eliminate semicolons from --version string

### DIFF
--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -173,6 +173,7 @@ append_target_expression(PROPERTY COMPILE_OPTIONS)
 append_target_expression(PROPERTY LINK_FLAGS) # TODO(dundargoc): Replace/complement with LINK_OPTIONS when minimum version is 3.13+
 append_target_expression(PREFIX "-D" PROPERTY COMPILE_DEFINITIONS)
 append_target_expression(PREFIX "-I" PROPERTY INCLUDE_DIRECTORIES)
+string(REPLACE ";" " " VERSION_STRING "${VERSION_STRING}") # Remove ; from LINK_FLAGS/LINK_OPTIONS
 string(REPLACE "  " " " VERSION_STRING "${VERSION_STRING}") # Remove duplicate whitespace
 
 configure_file(versiondef.h.in auto/versiondef.h.gen)


### PR DESCRIPTION
Refactor the --version string to remove semicolons. Although semicolons are present in LINK_FLAGS/LINK_OPTIONS, they are not actually included during compilation.