### PR TITLE
vim-patch:9.0.2178: reg_executing() wrong for :normal with range

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1160,6 +1160,7 @@ int do_execreg(int regname, int colon, int addcr, int silent)
       }
     }
     reg_executing = regname == 0 ? '"' : regname;  // disable the 'q' command
+    pending_end_reg_executing = false;
   }
   return retval;
 }

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -801,6 +801,23 @@ func Test_end_reg_executing()
   bwipe!
 endfunc
 
+func Test_reg_executing_in_range_normal()
+  new
+  set showcmd
+  call setline(1, range(10))
+  let g:log = []
+  nnoremap s <Cmd>let g:log += [reg_executing()]<CR>
+  let @r = 's'
+
+  %normal @r
+  call assert_equal(repeat(['r'], 10), g:log)
+
+  nunmap s
+  unlet g:log
+  set showcmd&
+  bwipe!
+endfunc
+
 " An operator-pending mode mapping shouldn't be applied to keys typed in
 " Insert mode immediately after a character search when replaying.
 func Test_replay_charsearch_omap()


### PR DESCRIPTION
Fix #26612

#### vim-patch:9.0.2178: reg_executing() wrong for :normal with range

Problem:  reg_executing() returns wrong result in :normal with range
          when 'showcmd' is set (after 8.2.4705).
Solution: Reset "pending_end_reg_executing" when executing a register.

closes: vim/vim#13707

https://github.com/vim/vim/commit/615202bd0ebc1d8e3532f24b9b7232c2fd86b181