### PR TITLE
fix(buffer): do not filter help buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -302,9 +302,9 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags_arg)
     }
 #endif
 
-    // Help buffer is filtered.
+    // Help buffer: populate *local-additions* in help.txt
     if (bt_help(curbuf)) {
-      fix_help_buffer();
+      get_local_additions();
     }
   } else if (read_stdin) {
     int save_bin = curbuf->b_p_bin;


### PR DESCRIPTION
Problem: If a help buffer is opened without legacy syntax set (because treesitter is enabled), Vim strips (some) markup. This means the syntax engine fails to parse (some) syntax if treesitter highlighting is disabled again.

Solution: Do not strip the help buffer of markup since (legacy or treesitter) highlighting is always enabled in Nvim. Similarly, remove redundant setting of filetype and give the function a more descriptive name.

fixes #26650
