### PR TITLE
refactor: soft-deprecate diagnostic signs configured with :sign-define

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -116,6 +116,9 @@ internally and are no longer exposed as part of the API. Instead, use
 - *vim.lsp.diagnostic.set_underline()*
 - *vim.lsp.diagnostic.set_virtual_text()*
 
+Configuring |diagnostic-signs| with |:sign-define| or |sign_define()| is no
+longer supported. Use the "signs" key of |vim.diagnostic.config()| instead.
+
 LSP FUNCTIONS
 - *vim.lsp.buf.server_ready()*
   Use |LspAttach| instead, depending on your use-case. "Server ready" is not

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -317,12 +317,24 @@ SIGNS                                                   *diagnostic-signs*
 
 Signs are defined for each diagnostic severity. The default text for each sign
 is the first letter of the severity name (for example, "E" for ERROR). Signs
-can be customized using the following: >vim
+can be customized with |vim.diagnostic.config()|. Example: >lua
 
-    sign define DiagnosticSignError text=E texthl=DiagnosticSignError linehl= numhl=
-    sign define DiagnosticSignWarn text=W texthl=DiagnosticSignWarn linehl= numhl=
-    sign define DiagnosticSignInfo text=I texthl=DiagnosticSignInfo linehl= numhl=
-    sign define DiagnosticSignHint text=H texthl=DiagnosticSignHint linehl= numhl=
+    -- Highlight entire line for errors
+    -- Highlight the line number for warnings
+    vim.diagnostic.config({
+        signs = {
+            text = {
+                [vim.diagnostic.severity.ERROR] = '',
+                [vim.diagnostic.severity.WARN] = '',
+            },
+            linehl = {
+                [vim.diagnostic.severity.ERROR] = 'ErrorMsg',
+            },
+            numhl = {
+                [vim.diagnostic.severity.WARN] = 'WarningMsg',
+            },
+        },
+    })
 
 When the "severity_sort" option is set (see |vim.diagnostic.config()|) the
 priority of each sign depends on the severity of the associated diagnostic.
@@ -427,8 +439,8 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                              end
 <
 
-                     • signs: (default true) Use signs for diagnostics.
-                       Options:
+                     • signs: (default true) Use signs for diagnostics
+                       |diagnostic-signs|. Options:
                        • severity: Only show signs for diagnostics matching
                          the given severity |diagnostic-severity|
                        • priority: (number, default 10) Base priority to use

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -387,6 +387,9 @@ DEPRECATIONS                                                *news-deprecations*
 The following functions are now deprecated and will be removed in a future
 release.
 
+• Configuring |diagnostic-signs| using |:sign-define| or |sign_define()|. Use
+  the "signs" key of |vim.diagnostic.config()| instead.
+
 • Checkhealth functions:
   - |health#report_error|, |vim.health.report_error()|	Use |vim.health.error()| instead.
   - |health#report_info|, |vim.health.report_info()|	Use |vim.health.info()| instead.

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -588,7 +588,7 @@ end
 ---                           return diagnostic.message
 ---                         end
 ---                       </pre>
----       - signs: (default true) Use signs for diagnostics. Options:
+---       - signs: (default true) Use signs for diagnostics |diagnostic-signs|. Options:
 ---                * severity: Only show signs for diagnostics matching the given
 ---                severity |diagnostic-severity|
 ---                * priority: (number, default 10) Base priority to use for signs. When
@@ -881,7 +881,52 @@ M.handlers.signs = {
         api.nvim_create_namespace(string.format('%s/diagnostic/signs', ns.name))
     end
 
-    local text = {}
+    --- Handle legacy diagnostic sign definitions
+    --- These were deprecated in 0.10 and will be removed in 0.12
+    if opts.signs and not opts.signs.text and not opts.signs.numhl and not opts.signs.texthl then
+      for _, v in ipairs({ 'Error', 'Warn', 'Info', 'Hint' }) do
+        local name = string.format('DiagnosticSign%s', v)
+        local sign = vim.fn.sign_getdefined(name)[1]
+        if sign then
+          local severity = M.severity[v:upper()]
+          if vim.fn.has('nvim-0.11') == 1 then
+            vim.deprecate(
+              'Defining diagnostic signs with :sign-define or sign_define()',
+              'vim.diagnostic.config()',
+              '0.12',
+              nil,
+              false
+            )
+          end
+
+          if not opts.signs.text then
+            opts.signs.text = {}
+          end
+
+          if not opts.signs.numhl then
+            opts.signs.numhl = {}
+          end
+
+          if not opts.signs.linehl then
+            opts.signs.linehl = {}
+          end
+
+          if opts.signs.text[severity] == nil then
+            opts.signs.text[severity] = sign.text or ''
+          end
+
+          if opts.signs.numhl[severity] == nil then
+            opts.signs.numhl[severity] = sign.numhl
+          end
+
+          if opts.signs.linehl[severity] == nil then
+            opts.signs.linehl[severity] = sign.linehl
+          end
+        end
+      end
+    end
+
+    local text = {} ---@type table<string, string>
     for k in pairs(M.severity) do
       if opts.signs.text and opts.signs.text[k] then
         text[k] = opts.signs.text[k]


### PR DESCRIPTION
Diagnostic signs should now be configured with vim.diagnostic.config(), but "legacy" sign definitions are still supported for two more release cycles to help minimize breaking changes.

Ref: https://github.com/neovim/neovim/pull/26193#issuecomment-1859163716
