### PR TITLE
refactor(IWYU): add "private" pragma to more generated headers

### DIFF
--- a/src/nvim/api/private/dispatch.h
+++ b/src/nvim/api/private/dispatch.h
@@ -26,6 +26,6 @@ extern const MsgpackRpcRequestHandler method_handlers[];
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/dispatch.h.generated.h"
-# include "api/private/dispatch_wrappers.h.generated.h"  // IWYU pragma: export
-# include "keysets_defs.generated.h"  // IWYU pragma: export
+# include "api/private/dispatch_wrappers.h.generated.h"
+# include "keysets_defs.generated.h"
 #endif

--- a/src/nvim/api/ui.h
+++ b/src/nvim/api/ui.h
@@ -9,5 +9,5 @@
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/ui.h.generated.h"
-# include "ui_events_remote.h.generated.h"  // IWYU pragma: export
+# include "ui_events_remote.h.generated.h"
 #endif

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -106,7 +106,7 @@ for i = 6, #arg do
   end
   headers[#headers + 1] = parts[#parts - 1] .. '/' .. parts[#parts]
 
-  local input = io.open(full_path, 'rb')
+  local input = assert(io.open(full_path, 'rb'))
 
   local tmp = c_grammar.grammar:match(input:read('*all'))
   for j = 1, #tmp do
@@ -216,16 +216,16 @@ end
 
 -- serialize the API metadata using msgpack and embed into the resulting
 -- binary for easy querying by clients
-local funcs_metadata_output = io.open(funcs_metadata_outputf, 'wb')
+local funcs_metadata_output = assert(io.open(funcs_metadata_outputf, 'wb'))
 local packed = mpack.encode(exported_functions)
 local dump_bin_array = require('generators.dump_bin_array')
 dump_bin_array(funcs_metadata_output, 'funcs_metadata', packed)
 funcs_metadata_output:close()
 
 -- start building the dispatch wrapper output
-local output = io.open(dispatch_outputf, 'wb')
+local output = assert(io.open(dispatch_outputf, 'wb'))
 
-local keysets_defs = io.open(keysets_outputf, 'wb')
+local keysets_defs = assert(io.open(keysets_outputf, 'wb'))
 
 -- ===========================================================================
 -- NEW API FILES MUST GO HERE.
@@ -256,6 +256,8 @@ output:write([[
 #include "nvim/ui_client.h"
 
 ]])
+
+keysets_defs:write('// IWYU pragma: private, include "nvim/api/private/dispatch.h"\n\n')
 
 for _, k in ipairs(keysets) do
   local c_name = {}
@@ -633,7 +635,7 @@ output:write(hashfun)
 output:close()
 
 functions.keysets = keysets
-local mpack_output = io.open(mpack_outputf, 'wb')
+local mpack_output = assert(io.open(mpack_outputf, 'wb'))
 mpack_output:write(mpack.encode(functions))
 mpack_output:close()
 
@@ -653,7 +655,7 @@ local function write_shifted_output(_, str)
 end
 
 -- start building lua output
-output = io.open(lua_c_bindings_outputf, 'wb')
+output = assert(io.open(lua_c_bindings_outputf, 'wb'))
 
 output:write([[
 #include <lua.h>

--- a/src/nvim/generators/gen_declarations.lua
+++ b/src/nvim/generators/gen_declarations.lua
@@ -207,6 +207,22 @@ if fname:find('.*/src/nvim/.*%.c$') then
 // IWYU pragma: private, include "%s"
 ]]):format(header_fname:gsub('.*/src/nvim/', 'nvim/')) .. non_static
   end
+elseif non_static_fname:find('/include/api/private/dispatch_wrappers%.h%.generated%.h$') then
+  non_static = [[
+// IWYU pragma: private, include "nvim/api/private/dispatch.h"
+]] .. non_static
+elseif non_static_fname:find('/include/ui_events_call%.h%.generated%.h$') then
+  non_static = [[
+// IWYU pragma: private, include "nvim/ui.h"
+]] .. non_static
+elseif non_static_fname:find('/include/ui_events_client%.h%.generated%.h$') then
+  non_static = [[
+// IWYU pragma: private, include "nvim/ui_client.h"
+]] .. non_static
+elseif non_static_fname:find('/include/ui_events_remote%.h%.generated%.h$') then
+  non_static = [[
+// IWYU pragma: private, include "nvim/api/ui.h"
+]] .. non_static
 end
 
 local filepattern = '^#%a* (%d+) "([^"]-)/?([^"/]+)"'

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2,7 +2,6 @@
 // - Put it in options.lua
 // - For a global option: Add a variable for it in option_vars.h.
 // - For a buffer or window local option:
-//   - Add a BV_XX or WV_XX entry to option_vars.h
 //   - Add a variable to the window or buffer struct in buffer_defs.h.
 //   - For a window option, add some code to copy_winopt().
 //   - For a window string option, add code to check_winopt()

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -131,5 +131,5 @@ typedef enum {
 } OptReqScope;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "options_enum.generated.h"  // IWYU pragma: export
+# include "options_enum.generated.h"
 #endif

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -27,7 +27,7 @@ EXTERN const char *ui_ext_names[] INIT( = {
 // uncrustify:off
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"
-# include "ui_events_call.h.generated.h"  // IWYU pragma: export
+# include "ui_events_call.h.generated.h"
 #endif
 // uncrustify:on
 

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -39,6 +39,6 @@ EXTERN bool ui_client_forward_stdin INIT( = false);
 // uncrustify:off
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui_client.h.generated.h"
-# include "ui_events_client.h.generated.h"  // IWYU pragma: export
+# include "ui_events_client.h.generated.h"
 #endif
 // uncrustify:on


### PR DESCRIPTION
"export" only prevents IWYU from adding these headers if the headers
that export them are included, while "private" ensures that IWYU never
adds these headers.
