### PR TITLE
feat: ui graphical protocol

### DIFF
--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -17,6 +17,7 @@ EXTERN const char *ui_ext_names[] INIT( = {
   "ext_tabline",
   "ext_wildmenu",
   "ext_messages",
+  "ext_graphics",
   "ext_linegrid",
   "ext_multigrid",
   "ext_hlstate",

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -13,6 +13,7 @@ typedef enum {
   kUITabline,
   kUIWildmenu,
   kUIMessages,
+  kUIExtGraphics,
 #define kUIGlobalCount kUILinegrid
   kUILinegrid,
   kUIMultigrid,


### PR DESCRIPTION
A new UI protocol that handles graphics.
Three possible graphical element types: buffer-local, window-local, and global.
- [ ] The buffer-local one uses extmark for the position of the graphical element.
  - [ ] Add documentation about if the graphic is cut off by a window boundary, then only the part in the buffer should be seen.
- [ ] The window-local one uses window positioning
  - [ ] A negative positioning, which would calculate from the bottom/right instead of the top/left.
- [ ] The global one works similarly to the window-local one but uses global positioning instead.

### Aditional notes
After implementing the protocol, I suggest implementing a fallback system for the neovim tui: by default, a program that converts graphics to ASCII art would be used. A new option should also be added, that can specify an external program to use to convert graphics to ASCII art. There should also be an option to disable this feature. I also propose that a graphical element could set the ASCII art fallback, instead of relying on a program.

Later on, we could extend the neovim-tui UI handler to work with terminals that implement some sort of graphical rendering.
Related issues: https://github.com/neovim/neovim/issues/4500, https://github.com/neovim/neovim/issues/12991