### PR TITLE
docs(treesitter): explicitly mention ranges are 0-indexed, end-exclusive

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -35,7 +35,7 @@ TREESITTER TREES                                             *treesitter-tree*
 
 A "treesitter tree" represents the parsed contents of a buffer, which can be
 used to perform further analysis. It is a |userdata| reference to an object
-held by the tree-sitter library.
+held by the tree-sitter C library.
 
 An instance `TSTree` of a treesitter tree supports the following methods.
 
@@ -51,7 +51,7 @@ TREESITTER NODES                                             *treesitter-node*
 
 A "treesitter node" represents one specific element of the parsed contents of
 a buffer, which can be captured by a |Query| for, e.g., highlighting. It is
-a |userdata| reference to an object held by the tree-sitter library.
+a |userdata| reference to an object held by the tree-sitter C library.
 
 An instance `TSNode` of a treesitter node supports the following methods.
 
@@ -95,16 +95,18 @@ TSNode:named_child({index})                              *TSNode:named_child()*
 
 TSNode:start()                                          *TSNode:start()*
     Get the node's start position. Return three values: the row, column and
-    total byte count (all zero-based).
+    total byte count (all 0-indexed).
 
 TSNode:end_()                                           *TSNode:end_()*
     Get the node's end position. Return three values: the row, column and
-    total byte count (all zero-based).
+    total byte count (all 0-indexed). The end position is exclusive.
 
 TSNode:range({include_bytes})                           *TSNode:range()*
-    Get the range of the node.
+    Get the range of the node. The start position is inclusive, but the end
+    position is exclusive (end-exclusive). The start and the end positions
+    are 0-indexed.
 
-    Return four or six values:
+    Return a table of four values or six values:
         - start row
         - start column
         - start byte (if {include_bytes} is `true`)
@@ -155,12 +157,13 @@ TSNode:tree()                                           *TSNode:tree()*
                                                 *TSNode:descendant_for_range()*
 TSNode:descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})
     Get the smallest node within this node that spans the given range of (row,
-    column) positions
+    column) positions. The range follows the convention of |TSNode:range()|.
 
                                           *TSNode:named_descendant_for_range()*
 TSNode:named_descendant_for_range({start_row}, {start_col}, {end_row}, {end_col})
     Get the smallest named node within this node that spans the given range of
-    (row, column) positions
+    (row, column) positions. The range follows the convention of
+    |TSNode:range()|.
                                                         *TSNode:equal()*
 TSNode:equal({node})
     Check if {node} refers to the same node within the same tree.
@@ -282,9 +285,9 @@ The following directives are built in:
             ((node1) @left (node2) @right (#set! "type" "pair"))
 <
     `offset!`                                      *treesitter-directive-offset!*
-        Takes the range of the captured node and applies an offset. This will
-        generate a new range object for the captured node as
-        `metadata[capture_id].range`.
+        Takes the range of the captured node and applies an offset (range is
+        0-indexed and end-exclusive). This will generate a new range object
+        for the captured node as `metadata[capture_id].range`.
 
         Parameters: ~
             {capture_id}
@@ -628,7 +631,8 @@ get_node_range({node_or_range})              *vim.treesitter.get_node_range()*
     Returns the node's range or an unpacked range table
 
     Parameters: ~
-      • {node_or_range}  (|TSNode| | table) Node or table of positions
+      • {node_or_range}  (|TSNode| | Range) Node or table of positions. see
+                         |TSNode:range()|.
 
     Return (multiple): ~
         (integer) start_row
@@ -668,8 +672,8 @@ get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
         |LanguageTree| object to use for parsing
 
 get_range({node}, {source}, {metadata})           *vim.treesitter.get_range()*
-    Get the range of a |TSNode|. Can also supply {source} and {metadata} to
-    get the range with directives applied.
+    Get the range of a |TSNode| with bytes information included. Can also
+    supply {source} and {metadata} to get the range with directives applied.
 
     Parameters: ~
       • {node}      |TSNode|
@@ -678,7 +682,7 @@ get_range({node}, {source}, {metadata})           *vim.treesitter.get_range()*
       • {metadata}  TSMetadata|nil
 
     Return: ~
-        (table)
+        (table) a Range6 table containing six values.
 
                                           *vim.treesitter.get_string_parser()*
 get_string_parser({str}, {lang}, {opts})
@@ -1103,7 +1107,8 @@ LanguageTree:contains({range})                       *LanguageTree:contains()*
     Determines whether {range} is contained in the |LanguageTree|.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }` Range
+                 is 0-indexed and end-exclusive.
 
     Return: ~
         (boolean)
@@ -1157,7 +1162,8 @@ LanguageTree:language_for_range({range})
     Gets the appropriate language that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }` Range
+                 is 0-indexed and end-exclusive.
 
     Return: ~
         |LanguageTree| Managing {range}
@@ -1167,7 +1173,8 @@ LanguageTree:named_node_for_range({range}, {opts})
     Gets the smallest named node that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }` Range
+                 is 0-indexed and end-exclusive.
       • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
@@ -1187,10 +1194,17 @@ LanguageTree:parse({range})                             *LanguageTree:parse()*
 
     Parameters: ~
       • {range}  boolean|Range|nil: Parse this range in the parser's source.
-                 Set to `true` to run a complete parse of the source (Note:
-                 Can be slow!) Set to `false|nil` to only parse regions with
-                 empty ranges (typically only the root tree without
-                 injections).
+                 • If table, this may contain 2, 4, or 6 integers:
+                   • `{ start_line, end_line }`
+                   • `{ start_line, start_col, end_line, end_col }`
+                   • `{ start_line, start_col, start_byte, end_line, end_col,
+                     end_byte }`
+                   • Index is 0-based and always end-exclusive.
+
+                 • If `true`, run a complete parse of the source (Note: Can be
+                   slow!)
+                 • If `false|nil`, only parse regions with empty ranges
+                   (typically only the root tree without injections).
 
     Return: ~
         table<integer, TSTree>
@@ -1226,7 +1240,8 @@ LanguageTree:tree_for_range({range}, {opts})
     Gets the tree that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }` Range
