### PR TITLE
vim-patch:9.0.2177: Wrong cursor position when dragging out of window

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1849,13 +1849,13 @@ static void mouse_check_grid(colnr_T *vcolp, int *flagsp)
   int click_col = mouse_col;
 
   // XXX: this doesn't change click_grid if it is 1, even with multigrid
-  win_T *wp = mouse_find_win(&click_grid, &click_row, &click_col);
-  // Only use vcols[] after the window was redrawn.  Mainly matters
-  // for tests, a user would not click before redrawing.
-  if (wp == NULL || wp->w_redr_type != 0) {
+  if (mouse_find_win(&click_grid, &click_row, &click_col) != curwin
+      // Only use vcols[] after the window was redrawn.  Mainly matters
+      // for tests, a user would not click before redrawing.
+      || curwin->w_redr_type != 0) {
     return;
   }
-  ScreenGrid *gp = &wp->w_grid;
+  ScreenGrid *gp = &curwin->w_grid;
   int start_row = 0;
   int start_col = 0;
   grid_adjust(&gp, &start_row, &start_col);
@@ -1891,12 +1891,12 @@ static void mouse_check_grid(colnr_T *vcolp, int *flagsp)
       if (eol_vcol < 0) {
         // Empty line or whole line before w_leftcol,
         // with columns before buffer text
-        eol_vcol = wp->w_leftcol - 1;
+        eol_vcol = curwin->w_leftcol - 1;
       }
       *vcolp = eol_vcol + (int)(off - off_r);
     } else {
       // Empty line or whole line before w_leftcol
-      *vcolp = click_col - start_col + wp->w_leftcol;
+      *vcolp = click_col - start_col + curwin->w_leftcol;
     }
   } else if (col_from_screen >= 0) {
     // Use the virtual column from vcols[], it is accurate also after

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1589,6 +1589,41 @@ func Test_Visual_r_CTRL_C()
   call feedkeys("\<c-v>$gr\<c-c>", 'tx')
   call assert_equal([''], getline(1, 1))
   bw!
-endfu
+endfunc
+
+func Test_visual_drag_out_of_window()
+  rightbelow vnew
+  call setline(1, '123456789')
+  set mouse=a
+  func ClickExpr(off)
+    call Ntest_setmouse(1, getwininfo(win_getid())[0].wincol + a:off)
+    return "\<LeftMouse>"
+  endfunc
+  func DragExpr(off)
+    call Ntest_setmouse(1, getwininfo(win_getid())[0].wincol + a:off)
+    return "\<LeftDrag>"
+  endfunc
+
+  nnoremap <expr> <F2> ClickExpr(5)
+  nnoremap <expr> <F3> DragExpr(-1)
+  redraw
+  call feedkeys("\<F2>\<F3>\<LeftRelease>", 'tx')
+  call assert_equal([1, 6], [col('.'), col('v')])
+  call feedkeys("\<Esc>", 'tx')
+
+  nnoremap <expr> <F2> ClickExpr(6)
+  nnoremap <expr> <F3> DragExpr(-2)
+  redraw
+  call feedkeys("\<F2>\<F3>\<LeftRelease>", 'tx')
+  call assert_equal([1, 7], [col('.'), col('v')])
+  call feedkeys("\<Esc>", 'tx')
+
+  nunmap <F2>
+  nunmap <F3>
+  delfunc ClickExpr
+  delfunc DragExpr
+  set mouse&
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2177: Wrong cursor position when dragging out of window

Problem:  Wrong cursor position when dragging out of window.
Solution: Don't use ScreenCols[] when mouse is not in current window.

closes: vim/vim#13717

https://github.com/vim/vim/commit/ec14924368e23f2430815c009bd554f88de9c57f