### PR TITLE
fix(osc52): use nvim_chan_send() to stderr for copying

### DIFF
--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -13,7 +13,9 @@ function M.copy(reg)
   local clipboard = reg == '+' and 'c' or 'p'
   return function(lines)
     local s = table.concat(lines, '\n')
-    io.stdout:write(osc52(clipboard, vim.base64.encode(s)))
+    -- The data to be written here can be quite long.
+    -- Use nvim_chan_send() as io.stdout:write() doesn't handle EAGAIN. #26688
+    vim.api.nvim_chan_send(2, osc52(clipboard, vim.base64.encode(s)))
   end
 end
 


### PR DESCRIPTION
The data to be written can be very long, so use nvim_chan_send() instead
of io.stdout:write() as the latter doesn't handle EAGAIN.

A difference of these two approaches is that nvim_chan_send() writes to
stderr, not stdout, so it won't work if client stderr is redirected.

Fix #26688
