### PR TITLE
refactor(options)!: use `OptVal` for option default values

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -104,6 +104,10 @@ OPTIONS
   changes according to related options. It takes care of alignment, 'number',
   'relativenumber' and 'signcolumn' set to "number". The now redundant `%r` item
   is no longer treated specially for 'statuscolumn'.
+• `:set {option}<` removes the local value for all |global-local| options instead
+  of just string |global-local| options.
+• `:setlocal {option}<` copies the global value to the local value for number
+  and boolean |global-local| options instead of removing the local value.
 
 PLUGINS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -306,19 +306,13 @@ created, thus they behave slightly differently:
 
 :se[t] {option}<	Set the effective value of {option} to its global
 			value.
-			For string |global-local| options, the local value is
-			removed, so that the global value will be used.
+			For |global-local| options, the local value is removed,
+			so that the global value will be used.
 			For all other options, the global value is copied to
 			the local value.
 
 :setl[ocal] {option}<	Set the effective value of {option} to its global
-			value.
-			For number and boolean |global-local| options, the
-			local value is removed, so that the global value will
-			be used.
-			For all other options, including string |global-local|
-			options, the global value is copied to the local
-			value.
+			value by copying the global value to the local value.
 
 Note that the behaviour for |global-local| options is slightly different
 between string and number-based options.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -339,10 +339,8 @@ Normal commands:
 
 Options:
 
-Local values for global-local number/boolean options are unset when the option
-is set without a scope (e.g. by using |:set|), similarly to how global-local
-string options work.
-
+- `:set {option}<` removes local value for all |global-local| options.
+- `:setlocal {option}<` copies global value to local value for all options.
 - 'autoread'    works in the terminal (if it supports "focus" events)
 - 'cpoptions'   flags: |cpo-_|
 - 'diffopt'     "linematch" feature

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -60,13 +60,7 @@ typedef struct {
   /// cmdline. Only useful for string options.
   opt_expand_cb_T opt_expand_cb;
 
-  // TODO(famiu): Use OptVal for def_val.
-  union {
-    int boolean;
-    OptInt number;
-    char *string;
-  } def_val;         ///< default value for variable
-
+  OptVal def_val;    ///< default value
   LastSet last_set;  ///< script in which the option was last set
 } vimoption_T;
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8,8 +8,7 @@
 --- @field short_desc? string|fun(): string
 --- @field varname? string
 --- @field pv_name? string
---- @field type 'boolean'|'number'|'string'
---- @field hidden? boolean
+--- @field type vim.option_type|vim.option_type[]
 --- @field immutable? boolean
 --- @field list? 'comma'|'onecomma'|'commacolon'|'onecommacolon'|'flags'|'flagscomma'
 --- @field scope vim.option_scope[]
@@ -43,6 +42,8 @@
 --- @field meta? integer|boolean|string Default to use in Lua meta files
 
 --- @alias vim.option_scope 'global'|'buffer'|'window'
+--- @alias vim.option_type 'boolean'|'number'|'string'
+--- @alias vim.option_value boolean|number|string
 
 --- @alias vim.option_redraw
 --- |'statuslines'
@@ -61,18 +62,11 @@ local function cstr(s)
 end
 
 --- @param s string
---- @return fun(): string
-local function macros(s)
+--- @param t vim.option_type
+--- @return fun(): string, vim.option_type
+local function macros(s, t)
   return function()
-    return '.string=' .. s
-  end
-end
-
---- @param s string
---- @return fun(): string
-local function imacros(s)
-  return function()
-    return '.number=' .. s
+    return s, t
   end
 end
 
