### PR TITLE
Backport to release-0.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,10 +200,10 @@ jobs:
           DEBUG: api
         run: |
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/notes.md" > "$RUNNER_TEMP/notes.md"
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos/* nvim-linux64/* appimage/* nvim-win64/*
           if [ "$TAG_NAME" != "nightly" ]; then
             gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos/* nvim-linux64/* appimage/* nvim-win64/*
           fi
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos/* nvim-linux64/* appimage/* nvim-win64/*
 
   publish-winget:
     needs: publish

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2626,8 +2626,7 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
   }
 
   if ((curwin->w_p_scr <= 0
-       || (curwin->w_p_scr > curwin->w_height
-           && curwin->w_height > 0))
+       || (curwin->w_p_scr > curwin->w_height_inner && curwin->w_height_inner > 0))
       && full_screen) {
     if (pp == &(curwin->w_p_scr)) {
       if (curwin->w_p_scr != 0) {
@@ -2637,8 +2636,8 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
     } else if (curwin->w_p_scr <= 0) {
       // If 'scroll' became invalid because of a side effect silently adjust it.
       curwin->w_p_scr = 1;
-    } else {  // curwin->w_p_scr > curwin->w_height
-      curwin->w_p_scr = curwin->w_height;
+    } else {  // curwin->w_p_scr > curwin->w_height_inner
+      curwin->w_p_scr = curwin->w_height_inner;
     }
   }
   if ((p_sj < -100 || p_sj >= Rows) && full_screen) {

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -886,6 +886,12 @@ describe('ext_multigrid', function()
       eq(20, win_info.height)
     end)
 
+    it("'scroll' option works properly", function()
+      eq(10, meths.get_option_value('scroll', { win = 0 }))
+      meths.set_option_value('scroll', 15, { win = 0 })
+      eq(15, meths.get_option_value('scroll', { win = 0 }))
+    end)
+
     it('gets written till grid width', function()
       insert(('a'):rep(60).."\n")
       screen:expect{grid=[[

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -259,6 +259,7 @@ local ext_keys = {
 --              row. Last character of each row (typically "|") is stripped.
 --              Common indentation is stripped.
 --              "{MATCH:x}" in a line is matched against Lua pattern `x`.
+--              "*count" at the end of a line means it repeats `count` times.
 -- attr_ids:    Expected text attributes. Screen rows are transformed according
 --              to this table, as follows: each substring S composed of
 --              characters having the same attributes will be substituted by
@@ -375,14 +376,26 @@ function Screen:expect(expected, attr_ids, ...)
     end
 
     if grid ~= nil then
-      local err_msg, msg_expected_rows = nil, {}
+      for i, row in ipairs(expected_rows) do
+        local count
+        row, count = row:match('^(.*%|)%*(%d+)$')
+        if row then
+          count = tonumber(count)
+          table.remove(expected_rows, i)
+          for _ = 1, count do
+            table.insert(expected_rows, i, row)
+          end
+        end
+      end
+      local err_msg = nil
       -- `expected` must match the screen lines exactly.
       if #actual_rows ~= #expected_rows then
         err_msg = "Expected screen height " .. #expected_rows
         .. ' differs from actual height ' .. #actual_rows .. '.'
       end
+      local msg_expected_rows = shallowcopy(expected_rows)
+      local msg_actual_rows = shallowcopy(actual_rows)
       for i, row in ipairs(expected_rows) do
-        msg_expected_rows[i] = row
         local pat = nil
         if actual_rows[i] and row ~= actual_rows[i] then
           local after = row
@@ -399,7 +412,7 @@ function Screen:expect(expected, attr_ids, ...)
         if row ~= actual_rows[i] and (not pat or not actual_rows[i]:match(pat)) then
           msg_expected_rows[i] = '*' .. msg_expected_rows[i]
           if i <= #actual_rows then
-            actual_rows[i] = '*' .. actual_rows[i]
+            msg_actual_rows[i] = '*' .. msg_actual_rows[i]
           end
           if err_msg == nil then
             err_msg = 'Row ' .. tostring(i) .. ' did not match.'
@@ -409,10 +422,10 @@ function Screen:expect(expected, attr_ids, ...)
       if err_msg ~= nil then
         return (
           err_msg..'\nExpected:\n  |'..table.concat(msg_expected_rows, '\n  |')..'\n'
-          ..'Actual:\n  |'..table.concat(actual_rows, '\n  |')..'\n\n'..[[
+          ..'Actual:\n  |'..table.concat(msg_actual_rows, '\n  |')..'\n\n'..[[
 To print the expect() call that would assert the current screen state, use
 screen:snapshot_util(). In case of non-deterministic failures, use
-screen:redraw_debug() to show all intermediate screen states.  ]])
+screen:redraw_debug() to show all intermediate screen states.]])
       end
     end
 
@@ -619,7 +632,7 @@ between asynchronous (feed(), nvim_input()) and synchronous API calls.
 
   if err then
     if eof then err = err..'\n\n'..eof[2] end
-    busted.fail(err, 3)
+    busted.fail(err .. '\n\nSnapshot:\n' .. self:_print_snapshot(), 3)
   elseif did_warn then
     if eof then print(eof[2]) end
     local tb = debug.traceback()
@@ -1295,7 +1308,6 @@ end
 -- Returns the current screen state in the form of a screen:expect()
 -- keyword-args map.
 function Screen:get_snapshot(attrs, ignore)
-  attrs = attrs or self._default_attr_ids
   if ignore == nil then
     ignore = self._default_attr_ignore
   end
@@ -1304,6 +1316,11 @@ function Screen:get_snapshot(attrs, ignore)
       ignore = ignore,
       mutable = true, -- allow _row_repr to add missing highlights
   }
+  if attrs == nil then
+    attrs = self._default_attr_ids
+  else
+    attr_state.modified = true
+  end
 
   if attrs ~= nil then
     for i, a in pairs(attrs) do
@@ -1315,6 +1332,17 @@ function Screen:get_snapshot(attrs, ignore)
   end
 
   local lines = self:render(true, attr_state, true)
+
+  for i, row in ipairs(lines) do
+    local count = 1
+    while i < #lines and lines[i + 1] == row do
+      count = count + 1
+      table.remove(lines, i + 1)
+    end
+    if count > 1 then
+      lines[i] = lines[i] .. '*' .. count
+    end
+  end
 
   local ext_state = self:_extstate_repr(attr_state)
   for k, v in pairs(ext_state) do
@@ -1371,7 +1399,7 @@ local function fmt_ext_state(name, state)
   end
 end
 
-function Screen:print_snapshot(attrs, ignore)
+function Screen:_print_snapshot(attrs, ignore)
   local kwargs, ext_state, attr_state = self:get_snapshot(attrs, ignore)
   local attrstr = ""
   if attr_state.modified then
@@ -1389,16 +1417,19 @@ function Screen:print_snapshot(attrs, ignore)
     attrstr = (", attr_ids={\n"..table.concat(attrstrs, "\n").."\n}")
   end
 
-  print( "\nscreen:expect{grid=[[")
-  print(kwargs.grid)
-  io.stdout:write( "]]"..attrstr)
+  local result = 'screen:expect{grid=[[\n' .. kwargs.grid .. '\n]]' .. attrstr
   for _, k in ipairs(ext_keys) do
     if ext_state[k] ~= nil and not (k == "win_viewport" and not self.options.ext_multigrid) then
-      io.stdout:write(", "..k.."="..fmt_ext_state(k, ext_state[k]))
+      result = result .. ', ' .. k .. '=' ..  fmt_ext_state(k, ext_state[k])
     end
   end
-  print("}\n")
-  io.stdout:flush()
+  result = result .. '}'
+
+  return result
+end
+
+function Screen:print_snapshot(attrs, ignore)
+  print('\n' .. self:_print_snapshot(attrs, ignore) .. '\n')
 end
 
 function Screen:_insert_hl_id(attr_state, hl_id)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -259,12 +259,13 @@ local ext_keys = {
 --              row. Last character of each row (typically "|") is stripped.
 --              Common indentation is stripped.
 --              "{MATCH:x}" in a line is matched against Lua pattern `x`.
---              "*count" at the end of a line means it repeats `count` times.
+--              "*n" at the end of a line means it repeats `n` times.
 -- attr_ids:    Expected text attributes. Screen rows are transformed according
 --              to this table, as follows: each substring S composed of
 --              characters having the same attributes will be substituted by
 --              "{K:S}", where K is a key in `attr_ids`. Any unexpected
 --              attributes in the final state are an error.
+--              Use an empty table for a text-only (no attributes) expectation.
 --              Use screen:set_default_attr_ids() to define attributes for many
 --              expect() calls.
 -- extmarks:    Expected win_extmarks accumulated for the grids. For each grid,
@@ -344,8 +345,11 @@ function Screen:expect(expected, attr_ids, ...)
     end
   end
   local attr_state = {
-      ids = attr_ids or self._default_attr_ids,
+    ids = attr_ids or self._default_attr_ids,
   }
+  if isempty(attr_ids) then
+    attr_state.ids = nil
+  end
   if self._options.ext_linegrid then
     attr_state.id_to_index = self:linegrid_check_attrs(attr_state.ids or {})
   end
@@ -1252,7 +1256,7 @@ end
 
 -- Generates tests. Call it where Screen:expect() would be. Waits briefly, then
 -- dumps the current screen state in the form of Screen:expect().
--- Use snapshot_util({},true) to generate a text-only (no attributes) test.
+-- Use snapshot_util({}) to generate a text-only (no attributes) test.
 --
 -- @see Screen:redraw_debug()
 function Screen:snapshot_util(attrs, ignore, request_cb)
@@ -1312,12 +1316,15 @@ function Screen:get_snapshot(attrs, ignore)
     ignore = self._default_attr_ignore
   end
   local attr_state = {
-      ids = {},
-      ignore = ignore,
-      mutable = true, -- allow _row_repr to add missing highlights
+    ids = {},
+    ignore = ignore,
+    mutable = true, -- allow _row_repr to add missing highlights
   }
   if attrs == nil then
     attrs = self._default_attr_ids
+  elseif isempty(attrs) then
+    attrs = nil
+    attr_state.ids = nil
   else
     attr_state.modified = true
   end
@@ -1328,7 +1335,7 @@ function Screen:get_snapshot(attrs, ignore)
     end
   end
   if self._options.ext_linegrid then
-    attr_state.id_to_index = self:linegrid_check_attrs(attr_state.ids)
+    attr_state.id_to_index = self:linegrid_check_attrs(attr_state.ids or {})
   end
 
   local lines = self:render(true, attr_state, true)
@@ -1415,6 +1422,8 @@ function Screen:_print_snapshot(attrs, ignore)
       table.insert(attrstrs, "  "..keyval.." = "..dict..";")
     end
     attrstr = (", attr_ids={\n"..table.concat(attrstrs, "\n").."\n}")
+  elseif isempty(attrs) then
+    attrstr = ', attr_ids={}'
   end
 
   local result = 'screen:expect{grid=[[\n' .. kwargs.grid .. '\n]]' .. attrstr
@@ -1430,6 +1439,7 @@ end
 
 function Screen:print_snapshot(attrs, ignore)
   print('\n' .. self:_print_snapshot(attrs, ignore) .. '\n')
+  io.stdout:flush()
 end
 
 function Screen:_insert_hl_id(attr_state, hl_id)


### PR DESCRIPTION
- test: allow avoiding repeated screen lines in expected states
- test: make text-only snapshots work
- fix(options): setting 'scroll' with resized grid
- ci(release): create version tag after "stable" tag
