### PR TITLE
fix(termdebug): improve :Evaluate floating window

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -240,7 +240,7 @@ gdb window and use a "print" command, e.g.: >
 If mouse pointer movements are working, Vim will also show a balloon when the
 mouse rests on text that can be evaluated by gdb.
 You can also use the "K" mapping that will either use Nvim floating windows
-if available to show the results or print below the status bar.
+to show the results.
 
 Now go back to the source window and put the cursor on the first line after
 the for loop, then type: >
@@ -320,6 +320,8 @@ Inspecting variables ~
 
 This is similar to using "print" in the gdb window.
 You can usually shorten `:Evaluate` to `:Ev`.
+The result is displayed in a floating window.
+You can move the cursor to this window by running `:Evaluate` (or `K`) again.
 
 
 Navigating stack frames ~
@@ -474,10 +476,6 @@ If the command needs an argument use a List: >vim
 	let g:termdebug_config['command'] = ['rr', 'replay', '--']
 If there is no g:termdebug_config you can use: >vim
 	let g:termdebugger = ['rr', 'replay', '--']
-
-To not use Nvim floating windows for previewing variable evaluation, set the
-`g:termdebug_useFloatingHover` variable like this: >vim
-	let g:termdebug_useFloatingHover = 0
 
 If you are a mouse person, you can also define a mapping using your right
 click to one of the terminal command like evaluate the variable under the


### PR DESCRIPTION
Problem:
- The :Evaluate result window is not cleaned up when the cursor moves.
- This window is not focusable.

Solution:
Replace the old implementation from autozimu/LanguageClient-neovim with vim.lsp.util.open_floating_preview and implement custom focusing logic. Also remove g:termdebug_useFloatingHover option now that it's working correctly.