### PR TITLE
fix!(api): ensure buffer is loaded in most buffer related api methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <h1 align="center">
   <img src="https://raw.githubusercontent.com/neovim/neovim.github.io/master/logos/neovim-logo-300x87.png" alt="Neovim">
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -893,11 +893,6 @@ Object nvim_buf_get_var(Buffer buffer, String name, Error *err)
     return rv;
   }
 
-  // load buffer first if it's not loaded
-  if (!buf_ensure_loaded(buf)) {
-    api_set_error(err, kErrorTypeException, "Failed to load buffer");
-    return rv;
-  }
   return dict_get_value(buf->b_vars, name, err);
 }
 
@@ -977,12 +972,6 @@ void nvim_buf_set_var(Buffer buffer, String name, Object value, Error *err)
     return;
   }
 
-  // load buffer first if it's not loaded
-  if (!buf_ensure_loaded(buf)) {
-    api_set_error(err, kErrorTypeException, "Failed to load buffer");
-    return;
-  }
-
   dict_set_var(buf->b_vars, name, value, false, false, err);
 }
 
@@ -1000,11 +989,6 @@ void nvim_buf_del_var(Buffer buffer, String name, Error *err)
     return;
   }
 
-  // load buffer first if it's not loaded
-  if (!buf_ensure_loaded(buf)) {
-    api_set_error(err, kErrorTypeException, "Failed to load buffer");
-    return;
-  }
   dict_set_var(buf->b_vars, name, NIL, true, false, err);
 }
 
@@ -1125,7 +1109,6 @@ void nvim_buf_delete(Buffer buffer, Dict(buf_delete) *opts, Error *err)
 Boolean nvim_buf_is_valid(Buffer buffer)
   FUNC_API_SINCE(1)
 {
-  // is the check needed here?
   Error stub = ERROR_INIT;
   Boolean ret = find_buffer_by_handle(buffer, &stub) != NULL;
   api_clear_error(&stub);

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -163,12 +163,6 @@ Boolean nvim_buf_attach(uint64_t channel_id, Buffer buffer, Boolean send_buffer,
     return false;
   }
 
-  // load buffer first if it's not loaded
-  if (!buf_ensure_loaded(buf)) {
-    api_set_error(err, kErrorTypeException, "Failed to load buffer");
-    return false;
-  }
-
   BufUpdateCallbacks cb = BUF_UPDATE_CALLBACKS_INIT;
 
   if (channel_id == LUA_INTERNAL_CALL) {
@@ -922,11 +916,6 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
     return -1;
   }
 
-  // load buffer first if it's not loaded
-  if (!buf_ensure_loaded(buf)) {
-    api_set_error(err, kErrorTypeException, "Failed to load buffer");
-    return -1;
-  }
   return buf_get_changedtick(buf);
 }
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -117,36 +117,6 @@ describe('api/buf', function()
       eq({5, 2}, meths.win_get_cursor(win2))
     end)
 
