### PR TITLE
docs(diagnostic): add return value of `vim.diagnostic.config()`

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -466,6 +466,9 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
       • {namespace}  (integer|nil) Update the options for the given namespace.
                      When omitted, update the global diagnostic options.
 
+    Return: ~
+        (table|nil) table of current diagnostic config if `opts` is omitted.
+
 disable({bufnr}, {namespace})                       *vim.diagnostic.disable()*
     Disable diagnostics in the given buffer.
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -617,6 +617,8 @@ end
 ---
 ---@param namespace integer|nil Update the options for the given namespace. When omitted, update the
 ---                            global diagnostic options.
+---
+---@return table|nil table of current diagnostic config if `opts` is omitted.
 function M.config(opts, namespace)
   vim.validate({
     opts = { opts, 't', true },


### PR DESCRIPTION
Although the return value is mentioned before
https://github.com/neovim/neovim/blob/5a2536de0c4beae4eba50a0d2868983c1690ecc7/runtime/lua/vim/diagnostic.lua#L551
The dostring for the return value of this function is still missing, thus the type hint is wrong.