@@ -994,7 +988,7 @@ return {
     {
       cb = 'did_set_cedit',
       defaults = {
-        if_true = macros('CTRL_F_STR'),
+        if_true = macros('CTRL_F_STR', 'string'),
         doc = 'CTRL-F',
       },
       desc = [=[
@@ -1288,7 +1282,7 @@ return {
       abbreviation = 'co',
       cb = 'did_set_lines_or_columns',
       defaults = {
-        if_true = imacros('DFLT_COLS'),
+        if_true = macros('DFLT_COLS', 'number'),
         doc = '80 or terminal width',
       },
       desc = [=[
@@ -1630,7 +1624,7 @@ return {
     {
       abbreviation = 'cpo',
       cb = 'did_set_cpoptions',
-      defaults = { if_true = macros('CPO_VIM') },
+      defaults = { if_true = macros('CPO_VIM', 'string') },
       desc = [=[
         A sequence of single character flags.  When a character is present
         this indicates Vi-compatible behavior.  This is used for things where
@@ -2368,7 +2362,7 @@ return {
     {
       abbreviation = 'enc',
       cb = 'did_set_encoding',
-      defaults = { if_true = macros('ENC_DFLT') },
+      defaults = { if_true = macros('ENC_DFLT', 'string') },
       deny_in_modelines = true,
       desc = [=[
         String-encoding used internally and for |RPC| communication.
@@ -2492,7 +2486,7 @@ return {
     },
     {
       abbreviation = 'ef',
-      defaults = { if_true = macros('DFLT_ERRORFILE') },
+      defaults = { if_true = macros('DFLT_ERRORFILE', 'string') },
       desc = [=[
         Name of the errorfile for the QuickFix mode (see |:cf|).
         When the "-q" command-line argument is used, 'errorfile' is set to the
@@ -2514,7 +2508,7 @@ return {
     {
       abbreviation = 'efm',
       defaults = {
-        if_true = macros('DFLT_EFM'),
+        if_true = macros('DFLT_EFM', 'string'),
         doc = 'is very long',
       },
       deny_duplicates = true,
@@ -2706,7 +2700,7 @@ return {
       alloced = true,
       cb = 'did_set_fileformat',
       defaults = {
-        if_true = macros('DFLT_FF'),
+        if_true = macros('DFLT_FF', 'string'),
         doc = 'Windows: "dos", Unix: "unix"',
       },
       desc = [=[
@@ -2739,7 +2733,7 @@ return {
       abbreviation = 'ffs',
       cb = 'did_set_fileformats',
       defaults = {
-        if_true = macros('DFLT_FFS_VIM'),
+        if_true = macros('DFLT_FFS_VIM', 'string'),
         doc = 'Windows: "dos,unix", Unix: "unix,dos"',
       },
       deny_duplicates = true,
@@ -3316,7 +3310,7 @@ return {
       abbreviation = 'fo',
       alloced = true,
       cb = 'did_set_formatoptions',
-      defaults = { if_true = macros('DFLT_FO_VIM') },
+      defaults = { if_true = macros('DFLT_FO_VIM', 'string') },
       desc = [=[
         This is a sequence of letters which describes how automatic
         formatting is to be done.
@@ -3409,7 +3403,7 @@ return {
     },
     {
       abbreviation = 'gfm',
-      defaults = { if_true = macros('DFLT_GREPFORMAT') },
+      defaults = { if_true = macros('DFLT_GREPFORMAT', 'string') },
       deny_duplicates = true,
       desc = [=[
         Format to recognize for the ":grep" command output.
@@ -3773,6 +3767,7 @@ return {
     },
     {
       abbreviation = 'gtl',
+      defaults = { if_true = '' },
       desc = [=[
         When non-empty describes the text to use in a label of the GUI tab
         pages line.  When empty and when the result is empty Vim will use a
@@ -3798,6 +3793,7 @@ return {
     },
     {
       abbreviation = 'gtt',
+      defaults = { if_true = '' },
       desc = [=[
         When non-empty describes the text to use in a tooltip for the GUI tab
         pages line.  When empty Vim will use a default tooltip.
@@ -3817,7 +3813,7 @@ return {
       abbreviation = 'hf',
       cb = 'did_set_helpfile',
       defaults = {
-        if_true = macros('DFLT_HELPFILE'),
+        if_true = macros('DFLT_HELPFILE', 'string'),
         doc = [[(MS-Windows) "$VIMRUNTIME\doc\help.txt"
                   (others) "$VIMRUNTIME/doc/help.txt"]],
       },
@@ -3914,7 +3910,7 @@ return {
     {
       abbreviation = 'hl',
       cb = 'did_set_highlight',
-      defaults = { if_true = macros('HIGHLIGHT_INIT') },
+      defaults = { if_true = macros('HIGHLIGHT_INIT', 'string') },
       deny_duplicates = true,
       full_name = 'highlight',
       list = 'onecomma',
@@ -4080,7 +4076,7 @@ return {
     {
       abbreviation = 'imi',
       cb = 'did_set_iminsert',
-      defaults = { if_true = imacros('B_IMODE_NONE') },
+      defaults = { if_true = macros('B_IMODE_NONE', 'number') },
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used in
         Insert mode.  Valid values:
@@ -4106,7 +4102,7 @@ return {
     },
     {
       abbreviation = 'ims',
-      defaults = { if_true = imacros('B_IMODE_USE_INSERT') },
+      defaults = { if_true = macros('B_IMODE_USE_INSERT', 'number') },
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used when
         entering a search pattern.  Valid values:
@@ -4812,7 +4808,7 @@ return {
     {
       cb = 'did_set_lines_or_columns',
       defaults = {
-        if_true = imacros('DFLT_ROWS'),
+        if_true = macros('DFLT_ROWS', 'number'),
         doc = '24 or terminal height',
       },
       desc = [=[
@@ -4900,7 +4896,7 @@ return {
     {
       abbreviation = 'lw',
       defaults = {
-        if_true = macros('LISPWORD_VALUE'),
+        if_true = macros('LISPWORD_VALUE', 'string'),
         doc = 'is very long',
       },
       deny_duplicates = true,
@@ -5210,7 +5206,7 @@ return {
     },
     {
       abbreviation = 'mco',
-      defaults = { if_true = imacros('MAX_MCO') },
+      defaults = { if_true = macros('MAX_MCO', 'number') },
       full_name = 'maxcombine',
       scope = { 'global' },
       short_desc = N_('maximum nr of combining characters displayed'),
@@ -9613,7 +9609,7 @@ return {
       abbreviation = 'wc',
       cb = 'did_set_wildchar',
       defaults = {
-        if_true = imacros('TAB'),
+        if_true = macros('TAB', 'number'),
         doc = '<Tab>',
       },
       desc = [=[

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1386,7 +1386,8 @@ func Test_local_scrolloff()
   call assert_equal(5, &so)
   wincmd w
   call assert_equal(3, &so)
-  setlocal so<
+  "setlocal so<
+  set so<
   call assert_equal(5, &so)
   setglob so=8
   call assert_equal(8, &so)
@@ -1403,7 +1404,8 @@ func Test_local_scrolloff()
   call assert_equal(7, &siso)
   wincmd w
   call assert_equal(3, &siso)
-  setlocal siso<
+  "setlocal siso<
+  set siso<
   call assert_equal(7, &siso)
   setglob siso=4
   call assert_equal(4, &siso)
@@ -1595,17 +1597,17 @@ func Test_set_number_global_local_option()
   call assert_equal(12, &l:scrolloff)
   call assert_equal(12, &scrolloff)
 
-  " :set {option}< set the effective value of {option} to its global value.
-  set scrolloff<
-  " Nvim: local value is removed
-  " call assert_equal(10, &l:scrolloff)
-  call assert_equal(-1, &l:scrolloff)
+  " :setlocal {option}< set the effective value of {option} to its global value.
+  "set scrolloff<
+  setlocal scrolloff<
+  call assert_equal(10, &l:scrolloff)
   call assert_equal(10, &scrolloff)
 
-  " :setlocal {option}< removes the local value, so that the global value will be used.
+  " :set {option}< removes the local value, so that the global value will be used.
   setglobal scrolloff=15
   setlocal scrolloff=18
-  setlocal scrolloff<
+  "setlocal scrolloff<
+  set scrolloff<
   call assert_equal(-1, &l:scrolloff)
   call assert_equal(15, &scrolloff)
 
@@ -1620,17 +1622,17 @@ func Test_set_boolean_global_local_option()
   call assert_equal(0, &l:autoread)
   call assert_equal(0, &autoread)
 
-  " :set {option}< set the effective value of {option} to its global value.
-  set autoread<
-  " Nvim: local value is removed
-  " call assert_equal(1, &l:autoread)
-  call assert_equal(-1, &l:autoread)
+  " :setlocal {option}< set the effective value of {option} to its global value.
+  "set autoread<
+  setlocal autoread<
+  call assert_equal(1, &l:autoread)
   call assert_equal(1, &autoread)
 
-  " :setlocal {option}< removes the local value, so that the global value will be used.
+  " :set {option}< removes the local value, so that the global value will be used.
   setglobal noautoread
   setlocal autoread
-  setlocal autoread<
+  "setlocal autoread<
+  set autoread<
   call assert_equal(-1, &l:autoread)
   call assert_equal(0, &autoread)
 

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -187,7 +187,8 @@ func Test_global_local_undolevels()
 
   " Resetting the local 'undolevels' value to use the global value
   setlocal undolevels=5
-  setlocal undolevels<
+  "setlocal undolevels<
+  set undolevels<
   call assert_equal(-123456, &l:undolevels)
 
   " Drop created windows


### PR DESCRIPTION
Problem: We use `void *` for option default values, which is confusing and can cause problems with type-correctness. It also doesn't accomodate for multitype options. On top of that, it also leads to default boolean option values not behaving correctly on big endian systems.

Solution: Use `OptVal` for option default values.

BREAKING CHANGE:
- `:set {option}<` removes the local value for all global-local options instead of just string global-local options.
- `:setlocal {option}<` copies the global value to the local value for number and boolean global-local options instead of removing the local value.