+                 is 0-indexed and end-exclusive.
       • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)

--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -2,23 +2,23 @@ local api = vim.api
 
 local M = {}
 
----@class Range2
----@field [1] integer start row
----@field [2] integer end row
+---@class Range2 Range represented by rows
+---@field [1] integer start row (0-indexed).
+---@field [2] integer end row (0-indexed, exclusive).
 
----@class Range4
----@field [1] integer start row
----@field [2] integer start column
----@field [3] integer end row
----@field [4] integer end column
+---@class Range4 Range represented by rows and columns
+---@field [1] integer start row (0-indexed)
+---@field [2] integer start column (0-indexed)
+---@field [3] integer end row (0-indexed)
+---@field [4] integer end column (0-indexed, exclusive)
 
----@class Range6
----@field [1] integer start row
----@field [2] integer start column
----@field [3] integer start bytes
----@field [4] integer end row
----@field [5] integer end column
----@field [6] integer end bytes
+---@class Range6 Range represented by rows, columns, and bytes
+---@field [1] integer start row (0-indexed)
+---@field [2] integer start column (0-indexed)
+---@field [3] integer start bytes (0-indexed)
+---@field [4] integer end row (0-indexed)
+---@field [5] integer end column (0-indexed, exclusive)
+---@field [6] integer end bytes (0-indexed, exclusive)
 
 ---@alias Range Range2|Range4|Range6
 
@@ -72,7 +72,7 @@ setmetatable(M.cmp_pos, { __call = cmp_pos })
 
 ---@private
 ---Check if a variable is a valid range object
----@param r any
+---@param r Range|any
 ---@return boolean
 function M.validate(r)
   if type(r) ~= 'table' or #r ~= 6 and #r ~= 4 then
@@ -126,6 +126,7 @@ end
 ---@param r Range6
 ---@return integer, integer, integer, integer, integer, integer
 function M.unpack6(r)
+  assert(#r == 6, 'invalid Range6 given')
   return r[1], r[2], r[3], r[4], r[5], r[6]
 end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -416,8 +416,13 @@ end
 --- otherwise (typically injections) only if it intersects {range} (or if {range} is `true`).
 ---
 --- @param range boolean|Range|nil: Parse this range in the parser's source.
----     Set to `true` to run a complete parse of the source (Note: Can be slow!)
----     Set to `false|nil` to only parse regions with empty ranges (typically
+---     - If table, this may contain 2, 4, or 6 integers:
+---        - `{ start_line, end_line }`
+---        - `{ start_line, start_col, end_line, end_col }`
+---        - `{ start_line, start_col, start_byte, end_line, end_col, end_byte }`
+---        - Index is 0-based and always end-exclusive.
+---     - If `true`, run a complete parse of the source (Note: Can be slow!)
+---     - If `false|nil`, only parse regions with empty ranges (typically
 ---     only the root tree without injections).
 --- @return table<integer, TSTree>
 function LanguageTree:parse(range)
@@ -1084,6 +1089,7 @@ end
 --- Determines whether {range} is contained in the |LanguageTree|.
 ---
 ---@param range Range4 `{ start_line, start_col, end_line, end_col }`
+---              Range is 0-indexed and end-exclusive.
 ---@return boolean
 function LanguageTree:contains(range)
   for _, tree in pairs(self._trees) do
@@ -1098,6 +1104,7 @@ end
 --- Gets the tree that contains {range}.
 ---
 ---@param range Range4 `{ start_line, start_col, end_line, end_col }`
+---              Range is 0-indexed and end-exclusive.
 ---@param opts table|nil Optional keyword arguments:
 ---             - ignore_injections boolean Ignore injected languages (default true)
 ---@return TSTree|nil
@@ -1126,6 +1133,7 @@ end
 --- Gets the smallest named node that contains {range}.
 ---
 ---@param range Range4 `{ start_line, start_col, end_line, end_col }`
+---              Range is 0-indexed and end-exclusive.
 ---@param opts table|nil Optional keyword arguments:
 ---             - ignore_injections boolean Ignore injected languages (default true)
 ---@return TSNode | nil Found node
@@ -1139,6 +1147,7 @@ end
 --- Gets the appropriate language that contains {range}.
 ---
 ---@param range Range4 `{ start_line, start_col, end_line, end_col }`
+---              Range is 0-indexed and end-exclusive.
 ---@return LanguageTree Managing {range}
 function LanguageTree:language_for_range(range)
   for _, child in pairs(self._children) do


### PR DESCRIPTION
Fixes:

- Fixes #26569

Relevant to:

- #10058 (`:help api-indexing`)
- #25509 (general range abstraction)
- #24647 (Range2)