### PR TITLE
refactor: move some anonymous enums back to non-defs headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,6 @@ iwyu: build/.ran-cmake
 	|src/nvim/buffer.h\
 	|src/nvim/buffer_defs.h\
 	|src/nvim/channel.h\
-	|src/nvim/channel_defs.h\
 	|src/nvim/charset.h\
 	|src/nvim/drawline.h\
 	|src/nvim/eval.h\

--- a/src/clint.py
+++ b/src/clint.py
@@ -905,7 +905,6 @@ def CheckIncludes(filename, lines, error):
             "src/nvim/buffer.h",
             "src/nvim/buffer_defs.h",
             "src/nvim/channel.h",
-            "src/nvim/channel_defs.h",
             "src/nvim/charset.h",
             "src/nvim/drawline.h",
             "src/nvim/eval.h",
@@ -950,8 +949,6 @@ def CheckIncludes(filename, lines, error):
             "klib/klist.h",
             "klib/kvec.h",
             "nvim/func_attr.h",
-            "nvim/gettext.h",
-            "nvim/globals.h"
             ]
 
     for i in check_includes_ignore:

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -5,9 +5,9 @@
 
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
+#include "nvim/buffer_defs.h"  // IWYU pragma: keep
+#include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_eval_defs.h"
-#include "nvim/gettext.h"
-#include "nvim/globals.h"
 #include "nvim/macros_defs.h"
 #include "nvim/map_defs.h"
 #include "nvim/message_defs.h"  // IWYU pragma: keep

--- a/src/nvim/channel_defs.h
+++ b/src/nvim/channel_defs.h
@@ -4,18 +4,11 @@
 #include <stdlib.h>
 
 #include "nvim/eval/typval_defs.h"
-#include "nvim/event/libuv_process.h"
-#include "nvim/event/multiqueue.h"
-#include "nvim/event/process.h"
-#include "nvim/event/socket.h"
-#include "nvim/event/stream.h"
+#include "nvim/event/defs.h"
 #include "nvim/garray_defs.h"
 #include "nvim/macros_defs.h"
-#include "nvim/main.h"
 #include "nvim/map_defs.h"
 #include "nvim/msgpack_rpc/channel_defs.h"
-#include "nvim/os/pty_process.h"
-#include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 
 #define CHAN_STDIO 1

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -2,6 +2,24 @@
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: export
 
+/// flags for do_ecmd()
+enum {
+  ECMD_HIDE       = 0x01,  ///< don't free the current buffer
+  ECMD_SET_HELP   = 0x02,  ///< set b_help flag of (new) buffer before opening file
+  ECMD_OLDBUF     = 0x04,  ///< use existing buffer if it exists
+  ECMD_FORCEIT    = 0x08,  ///< ! used in Ex command
+  ECMD_ADDBUF     = 0x10,  ///< don't edit, just add to buffer list
+  ECMD_ALTBUF     = 0x20,  ///< like ECMD_ADDBUF and set the alternate file
+  ECMD_NOWINENTER = 0x40,  ///< do not trigger BufWinEnter
+};
+
+/// for lnum argument in do_ecmd()
+enum {
+  ECMD_LASTL = 0,   ///< use last position in loaded file
+  ECMD_LAST  = -1,  ///< use last position in all files
+  ECMD_ONE   = 1,   ///< use first line
+};
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ex_cmds.h.generated.h"
 #endif

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -230,24 +230,6 @@ typedef struct {
   } magic;
 } CmdParseInfo;
 
