### PR TITLE
vim-patch:9.0.2183: Maximum callback depth is not configurable

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -127,8 +127,6 @@ This happens when an Ex command executes an Ex command that executes an Ex
 command, etc.  The limit is 200 or the value of 'maxfuncdepth', whatever is
 larger.  When it's more there probably is an endless loop.  Probably a
 |:execute| or |:source| command is involved.
-Can also happen with a recursive callback function (|channel-callback|).
-A limit of 20 is used here.
 
 							*E254*  >
   Cannot allocate color {name}

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4027,6 +4027,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
+	Also used for maximum depth of callback functions.
 
 					*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4037,6 +4037,7 @@ vim.go.mat = vim.go.matchtime
 --- Increasing this limit above 200 also changes the maximum for Ex
 --- command recursion, see `E169`.
 --- See also `:function`.
+--- Also used for maximum depth of callback functions.
 ---
 --- @type integer
 vim.o.maxfuncdepth = 100

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -89,8 +89,6 @@
 
 #define DICT_MAXNEST 100        // maximum nesting of lists and dicts
 
-#define MAX_CALLBACK_DEPTH 20
-
 static const char *e_missbrac = N_("E111: Missing ']'");
 static const char *e_list_end = N_("E697: Missing end of List ']': %s");
 static const char e_cannot_slice_dictionary[]
@@ -6061,7 +6059,7 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
                    typval_T *const rettv)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (callback_depth > MAX_CALLBACK_DEPTH) {
+  if (callback_depth > p_mfd) {
     emsg(_(e_command_too_recursive));
     return false;
   }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5158,6 +5158,7 @@ return {
         Increasing this limit above 200 also changes the maximum for Ex
         command recursion, see |E169|.
         See also |:function|.
+        Also used for maximum depth of callback functions.
       ]=],
       full_name = 'maxfuncdepth',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:9.0.2183: Maximum callback depth is not configurable

Problem:  Maximum callback depth is not configurable.
Solution: Revert patch 9.0.2103.  Set 'maxfuncdepth' in test.

closes: vim/vim#13736

https://github.com/vim/vim/commit/fe583b1e5987fbfdb5f2141c133dbff9665ed301