-    it('line_count has defined behaviour for unloaded buffers', function()
-      -- we'll need to know our bufnr for when it gets unloaded
-      local bufnr = curbuf('get_number')
-      -- replace the buffer contents with these three lines
-      request('nvim_buf_set_lines', bufnr, 0, -1, 1, {"line1", "line2", "line3", "line4"})
-      -- check the line count is correct
-      eq(4, request('nvim_buf_line_count', bufnr))
-      -- force unload the buffer (this will discard changes)
-      command('new')
-      command('bunload! '..bufnr)
-      -- line count for an unloaded buffer should always be 0
-      eq(0, request('nvim_buf_line_count', bufnr))
-    end)
-
-    it('get_lines has defined behaviour for unloaded buffers', function()
-      -- we'll need to know our bufnr for when it gets unloaded
-      local bufnr = curbuf('get_number')
-      -- replace the buffer contents with these three lines
-      buffer('set_lines', bufnr, 0, -1, 1, {"line1", "line2", "line3", "line4"})
-      -- confirm that getting lines works
-      eq({"line2", "line3"}, buffer('get_lines', bufnr, 1, 3, 1))
-      -- force unload the buffer (this will discard changes)
-      command('new')
-      command('bunload! '..bufnr)
-      -- attempting to get lines now always gives empty list
-      eq({}, buffer('get_lines', bufnr, 1, 3, 1))
-      -- it's impossible to get out-of-bounds errors for an unloaded buffer
-      eq({}, buffer('get_lines', bufnr, 8888, 9999, 1))
-    end)
-
     describe('handles topline', function()
       local screen
       before_each(function()

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -117,6 +117,27 @@ describe('api/buf', function()
       eq({5, 2}, meths.win_get_cursor(win2))
     end)
 
+    it('line_count has defined behaviour for unloaded buffers', function()
+      -- we'll need to know our bufnr for when it gets unloaded
+      local bufnr = curbuf('get_number')
+      -- replace the buffer contents with these three lines
+      request('nvim_buf_set_lines', bufnr, 0, -1, 1, {"line1", "line2", "line3", "line4"})
+      -- check the line count is correct
+      eq(4, request('nvim_buf_line_count', bufnr))
+      -- force unload the buffer (this will discard changes)
+      command('new')
+      command('bunload! '..bufnr)
+    end)
+
+    it('get_lines has defined behaviour for unloaded buffers', function()
+      -- we'll need to know our bufnr for when it gets unloaded
+      local bufnr = curbuf('get_number')
+      -- replace the buffer contents with these three lines
+      buffer('set_lines', bufnr, 0, -1, 1, {"line1", "line2", "line3", "line4"})
+      -- confirm that getting lines works
+      eq({"line2", "line3"}, buffer('get_lines', bufnr, 1, 3, 1))
+    end)
+
     describe('handles topline', function()
       local screen
       before_each(function()
@@ -1796,9 +1817,6 @@ describe('api/buf', function()
       command("set hidden")
       command("enew")
       eq(6, bufmeths.get_offset(1,1))
-      command("bunload! 1")
-      eq(-1, bufmeths.get_offset(1,1))
-      eq(-1, bufmeths.get_offset(1,0))
     end)
 
     it('works in empty buffer', function()

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -12,10 +12,8 @@ local testdir = 'Xtest-editorconfig'
 local function test_case(name, expected, buffer)
   local filename = testdir .. pathsep .. name
   local buf = buffer and buffer or 0
-  --io.write("file", filename)
   command('edit ' .. filename)
   for opt, val in pairs(expected) do
-    --io.write("value", tostring(meths.get_option_value(opt, {buf=buf})))
     eq(val, meths.get_option_value(opt, {buf=buf}), name)
   end
 end

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -169,9 +169,9 @@ describe('editorconfig', function()
     local filename = testdir .. pathsep .. 'trim.txt'
     -- luacheck: push ignore 613
     local untrimmed = [[
-This line ends in whitespace
-So does this one
-And this one
+This line ends in whitespace 
+So does this one    
+And this one         
 But not this one
 ]]
     -- luacheck: pop

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -9,11 +9,14 @@ local exec_lua = helpers.exec_lua
 
 local testdir = 'Xtest-editorconfig'
 
-local function test_case(name, expected)
+local function test_case(name, expected, buffer)
   local filename = testdir .. pathsep .. name
+  local buf = buffer and buffer or 0
+  --io.write("file", filename)
   command('edit ' .. filename)
   for opt, val in pairs(expected) do
-    eq(val, meths.get_option_value(opt, {buf=0}), name)
+    --io.write("value", tostring(meths.get_option_value(opt, {buf=buf})))
+    eq(val, meths.get_option_value(opt, {buf=buf}), name)
   end
 end
 
@@ -168,9 +171,9 @@ describe('editorconfig', function()
     local filename = testdir .. pathsep .. 'trim.txt'
     -- luacheck: push ignore 613
     local untrimmed = [[
-This line ends in whitespace 
-So does this one    
-And this one         
+This line ends in whitespace
+So does this one
+And this one
 But not this one
 ]]
     -- luacheck: pop
@@ -203,9 +206,10 @@ But not this one
   it('can be disabled per-buffer', function()
     meths.set_option_value('shiftwidth', 42, {})
     local bufnr = funcs.bufadd(testdir .. pathsep .. '3_space.txt')
-    meths.buf_set_var(bufnr, 'editorconfig', false)
-    test_case('3_space.txt', { shiftwidth = 42 })
-    test_case('4_space.py', { shiftwidth = 4 })
+    meths.buf_set_var(bufnr, 'editorconfig', false);
+    -- the order of the following test cases matters
+    test_case('3_space.txt', { shiftwidth = 42 }, 1)
+    test_case('4_space.py', { shiftwidth = 4 }, 0)
   end)
 
   it('does not operate on invalid buffers', function()


### PR DESCRIPTION
calls `buf_ensure_loaded` for the following methods: 

```
- nvim_buf_line_count()

- nvim_buf_detach()

- nvim_buf_get_lines()
- nvim_buf_set_lines()

- nvim_buf_set_text()
- nvim_buf_get_text()

- nvim_buf_get_offset()

- nvim_buf_get_mark()
- nvim_buf_del_mark()
- nvim_buf_set_mark()

- nvim_buf_set_name()
- nvim_buf_get_name()

```

accorinding to the discussion in this PR and over at #10070, the rest of the methods do not need to ensure the buffer is already loaded. 


resolves #10070

TODO: document the changes as breaking changes as described [here](https://github.com/neovim/neovim/pull/26666#discussion_r1433187500) 