-/// flags for do_ecmd()
-enum {
-  ECMD_HIDE       = 0x01,  ///< don't free the current buffer
-  ECMD_SET_HELP   = 0x02,  ///< set b_help flag of (new) buffer before opening file
-  ECMD_OLDBUF     = 0x04,  ///< use existing buffer if it exists
-  ECMD_FORCEIT    = 0x08,  ///< ! used in Ex command
-  ECMD_ADDBUF     = 0x10,  ///< don't edit, just add to buffer list
-  ECMD_ALTBUF     = 0x20,  ///< like ECMD_ADDBUF and set the alternate file
-  ECMD_NOWINENTER = 0x40,  ///< do not trigger BufWinEnter
-};
-
-/// for lnum argument in do_ecmd()
-enum {
-  ECMD_LASTL = 0,   ///< use last position in loaded file
-  ECMD_LAST  = -1,  ///< use last position in all files
-  ECMD_ONE   = 1,   ///< use first line
-};
-
 /// Previous :substitute replacement string definition
 typedef struct {
   char *sub;            ///< Previous replacement string.

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -236,6 +236,7 @@ local keysets_defs = io.open(keysets_outputf, 'wb')
 output:write([[
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_getln.h"
+#include "nvim/globals.h"
 #include "nvim/log.h"
 #include "nvim/map_defs.h"
 #include "nvim/msgpack_rpc/helpers.h"
@@ -662,6 +663,7 @@ output:write([[
 #include "nvim/ex_docmd.h"
 #include "nvim/ex_getln.h"
 #include "nvim/func_attr.h"
+#include "nvim/globals.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/dispatch.h"

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "auto/config.h"
 #include "nvim/log_defs.h"  // IWYU pragma: export
 #include "nvim/macros_defs.h"
 

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -1,12 +1,35 @@
 #pragma once
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>  // IWYU pragma: keep
+#include <stdio.h>
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/grid_defs.h"
 #include "nvim/macros_defs.h"
 #include "nvim/message_defs.h"  // IWYU pragma: export
+
+/// Types of dialogs passed to do_dialog().
+enum {
+  VIM_GENERIC   = 0,
+  VIM_ERROR     = 1,
+  VIM_WARNING   = 2,
+  VIM_INFO      = 3,
+  VIM_QUESTION  = 4,
+  VIM_LAST_TYPE = 4,  ///< sentinel value
+};
+
+/// Return values for functions like vim_dialogyesno()
+enum {
+  VIM_YES        = 2,
+  VIM_NO         = 3,
+  VIM_CANCEL     = 4,
+  VIM_ALL        = 5,
+  VIM_DISCARDALL = 6,
+};
+
+enum { MSG_HIST = 0x1000, };  ///< special attribute addition: Put message in history
 
 /// First message
 extern MessageHistoryEntry *first_msg_hist;
@@ -37,4 +60,15 @@ EXTERN int msg_listdo_overwrite INIT( = 0);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "message.h.generated.h"
+#endif
+
+// Prefer using semsg(), because perror() may send the output to the wrong
+// destination and mess up the screen.
+#define PERROR(msg) (void)semsg("%s: %s", (msg), strerror(errno))
+
+#ifndef MSWIN
+/// Headless (no UI) error message handler.
+# define os_errmsg(str)        fprintf(stderr, "%s", (str))
+/// Headless (no UI) message handler.
+# define os_msg(str)           printf("%s", (str))
 #endif

--- a/src/nvim/message_defs.h
+++ b/src/nvim/message_defs.h
@@ -1,34 +1,11 @@
 #pragma once
 
-#include <errno.h>
 #include <stdbool.h>
-#include <stdio.h>
 
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/grid_defs.h"
 #include "nvim/macros_defs.h"
-
-/// Types of dialogs passed to do_dialog().
-enum {
-  VIM_GENERIC   = 0,
-  VIM_ERROR     = 1,
-  VIM_WARNING   = 2,
-  VIM_INFO      = 3,
-  VIM_QUESTION  = 4,
-  VIM_LAST_TYPE = 4,  ///< sentinel value
-};
-
-/// Return values for functions like vim_dialogyesno()
-enum {
-  VIM_YES        = 2,
-  VIM_NO         = 3,
-  VIM_CANCEL     = 4,
-  VIM_ALL        = 5,
-  VIM_DISCARDALL = 6,
-};
-
-enum { MSG_HIST = 0x1000, };  ///< special attribute addition: Put message in history
 
 typedef struct {
   String text;
@@ -46,14 +23,3 @@ typedef struct msg_hist {
   bool multiline;         ///< Multiline message.
   HlMessage multiattr;    ///< multiattr message.
 } MessageHistoryEntry;
-
-// Prefer using semsg(), because perror() may send the output to the wrong
-// destination and mess up the screen.
-#define PERROR(msg) (void)semsg("%s: %s", (msg), strerror(errno))
-
-#ifndef MSWIN
-/// Headless (no UI) error message handler.
-# define os_errmsg(str)        fprintf(stderr, "%s", (str))
-/// Headless (no UI) message handler.
-# define os_msg(str)           printf("%s", (str))
-#endif

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>  // IWYU pragma: keep
 

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -20,6 +20,7 @@
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/garray.h"
 #include "nvim/gettext.h"
+#include "nvim/globals.h"
 #include "nvim/macros_defs.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"


### PR DESCRIPTION
It isn't really useful to put anonymous enums only used as arguments to
functions calls in _defs.h headers, as they will only be used by a file
that calls those functions, which requires including a non-defs header.

Also move os_msg() and os_errmsg() back to message.h, as on Windows they
are actual functions instead of macros.

Also remove gettext.h and globals.h from private/helpers.h.
