### PR TITLE
docs: detab generated docs

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*	Nvim
+*builtin.txt*    Nvim
 
 
 		  NVIM REFERENCE MANUAL
@@ -10,8999 +10,8929 @@ For functions grouped by what they are used for see |function-list|.
 
 				      Type |gO| to see the table of contents.
 ==============================================================================
-1. Details					*builtin-function-details*
+1. Details                                       *builtin-function-details*
 
 abs({expr})                                                              *abs()*
-		Return the absolute value of {expr}.  When {expr} evaluates to
-		a |Float| abs() returns a |Float|.  When {expr} can be
-		converted to a |Number| abs() returns a |Number|.  Otherwise
-		abs() gives an error message and returns -1.
-		Examples: >vim
-			echo abs(1.456)
-<			1.456  >vim
-			echo abs(-5.456)
-<			5.456  >vim
-			echo abs(-4)
-<			4
+                Return the absolute value of {expr}.  When {expr} evaluates to
+                a |Float| abs() returns a |Float|.  When {expr} can be
+                converted to a |Number| abs() returns a |Number|.  Otherwise
+                abs() gives an error message and returns -1.
+                Examples: >vim
+                        echo abs(1.456)
+<                        1.456  >vim
+                        echo abs(-5.456)
+<                        5.456  >vim
+                        echo abs(-4)
+<                        4
 
 acos({expr})                                                            *acos()*
-		Return the arc cosine of {expr} measured in radians, as a
-		|Float| in the range of [0, pi].
-		{expr} must evaluate to a |Float| or a |Number| in the range
-		[-1, 1].
-		Returns NaN if {expr} is outside the range [-1, 1].  Returns
-		0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo acos(0)
-<			1.570796 >vim
-			echo acos(-0.5)
-<			2.094395
+                Return the arc cosine of {expr} measured in radians, as a
+                |Float| in the range of [0, pi].
+                {expr} must evaluate to a |Float| or a |Number| in the range
+                [-1, 1].
+                Returns NaN if {expr} is outside the range [-1, 1].  Returns
+                0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo acos(0)
+<                        1.570796 >vim
+                        echo acos(-0.5)
+<                        2.094395
 
 add({object}, {expr})                                                    *add()*
-		Append the item {expr} to |List| or |Blob| {object}.  Returns
-		the resulting |List| or |Blob|.  Examples: >vim
-			let alist = add([1, 2, 3], item)
-			call add(mylist, "woodstock")
-<		Note that when {expr} is a |List| it is appended as a single
-		item.  Use |extend()| to concatenate |Lists|.
-		When {object} is a |Blob| then {expr} must be a number.
-		Use |insert()| to add an item at another position.
-		Returns 1 if {object} is not a |List| or a |Blob|.
+                Append the item {expr} to |List| or |Blob| {object}.  Returns
+                the resulting |List| or |Blob|.  Examples: >vim
+                        let alist = add([1, 2, 3], item)
+                        call add(mylist, "woodstock")
+<                Note that when {expr} is a |List| it is appended as a single
+                item.  Use |extend()| to concatenate |Lists|.
+                When {object} is a |Blob| then {expr} must be a number.
+                Use |insert()| to add an item at another position.
+                Returns 1 if {object} is not a |List| or a |Blob|.
 
 and({expr}, {expr})                                                      *and()*
-		Bitwise AND on the two arguments.  The arguments are converted
-		to a number.  A List, Dict or Float argument causes an error.
-		Also see `or()` and `xor()`.
-		Example: >vim
-			let flag = and(bits, 0x80)
+                Bitwise AND on the two arguments.  The arguments are converted
+                to a number.  A List, Dict or Float argument causes an error.
+                Also see `or()` and `xor()`.
+                Example: >vim
+                        let flag = and(bits, 0x80)
 <
-
 api_info()                                                          *api_info()*
-		Returns Dictionary of |api-metadata|.
+                Returns Dictionary of |api-metadata|.
 
-		View it in a nice human-readable format: >vim
-		       lua vim.print(vim.fn.api_info())
+                View it in a nice human-readable format: >vim
+                       lua vim.print(vim.fn.api_info())
 <
-
 append({lnum}, {text})                                                *append()*
-		When {text} is a |List|: Append each item of the |List| as a
-		text line below line {lnum} in the current buffer.
-		Otherwise append {text} as one text line below line {lnum} in
-		the current buffer.
-		Any type of item is accepted and converted to a String.
-		{lnum} can be zero to insert a line before the first one.
-		{lnum} is used like with |getline()|.
-		Returns 1 for failure ({lnum} out of range or out of memory),
-		0 for success.  When {text} is an empty list zero is returned,
-		no matter the value of {lnum}.  Example: >vim
-			let failed = append(line('$'), "# THE END")
-			let failed = append(0, ["Chapter 1", "the beginning"])
+                When {text} is a |List|: Append each item of the |List| as a
+                text line below line {lnum} in the current buffer.
+                Otherwise append {text} as one text line below line {lnum} in
+                the current buffer.
+                Any type of item is accepted and converted to a String.
+                {lnum} can be zero to insert a line before the first one.
+                {lnum} is used like with |getline()|.
+                Returns 1 for failure ({lnum} out of range or out of memory),
+                0 for success.  When {text} is an empty list zero is returned,
+                no matter the value of {lnum}.  Example: >vim
+                        let failed = append(line('$'), "# THE END")
+                        let failed = append(0, ["Chapter 1", "the beginning"])
 <
-
 appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
-		Like |append()| but append the text in buffer {expr}.
+                Like |append()| but append the text in buffer {expr}.
 
-		This function works only for loaded buffers. First call
-		|bufload()| if needed.
+                This function works only for loaded buffers. First call
+                |bufload()| if needed.
 
-		For the use of {buf}, see |bufname()|.
+                For the use of {buf}, see |bufname()|.
 
-		{lnum} is the line number to append below.  Note that using
-		|line()| would use the current buffer, not the one appending
-		to.  Use "$" to append at the end of the buffer.  Other string
-		values are not supported.
+                {lnum} is the line number to append below.  Note that using
+                |line()| would use the current buffer, not the one appending
+                to.  Use "$" to append at the end of the buffer.  Other string
+                values are not supported.
 
-		On success 0 is returned, on failure 1 is returned.
+                On success 0 is returned, on failure 1 is returned.
 
-		If {buf} is not a valid buffer or {lnum} is not valid, an
-		error message is given. Example: >vim
-			let failed = appendbufline(13, 0, "# THE START")
-<		However, when {text} is an empty list then no error is given
-		for an invalid {lnum}, since {lnum} isn't actually used.
+                If {buf} is not a valid buffer or {lnum} is not valid, an
+                error message is given. Example: >vim
+                        let failed = appendbufline(13, 0, "# THE START")
+<                However, when {text} is an empty list then no error is given
+                for an invalid {lnum}, since {lnum} isn't actually used.
 
 argc([{winid}])                                                         *argc()*
-		The result is the number of files in the argument list.  See
-		|arglist|.
-		If {winid} is not supplied, the argument list of the current
-		window is used.
-		If {winid} is -1, the global argument list is used.
-		Otherwise {winid} specifies the window of which the argument
-		list is used: either the window number or the window ID.
-		Returns -1 if the {winid} argument is invalid.
+                The result is the number of files in the argument list.  See
+                |arglist|.
+                If {winid} is not supplied, the argument list of the current
+                window is used.
+                If {winid} is -1, the global argument list is used.
+                Otherwise {winid} specifies the window of which the argument
+                list is used: either the window number or the window ID.
+                Returns -1 if the {winid} argument is invalid.
 
 argidx()                                                              *argidx()*
-		The result is the current index in the argument list.  0 is
-		the first file.  argc() - 1 is the last one.  See |arglist|.
+                The result is the current index in the argument list.  0 is
+                the first file.  argc() - 1 is the last one.  See |arglist|.
 
 arglistid([{winnr} [, {tabnr}]])                                   *arglistid()*
-		Return the argument list ID.  This is a number which
-		identifies the argument list being used.  Zero is used for the
-		global argument list.  See |arglist|.
-		Returns -1 if the arguments are invalid.
+                Return the argument list ID.  This is a number which
+                identifies the argument list being used.  Zero is used for the
+                global argument list.  See |arglist|.
+                Returns -1 if the arguments are invalid.
 
-		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
-		With {winnr} and {tabnr} use the window in the specified tab
-		page.
-		{winnr} can be the window number or the |window-ID|.
+                Without arguments use the current window.
+                With {winnr} only use this window in the current tab page.
+                With {winnr} and {tabnr} use the window in the specified tab
+                page.
+                {winnr} can be the window number or the |window-ID|.
 
 argv([{nr} [, {winid}]])                                                *argv()*
-		The result is the {nr}th file in the argument list.  See
-		|arglist|.  "argv(0)" is the first one.  Example: >vim
-			let i = 0
-			while i < argc()
-			  let f = escape(fnameescape(argv(i)), '.')
-			  exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
-			  let i = i + 1
-			endwhile
-<		Without the {nr} argument, or when {nr} is -1, a |List| with
-		the whole |arglist| is returned.
+                The result is the {nr}th file in the argument list.  See
+                |arglist|.  "argv(0)" is the first one.  Example: >vim
+                        let i = 0
+                        while i < argc()
+                          let f = escape(fnameescape(argv(i)), '.')
+                          exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
+                          let i = i + 1
+                        endwhile
+<                Without the {nr} argument, or when {nr} is -1, a |List| with
+                the whole |arglist| is returned.
 
-		The {winid} argument specifies the window ID, see |argc()|.
-		For the Vim command line arguments see |v:argv|.
+                The {winid} argument specifies the window ID, see |argc()|.
+                For the Vim command line arguments see |v:argv|.
 
-		Returns an empty string if {nr}th argument is not present in
-		the argument list.  Returns an empty List if the {winid}
-		argument is invalid.
+                Returns an empty string if {nr}th argument is not present in
+                the argument list.  Returns an empty List if the {winid}
+                argument is invalid.
 
 asin({expr})                                                            *asin()*
-		Return the arc sine of {expr} measured in radians, as a |Float|
-		in the range of [-pi/2, pi/2].
-		{expr} must evaluate to a |Float| or a |Number| in the range
-		[-1, 1].
-		Returns NaN if {expr} is outside the range [-1, 1].  Returns
-		0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo asin(0.8)
-<			0.927295 >vim
-			echo asin(-0.5)
-<			-0.523599
+                Return the arc sine of {expr} measured in radians, as a |Float|
+                in the range of [-pi/2, pi/2].
+                {expr} must evaluate to a |Float| or a |Number| in the range
+                [-1, 1].
+                Returns NaN if {expr} is outside the range [-1, 1].  Returns
+                0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo asin(0.8)
+<                        0.927295 >vim
+                        echo asin(-0.5)
+<                        -0.523599
 
 assert_beeps({cmd})                                             *assert_beeps()*
-		Run {cmd} and add an error message to |v:errors| if it does
-		NOT produce a beep or visual bell.
-		Also see |assert_fails()|, |assert_nobeep()| and
-		|assert-return|.
+                Run {cmd} and add an error message to |v:errors| if it does
+                NOT produce a beep or visual bell.
+                Also see |assert_fails()|, |assert_nobeep()| and
+                |assert-return|.
 
 assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
-		When {expected} and {actual} are not equal an error message is
-		added to |v:errors| and 1 is returned.  Otherwise zero is
-		returned. |assert-return|
-		The error is in the form "Expected {expected} but got
-		{actual}".  When {msg} is present it is prefixed to that.
+                When {expected} and {actual} are not equal an error message is
+                added to |v:errors| and 1 is returned.  Otherwise zero is
+                returned. |assert-return|
+                The error is in the form "Expected {expected} but got
+                {actual}".  When {msg} is present it is prefixed to that.
 
-		There is no automatic conversion, the String "4" is different
-		from the Number 4.  And the number 4 is different from the
-		Float 4.0.  The value of 'ignorecase' is not used here, case
-		always matters.
-		Example: >vim
-			assert_equal('foo', 'bar')
-<		Will result in a string to be added to |v:errors|:
-			test.vim line 12: Expected 'foo' but got 'bar' ~
+                There is no automatic conversion, the String "4" is different
+                from the Number 4.  And the number 4 is different from the
+                Float 4.0.  The value of 'ignorecase' is not used here, case
+                always matters.
+                Example: >vim
+                        assert_equal('foo', 'bar')
+<                Will result in a string to be added to |v:errors|:
+                        test.vim line 12: Expected 'foo' but got 'bar' ~
 
 assert_equalfile({fname-one}, {fname-two})                  *assert_equalfile()*
-		When the files {fname-one} and {fname-two} do not contain
-		exactly the same text an error message is added to |v:errors|.
-		Also see |assert-return|.
-		When {fname-one} or {fname-two} does not exist the error will
-		mention that.
+                When the files {fname-one} and {fname-two} do not contain
+                exactly the same text an error message is added to |v:errors|.
+                Also see |assert-return|.
+                When {fname-one} or {fname-two} does not exist the error will
+                mention that.
 
 assert_exception({error} [, {msg}])                         *assert_exception()*
-		When v:exception does not contain the string {error} an error
-		message is added to |v:errors|.  Also see |assert-return|.
-		This can be used to assert that a command throws an exception.
-		Using the error number, followed by a colon, avoids problems
-		with translations: >vim
-			try
-			  commandthatfails
-			  call assert_false(1, 'command should have failed')
-			catch
-			  call assert_exception('E492:')
-			endtry
+                When v:exception does not contain the string {error} an error
+                message is added to |v:errors|.  Also see |assert-return|.
+                This can be used to assert that a command throws an exception.
+                Using the error number, followed by a colon, avoids problems
+                with translations: >vim
+                        try
+                          commandthatfails
+                          call assert_false(1, 'command should have failed')
+                        catch
+                          call assert_exception('E492:')
+                        endtry
 <
-
                                                                 *assert_fails()*
 assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
-		Run {cmd} and add an error message to |v:errors| if it does
-		NOT produce an error or when {error} is not found in the
-		error message.  Also see |assert-return|.
+                Run {cmd} and add an error message to |v:errors| if it does
+                NOT produce an error or when {error} is not found in the
+                error message.  Also see |assert-return|.
 
-		When {error} is a string it must be found literally in the
-		first reported error. Most often this will be the error code,
-		including the colon, e.g. "E123:". >vim
-			assert_fails('bad cmd', 'E987:')
+                When {error} is a string it must be found literally in the
+                first reported error. Most often this will be the error code,
+                including the colon, e.g. "E123:". >vim
+                        assert_fails('bad cmd', 'E987:')
 <
-		When {error} is a |List| with one or two strings, these are
-		used as patterns.  The first pattern is matched against the
-		first reported error: >vim
-			assert_fails('cmd', ['E987:.*expected bool'])
-<		The second pattern, if present, is matched against the last
-		reported error.  To only match the last error use an empty
-		string for the first error: >vim
-			assert_fails('cmd', ['', 'E987:'])
+                When {error} is a |List| with one or two strings, these are
+                used as patterns.  The first pattern is matched against the
+                first reported error: >vim
+                        assert_fails('cmd', ['E987:.*expected bool'])
+<                The second pattern, if present, is matched against the last
+                reported error.  To only match the last error use an empty
+                string for the first error: >vim
+                        assert_fails('cmd', ['', 'E987:'])
 <
-		If {msg} is empty then it is not used.  Do this to get the
-		default message when passing the {lnum} argument.
+                If {msg} is empty then it is not used.  Do this to get the
+                default message when passing the {lnum} argument.
 
-		When {lnum} is present and not negative, and the {error}
-		argument is present and matches, then this is compared with
-		the line number at which the error was reported. That can be
-		the line number in a function or in a script.
+                When {lnum} is present and not negative, and the {error}
+                argument is present and matches, then this is compared with
+                the line number at which the error was reported. That can be
+                the line number in a function or in a script.
 
-		When {context} is present it is used as a pattern and matched
-		against the context (script name or function name) where
-		{lnum} is located in.
+                When {context} is present it is used as a pattern and matched
+                against the context (script name or function name) where
+                {lnum} is located in.
 
-		Note that beeping is not considered an error, and some failing
-		commands only beep.  Use |assert_beeps()| for those.
+                Note that beeping is not considered an error, and some failing
+                commands only beep.  Use |assert_beeps()| for those.
 
 assert_false({actual} [, {msg}])                                *assert_false()*
-		When {actual} is not false an error message is added to
-		|v:errors|, like with |assert_equal()|.
-		The error is in the form "Expected False but got {actual}".
-		When {msg} is present it is prepended to that.
-		Also see |assert-return|.
+                When {actual} is not false an error message is added to
+                |v:errors|, like with |assert_equal()|.
+                The error is in the form "Expected False but got {actual}".
+                When {msg} is present it is prepended to that.
+                Also see |assert-return|.
 
-		A value is false when it is zero. When {actual} is not a
-		number the assert fails.
+                A value is false when it is zero. When {actual} is not a
+                number the assert fails.
 
 assert_inrange({lower}, {upper}, {actual} [, {msg}])          *assert_inrange()*
-		This asserts number and |Float| values.  When {actual}  is lower
-		than {lower} or higher than {upper} an error message is added
-		to |v:errors|.  Also see |assert-return|.
-		The error is in the form "Expected range {lower} - {upper},
-		but got {actual}".  When {msg} is present it is prefixed to
-		that.
+                This asserts number and |Float| values.  When {actual}  is lower
+                than {lower} or higher than {upper} an error message is added
+                to |v:errors|.  Also see |assert-return|.
+                The error is in the form "Expected range {lower} - {upper},
+                but got {actual}".  When {msg} is present it is prefixed to
+                that.
 
 assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
-		When {pattern} does not match {actual} an error message is
-		added to |v:errors|.  Also see |assert-return|.
-		The error is in the form "Pattern {pattern} does not match
-		{actual}".  When {msg} is present it is prefixed to that.
+                When {pattern} does not match {actual} an error message is
+                added to |v:errors|.  Also see |assert-return|.
+                The error is in the form "Pattern {pattern} does not match
+                {actual}".  When {msg} is present it is prefixed to that.
 
-		{pattern} is used as with |expr-=~|: The matching is always done
-		like 'magic' was set and 'cpoptions' is empty, no matter what
-		the actual value of 'magic' or 'cpoptions' is.
+                {pattern} is used as with |expr-=~|: The matching is always done
+                like 'magic' was set and 'cpoptions' is empty, no matter what
+                the actual value of 'magic' or 'cpoptions' is.
 
-		{actual} is used as a string, automatic conversion applies.
-		Use "^" and "$" to match with the start and end of the text.
-		Use both to match the whole text.
+                {actual} is used as a string, automatic conversion applies.
+                Use "^" and "$" to match with the start and end of the text.
+                Use both to match the whole text.
 
-		Example: >vim
-			assert_match('^f.*o$', 'foobar')
-<		Will result in a string to be added to |v:errors|:
-			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+                Example: >vim
+                        assert_match('^f.*o$', 'foobar')
+<                Will result in a string to be added to |v:errors|:
+                        test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
 assert_nobeep({cmd})                                           *assert_nobeep()*
-		Run {cmd} and add an error message to |v:errors| if it
-		produces a beep or visual bell.
-		Also see |assert_beeps()|.
+                Run {cmd} and add an error message to |v:errors| if it
+                produces a beep or visual bell.
+                Also see |assert_beeps()|.
 
 assert_notequal({expected}, {actual} [, {msg}])              *assert_notequal()*
-		The opposite of `assert_equal()`: add an error message to
-		|v:errors| when {expected} and {actual} are equal.
-		Also see |assert-return|.
+                The opposite of `assert_equal()`: add an error message to
+                |v:errors| when {expected} and {actual} are equal.
+                Also see |assert-return|.
 
 assert_notmatch({pattern}, {actual} [, {msg}])               *assert_notmatch()*
-		The opposite of `assert_match()`: add an error message to
-		|v:errors| when {pattern} matches {actual}.
-		Also see |assert-return|.
+                The opposite of `assert_match()`: add an error message to
+                |v:errors| when {pattern} matches {actual}.
+                Also see |assert-return|.
 
 assert_report({msg})                                           *assert_report()*
-		Report a test failure directly, using String {msg}.
-		Always returns one.
+                Report a test failure directly, using String {msg}.
+                Always returns one.
 
 assert_true({actual} [, {msg}])                                  *assert_true()*
-		When {actual} is not true an error message is added to
-		|v:errors|, like with |assert_equal()|.
-		Also see |assert-return|.
-		A value is |TRUE| when it is a non-zero number or |v:true|.
-		When {actual} is not a number or |v:true| the assert fails.
-		When {msg} is given it precedes the default message.
+                When {actual} is not true an error message is added to
+                |v:errors|, like with |assert_equal()|.
+                Also see |assert-return|.
+                A value is |TRUE| when it is a non-zero number or |v:true|.
+                When {actual} is not a number or |v:true| the assert fails.
+                When {msg} is given it precedes the default message.
 
 atan({expr})                                                            *atan()*
-		Return the principal value of the arc tangent of {expr}, in
-		the range [-pi/2, +pi/2] radians, as a |Float|.
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo atan(100)
-<			1.560797 >vim
-			echo atan(-4.01)
-<			-1.326405
+                Return the principal value of the arc tangent of {expr}, in
+                the range [-pi/2, +pi/2] radians, as a |Float|.
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo atan(100)
+<                        1.560797 >vim
+                        echo atan(-4.01)
+<                        -1.326405
 
 atan2({expr1}, {expr2})                                                *atan2()*
-		Return the arc tangent of {expr1} / {expr2}, measured in
-		radians, as a |Float| in the range [-pi, pi].
-		{expr1} and {expr2} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
-		|Number|.
-		Examples: >vim
-			echo atan2(-1, 1)
-<			-0.785398 >vim
-			echo atan2(1, -1)
-<			2.356194
+                Return the arc tangent of {expr1} / {expr2}, measured in
+                radians, as a |Float| in the range [-pi, pi].
+                {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
+                |Number|.
+                Examples: >vim
+                        echo atan2(-1, 1)
+<                        -0.785398 >vim
+                        echo atan2(1, -1)
+<                        2.356194
 
 blob2list({blob})                                                  *blob2list()*
-		Return a List containing the number value of each byte in Blob
-		{blob}.  Examples: >vim
-			blob2list(0z0102.0304)	" returns [1, 2, 3, 4]
-			blob2list(0z)		" returns []
-<		Returns an empty List on error.  |list2blob()| does the
-		opposite.
+                Return a List containing the number value of each byte in Blob
+                {blob}.  Examples: >vim
+                        blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
+                        blob2list(0z)           " returns []
+<                Returns an empty List on error.  |list2blob()| does the
+                opposite.
 
 browse({save}, {title}, {initdir}, {default})                         *browse()*
-		Put up a file requester.  This only works when "has("browse")"
-		returns |TRUE| (only in some GUI versions).
-		The input fields are:
-		    {save}	when |TRUE|, select file to write
-		    {title}	title for the requester
-		    {initdir}	directory to start browsing in
-		    {default}	default file name
-		An empty string is returned when the "Cancel" button is hit,
-		something went wrong, or browsing is not possible.
+                Put up a file requester.  This only works when "has("browse")"
+                returns |TRUE| (only in some GUI versions).
+                The input fields are:
+                    {save}      when |TRUE|, select file to write
+                    {title}     title for the requester
+                    {initdir}   directory to start browsing in
+                    {default}   default file name
+                An empty string is returned when the "Cancel" button is hit,
+                something went wrong, or browsing is not possible.
 
 browsedir({title}, {initdir})                                      *browsedir()*
-		Put up a directory requester.  This only works when
-		"has("browse")" returns |TRUE| (only in some GUI versions).
-		On systems where a directory browser is not supported a file
-		browser is used.  In that case: select a file in the directory
-		to be used.
-		The input fields are:
-		    {title}	title for the requester
-		    {initdir}	directory to start browsing in
-		When the "Cancel" button is hit, something went wrong, or
-		browsing is not possible, an empty string is returned.
+                Put up a directory requester.  This only works when
+                "has("browse")" returns |TRUE| (only in some GUI versions).
+                On systems where a directory browser is not supported a file
+                browser is used.  In that case: select a file in the directory
+                to be used.
+                The input fields are:
+                    {title}     title for the requester
+                    {initdir}   directory to start browsing in
+                When the "Cancel" button is hit, something went wrong, or
+                browsing is not possible, an empty string is returned.
 
 bufadd({name})                                                        *bufadd()*
-		Add a buffer to the buffer list with name {name} (must be a
-		String).
-		If a buffer for file {name} already exists, return that buffer
-		number.  Otherwise return the buffer number of the newly
-		created buffer.  When {name} is an empty string then a new
-		buffer is always created.
-		The buffer will not have 'buflisted' set and not be loaded
-		yet.  To add some text to the buffer use this: >vim
-			let bufnr = bufadd('someName')
-			call bufload(bufnr)
-			call setbufline(bufnr, 1, ['some', 'text'])
-<		Returns 0 on error.
+                Add a buffer to the buffer list with name {name} (must be a
+                String).
+                If a buffer for file {name} already exists, return that buffer
+                number.  Otherwise return the buffer number of the newly
+                created buffer.  When {name} is an empty string then a new
+                buffer is always created.
+                The buffer will not have 'buflisted' set and not be loaded
+                yet.  To add some text to the buffer use this: >vim
+                        let bufnr = bufadd('someName')
+                        call bufload(bufnr)
+                        call setbufline(bufnr, 1, ['some', 'text'])
+<                Returns 0 on error.
 
 bufexists({buf})                                                   *bufexists()*
-		The result is a Number, which is |TRUE| if a buffer called
-		{buf} exists.
-		If the {buf} argument is a number, buffer numbers are used.
-		Number zero is the alternate buffer for the current window.
+                The result is a Number, which is |TRUE| if a buffer called
+                {buf} exists.
+                If the {buf} argument is a number, buffer numbers are used.
+                Number zero is the alternate buffer for the current window.
 
-		If the {buf} argument is a string it must match a buffer name
-		exactly.  The name can be:
-		- Relative to the current directory.
-		- A full path.
-		- The name of a buffer with 'buftype' set to "nofile".
-		- A URL name.
-		Unlisted buffers will be found.
-		Note that help files are listed by their short name in the
-		output of |:buffers|, but bufexists() requires using their
-		long name to be able to find them.
-		bufexists() may report a buffer exists, but to use the name
-		with a |:buffer| command you may need to use |expand()|.  Esp
-		for MS-Windows 8.3 names in the form "c:\DOCUME~1"
-		Use "bufexists(0)" to test for the existence of an alternate
-		file name.
+                If the {buf} argument is a string it must match a buffer name
+                exactly.  The name can be:
+                - Relative to the current directory.
+                - A full path.
+                - The name of a buffer with 'buftype' set to "nofile".
+                - A URL name.
+                Unlisted buffers will be found.
+                Note that help files are listed by their short name in the
+                output of |:buffers|, but bufexists() requires using their
+                long name to be able to find them.
+                bufexists() may report a buffer exists, but to use the name
+                with a |:buffer| command you may need to use |expand()|.  Esp
+                for MS-Windows 8.3 names in the form "c:\DOCUME~1"
+                Use "bufexists(0)" to test for the existence of an alternate
+                file name.
 
 buflisted({buf})                                                   *buflisted()*
-		The result is a Number, which is |TRUE| if a buffer called
-		{buf} exists and is listed (has the 'buflisted' option set).
-		The {buf} argument is used like with |bufexists()|.
+                The result is a Number, which is |TRUE| if a buffer called
+                {buf} exists and is listed (has the 'buflisted' option set).
+                The {buf} argument is used like with |bufexists()|.
 
 bufload({buf})                                                       *bufload()*
-		Ensure the buffer {buf} is loaded.  When the buffer name
-		refers to an existing file then the file is read.  Otherwise
-		the buffer will be empty.  If the buffer was already loaded
-		then there is no change.  If the buffer is not related to a
-		file then no file is read (e.g., when 'buftype' is "nofile").
-		If there is an existing swap file for the file of the buffer,
-		there will be no dialog, the buffer will be loaded anyway.
-		The {buf} argument is used like with |bufexists()|.
+                Ensure the buffer {buf} is loaded.  When the buffer name
+                refers to an existing file then the file is read.  Otherwise
+                the buffer will be empty.  If the buffer was already loaded
+                then there is no change.  If the buffer is not related to a
+                file then no file is read (e.g., when 'buftype' is "nofile").
+                If there is an existing swap file for the file of the buffer,
+                there will be no dialog, the buffer will be loaded anyway.
+                The {buf} argument is used like with |bufexists()|.
 
 bufloaded({buf})                                                   *bufloaded()*
-		The result is a Number, which is |TRUE| if a buffer called
-		{buf} exists and is loaded (shown in a window or hidden).
-		The {buf} argument is used like with |bufexists()|.
+                The result is a Number, which is |TRUE| if a buffer called
+                {buf} exists and is loaded (shown in a window or hidden).
+                The {buf} argument is used like with |bufexists()|.
 
 bufname([{buf}])                                                     *bufname()*
-		The result is the name of a buffer.  Mostly as it is displayed
-		by the `:ls` command, but not using special names such as
-		"[No Name]".
-		If {buf} is omitted the current buffer is used.
-		If {buf} is a Number, that buffer number's name is given.
-		Number zero is the alternate buffer for the current window.
-		If {buf} is a String, it is used as a |file-pattern| to match
-		with the buffer names.  This is always done like 'magic' is
-		set and 'cpoptions' is empty.  When there is more than one
-		match an empty string is returned.
-		"" or "%" can be used for the current buffer, "#" for the
-		alternate buffer.
-		A full match is preferred, otherwise a match at the start, end
-		or middle of the buffer name is accepted.  If you only want a
-		full match then put "^" at the start and "$" at the end of the
-		pattern.
-		Listed buffers are found first.  If there is a single match
-		with a listed buffer, that one is returned.  Next unlisted
-		buffers are searched for.
-		If the {buf} is a String, but you want to use it as a buffer
-		number, force it to be a Number by adding zero to it: >vim
-			echo bufname("3" + 0)
-<		If the buffer doesn't exist, or doesn't have a name, an empty
-		string is returned. >vim
-			echo bufname("#")	" alternate buffer name
-			echo bufname(3)		" name of buffer 3
-			echo bufname("%")	" name of current buffer
-			echo bufname("file2")	" name of buffer where "file2" matches.
+                The result is the name of a buffer.  Mostly as it is displayed
+                by the `:ls` command, but not using special names such as
+                "[No Name]".
+                If {buf} is omitted the current buffer is used.
+                If {buf} is a Number, that buffer number's name is given.
+                Number zero is the alternate buffer for the current window.
+                If {buf} is a String, it is used as a |file-pattern| to match
+                with the buffer names.  This is always done like 'magic' is
+                set and 'cpoptions' is empty.  When there is more than one
+                match an empty string is returned.
+                "" or "%" can be used for the current buffer, "#" for the
+                alternate buffer.
+                A full match is preferred, otherwise a match at the start, end
+                or middle of the buffer name is accepted.  If you only want a
+                full match then put "^" at the start and "$" at the end of the
+                pattern.
+                Listed buffers are found first.  If there is a single match
+                with a listed buffer, that one is returned.  Next unlisted
+                buffers are searched for.
+                If the {buf} is a String, but you want to use it as a buffer
+                number, force it to be a Number by adding zero to it: >vim
+                        echo bufname("3" + 0)
+<                If the buffer doesn't exist, or doesn't have a name, an empty
+                string is returned. >vim
+                        echo bufname("#")       " alternate buffer name
+                        echo bufname(3)         " name of buffer 3
+                        echo bufname("%")       " name of current buffer
+                        echo bufname("file2")   " name of buffer where "file2" matches.
 <
-
 bufnr([{buf} [, {create}]])                                            *bufnr()*
-		The result is the number of a buffer, as it is displayed by
-		the `:ls` command.  For the use of {buf}, see |bufname()|
-		above.
-		If the buffer doesn't exist, -1 is returned.  Or, if the
-		{create} argument is present and TRUE, a new, unlisted,
-		buffer is created and its number is returned.
-		bufnr("$") is the last buffer: >vim
-			let last_buffer = bufnr("$")
-<		The result is a Number, which is the highest buffer number
-		of existing buffers.  Note that not all buffers with a smaller
-		number necessarily exist, because ":bwipeout" may have removed
-		them.  Use bufexists() to test for the existence of a buffer.
+                The result is the number of a buffer, as it is displayed by
+                the `:ls` command.  For the use of {buf}, see |bufname()|
+                above.
+                If the buffer doesn't exist, -1 is returned.  Or, if the
+                {create} argument is present and TRUE, a new, unlisted,
+                buffer is created and its number is returned.
+                bufnr("$") is the last buffer: >vim
+                        let last_buffer = bufnr("$")
+<                The result is a Number, which is the highest buffer number
+                of existing buffers.  Note that not all buffers with a smaller
+                number necessarily exist, because ":bwipeout" may have removed
+                them.  Use bufexists() to test for the existence of a buffer.
 
 bufwinid({buf})                                                     *bufwinid()*
-		The result is a Number, which is the |window-ID| of the first
-		window associated with buffer {buf}.  For the use of {buf},
-		see |bufname()| above.  If buffer {buf} doesn't exist or
-		there is no such window, -1 is returned.  Example: >vim
+                The result is a Number, which is the |window-ID| of the first
+                window associated with buffer {buf}.  For the use of {buf},
+                see |bufname()| above.  If buffer {buf} doesn't exist or
+                there is no such window, -1 is returned.  Example: >vim
 
-			echo "A window containing buffer 1 is " .. (bufwinid(1))
+                        echo "A window containing buffer 1 is " .. (bufwinid(1))
 <
-		Only deals with the current tab page.  See |win_findbuf()| for
-		finding more.
+                Only deals with the current tab page.  See |win_findbuf()| for
+                finding more.
 
 bufwinnr({buf})                                                     *bufwinnr()*
-		Like |bufwinid()| but return the window number instead of the
-		|window-ID|.
-		If buffer {buf} doesn't exist or there is no such window, -1
-		is returned.  Example: >vim
+                Like |bufwinid()| but return the window number instead of the
+                |window-ID|.
+                If buffer {buf} doesn't exist or there is no such window, -1
+                is returned.  Example: >vim
 
-			echo "A window containing buffer 1 is " .. (bufwinnr(1))
+                        echo "A window containing buffer 1 is " .. (bufwinnr(1))
 
-<		The number can be used with |CTRL-W_w| and ":wincmd w"
-		|:wincmd|.
+<                The number can be used with |CTRL-W_w| and ":wincmd w"
+                |:wincmd|.
 
 byte2line({byte})                                                  *byte2line()*
-		Return the line number that contains the character at byte
-		count {byte} in the current buffer.  This includes the
-		end-of-line character, depending on the 'fileformat' option
-		for the current buffer.  The first character has byte count
-		one.
-		Also see |line2byte()|, |go| and |:goto|.
+                Return the line number that contains the character at byte
+                count {byte} in the current buffer.  This includes the
+                end-of-line character, depending on the 'fileformat' option
+                for the current buffer.  The first character has byte count
+                one.
+                Also see |line2byte()|, |go| and |:goto|.
 
-		Returns -1 if the {byte} value is invalid.
+                Returns -1 if the {byte} value is invalid.
 
 byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
-		Return byte index of the {nr}th character in the String
-		{expr}.  Use zero for the first character, it then returns
-		zero.
-		If there are no multibyte characters the returned value is
-		equal to {nr}.
-		Composing characters are not counted separately, their byte
-		length is added to the preceding base character.  See
-		|byteidxcomp()| below for counting composing characters
-		separately.
-		When {utf16} is present and TRUE, {nr} is used as the UTF-16
-		index in the String {expr} instead of as the character index.
-		The UTF-16 index is the index in the string when it is encoded
-		with 16-bit words.  If the specified UTF-16 index is in the
-		middle of a character (e.g. in a 4-byte character), then the
-		byte index of the first byte in the character is returned.
-		Refer to |string-offset-encoding| for more information.
-		Example : >vim
-			echo matchstr(str, ".", byteidx(str, 3))
-<		will display the fourth character.  Another way to do the
-		same: >vim
-			let s = strpart(str, byteidx(str, 3))
-			echo strpart(s, 0, byteidx(s, 1))
-<		Also see |strgetchar()| and |strcharpart()|.
+                Return byte index of the {nr}th character in the String
+                {expr}.  Use zero for the first character, it then returns
+                zero.
+                If there are no multibyte characters the returned value is
+                equal to {nr}.
+                Composing characters are not counted separately, their byte
+                length is added to the preceding base character.  See
+                |byteidxcomp()| below for counting composing characters
+                separately.
+                When {utf16} is present and TRUE, {nr} is used as the UTF-16
+                index in the String {expr} instead of as the character index.
+                The UTF-16 index is the index in the string when it is encoded
+                with 16-bit words.  If the specified UTF-16 index is in the
+                middle of a character (e.g. in a 4-byte character), then the
+                byte index of the first byte in the character is returned.
+                Refer to |string-offset-encoding| for more information.
+                Example : >vim
+                        echo matchstr(str, ".", byteidx(str, 3))
+<                will display the fourth character.  Another way to do the
+                same: >vim
+                        let s = strpart(str, byteidx(str, 3))
+                        echo strpart(s, 0, byteidx(s, 1))
+<                Also see |strgetchar()| and |strcharpart()|.
 
-		If there are less than {nr} characters -1 is returned.
-		If there are exactly {nr} characters the length of the string
-		in bytes is returned.
-		See |charidx()| and |utf16idx()| for getting the character and
-		UTF-16 index respectively from the byte index.
-		Examples: >vim
-			echo byteidx('a😊😊', 2)	" returns 5
-			echo byteidx('a😊😊', 2, 1)	" returns 1
-			echo byteidx('a😊😊', 3, 1)	" returns 5
+                If there are less than {nr} characters -1 is returned.
+                If there are exactly {nr} characters the length of the string
+                in bytes is returned.
+                See |charidx()| and |utf16idx()| for getting the character and
+                UTF-16 index respectively from the byte index.
+                Examples: >vim
+                        echo byteidx('a😊😊', 2)        " returns 5
+                        echo byteidx('a😊😊', 2, 1)     " returns 1
+                        echo byteidx('a😊😊', 3, 1)     " returns 5
 <
-
 byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
-		Like byteidx(), except that a composing character is counted
-		as a separate character.  Example: >vim
-			let s = 'e' .. nr2char(0x301)
-			echo byteidx(s, 1)
-			echo byteidxcomp(s, 1)
-			echo byteidxcomp(s, 2)
-<		The first and third echo result in 3 ('e' plus composing
-		character is 3 bytes), the second echo results in 1 ('e' is
-		one byte).
+                Like byteidx(), except that a composing character is counted
+                as a separate character.  Example: >vim
+                        let s = 'e' .. nr2char(0x301)
+                        echo byteidx(s, 1)
+                        echo byteidxcomp(s, 1)
+                        echo byteidxcomp(s, 2)
+<                The first and third echo result in 3 ('e' plus composing
+                character is 3 bytes), the second echo results in 1 ('e' is
+                one byte).
 
 call({func}, {arglist} [, {dict}])                                 *call()* *E699*
-		Call function {func} with the items in |List| {arglist} as
-		arguments.
-		{func} can either be a |Funcref| or the name of a function.
-		a:firstline and a:lastline are set to the cursor line.
-		Returns the return value of the called function.
-		{dict} is for functions with the "dict" attribute.  It will be
-		used to set the local variable "self". |Dictionary-function|
+                Call function {func} with the items in |List| {arglist} as
+                arguments.
+                {func} can either be a |Funcref| or the name of a function.
+                a:firstline and a:lastline are set to the cursor line.
+                Returns the return value of the called function.
+                {dict} is for functions with the "dict" attribute.  It will be
+                used to set the local variable "self". |Dictionary-function|
 
 ceil({expr})                                                            *ceil()*
-		Return the smallest integral value greater than or equal to
-		{expr} as a |Float| (round up).
-		{expr} must evaluate to a |Float| or a |Number|.
-		Examples: >vim
-			echo ceil(1.456)
-<			2.0  >vim
-			echo ceil(-5.456)
-<			-5.0  >vim
-			echo ceil(4.0)
-<			4.0
+                Return the smallest integral value greater than or equal to
+                {expr} as a |Float| (round up).
+                {expr} must evaluate to a |Float| or a |Number|.
+                Examples: >vim
+                        echo ceil(1.456)
+<                        2.0  >vim
+                        echo ceil(-5.456)
+<                        -5.0  >vim
+                        echo ceil(4.0)
+<                        4.0
 
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
 chanclose({id} [, {stream}])                                       *chanclose()*
-		Close a channel or a specific stream associated with it.
-		For a job, {stream} can be one of "stdin", "stdout",
-		"stderr" or "rpc" (closes stdin/stdout for a job started
-		with `"rpc":v:true`) If {stream} is omitted, all streams
-		are closed. If the channel is a pty, this will then close the
-		pty master, sending SIGHUP to the job process.
-		For a socket, there is only one stream, and {stream} should be
-		omitted.
+                Close a channel or a specific stream associated with it.
+                For a job, {stream} can be one of "stdin", "stdout",
+                "stderr" or "rpc" (closes stdin/stdout for a job started
+                with `"rpc":v:true`) If {stream} is omitted, all streams
+                are closed. If the channel is a pty, this will then close the
+                pty master, sending SIGHUP to the job process.
+                For a socket, there is only one stream, and {stream} should be
+                omitted.
 
 changenr()                                                          *changenr()*
-		Return the number of the most recent change.  This is the same
-		number as what is displayed with |:undolist| and can be used
-		with the |:undo| command.
-		When a change was made it is the number of that change.  After
-		redo it is the number of the redone change.  After undo it is
-		one less than the number of the undone change.
-		Returns 0 if the undo list is empty.
+                Return the number of the most recent change.  This is the same
+                number as what is displayed with |:undolist| and can be used
+                with the |:undo| command.
+                When a change was made it is the number of that change.  After
+                redo it is the number of the redone change.  After undo it is
+                one less than the number of the undone change.
+                Returns 0 if the undo list is empty.
 
 chansend({id}, {data})                                              *chansend()*
-		Send data to channel {id}. For a job, it writes it to the
-		stdin of the process. For the stdio channel |channel-stdio|,
-		it writes to Nvim's stdout.  Returns the number of bytes
-		written if the write succeeded, 0 otherwise.
-		See |channel-bytes| for more information.
+                Send data to channel {id}. For a job, it writes it to the
+                stdin of the process. For the stdio channel |channel-stdio|,
+                it writes to Nvim's stdout.  Returns the number of bytes
+                written if the write succeeded, 0 otherwise.
+                See |channel-bytes| for more information.
 
-		{data} may be a string, string convertible, |Blob|, or a list.
-		If {data} is a list, the items will be joined by newlines; any
-		newlines in an item will be sent as NUL. To send a final
-		newline, include a final empty string. Example: >vim
-			call chansend(id, ["abc", "123\n456", ""])
-<		will send "abc<NL>123<NUL>456<NL>".
+                {data} may be a string, string convertible, |Blob|, or a list.
+                If {data} is a list, the items will be joined by newlines; any
+                newlines in an item will be sent as NUL. To send a final
+                newline, include a final empty string. Example: >vim
+                        call chansend(id, ["abc", "123\n456", ""])
+<                will send "abc<NL>123<NUL>456<NL>".
 
-		chansend() writes raw data, not RPC messages.  If the channel
-		was created with `"rpc":v:true` then the channel expects RPC
-		messages, use |rpcnotify()| and |rpcrequest()| instead.
+                chansend() writes raw data, not RPC messages.  If the channel
+                was created with `"rpc":v:true` then the channel expects RPC
+                messages, use |rpcnotify()| and |rpcrequest()| instead.
 
 char2nr({string} [, {utf8}])                                         *char2nr()*
-		Return Number value of the first char in {string}.
-		Examples: >vim
-			echo char2nr(" ")	" returns 32
-			echo char2nr("ABC")	" returns 65
-			echo char2nr("á")	" returns 225
-			echo char2nr("á"[0])	" returns 195
-			echo char2nr("\<M-x>")	" returns 128
-<		Non-ASCII characters are always treated as UTF-8 characters.
-		{utf8} is ignored, it exists only for backwards-compatibility.
-		A combining character is a separate character.
-		|nr2char()| does the opposite.
+                Return Number value of the first char in {string}.
+                Examples: >vim
+                        echo char2nr(" ")       " returns 32
+                        echo char2nr("ABC")     " returns 65
+                        echo char2nr("á")       " returns 225
+                        echo char2nr("á"[0])    " returns 195
+                        echo char2nr("\<M-x>")  " returns 128
+<                Non-ASCII characters are always treated as UTF-8 characters.
+                {utf8} is ignored, it exists only for backwards-compatibility.
+                A combining character is a separate character.
+                |nr2char()| does the opposite.
 
-		Returns 0 if {string} is not a |String|.
+                Returns 0 if {string} is not a |String|.
 
 charclass({string})                                                *charclass()*
-		Return the character class of the first character in {string}.
-		The character class is one of:
-			0	blank
-			1	punctuation
-			2	word character
-			3	emoji
-			other	specific Unicode class
-		The class is used in patterns and word motions.
-		Returns 0 if {string} is not a |String|.
+                Return the character class of the first character in {string}.
+                The character class is one of:
+                        0       blank
+                        1       punctuation
+                        2       word character
+                        3       emoji
+                        other   specific Unicode class
+                The class is used in patterns and word motions.
+                Returns 0 if {string} is not a |String|.
 
 charcol({expr} [, {winid}])                                          *charcol()*
-		Same as |col()| but returns the character index of the column
-		position given with {expr} instead of the byte position.
+                Same as |col()| but returns the character index of the column
+                position given with {expr} instead of the byte position.
 
-		Example:
-		With the cursor on '세' in line 5 with text "여보세요": >vim
-			echo charcol('.')	" returns 3
-			echo col('.')		" returns 7
+                Example:
+                With the cursor on '세' in line 5 with text "여보세요": >vim
+                        echo charcol('.')       " returns 3
+                        echo col('.')           " returns 7
 
 charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
-		Return the character index of the byte at {idx} in {string}.
-		The index of the first character is zero.
-		If there are no multibyte characters the returned value is
-		equal to {idx}.
+                Return the character index of the byte at {idx} in {string}.
+                The index of the first character is zero.
+                If there are no multibyte characters the returned value is
+                equal to {idx}.
 
-		When {countcc} is omitted or |FALSE|, then composing characters
-		are not counted separately, their byte length is added to the
-		preceding base character.
-		When {countcc} is |TRUE|, then composing characters are
-		counted as separate characters.
+                When {countcc} is omitted or |FALSE|, then composing characters
+                are not counted separately, their byte length is added to the
+                preceding base character.
+                When {countcc} is |TRUE|, then composing characters are
+                counted as separate characters.
 
-		When {utf16} is present and TRUE, {idx} is used as the UTF-16
-		index in the String {expr} instead of as the byte index.
+                When {utf16} is present and TRUE, {idx} is used as the UTF-16
+                index in the String {expr} instead of as the byte index.
 
-		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes. If there are exactly {idx} bytes the length
-		of the string in characters is returned.
+                Returns -1 if the arguments are invalid or if there are less
+                than {idx} bytes. If there are exactly {idx} bytes the length
+                of the string in characters is returned.
 
-		An error is given and -1 is returned if the first argument is
-		not a string, the second argument is not a number or when the
-		third argument is present and is not zero or one.
+                An error is given and -1 is returned if the first argument is
+                not a string, the second argument is not a number or when the
+                third argument is present and is not zero or one.
 
-		See |byteidx()| and |byteidxcomp()| for getting the byte index
-		from the character index and |utf16idx()| for getting the
-		UTF-16 index from the character index.
-		Refer to |string-offset-encoding| for more information.
-		Examples: >vim
-			echo charidx('áb́ć', 3)		" returns 1
-			echo charidx('áb́ć', 6, 1)	" returns 4
-			echo charidx('áb́ć', 16)		" returns -1
-			echo charidx('a😊😊', 4, 0, 1)	" returns 2
+                See |byteidx()| and |byteidxcomp()| for getting the byte index
+                from the character index and |utf16idx()| for getting the
+                UTF-16 index from the character index.
+                Refer to |string-offset-encoding| for more information.
+                Examples: >vim
+                        echo charidx('áb́ć', 3)          " returns 1
+                        echo charidx('áb́ć', 6, 1)       " returns 4
+                        echo charidx('áb́ć', 16)         " returns -1
+                        echo charidx('a😊😊', 4, 0, 1)  " returns 2
 <
-
 chdir({dir})                                                           *chdir()*
-		Change the current working directory to {dir}.  The scope of
-		the directory change depends on the directory of the current
-		window:
-			- If the current window has a window-local directory
-			  (|:lcd|), then changes the window local directory.
-			- Otherwise, if the current tabpage has a local
-			  directory (|:tcd|) then changes the tabpage local
-			  directory.
-			- Otherwise, changes the global directory.
-		{dir} must be a String.
-		If successful, returns the previous working directory.  Pass
-		this to another chdir() to restore the directory.
-		On failure, returns an empty string.
+                Change the current working directory to {dir}.  The scope of
+                the directory change depends on the directory of the current
+                window:
+                        - If the current window has a window-local directory
+                          (|:lcd|), then changes the window local directory.
+                        - Otherwise, if the current tabpage has a local
+                          directory (|:tcd|) then changes the tabpage local
+                          directory.
+                        - Otherwise, changes the global directory.
+                {dir} must be a String.
+                If successful, returns the previous working directory.  Pass
+                this to another chdir() to restore the directory.
+                On failure, returns an empty string.
 
-		Example: >vim
-			let save_dir = chdir(newdir)
-			if save_dir != ""
-			   " ... do some work
-			   call chdir(save_dir)
-			endif
+                Example: >vim
+                        let save_dir = chdir(newdir)
+                        if save_dir != ""
+                           " ... do some work
+                           call chdir(save_dir)
+                        endif
 
 cindent({lnum})                                                      *cindent()*
-		Get the amount of indent for line {lnum} according the C
-		indenting rules, as with 'cindent'.
-		The indent is counted in spaces, the value of 'tabstop' is
-		relevant.  {lnum} is used just like in |getline()|.
-		When {lnum} is invalid -1 is returned.
-		See |C-indenting|.
+                Get the amount of indent for line {lnum} according the C
+                indenting rules, as with 'cindent'.
+                The indent is counted in spaces, the value of 'tabstop' is
+                relevant.  {lnum} is used just like in |getline()|.
+                When {lnum} is invalid -1 is returned.
+                See |C-indenting|.
 
 clearmatches([{win}])                                           *clearmatches()*
-		Clears all matches previously defined for the current window
-		by |matchadd()| and the |:match| commands.
-		If {win} is specified, use the window with this number or
-		window ID instead of the current window.
+                Clears all matches previously defined for the current window
+                by |matchadd()| and the |:match| commands.
+                If {win} is specified, use the window with this number or
+                window ID instead of the current window.
 
 col({expr} [, {winid}])                                                  *col()*
-		The result is a Number, which is the byte index of the column
-		position given with {expr}.  The accepted positions are:
-		    .	    the cursor position
-		    $	    the end of the cursor line (the result is the
-			    number of bytes in the cursor line plus one)
-		    'x	    position of mark x (if the mark is not set, 0 is
-			    returned)
-		    v       In Visual mode: the start of the Visual area (the
-			    cursor is the end).  When not in Visual mode
-			    returns the cursor position.  Differs from |'<| in
-			    that it's updated right away.
-		Additionally {expr} can be [lnum, col]: a |List| with the line
-		and column number. Most useful when the column is "$", to get
-		the last column of a specific line.  When "lnum" or "col" is
-		out of range then col() returns zero.
-		With the optional {winid} argument the values are obtained for
-		that window instead of the current window.
-		To get the line number use |line()|.  To get both use
-		|getpos()|.
-		For the screen column position use |virtcol()|.  For the
-		character position use |charcol()|.
-		Note that only marks in the current file can be used.
-		Examples: >vim
-			echo col(".")			" column of cursor
-			echo col("$")			" length of cursor line plus one
-			echo col("'t")			" column of mark t
-			echo col("'" .. markname)	" column of mark markname
-<		The first column is 1.  Returns 0 if {expr} is invalid or when
-		the window with ID {winid} is not found.
-		For an uppercase mark the column may actually be in another
-		buffer.
-		For the cursor position, when 'virtualedit' is active, the
-		column is one higher if the cursor is after the end of the
-		line.  Also, when using a <Cmd> mapping the cursor isn't
-		moved, this can be used to obtain the column in Insert mode: >vim
-			imap <F2> <Cmd>echo col(".").."\n"<CR>
+                The result is a Number, which is the byte index of the column
+                position given with {expr}.  The accepted positions are:
+                    .       the cursor position
+                    $       the end of the cursor line (the result is the
+                            number of bytes in the cursor line plus one)
+                    'x      position of mark x (if the mark is not set, 0 is
+                            returned)
+                    v       In Visual mode: the start of the Visual area (the
+                            cursor is the end).  When not in Visual mode
+                            returns the cursor position.  Differs from |'<| in
+                            that it's updated right away.
+                Additionally {expr} can be [lnum, col]: a |List| with the line
+                and column number. Most useful when the column is "$", to get
+                the last column of a specific line.  When "lnum" or "col" is
+                out of range then col() returns zero.
+                With the optional {winid} argument the values are obtained for
+                that window instead of the current window.
+                To get the line number use |line()|.  To get both use
+                |getpos()|.
+                For the screen column position use |virtcol()|.  For the
+                character position use |charcol()|.
+                Note that only marks in the current file can be used.
+                Examples: >vim
+                        echo col(".")                   " column of cursor
+                        echo col("$")                   " length of cursor line plus one
+                        echo col("'t")                  " column of mark t
+                        echo col("'" .. markname)       " column of mark markname
+<                The first column is 1.  Returns 0 if {expr} is invalid or when
+                the window with ID {winid} is not found.
+                For an uppercase mark the column may actually be in another
+                buffer.
+                For the cursor position, when 'virtualedit' is active, the
+                column is one higher if the cursor is after the end of the
+                line.  Also, when using a <Cmd> mapping the cursor isn't
+                moved, this can be used to obtain the column in Insert mode: >vim
+                        imap <F2> <Cmd>echo col(".").."\n"<CR>
 
 complete({startcol}, {matches})                                *complete()* *E785*
-		Set the matches for Insert mode completion.
-		Can only be used in Insert mode.  You need to use a mapping
-		with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
-		or with an expression mapping.
-		{startcol} is the byte offset in the line where the completed
-		text start.  The text up to the cursor is the original text
-		that will be replaced by the matches.  Use col('.') for an
-		empty string.  "col('.') - 1" will replace one character by a
-		match.
-		{matches} must be a |List|.  Each |List| item is one match.
-		See |complete-items| for the kind of items that are possible.
-		"longest" in 'completeopt' is ignored.
-		Note that the after calling this function you need to avoid
-		inserting anything that would cause completion to stop.
-		The match can be selected with CTRL-N and CTRL-P as usual with
-		Insert mode completion.  The popup menu will appear if
-		specified, see |ins-completion-menu|.
-		Example: >vim
-			inoremap <F5> <C-R>=ListMonths()<CR>
+                Set the matches for Insert mode completion.
+                Can only be used in Insert mode.  You need to use a mapping
+                with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
+                or with an expression mapping.
+                {startcol} is the byte offset in the line where the completed
+                text start.  The text up to the cursor is the original text
+                that will be replaced by the matches.  Use col('.') for an
+                empty string.  "col('.') - 1" will replace one character by a
+                match.
+                {matches} must be a |List|.  Each |List| item is one match.
+                See |complete-items| for the kind of items that are possible.
+                "longest" in 'completeopt' is ignored.
+                Note that the after calling this function you need to avoid
+                inserting anything that would cause completion to stop.
+                The match can be selected with CTRL-N and CTRL-P as usual with
+                Insert mode completion.  The popup menu will appear if
+                specified, see |ins-completion-menu|.
+                Example: >vim
+                        inoremap <F5> <C-R>=ListMonths()<CR>
 
-			func ListMonths()
-			  call complete(col('.'), ['January', 'February', 'March',
-			    \ 'April', 'May', 'June', 'July', 'August', 'September',
-			    \ 'October', 'November', 'December'])
-			  return ''
-			endfunc
-<		This isn't very useful, but it shows how it works.  Note that
-		an empty string is returned to avoid a zero being inserted.
+                        func ListMonths()
+                          call complete(col('.'), ['January', 'February', 'March',
+                            \ 'April', 'May', 'June', 'July', 'August', 'September',
+                            \ 'October', 'November', 'December'])
+                          return ''
+                        endfunc
+<                This isn't very useful, but it shows how it works.  Note that
+                an empty string is returned to avoid a zero being inserted.
 
 complete_add({expr})                                            *complete_add()*
-		Add {expr} to the list of matches.  Only to be used by the
-		function specified with the 'completefunc' option.
-		Returns 0 for failure (empty string or out of memory),
-		1 when the match was added, 2 when the match was already in
-		the list.
-		See |complete-functions| for an explanation of {expr}.  It is
-		the same as one item in the list that 'omnifunc' would return.
+                Add {expr} to the list of matches.  Only to be used by the
+                function specified with the 'completefunc' option.
+                Returns 0 for failure (empty string or out of memory),
+                1 when the match was added, 2 when the match was already in
+                the list.
+                See |complete-functions| for an explanation of {expr}.  It is
+                the same as one item in the list that 'omnifunc' would return.
 
 complete_check()                                              *complete_check()*
-		Check for a key typed while looking for completion matches.
-		This is to be used when looking for matches takes some time.
-		Returns |TRUE| when searching for matches is to be aborted,
-		zero otherwise.
-		Only to be used by the function specified with the
-		'completefunc' option.
+                Check for a key typed while looking for completion matches.
+                This is to be used when looking for matches takes some time.
+                Returns |TRUE| when searching for matches is to be aborted,
+                zero otherwise.
+                Only to be used by the function specified with the
+                'completefunc' option.
 
 complete_info([{what}])                                        *complete_info()*
-		Returns a |Dictionary| with information about Insert mode
-		completion.  See |ins-completion|.
-		The items are:
-		   mode		Current completion mode name string.
-				See |complete_info_mode| for the values.
-		   pum_visible	|TRUE| if popup menu is visible.
-				See |pumvisible()|.
-		   items	List of completion matches.  Each item is a
-				dictionary containing the entries "word",
-				"abbr", "menu", "kind", "info" and "user_data".
-				See |complete-items|.
-		   selected	Selected item index.  First index is zero.
-				Index is -1 if no item is selected (showing
-				typed text only, or the last completion after
-				no item is selected when using the <Up> or
-				<Down> keys)
-		   inserted	Inserted string. [NOT IMPLEMENTED YET]
-		   preview_winid     Info floating preview window id.
-		   preview_bufnr     Info floating preview buffer id.
+                Returns a |Dictionary| with information about Insert mode
+                completion.  See |ins-completion|.
+                The items are:
+                   mode         Current completion mode name string.
+                                See |complete_info_mode| for the values.
+                   pum_visible  |TRUE| if popup menu is visible.
+                                See |pumvisible()|.
+                   items        List of completion matches.  Each item is a
+                                dictionary containing the entries "word",
+                                "abbr", "menu", "kind", "info" and "user_data".
+                                See |complete-items|.
+                   selected     Selected item index.  First index is zero.
+                                Index is -1 if no item is selected (showing
+                                typed text only, or the last completion after
+                                no item is selected when using the <Up> or
+                                <Down> keys)
+                   inserted     Inserted string. [NOT IMPLEMENTED YET]
+                   preview_winid     Info floating preview window id.
+                   preview_bufnr     Info floating preview buffer id.
 
-							*complete_info_mode*
-		mode values are:
-		   ""		     Not in completion mode
-		   "keyword"	     Keyword completion |i_CTRL-X_CTRL-N|
-		   "ctrl_x"	     Just pressed CTRL-X |i_CTRL-X|
-		   "scroll"	     Scrolling with |i_CTRL-X_CTRL-E| or
-				     |i_CTRL-X_CTRL-Y|
-		   "whole_line"	     Whole lines |i_CTRL-X_CTRL-L|
-		   "files"	     File names |i_CTRL-X_CTRL-F|
-		   "tags"	     Tags |i_CTRL-X_CTRL-]|
-		   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
-		   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
-		   "dictionary"	     Dictionary |i_CTRL-X_CTRL-K|
-		   "thesaurus"	     Thesaurus |i_CTRL-X_CTRL-T|
-		   "cmdline"	     Vim Command line |i_CTRL-X_CTRL-V|
-		   "function"	     User defined completion |i_CTRL-X_CTRL-U|
-		   "omni"	     Omni completion |i_CTRL-X_CTRL-O|
-		   "spell"	     Spelling suggestions |i_CTRL-X_s|
-		   "eval"	     |complete()| completion
-		   "unknown"	     Other internal modes
+                                                        *complete_info_mode*
+                mode values are:
+                   ""                Not in completion mode
+                   "keyword"         Keyword completion |i_CTRL-X_CTRL-N|
+                   "ctrl_x"          Just pressed CTRL-X |i_CTRL-X|
+                   "scroll"          Scrolling with |i_CTRL-X_CTRL-E| or
+                                     |i_CTRL-X_CTRL-Y|
+                   "whole_line"      Whole lines |i_CTRL-X_CTRL-L|
+                   "files"           File names |i_CTRL-X_CTRL-F|
+                   "tags"            Tags |i_CTRL-X_CTRL-]|
+                   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
+                   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
+                   "dictionary"      Dictionary |i_CTRL-X_CTRL-K|
+                   "thesaurus"       Thesaurus |i_CTRL-X_CTRL-T|
+                   "cmdline"         Vim Command line |i_CTRL-X_CTRL-V|
+                   "function"        User defined completion |i_CTRL-X_CTRL-U|
+                   "omni"            Omni completion |i_CTRL-X_CTRL-O|
+                   "spell"           Spelling suggestions |i_CTRL-X_s|
+                   "eval"            |complete()| completion
+                   "unknown"         Other internal modes
 
-		If the optional {what} list argument is supplied, then only
-		the items listed in {what} are returned.  Unsupported items in
-		{what} are silently ignored.
+                If the optional {what} list argument is supplied, then only
+                the items listed in {what} are returned.  Unsupported items in
+                {what} are silently ignored.
 
-		To get the position and size of the popup menu, see
-		|pum_getpos()|. It's also available in |v:event| during the
-		|CompleteChanged| event.
+                To get the position and size of the popup menu, see
+                |pum_getpos()|. It's also available in |v:event| during the
+                |CompleteChanged| event.
 
-		Returns an empty |Dictionary| on error.
+                Returns an empty |Dictionary| on error.
 
-		Examples: >vim
-			" Get all items
-			call complete_info()
-			" Get only 'mode'
-			call complete_info(['mode'])
-			" Get only 'mode' and 'pum_visible'
-			call complete_info(['mode', 'pum_visible'])
+                Examples: >vim
+                        " Get all items
+                        call complete_info()
+                        " Get only 'mode'
+                        call complete_info(['mode'])
+                        " Get only 'mode' and 'pum_visible'
+                        call complete_info(['mode', 'pum_visible'])
 
 confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
-		confirm() offers the user a dialog, from which a choice can be
-		made.  It returns the number of the choice.  For the first
-		choice this is 1.
+                confirm() offers the user a dialog, from which a choice can be
+                made.  It returns the number of the choice.  For the first
+                choice this is 1.
 
-		{msg} is displayed in a dialog with {choices} as the
-		alternatives.  When {choices} is missing or empty, "&OK" is
-		used (and translated).
-		{msg} is a String, use '\n' to include a newline.  Only on
-		some systems the string is wrapped when it doesn't fit.
+                {msg} is displayed in a dialog with {choices} as the
+                alternatives.  When {choices} is missing or empty, "&OK" is
+                used (and translated).
+                {msg} is a String, use '\n' to include a newline.  Only on
+                some systems the string is wrapped when it doesn't fit.
 
-		{choices} is a String, with the individual choices separated
-		by '\n', e.g. >vim
-			confirm("Save changes?", "&Yes\n&No\n&Cancel")
-<		The letter after the '&' is the shortcut key for that choice.
-		Thus you can type 'c' to select "Cancel".  The shortcut does
-		not need to be the first letter: >vim
-			confirm("file has been modified", "&Save\nSave &All")
-<		For the console, the first letter of each choice is used as
-		the default shortcut key.  Case is ignored.
+                {choices} is a String, with the individual choices separated
+                by '\n', e.g. >vim
+                        confirm("Save changes?", "&Yes\n&No\n&Cancel")
+<                The letter after the '&' is the shortcut key for that choice.
+                Thus you can type 'c' to select "Cancel".  The shortcut does
+                not need to be the first letter: >vim
+                        confirm("file has been modified", "&Save\nSave &All")
+<                For the console, the first letter of each choice is used as
+                the default shortcut key.  Case is ignored.
 
-		The optional {type} String argument gives the type of dialog.
-		It can be one of these values: "Error", "Question", "Info",
-		"Warning" or "Generic".  Only the first character is relevant.
-		When {type} is omitted, "Generic" is used.
+                The optional {type} String argument gives the type of dialog.
+                It can be one of these values: "Error", "Question", "Info",
+                "Warning" or "Generic".  Only the first character is relevant.
+                When {type} is omitted, "Generic" is used.
 
-		The optional {type} argument gives the type of dialog.  This
-		is only used for the icon of the Win32 GUI.  It can be one of
-		these values: "Error", "Question", "Info", "Warning" or
-		"Generic".  Only the first character is relevant.
-		When {type} is omitted, "Generic" is used.
+                The optional {type} argument gives the type of dialog.  This
+                is only used for the icon of the Win32 GUI.  It can be one of
+                these values: "Error", "Question", "Info", "Warning" or
+                "Generic".  Only the first character is relevant.
+                When {type} is omitted, "Generic" is used.
 
-		If the user aborts the dialog by pressing <Esc>, CTRL-C,
-		or another valid interrupt key, confirm() returns 0.
+                If the user aborts the dialog by pressing <Esc>, CTRL-C,
+                or another valid interrupt key, confirm() returns 0.
 
-		An example: >vim
-		   let choice = confirm("What do you want?",
-					\ "&Apples\n&Oranges\n&Bananas", 2)
-		   if choice == 0
-			echo "make up your mind!"
-		   elseif choice == 3
-			echo "tasteful"
-		   else
-			echo "I prefer bananas myself."
-		   endif
-<		In a GUI dialog, buttons are used.  The layout of the buttons
-		depends on the 'v' flag in 'guioptions'.  If it is included,
-		the buttons are always put vertically.  Otherwise,  confirm()
-		tries to put the buttons in one horizontal line.  If they
-		don't fit, a vertical layout is used anyway.  For some systems
-		the horizontal layout is always used.
+                An example: >vim
+                   let choice = confirm("What do you want?",
+                                        \ "&Apples\n&Oranges\n&Bananas", 2)
+                   if choice == 0
+                        echo "make up your mind!"
+                   elseif choice == 3
+                        echo "tasteful"
+                   else
+                        echo "I prefer bananas myself."
+                   endif
+<                In a GUI dialog, buttons are used.  The layout of the buttons
+                depends on the 'v' flag in 'guioptions'.  If it is included,
+                the buttons are always put vertically.  Otherwise,  confirm()
+                tries to put the buttons in one horizontal line.  If they
+                don't fit, a vertical layout is used anyway.  For some systems
+                the horizontal layout is always used.
 
 copy({expr})                                                            *copy()*
-		Make a copy of {expr}.  For Numbers and Strings this isn't
-		different from using {expr} directly.
-		When {expr} is a |List| a shallow copy is created.  This means
-		that the original |List| can be changed without changing the
-		copy, and vice versa.  But the items are identical, thus
-		changing an item changes the contents of both |Lists|.
-		A |Dictionary| is copied in a similar way as a |List|.
-		Also see |deepcopy()|.
+                Make a copy of {expr}.  For Numbers and Strings this isn't
+                different from using {expr} directly.
+                When {expr} is a |List| a shallow copy is created.  This means
+                that the original |List| can be changed without changing the
+                copy, and vice versa.  But the items are identical, thus
+                changing an item changes the contents of both |Lists|.
+                A |Dictionary| is copied in a similar way as a |List|.
+                Also see |deepcopy()|.
 
 cos({expr})                                                              *cos()*
-		Return the cosine of {expr}, measured in radians, as a |Float|.
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo cos(100)
-<			0.862319 >vim
-			echo cos(-4.01)
-<			-0.646043
+                Return the cosine of {expr}, measured in radians, as a |Float|.
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo cos(100)
+<                        0.862319 >vim
+                        echo cos(-4.01)
+<                        -0.646043
 
 cosh({expr})                                                            *cosh()*
-		Return the hyperbolic cosine of {expr} as a |Float| in the range
-		[1, inf].
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo cosh(0.5)
-<			1.127626 >vim
-			echo cosh(-0.5)
-<			-1.127626
+                Return the hyperbolic cosine of {expr} as a |Float| in the range
+                [1, inf].
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo cosh(0.5)
+<                        1.127626 >vim
+                        echo cosh(-0.5)
+<                        -1.127626
 
 count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E706*
-		Return the number of times an item with value {expr} appears
-		in |String|, |List| or |Dictionary| {comp}.
+                Return the number of times an item with value {expr} appears
+                in |String|, |List| or |Dictionary| {comp}.
 
-		If {start} is given then start with the item with this index.
-		{start} can only be used with a |List|.
+                If {start} is given then start with the item with this index.
+                {start} can only be used with a |List|.
 
-		When {ic} is given and it's |TRUE| then case is ignored.
+                When {ic} is given and it's |TRUE| then case is ignored.
 
-		When {comp} is a string then the number of not overlapping
-		occurrences of {expr} is returned. Zero is returned when
-		{expr} is an empty string.
+                When {comp} is a string then the number of not overlapping
+                occurrences of {expr} is returned. Zero is returned when
+                {expr} is an empty string.
 
 ctxget([{index}])                                                     *ctxget()*
-		Returns a |Dictionary| representing the |context| at {index}
-		from the top of the |context-stack| (see |context-dict|).
-		If {index} is not given, it is assumed to be 0 (i.e.: top).
+                Returns a |Dictionary| representing the |context| at {index}
+                from the top of the |context-stack| (see |context-dict|).
+                If {index} is not given, it is assumed to be 0 (i.e.: top).
 
 ctxpop()                                                              *ctxpop()*
-		Pops and restores the |context| at the top of the
-		|context-stack|.
+                Pops and restores the |context| at the top of the
+                |context-stack|.
 
 ctxpush([{types}])                                                   *ctxpush()*
-		Pushes the current editor state (|context|) on the
-		|context-stack|.
-		If {types} is given and is a |List| of |String|s, it specifies
-		which |context-types| to include in the pushed context.
-		Otherwise, all context types are included.
+                Pushes the current editor state (|context|) on the
+                |context-stack|.
+                If {types} is given and is a |List| of |String|s, it specifies
+                which |context-types| to include in the pushed context.
+                Otherwise, all context types are included.
 
 ctxset({context} [, {index}])                                         *ctxset()*
-		Sets the |context| at {index} from the top of the
-		|context-stack| to that represented by {context}.
-		{context} is a Dictionary with context data (|context-dict|).
-		If {index} is not given, it is assumed to be 0 (i.e.: top).
+                Sets the |context| at {index} from the top of the
+                |context-stack| to that represented by {context}.
+                {context} is a Dictionary with context data (|context-dict|).
+                If {index} is not given, it is assumed to be 0 (i.e.: top).
 
 ctxsize()                                                            *ctxsize()*
-		Returns the size of the |context-stack|.
+                Returns the size of the |context-stack|.
 
 cursor({lnum}, {col} [, {off}])
 cursor({list})                                                        *cursor()*
-		Positions the cursor at the column (byte count) {col} in the
-		line {lnum}.  The first column is one.
+                Positions the cursor at the column (byte count) {col} in the
+                line {lnum}.  The first column is one.
 
-		When there is one argument {list} this is used as a |List|
-		with two, three or four item:
-			[{lnum}, {col}]
-			[{lnum}, {col}, {off}]
-			[{lnum}, {col}, {off}, {curswant}]
-		This is like the return value of |getpos()| or |getcurpos()|,
-		but without the first item.
+                When there is one argument {list} this is used as a |List|
+                with two, three or four item:
+                        [{lnum}, {col}]
+                        [{lnum}, {col}, {off}]
+                        [{lnum}, {col}, {off}, {curswant}]
+                This is like the return value of |getpos()| or |getcurpos()|,
+                but without the first item.
 
-		To position the cursor using {col} as the character count, use
-		|setcursorcharpos()|.
+                To position the cursor using {col} as the character count, use
+                |setcursorcharpos()|.
 
-		Does not change the jumplist.
-		{lnum} is used like with |getline()|, except that if {lnum} is
-		zero, the cursor will stay in the current line.
-		If {lnum} is greater than the number of lines in the buffer,
-		the cursor will be positioned at the last line in the buffer.
-		If {col} is greater than the number of bytes in the line,
-		the cursor will be positioned at the last character in the
-		line.
-		If {col} is zero, the cursor will stay in the current column.
-		If {curswant} is given it is used to set the preferred column
-		for vertical movement.  Otherwise {col} is used.
+                Does not change the jumplist.
+                {lnum} is used like with |getline()|, except that if {lnum} is
+                zero, the cursor will stay in the current line.
+                If {lnum} is greater than the number of lines in the buffer,
+                the cursor will be positioned at the last line in the buffer.
+                If {col} is greater than the number of bytes in the line,
+                the cursor will be positioned at the last character in the
+                line.
+                If {col} is zero, the cursor will stay in the current column.
+                If {curswant} is given it is used to set the preferred column
+                for vertical movement.  Otherwise {col} is used.
 
-		When 'virtualedit' is used {off} specifies the offset in
-		screen columns from the start of the character.  E.g., a
-		position within a <Tab> or after the last character.
-		Returns 0 when the position could be set, -1 otherwise.
+                When 'virtualedit' is used {off} specifies the offset in
+                screen columns from the start of the character.  E.g., a
+                position within a <Tab> or after the last character.
+                Returns 0 when the position could be set, -1 otherwise.
 
 debugbreak({pid})                                                 *debugbreak()*
-		Specifically used to interrupt a program being debugged.  It
-		will cause process {pid} to get a SIGTRAP.  Behavior for other
-		processes is undefined. See |terminal-debug|.
-		(Sends a SIGINT to a process {pid} other than MS-Windows)
+                Specifically used to interrupt a program being debugged.  It
+                will cause process {pid} to get a SIGTRAP.  Behavior for other
+                processes is undefined. See |terminal-debug|.
+                (Sends a SIGINT to a process {pid} other than MS-Windows)
 
-		Returns |TRUE| if successfully interrupted the program.
-		Otherwise returns |FALSE|.
+                Returns |TRUE| if successfully interrupted the program.
+                Otherwise returns |FALSE|.
 
 deepcopy({expr} [, {noref}])                                   *deepcopy()* *E698*
-		Make a copy of {expr}.  For Numbers and Strings this isn't
-		different from using {expr} directly.
-		When {expr} is a |List| a full copy is created.  This means
-		that the original |List| can be changed without changing the
-		copy, and vice versa.  When an item is a |List|, a copy for it
-		is made, recursively.  Thus changing an item in the copy does
-		not change the contents of the original |List|.
+                Make a copy of {expr}.  For Numbers and Strings this isn't
+                different from using {expr} directly.
+                When {expr} is a |List| a full copy is created.  This means
+                that the original |List| can be changed without changing the
+                copy, and vice versa.  When an item is a |List|, a copy for it
+                is made, recursively.  Thus changing an item in the copy does
+                not change the contents of the original |List|.
 
-		When {noref} is omitted or zero a contained |List| or
-		|Dictionary| is only copied once.  All references point to
-		this single copy.  With {noref} set to 1 every occurrence of a
-		|List| or |Dictionary| results in a new copy.  This also means
-		that a cyclic reference causes deepcopy() to fail.
-								*E724*
-		Nesting is possible up to 100 levels.  When there is an item
-		that refers back to a higher level making a deep copy with
-		{noref} set to 1 will fail.
-		Also see |copy()|.
+                When {noref} is omitted or zero a contained |List| or
+                |Dictionary| is only copied once.  All references point to
+                this single copy.  With {noref} set to 1 every occurrence of a
+                |List| or |Dictionary| results in a new copy.  This also means
+                that a cyclic reference causes deepcopy() to fail.
+                                                                *E724*
+                Nesting is possible up to 100 levels.  When there is an item
+                that refers back to a higher level making a deep copy with
+                {noref} set to 1 will fail.
+                Also see |copy()|.
 
 delete({fname} [, {flags}])                                           *delete()*
-		Without {flags} or with {flags} empty: Deletes the file by the
-		name {fname}.
+                Without {flags} or with {flags} empty: Deletes the file by the
+                name {fname}.
 
-		This also works when {fname} is a symbolic link.  The symbolic
-		link itself is deleted, not what it points to.
+                This also works when {fname} is a symbolic link.  The symbolic
+                link itself is deleted, not what it points to.
 
-		When {flags} is "d": Deletes the directory by the name
-		{fname}.  This fails when directory {fname} is not empty.
+                When {flags} is "d": Deletes the directory by the name
+                {fname}.  This fails when directory {fname} is not empty.
 
-		When {flags} is "rf": Deletes the directory by the name
-		{fname} and everything in it, recursively.  BE CAREFUL!
-		Note: on MS-Windows it is not possible to delete a directory
-		that is being used.
+                When {flags} is "rf": Deletes the directory by the name
+                {fname} and everything in it, recursively.  BE CAREFUL!
+                Note: on MS-Windows it is not possible to delete a directory
+                that is being used.
 
-		The result is a Number, which is 0/false if the delete
-		operation was successful and -1/true when the deletion failed
-		or partly failed.
+                The result is a Number, which is 0/false if the delete
+                operation was successful and -1/true when the deletion failed
+                or partly failed.
 
 deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
-		Delete lines {first} to {last} (inclusive) from buffer {buf}.
-		If {last} is omitted then delete line {first} only.
-		On success 0 is returned, on failure 1 is returned.
+                Delete lines {first} to {last} (inclusive) from buffer {buf}.
+                If {last} is omitted then delete line {first} only.
+                On success 0 is returned, on failure 1 is returned.
 
-		This function works only for loaded buffers. First call
-		|bufload()| if needed.
+                This function works only for loaded buffers. First call
+                |bufload()| if needed.
 
-		For the use of {buf}, see |bufname()| above.
+                For the use of {buf}, see |bufname()| above.
 
-		{first} and {last} are used like with |getline()|. Note that
-		when using |line()| this refers to the current buffer. Use "$"
-		to refer to the last line in buffer {buf}.
+                {first} and {last} are used like with |getline()|. Note that
+                when using |line()| this refers to the current buffer. Use "$"
+                to refer to the last line in buffer {buf}.
 
 dictwatcheradd({dict}, {pattern}, {callback})                 *dictwatcheradd()*
-		Adds a watcher to a dictionary. A dictionary watcher is
-		identified by three components:
+                Adds a watcher to a dictionary. A dictionary watcher is
+                identified by three components:
 
-		- A dictionary({dict});
-		- A key pattern({pattern}).
-		- A function({callback}).
+                - A dictionary({dict});
+                - A key pattern({pattern}).
+                - A function({callback}).
 
-		After this is called, every change on {dict} and on keys
-		matching {pattern} will result in {callback} being invoked.
+                After this is called, every change on {dict} and on keys
+                matching {pattern} will result in {callback} being invoked.
 
-		For example, to watch all global variables: >vim
-			silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
-			function! OnDictChanged(d,k,z)
-			  echomsg string(a:k) string(a:z)
-			endfunction
-			call dictwatcheradd(g:, '*', 'OnDictChanged')
+                For example, to watch all global variables: >vim
+                        silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
+                        function! OnDictChanged(d,k,z)
+                          echomsg string(a:k) string(a:z)
+                        endfunction
+                        call dictwatcheradd(g:, '*', 'OnDictChanged')
 <
-		For now {pattern} only accepts very simple patterns that can
-		contain a "*" at the end of the string, in which case it will
-		match every key that begins with the substring before the "*".
-		That means if "*" is not the last character of {pattern}, only
-		keys that are exactly equal as {pattern} will be matched.
+                For now {pattern} only accepts very simple patterns that can
+                contain a "*" at the end of the string, in which case it will
+                match every key that begins with the substring before the "*".
+                That means if "*" is not the last character of {pattern}, only
+                keys that are exactly equal as {pattern} will be matched.
 
-		The {callback} receives three arguments:
+                The {callback} receives three arguments:
 
-		- The dictionary being watched.
-		- The key which changed.
-		- A dictionary containing the new and old values for the key.
+                - The dictionary being watched.
+                - The key which changed.
+                - A dictionary containing the new and old values for the key.
 
-		The type of change can be determined by examining the keys
-		present on the third argument:
+                The type of change can be determined by examining the keys
+                present on the third argument:
 
-		- If contains both `old` and `new`, the key was updated.
-		- If it contains only `new`, the key was added.
-		- If it contains only `old`, the key was deleted.
+                - If contains both `old` and `new`, the key was updated.
+                - If it contains only `new`, the key was added.
+                - If it contains only `old`, the key was deleted.
 
-		This function can be used by plugins to implement options with
-		validation and parsing logic.
+                This function can be used by plugins to implement options with
+                validation and parsing logic.
 
 dictwatcherdel({dict}, {pattern}, {callback})                 *dictwatcherdel()*
-		Removes a watcher added  with |dictwatcheradd()|. All three
-		arguments must match the ones passed to |dictwatcheradd()| in
-		order for the watcher to be successfully deleted.
+                Removes a watcher added  with |dictwatcheradd()|. All three
+                arguments must match the ones passed to |dictwatcheradd()| in
+                order for the watcher to be successfully deleted.
 
 did_filetype()                                                  *did_filetype()*
-		Returns |TRUE| when autocommands are being executed and the
-		FileType event has been triggered at least once.  Can be used
-		to avoid triggering the FileType event again in the scripts
-		that detect the file type. |FileType|
-		Returns |FALSE| when `:setf FALLBACK` was used.
-		When editing another file, the counter is reset, thus this
-		really checks if the FileType event has been triggered for the
-		current buffer.  This allows an autocommand that starts
-		editing another buffer to set 'filetype' and load a syntax
-		file.
+                Returns |TRUE| when autocommands are being executed and the
+                FileType event has been triggered at least once.  Can be used
+                to avoid triggering the FileType event again in the scripts
+                that detect the file type. |FileType|
+                Returns |FALSE| when `:setf FALLBACK` was used.
+                When editing another file, the counter is reset, thus this
+                really checks if the FileType event has been triggered for the
+                current buffer.  This allows an autocommand that starts
+                editing another buffer to set 'filetype' and load a syntax
+                file.
 
 diff_filler({lnum})                                              *diff_filler()*
-		Returns the number of filler lines above line {lnum}.
-		These are the lines that were inserted at this point in
-		another diff'ed window.  These filler lines are shown in the
-		display but don't exist in the buffer.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
-		Returns 0 if the current window is not in diff mode.
+                Returns the number of filler lines above line {lnum}.
+                These are the lines that were inserted at this point in
+                another diff'ed window.  These filler lines are shown in the
+                display but don't exist in the buffer.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
+                Returns 0 if the current window is not in diff mode.
 
 diff_hlID({lnum}, {col})                                           *diff_hlID()*
-		Returns the highlight ID for diff mode at line {lnum} column
-		{col} (byte index).  When the current line does not have a
-		diff change zero is returned.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
-		{col} is 1 for the leftmost column, {lnum} is 1 for the first
-		line.
-		The highlight ID can be used with |synIDattr()| to obtain
-		syntax information about the highlighting.
+                Returns the highlight ID for diff mode at line {lnum} column
+                {col} (byte index).  When the current line does not have a
+                diff change zero is returned.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
+                {col} is 1 for the leftmost column, {lnum} is 1 for the first
+                line.
+                The highlight ID can be used with |synIDattr()| to obtain
+                syntax information about the highlighting.
 
 digraph_get({chars})                                       *digraph_get()* *E1214*
-		Return the digraph of {chars}.  This should be a string with
-		exactly two characters.  If {chars} are not just two
-		characters, or the digraph of {chars} does not exist, an error
-		is given and an empty string is returned.
+                Return the digraph of {chars}.  This should be a string with
+                exactly two characters.  If {chars} are not just two
+                characters, or the digraph of {chars} does not exist, an error
+                is given and an empty string is returned.
 
-		Also see |digraph_getlist()|.
+                Also see |digraph_getlist()|.
 
-		Examples: >vim
-		" Get a built-in digraph
-		echo digraph_get('00')		" Returns '∞'
+                Examples: >vim
+                " Get a built-in digraph
+                echo digraph_get('00')          " Returns '∞'
 
-		" Get a user-defined digraph
-		call digraph_set('aa', 'あ')
-		echo digraph_get('aa')		" Returns 'あ'
+                " Get a user-defined digraph
+                call digraph_set('aa', 'あ')
+                echo digraph_get('aa')          " Returns 'あ'
 <
-
 digraph_getlist([{listall}])                                 *digraph_getlist()*
-		Return a list of digraphs.  If the {listall} argument is given
-		and it is TRUE, return all digraphs, including the default
-		digraphs.  Otherwise, return only user-defined digraphs.
+                Return a list of digraphs.  If the {listall} argument is given
+                and it is TRUE, return all digraphs, including the default
+                digraphs.  Otherwise, return only user-defined digraphs.
 
-		Also see |digraph_get()|.
+                Also see |digraph_get()|.
 
-		Examples: >vim
-		" Get user-defined digraphs
-		echo digraph_getlist()
+                Examples: >vim
+                " Get user-defined digraphs
+                echo digraph_getlist()
 
-		" Get all the digraphs, including default digraphs
-		echo digraph_getlist(1)
+                " Get all the digraphs, including default digraphs
+                echo digraph_getlist(1)
 <
-
 digraph_set({chars}, {digraph})                                  *digraph_set()*
-		Add digraph {chars} to the list.  {chars} must be a string
-		with two characters.  {digraph} is a string with one UTF-8
-		encoded character.  *E1215*
-		Be careful, composing characters are NOT ignored.  This
-		function is similar to |:digraphs| command, but useful to add
-		digraphs start with a white space.
+                Add digraph {chars} to the list.  {chars} must be a string
+                with two characters.  {digraph} is a string with one UTF-8
+                encoded character.  *E1215*
+                Be careful, composing characters are NOT ignored.  This
+                function is similar to |:digraphs| command, but useful to add
+                digraphs start with a white space.
 
-		The function result is v:true if |digraph| is registered.  If
-		this fails an error message is given and v:false is returned.
+                The function result is v:true if |digraph| is registered.  If
+                this fails an error message is given and v:false is returned.
 
-		If you want to define multiple digraphs at once, you can use
-		|digraph_setlist()|.
+                If you want to define multiple digraphs at once, you can use
+                |digraph_setlist()|.
 
-		Example: >vim
-			call digraph_set('  ', 'あ')
+                Example: >vim
+                        call digraph_set('  ', 'あ')
 <
-		Can be used as a |method|: >vim
-			GetString()->digraph_set('あ')
+                Can be used as a |method|: >vim
+                        GetString()->digraph_set('あ')
 <
-
 digraph_setlist({digraphlist})                               *digraph_setlist()*
-		Similar to |digraph_set()| but this function can add multiple
-		digraphs at once.  {digraphlist} is a list composed of lists,
-		where each list contains two strings with {chars} and
-		{digraph} as in |digraph_set()|. *E1216*
-		Example: >vim
-		    call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
+                Similar to |digraph_set()| but this function can add multiple
+                digraphs at once.  {digraphlist} is a list composed of lists,
+                where each list contains two strings with {chars} and
+                {digraph} as in |digraph_set()|. *E1216*
+                Example: >vim
+                    call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
 <
-		It is similar to the following: >vim
-		    for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
-			  call digraph_set(chars, digraph)
-		    endfor
-<		Except that the function returns after the first error,
-		following digraphs will not be added.
+                It is similar to the following: >vim
+                    for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
+                          call digraph_set(chars, digraph)
+                    endfor
+<                Except that the function returns after the first error,
+                following digraphs will not be added.
 
-		Can be used as a |method|: >vim
-		    GetList()->digraph_setlist()
+                Can be used as a |method|: >vim
+                    GetList()->digraph_setlist()
 <
-
 empty({expr})                                                          *empty()*
-		Return the Number 1 if {expr} is empty, zero otherwise.
-		- A |List| or |Dictionary| is empty when it does not have any
-		  items.
-		- A |String| is empty when its length is zero.
-		- A |Number| and |Float| are empty when their value is zero.
-		- |v:false| and |v:null| are empty, |v:true| is not.
-		- A |Blob| is empty when its length is zero.
+                Return the Number 1 if {expr} is empty, zero otherwise.
+                - A |List| or |Dictionary| is empty when it does not have any
+                  items.
+                - A |String| is empty when its length is zero.
+                - A |Number| and |Float| are empty when their value is zero.
+                - |v:false| and |v:null| are empty, |v:true| is not.
+                - A |Blob| is empty when its length is zero.
 
 environ()                                                            *environ()*
-		Return all of environment variables as dictionary. You can
-		check if an environment variable exists like this: >vim
-			echo has_key(environ(), 'HOME')
-<		Note that the variable name may be CamelCase; to ignore case
-		use this: >vim
-			echo index(keys(environ()), 'HOME', 0, 1) != -1
+                Return all of environment variables as dictionary. You can
+                check if an environment variable exists like this: >vim
+                        echo has_key(environ(), 'HOME')
+<                Note that the variable name may be CamelCase; to ignore case
+                use this: >vim
+                        echo index(keys(environ()), 'HOME', 0, 1) != -1
 <
-
 escape({string}, {chars})                                             *escape()*
-		Escape the characters in {chars} that occur in {string} with a
-		backslash.  Example: >vim
-			echo escape('c:\program files\vim', ' \')
-<		results in: >
-			c:\\program\ files\\vim
-<		Also see |shellescape()| and |fnameescape()|.
+                Escape the characters in {chars} that occur in {string} with a
+                backslash.  Example: >vim
+                        echo escape('c:\program files\vim', ' \')
+<                results in: >
+                        c:\\program\ files\\vim
+<                Also see |shellescape()| and |fnameescape()|.
 
 eval({string})                                                          *eval()*
-		Evaluate {string} and return the result.  Especially useful to
-		turn the result of |string()| back into the original value.
-		This works for Numbers, Floats, Strings, Blobs and composites
-		of them.  Also works for |Funcref|s that refer to existing
-		functions.
+                Evaluate {string} and return the result.  Especially useful to
+                turn the result of |string()| back into the original value.
+                This works for Numbers, Floats, Strings, Blobs and composites
+                of them.  Also works for |Funcref|s that refer to existing
+                functions.
 
 eventhandler()                                                  *eventhandler()*
-		Returns 1 when inside an event handler.  That is that Vim got
-		interrupted while waiting for the user to type a character,
-		e.g., when dropping a file on Vim.  This means interactive
-		commands cannot be used.  Otherwise zero is returned.
+                Returns 1 when inside an event handler.  That is that Vim got
+                interrupted while waiting for the user to type a character,
+                e.g., when dropping a file on Vim.  This means interactive
+                commands cannot be used.  Otherwise zero is returned.
 
 executable({expr})                                                *executable()*
-		This function checks if an executable with the name {expr}
-		exists.  {expr} must be the name of the program without any
-		arguments.
-		executable() uses the value of $PATH and/or the normal
-		searchpath for programs.		*PATHEXT*
-		On MS-Windows the ".exe", ".bat", etc. can optionally be
-		included.  Then the extensions in $PATHEXT are tried.  Thus if
-		"foo.exe" does not exist, "foo.exe.bat" can be found.  If
-		$PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
-		by itself can be used in $PATHEXT to try using the name
-		without an extension.  When 'shell' looks like a Unix shell,
-		then the name is also tried without adding an extension.
-		On MS-Windows it only checks if the file exists and is not a
-		directory, not if it's really executable.
-		On Windows an executable in the same directory as Vim is
-		always found (it is added to $PATH at |startup|).
-		The result is a Number:
-			1	exists
-			0	does not exist
-			-1	not implemented on this system
-		|exepath()| can be used to get the full path of an executable.
+                This function checks if an executable with the name {expr}
+                exists.  {expr} must be the name of the program without any
+                arguments.
+                executable() uses the value of $PATH and/or the normal
+                searchpath for programs.                *PATHEXT*
+                On MS-Windows the ".exe", ".bat", etc. can optionally be
+                included.  Then the extensions in $PATHEXT are tried.  Thus if
+                "foo.exe" does not exist, "foo.exe.bat" can be found.  If
+                $PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
+                by itself can be used in $PATHEXT to try using the name
+                without an extension.  When 'shell' looks like a Unix shell,
+                then the name is also tried without adding an extension.
+                On MS-Windows it only checks if the file exists and is not a
+                directory, not if it's really executable.
+                On Windows an executable in the same directory as Vim is
+                always found (it is added to $PATH at |startup|).
+                The result is a Number:
+                        1       exists
+                        0       does not exist
+                        -1      not implemented on this system
+                |exepath()| can be used to get the full path of an executable.
 
 execute({command} [, {silent}])                                      *execute()*
-		Execute {command} and capture its output.
-		If {command} is a |String|, returns {command} output.
-		If {command} is a |List|, returns concatenated outputs.
-		Line continuations in {command} are not recognized.
-		Examples: >vim
-			echo execute('echon "foo"')
-<			foo >vim
-			echo execute(['echon "foo"', 'echon "bar"'])
-<			foobar
+                Execute {command} and capture its output.
+                If {command} is a |String|, returns {command} output.
+                If {command} is a |List|, returns concatenated outputs.
+                Line continuations in {command} are not recognized.
+                Examples: >vim
+                        echo execute('echon "foo"')
+<                       foo >vim
+                        echo execute(['echon "foo"', 'echon "bar"'])
+<                       foobar
 
-		The optional {silent} argument can have these values:
-			""		no `:silent` used
-			"silent"	`:silent` used
-			"silent!"	`:silent!` used
-		The default is "silent".  Note that with "silent!", unlike
-		`:redir`, error messages are dropped.
+                The optional {silent} argument can have these values:
+                        ""              no `:silent` used
+                        "silent"        `:silent` used
+                        "silent!"       `:silent!` used
+                The default is "silent".  Note that with "silent!", unlike
+                `:redir`, error messages are dropped.
 
-		To get a list of lines use `split()` on the result: >vim
-			execute('args')->split("\n")
+                To get a list of lines use `split()` on the result: >vim
+                        execute('args')->split("\n")
 
-<		This function is not available in the |sandbox|.
-		Note: If nested, an outer execute() will not observe output of
-		the inner calls.
-		Note: Text attributes (highlights) are not captured.
-		To execute a command in another window than the current one
-		use `win_execute()`.
+<                This function is not available in the |sandbox|.
+                Note: If nested, an outer execute() will not observe output of
+                the inner calls.
+                Note: Text attributes (highlights) are not captured.
+                To execute a command in another window than the current one
+                use `win_execute()`.
 
 exepath({expr})                                                      *exepath()*
-		Returns the full path of {expr} if it is an executable and
-		given as a (partial or full) path or is found in $PATH.
-		Returns empty string otherwise.
-		If {expr} starts with "./" the |current-directory| is used.
+                Returns the full path of {expr} if it is an executable and
+                given as a (partial or full) path or is found in $PATH.
+                Returns empty string otherwise.
+                If {expr} starts with "./" the |current-directory| is used.
 
 exists({expr})                                                        *exists()*
-		The result is a Number, which is |TRUE| if {expr} is
-		defined, zero otherwise.
+                The result is a Number, which is |TRUE| if {expr} is
+                defined, zero otherwise.
 
-		For checking for a supported feature use |has()|.
-		For checking if a file exists use |filereadable()|.
+                For checking for a supported feature use |has()|.
+                For checking if a file exists use |filereadable()|.
 
-		The {expr} argument is a string, which contains one of these:
-			varname		internal variable (see
-			dict.key	|internal-variables|).  Also works
-			list[i]		for |curly-braces-names|, |Dictionary|
-					entries, |List| items, etc.
-					Beware that evaluating an index may
-					cause an error message for an invalid
-					expression.  E.g.: >vim
-					   let l = [1, 2, 3]
-					   echo exists("l[5]")
-<					   0 >vim
-					   echo exists("l[xx]")
-<					   E121: Undefined variable: xx
-					   0
-			&option-name	Vim option (only checks if it exists,
-					not if it really works)
-			+option-name	Vim option that works.
-			$ENVNAME	environment variable (could also be
-					done by comparing with an empty
-					string)
-			`*funcname`	built-in function (see |functions|)
-					or user defined function (see
-					|user-function|). Also works for a
-					variable that is a Funcref.
-			:cmdname	Ex command: built-in command, user
-					command or command modifier |:command|.
-					Returns:
-					1  for match with start of a command
-					2  full match with a command
-					3  matches several user commands
-					To check for a supported command
-					always check the return value to be 2.
-			:2match		The |:2match| command.
-			:3match		The |:3match| command (but you
-					probably should not use it, it is
-					reserved for internal usage)
-			#event		autocommand defined for this event
-			#event#pattern	autocommand defined for this event and
-					pattern (the pattern is taken
-					literally and compared to the
-					autocommand patterns character by
-					character)
-			#group		autocommand group exists
-			#group#event	autocommand defined for this group and
-					event.
-			#group#event#pattern
-					autocommand defined for this group,
-					event and pattern.
-			##event		autocommand for this event is
-					supported.
+                The {expr} argument is a string, which contains one of these:
+                        varname         internal variable (see
+                        dict.key        |internal-variables|).  Also works
+                        list[i]         for |curly-braces-names|, |Dictionary|
+                                        entries, |List| items, etc.
+                                        Beware that evaluating an index may
+                                        cause an error message for an invalid
+                                        expression.  E.g.: >vim
+                                           let l = [1, 2, 3]
+                                           echo exists("l[5]")
+<                                          0 >vim
+                                           echo exists("l[xx]")
+<                                          E121: Undefined variable: xx
+                                           0
+                        &option-name    Vim option (only checks if it exists,
+                                        not if it really works)
+                        +option-name    Vim option that works.
+                        $ENVNAME        environment variable (could also be
+                                        done by comparing with an empty
+                                        string)
+                        `*funcname`     built-in function (see |functions|)
+                                        or user defined function (see
+                                        |user-function|). Also works for a
+                                        variable that is a Funcref.
+                        :cmdname        Ex command: built-in command, user
+                                        command or command modifier |:command|.
+                                        Returns:
+                                        1  for match with start of a command
+                                        2  full match with a command
+                                        3  matches several user commands
+                                        To check for a supported command
+                                        always check the return value to be 2.
+                        :2match         The |:2match| command.
+                        :3match         The |:3match| command (but you
+                                        probably should not use it, it is
+                                        reserved for internal usage)
+                        #event          autocommand defined for this event
+                        #event#pattern  autocommand defined for this event and
+                                        pattern (the pattern is taken
+                                        literally and compared to the
+                                        autocommand patterns character by
+                                        character)
+                        #group          autocommand group exists
+                        #group#event    autocommand defined for this group and
+                                        event.
+                        #group#event#pattern
+                                        autocommand defined for this group,
+                                        event and pattern.
+                        ##event         autocommand for this event is
+                                        supported.
 
-		Examples: >vim
-			echo exists("&mouse")
-			echo exists("$HOSTNAME")
-			echo exists("*strftime")
-			echo exists("*s:MyFunc")
-			echo exists("*MyFunc")
-			echo exists("bufcount")
-			echo exists(":Make")
-			echo exists("#CursorHold")
-			echo exists("#BufReadPre#*.gz")
-			echo exists("#filetypeindent")
-			echo exists("#filetypeindent#FileType")
-			echo exists("#filetypeindent#FileType#*")
-			echo exists("##ColorScheme")
-<		There must be no space between the symbol (&/$/*/#) and the
-		name.
-		There must be no extra characters after the name, although in
-		a few cases this is ignored.  That may become stricter in the
-		future, thus don't count on it!
-		Working example: >vim
-			echo exists(":make")
-<		NOT working example: >vim
-			echo exists(":make install")
+                Examples: >vim
+                        echo exists("&mouse")
+                        echo exists("$HOSTNAME")
+                        echo exists("*strftime")
+                        echo exists("*s:MyFunc")
+                        echo exists("*MyFunc")
+                        echo exists("bufcount")
+                        echo exists(":Make")
+                        echo exists("#CursorHold")
+                        echo exists("#BufReadPre#*.gz")
+                        echo exists("#filetypeindent")
+                        echo exists("#filetypeindent#FileType")
+                        echo exists("#filetypeindent#FileType#*")
+                        echo exists("##ColorScheme")
+<                There must be no space between the symbol (&/$/*/#) and the
+                name.
+                There must be no extra characters after the name, although in
+                a few cases this is ignored.  That may become stricter in the
+                future, thus don't count on it!
+                Working example: >vim
+                        echo exists(":make")
+<                NOT working example: >vim
+                        echo exists(":make install")
 
-<		Note that the argument must be a string, not the name of the
-		variable itself.  For example: >vim
-			echo exists(bufcount)
-<		This doesn't check for existence of the "bufcount" variable,
-		but gets the value of "bufcount", and checks if that exists.
+<                Note that the argument must be a string, not the name of the
+                variable itself.  For example: >vim
+                        echo exists(bufcount)
+<                This doesn't check for existence of the "bufcount" variable,
+                but gets the value of "bufcount", and checks if that exists.
 
 exp({expr})                                                              *exp()*
-		Return the exponential of {expr} as a |Float| in the range
-		[0, inf].
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo exp(2)
-<			7.389056 >vim
-			echo exp(-1)
-<			0.367879
+                Return the exponential of {expr} as a |Float| in the range
+                [0, inf].
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo exp(2)
+<                        7.389056 >vim
+                        echo exp(-1)
+<                        0.367879
 
 expand({string} [, {nosuf} [, {list}]])                               *expand()*
-		Expand wildcards and the following special keywords in
-		{string}.  'wildignorecase' applies.
+                Expand wildcards and the following special keywords in
+                {string}.  'wildignorecase' applies.
 
-		If {list} is given and it is |TRUE|, a List will be returned.
-		Otherwise the result is a String and when there are several
-		matches, they are separated by <NL> characters.
+                If {list} is given and it is |TRUE|, a List will be returned.
+                Otherwise the result is a String and when there are several
+                matches, they are separated by <NL> characters.
 
-		If the expansion fails, the result is an empty string.  A name
-		for a non-existing file is not included, unless {string} does
-		not start with '%', '#' or '<', see below.
+                If the expansion fails, the result is an empty string.  A name
+                for a non-existing file is not included, unless {string} does
+                not start with '%', '#' or '<', see below.
 
-		When {string} starts with '%', '#' or '<', the expansion is
-		done like for the |cmdline-special| variables with their
-		associated modifiers.  Here is a short overview:
+                When {string} starts with '%', '#' or '<', the expansion is
+                done like for the |cmdline-special| variables with their
+                associated modifiers.  Here is a short overview:
 
-			%		current file name
-			#		alternate file name
-			#n		alternate file name n
-			<cfile>		file name under the cursor
-			<afile>		autocmd file name
-			<abuf>		autocmd buffer number (as a String!)
-			<amatch>	autocmd matched name
-			<cexpr>		C expression under the cursor
-			<sfile>		sourced script file or function name
-			<slnum>		sourced script line number or function
-					line number
-			<sflnum>	script file line number, also when in
-					a function
-			<SID>		"<SNR>123_"  where "123" is the
-					current script ID  |<SID>|
-			<script>	sourced script file, or script file
-					where the current function was defined
-			<stack>		call stack
-			<cword>		word under the cursor
-			<cWORD>		WORD under the cursor
-			<client>	the {clientid} of the last received
-					message
-		Modifiers:
-			:p		expand to full path
-			:h		head (last path component removed)
-			:t		tail (last path component only)
-			:r		root (one extension removed)
-			:e		extension only
+                        %               current file name
+                        #               alternate file name
+                        #n              alternate file name n
+                        <cfile>         file name under the cursor
+                        <afile>         autocmd file name
+                        <abuf>          autocmd buffer number (as a String!)
+                        <amatch>        autocmd matched name
+                        <cexpr>         C expression under the cursor
+                        <sfile>         sourced script file or function name
+                        <slnum>         sourced script line number or function
+                                        line number
+                        <sflnum>        script file line number, also when in
+                                        a function
+                        <SID>           "<SNR>123_"  where "123" is the
+                                        current script ID  |<SID>|
+                        <script>        sourced script file, or script file
+                                        where the current function was defined
+                        <stack>         call stack
+                        <cword>         word under the cursor
+                        <cWORD>         WORD under the cursor
+                        <client>        the {clientid} of the last received
+                                        message
+                Modifiers:
+                        :p              expand to full path
+                        :h              head (last path component removed)
+                        :t              tail (last path component only)
+                        :r              root (one extension removed)
+                        :e              extension only
 
-		Example: >vim
-			let &tags = expand("%:p:h") .. "/tags"
-<		Note that when expanding a string that starts with '%', '#' or
-		'<', any following text is ignored.  This does NOT work: >vim
-			let doesntwork = expand("%:h.bak")
-<		Use this: >vim
-			let doeswork = expand("%:h") .. ".bak"
-<		Also note that expanding "<cfile>" and others only returns the
-		referenced file name without further expansion.  If "<cfile>"
-		is "~/.cshrc", you need to do another expand() to have the
-		"~/" expanded into the path of the home directory: >vim
-			echo expand(expand("<cfile>"))
+                Example: >vim
+                        let &tags = expand("%:p:h") .. "/tags"
+<                Note that when expanding a string that starts with '%', '#' or
+                '<', any following text is ignored.  This does NOT work: >vim
+                        let doesntwork = expand("%:h.bak")
+<                Use this: >vim
+                        let doeswork = expand("%:h") .. ".bak"
+<                Also note that expanding "<cfile>" and others only returns the
+                referenced file name without further expansion.  If "<cfile>"
+                is "~/.cshrc", you need to do another expand() to have the
+                "~/" expanded into the path of the home directory: >vim
+                        echo expand(expand("<cfile>"))
 <
-		There cannot be white space between the variables and the
-		following modifier.  The |fnamemodify()| function can be used
-		to modify normal file names.
+                There cannot be white space between the variables and the
+                following modifier.  The |fnamemodify()| function can be used
+                to modify normal file names.
 
-		When using '%' or '#', and the current or alternate file name
-		is not defined, an empty string is used.  Using "%:p" in a
-		buffer with no name, results in the current directory, with a
-		'/' added.
-		When 'verbose' is set then expanding '%', '#' and <> items
-		will result in an error message if the argument cannot be
-		expanded.
+                When using '%' or '#', and the current or alternate file name
+                is not defined, an empty string is used.  Using "%:p" in a
+                buffer with no name, results in the current directory, with a
+                '/' added.
+                When 'verbose' is set then expanding '%', '#' and <> items
+                will result in an error message if the argument cannot be
+                expanded.
 
-		When {string} does not start with '%', '#' or '<', it is
-		expanded like a file name is expanded on the command line.
-		'suffixes' and 'wildignore' are used, unless the optional
-		{nosuf} argument is given and it is |TRUE|.
-		Names for non-existing files are included.  The "**" item can
-		be used to search in a directory tree.  For example, to find
-		all "README" files in the current directory and below: >vim
-			echo expand("**/README")
+                When {string} does not start with '%', '#' or '<', it is
+                expanded like a file name is expanded on the command line.
+                'suffixes' and 'wildignore' are used, unless the optional
+                {nosuf} argument is given and it is |TRUE|.
+                Names for non-existing files are included.  The "**" item can
+                be used to search in a directory tree.  For example, to find
+                all "README" files in the current directory and below: >vim
+                        echo expand("**/README")
 <
-		expand() can also be used to expand variables and environment
-		variables that are only known in a shell.  But this can be
-		slow, because a shell may be used to do the expansion.  See
-		|expr-env-expand|.
-		The expanded variable is still handled like a list of file
-		names.  When an environment variable cannot be expanded, it is
-		left unchanged.  Thus ":echo expand('$FOOBAR')" results in
-		"$FOOBAR".
+                expand() can also be used to expand variables and environment
+                variables that are only known in a shell.  But this can be
+                slow, because a shell may be used to do the expansion.  See
+                |expr-env-expand|.
+                The expanded variable is still handled like a list of file
+                names.  When an environment variable cannot be expanded, it is
+                left unchanged.  Thus ":echo expand('$FOOBAR')" results in
+                "$FOOBAR".
 
-		See |glob()| for finding existing files.  See |system()| for
-		getting the raw output of an external command.
+                See |glob()| for finding existing files.  See |system()| for
+                getting the raw output of an external command.
 
 expandcmd({string} [, {options}])                                  *expandcmd()*
-		Expand special items in String {string} like what is done for
-		an Ex command such as `:edit`.  This expands special keywords,
-		like with |expand()|, and environment variables, anywhere in
-		{string}.  "~user" and "~/path" are only expanded at the
-		start.
+                Expand special items in String {string} like what is done for
+                an Ex command such as `:edit`.  This expands special keywords,
+                like with |expand()|, and environment variables, anywhere in
+                {string}.  "~user" and "~/path" are only expanded at the
+                start.
 
-		The following items are supported in the {options} Dict
-		argument:
-		    errmsg	If set to TRUE, error messages are displayed
-				if an error is encountered during expansion.
-				By default, error messages are not displayed.
+                The following items are supported in the {options} Dict
+                argument:
+                    errmsg      If set to TRUE, error messages are displayed
+                                if an error is encountered during expansion.
+                                By default, error messages are not displayed.
 
-		Returns the expanded string.  If an error is encountered
-		during expansion, the unmodified {string} is returned.
+                Returns the expanded string.  If an error is encountered
+                during expansion, the unmodified {string} is returned.
 
-		Example: >vim
-			echo expandcmd('make %<.o')
-<		 >
-			make /path/runtime/doc/builtin.o
-<		 >vim
-			echo expandcmd('make %<.o', {'errmsg': v:true})
+                Example: >vim
+                        echo expandcmd('make %<.o')
+<                 >
+                        make /path/runtime/doc/builtin.o
+<                 >vim
+                        echo expandcmd('make %<.o', {'errmsg': v:true})
 <
-
 extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
-		{expr1} and {expr2} must be both |Lists| or both
-		|Dictionaries|.
+                {expr1} and {expr2} must be both |Lists| or both
+                |Dictionaries|.
 
-		If they are |Lists|: Append {expr2} to {expr1}.
-		If {expr3} is given insert the items of {expr2} before the
-		item with index {expr3} in {expr1}.  When {expr3} is zero
-		insert before the first item.  When {expr3} is equal to
-		len({expr1}) then {expr2} is appended.
-		Examples: >vim
-			echo sort(extend(mylist, [7, 5]))
-			call extend(mylist, [2, 3], 1)
-<		When {expr1} is the same List as {expr2} then the number of
-		items copied is equal to the original length of the List.
-		E.g., when {expr3} is 1 you get N new copies of the first item
-		(where N is the original length of the List).
-		Use |add()| to concatenate one item to a list.  To concatenate
-		two lists into a new list use the + operator: >vim
-			let newlist = [1, 2, 3] + [4, 5]
+                If they are |Lists|: Append {expr2} to {expr1}.
+                If {expr3} is given insert the items of {expr2} before the
+                item with index {expr3} in {expr1}.  When {expr3} is zero
+                insert before the first item.  When {expr3} is equal to
+                len({expr1}) then {expr2} is appended.
+                Examples: >vim
+                        echo sort(extend(mylist, [7, 5]))
+                        call extend(mylist, [2, 3], 1)
+<                When {expr1} is the same List as {expr2} then the number of
+                items copied is equal to the original length of the List.
+                E.g., when {expr3} is 1 you get N new copies of the first item
+                (where N is the original length of the List).
+                Use |add()| to concatenate one item to a list.  To concatenate
+                two lists into a new list use the + operator: >vim
+                        let newlist = [1, 2, 3] + [4, 5]
 <
-		If they are |Dictionaries|:
-		Add all entries from {expr2} to {expr1}.
-		If a key exists in both {expr1} and {expr2} then {expr3} is
-		used to decide what to do:
-		{expr3} = "keep": keep the value of {expr1}
-		{expr3} = "force": use the value of {expr2}
-		{expr3} = "error": give an error message		*E737*
-		When {expr3} is omitted then "force" is assumed.
+                If they are |Dictionaries|:
+                Add all entries from {expr2} to {expr1}.
+                If a key exists in both {expr1} and {expr2} then {expr3} is
+                used to decide what to do:
+                {expr3} = "keep": keep the value of {expr1}
+                {expr3} = "force": use the value of {expr2}
+                {expr3} = "error": give an error message                *E737*
+                When {expr3} is omitted then "force" is assumed.
 
-		{expr1} is changed when {expr2} is not empty.  If necessary
-		make a copy of {expr1} first.
-		{expr2} remains unchanged.
-		When {expr1} is locked and {expr2} is not empty the operation
-		fails.
-		Returns {expr1}.  Returns 0 on error.
+                {expr1} is changed when {expr2} is not empty.  If necessary
+                make a copy of {expr1} first.
+                {expr2} remains unchanged.
+                When {expr1} is locked and {expr2} is not empty the operation
+                fails.
+                Returns {expr1}.  Returns 0 on error.
 
 extendnew({expr1}, {expr2} [, {expr3}])                            *extendnew()*
-		Like |extend()| but instead of adding items to {expr1} a new
-		List or Dictionary is created and returned.  {expr1} remains
-		unchanged.
+                Like |extend()| but instead of adding items to {expr1} a new
+                List or Dictionary is created and returned.  {expr1} remains
+                unchanged.
 
 feedkeys({string} [, {mode}])                                       *feedkeys()*
-		Characters in {string} are queued for processing as if they
-		come from a mapping or were typed by the user.
+                Characters in {string} are queued for processing as if they
+                come from a mapping or were typed by the user.
 
-		By default the string is added to the end of the typeahead
-		buffer, thus if a mapping is still being executed the
-		characters come after them.  Use the 'i' flag to insert before
-		other characters, they will be executed next, before any
-		characters from a mapping.
+                By default the string is added to the end of the typeahead
+                buffer, thus if a mapping is still being executed the
+                characters come after them.  Use the 'i' flag to insert before
+                other characters, they will be executed next, before any
+                characters from a mapping.
 
-		The function does not wait for processing of keys contained in
-		{string}.
+                The function does not wait for processing of keys contained in
+                {string}.
 
-		To include special keys into {string}, use double-quotes
-		and "\..." notation |expr-quote|. For example,
-		feedkeys("\<CR>") simulates pressing of the <Enter> key. But
-		feedkeys('\<CR>') pushes 5 characters.
-		The |<Ignore>| keycode may be used to exit the
-		wait-for-character without doing anything.
+                To include special keys into {string}, use double-quotes
+                and "\..." notation |expr-quote|. For example,
+                feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+                feedkeys('\<CR>') pushes 5 characters.
+                The |<Ignore>| keycode may be used to exit the
+                wait-for-character without doing anything.
 
-		{mode} is a String, which can contain these character flags:
-		'm'	Remap keys. This is default.  If {mode} is absent,
-			keys are remapped.
-		'n'	Do not remap keys.
-		't'	Handle keys as if typed; otherwise they are handled as
-			if coming from a mapping.  This matters for undo,
-			opening folds, etc.
-		'i'	Insert the string instead of appending (see above).
-		'x'	Execute commands until typeahead is empty.  This is
-			similar to using ":normal!".  You can call feedkeys()
-			several times without 'x' and then one time with 'x'
-			(possibly with an empty {string}) to execute all the
-			typeahead.  Note that when Vim ends in Insert mode it
-			will behave as if <Esc> is typed, to avoid getting
-			stuck, waiting for a character to be typed before the
-			script continues.
-			Note that if you manage to call feedkeys() while
-			executing commands, thus calling it recursively, then
-			all typeahead will be consumed by the last call.
-		'!'	When used with 'x' will not end Insert mode. Can be
-			used in a test when a timer is set to exit Insert mode
-			a little later.  Useful for testing CursorHoldI.
+                {mode} is a String, which can contain these character flags:
+                'm'     Remap keys. This is default.  If {mode} is absent,
+                        keys are remapped.
+                'n'     Do not remap keys.
+                't'     Handle keys as if typed; otherwise they are handled as
+                        if coming from a mapping.  This matters for undo,
+                        opening folds, etc.
+                'i'     Insert the string instead of appending (see above).
+                'x'     Execute commands until typeahead is empty.  This is
+                        similar to using ":normal!".  You can call feedkeys()
+                        several times without 'x' and then one time with 'x'
+                        (possibly with an empty {string}) to execute all the
+                        typeahead.  Note that when Vim ends in Insert mode it
+                        will behave as if <Esc> is typed, to avoid getting
+                        stuck, waiting for a character to be typed before the
+                        script continues.
+                        Note that if you manage to call feedkeys() while
+                        executing commands, thus calling it recursively, then
+                        all typeahead will be consumed by the last call.
+                '!'     When used with 'x' will not end Insert mode. Can be
+                        used in a test when a timer is set to exit Insert mode
+                        a little later.  Useful for testing CursorHoldI.
 
-		Return value is always 0.
+                Return value is always 0.
 
 filereadable({file})                                            *filereadable()*
-		The result is a Number, which is |TRUE| when a file with the
-		name {file} exists, and can be read.  If {file} doesn't exist,
-		or is a directory, the result is |FALSE|.  {file} is any
-		expression, which is used as a String.
-		If you don't care about the file being readable you can use
-		|glob()|.
-		{file} is used as-is, you may want to expand wildcards first: >vim
-			echo filereadable('~/.vimrc')
-<		 >
-			0
-<		 >vim
-			echo filereadable(expand('~/.vimrc'))
-<		 >
-			1
+                The result is a Number, which is |TRUE| when a file with the
+                name {file} exists, and can be read.  If {file} doesn't exist,
+                or is a directory, the result is |FALSE|.  {file} is any
+                expression, which is used as a String.
+                If you don't care about the file being readable you can use
+                |glob()|.
+                {file} is used as-is, you may want to expand wildcards first: >vim
+                        echo filereadable('~/.vimrc')
+<                 >
+                        0
+<                 >vim
+                        echo filereadable(expand('~/.vimrc'))
+<                 >
+                        1
 <
-
 filewritable({file})                                            *filewritable()*
-		The result is a Number, which is 1 when a file with the
-		name {file} exists, and can be written.  If {file} doesn't
-		exist, or is not writable, the result is 0.  If {file} is a
-		directory, and we can write to it, the result is 2.
+                The result is a Number, which is 1 when a file with the
+                name {file} exists, and can be written.  If {file} doesn't
+                exist, or is not writable, the result is 0.  If {file} is a
+                directory, and we can write to it, the result is 2.
 
 filter({expr1}, {expr2})                                              *filter()*
-		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-		For each item in {expr1} evaluate {expr2} and when the result
-		is zero or false remove the item from the |List| or
-		|Dictionary|.  Similarly for each byte in a |Blob| and each
-		character in a |String|.
+                {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
+                For each item in {expr1} evaluate {expr2} and when the result
+                is zero or false remove the item from the |List| or
+                |Dictionary|.  Similarly for each byte in a |Blob| and each
+                character in a |String|.
 
-		{expr2} must be a |string| or |Funcref|.
+                {expr2} must be a |string| or |Funcref|.
 
-		If {expr2} is a |string|, inside {expr2} |v:val| has the value
-		of the current item.  For a |Dictionary| |v:key| has the key
-		of the current item and for a |List| |v:key| has the index of
-		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
-		current character.
-		Examples: >vim
-			call filter(mylist, 'v:val !~ "OLD"')
-<		Removes the items where "OLD" appears. >vim
-			call filter(mydict, 'v:key >= 8')
-<		Removes the items with a key below 8. >vim
-			call filter(var, 0)
-<		Removes all the items, thus clears the |List| or |Dictionary|.
+                If {expr2} is a |string|, inside {expr2} |v:val| has the value
+                of the current item.  For a |Dictionary| |v:key| has the key
+                of the current item and for a |List| |v:key| has the index of
+                the current item.  For a |Blob| |v:key| has the index of the
+                current byte. For a |String| |v:key| has the index of the
+                current character.
+                Examples: >vim
+                        call filter(mylist, 'v:val !~ "OLD"')
+<                Removes the items where "OLD" appears. >vim
+                        call filter(mydict, 'v:key >= 8')
+<                Removes the items with a key below 8. >vim
+                        call filter(var, 0)
+<                Removes all the items, thus clears the |List| or |Dictionary|.
 
-		Note that {expr2} is the result of expression and is then
-		used as an expression again.  Often it is good to use a
-		|literal-string| to avoid having to double backslashes.
+                Note that {expr2} is the result of expression and is then
+                used as an expression again.  Often it is good to use a
+                |literal-string| to avoid having to double backslashes.
 
-		If {expr2} is a |Funcref| it must take two arguments:
-			1. the key or the index of the current item.
-			2. the value of the current item.
-		The function must return |TRUE| if the item should be kept.
-		Example that keeps the odd items of a list: >vim
-			func Odd(idx, val)
-			  return a:idx % 2 == 1
-			endfunc
-			call filter(mylist, function('Odd'))
-<		It is shorter when using a |lambda|: >vim
-			call filter(myList, {idx, val -> idx * val <= 42})
-<		If you do not use "val" you can leave it out: >vim
-			call filter(myList, {idx -> idx % 2 == 1})
+                If {expr2} is a |Funcref| it must take two arguments:
+                        1. the key or the index of the current item.
+                        2. the value of the current item.
+                The function must return |TRUE| if the item should be kept.
+                Example that keeps the odd items of a list: >vim
+                        func Odd(idx, val)
+                          return a:idx % 2 == 1
+                        endfunc
+                        call filter(mylist, function('Odd'))
+<                It is shorter when using a |lambda|: >vim
+                        call filter(myList, {idx, val -> idx * val <= 42})
+<                If you do not use "val" you can leave it out: >vim
+                        call filter(myList, {idx -> idx % 2 == 1})
 <
-		For a |List| and a |Dictionary| the operation is done
-		in-place.  If you want it to remain unmodified make a copy
-		first: >vim
-			let l = filter(copy(mylist), 'v:val =~ "KEEP"')
+                For a |List| and a |Dictionary| the operation is done
+                in-place.  If you want it to remain unmodified make a copy
+                first: >vim
+                        let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 
-<		Returns {expr1}, the |List| or |Dictionary| that was filtered,
-		or a new |Blob| or |String|.
-		When an error is encountered while evaluating {expr2} no
-		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+<                Returns {expr1}, the |List| or |Dictionary| that was filtered,
+                or a new |Blob| or |String|.
+                When an error is encountered while evaluating {expr2} no
+                further items in {expr1} are processed.
+                When {expr2} is a Funcref errors inside a function are ignored,
+                unless it was defined with the "abort" flag.
 
 finddir({name} [, {path} [, {count}]])                               *finddir()*
-		Find directory {name} in {path}.  Supports both downwards and
-		upwards recursive directory searches.  See |file-searching|
-		for the syntax of {path}.
+                Find directory {name} in {path}.  Supports both downwards and
+                upwards recursive directory searches.  See |file-searching|
+                for the syntax of {path}.
 
-		Returns the path of the first found match.  When the found
-		directory is below the current directory a relative path is
-		returned.  Otherwise a full path is returned.
-		If {path} is omitted or empty then 'path' is used.
+                Returns the path of the first found match.  When the found
+                directory is below the current directory a relative path is
+                returned.  Otherwise a full path is returned.
+                If {path} is omitted or empty then 'path' is used.
 
-		If the optional {count} is given, find {count}'s occurrence of
-		{name} in {path} instead of the first one.
-		When {count} is negative return all the matches in a |List|.
+                If the optional {count} is given, find {count}'s occurrence of
+                {name} in {path} instead of the first one.
+                When {count} is negative return all the matches in a |List|.
 
-		Returns an empty string if the directory is not found.
+                Returns an empty string if the directory is not found.
 
-		This is quite similar to the ex-command `:find`.
+                This is quite similar to the ex-command `:find`.
 
 findfile({name} [, {path} [, {count}]])                             *findfile()*
-		Just like |finddir()|, but find a file instead of a directory.
-		Uses 'suffixesadd'.
-		Example: >vim
-			echo findfile("tags.vim", ".;")
-<		Searches from the directory of the current file upwards until
-		it finds the file "tags.vim".
+                Just like |finddir()|, but find a file instead of a directory.
+                Uses 'suffixesadd'.
+                Example: >vim
+                        echo findfile("tags.vim", ".;")
+<                Searches from the directory of the current file upwards until
+                it finds the file "tags.vim".
 
 flatten({list} [, {maxdepth}])                                       *flatten()*
-		Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
-		the result is a |List| without nesting, as if {maxdepth} is
-		a very large number.
-		The {list} is changed in place, use |flattennew()| if you do
-		not want that.
-								*E900*
-		{maxdepth} means how deep in nested lists changes are made.
-		{list} is not modified when {maxdepth} is 0.
-		{maxdepth} must be positive number.
+                Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
+                the result is a |List| without nesting, as if {maxdepth} is
+                a very large number.
+                The {list} is changed in place, use |flattennew()| if you do
+                not want that.
+                                                                *E900*
+                {maxdepth} means how deep in nested lists changes are made.
+                {list} is not modified when {maxdepth} is 0.
+                {maxdepth} must be positive number.
 
-		If there is an error the number zero is returned.
+                If there is an error the number zero is returned.
 
-		Example: >vim
-			echo flatten([1, [2, [3, 4]], 5])
-<			[1, 2, 3, 4, 5] >vim
-			echo flatten([1, [2, [3, 4]], 5], 1)
-<			[1, 2, [3, 4], 5]
+                Example: >vim
+                        echo flatten([1, [2, [3, 4]], 5])
+<                        [1, 2, 3, 4, 5] >vim
+                        echo flatten([1, [2, [3, 4]], 5], 1)
+<                        [1, 2, [3, 4], 5]
 
 flattennew({list} [, {maxdepth}])                                 *flattennew()*
-		Like |flatten()| but first make a copy of {list}.
+                Like |flatten()| but first make a copy of {list}.
 
 float2nr({expr})                                                    *float2nr()*
-		Convert {expr} to a Number by omitting the part after the
-		decimal point.
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0 if {expr} is not a |Float| or a |Number|.
-		When the value of {expr} is out of range for a |Number| the
-		result is truncated to 0x7fffffff or -0x7fffffff (or when
-		64-bit Number support is enabled, 0x7fffffffffffffff or
-		-0x7fffffffffffffff).  NaN results in -0x80000000 (or when
-		64-bit Number support is enabled, -0x8000000000000000).
-		Examples: >vim
-			echo float2nr(3.95)
-<			3  >vim
-			echo float2nr(-23.45)
-<			-23  >vim
-			echo float2nr(1.0e100)
-<			2147483647  (or 9223372036854775807) >vim
-			echo float2nr(-1.0e150)
-<			-2147483647 (or -9223372036854775807) >vim
-			echo float2nr(1.0e-100)
-<			0
+                Convert {expr} to a Number by omitting the part after the
+                decimal point.
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0 if {expr} is not a |Float| or a |Number|.
+                When the value of {expr} is out of range for a |Number| the
+                result is truncated to 0x7fffffff or -0x7fffffff (or when
+                64-bit Number support is enabled, 0x7fffffffffffffff or
+                -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
+                64-bit Number support is enabled, -0x8000000000000000).
+                Examples: >vim
+                        echo float2nr(3.95)
+<                        3  >vim
+                        echo float2nr(-23.45)
+<                        -23  >vim
+                        echo float2nr(1.0e100)
+<                        2147483647  (or 9223372036854775807) >vim
+                        echo float2nr(-1.0e150)
+<                        -2147483647 (or -9223372036854775807) >vim
+                        echo float2nr(1.0e-100)
+<                        0
 
 floor({expr})                                                          *floor()*
-		Return the largest integral value less than or equal to
-		{expr} as a |Float| (round down).
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo floor(1.856)
-<			1.0  >vim
-			echo floor(-5.456)
-<			-6.0  >vim
-			echo floor(4.0)
-<			4.0
+                Return the largest integral value less than or equal to
+                {expr} as a |Float| (round down).
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo floor(1.856)
+<                        1.0  >vim
+                        echo floor(-5.456)
+<                        -6.0  >vim
+                        echo floor(4.0)
+<                        4.0
 
 fmod({expr1}, {expr2})                                                  *fmod()*
-		Return the remainder of {expr1} / {expr2}, even if the
-		division is not representable.  Returns {expr1} - i * {expr2}
-		for some integer i such that if {expr2} is non-zero, the
-		result has the same sign as {expr1} and magnitude less than
-		the magnitude of {expr2}.  If {expr2} is zero, the value
-		returned is zero.  The value returned is a |Float|.
-		{expr1} and {expr2} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
-		|Number|.
-		Examples: >vim
-			echo fmod(12.33, 1.22)
-<			0.13 >vim
-			echo fmod(-12.33, 1.22)
-<			-0.13
+                Return the remainder of {expr1} / {expr2}, even if the
+                division is not representable.  Returns {expr1} - i * {expr2}
+                for some integer i such that if {expr2} is non-zero, the
+                result has the same sign as {expr1} and magnitude less than
+                the magnitude of {expr2}.  If {expr2} is zero, the value
+                returned is zero.  The value returned is a |Float|.
+                {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
+                |Number|.
+                Examples: >vim
+                        echo fmod(12.33, 1.22)
+<                        0.13 >vim
+                        echo fmod(-12.33, 1.22)
+<                        -0.13
 
 fnameescape({string})                                            *fnameescape()*
-		Escape {string} for use as file name command argument.  All
-		characters that have a special meaning, such as `'%'` and `'|'`
-		are escaped with a backslash.
-		For most systems the characters escaped are
-		" \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
-		appears in a filename, it depends on the value of 'isfname'.
-		A leading '+' and '>' is also escaped (special after |:edit|
-		and |:write|).  And a "-" by itself (special after |:cd|).
-		Returns an empty string on error.
-		Example: >vim
-			let fname = '+some str%nge|name'
-			exe "edit " .. fnameescape(fname)
-<		results in executing: >vim
-			edit \+some\ str\%nge\|name
+                Escape {string} for use as file name command argument.  All
+                characters that have a special meaning, such as `'%'` and `'|'`
+                are escaped with a backslash.
+                For most systems the characters escaped are
+                " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
+                appears in a filename, it depends on the value of 'isfname'.
+                A leading '+' and '>' is also escaped (special after |:edit|
+                and |:write|).  And a "-" by itself (special after |:cd|).
+                Returns an empty string on error.
+                Example: >vim
+                        let fname = '+some str%nge|name'
+                        exe "edit " .. fnameescape(fname)
+<                results in executing: >vim
+                        edit \+some\ str\%nge\|name
 <
-
 fnamemodify({fname}, {mods})                                     *fnamemodify()*
-		Modify file name {fname} according to {mods}.  {mods} is a
-		string of characters like it is used for file names on the
-		command line.  See |filename-modifiers|.
-		Example: >vim
-			echo fnamemodify("main.c", ":p:h")
-<		results in: >
-			/home/user/vim/vim/src
-<		If {mods} is empty or an unsupported modifier is used then
-		{fname} is returned.
-		When {fname} is empty then with {mods} ":h" returns ".", so
-		that `:cd` can be used with it.  This is different from
-		expand('%:h') without a buffer name, which returns an empty
-		string.
-		Note: Environment variables don't work in {fname}, use
-		|expand()| first then.
+                Modify file name {fname} according to {mods}.  {mods} is a
+                string of characters like it is used for file names on the
+                command line.  See |filename-modifiers|.
+                Example: >vim
+                        echo fnamemodify("main.c", ":p:h")
+<                results in: >
+                        /home/user/vim/vim/src
+<                If {mods} is empty or an unsupported modifier is used then
+                {fname} is returned.
+                When {fname} is empty then with {mods} ":h" returns ".", so
+                that `:cd` can be used with it.  This is different from
+                expand('%:h') without a buffer name, which returns an empty
+                string.
+                Note: Environment variables don't work in {fname}, use
+                |expand()| first then.
 
 foldclosed({lnum})                                                *foldclosed()*
-		The result is a Number.  If the line {lnum} is in a closed
-		fold, the result is the number of the first line in that fold.
-		If the line {lnum} is not in a closed fold, -1 is returned.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
+                The result is a Number.  If the line {lnum} is in a closed
+                fold, the result is the number of the first line in that fold.
+                If the line {lnum} is not in a closed fold, -1 is returned.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
 
 foldclosedend({lnum})                                          *foldclosedend()*
-		The result is a Number.  If the line {lnum} is in a closed
-		fold, the result is the number of the last line in that fold.
-		If the line {lnum} is not in a closed fold, -1 is returned.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
+                The result is a Number.  If the line {lnum} is in a closed
+                fold, the result is the number of the last line in that fold.
+                If the line {lnum} is not in a closed fold, -1 is returned.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
 
 foldlevel({lnum})                                                  *foldlevel()*
-		The result is a Number, which is the foldlevel of line {lnum}
-		in the current buffer.  For nested folds the deepest level is
-		returned.  If there is no fold at line {lnum}, zero is
-		returned.  It doesn't matter if the folds are open or closed.
-		When used while updating folds (from 'foldexpr') -1 is
-		returned for lines where folds are still to be updated and the
-		foldlevel is unknown.  As a special case the level of the
-		previous line is usually available.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
+                The result is a Number, which is the foldlevel of line {lnum}
+                in the current buffer.  For nested folds the deepest level is
+                returned.  If there is no fold at line {lnum}, zero is
+                returned.  It doesn't matter if the folds are open or closed.
+                When used while updating folds (from 'foldexpr') -1 is
+                returned for lines where folds are still to be updated and the
+                foldlevel is unknown.  As a special case the level of the
+                previous line is usually available.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
 
 foldtext()                                                          *foldtext()*
-		Returns a String, to be displayed for a closed fold.  This is
-		the default function used for the 'foldtext' option and should
-		only be called from evaluating 'foldtext'.  It uses the
-		|v:foldstart|, |v:foldend| and |v:folddashes| variables.
-		The returned string looks like this: >
-			+-- 45 lines: abcdef
-<		The number of leading dashes depends on the foldlevel.  The
-		"45" is the number of lines in the fold.  "abcdef" is the text
-		in the first non-blank line of the fold.  Leading white space,
-		"//" or "/*" and the text from the 'foldmarker' and
-		'commentstring' options is removed.
-		When used to draw the actual foldtext, the rest of the line
-		will be filled with the fold char from the 'fillchars'
-		setting.
-		Returns an empty string when there is no fold.
+                Returns a String, to be displayed for a closed fold.  This is
+                the default function used for the 'foldtext' option and should
+                only be called from evaluating 'foldtext'.  It uses the
+                |v:foldstart|, |v:foldend| and |v:folddashes| variables.
+                The returned string looks like this: >
+                        +-- 45 lines: abcdef
+<                The number of leading dashes depends on the foldlevel.  The
+                "45" is the number of lines in the fold.  "abcdef" is the text
+                in the first non-blank line of the fold.  Leading white space,
+                "//" or "/*" and the text from the 'foldmarker' and
+                'commentstring' options is removed.
+                When used to draw the actual foldtext, the rest of the line
+                will be filled with the fold char from the 'fillchars'
+                setting.
+                Returns an empty string when there is no fold.
 
 foldtextresult({lnum})                                        *foldtextresult()*
-		Returns the text that is displayed for the closed fold at line
-		{lnum}.  Evaluates 'foldtext' in the appropriate context.
-		When there is no closed fold at {lnum} an empty string is
-		returned.
-		{lnum} is used like with |getline()|.  Thus "." is the current
-		line, "'m" mark m, etc.
-		Useful when exporting folded text, e.g., to HTML.
+                Returns the text that is displayed for the closed fold at line
+                {lnum}.  Evaluates 'foldtext' in the appropriate context.
+                When there is no closed fold at {lnum} an empty string is
+                returned.
+                {lnum} is used like with |getline()|.  Thus "." is the current
+                line, "'m" mark m, etc.
+                Useful when exporting folded text, e.g., to HTML.
 
 
 fullcommand({name})                                              *fullcommand()*
-		Get the full command name from a short abbreviated command
-		name; see |20.2| for details on command abbreviations.
+                Get the full command name from a short abbreviated command
+                name; see |20.2| for details on command abbreviations.
 
-		The string argument {name} may start with a `:` and can
-		include a [range], these are skipped and not returned.
-		Returns an empty string if a command doesn't exist or if it's
-		ambiguous (for user-defined commands).
+                The string argument {name} may start with a `:` and can
+                include a [range], these are skipped and not returned.
+                Returns an empty string if a command doesn't exist or if it's
+                ambiguous (for user-defined commands).
 
-		For example `fullcommand('s')`, `fullcommand('sub')`,
-		`fullcommand(':%substitute')` all return "substitute".
+                For example `fullcommand('s')`, `fullcommand('sub')`,
+                `fullcommand(':%substitute')` all return "substitute".
 
 funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
-		Just like |function()|, but the returned Funcref will lookup
-		the function by reference, not by name.  This matters when the
-		function {name} is redefined later.
+                Just like |function()|, but the returned Funcref will lookup
+                the function by reference, not by name.  This matters when the
+                function {name} is redefined later.
 
-		Unlike |function()|, {name} must be an existing user function.
-		It only works for an autoloaded function if it has already
-		been loaded (to avoid mistakenly loading the autoload script
-		when only intending to use the function name, use |function()|
-		instead). {name} cannot be a builtin function.
-		Returns 0 on error.
+                Unlike |function()|, {name} must be an existing user function.
+                It only works for an autoloaded function if it has already
+                been loaded (to avoid mistakenly loading the autoload script
+                when only intending to use the function name, use |function()|
+                instead). {name} cannot be a builtin function.
+                Returns 0 on error.
 
 function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* *E923*
-		Return a |Funcref| variable that refers to function {name}.
-		{name} can be the name of a user defined function or an
-		internal function.
+                Return a |Funcref| variable that refers to function {name}.
+                {name} can be the name of a user defined function or an
+                internal function.
 
-		{name} can also be a Funcref or a partial. When it is a
-		partial the dict stored in it will be used and the {dict}
-		argument is not allowed. E.g.: >vim
-			let FuncWithArg = function(dict.Func, [arg])
-			let Broken = function(dict.Func, [arg], dict)
+                {name} can also be a Funcref or a partial. When it is a
+                partial the dict stored in it will be used and the {dict}
+                argument is not allowed. E.g.: >vim
+                        let FuncWithArg = function(dict.Func, [arg])
+                        let Broken = function(dict.Func, [arg], dict)
 <
-		When using the Funcref the function will be found by {name},
-		also when it was redefined later. Use |funcref()| to keep the
-		same function.
+                When using the Funcref the function will be found by {name},
+                also when it was redefined later. Use |funcref()| to keep the
+                same function.
 
-		When {arglist} or {dict} is present this creates a partial.
-		That means the argument list and/or the dictionary is stored in
-		the Funcref and will be used when the Funcref is called.
+                When {arglist} or {dict} is present this creates a partial.
+                That means the argument list and/or the dictionary is stored in
+                the Funcref and will be used when the Funcref is called.
 
-		The arguments are passed to the function in front of other
-		arguments, but after any argument from |method|.  Example: >vim
-			func Callback(arg1, arg2, name)
-			"...
-			endfunc
-			let Partial = function('Callback', ['one', 'two'])
-			"...
-			call Partial('name')
-<		Invokes the function as with: >vim
-			call Callback('one', 'two', 'name')
+                The arguments are passed to the function in front of other
+                arguments, but after any argument from |method|.  Example: >vim
+                        func Callback(arg1, arg2, name)
+                        "...
+                        endfunc
+                        let Partial = function('Callback', ['one', 'two'])
+                        "...
+                        call Partial('name')
+<                Invokes the function as with: >vim
+                        call Callback('one', 'two', 'name')
 
-<		With a |method|: >vim
-			func Callback(one, two, three)
-			"...
-			endfunc
-			let Partial = function('Callback', ['two'])
-			"...
-			eval 'one'->Partial('three')
-<		Invokes the function as with: >vim
-			call Callback('one', 'two', 'three')
+<                With a |method|: >vim
+                        func Callback(one, two, three)
+                        "...
+                        endfunc
+                        let Partial = function('Callback', ['two'])
+                        "...
+                        eval 'one'->Partial('three')
+<                Invokes the function as with: >vim
+                        call Callback('one', 'two', 'three')
 
-<		The function() call can be nested to add more arguments to the
-		Funcref.  The extra arguments are appended to the list of
-		arguments.  Example: >vim
-			func Callback(arg1, arg2, name)
-			"...
-			endfunc
-			let Func = function('Callback', ['one'])
-			let Func2 = function(Func, ['two'])
-			"...
-			call Func2('name')
-<		Invokes the function as with: >vim
-			call Callback('one', 'two', 'name')
+<                The function() call can be nested to add more arguments to the
+                Funcref.  The extra arguments are appended to the list of
+                arguments.  Example: >vim
+                        func Callback(arg1, arg2, name)
+                        "...
+                        endfunc
+                        let Func = function('Callback', ['one'])
+                        let Func2 = function(Func, ['two'])
+                        "...
+                        call Func2('name')
+<                Invokes the function as with: >vim
+                        call Callback('one', 'two', 'name')
 
-<		The Dictionary is only useful when calling a "dict" function.
-		In that case the {dict} is passed in as "self". Example: >vim
-			function Callback() dict
-			   echo "called for " .. self.name
-			endfunction
-			"...
-			let context = {"name": "example"}
-			let Func = function('Callback', context)
-			"...
-			call Func()	" will echo: called for example
-<		The use of function() is not needed when there are no extra
-		arguments, these two are equivalent, if Callback() is defined
-		as context.Callback(): >vim
-			let Func = function('Callback', context)
-			let Func = context.Callback
+<                The Dictionary is only useful when calling a "dict" function.
+                In that case the {dict} is passed in as "self". Example: >vim
+                        function Callback() dict
+                           echo "called for " .. self.name
+                        endfunction
+                        "...
+                        let context = {"name": "example"}
+                        let Func = function('Callback', context)
+                        "...
+                        call Func()     " will echo: called for example
+<                The use of function() is not needed when there are no extra
+                arguments, these two are equivalent, if Callback() is defined
+                as context.Callback(): >vim
+                        let Func = function('Callback', context)
+                        let Func = context.Callback
 
-<		The argument list and the Dictionary can be combined: >vim
-			function Callback(arg1, count) dict
-			"...
-			endfunction
-			let context = {"name": "example"}
-			let Func = function('Callback', ['one'], context)
-			"...
-			call Func(500)
-<		Invokes the function as with: >vim
-			call context.Callback('one', 500)
+<                The argument list and the Dictionary can be combined: >vim
+                        function Callback(arg1, count) dict
+                        "...
+                        endfunction
+                        let context = {"name": "example"}
+                        let Func = function('Callback', ['one'], context)
+                        "...
+                        call Func(500)
+<                Invokes the function as with: >vim
+                        call context.Callback('one', 500)
 <
-		Returns 0 on error.
+                Returns 0 on error.
 
 garbagecollect([{atexit}])                                    *garbagecollect()*
-		Cleanup unused |Lists| and |Dictionaries| that have circular
-		references.
+                Cleanup unused |Lists| and |Dictionaries| that have circular
+                references.
 
-		There is hardly ever a need to invoke this function, as it is
-		automatically done when Vim runs out of memory or is waiting
-		for the user to press a key after 'updatetime'.  Items without
-		circular references are always freed when they become unused.
-		This is useful if you have deleted a very big |List| and/or
-		|Dictionary| with circular references in a script that runs
-		for a long time.
+                There is hardly ever a need to invoke this function, as it is
+                automatically done when Vim runs out of memory or is waiting
+                for the user to press a key after 'updatetime'.  Items without
+                circular references are always freed when they become unused.
+                This is useful if you have deleted a very big |List| and/or
+                |Dictionary| with circular references in a script that runs
+                for a long time.
 
-		When the optional {atexit} argument is one, garbage
-		collection will also be done when exiting Vim, if it wasn't
-		done before.  This is useful when checking for memory leaks.
+                When the optional {atexit} argument is one, garbage
+                collection will also be done when exiting Vim, if it wasn't
+                done before.  This is useful when checking for memory leaks.
 
-		The garbage collection is not done immediately but only when
-		it's safe to perform.  This is when waiting for the user to
-		type a character.
+                The garbage collection is not done immediately but only when
+                it's safe to perform.  This is when waiting for the user to
+                type a character.
 
 get({list}, {idx} [, {default}])                                         *get()*
-		Get item {idx} from |List| {list}.  When this item is not
-		available return {default}.  Return zero when {default} is
-		omitted.
+                Get item {idx} from |List| {list}.  When this item is not
+                available return {default}.  Return zero when {default} is
+                omitted.
 
 get({blob}, {idx} [, {default}])
-		Get byte {idx} from |Blob| {blob}.  When this byte is not
-		available return {default}.  Return -1 when {default} is
-		omitted.
+                Get byte {idx} from |Blob| {blob}.  When this byte is not
+                available return {default}.  Return -1 when {default} is
+                omitted.
 
 get({dict}, {key} [, {default}])
-		Get item with key {key} from |Dictionary| {dict}.  When this
-		item is not available return {default}.  Return zero when
-		{default} is omitted.  Useful example: >vim
-			let val = get(g:, 'var_name', 'default')
-<		This gets the value of g:var_name if it exists, and uses
-		"default" when it does not exist.
+                Get item with key {key} from |Dictionary| {dict}.  When this
+                item is not available return {default}.  Return zero when
+                {default} is omitted.  Useful example: >vim
+                        let val = get(g:, 'var_name', 'default')
+<                This gets the value of g:var_name if it exists, and uses
+                "default" when it does not exist.
 
 get({func}, {what})
-		Get item {what} from Funcref {func}.  Possible values for
-		{what} are:
-			"name"	The function name
-			"func"	The function
-			"dict"	The dictionary
-			"args"	The list with arguments
-		Returns zero on error.
+                Get item {what} from Funcref {func}.  Possible values for
+                {what} are:
+                        "name"  The function name
+                        "func"  The function
+                        "dict"  The dictionary
+                        "args"  The list with arguments
+                Returns zero on error.
 
 getbufinfo([{buf}])
 getbufinfo([{dict}])                                              *getbufinfo()*
-		Get information about buffers as a List of Dictionaries.
+                Get information about buffers as a List of Dictionaries.
 
-		Without an argument information about all the buffers is
-		returned.
+                Without an argument information about all the buffers is
+                returned.
 
-		When the argument is a |Dictionary| only the buffers matching
-		the specified criteria are returned.  The following keys can
-		be specified in {dict}:
-			buflisted	include only listed buffers.
-			bufloaded	include only loaded buffers.
-			bufmodified	include only modified buffers.
+                When the argument is a |Dictionary| only the buffers matching
+                the specified criteria are returned.  The following keys can
+                be specified in {dict}:
+                        buflisted       include only listed buffers.
+                        bufloaded       include only loaded buffers.
+                        bufmodified     include only modified buffers.
 
-		Otherwise, {buf} specifies a particular buffer to return
-		information for.  For the use of {buf}, see |bufname()|
-		above.  If the buffer is found the returned List has one item.
-		Otherwise the result is an empty list.
+                Otherwise, {buf} specifies a particular buffer to return
+                information for.  For the use of {buf}, see |bufname()|
+                above.  If the buffer is found the returned List has one item.
+                Otherwise the result is an empty list.
 
-		Each returned List item is a dictionary with the following
-		entries:
-			bufnr		Buffer number.
-			changed		TRUE if the buffer is modified.
-			changedtick	Number of changes made to the buffer.
-			hidden		TRUE if the buffer is hidden.
-			lastused	Timestamp in seconds, like
-					|localtime()|, when the buffer was
-					last used.
-			listed		TRUE if the buffer is listed.
-			lnum		Line number used for the buffer when
-					opened in the current window.
-					Only valid if the buffer has been
-					displayed in the window in the past.
-					If you want the line number of the
-					last known cursor position in a given
-					window, use |line()|: >vim
-						echo line('.', {winid})
+                Each returned List item is a dictionary with the following
+                entries:
+                        bufnr           Buffer number.
+                        changed         TRUE if the buffer is modified.
+                        changedtick     Number of changes made to the buffer.
+                        hidden          TRUE if the buffer is hidden.
+                        lastused        Timestamp in seconds, like
+                                        |localtime()|, when the buffer was
+                                        last used.
+                        listed          TRUE if the buffer is listed.
+                        lnum            Line number used for the buffer when
+                                        opened in the current window.
+                                        Only valid if the buffer has been
+                                        displayed in the window in the past.
+                                        If you want the line number of the
+                                        last known cursor position in a given
+                                        window, use |line()|: >vim
+                                                echo line('.', {winid})
 <
-			linecount	Number of lines in the buffer (only
-					valid when loaded)
-			loaded		TRUE if the buffer is loaded.
-			name		Full path to the file in the buffer.
-			signs		List of signs placed in the buffer.
-					Each list item is a dictionary with
-					the following fields:
-					    id	  sign identifier
-					    lnum  line number
-					    name  sign name
-			variables	A reference to the dictionary with
-					buffer-local variables.
-			windows		List of |window-ID|s that display this
-					buffer
+                        linecount       Number of lines in the buffer (only
+                                        valid when loaded)
+                        loaded          TRUE if the buffer is loaded.
+                        name            Full path to the file in the buffer.
+                        signs           List of signs placed in the buffer.
+                                        Each list item is a dictionary with
+                                        the following fields:
+                                            id    sign identifier
+                                            lnum  line number
+                                            name  sign name
+                        variables       A reference to the dictionary with
+                                        buffer-local variables.
+                        windows         List of |window-ID|s that display this
+                                        buffer
 
-		Examples: >vim
-			for buf in getbufinfo()
-			    echo buf.name
-			endfor
-			for buf in getbufinfo({'buflisted':1})
-			    if buf.changed
-				" ....
-			    endif
-			endfor
+                Examples: >vim
+                        for buf in getbufinfo()
+                            echo buf.name
+                        endfor
+                        for buf in getbufinfo({'buflisted':1})
+                            if buf.changed
+                                " ....
+                            endif
+                        endfor
 <
-		To get buffer-local options use: >vim
-			getbufvar({bufnr}, '&option_name')
+                To get buffer-local options use: >vim
+                        getbufvar({bufnr}, '&option_name')
 <
-
 getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
-		Return a |List| with the lines starting from {lnum} to {end}
-		(inclusive) in the buffer {buf}.  If {end} is omitted, a
-		|List| with only the line {lnum} is returned.  See
-		`getbufoneline()` for only getting the line.
+                Return a |List| with the lines starting from {lnum} to {end}
+                (inclusive) in the buffer {buf}.  If {end} is omitted, a
+                |List| with only the line {lnum} is returned.  See
+                `getbufoneline()` for only getting the line.
 
-		For the use of {buf}, see |bufname()| above.
+                For the use of {buf}, see |bufname()| above.
 
-		For {lnum} and {end} "$" can be used for the last line of the
-		buffer.  Otherwise a number must be used.
+                For {lnum} and {end} "$" can be used for the last line of the
+                buffer.  Otherwise a number must be used.
 
-		When {lnum} is smaller than 1 or bigger than the number of
-		lines in the buffer, an empty |List| is returned.
+                When {lnum} is smaller than 1 or bigger than the number of
+                lines in the buffer, an empty |List| is returned.
 
-		When {end} is greater than the number of lines in the buffer,
-		it is treated as {end} is set to the number of lines in the
-		buffer.  When {end} is before {lnum} an empty |List| is
-		returned.
+                When {end} is greater than the number of lines in the buffer,
+                it is treated as {end} is set to the number of lines in the
+                buffer.  When {end} is before {lnum} an empty |List| is
+                returned.
 
-		This function works only for loaded buffers.  For unloaded and
-		non-existing buffers, an empty |List| is returned.
+                This function works only for loaded buffers.  For unloaded and
+                non-existing buffers, an empty |List| is returned.
 
-		Example: >vim
-			let lines = getbufline(bufnr("myfile"), 1, "$")
+                Example: >vim
+                        let lines = getbufline(bufnr("myfile"), 1, "$")
 
 getbufoneline({buf}, {lnum})                                   *getbufoneline()*
-		Just like `getbufline()` but only get one line and return it
-		as a string.
+                Just like `getbufline()` but only get one line and return it
+                as a string.
 
 getbufvar({buf}, {varname} [, {def}])                              *getbufvar()*
-		The result is the value of option or local buffer variable
-		{varname} in buffer {buf}.  Note that the name without "b:"
-		must be used.
-		The {varname} argument is a string.
-		When {varname} is empty returns a |Dictionary| with all the
-		buffer-local variables.
-		When {varname} is equal to "&" returns a |Dictionary| with all
-		the buffer-local options.
-		Otherwise, when {varname} starts with "&" returns the value of
-		a buffer-local option.
-		This also works for a global or buffer-local option, but it
-		doesn't work for a global variable, window-local variable or
-		window-local option.
-		For the use of {buf}, see |bufname()| above.
-		When the buffer or variable doesn't exist {def} or an empty
-		string is returned, there is no error message.
-		Examples: >vim
-			let bufmodified = getbufvar(1, "&mod")
-			echo "todo myvar = " .. getbufvar("todo", "myvar")
+                The result is the value of option or local buffer variable
+                {varname} in buffer {buf}.  Note that the name without "b:"
+                must be used.
+                The {varname} argument is a string.
+                When {varname} is empty returns a |Dictionary| with all the
+                buffer-local variables.
+                When {varname} is equal to "&" returns a |Dictionary| with all
+                the buffer-local options.
+                Otherwise, when {varname} starts with "&" returns the value of
+                a buffer-local option.
+                This also works for a global or buffer-local option, but it
+                doesn't work for a global variable, window-local variable or
+                window-local option.
+                For the use of {buf}, see |bufname()| above.
+                When the buffer or variable doesn't exist {def} or an empty
+                string is returned, there is no error message.
+                Examples: >vim
+                        let bufmodified = getbufvar(1, "&mod")
+                        echo "todo myvar = " .. getbufvar("todo", "myvar")
 
 getcellwidths()                                                *getcellwidths()*
-		Returns a |List| of cell widths of character ranges overridden
-		by |setcellwidths()|.  The format is equal to the argument of
-		|setcellwidths()|.  If no character ranges have their cell
-		widths overridden, an empty List is returned.
+                Returns a |List| of cell widths of character ranges overridden
+                by |setcellwidths()|.  The format is equal to the argument of
+                |setcellwidths()|.  If no character ranges have their cell
+                widths overridden, an empty List is returned.
 
 getchangelist([{buf}])                                         *getchangelist()*
-		Returns the |changelist| for the buffer {buf}. For the use
-		of {buf}, see |bufname()| above. If buffer {buf} doesn't
-		exist, an empty list is returned.
+                Returns the |changelist| for the buffer {buf}. For the use
+                of {buf}, see |bufname()| above. If buffer {buf} doesn't
+                exist, an empty list is returned.
 
-		The returned list contains two entries: a list with the change
-		locations and the current position in the list.  Each
-		entry in the change list is a dictionary with the following
-		entries:
-			col		column number
-			coladd		column offset for 'virtualedit'
-			lnum		line number
-		If buffer {buf} is the current buffer, then the current
-		position refers to the position in the list. For other
-		buffers, it is set to the length of the list.
+                The returned list contains two entries: a list with the change
+                locations and the current position in the list.  Each
+                entry in the change list is a dictionary with the following
+                entries:
+                        col             column number
+                        coladd          column offset for 'virtualedit'
+                        lnum            line number
+                If buffer {buf} is the current buffer, then the current
+                position refers to the position in the list. For other
+                buffers, it is set to the length of the list.
 
 getchar([expr])                                                      *getchar()*
-		Get a single character from the user or input stream.
-		If [expr] is omitted, wait until a character is available.
-		If [expr] is 0, only get a character when one is available.
-			Return zero otherwise.
-		If [expr] is 1, only check if a character is available, it is
-			not consumed.  Return zero if no character available.
-		If you prefer always getting a string use |getcharstr()|.
+                Get a single character from the user or input stream.
+                If [expr] is omitted, wait until a character is available.
+                If [expr] is 0, only get a character when one is available.
+                        Return zero otherwise.
+                If [expr] is 1, only check if a character is available, it is
+                        not consumed.  Return zero if no character available.
+                If you prefer always getting a string use |getcharstr()|.
 
-		Without [expr] and when [expr] is 0 a whole character or
-		special key is returned.  If it is a single character, the
-		result is a Number.  Use |nr2char()| to convert it to a String.
-		Otherwise a String is returned with the encoded character.
-		For a special key it's a String with a sequence of bytes
-		starting with 0x80 (decimal: 128).  This is the same value as
-		the String "\<Key>", e.g., "\<Left>".  The returned value is
-		also a String when a modifier (shift, control, alt) was used
-		that is not included in the character.
+                Without [expr] and when [expr] is 0 a whole character or
+                special key is returned.  If it is a single character, the
+                result is a Number.  Use |nr2char()| to convert it to a String.
+                Otherwise a String is returned with the encoded character.
+                For a special key it's a String with a sequence of bytes
+                starting with 0x80 (decimal: 128).  This is the same value as
+                the String "\<Key>", e.g., "\<Left>".  The returned value is
+                also a String when a modifier (shift, control, alt) was used
+                that is not included in the character.
 
-		When [expr] is 0 and Esc is typed, there will be a short delay
-		while Vim waits to see if this is the start of an escape
-		sequence.
+                When [expr] is 0 and Esc is typed, there will be a short delay
+                while Vim waits to see if this is the start of an escape
+                sequence.
 
-		When [expr] is 1 only the first byte is returned.  For a
-		one-byte character it is the character itself as a number.
-		Use nr2char() to convert it to a String.
+                When [expr] is 1 only the first byte is returned.  For a
+                one-byte character it is the character itself as a number.
+                Use nr2char() to convert it to a String.
 
-		Use getcharmod() to obtain any additional modifiers.
+                Use getcharmod() to obtain any additional modifiers.
 
-		When the user clicks a mouse button, the mouse event will be
-		returned.  The position can then be found in |v:mouse_col|,
-		|v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
-		|getmousepos()| can also be used.  Mouse move events will be
-		ignored.
-		This example positions the mouse as it would normally happen: >vim
-			let c = getchar()
-			if c == "\<LeftMouse>" && v:mouse_win > 0
-			  exe v:mouse_win .. "wincmd w"
-			  exe v:mouse_lnum
-			  exe "normal " .. v:mouse_col .. "|"
-			endif
+                When the user clicks a mouse button, the mouse event will be
+                returned.  The position can then be found in |v:mouse_col|,
+                |v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
+                |getmousepos()| can also be used.  Mouse move events will be
+                ignored.
+                This example positions the mouse as it would normally happen: >vim
+                        let c = getchar()
+                        if c == "\<LeftMouse>" && v:mouse_win > 0
+                          exe v:mouse_win .. "wincmd w"
+                          exe v:mouse_lnum
+                          exe "normal " .. v:mouse_col .. "|"
+                        endif
 <
-		There is no prompt, you will somehow have to make clear to the
-		user that a character has to be typed.  The screen is not
-		redrawn, e.g. when resizing the window.
+                There is no prompt, you will somehow have to make clear to the
+                user that a character has to be typed.  The screen is not
+                redrawn, e.g. when resizing the window.
 
-		There is no mapping for the character.
-		Key codes are replaced, thus when the user presses the <Del>
-		key you get the code for the <Del> key, not the raw character
-		sequence.  Examples: >vim
-			getchar() == "\<Del>"
-			getchar() == "\<S-Left>"
-<		This example redefines "f" to ignore case: >vim
-			nmap f :call FindChar()<CR>
-			function FindChar()
-			  let c = nr2char(getchar())
-			  while col('.') < col('$') - 1
-			    normal l
-			    if getline('.')[col('.') - 1] ==? c
-			      break
-			    endif
-			  endwhile
-			endfunction
+                There is no mapping for the character.
+                Key codes are replaced, thus when the user presses the <Del>
+                key you get the code for the <Del> key, not the raw character
+                sequence.  Examples: >vim
+                        getchar() == "\<Del>"
+                        getchar() == "\<S-Left>"
+<                This example redefines "f" to ignore case: >vim
+                        nmap f :call FindChar()<CR>
+                        function FindChar()
+                          let c = nr2char(getchar())
+                          while col('.') < col('$') - 1
+                            normal l
+                            if getline('.')[col('.') - 1] ==? c
+                              break
+                            endif
+                          endwhile
+                        endfunction
 <
-
 getcharmod()                                                      *getcharmod()*
-		The result is a Number which is the state of the modifiers for
-		the last obtained character with getchar() or in another way.
-		These values are added together:
-			2	shift
-			4	control
-			8	alt (meta)
-			16	meta (when it's different from ALT)
-			32	mouse double click
-			64	mouse triple click
-			96	mouse quadruple click (== 32 + 64)
-			128	command (Macintosh only)
-		Only the modifiers that have not been included in the
-		character itself are obtained.  Thus Shift-a results in "A"
-		without a modifier.  Returns 0 if no modifiers are used.
+                The result is a Number which is the state of the modifiers for
+                the last obtained character with getchar() or in another way.
+                These values are added together:
+                        2       shift
+                        4       control
+                        8       alt (meta)
+                        16      meta (when it's different from ALT)
+                        32      mouse double click
+                        64      mouse triple click
+                        96      mouse quadruple click (== 32 + 64)
+                        128     command (Macintosh only)
+                Only the modifiers that have not been included in the
+                character itself are obtained.  Thus Shift-a results in "A"
+                without a modifier.  Returns 0 if no modifiers are used.
 
 getcharpos({expr})                                                *getcharpos()*
-		Get the position for String {expr}. Same as |getpos()| but the
-		column number in the returned List is a character index
-		instead of a byte index.
-		If |getpos()| returns a very large column number, equal to
-		|v:maxcol|, then getcharpos() will return the character index
-		of the last character.
+                Get the position for String {expr}. Same as |getpos()| but the
+                column number in the returned List is a character index
+                instead of a byte index.
+                If |getpos()| returns a very large column number, equal to
+                |v:maxcol|, then getcharpos() will return the character index
+                of the last character.
 
-		Example:
-		With the cursor on '세' in line 5 with text "여보세요": >vim
-			getcharpos('.')		returns [0, 5, 3, 0]
-			getpos('.')		returns [0, 5, 7, 0]
+                Example:
+                With the cursor on '세' in line 5 with text "여보세요": >vim
+                        getcharpos('.')         returns [0, 5, 3, 0]
+                        getpos('.')             returns [0, 5, 7, 0]
 <
-
 getcharsearch()                                                *getcharsearch()*
-		Return the current character search information as a {dict}
-		with the following entries:
+                Return the current character search information as a {dict}
+                with the following entries:
 
-		    char	character previously used for a character
-				search (|t|, |f|, |T|, or |F|); empty string
-				if no character search has been performed
-		    forward	direction of character search; 1 for forward,
-				0 for backward
-		    until	type of character search; 1 for a |t| or |T|
-				character search, 0 for an |f| or |F|
-				character search
+                    char        character previously used for a character
+                                search (|t|, |f|, |T|, or |F|); empty string
+                                if no character search has been performed
+                    forward     direction of character search; 1 for forward,
+                                0 for backward
+                    until       type of character search; 1 for a |t| or |T|
+                                character search, 0 for an |f| or |F|
+                                character search
 
-		This can be useful to always have |;| and |,| search
-		forward/backward regardless of the direction of the previous
-		character search: >vim
-			nnoremap <expr> ; getcharsearch().forward ? ';' : ','
-			nnoremap <expr> , getcharsearch().forward ? ',' : ';'
-<		Also see |setcharsearch()|.
+                This can be useful to always have |;| and |,| search
+                forward/backward regardless of the direction of the previous
+                character search: >vim
+                        nnoremap <expr> ; getcharsearch().forward ? ';' : ','
+                        nnoremap <expr> , getcharsearch().forward ? ',' : ';'
+<                Also see |setcharsearch()|.
 
 getcharstr([expr])                                                *getcharstr()*
-		Get a single character from the user or input stream as a
-		string.
-		If [expr] is omitted, wait until a character is available.
-		If [expr] is 0 or false, only get a character when one is
-			available.  Return an empty string otherwise.
-		If [expr] is 1 or true, only check if a character is
-			available, it is not consumed.  Return an empty string
-			if no character is available.
-		Otherwise this works like |getchar()|, except that a number
-		result is converted to a string.
+                Get a single character from the user or input stream as a
+                string.
+                If [expr] is omitted, wait until a character is available.
+                If [expr] is 0 or false, only get a character when one is
+                        available.  Return an empty string otherwise.
+                If [expr] is 1 or true, only check if a character is
+                        available, it is not consumed.  Return an empty string
+                        if no character is available.
+                Otherwise this works like |getchar()|, except that a number
+                result is converted to a string.
 
 getcmdcompltype()                                            *getcmdcompltype()*
-		Return the type of the current command-line completion.
-		Only works when the command line is being edited, thus
-		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
-		See |:command-completion| for the return string.
-		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-		|setcmdline()|.
-		Returns an empty string when completion is not defined.
+                Return the type of the current command-line completion.
+                Only works when the command line is being edited, thus
+                requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
+                See |:command-completion| for the return string.
+                Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
+                |setcmdline()|.
+                Returns an empty string when completion is not defined.
 
 getcmdline()                                                      *getcmdline()*
-		Return the current command-line.  Only works when the command
-		line is being edited, thus requires use of |c_CTRL-\_e| or
-		|c_CTRL-R_=|.
-		Example: >vim
-			cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
-<		Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
-		|setcmdline()|.
-		Returns an empty string when entering a password or using
-		|inputsecret()|.
+                Return the current command-line.  Only works when the command
+                line is being edited, thus requires use of |c_CTRL-\_e| or
+                |c_CTRL-R_=|.
+                Example: >vim
+                        cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
+<                Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
+                |setcmdline()|.
+                Returns an empty string when entering a password or using
+                |inputsecret()|.
 
 getcmdpos()                                                        *getcmdpos()*
-		Return the position of the cursor in the command line as a
-		byte count.  The first column is 1.
-		Only works when editing the command line, thus requires use of
-		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-		Returns 0 otherwise.
-		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-		|setcmdline()|.
+                Return the position of the cursor in the command line as a
+                byte count.  The first column is 1.
+                Only works when editing the command line, thus requires use of
+                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+                Returns 0 otherwise.
+                Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
+                |setcmdline()|.
 
 getcmdscreenpos()                                            *getcmdscreenpos()*
-		Return the screen position of the cursor in the command line
-		as a byte count.  The first column is 1.
-		Instead of |getcmdpos()|, it adds the prompt position.
-		Only works when editing the command line, thus requires use of
-		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-		Returns 0 otherwise.
-		Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
-		|setcmdline()|.
+                Return the screen position of the cursor in the command line
+                as a byte count.  The first column is 1.
+                Instead of |getcmdpos()|, it adds the prompt position.
+                Only works when editing the command line, thus requires use of
+                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+                Returns 0 otherwise.
+                Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
+                |setcmdline()|.
 
 getcmdtype()                                                      *getcmdtype()*
-		Return the current command-line type. Possible return values
-		are:
-		    :	normal Ex command
-		    >	debug mode command |debug-mode|
-		    /	forward search command
-		    ?	backward search command
-		    @	|input()| command
-		    `-`	|:insert| or |:append| command
-		    =	|i_CTRL-R_=|
-		Only works when editing the command line, thus requires use of
-		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-		Returns an empty string otherwise.
-		Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
+                Return the current command-line type. Possible return values
+                are:
+                    :   normal Ex command
+                    >   debug mode command |debug-mode|
+                    /   forward search command
+                    ?   backward search command
+                    @   |input()| command
+                    `-` |:insert| or |:append| command
+                    =   |i_CTRL-R_=|
+                Only works when editing the command line, thus requires use of
+                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+                Returns an empty string otherwise.
+                Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 
 getcmdwintype()                                                *getcmdwintype()*
-		Return the current |command-line-window| type. Possible return
-		values are the same as |getcmdtype()|. Returns an empty string
-		when not in the command-line window.
+                Return the current |command-line-window| type. Possible return
+                values are the same as |getcmdtype()|. Returns an empty string
+                when not in the command-line window.
 
 getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
-		Return a list of command-line completion matches. The String
-		{type} argument specifies what for.  The following completion
-		types are supported:
+                Return a list of command-line completion matches. The String
+                {type} argument specifies what for.  The following completion
+                types are supported:
 
-		arglist		file names in argument list
-		augroup		autocmd groups
-		buffer		buffer names
-		breakpoint	|:breakadd| and |:breakdel| suboptions
-		cmdline		|cmdline-completion| result
-		color		color schemes
-		command		Ex command
-		compiler	compilers
-		custom,{func}	custom completion, defined via {func}
-		customlist,{func} custom completion, defined via {func}
-		diff_buffer	|:diffget| and |:diffput| completion
-		dir		directory names
-		environment	environment variable names
-		event		autocommand events
-		expression	Vim expression
-		file		file and directory names
-		file_in_path	file and directory names in |'path'|
-		filetype	filetype names |'filetype'|
-		function	function name
-		help		help subjects
-		highlight	highlight groups
-		history		|:history| suboptions
-		locale		locale names (as output of locale -a)
-		mapclear	buffer argument
-		mapping		mapping name
-		menu		menus
-		messages	|:messages| suboptions
-		option		options
-		packadd		optional package |pack-add| names
-		runtime		|:runtime| completion
-		scriptnames	sourced script names |:scriptnames|
-		shellcmd	Shell command
-		sign		|:sign| suboptions
-		syntax		syntax file names |'syntax'|
-		syntime		|:syntime| suboptions
-		tag		tags
-		tag_listfiles	tags, file names
-		user		user names
-		var		user variables
+                arglist         file names in argument list
+                augroup         autocmd groups
+                buffer          buffer names
+                breakpoint      |:breakadd| and |:breakdel| suboptions
+                cmdline         |cmdline-completion| result
+                color           color schemes
+                command         Ex command
+                compiler        compilers
+                custom,{func}   custom completion, defined via {func}
+                customlist,{func} custom completion, defined via {func}
+                diff_buffer     |:diffget| and |:diffput| completion
+                dir             directory names
+                environment     environment variable names
+                event           autocommand events
+                expression      Vim expression
+                file            file and directory names
+                file_in_path    file and directory names in |'path'|
+                filetype        filetype names |'filetype'|
+                function        function name
+                help            help subjects
+                highlight       highlight groups
+                history         |:history| suboptions
+                locale          locale names (as output of locale -a)
+                mapclear        buffer argument
+                mapping         mapping name
+                menu            menus
+                messages        |:messages| suboptions
+                option          options
+                packadd         optional package |pack-add| names
+                runtime         |:runtime| completion
+                scriptnames     sourced script names |:scriptnames|
+                shellcmd        Shell command
+                sign            |:sign| suboptions
+                syntax          syntax file names |'syntax'|
+                syntime         |:syntime| suboptions
+                tag             tags
+                tag_listfiles   tags, file names
+                user            user names
+                var             user variables
 
-		If {pat} is an empty string, then all the matches are
-		returned.  Otherwise only items matching {pat} are returned.
-		See |wildcards| for the use of special characters in {pat}.
+                If {pat} is an empty string, then all the matches are
+                returned.  Otherwise only items matching {pat} are returned.
+                See |wildcards| for the use of special characters in {pat}.
 
-		If the optional {filtered} flag is set to 1, then 'wildignore'
-		is applied to filter the results.  Otherwise all the matches
-		are returned. The 'wildignorecase' option always applies.
+                If the optional {filtered} flag is set to 1, then 'wildignore'
+                is applied to filter the results.  Otherwise all the matches
+                are returned. The 'wildignorecase' option always applies.
 
-		If the 'wildoptions' option contains "fuzzy", then fuzzy
-		matching is used to get the completion matches. Otherwise
-		regular expression matching is used.  Thus this function
-		follows the user preference, what happens on the command line.
-		If you do not want this you can make 'wildoptions' empty
-		before calling getcompletion() and restore it afterwards.
+                If the 'wildoptions' option contains "fuzzy", then fuzzy
+                matching is used to get the completion matches. Otherwise
+                regular expression matching is used.  Thus this function
+                follows the user preference, what happens on the command line.
+                If you do not want this you can make 'wildoptions' empty
+                before calling getcompletion() and restore it afterwards.
 
-		If {type} is "cmdline", then the |cmdline-completion| result is
-		returned.  For example, to complete the possible values after
-		a ":call" command: >vim
-			echo getcompletion('call ', 'cmdline')
+                If {type} is "cmdline", then the |cmdline-completion| result is
+                returned.  For example, to complete the possible values after
+                a ":call" command: >vim
+                        echo getcompletion('call ', 'cmdline')
 <
-		If there are no matches, an empty list is returned.  An
-		invalid value for {type} produces an error.
+                If there are no matches, an empty list is returned.  An
+                invalid value for {type} produces an error.
 
 getcurpos([{winid}])                                               *getcurpos()*
-		Get the position of the cursor.  This is like getpos('.'), but
-		includes an extra "curswant" item in the list:
-		    [0, lnum, col, off, curswant] ~
-		The "curswant" number is the preferred column when moving the
-		cursor vertically.  After |$| command it will be a very large
-		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
-		|getpos()|.
-		The first "bufnum" item is always zero. The byte position of
-		the cursor is returned in "col". To get the character
-		position, use |getcursorcharpos()|.
+                Get the position of the cursor.  This is like getpos('.'), but
+                includes an extra "curswant" item in the list:
+                    [0, lnum, col, off, curswant] ~
+                The "curswant" number is the preferred column when moving the
+                cursor vertically.  After |$| command it will be a very large
+                number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
+                |getpos()|.
+                The first "bufnum" item is always zero. The byte position of
+                the cursor is returned in "col". To get the character
+                position, use |getcursorcharpos()|.
 
-		The optional {winid} argument can specify the window.  It can
-		be the window number or the |window-ID|.  The last known
-		cursor position is returned, this may be invalid for the
-		current value of the buffer if it is not the current window.
-		If {winid} is invalid a list with zeroes is returned.
+                The optional {winid} argument can specify the window.  It can
+                be the window number or the |window-ID|.  The last known
+                cursor position is returned, this may be invalid for the
+                current value of the buffer if it is not the current window.
+                If {winid} is invalid a list with zeroes is returned.
 
-		This can be used to save and restore the cursor position: >vim
-			let save_cursor = getcurpos()
-			MoveTheCursorAround
-			call setpos('.', save_cursor)
-<		Note that this only works within the window.  See
-		|winrestview()| for restoring more state.
+                This can be used to save and restore the cursor position: >vim
+                        let save_cursor = getcurpos()
+                        MoveTheCursorAround
+                        call setpos('.', save_cursor)
+<                Note that this only works within the window.  See
+                |winrestview()| for restoring more state.
 
 getcursorcharpos([{winid}])                                 *getcursorcharpos()*
-		Same as |getcurpos()| but the column number in the returned
-		List is a character index instead of a byte index.
+                Same as |getcurpos()| but the column number in the returned
+                List is a character index instead of a byte index.
 
-		Example:
-		With the cursor on '보' in line 3 with text "여보세요": >vim
-			getcursorcharpos()	" returns [0, 3, 2, 0, 3]
-			getcurpos()		" returns [0, 3, 4, 0, 3]
+                Example:
+                With the cursor on '보' in line 3 with text "여보세요": >vim
+                        getcursorcharpos()      " returns [0, 3, 2, 0, 3]
+                        getcurpos()             " returns [0, 3, 4, 0, 3]
 <
-
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
-		With no arguments, returns the name of the effective
-		|current-directory|. With {winnr} or {tabnr} the working
-		directory of that scope is returned, and 'autochdir' is
-		ignored.
-		Tabs and windows are identified by their respective numbers,
-		0 means current tab or window. Missing tab number implies 0.
-		Thus the following are equivalent: >vim
-			getcwd(0)
-			getcwd(0, 0)
-<		If {winnr} is -1 it is ignored, only the tab is resolved.
-		{winnr} can be the window number or the |window-ID|.
-		If both {winnr} and {tabnr} are -1 the global working
-		directory is returned.
-		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+                With no arguments, returns the name of the effective
+                |current-directory|. With {winnr} or {tabnr} the working
+                directory of that scope is returned, and 'autochdir' is
+                ignored.
+                Tabs and windows are identified by their respective numbers,
+                0 means current tab or window. Missing tab number implies 0.
+                Thus the following are equivalent: >vim
+                        getcwd(0)
+                        getcwd(0, 0)
+<                If {winnr} is -1 it is ignored, only the tab is resolved.
+                {winnr} can be the window number or the |window-ID|.
+                If both {winnr} and {tabnr} are -1 the global working
+                directory is returned.
+                Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
 getenv({name})                                                        *getenv()*
-		Return the value of environment variable {name}.  The {name}
-		argument is a string, without a leading '$'.  Example: >vim
-			myHome = getenv('HOME')
+                Return the value of environment variable {name}.  The {name}
+                argument is a string, without a leading '$'.  Example: >vim
+                        myHome = getenv('HOME')
 
-<		When the variable does not exist |v:null| is returned.  That
-		is different from a variable set to an empty string.
-		See also |expr-env|.
+<                When the variable does not exist |v:null| is returned.  That
+                is different from a variable set to an empty string.
+                See also |expr-env|.
 
 getfontname([{name}])                                            *getfontname()*
-		Without an argument returns the name of the normal font being
-		used.  Like what is used for the Normal highlight group
-		|hl-Normal|.
-		With an argument a check is done whether String {name} is a
-		valid font name.  If not then an empty string is returned.
-		Otherwise the actual font name is returned, or {name} if the
-		GUI does not support obtaining the real name.
-		Only works when the GUI is running, thus not in your vimrc or
-		gvimrc file.  Use the |GUIEnter| autocommand to use this
-		function just after the GUI has started.
+                Without an argument returns the name of the normal font being
+                used.  Like what is used for the Normal highlight group
+                |hl-Normal|.
+                With an argument a check is done whether String {name} is a
+                valid font name.  If not then an empty string is returned.
+                Otherwise the actual font name is returned, or {name} if the
+                GUI does not support obtaining the real name.
+                Only works when the GUI is running, thus not in your vimrc or
+                gvimrc file.  Use the |GUIEnter| autocommand to use this
+                function just after the GUI has started.
 
 getfperm({fname})                                                   *getfperm()*
-		The result is a String, which is the read, write, and execute
-		permissions of the given file {fname}.
-		If {fname} does not exist or its directory cannot be read, an
-		empty string is returned.
-		The result is of the form "rwxrwxrwx", where each group of
-		"rwx" flags represent, in turn, the permissions of the owner
-		of the file, the group the file belongs to, and other users.
-		If a user does not have a given permission the flag for this
-		is replaced with the string "-".  Examples: >vim
-			echo getfperm("/etc/passwd")
-			echo getfperm(expand("~/.config/nvim/init.vim"))
-<		This will hopefully (from a security point of view) display
-		the string "rw-r--r--" or even "rw-------".
+                The result is a String, which is the read, write, and execute
+                permissions of the given file {fname}.
+                If {fname} does not exist or its directory cannot be read, an
+                empty string is returned.
+                The result is of the form "rwxrwxrwx", where each group of
+                "rwx" flags represent, in turn, the permissions of the owner
+                of the file, the group the file belongs to, and other users.
+                If a user does not have a given permission the flag for this
+                is replaced with the string "-".  Examples: >vim
+                        echo getfperm("/etc/passwd")
+                        echo getfperm(expand("~/.config/nvim/init.vim"))
+<                This will hopefully (from a security point of view) display
+                the string "rw-r--r--" or even "rw-------".
 
-		For setting permissions use |setfperm()|.
+                For setting permissions use |setfperm()|.
 
 getfsize({fname})                                                   *getfsize()*
-		The result is a Number, which is the size in bytes of the
-		given file {fname}.
-		If {fname} is a directory, 0 is returned.
-		If the file {fname} can't be found, -1 is returned.
-		If the size of {fname} is too big to fit in a Number then -2
-		is returned.
+                The result is a Number, which is the size in bytes of the
+                given file {fname}.
+                If {fname} is a directory, 0 is returned.
+                If the file {fname} can't be found, -1 is returned.
+                If the size of {fname} is too big to fit in a Number then -2
+                is returned.
 
 getftime({fname})                                                   *getftime()*
-		The result is a Number, which is the last modification time of
-		the given file {fname}.  The value is measured as seconds
-		since 1st Jan 1970, and may be passed to strftime().  See also
-		|localtime()| and |strftime()|.
-		If the file {fname} can't be found -1 is returned.
+                The result is a Number, which is the last modification time of
+                the given file {fname}.  The value is measured as seconds
+                since 1st Jan 1970, and may be passed to strftime().  See also
+                |localtime()| and |strftime()|.
+                If the file {fname} can't be found -1 is returned.
 
 getftype({fname})                                                   *getftype()*
-		The result is a String, which is a description of the kind of
-		file of the given file {fname}.
-		If {fname} does not exist an empty string is returned.
-		Here is a table over different kinds of files and their
-		results:
-			Normal file		"file"
-			Directory		"dir"
-			Symbolic link		"link"
-			Block device		"bdev"
-			Character device	"cdev"
-			Socket			"socket"
-			FIFO			"fifo"
-			All other		"other"
-		Example: >vim
-			getftype("/home")
-<		Note that a type such as "link" will only be returned on
-		systems that support it.  On some systems only "dir" and
-		"file" are returned.
+                The result is a String, which is a description of the kind of
+                file of the given file {fname}.
+                If {fname} does not exist an empty string is returned.
+                Here is a table over different kinds of files and their
+                results:
+                        Normal file             "file"
+                        Directory               "dir"
+                        Symbolic link           "link"
+                        Block device            "bdev"
+                        Character device        "cdev"
+                        Socket                  "socket"
+                        FIFO                    "fifo"
+                        All other               "other"
+                Example: >vim
+                        getftype("/home")
+<                Note that a type such as "link" will only be returned on
+                systems that support it.  On some systems only "dir" and
+                "file" are returned.
 
 getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
-		Returns the |jumplist| for the specified window.
+                Returns the |jumplist| for the specified window.
 
-		Without arguments use the current window.
-		With {winnr} only use this window in the current tab page.
-		{winnr} can also be a |window-ID|.
-		With {winnr} and {tabnr} use the window in the specified tab
-		page.  If {winnr} or {tabnr} is invalid, an empty list is
-		returned.
+                Without arguments use the current window.
+                With {winnr} only use this window in the current tab page.
+                {winnr} can also be a |window-ID|.
+                With {winnr} and {tabnr} use the window in the specified tab
+                page.  If {winnr} or {tabnr} is invalid, an empty list is
+                returned.
 
-		The returned list contains two entries: a list with the jump
-		locations and the last used jump position number in the list.
-		Each entry in the jump location list is a dictionary with
-		the following entries:
-			bufnr		buffer number
-			col		column number
-			coladd		column offset for 'virtualedit'
-			filename	filename if available
-			lnum		line number
+                The returned list contains two entries: a list with the jump
+                locations and the last used jump position number in the list.
+                Each entry in the jump location list is a dictionary with
+                the following entries:
+                        bufnr           buffer number
+                        col             column number
+                        coladd          column offset for 'virtualedit'
+                        filename        filename if available
+                        lnum            line number
 
 getline({lnum} [, {end}])                                            *getline()*
-		Without {end} the result is a String, which is line {lnum}
-		from the current buffer.  Example: >vim
-			getline(1)
-<		When {lnum} is a String that doesn't start with a
-		digit, |line()| is called to translate the String into a Number.
-		To get the line under the cursor: >vim
-			getline(".")
-<		When {lnum} is a number smaller than 1 or bigger than the
-		number of lines in the buffer, an empty string is returned.
+                Without {end} the result is a String, which is line {lnum}
+                from the current buffer.  Example: >vim
+                        getline(1)
+<                When {lnum} is a String that doesn't start with a
+                digit, |line()| is called to translate the String into a Number.
+                To get the line under the cursor: >vim
+                        getline(".")
+<                When {lnum} is a number smaller than 1 or bigger than the
+                number of lines in the buffer, an empty string is returned.
 
-		When {end} is given the result is a |List| where each item is
-		a line from the current buffer in the range {lnum} to {end},
-		including line {end}.
-		{end} is used in the same way as {lnum}.
-		Non-existing lines are silently omitted.
-		When {end} is before {lnum} an empty |List| is returned.
-		Example: >vim
-			let start = line('.')
-			let end = search("^$") - 1
-			let lines = getline(start, end)
+                When {end} is given the result is a |List| where each item is
+                a line from the current buffer in the range {lnum} to {end},
+                including line {end}.
+                {end} is used in the same way as {lnum}.
+                Non-existing lines are silently omitted.
+                When {end} is before {lnum} an empty |List| is returned.
+                Example: >vim
+                        let start = line('.')
+                        let end = search("^$") - 1
+                        let lines = getline(start, end)
 
-<		To get lines from another buffer see |getbufline()| and
-		|getbufoneline()|
+<                To get lines from another buffer see |getbufline()| and
+                |getbufoneline()|
 
 getloclist({nr} [, {what}])                                       *getloclist()*
-		Returns a |List| with all the entries in the location list for
-		window {nr}.  {nr} can be the window number or the |window-ID|.
-		When {nr} is zero the current window is used.
+                Returns a |List| with all the entries in the location list for
+                window {nr}.  {nr} can be the window number or the |window-ID|.
+                When {nr} is zero the current window is used.
 
-		For a location list window, the displayed location list is
-		returned.  For an invalid window number {nr}, an empty list is
-		returned. Otherwise, same as |getqflist()|.
+                For a location list window, the displayed location list is
+                returned.  For an invalid window number {nr}, an empty list is
+                returned. Otherwise, same as |getqflist()|.
 
-		If the optional {what} dictionary argument is supplied, then
-		returns the items listed in {what} as a dictionary. Refer to
-		|getqflist()| for the supported items in {what}.
+                If the optional {what} dictionary argument is supplied, then
+                returns the items listed in {what} as a dictionary. Refer to
+                |getqflist()| for the supported items in {what}.
 
-		In addition to the items supported by |getqflist()| in {what},
-		the following item is supported by |getloclist()|:
+                In addition to the items supported by |getqflist()| in {what},
+                the following item is supported by |getloclist()|:
 
-			filewinid	id of the window used to display files
-					from the location list. This field is
-					applicable only when called from a
-					location list window. See
-					|location-list-file-window| for more
-					details.
+                        filewinid       id of the window used to display files
+                                        from the location list. This field is
+                                        applicable only when called from a
+                                        location list window. See
+                                        |location-list-file-window| for more
+                                        details.
 
-		Returns a |Dictionary| with default values if there is no
-		location list for the window {nr}.
-		Returns an empty Dictionary if window {nr} does not exist.
+                Returns a |Dictionary| with default values if there is no
+                location list for the window {nr}.
+                Returns an empty Dictionary if window {nr} does not exist.
 
-		Examples (See also |getqflist-examples|): >vim
-			echo getloclist(3, {'all': 0})
-			echo getloclist(5, {'filewinid': 0})
+                Examples (See also |getqflist-examples|): >vim
+                        echo getloclist(3, {'all': 0})
+                        echo getloclist(5, {'filewinid': 0})
 <
-
 getmarklist([{buf}])                                             *getmarklist()*
-		Without the {buf} argument returns a |List| with information
-		about all the global marks. |mark|
+                Without the {buf} argument returns a |List| with information
+                about all the global marks. |mark|
 
-		If the optional {buf} argument is specified, returns the
-		local marks defined in buffer {buf}.  For the use of {buf},
-		see |bufname()|.  If {buf} is invalid, an empty list is
-		returned.
+                If the optional {buf} argument is specified, returns the
+                local marks defined in buffer {buf}.  For the use of {buf},
+                see |bufname()|.  If {buf} is invalid, an empty list is
+                returned.
 
-		Each item in the returned List is a |Dict| with the following:
-		    mark   name of the mark prefixed by "'"
-		    pos	   a |List| with the position of the mark:
-				[bufnum, lnum, col, off]
-			   Refer to |getpos()| for more information.
-		    file   file name
+                Each item in the returned List is a |Dict| with the following:
+                    mark   name of the mark prefixed by "'"
+                    pos    a |List| with the position of the mark:
+                                [bufnum, lnum, col, off]
+                           Refer to |getpos()| for more information.
+                    file   file name
 
-		Refer to |getpos()| for getting information about a specific
-		mark.
+                Refer to |getpos()| for getting information about a specific
+                mark.
 
 getmatches([{win}])                                               *getmatches()*
-		Returns a |List| with all matches previously defined for the
-		current window by |matchadd()| and the |:match| commands.
-		|getmatches()| is useful in combination with |setmatches()|,
-		as |setmatches()| can restore a list of matches saved by
-		|getmatches()|.
-		If {win} is specified, use the window with this number or
-		window ID instead of the current window.  If {win} is invalid,
-		an empty list is returned.
-		Example: >vim
-			echo getmatches()
-<		 >
-			[{"group": "MyGroup1", "pattern": "TODO",
-			"priority": 10, "id": 1}, {"group": "MyGroup2",
-			"pattern": "FIXME", "priority": 10, "id": 2}]
-<		 >vim
-			let m = getmatches()
-			call clearmatches()
-			echo getmatches()
-<		 >
-			[]
-<		 >vim
-			call setmatches(m)
-			echo getmatches()
-<		 >
-			[{"group": "MyGroup1", "pattern": "TODO",
-			"priority": 10, "id": 1}, {"group": "MyGroup2",
-			"pattern": "FIXME", "priority": 10, "id": 2}]
-<		 >vim
-			unlet m
+                Returns a |List| with all matches previously defined for the
+                current window by |matchadd()| and the |:match| commands.
+                |getmatches()| is useful in combination with |setmatches()|,
+                as |setmatches()| can restore a list of matches saved by
+                |getmatches()|.
+                If {win} is specified, use the window with this number or
+                window ID instead of the current window.  If {win} is invalid,
+                an empty list is returned.
+                Example: >vim
+                        echo getmatches()
+<                 >
+                        [{"group": "MyGroup1", "pattern": "TODO",
+                        "priority": 10, "id": 1}, {"group": "MyGroup2",
+                        "pattern": "FIXME", "priority": 10, "id": 2}]
+<                 >vim
+                        let m = getmatches()
+                        call clearmatches()
+                        echo getmatches()
+<                 >
+                        []
+<                 >vim
+                        call setmatches(m)
+                        echo getmatches()
+<                 >
+                        [{"group": "MyGroup1", "pattern": "TODO",
+                        "priority": 10, "id": 1}, {"group": "MyGroup2",
+                        "pattern": "FIXME", "priority": 10, "id": 2}]
+<                 >vim
+                        unlet m
 <
-
 getmousepos()                                                    *getmousepos()*
-		Returns a |Dictionary| with the last known position of the
-		mouse.  This can be used in a mapping for a mouse click.  The
-		items are:
-			screenrow	screen row
-			screencol	screen column
-			winid		Window ID of the click
-			winrow		row inside "winid"
-			wincol		column inside "winid"
-			line		text line inside "winid"
-			column		text column inside "winid"
-			coladd		offset (in screen columns) from the
-					start of the clicked char
-		All numbers are 1-based.
+                Returns a |Dictionary| with the last known position of the
+                mouse.  This can be used in a mapping for a mouse click.  The
+                items are:
+                        screenrow       screen row
+                        screencol       screen column
+                        winid           Window ID of the click
+                        winrow          row inside "winid"
+                        wincol          column inside "winid"
+                        line            text line inside "winid"
+                        column          text column inside "winid"
+                        coladd          offset (in screen columns) from the
+                                        start of the clicked char
+                All numbers are 1-based.
 
-		If not over a window, e.g. when in the command line, then only
-		"screenrow" and "screencol" are valid, the others are zero.
+                If not over a window, e.g. when in the command line, then only
+                "screenrow" and "screencol" are valid, the others are zero.
 
-		When on the status line below a window or the vertical
-		separator right of a window, the "line" and "column" values
-		are zero.
+                When on the status line below a window or the vertical
+                separator right of a window, the "line" and "column" values
+                are zero.
 
-		When the position is after the text then "column" is the
-		length of the text in bytes plus one.
+                When the position is after the text then "column" is the
+                length of the text in bytes plus one.
 
-		If the mouse is over a focusable floating window then that
-		window is used.
+                If the mouse is over a focusable floating window then that
+                window is used.
 
-		When using |getchar()| the Vim variables |v:mouse_lnum|,
-		|v:mouse_col| and |v:mouse_winid| also provide these values.
+                When using |getchar()| the Vim variables |v:mouse_lnum|,
+                |v:mouse_col| and |v:mouse_winid| also provide these values.
 
 getpid()                                                              *getpid()*
-		Return a Number which is the process ID of the Vim process.
-		This is a unique number, until Vim exits.
+                Return a Number which is the process ID of the Vim process.
+                This is a unique number, until Vim exits.
 
 getpos({expr})                                                        *getpos()*
-		Get the position for String {expr}.  For possible values of
-		{expr} see |line()|.  For getting the cursor position see
-		|getcurpos()|.
-		The result is a |List| with four numbers:
-		    [bufnum, lnum, col, off]
-		"bufnum" is zero, unless a mark like '0 or 'A is used, then it
-		is the buffer number of the mark.
-		"lnum" and "col" are the position in the buffer.  The first
-		column is 1.
-		The "off" number is zero, unless 'virtualedit' is used.  Then
-		it is the offset in screen columns from the start of the
-		character.  E.g., a position within a <Tab> or after the last
-		character.
-		Note that for '< and '> Visual mode matters: when it is "V"
-		(visual line mode) the column of '< is zero and the column of
-		'> is a large number equal to |v:maxcol|.
-		The column number in the returned List is the byte position
-		within the line. To get the character position in the line,
-		use |getcharpos()|.
-		A very large column number equal to |v:maxcol| can be returned,
-		in which case it means "after the end of the line".
-		If {expr} is invalid, returns a list with all zeros.
-		This can be used to save and restore the position of a mark: >vim
-			let save_a_mark = getpos("'a")
-			" ...
-			call setpos("'a", save_a_mark)
-<		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+                Get the position for String {expr}.  For possible values of
+                {expr} see |line()|.  For getting the cursor position see
+                |getcurpos()|.
+                The result is a |List| with four numbers:
+                    [bufnum, lnum, col, off]
+                "bufnum" is zero, unless a mark like '0 or 'A is used, then it
+                is the buffer number of the mark.
+                "lnum" and "col" are the position in the buffer.  The first
+                column is 1.
+                The "off" number is zero, unless 'virtualedit' is used.  Then
+                it is the offset in screen columns from the start of the
+                character.  E.g., a position within a <Tab> or after the last
+                character.
+                Note that for '< and '> Visual mode matters: when it is "V"
+                (visual line mode) the column of '< is zero and the column of
+                '> is a large number equal to |v:maxcol|.
+                The column number in the returned List is the byte position
+                within the line. To get the character position in the line,
+                use |getcharpos()|.
+                A very large column number equal to |v:maxcol| can be returned,
+                in which case it means "after the end of the line".
+                If {expr} is invalid, returns a list with all zeros.
+                This can be used to save and restore the position of a mark: >vim
+                        let save_a_mark = getpos("'a")
+                        " ...
+                        call setpos("'a", save_a_mark)
+<                Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
 getqflist([{what}])                                                *getqflist()*
-		Returns a |List| with all the current quickfix errors.  Each
-		list item is a dictionary with these entries:
-			bufnr	number of buffer that has the file name, use
-				bufname() to get the name
-			module	module name
-			lnum	line number in the buffer (first line is 1)
-			end_lnum
-				end of line number if the item is multiline
-			col	column number (first column is 1)
-			end_col	end of column number if the item has range
-			vcol	|TRUE|: "col" is visual column
-				|FALSE|: "col" is byte index
-			nr	error number
-			pattern	search pattern used to locate the error
-			text	description of the error
-			type	type of the error, 'E', '1', etc.
-			valid	|TRUE|: recognized error message
-			user_data
-				custom data associated with the item, can be
-				any type.
+                Returns a |List| with all the current quickfix errors.  Each
+                list item is a dictionary with these entries:
+                        bufnr   number of buffer that has the file name, use
+                                bufname() to get the name
+                        module  module name
+                        lnum    line number in the buffer (first line is 1)
+                        end_lnum
+                                end of line number if the item is multiline
+                        col     column number (first column is 1)
+                        end_col end of column number if the item has range
+                        vcol    |TRUE|: "col" is visual column
+                                |FALSE|: "col" is byte index
+                        nr      error number
+                        pattern search pattern used to locate the error
+                        text    description of the error
+                        type    type of the error, 'E', '1', etc.
+                        valid   |TRUE|: recognized error message
+                        user_data
+                                custom data associated with the item, can be
+                                any type.
 
-		When there is no error list or it's empty, an empty list is
-		returned. Quickfix list entries with a non-existing buffer
-		number are returned with "bufnr" set to zero (Note: some
-		functions accept buffer number zero for the alternate buffer,
-		you may need to explicitly check for zero).
+                When there is no error list or it's empty, an empty list is
+                returned. Quickfix list entries with a non-existing buffer
+                number are returned with "bufnr" set to zero (Note: some
+                functions accept buffer number zero for the alternate buffer,
+                you may need to explicitly check for zero).
 
-		Useful application: Find pattern matches in multiple files and
-		do something with them: >vim
-			vimgrep /theword/jg *.c
-			for d in getqflist()
-			   echo bufname(d.bufnr) ':' d.lnum '=' d.text
-			endfor
+                Useful application: Find pattern matches in multiple files and
+                do something with them: >vim
+                        vimgrep /theword/jg *.c
+                        for d in getqflist()
+                           echo bufname(d.bufnr) ':' d.lnum '=' d.text
+                        endfor
 <
-		If the optional {what} dictionary argument is supplied, then
-		returns only the items listed in {what} as a dictionary. The
-		following string items are supported in {what}:
-			changedtick	get the total number of changes made
-					to the list |quickfix-changedtick|
-			context	get the |quickfix-context|
-			efm	errorformat to use when parsing "lines". If
-				not present, then the 'errorformat' option
-				value is used.
-			id	get information for the quickfix list with
-				|quickfix-ID|; zero means the id for the
-				current list or the list specified by "nr"
-			idx	get information for the quickfix entry at this
-				index in the list specified by "id" or "nr".
-				If set to zero, then uses the current entry.
-				See |quickfix-index|
-			items	quickfix list entries
-			lines	parse a list of lines using 'efm' and return
-				the resulting entries.  Only a |List| type is
-				accepted.  The current quickfix list is not
-				modified. See |quickfix-parse|.
-			nr	get information for this quickfix list; zero
-				means the current quickfix list and "$" means
-				the last quickfix list
-			qfbufnr number of the buffer displayed in the quickfix
-				window. Returns 0 if the quickfix buffer is
-				not present. See |quickfix-buffer|.
-			size	number of entries in the quickfix list
-			title	get the list title |quickfix-title|
-			winid	get the quickfix |window-ID|
-			all	all of the above quickfix properties
-		Non-string items in {what} are ignored. To get the value of a
-		particular item, set it to zero.
-		If "nr" is not present then the current quickfix list is used.
-		If both "nr" and a non-zero "id" are specified, then the list
-		specified by "id" is used.
-		To get the number of lists in the quickfix stack, set "nr" to
-		"$" in {what}. The "nr" value in the returned dictionary
-		contains the quickfix stack size.
-		When "lines" is specified, all the other items except "efm"
-		are ignored.  The returned dictionary contains the entry
-		"items" with the list of entries.
+                If the optional {what} dictionary argument is supplied, then
+                returns only the items listed in {what} as a dictionary. The
+                following string items are supported in {what}:
+                        changedtick     get the total number of changes made
+                                        to the list |quickfix-changedtick|
+                        context get the |quickfix-context|
+                        efm     errorformat to use when parsing "lines". If
+                                not present, then the 'errorformat' option
+                                value is used.
+                        id      get information for the quickfix list with
+                                |quickfix-ID|; zero means the id for the
+                                current list or the list specified by "nr"
+                        idx     get information for the quickfix entry at this
+                                index in the list specified by "id" or "nr".
+                                If set to zero, then uses the current entry.
+                                See |quickfix-index|
+                        items   quickfix list entries
+                        lines   parse a list of lines using 'efm' and return
+                                the resulting entries.  Only a |List| type is
+                                accepted.  The current quickfix list is not
+                                modified. See |quickfix-parse|.
+                        nr      get information for this quickfix list; zero
+                                means the current quickfix list and "$" means
+                                the last quickfix list
+                        qfbufnr number of the buffer displayed in the quickfix
+                                window. Returns 0 if the quickfix buffer is
+                                not present. See |quickfix-buffer|.
+                        size    number of entries in the quickfix list
+                        title   get the list title |quickfix-title|
+                        winid   get the quickfix |window-ID|
+                        all     all of the above quickfix properties
+                Non-string items in {what} are ignored. To get the value of a
+                particular item, set it to zero.
+                If "nr" is not present then the current quickfix list is used.
+                If both "nr" and a non-zero "id" are specified, then the list
+                specified by "id" is used.
+                To get the number of lists in the quickfix stack, set "nr" to
+                "$" in {what}. The "nr" value in the returned dictionary
+                contains the quickfix stack size.
+                When "lines" is specified, all the other items except "efm"
+                are ignored.  The returned dictionary contains the entry
+                "items" with the list of entries.
 
-		The returned dictionary contains the following entries:
-			changedtick	total number of changes made to the
-					list |quickfix-changedtick|
-			context	quickfix list context. See |quickfix-context|
-				If not present, set to "".
-			id	quickfix list ID |quickfix-ID|. If not
-				present, set to 0.
-			idx	index of the quickfix entry in the list. If not
-				present, set to 0.
-			items	quickfix list entries. If not present, set to
-				an empty list.
-			nr	quickfix list number. If not present, set to 0
-			qfbufnr	number of the buffer displayed in the quickfix
-				window. If not present, set to 0.
-			size	number of entries in the quickfix list. If not
-				present, set to 0.
-			title	quickfix list title text. If not present, set
-				to "".
-			winid	quickfix |window-ID|. If not present, set to 0
+                The returned dictionary contains the following entries:
+                        changedtick     total number of changes made to the
+                                        list |quickfix-changedtick|
+                        context quickfix list context. See |quickfix-context|
+                                If not present, set to "".
+                        id      quickfix list ID |quickfix-ID|. If not
+                                present, set to 0.
+                        idx     index of the quickfix entry in the list. If not
+                                present, set to 0.
+                        items   quickfix list entries. If not present, set to
+                                an empty list.
+                        nr      quickfix list number. If not present, set to 0
+                        qfbufnr number of the buffer displayed in the quickfix
+                                window. If not present, set to 0.
+                        size    number of entries in the quickfix list. If not
+                                present, set to 0.
+                        title   quickfix list title text. If not present, set
+                                to "".
+                        winid   quickfix |window-ID|. If not present, set to 0
 
-		Examples (See also |getqflist-examples|): >vim
-			echo getqflist({'all': 1})
-			echo getqflist({'nr': 2, 'title': 1})
-			echo getqflist({'lines' : ["F1:10:L10"]})
+                Examples (See also |getqflist-examples|): >vim
+                        echo getqflist({'all': 1})
+                        echo getqflist({'nr': 2, 'title': 1})
+                        echo getqflist({'lines' : ["F1:10:L10"]})
 <
-
 getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
-		The result is a String, which is the contents of register
-		{regname}.  Example: >vim
-			let cliptext = getreg('*')
-<		When register {regname} was not set the result is an empty
-		string.
-		The {regname} argument must be a string.
+                The result is a String, which is the contents of register
+                {regname}.  Example: >vim
+                        let cliptext = getreg('*')
+<                When register {regname} was not set the result is an empty
+                string.
+                The {regname} argument must be a string.
 
-		getreg('=') returns the last evaluated value of the expression
-		register.  (For use in maps.)
-		getreg('=', 1) returns the expression itself, so that it can
-		be restored with |setreg()|.  For other registers the extra
-		argument is ignored, thus you can always give it.
+                getreg('=') returns the last evaluated value of the expression
+                register.  (For use in maps.)
+                getreg('=', 1) returns the expression itself, so that it can
+                be restored with |setreg()|.  For other registers the extra
+                argument is ignored, thus you can always give it.
 
-		If {list} is present and |TRUE|, the result type is changed
-		to |List|. Each list item is one text line. Use it if you care
-		about zero bytes possibly present inside register: without
-		third argument both NLs and zero bytes are represented as NLs
-		(see |NL-used-for-Nul|).
-		When the register was not set an empty list is returned.
+                If {list} is present and |TRUE|, the result type is changed
+                to |List|. Each list item is one text line. Use it if you care
+                about zero bytes possibly present inside register: without
+                third argument both NLs and zero bytes are represented as NLs
+                (see |NL-used-for-Nul|).
+                When the register was not set an empty list is returned.
 
-		If {regname} is not specified, |v:register| is used.
+                If {regname} is not specified, |v:register| is used.
 
 getreginfo([{regname}])                                           *getreginfo()*
-		Returns detailed information about register {regname} as a
-		Dictionary with the following entries:
-			regcontents	List of lines contained in register
-					{regname}, like
-					getreg({regname}, 1, 1).
-			regtype		the type of register {regname}, as in
-					|getregtype()|.
-			isunnamed	Boolean flag, v:true if this register
-					is currently pointed to by the unnamed
-					register.
-			points_to	for the unnamed register, gives the
-					single letter name of the register
-					currently pointed to (see |quotequote|).
-					For example, after deleting a line
-					with `dd`, this field will be "1",
-					which is the register that got the
-					deleted text.
+                Returns detailed information about register {regname} as a
+                Dictionary with the following entries:
+                        regcontents     List of lines contained in register
+                                        {regname}, like
+                                        getreg({regname}, 1, 1).
+                        regtype         the type of register {regname}, as in
+                                        |getregtype()|.
+                        isunnamed       Boolean flag, v:true if this register
+                                        is currently pointed to by the unnamed
+                                        register.
+                        points_to       for the unnamed register, gives the
+                                        single letter name of the register
+                                        currently pointed to (see |quotequote|).
+                                        For example, after deleting a line
+                                        with `dd`, this field will be "1",
+                                        which is the register that got the
+                                        deleted text.
 
-		The {regname} argument is a string.  If {regname} is invalid
-		or not set, an empty Dictionary will be returned.
-		If {regname} is not specified, |v:register| is used.
-		The returned Dictionary can be passed to |setreg()|.
+                The {regname} argument is a string.  If {regname} is invalid
+                or not set, an empty Dictionary will be returned.
+                If {regname} is not specified, |v:register| is used.
+                The returned Dictionary can be passed to |setreg()|.
 
 getregtype([{regname}])                                           *getregtype()*
-		The result is a String, which is type of register {regname}.
-		The value will be one of:
-		    "v"			for |charwise| text
-		    "V"			for |linewise| text
-		    "<CTRL-V>{width}"	for |blockwise-visual| text
-		    ""			for an empty or unknown register
-		<CTRL-V> is one character with value 0x16.
-		The {regname} argument is a string.  If {regname} is not
-		specified, |v:register| is used.
+                The result is a String, which is type of register {regname}.
+                The value will be one of:
+                    "v"                 for |charwise| text
+                    "V"                 for |linewise| text
+                    "<CTRL-V>{width}"   for |blockwise-visual| text
+                    ""                  for an empty or unknown register
+                <CTRL-V> is one character with value 0x16.
+                The {regname} argument is a string.  If {regname} is not
+                specified, |v:register| is used.
 
 getscriptinfo([{opts}])                                        *getscriptinfo()*
-		Returns a |List| with information about all the sourced Vim
-		scripts in the order they were sourced, like what
-		`:scriptnames` shows.
+                Returns a |List| with information about all the sourced Vim
+                scripts in the order they were sourced, like what
+                `:scriptnames` shows.
 
-		The optional Dict argument {opts} supports the following
-		optional items:
-		    name	Script name match pattern. If specified,
-				and "sid" is not specified, information about
-				scripts with a name that match the pattern
-				"name" are returned.
-		    sid		Script ID |<SID>|.  If specified, only
-				information about the script with ID "sid" is
-				returned and "name" is ignored.
+                The optional Dict argument {opts} supports the following
+                optional items:
+                    name        Script name match pattern. If specified,
+                                and "sid" is not specified, information about
+                                scripts with a name that match the pattern
+                                "name" are returned.
+                    sid         Script ID |<SID>|.  If specified, only
+                                information about the script with ID "sid" is
+                                returned and "name" is ignored.
 
-		Each item in the returned List is a |Dict| with the following
-		items:
-		    autoload	Always set to FALSE.
-		    functions   List of script-local function names defined in
-				the script.  Present only when a particular
-				script is specified using the "sid" item in
-				{opts}.
-		    name	Vim script file name.
-		    sid		Script ID |<SID>|.
-		    variables   A dictionary with the script-local variables.
-				Present only when a particular script is
-				specified using the "sid" item in {opts}.
-				Note that this is a copy, the value of
-				script-local variables cannot be changed using
-				this dictionary.
-		    version	Vim script version, always 1
+                Each item in the returned List is a |Dict| with the following
+                items:
+                    autoload    Always set to FALSE.
+                    functions   List of script-local function names defined in
+                                the script.  Present only when a particular
+                                script is specified using the "sid" item in
+                                {opts}.
+                    name        Vim script file name.
+                    sid         Script ID |<SID>|.
+                    variables   A dictionary with the script-local variables.
+                                Present only when a particular script is
+                                specified using the "sid" item in {opts}.
+                                Note that this is a copy, the value of
+                                script-local variables cannot be changed using
+                                this dictionary.
+                    version     Vim script version, always 1
 
-		Examples: >vim
-			echo getscriptinfo({'name': 'myscript'})
-			echo getscriptinfo({'sid': 15}).variables
+                Examples: >vim
+                        echo getscriptinfo({'name': 'myscript'})
+                        echo getscriptinfo({'sid': 15}).variables
 <
-
 gettabinfo([{tabnr}])                                             *gettabinfo()*
-		If {tabnr} is not specified, then information about all the
-		tab pages is returned as a |List|. Each List item is a
-		|Dictionary|.  Otherwise, {tabnr} specifies the tab page
-		number and information about that one is returned.  If the tab
-		page does not exist an empty List is returned.
+                If {tabnr} is not specified, then information about all the
+                tab pages is returned as a |List|. Each List item is a
+                |Dictionary|.  Otherwise, {tabnr} specifies the tab page
+                number and information about that one is returned.  If the tab
+                page does not exist an empty List is returned.
 
-		Each List item is a |Dictionary| with the following entries:
-			tabnr		tab page number.
-			variables	a reference to the dictionary with
-					tabpage-local variables
-			windows		List of |window-ID|s in the tab page.
+                Each List item is a |Dictionary| with the following entries:
+                        tabnr           tab page number.
+                        variables       a reference to the dictionary with
+                                        tabpage-local variables
+                        windows         List of |window-ID|s in the tab page.
 
 gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
-		Get the value of a tab-local variable {varname} in tab page
-		{tabnr}. |t:var|
-		Tabs are numbered starting with one.
-		The {varname} argument is a string.  When {varname} is empty a
-		dictionary with all tab-local variables is returned.
-		Note that the name without "t:" must be used.
-		When the tab or variable doesn't exist {def} or an empty
-		string is returned, there is no error message.
+                Get the value of a tab-local variable {varname} in tab page
+                {tabnr}. |t:var|
+                Tabs are numbered starting with one.
+                The {varname} argument is a string.  When {varname} is empty a
+                dictionary with all tab-local variables is returned.
+                Note that the name without "t:" must be used.
+                When the tab or variable doesn't exist {def} or an empty
+                string is returned, there is no error message.
 
 gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
-		Get the value of window-local variable {varname} in window
-		{winnr} in tab page {tabnr}.
-		The {varname} argument is a string.  When {varname} is empty a
-		dictionary with all window-local variables is returned.
-		When {varname} is equal to "&" get the values of all
-		window-local options in a |Dictionary|.
-		Otherwise, when {varname} starts with "&" get the value of a
-		window-local option.
-		Note that {varname} must be the name without "w:".
-		Tabs are numbered starting with one.  For the current tabpage
-		use |getwinvar()|.
-		{winnr} can be the window number or the |window-ID|.
-		When {winnr} is zero the current window is used.
-		This also works for a global option, buffer-local option and
-		window-local option, but it doesn't work for a global variable
-		or buffer-local variable.
-		When the tab, window or variable doesn't exist {def} or an
-		empty string is returned, there is no error message.
-		Examples: >vim
-			let list_is_on = gettabwinvar(1, 2, '&list')
-			echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
+                Get the value of window-local variable {varname} in window
+                {winnr} in tab page {tabnr}.
+                The {varname} argument is a string.  When {varname} is empty a
+                dictionary with all window-local variables is returned.
+                When {varname} is equal to "&" get the values of all
+                window-local options in a |Dictionary|.
+                Otherwise, when {varname} starts with "&" get the value of a
+                window-local option.
+                Note that {varname} must be the name without "w:".
+                Tabs are numbered starting with one.  For the current tabpage
+                use |getwinvar()|.
+                {winnr} can be the window number or the |window-ID|.
+                When {winnr} is zero the current window is used.
+                This also works for a global option, buffer-local option and
+                window-local option, but it doesn't work for a global variable
+                or buffer-local variable.
+                When the tab, window or variable doesn't exist {def} or an
+                empty string is returned, there is no error message.
+                Examples: >vim
+                        let list_is_on = gettabwinvar(1, 2, '&list')
+                        echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
 <
-		To obtain all window-local variables use: >vim
-			gettabwinvar({tabnr}, {winnr}, '&')
+                To obtain all window-local variables use: >vim
+                        gettabwinvar({tabnr}, {winnr}, '&')
 <
-
 gettagstack([{winnr}])                                           *gettagstack()*
-		The result is a Dict, which is the tag stack of window {winnr}.
-		{winnr} can be the window number or the |window-ID|.
-		When {winnr} is not specified, the current window is used.
-		When window {winnr} doesn't exist, an empty Dict is returned.
+                The result is a Dict, which is the tag stack of window {winnr}.
+                {winnr} can be the window number or the |window-ID|.
+                When {winnr} is not specified, the current window is used.
+                When window {winnr} doesn't exist, an empty Dict is returned.
 
-		The returned dictionary contains the following entries:
-			curidx		Current index in the stack. When at
-					top of the stack, set to (length + 1).
-					Index of bottom of the stack is 1.
-			items		List of items in the stack. Each item
-					is a dictionary containing the
-					entries described below.
-			length		Number of entries in the stack.
+                The returned dictionary contains the following entries:
+                        curidx          Current index in the stack. When at
+                                        top of the stack, set to (length + 1).
+                                        Index of bottom of the stack is 1.
+                        items           List of items in the stack. Each item
+                                        is a dictionary containing the
+                                        entries described below.
+                        length          Number of entries in the stack.
 
-		Each item in the stack is a dictionary with the following
-		entries:
-			bufnr		buffer number of the current jump
-			from		cursor position before the tag jump.
-					See |getpos()| for the format of the
-					returned list.
-			matchnr		current matching tag number. Used when
-					multiple matching tags are found for a
-					name.
-			tagname		name of the tag
+                Each item in the stack is a dictionary with the following
+                entries:
+                        bufnr           buffer number of the current jump
+                        from            cursor position before the tag jump.
+                                        See |getpos()| for the format of the
+                                        returned list.
+                        matchnr         current matching tag number. Used when
+                                        multiple matching tags are found for a
+                                        name.
+                        tagname         name of the tag
 
-		See |tagstack| for more information about the tag stack.
+                See |tagstack| for more information about the tag stack.
 
 gettext({text})                                                      *gettext()*
-		Translate String {text} if possible.
-		This is mainly for use in the distributed Vim scripts.  When
-		generating message translations the {text} is extracted by
-		xgettext, the translator can add the translated message in the
-		.po file and Vim will lookup the translation when gettext() is
-		called.
-		For {text} double quoted strings are preferred, because
-		xgettext does not understand escaping in single quoted
-		strings.
+                Translate String {text} if possible.
+                This is mainly for use in the distributed Vim scripts.  When
+                generating message translations the {text} is extracted by
+                xgettext, the translator can add the translated message in the
+                .po file and Vim will lookup the translation when gettext() is
+                called.
+                For {text} double quoted strings are preferred, because
+                xgettext does not understand escaping in single quoted
+                strings.
 
 getwininfo([{winid}])                                             *getwininfo()*
-		Returns information about windows as a |List| with Dictionaries.
+                Returns information about windows as a |List| with Dictionaries.
 
-		If {winid} is given Information about the window with that ID
-		is returned, as a |List| with one item.  If the window does not
-		exist the result is an empty list.
+                If {winid} is given Information about the window with that ID
+                is returned, as a |List| with one item.  If the window does not
+                exist the result is an empty list.
 
-		Without {winid} information about all the windows in all the
-		tab pages is returned.
+                Without {winid} information about all the windows in all the
+                tab pages is returned.
 
-		Each List item is a |Dictionary| with the following entries:
-			botline		last complete displayed buffer line
-			bufnr		number of buffer in the window
-			height		window height (excluding winbar)
-			loclist		1 if showing a location list
-			quickfix	1 if quickfix or location list window
-			terminal	1 if a terminal window
-			tabnr		tab page number
-			topline		first displayed buffer line
-			variables	a reference to the dictionary with
-					window-local variables
-			width		window width
-			winbar		1 if the window has a toolbar, 0
-					otherwise
-			wincol		leftmost screen column of the window;
-					"col" from |win_screenpos()|
-			textoff		number of columns occupied by any
-					'foldcolumn', 'signcolumn' and line
-					number in front of the text
-			winid		|window-ID|
-			winnr		window number
-			winrow		topmost screen line of the window;
-					"row" from |win_screenpos()|
+                Each List item is a |Dictionary| with the following entries:
+                        botline         last complete displayed buffer line
+                        bufnr           number of buffer in the window
+                        height          window height (excluding winbar)
+                        loclist         1 if showing a location list
+                        quickfix        1 if quickfix or location list window
+                        terminal        1 if a terminal window
+                        tabnr           tab page number
+                        topline         first displayed buffer line
+                        variables       a reference to the dictionary with
+                                        window-local variables
+                        width           window width
+                        winbar          1 if the window has a toolbar, 0
+                                        otherwise
+                        wincol          leftmost screen column of the window;
+                                        "col" from |win_screenpos()|
+                        textoff         number of columns occupied by any
+                                        'foldcolumn', 'signcolumn' and line
+                                        number in front of the text
+                        winid           |window-ID|
+                        winnr           window number
+                        winrow          topmost screen line of the window;
+                                        "row" from |win_screenpos()|
 
 getwinpos([{timeout}])                                             *getwinpos()*
-		The result is a |List| with two numbers, the result of
-		|getwinposx()| and |getwinposy()| combined:
-			[x-pos, y-pos]
-		{timeout} can be used to specify how long to wait in msec for
-		a response from the terminal.  When omitted 100 msec is used.
+                The result is a |List| with two numbers, the result of
+                |getwinposx()| and |getwinposy()| combined:
+                        [x-pos, y-pos]
+                {timeout} can be used to specify how long to wait in msec for
+                a response from the terminal.  When omitted 100 msec is used.
 
-		Use a longer time for a remote terminal.
-		When using a value less than 10 and no response is received
-		within that time, a previously reported position is returned,
-		if available.  This can be used to poll for the position and
-		do some work in the meantime: >vim
-			while 1
-			  let res = getwinpos(1)
-			  if res[0] >= 0
-			    break
-			  endif
-			  " Do some work here
-			endwhile
+                Use a longer time for a remote terminal.
+                When using a value less than 10 and no response is received
+                within that time, a previously reported position is returned,
+                if available.  This can be used to poll for the position and
+                do some work in the meantime: >vim
+                        while 1
+                          let res = getwinpos(1)
+                          if res[0] >= 0
+                            break
+                          endif
+                          " Do some work here
+                        endwhile
 <
-
 getwinposx()                                                      *getwinposx()*
-		The result is a Number, which is the X coordinate in pixels of
-		the left hand side of the GUI Vim window.  The result will be
-		-1 if the information is not available.
-		The value can be used with `:winpos`.
+                The result is a Number, which is the X coordinate in pixels of
+                the left hand side of the GUI Vim window.  The result will be
+                -1 if the information is not available.
+                The value can be used with `:winpos`.
 
 getwinposy()                                                      *getwinposy()*
-		The result is a Number, which is the Y coordinate in pixels of
-		the top of the GUI Vim window.  The result will be -1 if the
-		information is not available.
-		The value can be used with `:winpos`.
+                The result is a Number, which is the Y coordinate in pixels of
+                the top of the GUI Vim window.  The result will be -1 if the
+                information is not available.
+                The value can be used with `:winpos`.
 
 getwinvar({winnr}, {varname} [, {def}])                            *getwinvar()*
-		Like |gettabwinvar()| for the current tabpage.
-		Examples: >vim
-			let list_is_on = getwinvar(2, '&list')
-			echo "myvar = " .. getwinvar(1, 'myvar')
+                Like |gettabwinvar()| for the current tabpage.
+                Examples: >vim
+                        let list_is_on = getwinvar(2, '&list')
+                        echo "myvar = " .. getwinvar(1, 'myvar')
 
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
-		Expand the file wildcards in {expr}.  See |wildcards| for the
-		use of special characters.
+                Expand the file wildcards in {expr}.  See |wildcards| for the
+                use of special characters.
 
-		Unless the optional {nosuf} argument is given and is |TRUE|,
-		the 'suffixes' and 'wildignore' options apply: Names matching
-		one of the patterns in 'wildignore' will be skipped and
-		'suffixes' affect the ordering of matches.
-		'wildignorecase' always applies.
+                Unless the optional {nosuf} argument is given and is |TRUE|,
+                the 'suffixes' and 'wildignore' options apply: Names matching
+                one of the patterns in 'wildignore' will be skipped and
+                'suffixes' affect the ordering of matches.
+                'wildignorecase' always applies.
 
-		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is,
-		you also get filenames containing newlines correctly.
-		Otherwise the result is a String and when there are several
-		matches, they are separated by <NL> characters.
+                When {list} is present and it is |TRUE| the result is a |List|
+                with all matching files. The advantage of using a List is,
+                you also get filenames containing newlines correctly.
+                Otherwise the result is a String and when there are several
+                matches, they are separated by <NL> characters.
 
-		If the expansion fails, the result is an empty String or List.
+                If the expansion fails, the result is an empty String or List.
 
-		You can also use |readdir()| if you need to do complicated
-		things, such as limiting the number of matches.
+                You can also use |readdir()| if you need to do complicated
+                things, such as limiting the number of matches.
 
-		A name for a non-existing file is not included.  A symbolic
-		link is only included if it points to an existing file.
-		However, when the {alllinks} argument is present and it is
-		|TRUE| then all symbolic links are included.
+                A name for a non-existing file is not included.  A symbolic
+                link is only included if it points to an existing file.
+                However, when the {alllinks} argument is present and it is
+                |TRUE| then all symbolic links are included.
 
-		For most systems backticks can be used to get files names from
-		any external command.  Example: >vim
-			let tagfiles = glob("`find . -name tags -print`")
-			let &tags = substitute(tagfiles, "\n", ",", "g")
-<		The result of the program inside the backticks should be one
-		item per line.  Spaces inside an item are allowed.
+                For most systems backticks can be used to get files names from
+                any external command.  Example: >vim
+                        let tagfiles = glob("`find . -name tags -print`")
+                        let &tags = substitute(tagfiles, "\n", ",", "g")
+<                The result of the program inside the backticks should be one
+                item per line.  Spaces inside an item are allowed.
 
-		See |expand()| for expanding special Vim variables.  See
-		|system()| for getting the raw output of an external command.
+                See |expand()| for expanding special Vim variables.  See
+                |system()| for getting the raw output of an external command.
 
 glob2regpat({string})                                            *glob2regpat()*
-		Convert a file pattern, as used by glob(), into a search
-		pattern.  The result can be used to match with a string that
-		is a file name.  E.g. >vim
-			if filename =~ glob2regpat('Make*.mak')
-			  " ...
-			endif
-<		This is equivalent to: >vim
-			if filename =~ '^Make.*\.mak$'
-			  " ...
-			endif
-<		When {string} is an empty string the result is "^$", match an
-		empty string.
-		Note that the result depends on the system.  On MS-Windows
-		a backslash usually means a path separator.
+                Convert a file pattern, as used by glob(), into a search
+                pattern.  The result can be used to match with a string that
+                is a file name.  E.g. >vim
+                        if filename =~ glob2regpat('Make*.mak')
+                          " ...
+                        endif
+<                This is equivalent to: >vim
+                        if filename =~ '^Make.*\.mak$'
+                          " ...
+                        endif
+<                When {string} is an empty string the result is "^$", match an
+                empty string.
+                Note that the result depends on the system.  On MS-Windows
+                a backslash usually means a path separator.
 
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
-		Perform glob() for String {expr} on all directories in {path}
-		and concatenate the results.  Example: >vim
-			echo globpath(&rtp, "syntax/c.vim")
+                Perform glob() for String {expr} on all directories in {path}
+                and concatenate the results.  Example: >vim
+                        echo globpath(&rtp, "syntax/c.vim")
 <
-		{path} is a comma-separated list of directory names.  Each
-		directory name is prepended to {expr} and expanded like with
-		|glob()|.  A path separator is inserted when needed.
-		To add a comma inside a directory name escape it with a
-		backslash.  Note that on MS-Windows a directory may have a
-		trailing backslash, remove it if you put a comma after it.
-		If the expansion fails for one of the directories, there is no
-		error message.
+                {path} is a comma-separated list of directory names.  Each
+                directory name is prepended to {expr} and expanded like with
+                |glob()|.  A path separator is inserted when needed.
+                To add a comma inside a directory name escape it with a
+                backslash.  Note that on MS-Windows a directory may have a
+                trailing backslash, remove it if you put a comma after it.
+                If the expansion fails for one of the directories, there is no
+                error message.
 
-		Unless the optional {nosuf} argument is given and is |TRUE|,
-		the 'suffixes' and 'wildignore' options apply: Names matching
-		one of the patterns in 'wildignore' will be skipped and
-		'suffixes' affect the ordering of matches.
+                Unless the optional {nosuf} argument is given and is |TRUE|,
+                the 'suffixes' and 'wildignore' options apply: Names matching
+                one of the patterns in 'wildignore' will be skipped and
+                'suffixes' affect the ordering of matches.
 
-		When {list} is present and it is |TRUE| the result is a |List|
-		with all matching files. The advantage of using a List is, you
-		also get filenames containing newlines correctly. Otherwise
-		the result is a String and when there are several matches,
-		they are separated by <NL> characters.  Example: >vim
-			echo globpath(&rtp, "syntax/c.vim", 0, 1)
+                When {list} is present and it is |TRUE| the result is a |List|
+                with all matching files. The advantage of using a List is, you
+                also get filenames containing newlines correctly. Otherwise
+                the result is a String and when there are several matches,
+                they are separated by <NL> characters.  Example: >vim
+                        echo globpath(&rtp, "syntax/c.vim", 0, 1)
 <
-		{allinks} is used as with |glob()|.
+                {allinks} is used as with |glob()|.
 
-		The "**" item can be used to search in a directory tree.
-		For example, to find all "README.txt" files in the directories
-		in 'runtimepath' and below: >vim
-			echo globpath(&rtp, "**/README.txt")
-<		Upwards search and limiting the depth of "**" is not
-		supported, thus using 'path' will not always work properly.
+                The "**" item can be used to search in a directory tree.
+                For example, to find all "README.txt" files in the directories
+                in 'runtimepath' and below: >vim
+                        echo globpath(&rtp, "**/README.txt")
+<                Upwards search and limiting the depth of "**" is not
+                supported, thus using 'path' will not always work properly.
 
 has({feature})                                                           *has()*
-		Returns 1 if {feature} is supported, 0 otherwise.  The
-		{feature} argument is a feature name like "nvim-0.2.1" or
-		"win32", see below.  See also |exists()|.
+                Returns 1 if {feature} is supported, 0 otherwise.  The
+                {feature} argument is a feature name like "nvim-0.2.1" or
+                "win32", see below.  See also |exists()|.
 
-		To get the system name use |vim.uv|.os_uname() in Lua: >lua
-			print(vim.uv.os_uname().sysname)
+                To get the system name use |vim.uv|.os_uname() in Lua: >lua
+                        print(vim.uv.os_uname().sysname)
 
-<		If the code has a syntax error then Vimscript may skip the
-		rest of the line.  Put |:if| and |:endif| on separate lines to
-		avoid the syntax error: >vim
-			if has('feature')
-			  let x = this_breaks_without_the_feature()
-			endif
+<                If the code has a syntax error then Vimscript may skip the
+                rest of the line.  Put |:if| and |:endif| on separate lines to
+                avoid the syntax error: >vim
+                        if has('feature')
+                          let x = this_breaks_without_the_feature()
+                        endif
 <
-		Vim's compile-time feature-names (prefixed with "+") are not
-		recognized because Nvim is always compiled with all possible
-		features. |feature-compile|
+                Vim's compile-time feature-names (prefixed with "+") are not
+                recognized because Nvim is always compiled with all possible
+                features. |feature-compile|
 
-		Feature names can be:
-		1.  Nvim version. For example the "nvim-0.2.1" feature means
-		    that Nvim is version 0.2.1 or later: >vim
-			if has("nvim-0.2.1")
-			  " ...
-			endif
+                Feature names can be:
+                1.  Nvim version. For example the "nvim-0.2.1" feature means
+                    that Nvim is version 0.2.1 or later: >vim
+                        if has("nvim-0.2.1")
+                          " ...
+                        endif
 
-<		2.  Runtime condition or other pseudo-feature. For example the
-		    "win32" feature checks if the current system is Windows: >vim
-			if has("win32")
-			  " ...
-			endif
-<							*feature-list*
-		    List of supported pseudo-feature names:
-			acl		|ACL| support.
-			bsd		BSD system (not macOS, use "mac" for that).
-			clipboard	|clipboard| provider is available.
-			fname_case	Case in file names matters (for Darwin and MS-Windows
-					this is not present).
-			gui_running	Nvim has a GUI.
-			iconv		Can use |iconv()| for conversion.
-			linux		Linux system.
-			mac		MacOS system.
-			nvim		This is Nvim.
-			python3		Legacy Vim |python3| interface. |has-python|
-			pythonx		Legacy Vim |python_x| interface. |has-pythonx|
-			sun		SunOS system.
-			ttyin		input is a terminal (tty).
-			ttyout		output is a terminal (tty).
-			unix		Unix system.
-			*vim_starting*	True during |startup|.
-			win32		Windows system (32 or 64 bit).
-			win64		Windows system (64 bit).
-			wsl		WSL (Windows Subsystem for Linux) system.
+<                2.  Runtime condition or other pseudo-feature. For example the
+                    "win32" feature checks if the current system is Windows: >vim
+                        if has("win32")
+                          " ...
+                        endif
+<                                                       *feature-list*
+                    List of supported pseudo-feature names:
+                        acl             |ACL| support.
+                        bsd             BSD system (not macOS, use "mac" for that).
+                        clipboard       |clipboard| provider is available.
+                        fname_case      Case in file names matters (for Darwin and MS-Windows
+                                        this is not present).
+                        gui_running     Nvim has a GUI.
+                        iconv           Can use |iconv()| for conversion.
+                        linux           Linux system.
+                        mac             MacOS system.
+                        nvim            This is Nvim.
+                        python3         Legacy Vim |python3| interface. |has-python|
+                        pythonx         Legacy Vim |python_x| interface. |has-pythonx|
+                        sun             SunOS system.
+                        ttyin           input is a terminal (tty).
+                        ttyout          output is a terminal (tty).
+                        unix            Unix system.
+                        *vim_starting*  True during |startup|.
+                        win32           Windows system (32 or 64 bit).
+                        win64           Windows system (64 bit).
+                        wsl             WSL (Windows Subsystem for Linux) system.
 
-							*has-patch*
-		3.  Vim patch. For example the "patch123" feature means that
-		    Vim patch 123 at the current |v:version| was included: >vim
-			if v:version > 602 || v:version == 602 && has("patch148")
-			  " ...
-			endif
+                                                        *has-patch*
+                3.  Vim patch. For example the "patch123" feature means that
+                    Vim patch 123 at the current |v:version| was included: >vim
+                        if v:version > 602 || v:version == 602 && has("patch148")
+                          " ...
+                        endif
 
-<		4.  Vim version. For example the "patch-7.4.237" feature means
-		    that Nvim is Vim-compatible to version 7.4.237 or later. >vim
-			if has("patch-7.4.237")
-			  " ...
-			endif
+<                4.  Vim version. For example the "patch-7.4.237" feature means
+                    that Nvim is Vim-compatible to version 7.4.237 or later. >vim
+                        if has("patch-7.4.237")
+                          " ...
+                        endif
 <
-
 has_key({dict}, {key})                                               *has_key()*
-		The result is a Number, which is TRUE if |Dictionary| {dict}
-		has an entry with key {key}.  FALSE otherwise. The {key}
-		argument is a string.
+                The result is a Number, which is TRUE if |Dictionary| {dict}
+                has an entry with key {key}.  FALSE otherwise. The {key}
+                argument is a string.
 
 haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
-		The result is a Number, which is 1 when the window has set a
-		local path via |:lcd| or when {winnr} is -1 and the tabpage
-		has set a local path via |:tcd|, otherwise 0.
+                The result is a Number, which is 1 when the window has set a
+                local path via |:lcd| or when {winnr} is -1 and the tabpage
+                has set a local path via |:tcd|, otherwise 0.
 
-		Tabs and windows are identified by their respective numbers,
-		0 means current tab or window. Missing argument implies 0.
-		Thus the following are equivalent: >vim
-			echo haslocaldir()
-			echo haslocaldir(0)
-			echo haslocaldir(0, 0)
-<		With {winnr} use that window in the current tabpage.
-		With {winnr} and {tabnr} use the window in that tabpage.
-		{winnr} can be the window number or the |window-ID|.
-		If {winnr} is -1 it is ignored, only the tab is resolved.
-		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+                Tabs and windows are identified by their respective numbers,
+                0 means current tab or window. Missing argument implies 0.
+                Thus the following are equivalent: >vim
+                        echo haslocaldir()
+                        echo haslocaldir(0)
+                        echo haslocaldir(0, 0)
+<                With {winnr} use that window in the current tabpage.
+                With {winnr} and {tabnr} use the window in that tabpage.
+                {winnr} can be the window number or the |window-ID|.
+                If {winnr} is -1 it is ignored, only the tab is resolved.
+                Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
 hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
-		The result is a Number, which is TRUE if there is a mapping
-		that contains {what} in somewhere in the rhs (what it is
-		mapped to) and this mapping exists in one of the modes
-		indicated by {mode}.
-		The arguments {what} and {mode} are strings.
-		When {abbr} is there and it is |TRUE| use abbreviations
-		instead of mappings.  Don't forget to specify Insert and/or
-		Command-line mode.
-		Both the global mappings and the mappings local to the current
-		buffer are checked for a match.
-		If no matching mapping is found FALSE is returned.
-		The following characters are recognized in {mode}:
-			n	Normal mode
-			v	Visual and Select mode
-			x	Visual mode
-			s	Select mode
-			o	Operator-pending mode
-			i	Insert mode
-			l	Language-Argument ("r", "f", "t", etc.)
-			c	Command-line mode
-		When {mode} is omitted, "nvo" is used.
+                The result is a Number, which is TRUE if there is a mapping
+                that contains {what} in somewhere in the rhs (what it is
+                mapped to) and this mapping exists in one of the modes
+                indicated by {mode}.
+                The arguments {what} and {mode} are strings.
+                When {abbr} is there and it is |TRUE| use abbreviations
+                instead of mappings.  Don't forget to specify Insert and/or
+                Command-line mode.
+                Both the global mappings and the mappings local to the current
+                buffer are checked for a match.
+                If no matching mapping is found FALSE is returned.
+                The following characters are recognized in {mode}:
+                        n       Normal mode
+                        v       Visual and Select mode
+                        x       Visual mode
+                        s       Select mode
+                        o       Operator-pending mode
+                        i       Insert mode
+                        l       Language-Argument ("r", "f", "t", etc.)
+                        c       Command-line mode
+                When {mode} is omitted, "nvo" is used.
 
-		This function is useful to check if a mapping already exists
-		to a function in a Vim script.  Example: >vim
-			if !hasmapto('\ABCdoit')
-			   map <Leader>d \ABCdoit
-			endif
-<		This installs the mapping to "\ABCdoit" only if there isn't
-		already a mapping to "\ABCdoit".
+                This function is useful to check if a mapping already exists
+                to a function in a Vim script.  Example: >vim
+                        if !hasmapto('\ABCdoit')
+                           map <Leader>d \ABCdoit
+                        endif
+<                This installs the mapping to "\ABCdoit" only if there isn't
+                already a mapping to "\ABCdoit".
 
 histadd({history}, {item})                                           *histadd()*
-		Add the String {item} to the history {history} which can be
-		one of:					*hist-names*
-			"cmd"	 or ":"	  command line history
-			"search" or "/"   search pattern history
-			"expr"	 or "="   typed expression history
-			"input"  or "@"	  input line history
-			"debug"  or ">"   debug command history
-			empty		  the current or last used history
-		The {history} string does not need to be the whole name, one
-		character is sufficient.
-		If {item} does already exist in the history, it will be
-		shifted to become the newest entry.
-		The result is a Number: TRUE if the operation was successful,
-		otherwise FALSE is returned.
+                Add the String {item} to the history {history} which can be
+                one of:                                 *hist-names*
+                        "cmd"    or ":"   command line history
+                        "search" or "/"   search pattern history
+                        "expr"   or "="   typed expression history
+                        "input"  or "@"   input line history
+                        "debug"  or ">"   debug command history
+                        empty             the current or last used history
+                The {history} string does not need to be the whole name, one
+                character is sufficient.
+                If {item} does already exist in the history, it will be
+                shifted to become the newest entry.
+                The result is a Number: TRUE if the operation was successful,
+                otherwise FALSE is returned.
 
-		Example: >vim
-			call histadd("input", strftime("%Y %b %d"))
-			let date=input("Enter date: ")
-<		This function is not available in the |sandbox|.
+                Example: >vim
+                        call histadd("input", strftime("%Y %b %d"))
+                        let date=input("Enter date: ")
+<                This function is not available in the |sandbox|.
 
 histdel({history} [, {item}])                                        *histdel()*
-		Clear {history}, i.e. delete all its entries.  See |hist-names|
-		for the possible values of {history}.
+                Clear {history}, i.e. delete all its entries.  See |hist-names|
+                for the possible values of {history}.
 
-		If the parameter {item} evaluates to a String, it is used as a
-		regular expression.  All entries matching that expression will
-		be removed from the history (if there are any).
-		Upper/lowercase must match, unless "\c" is used |/\c|.
-		If {item} evaluates to a Number, it will be interpreted as
-		an index, see |:history-indexing|.  The respective entry will
-		be removed if it exists.
+                If the parameter {item} evaluates to a String, it is used as a
+                regular expression.  All entries matching that expression will
+                be removed from the history (if there are any).
+                Upper/lowercase must match, unless "\c" is used |/\c|.
+                If {item} evaluates to a Number, it will be interpreted as
+                an index, see |:history-indexing|.  The respective entry will
+                be removed if it exists.
 
-		The result is TRUE for a successful operation, otherwise FALSE
-		is returned.
+                The result is TRUE for a successful operation, otherwise FALSE
+                is returned.
 
-		Examples:
-		Clear expression register history: >vim
-			call histdel("expr")
+                Examples:
+                Clear expression register history: >vim
+                        call histdel("expr")
 <
-		Remove all entries starting with "*" from the search history: >vim
-			call histdel("/", '^\*')
+                Remove all entries starting with "*" from the search history: >vim
+                        call histdel("/", '^\*')
 <
-		The following three are equivalent: >vim
-			call histdel("search", histnr("search"))
-			call histdel("search", -1)
-			call histdel("search", '^' .. histget("search", -1) .. '$')
+                The following three are equivalent: >vim
+                        call histdel("search", histnr("search"))
+                        call histdel("search", -1)
+                        call histdel("search", '^' .. histget("search", -1) .. '$')
 <
-		To delete the last search pattern and use the last-but-one for
-		the "n" command and 'hlsearch': >vim
-			call histdel("search", -1)
-			let @/ = histget("search", -1)
+                To delete the last search pattern and use the last-but-one for
+                the "n" command and 'hlsearch': >vim
+                        call histdel("search", -1)
+                        let @/ = histget("search", -1)
 <
-
 histget({history} [, {index}])                                       *histget()*
-		The result is a String, the entry with Number {index} from
-		{history}.  See |hist-names| for the possible values of
-		{history}, and |:history-indexing| for {index}.  If there is
-		no such entry, an empty String is returned.  When {index} is
-		omitted, the most recent item from the history is used.
+                The result is a String, the entry with Number {index} from
+                {history}.  See |hist-names| for the possible values of
+                {history}, and |:history-indexing| for {index}.  If there is
+                no such entry, an empty String is returned.  When {index} is
+                omitted, the most recent item from the history is used.
 
-		Examples:
-		Redo the second last search from history. >vim
-			execute '/' .. histget("search", -2)
+                Examples:
+                Redo the second last search from history. >vim
+                        execute '/' .. histget("search", -2)
 
-<		Define an Ex command ":H {num}" that supports re-execution of
-		the {num}th entry from the output of |:history|. >vim
-			command -nargs=1 H execute histget("cmd", 0+<args>)
+<                Define an Ex command ":H {num}" that supports re-execution of
+                the {num}th entry from the output of |:history|. >vim
+                        command -nargs=1 H execute histget("cmd", 0+<args>)
 <
-
 histnr({history})                                                     *histnr()*
-		The result is the Number of the current entry in {history}.
-		See |hist-names| for the possible values of {history}.
-		If an error occurred, -1 is returned.
+                The result is the Number of the current entry in {history}.
+                See |hist-names| for the possible values of {history}.
+                If an error occurred, -1 is returned.
 
-		Example: >vim
-			let inp_index = histnr("expr")
+                Example: >vim
+                        let inp_index = histnr("expr")
 
 hlID({name})                                                            *hlID()*
-		The result is a Number, which is the ID of the highlight group
-		with name {name}.  When the highlight group doesn't exist,
-		zero is returned.
-		This can be used to retrieve information about the highlight
-		group.  For example, to get the background color of the
-		"Comment" group: >vim
-			echo synIDattr(synIDtrans(hlID("Comment")), "bg")
+                The result is a Number, which is the ID of the highlight group
+                with name {name}.  When the highlight group doesn't exist,
+                zero is returned.
+                This can be used to retrieve information about the highlight
+                group.  For example, to get the background color of the
+                "Comment" group: >vim
+                        echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 <
-
 hlexists({name})                                                    *hlexists()*
-		The result is a Number, which is TRUE if a highlight group
-		called {name} exists.  This is when the group has been
-		defined in some way.  Not necessarily when highlighting has
-		been defined for it, it may also have been used for a syntax
-		item.
+                The result is a Number, which is TRUE if a highlight group
+                called {name} exists.  This is when the group has been
+                defined in some way.  Not necessarily when highlighting has
+                been defined for it, it may also have been used for a syntax
+                item.
 
 hostname()                                                          *hostname()*
-		The result is a String, which is the name of the machine on
-		which Vim is currently running.  Machine names greater than
-		256 characters long are truncated.
+                The result is a String, which is the name of the machine on
+                which Vim is currently running.  Machine names greater than
+                256 characters long are truncated.
 
 iconv({string}, {from}, {to})                                          *iconv()*
-		The result is a String, which is the text {string} converted
-		from encoding {from} to encoding {to}.
-		When the conversion completely fails an empty string is
-		returned.  When some characters could not be converted they
-		are replaced with "?".
-		The encoding names are whatever the iconv() library function
-		can accept, see ":!man 3 iconv".
-		Note that Vim uses UTF-8 for all Unicode encodings, conversion
-		from/to UCS-2 is automatically changed to use UTF-8.  You
-		cannot use UCS-2 in a string anyway, because of the NUL bytes.
+                The result is a String, which is the text {string} converted
+                from encoding {from} to encoding {to}.
+                When the conversion completely fails an empty string is
+                returned.  When some characters could not be converted they
+                are replaced with "?".
+                The encoding names are whatever the iconv() library function
+                can accept, see ":!man 3 iconv".
+                Note that Vim uses UTF-8 for all Unicode encodings, conversion
+                from/to UCS-2 is automatically changed to use UTF-8.  You
+                cannot use UCS-2 in a string anyway, because of the NUL bytes.
 
 id({expr})                                                                *id()*
-		Returns a |String| which is a unique identifier of the
-		container type (|List|, |Dict|, |Blob| and |Partial|). It is
-		guaranteed that for the mentioned types `id(v1) ==# id(v2)`
-		returns true iff `type(v1) == type(v2) && v1 is v2`.
-		Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
-		`v:_null_blob` have the same `id()` with different types
-		because they are internally represented as NULL pointers.
-		`id()` returns a hexadecimal representanion of the pointers to
-		the containers (i.e. like `0x994a40`), same as `printf("%p",
-		{expr})`, but it is advised against counting on the exact
-		format of the return value.
+                Returns a |String| which is a unique identifier of the
+                container type (|List|, |Dict|, |Blob| and |Partial|). It is
+                guaranteed that for the mentioned types `id(v1) ==# id(v2)`
+                returns true iff `type(v1) == type(v2) && v1 is v2`.
+                Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
+                `v:_null_blob` have the same `id()` with different types
+                because they are internally represented as NULL pointers.
+                `id()` returns a hexadecimal representanion of the pointers to
+                the containers (i.e. like `0x994a40`), same as `printf("%p",
+                {expr})`, but it is advised against counting on the exact
+                format of the return value.
 
-		It is not guaranteed that `id(no_longer_existing_container)`
-		will not be equal to some other `id()`: new containers may
-		reuse identifiers of the garbage-collected ones.
+                It is not guaranteed that `id(no_longer_existing_container)`
+                will not be equal to some other `id()`: new containers may
+                reuse identifiers of the garbage-collected ones.
 
 indent({lnum})                                                        *indent()*
-		The result is a Number, which is indent of line {lnum} in the
-		current buffer.  The indent is counted in spaces, the value
-		of 'tabstop' is relevant.  {lnum} is used just like in
-		|getline()|.
-		When {lnum} is invalid -1 is returned.
+                The result is a Number, which is indent of line {lnum} in the
+                current buffer.  The indent is counted in spaces, the value
+                of 'tabstop' is relevant.  {lnum} is used just like in
+                |getline()|.
+                When {lnum} is invalid -1 is returned.
 
 index({object}, {expr} [, {start} [, {ic}]])                           *index()*
-		Find {expr} in {object} and return its index.  See
-		|indexof()| for using a lambda to select the item.
+                Find {expr} in {object} and return its index.  See
+                |indexof()| for using a lambda to select the item.
 
-		If {object} is a |List| return the lowest index where the item
-		has a value equal to {expr}.  There is no automatic
-		conversion, so the String "4" is different from the Number 4.
-		And the Number 4 is different from the Float 4.0.  The value
-		of 'ignorecase' is not used here, case matters as indicated by
-		the {ic} argument.
+                If {object} is a |List| return the lowest index where the item
+                has a value equal to {expr}.  There is no automatic
+                conversion, so the String "4" is different from the Number 4.
+                And the Number 4 is different from the Float 4.0.  The value
+                of 'ignorecase' is not used here, case matters as indicated by
+                the {ic} argument.
 
-		If {object} is a |Blob| return the lowest index where the byte
-		value is equal to {expr}.
+                If {object} is a |Blob| return the lowest index where the byte
+                value is equal to {expr}.
 
-		If {start} is given then start looking at the item with index
-		{start} (may be negative for an item relative to the end).
+                If {start} is given then start looking at the item with index
+                {start} (may be negative for an item relative to the end).
 
-		When {ic} is given and it is |TRUE|, ignore case.  Otherwise
-		case must match.
+                When {ic} is given and it is |TRUE|, ignore case.  Otherwise
+                case must match.
 
-		-1 is returned when {expr} is not found in {object}.
-		Example: >vim
-			let idx = index(words, "the")
-			if index(numbers, 123) >= 0
-			  " ...
-			endif
+                -1 is returned when {expr} is not found in {object}.
+                Example: >vim
+                        let idx = index(words, "the")
+                        if index(numbers, 123) >= 0
+                          " ...
+                        endif
 
 indexof({object}, {expr} [, {opts}])                                 *indexof()*
-		Returns the index of an item in {object} where {expr} is
-		v:true.  {object} must be a |List| or a |Blob|.
+                Returns the index of an item in {object} where {expr} is
+                v:true.  {object} must be a |List| or a |Blob|.
 
-		If {object} is a |List|, evaluate {expr} for each item in the
-		List until the expression is v:true and return the index of
-		this item.
+                If {object} is a |List|, evaluate {expr} for each item in the
+                List until the expression is v:true and return the index of
+                this item.
 
-		If {object} is a |Blob| evaluate {expr} for each byte in the
-		Blob until the expression is v:true and return the index of
-		this byte.
+                If {object} is a |Blob| evaluate {expr} for each byte in the
+                Blob until the expression is v:true and return the index of
+                this byte.
 
-		{expr} must be a |string| or |Funcref|.
+                {expr} must be a |string| or |Funcref|.
 
-		If {expr} is a |string|: If {object} is a |List|, inside
-		{expr} |v:key| has the index of the current List item and
-		|v:val| has the value of the item.  If {object} is a |Blob|,
-		inside {expr} |v:key| has the index of the current byte and
-		|v:val| has the byte value.
+                If {expr} is a |string|: If {object} is a |List|, inside
+                {expr} |v:key| has the index of the current List item and
+                |v:val| has the value of the item.  If {object} is a |Blob|,
+                inside {expr} |v:key| has the index of the current byte and
+                |v:val| has the byte value.
 
-		If {expr} is a |Funcref| it must take two arguments:
-			1. the key or the index of the current item.
-			2. the value of the current item.
-		The function must return |TRUE| if the item is found and the
-		search should stop.
+                If {expr} is a |Funcref| it must take two arguments:
+                        1. the key or the index of the current item.
+                        2. the value of the current item.
+                The function must return |TRUE| if the item is found and the
+                search should stop.
 
-		The optional argument {opts} is a Dict and supports the
-		following items:
-		    startidx	start evaluating {expr} at the item with this
-				index; may be negative for an item relative to
-				the end
-		Returns -1 when {expr} evaluates to v:false for all the items.
-		Example: >vim
-			let l = [#{n: 10}, #{n: 20}, #{n: 30}]
-			echo indexof(l, "v:val.n == 20")
-			echo indexof(l, {i, v -> v.n == 30})
-			echo indexof(l, "v:val.n == 20", #{startidx: 1})
+                The optional argument {opts} is a Dict and supports the
+                following items:
+                    startidx    start evaluating {expr} at the item with this
+                                index; may be negative for an item relative to
+                                the end
+                Returns -1 when {expr} evaluates to v:false for all the items.
+                Example: >vim
+                        let l = [#{n: 10}, #{n: 20}, #{n: 30}]
+                        echo indexof(l, "v:val.n == 20")
+                        echo indexof(l, {i, v -> v.n == 30})
+                        echo indexof(l, "v:val.n == 20", #{startidx: 1})
 
 input({prompt} [, {text} [, {completion}]])                            *input()*
 
 input({opts})
-		The result is a String, which is whatever the user typed on
-		the command-line.  The {prompt} argument is either a prompt
-		string, or a blank string (for no prompt).  A '\n' can be used
-		in the prompt to start a new line.
+                The result is a String, which is whatever the user typed on
+                the command-line.  The {prompt} argument is either a prompt
+                string, or a blank string (for no prompt).  A '\n' can be used
+                in the prompt to start a new line.
 
-		In the second form it accepts a single dictionary with the
-		following keys, any of which may be omitted:
+                In the second form it accepts a single dictionary with the
+                following keys, any of which may be omitted:
 
-		Key           Default  Description ~
-		prompt        ""       Same as {prompt} in the first form.
-		default       ""       Same as {text} in the first form.
-		completion    nothing  Same as {completion} in the first form.
-		cancelreturn  ""       The value returned when the dialog is
-		                       cancelled.
-		highlight     nothing  Highlight handler: |Funcref|.
+                Key           Default  Description ~
+                prompt        ""       Same as {prompt} in the first form.
+                default       ""       Same as {text} in the first form.
+                completion    nothing  Same as {completion} in the first form.
+                cancelreturn  ""       The value returned when the dialog is
+                                       cancelled.
+                highlight     nothing  Highlight handler: |Funcref|.
 
-		The highlighting set with |:echohl| is used for the prompt.
-		The input is entered just like a command-line, with the same
-		editing commands and mappings.  There is a separate history
-		for lines typed for input().
-		Example: >vim
-			if input("Coffee or beer? ") == "beer"
-			  echo "Cheers!"
-			endif
+                The highlighting set with |:echohl| is used for the prompt.
+                The input is entered just like a command-line, with the same
+                editing commands and mappings.  There is a separate history
+                for lines typed for input().
+                Example: >vim
+                        if input("Coffee or beer? ") == "beer"
+                          echo "Cheers!"
+                        endif
 <
-		If the optional {text} argument is present and not empty, this
-		is used for the default reply, as if the user typed this.
-		Example: >vim
-			let color = input("Color? ", "white")
+                If the optional {text} argument is present and not empty, this
+                is used for the default reply, as if the user typed this.
+                Example: >vim
+                        let color = input("Color? ", "white")
 
-<		The optional {completion} argument specifies the type of
-		completion supported for the input.  Without it completion is
-		not performed.  The supported completion types are the same as
-		that can be supplied to a user-defined command using the
-		"-complete=" argument.  Refer to |:command-completion| for
-		more information.  Example: >vim
-			let fname = input("File: ", "", "file")
+<                The optional {completion} argument specifies the type of
+                completion supported for the input.  Without it completion is
+                not performed.  The supported completion types are the same as
+                that can be supplied to a user-defined command using the
+                "-complete=" argument.  Refer to |:command-completion| for
+                more information.  Example: >vim
+                        let fname = input("File: ", "", "file")
 
-<					*input()-highlight* *E5400* *E5402*
-		The optional `highlight` key allows specifying function which
-		will be used for highlighting user input.  This function
-		receives user input as its only argument and must return
-		a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
-		where
-			hl_start_col is the first highlighted column,
-			hl_end_col is the last highlighted column (+ 1!),
-			hl_group is |:hi| group used for highlighting.
-					      *E5403* *E5404* *E5405* *E5406*
-		Both hl_start_col and hl_end_col + 1 must point to the start
-		of the multibyte character (highlighting must not break
-		multibyte characters), hl_end_col + 1 may be equal to the
-		input length.  Start column must be in range [0, len(input)),
-		end column must be in range (hl_start_col, len(input)],
-		sections must be ordered so that next hl_start_col is greater
-		then or equal to previous hl_end_col.
+<                                       *input()-highlight* *E5400* *E5402*
+                The optional `highlight` key allows specifying function which
+                will be used for highlighting user input.  This function
+                receives user input as its only argument and must return
+                a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
+                where
+                        hl_start_col is the first highlighted column,
+                        hl_end_col is the last highlighted column (+ 1!),
+                        hl_group is |:hi| group used for highlighting.
+                                              *E5403* *E5404* *E5405* *E5406*
+                Both hl_start_col and hl_end_col + 1 must point to the start
+                of the multibyte character (highlighting must not break
+                multibyte characters), hl_end_col + 1 may be equal to the
+                input length.  Start column must be in range [0, len(input)),
+                end column must be in range (hl_start_col, len(input)],
+                sections must be ordered so that next hl_start_col is greater
+                then or equal to previous hl_end_col.
 
-		Example (try some input with parentheses): >vim
-			highlight RBP1 guibg=Red ctermbg=red
-			highlight RBP2 guibg=Yellow ctermbg=yellow
-			highlight RBP3 guibg=Green ctermbg=green
-			highlight RBP4 guibg=Blue ctermbg=blue
-			let g:rainbow_levels = 4
-			function! RainbowParens(cmdline)
-			  let ret = []
-			  let i = 0
-			  let lvl = 0
-			  while i < len(a:cmdline)
-			    if a:cmdline[i] is# '('
-			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-			      let lvl += 1
-			    elseif a:cmdline[i] is# ')'
-			      let lvl -= 1
-			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-			    endif
-			    let i += 1
-			  endwhile
-			  return ret
-			endfunction
-			call input({'prompt':'>','highlight':'RainbowParens'})
+                Example (try some input with parentheses): >vim
+                        highlight RBP1 guibg=Red ctermbg=red
+                        highlight RBP2 guibg=Yellow ctermbg=yellow
+                        highlight RBP3 guibg=Green ctermbg=green
+                        highlight RBP4 guibg=Blue ctermbg=blue
+                        let g:rainbow_levels = 4
+                        function! RainbowParens(cmdline)
+                          let ret = []
+                          let i = 0
+                          let lvl = 0
+                          while i < len(a:cmdline)
+                            if a:cmdline[i] is# '('
+                              call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+                              let lvl += 1
+                            elseif a:cmdline[i] is# ')'
+                              let lvl -= 1
+                              call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+                            endif
+                            let i += 1
+                          endwhile
+                          return ret
+                        endfunction
+                        call input({'prompt':'>','highlight':'RainbowParens'})
 <
-		Highlight function is called at least once for each new
-		displayed input string, before command-line is redrawn.  It is
-		expected that function is pure for the duration of one input()
-		call, i.e. it produces the same output for the same input, so
-		output may be memoized.  Function is run like under |:silent|
-		modifier. If the function causes any errors, it will be
-		skipped for the duration of the current input() call.
+                Highlight function is called at least once for each new
+                displayed input string, before command-line is redrawn.  It is
+                expected that function is pure for the duration of one input()
+                call, i.e. it produces the same output for the same input, so
+                output may be memoized.  Function is run like under |:silent|
+                modifier. If the function causes any errors, it will be
+                skipped for the duration of the current input() call.
 
-		Highlighting is disabled if command-line contains arabic
-		characters.
+                Highlighting is disabled if command-line contains arabic
+                characters.
 
-		NOTE: This function must not be used in a startup file, for
-		the versions that only run in GUI mode (e.g., the Win32 GUI).
-		Note: When input() is called from within a mapping it will
-		consume remaining characters from that mapping, because a
-		mapping is handled like the characters were typed.
-		Use |inputsave()| before input() and |inputrestore()|
-		after input() to avoid that.  Another solution is to avoid
-		that further characters follow in the mapping, e.g., by using
-		|:execute| or |:normal|.
+                NOTE: This function must not be used in a startup file, for
+                the versions that only run in GUI mode (e.g., the Win32 GUI).
+                Note: When input() is called from within a mapping it will
+                consume remaining characters from that mapping, because a
+                mapping is handled like the characters were typed.
+                Use |inputsave()| before input() and |inputrestore()|
+                after input() to avoid that.  Another solution is to avoid
+                that further characters follow in the mapping, e.g., by using
+                |:execute| or |:normal|.
 
-		Example with a mapping: >vim
-			nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
-			function GetFoo()
-			  call inputsave()
-			  let g:Foo = input("enter search pattern: ")
-			  call inputrestore()
-			endfunction
+                Example with a mapping: >vim
+                        nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
+                        function GetFoo()
+                          call inputsave()
+                          let g:Foo = input("enter search pattern: ")
+                          call inputrestore()
+                        endfunction
 
 inputlist({textlist})                                              *inputlist()*
-		{textlist} must be a |List| of strings.  This |List| is
-		displayed, one string per line.  The user will be prompted to
-		enter a number, which is returned.
-		The user can also select an item by clicking on it with the
-		mouse, if the mouse is enabled in the command line ('mouse' is
-		"a" or includes "c").  For the first string 0 is returned.
-		When clicking above the first item a negative number is
-		returned.  When clicking on the prompt one more than the
-		length of {textlist} is returned.
-		Make sure {textlist} has less than 'lines' entries, otherwise
-		it won't work.  It's a good idea to put the entry number at
-		the start of the string.  And put a prompt in the first item.
-		Example: >vim
-			let color = inputlist(['Select color:', '1. red',
-				\ '2. green', '3. blue'])
+                {textlist} must be a |List| of strings.  This |List| is
+                displayed, one string per line.  The user will be prompted to
+                enter a number, which is returned.
+                The user can also select an item by clicking on it with the
+                mouse, if the mouse is enabled in the command line ('mouse' is
+                "a" or includes "c").  For the first string 0 is returned.
+                When clicking above the first item a negative number is
+                returned.  When clicking on the prompt one more than the
+                length of {textlist} is returned.
+                Make sure {textlist} has less than 'lines' entries, otherwise
+                it won't work.  It's a good idea to put the entry number at
+                the start of the string.  And put a prompt in the first item.
+                Example: >vim
+                        let color = inputlist(['Select color:', '1. red',
+                                \ '2. green', '3. blue'])
 
 inputrestore()                                                  *inputrestore()*
-		Restore typeahead that was saved with a previous |inputsave()|.
-		Should be called the same number of times inputsave() is
-		called.  Calling it more often is harmless though.
-		Returns TRUE when there is nothing to restore, FALSE otherwise.
+                Restore typeahead that was saved with a previous |inputsave()|.
+                Should be called the same number of times inputsave() is
+                called.  Calling it more often is harmless though.
+                Returns TRUE when there is nothing to restore, FALSE otherwise.
 
 inputsave()                                                        *inputsave()*
-		Preserve typeahead (also from mappings) and clear it, so that
-		a following prompt gets input from the user.  Should be
-		followed by a matching inputrestore() after the prompt.  Can
-		be used several times, in which case there must be just as
-		many inputrestore() calls.
-		Returns TRUE when out of memory, FALSE otherwise.
+                Preserve typeahead (also from mappings) and clear it, so that
+                a following prompt gets input from the user.  Should be
+                followed by a matching inputrestore() after the prompt.  Can
+                be used several times, in which case there must be just as
+                many inputrestore() calls.
+                Returns TRUE when out of memory, FALSE otherwise.
 
 inputsecret({prompt} [, {text}])                                 *inputsecret()*
-		This function acts much like the |input()| function with but
-		two exceptions:
-		a) the user's response will be displayed as a sequence of
-		asterisks ("*") thereby keeping the entry secret, and
-		b) the user's response will not be recorded on the input
-		|history| stack.
-		The result is a String, which is whatever the user actually
-		typed on the command-line in response to the issued prompt.
-		NOTE: Command-line completion is not supported.
+                This function acts much like the |input()| function with but
+                two exceptions:
+                a) the user's response will be displayed as a sequence of
+                asterisks ("*") thereby keeping the entry secret, and
+                b) the user's response will not be recorded on the input
+                |history| stack.
+                The result is a String, which is whatever the user actually
+                typed on the command-line in response to the issued prompt.
+                NOTE: Command-line completion is not supported.
 
 insert({object}, {item} [, {idx}])                                    *insert()*
-		When {object} is a |List| or a |Blob| insert {item} at the start
-		of it.
+                When {object} is a |List| or a |Blob| insert {item} at the start
+                of it.
 
-		If {idx} is specified insert {item} before the item with index
-		{idx}.  If {idx} is zero it goes before the first item, just
-		like omitting {idx}.  A negative {idx} is also possible, see
-		|list-index|.  -1 inserts just before the last item.
+                If {idx} is specified insert {item} before the item with index
+                {idx}.  If {idx} is zero it goes before the first item, just
+                like omitting {idx}.  A negative {idx} is also possible, see
+                |list-index|.  -1 inserts just before the last item.
 
-		Returns the resulting |List| or |Blob|.  Examples: >vim
-			let mylist = insert([2, 3, 5], 1)
-			call insert(mylist, 4, -1)
-			call insert(mylist, 6, len(mylist))
-<		The last example can be done simpler with |add()|.
-		Note that when {item} is a |List| it is inserted as a single
-		item.  Use |extend()| to concatenate |Lists|.
+                Returns the resulting |List| or |Blob|.  Examples: >vim
+                        let mylist = insert([2, 3, 5], 1)
+                        call insert(mylist, 4, -1)
+                        call insert(mylist, 6, len(mylist))
+<                The last example can be done simpler with |add()|.
+                Note that when {item} is a |List| it is inserted as a single
+                item.  Use |extend()| to concatenate |Lists|.
 
 interrupt()                                                        *interrupt()*
-		Interrupt script execution.  It works more or less like the
-		user typing CTRL-C, most commands won't execute and control
-		returns to the user.  This is useful to abort execution
-		from lower down, e.g. in an autocommand.  Example: >vim
-		function s:check_typoname(file)
-		   if fnamemodify(a:file, ':t') == '['
-		       echomsg 'Maybe typo'
-		       call interrupt()
-		   endif
-		endfunction
-		au BufWritePre * call s:check_typoname(expand('<amatch>'))
+                Interrupt script execution.  It works more or less like the
+                user typing CTRL-C, most commands won't execute and control
+                returns to the user.  This is useful to abort execution
+                from lower down, e.g. in an autocommand.  Example: >vim
+                function s:check_typoname(file)
+                   if fnamemodify(a:file, ':t') == '['
+                       echomsg 'Maybe typo'
+                       call interrupt()
+                   endif
+                endfunction
+                au BufWritePre * call s:check_typoname(expand('<amatch>'))
 <
-
 invert({expr})                                                        *invert()*
-		Bitwise invert.  The argument is converted to a number.  A
-		List, Dict or Float argument causes an error.  Example: >vim
-			let bits = invert(bits)
+                Bitwise invert.  The argument is converted to a number.  A
+                List, Dict or Float argument causes an error.  Example: >vim
+                        let bits = invert(bits)
 <
-
 isdirectory({directory})                                         *isdirectory()*
-		The result is a Number, which is |TRUE| when a directory
-		with the name {directory} exists.  If {directory} doesn't
-		exist, or isn't a directory, the result is |FALSE|.  {directory}
-		is any expression, which is used as a String.
+                The result is a Number, which is |TRUE| when a directory
+                with the name {directory} exists.  If {directory} doesn't
+                exist, or isn't a directory, the result is |FALSE|.  {directory}
+                is any expression, which is used as a String.
 
 isinf({expr})                                                          *isinf()*
-		Return 1 if {expr} is a positive infinity, or -1 a negative
-		infinity, otherwise 0. >vim
-			echo isinf(1.0 / 0.0)
-<			1 >vim
-			echo isinf(-1.0 / 0.0)
-<			-1
+                Return 1 if {expr} is a positive infinity, or -1 a negative
+                infinity, otherwise 0. >vim
+                        echo isinf(1.0 / 0.0)
+<                        1 >vim
+                        echo isinf(-1.0 / 0.0)
+<                        -1
 
 islocked({expr})                                               *islocked()* *E786*
-		The result is a Number, which is |TRUE| when {expr} is the
-		name of a locked variable.
-		The string argument {expr} must be the name of a variable,
-		|List| item or |Dictionary| entry, not the variable itself!
-		Example: >vim
-			let alist = [0, ['a', 'b'], 2, 3]
-			lockvar 1 alist
-			echo islocked('alist')		" 1
-			echo islocked('alist[1]')	" 0
+                The result is a Number, which is |TRUE| when {expr} is the
+                name of a locked variable.
+                The string argument {expr} must be the name of a variable,
+                |List| item or |Dictionary| entry, not the variable itself!
+                Example: >vim
+                        let alist = [0, ['a', 'b'], 2, 3]
+                        lockvar 1 alist
+                        echo islocked('alist')          " 1
+                        echo islocked('alist[1]')       " 0
 
-<		When {expr} is a variable that does not exist you get an error
-		message.  Use |exists()| to check for existence.
+<                When {expr} is a variable that does not exist you get an error
+                message.  Use |exists()| to check for existence.
 
 isnan({expr})                                                          *isnan()*
-		Return |TRUE| if {expr} is a float with value NaN. >vim
-			echo isnan(0.0 / 0.0)
-<			1
+                Return |TRUE| if {expr} is a float with value NaN. >vim
+                        echo isnan(0.0 / 0.0)
+<                        1
 
 items({dict})                                                          *items()*
-		Return a |List| with all the key-value pairs of {dict}.  Each
-		|List| item is a list with two items: the key of a {dict}
-		entry and the value of this entry.  The |List| is in arbitrary
-		order.  Also see |keys()| and |values()|.
-		Example: >vim
-			for [key, value] in items(mydict)
-			   echo key .. ': ' .. value
-			endfor
+                Return a |List| with all the key-value pairs of {dict}.  Each
+                |List| item is a list with two items: the key of a {dict}
+                entry and the value of this entry.  The |List| is in arbitrary
+                order.  Also see |keys()| and |values()|.
+                Example: >vim
+                        for [key, value] in items(mydict)
+                           echo key .. ': ' .. value
+                        endfor
 
 jobpid({job})                                                         *jobpid()*
-		Return the PID (process id) of |job-id| {job}.
+                Return the PID (process id) of |job-id| {job}.
 
 jobresize({job}, {width}, {height})                                *jobresize()*
-		Resize the pseudo terminal window of |job-id| {job} to {width}
-		columns and {height} rows.
-		Fails if the job was not started with `"pty":v:true`.
+                Resize the pseudo terminal window of |job-id| {job} to {width}
+                columns and {height} rows.
+                Fails if the job was not started with `"pty":v:true`.
 
 jobstart({cmd} [, {opts}])                                          *jobstart()*
-		Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
+                Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
 
-		Spawns {cmd} as a job.
-		If {cmd} is a List it runs directly (no 'shell').
-		If {cmd} is a String it runs in the 'shell', like this: >vim
-		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
-<		(See |shell-unquoting| for details.)
+                Spawns {cmd} as a job.
+                If {cmd} is a List it runs directly (no 'shell').
+                If {cmd} is a String it runs in the 'shell', like this: >vim
+                  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
+<                (See |shell-unquoting| for details.)
 
-		Example: >vim
-		  call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
+                Example: >vim
+                  call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
 <
-		Returns |job-id| on success, 0 on invalid arguments (or job
-		table is full), -1 if {cmd}[0] or 'shell' is not executable.
-		The returned job-id is a valid |channel-id| representing the
-		job's stdio streams. Use |chansend()| (or |rpcnotify()| and
-		|rpcrequest()| if "rpc" was enabled) to send data to stdin and
-		|chanclose()| to close the streams without stopping the job.
+                Returns |job-id| on success, 0 on invalid arguments (or job
+                table is full), -1 if {cmd}[0] or 'shell' is not executable.
+                The returned job-id is a valid |channel-id| representing the
+                job's stdio streams. Use |chansend()| (or |rpcnotify()| and
+                |rpcrequest()| if "rpc" was enabled) to send data to stdin and
+                |chanclose()| to close the streams without stopping the job.
 
-		See |job-control| and |RPC|.
+                See |job-control| and |RPC|.
 
-		NOTE: on Windows if {cmd} is a List:
-		  - cmd[0] must be an executable (not a "built-in"). If it is
-		    in $PATH it can be called by name, without an extension: >vim
-		      call jobstart(['ping', 'neovim.io'])
-<		    If it is a full or partial path, extension is required: >vim
-		      call jobstart(['System32\ping.exe', 'neovim.io'])
-<		  - {cmd} is collapsed to a string of quoted args as expected
-		    by CommandLineToArgvW https://msdn.microsoft.com/bb776391
-		    unless cmd[0] is some form of "cmd.exe".
+                NOTE: on Windows if {cmd} is a List:
+                  - cmd[0] must be an executable (not a "built-in"). If it is
+                    in $PATH it can be called by name, without an extension: >vim
+                      call jobstart(['ping', 'neovim.io'])
+<                    If it is a full or partial path, extension is required: >vim
+                      call jobstart(['System32\ping.exe', 'neovim.io'])
+<                  - {cmd} is collapsed to a string of quoted args as expected
+                    by CommandLineToArgvW https://msdn.microsoft.com/bb776391
+                    unless cmd[0] is some form of "cmd.exe".
 
-							*jobstart-env*
-		The job environment is initialized as follows:
-		  $NVIM                is set to |v:servername| of the parent Nvim
-		  $NVIM_LISTEN_ADDRESS is unset
-		  $NVIM_LOG_FILE       is unset
-		  $VIM                 is unset
-		  $VIMRUNTIME          is unset
-		You can set these with the `env` option.
+                                                        *jobstart-env*
+                The job environment is initialized as follows:
+                  $NVIM                is set to |v:servername| of the parent Nvim
+                  $NVIM_LISTEN_ADDRESS is unset
+                  $NVIM_LOG_FILE       is unset
+                  $VIM                 is unset
+                  $VIMRUNTIME          is unset
+                You can set these with the `env` option.
 
-							*jobstart-options*
-		{opts} is a dictionary with these keys:
-		  clear_env:  (boolean) `env` defines the job environment
-			      exactly, instead of merging current environment.
-		  cwd:	      (string, default=|current-directory|) Working
-			      directory of the job.
-		  detach:     (boolean) Detach the job process: it will not be
-			      killed when Nvim exits. If the process exits
-			      before Nvim, `on_exit` will be invoked.
-		  env:	      (dict) Map of environment variable name:value
-			      pairs extending (or replace with "clear_env")
-			      the current environment. |jobstart-env|
-		  height:     (number) Height of the `pty` terminal.
-		  |on_exit|:    (function) Callback invoked when the job exits.
-		  |on_stdout|:  (function) Callback invoked when the job emits
-			      stdout data.
-		  |on_stderr|:  (function) Callback invoked when the job emits
-			      stderr data.
-		  overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
-			      stdio passed to the child process. Only on
-			      MS-Windows; ignored on other platforms.
-		  pty:	      (boolean) Connect the job to a new pseudo
-			      terminal, and its streams to the master file
-			      descriptor. `on_stdout` receives all output,
-			      `on_stderr` is ignored. |terminal-start|
-		  rpc:	      (boolean) Use |msgpack-rpc| to communicate with
-			      the job over stdio. Then `on_stdout` is ignored,
-			      but `on_stderr` can still be used.
-		  stderr_buffered: (boolean) Collect data until EOF (stream closed)
-			      before invoking `on_stderr`. |channel-buffered|
-		  stdout_buffered: (boolean) Collect data until EOF (stream
-			      closed) before invoking `on_stdout`. |channel-buffered|
-		  stdin:      (string) Either "pipe" (default) to connect the
-			      job's stdin to a channel or "null" to disconnect
-			      stdin.
-		  width:      (number) Width of the `pty` terminal.
+                                                        *jobstart-options*
+                {opts} is a dictionary with these keys:
+                  clear_env:  (boolean) `env` defines the job environment
+                              exactly, instead of merging current environment.
+                  cwd:        (string, default=|current-directory|) Working
+                              directory of the job.
+                  detach:     (boolean) Detach the job process: it will not be
+                              killed when Nvim exits. If the process exits
+                              before Nvim, `on_exit` will be invoked.
+                  env:        (dict) Map of environment variable name:value
+                              pairs extending (or replace with "clear_env")
+                              the current environment. |jobstart-env|
+                  height:     (number) Height of the `pty` terminal.
+                  |on_exit|:    (function) Callback invoked when the job exits.
+                  |on_stdout|:  (function) Callback invoked when the job emits
+                              stdout data.
+                  |on_stderr|:  (function) Callback invoked when the job emits
+                              stderr data.
+                  overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
+                              stdio passed to the child process. Only on
+                              MS-Windows; ignored on other platforms.
+                  pty:        (boolean) Connect the job to a new pseudo
+                              terminal, and its streams to the master file
+                              descriptor. `on_stdout` receives all output,
+                              `on_stderr` is ignored. |terminal-start|
+                  rpc:        (boolean) Use |msgpack-rpc| to communicate with
+                              the job over stdio. Then `on_stdout` is ignored,
+                              but `on_stderr` can still be used.
+                  stderr_buffered: (boolean) Collect data until EOF (stream closed)
+                              before invoking `on_stderr`. |channel-buffered|
+                  stdout_buffered: (boolean) Collect data until EOF (stream
+                              closed) before invoking `on_stdout`. |channel-buffered|
+                  stdin:      (string) Either "pipe" (default) to connect the
+                              job's stdin to a channel or "null" to disconnect
+                              stdin.
+                  width:      (number) Width of the `pty` terminal.
 
-		{opts} is passed as |self| dictionary to the callback; the
-		caller may set other keys to pass application-specific data.
+                {opts} is passed as |self| dictionary to the callback; the
+                caller may set other keys to pass application-specific data.
 
-		Returns:
-		  - |channel-id| on success
-		  - 0 on invalid arguments
-		  - -1 if {cmd}[0] is not executable.
-		See also |job-control|, |channel|, |msgpack-rpc|.
+                Returns:
+                  - |channel-id| on success
+                  - 0 on invalid arguments
+                  - -1 if {cmd}[0] is not executable.
+                See also |job-control|, |channel|, |msgpack-rpc|.
 
 jobstop({id})                                                        *jobstop()*
-		Stop |job-id| {id} by sending SIGTERM to the job process. If
-		the process does not terminate after a timeout then SIGKILL
-		will be sent. When the job terminates its |on_exit| handler
-		(if any) will be invoked.
-		See |job-control|.
+                Stop |job-id| {id} by sending SIGTERM to the job process. If
+                the process does not terminate after a timeout then SIGKILL
+                will be sent. When the job terminates its |on_exit| handler
+                (if any) will be invoked.
+                See |job-control|.
 
-		Returns 1 for valid job id, 0 for invalid id, including jobs have
-		exited or stopped.
+                Returns 1 for valid job id, 0 for invalid id, including jobs have
+                exited or stopped.
 
 jobwait({jobs} [, {timeout}])                                        *jobwait()*
-		Waits for jobs and their |on_exit| handlers to complete.
+                Waits for jobs and their |on_exit| handlers to complete.
 
-		{jobs} is a List of |job-id|s to wait for.
-		{timeout} is the maximum waiting time in milliseconds. If
-		omitted or -1, wait forever.
+                {jobs} is a List of |job-id|s to wait for.
+                {timeout} is the maximum waiting time in milliseconds. If
+                omitted or -1, wait forever.
 
-		Timeout of 0 can be used to check the status of a job: >vim
-			let running = jobwait([{job-id}], 0)[0] == -1
+                Timeout of 0 can be used to check the status of a job: >vim
+                        let running = jobwait([{job-id}], 0)[0] == -1
 <
-		During jobwait() callbacks for jobs not in the {jobs} list may
-		be invoked. The screen will not redraw unless |:redraw| is
-		invoked by a callback.
+                During jobwait() callbacks for jobs not in the {jobs} list may
+                be invoked. The screen will not redraw unless |:redraw| is
+                invoked by a callback.
 
-		Returns a list of len({jobs}) integers, where each integer is
-		the status of the corresponding job:
-			Exit-code, if the job exited
-			-1 if the timeout was exceeded
-			-2 if the job was interrupted (by |CTRL-C|)
-			-3 if the job-id is invalid
+                Returns a list of len({jobs}) integers, where each integer is
+                the status of the corresponding job:
+                        Exit-code, if the job exited
+                        -1 if the timeout was exceeded
+                        -2 if the job was interrupted (by |CTRL-C|)
+                        -3 if the job-id is invalid
 
 join({list} [, {sep}])                                                  *join()*
-		Join the items in {list} together into one String.
-		When {sep} is specified it is put in between the items.  If
-		{sep} is omitted a single space is used.
-		Note that {sep} is not added at the end.  You might want to
-		add it there too: >vim
-			let lines = join(mylist, "\n") .. "\n"
-<		String items are used as-is.  |Lists| and |Dictionaries| are
-		converted into a string like with |string()|.
-		The opposite function is |split()|.
+                Join the items in {list} together into one String.
+                When {sep} is specified it is put in between the items.  If
+                {sep} is omitted a single space is used.
+                Note that {sep} is not added at the end.  You might want to
+                add it there too: >vim
+                        let lines = join(mylist, "\n") .. "\n"
+<                String items are used as-is.  |Lists| and |Dictionaries| are
+                converted into a string like with |string()|.
+                The opposite function is |split()|.
 
 json_decode({expr})                                              *json_decode()*
-		Convert {expr} from JSON object.  Accepts |readfile()|-style
-		list as the input, as well as regular string.  May output any
-		Vim value. In the following cases it will output
-		|msgpack-special-dict|:
-		1. Dictionary contains duplicate key.
-		2. String contains NUL byte.  Two special dictionaries: for
-		   dictionary and for string will be emitted in case string
-		   with NUL byte was a dictionary key.
+                Convert {expr} from JSON object.  Accepts |readfile()|-style
+                list as the input, as well as regular string.  May output any
+                Vim value. In the following cases it will output
+                |msgpack-special-dict|:
+                1. Dictionary contains duplicate key.
+                2. String contains NUL byte.  Two special dictionaries: for
+                   dictionary and for string will be emitted in case string
+                   with NUL byte was a dictionary key.
 
-		Note: function treats its input as UTF-8 always.  The JSON
-		standard allows only a few encodings, of which UTF-8 is
-		recommended and the only one required to be supported.
-		Non-UTF-8 characters are an error.
+                Note: function treats its input as UTF-8 always.  The JSON
+                standard allows only a few encodings, of which UTF-8 is
+                recommended and the only one required to be supported.
+                Non-UTF-8 characters are an error.
 
 json_encode({expr})                                              *json_encode()*
-		Convert {expr} into a JSON string.  Accepts
-		|msgpack-special-dict| as the input.  Will not convert
-		|Funcref|s, mappings with non-string keys (can be created as
-		|msgpack-special-dict|), values with self-referencing
-		containers, strings which contain non-UTF-8 characters,
-		pseudo-UTF-8 strings which contain codepoints reserved for
-		surrogate pairs (such strings are not valid UTF-8 strings).
-		Non-printable characters are converted into "\u1234" escapes
-		or special escapes like "\t", other are dumped as-is.
-		|Blob|s are converted to arrays of the individual bytes.
+                Convert {expr} into a JSON string.  Accepts
+                |msgpack-special-dict| as the input.  Will not convert
+                |Funcref|s, mappings with non-string keys (can be created as
+                |msgpack-special-dict|), values with self-referencing
+                containers, strings which contain non-UTF-8 characters,
+                pseudo-UTF-8 strings which contain codepoints reserved for
+                surrogate pairs (such strings are not valid UTF-8 strings).
+                Non-printable characters are converted into "\u1234" escapes
+                or special escapes like "\t", other are dumped as-is.
+                |Blob|s are converted to arrays of the individual bytes.
 
 keys({dict})                                                            *keys()*
-		Return a |List| with all the keys of {dict}.  The |List| is in
-		arbitrary order.  Also see |items()| and |values()|.
+                Return a |List| with all the keys of {dict}.  The |List| is in
+                arbitrary order.  Also see |items()| and |values()|.
 
 keytrans({string})                                                  *keytrans()*
-		Turn the internal byte representation of keys into a form that
-		can be used for |:map|.  E.g. >vim
-			let xx = "\<C-Home>"
-			echo keytrans(xx)
-<			<C-Home>
+                Turn the internal byte representation of keys into a form that
+                can be used for |:map|.  E.g. >vim
+                        let xx = "\<C-Home>"
+                        echo keytrans(xx)
+<                       <C-Home>
 
 len({expr})                                                         *len()* *E701*
-		The result is a Number, which is the length of the argument.
-		When {expr} is a String or a Number the length in bytes is
-		used, as with |strlen()|.
-		When {expr} is a |List| the number of items in the |List| is
-		returned.
-		When {expr} is a |Blob| the number of bytes is returned.
-		When {expr} is a |Dictionary| the number of entries in the
-		|Dictionary| is returned.
-		Otherwise an error is given and returns zero.
+                The result is a Number, which is the length of the argument.
+                When {expr} is a String or a Number the length in bytes is
+                used, as with |strlen()|.
+                When {expr} is a |List| the number of items in the |List| is
+                returned.
+                When {expr} is a |Blob| the number of bytes is returned.
+                When {expr} is a |Dictionary| the number of entries in the
+                |Dictionary| is returned.
+                Otherwise an error is given and returns zero.
 
 libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E368*
-		Call function {funcname} in the run-time library {libname}
-		with single argument {argument}.
-		This is useful to call functions in a library that you
-		especially made to be used with Vim.  Since only one argument
-		is possible, calling standard library functions is rather
-		limited.
-		The result is the String returned by the function.  If the
-		function returns NULL, this will appear as an empty string ""
-		to Vim.
-		If the function returns a number, use libcallnr()!
-		If {argument} is a number, it is passed to the function as an
-		int; if {argument} is a string, it is passed as a
-		null-terminated string.
+                Call function {funcname} in the run-time library {libname}
+                with single argument {argument}.
+                This is useful to call functions in a library that you
+                especially made to be used with Vim.  Since only one argument
+                is possible, calling standard library functions is rather
+                limited.
+                The result is the String returned by the function.  If the
+                function returns NULL, this will appear as an empty string ""
+                to Vim.
+                If the function returns a number, use libcallnr()!
+                If {argument} is a number, it is passed to the function as an
+                int; if {argument} is a string, it is passed as a
+                null-terminated string.
 
-		libcall() allows you to write your own 'plug-in' extensions to
-		Vim without having to recompile the program.  It is NOT a
-		means to call system functions!  If you try to do so Vim will
-		very probably crash.
+                libcall() allows you to write your own 'plug-in' extensions to
+                Vim without having to recompile the program.  It is NOT a
+                means to call system functions!  If you try to do so Vim will
+                very probably crash.
 
-		For Win32, the functions you write must be placed in a DLL
-		and use the normal C calling convention (NOT Pascal which is
-		used in Windows System DLLs).  The function must take exactly
-		one parameter, either a character pointer or a long integer,
-		and must return a character pointer or NULL.  The character
-		pointer returned must point to memory that will remain valid
-		after the function has returned (e.g. in static data in the
-		DLL).  If it points to allocated memory, that memory will
-		leak away.  Using a static buffer in the function should work,
-		it's then freed when the DLL is unloaded.
+                For Win32, the functions you write must be placed in a DLL
+                and use the normal C calling convention (NOT Pascal which is
+                used in Windows System DLLs).  The function must take exactly
+                one parameter, either a character pointer or a long integer,
+                and must return a character pointer or NULL.  The character
+                pointer returned must point to memory that will remain valid
+                after the function has returned (e.g. in static data in the
+                DLL).  If it points to allocated memory, that memory will
+                leak away.  Using a static buffer in the function should work,
+                it's then freed when the DLL is unloaded.
 
-		WARNING: If the function returns a non-valid pointer, Vim may
-		crash!	This also happens if the function returns a number,
-		because Vim thinks it's a pointer.
-		For Win32 systems, {libname} should be the filename of the DLL
-		without the ".DLL" suffix.  A full path is only required if
-		the DLL is not in the usual places.
-		For Unix: When compiling your own plugins, remember that the
-		object code must be compiled as position-independent ('PIC').
-		Examples: >vim
-			echo libcall("libc.so", "getenv", "HOME")
+                WARNING: If the function returns a non-valid pointer, Vim may
+                crash!  This also happens if the function returns a number,
+                because Vim thinks it's a pointer.
+                For Win32 systems, {libname} should be the filename of the DLL
+                without the ".DLL" suffix.  A full path is only required if
+                the DLL is not in the usual places.
+                For Unix: When compiling your own plugins, remember that the
+                object code must be compiled as position-independent ('PIC').
+                Examples: >vim
+                        echo libcall("libc.so", "getenv", "HOME")
 
 libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
-		Just like |libcall()|, but used for a function that returns an
-		int instead of a string.
-		Examples: >vim
-			echo libcallnr("/usr/lib/libc.so", "getpid", "")
-			call libcallnr("libc.so", "printf", "Hello World!\n")
-			call libcallnr("libc.so", "sleep", 10)
+                Just like |libcall()|, but used for a function that returns an
+                int instead of a string.
+                Examples: >vim
+                        echo libcallnr("/usr/lib/libc.so", "getpid", "")
+                        call libcallnr("libc.so", "printf", "Hello World!\n")
+                        call libcallnr("libc.so", "sleep", 10)
 <
-
 line({expr} [, {winid}])                                                *line()*
-		The result is a Number, which is the line number of the file
-		position given with {expr}.  The {expr} argument is a string.
-		The accepted positions are:
-		    .	    the cursor position
-		    $	    the last line in the current buffer
-		    'x	    position of mark x (if the mark is not set, 0 is
-			    returned)
-		    w0	    first line visible in current window (one if the
-			    display isn't updated, e.g. in silent Ex mode)
-		    w$	    last line visible in current window (this is one
-			    less than "w0" if no lines are visible)
-		    v	    In Visual mode: the start of the Visual area (the
-			    cursor is the end).  When not in Visual mode
-			    returns the cursor position.  Differs from |'<| in
-			    that it's updated right away.
-		Note that a mark in another file can be used.  The line number
-		then applies to another buffer.
-		To get the column number use |col()|.  To get both use
-		|getpos()|.
-		With the optional {winid} argument the values are obtained for
-		that window instead of the current window.
-		Returns 0 for invalid values of {expr} and {winid}.
-		Examples: >vim
-			echo line(".")			" line number of the cursor
-			echo line(".", winid)		" idem, in window "winid"
-			echo line("'t")			" line number of mark t
-			echo line("'" .. marker)	" line number of mark marker
+                The result is a Number, which is the line number of the file
+                position given with {expr}.  The {expr} argument is a string.
+                The accepted positions are:
+                    .       the cursor position
+                    $       the last line in the current buffer
+                    'x      position of mark x (if the mark is not set, 0 is
+                            returned)
+                    w0      first line visible in current window (one if the
+                            display isn't updated, e.g. in silent Ex mode)
+                    w$      last line visible in current window (this is one
+                            less than "w0" if no lines are visible)
+                    v       In Visual mode: the start of the Visual area (the
+                            cursor is the end).  When not in Visual mode
+                            returns the cursor position.  Differs from |'<| in
+                            that it's updated right away.
+                Note that a mark in another file can be used.  The line number
+                then applies to another buffer.
+                To get the column number use |col()|.  To get both use
+                |getpos()|.
+                With the optional {winid} argument the values are obtained for
+                that window instead of the current window.
+                Returns 0 for invalid values of {expr} and {winid}.
+                Examples: >vim
+                        echo line(".")                  " line number of the cursor
+                        echo line(".", winid)           " idem, in window "winid"
+                        echo line("'t")                 " line number of mark t
+                        echo line("'" .. marker)        " line number of mark marker
 <
-		To jump to the last known position when opening a file see
-		|last-position-jump|.
+                To jump to the last known position when opening a file see
+                |last-position-jump|.
 
 line2byte({lnum})                                                  *line2byte()*
-		Return the byte count from the start of the buffer for line
-		{lnum}.  This includes the end-of-line character, depending on
-		the 'fileformat' option for the current buffer.  The first
-		line returns 1. UTF-8 encoding is used, 'fileencoding' is
-		ignored.  This can also be used to get the byte count for the
-		line just below the last line: >vim
-			echo line2byte(line("$") + 1)
-<		This is the buffer size plus one.  If 'fileencoding' is empty
-		it is the file size plus one.  {lnum} is used like with
-		|getline()|.  When {lnum} is invalid -1 is returned.
-		Also see |byte2line()|, |go| and |:goto|.
+                Return the byte count from the start of the buffer for line
+                {lnum}.  This includes the end-of-line character, depending on
+                the 'fileformat' option for the current buffer.  The first
+                line returns 1. UTF-8 encoding is used, 'fileencoding' is
+                ignored.  This can also be used to get the byte count for the
+                line just below the last line: >vim
+                        echo line2byte(line("$") + 1)
+<                This is the buffer size plus one.  If 'fileencoding' is empty
+                it is the file size plus one.  {lnum} is used like with
+                |getline()|.  When {lnum} is invalid -1 is returned.
+                Also see |byte2line()|, |go| and |:goto|.
 
 lispindent({lnum})                                                *lispindent()*
-		Get the amount of indent for line {lnum} according the lisp
-		indenting rules, as with 'lisp'.
-		The indent is counted in spaces, the value of 'tabstop' is
-		relevant.  {lnum} is used just like in |getline()|.
-		When {lnum} is invalid, -1 is returned.
+                Get the amount of indent for line {lnum} according the lisp
+                indenting rules, as with 'lisp'.
+                The indent is counted in spaces, the value of 'tabstop' is
+                relevant.  {lnum} is used just like in |getline()|.
+                When {lnum} is invalid, -1 is returned.
 
 list2blob({list})                                                  *list2blob()*
-		Return a Blob concatenating all the number values in {list}.
-		Examples: >vim
-			echo list2blob([1, 2, 3, 4])	" returns 0z01020304
-			echo list2blob([])		" returns 0z
-<		Returns an empty Blob on error.  If one of the numbers is
-		negative or more than 255 error *E1239* is given.
+                Return a Blob concatenating all the number values in {list}.
+                Examples: >vim
+                        echo list2blob([1, 2, 3, 4])    " returns 0z01020304
+                        echo list2blob([])              " returns 0z
+<                Returns an empty Blob on error.  If one of the numbers is
+                negative or more than 255 error *E1239* is given.
 
-		|blob2list()| does the opposite.
+                |blob2list()| does the opposite.
 
 list2str({list} [, {utf8}])                                         *list2str()*
-		Convert each number in {list} to a character string can
-		concatenate them all.  Examples: >vim
-			echo list2str([32])		" returns " "
-			echo list2str([65, 66, 67])	" returns "ABC"
-<		The same can be done (slowly) with: >vim
-			echo join(map(list, {nr, val -> nr2char(val)}), '')
-<		|str2list()| does the opposite.
+                Convert each number in {list} to a character string can
+                concatenate them all.  Examples: >vim
+                        echo list2str([32])             " returns " "
+                        echo list2str([65, 66, 67])     " returns "ABC"
+<                The same can be done (slowly) with: >vim
+                        echo join(map(list, {nr, val -> nr2char(val)}), '')
+<                |str2list()| does the opposite.
 
-		UTF-8 encoding is always used, {utf8} option has no effect,
-		and exists only for backwards-compatibility.
-		With UTF-8 composing characters work as expected: >vim
-			echo list2str([97, 769])	" returns "á"
+                UTF-8 encoding is always used, {utf8} option has no effect,
+                and exists only for backwards-compatibility.
+                With UTF-8 composing characters work as expected: >vim
+                        echo list2str([97, 769])        " returns "á"
 <
-		Returns an empty string on error.
+                Returns an empty string on error.
 
 localtime()                                                        *localtime()*
-		Return the current time, measured as seconds since 1st Jan
-		1970.  See also |strftime()|, |strptime()| and |getftime()|.
+                Return the current time, measured as seconds since 1st Jan
+                1970.  See also |strftime()|, |strptime()| and |getftime()|.
 
 log({expr})                                                              *log()*
-		Return the natural logarithm (base e) of {expr} as a |Float|.
-		{expr} must evaluate to a |Float| or a |Number| in the range
-		(0, inf].
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo log(10)
-<			2.302585 >vim
-			echo log(exp(5))
-<			5.0
+                Return the natural logarithm (base e) of {expr} as a |Float|.
+                {expr} must evaluate to a |Float| or a |Number| in the range
+                (0, inf].
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo log(10)
+<                        2.302585 >vim
+                        echo log(exp(5))
+<                        5.0
 
 log10({expr})                                                          *log10()*
-		Return the logarithm of Float {expr} to base 10 as a |Float|.
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo log10(1000)
-<			3.0 >vim
-			echo log10(0.01)
-<			-2.0
+                Return the logarithm of Float {expr} to base 10 as a |Float|.
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo log10(1000)
+<                        3.0 >vim
+                        echo log10(0.01)
+<                        -2.0
 
 luaeval({expr} [, {expr}])                                           *luaeval()*
-		Evaluate Lua expression {expr} and return its result converted
-		to Vim data structures. See |lua-eval| for more details.
+                Evaluate Lua expression {expr} and return its result converted
+                to Vim data structures. See |lua-eval| for more details.
 
 map({expr1}, {expr2})                                                    *map()*
-		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-		When {expr1} is a |List|| or |Dictionary|, replace each
-		item in {expr1} with the result of evaluating {expr2}.
-		For a |Blob| each byte is replaced.
-		For a |String|, each character, including composing
-		characters, is replaced.
-		If the item type changes you may want to use |mapnew()| to
-		create a new List or Dictionary.
+                {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
+                When {expr1} is a |List|| or |Dictionary|, replace each
+                item in {expr1} with the result of evaluating {expr2}.
+                For a |Blob| each byte is replaced.
+                For a |String|, each character, including composing
+                characters, is replaced.
+                If the item type changes you may want to use |mapnew()| to
+                create a new List or Dictionary.
 
-		{expr2} must be a |String| or |Funcref|.
+                {expr2} must be a |String| or |Funcref|.
 
-		If {expr2} is a |String|, inside {expr2} |v:val| has the value
-		of the current item.  For a |Dictionary| |v:key| has the key
-		of the current item and for a |List| |v:key| has the index of
-		the current item.  For a |Blob| |v:key| has the index of the
-		current byte. For a |String| |v:key| has the index of the
-		current character.
-		Example: >vim
-			call map(mylist, '"> " .. v:val .. " <"')
-<		This puts "> " before and " <" after each item in "mylist".
+                If {expr2} is a |String|, inside {expr2} |v:val| has the value
+                of the current item.  For a |Dictionary| |v:key| has the key
+                of the current item and for a |List| |v:key| has the index of
+                the current item.  For a |Blob| |v:key| has the index of the
+                current byte. For a |String| |v:key| has the index of the
+                current character.
+                Example: >vim
+                        call map(mylist, '"> " .. v:val .. " <"')
+<                This puts "> " before and " <" after each item in "mylist".
 
-		Note that {expr2} is the result of an expression and is then
-		used as an expression again.  Often it is good to use a
-		|literal-string| to avoid having to double backslashes.  You
-		still have to double ' quotes
+                Note that {expr2} is the result of an expression and is then
+                used as an expression again.  Often it is good to use a
+                |literal-string| to avoid having to double backslashes.  You
+                still have to double ' quotes
 
-		If {expr2} is a |Funcref| it is called with two arguments:
-			1. The key or the index of the current item.
-			2. the value of the current item.
-		The function must return the new value of the item. Example
-		that changes each value by "key-value": >vim
-			func KeyValue(key, val)
-			  return a:key .. '-' .. a:val
-			endfunc
-			call map(myDict, function('KeyValue'))
-<		It is shorter when using a |lambda|: >vim
-			call map(myDict, {key, val -> key .. '-' .. val})
-<		If you do not use "val" you can leave it out: >vim
-			call map(myDict, {key -> 'item: ' .. key})
-<		If you do not use "key" you can use a short name: >vim
-			call map(myDict, {_, val -> 'item: ' .. val})
+                If {expr2} is a |Funcref| it is called with two arguments:
+                        1. The key or the index of the current item.
+                        2. the value of the current item.
+                The function must return the new value of the item. Example
+                that changes each value by "key-value": >vim
+                        func KeyValue(key, val)
+                          return a:key .. '-' .. a:val
+                        endfunc
+                        call map(myDict, function('KeyValue'))
+<                It is shorter when using a |lambda|: >vim
+                        call map(myDict, {key, val -> key .. '-' .. val})
+<                If you do not use "val" you can leave it out: >vim
+                        call map(myDict, {key -> 'item: ' .. key})
+<                If you do not use "key" you can use a short name: >vim
+                        call map(myDict, {_, val -> 'item: ' .. val})
 <
-		The operation is done in-place for a |List| and |Dictionary|.
-		If you want it to remain unmodified make a copy first: >vim
-			let tlist = map(copy(mylist), ' v:val .. "\t"')
+                The operation is done in-place for a |List| and |Dictionary|.
+                If you want it to remain unmodified make a copy first: >vim
+                        let tlist = map(copy(mylist), ' v:val .. "\t"')
 
-<		Returns {expr1}, the |List| or |Dictionary| that was filtered,
-		or a new |Blob| or |String|.
-		When an error is encountered while evaluating {expr2} no
-		further items in {expr1} are processed.
-		When {expr2} is a Funcref errors inside a function are ignored,
-		unless it was defined with the "abort" flag.
+<                Returns {expr1}, the |List| or |Dictionary| that was filtered,
+                or a new |Blob| or |String|.
+                When an error is encountered while evaluating {expr2} no
+                further items in {expr1} are processed.
+                When {expr2} is a Funcref errors inside a function are ignored,
+                unless it was defined with the "abort" flag.
 
 maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
-		When {dict} is omitted or zero: Return the rhs of mapping
-		{name} in mode {mode}.  The returned String has special
-		characters translated like in the output of the ":map" command
-		listing. When {dict} is TRUE a dictionary is returned, see
-		below. To get a list of all mappings see |maplist()|.
+                When {dict} is omitted or zero: Return the rhs of mapping
+                {name} in mode {mode}.  The returned String has special
+                characters translated like in the output of the ":map" command
+                listing. When {dict} is TRUE a dictionary is returned, see
+                below. To get a list of all mappings see |maplist()|.
 
-		When there is no mapping for {name}, an empty String is
-		returned if {dict} is FALSE, otherwise returns an empty Dict.
-		When the mapping for {name} is empty, then "<Nop>" is
-		returned.
+                When there is no mapping for {name}, an empty String is
+                returned if {dict} is FALSE, otherwise returns an empty Dict.
+                When the mapping for {name} is empty, then "<Nop>" is
+                returned.
 
-		The {name} can have special key names, like in the ":map"
-		command.
+                The {name} can have special key names, like in the ":map"
+                command.
 
-		{mode} can be one of these strings:
-			"n"	Normal
-			"v"	Visual (including Select)
-			"o"	Operator-pending
-			"i"	Insert
-			"c"	Cmd-line
-			"s"	Select
-			"x"	Visual
-			"l"	langmap |language-mapping|
-			"t"	Terminal
-			""	Normal, Visual and Operator-pending
-		When {mode} is omitted, the modes for "" are used.
+                {mode} can be one of these strings:
+                        "n"     Normal
+                        "v"     Visual (including Select)
+                        "o"     Operator-pending
+                        "i"     Insert
+                        "c"     Cmd-line
+                        "s"     Select
+                        "x"     Visual
+                        "l"     langmap |language-mapping|
+                        "t"     Terminal
+                        ""      Normal, Visual and Operator-pending
+                When {mode} is omitted, the modes for "" are used.
 
-		When {abbr} is there and it is |TRUE| use abbreviations
-		instead of mappings.
+                When {abbr} is there and it is |TRUE| use abbreviations
+                instead of mappings.
 
-		When {dict} is there and it is |TRUE| return a dictionary
-		containing all the information of the mapping with the
-		following items:			*mapping-dict*
-		  "lhs"	     The {lhs} of the mapping as it would be typed
-		  "lhsraw"   The {lhs} of the mapping as raw bytes
-		  "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
-			      form, only present when it differs from "lhsraw"
-		  "rhs"	     The {rhs} of the mapping as typed.
-		  "silent"   1 for a |:map-silent| mapping, else 0.
-		  "noremap"  1 if the {rhs} of the mapping is not remappable.
-		  "script"   1 if mapping was defined with <script>.
-		  "expr"     1 for an expression mapping (|:map-<expr>|).
-		  "buffer"   1 for a buffer local mapping (|:map-local|).
-		  "mode"     Modes for which the mapping is defined. In
-			     addition to the modes mentioned above, these
-			     characters will be used:
-			     " "     Normal, Visual and Operator-pending
-			     "!"     Insert and Commandline mode
-				     (|mapmode-ic|)
-		  "sid"	     The script local ID, used for <sid> mappings
-			     (|<SID>|).  Negative for special contexts.
-		  "scriptversion"  The version of the script, always 1.
-		  "lnum"     The line number in "sid", zero if unknown.
-		  "nowait"   Do not wait for other, longer mappings.
-			     (|:map-<nowait>|).
-		  "abbr"     True if this is an |abbreviation|.
-		  "mode_bits" Nvim's internal binary representation of "mode".
-			     |mapset()| ignores this; only "mode" is used.
-			     See |maplist()| for usage examples. The values
-			     are from src/nvim/state_defs.h and may change in
-			     the future.
+                When {dict} is there and it is |TRUE| return a dictionary
+                containing all the information of the mapping with the
+                following items:                        *mapping-dict*
+                  "lhs"      The {lhs} of the mapping as it would be typed
+                  "lhsraw"   The {lhs} of the mapping as raw bytes
+                  "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
+                              form, only present when it differs from "lhsraw"
+                  "rhs"      The {rhs} of the mapping as typed.
+                  "silent"   1 for a |:map-silent| mapping, else 0.
+                  "noremap"  1 if the {rhs} of the mapping is not remappable.
+                  "script"   1 if mapping was defined with <script>.
+                  "expr"     1 for an expression mapping (|:map-<expr>|).
+                  "buffer"   1 for a buffer local mapping (|:map-local|).
+                  "mode"     Modes for which the mapping is defined. In
+                             addition to the modes mentioned above, these
+                             characters will be used:
+                             " "     Normal, Visual and Operator-pending
+                             "!"     Insert and Commandline mode
+                                     (|mapmode-ic|)
+                  "sid"      The script local ID, used for <sid> mappings
+                             (|<SID>|).  Negative for special contexts.
+                  "scriptversion"  The version of the script, always 1.
+                  "lnum"     The line number in "sid", zero if unknown.
+                  "nowait"   Do not wait for other, longer mappings.
+                             (|:map-<nowait>|).
+                  "abbr"     True if this is an |abbreviation|.
+                  "mode_bits" Nvim's internal binary representation of "mode".
+                             |mapset()| ignores this; only "mode" is used.
+                             See |maplist()| for usage examples. The values
+                             are from src/nvim/state_defs.h and may change in
+                             the future.
 
-		The dictionary can be used to restore a mapping with
-		|mapset()|.
+                The dictionary can be used to restore a mapping with
+                |mapset()|.
 
-		The mappings local to the current buffer are checked first,
-		then the global mappings.
-		This function can be used to map a key even when it's already
-		mapped, and have it do the original mapping too.  Sketch: >vim
-			exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+                The mappings local to the current buffer are checked first,
+                then the global mappings.
+                This function can be used to map a key even when it's already
+                mapped, and have it do the original mapping too.  Sketch: >vim
+                        exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
 mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
-		Check if there is a mapping that matches with {name} in mode
-		{mode}.  See |maparg()| for {mode} and special names in
-		{name}.
-		When {abbr} is there and it is non-zero use abbreviations
-		instead of mappings.
-		A match happens with a mapping that starts with {name} and
-		with a mapping which is equal to the start of {name}.
+                Check if there is a mapping that matches with {name} in mode
+                {mode}.  See |maparg()| for {mode} and special names in
+                {name}.
+                When {abbr} is there and it is non-zero use abbreviations
+                instead of mappings.
+                A match happens with a mapping that starts with {name} and
+                with a mapping which is equal to the start of {name}.
 
-			matches mapping "a"	"ab"	"abc" ~
-		   mapcheck("a")	yes	yes	 yes
-		   mapcheck("abc")	yes	yes	 yes
-		   mapcheck("ax")	yes	no	 no
-		   mapcheck("b")	no	no	 no
+                        matches mapping "a"     "ab"    "abc" ~
+                   mapcheck("a")        yes     yes      yes
+                   mapcheck("abc")      yes     yes      yes
+                   mapcheck("ax")       yes     no       no
+                   mapcheck("b")        no      no       no
 
-		The difference with maparg() is that mapcheck() finds a
-		mapping that matches with {name}, while maparg() only finds a
-		mapping for {name} exactly.
-		When there is no mapping that starts with {name}, an empty
-		String is returned.  If there is one, the RHS of that mapping
-		is returned.  If there are several mappings that start with
-		{name}, the RHS of one of them is returned.  This will be
-		"<Nop>" if the RHS is empty.
-		The mappings local to the current buffer are checked first,
-		then the global mappings.
-		This function can be used to check if a mapping can be added
-		without being ambiguous.  Example: >vim
-			if mapcheck("_vv") == ""
-			   map _vv :set guifont=7x13<CR>
-			endif
-<		This avoids adding the "_vv" mapping when there already is a
-		mapping for "_v" or for "_vvv".
+                The difference with maparg() is that mapcheck() finds a
+                mapping that matches with {name}, while maparg() only finds a
+                mapping for {name} exactly.
+                When there is no mapping that starts with {name}, an empty
+                String is returned.  If there is one, the RHS of that mapping
+                is returned.  If there are several mappings that start with
+                {name}, the RHS of one of them is returned.  This will be
+                "<Nop>" if the RHS is empty.
+                The mappings local to the current buffer are checked first,
+                then the global mappings.
+                This function can be used to check if a mapping can be added
+                without being ambiguous.  Example: >vim
+                        if mapcheck("_vv") == ""
+                           map _vv :set guifont=7x13<CR>
+                        endif
+<                This avoids adding the "_vv" mapping when there already is a
+                mapping for "_v" or for "_vvv".
 
 maplist([{abbr}])                                                    *maplist()*
-		Returns a |List| of all mappings.  Each List item is a |Dict|,
-		the same as what is returned by |maparg()|, see
-		|mapping-dict|.  When {abbr} is there and it is |TRUE| use
-		abbreviations instead of mappings.
+                Returns a |List| of all mappings.  Each List item is a |Dict|,
+                the same as what is returned by |maparg()|, see
+                |mapping-dict|.  When {abbr} is there and it is |TRUE| use
+                abbreviations instead of mappings.
 
-		Example to show all mappings with "MultiMatch" in rhs: >vim
-			echo maplist()->filter({_, m ->
-				\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
-				\ })
-<		It can be tricky to find mappings for particular |:map-modes|.
-		|mapping-dict|'s "mode_bits" can simplify this. For example,
-		the mode_bits for Normal, Insert or Command-line modes are
-		0x19. To find all the mappings available in those modes you
-		can do: >vim
-			let saved_maps = []
-			for m in maplist()
-			    if and(m.mode_bits, 0x19) != 0
-				eval saved_maps->add(m)
-			    endif
-			endfor
-			echo saved_maps->mapnew({_, m -> m.lhs})
-<		The values of the mode_bits are defined in Nvim's
-		src/nvim/state_defs.h file and they can be discovered at
-		runtime using |:map-commands| and "maplist()". Example: >vim
-			omap xyzzy <Nop>
-			let op_bit = maplist()->filter(
-			    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
-			ounmap xyzzy
-			echo printf("Operator-pending mode bit: 0x%x", op_bit)
+                Example to show all mappings with "MultiMatch" in rhs: >vim
+                        echo maplist()->filter({_, m ->
+                                \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
+                                \ })
+<                It can be tricky to find mappings for particular |:map-modes|.
+                |mapping-dict|'s "mode_bits" can simplify this. For example,
+                the mode_bits for Normal, Insert or Command-line modes are
+                0x19. To find all the mappings available in those modes you
+                can do: >vim
+                        let saved_maps = []
+                        for m in maplist()
+                            if and(m.mode_bits, 0x19) != 0
+                                eval saved_maps->add(m)
+                            endif
+                        endfor
+                        echo saved_maps->mapnew({_, m -> m.lhs})
+<                The values of the mode_bits are defined in Nvim's
+                src/nvim/state_defs.h file and they can be discovered at
+                runtime using |:map-commands| and "maplist()". Example: >vim
+                        omap xyzzy <Nop>
+                        let op_bit = maplist()->filter(
+                            \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
+                        ounmap xyzzy
+                        echo printf("Operator-pending mode bit: 0x%x", op_bit)
 
 mapnew({expr1}, {expr2})                                              *mapnew()*
-		Like |map()| but instead of replacing items in {expr1} a new
-		List or Dictionary is created and returned.  {expr1} remains
-		unchanged.  Items can still be changed by {expr2}, if you
-		don't want that use |deepcopy()| first.
+                Like |map()| but instead of replacing items in {expr1} a new
+                List or Dictionary is created and returned.  {expr1} remains
+                unchanged.  Items can still be changed by {expr2}, if you
+                don't want that use |deepcopy()| first.
 
 mapset({mode}, {abbr}, {dict})                                        *mapset()*
-		Restore a mapping from a dictionary, possibly returned by
-		|maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
-		is true, is set on the current buffer; it is up to the caller
-		to ensure that the intended buffer is the current buffer. This
-		feature allows copying mappings from one buffer to another.
-		The dict.mode value may restore a single mapping that covers
-		more than one mode, like with mode values of '!', ' ', "nox",
-		or 'v'. *E1276*
+                Restore a mapping from a dictionary, possibly returned by
+                |maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
+                is true, is set on the current buffer; it is up to the caller
+                to ensure that the intended buffer is the current buffer. This
+                feature allows copying mappings from one buffer to another.
+                The dict.mode value may restore a single mapping that covers
+                more than one mode, like with mode values of '!', ' ', "nox",
+                or 'v'. *E1276*
 
-		In the first form, {mode} and {abbr} should be the same as
-		for the call to |maparg()|. *E460*
-		{mode} is used to define the mode in which the mapping is set,
-		not the "mode" entry in {dict}.
-		Example for saving and restoring a mapping: >vim
-			let save_map = maparg('K', 'n', 0, 1)
-			nnoremap K somethingelse
-			" ...
-			call mapset('n', 0, save_map)
-<		Note that if you are going to replace a map in several modes,
-		e.g. with `:map!`, you need to save/restore the mapping for
-		all of them, when they might differ.
+                In the first form, {mode} and {abbr} should be the same as
+                for the call to |maparg()|. *E460*
+                {mode} is used to define the mode in which the mapping is set,
+                not the "mode" entry in {dict}.
+                Example for saving and restoring a mapping: >vim
+                        let save_map = maparg('K', 'n', 0, 1)
+                        nnoremap K somethingelse
+                        " ...
+                        call mapset('n', 0, save_map)
+<                Note that if you are going to replace a map in several modes,
+                e.g. with `:map!`, you need to save/restore the mapping for
+                all of them, when they might differ.
 
-		In the second form, with {dict} as the only argument, mode
-		and abbr are taken from the dict.
-		Example: >vim
-			let save_maps = maplist()->filter(
-						\ {_, m -> m.lhs == 'K'})
-			nnoremap K somethingelse
-			cnoremap K somethingelse2
-			" ...
-			unmap K
-			for d in save_maps
-			    call mapset(d)
-			endfor
+                In the second form, with {dict} as the only argument, mode
+                and abbr are taken from the dict.
+                Example: >vim
+                        let save_maps = maplist()->filter(
+                                                \ {_, m -> m.lhs == 'K'})
+                        nnoremap K somethingelse
+                        cnoremap K somethingelse2
+                        " ...
+                        unmap K
+                        for d in save_maps
+                            call mapset(d)
+                        endfor
 
 match({expr}, {pat} [, {start} [, {count}]])                           *match()*
-		When {expr} is a |List| then this returns the index of the
-		first item where {pat} matches.  Each item is used as a
-		String, |Lists| and |Dictionaries| are used as echoed.
+                When {expr} is a |List| then this returns the index of the
+                first item where {pat} matches.  Each item is used as a
+                String, |Lists| and |Dictionaries| are used as echoed.
 
-		Otherwise, {expr} is used as a String.  The result is a
-		Number, which gives the index (byte offset) in {expr} where
-		{pat} matches.
+                Otherwise, {expr} is used as a String.  The result is a
+                Number, which gives the index (byte offset) in {expr} where
+                {pat} matches.
 
-		A match at the first character or |List| item returns zero.
-		If there is no match -1 is returned.
+                A match at the first character or |List| item returns zero.
+                If there is no match -1 is returned.
 
-		For getting submatches see |matchlist()|.
-		Example: >vim
-			echo match("testing", "ing")	" results in 4
-			echo match([1, 'x'], '\a')	" results in 1
-<		See |string-match| for how {pat} is used.
-								*strpbrk()*
-		Vim doesn't have a strpbrk() function.  But you can do: >vim
-			let sepidx = match(line, '[.,;: \t]')
-<								*strcasestr()*
-		Vim doesn't have a strcasestr() function.  But you can add
-		"\c" to the pattern to ignore case: >vim
-			let idx = match(haystack, '\cneedle')
+                For getting submatches see |matchlist()|.
+                Example: >vim
+                        echo match("testing", "ing")    " results in 4
+                        echo match([1, 'x'], '\a')      " results in 1
+<                See |string-match| for how {pat} is used.
+                                                                *strpbrk()*
+                Vim doesn't have a strpbrk() function.  But you can do: >vim
+                        let sepidx = match(line, '[.,;: \t]')
+<                                                               *strcasestr()*
+                Vim doesn't have a strcasestr() function.  But you can add
+                "\c" to the pattern to ignore case: >vim
+                        let idx = match(haystack, '\cneedle')
 <
-		If {start} is given, the search starts from byte index
-		{start} in a String or item {start} in a |List|.
-		The result, however, is still the index counted from the
-		first character/item.  Example: >vim
-			echo match("testing", "ing", 2)
-<		result is again "4". >vim
-			echo match("testing", "ing", 4)
-<		result is again "4". >vim
-			echo match("testing", "t", 2)
-<		result is "3".
-		For a String, if {start} > 0 then it is like the string starts
-		{start} bytes later, thus "^" will match at {start}.  Except
-		when {count} is given, then it's like matches before the
-		{start} byte are ignored (this is a bit complicated to keep it
-		backwards compatible).
-		For a String, if {start} < 0, it will be set to 0.  For a list
-		the index is counted from the end.
-		If {start} is out of range ({start} > strlen({expr}) for a
-		String or {start} > len({expr}) for a |List|) -1 is returned.
+                If {start} is given, the search starts from byte index
+                {start} in a String or item {start} in a |List|.
+                The result, however, is still the index counted from the
+                first character/item.  Example: >vim
+                        echo match("testing", "ing", 2)
+<                result is again "4". >vim
+                        echo match("testing", "ing", 4)
+<                result is again "4". >vim
+                        echo match("testing", "t", 2)
+<                result is "3".
+                For a String, if {start} > 0 then it is like the string starts
+                {start} bytes later, thus "^" will match at {start}.  Except
+                when {count} is given, then it's like matches before the
+                {start} byte are ignored (this is a bit complicated to keep it
+                backwards compatible).
+                For a String, if {start} < 0, it will be set to 0.  For a list
+                the index is counted from the end.
+                If {start} is out of range ({start} > strlen({expr}) for a
+                String or {start} > len({expr}) for a |List|) -1 is returned.
 
-		When {count} is given use the {count}th match.  When a match
-		is found in a String the search for the next one starts one
-		character further.  Thus this example results in 1: >vim
-			echo match("testing", "..", 0, 2)
-<		In a |List| the search continues in the next item.
-		Note that when {count} is added the way {start} works changes,
-		see above.
+                When {count} is given use the {count}th match.  When a match
+                is found in a String the search for the next one starts one
+                character further.  Thus this example results in 1: >vim
+                        echo match("testing", "..", 0, 2)
+<                In a |List| the search continues in the next item.
+                Note that when {count} is added the way {start} works changes,
+                see above.
 
-		See |pattern| for the patterns that are accepted.
-		The 'ignorecase' option is used to set the ignore-caseness of
-		the pattern.  'smartcase' is NOT used.  The matching is always
-		done like 'magic' is set and 'cpoptions' is empty.
-		Note that a match at the start is preferred, thus when the
-		pattern is using "*" (any number of matches) it tends to find
-		zero matches at the start instead of a number of matches
-		further down in the text.
+                See |pattern| for the patterns that are accepted.
+                The 'ignorecase' option is used to set the ignore-caseness of
+                the pattern.  'smartcase' is NOT used.  The matching is always
+                done like 'magic' is set and 'cpoptions' is empty.
+                Note that a match at the start is preferred, thus when the
+                pattern is using "*" (any number of matches) it tends to find
+                zero matches at the start instead of a number of matches
+                further down in the text.
 
                                                 *matchadd()* *E798* *E799* *E801* *E957*
 matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
-		Defines a pattern to be highlighted in the current window (a
-		"match").  It will be highlighted with {group}.  Returns an
-		identification number (ID), which can be used to delete the
-		match using |matchdelete()|.  The ID is bound to the window.
-		Matching is case sensitive and magic, unless case sensitivity
-		or magicness are explicitly overridden in {pattern}.  The
-		'magic', 'smartcase' and 'ignorecase' options are not used.
-		The "Conceal" value is special, it causes the match to be
-		concealed.
+                Defines a pattern to be highlighted in the current window (a
+                "match").  It will be highlighted with {group}.  Returns an
+                identification number (ID), which can be used to delete the
+                match using |matchdelete()|.  The ID is bound to the window.
+                Matching is case sensitive and magic, unless case sensitivity
+                or magicness are explicitly overridden in {pattern}.  The
+                'magic', 'smartcase' and 'ignorecase' options are not used.
+                The "Conceal" value is special, it causes the match to be
+                concealed.
 
-		The optional {priority} argument assigns a priority to the
-		match.  A match with a high priority will have its
-		highlighting overrule that of a match with a lower priority.
-		A priority is specified as an integer (negative numbers are no
-		exception).  If the {priority} argument is not specified, the
-		default priority is 10.  The priority of 'hlsearch' is zero,
-		hence all matches with a priority greater than zero will
-		overrule it.  Syntax highlighting (see 'syntax') is a separate
-		mechanism, and regardless of the chosen priority a match will
-		always overrule syntax highlighting.
+                The optional {priority} argument assigns a priority to the
+                match.  A match with a high priority will have its
+                highlighting overrule that of a match with a lower priority.
+                A priority is specified as an integer (negative numbers are no
+                exception).  If the {priority} argument is not specified, the
+                default priority is 10.  The priority of 'hlsearch' is zero,
+                hence all matches with a priority greater than zero will
+                overrule it.  Syntax highlighting (see 'syntax') is a separate
+                mechanism, and regardless of the chosen priority a match will
+                always overrule syntax highlighting.
 
-		The optional {id} argument allows the request for a specific
-		match ID.  If a specified ID is already taken, an error
-		message will appear and the match will not be added.  An ID
-		is specified as a positive integer (zero excluded).  IDs 1, 2
-		and 3 are reserved for |:match|, |:2match| and |:3match|,
-		respectively.  3 is reserved for use by the |matchparen|
-		plugin.
-		If the {id} argument is not specified or -1, |matchadd()|
-		automatically chooses a free ID, which is at least 1000.
+                The optional {id} argument allows the request for a specific
+                match ID.  If a specified ID is already taken, an error
+                message will appear and the match will not be added.  An ID
+                is specified as a positive integer (zero excluded).  IDs 1, 2
+                and 3 are reserved for |:match|, |:2match| and |:3match|,
+                respectively.  3 is reserved for use by the |matchparen|
+                plugin.
+                If the {id} argument is not specified or -1, |matchadd()|
+                automatically chooses a free ID, which is at least 1000.
 
-		The optional {dict} argument allows for further custom
-		values. Currently this is used to specify a match specific
-		conceal character that will be shown for |hl-Conceal|
-		highlighted matches. The dict can have the following members:
+                The optional {dict} argument allows for further custom
+                values. Currently this is used to specify a match specific
+                conceal character that will be shown for |hl-Conceal|
+                highlighted matches. The dict can have the following members:
 
-			conceal	    Special character to show instead of the
-				    match (only for |hl-Conceal| highlighted
-				    matches, see |:syn-cchar|)
-			window	    Instead of the current window use the
-				    window with this number or window ID.
+                        conceal     Special character to show instead of the
+                                    match (only for |hl-Conceal| highlighted
+                                    matches, see |:syn-cchar|)
+                        window      Instead of the current window use the
+                                    window with this number or window ID.
 
-		The number of matches is not limited, as it is the case with
-		the |:match| commands.
+                The number of matches is not limited, as it is the case with
+                the |:match| commands.
 
-		Returns -1 on error.
+                Returns -1 on error.
 
-		Example: >vim
-			highlight MyGroup ctermbg=green guibg=green
-			let m = matchadd("MyGroup", "TODO")
-<		Deletion of the pattern: >vim
-			call matchdelete(m)
+                Example: >vim
+                        highlight MyGroup ctermbg=green guibg=green
+                        let m = matchadd("MyGroup", "TODO")
+<                Deletion of the pattern: >vim
+                        call matchdelete(m)
 
-<		A list of matches defined by |matchadd()| and |:match| are
-		available from |getmatches()|.  All matches can be deleted in
-		one operation by |clearmatches()|.
+<                A list of matches defined by |matchadd()| and |:match| are
+                available from |getmatches()|.  All matches can be deleted in
+                one operation by |clearmatches()|.
 
 matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
-		Same as |matchadd()|, but requires a list of positions {pos}
-		instead of a pattern. This command is faster than |matchadd()|
-		because it does not require to handle regular expressions and
-		sets buffer line boundaries to redraw screen. It is supposed
-		to be used when fast match additions and deletions are
-		required, for example to highlight matching parentheses.
-							*E5030* *E5031*
-		{pos} is a list of positions.  Each position can be one of
-		these:
-		- A number.  This whole line will be highlighted.  The first
-		  line has number 1.
-		- A list with one number, e.g., [23]. The whole line with this
-		  number will be highlighted.
-		- A list with two numbers, e.g., [23, 11]. The first number is
-		  the line number, the second one is the column number (first
-		  column is 1, the value must correspond to the byte index as
-		  |col()| would return).  The character at this position will
-		  be highlighted.
-		- A list with three numbers, e.g., [23, 11, 3]. As above, but
-		  the third number gives the length of the highlight in bytes.
+                Same as |matchadd()|, but requires a list of positions {pos}
+                instead of a pattern. This command is faster than |matchadd()|
+                because it does not require to handle regular expressions and
+                sets buffer line boundaries to redraw screen. It is supposed
+                to be used when fast match additions and deletions are
+                required, for example to highlight matching parentheses.
+                                                        *E5030* *E5031*
+                {pos} is a list of positions.  Each position can be one of
+                these:
+                - A number.  This whole line will be highlighted.  The first
+                  line has number 1.
+                - A list with one number, e.g., [23]. The whole line with this
+                  number will be highlighted.
+                - A list with two numbers, e.g., [23, 11]. The first number is
+                  the line number, the second one is the column number (first
+                  column is 1, the value must correspond to the byte index as
+                  |col()| would return).  The character at this position will
+                  be highlighted.
+                - A list with three numbers, e.g., [23, 11, 3]. As above, but
+                  the third number gives the length of the highlight in bytes.
 
-		Entries with zero and negative line numbers are silently
-		ignored, as well as entries with negative column numbers and
-		lengths.
+                Entries with zero and negative line numbers are silently
+                ignored, as well as entries with negative column numbers and
+                lengths.
 
-		Returns -1 on error.
+                Returns -1 on error.
 
-		Example: >vim
-			highlight MyGroup ctermbg=green guibg=green
-			let m = matchaddpos("MyGroup", [[23, 24], 34])
-<		Deletion of the pattern: >vim
-			call matchdelete(m)
+                Example: >vim
+                        highlight MyGroup ctermbg=green guibg=green
+                        let m = matchaddpos("MyGroup", [[23, 24], 34])
+<                Deletion of the pattern: >vim
+                        call matchdelete(m)
 
-<		Matches added by |matchaddpos()| are returned by
-		|getmatches()|.
+<                Matches added by |matchaddpos()| are returned by
+                |getmatches()|.
 
 matcharg({nr})                                                      *matcharg()*
-		Selects the {nr} match item, as set with a |:match|,
-		|:2match| or |:3match| command.
-		Return a |List| with two elements:
-			The name of the highlight group used
-			The pattern used.
-		When {nr} is not 1, 2 or 3 returns an empty |List|.
-		When there is no match item set returns ['', ''].
-		This is useful to save and restore a |:match|.
-		Highlighting matches using the |:match| commands are limited
-		to three matches. |matchadd()| does not have this limitation.
+                Selects the {nr} match item, as set with a |:match|,
+                |:2match| or |:3match| command.
+                Return a |List| with two elements:
+                        The name of the highlight group used
+                        The pattern used.
+                When {nr} is not 1, 2 or 3 returns an empty |List|.
+                When there is no match item set returns ['', ''].
+                This is useful to save and restore a |:match|.
+                Highlighting matches using the |:match| commands are limited
+                to three matches. |matchadd()| does not have this limitation.
 
 matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E803*
-		Deletes a match with ID {id} previously defined by |matchadd()|
-		or one of the |:match| commands.  Returns 0 if successful,
-		otherwise -1.  See example for |matchadd()|.  All matches can
-		be deleted in one operation by |clearmatches()|.
-		If {win} is specified, use the window with this number or
-		window ID instead of the current window.
+                Deletes a match with ID {id} previously defined by |matchadd()|
+                or one of the |:match| commands.  Returns 0 if successful,
+                otherwise -1.  See example for |matchadd()|.  All matches can
+                be deleted in one operation by |clearmatches()|.
+                If {win} is specified, use the window with this number or
+                window ID instead of the current window.
 
 matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
-		Same as |match()|, but return the index of first character
-		after the match.  Example: >vim
-			echo matchend("testing", "ing")
-<		results in "7".
-							*strspn()* *strcspn()*
-		Vim doesn't have a strspn() or strcspn() function, but you can
-		do it with matchend(): >vim
-			let span = matchend(line, '[a-zA-Z]')
-			let span = matchend(line, '[^a-zA-Z]')
-<		Except that -1 is returned when there are no matches.
+                Same as |match()|, but return the index of first character
+                after the match.  Example: >vim
+                        echo matchend("testing", "ing")
+<                results in "7".
+                                                        *strspn()* *strcspn()*
+                Vim doesn't have a strspn() or strcspn() function, but you can
+                do it with matchend(): >vim
+                        let span = matchend(line, '[a-zA-Z]')
+                        let span = matchend(line, '[^a-zA-Z]')
+<                Except that -1 is returned when there are no matches.
 
-		The {start}, if given, has the same meaning as for |match()|. >vim
-			echo matchend("testing", "ing", 2)
-<		results in "7". >vim
-			echo matchend("testing", "ing", 5)
-<		result is "-1".
-		When {expr} is a |List| the result is equal to |match()|.
+                The {start}, if given, has the same meaning as for |match()|. >vim
+                        echo matchend("testing", "ing", 2)
+<                results in "7". >vim
+                        echo matchend("testing", "ing", 5)
+<                result is "-1".
+                When {expr} is a |List| the result is equal to |match()|.
 
 matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
-		If {list} is a list of strings, then returns a |List| with all
-		the strings in {list} that fuzzy match {str}. The strings in
-		the returned list are sorted based on the matching score.
+                If {list} is a list of strings, then returns a |List| with all
+                the strings in {list} that fuzzy match {str}. The strings in
+                the returned list are sorted based on the matching score.
 
-		The optional {dict} argument always supports the following
-		items:
-		    matchseq	When this item is present return only matches
-				that contain the characters in {str} in the
-				given sequence.
-		    limit	Maximum number of matches in {list} to be
-				returned.  Zero means no limit.
+                The optional {dict} argument always supports the following
+                items:
+                    matchseq    When this item is present return only matches
+                                that contain the characters in {str} in the
+                                given sequence.
+                    limit       Maximum number of matches in {list} to be
+                                returned.  Zero means no limit.
 
-		If {list} is a list of dictionaries, then the optional {dict}
-		argument supports the following additional items:
-		    key		Key of the item which is fuzzy matched against
-				{str}. The value of this item should be a
-				string.
-		    text_cb	|Funcref| that will be called for every item
-				in {list} to get the text for fuzzy matching.
-				This should accept a dictionary item as the
-				argument and return the text for that item to
-				use for fuzzy matching.
+                If {list} is a list of dictionaries, then the optional {dict}
+                argument supports the following additional items:
+                    key         Key of the item which is fuzzy matched against
+                                {str}. The value of this item should be a
+                                string.
+                    text_cb     |Funcref| that will be called for every item
+                                in {list} to get the text for fuzzy matching.
+                                This should accept a dictionary item as the
+                                argument and return the text for that item to
+                                use for fuzzy matching.
 
-		{str} is treated as a literal string and regular expression
-		matching is NOT supported.  The maximum supported {str} length
-		is 256.
+                {str} is treated as a literal string and regular expression
+                matching is NOT supported.  The maximum supported {str} length
+                is 256.
 
-		When {str} has multiple words each separated by white space,
-		then the list of strings that have all the words is returned.
+                When {str} has multiple words each separated by white space,
+                then the list of strings that have all the words is returned.
 
-		If there are no matching strings or there is an error, then an
-		empty list is returned. If length of {str} is greater than
-		256, then returns an empty list.
+                If there are no matching strings or there is an error, then an
+                empty list is returned. If length of {str} is greater than
+                256, then returns an empty list.
 
-		When {limit} is given, matchfuzzy() will find up to this
-		number of matches in {list} and return them in sorted order.
+                When {limit} is given, matchfuzzy() will find up to this
+                number of matches in {list} and return them in sorted order.
 
-		Refer to |fuzzy-matching| for more information about fuzzy
-		matching strings.
+                Refer to |fuzzy-matching| for more information about fuzzy
+                matching strings.
 
-		Example: >vim
-		   echo matchfuzzy(["clay", "crow"], "cay")
-<		results in ["clay"]. >vim
-		   echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
-<		results in a list of buffer names fuzzy matching "ndl". >vim
-		   echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
-<		results in a list of buffer information dicts with buffer
-		names fuzzy matching "ndl". >vim
-		   echo getbufinfo()->matchfuzzy("spl",
-						\ {'text_cb' : {v -> v.name}})
-<		results in a list of buffer information dicts with buffer
-		names fuzzy matching "spl". >vim
-		   echo v:oldfiles->matchfuzzy("test")
-<		results in a list of file names fuzzy matching "test". >vim
-		   let l = readfile("buffer.c")->matchfuzzy("str")
-<		results in a list of lines in "buffer.c" fuzzy matching "str". >vim
-		   echo ['one two', 'two one']->matchfuzzy('two one')
-<		results in `['two one', 'one two']` . >vim
-		   echo ['one two', 'two one']->matchfuzzy('two one',
-						\ {'matchseq': 1})
-<		results in `['two one']`.
+                Example: >vim
+                   echo matchfuzzy(["clay", "crow"], "cay")
+<                results in ["clay"]. >vim
+                   echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
+<                results in a list of buffer names fuzzy matching "ndl". >vim
+                   echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
+<                results in a list of buffer information dicts with buffer
+                names fuzzy matching "ndl". >vim
+                   echo getbufinfo()->matchfuzzy("spl",
+                                                \ {'text_cb' : {v -> v.name}})
+<                results in a list of buffer information dicts with buffer
+                names fuzzy matching "spl". >vim
+                   echo v:oldfiles->matchfuzzy("test")
+<                results in a list of file names fuzzy matching "test". >vim
+                   let l = readfile("buffer.c")->matchfuzzy("str")
+<                results in a list of lines in "buffer.c" fuzzy matching "str". >vim
+                   echo ['one two', 'two one']->matchfuzzy('two one')
+<                results in `['two one', 'one two']` . >vim
+                   echo ['one two', 'two one']->matchfuzzy('two one',
+                                                \ {'matchseq': 1})
+<                results in `['two one']`.
 
 matchfuzzypos({list}, {str} [, {dict}])                        *matchfuzzypos()*
-		Same as |matchfuzzy()|, but returns the list of matched
-		strings, the list of character positions where characters
-		in {str} matches and a list of matching scores.  You can
-		use |byteidx()| to convert a character position to a byte
-		position.
+                Same as |matchfuzzy()|, but returns the list of matched
+                strings, the list of character positions where characters
+                in {str} matches and a list of matching scores.  You can
+                use |byteidx()| to convert a character position to a byte
+                position.
 
-		If {str} matches multiple times in a string, then only the
-		positions for the best match is returned.
+                If {str} matches multiple times in a string, then only the
+                positions for the best match is returned.
 
-		If there are no matching strings or there is an error, then a
-		list with three empty list items is returned.
+                If there are no matching strings or there is an error, then a
+                list with three empty list items is returned.
 
-		Example: >vim
-			echo matchfuzzypos(['testing'], 'tsg')
-<		results in [["testing"], [[0, 2, 6]], [99]] >vim
-			echo matchfuzzypos(['clay', 'lacy'], 'la')
-<		results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
-			echo [{'text': 'hello', 'id' : 10}]
-				\ ->matchfuzzypos('ll', {'key' : 'text'})
-<		results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
+                Example: >vim
+                        echo matchfuzzypos(['testing'], 'tsg')
+<                results in [["testing"], [[0, 2, 6]], [99]] >vim
+                        echo matchfuzzypos(['clay', 'lacy'], 'la')
+<                results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
+                        echo [{'text': 'hello', 'id' : 10}]
+                                \ ->matchfuzzypos('ll', {'key' : 'text'})
+<                results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 
 matchlist({expr}, {pat} [, {start} [, {count}]])                   *matchlist()*
-		Same as |match()|, but return a |List|.  The first item in the
-		list is the matched string, same as what matchstr() would
-		return.  Following items are submatches, like "\1", "\2", etc.
-		in |:substitute|.  When an optional submatch didn't match an
-		empty string is used.  Example: >vim
-			echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
-<		Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
-		When there is no match an empty list is returned.
+                Same as |match()|, but return a |List|.  The first item in the
+                list is the matched string, same as what matchstr() would
+                return.  Following items are submatches, like "\1", "\2", etc.
+                in |:substitute|.  When an optional submatch didn't match an
+                empty string is used.  Example: >vim
+                        echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
+<                Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
+                When there is no match an empty list is returned.
 
-		You can pass in a List, but that is not very useful.
+                You can pass in a List, but that is not very useful.
 
 matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
-		Same as |match()|, but return the matched string.  Example: >vim
-			echo matchstr("testing", "ing")
-<		results in "ing".
-		When there is no match "" is returned.
-		The {start}, if given, has the same meaning as for |match()|. >vim
-			echo matchstr("testing", "ing", 2)
-<		results in "ing". >vim
-			echo matchstr("testing", "ing", 5)
-<		result is "".
-		When {expr} is a |List| then the matching item is returned.
-		The type isn't changed, it's not necessarily a String.
+                Same as |match()|, but return the matched string.  Example: >vim
+                        echo matchstr("testing", "ing")
+<                results in "ing".
+                When there is no match "" is returned.
+                The {start}, if given, has the same meaning as for |match()|. >vim
+                        echo matchstr("testing", "ing", 2)
+<                results in "ing". >vim
+                        echo matchstr("testing", "ing", 5)
+<                result is "".
+                When {expr} is a |List| then the matching item is returned.
+                The type isn't changed, it's not necessarily a String.
 
 matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
-		Same as |matchstr()|, but return the matched string, the start
-		position and the end position of the match.  Example: >vim
-			echo matchstrpos("testing", "ing")
-<		results in ["ing", 4, 7].
-		When there is no match ["", -1, -1] is returned.
-		The {start}, if given, has the same meaning as for |match()|. >vim
-			echo matchstrpos("testing", "ing", 2)
-<		results in ["ing", 4, 7]. >vim
-			echo matchstrpos("testing", "ing", 5)
-<		result is ["", -1, -1].
-		When {expr} is a |List| then the matching item, the index
-		of first item where {pat} matches, the start position and the
-		end position of the match are returned. >vim
-			echo matchstrpos([1, '__x'], '\a')
-<		result is ["x", 1, 2, 3].
-		The type isn't changed, it's not necessarily a String.
+                Same as |matchstr()|, but return the matched string, the start
+                position and the end position of the match.  Example: >vim
+                        echo matchstrpos("testing", "ing")
+<                results in ["ing", 4, 7].
+                When there is no match ["", -1, -1] is returned.
+                The {start}, if given, has the same meaning as for |match()|. >vim
+                        echo matchstrpos("testing", "ing", 2)
+<                results in ["ing", 4, 7]. >vim
+                        echo matchstrpos("testing", "ing", 5)
+<                result is ["", -1, -1].
+                When {expr} is a |List| then the matching item, the index
+                of first item where {pat} matches, the start position and the
+                end position of the match are returned. >vim
+                        echo matchstrpos([1, '__x'], '\a')
+<                result is ["x", 1, 2, 3].
+                The type isn't changed, it's not necessarily a String.
 
 max({expr})                                                              *max()*
-		Return the maximum value of all items in {expr}. Example: >vim
-			echo max([apples, pears, oranges])
+                Return the maximum value of all items in {expr}. Example: >vim
+                        echo max([apples, pears, oranges])
 
-<		{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
-		it returns the maximum of all values in the Dictionary.
-		If {expr} is neither a List nor a Dictionary, or one of the
-		items in {expr} cannot be used as a Number this results in
-		                an error.  An empty |List| or |Dictionary| results in zero.
+<                {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+                it returns the maximum of all values in the Dictionary.
+                If {expr} is neither a List nor a Dictionary, or one of the
+                items in {expr} cannot be used as a Number this results in
+                                an error.  An empty |List| or |Dictionary| results in zero.
 
 menu_get({path} [, {modes}])                                        *menu_get()*
-		Returns a |List| of |Dictionaries| describing |menus| (defined
-		by |:menu|, |:amenu|, …), including |hidden-menus|.
+                Returns a |List| of |Dictionaries| describing |menus| (defined
+                by |:menu|, |:amenu|, …), including |hidden-menus|.
 
-		{path} matches a menu by name, or all menus if {path} is an
-		empty string.  Example: >vim
-			echo menu_get('File','')
-			echo menu_get('')
+                {path} matches a menu by name, or all menus if {path} is an
+                empty string.  Example: >vim
+                        echo menu_get('File','')
+                        echo menu_get('')
 <
-		{modes} is a string of zero or more modes (see |maparg()| or
-		|creating-menus| for the list of modes). "a" means "all".
+                {modes} is a string of zero or more modes (see |maparg()| or
+                |creating-menus| for the list of modes). "a" means "all".
 
-		Example: >vim
-			nnoremenu &Test.Test inormal
-			inoremenu Test.Test insert
-			vnoremenu Test.Test x
-			echo menu_get("")
+                Example: >vim
+                        nnoremenu &Test.Test inormal
+                        inoremenu Test.Test insert
+                        vnoremenu Test.Test x
+                        echo menu_get("")
 
-<		returns something like this: >
+<                returns something like this: >
 
-			[ {
-			  "hidden": 0,
-			  "name": "Test",
-			  "priority": 500,
-			  "shortcut": 84,
-			  "submenus": [ {
-			    "hidden": 0,
-			    "mappings": {
-			      i": {
-				"enabled": 1,
-				"noremap": 1,
-				"rhs": "insert",
-				"sid": 1,
-				"silent": 0
-			      },
-			      n": { ... },
-			      s": { ... },
-			      v": { ... }
-			    },
-			    "name": "Test",
-			    "priority": 500,
-			    "shortcut": 0
-			  } ]
-			} ]
+                        [ {
+                          "hidden": 0,
+                          "name": "Test",
+                          "priority": 500,
+                          "shortcut": 84,
+                          "submenus": [ {
+                            "hidden": 0,
+                            "mappings": {
+                              i": {
+                                "enabled": 1,
+                                "noremap": 1,
+                                "rhs": "insert",
+                                "sid": 1,
+                                "silent": 0
+                              },
+                              n": { ... },
+                              s": { ... },
+                              v": { ... }
+                            },
+                            "name": "Test",
+                            "priority": 500,
+                            "shortcut": 0
+                          } ]
+                        } ]
 <
-
 menu_info({name} [, {mode}])                                       *menu_info()*
-		Return information about the specified menu {name} in
-		mode {mode}. The menu name should be specified without the
-		shortcut character ('&'). If {name} is "", then the top-level
-		menu names are returned.
+                Return information about the specified menu {name} in
+                mode {mode}. The menu name should be specified without the
+                shortcut character ('&'). If {name} is "", then the top-level
+                menu names are returned.
 
-		{mode} can be one of these strings:
-			"n"	Normal
-			"v"	Visual (including Select)
-			"o"	Operator-pending
-			"i"	Insert
-			"c"	Cmd-line
-			"s"	Select
-			"x"	Visual
-			"t"	Terminal-Job
-			""	Normal, Visual and Operator-pending
-			"!"	Insert and Cmd-line
-		When {mode} is omitted, the modes for "" are used.
+                {mode} can be one of these strings:
+                        "n"     Normal
+                        "v"     Visual (including Select)
+                        "o"     Operator-pending
+                        "i"     Insert
+                        "c"     Cmd-line
+                        "s"     Select
+                        "x"     Visual
+                        "t"     Terminal-Job
+                        ""      Normal, Visual and Operator-pending
+                        "!"     Insert and Cmd-line
+                When {mode} is omitted, the modes for "" are used.
 
-		Returns a |Dictionary| containing the following items:
-		  accel		menu item accelerator text |menu-text|
-		  display	display name (name without '&')
-		  enabled	v:true if this menu item is enabled
-				Refer to |:menu-enable|
-		  icon		name of the icon file (for toolbar)
-				|toolbar-icon|
-		  iconidx	index of a built-in icon
-		  modes		modes for which the menu is defined. In
-				addition to the modes mentioned above, these
-				characters will be used:
-				" "	Normal, Visual and Operator-pending
-		  name		menu item name.
-		  noremenu	v:true if the {rhs} of the menu item is not
-				remappable else v:false.
-		  priority	menu order priority |menu-priority|
-		  rhs		right-hand-side of the menu item. The returned
-				string has special characters translated like
-				in the output of the ":menu" command listing.
-				When the {rhs} of a menu item is empty, then
-				"<Nop>" is returned.
-		  script	v:true if script-local remapping of {rhs} is
-				allowed else v:false.  See |:menu-script|.
-		  shortcut	shortcut key (character after '&' in
-				the menu name) |menu-shortcut|
-		  silent	v:true if the menu item is created
-				with <silent> argument |:menu-silent|
-		  submenus	|List| containing the names of
-				all the submenus.  Present only if the menu
-				item has submenus.
+                Returns a |Dictionary| containing the following items:
+                  accel         menu item accelerator text |menu-text|
+                  display       display name (name without '&')
+                  enabled       v:true if this menu item is enabled
+                                Refer to |:menu-enable|
+                  icon          name of the icon file (for toolbar)
+                                |toolbar-icon|
+                  iconidx       index of a built-in icon
+                  modes         modes for which the menu is defined. In
+                                addition to the modes mentioned above, these
+                                characters will be used:
+                                " "     Normal, Visual and Operator-pending
+                  name          menu item name.
+                  noremenu      v:true if the {rhs} of the menu item is not
+                                remappable else v:false.
+                  priority      menu order priority |menu-priority|
+                  rhs           right-hand-side of the menu item. The returned
+                                string has special characters translated like
+                                in the output of the ":menu" command listing.
+                                When the {rhs} of a menu item is empty, then
+                                "<Nop>" is returned.
+                  script        v:true if script-local remapping of {rhs} is
+                                allowed else v:false.  See |:menu-script|.
+                  shortcut      shortcut key (character after '&' in
+                                the menu name) |menu-shortcut|
+                  silent        v:true if the menu item is created
+                                with <silent> argument |:menu-silent|
+                  submenus      |List| containing the names of
+                                all the submenus.  Present only if the menu
+                                item has submenus.
 
-		Returns an empty dictionary if the menu item is not found.
+                Returns an empty dictionary if the menu item is not found.
 
-		Examples: >vim
-			echo menu_info('Edit.Cut')
-			echo menu_info('File.Save', 'n')
+                Examples: >vim
+                        echo menu_info('Edit.Cut')
+                        echo menu_info('File.Save', 'n')
 
-			" Display the entire menu hierarchy in a buffer
-			func ShowMenu(name, pfx)
-			  let m = menu_info(a:name)
-			  call append(line('$'), a:pfx .. m.display)
-			  for child in m->get('submenus', [])
-			    call ShowMenu(a:name .. '.' .. escape(child, '.'),
-							\ a:pfx .. '    ')
-			  endfor
-			endfunc
-			new
-			for topmenu in menu_info('').submenus
-			  call ShowMenu(topmenu, '')
-			endfor
+                        " Display the entire menu hierarchy in a buffer
+                        func ShowMenu(name, pfx)
+                          let m = menu_info(a:name)
+                          call append(line('$'), a:pfx .. m.display)
+                          for child in m->get('submenus', [])
+                            call ShowMenu(a:name .. '.' .. escape(child, '.'),
+                                                        \ a:pfx .. '    ')
+                          endfor
+                        endfunc
+                        new
+                        for topmenu in menu_info('').submenus
+                          call ShowMenu(topmenu, '')
+                        endfor
 <
-
 min({expr})                                                              *min()*
-		Return the minimum value of all items in {expr}. Example: >vim
-			echo min([apples, pears, oranges])
+                Return the minimum value of all items in {expr}. Example: >vim
+                        echo min([apples, pears, oranges])
 
-<		{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
-		it returns the minimum of all values in the Dictionary.
-		If {expr} is neither a List nor a Dictionary, or one of the
-		items in {expr} cannot be used as a Number this results in
-		an error.  An empty |List| or |Dictionary| results in zero.
+<                {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+                it returns the minimum of all values in the Dictionary.
+                If {expr} is neither a List nor a Dictionary, or one of the
+                items in {expr} cannot be used as a Number this results in
+                an error.  An empty |List| or |Dictionary| results in zero.
 
 mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
-		Create directory {name}.
+                Create directory {name}.
 
-		When {flags} is present it must be a string.  An empty string
-		has no effect.
+                When {flags} is present it must be a string.  An empty string
+                has no effect.
 
-		If {flags} contains "p" then intermediate directories are
-		created as necessary.
+                If {flags} contains "p" then intermediate directories are
+                created as necessary.
 
-		If {flags} contains "D" then {name} is deleted at the end of
-		the current function, as with: >vim
-			defer delete({name}, 'd')
+                If {flags} contains "D" then {name} is deleted at the end of
+                the current function, as with: >vim
+                        defer delete({name}, 'd')
 <
-		If {flags} contains "R" then {name} is deleted recursively at
-		the end of the current function, as with: >vim
-			defer delete({name}, 'rf')
-<		Note that when {name} has more than one part and "p" is used
-		some directories may already exist.  Only the first one that
-		is created and what it contains is scheduled to be deleted.
-		E.g. when using: >vim
-			call mkdir('subdir/tmp/autoload', 'pR')
-<		and "subdir" already exists then "subdir/tmp" will be
-		scheduled for deletion, like with: >vim
-			defer delete('subdir/tmp', 'rf')
+                If {flags} contains "R" then {name} is deleted recursively at
+                the end of the current function, as with: >vim
+                        defer delete({name}, 'rf')
+<                Note that when {name} has more than one part and "p" is used
+                some directories may already exist.  Only the first one that
+                is created and what it contains is scheduled to be deleted.
+                E.g. when using: >vim
+                        call mkdir('subdir/tmp/autoload', 'pR')
+<                and "subdir" already exists then "subdir/tmp" will be
+                scheduled for deletion, like with: >vim
+                        defer delete('subdir/tmp', 'rf')
 <
-		If {prot} is given it is used to set the protection bits of
-		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
-		the user, readable for others).  Use 0o700 to make it
-		unreadable for others.
+                If {prot} is given it is used to set the protection bits of
+                the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
+                the user, readable for others).  Use 0o700 to make it
+                unreadable for others.
 
-		{prot} is applied for all parts of {name}.  Thus if you create
-		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
-			call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
+                {prot} is applied for all parts of {name}.  Thus if you create
+                /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+                        call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
-<		This function is not available in the |sandbox|.
+<                This function is not available in the |sandbox|.
 
-		If you try to create an existing directory with {flags} set to
-		"p" mkdir() will silently exit.
+                If you try to create an existing directory with {flags} set to
+                "p" mkdir() will silently exit.
 
-		The function result is a Number, which is TRUE if the call was
-		successful or FALSE if the directory creation failed or partly
-		failed.
+                The function result is a Number, which is TRUE if the call was
+                successful or FALSE if the directory creation failed or partly
+                failed.
 
 mode([expr])                                                            *mode()*
-		Return a string that indicates the current mode.
-		If [expr] is supplied and it evaluates to a non-zero Number or
-		a non-empty String (|non-zero-arg|), then the full mode is
-		returned, otherwise only the first letter is returned.
-		Also see |state()|.
+                Return a string that indicates the current mode.
+                If [expr] is supplied and it evaluates to a non-zero Number or
+                a non-empty String (|non-zero-arg|), then the full mode is
+                returned, otherwise only the first letter is returned.
+                Also see |state()|.
 
-		   n	    Normal
-		   no	    Operator-pending
-		   nov	    Operator-pending (forced charwise |o_v|)
-		   noV	    Operator-pending (forced linewise |o_V|)
-		   noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
-				CTRL-V is one character
-		   niI	    Normal using |i_CTRL-O| in |Insert-mode|
-		   niR	    Normal using |i_CTRL-O| in |Replace-mode|
-		   niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
-		   nt	    Normal in |terminal-emulator| (insert goes to
-				Terminal mode)
-		   ntT	    Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
-		   v	    Visual by character
-		   vs	    Visual by character using |v_CTRL-O| in Select mode
-		   V	    Visual by line
-		   Vs	    Visual by line using |v_CTRL-O| in Select mode
-		   CTRL-V   Visual blockwise
-		   CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
-		   s	    Select by character
-		   S	    Select by line
-		   CTRL-S   Select blockwise
-		   i	    Insert
-		   ic	    Insert mode completion |compl-generic|
-		   ix	    Insert mode |i_CTRL-X| completion
-		   R	    Replace |R|
-		   Rc	    Replace mode completion |compl-generic|
-		   Rx	    Replace mode |i_CTRL-X| completion
-		   Rv	    Virtual Replace |gR|
-		   Rvc	    Virtual Replace mode completion |compl-generic|
-		   Rvx	    Virtual Replace mode |i_CTRL-X| completion
-		   c	    Command-line editing
-		   cr	    Command-line editing overstrike mode |c_<Insert>|
-		   cv	    Vim Ex mode |gQ|
-		   cvr	    Vim Ex mode while in overstrike mode |c_<Insert>|
-		   r	    Hit-enter prompt
-		   rm	    The -- more -- prompt
-		   r?	    A |:confirm| query of some sort
-		   !	    Shell or external command is executing
-		   t	    Terminal mode: keys go to the job
+                   n        Normal
+                   no       Operator-pending
+                   nov      Operator-pending (forced charwise |o_v|)
+                   noV      Operator-pending (forced linewise |o_V|)
+                   noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
+                                CTRL-V is one character
+                   niI      Normal using |i_CTRL-O| in |Insert-mode|
+                   niR      Normal using |i_CTRL-O| in |Replace-mode|
+                   niV      Normal using |i_CTRL-O| in |Virtual-Replace-mode|
+                   nt       Normal in |terminal-emulator| (insert goes to
+                                Terminal mode)
+                   ntT      Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
+                   v        Visual by character
+                   vs       Visual by character using |v_CTRL-O| in Select mode
+                   V        Visual by line
+                   Vs       Visual by line using |v_CTRL-O| in Select mode
+                   CTRL-V   Visual blockwise
+                   CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
+                   s        Select by character
+                   S        Select by line
+                   CTRL-S   Select blockwise
+                   i        Insert
+                   ic       Insert mode completion |compl-generic|
+                   ix       Insert mode |i_CTRL-X| completion
+                   R        Replace |R|
+                   Rc       Replace mode completion |compl-generic|
+                   Rx       Replace mode |i_CTRL-X| completion
+                   Rv       Virtual Replace |gR|
+                   Rvc      Virtual Replace mode completion |compl-generic|
+                   Rvx      Virtual Replace mode |i_CTRL-X| completion
+                   c        Command-line editing
+                   cr       Command-line editing overstrike mode |c_<Insert>|
+                   cv       Vim Ex mode |gQ|
+                   cvr      Vim Ex mode while in overstrike mode |c_<Insert>|
+                   r        Hit-enter prompt
+                   rm       The -- more -- prompt
+                   r?       A |:confirm| query of some sort
+                   !        Shell or external command is executing
+                   t        Terminal mode: keys go to the job
 
-		This is useful in the 'statusline' option or RPC calls. In
-		most other places it always returns "c" or "n".
-		Note that in the future more modes and more specific modes may
-		be added. It's better not to compare the whole string but only
-		the leading character(s).
-		Also see |visualmode()|.
+                This is useful in the 'statusline' option or RPC calls. In
+                most other places it always returns "c" or "n".
+                Note that in the future more modes and more specific modes may
+                be added. It's better not to compare the whole string but only
+                the leading character(s).
+                Also see |visualmode()|.
 
 msgpackdump({list} [, {type}])                                   *msgpackdump()*
-		Convert a list of Vimscript objects to msgpack. Returned value is a
-		|readfile()|-style list. When {type} contains "B", a |Blob| is
-		returned instead. Example: >vim
-			call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
-<		or, using a |Blob|: >vim
-			call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
+                Convert a list of Vimscript objects to msgpack. Returned value is a
+                |readfile()|-style list. When {type} contains "B", a |Blob| is
+                returned instead. Example: >vim
+                        call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
+<                or, using a |Blob|: >vim
+                        call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
 <
-		This will write the single 0x80 byte to a `fname.mpack` file
-		(dictionary with zero items is represented by 0x80 byte in
-		messagepack).
+                This will write the single 0x80 byte to a `fname.mpack` file
+                (dictionary with zero items is represented by 0x80 byte in
+                messagepack).
 
-		Limitations:				*E5004* *E5005*
-		1. |Funcref|s cannot be dumped.
-		2. Containers that reference themselves cannot be dumped.
-		3. Dictionary keys are always dumped as STR strings.
-		4. Other strings and |Blob|s are always dumped as BIN strings.
-		5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
+                Limitations:                            *E5004* *E5005*
+                1. |Funcref|s cannot be dumped.
+                2. Containers that reference themselves cannot be dumped.
+                3. Dictionary keys are always dumped as STR strings.
+                4. Other strings and |Blob|s are always dumped as BIN strings.
+                5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
 
 msgpackparse({data})                                            *msgpackparse()*
-		Convert a |readfile()|-style list or a |Blob| to a list of
-		Vimscript objects.
-		Example: >vim
-			let fname = expand('~/.config/nvim/shada/main.shada')
-			let mpack = readfile(fname, 'b')
-			let shada_objects = msgpackparse(mpack)
-<		This will read ~/.config/nvim/shada/main.shada file to
-		`shada_objects` list.
+                Convert a |readfile()|-style list or a |Blob| to a list of
+                Vimscript objects.
+                Example: >vim
+                        let fname = expand('~/.config/nvim/shada/main.shada')
+                        let mpack = readfile(fname, 'b')
+                        let shada_objects = msgpackparse(mpack)
+<                This will read ~/.config/nvim/shada/main.shada file to
+                `shada_objects` list.
 
-		Limitations:
-		1. Mapping ordering is not preserved unless messagepack
-		   mapping is dumped using generic mapping
-		   (|msgpack-special-map|).
-		2. Since the parser aims to preserve all data untouched
-		   (except for 1.) some strings are parsed to
-		   |msgpack-special-dict| format which is not convenient to
-		   use.
-							*msgpack-special-dict*
-		Some messagepack strings may be parsed to special
-		dictionaries. Special dictionaries are dictionaries which
+                Limitations:
+                1. Mapping ordering is not preserved unless messagepack
+                   mapping is dumped using generic mapping
+                   (|msgpack-special-map|).
+                2. Since the parser aims to preserve all data untouched
+                   (except for 1.) some strings are parsed to
+                   |msgpack-special-dict| format which is not convenient to
+                   use.
+                                                        *msgpack-special-dict*
+                Some messagepack strings may be parsed to special
+                dictionaries. Special dictionaries are dictionaries which
 
-		1. Contain exactly two keys: `_TYPE` and `_VAL`.
-		2. `_TYPE` key is one of the types found in |v:msgpack_types|
-		   variable.
-		3. Value for `_VAL` has the following format (Key column
-		   contains name of the key from |v:msgpack_types|):
+                1. Contain exactly two keys: `_TYPE` and `_VAL`.
+                2. `_TYPE` key is one of the types found in |v:msgpack_types|
+                   variable.
+                3. Value for `_VAL` has the following format (Key column
+                   contains name of the key from |v:msgpack_types|):
 
-		Key	Value ~
-		nil	Zero, ignored when dumping.  Not returned by
-			|msgpackparse()| since |v:null| was introduced.
-		boolean	One or zero.  When dumping it is only checked that
-			value is a |Number|.  Not returned by |msgpackparse()|
-			since |v:true| and |v:false| were introduced.
-		integer	|List| with four numbers: sign (-1 or 1), highest two
-			bits, number with bits from 62nd to 31st, lowest 31
-			bits. I.e. to get actual number one will need to use
-			code like >
-				_VAL[0] * ((_VAL[1] << 62)
-				           & (_VAL[2] << 31)
-				           & _VAL[3])
-<			Special dictionary with this type will appear in
-			|msgpackparse()| output under one of the following
-			circumstances:
-			1. |Number| is 32-bit and value is either above
-			   INT32_MAX or below INT32_MIN.
-			2. |Number| is 64-bit and value is above INT64_MAX. It
-			   cannot possibly be below INT64_MIN because msgpack
-			   C parser does not support such values.
-		float	|Float|. This value cannot possibly appear in
-			|msgpackparse()| output.
-		string	|readfile()|-style list of strings. This value will
-			appear in |msgpackparse()| output if string contains
-			zero byte or if string is a mapping key and mapping is
-			being represented as special dictionary for other
-			reasons.
-		binary	|String|, or |Blob| if binary string contains zero
-			byte. This value cannot appear in |msgpackparse()|
-			output since blobs were introduced.
-		array	|List|. This value cannot appear in |msgpackparse()|
-			output.
-							*msgpack-special-map*
-		map	|List| of |List|s with two items (key and value) each.
-			This value will appear in |msgpackparse()| output if
-			parsed mapping contains one of the following keys:
-			1. Any key that is not a string (including keys which
-			   are binary strings).
-			2. String with NUL byte inside.
-			3. Duplicate key.
-		ext	|List| with two values: first is a signed integer
-			representing extension type. Second is
-			|readfile()|-style list of strings.
+                Key     Value ~
+                nil     Zero, ignored when dumping.  Not returned by
+                        |msgpackparse()| since |v:null| was introduced.
+                boolean One or zero.  When dumping it is only checked that
+                        value is a |Number|.  Not returned by |msgpackparse()|
+                        since |v:true| and |v:false| were introduced.
+                integer |List| with four numbers: sign (-1 or 1), highest two
+                        bits, number with bits from 62nd to 31st, lowest 31
+                        bits. I.e. to get actual number one will need to use
+                        code like >
+                                _VAL[0] * ((_VAL[1] << 62)
+                                           & (_VAL[2] << 31)
+                                           & _VAL[3])
+<                       Special dictionary with this type will appear in
+                        |msgpackparse()| output under one of the following
+                        circumstances:
+                        1. |Number| is 32-bit and value is either above
+                           INT32_MAX or below INT32_MIN.
+                        2. |Number| is 64-bit and value is above INT64_MAX. It
+                           cannot possibly be below INT64_MIN because msgpack
+                           C parser does not support such values.
+                float   |Float|. This value cannot possibly appear in
+                        |msgpackparse()| output.
+                string  |readfile()|-style list of strings. This value will
+                        appear in |msgpackparse()| output if string contains
+                        zero byte or if string is a mapping key and mapping is
+                        being represented as special dictionary for other
+                        reasons.
+                binary  |String|, or |Blob| if binary string contains zero
+                        byte. This value cannot appear in |msgpackparse()|
+                        output since blobs were introduced.
+                array   |List|. This value cannot appear in |msgpackparse()|
+                        output.
+                                                        *msgpack-special-map*
+                map     |List| of |List|s with two items (key and value) each.
+                        This value will appear in |msgpackparse()| output if
+                        parsed mapping contains one of the following keys:
+                        1. Any key that is not a string (including keys which
+                           are binary strings).
+                        2. String with NUL byte inside.
+                        3. Duplicate key.
+                ext     |List| with two values: first is a signed integer
+                        representing extension type. Second is
+                        |readfile()|-style list of strings.
 
 nextnonblank({lnum})                                            *nextnonblank()*
-		Return the line number of the first line at or below {lnum}
-		that is not blank.  Example: >vim
-			if getline(nextnonblank(1)) =~ "Java" | endif
-<		When {lnum} is invalid or there is no non-blank line at or
-		below it, zero is returned.
-		{lnum} is used like with |getline()|.
-		See also |prevnonblank()|.
+                Return the line number of the first line at or below {lnum}
+                that is not blank.  Example: >vim
+                        if getline(nextnonblank(1)) =~ "Java" | endif
+<                When {lnum} is invalid or there is no non-blank line at or
+                below it, zero is returned.
+                {lnum} is used like with |getline()|.
+                See also |prevnonblank()|.
 
 nr2char({expr} [, {utf8}])                                           *nr2char()*
-		Return a string with a single character, which has the number
-		value {expr}.  Examples: >vim
-			echo nr2char(64)		" returns '@'
-			echo nr2char(32)		" returns ' '
-<		Example for "utf-8": >vim
-			echo nr2char(300)		" returns I with bow character
+                Return a string with a single character, which has the number
+                value {expr}.  Examples: >vim
+                        echo nr2char(64)                " returns '@'
+                        echo nr2char(32)                " returns ' '
+<                Example for "utf-8": >vim
+                        echo nr2char(300)               " returns I with bow character
 <
-		UTF-8 encoding is always used, {utf8} option has no effect,
-		and exists only for backwards-compatibility.
-		Note that a NUL character in the file is specified with
-		nr2char(10), because NULs are represented with newline
-		characters.  nr2char(0) is a real NUL and terminates the
-		string, thus results in an empty string.
+                UTF-8 encoding is always used, {utf8} option has no effect,
+                and exists only for backwards-compatibility.
+                Note that a NUL character in the file is specified with
+                nr2char(10), because NULs are represented with newline
+                characters.  nr2char(0) is a real NUL and terminates the
+                string, thus results in an empty string.
 
 nvim_...({...})                                      *nvim_...()* *E5555* *eval-api*
-		Call nvim |api| functions. The type checking of arguments will
-		be stricter than for most other builtins. For instance,
-		if Integer is expected, a |Number| must be passed in, a
-		|String| will not be autoconverted.
-		Buffer numbers, as returned by |bufnr()| could be used as
-		first argument to nvim_buf_... functions.  All functions
-		expecting an object (buffer, window or tabpage) can
-		also take the numerical value 0 to indicate the current
-		(focused) object.
+                Call nvim |api| functions. The type checking of arguments will
+                be stricter than for most other builtins. For instance,
+                if Integer is expected, a |Number| must be passed in, a
+                |String| will not be autoconverted.
+                Buffer numbers, as returned by |bufnr()| could be used as
+                first argument to nvim_buf_... functions.  All functions
+                expecting an object (buffer, window or tabpage) can
+                also take the numerical value 0 to indicate the current
+                (focused) object.
 
 or({expr}, {expr})                                                        *or()*
-		Bitwise OR on the two arguments.  The arguments are converted
-		to a number.  A List, Dict or Float argument causes an error.
-		Also see `and()` and `xor()`.
-		Example: >vim
-			let bits = or(bits, 0x80)
+                Bitwise OR on the two arguments.  The arguments are converted
+                to a number.  A List, Dict or Float argument causes an error.
+                Also see `and()` and `xor()`.
+                Example: >vim
+                        let bits = or(bits, 0x80)
 
-<		Rationale: The reason this is a function and not using the "|"
-		character like many languages, is that Vi has always used "|"
-		to separate commands.  In many places it would not be clear if
-		"|" is an operator or a command separator.
+<                Rationale: The reason this is a function and not using the "|"
+                character like many languages, is that Vi has always used "|"
+                to separate commands.  In many places it would not be clear if
+                "|" is an operator or a command separator.
 
 pathshorten({path} [, {len}])                                    *pathshorten()*
-		Shorten directory names in the path {path} and return the
-		result.  The tail, the file name, is kept as-is.  The other
-		components in the path are reduced to {len} letters in length.
-		If {len} is omitted or smaller than 1 then 1 is used (single
-		letters).  Leading '~' and '.' characters are kept.  Examples: >vim
-			echo pathshorten('~/.config/nvim/autoload/file1.vim')
-<			~/.c/n/a/file1.vim ~
+                Shorten directory names in the path {path} and return the
+                result.  The tail, the file name, is kept as-is.  The other
+                components in the path are reduced to {len} letters in length.
+                If {len} is omitted or smaller than 1 then 1 is used (single
+                letters).  Leading '~' and '.' characters are kept.  Examples: >vim
+                        echo pathshorten('~/.config/nvim/autoload/file1.vim')
+<                       ~/.c/n/a/file1.vim ~
 >vim
-			echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
-<			~/.co/nv/au/file2.vim ~
-		It doesn't matter if the path exists or not.
-		Returns an empty string on error.
+                        echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
+<                       ~/.co/nv/au/file2.vim ~
+                It doesn't matter if the path exists or not.
+                Returns an empty string on error.
 
 perleval({expr})                                                    *perleval()*
-		Evaluate |perl| expression {expr} and return its result
-		converted to Vim data structures.
-		Numbers and strings are returned as they are (strings are
-		copied though).
-		Lists are represented as Vim |List| type.
-		Dictionaries are represented as Vim |Dictionary| type,
-		non-string keys result in error.
+                Evaluate |perl| expression {expr} and return its result
+                converted to Vim data structures.
+                Numbers and strings are returned as they are (strings are
+                copied though).
+                Lists are represented as Vim |List| type.
+                Dictionaries are represented as Vim |Dictionary| type,
+                non-string keys result in error.
 
-		Note: If you want an array or hash, {expr} must return a
-		reference to it.
-		Example: >vim
-			echo perleval('[1 .. 4]')
-<			[1, 2, 3, 4]
+                Note: If you want an array or hash, {expr} must return a
+                reference to it.
+                Example: >vim
+                        echo perleval('[1 .. 4]')
+<                       [1, 2, 3, 4]
 
 pow({x}, {y})                                                            *pow()*
-		Return the power of {x} to the exponent {y} as a |Float|.
-		{x} and {y} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo pow(3, 3)
-<			27.0 >vim
-			echo pow(2, 16)
-<			65536.0 >vim
-			echo pow(32, 0.20)
-<			2.0
+                Return the power of {x} to the exponent {y} as a |Float|.
+                {x} and {y} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo pow(3, 3)
+<                        27.0 >vim
+                        echo pow(2, 16)
+<                        65536.0 >vim
+                        echo pow(32, 0.20)
+<                        2.0
 
 prevnonblank({lnum})                                            *prevnonblank()*
-		Return the line number of the first line at or above {lnum}
-		that is not blank.  Example: >vim
-			let ind = indent(prevnonblank(v:lnum - 1))
-<		When {lnum} is invalid or there is no non-blank line at or
-		above it, zero is returned.
-		{lnum} is used like with |getline()|.
-		Also see |nextnonblank()|.
+                Return the line number of the first line at or above {lnum}
+                that is not blank.  Example: >vim
+                        let ind = indent(prevnonblank(v:lnum - 1))
+<                When {lnum} is invalid or there is no non-blank line at or
+                above it, zero is returned.
+                {lnum} is used like with |getline()|.
+                Also see |nextnonblank()|.
 
 printf({fmt}, {expr1} ...)                                            *printf()*
-		Return a String with {fmt}, where "%" items are replaced by
-		the formatted form of their respective arguments.  Example: >vim
-			echo printf("%4d: E%d %.30s", lnum, errno, msg)
-<		May result in:
-			"  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
+                Return a String with {fmt}, where "%" items are replaced by
+                the formatted form of their respective arguments.  Example: >vim
+                        echo printf("%4d: E%d %.30s", lnum, errno, msg)
+<                May result in:
+                        "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 
-		When used as a |method| the base is passed as the second
-		argument: >vim
-			Compute()->printf("result: %d")
+                When used as a |method| the base is passed as the second
+                argument: >vim
+                        Compute()->printf("result: %d")
 <
-		You can use `call()` to pass the items as a list.
+                You can use `call()` to pass the items as a list.
 
-		Often used items are:
-		  %s	string
-		  %6S	string right-aligned in 6 display cells
-		  %6s	string right-aligned in 6 bytes
-		  %.9s	string truncated to 9 bytes
-		  %c	single byte
-		  %d	decimal number
-		  %5d	decimal number padded with spaces to 5 characters
-		  %b	binary number
-		  %08b	binary number padded with zeros to at least 8 characters
-		  %B	binary number using upper case letters
-		  %x	hex number
-		  %04x	hex number padded with zeros to at least 4 characters
-		  %X	hex number using upper case letters
-		  %o	octal number
-		  %f	floating point number as 12.23, inf, -inf or nan
-		  %F	floating point number as 12.23, INF, -INF or NAN
-		  %e	floating point number as 1.23e3, inf, -inf or nan
-		  %E	floating point number as 1.23E3, INF, -INF or NAN
-		  %g	floating point number, as %f or %e depending on value
-		  %G	floating point number, as %F or %E depending on value
-		  %%	the % character itself
-		  %p	representation of the pointer to the container
+                Often used items are:
+                  %s    string
+                  %6S   string right-aligned in 6 display cells
+                  %6s   string right-aligned in 6 bytes
+                  %.9s  string truncated to 9 bytes
+                  %c    single byte
+                  %d    decimal number
+                  %5d   decimal number padded with spaces to 5 characters
+                  %b    binary number
+                  %08b  binary number padded with zeros to at least 8 characters
+                  %B    binary number using upper case letters
+                  %x    hex number
+                  %04x  hex number padded with zeros to at least 4 characters
+                  %X    hex number using upper case letters
+                  %o    octal number
+                  %f    floating point number as 12.23, inf, -inf or nan
+                  %F    floating point number as 12.23, INF, -INF or NAN
+                  %e    floating point number as 1.23e3, inf, -inf or nan
+                  %E    floating point number as 1.23E3, INF, -INF or NAN
+                  %g    floating point number, as %f or %e depending on value
+                  %G    floating point number, as %F or %E depending on value
+                  %%    the % character itself
+                  %p    representation of the pointer to the container
 
-		Conversion specifications start with '%' and end with the
-		conversion type.  All other characters are copied unchanged to
-		the result.
+                Conversion specifications start with '%' and end with the
+                conversion type.  All other characters are copied unchanged to
+                the result.
 
-		The "%" starts a conversion specification.  The following
-		arguments appear in sequence:
+                The "%" starts a conversion specification.  The following
+                arguments appear in sequence:
 
-			% [pos-argument] [flags] [field-width] [.precision] type
+                        % [pos-argument] [flags] [field-width] [.precision] type
 
-		pos-argument
-			At most one positional argument specifier. These
-			take the form {n$}, where n is >= 1.
+                pos-argument
+                        At most one positional argument specifier. These
+                        take the form {n$}, where n is >= 1.
 
-		flags
-			Zero or more of the following flags:
+                flags
+                        Zero or more of the following flags:
 
-		    #	      The value should be converted to an "alternate
-			      form".  For c, d, and s conversions, this option
-			      has no effect.  For o conversions, the precision
-			      of the number is increased to force the first
-			      character of the output string to a zero (except
-			      if a zero value is printed with an explicit
-			      precision of zero).
-			      For x and X conversions, a non-zero result has
-			      the string "0x" (or "0X" for X conversions)
-			      prepended to it.
+                    #         The value should be converted to an "alternate
+                              form".  For c, d, and s conversions, this option
+                              has no effect.  For o conversions, the precision
+                              of the number is increased to force the first
+                              character of the output string to a zero (except
+                              if a zero value is printed with an explicit
+                              precision of zero).
+                              For x and X conversions, a non-zero result has
+                              the string "0x" (or "0X" for X conversions)
+                              prepended to it.
 
-		    0 (zero)  Zero padding.  For all conversions the converted
-			      value is padded on the left with zeros rather
-			      than blanks.  If a precision is given with a
-			      numeric conversion (d, o, x, and X), the 0 flag
-			      is ignored.
+                    0 (zero)  Zero padding.  For all conversions the converted
+                              value is padded on the left with zeros rather
+                              than blanks.  If a precision is given with a
+                              numeric conversion (d, o, x, and X), the 0 flag
+                              is ignored.
 
-		    -	      A negative field width flag; the converted value
-			      is to be left adjusted on the field boundary.
-			      The converted value is padded on the right with
-			      blanks, rather than on the left with blanks or
-			      zeros.  A - overrides a 0 if both are given.
+                    -         A negative field width flag; the converted value
+                              is to be left adjusted on the field boundary.
+                              The converted value is padded on the right with
+                              blanks, rather than on the left with blanks or
+                              zeros.  A - overrides a 0 if both are given.
 
-		    ' ' (space)  A blank should be left before a positive
-			      number produced by a signed conversion (d).
+                    ' ' (space)  A blank should be left before a positive
+                              number produced by a signed conversion (d).
 
-		    +	      A sign must always be placed before a number
-			      produced by a signed conversion.  A + overrides
-			      a space if both are used.
+                    +         A sign must always be placed before a number
+                              produced by a signed conversion.  A + overrides
+                              a space if both are used.
 
-		field-width
-			An optional decimal digit string specifying a minimum
-			field width.  If the converted value has fewer bytes
-			than the field width, it will be padded with spaces on
-			the left (or right, if the left-adjustment flag has
-			been given) to fill out the field width.  For the S
-			conversion the count is in cells.
+                field-width
+                        An optional decimal digit string specifying a minimum
+                        field width.  If the converted value has fewer bytes
+                        than the field width, it will be padded with spaces on
+                        the left (or right, if the left-adjustment flag has
+                        been given) to fill out the field width.  For the S
+                        conversion the count is in cells.
 
-		.precision
-			An optional precision, in the form of a period '.'
-			followed by an optional digit string.  If the digit
-			string is omitted, the precision is taken as zero.
-			This gives the minimum number of digits to appear for
-			d, o, x, and X conversions, the maximum number of
-			bytes to be printed from a string for s conversions,
-			or the maximum number of cells to be printed from a
-			string for S conversions.
-			For floating point it is the number of digits after
-			the decimal point.
+                .precision
+                        An optional precision, in the form of a period '.'
+                        followed by an optional digit string.  If the digit
+                        string is omitted, the precision is taken as zero.
+                        This gives the minimum number of digits to appear for
+                        d, o, x, and X conversions, the maximum number of
+                        bytes to be printed from a string for s conversions,
+                        or the maximum number of cells to be printed from a
+                        string for S conversions.
+                        For floating point it is the number of digits after
+                        the decimal point.
 
-		type
-			A character that specifies the type of conversion to
-			be applied, see below.
+                type
+                        A character that specifies the type of conversion to
+                        be applied, see below.
 
-		A field width or precision, or both, may be indicated by an
-		asterisk "*" instead of a digit string.  In this case, a
-		Number argument supplies the field width or precision.  A
-		negative field width is treated as a left adjustment flag
-		followed by a positive field width; a negative precision is
-		treated as though it were missing.  Example: >vim
-			echo printf("%d: %.*s", nr, width, line)
-<		This limits the length of the text used from "line" to
-		"width" bytes.
+                A field width or precision, or both, may be indicated by an
+                asterisk "*" instead of a digit string.  In this case, a
+                Number argument supplies the field width or precision.  A
+                negative field width is treated as a left adjustment flag
+                followed by a positive field width; a negative precision is
+                treated as though it were missing.  Example: >vim
+                        echo printf("%d: %.*s", nr, width, line)
+<                This limits the length of the text used from "line" to
+                "width" bytes.
 
-		If the argument to be formatted is specified using a
-		positional argument specifier, and a '*' is used to indicate
-		that a number argument is to be used to specify the width or
-		precision, the argument(s) to be used must also be specified
-		using a {n$} positional argument specifier. See |printf-$|.
+                If the argument to be formatted is specified using a
+                positional argument specifier, and a '*' is used to indicate
+                that a number argument is to be used to specify the width or
+                precision, the argument(s) to be used must also be specified
+                using a {n$} positional argument specifier. See |printf-$|.
 
-		The conversion specifiers and their meanings are:
+                The conversion specifiers and their meanings are:
 
-				*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
-		dbBoxX	The Number argument is converted to signed decimal (d),
-			unsigned binary (b and B), unsigned octal (o), or
-			unsigned hexadecimal (x and X) notation.  The letters
-			"abcdef" are used for x conversions; the letters
-			"ABCDEF" are used for X conversions.  The precision, if
-			any, gives the minimum number of digits that must
-			appear; if the converted value requires fewer digits, it
-			is padded on the left with zeros.  In no case does a
-			non-existent or small field width cause truncation of a
-			numeric field; if the result of a conversion is wider
-			than the field width, the field is expanded to contain
-			the conversion result.
-			The 'h' modifier indicates the argument is 16 bits.
-			The 'l' modifier indicates the argument is a long
-			integer.  The size will be 32 bits or 64 bits
-			depending on your platform.
-			The "ll" modifier indicates the argument is 64 bits.
-			The b and B conversion specifiers never take a width
-			modifier and always assume their argument is a 64 bit
-			integer.
-			Generally, these modifiers are not useful. They are
-			ignored when type is known from the argument.
+                                *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
+                dbBoxX  The Number argument is converted to signed decimal (d),
+                        unsigned binary (b and B), unsigned octal (o), or
+                        unsigned hexadecimal (x and X) notation.  The letters
+                        "abcdef" are used for x conversions; the letters
+                        "ABCDEF" are used for X conversions.  The precision, if
+                        any, gives the minimum number of digits that must
+                        appear; if the converted value requires fewer digits, it
+                        is padded on the left with zeros.  In no case does a
+                        non-existent or small field width cause truncation of a
+                        numeric field; if the result of a conversion is wider
+                        than the field width, the field is expanded to contain
+                        the conversion result.
+                        The 'h' modifier indicates the argument is 16 bits.
+                        The 'l' modifier indicates the argument is a long
+                        integer.  The size will be 32 bits or 64 bits
+                        depending on your platform.
+                        The "ll" modifier indicates the argument is 64 bits.
+                        The b and B conversion specifiers never take a width
+                        modifier and always assume their argument is a 64 bit
+                        integer.
+                        Generally, these modifiers are not useful. They are
+                        ignored when type is known from the argument.
 
-		i	alias for d
-		D	alias for ld
-		U	alias for lu
-		O	alias for lo
+                i       alias for d
+                D       alias for ld
+                U       alias for lu
+                O       alias for lo
 
-							*printf-c*
-		c	The Number argument is converted to a byte, and the
-			resulting character is written.
+                                                        *printf-c*
+                c       The Number argument is converted to a byte, and the
+                        resulting character is written.
 
-							*printf-s*
-		s	The text of the String argument is used.  If a
-			precision is specified, no more bytes than the number
-			specified are used.
-			If the argument is not a String type, it is
-			automatically converted to text with the same format
-			as ":echo".
-							*printf-S*
-		S	The text of the String argument is used.  If a
-			precision is specified, no more display cells than the
-			number specified are used.
+                                                        *printf-s*
+                s       The text of the String argument is used.  If a
+                        precision is specified, no more bytes than the number
+                        specified are used.
+                        If the argument is not a String type, it is
+                        automatically converted to text with the same format
+                        as ":echo".
+                                                        *printf-S*
+                S       The text of the String argument is used.  If a
+                        precision is specified, no more display cells than the
+                        number specified are used.
 
-							*printf-f* *E807*
-		f F	The Float argument is converted into a string of the
-			form 123.456.  The precision specifies the number of
-			digits after the decimal point.  When the precision is
-			zero the decimal point is omitted.  When the precision
-			is not specified 6 is used.  A really big number
-			(out of range or dividing by zero) results in "inf"
-			 or "-inf" with %f (INF or -INF with %F).
-			 "0.0 / 0.0" results in "nan" with %f (NAN with %F).
-			Example: >vim
-				echo printf("%.2f", 12.115)
-<				12.12
-			Note that roundoff depends on the system libraries.
-			Use |round()| when in doubt.
+                                                        *printf-f* *E807*
+                f F     The Float argument is converted into a string of the
+                        form 123.456.  The precision specifies the number of
+                        digits after the decimal point.  When the precision is
+                        zero the decimal point is omitted.  When the precision
+                        is not specified 6 is used.  A really big number
+                        (out of range or dividing by zero) results in "inf"
+                         or "-inf" with %f (INF or -INF with %F).
+                         "0.0 / 0.0" results in "nan" with %f (NAN with %F).
+                        Example: >vim
+                                echo printf("%.2f", 12.115)
+<                               12.12
+                        Note that roundoff depends on the system libraries.
+                        Use |round()| when in doubt.
 
-							*printf-e* *printf-E*
-		e E	The Float argument is converted into a string of the
-			form 1.234e+03 or 1.234E+03 when using 'E'.  The
-			precision specifies the number of digits after the
-			decimal point, like with 'f'.
+                                                        *printf-e* *printf-E*
+                e E     The Float argument is converted into a string of the
+                        form 1.234e+03 or 1.234E+03 when using 'E'.  The
+                        precision specifies the number of digits after the
+                        decimal point, like with 'f'.
 
-							*printf-g* *printf-G*
-		g G	The Float argument is converted like with 'f' if the
-			value is between 0.001 (inclusive) and 10000000.0
-			(exclusive).  Otherwise 'e' is used for 'g' and 'E'
-			for 'G'.  When no precision is specified superfluous
-			zeroes and '+' signs are removed, except for the zero
-			immediately after the decimal point.  Thus 10000000.0
-			results in 1.0e7.
+                                                        *printf-g* *printf-G*
+                g G     The Float argument is converted like with 'f' if the
+                        value is between 0.001 (inclusive) and 10000000.0
+                        (exclusive).  Otherwise 'e' is used for 'g' and 'E'
+                        for 'G'.  When no precision is specified superfluous
+                        zeroes and '+' signs are removed, except for the zero
+                        immediately after the decimal point.  Thus 10000000.0
+                        results in 1.0e7.
 
-							*printf-%*
-		%	A '%' is written.  No argument is converted.  The
-			complete conversion specification is "%%".
+                                                        *printf-%*
+                %       A '%' is written.  No argument is converted.  The
+                        complete conversion specification is "%%".
 
-		When a Number argument is expected a String argument is also
-		accepted and automatically converted.
-		When a Float or String argument is expected a Number argument
-		is also accepted and automatically converted.
-		Any other argument type results in an error message.
+                When a Number argument is expected a String argument is also
+                accepted and automatically converted.
+                When a Float or String argument is expected a Number argument
+                is also accepted and automatically converted.
+                Any other argument type results in an error message.
 
-							*E766* *E767*
-		The number of {exprN} arguments must exactly match the number
-		of "%" items.  If there are not sufficient or too many
-		arguments an error is given.  Up to 18 arguments can be used.
+                                                        *E766* *E767*
+                The number of {exprN} arguments must exactly match the number
+                of "%" items.  If there are not sufficient or too many
+                arguments an error is given.  Up to 18 arguments can be used.
 
-							*printf-$*
-		In certain languages, error and informative messages are
-		more readable when the order of words is different from the
-		corresponding message in English. To accommodate translations
-		having a different word order, positional arguments may be
-		used to indicate this. For instance: >vim
+                                                        *printf-$*
+                In certain languages, error and informative messages are
+                more readable when the order of words is different from the
+                corresponding message in English. To accommodate translations
+                having a different word order, positional arguments may be
+                used to indicate this. For instance: >vim
 
-		    #, c-format
-		    msgid "%s returning %s"
-		    msgstr "waarde %2$s komt terug van %1$s"
+                    #, c-format
+                    msgid "%s returning %s"
+                    msgstr "waarde %2$s komt terug van %1$s"
 <
-		In this example, the sentence has its 2 string arguments
-		reversed in the output. >vim
+                In this example, the sentence has its 2 string arguments
+                reversed in the output. >vim
 
-		    echo printf(
-			"In The Netherlands, vim's creator's name is: %1$s %2$s",
-			"Bram", "Moolenaar")
-<		    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+                    echo printf(
+                        "In The Netherlands, vim's creator's name is: %1$s %2$s",
+                        "Bram", "Moolenaar")
+<                    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
-		    echo printf(
-			"In Belgium, vim's creator's name is: %2$s %1$s",
-			"Bram", "Moolenaar")
-<		    In Belgium, vim's creator's name is: Moolenaar Bram
+                    echo printf(
+                        "In Belgium, vim's creator's name is: %2$s %1$s",
+                        "Bram", "Moolenaar")
+<                    In Belgium, vim's creator's name is: Moolenaar Bram
 
-		Width (and precision) can be specified using the '*' specifier.
-		In this case, you must specify the field width position in the
-		argument list. >vim
+                Width (and precision) can be specified using the '*' specifier.
+                In this case, you must specify the field width position in the
+                argument list. >vim
 
-		    echo printf("%1$*2$.*3$d", 1, 2, 3)
-<		    001 >vim
-		    echo printf("%2$*3$.*1$d", 1, 2, 3)
-<		      2 >vim
-		    echo printf("%3$*1$.*2$d", 1, 2, 3)
-<		    03 >vim
-		    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-<		    1.414
+                    echo printf("%1$*2$.*3$d", 1, 2, 3)
+<                    001 >vim
+                    echo printf("%2$*3$.*1$d", 1, 2, 3)
+<                      2 >vim
+                    echo printf("%3$*1$.*2$d", 1, 2, 3)
+<                    03 >vim
+                    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+<                    1.414
 
-		You can mix specifying the width and/or precision directly
-		and via positional arguments: >vim
+                You can mix specifying the width and/or precision directly
+                and via positional arguments: >vim
 
-		    echo printf("%1$4.*2$f", 1.4142135, 6)
-<		    1.414214 >vim
-		    echo printf("%1$*2$.4f", 1.4142135, 6)
-<		    1.4142 >vim
-		    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-<		      1.41
+                    echo printf("%1$4.*2$f", 1.4142135, 6)
+<                    1.414214 >vim
+                    echo printf("%1$*2$.4f", 1.4142135, 6)
+<                    1.4142 >vim
+                    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+<                      1.41
 
-							*E1500*
-		You cannot mix positional and non-positional arguments: >vim
-		    echo printf("%s%1$s", "One", "Two")
-<		    E1500: Cannot mix positional and non-positional arguments:
-		    %s%1$s
+                                                        *E1500*
+                You cannot mix positional and non-positional arguments: >vim
+                    echo printf("%s%1$s", "One", "Two")
+<                    E1500: Cannot mix positional and non-positional arguments:
+                    %s%1$s
 
-							*E1501*
-		You cannot skip a positional argument in a format string: >vim
-		    echo printf("%3$s%1$s", "One", "Two", "Three")
-<		    E1501: format argument 2 unused in $-style format:
-		    %3$s%1$s
+                                                        *E1501*
+                You cannot skip a positional argument in a format string: >vim
+                    echo printf("%3$s%1$s", "One", "Two", "Three")
+<                    E1501: format argument 2 unused in $-style format:
+                    %3$s%1$s
 
-							*E1502*
-		You can re-use a [field-width] (or [precision]) argument: >vim
-		    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-<		    1 at width 2 is: 01
+                                                        *E1502*
+                You can re-use a [field-width] (or [precision]) argument: >vim
+                    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+<                    1 at width 2 is: 01
 
-		However, you can't use it as a different type: >vim
-		    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-<		    E1502: Positional argument 2 used as field width reused as
-		    different type: long int/int
+                However, you can't use it as a different type: >vim
+                    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+<                    E1502: Positional argument 2 used as field width reused as
+                    different type: long int/int
 
-							*E1503*
-		When a positional argument is used, but not the correct number
-		or arguments is given, an error is raised: >vim
-		    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-<		    E1503: Positional argument 3 out of bounds: %1$d at width
-		    %2$d is: %01$*2$.*3$d
+                                                        *E1503*
+                When a positional argument is used, but not the correct number
+                or arguments is given, an error is raised: >vim
+                    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+<                    E1503: Positional argument 3 out of bounds: %1$d at width
+                    %2$d is: %01$*2$.*3$d
 
-		Only the first error is reported: >vim
-		    echo printf("%01$*2$.*3$d %4$d", 1, 2)
-<		    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
-		    %4$d
+                Only the first error is reported: >vim
+                    echo printf("%01$*2$.*3$d %4$d", 1, 2)
+<                    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+                    %4$d
 
-							*E1504*
-		A positional argument can be used more than once: >vim
-		    echo printf("%1$s %2$s %1$s", "One", "Two")
-<		    One Two One
+                                                        *E1504*
+                A positional argument can be used more than once: >vim
+                    echo printf("%1$s %2$s %1$s", "One", "Two")
+<                    One Two One
 
-		However, you can't use a different type the second time: >vim
-		    echo printf("%1$s %2$s %1$d", "One", "Two")
-<		    E1504: Positional argument 1 type used inconsistently:
-		    int/string
+                However, you can't use a different type the second time: >vim
+                    echo printf("%1$s %2$s %1$d", "One", "Two")
+<                    E1504: Positional argument 1 type used inconsistently:
+                    int/string
 
-							*E1505*
-		Various other errors that lead to a format string being
-		wrongly formatted lead to: >vim
-		    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-<		    E1505: Invalid format specifier: %1$d at width %2$d is:
-		    %01$*2$.3$d
+                                                        *E1505*
+                Various other errors that lead to a format string being
+                wrongly formatted lead to: >vim
+                    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+<                    E1505: Invalid format specifier: %1$d at width %2$d is:
+                    %01$*2$.3$d
 
-							*E1507*
-		This internal error indicates that the logic to parse a
-		positional format argument ran into a problem that couldn't be
-		otherwise reported.  Please file a bug against Vim if you run
-		into this, copying the exact format string and parameters that
-		were used.
+                                                        *E1507*
+                This internal error indicates that the logic to parse a
+                positional format argument ran into a problem that couldn't be
+                otherwise reported.  Please file a bug against Vim if you run
+                into this, copying the exact format string and parameters that
+                were used.
 
 prompt_getprompt({buf})                                     *prompt_getprompt()*
-		Returns the effective prompt text for buffer {buf}.  {buf} can
-		be a buffer name or number.  See |prompt-buffer|.
+                Returns the effective prompt text for buffer {buf}.  {buf} can
+                be a buffer name or number.  See |prompt-buffer|.
 
-		If the buffer doesn't exist or isn't a prompt buffer, an empty
-		string is returned.
+                If the buffer doesn't exist or isn't a prompt buffer, an empty
+                string is returned.
 
 prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
-		Set prompt callback for buffer {buf} to {expr}.  When {expr}
-		is an empty string the callback is removed.  This has only
-		effect if {buf} has 'buftype' set to "prompt".
+                Set prompt callback for buffer {buf} to {expr}.  When {expr}
+                is an empty string the callback is removed.  This has only
+                effect if {buf} has 'buftype' set to "prompt".
 
-		The callback is invoked when pressing Enter.  The current
-		buffer will always be the prompt buffer.  A new line for a
-		prompt is added before invoking the callback, thus the prompt
-		for which the callback was invoked will be in the last but one
-		line.
-		If the callback wants to add text to the buffer, it must
-		insert it above the last line, since that is where the current
-		prompt is.  This can also be done asynchronously.
-		The callback is invoked with one argument, which is the text
-		that was entered at the prompt.  This can be an empty string
-		if the user only typed Enter.
-		Example: >vim
-		   func s:TextEntered(text)
-		     if a:text == 'exit' || a:text == 'quit'
-		       stopinsert
-		       " Reset 'modified' to allow the buffer to be closed.
-		       " We assume there is nothing useful to be saved.
-		       set nomodified
-		       close
-		     else
-		       " Do something useful with "a:text".  In this example
-		       " we just repeat it.
-		       call append(line('$') - 1, 'Entered: "' .. a:text .. '"')
-		     endif
-		   endfunc
-		   call prompt_setcallback(bufnr(), function('s:TextEntered'))
+                The callback is invoked when pressing Enter.  The current
+                buffer will always be the prompt buffer.  A new line for a
+                prompt is added before invoking the callback, thus the prompt
+                for which the callback was invoked will be in the last but one
+                line.
+                If the callback wants to add text to the buffer, it must
+                insert it above the last line, since that is where the current
+                prompt is.  This can also be done asynchronously.
+                The callback is invoked with one argument, which is the text
+                that was entered at the prompt.  This can be an empty string
+                if the user only typed Enter.
+                Example: >vim
+                   func s:TextEntered(text)
+                     if a:text == 'exit' || a:text == 'quit'
+                       stopinsert
+                       " Reset 'modified' to allow the buffer to be closed.
+                       " We assume there is nothing useful to be saved.
+                       set nomodified
+                       close
+                     else
+                       " Do something useful with "a:text".  In this example
+                       " we just repeat it.
+                       call append(line('$') - 1, 'Entered: "' .. a:text .. '"')
+                     endif
+                   endfunc
+                   call prompt_setcallback(bufnr(), function('s:TextEntered'))
 
 prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
-		Set a callback for buffer {buf} to {expr}.  When {expr} is an
-		empty string the callback is removed.  This has only effect if
-		{buf} has 'buftype' set to "prompt".
+                Set a callback for buffer {buf} to {expr}.  When {expr} is an
+                empty string the callback is removed.  This has only effect if
+                {buf} has 'buftype' set to "prompt".
 
-		This callback will be invoked when pressing CTRL-C in Insert
-		mode.  Without setting a callback Vim will exit Insert mode,
-		as in any buffer.
+                This callback will be invoked when pressing CTRL-C in Insert
+                mode.  Without setting a callback Vim will exit Insert mode,
+                as in any buffer.
 
 prompt_setprompt({buf}, {text})                             *prompt_setprompt()*
-		Set prompt for buffer {buf} to {text}.  You most likely want
-		{text} to end in a space.
-		The result is only visible if {buf} has 'buftype' set to
-		"prompt".  Example: >vim
-			call prompt_setprompt(bufnr(''), 'command: ')
+                Set prompt for buffer {buf} to {text}.  You most likely want
+                {text} to end in a space.
+                The result is only visible if {buf} has 'buftype' set to
+                "prompt".  Example: >vim
+                        call prompt_setprompt(bufnr(''), 'command: ')
 <
-
 pum_getpos()                                                      *pum_getpos()*
-		If the popup menu (see |ins-completion-menu|) is not visible,
-		returns an empty |Dictionary|, otherwise, returns a
-		|Dictionary| with the following keys:
-			height		nr of items visible
-			width		screen cells
-			row		top screen row (0 first row)
-			col		leftmost screen column (0 first col)
-			size		total nr of items
-			scrollbar	|TRUE| if scrollbar is visible
+                If the popup menu (see |ins-completion-menu|) is not visible,
+                returns an empty |Dictionary|, otherwise, returns a
+                |Dictionary| with the following keys:
+                        height          nr of items visible
+                        width           screen cells
+                        row             top screen row (0 first row)
+                        col             leftmost screen column (0 first col)
+                        size            total nr of items
+                        scrollbar       |TRUE| if scrollbar is visible
 
-		The values are the same as in |v:event| during |CompleteChanged|.
+                The values are the same as in |v:event| during |CompleteChanged|.
 
 pumvisible()                                                      *pumvisible()*
-		Returns non-zero when the popup menu is visible, zero
-		otherwise.  See |ins-completion-menu|.
-		This can be used to avoid some things that would remove the
-		popup menu.
+                Returns non-zero when the popup menu is visible, zero
+                otherwise.  See |ins-completion-menu|.
+                This can be used to avoid some things that would remove the
+                popup menu.
 
 py3eval({expr})                                                      *py3eval()*
-		Evaluate Python expression {expr} and return its result
-		converted to Vim data structures.
-		Numbers and strings are returned as they are (strings are
-		copied though, Unicode strings are additionally converted to
-		UTF-8).
-		Lists are represented as Vim |List| type.
-		Dictionaries are represented as Vim |Dictionary| type with
-		keys converted to strings.
+                Evaluate Python expression {expr} and return its result
+                converted to Vim data structures.
+                Numbers and strings are returned as they are (strings are
+                copied though, Unicode strings are additionally converted to
+                UTF-8).
+                Lists are represented as Vim |List| type.
+                Dictionaries are represented as Vim |Dictionary| type with
+                keys converted to strings.
 
 pyeval({expr})                                              *pyeval()* *E858* *E859*
-		Evaluate Python expression {expr} and return its result
-		converted to Vim data structures.
-		Numbers and strings are returned as they are (strings are
-		copied though).
-		Lists are represented as Vim |List| type.
-		Dictionaries are represented as Vim |Dictionary| type,
-		non-string keys result in error.
+                Evaluate Python expression {expr} and return its result
+                converted to Vim data structures.
+                Numbers and strings are returned as they are (strings are
+                copied though).
+                Lists are represented as Vim |List| type.
+                Dictionaries are represented as Vim |Dictionary| type,
+                non-string keys result in error.
 
 pyxeval({expr})                                                      *pyxeval()*
-		Evaluate Python expression {expr} and return its result
-		converted to Vim data structures.
-		Uses Python 2 or 3, see |python_x| and 'pyxversion'.
-		See also: |pyeval()|, |py3eval()|
+                Evaluate Python expression {expr} and return its result
+                converted to Vim data structures.
+                Uses Python 2 or 3, see |python_x| and 'pyxversion'.
+                See also: |pyeval()|, |py3eval()|
 
 rand([{expr}])                                                          *rand()*
-		Return a pseudo-random Number generated with an xoshiro128**
-		algorithm using seed {expr}.  The returned number is 32 bits,
-		also on 64 bits systems, for consistency.
-		{expr} can be initialized by |srand()| and will be updated by
-		rand().  If {expr} is omitted, an internal seed value is used
-		and updated.
-		Returns -1 if {expr} is invalid.
+                Return a pseudo-random Number generated with an xoshiro128**
+                algorithm using seed {expr}.  The returned number is 32 bits,
+                also on 64 bits systems, for consistency.
+                {expr} can be initialized by |srand()| and will be updated by
+                rand().  If {expr} is omitted, an internal seed value is used
+                and updated.
+                Returns -1 if {expr} is invalid.
 
-		Examples: >vim
-			echo rand()
-			let seed = srand()
-			echo rand(seed)
-			echo rand(seed) % 16  " random number 0 - 15
+                Examples: >vim
+                        echo rand()
+                        let seed = srand()
+                        echo rand(seed)
+                        echo rand(seed) % 16  " random number 0 - 15
 <
-
 range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E727*
-		Returns a |List| with Numbers:
-		- If only {expr} is specified: [0, 1, ..., {expr} - 1]
-		- If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
-		- If {stride} is specified: [{expr}, {expr} + {stride}, ...,
-		  {max}] (increasing {expr} with {stride} each time, not
-		  producing a value past {max}).
-		When the maximum is one before the start the result is an
-		empty list.  When the maximum is more than one before the
-		start this is an error.
-		Examples: >vim
-			echo range(4)		" [0, 1, 2, 3]
-			echo range(2, 4)	" [2, 3, 4]
-			echo range(2, 9, 3)	" [2, 5, 8]
-			echo range(2, -2, -1)	" [2, 1, 0, -1, -2]
-			echo range(0)		" []
-			echo range(2, 0)	" error!
+                Returns a |List| with Numbers:
+                - If only {expr} is specified: [0, 1, ..., {expr} - 1]
+                - If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
+                - If {stride} is specified: [{expr}, {expr} + {stride}, ...,
+                  {max}] (increasing {expr} with {stride} each time, not
+                  producing a value past {max}).
+                When the maximum is one before the start the result is an
+                empty list.  When the maximum is more than one before the
+                start this is an error.
+                Examples: >vim
+                        echo range(4)           " [0, 1, 2, 3]
+                        echo range(2, 4)        " [2, 3, 4]
+                        echo range(2, 9, 3)     " [2, 5, 8]
+                        echo range(2, -2, -1)   " [2, 1, 0, -1, -2]
+                        echo range(0)           " []
+                        echo range(2, 0)        " error!
 <
-
 readblob({fname} [, {offset} [, {size}]])                           *readblob()*
-		Read file {fname} in binary mode and return a |Blob|.
-		If {offset} is specified, read the file from the specified
-		offset.  If it is a negative value, it is used as an offset
-		from the end of the file.  E.g., to read the last 12 bytes: >vim
-			echo readblob('file.bin', -12)
-<		If {size} is specified, only the specified size will be read.
-		E.g. to read the first 100 bytes of a file: >vim
-			echo readblob('file.bin', 0, 100)
-<		If {size} is -1 or omitted, the whole data starting from
-		{offset} will be read.
-		This can be also used to read the data from a character device
-		on Unix when {size} is explicitly set.  Only if the device
-		supports seeking {offset} can be used.  Otherwise it should be
-		zero.  E.g. to read 10 bytes from a serial console: >vim
-			echo readblob('/dev/ttyS0', 0, 10)
-<		When the file can't be opened an error message is given and
-		the result is an empty |Blob|.
-		When the offset is beyond the end of the file the result is an
-		empty blob.
-		When trying to read more bytes than are available the result
-		is truncated.
-		Also see |readfile()| and |writefile()|.
+                Read file {fname} in binary mode and return a |Blob|.
+                If {offset} is specified, read the file from the specified
+                offset.  If it is a negative value, it is used as an offset
+                from the end of the file.  E.g., to read the last 12 bytes: >vim
+                        echo readblob('file.bin', -12)
+<                If {size} is specified, only the specified size will be read.
+                E.g. to read the first 100 bytes of a file: >vim
+                        echo readblob('file.bin', 0, 100)
+<                If {size} is -1 or omitted, the whole data starting from
+                {offset} will be read.
+                This can be also used to read the data from a character device
+                on Unix when {size} is explicitly set.  Only if the device
+                supports seeking {offset} can be used.  Otherwise it should be
+                zero.  E.g. to read 10 bytes from a serial console: >vim
+                        echo readblob('/dev/ttyS0', 0, 10)
+<                When the file can't be opened an error message is given and
+                the result is an empty |Blob|.
+                When the offset is beyond the end of the file the result is an
+                empty blob.
+                When trying to read more bytes than are available the result
+                is truncated.
+                Also see |readfile()| and |writefile()|.
 
 readdir({directory} [, {expr}])                                      *readdir()*
-		Return a list with file and directory names in {directory}.
-		You can also use |glob()| if you don't need to do complicated
-		things, such as limiting the number of matches.
+                Return a list with file and directory names in {directory}.
+                You can also use |glob()| if you don't need to do complicated
+                things, such as limiting the number of matches.
 
-		When {expr} is omitted all entries are included.
-		When {expr} is given, it is evaluated to check what to do:
-			If {expr} results in -1 then no further entries will
-			be handled.
-			If {expr} results in 0 then this entry will not be
-			added to the list.
-			If {expr} results in 1 then this entry will be added
-			to the list.
-		Each time {expr} is evaluated |v:val| is set to the entry name.
-		When {expr} is a function the name is passed as the argument.
-		For example, to get a list of files ending in ".txt": >vim
-		  echo readdir(dirname, {n -> n =~ '.txt$'})
-<		To skip hidden and backup files: >vim
-		  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
+                When {expr} is omitted all entries are included.
+                When {expr} is given, it is evaluated to check what to do:
+                        If {expr} results in -1 then no further entries will
+                        be handled.
+                        If {expr} results in 0 then this entry will not be
+                        added to the list.
+                        If {expr} results in 1 then this entry will be added
+                        to the list.
+                Each time {expr} is evaluated |v:val| is set to the entry name.
+                When {expr} is a function the name is passed as the argument.
+                For example, to get a list of files ending in ".txt": >vim
+                  echo readdir(dirname, {n -> n =~ '.txt$'})
+<                To skip hidden and backup files: >vim
+                  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 
-<		If you want to get a directory tree: >vim
-		  function! s:tree(dir)
-		      return {a:dir : map(readdir(a:dir),
-		      \ {_, x -> isdirectory(x) ?
-		      \          {x : s:tree(a:dir .. '/' .. x)} : x})}
-		  endfunction
-		  echo s:tree(".")
+<                If you want to get a directory tree: >vim
+                  function! s:tree(dir)
+                      return {a:dir : map(readdir(a:dir),
+                      \ {_, x -> isdirectory(x) ?
+                      \          {x : s:tree(a:dir .. '/' .. x)} : x})}
+                  endfunction
+                  echo s:tree(".")
 <
-		Returns an empty List on error.
+                Returns an empty List on error.
 
 readfile({fname} [, {type} [, {max}]])                              *readfile()*
-		Read file {fname} and return a |List|, each line of the file
-		as an item.  Lines are broken at NL characters.  Macintosh
-		files separated with CR will result in a single long line
-		(unless a NL appears somewhere).
-		All NUL characters are replaced with a NL character.
-		When {type} contains "b" binary mode is used:
-		- When the last line ends in a NL an extra empty list item is
-		  added.
-		- No CR characters are removed.
-		Otherwise:
-		- CR characters that appear before a NL are removed.
-		- Whether the last line ends in a NL or not does not matter.
-		- Any UTF-8 byte order mark is removed from the text.
-		When {max} is given this specifies the maximum number of lines
-		to be read.  Useful if you only want to check the first ten
-		lines of a file: >vim
-			for line in readfile(fname, '', 10)
-			  if line =~ 'Date' | echo line | endif
-			endfor
-<		When {max} is negative -{max} lines from the end of the file
-		are returned, or as many as there are.
-		When {max} is zero the result is an empty list.
-		Note that without {max} the whole file is read into memory.
-		Also note that there is no recognition of encoding.  Read a
-		file into a buffer if you need to.
-		Deprecated (use |readblob()| instead): When {type} contains
-		"B" a |Blob| is returned with the binary data of the file
-		unmodified.
-		When the file can't be opened an error message is given and
-		the result is an empty list.
-		Also see |writefile()|.
+                Read file {fname} and return a |List|, each line of the file
+                as an item.  Lines are broken at NL characters.  Macintosh
+                files separated with CR will result in a single long line
+                (unless a NL appears somewhere).
+                All NUL characters are replaced with a NL character.
+                When {type} contains "b" binary mode is used:
+                - When the last line ends in a NL an extra empty list item is
+                  added.
+                - No CR characters are removed.
+                Otherwise:
+                - CR characters that appear before a NL are removed.
+                - Whether the last line ends in a NL or not does not matter.
+                - Any UTF-8 byte order mark is removed from the text.
+                When {max} is given this specifies the maximum number of lines
+                to be read.  Useful if you only want to check the first ten
+                lines of a file: >vim
+                        for line in readfile(fname, '', 10)
+                          if line =~ 'Date' | echo line | endif
+                        endfor
+<                When {max} is negative -{max} lines from the end of the file
+                are returned, or as many as there are.
+                When {max} is zero the result is an empty list.
+                Note that without {max} the whole file is read into memory.
+                Also note that there is no recognition of encoding.  Read a
+                file into a buffer if you need to.
+                Deprecated (use |readblob()| instead): When {type} contains
+                "B" a |Blob| is returned with the binary data of the file
+                unmodified.
+                When the file can't be opened an error message is given and
+                the result is an empty list.
+                Also see |writefile()|.
 
 reduce({object}, {func} [, {initial}])                           *reduce()* *E998*
-		{func} is called for every item in {object}, which can be a
-		|String|, |List| or a |Blob|.  {func} is called with two
-		arguments: the result so far and current item.  After
-		processing all items the result is returned.
+                {func} is called for every item in {object}, which can be a
+                |String|, |List| or a |Blob|.  {func} is called with two
+                arguments: the result so far and current item.  After
+                processing all items the result is returned.
 
-		{initial} is the initial result.  When omitted, the first item
-		in {object} is used and {func} is first called for the second
-		item.  If {initial} is not given and {object} is empty no
-		result can be computed, an E998 error is given.
+                {initial} is the initial result.  When omitted, the first item
+                in {object} is used and {func} is first called for the second
+                item.  If {initial} is not given and {object} is empty no
+                result can be computed, an E998 error is given.
 
-		Examples: >vim
-			echo reduce([1, 3, 5], { acc, val -> acc + val })
-			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
-			echo reduce(0z1122, { acc, val -> 2 * acc + val })
-			echo reduce('xyz', { acc, val -> acc .. ',' .. val })
+                Examples: >vim
+                        echo reduce([1, 3, 5], { acc, val -> acc + val })
+                        echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+                        echo reduce(0z1122, { acc, val -> 2 * acc + val })
+                        echo reduce('xyz', { acc, val -> acc .. ',' .. val })
 <
-
 reg_executing()                                                *reg_executing()*
-		Returns the single letter name of the register being executed.
-		Returns an empty string when no register is being executed.
-		See |@|.
+                Returns the single letter name of the register being executed.
+                Returns an empty string when no register is being executed.
+                See |@|.
 
 reg_recorded()                                                  *reg_recorded()*
-		Returns the single letter name of the last recorded register.
-		Returns an empty string when nothing was recorded yet.
-		See |q| and |Q|.
+                Returns the single letter name of the last recorded register.
+                Returns an empty string when nothing was recorded yet.
+                See |q| and |Q|.
 
 reg_recording()                                                *reg_recording()*
-		Returns the single letter name of the register being recorded.
-		Returns an empty string when not recording.  See |q|.
+                Returns the single letter name of the register being recorded.
+                Returns an empty string when not recording.  See |q|.
 
 reltime()
 reltime({start})
 reltime({start}, {end})                                              *reltime()*
-		Return an item that represents a time value.  The item is a
-		list with items that depend on the system.
-		The item can be passed to |reltimestr()| to convert it to a
-		string or |reltimefloat()| to convert to a Float.
+                Return an item that represents a time value.  The item is a
+                list with items that depend on the system.
+                The item can be passed to |reltimestr()| to convert it to a
+                string or |reltimefloat()| to convert to a Float.
 
-		Without an argument it returns the current "relative time", an
-		implementation-defined value meaningful only when used as an
-		argument to |reltime()|, |reltimestr()| and |reltimefloat()|.
+                Without an argument it returns the current "relative time", an
+                implementation-defined value meaningful only when used as an
+                argument to |reltime()|, |reltimestr()| and |reltimefloat()|.
 
-		With one argument it returns the time passed since the time
-		specified in the argument.
-		With two arguments it returns the time passed between {start}
-		and {end}.
+                With one argument it returns the time passed since the time
+                specified in the argument.
+                With two arguments it returns the time passed between {start}
+                and {end}.
 
-		The {start} and {end} arguments must be values returned by
-		reltime().  Returns zero on error.
+                The {start} and {end} arguments must be values returned by
+                reltime().  Returns zero on error.
 
-		Note: |localtime()| returns the current (non-relative) time.
+                Note: |localtime()| returns the current (non-relative) time.
 
 reltimefloat({time})                                            *reltimefloat()*
-		Return a Float that represents the time value of {time}.
-		Unit of time is seconds.
-		Example:
-			let start = reltime()
-			call MyFunction()
-			let seconds = reltimefloat(reltime(start))
-		See the note of reltimestr() about overhead.
-		Also see |profiling|.
-		If there is an error an empty string is returned
+                Return a Float that represents the time value of {time}.
+                Unit of time is seconds.
+                Example:
+                        let start = reltime()
+                        call MyFunction()
+                        let seconds = reltimefloat(reltime(start))
+                See the note of reltimestr() about overhead.
+                Also see |profiling|.
+                If there is an error an empty string is returned
 
 reltimestr({time})                                                *reltimestr()*
-		Return a String that represents the time value of {time}.
-		This is the number of seconds, a dot and the number of
-		microseconds.  Example: >vim
-			let start = reltime()
-			call MyFunction()
-			echo reltimestr(reltime(start))
-<		Note that overhead for the commands will be added to the time.
-		Leading spaces are used to make the string align nicely.  You
-		can use split() to remove it. >vim
-			echo split(reltimestr(reltime(start)))[0]
-<		Also see |profiling|.
-		If there is an error an empty string is returned
+                Return a String that represents the time value of {time}.
+                This is the number of seconds, a dot and the number of
+                microseconds.  Example: >vim
+                        let start = reltime()
+                        call MyFunction()
+                        echo reltimestr(reltime(start))
+<                Note that overhead for the commands will be added to the time.
+                Leading spaces are used to make the string align nicely.  You
+                can use split() to remove it. >vim
+                        echo split(reltimestr(reltime(start)))[0]
+<                Also see |profiling|.
+                If there is an error an empty string is returned
 
 remove({list}, {idx})
 remove({list}, {idx}, {end})                                          *remove()*
-		Without {end}: Remove the item at {idx} from |List| {list} and
-		return the item.
-		With {end}: Remove items from {idx} to {end} (inclusive) and
-		return a |List| with these items.  When {idx} points to the same
-		item as {end} a list with one item is returned.  When {end}
-		points to an item before {idx} this is an error.
-		See |list-index| for possible values of {idx} and {end}.
-		Returns zero on error.
-		Example: >vim
-			echo "last item: " .. remove(mylist, -1)
-			call remove(mylist, 0, 9)
+                Without {end}: Remove the item at {idx} from |List| {list} and
+                return the item.
+                With {end}: Remove items from {idx} to {end} (inclusive) and
+                return a |List| with these items.  When {idx} points to the same
+                item as {end} a list with one item is returned.  When {end}
+                points to an item before {idx} this is an error.
+                See |list-index| for possible values of {idx} and {end}.
+                Returns zero on error.
+                Example: >vim
+                        echo "last item: " .. remove(mylist, -1)
+                        call remove(mylist, 0, 9)
 <
-		Use |delete()| to remove a file.
+                Use |delete()| to remove a file.
 
 remove({blob}, {idx})
 remove({blob}, {idx}, {end})
-		Without {end}: Remove the byte at {idx} from |Blob| {blob} and
-		return the byte.
-		With {end}: Remove bytes from {idx} to {end} (inclusive) and
-		return a |Blob| with these bytes.  When {idx} points to the same
-		byte as {end} a |Blob| with one byte is returned.  When {end}
-		points to a byte before {idx} this is an error.
-		Returns zero on error.
-		Example: >vim
-			echo "last byte: " .. remove(myblob, -1)
-			call remove(mylist, 0, 9)
+                Without {end}: Remove the byte at {idx} from |Blob| {blob} and
+                return the byte.
+                With {end}: Remove bytes from {idx} to {end} (inclusive) and
+                return a |Blob| with these bytes.  When {idx} points to the same
+                byte as {end} a |Blob| with one byte is returned.  When {end}
+                points to a byte before {idx} this is an error.
+                Returns zero on error.
+                Example: >vim
+                        echo "last byte: " .. remove(myblob, -1)
+                        call remove(mylist, 0, 9)
 <
-
 remove({dict}, {key})
-		Remove the entry from {dict} with key {key} and return it.
-		Example: >vim
-			echo "removed " .. remove(dict, "one")
-<		If there is no {key} in {dict} this is an error.
-		Returns zero on error.
+                Remove the entry from {dict} with key {key} and return it.
+                Example: >vim
+                        echo "removed " .. remove(dict, "one")
+<                If there is no {key} in {dict} this is an error.
+                Returns zero on error.
 
 rename({from}, {to})                                                  *rename()*
-		Rename the file by the name {from} to the name {to}.  This
-		should also work to move files across file systems.  The
-		result is a Number, which is 0 if the file was renamed
-		successfully, and non-zero when the renaming failed.
-		NOTE: If {to} exists it is overwritten without warning.
-		This function is not available in the |sandbox|.
+                Rename the file by the name {from} to the name {to}.  This
+                should also work to move files across file systems.  The
+                result is a Number, which is 0 if the file was renamed
+                successfully, and non-zero when the renaming failed.
+                NOTE: If {to} exists it is overwritten without warning.
+                This function is not available in the |sandbox|.
 
 repeat({expr}, {count})                                               *repeat()*
-		Repeat {expr} {count} times and return the concatenated
-		result.  Example: >vim
-			let separator = repeat('-', 80)
-<		When {count} is zero or negative the result is empty.
-		When {expr} is a |List| or a |Blob| the result is {expr}
-		concatenated {count} times.  Example: >vim
-			let longlist = repeat(['a', 'b'], 3)
-<		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+                Repeat {expr} {count} times and return the concatenated
+                result.  Example: >vim
+                        let separator = repeat('-', 80)
+<                When {count} is zero or negative the result is empty.
+                When {expr} is a |List| or a |Blob| the result is {expr}
+                concatenated {count} times.  Example: >vim
+                        let longlist = repeat(['a', 'b'], 3)
+<                Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
 resolve({filename})                                             *resolve()* *E655*
-		On MS-Windows, when {filename} is a shortcut (a .lnk file),
-		returns the path the shortcut points to in a simplified form.
-		On Unix, repeat resolving symbolic links in all path
-		components of {filename} and return the simplified result.
-		To cope with link cycles, resolving of symbolic links is
-		stopped after 100 iterations.
-		On other systems, return the simplified {filename}.
-		The simplification step is done as by |simplify()|.
-		resolve() keeps a leading path component specifying the
-		current directory (provided the result is still a relative
-		path name) and also keeps a trailing path separator.
+                On MS-Windows, when {filename} is a shortcut (a .lnk file),
+                returns the path the shortcut points to in a simplified form.
+                On Unix, repeat resolving symbolic links in all path
+                components of {filename} and return the simplified result.
+                To cope with link cycles, resolving of symbolic links is
+                stopped after 100 iterations.
+                On other systems, return the simplified {filename}.
+                The simplification step is done as by |simplify()|.
+                resolve() keeps a leading path component specifying the
+                current directory (provided the result is still a relative
+                path name) and also keeps a trailing path separator.
 
 reverse({object})                                                    *reverse()*
-		Reverse the order of items in {object}.  {object} can be a
-		|List|, a |Blob| or a |String|.  For a List and a Blob the
-		items are reversed in-place and {object} is returned.
-		For a String a new String is returned.
-		Returns zero if {object} is not a List, Blob or a String.
-		If you want a List or Blob to remain unmodified make a copy
-		first: >vim
-			let revlist = reverse(copy(mylist))
+                Reverse the order of items in {object}.  {object} can be a
+                |List|, a |Blob| or a |String|.  For a List and a Blob the
+                items are reversed in-place and {object} is returned.
+                For a String a new String is returned.
+                Returns zero if {object} is not a List, Blob or a String.
+                If you want a List or Blob to remain unmodified make a copy
+                first: >vim
+                        let revlist = reverse(copy(mylist))
 <
-
 round({expr})                                                          *round()*
-		Round off {expr} to the nearest integral value and return it
-		as a |Float|.  If {expr} lies halfway between two integral
-		values, then use the larger one (away from zero).
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo round(0.456)
-<			0.0  >vim
-			echo round(4.5)
-<			5.0 >vim
-			echo round(-4.5)
-<			-5.0
+                Round off {expr} to the nearest integral value and return it
+                as a |Float|.  If {expr} lies halfway between two integral
+                values, then use the larger one (away from zero).
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo round(0.456)
+<                        0.0  >vim
+                        echo round(4.5)
+<                        5.0 >vim
+                        echo round(-4.5)
+<                        -5.0
 
 rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
-		Sends {event} to {channel} via |RPC| and returns immediately.
-		If {channel} is 0, the event is broadcast to all channels.
-		Example: >vim
-			au VimLeave call rpcnotify(0, "leaving")
+                Sends {event} to {channel} via |RPC| and returns immediately.
+                If {channel} is 0, the event is broadcast to all channels.
+                Example: >vim
+                        au VimLeave call rpcnotify(0, "leaving")
 <
-
 rpcrequest({channel}, {method} [, {args}...])                     *rpcrequest()*
-		Sends a request to {channel} to invoke {method} via
-		|RPC| and blocks until a response is received.
-		Example: >vim
-			let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+                Sends a request to {channel} to invoke {method} via
+                |RPC| and blocks until a response is received.
+                Example: >vim
+                        let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 <
-
 rpcstart({prog} [, {argv}])                                         *rpcstart()*
-		Deprecated. Replace  >vim
-			let id = rpcstart('prog', ['arg1', 'arg2'])
-<		with >vim
-			let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+                Deprecated. Replace  >vim
+                        let id = rpcstart('prog', ['arg1', 'arg2'])
+<                with >vim
+                        let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 <
-
 rubyeval({expr})                                                    *rubyeval()*
-		Evaluate Ruby expression {expr} and return its result
-		converted to Vim data structures.
-		Numbers, floats and strings are returned as they are (strings
-		are copied though).
-		Arrays are represented as Vim |List| type.
-		Hashes are represented as Vim |Dictionary| type.
-		Other objects are represented as strings resulted from their
-		"Object#to_s" method.
+                Evaluate Ruby expression {expr} and return its result
+                converted to Vim data structures.
+                Numbers, floats and strings are returned as they are (strings
+                are copied though).
+                Arrays are represented as Vim |List| type.
+                Hashes are represented as Vim |Dictionary| type.
+                Other objects are represented as strings resulted from their
+                "Object#to_s" method.
 
 screenattr({row}, {col})                                          *screenattr()*
-		Like |screenchar()|, but return the attribute.  This is a rather
-		arbitrary number that can only be used to compare to the
-		attribute at other positions.
-		Returns -1 when row or col is out of range.
+                Like |screenchar()|, but return the attribute.  This is a rather
+                arbitrary number that can only be used to compare to the
+                attribute at other positions.
+                Returns -1 when row or col is out of range.
 
 screenchar({row}, {col})                                          *screenchar()*
-		The result is a Number, which is the character at position
-		[row, col] on the screen.  This works for every possible
-		screen position, also status lines, window separators and the
-		command line.  The top left position is row one, column one
-		The character excludes composing characters.  For double-byte
-		encodings it may only be the first byte.
-		This is mainly to be used for testing.
-		Returns -1 when row or col is out of range.
+                The result is a Number, which is the character at position
+                [row, col] on the screen.  This works for every possible
+                screen position, also status lines, window separators and the
+                command line.  The top left position is row one, column one
+                The character excludes composing characters.  For double-byte
+                encodings it may only be the first byte.
+                This is mainly to be used for testing.
+                Returns -1 when row or col is out of range.
 
 screenchars({row}, {col})                                        *screenchars()*
-		The result is a |List| of Numbers.  The first number is the same
-		as what |screenchar()| returns.  Further numbers are
-		composing characters on top of the base character.
-		This is mainly to be used for testing.
-		Returns an empty List when row or col is out of range.
+                The result is a |List| of Numbers.  The first number is the same
+                as what |screenchar()| returns.  Further numbers are
+                composing characters on top of the base character.
+                This is mainly to be used for testing.
+                Returns an empty List when row or col is out of range.
 
 screencol()                                                        *screencol()*
-		The result is a Number, which is the current screen column of
-		the cursor. The leftmost column has number 1.
-		This function is mainly used for testing.
+                The result is a Number, which is the current screen column of
+                the cursor. The leftmost column has number 1.
+                This function is mainly used for testing.
 
-		Note: Always returns the current screen column, thus if used
-		in a command (e.g. ":echo screencol()") it will return the
-		column inside the command line, which is 1 when the command is
-		executed. To get the cursor position in the file use one of
-		the following mappings: >vim
-			nnoremap <expr> GG ":echom " .. screencol() .. "\n"
-			nnoremap <silent> GG :echom screencol()<CR>
-			noremap GG <Cmd>echom screencol()<Cr>
+                Note: Always returns the current screen column, thus if used
+                in a command (e.g. ":echo screencol()") it will return the
+                column inside the command line, which is 1 when the command is
+                executed. To get the cursor position in the file use one of
+                the following mappings: >vim
+                        nnoremap <expr> GG ":echom " .. screencol() .. "\n"
+                        nnoremap <silent> GG :echom screencol()<CR>
+                        noremap GG <Cmd>echom screencol()<Cr>
 <
-
 screenpos({winid}, {lnum}, {col})                                  *screenpos()*
-		The result is a Dict with the screen position of the text
-		character in window {winid} at buffer line {lnum} and column
-		{col}.  {col} is a one-based byte index.
-		The Dict has these members:
-			row	screen row
-			col	first screen column
-			endcol	last screen column
-			curscol	cursor screen column
-		If the specified position is not visible, all values are zero.
-		The "endcol" value differs from "col" when the character
-		occupies more than one screen cell.  E.g. for a Tab "col" can
-		be 1 and "endcol" can be 8.
-		The "curscol" value is where the cursor would be placed.  For
-		a Tab it would be the same as "endcol", while for a double
-		width character it would be the same as "col".
-		The |conceal| feature is ignored here, the column numbers are
-		as if 'conceallevel' is zero.  You can set the cursor to the
-		right position and use |screencol()| to get the value with
-		|conceal| taken into account.
-		If the position is in a closed fold the screen position of the
-		first character is returned, {col} is not used.
-		Returns an empty Dict if {winid} is invalid.
+                The result is a Dict with the screen position of the text
+                character in window {winid} at buffer line {lnum} and column
+                {col}.  {col} is a one-based byte index.
+                The Dict has these members:
+                        row     screen row
+                        col     first screen column
+                        endcol  last screen column
+                        curscol cursor screen column
+                If the specified position is not visible, all values are zero.
+                The "endcol" value differs from "col" when the character
+                occupies more than one screen cell.  E.g. for a Tab "col" can
+                be 1 and "endcol" can be 8.
+                The "curscol" value is where the cursor would be placed.  For
+                a Tab it would be the same as "endcol", while for a double
+                width character it would be the same as "col".
+                The |conceal| feature is ignored here, the column numbers are
+                as if 'conceallevel' is zero.  You can set the cursor to the
+                right position and use |screencol()| to get the value with
+                |conceal| taken into account.
+                If the position is in a closed fold the screen position of the
+                first character is returned, {col} is not used.
+                Returns an empty Dict if {winid} is invalid.
 
 screenrow()                                                        *screenrow()*
-		The result is a Number, which is the current screen row of the
-		cursor.  The top line has number one.
-		This function is mainly used for testing.
-		Alternatively you can use |winline()|.
+                The result is a Number, which is the current screen row of the
+                cursor.  The top line has number one.
+                This function is mainly used for testing.
+                Alternatively you can use |winline()|.
 
-		Note: Same restrictions as with |screencol()|.
+                Note: Same restrictions as with |screencol()|.
 
 screenstring({row}, {col})                                      *screenstring()*
-		The result is a String that contains the base character and
-		any composing characters at position [row, col] on the screen.
-		This is like |screenchars()| but returning a String with the
-		characters.
-		This is mainly to be used for testing.
-		Returns an empty String when row or col is out of range.
+                The result is a String that contains the base character and
+                any composing characters at position [row, col] on the screen.
+                This is like |screenchars()| but returning a String with the
+                characters.
+                This is mainly to be used for testing.
+                Returns an empty String when row or col is out of range.
 
 search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
-		Search for regexp pattern {pattern}.  The search starts at the
-		cursor position (you can use |cursor()| to set it).
+                Search for regexp pattern {pattern}.  The search starts at the
+                cursor position (you can use |cursor()| to set it).
 
-		When a match has been found its line number is returned.
-		If there is no match a 0 is returned and the cursor doesn't
-		move.  No error message is given.
+                When a match has been found its line number is returned.
+                If there is no match a 0 is returned and the cursor doesn't
+                move.  No error message is given.
 
-		{flags} is a String, which can contain these character flags:
-		'b'	search Backward instead of forward
-		'c'	accept a match at the Cursor position
-		'e'	move to the End of the match
-		'n'	do Not move the cursor
-		'p'	return number of matching sub-Pattern (see below)
-		's'	Set the ' mark at the previous location of the cursor
-		'w'	Wrap around the end of the file
-		'W'	don't Wrap around the end of the file
-		'z'	start searching at the cursor column instead of Zero
-		If neither 'w' or 'W' is given, the 'wrapscan' option applies.
+                {flags} is a String, which can contain these character flags:
+                'b'     search Backward instead of forward
+                'c'     accept a match at the Cursor position
+                'e'     move to the End of the match
+                'n'     do Not move the cursor
+                'p'     return number of matching sub-Pattern (see below)
+                's'     Set the ' mark at the previous location of the cursor
+                'w'     Wrap around the end of the file
+                'W'     don't Wrap around the end of the file
+                'z'     start searching at the cursor column instead of Zero
+                If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
-		If the 's' flag is supplied, the ' mark is set, only if the
-		cursor is moved. The 's' flag cannot be combined with the 'n'
-		flag.
+                If the 's' flag is supplied, the ' mark is set, only if the
+                cursor is moved. The 's' flag cannot be combined with the 'n'
+                flag.
 
-		'ignorecase', 'smartcase' and 'magic' are used.
+                'ignorecase', 'smartcase' and 'magic' are used.
 
-		When the 'z' flag is not given, forward searching always
-		starts in column zero and then matches before the cursor are
-		skipped.  When the 'c' flag is present in 'cpo' the next
-		search starts after the match.  Without the 'c' flag the next
-		search starts one column after the start of the match.  This
-		matters for overlapping matches.  See |cpo-c|.  You can also
-		insert "\ze" to change where the match ends, see  |/\ze|.
+                When the 'z' flag is not given, forward searching always
+                starts in column zero and then matches before the cursor are
+                skipped.  When the 'c' flag is present in 'cpo' the next
+                search starts after the match.  Without the 'c' flag the next
+                search starts one column after the start of the match.  This
+                matters for overlapping matches.  See |cpo-c|.  You can also
+                insert "\ze" to change where the match ends, see  |/\ze|.
 
-		When searching backwards and the 'z' flag is given then the
-		search starts in column zero, thus no match in the current
-		line will be found (unless wrapping around the end of the
-		file).
+                When searching backwards and the 'z' flag is given then the
+                search starts in column zero, thus no match in the current
+                line will be found (unless wrapping around the end of the
+                file).
 
-		When the {stopline} argument is given then the search stops
-		after searching this line.  This is useful to restrict the
-		search to a range of lines.  Examples: >vim
-			let match = search('(', 'b', line("w0"))
-			let end = search('END', '', line("w$"))
-<		When {stopline} is used and it is not zero this also implies
-		that the search does not wrap around the end of the file.
-		A zero value is equal to not giving the argument.
+                When the {stopline} argument is given then the search stops
+                after searching this line.  This is useful to restrict the
+                search to a range of lines.  Examples: >vim
+                        let match = search('(', 'b', line("w0"))
+                        let end = search('END', '', line("w$"))
+<                When {stopline} is used and it is not zero this also implies
+                that the search does not wrap around the end of the file.
+                A zero value is equal to not giving the argument.
 
-		When the {timeout} argument is given the search stops when
-		more than this many milliseconds have passed.  Thus when
-		{timeout} is 500 the search stops after half a second.
-		The value must not be negative.  A zero value is like not
-		giving the argument.
+                When the {timeout} argument is given the search stops when
+                more than this many milliseconds have passed.  Thus when
+                {timeout} is 500 the search stops after half a second.
+                The value must not be negative.  A zero value is like not
+                giving the argument.
 
-		If the {skip} expression is given it is evaluated with the
-		cursor positioned on the start of a match.  If it evaluates to
-		non-zero this match is skipped.  This can be used, for
-		example, to skip a match in a comment or a string.
-		{skip} can be a string, which is evaluated as an expression, a
-		function reference or a lambda.
-		When {skip} is omitted or empty, every match is accepted.
-		When evaluating {skip} causes an error the search is aborted
-		and -1 returned.
-							*search()-sub-match*
-		With the 'p' flag the returned value is one more than the
-		first sub-match in \(\).  One if none of them matched but the
-		whole pattern did match.
-		To get the column number too use |searchpos()|.
+                If the {skip} expression is given it is evaluated with the
+                cursor positioned on the start of a match.  If it evaluates to
+                non-zero this match is skipped.  This can be used, for
+                example, to skip a match in a comment or a string.
+                {skip} can be a string, which is evaluated as an expression, a
+                function reference or a lambda.
+                When {skip} is omitted or empty, every match is accepted.
+                When evaluating {skip} causes an error the search is aborted
+                and -1 returned.
+                                                        *search()-sub-match*
+                With the 'p' flag the returned value is one more than the
+                first sub-match in \(\).  One if none of them matched but the
+                whole pattern did match.
+                To get the column number too use |searchpos()|.
 
-		The cursor will be positioned at the match, unless the 'n'
-		flag is used.
+                The cursor will be positioned at the match, unless the 'n'
+                flag is used.
 
-		Example (goes over all files in the argument list): >vim
-		    let n = 1
-		    while n <= argc()	    " loop over all files in arglist
-		      exe "argument " .. n
-		      " start at the last char in the file and wrap for the
-		      " first search to find match at start of file
-		      normal G$
-		      let flags = "w"
-		      while search("foo", flags) > 0
-		        s/foo/bar/g
-		        let flags = "W"
-		      endwhile
-		      update		    " write the file if modified
-		      let n = n + 1
-		    endwhile
+                Example (goes over all files in the argument list): >vim
+                    let n = 1
+                    while n <= argc()       " loop over all files in arglist
+                      exe "argument " .. n
+                      " start at the last char in the file and wrap for the
+                      " first search to find match at start of file
+                      normal G$
+                      let flags = "w"
+                      while search("foo", flags) > 0
+                        s/foo/bar/g
+                        let flags = "W"
+                      endwhile
+                      update                " write the file if modified
+                      let n = n + 1
+                    endwhile
 <
-		Example for using some flags: >vim
-		    echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
-<		This will search for the keywords "if", "else", and "endif"
-		under or after the cursor.  Because of the 'p' flag, it
-		returns 1, 2, or 3 depending on which keyword is found, or 0
-		if the search fails.  With the cursor on the first word of the
-		line:
-		    if (foo == 0) | let foo = foo + 1 | endif ~
-		the function returns 1.  Without the 'c' flag, the function
-		finds the "endif" and returns 3.  The same thing happens
-		without the 'e' flag if the cursor is on the "f" of "if".
-		The 'n' flag tells the function not to move the cursor.
+                Example for using some flags: >vim
+                    echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
+<                This will search for the keywords "if", "else", and "endif"
+                under or after the cursor.  Because of the 'p' flag, it
+                returns 1, 2, or 3 depending on which keyword is found, or 0
+                if the search fails.  With the cursor on the first word of the
+                line:
+                    if (foo == 0) | let foo = foo + 1 | endif ~
+                the function returns 1.  Without the 'c' flag, the function
+                finds the "endif" and returns 3.  The same thing happens
+                without the 'e' flag if the cursor is on the "f" of "if".
+                The 'n' flag tells the function not to move the cursor.
 
 searchcount([{options}])                                         *searchcount()*
-		Get or update the last search count, like what is displayed
-		without the "S" flag in 'shortmess'.  This works even if
-		'shortmess' does contain the "S" flag.
+                Get or update the last search count, like what is displayed
+                without the "S" flag in 'shortmess'.  This works even if
+                'shortmess' does contain the "S" flag.
 
-		This returns a |Dictionary|. The dictionary is empty if the
-		previous pattern was not set and "pattern" was not specified.
+                This returns a |Dictionary|. The dictionary is empty if the
+                previous pattern was not set and "pattern" was not specified.
 
-		  key		type		meaning ~
-		  current	|Number|	current position of match;
-						0 if the cursor position is
-						before the first match
-		  exact_match	|Boolean|	1 if "current" is matched on
-						"pos", otherwise 0
-		  total		|Number|	total count of matches found
-		  incomplete	|Number|	0: search was fully completed
-						1: recomputing was timed out
-						2: max count exceeded
+                  key           type            meaning ~
+                  current       |Number|        current position of match;
+                                                0 if the cursor position is
+                                                before the first match
+                  exact_match   |Boolean|       1 if "current" is matched on
+                                                "pos", otherwise 0
+                  total         |Number|        total count of matches found
+                  incomplete    |Number|        0: search was fully completed
+                                                1: recomputing was timed out
+                                                2: max count exceeded
 
-		For {options} see further down.
+                For {options} see further down.
 
-		To get the last search count when |n| or |N| was pressed, call
-		this function with `recompute: 0` . This sometimes returns
-		wrong information because |n| and |N|'s maximum count is 99.
-		If it exceeded 99 the result must be max count + 1 (100). If
-		you want to get correct information, specify `recompute: 1`: >vim
+                To get the last search count when |n| or |N| was pressed, call
+                this function with `recompute: 0` . This sometimes returns
+                wrong information because |n| and |N|'s maximum count is 99.
+                If it exceeded 99 the result must be max count + 1 (100). If
+                you want to get correct information, specify `recompute: 1`: >vim
 
-			" result == maxcount + 1 (100) when many matches
-			let result = searchcount(#{recompute: 0})
+                        " result == maxcount + 1 (100) when many matches
+                        let result = searchcount(#{recompute: 0})
 
-			" Below returns correct result (recompute defaults
-			" to 1)
-			let result = searchcount()
+                        " Below returns correct result (recompute defaults
+                        " to 1)
+                        let result = searchcount()
 <
-		The function is useful to add the count to 'statusline': >vim
-			function! LastSearchCount() abort
-			  let result = searchcount(#{recompute: 0})
-			  if empty(result)
-			    return ''
-			  endif
-			  if result.incomplete ==# 1     " timed out
-			    return printf(' /%s [?/??]', @/)
-			  elseif result.incomplete ==# 2 " max count exceeded
-			    if result.total > result.maxcount &&
-			    \  result.current > result.maxcount
-			      return printf(' /%s [>%d/>%d]', @/,
-			      \             result.current, result.total)
-			    elseif result.total > result.maxcount
-			      return printf(' /%s [%d/>%d]', @/,
-			      \             result.current, result.total)
-			    endif
-			  endif
-			  return printf(' /%s [%d/%d]', @/,
-			  \             result.current, result.total)
-			endfunction
-			let &statusline ..= '%{LastSearchCount()}'
+                The function is useful to add the count to 'statusline': >vim
+                        function! LastSearchCount() abort
+                          let result = searchcount(#{recompute: 0})
+                          if empty(result)
+                            return ''
+                          endif
+                          if result.incomplete ==# 1     " timed out
+                            return printf(' /%s [?/??]', @/)
+                          elseif result.incomplete ==# 2 " max count exceeded
+                            if result.total > result.maxcount &&
+                            \  result.current > result.maxcount
+                              return printf(' /%s [>%d/>%d]', @/,
+                              \             result.current, result.total)
+                            elseif result.total > result.maxcount
+                              return printf(' /%s [%d/>%d]', @/,
+                              \             result.current, result.total)
+                            endif
+                          endif
+                          return printf(' /%s [%d/%d]', @/,
+                          \             result.current, result.total)
+                        endfunction
+                        let &statusline ..= '%{LastSearchCount()}'
 
-			" Or if you want to show the count only when
-			" 'hlsearch' was on
-			" let &statusline ..=
-			" \   '%{v:hlsearch ? LastSearchCount() : ""}'
+                        " Or if you want to show the count only when
+                        " 'hlsearch' was on
+                        " let &statusline ..=
+                        " \   '%{v:hlsearch ? LastSearchCount() : ""}'
 <
-		You can also update the search count, which can be useful in a
-		|CursorMoved| or |CursorMovedI| autocommand: >vim
+                You can also update the search count, which can be useful in a
+                |CursorMoved| or |CursorMovedI| autocommand: >vim
 
-			autocmd CursorMoved,CursorMovedI *
-			  \ let s:searchcount_timer = timer_start(
-			  \   200, function('s:update_searchcount'))
-			function! s:update_searchcount(timer) abort
-			  if a:timer ==# s:searchcount_timer
-			    call searchcount(#{
-			    \ recompute: 1, maxcount: 0, timeout: 100})
-			    redrawstatus
-			  endif
-			endfunction
+                        autocmd CursorMoved,CursorMovedI *
+                          \ let s:searchcount_timer = timer_start(
+                          \   200, function('s:update_searchcount'))
+                        function! s:update_searchcount(timer) abort
+                          if a:timer ==# s:searchcount_timer
+                            call searchcount(#{
+                            \ recompute: 1, maxcount: 0, timeout: 100})
+                            redrawstatus
+                          endif
+                        endfunction
 <
-		This can also be used to count matched texts with specified
-		pattern in the current buffer using "pattern":  >vim
+                This can also be used to count matched texts with specified
+                pattern in the current buffer using "pattern":  >vim
 
-			" Count '\<foo\>' in this buffer
-			" (Note that it also updates search count)
-			let result = searchcount(#{pattern: '\<foo\>'})
+                        " Count '\<foo\>' in this buffer
+                        " (Note that it also updates search count)
+                        let result = searchcount(#{pattern: '\<foo\>'})
 
-			" To restore old search count by old pattern,
-			" search again
-			call searchcount()
+                        " To restore old search count by old pattern,
+                        " search again
+                        call searchcount()
 <
-		{options} must be a |Dictionary|. It can contain:
-		  key		type		meaning ~
-		  recompute	|Boolean|	if |TRUE|, recompute the count
-						like |n| or |N| was executed.
-						otherwise returns the last
-						computed result (when |n| or
-						|N| was used when "S" is not
-						in 'shortmess', or this
-						function was called).
-						(default: |TRUE|)
-		  pattern	|String|	recompute if this was given
-						and different with |@/|.
-						this works as same as the
-						below command is executed
-						before calling this function >vim
-						  let @/ = pattern
-<						(default: |@/|)
-		  timeout	|Number|	0 or negative number is no
-						timeout. timeout milliseconds
-						for recomputing the result
-						(default: 0)
-		  maxcount	|Number|	0 or negative number is no
-						limit. max count of matched
-						text while recomputing the
-						result.  if search exceeded
-						total count, "total" value
-						becomes `maxcount + 1`
-						(default: 0)
-		  pos		|List|		`[lnum, col, off]` value
-						when recomputing the result.
-						this changes "current" result
-						value. see |cursor()|, |getpos()|
-						(default: cursor's position)
+                {options} must be a |Dictionary|. It can contain:
+                  key           type            meaning ~
+                  recompute     |Boolean|         if |TRUE|, recompute the count
+                                                like |n| or |N| was executed.
+                                                otherwise returns the last
+                                                computed result (when |n| or
+                                                |N| was used when "S" is not
+                                                in 'shortmess', or this
+                                                function was called).
+                                                (default: |TRUE|)
+                  pattern       |String|          recompute if this was given
+                                                and different with |@/|.
+                                                this works as same as the
+                                                below command is executed
+                                                before calling this function >vim
+                                                  let @/ = pattern
+<                                               (default: |@/|)
+                  timeout       |Number|          0 or negative number is no
+                                                timeout. timeout milliseconds
+                                                for recomputing the result
+                                                (default: 0)
+                  maxcount      |Number|          0 or negative number is no
+                                                limit. max count of matched
+                                                text while recomputing the
+                                                result.  if search exceeded
+                                                total count, "total" value
+                                                becomes `maxcount + 1`
+                                                (default: 0)
+                  pos           |List|            `[lnum, col, off]` value
+                                                when recomputing the result.
+                                                this changes "current" result
+                                                value. see |cursor()|, |getpos()|
+                                                (default: cursor's position)
 
 searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
-		Search for the declaration of {name}.
+                Search for the declaration of {name}.
 
-		With a non-zero {global} argument it works like |gD|, find
-		first match in the file.  Otherwise it works like |gd|, find
-		first match in the function.
+                With a non-zero {global} argument it works like |gD|, find
+                first match in the file.  Otherwise it works like |gd|, find
+                first match in the function.
 
-		With a non-zero {thisblock} argument matches in a {} block
-		that ends before the cursor position are ignored.  Avoids
-		finding variable declarations only valid in another scope.
+                With a non-zero {thisblock} argument matches in a {} block
+                that ends before the cursor position are ignored.  Avoids
+                finding variable declarations only valid in another scope.
 
-		Moves the cursor to the found match.
-		Returns zero for success, non-zero for failure.
-		Example: >vim
-			if searchdecl('myvar') == 0
-			   echo getline('.')
-			endif
+                Moves the cursor to the found match.
+                Returns zero for success, non-zero for failure.
+                Example: >vim
+                        if searchdecl('myvar') == 0
+                           echo getline('.')
+                        endif
 <
-
                                                                   *searchpair()*
 searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
-		Search for the match of a nested start-end pair.  This can be
-		used to find the "endif" that matches an "if", while other
-		if/endif pairs in between are ignored.
-		The search starts at the cursor.  The default is to search
-		forward, include 'b' in {flags} to search backward.
-		If a match is found, the cursor is positioned at it and the
-		line number is returned.  If no match is found 0 or -1 is
-		returned and the cursor doesn't move.  No error message is
-		given.
+                Search for the match of a nested start-end pair.  This can be
+                used to find the "endif" that matches an "if", while other
+                if/endif pairs in between are ignored.
+                The search starts at the cursor.  The default is to search
+                forward, include 'b' in {flags} to search backward.
+                If a match is found, the cursor is positioned at it and the
+                line number is returned.  If no match is found 0 or -1 is
+                returned and the cursor doesn't move.  No error message is
+                given.
 
-		{start}, {middle} and {end} are patterns, see |pattern|.  They
-		must not contain \( \) pairs.  Use of \%( \) is allowed.  When
-		{middle} is not empty, it is found when searching from either
-		direction, but only when not in a nested start-end pair.  A
-		typical use is: >vim
-			echo searchpair('\<if\>', '\<else\>', '\<endif\>')
-<		By leaving {middle} empty the "else" is skipped.
+                {start}, {middle} and {end} are patterns, see |pattern|.  They
+                must not contain \( \) pairs.  Use of \%( \) is allowed.  When
+                {middle} is not empty, it is found when searching from either
+                direction, but only when not in a nested start-end pair.  A
+                typical use is: >vim
+                        echo searchpair('\<if\>', '\<else\>', '\<endif\>')
+<                By leaving {middle} empty the "else" is skipped.
 
-		{flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
-		|search()|.  Additionally:
-		'r'	Repeat until no more matches found; will find the
-			outer pair.  Implies the 'W' flag.
-		'm'	Return number of matches instead of line number with
-			the match; will be > 1 when 'r' is used.
-		Note: it's nearly always a good idea to use the 'W' flag, to
-		avoid wrapping around the end of the file.
+                {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
+                |search()|.  Additionally:
+                'r'     Repeat until no more matches found; will find the
+                        outer pair.  Implies the 'W' flag.
+                'm'     Return number of matches instead of line number with
+                        the match; will be > 1 when 'r' is used.
+                Note: it's nearly always a good idea to use the 'W' flag, to
+                avoid wrapping around the end of the file.
 
-		When a match for {start}, {middle} or {end} is found, the
-		{skip} expression is evaluated with the cursor positioned on
-		the start of the match.  It should return non-zero if this
-		match is to be skipped.  E.g., because it is inside a comment
-		or a string.
-		When {skip} is omitted or empty, every match is accepted.
-		When evaluating {skip} causes an error the search is aborted
-		and -1 returned.
-		{skip} can be a string, a lambda, a funcref or a partial.
-		Anything else makes the function fail.
+                When a match for {start}, {middle} or {end} is found, the
+                {skip} expression is evaluated with the cursor positioned on
+                the start of the match.  It should return non-zero if this
+                match is to be skipped.  E.g., because it is inside a comment
+                or a string.
+                When {skip} is omitted or empty, every match is accepted.
+                When evaluating {skip} causes an error the search is aborted
+                and -1 returned.
+                {skip} can be a string, a lambda, a funcref or a partial.
+                Anything else makes the function fail.
 
-		For {stopline} and {timeout} see |search()|.
+                For {stopline} and {timeout} see |search()|.
 
-		The value of 'ignorecase' is used.  'magic' is ignored, the
-		patterns are used like it's on.
+                The value of 'ignorecase' is used.  'magic' is ignored, the
+                patterns are used like it's on.
 
-		The search starts exactly at the cursor.  A match with
-		{start}, {middle} or {end} at the next character, in the
-		direction of searching, is the first one found.  Example: >vim
-			if 1
-			  if 2
-			  endif 2
-			endif 1
-<		When starting at the "if 2", with the cursor on the "i", and
-		searching forwards, the "endif 2" is found.  When starting on
-		the character just before the "if 2", the "endif 1" will be
-		found.  That's because the "if 2" will be found first, and
-		then this is considered to be a nested if/endif from "if 2" to
-		"endif 2".
-		When searching backwards and {end} is more than one character,
-		it may be useful to put "\zs" at the end of the pattern, so
-		that when the cursor is inside a match with the end it finds
-		the matching start.
+                The search starts exactly at the cursor.  A match with
+                {start}, {middle} or {end} at the next character, in the
+                direction of searching, is the first one found.  Example: >vim
+                        if 1
+                          if 2
+                          endif 2
+                        endif 1
+<                When starting at the "if 2", with the cursor on the "i", and
+                searching forwards, the "endif 2" is found.  When starting on
+                the character just before the "if 2", the "endif 1" will be
+                found.  That's because the "if 2" will be found first, and
+                then this is considered to be a nested if/endif from "if 2" to
+                "endif 2".
+                When searching backwards and {end} is more than one character,
+                it may be useful to put "\zs" at the end of the pattern, so
+                that when the cursor is inside a match with the end it finds
+                the matching start.
 
-		Example, to find the "endif" command in a Vim script: >vim
+                Example, to find the "endif" command in a Vim script: >vim
 
-			echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
-			\ 'getline(".") =~ "^\\s*\""')
+                        echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
+                        \ 'getline(".") =~ "^\\s*\""')
 
-<		The cursor must be at or after the "if" for which a match is
-		to be found.  Note that single-quote strings are used to avoid
-		having to double the backslashes.  The skip expression only
-		catches comments at the start of a line, not after a command.
-		Also, a word "en" or "if" halfway through a line is considered
-		a match.
-		Another example, to search for the matching "{" of a "}": >vim
+<                The cursor must be at or after the "if" for which a match is
+                to be found.  Note that single-quote strings are used to avoid
+                having to double the backslashes.  The skip expression only
+                catches comments at the start of a line, not after a command.
+                Also, a word "en" or "if" halfway through a line is considered
+                a match.
+                Another example, to search for the matching "{" of a "}": >vim
 
-			echo searchpair('{', '', '}', 'bW')
+                        echo searchpair('{', '', '}', 'bW')
 
-<		This works when the cursor is at or before the "}" for which a
-		match is to be found.  To reject matches that syntax
-		highlighting recognized as strings: >vim
+<                This works when the cursor is at or before the "}" for which a
+                match is to be found.  To reject matches that syntax
+                highlighting recognized as strings: >vim
 
-			echo searchpair('{', '', '}', 'bW',
-			     \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
+                        echo searchpair('{', '', '}', 'bW',
+                             \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
 <
-
                                                                *searchpairpos()*
 searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
-		Same as |searchpair()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
-		is the line number and the second element is the byte index of
-		the column position of the match.  If no match is found,
-		returns [0, 0]. >vim
+                Same as |searchpair()|, but returns a |List| with the line and
+                column position of the match. The first element of the |List|
+                is the line number and the second element is the byte index of
+                the column position of the match.  If no match is found,
+                returns [0, 0]. >vim
 
-			let [lnum,col] = searchpairpos('{', '', '}', 'n')
+                        let [lnum,col] = searchpairpos('{', '', '}', 'n')
 <
-		See |match-parens| for a bigger and more useful example.
+                See |match-parens| for a bigger and more useful example.
 
                                                                    *searchpos()*
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
-		Same as |search()|, but returns a |List| with the line and
-		column position of the match. The first element of the |List|
-		is the line number and the second element is the byte index of
-		the column position of the match. If no match is found,
-		returns [0, 0].
-		Example: >vim
-			let [lnum, col] = searchpos('mypattern', 'n')
+                Same as |search()|, but returns a |List| with the line and
+                column position of the match. The first element of the |List|
+                is the line number and the second element is the byte index of
+                the column position of the match. If no match is found,
+                returns [0, 0].
+                Example: >vim
+                        let [lnum, col] = searchpos('mypattern', 'n')
 
-<		When the 'p' flag is given then there is an extra item with
-		the sub-pattern match number |search()-sub-match|.  Example: >vim
-			let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
-<		In this example "submatch" is 2 when a lowercase letter is
-		found |/\l|, 3 when an uppercase letter is found |/\u|.
+<                When the 'p' flag is given then there is an extra item with
+                the sub-pattern match number |search()-sub-match|.  Example: >vim
+                        let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
+<                In this example "submatch" is 2 when a lowercase letter is
+                found |/\l|, 3 when an uppercase letter is found |/\u|.
 
 serverlist()                                                      *serverlist()*
-		Returns a list of server addresses, or empty if all servers
-		were stopped. |serverstart()| |serverstop()|
-		Example: >vim
-			echo serverlist()
+                Returns a list of server addresses, or empty if all servers
+                were stopped. |serverstart()| |serverstop()|
+                Example: >vim
+                        echo serverlist()
 <
-
 serverstart([{address}])                                         *serverstart()*
-		Opens a socket or named pipe at {address} and listens for
-		|RPC| messages. Clients can send |API| commands to the
-		returned address to control Nvim.
+                Opens a socket or named pipe at {address} and listens for
+                |RPC| messages. Clients can send |API| commands to the
+                returned address to control Nvim.
 
-		Returns the address string (which may differ from the
-		{address} argument, see below).
+                Returns the address string (which may differ from the
+                {address} argument, see below).
 
-		- If {address} has a colon (":") it is a TCP/IPv4/IPv6 address
-		  where the last ":" separates host and port (empty or zero
-		  assigns a random port).
-		- Else {address} is the path to a named pipe (except on Windows).
-		  - If {address} has no slashes ("/") it is treated as the
-		    "name" part of a generated path in this format: >vim
-			stdpath("run").."/{name}.{pid}.{counter}"
-<		  - If {address} is omitted the name is "nvim". >vim
-			echo serverstart()
-<		 >
-			=> /tmp/nvim.bram/oknANW/nvim.15430.5
+                - If {address} has a colon (":") it is a TCP/IPv4/IPv6 address
+                  where the last ":" separates host and port (empty or zero
+                  assigns a random port).
+                - Else {address} is the path to a named pipe (except on Windows).
+                  - If {address} has no slashes ("/") it is treated as the
+                    "name" part of a generated path in this format: >vim
+                        stdpath("run").."/{name}.{pid}.{counter}"
+<                  - If {address} is omitted the name is "nvim". >vim
+                        echo serverstart()
+<                 >
+                        => /tmp/nvim.bram/oknANW/nvim.15430.5
 <
-		Example bash command to list all Nvim servers: >bash
-			ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
+                Example bash command to list all Nvim servers: >bash
+                        ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
 
-<		Example named pipe: >vim
-			if has('win32')
-			  echo serverstart('\\.\pipe\nvim-pipe-1234')
-			else
-			  echo serverstart('nvim.sock')
-			endif
+<                Example named pipe: >vim
+                        if has('win32')
+                          echo serverstart('\\.\pipe\nvim-pipe-1234')
+                        else
+                          echo serverstart('nvim.sock')
+                        endif
 <
-		Example TCP/IP address: >vim
-			echo serverstart('::1:12345')
+                Example TCP/IP address: >vim
+                        echo serverstart('::1:12345')
 <
-
 serverstop({address})                                             *serverstop()*
-		Closes the pipe or socket at {address}.
-		Returns TRUE if {address} is valid, else FALSE.
-		If |v:servername| is stopped it is set to the next available
-		address in |serverlist()|.
+                Closes the pipe or socket at {address}.
+                Returns TRUE if {address} is valid, else FALSE.
+                If |v:servername| is stopped it is set to the next available
+                address in |serverlist()|.
 
 setbufline({buf}, {lnum}, {text})                                 *setbufline()*
-		Set line {lnum} to {text} in buffer {buf}.  This works like
-		|setline()| for the specified buffer.
+                Set line {lnum} to {text} in buffer {buf}.  This works like
+                |setline()| for the specified buffer.
 
-		This function works only for loaded buffers. First call
-		|bufload()| if needed.
+                This function works only for loaded buffers. First call
+                |bufload()| if needed.
 
-		To insert lines use |appendbufline()|.
+                To insert lines use |appendbufline()|.
 
-		{text} can be a string to set one line, or a List of strings
-		to set multiple lines.  If the List extends below the last
-		line then those lines are added.  If the List is empty then
-		nothing is changed and zero is returned.
+                {text} can be a string to set one line, or a List of strings
+                to set multiple lines.  If the List extends below the last
+                line then those lines are added.  If the List is empty then
+                nothing is changed and zero is returned.
 
-		For the use of {buf}, see |bufname()| above.
+                For the use of {buf}, see |bufname()| above.
 
-		{lnum} is used like with |setline()|.
-		Use "$" to refer to the last line in buffer {buf}.
-		When {lnum} is just below the last line the {text} will be
-		added below the last line.
-		On success 0 is returned, on failure 1 is returned.
+                {lnum} is used like with |setline()|.
+                Use "$" to refer to the last line in buffer {buf}.
+                When {lnum} is just below the last line the {text} will be
+                added below the last line.
+                On success 0 is returned, on failure 1 is returned.
 
-		If {buf} is not a valid buffer or {lnum} is not valid, an
-		error message is given.
+                If {buf} is not a valid buffer or {lnum} is not valid, an
+                error message is given.
 
 setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
-		Set option or local variable {varname} in buffer {buf} to
-		{val}.
-		This also works for a global or local window option, but it
-		doesn't work for a global or local window variable.
-		For a local window option the global value is unchanged.
-		For the use of {buf}, see |bufname()| above.
-		The {varname} argument is a string.
-		Note that the variable name without "b:" must be used.
-		Examples: >vim
-			call setbufvar(1, "&mod", 1)
-			call setbufvar("todo", "myvar", "foobar")
-<		This function is not available in the |sandbox|.
+                Set option or local variable {varname} in buffer {buf} to
+                {val}.
+                This also works for a global or local window option, but it
+                doesn't work for a global or local window variable.
+                For a local window option the global value is unchanged.
+                For the use of {buf}, see |bufname()| above.
+                The {varname} argument is a string.
+                Note that the variable name without "b:" must be used.
+                Examples: >vim
+                        call setbufvar(1, "&mod", 1)
+                        call setbufvar("todo", "myvar", "foobar")
+<                This function is not available in the |sandbox|.
 
 setcellwidths({list})                                          *setcellwidths()*
-		Specify overrides for cell widths of character ranges.  This
-		tells Vim how wide characters are when displayed in the
-		terminal, counted in screen cells.  The values override
-		'ambiwidth'.  Example: >vim
-		   call setcellwidths([
-				\ [0x111, 0x111, 1],
-				\ [0x2194, 0x2199, 2],
-				\ ])
+                Specify overrides for cell widths of character ranges.  This
+                tells Vim how wide characters are when displayed in the
+                terminal, counted in screen cells.  The values override
+                'ambiwidth'.  Example: >vim
+                   call setcellwidths([
+                                \ [0x111, 0x111, 1],
+                                \ [0x2194, 0x2199, 2],
+                                \ ])
 
-<		The {list} argument is a List of Lists with each three
-		numbers: [{low}, {high}, {width}].	*E1109* *E1110*
-		{low} and {high} can be the same, in which case this refers to
-		one character.  Otherwise it is the range of characters from
-		{low} to {high} (inclusive).		*E1111* *E1114*
-		Only characters with value 0x80 and higher can be used.
+<                The {list} argument is a List of Lists with each three
+                numbers: [{low}, {high}, {width}].      *E1109* *E1110*
+                {low} and {high} can be the same, in which case this refers to
+                one character.  Otherwise it is the range of characters from
+                {low} to {high} (inclusive).            *E1111* *E1114*
+                Only characters with value 0x80 and higher can be used.
 
-		{width} must be either 1 or 2, indicating the character width
-		in screen cells.			*E1112*
-		An error is given if the argument is invalid, also when a
-		range overlaps with another.		*E1113*
+                {width} must be either 1 or 2, indicating the character width
+                in screen cells.                        *E1112*
+                An error is given if the argument is invalid, also when a
+                range overlaps with another.            *E1113*
 
-		If the new value causes 'fillchars' or 'listchars' to become
-		invalid it is rejected and an error is given.
+                If the new value causes 'fillchars' or 'listchars' to become
+                invalid it is rejected and an error is given.
 
-		To clear the overrides pass an empty {list}: >vim
-		   call setcellwidths([])
+                To clear the overrides pass an empty {list}: >vim
+                   call setcellwidths([])
 
-<		You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
-		the effect for known emoji characters.  Move the cursor
-		through the text to check if the cell widths of your terminal
-		match with what Vim knows about each emoji.  If it doesn't
-		look right you need to adjust the {list} argument.
+<                You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
+                the effect for known emoji characters.  Move the cursor
+                through the text to check if the cell widths of your terminal
+                match with what Vim knows about each emoji.  If it doesn't
+                look right you need to adjust the {list} argument.
 
 setcharpos({expr}, {list})                                        *setcharpos()*
-		Same as |setpos()| but uses the specified column number as the
-		character index instead of the byte index in the line.
+                Same as |setpos()| but uses the specified column number as the
+                character index instead of the byte index in the line.
 
-		Example:
-		With the text "여보세요" in line 8: >vim
-			call setcharpos('.', [0, 8, 4, 0])
-<		positions the cursor on the fourth character '요'. >vim
-			call setpos('.', [0, 8, 4, 0])
-<		positions the cursor on the second character '보'.
+                Example:
+                With the text "여보세요" in line 8: >vim
+                        call setcharpos('.', [0, 8, 4, 0])
+<                positions the cursor on the fourth character '요'. >vim
+                        call setpos('.', [0, 8, 4, 0])
+<                positions the cursor on the second character '보'.
 
 setcharsearch({dict})                                          *setcharsearch()*
-		Set the current character search information to {dict},
-		which contains one or more of the following entries:
+                Set the current character search information to {dict},
+                which contains one or more of the following entries:
 
-		    char	character which will be used for a subsequent
-				|,| or |;| command; an empty string clears the
-				character search
-		    forward	direction of character search; 1 for forward,
-				0 for backward
-		    until	type of character search; 1 for a |t| or |T|
-				character search, 0 for an |f| or |F|
-				character search
+                    char        character which will be used for a subsequent
+                                |,| or |;| command; an empty string clears the
+                                character search
+                    forward     direction of character search; 1 for forward,
+                                0 for backward
+                    until       type of character search; 1 for a |t| or |T|
+                                character search, 0 for an |f| or |F|
+                                character search
 
-		This can be useful to save/restore a user's character search
-		from a script: >vim
-			let prevsearch = getcharsearch()
-			" Perform a command which clobbers user's search
-			call setcharsearch(prevsearch)
-<		Also see |getcharsearch()|.
+                This can be useful to save/restore a user's character search
+                from a script: >vim
+                        let prevsearch = getcharsearch()
+                        " Perform a command which clobbers user's search
+                        call setcharsearch(prevsearch)
+<                Also see |getcharsearch()|.
 
 setcmdline({str} [, {pos}])                                       *setcmdline()*
-		Set the command line to {str} and set the cursor position to
-		{pos}.
-		If {pos} is omitted, the cursor is positioned after the text.
-		Returns 0 when successful, 1 when not editing the command
-		line.
+                Set the command line to {str} and set the cursor position to
+                {pos}.
+                If {pos} is omitted, the cursor is positioned after the text.
+                Returns 0 when successful, 1 when not editing the command
+                line.
 
 setcmdpos({pos})                                                   *setcmdpos()*
-		Set the cursor position in the command line to byte position
-		{pos}.  The first position is 1.
-		Use |getcmdpos()| to obtain the current position.
-		Only works while editing the command line, thus you must use
-		|c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
-		|c_CTRL-\_e| and |c_CTRL-R_CTRL-R| with '=' the position is
-		set after the command line is set to the expression.  For
-		|c_CTRL-R_=| it is set after evaluating the expression but
-		before inserting the resulting text.
-		When the number is too big the cursor is put at the end of the
-		line.  A number smaller than one has undefined results.
-		Returns 0 when successful, 1 when not editing the command
-		line.
+                Set the cursor position in the command line to byte position
+                {pos}.  The first position is 1.
+                Use |getcmdpos()| to obtain the current position.
+                Only works while editing the command line, thus you must use
+                |c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
+                |c_CTRL-\_e| and |c_CTRL-R_CTRL-R| with '=' the position is
+                set after the command line is set to the expression.  For
+                |c_CTRL-R_=| it is set after evaluating the expression but
+                before inserting the resulting text.
+                When the number is too big the cursor is put at the end of the
+                line.  A number smaller than one has undefined results.
+                Returns 0 when successful, 1 when not editing the command
+                line.
 
 setcursorcharpos({lnum}, {col} [, {off}])
 setcursorcharpos({list})                                    *setcursorcharpos()*
-		Same as |cursor()| but uses the specified column number as the
-		character index instead of the byte index in the line.
+                Same as |cursor()| but uses the specified column number as the
+                character index instead of the byte index in the line.
 
-		Example:
-		With the text "여보세요" in line 4: >vim
-			call setcursorcharpos(4, 3)
-<		positions the cursor on the third character '세'. >vim
-			call cursor(4, 3)
-<		positions the cursor on the first character '여'.
+                Example:
+                With the text "여보세요" in line 4: >vim
+                        call setcursorcharpos(4, 3)
+<                positions the cursor on the third character '세'. >vim
+                        call cursor(4, 3)
+<                positions the cursor on the first character '여'.
 
 setenv({name}, {val})                                                 *setenv()*
-		Set environment variable {name} to {val}.  Example: >vim
-			call setenv('HOME', '/home/myhome')
+                Set environment variable {name} to {val}.  Example: >vim
+                        call setenv('HOME', '/home/myhome')
 
-<		When {val} is |v:null| the environment variable is deleted.
-		See also |expr-env|.
+<                When {val} is |v:null| the environment variable is deleted.
+                See also |expr-env|.
 
 setfperm({fname}, {mode})                                     *setfperm()* *chmod*
-		Set the file permissions for {fname} to {mode}.
-		{mode} must be a string with 9 characters.  It is of the form
-		"rwxrwxrwx", where each group of "rwx" flags represent, in
-		turn, the permissions of the owner of the file, the group the
-		file belongs to, and other users.  A '-' character means the
-		permission is off, any other character means on.  Multi-byte
-		characters are not supported.
+                Set the file permissions for {fname} to {mode}.
+                {mode} must be a string with 9 characters.  It is of the form
+                "rwxrwxrwx", where each group of "rwx" flags represent, in
+                turn, the permissions of the owner of the file, the group the
+                file belongs to, and other users.  A '-' character means the
+                permission is off, any other character means on.  Multi-byte
+                characters are not supported.
 
-		For example "rw-r-----" means read-write for the user,
-		readable by the group, not accessible by others.  "xx-x-----"
-		would do the same thing.
+                For example "rw-r-----" means read-write for the user,
+                readable by the group, not accessible by others.  "xx-x-----"
+                would do the same thing.
 
-		Returns non-zero for success, zero for failure.
+                Returns non-zero for success, zero for failure.
 
-		To read permissions see |getfperm()|.
+                To read permissions see |getfperm()|.
 
 setline({lnum}, {text})                                              *setline()*
-		Set line {lnum} of the current buffer to {text}.  To insert
-		lines use |append()|. To set lines in another buffer use
-		|setbufline()|.
+                Set line {lnum} of the current buffer to {text}.  To insert
+                lines use |append()|. To set lines in another buffer use
+                |setbufline()|.
 
-		{lnum} is used like with |getline()|.
-		When {lnum} is just below the last line the {text} will be
-		added below the last line.
-		{text} can be any type or a List of any type, each item is
-		converted to a String.  When {text} is an empty List then
-		nothing is changed and FALSE is returned.
+                {lnum} is used like with |getline()|.
+                When {lnum} is just below the last line the {text} will be
+                added below the last line.
+                {text} can be any type or a List of any type, each item is
+                converted to a String.  When {text} is an empty List then
+                nothing is changed and FALSE is returned.
 
-		If this succeeds, FALSE is returned.  If this fails (most likely
-		because {lnum} is invalid) TRUE is returned.
+                If this succeeds, FALSE is returned.  If this fails (most likely
+                because {lnum} is invalid) TRUE is returned.
 
-		Example: >vim
-			call setline(5, strftime("%c"))
+                Example: >vim
+                        call setline(5, strftime("%c"))
 
-<		When {text} is a |List| then line {lnum} and following lines
-		will be set to the items in the list.  Example: >vim
-			call setline(5, ['aaa', 'bbb', 'ccc'])
-<		This is equivalent to: >vim
-			for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
-			  call setline(n, l)
-			endfor
+<                When {text} is a |List| then line {lnum} and following lines
+                will be set to the items in the list.  Example: >vim
+                        call setline(5, ['aaa', 'bbb', 'ccc'])
+<                This is equivalent to: >vim
+                        for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
+                          call setline(n, l)
+                        endfor
 
-<		Note: The '[ and '] marks are not set.
+<                Note: The '[ and '] marks are not set.
 
 setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
-		Create or replace or add to the location list for window {nr}.
-		{nr} can be the window number or the |window-ID|.
-		When {nr} is zero the current window is used.
+                Create or replace or add to the location list for window {nr}.
+                {nr} can be the window number or the |window-ID|.
+                When {nr} is zero the current window is used.
 
-		For a location list window, the displayed location list is
-		modified.  For an invalid window number {nr}, -1 is returned.
-		Otherwise, same as |setqflist()|.
-		Also see |location-list|.
+                For a location list window, the displayed location list is
+                modified.  For an invalid window number {nr}, -1 is returned.
+                Otherwise, same as |setqflist()|.
+                Also see |location-list|.
 
-		For {action} see |setqflist-action|.
+                For {action} see |setqflist-action|.
 
-		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. Refer to |setqflist()|
-		for the list of supported keys in {what}.
+                If the optional {what} dictionary argument is supplied, then
+                only the items listed in {what} are set. Refer to |setqflist()|
+                for the list of supported keys in {what}.
 
 setmatches({list} [, {win}])                                      *setmatches()*
-		Restores a list of matches saved by |getmatches()| for the
-		current window.  Returns 0 if successful, otherwise -1.  All
-		current matches are cleared before the list is restored.  See
-		example for |getmatches()|.
-		If {win} is specified, use the window with this number or
-		window ID instead of the current window.
+                Restores a list of matches saved by |getmatches()| for the
+                current window.  Returns 0 if successful, otherwise -1.  All
+                current matches are cleared before the list is restored.  See
+                example for |getmatches()|.
+                If {win} is specified, use the window with this number or
+                window ID instead of the current window.
 
 setpos({expr}, {list})                                                *setpos()*
-		Set the position for String {expr}.  Possible values:
-			.	the cursor
-			'x	mark x
+                Set the position for String {expr}.  Possible values:
+                        .       the cursor
+                        'x      mark x
 
-		{list} must be a |List| with four or five numbers:
-		    [bufnum, lnum, col, off]
-		    [bufnum, lnum, col, off, curswant]
+                {list} must be a |List| with four or five numbers:
+                    [bufnum, lnum, col, off]
+                    [bufnum, lnum, col, off, curswant]
 
-		"bufnum" is the buffer number.	Zero can be used for the
-		current buffer.  When setting an uppercase mark "bufnum" is
-		used for the mark position.  For other marks it specifies the
-		buffer to set the mark in.  You can use the |bufnr()| function
-		to turn a file name into a buffer number.
-		For setting the cursor and the ' mark "bufnum" is ignored,
-		since these are associated with a window, not a buffer.
-		Does not change the jumplist.
+                "bufnum" is the buffer number.  Zero can be used for the
+                current buffer.  When setting an uppercase mark "bufnum" is
+                used for the mark position.  For other marks it specifies the
+                buffer to set the mark in.  You can use the |bufnr()| function
+                to turn a file name into a buffer number.
+                For setting the cursor and the ' mark "bufnum" is ignored,
+                since these are associated with a window, not a buffer.
+                Does not change the jumplist.
 
-		"lnum" and "col" are the position in the buffer.  The first
-		column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-		smaller than 1 then 1 is used. To use the character count
-		instead of the byte count, use |setcharpos()|.
+                "lnum" and "col" are the position in the buffer.  The first
+                column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
+                smaller than 1 then 1 is used. To use the character count
+                instead of the byte count, use |setcharpos()|.
 
-		The "off" number is only used when 'virtualedit' is set. Then
-		it is the offset in screen columns from the start of the
-		character.  E.g., a position within a <Tab> or after the last
-		character.
+                The "off" number is only used when 'virtualedit' is set. Then
+                it is the offset in screen columns from the start of the
+                character.  E.g., a position within a <Tab> or after the last
+                character.
 
-		The "curswant" number is only used when setting the cursor
-		position.  It sets the preferred column for when moving the
-		cursor vertically.  When the "curswant" number is missing the
-		preferred column is not set.  When it is present and setting a
-		mark position it is not used.
+                The "curswant" number is only used when setting the cursor
+                position.  It sets the preferred column for when moving the
+                cursor vertically.  When the "curswant" number is missing the
+                preferred column is not set.  When it is present and setting a
+                mark position it is not used.
 
-		Note that for '< and '> changing the line number may result in
-		the marks to be effectively be swapped, so that '< is always
-		before '>.
+                Note that for '< and '> changing the line number may result in
+                the marks to be effectively be swapped, so that '< is always
+                before '>.
 
-		Returns 0 when the position could be set, -1 otherwise.
-		An error message is given if {expr} is invalid.
+                Returns 0 when the position could be set, -1 otherwise.
+                An error message is given if {expr} is invalid.
 
-		Also see |setcharpos()|, |getpos()| and |getcurpos()|.
+                Also see |setcharpos()|, |getpos()| and |getcurpos()|.
 
-		This does not restore the preferred column for moving
-		vertically; if you set the cursor position with this, |j| and
-		|k| motions will jump to previous columns!  Use |cursor()| to
-		also set the preferred column.  Also see the "curswant" key in
-		|winrestview()|.
+                This does not restore the preferred column for moving
+                vertically; if you set the cursor position with this, |j| and
+                |k| motions will jump to previous columns!  Use |cursor()| to
+                also set the preferred column.  Also see the "curswant" key in
+                |winrestview()|.
 
 setqflist({list} [, {action} [, {what}]])                          *setqflist()*
-		Create or replace or add to the quickfix list.
+                Create or replace or add to the quickfix list.
 
-		If the optional {what} dictionary argument is supplied, then
-		only the items listed in {what} are set. The first {list}
-		argument is ignored.  See below for the supported items in
-		{what}.
-							*setqflist-what*
-		When {what} is not present, the items in {list} are used.  Each
-		item must be a dictionary.  Non-dictionary items in {list} are
-		ignored.  Each dictionary item can contain the following
-		entries:
+                If the optional {what} dictionary argument is supplied, then
+                only the items listed in {what} are set. The first {list}
+                argument is ignored.  See below for the supported items in
+                {what}.
+                                                        *setqflist-what*
+                When {what} is not present, the items in {list} are used.  Each
+                item must be a dictionary.  Non-dictionary items in {list} are
+                ignored.  Each dictionary item can contain the following
+                entries:
 
-		    bufnr	buffer number; must be the number of a valid
-				buffer
-		    filename	name of a file; only used when "bufnr" is not
-				present or it is invalid.
-		    module	name of a module; if given it will be used in
-				quickfix error window instead of the filename.
-		    lnum	line number in the file
-		    end_lnum	end of lines, if the item spans multiple lines
-		    pattern	search pattern used to locate the error
-		    col		column number
-		    vcol	when non-zero: "col" is visual column
-				when zero: "col" is byte index
-		    end_col	end column, if the item spans multiple columns
-		    nr		error number
-		    text	description of the error
-		    type	single-character error type, 'E', 'W', etc.
-		    valid	recognized error message
-		    user_data
-				custom data associated with the item, can be
-				any type.
+                    bufnr       buffer number; must be the number of a valid
+                                buffer
+                    filename    name of a file; only used when "bufnr" is not
+                                present or it is invalid.
+                    module      name of a module; if given it will be used in
+                                quickfix error window instead of the filename.
+                    lnum        line number in the file
+                    end_lnum    end of lines, if the item spans multiple lines
+                    pattern     search pattern used to locate the error
+                    col         column number
+                    vcol        when non-zero: "col" is visual column
+                                when zero: "col" is byte index
+                    end_col     end column, if the item spans multiple columns
+                    nr          error number
+                    text        description of the error
+                    type        single-character error type, 'E', 'W', etc.
+                    valid       recognized error message
+                    user_data
+                                custom data associated with the item, can be
+                                any type.
 
-		The "col", "vcol", "nr", "type" and "text" entries are
-		optional.  Either "lnum" or "pattern" entry can be used to
-		locate a matching error line.
-		If the "filename" and "bufnr" entries are not present or
-		neither the "lnum" or "pattern" entries are present, then the
-		item will not be handled as an error line.
-		If both "pattern" and "lnum" are present then "pattern" will
-		be used.
-		If the "valid" entry is not supplied, then the valid flag is
-		set when "bufnr" is a valid buffer or "filename" exists.
-		If you supply an empty {list}, the quickfix list will be
-		cleared.
-		Note that the list is not exactly the same as what
-		|getqflist()| returns.
+                The "col", "vcol", "nr", "type" and "text" entries are
+                optional.  Either "lnum" or "pattern" entry can be used to
+                locate a matching error line.
+                If the "filename" and "bufnr" entries are not present or
+                neither the "lnum" or "pattern" entries are present, then the
+                item will not be handled as an error line.
+                If both "pattern" and "lnum" are present then "pattern" will
+                be used.
+                If the "valid" entry is not supplied, then the valid flag is
+                set when "bufnr" is a valid buffer or "filename" exists.
+                If you supply an empty {list}, the quickfix list will be
+                cleared.
+                Note that the list is not exactly the same as what
+                |getqflist()| returns.
 
-		{action} values:		*setqflist-action* *E927*
-		'a'	The items from {list} are added to the existing
-			quickfix list. If there is no existing list, then a
-			new list is created.
+                {action} values:                *setqflist-action* *E927*
+                'a'     The items from {list} are added to the existing
+                        quickfix list. If there is no existing list, then a
+                        new list is created.
 
-		'r'	The items from the current quickfix list are replaced
-			with the items from {list}.  This can also be used to
-			clear the list: >vim
-				call setqflist([], 'r')
+                'r'     The items from the current quickfix list are replaced
+                        with the items from {list}.  This can also be used to
+                        clear the list: >vim
+                                call setqflist([], 'r')
 <
-		'f'	All the quickfix lists in the quickfix stack are
-			freed.
+                'f'     All the quickfix lists in the quickfix stack are
+                        freed.
 
-		If {action} is not present or is set to ' ', then a new list
-		is created. The new quickfix list is added after the current
-		quickfix list in the stack and all the following lists are
-		freed. To add a new quickfix list at the end of the stack,
-		set "nr" in {what} to "$".
+                If {action} is not present or is set to ' ', then a new list
+                is created. The new quickfix list is added after the current
+                quickfix list in the stack and all the following lists are
+                freed. To add a new quickfix list at the end of the stack,
+                set "nr" in {what} to "$".
 
-		The following items can be specified in dictionary {what}:
-		    context	quickfix list context. See |quickfix-context|
-		    efm		errorformat to use when parsing text from
-				"lines". If this is not present, then the
-				'errorformat' option value is used.
-				See |quickfix-parse|
-		    id		quickfix list identifier |quickfix-ID|
-		    idx		index of the current entry in the quickfix
-				list specified by "id" or "nr". If set to '$',
-				then the last entry in the list is set as the
-				current entry.  See |quickfix-index|
-		    items	list of quickfix entries. Same as the {list}
-				argument.
-		    lines	use 'errorformat' to parse a list of lines and
-				add the resulting entries to the quickfix list
-				{nr} or {id}.  Only a |List| value is supported.
-				See |quickfix-parse|
-		    nr		list number in the quickfix stack; zero
-				means the current quickfix list and "$" means
-				the last quickfix list.
-		    quickfixtextfunc
-				function to get the text to display in the
-				quickfix window.  The value can be the name of
-				a function or a funcref or a lambda.  Refer to
-				|quickfix-window-function| for an explanation
-				of how to write the function and an example.
-		    title	quickfix list title text. See |quickfix-title|
-		Unsupported keys in {what} are ignored.
-		If the "nr" item is not present, then the current quickfix list
-		is modified. When creating a new quickfix list, "nr" can be
-		set to a value one greater than the quickfix stack size.
-		When modifying a quickfix list, to guarantee that the correct
-		list is modified, "id" should be used instead of "nr" to
-		specify the list.
+                The following items can be specified in dictionary {what}:
+                    context     quickfix list context. See |quickfix-context|
+                    efm         errorformat to use when parsing text from
+                                "lines". If this is not present, then the
+                                'errorformat' option value is used.
+                                See |quickfix-parse|
+                    id          quickfix list identifier |quickfix-ID|
+                    idx         index of the current entry in the quickfix
+                                list specified by "id" or "nr". If set to '$',
+                                then the last entry in the list is set as the
+                                current entry.  See |quickfix-index|
+                    items       list of quickfix entries. Same as the {list}
+                                argument.
+                    lines       use 'errorformat' to parse a list of lines and
+                                add the resulting entries to the quickfix list
+                                {nr} or {id}.  Only a |List| value is supported.
+                                See |quickfix-parse|
+                    nr          list number in the quickfix stack; zero
+                                means the current quickfix list and "$" means
+                                the last quickfix list.
+                    quickfixtextfunc
+                                function to get the text to display in the
+                                quickfix window.  The value can be the name of
+                                a function or a funcref or a lambda.  Refer to
+                                |quickfix-window-function| for an explanation
+                                of how to write the function and an example.
+                    title       quickfix list title text. See |quickfix-title|
+                Unsupported keys in {what} are ignored.
+                If the "nr" item is not present, then the current quickfix list
+                is modified. When creating a new quickfix list, "nr" can be
+                set to a value one greater than the quickfix stack size.
+                When modifying a quickfix list, to guarantee that the correct
+                list is modified, "id" should be used instead of "nr" to
+                specify the list.
 
-		Examples (See also |setqflist-examples|): >vim
-		   call setqflist([], 'r', {'title': 'My search'})
-		   call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
-		   call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
+                Examples (See also |setqflist-examples|): >vim
+                   call setqflist([], 'r', {'title': 'My search'})
+                   call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+                   call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
 <
-		Returns zero for success, -1 for failure.
+                Returns zero for success, -1 for failure.
 
-		This function can be used to create a quickfix list
-		independent of the 'errorformat' setting.  Use a command like
-		`:cc 1` to jump to the first position.
+                This function can be used to create a quickfix list
+                independent of the 'errorformat' setting.  Use a command like
+                `:cc 1` to jump to the first position.
 
 setreg({regname}, {value} [, {options}])                              *setreg()*
-		Set the register {regname} to {value}.
-		If {regname} is "" or "@", the unnamed register '"' is used.
-		The {regname} argument is a string.
+                Set the register {regname} to {value}.
+                If {regname} is "" or "@", the unnamed register '"' is used.
+                The {regname} argument is a string.
 
-		{value} may be any value returned by |getreg()| or
-		|getreginfo()|, including a |List| or |Dict|.
-		If {options} contains "a" or {regname} is upper case,
-		then the value is appended.
+                {value} may be any value returned by |getreg()| or
+                |getreginfo()|, including a |List| or |Dict|.
+                If {options} contains "a" or {regname} is upper case,
+                then the value is appended.
 
-		{options} can also contain a register type specification:
-		    "c" or "v"	      |charwise| mode
-		    "l" or "V"	      |linewise| mode
-		    "b" or "<CTRL-V>" |blockwise-visual| mode
-		If a number immediately follows "b" or "<CTRL-V>" then this is
-		used as the width of the selection - if it is not specified
-		then the width of the block is set to the number of characters
-		in the longest line (counting a <Tab> as 1 character).
-		If {options} contains "u" or '"', then the unnamed register is
-		set to point to register {regname}.
+                {options} can also contain a register type specification:
+                    "c" or "v"        |charwise| mode
+                    "l" or "V"        |linewise| mode
+                    "b" or "<CTRL-V>" |blockwise-visual| mode
+                If a number immediately follows "b" or "<CTRL-V>" then this is
+                used as the width of the selection - if it is not specified
+                then the width of the block is set to the number of characters
+                in the longest line (counting a <Tab> as 1 character).
+                If {options} contains "u" or '"', then the unnamed register is
+                set to point to register {regname}.
 
-		If {options} contains no register settings, then the default
-		is to use character mode unless {value} ends in a <NL> for
-		string {value} and linewise mode for list {value}. Blockwise
-		mode is never selected automatically.
-		Returns zero for success, non-zero for failure.
+                If {options} contains no register settings, then the default
+                is to use character mode unless {value} ends in a <NL> for
+                string {value} and linewise mode for list {value}. Blockwise
+                mode is never selected automatically.
+                Returns zero for success, non-zero for failure.
 
-							*E883*
-		Note: you may not use |List| containing more than one item to
-		      set search and expression registers. Lists containing no
-		      items act like empty strings.
+                                                        *E883*
+                Note: you may not use |List| containing more than one item to
+                      set search and expression registers. Lists containing no
+                      items act like empty strings.
 
-		Examples: >vim
-			call setreg(v:register, @*)
-			call setreg('*', @%, 'ac')
-			call setreg('a', "1\n2\n3", 'b5')
-			call setreg('"', { 'points_to': 'a'})
+                Examples: >vim
+                        call setreg(v:register, @*)
+                        call setreg('*', @%, 'ac')
+                        call setreg('a', "1\n2\n3", 'b5')
+                        call setreg('"', { 'points_to': 'a'})
 
-<		This example shows using the functions to save and restore a
-		register: >vim
-			let var_a = getreginfo()
-			call setreg('a', var_a)
-<		or: >vim
-			let var_a = getreg('a', 1, 1)
-			let var_amode = getregtype('a')
-			" ....
-			call setreg('a', var_a, var_amode)
-<		Note: you may not reliably restore register value
-		without using the third argument to |getreg()| as without it
-		newlines are represented as newlines AND Nul bytes are
-		represented as newlines as well, see |NL-used-for-Nul|.
+<                This example shows using the functions to save and restore a
+                register: >vim
+                        let var_a = getreginfo()
+                        call setreg('a', var_a)
+<                or: >vim
+                        let var_a = getreg('a', 1, 1)
+                        let var_amode = getregtype('a')
+                        " ....
+                        call setreg('a', var_a, var_amode)
+<                Note: you may not reliably restore register value
+                without using the third argument to |getreg()| as without it
+                newlines are represented as newlines AND Nul bytes are
+                represented as newlines as well, see |NL-used-for-Nul|.
 
-		You can also change the type of a register by appending
-		nothing: >vim
-			call setreg('a', '', 'al')
+                You can also change the type of a register by appending
+                nothing: >vim
+                        call setreg('a', '', 'al')
 
 settabvar({tabnr}, {varname}, {val})                               *settabvar()*
-		Set tab-local variable {varname} to {val} in tab page {tabnr}.
-		|t:var|
-		The {varname} argument is a string.
-		Note that the variable name without "t:" must be used.
-		Tabs are numbered starting with one.
-		This function is not available in the |sandbox|.
+                Set tab-local variable {varname} to {val} in tab page {tabnr}.
+                |t:var|
+                The {varname} argument is a string.
+                Note that the variable name without "t:" must be used.
+                Tabs are numbered starting with one.
+                This function is not available in the |sandbox|.
 
 settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
-		Set option or local variable {varname} in window {winnr} to
-		{val}.
-		Tabs are numbered starting with one.  For the current tabpage
-		use |setwinvar()|.
-		{winnr} can be the window number or the |window-ID|.
-		When {winnr} is zero the current window is used.
-		This also works for a global or local buffer option, but it
-		doesn't work for a global or local buffer variable.
-		For a local buffer option the global value is unchanged.
-		Note that the variable name without "w:" must be used.
-		Examples: >vim
-			call settabwinvar(1, 1, "&list", 0)
-			call settabwinvar(3, 2, "myvar", "foobar")
-<		This function is not available in the |sandbox|.
+                Set option or local variable {varname} in window {winnr} to
+                {val}.
+                Tabs are numbered starting with one.  For the current tabpage
+                use |setwinvar()|.
+                {winnr} can be the window number or the |window-ID|.
+                When {winnr} is zero the current window is used.
+                This also works for a global or local buffer option, but it
+                doesn't work for a global or local buffer variable.
+                For a local buffer option the global value is unchanged.
+                Note that the variable name without "w:" must be used.
+                Examples: >vim
+                        call settabwinvar(1, 1, "&list", 0)
+                        call settabwinvar(3, 2, "myvar", "foobar")
+<                This function is not available in the |sandbox|.
 
 settagstack({nr}, {dict} [, {action}])                           *settagstack()*
-		Modify the tag stack of the window {nr} using {dict}.
-		{nr} can be the window number or the |window-ID|.
+                Modify the tag stack of the window {nr} using {dict}.
+                {nr} can be the window number or the |window-ID|.
 
-		For a list of supported items in {dict}, refer to
-		|gettagstack()|. "curidx" takes effect before changing the tag
-		stack.
-							*E962*
-		How the tag stack is modified depends on the {action}
-		argument:
-		- If {action} is not present or is set to 'r', then the tag
-		  stack is replaced.
-		- If {action} is set to 'a', then new entries from {dict} are
-		  pushed (added) onto the tag stack.
-		- If {action} is set to 't', then all the entries from the
-		  current entry in the tag stack or "curidx" in {dict} are
-		  removed and then new entries are pushed to the stack.
+                For a list of supported items in {dict}, refer to
+                |gettagstack()|. "curidx" takes effect before changing the tag
+                stack.
+                                                        *E962*
+                How the tag stack is modified depends on the {action}
+                argument:
+                - If {action} is not present or is set to 'r', then the tag
+                  stack is replaced.
+                - If {action} is set to 'a', then new entries from {dict} are
+                  pushed (added) onto the tag stack.
+                - If {action} is set to 't', then all the entries from the
+                  current entry in the tag stack or "curidx" in {dict} are
+                  removed and then new entries are pushed to the stack.
 
-		The current index is set to one after the length of the tag
-		stack after the modification.
+                The current index is set to one after the length of the tag
+                stack after the modification.
 
-		Returns zero for success, -1 for failure.
+                Returns zero for success, -1 for failure.
 
-		Examples (for more examples see |tagstack-examples|):
-		    Empty the tag stack of window 3: >vim
-			call settagstack(3, {'items' : []})
+                Examples (for more examples see |tagstack-examples|):
+                    Empty the tag stack of window 3: >vim
+                        call settagstack(3, {'items' : []})
 
-<		    Save and restore the tag stack: >vim
-			let stack = gettagstack(1003)
-			" do something else
-			call settagstack(1003, stack)
-			unlet stack
+<                    Save and restore the tag stack: >vim
+                        let stack = gettagstack(1003)
+                        " do something else
+                        call settagstack(1003, stack)
+                        unlet stack
 <
-
 setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
-		Like |settabwinvar()| for the current tab page.
-		Examples: >vim
-			call setwinvar(1, "&list", 0)
-			call setwinvar(2, "myvar", "foobar")
+                Like |settabwinvar()| for the current tab page.
+                Examples: >vim
+                        call setwinvar(1, "&list", 0)
+                        call setwinvar(2, "myvar", "foobar")
 
 sha256({string})                                                      *sha256()*
-		Returns a String with 64 hex characters, which is the SHA256
-		checksum of {string}.
+                Returns a String with 64 hex characters, which is the SHA256
+                checksum of {string}.
 
 shellescape({string} [, {special}])                              *shellescape()*
-		Escape {string} for use as a shell command argument.
+                Escape {string} for use as a shell command argument.
 
-		On Windows when 'shellslash' is not set, encloses {string} in
-		double-quotes and doubles all double-quotes within {string}.
-		Otherwise encloses {string} in single-quotes and replaces all
-		"'" with "'\''".
+                On Windows when 'shellslash' is not set, encloses {string} in
+                double-quotes and doubles all double-quotes within {string}.
+                Otherwise encloses {string} in single-quotes and replaces all
+                "'" with "'\''".
 
-		If {special} is a |non-zero-arg|:
-		- Special items such as "!", "%", "#" and "<cword>" will be
-		  preceded by a backslash. The backslash will be removed again
-		  by the |:!| command.
-		- The <NL> character is escaped.
+                If {special} is a |non-zero-arg|:
+                - Special items such as "!", "%", "#" and "<cword>" will be
+                  preceded by a backslash. The backslash will be removed again
+                  by the |:!| command.
+                - The <NL> character is escaped.
 
-		If 'shell' contains "csh" in the tail:
-		- The "!" character will be escaped. This is because csh and
-		  tcsh use "!" for history replacement even in single-quotes.
-		- The <NL> character is escaped (twice if {special} is
-		  a |non-zero-arg|).
+                If 'shell' contains "csh" in the tail:
+                - The "!" character will be escaped. This is because csh and
+                  tcsh use "!" for history replacement even in single-quotes.
+                - The <NL> character is escaped (twice if {special} is
+                  a |non-zero-arg|).
 
-		If 'shell' contains "fish" in the tail, the "\" character will
-		be escaped because in fish it is used as an escape character
-		inside single quotes.
+                If 'shell' contains "fish" in the tail, the "\" character will
+                be escaped because in fish it is used as an escape character
+                inside single quotes.
 
-		Example of use with a |:!| command: >vim
-		    exe '!dir ' .. shellescape(expand('<cfile>'), 1)
-<		This results in a directory listing for the file under the
-		cursor.  Example of use with |system()|: >vim
-		    call system("chmod +w -- " .. shellescape(expand("%")))
-<		See also |::S|.
+                Example of use with a |:!| command: >vim
+                    exe '!dir ' .. shellescape(expand('<cfile>'), 1)
+<                This results in a directory listing for the file under the
+                cursor.  Example of use with |system()|: >vim
+                    call system("chmod +w -- " .. shellescape(expand("%")))
+<                See also |::S|.
 
 shiftwidth([{col}])                                               *shiftwidth()*
-		Returns the effective value of 'shiftwidth'. This is the
-		'shiftwidth' value unless it is zero, in which case it is the
-		'tabstop' value.  To be backwards compatible in indent
-		plugins, use this: >vim
-			if exists('*shiftwidth')
-			  func s:sw()
-			    return shiftwidth()
-			  endfunc
-			else
-			  func s:sw()
-			    return &sw
-			  endfunc
-			endif
-<		And then use s:sw() instead of &sw.
+                Returns the effective value of 'shiftwidth'. This is the
+                'shiftwidth' value unless it is zero, in which case it is the
+                'tabstop' value.  To be backwards compatible in indent
+                plugins, use this: >vim
+                        if exists('*shiftwidth')
+                          func s:sw()
+                            return shiftwidth()
+                          endfunc
+                        else
+                          func s:sw()
+                            return &sw
+                          endfunc
+                        endif
+<                And then use s:sw() instead of &sw.
 
-		When there is one argument {col} this is used as column number
-		for which to return the 'shiftwidth' value. This matters for the
-		'vartabstop' feature. If no {col} argument is given, column 1
-		will be assumed.
+                When there is one argument {col} this is used as column number
+                for which to return the 'shiftwidth' value. This matters for the
+                'vartabstop' feature. If no {col} argument is given, column 1
+                will be assumed.
 
 sign_define({name} [, {dict}])
 sign_define({list})                                              *sign_define()*
-		Define a new sign named {name} or modify the attributes of an
-		existing sign.  This is similar to the |:sign-define| command.
+                Define a new sign named {name} or modify the attributes of an
+                existing sign.  This is similar to the |:sign-define| command.
 
-		Prefix {name} with a unique text to avoid name collisions.
-		There is no {group} like with placing signs.
+                Prefix {name} with a unique text to avoid name collisions.
+                There is no {group} like with placing signs.
 
-		The {name} can be a String or a Number.  The optional {dict}
-		argument specifies the sign attributes.  The following values
-		are supported:
-		   icon		full path to the bitmap file for the sign.
-		   linehl	highlight group used for the whole line the
-				sign is placed in.
-		   numhl	highlight group used for the line number where
-				the sign is placed.
-		   text		text that is displayed when there is no icon
-				or the GUI is not being used.
-		   texthl	highlight group used for the text item
-		   culhl	highlight group used for the text item when
-				the cursor is on the same line as the sign and
-				'cursorline' is enabled.
+                The {name} can be a String or a Number.  The optional {dict}
+                argument specifies the sign attributes.  The following values
+                are supported:
+                   icon         full path to the bitmap file for the sign.
+                   linehl       highlight group used for the whole line the
+                                sign is placed in.
+                   numhl        highlight group used for the line number where
+                                the sign is placed.
+                   text         text that is displayed when there is no icon
+                                or the GUI is not being used.
+                   texthl       highlight group used for the text item
+                   culhl        highlight group used for the text item when
+                                the cursor is on the same line as the sign and
+                                'cursorline' is enabled.
 
-		If the sign named {name} already exists, then the attributes
-		of the sign are updated.
+                If the sign named {name} already exists, then the attributes
+                of the sign are updated.
 
-		The one argument {list} can be used to define a list of signs.
-		Each list item is a dictionary with the above items in {dict}
-		and a "name" item for the sign name.
+                The one argument {list} can be used to define a list of signs.
+                Each list item is a dictionary with the above items in {dict}
+                and a "name" item for the sign name.
 
-		Returns 0 on success and -1 on failure.  When the one argument
-		{list} is used, then returns a List of values one for each
-		defined sign.
+                Returns 0 on success and -1 on failure.  When the one argument
+                {list} is used, then returns a List of values one for each
+                defined sign.
 
-		Examples: >vim
-			call sign_define("mySign", {
-				\ "text" : "=>",
-				\ "texthl" : "Error",
-				\ "linehl" : "Search"})
-			call sign_define([
-				\ {'name' : 'sign1',
-				\  'text' : '=>'},
-				\ {'name' : 'sign2',
-				\  'text' : '!!'}
-				\ ])
+                Examples: >vim
+                        call sign_define("mySign", {
+                                \ "text" : "=>",
+                                \ "texthl" : "Error",
+                                \ "linehl" : "Search"})
+                        call sign_define([
+                                \ {'name' : 'sign1',
+                                \  'text' : '=>'},
+                                \ {'name' : 'sign2',
+                                \  'text' : '!!'}
+                                \ ])
 <
-
 sign_getdefined([{name}])                                    *sign_getdefined()*
-		Get a list of defined signs and their attributes.
-		This is similar to the |:sign-list| command.
+                Get a list of defined signs and their attributes.
+                This is similar to the |:sign-list| command.
 
-		If the {name} is not supplied, then a list of all the defined
-		signs is returned. Otherwise the attribute of the specified
-		sign is returned.
+                If the {name} is not supplied, then a list of all the defined
+                signs is returned. Otherwise the attribute of the specified
+                sign is returned.
 
-		Each list item in the returned value is a dictionary with the
-		following entries:
-		   icon		full path to the bitmap file of the sign
-		   linehl	highlight group used for the whole line the
-				sign is placed in; not present if not set.
-		   name		name of the sign
-		   numhl	highlight group used for the line number where
-				the sign is placed; not present if not set.
-		   text		text that is displayed when there is no icon
-				or the GUI is not being used.
-		   texthl	highlight group used for the text item; not
-				present if not set.
-		   culhl	highlight group used for the text item when
-				the cursor is on the same line as the sign and
-				'cursorline' is enabled; not present if not
-				set.
+                Each list item in the returned value is a dictionary with the
+                following entries:
+                   icon         full path to the bitmap file of the sign
+                   linehl       highlight group used for the whole line the
+                                sign is placed in; not present if not set.
+                   name         name of the sign
+                   numhl        highlight group used for the line number where
+                                the sign is placed; not present if not set.
+                   text         text that is displayed when there is no icon
+                                or the GUI is not being used.
+                   texthl       highlight group used for the text item; not
+                                present if not set.
+                   culhl        highlight group used for the text item when
+                                the cursor is on the same line as the sign and
+                                'cursorline' is enabled; not present if not
+                                set.
 
-		Returns an empty List if there are no signs and when {name} is
-		not found.
+                Returns an empty List if there are no signs and when {name} is
+                not found.
 
-		Examples: >vim
-			" Get a list of all the defined signs
-			echo sign_getdefined()
+                Examples: >vim
+                        " Get a list of all the defined signs
+                        echo sign_getdefined()
 
-			" Get the attribute of the sign named mySign
-			echo sign_getdefined("mySign")
+                        " Get the attribute of the sign named mySign
+                        echo sign_getdefined("mySign")
 <
-
 sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
-		Return a list of signs placed in a buffer or all the buffers.
-		This is similar to the |:sign-place-list| command.
+                Return a list of signs placed in a buffer or all the buffers.
+                This is similar to the |:sign-place-list| command.
 
-		If the optional buffer name {buf} is specified, then only the
-		list of signs placed in that buffer is returned.  For the use
-		of {buf}, see |bufname()|. The optional {dict} can contain
-		the following entries:
-		   group	select only signs in this group
-		   id		select sign with this identifier
-		   lnum		select signs placed in this line. For the use
-				of {lnum}, see |line()|.
-		If {group} is "*", then signs in all the groups including the
-		global group are returned. If {group} is not supplied or is an
-		empty string, then only signs in the global group are
-		returned.  If no arguments are supplied, then signs in the
-		global group placed in all the buffers are returned.
-		See |sign-group|.
+                If the optional buffer name {buf} is specified, then only the
+                list of signs placed in that buffer is returned.  For the use
+                of {buf}, see |bufname()|. The optional {dict} can contain
+                the following entries:
+                   group        select only signs in this group
+                   id           select sign with this identifier
+                   lnum         select signs placed in this line. For the use
+                                of {lnum}, see |line()|.
+                If {group} is "*", then signs in all the groups including the
+                global group are returned. If {group} is not supplied or is an
+                empty string, then only signs in the global group are
+                returned.  If no arguments are supplied, then signs in the
+                global group placed in all the buffers are returned.
+                See |sign-group|.
 
-		Each list item in the returned value is a dictionary with the
-		following entries:
-			bufnr	number of the buffer with the sign
-			signs	list of signs placed in {bufnr}. Each list
-				item is a dictionary with the below listed
-				entries
+                Each list item in the returned value is a dictionary with the
+                following entries:
+                        bufnr   number of the buffer with the sign
+                        signs   list of signs placed in {bufnr}. Each list
+                                item is a dictionary with the below listed
+                                entries
 
-		The dictionary for each sign contains the following entries:
-			group	 sign group. Set to '' for the global group.
-			id	 identifier of the sign
-			lnum	 line number where the sign is placed
-			name	 name of the defined sign
-			priority sign priority
+                The dictionary for each sign contains the following entries:
+                        group    sign group. Set to '' for the global group.
+                        id       identifier of the sign
+                        lnum     line number where the sign is placed
+                        name     name of the defined sign
+                        priority sign priority
 
-		The returned signs in a buffer are ordered by their line
-		number and priority.
+                The returned signs in a buffer are ordered by their line
+                number and priority.
 
-		Returns an empty list on failure or if there are no placed
-		signs.
+                Returns an empty list on failure or if there are no placed
+                signs.
 
-		Examples: >vim
-			" Get a List of signs placed in eval.c in the
-			" global group
-			echo sign_getplaced("eval.c")
+                Examples: >vim
+                        " Get a List of signs placed in eval.c in the
+                        " global group
+                        echo sign_getplaced("eval.c")
 
-			" Get a List of signs in group 'g1' placed in eval.c
-			echo sign_getplaced("eval.c", {'group' : 'g1'})
+                        " Get a List of signs in group 'g1' placed in eval.c
+                        echo sign_getplaced("eval.c", {'group' : 'g1'})
 
-			" Get a List of signs placed at line 10 in eval.c
-			echo sign_getplaced("eval.c", {'lnum' : 10})
+                        " Get a List of signs placed at line 10 in eval.c
+                        echo sign_getplaced("eval.c", {'lnum' : 10})
 
-			" Get sign with identifier 10 placed in a.py
-			echo sign_getplaced("a.py", {'id' : 10})
+                        " Get sign with identifier 10 placed in a.py
+                        echo sign_getplaced("a.py", {'id' : 10})
 
-			" Get sign with id 20 in group 'g1' placed in a.py
-			echo sign_getplaced("a.py", {'group' : 'g1',
-							\  'id' : 20})
+                        " Get sign with id 20 in group 'g1' placed in a.py
+                        echo sign_getplaced("a.py", {'group' : 'g1',
+                                                        \  'id' : 20})
 
-			" Get a List of all the placed signs
-			echo sign_getplaced()
+                        " Get a List of all the placed signs
+                        echo sign_getplaced()
 <
-
 sign_jump({id}, {group}, {buf})                                    *sign_jump()*
-		Open the buffer {buf} or jump to the window that contains
-		{buf} and position the cursor at sign {id} in group {group}.
-		This is similar to the |:sign-jump| command.
+                Open the buffer {buf} or jump to the window that contains
+                {buf} and position the cursor at sign {id} in group {group}.
+                This is similar to the |:sign-jump| command.
 
-		If {group} is an empty string, then the global group is used.
-		For the use of {buf}, see |bufname()|.
+                If {group} is an empty string, then the global group is used.
+                For the use of {buf}, see |bufname()|.
 
-		Returns the line number of the sign. Returns -1 if the
-		arguments are invalid.
+                Returns the line number of the sign. Returns -1 if the
+                arguments are invalid.
 
-		Example: >vim
-			" Jump to sign 10 in the current buffer
-			call sign_jump(10, '', '')
+                Example: >vim
+                        " Jump to sign 10 in the current buffer
+                        call sign_jump(10, '', '')
 <
-
 sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
-		Place the sign defined as {name} at line {lnum} in file or
-		buffer {buf} and assign {id} and {group} to sign.  This is
-		similar to the |:sign-place| command.
+                Place the sign defined as {name} at line {lnum} in file or
+                buffer {buf} and assign {id} and {group} to sign.  This is
+                similar to the |:sign-place| command.
 
-		If the sign identifier {id} is zero, then a new identifier is
-		allocated.  Otherwise the specified number is used. {group} is
-		the sign group name. To use the global sign group, use an
-		empty string.  {group} functions as a namespace for {id}, thus
-		two groups can use the same IDs. Refer to |sign-identifier|
-		and |sign-group| for more information.
+                If the sign identifier {id} is zero, then a new identifier is
+                allocated.  Otherwise the specified number is used. {group} is
+                the sign group name. To use the global sign group, use an
+                empty string.  {group} functions as a namespace for {id}, thus
+                two groups can use the same IDs. Refer to |sign-identifier|
+                and |sign-group| for more information.
 
-		{name} refers to a defined sign.
-		{buf} refers to a buffer name or number. For the accepted
-		values, see |bufname()|.
+                {name} refers to a defined sign.
+                {buf} refers to a buffer name or number. For the accepted
+                values, see |bufname()|.
 
-		The optional {dict} argument supports the following entries:
-			lnum		line number in the file or buffer
-					{buf} where the sign is to be placed.
-					For the accepted values, see |line()|.
-			priority	priority of the sign. See
-					|sign-priority| for more information.
+                The optional {dict} argument supports the following entries:
+                        lnum            line number in the file or buffer
+                                        {buf} where the sign is to be placed.
+                                        For the accepted values, see |line()|.
+                        priority        priority of the sign. See
+                                        |sign-priority| for more information.
 
-		If the optional {dict} is not specified, then it modifies the
-		placed sign {id} in group {group} to use the defined sign
-		{name}.
+                If the optional {dict} is not specified, then it modifies the
+                placed sign {id} in group {group} to use the defined sign
+                {name}.
 
-		Returns the sign identifier on success and -1 on failure.
+                Returns the sign identifier on success and -1 on failure.
 
-		Examples: >vim
-			" Place a sign named sign1 with id 5 at line 20 in
-			" buffer json.c
-			call sign_place(5, '', 'sign1', 'json.c',
-							\ {'lnum' : 20})
+                Examples: >vim
+                        " Place a sign named sign1 with id 5 at line 20 in
+                        " buffer json.c
+                        call sign_place(5, '', 'sign1', 'json.c',
+                                                        \ {'lnum' : 20})
 
-			" Updates sign 5 in buffer json.c to use sign2
-			call sign_place(5, '', 'sign2', 'json.c')
+                        " Updates sign 5 in buffer json.c to use sign2
+                        call sign_place(5, '', 'sign2', 'json.c')
 
-			" Place a sign named sign3 at line 30 in
-			" buffer json.c with a new identifier
-			let id = sign_place(0, '', 'sign3', 'json.c',
-							\ {'lnum' : 30})
+                        " Place a sign named sign3 at line 30 in
+                        " buffer json.c with a new identifier
+                        let id = sign_place(0, '', 'sign3', 'json.c',
+                                                        \ {'lnum' : 30})
 
-			" Place a sign named sign4 with id 10 in group 'g3'
-			" at line 40 in buffer json.c with priority 90
-			call sign_place(10, 'g3', 'sign4', 'json.c',
-					\ {'lnum' : 40, 'priority' : 90})
+                        " Place a sign named sign4 with id 10 in group 'g3'
+                        " at line 40 in buffer json.c with priority 90
+                        call sign_place(10, 'g3', 'sign4', 'json.c',
+                                        \ {'lnum' : 40, 'priority' : 90})
 <
-
 sign_placelist({list})                                        *sign_placelist()*
-		Place one or more signs.  This is similar to the
-		|sign_place()| function.  The {list} argument specifies the
-		List of signs to place. Each list item is a dict with the
-		following sign attributes:
-		    buffer	Buffer name or number. For the accepted
-				values, see |bufname()|.
-		    group	Sign group. {group} functions as a namespace
-				for {id}, thus two groups can use the same
-				IDs. If not specified or set to an empty
-				string, then the global group is used.   See
-				|sign-group| for more information.
-		    id		Sign identifier. If not specified or zero,
-				then a new unique identifier is allocated.
-				Otherwise the specified number is used. See
-				|sign-identifier| for more information.
-		    lnum	Line number in the buffer where the sign is to
-				be placed. For the accepted values, see
-				|line()|.
-		    name	Name of the sign to place. See |sign_define()|
-				for more information.
-		    priority	Priority of the sign. When multiple signs are
-				placed on a line, the sign with the highest
-				priority is used. If not specified, the
-				default value of 10 is used. See
-				|sign-priority| for more information.
+                Place one or more signs.  This is similar to the
+                |sign_place()| function.  The {list} argument specifies the
+                List of signs to place. Each list item is a dict with the
+                following sign attributes:
+                    buffer      Buffer name or number. For the accepted
+                                values, see |bufname()|.
+                    group       Sign group. {group} functions as a namespace
+                                for {id}, thus two groups can use the same
+                                IDs. If not specified or set to an empty
+                                string, then the global group is used.   See
+                                |sign-group| for more information.
+                    id          Sign identifier. If not specified or zero,
+                                then a new unique identifier is allocated.
+                                Otherwise the specified number is used. See
+                                |sign-identifier| for more information.
+                    lnum        Line number in the buffer where the sign is to
+                                be placed. For the accepted values, see
+                                |line()|.
+                    name        Name of the sign to place. See |sign_define()|
+                                for more information.
+                    priority    Priority of the sign. When multiple signs are
+                                placed on a line, the sign with the highest
+                                priority is used. If not specified, the
+                                default value of 10 is used. See
+                                |sign-priority| for more information.
 
-		If {id} refers to an existing sign, then the existing sign is
-		modified to use the specified {name} and/or {priority}.
+                If {id} refers to an existing sign, then the existing sign is
+                modified to use the specified {name} and/or {priority}.
 
-		Returns a List of sign identifiers. If failed to place a
-		sign, the corresponding list item is set to -1.
+                Returns a List of sign identifiers. If failed to place a
+                sign, the corresponding list item is set to -1.
 
-		Examples: >vim
-			" Place sign s1 with id 5 at line 20 and id 10 at line
-			" 30 in buffer a.c
-			let [n1, n2] = sign_placelist([
-				\ {'id' : 5,
-				\  'name' : 's1',
-				\  'buffer' : 'a.c',
-				\  'lnum' : 20},
-				\ {'id' : 10,
-				\  'name' : 's1',
-				\  'buffer' : 'a.c',
-				\  'lnum' : 30}
-				\ ])
+                Examples: >vim
+                        " Place sign s1 with id 5 at line 20 and id 10 at line
+                        " 30 in buffer a.c
+                        let [n1, n2] = sign_placelist([
+                                \ {'id' : 5,
+                                \  'name' : 's1',
+                                \  'buffer' : 'a.c',
+                                \  'lnum' : 20},
+                                \ {'id' : 10,
+                                \  'name' : 's1',
+                                \  'buffer' : 'a.c',
+                                \  'lnum' : 30}
+                                \ ])
 
-			" Place sign s1 in buffer a.c at line 40 and 50
-			" with auto-generated identifiers
-			let [n1, n2] = sign_placelist([
-				\ {'name' : 's1',
-				\  'buffer' : 'a.c',
-				\  'lnum' : 40},
-				\ {'name' : 's1',
-				\  'buffer' : 'a.c',
-				\  'lnum' : 50}
-				\ ])
+                        " Place sign s1 in buffer a.c at line 40 and 50
+                        " with auto-generated identifiers
+                        let [n1, n2] = sign_placelist([
+                                \ {'name' : 's1',
+                                \  'buffer' : 'a.c',
+                                \  'lnum' : 40},
+                                \ {'name' : 's1',
+                                \  'buffer' : 'a.c',
+                                \  'lnum' : 50}
+                                \ ])
 <
-
 sign_undefine([{name}])
 sign_undefine({list})                                          *sign_undefine()*
-		Deletes a previously defined sign {name}. This is similar to
-		the |:sign-undefine| command. If {name} is not supplied, then
-		deletes all the defined signs.
+                Deletes a previously defined sign {name}. This is similar to
+                the |:sign-undefine| command. If {name} is not supplied, then
+                deletes all the defined signs.
 
-		The one argument {list} can be used to undefine a list of
-		signs. Each list item is the name of a sign.
+                The one argument {list} can be used to undefine a list of
+                signs. Each list item is the name of a sign.
 
-		Returns 0 on success and -1 on failure.  For the one argument
-		{list} call, returns a list of values one for each undefined
-		sign.
+                Returns 0 on success and -1 on failure.  For the one argument
+                {list} call, returns a list of values one for each undefined
+                sign.
 
-		Examples: >vim
-			" Delete a sign named mySign
-			call sign_undefine("mySign")
+                Examples: >vim
+                        " Delete a sign named mySign
+                        call sign_undefine("mySign")
 
-			" Delete signs 'sign1' and 'sign2'
-			call sign_undefine(["sign1", "sign2"])
+                        " Delete signs 'sign1' and 'sign2'
+                        call sign_undefine(["sign1", "sign2"])
 
-			" Delete all the signs
-			call sign_undefine()
+                        " Delete all the signs
+                        call sign_undefine()
 <
-
 sign_unplace({group} [, {dict}])                                *sign_unplace()*
-		Remove a previously placed sign in one or more buffers.  This
-		is similar to the |:sign-unplace| command.
+                Remove a previously placed sign in one or more buffers.  This
+                is similar to the |:sign-unplace| command.
 
-		{group} is the sign group name. To use the global sign group,
-		use an empty string.  If {group} is set to "*", then all the
-		groups including the global group are used.
-		The signs in {group} are selected based on the entries in
-		{dict}.  The following optional entries in {dict} are
-		supported:
-			buffer	buffer name or number. See |bufname()|.
-			id	sign identifier
-		If {dict} is not supplied, then all the signs in {group} are
-		removed.
+                {group} is the sign group name. To use the global sign group,
+                use an empty string.  If {group} is set to "*", then all the
+                groups including the global group are used.
+                The signs in {group} are selected based on the entries in
+                {dict}.  The following optional entries in {dict} are
+                supported:
+                        buffer  buffer name or number. See |bufname()|.
+                        id      sign identifier
+                If {dict} is not supplied, then all the signs in {group} are
+                removed.
 
-		Returns 0 on success and -1 on failure.
+                Returns 0 on success and -1 on failure.
 
-		Examples: >vim
-			" Remove sign 10 from buffer a.vim
-			call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
+                Examples: >vim
+                        " Remove sign 10 from buffer a.vim
+                        call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
 
-			" Remove sign 20 in group 'g1' from buffer 3
-			call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
+                        " Remove sign 20 in group 'g1' from buffer 3
+                        call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
 
-			" Remove all the signs in group 'g2' from buffer 10
-			call sign_unplace('g2', {'buffer' : 10})
+                        " Remove all the signs in group 'g2' from buffer 10
+                        call sign_unplace('g2', {'buffer' : 10})
 
-			" Remove sign 30 in group 'g3' from all the buffers
-			call sign_unplace('g3', {'id' : 30})
+                        " Remove sign 30 in group 'g3' from all the buffers
+                        call sign_unplace('g3', {'id' : 30})
 
-			" Remove all the signs placed in buffer 5
-			call sign_unplace('*', {'buffer' : 5})
+                        " Remove all the signs placed in buffer 5
+                        call sign_unplace('*', {'buffer' : 5})
 
-			" Remove the signs in group 'g4' from all the buffers
-			call sign_unplace('g4')
+                        " Remove the signs in group 'g4' from all the buffers
+                        call sign_unplace('g4')
 
-			" Remove sign 40 from all the buffers
-			call sign_unplace('*', {'id' : 40})
+                        " Remove sign 40 from all the buffers
+                        call sign_unplace('*', {'id' : 40})
 
-			" Remove all the placed signs from all the buffers
-			call sign_unplace('*')
+                        " Remove all the placed signs from all the buffers
+                        call sign_unplace('*')
 
 sign_unplacelist({list})                                    *sign_unplacelist()*
-		Remove previously placed signs from one or more buffers.  This
-		is similar to the |sign_unplace()| function.
+                Remove previously placed signs from one or more buffers.  This
+                is similar to the |sign_unplace()| function.
 
-		The {list} argument specifies the List of signs to remove.
-		Each list item is a dict with the following sign attributes:
-		    buffer	buffer name or number. For the accepted
-				values, see |bufname()|. If not specified,
-				then the specified sign is removed from all
-				the buffers.
-		    group	sign group name. If not specified or set to an
-				empty string, then the global sign group is
-				used. If set to "*", then all the groups
-				including the global group are used.
-		    id		sign identifier. If not specified, then all
-				the signs in the specified group are removed.
+                The {list} argument specifies the List of signs to remove.
+                Each list item is a dict with the following sign attributes:
+                    buffer      buffer name or number. For the accepted
+                                values, see |bufname()|. If not specified,
+                                then the specified sign is removed from all
+                                the buffers.
+                    group       sign group name. If not specified or set to an
+                                empty string, then the global sign group is
+                                used. If set to "*", then all the groups
+                                including the global group are used.
+                    id          sign identifier. If not specified, then all
+                                the signs in the specified group are removed.
 
-		Returns a List where an entry is set to 0 if the corresponding
-		sign was successfully removed or -1 on failure.
+                Returns a List where an entry is set to 0 if the corresponding
+                sign was successfully removed or -1 on failure.
 
-		Example: >vim
-			" Remove sign with id 10 from buffer a.vim and sign
-			" with id 20 from buffer b.vim
-			call sign_unplacelist([
-				\ {'id' : 10, 'buffer' : "a.vim"},
-				\ {'id' : 20, 'buffer' : 'b.vim'},
-				\ ])
+                Example: >vim
+                        " Remove sign with id 10 from buffer a.vim and sign
+                        " with id 20 from buffer b.vim
+                        call sign_unplacelist([
+                                \ {'id' : 10, 'buffer' : "a.vim"},
+                                \ {'id' : 20, 'buffer' : 'b.vim'},
+                                \ ])
 <
-
 simplify({filename})                                                *simplify()*
-		Simplify the file name as much as possible without changing
-		the meaning.  Shortcuts (on MS-Windows) or symbolic links (on
-		Unix) are not resolved.  If the first path component in
-		{filename} designates the current directory, this will be
-		valid for the result as well.  A trailing path separator is
-		not removed either. On Unix "//path" is unchanged, but
-		"///path" is simplified to "/path" (this follows the Posix
-		standard).
-		Example: >vim
-			simplify("./dir/.././/file/") == "./file/"
-<		Note: The combination "dir/.." is only removed if "dir" is
-		a searchable directory or does not exist.  On Unix, it is also
-		removed when "dir" is a symbolic link within the same
-		directory.  In order to resolve all the involved symbolic
-		links before simplifying the path name, use |resolve()|.
+                Simplify the file name as much as possible without changing
+                the meaning.  Shortcuts (on MS-Windows) or symbolic links (on
+                Unix) are not resolved.  If the first path component in
+                {filename} designates the current directory, this will be
+                valid for the result as well.  A trailing path separator is
+                not removed either. On Unix "//path" is unchanged, but
+                "///path" is simplified to "/path" (this follows the Posix
+                standard).
+                Example: >vim
+                        simplify("./dir/.././/file/") == "./file/"
+<                Note: The combination "dir/.." is only removed if "dir" is
+                a searchable directory or does not exist.  On Unix, it is also
+                removed when "dir" is a symbolic link within the same
+                directory.  In order to resolve all the involved symbolic
+                links before simplifying the path name, use |resolve()|.
 
 sin({expr})                                                              *sin()*
-		Return the sine of {expr}, measured in radians, as a |Float|.
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo sin(100)
-<			-0.506366 >vim
-			echo sin(-4.01)
-<			0.763301
+                Return the sine of {expr}, measured in radians, as a |Float|.
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo sin(100)
+<                        -0.506366 >vim
+                        echo sin(-4.01)
+<                        0.763301
 
 sinh({expr})                                                            *sinh()*
-		Return the hyperbolic sine of {expr} as a |Float| in the range
-		[-inf, inf].
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo sinh(0.5)
-<			0.521095 >vim
-			echo sinh(-0.9)
-<			-1.026517
+                Return the hyperbolic sine of {expr} as a |Float| in the range
+                [-inf, inf].
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo sinh(0.5)
+<                       0.521095 >vim
+                        echo sinh(-0.9)
+<                       -1.026517
 
 slice({expr}, {start} [, {end}])                                       *slice()*
-		Similar to using a |slice| "expr[start : end]", but "end" is
-		used exclusive.  And for a string the indexes are used as
-		character indexes instead of byte indexes.
-		Also, composing characters are not counted.
-		When {end} is omitted the slice continues to the last item.
-		When {end} is -1 the last item is omitted.
-		Returns an empty value if {start} or {end} are invalid.
+                Similar to using a |slice| "expr[start : end]", but "end" is
+                used exclusive.  And for a string the indexes are used as
+                character indexes instead of byte indexes.
+                Also, composing characters are not counted.
+                When {end} is omitted the slice continues to the last item.
+                When {end} is -1 the last item is omitted.
+                Returns an empty value if {start} or {end} are invalid.
 
 sockconnect({mode}, {address} [, {opts}])                        *sockconnect()*
-		Connect a socket to an address. If {mode} is "pipe" then
-		{address} should be the path of a local domain socket (on
-		unix) or named pipe (on Windows). If {mode} is "tcp" then
-		{address} should be of the form "host:port" where the host
-		should be an ip address or host name, and port the port
-		number.
+                Connect a socket to an address. If {mode} is "pipe" then
+                {address} should be the path of a local domain socket (on
+                unix) or named pipe (on Windows). If {mode} is "tcp" then
+                {address} should be of the form "host:port" where the host
+                should be an ip address or host name, and port the port
+                number.
 
-		For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
-		|luv-tcp-handle|.
+                For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
+                |luv-tcp-handle|.
 
-		Returns a |channel| ID. Close the socket with |chanclose()|.
-		Use |chansend()| to send data over a bytes socket, and
-		|rpcrequest()| and |rpcnotify()| to communicate with a RPC
-		socket.
+                Returns a |channel| ID. Close the socket with |chanclose()|.
+                Use |chansend()| to send data over a bytes socket, and
+                |rpcrequest()| and |rpcnotify()| to communicate with a RPC
+                socket.
 
-		{opts} is an optional dictionary with these keys:
-		  |on_data| : callback invoked when data was read from socket
-		  data_buffered : read socket data in |channel-buffered| mode.
-		  rpc     : If set, |msgpack-rpc| will be used to communicate
-			    over the socket.
-		Returns:
-		  - The channel ID on success (greater than zero)
-		  - 0 on invalid arguments or connection failure.
+                {opts} is an optional dictionary with these keys:
+                  |on_data| : callback invoked when data was read from socket
+                  data_buffered : read socket data in |channel-buffered| mode.
+                  rpc     : If set, |msgpack-rpc| will be used to communicate
+                            over the socket.
+                Returns:
+                  - The channel ID on success (greater than zero)
+                  - 0 on invalid arguments or connection failure.
 
 sort({list} [, {how} [, {dict}]])                                  *sort()* *E702*
-		Sort the items in {list} in-place.  Returns {list}.
+                Sort the items in {list} in-place.  Returns {list}.
 
-		If you want a list to remain unmodified make a copy first: >vim
-			let sortedlist = sort(copy(mylist))
+                If you want a list to remain unmodified make a copy first: >vim
+                        let sortedlist = sort(copy(mylist))
 
-<		When {how} is omitted or is a string, then sort() uses the
-		string representation of each item to sort on.  Numbers sort
-		after Strings, |Lists| after Numbers.  For sorting text in the
-		current buffer use |:sort|.
+<                When {how} is omitted or is a string, then sort() uses the
+                string representation of each item to sort on.  Numbers sort
+                after Strings, |Lists| after Numbers.  For sorting text in the
+                current buffer use |:sort|.
 
-		When {how} is given and it is 'i' then case is ignored.
-		For backwards compatibility, the value one can be used to
-		ignore case.  Zero means to not ignore case.
+                When {how} is given and it is 'i' then case is ignored.
+                For backwards compatibility, the value one can be used to
+                ignore case.  Zero means to not ignore case.
 
-		When {how} is given and it is 'l' then the current collation
-		locale is used for ordering. Implementation details: strcoll()
-		is used to compare strings. See |:language| check or set the
-		collation locale. |v:collate| can also be used to check the
-		current locale. Sorting using the locale typically ignores
-		case. Example: >vim
-			" ö is sorted similarly to o with English locale.
-			language collate en_US.UTF8
-			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<			['n', 'o', 'O', 'ö', 'p', 'z'] ~
+                When {how} is given and it is 'l' then the current collation
+                locale is used for ordering. Implementation details: strcoll()
+                is used to compare strings. See |:language| check or set the
+                collation locale. |v:collate| can also be used to check the
+                current locale. Sorting using the locale typically ignores
+                case. Example: >vim
+                        " ö is sorted similarly to o with English locale.
+                        language collate en_US.UTF8
+                        echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<                        ['n', 'o', 'O', 'ö', 'p', 'z'] ~
 >vim
-			" ö is sorted after z with Swedish locale.
-			language collate sv_SE.UTF8
-			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<			['n', 'o', 'O', 'p', 'z', 'ö'] ~
-		This does not work properly on Mac.
+                        " ö is sorted after z with Swedish locale.
+                        language collate sv_SE.UTF8
+                        echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<                        ['n', 'o', 'O', 'p', 'z', 'ö'] ~
+                This does not work properly on Mac.
 
-		When {how} is given and it is 'n' then all items will be
-		sorted numerical (Implementation detail: this uses the
-		strtod() function to parse numbers, Strings, Lists, Dicts and
-		Funcrefs will be considered as being 0).
+                When {how} is given and it is 'n' then all items will be
+                sorted numerical (Implementation detail: this uses the
+                strtod() function to parse numbers, Strings, Lists, Dicts and
+                Funcrefs will be considered as being 0).
 
-		When {how} is given and it is 'N' then all items will be
-		sorted numerical. This is like 'n' but a string containing
-		digits will be used as the number they represent.
+                When {how} is given and it is 'N' then all items will be
+                sorted numerical. This is like 'n' but a string containing
+                digits will be used as the number they represent.
 
-		When {how} is given and it is 'f' then all items will be
-		sorted numerical. All values must be a Number or a Float.
+                When {how} is given and it is 'f' then all items will be
+                sorted numerical. All values must be a Number or a Float.
 
-		When {how} is a |Funcref| or a function name, this function
-		is called to compare items.  The function is invoked with two
-		items as argument and must return zero if they are equal, 1 or
-		bigger if the first one sorts after the second one, -1 or
-		smaller if the first one sorts before the second one.
+                When {how} is a |Funcref| or a function name, this function
+                is called to compare items.  The function is invoked with two
+                items as argument and must return zero if they are equal, 1 or
+                bigger if the first one sorts after the second one, -1 or
+                smaller if the first one sorts before the second one.
 
-		{dict} is for functions with the "dict" attribute.  It will be
-		used to set the local variable "self". |Dictionary-function|
+                {dict} is for functions with the "dict" attribute.  It will be
+                used to set the local variable "self". |Dictionary-function|
 
-		The sort is stable, items which compare equal (as number or as
-		string) will keep their relative position. E.g., when sorting
-		on numbers, text strings will sort next to each other, in the
-		same order as they were originally.
+                The sort is stable, items which compare equal (as number or as
+                string) will keep their relative position. E.g., when sorting
+                on numbers, text strings will sort next to each other, in the
+                same order as they were originally.
 
 
-		Example: >vim
-			func MyCompare(i1, i2)
-			   return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
-			endfunc
-			eval mylist->sort("MyCompare")
-<		A shorter compare version for this specific simple case, which
-		ignores overflow: >vim
-			func MyCompare(i1, i2)
-			   return a:i1 - a:i2
-			endfunc
-<		For a simple expression you can use a lambda: >vim
-			eval mylist->sort({i1, i2 -> i1 - i2})
+                Example: >vim
+                        func MyCompare(i1, i2)
+                           return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
+                        endfunc
+                        eval mylist->sort("MyCompare")
+<                A shorter compare version for this specific simple case, which
+                ignores overflow: >vim
+                        func MyCompare(i1, i2)
+                           return a:i1 - a:i2
+                        endfunc
+<                For a simple expression you can use a lambda: >vim
+                        eval mylist->sort({i1, i2 -> i1 - i2})
 <
-
 soundfold({word})                                                  *soundfold()*
-		Return the sound-folded equivalent of {word}.  Uses the first
-		language in 'spelllang' for the current window that supports
-		soundfolding.  'spell' must be set.  When no sound folding is
-		possible the {word} is returned unmodified.
-		This can be used for making spelling suggestions.  Note that
-		the method can be quite slow.
+                Return the sound-folded equivalent of {word}.  Uses the first
+                language in 'spelllang' for the current window that supports
+                soundfolding.  'spell' must be set.  When no sound folding is
+                possible the {word} is returned unmodified.
+                This can be used for making spelling suggestions.  Note that
+                the method can be quite slow.
 
 spellbadword([{sentence}])                                      *spellbadword()*
-		Without argument: The result is the badly spelled word under
-		or after the cursor.  The cursor is moved to the start of the
-		bad word.  When no bad word is found in the cursor line the
-		result is an empty string and the cursor doesn't move.
+                Without argument: The result is the badly spelled word under
+                or after the cursor.  The cursor is moved to the start of the
+                bad word.  When no bad word is found in the cursor line the
+                result is an empty string and the cursor doesn't move.
 
-		With argument: The result is the first word in {sentence} that
-		is badly spelled.  If there are no spelling mistakes the
-		result is an empty string.
+                With argument: The result is the first word in {sentence} that
+                is badly spelled.  If there are no spelling mistakes the
+                result is an empty string.
 
-		The return value is a list with two items:
-		- The badly spelled word or an empty string.
-		- The type of the spelling error:
-			"bad"		spelling mistake
-			"rare"		rare word
-			"local"		word only valid in another region
-			"caps"		word should start with Capital
-		Example: >vim
-			echo spellbadword("the quik brown fox")
-<			['quik', 'bad'] ~
+                The return value is a list with two items:
+                - The badly spelled word or an empty string.
+                - The type of the spelling error:
+                        "bad"           spelling mistake
+                        "rare"          rare word
+                        "local"         word only valid in another region
+                        "caps"          word should start with Capital
+                Example: >vim
+                        echo spellbadword("the quik brown fox")
+<                        ['quik', 'bad'] ~
 
-		The spelling information for the current window and the value
-		of 'spelllang' are used.
+                The spelling information for the current window and the value
+                of 'spelllang' are used.
 
 spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
-		Return a |List| with spelling suggestions to replace {word}.
-		When {max} is given up to this number of suggestions are
-		returned.  Otherwise up to 25 suggestions are returned.
+                Return a |List| with spelling suggestions to replace {word}.
+                When {max} is given up to this number of suggestions are
+                returned.  Otherwise up to 25 suggestions are returned.
 
-		When the {capital} argument is given and it's non-zero only
-		suggestions with a leading capital will be given.  Use this
-		after a match with 'spellcapcheck'.
+                When the {capital} argument is given and it's non-zero only
+                suggestions with a leading capital will be given.  Use this
+                after a match with 'spellcapcheck'.
 
-		{word} can be a badly spelled word followed by other text.
-		This allows for joining two words that were split.  The
-		suggestions also include the following text, thus you can
-		replace a line.
+                {word} can be a badly spelled word followed by other text.
+                This allows for joining two words that were split.  The
+                suggestions also include the following text, thus you can
+                replace a line.
 
-		{word} may also be a good word.  Similar words will then be
-		returned.  {word} itself is not included in the suggestions,
-		although it may appear capitalized.
+                {word} may also be a good word.  Similar words will then be
+                returned.  {word} itself is not included in the suggestions,
+                although it may appear capitalized.
 
-		The spelling information for the current window is used.  The
-		values of 'spelllang' and 'spellsuggest' are used.
+                The spelling information for the current window is used.  The
+                values of 'spelllang' and 'spellsuggest' are used.
 
 split({string} [, {pattern} [, {keepempty}]])                          *split()*
-		Make a |List| out of {string}.  When {pattern} is omitted or
-		empty each white-separated sequence of characters becomes an
-		item.
-		Otherwise the string is split where {pattern} matches,
-		removing the matched characters. 'ignorecase' is not used
-		here, add \c to ignore case. |/\c|
-		When the first or last item is empty it is omitted, unless the
-		{keepempty} argument is given and it's non-zero.
-		Other empty items are kept when {pattern} matches at least one
-		character or when {keepempty} is non-zero.
-		Example: >vim
-			let words = split(getline('.'), '\W\+')
-<		To split a string in individual characters: >vim
-			for c in split(mystring, '\zs') | endfor
-<		If you want to keep the separator you can also use '\zs' at
-		the end of the pattern: >vim
-			echo split('abc:def:ghi', ':\zs')
-<		 >
-			['abc:', 'def:', 'ghi']
+                Make a |List| out of {string}.  When {pattern} is omitted or
+                empty each white-separated sequence of characters becomes an
+                item.
+                Otherwise the string is split where {pattern} matches,
+                removing the matched characters. 'ignorecase' is not used
+                here, add \c to ignore case. |/\c|
+                When the first or last item is empty it is omitted, unless the
+                {keepempty} argument is given and it's non-zero.
+                Other empty items are kept when {pattern} matches at least one
+                character or when {keepempty} is non-zero.
+                Example: >vim
+                        let words = split(getline('.'), '\W\+')
+<                To split a string in individual characters: >vim
+                        for c in split(mystring, '\zs') | endfor
+<                If you want to keep the separator you can also use '\zs' at
+                the end of the pattern: >vim
+                        echo split('abc:def:ghi', ':\zs')
+<                 >
+                        ['abc:', 'def:', 'ghi']
 <
-		Splitting a table where the first element can be empty: >vim
-			let items = split(line, ':', 1)
-<		The opposite function is |join()|.
+                Splitting a table where the first element can be empty: >vim
+                        let items = split(line, ':', 1)
+<                The opposite function is |join()|.
 
 sqrt({expr})                                                            *sqrt()*
-		Return the non-negative square root of Float {expr} as a
-		|Float|.
-		{expr} must evaluate to a |Float| or a |Number|.  When {expr}
-		is negative the result is NaN (Not a Number).  Returns 0.0 if
-		{expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo sqrt(100)
-<			10.0 >vim
-			echo sqrt(-4.01)
-<			str2float("nan")
-		NaN may be different, it depends on system libraries.
+                Return the non-negative square root of Float {expr} as a
+                |Float|.
+                {expr} must evaluate to a |Float| or a |Number|.  When {expr}
+                is negative the result is NaN (Not a Number).  Returns 0.0 if
+                {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo sqrt(100)
+<                        10.0 >vim
+                        echo sqrt(-4.01)
+<                        str2float("nan")
+                NaN may be different, it depends on system libraries.
 
 srand([{expr}])                                                        *srand()*
-		Initialize seed used by |rand()|:
-		- If {expr} is not given, seed values are initialized by
-		  reading from /dev/urandom, if possible, or using time(NULL)
-		  a.k.a. epoch time otherwise; this only has second accuracy.
-		- If {expr} is given it must be a Number.  It is used to
-		  initialize the seed values.  This is useful for testing or
-		  when a predictable sequence is intended.
+                Initialize seed used by |rand()|:
+                - If {expr} is not given, seed values are initialized by
+                  reading from /dev/urandom, if possible, or using time(NULL)
+                  a.k.a. epoch time otherwise; this only has second accuracy.
+                - If {expr} is given it must be a Number.  It is used to
+                  initialize the seed values.  This is useful for testing or
+                  when a predictable sequence is intended.
 
-		Examples: >vim
-			let seed = srand()
-			let seed = srand(userinput)
-			echo rand(seed)
+                Examples: >vim
+                        let seed = srand()
+                        let seed = srand(userinput)
+                        echo rand(seed)
 <
-
 state([{what}])                                                        *state()*
-		Return a string which contains characters indicating the
-		current state.  Mostly useful in callbacks that want to do
-		work that may not always be safe.  Roughly this works like:
-		- callback uses state() to check if work is safe to do.
-		  Yes: then do it right away.
-		  No:  add to work queue and add a |SafeState| autocommand.
-		- When SafeState is triggered and executes your autocommand,
-		  check with `state()` if the work can be done now, and if yes
-		  remove it from the queue and execute.
-		  Remove the autocommand if the queue is now empty.
-		Also see |mode()|.
+                Return a string which contains characters indicating the
+                current state.  Mostly useful in callbacks that want to do
+                work that may not always be safe.  Roughly this works like:
+                - callback uses state() to check if work is safe to do.
+                  Yes: then do it right away.
+                  No:  add to work queue and add a |SafeState| autocommand.
+                - When SafeState is triggered and executes your autocommand,
+                  check with `state()` if the work can be done now, and if yes
+                  remove it from the queue and execute.
+                  Remove the autocommand if the queue is now empty.
+                Also see |mode()|.
 
-		When {what} is given only characters in this string will be
-		added.  E.g, this checks if the screen has scrolled: >vim
-			if state('s') == ''
-			   " screen has not scrolled
+                When {what} is given only characters in this string will be
+                added.  E.g, this checks if the screen has scrolled: >vim
+                        if state('s') == ''
+                           " screen has not scrolled
 <
-		These characters indicate the state, generally indicating that
-		something is busy:
-		    m	halfway a mapping, :normal command, feedkeys() or
-			stuffed command
-		    o	operator pending, e.g. after |d|
-		    a	Insert mode autocomplete active
-		    x	executing an autocommand
-		    S	not triggering SafeState, e.g. after |f| or a count
-		    c	callback invoked, including timer (repeats for
-			recursiveness up to "ccc")
-		    s	screen has scrolled for messages
+                These characters indicate the state, generally indicating that
+                something is busy:
+                    m   halfway a mapping, :normal command, feedkeys() or
+                        stuffed command
+                    o   operator pending, e.g. after |d|
+                    a   Insert mode autocomplete active
+                    x   executing an autocommand
+                    S   not triggering SafeState, e.g. after |f| or a count
+                    c   callback invoked, including timer (repeats for
+                        recursiveness up to "ccc")
+                    s   screen has scrolled for messages
 
 stdioopen({opts})                                                  *stdioopen()*
-		With |--headless| this opens stdin and stdout as a |channel|.
-		May be called only once. See |channel-stdio|. stderr is not
-		handled by this function, see |v:stderr|.
+                With |--headless| this opens stdin and stdout as a |channel|.
+                May be called only once. See |channel-stdio|. stderr is not
+                handled by this function, see |v:stderr|.
 
-		Close the stdio handles with |chanclose()|. Use |chansend()|
-		to send data to stdout, and |rpcrequest()| and |rpcnotify()|
-		to communicate over RPC.
+                Close the stdio handles with |chanclose()|. Use |chansend()|
+                to send data to stdout, and |rpcrequest()| and |rpcnotify()|
+                to communicate over RPC.
 
-		{opts} is a dictionary with these keys:
-		  |on_stdin| : callback invoked when stdin is written to.
-		  on_print : callback invoked when Nvim needs to print a
-			     message, with the message (whose type is string)
-			     as sole argument.
-		  stdin_buffered : read stdin in |channel-buffered| mode.
-		  rpc      : If set, |msgpack-rpc| will be used to communicate
-			     over stdio
-		Returns:
-		  - |channel-id| on success (value is always 1)
-		  - 0 on invalid arguments
+                {opts} is a dictionary with these keys:
+                  |on_stdin| : callback invoked when stdin is written to.
+                  on_print : callback invoked when Nvim needs to print a
+                             message, with the message (whose type is string)
+                             as sole argument.
+                  stdin_buffered : read stdin in |channel-buffered| mode.
+                  rpc      : If set, |msgpack-rpc| will be used to communicate
+                             over stdio
+                Returns:
+                  - |channel-id| on success (value is always 1)
+                  - 0 on invalid arguments
 
 stdpath({what})                                                *stdpath()* *E6100*
-		Returns |standard-path| locations of various default files and
-		directories.
+                Returns |standard-path| locations of various default files and
+                directories.
 
-		{what}       Type    Description ~
-		cache        String  Cache directory: arbitrary temporary
-		                     storage for plugins, etc.
-		config       String  User configuration directory. |init.vim|
-		                     is stored here.
-		config_dirs  List    Other configuration directories.
-		data         String  User data directory.
-		data_dirs    List    Other data directories.
-		log          String  Logs directory (for use by plugins too).
-		run          String  Run directory: temporary, local storage
-				     for sockets, named pipes, etc.
-		state        String  Session state directory: storage for file
-				     drafts, swap, undo, |shada|.
+                {what}       Type    Description ~
+                cache        String  Cache directory: arbitrary temporary
+                                     storage for plugins, etc.
+                config       String  User configuration directory. |init.vim|
+                                     is stored here.
+                config_dirs  List    Other configuration directories.
+                data         String  User data directory.
+                data_dirs    List    Other data directories.
+                log          String  Logs directory (for use by plugins too).
+                run          String  Run directory: temporary, local storage
+                                     for sockets, named pipes, etc.
+                state        String  Session state directory: storage for file
+                                     drafts, swap, undo, |shada|.
 
-		Example: >vim
-			echo stdpath("config")
+                Example: >vim
+                        echo stdpath("config")
 <
-
 str2float({string} [, {quoted}])                                   *str2float()*
-		Convert String {string} to a Float.  This mostly works the
-		same as when using a floating point number in an expression,
-		see |floating-point-format|.  But it's a bit more permissive.
-		E.g., "1e40" is accepted, while in an expression you need to
-		write "1.0e40".  The hexadecimal form "0x123" is also
-		accepted, but not others, like binary or octal.
-		When {quoted} is present and non-zero then embedded single
-		quotes before the dot are ignored, thus "1'000.0" is a
-		thousand.
-		Text after the number is silently ignored.
-		The decimal point is always '.', no matter what the locale is
-		set to.  A comma ends the number: "12,345.67" is converted to
-		12.0.  You can strip out thousands separators with
-		|substitute()|: >vim
-			let f = str2float(substitute(text, ',', '', 'g'))
+                Convert String {string} to a Float.  This mostly works the
+                same as when using a floating point number in an expression,
+                see |floating-point-format|.  But it's a bit more permissive.
+                E.g., "1e40" is accepted, while in an expression you need to
+                write "1.0e40".  The hexadecimal form "0x123" is also
+                accepted, but not others, like binary or octal.
+                When {quoted} is present and non-zero then embedded single
+                quotes before the dot are ignored, thus "1'000.0" is a
+                thousand.
+                Text after the number is silently ignored.
+                The decimal point is always '.', no matter what the locale is
+                set to.  A comma ends the number: "12,345.67" is converted to
+                12.0.  You can strip out thousands separators with
+                |substitute()|: >vim
+                        let f = str2float(substitute(text, ',', '', 'g'))
 <
-		Returns 0.0 if the conversion fails.
+                Returns 0.0 if the conversion fails.
 
 str2list({string} [, {utf8}])                                       *str2list()*
-		Return a list containing the number values which represent
-		each character in String {string}.  Examples: >vim
-			echo str2list(" ")		" returns [32]
-			echo str2list("ABC")		" returns [65, 66, 67]
-<		|list2str()| does the opposite.
+                Return a list containing the number values which represent
+                each character in String {string}.  Examples: >vim
+                        echo str2list(" ")              " returns [32]
+                        echo str2list("ABC")            " returns [65, 66, 67]
+<                |list2str()| does the opposite.
 
-		UTF-8 encoding is always used, {utf8} option has no effect,
-		and exists only for backwards-compatibility.
-		With UTF-8 composing characters are handled properly: >vim
-			echo str2list("á")		" returns [97, 769]
+                UTF-8 encoding is always used, {utf8} option has no effect,
+                and exists only for backwards-compatibility.
+                With UTF-8 composing characters are handled properly: >vim
+                        echo str2list("á")              " returns [97, 769]
 
 str2nr({string} [, {base}])                                           *str2nr()*
-		Convert string {string} to a number.
-		{base} is the conversion base, it can be 2, 8, 10 or 16.
-		When {quoted} is present and non-zero then embedded single
-		quotes are ignored, thus "1'000'000" is a million.
+                Convert string {string} to a number.
+                {base} is the conversion base, it can be 2, 8, 10 or 16.
+                When {quoted} is present and non-zero then embedded single
+                quotes are ignored, thus "1'000'000" is a million.
 
-		When {base} is omitted base 10 is used.  This also means that
-		a leading zero doesn't cause octal conversion to be used, as
-		with the default String to Number conversion.  Example: >vim
-			let nr = str2nr('0123')
+                When {base} is omitted base 10 is used.  This also means that
+                a leading zero doesn't cause octal conversion to be used, as
+                with the default String to Number conversion.  Example: >vim
+                        let nr = str2nr('0123')
 <
-		When {base} is 16 a leading "0x" or "0X" is ignored.  With a
-		different base the result will be zero. Similarly, when
-		{base} is 8 a leading "0", "0o" or "0O" is ignored, and when
-		{base} is 2 a leading "0b" or "0B" is ignored.
-		Text after the number is silently ignored.
+                When {base} is 16 a leading "0x" or "0X" is ignored.  With a
+                different base the result will be zero. Similarly, when
+                {base} is 8 a leading "0", "0o" or "0O" is ignored, and when
+                {base} is 2 a leading "0b" or "0B" is ignored.
+                Text after the number is silently ignored.
 
-		Returns 0 if {string} is empty or on error.
+                Returns 0 if {string} is empty or on error.
 
 strcharlen({string})                                              *strcharlen()*
-		The result is a Number, which is the number of characters
-		in String {string}.  Composing characters are ignored.
-		|strchars()| can count the number of characters, counting
-		composing characters separately.
+                The result is a Number, which is the number of characters
+                in String {string}.  Composing characters are ignored.
+                |strchars()| can count the number of characters, counting
+                composing characters separately.
 
-		Returns 0 if {string} is empty or on error.
+                Returns 0 if {string} is empty or on error.
 
-		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+                Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
 strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
-		Like |strpart()| but using character index and length instead
-		of byte index and length.
-		When {skipcc} is omitted or zero, composing characters are
-		counted separately.
-		When {skipcc} set to 1, Composing characters are ignored,
-		similar to  |slice()|.
-		When a character index is used where a character does not
-		exist it is omitted and counted as one character.  For
-		example: >vim
-			echo strcharpart('abc', -1, 2)
-<		results in 'a'.
+                Like |strpart()| but using character index and length instead
+                of byte index and length.
+                When {skipcc} is omitted or zero, composing characters are
+                counted separately.
+                When {skipcc} set to 1, Composing characters are ignored,
+                similar to  |slice()|.
+                When a character index is used where a character does not
+                exist it is omitted and counted as one character.  For
+                example: >vim
+                        echo strcharpart('abc', -1, 2)
+<                results in 'a'.
 
-		Returns an empty string on error.
+                Returns an empty string on error.
 
 strchars({string} [, {skipcc}])                                     *strchars()*
-		The result is a Number, which is the number of characters
-		in String {string}.
-		When {skipcc} is omitted or zero, composing characters are
-		counted separately.
-		When {skipcc} set to 1, Composing characters are ignored.
-		|strcharlen()| always does this.
+                The result is a Number, which is the number of characters
+                in String {string}.
+                When {skipcc} is omitted or zero, composing characters are
+                counted separately.
+                When {skipcc} set to 1, Composing characters are ignored.
+                |strcharlen()| always does this.
 
-		Returns zero on error.
+                Returns zero on error.
 
-		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+                Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
-		{skipcc} is only available after 7.4.755.  For backward
-		compatibility, you can define a wrapper function: >vim
-		    if has("patch-7.4.755")
-		      function s:strchars(str, skipcc)
-			return strchars(a:str, a:skipcc)
-		      endfunction
-		    else
-		      function s:strchars(str, skipcc)
-			if a:skipcc
-			  return strlen(substitute(a:str, ".", "x", "g"))
-			else
-			  return strchars(a:str)
-			endif
-		      endfunction
-		    endif
+                {skipcc} is only available after 7.4.755.  For backward
+                compatibility, you can define a wrapper function: >vim
+                    if has("patch-7.4.755")
+                      function s:strchars(str, skipcc)
+                        return strchars(a:str, a:skipcc)
+                      endfunction
+                    else
+                      function s:strchars(str, skipcc)
+                        if a:skipcc
+                          return strlen(substitute(a:str, ".", "x", "g"))
+                        else
+                          return strchars(a:str)
+                        endif
+                      endfunction
+                    endif
 <
-
 strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
-		The result is a Number, which is the number of display cells
-		String {string} occupies on the screen when it starts at {col}
-		(first column is zero).  When {col} is omitted zero is used.
-		Otherwise it is the screen column where to start.  This
-		matters for Tab characters.
-		The option settings of the current window are used.  This
-		matters for anything that's displayed differently, such as
-		'tabstop' and 'display'.
-		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
-		Returns zero on error.
-		Also see |strlen()|, |strwidth()| and |strchars()|.
+                The result is a Number, which is the number of display cells
+                String {string} occupies on the screen when it starts at {col}
+                (first column is zero).  When {col} is omitted zero is used.
+                Otherwise it is the screen column where to start.  This
+                matters for Tab characters.
+                The option settings of the current window are used.  This
+                matters for anything that's displayed differently, such as
+                'tabstop' and 'display'.
+                When {string} contains characters with East Asian Width Class
+                Ambiguous, this function's return value depends on 'ambiwidth'.
+                Returns zero on error.
+                Also see |strlen()|, |strwidth()| and |strchars()|.
 
 strftime({format} [, {time}])                                       *strftime()*
-		The result is a String, which is a formatted date and time, as
-		specified by the {format} string.  The given {time} is used,
-		or the current time if no time is given.  The accepted
-		{format} depends on your system, thus this is not portable!
-		See the manual page of the C function strftime() for the
-		format.  The maximum length of the result is 80 characters.
-		See also |localtime()|, |getftime()| and |strptime()|.
-		The language can be changed with the |:language| command.
-		Examples: >vim
-		  echo strftime("%c")		   " Sun Apr 27 11:49:23 1997
-		  echo strftime("%Y %b %d %X")	   " 1997 Apr 27 11:53:25
-		  echo strftime("%y%m%d %T")	   " 970427 11:53:55
-		  echo strftime("%H:%M")		   " 11:55
-		  echo strftime("%c", getftime("file.c"))
-						   " Show mod time of file.c.
+                The result is a String, which is a formatted date and time, as
+                specified by the {format} string.  The given {time} is used,
+                or the current time if no time is given.  The accepted
+                {format} depends on your system, thus this is not portable!
+                See the manual page of the C function strftime() for the
+                format.  The maximum length of the result is 80 characters.
+                See also |localtime()|, |getftime()| and |strptime()|.
+                The language can be changed with the |:language| command.
+                Examples: >vim
+                  echo strftime("%c")              " Sun Apr 27 11:49:23 1997
+                  echo strftime("%Y %b %d %X")     " 1997 Apr 27 11:53:25
+                  echo strftime("%y%m%d %T")       " 970427 11:53:55
+                  echo strftime("%H:%M")                   " 11:55
+                  echo strftime("%c", getftime("file.c"))
+                                                   " Show mod time of file.c.
 
 strgetchar({str}, {index})                                        *strgetchar()*
-		Get a Number corresponding to the character at {index} in
-		{str}.  This uses a zero-based character index, not a byte
-		index.  Composing characters are considered separate
-		characters here.  Use |nr2char()| to convert the Number to a
-		String.
-		Returns -1 if {index} is invalid.
-		Also see |strcharpart()| and |strchars()|.
+                Get a Number corresponding to the character at {index} in
+                {str}.  This uses a zero-based character index, not a byte
+                index.  Composing characters are considered separate
+                characters here.  Use |nr2char()| to convert the Number to a
+                String.
+                Returns -1 if {index} is invalid.
+                Also see |strcharpart()| and |strchars()|.
 
 stridx({haystack}, {needle} [, {start}])                              *stridx()*
-		The result is a Number, which gives the byte index in
-		{haystack} of the first occurrence of the String {needle}.
-		If {start} is specified, the search starts at index {start}.
-		This can be used to find a second match: >vim
-			let colon1 = stridx(line, ":")
-			let colon2 = stridx(line, ":", colon1 + 1)
-<		The search is done case-sensitive.
-		For pattern searches use |match()|.
-		-1 is returned if the {needle} does not occur in {haystack}.
-		See also |strridx()|.
-		Examples: >vim
-		  echo stridx("An Example", "Example")     " 3
-		  echo stridx("Starting point", "Start")   " 0
-		  echo stridx("Starting point", "start")   " -1
-<						*strstr()* *strchr()*
-		stridx() works similar to the C function strstr().  When used
-		with a single character it works similar to strchr().
+                The result is a Number, which gives the byte index in
+                {haystack} of the first occurrence of the String {needle}.
+                If {start} is specified, the search starts at index {start}.
+                This can be used to find a second match: >vim
+                        let colon1 = stridx(line, ":")
+                        let colon2 = stridx(line, ":", colon1 + 1)
+<                The search is done case-sensitive.
+                For pattern searches use |match()|.
+                -1 is returned if the {needle} does not occur in {haystack}.
+                See also |strridx()|.
+                Examples: >vim
+                  echo stridx("An Example", "Example")     " 3
+                  echo stridx("Starting point", "Start")   " 0
+                  echo stridx("Starting point", "start")   " -1
+<                                               *strstr()* *strchr()*
+                stridx() works similar to the C function strstr().  When used
+                with a single character it works similar to strchr().
 
 string({expr})                                                        *string()*
-		Return {expr} converted to a String.  If {expr} is a Number,
-		Float, String, Blob or a composition of them, then the result
-		can be parsed back with |eval()|.
-			{expr} type	result ~
-			String		'string'
-			Number		123
-			Float		123.123456 or 1.123456e8 or
-					`str2float('inf')`
-			Funcref		`function('name')`
-			Blob		0z00112233.44556677.8899
-			List		[item, item]
-			Dictionary	`{key: value, key: value}`
-		Note that in String values the ' character is doubled.
-		Also see |strtrans()|.
-		Note 2: Output format is mostly compatible with YAML, except
-		for infinite and NaN floating-point values representations
-		which use |str2float()|.  Strings are also dumped literally,
-		only single quote is escaped, which does not allow using YAML
-		for parsing back binary strings.  |eval()| should always work for
-		strings and floats though and this is the only official
-		method, use |msgpackdump()| or |json_encode()| if you need to
-		share data with other application.
+                Return {expr} converted to a String.  If {expr} is a Number,
+                Float, String, Blob or a composition of them, then the result
+                can be parsed back with |eval()|.
+                        {expr} type     result ~
+                        String          'string'
+                        Number          123
+                        Float           123.123456 or 1.123456e8 or
+                                        `str2float('inf')`
+                        Funcref         `function('name')`
+                        Blob            0z00112233.44556677.8899
+                        List            [item, item]
+                        Dictionary      `{key: value, key: value}`
+                Note that in String values the ' character is doubled.
+                Also see |strtrans()|.
+                Note 2: Output format is mostly compatible with YAML, except
+                for infinite and NaN floating-point values representations
+                which use |str2float()|.  Strings are also dumped literally,
+                only single quote is escaped, which does not allow using YAML
+                for parsing back binary strings.  |eval()| should always work for
+                strings and floats though and this is the only official
+                method, use |msgpackdump()| or |json_encode()| if you need to
+                share data with other application.
 
 strlen({string})                                                      *strlen()*
-		The result is a Number, which is the length of the String
-		{string} in bytes.
-		If the argument is a Number it is first converted to a String.
-		For other types an error is given and zero is returned.
-		If you want to count the number of multibyte characters use
-		|strchars()|.
-		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
+                The result is a Number, which is the length of the String
+                {string} in bytes.
+                If the argument is a Number it is first converted to a String.
+                For other types an error is given and zero is returned.
+                If you want to count the number of multibyte characters use
+                |strchars()|.
+                Also see |len()|, |strdisplaywidth()| and |strwidth()|.
 
 strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
-		The result is a String, which is part of {src}, starting from
-		byte {start}, with the byte length {len}.
-		When {chars} is present and TRUE then {len} is the number of
-		characters positions (composing characters are not counted
-		separately, thus "1" means one base character and any
-		following composing characters).
-		To count {start} as characters instead of bytes use
-		|strcharpart()|.
+                The result is a String, which is part of {src}, starting from
+                byte {start}, with the byte length {len}.
+                When {chars} is present and TRUE then {len} is the number of
+                characters positions (composing characters are not counted
+                separately, thus "1" means one base character and any
+                following composing characters).
+                To count {start} as characters instead of bytes use
+                |strcharpart()|.
 
-		When bytes are selected which do not exist, this doesn't
-		result in an error, the bytes are simply omitted.
-		If {len} is missing, the copy continues from {start} till the
-		end of the {src}. >vim
-			echo strpart("abcdefg", 3, 2)    " returns 'de'
-			echo strpart("abcdefg", -2, 4)   " returns 'ab'
-			echo strpart("abcdefg", 5, 4)    " returns 'fg'
-			echo strpart("abcdefg", 3)	 " returns 'defg'
+                When bytes are selected which do not exist, this doesn't
+                result in an error, the bytes are simply omitted.
+                If {len} is missing, the copy continues from {start} till the
+                end of the {src}. >vim
+                        echo strpart("abcdefg", 3, 2)    " returns 'de'
+                        echo strpart("abcdefg", -2, 4)   " returns 'ab'
+                        echo strpart("abcdefg", 5, 4)    " returns 'fg'
+                        echo strpart("abcdefg", 3)       " returns 'defg'
 
-<		Note: To get the first character, {start} must be 0.  For
-		example, to get the character under the cursor: >vim
-			strpart(getline("."), col(".") - 1, 1, v:true)
+<                Note: To get the first character, {start} must be 0.  For
+                example, to get the character under the cursor: >vim
+                        strpart(getline("."), col(".") - 1, 1, v:true)
 <
-		Returns an empty string on error.
+                Returns an empty string on error.
 
 strptime({format}, {timestring})                                    *strptime()*
-		The result is a Number, which is a unix timestamp representing
-		the date and time in {timestring}, which is expected to match
-		the format specified in {format}.
+                The result is a Number, which is a unix timestamp representing
+                the date and time in {timestring}, which is expected to match
+                the format specified in {format}.
 
-		The accepted {format} depends on your system, thus this is not
-		portable!  See the manual page of the C function strptime()
-		for the format.  Especially avoid "%c".  The value of $TZ also
-		matters.
+                The accepted {format} depends on your system, thus this is not
+                portable!  See the manual page of the C function strptime()
+                for the format.  Especially avoid "%c".  The value of $TZ also
+                matters.
 
-		If the {timestring} cannot be parsed with {format} zero is
-		returned.  If you do not know the format of {timestring} you
-		can try different {format} values until you get a non-zero
-		result.
+                If the {timestring} cannot be parsed with {format} zero is
+                returned.  If you do not know the format of {timestring} you
+                can try different {format} values until you get a non-zero
+                result.
 
-		See also |strftime()|.
-		Examples: >vim
-		  echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
-<		  862156163 >vim
-		  echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
-<		  Sun Apr 27 11:53:55 1997 >vim
-		  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
-<		  Sun Apr 27 12:53:55 1997
+                See also |strftime()|.
+                Examples: >vim
+                  echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
+<                  862156163 >vim
+                  echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
+<                  Sun Apr 27 11:53:55 1997 >vim
+                  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
+<                  Sun Apr 27 12:53:55 1997
 
 strridx({haystack}, {needle} [, {start}])                            *strridx()*
-		The result is a Number, which gives the byte index in
-		{haystack} of the last occurrence of the String {needle}.
-		When {start} is specified, matches beyond this index are
-		ignored.  This can be used to find a match before a previous
-		match: >vim
-			let lastcomma = strridx(line, ",")
-			let comma2 = strridx(line, ",", lastcomma - 1)
-<		The search is done case-sensitive.
-		For pattern searches use |match()|.
-		-1 is returned if the {needle} does not occur in {haystack}.
-		If the {needle} is empty the length of {haystack} is returned.
-		See also |stridx()|.  Examples: >vim
-		  echo strridx("an angry armadillo", "an")	     3
-<							*strrchr()*
-		When used with a single character it works similar to the C
-		function strrchr().
+                The result is a Number, which gives the byte index in
+                {haystack} of the last occurrence of the String {needle}.
+                When {start} is specified, matches beyond this index are
+                ignored.  This can be used to find a match before a previous
+                match: >vim
+                        let lastcomma = strridx(line, ",")
+                        let comma2 = strridx(line, ",", lastcomma - 1)
+<                The search is done case-sensitive.
+                For pattern searches use |match()|.
+                -1 is returned if the {needle} does not occur in {haystack}.
+                If the {needle} is empty the length of {haystack} is returned.
+                See also |stridx()|.  Examples: >vim
+                  echo strridx("an angry armadillo", "an")           3
+<                                                       *strrchr()*
+                When used with a single character it works similar to the C
+                function strrchr().
 
 strtrans({string})                                                  *strtrans()*
-		The result is a String, which is {string} with all unprintable
-		characters translated into printable characters |'isprint'|.
-		Like they are shown in a window.  Example: >vim
-			echo strtrans(@a)
-<		This displays a newline in register a as "^@" instead of
-		starting a new line.
+                The result is a String, which is {string} with all unprintable
+                characters translated into printable characters |'isprint'|.
+                Like they are shown in a window.  Example: >vim
+                        echo strtrans(@a)
+<                This displays a newline in register a as "^@" instead of
+                starting a new line.
 
-		Returns an empty string on error.
+                Returns an empty string on error.
 
 strutf16len({string} [, {countcc}])                              *strutf16len()*
-		The result is a Number, which is the number of UTF-16 code
-		units in String {string} (after converting it to UTF-16).
+                The result is a Number, which is the number of UTF-16 code
+                units in String {string} (after converting it to UTF-16).
 
-		When {countcc} is TRUE, composing characters are counted
-		separately.
-		When {countcc} is omitted or FALSE, composing characters are
-		ignored.
+                When {countcc} is TRUE, composing characters are counted
+                separately.
+                When {countcc} is omitted or FALSE, composing characters are
+                ignored.
 
-		Returns zero on error.
+                Returns zero on error.
 
-		Also see |strlen()| and |strcharlen()|.
-		Examples: >vim
-		    echo strutf16len('a')		" returns 1
-		    echo strutf16len('©')		" returns 1
-		    echo strutf16len('😊')		" returns 2
-		    echo strutf16len('ą́')		" returns 1
-		    echo strutf16len('ą́', v:true)	" returns 3
+                Also see |strlen()| and |strcharlen()|.
+                Examples: >vim
+                    echo strutf16len('a')               " returns 1
+                    echo strutf16len('©')               " returns 1
+                    echo strutf16len('😊')              " returns 2
+                    echo strutf16len('ą́')               " returns 1
+                    echo strutf16len('ą́', v:true)       " returns 3
 <
-
 strwidth({string})                                                  *strwidth()*
-		The result is a Number, which is the number of display cells
-		String {string} occupies.  A Tab character is counted as one
-		cell, alternatively use |strdisplaywidth()|.
-		When {string} contains characters with East Asian Width Class
-		Ambiguous, this function's return value depends on 'ambiwidth'.
-		Returns zero on error.
-		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
+                The result is a Number, which is the number of display cells
+                String {string} occupies.  A Tab character is counted as one
+                cell, alternatively use |strdisplaywidth()|.
+                When {string} contains characters with East Asian Width Class
+                Ambiguous, this function's return value depends on 'ambiwidth'.
+                Returns zero on error.
+                Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
 submatch({nr} [, {list}])                                      *submatch()* *E935*
-		Only for an expression in a |:substitute| command or
-		substitute() function.
-		Returns the {nr}th submatch of the matched text.  When {nr}
-		is 0 the whole matched text is returned.
-		Note that a NL in the string can stand for a line break of a
-		multi-line match or a NUL character in the text.
-		Also see |sub-replace-expression|.
+                Only for an expression in a |:substitute| command or
+                substitute() function.
+                Returns the {nr}th submatch of the matched text.  When {nr}
+                is 0 the whole matched text is returned.
+                Note that a NL in the string can stand for a line break of a
+                multi-line match or a NUL character in the text.
+                Also see |sub-replace-expression|.
 
-		If {list} is present and non-zero then submatch() returns
-		a list of strings, similar to |getline()| with two arguments.
-		NL characters in the text represent NUL characters in the
-		text.
-		Only returns more than one item for |:substitute|, inside
-		|substitute()| this list will always contain one or zero
-		items, since there are no real line breaks.
+                If {list} is present and non-zero then submatch() returns
+                a list of strings, similar to |getline()| with two arguments.
+                NL characters in the text represent NUL characters in the
+                text.
+                Only returns more than one item for |:substitute|, inside
+                |substitute()| this list will always contain one or zero
+                items, since there are no real line breaks.
 
-		When substitute() is used recursively only the submatches in
-		the current (deepest) call can be obtained.
+                When substitute() is used recursively only the submatches in
+                the current (deepest) call can be obtained.
 
-		Returns an empty string or list on error.
+                Returns an empty string or list on error.
 
-		Examples: >vim
-			s/\d\+/\=submatch(0) + 1/
-			echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
-<		This finds the first number in the line and adds one to it.
-		A line break is included as a newline character.
+                Examples: >vim
+                        s/\d\+/\=submatch(0) + 1/
+                        echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
+<                This finds the first number in the line and adds one to it.
+                A line break is included as a newline character.
 
 substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
-		The result is a String, which is a copy of {string}, in which
-		the first match of {pat} is replaced with {sub}.
-		When {flags} is "g", all matches of {pat} in {string} are
-		replaced.  Otherwise {flags} should be "".
+                The result is a String, which is a copy of {string}, in which
+                the first match of {pat} is replaced with {sub}.
+                When {flags} is "g", all matches of {pat} in {string} are
+                replaced.  Otherwise {flags} should be "".
 
-		This works like the ":substitute" command (without any flags).
-		But the matching with {pat} is always done like the 'magic'
-		option is set and 'cpoptions' is empty (to make scripts
-		portable).  'ignorecase' is still relevant, use |/\c| or |/\C|
-		if you want to ignore or match case and ignore 'ignorecase'.
-		'smartcase' is not used.  See |string-match| for how {pat} is
-		used.
+                This works like the ":substitute" command (without any flags).
+                But the matching with {pat} is always done like the 'magic'
+                option is set and 'cpoptions' is empty (to make scripts
+                portable).  'ignorecase' is still relevant, use |/\c| or |/\C|
+                if you want to ignore or match case and ignore 'ignorecase'.
+                'smartcase' is not used.  See |string-match| for how {pat} is
+                used.
 
-		A "~" in {sub} is not replaced with the previous {sub}.
-		Note that some codes in {sub} have a special meaning
-		|sub-replace-special|.  For example, to replace something with
-		"\n" (two characters), use "\\\\n" or '\\n'.
+                A "~" in {sub} is not replaced with the previous {sub}.
+                Note that some codes in {sub} have a special meaning
+                |sub-replace-special|.  For example, to replace something with
+                "\n" (two characters), use "\\\\n" or '\\n'.
 
-		When {pat} does not match in {string}, {string} is returned
-		unmodified.
+                When {pat} does not match in {string}, {string} is returned
+                unmodified.
 
-		Example: >vim
-			let &path = substitute(&path, ",\\=[^,]*$", "", "")
-<		This removes the last component of the 'path' option. >vim
-			echo substitute("testing", ".*", "\\U\\0", "")
-<		results in "TESTING".
+                Example: >vim
+                        let &path = substitute(&path, ",\\=[^,]*$", "", "")
+<                This removes the last component of the 'path' option. >vim
+                        echo substitute("testing", ".*", "\\U\\0", "")
+<                results in "TESTING".
 
-		When {sub} starts with "\=", the remainder is interpreted as
-		an expression. See |sub-replace-expression|.  Example: >vim
-			echo substitute(s, '%\(\x\x\)',
-			   \ '\=nr2char("0x" .. submatch(1))', 'g')
+                When {sub} starts with "\=", the remainder is interpreted as
+                an expression. See |sub-replace-expression|.  Example: >vim
+                        echo substitute(s, '%\(\x\x\)',
+                           \ '\=nr2char("0x" .. submatch(1))', 'g')
 
-<		When {sub} is a Funcref that function is called, with one
-		optional argument.  Example: >vim
-		   echo substitute(s, '%\(\x\x\)', SubNr, 'g')
-<		The optional argument is a list which contains the whole
-		matched string and up to nine submatches, like what
-		|submatch()| returns.  Example: >vim
-		   echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
+<                When {sub} is a Funcref that function is called, with one
+                optional argument.  Example: >vim
+                   echo substitute(s, '%\(\x\x\)', SubNr, 'g')
+<                The optional argument is a list which contains the whole
+                matched string and up to nine submatches, like what
+                |submatch()| returns.  Example: >vim
+                   echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
 
-<		Returns an empty string on error.
+<                Returns an empty string on error.
 
 swapfilelist()                                                  *swapfilelist()*
-		Returns a list of swap file names, like what "vim -r" shows.
-		See the |-r| command argument.  The 'directory' option is used
-		for the directories to inspect.  If you only want to get a
-		list of swap files in the current directory then temporarily
-		set 'directory' to a dot: >vim
-			let save_dir = &directory
-			let &directory = '.'
-			let swapfiles = swapfilelist()
-			let &directory = save_dir
+                Returns a list of swap file names, like what "vim -r" shows.
+                See the |-r| command argument.  The 'directory' option is used
+                for the directories to inspect.  If you only want to get a
+                list of swap files in the current directory then temporarily
+                set 'directory' to a dot: >vim
+                        let save_dir = &directory
+                        let &directory = '.'
+                        let swapfiles = swapfilelist()
+                        let &directory = save_dir
 
 swapinfo({fname})                                                   *swapinfo()*
-		The result is a dictionary, which holds information about the
-		swapfile {fname}. The available fields are:
-			version Vim version
-			user	user name
-			host	host name
-			fname	original file name
-			pid	PID of the Nvim process that created the swap
-				file, or zero if not running.
-			mtime	last modification time in seconds
-			inode	Optional: INODE number of the file
-			dirty	1 if file was modified, 0 if not
-		In case of failure an "error" item is added with the reason:
-			Cannot open file: file not found or in accessible
-			Cannot read file: cannot read first block
-			Not a swap file: does not contain correct block ID
-			Magic number mismatch: Info in first block is invalid
+                The result is a dictionary, which holds information about the
+                swapfile {fname}. The available fields are:
+                        version Vim version
+                        user    user name
+                        host    host name
+                        fname   original file name
+                        pid     PID of the Nvim process that created the swap
+                                file, or zero if not running.
+                        mtime   last modification time in seconds
+                        inode   Optional: INODE number of the file
+                        dirty   1 if file was modified, 0 if not
+                In case of failure an "error" item is added with the reason:
+                        Cannot open file: file not found or in accessible
+                        Cannot read file: cannot read first block
+                        Not a swap file: does not contain correct block ID
+                        Magic number mismatch: Info in first block is invalid
 
 swapname({buf})                                                     *swapname()*
-		The result is the swap file path of the buffer {buf}.
-		For the use of {buf}, see |bufname()| above.
-		If buffer {buf} is the current buffer, the result is equal to
-		|:swapname| (unless there is no swap file).
-		If buffer {buf} has no swap file, returns an empty string.
+                The result is the swap file path of the buffer {buf}.
+                For the use of {buf}, see |bufname()| above.
+                If buffer {buf} is the current buffer, the result is equal to
+                |:swapname| (unless there is no swap file).
+                If buffer {buf} has no swap file, returns an empty string.
 
 synID({lnum}, {col}, {trans})                                          *synID()*
-		The result is a Number, which is the syntax ID at the position
-		{lnum} and {col} in the current window.
-		The syntax ID can be used with |synIDattr()| and
-		|synIDtrans()| to obtain syntax information about text.
+                The result is a Number, which is the syntax ID at the position
+                {lnum} and {col} in the current window.
+                The syntax ID can be used with |synIDattr()| and
+                |synIDtrans()| to obtain syntax information about text.
 
-		{col} is 1 for the leftmost column, {lnum} is 1 for the first
-		line.  'synmaxcol' applies, in a longer line zero is returned.
-		Note that when the position is after the last character,
-		that's where the cursor can be in Insert mode, synID() returns
-		zero.  {lnum} is used like with |getline()|.
+                {col} is 1 for the leftmost column, {lnum} is 1 for the first
+                line.  'synmaxcol' applies, in a longer line zero is returned.
+                Note that when the position is after the last character,
+                that's where the cursor can be in Insert mode, synID() returns
+                zero.  {lnum} is used like with |getline()|.
 
-		When {trans} is |TRUE|, transparent items are reduced to the
-		item that they reveal.  This is useful when wanting to know
-		the effective color.  When {trans} is |FALSE|, the transparent
-		item is returned.  This is useful when wanting to know which
-		syntax item is effective (e.g. inside parens).
-		Warning: This function can be very slow.  Best speed is
-		obtained by going through the file in forward direction.
+                When {trans} is |TRUE|, transparent items are reduced to the
+                item that they reveal.  This is useful when wanting to know
+                the effective color.  When {trans} is |FALSE|, the transparent
+                item is returned.  This is useful when wanting to know which
+                syntax item is effective (e.g. inside parens).
+                Warning: This function can be very slow.  Best speed is
+                obtained by going through the file in forward direction.
 
-		Returns zero on error.
+                Returns zero on error.
 
-		Example (echoes the name of the syntax item under the cursor): >vim
-			echo synIDattr(synID(line("."), col("."), 1), "name")
+                Example (echoes the name of the syntax item under the cursor): >vim
+                        echo synIDattr(synID(line("."), col("."), 1), "name")
 <
-
 synIDattr({synID}, {what} [, {mode}])                              *synIDattr()*
-		The result is a String, which is the {what} attribute of
-		syntax ID {synID}.  This can be used to obtain information
-		about a syntax item.
-		{mode} can be "gui" or "cterm", to get the attributes
-		for that mode.  When {mode} is omitted, or an invalid value is
-		used, the attributes for the currently active highlighting are
-		used (GUI or cterm).
-		Use synIDtrans() to follow linked highlight groups.
-		{what}		result
-		"name"		the name of the syntax item
-		"fg"		foreground color (GUI: color name used to set
-				the color, cterm: color number as a string,
-				term: empty string)
-		"bg"		background color (as with "fg")
-		"font"		font name (only available in the GUI)
-				|highlight-font|
-		"sp"		special color (as with "fg") |guisp|
-		"fg#"		like "fg", but for the GUI and the GUI is
-				running the name in "#RRGGBB" form
-		"bg#"		like "fg#" for "bg"
-		"sp#"		like "fg#" for "sp"
-		"bold"		"1" if bold
-		"italic"	"1" if italic
-		"reverse"	"1" if reverse
-		"inverse"	"1" if inverse (= reverse)
-		"standout"	"1" if standout
-		"underline"	"1" if underlined
-		"undercurl"	"1" if undercurled
-		"underdouble"	"1" if double underlined
-		"underdotted"	"1" if dotted underlined
-		"underdashed"	"1" if dashed underlined
-		"strikethrough"	"1" if struckthrough
-		"altfont"	"1" if alternative font
-		"nocombine"	"1" if nocombine
+                The result is a String, which is the {what} attribute of
+                syntax ID {synID}.  This can be used to obtain information
+                about a syntax item.
+                {mode} can be "gui" or "cterm", to get the attributes
+                for that mode.  When {mode} is omitted, or an invalid value is
+                used, the attributes for the currently active highlighting are
+                used (GUI or cterm).
+                Use synIDtrans() to follow linked highlight groups.
+                {what}          result
+                "name"          the name of the syntax item
+                "fg"            foreground color (GUI: color name used to set
+                                the color, cterm: color number as a string,
+                                term: empty string)
+                "bg"            background color (as with "fg")
+                "font"          font name (only available in the GUI)
+                                |highlight-font|
+                "sp"            special color (as with "fg") |guisp|
+                "fg#"           like "fg", but for the GUI and the GUI is
+                                running the name in "#RRGGBB" form
+                "bg#"           like "fg#" for "bg"
+                "sp#"           like "fg#" for "sp"
+                "bold"          "1" if bold
+                "italic"        "1" if italic
+                "reverse"       "1" if reverse
+                "inverse"       "1" if inverse (= reverse)
+                "standout"      "1" if standout
+                "underline"     "1" if underlined
+                "undercurl"     "1" if undercurled
+                "underdouble"   "1" if double underlined
+                "underdotted"   "1" if dotted underlined
+                "underdashed"   "1" if dashed underlined
+                "strikethrough" "1" if struckthrough
+                "altfont"       "1" if alternative font
+                "nocombine"     "1" if nocombine
 
-		Returns an empty string on error.
+                Returns an empty string on error.
 
-		Example (echoes the color of the syntax item under the
-		cursor): >vim
-			echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
+                Example (echoes the color of the syntax item under the
+                cursor): >vim
+                        echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
 <
-		Can also be used as a |method|: >vim
-			echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+                Can also be used as a |method|: >vim
+                        echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
 <
-
 synIDtrans({synID})                                               *synIDtrans()*
-		The result is a Number, which is the translated syntax ID of
-		{synID}.  This is the syntax group ID of what is being used to
-		highlight the character.  Highlight links given with
-		":highlight link" are followed.
+                The result is a Number, which is the translated syntax ID of
+                {synID}.  This is the syntax group ID of what is being used to
+                highlight the character.  Highlight links given with
+                ":highlight link" are followed.
 
-		Returns zero on error.
+                Returns zero on error.
 
 synconcealed({lnum}, {col})                                     *synconcealed()*
-		The result is a |List| with currently three items:
-		1. The first item in the list is 0 if the character at the
-		   position {lnum} and {col} is not part of a concealable
-		   region, 1 if it is.  {lnum} is used like with |getline()|.
-		2. The second item in the list is a string. If the first item
-		   is 1, the second item contains the text which will be
-		   displayed in place of the concealed text, depending on the
-		   current setting of 'conceallevel' and 'listchars'.
-		3. The third and final item in the list is a number
-		   representing the specific syntax region matched in the
-		   line. When the character is not concealed the value is
-		   zero. This allows detection of the beginning of a new
-		   concealable region if there are two consecutive regions
-		   with the same replacement character.  For an example, if
-		   the text is "123456" and both "23" and "45" are concealed
-		   and replaced by the character "X", then:
-			call			returns ~
-			synconcealed(lnum, 1)   [0, '', 0]
-			synconcealed(lnum, 2)   [1, 'X', 1]
-			synconcealed(lnum, 3)   [1, 'X', 1]
-			synconcealed(lnum, 4)   [1, 'X', 2]
-			synconcealed(lnum, 5)   [1, 'X', 2]
-			synconcealed(lnum, 6)   [0, '', 0]
+                The result is a |List| with currently three items:
+                1. The first item in the list is 0 if the character at the
+                   position {lnum} and {col} is not part of a concealable
+                   region, 1 if it is.  {lnum} is used like with |getline()|.
+                2. The second item in the list is a string. If the first item
+                   is 1, the second item contains the text which will be
+                   displayed in place of the concealed text, depending on the
+                   current setting of 'conceallevel' and 'listchars'.
+                3. The third and final item in the list is a number
+                   representing the specific syntax region matched in the
+                   line. When the character is not concealed the value is
+                   zero. This allows detection of the beginning of a new
+                   concealable region if there are two consecutive regions
+                   with the same replacement character.  For an example, if
+                   the text is "123456" and both "23" and "45" are concealed
+                   and replaced by the character "X", then:
+                        call                    returns ~
+                        synconcealed(lnum, 1)   [0, '', 0]
+                        synconcealed(lnum, 2)   [1, 'X', 1]
+                        synconcealed(lnum, 3)   [1, 'X', 1]
+                        synconcealed(lnum, 4)   [1, 'X', 2]
+                        synconcealed(lnum, 5)   [1, 'X', 2]
+                        synconcealed(lnum, 6)   [0, '', 0]
 
 synstack({lnum}, {col})                                             *synstack()*
-		Return a |List|, which is the stack of syntax items at the
-		position {lnum} and {col} in the current window.  {lnum} is
-		used like with |getline()|.  Each item in the List is an ID
-		like what |synID()| returns.
-		The first item in the List is the outer region, following are
-		items contained in that one.  The last one is what |synID()|
-		returns, unless not the whole item is highlighted or it is a
-		transparent item.
-		This function is useful for debugging a syntax file.
-		Example that shows the syntax stack under the cursor: >vim
-			for id in synstack(line("."), col("."))
-			   echo synIDattr(id, "name")
-			endfor
-<		When the position specified with {lnum} and {col} is invalid
-		an empty list is returned.  The position just after the last
-		character in a line and the first column in an empty line are
-		valid positions.
+                Return a |List|, which is the stack of syntax items at the
+                position {lnum} and {col} in the current window.  {lnum} is
+                used like with |getline()|.  Each item in the List is an ID
+                like what |synID()| returns.
+                The first item in the List is the outer region, following are
+                items contained in that one.  The last one is what |synID()|
+                returns, unless not the whole item is highlighted or it is a
+                transparent item.
+                This function is useful for debugging a syntax file.
+                Example that shows the syntax stack under the cursor: >vim
+                        for id in synstack(line("."), col("."))
+                           echo synIDattr(id, "name")
+                        endfor
+<                When the position specified with {lnum} and {col} is invalid
+                an empty list is returned.  The position just after the last
+                character in a line and the first column in an empty line are
+                valid positions.
 
 system({cmd} [, {input}])                                        *system()* *E677*
-		Note: Prefer |vim.system()| in Lua.
+                Note: Prefer |vim.system()| in Lua.
 
-		Gets the output of {cmd} as a |string| (|systemlist()| returns
-		a |List|) and sets |v:shell_error| to the error code.
-		{cmd} is treated as in |jobstart()|:
-		If {cmd} is a List it runs directly (no 'shell').
-		If {cmd} is a String it runs in the 'shell', like this: >vim
-		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
+                Gets the output of {cmd} as a |string| (|systemlist()| returns
+                a |List|) and sets |v:shell_error| to the error code.
+                {cmd} is treated as in |jobstart()|:
+                If {cmd} is a List it runs directly (no 'shell').
+                If {cmd} is a String it runs in the 'shell', like this: >vim
+                  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
 
-<		Not to be used for interactive commands.
+<                Not to be used for interactive commands.
 
-		Result is a String, filtered to avoid platform-specific quirks:
-		- <CR><NL> is replaced with <NL>
-		- NUL characters are replaced with SOH (0x01)
+                Result is a String, filtered to avoid platform-specific quirks:
+                - <CR><NL> is replaced with <NL>
+                - NUL characters are replaced with SOH (0x01)
 
-		Example: >vim
-		    echo system(['ls', expand('%:h')])
+                Example: >vim
+                    echo system(['ls', expand('%:h')])
 
-<		If {input} is a string it is written to a pipe and passed as
-		stdin to the command.  The string is written as-is, line
-		separators are not changed.
-		If {input} is a |List| it is written to the pipe as
-		|writefile()| does with {binary} set to "b" (i.e. with
-		a newline between each list item, and newlines inside list
-		items converted to NULs).
-		When {input} is given and is a valid buffer id, the content of
-		the buffer is written to the file line by line, each line
-		terminated by NL (and NUL where the text has NL).
-								*E5677*
-		Note: system() cannot write to or read from backgrounded ("&")
-		shell commands, e.g.: >vim
-		    echo system("cat - &", "foo")
-<		which is equivalent to: >
-		    $ echo foo | bash -c 'cat - &'
-<		The pipes are disconnected (unless overridden by shell
-		redirection syntax) before input can reach it. Use
-		|jobstart()| instead.
+<                If {input} is a string it is written to a pipe and passed as
+                stdin to the command.  The string is written as-is, line
+                separators are not changed.
+                If {input} is a |List| it is written to the pipe as
+                |writefile()| does with {binary} set to "b" (i.e. with
+                a newline between each list item, and newlines inside list
+                items converted to NULs).
+                When {input} is given and is a valid buffer id, the content of
+                the buffer is written to the file line by line, each line
+                terminated by NL (and NUL where the text has NL).
+                                                                *E5677*
+                Note: system() cannot write to or read from backgrounded ("&")
+                shell commands, e.g.: >vim
+                    echo system("cat - &", "foo")
+<                which is equivalent to: >
+                    $ echo foo | bash -c 'cat - &'
+<                The pipes are disconnected (unless overridden by shell
+                redirection syntax) before input can reach it. Use
+                |jobstart()| instead.
 
-		Note: Use |shellescape()| or |::S| with |expand()| or
-		|fnamemodify()| to escape special characters in a command
-		argument. 'shellquote' and 'shellxquote' must be properly
-		configured. Example: >vim
-		    echo system('ls '..shellescape(expand('%:h')))
-		    echo system('ls '..expand('%:h:S'))
+                Note: Use |shellescape()| or |::S| with |expand()| or
+                |fnamemodify()| to escape special characters in a command
+                argument. 'shellquote' and 'shellxquote' must be properly
+                configured. Example: >vim
+                    echo system('ls '..shellescape(expand('%:h')))
+                    echo system('ls '..expand('%:h:S'))
 
-<		Unlike ":!cmd" there is no automatic check for changed files.
-		Use |:checktime| to force a check.
+<                Unlike ":!cmd" there is no automatic check for changed files.
+                Use |:checktime| to force a check.
 
 systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
-		Same as |system()|, but returns a |List| with lines (parts of
-		output separated by NL) with NULs transformed into NLs. Output
-		is the same as |readfile()| will output with {binary} argument
-		set to "b", except that a final newline is not preserved,
-		unless {keepempty} is non-zero.
-		Note that on MS-Windows you may get trailing CR characters.
+                Same as |system()|, but returns a |List| with lines (parts of
+                output separated by NL) with NULs transformed into NLs. Output
+                is the same as |readfile()| will output with {binary} argument
+                set to "b", except that a final newline is not preserved,
+                unless {keepempty} is non-zero.
+                Note that on MS-Windows you may get trailing CR characters.
 
-		To see the difference between "echo hello" and "echo -n hello"
-		use |system()| and |split()|: >vim
-			echo split(system('echo hello'), '\n', 1)
+                To see the difference between "echo hello" and "echo -n hello"
+                use |system()| and |split()|: >vim
+                        echo split(system('echo hello'), '\n', 1)
 <
-		Returns an empty string on error.
+                Returns an empty string on error.
 
 tabpagebuflist([{arg}])                                       *tabpagebuflist()*
-		The result is a |List|, where each item is the number of the
-		buffer associated with each window in the current tab page.
-		{arg} specifies the number of the tab page to be used. When
-		omitted the current tab page is used.
-		When {arg} is invalid the number zero is returned.
-		To get a list of all buffers in all tabs use this: >vim
-			let buflist = []
-			for i in range(tabpagenr('$'))
-			   call extend(buflist, tabpagebuflist(i + 1))
-			endfor
-<		Note that a buffer may appear in more than one window.
+                The result is a |List|, where each item is the number of the
+                buffer associated with each window in the current tab page.
+                {arg} specifies the number of the tab page to be used. When
+                omitted the current tab page is used.
+                When {arg} is invalid the number zero is returned.
+                To get a list of all buffers in all tabs use this: >vim
+                        let buflist = []
+                        for i in range(tabpagenr('$'))
+                           call extend(buflist, tabpagebuflist(i + 1))
+                        endfor
+<                Note that a buffer may appear in more than one window.
 
 tabpagenr([{arg}])                                                 *tabpagenr()*
-		The result is a Number, which is the number of the current
-		tab page.  The first tab page has number 1.
+                The result is a Number, which is the number of the current
+                tab page.  The first tab page has number 1.
 
-		The optional argument {arg} supports the following values:
-			$	the number of the last tab page (the tab page
-				count).
-			#	the number of the last accessed tab page
-				(where |g<Tab>| goes to).  If there is no
-				previous tab page, 0 is returned.
-		The number can be used with the |:tab| command.
+                The optional argument {arg} supports the following values:
+                        $       the number of the last tab page (the tab page
+                                count).
+                        #       the number of the last accessed tab page
+                                (where |g<Tab>| goes to).  If there is no
+                                previous tab page, 0 is returned.
+                The number can be used with the |:tab| command.
 
-		Returns zero on error.
+                Returns zero on error.
 
 tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
-		Like |winnr()| but for tab page {tabarg}.
-		{tabarg} specifies the number of tab page to be used.
-		{arg} is used like with |winnr()|:
-		- When omitted the current window number is returned.  This is
-		  the window which will be used when going to this tab page.
-		- When "$" the number of windows is returned.
-		- When "#" the previous window nr is returned.
-		Useful examples: >vim
-		    tabpagewinnr(1)	    " current window of tab page 1
-		    tabpagewinnr(4, '$')    " number of windows in tab page 4
-<		When {tabarg} is invalid zero is returned.
+                Like |winnr()| but for tab page {tabarg}.
+                {tabarg} specifies the number of tab page to be used.
+                {arg} is used like with |winnr()|:
+                - When omitted the current window number is returned.  This is
+                  the window which will be used when going to this tab page.
+                - When "$" the number of windows is returned.
+                - When "#" the previous window nr is returned.
+                Useful examples: >vim
+                    tabpagewinnr(1)         " current window of tab page 1
+                    tabpagewinnr(4, '$')    " number of windows in tab page 4
+<                When {tabarg} is invalid zero is returned.
 
 tagfiles()                                                          *tagfiles()*
-		Returns a |List| with the file names used to search for tags
-		for the current buffer.  This is the 'tags' option expanded.
+                Returns a |List| with the file names used to search for tags
+                for the current buffer.  This is the 'tags' option expanded.
 
 taglist({expr} [, {filename}])                                       *taglist()*
-		Returns a |List| of tags matching the regular expression {expr}.
+                Returns a |List| of tags matching the regular expression {expr}.
 
-		If {filename} is passed it is used to prioritize the results
-		in the same way that |:tselect| does. See |tag-priority|.
-		{filename} should be the full path of the file.
+                If {filename} is passed it is used to prioritize the results
+                in the same way that |:tselect| does. See |tag-priority|.
+                {filename} should be the full path of the file.
 
-		Each list item is a dictionary with at least the following
-		entries:
-			name		Name of the tag.
-			filename	Name of the file where the tag is
-					defined.  It is either relative to the
-					current directory or a full path.
-			cmd		Ex command used to locate the tag in
-					the file.
-			kind		Type of the tag.  The value for this
-					entry depends on the language specific
-					kind values.  Only available when
-					using a tags file generated by
-					Universal/Exuberant ctags or hdrtag.
-			static		A file specific tag.  Refer to
-					|static-tag| for more information.
-		More entries may be present, depending on the content of the
-		tags file: access, implementation, inherits and signature.
-		Refer to the ctags documentation for information about these
-		fields.  For C code the fields "struct", "class" and "enum"
-		may appear, they give the name of the entity the tag is
-		contained in.
+                Each list item is a dictionary with at least the following
+                entries:
+                        name            Name of the tag.
+                        filename        Name of the file where the tag is
+                                        defined.  It is either relative to the
+                                        current directory or a full path.
+                        cmd             Ex command used to locate the tag in
+                                        the file.
+                        kind            Type of the tag.  The value for this
+                                        entry depends on the language specific
+                                        kind values.  Only available when
+                                        using a tags file generated by
+                                        Universal/Exuberant ctags or hdrtag.
+                        static          A file specific tag.  Refer to
+                                        |static-tag| for more information.
+                More entries may be present, depending on the content of the
+                tags file: access, implementation, inherits and signature.
+                Refer to the ctags documentation for information about these
+                fields.  For C code the fields "struct", "class" and "enum"
+                may appear, they give the name of the entity the tag is
+                contained in.
 
-		The ex-command "cmd" can be either an ex search pattern, a
-		line number or a line number followed by a byte number.
+                The ex-command "cmd" can be either an ex search pattern, a
+                line number or a line number followed by a byte number.
 
-		If there are no matching tags, then an empty list is returned.
+                If there are no matching tags, then an empty list is returned.
 
-		To get an exact tag match, the anchors '^' and '$' should be
-		used in {expr}.  This also make the function work faster.
-		Refer to |tag-regexp| for more information about the tag
-		search regular expression pattern.
+                To get an exact tag match, the anchors '^' and '$' should be
+                used in {expr}.  This also make the function work faster.
+                Refer to |tag-regexp| for more information about the tag
+                search regular expression pattern.
 
-		Refer to |'tags'| for information about how the tags file is
-		located by Vim. Refer to |tags-file-format| for the format of
-		the tags file generated by the different ctags tools.
+                Refer to |'tags'| for information about how the tags file is
+                located by Vim. Refer to |tags-file-format| for the format of
+                the tags file generated by the different ctags tools.
 
 tan({expr})                                                              *tan()*
-		Return the tangent of {expr}, measured in radians, as a |Float|
-		in the range [-inf, inf].
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo tan(10)
-<			0.648361 >vim
-			echo tan(-4.01)
-<			-1.181502
+                Return the tangent of {expr}, measured in radians, as a |Float|
+                in the range [-inf, inf].
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo tan(10)
+<                        0.648361 >vim
+                        echo tan(-4.01)
+<                        -1.181502
 
 tanh({expr})                                                            *tanh()*
-		Return the hyperbolic tangent of {expr} as a |Float| in the
-		range [-1, 1].
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo tanh(0.5)
-<			0.462117 >vim
-			echo tanh(-1)
-<			-0.761594
+                Return the hyperbolic tangent of {expr} as a |Float| in the
+                range [-1, 1].
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo tanh(0.5)
+<                        0.462117 >vim
+                        echo tanh(-1)
+<                        -0.761594
 
 tempname()                                                          *tempname()*
-		Generates a (non-existent) filename located in the Nvim root
-		|tempdir|. Scripts can use the filename as a temporary file.
-		Example: >vim
-			let tmpfile = tempname()
-			exe "redir > " .. tmpfile
+                Generates a (non-existent) filename located in the Nvim root
+                |tempdir|. Scripts can use the filename as a temporary file.
+                Example: >vim
+                        let tmpfile = tempname()
+                        exe "redir > " .. tmpfile
 <
-
 termopen({cmd} [, {opts}])                                          *termopen()*
-		Spawns {cmd} in a new pseudo-terminal session connected
-		to the current (unmodified) buffer. Parameters and behavior
-		are the same as |jobstart()| except "pty", "width", "height",
-		and "TERM" are ignored: "height" and "width" are taken from
-		the current window. Note that termopen() implies a "pty" arg
-		to jobstart(), and thus has the implications documented at
-		|jobstart()|.
+                Spawns {cmd} in a new pseudo-terminal session connected
+                to the current (unmodified) buffer. Parameters and behavior
+                are the same as |jobstart()| except "pty", "width", "height",
+                and "TERM" are ignored: "height" and "width" are taken from
+                the current window. Note that termopen() implies a "pty" arg
+                to jobstart(), and thus has the implications documented at
+                |jobstart()|.
 
-		Returns the same values as jobstart().
+                Returns the same values as jobstart().
 
-		Terminal environment is initialized as in |jobstart-env|,
-		except $TERM is set to "xterm-256color". Full behavior is
-		described in |terminal|.
+                Terminal environment is initialized as in |jobstart-env|,
+                except $TERM is set to "xterm-256color". Full behavior is
+                described in |terminal|.
 
 test_garbagecollect_now()                            *test_garbagecollect_now()*
-		Like |garbagecollect()|, but executed right away.  This must
-		only be called directly to avoid any structure to exist
-		internally, and |v:testing| must have been set before calling
-		any function.
+                Like |garbagecollect()|, but executed right away.  This must
+                only be called directly to avoid any structure to exist
+                internally, and |v:testing| must have been set before calling
+                any function.
 
 
 timer_info([{id}])                                                *timer_info()*
-		Return a list with information about timers.
-		When {id} is given only information about this timer is
-		returned.  When timer {id} does not exist an empty list is
-		returned.
-		When {id} is omitted information about all timers is returned.
+                Return a list with information about timers.
+                When {id} is given only information about this timer is
+                returned.  When timer {id} does not exist an empty list is
+                returned.
+                When {id} is omitted information about all timers is returned.
 
-		For each timer the information is stored in a |Dictionary| with
-		these items:
-		    "id"	    the timer ID
-		    "time"	    time the timer was started with
-		    "repeat"	    number of times the timer will still fire;
-				    -1 means forever
-		    "callback"	    the callback
+                For each timer the information is stored in a |Dictionary| with
+                these items:
+                    "id"            the timer ID
+                    "time"          time the timer was started with
+                    "repeat"        number of times the timer will still fire;
+                                    -1 means forever
+                    "callback"      the callback
 
 timer_pause({timer}, {paused})                                   *timer_pause()*
-		Pause or unpause a timer.  A paused timer does not invoke its
-		callback when its time expires.  Unpausing a timer may cause
-		the callback to be invoked almost immediately if enough time
-		has passed.
+                Pause or unpause a timer.  A paused timer does not invoke its
+                callback when its time expires.  Unpausing a timer may cause
+                the callback to be invoked almost immediately if enough time
+                has passed.
 
-		Pausing a timer is useful to avoid the callback to be called
-		for a short time.
+                Pausing a timer is useful to avoid the callback to be called
+                for a short time.
 
-		If {paused} evaluates to a non-zero Number or a non-empty
-		String, then the timer is paused, otherwise it is unpaused.
-		See |non-zero-arg|.
+                If {paused} evaluates to a non-zero Number or a non-empty
+                String, then the timer is paused, otherwise it is unpaused.
+                See |non-zero-arg|.
 
 timer_start({time}, {callback} [, {options}])              *timer_start()* *timer*
-		Create a timer and return the timer ID.
+                Create a timer and return the timer ID.
 
-		{time} is the waiting time in milliseconds. This is the
-		minimum time before invoking the callback.  When the system is
-		busy or Vim is not waiting for input the time will be longer.
-		Zero can be used to execute the callback when Vim is back in
-		the main loop.
+                {time} is the waiting time in milliseconds. This is the
+                minimum time before invoking the callback.  When the system is
+                busy or Vim is not waiting for input the time will be longer.
+                Zero can be used to execute the callback when Vim is back in
+                the main loop.
 
-		{callback} is the function to call.  It can be the name of a
-		function or a |Funcref|.  It is called with one argument, which
-		is the timer ID.  The callback is only invoked when Vim is
-		waiting for input.
+                {callback} is the function to call.  It can be the name of a
+                function or a |Funcref|.  It is called with one argument, which
+                is the timer ID.  The callback is only invoked when Vim is
+                waiting for input.
 
-		{options} is a dictionary.  Supported entries:
-		   "repeat"	Number of times to repeat the callback.
-				-1 means forever.  Default is 1.
-				If the timer causes an error three times in a
-				row the repeat is cancelled.
+                {options} is a dictionary.  Supported entries:
+                   "repeat"     Number of times to repeat the callback.
+                                -1 means forever.  Default is 1.
+                                If the timer causes an error three times in a
+                                row the repeat is cancelled.
 
-		Returns -1 on error.
+                Returns -1 on error.
 
-		Example: >vim
-			func MyHandler(timer)
-			  echo 'Handler called'
-			endfunc
-			let timer = timer_start(500, 'MyHandler',
-				\ {'repeat': 3})
-<		This invokes MyHandler() three times at 500 msec intervals.
+                Example: >vim
+                        func MyHandler(timer)
+                          echo 'Handler called'
+                        endfunc
+                        let timer = timer_start(500, 'MyHandler',
+                                \ {'repeat': 3})
+<                This invokes MyHandler() three times at 500 msec intervals.
 
 timer_stop({timer})                                               *timer_stop()*
-		Stop a timer.  The timer callback will no longer be invoked.
-		{timer} is an ID returned by timer_start(), thus it must be a
-		Number.  If {timer} does not exist there is no error.
+                Stop a timer.  The timer callback will no longer be invoked.
+                {timer} is an ID returned by timer_start(), thus it must be a
+                Number.  If {timer} does not exist there is no error.
 
 timer_stopall()                                                *timer_stopall()*
-		Stop all timers.  The timer callbacks will no longer be
-		invoked.  Useful if some timers is misbehaving.  If there are
-		no timers there is no error.
+                Stop all timers.  The timer callbacks will no longer be
+                invoked.  Useful if some timers is misbehaving.  If there are
+                no timers there is no error.
 
 tolower({expr})                                                      *tolower()*
-		The result is a copy of the String given, with all uppercase
-		characters turned into lowercase (just like applying |gu| to
-		the string).  Returns an empty string on error.
+                The result is a copy of the String given, with all uppercase
+                characters turned into lowercase (just like applying |gu| to
+                the string).  Returns an empty string on error.
 
 toupper({expr})                                                      *toupper()*
-		The result is a copy of the String given, with all lowercase
-		characters turned into uppercase (just like applying |gU| to
-		the string).  Returns an empty string on error.
+                The result is a copy of the String given, with all lowercase
+                characters turned into uppercase (just like applying |gU| to
+                the string).  Returns an empty string on error.
 
 tr({src}, {fromstr}, {tostr})                                             *tr()*
-		The result is a copy of the {src} string with all characters
-		which appear in {fromstr} replaced by the character in that
-		position in the {tostr} string.  Thus the first character in
-		{fromstr} is translated into the first character in {tostr}
-		and so on.  Exactly like the unix "tr" command.
-		This code also deals with multibyte characters properly.
+                The result is a copy of the {src} string with all characters
+                which appear in {fromstr} replaced by the character in that
+                position in the {tostr} string.  Thus the first character in
+                {fromstr} is translated into the first character in {tostr}
+                and so on.  Exactly like the unix "tr" command.
+                This code also deals with multibyte characters properly.
 
-		Returns an empty string on error.
+                Returns an empty string on error.
 
-		Examples: >vim
-			echo tr("hello there", "ht", "HT")
-<		returns "Hello THere" >vim
-			echo tr("<blob>", "<>", "{}")
-<		returns "{blob}"
+                Examples: >vim
+                        echo tr("hello there", "ht", "HT")
+<                returns "Hello THere" >vim
+                        echo tr("<blob>", "<>", "{}")
+<                returns "{blob}"
 
 trim({text} [, {mask} [, {dir}]])                                       *trim()*
-		Return {text} as a String where any character in {mask} is
-		removed from the beginning and/or end of {text}.
+                Return {text} as a String where any character in {mask} is
+                removed from the beginning and/or end of {text}.
 
-		If {mask} is not given, or is an empty string, {mask} is all
-		characters up to 0x20, which includes Tab, space, NL and CR,
-		plus the non-breaking space character 0xa0.
+                If {mask} is not given, or is an empty string, {mask} is all
+                characters up to 0x20, which includes Tab, space, NL and CR,
+                plus the non-breaking space character 0xa0.
 
-		The optional {dir} argument specifies where to remove the
-		characters:
-			0	remove from the beginning and end of {text}
-			1	remove only at the beginning of {text}
-			2	remove only at the end of {text}
-		When omitted both ends are trimmed.
+                The optional {dir} argument specifies where to remove the
+                characters:
+                        0       remove from the beginning and end of {text}
+                        1       remove only at the beginning of {text}
+                        2       remove only at the end of {text}
+                When omitted both ends are trimmed.
 
-		This function deals with multibyte characters properly.
-		Returns an empty string on error.
+                This function deals with multibyte characters properly.
+                Returns an empty string on error.
 
-		Examples: >vim
-			echo trim("   some text ")
-<		returns "some text" >vim
-			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
-<		returns "RESERVE_TAIL" >vim
-			echo trim("rm<Xrm<>X>rrm", "rm<>")
-<		returns "Xrm<>X" (characters in the middle are not removed) >vim
-			echo trim("  vim  ", " ", 2)
-<		returns "  vim"
+                Examples: >vim
+                        echo trim("   some text ")
+<                returns "some text" >vim
+                        echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
+<                returns "RESERVE_TAIL" >vim
+                        echo trim("rm<Xrm<>X>rrm", "rm<>")
+<                returns "Xrm<>X" (characters in the middle are not removed) >vim
+                        echo trim("  vim  ", " ", 2)
+<                returns "  vim"
 
 trunc({expr})                                                          *trunc()*
-		Return the largest integral value with magnitude less than or
-		equal to {expr} as a |Float| (truncate towards zero).
-		{expr} must evaluate to a |Float| or a |Number|.
-		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-		Examples: >vim
-			echo trunc(1.456)
-<			1.0  >vim
-			echo trunc(-5.456)
-<			-5.0  >vim
-			echo trunc(4.0)
-<			4.0
+                Return the largest integral value with magnitude less than or
+                equal to {expr} as a |Float| (truncate towards zero).
+                {expr} must evaluate to a |Float| or a |Number|.
+                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+                Examples: >vim
+                        echo trunc(1.456)
+<                        1.0  >vim
+                        echo trunc(-5.456)
+<                        -5.0  >vim
+                        echo trunc(4.0)
+<                        4.0
 
 type({expr})                                                            *type()*
-		The result is a Number representing the type of {expr}.
-		Instead of using the number directly, it is better to use the
-		v:t_ variable that has the value:
-			Number:	    0  |v:t_number|
-			String:	    1  |v:t_string|
-			Funcref:    2  |v:t_func|
-			List:	    3  |v:t_list|
-			Dictionary: 4  |v:t_dict|
-			Float:	    5  |v:t_float|
-			Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
-			Null:	    7  (|v:null|)
-			Blob:	   10  |v:t_blob|
-		For backward compatibility, this method can be used: >vim
-			if type(myvar) == type(0) | endif
-			if type(myvar) == type("") | endif
-			if type(myvar) == type(function("tr")) | endif
-			if type(myvar) == type([]) | endif
-			if type(myvar) == type({}) | endif
-			if type(myvar) == type(0.0) | endif
-			if type(myvar) == type(v:true) | endif
-<		In place of checking for |v:null| type it is better to check
-		for |v:null| directly as it is the only value of this type: >vim
-			if myvar is v:null | endif
-<		To check if the v:t_ variables exist use this: >vim
-			if exists('v:t_number') | endif
+                The result is a Number representing the type of {expr}.
+                Instead of using the number directly, it is better to use the
+                v:t_ variable that has the value:
+                        Number:     0  |v:t_number|
+                        String:     1  |v:t_string|
+                        Funcref:    2  |v:t_func|
+                        List:       3  |v:t_list|
+                        Dictionary: 4  |v:t_dict|
+                        Float:      5  |v:t_float|
+                        Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
+                        Null:       7  (|v:null|)
+                        Blob:      10  |v:t_blob|
+                For backward compatibility, this method can be used: >vim
+                        if type(myvar) == type(0) | endif
+                        if type(myvar) == type("") | endif
+                        if type(myvar) == type(function("tr")) | endif
+                        if type(myvar) == type([]) | endif
+                        if type(myvar) == type({}) | endif
+                        if type(myvar) == type(0.0) | endif
+                        if type(myvar) == type(v:true) | endif
+<                In place of checking for |v:null| type it is better to check
+                for |v:null| directly as it is the only value of this type: >vim
+                        if myvar is v:null | endif
+<                To check if the v:t_ variables exist use this: >vim
+                        if exists('v:t_number') | endif
 
 undofile({name})                                                    *undofile()*
-		Return the name of the undo file that would be used for a file
-		with name {name} when writing.  This uses the 'undodir'
-		option, finding directories that exist.  It does not check if
-		the undo file exists.
-		{name} is always expanded to the full path, since that is what
-		is used internally.
-		If {name} is empty undofile() returns an empty string, since a
-		buffer without a file name will not write an undo file.
-		Useful in combination with |:wundo| and |:rundo|.
+                Return the name of the undo file that would be used for a file
+                with name {name} when writing.  This uses the 'undodir'
+                option, finding directories that exist.  It does not check if
+                the undo file exists.
+                {name} is always expanded to the full path, since that is what
+                is used internally.
+                If {name} is empty undofile() returns an empty string, since a
+                buffer without a file name will not write an undo file.
+                Useful in combination with |:wundo| and |:rundo|.
 
 undotree([{buf}])                                                   *undotree()*
-		Return the current state of the undo tree for the current
-		buffer, or for a specific buffer if {buf} is given.  The
-		result is a dictionary with the following items:
-		  "seq_last"	The highest undo sequence number used.
-		  "seq_cur"	The sequence number of the current position in
-				the undo tree.  This differs from "seq_last"
-				when some changes were undone.
-		  "time_cur"	Time last used for |:earlier| and related
-				commands.  Use |strftime()| to convert to
-				something readable.
-		  "save_last"	Number of the last file write.  Zero when no
-				write yet.
-		  "save_cur"	Number of the current position in the undo
-				tree.
-		  "synced"	Non-zero when the last undo block was synced.
-				This happens when waiting from input from the
-				user.  See |undo-blocks|.
-		  "entries"	A list of dictionaries with information about
-				undo blocks.
+                Return the current state of the undo tree for the current
+                buffer, or for a specific buffer if {buf} is given.  The
+                result is a dictionary with the following items:
+                  "seq_last"    The highest undo sequence number used.
+                  "seq_cur"     The sequence number of the current position in
+                                the undo tree.  This differs from "seq_last"
+                                when some changes were undone.
+                  "time_cur"    Time last used for |:earlier| and related
+                                commands.  Use |strftime()| to convert to
+                                something readable.
+                  "save_last"   Number of the last file write.  Zero when no
+                                write yet.
+                  "save_cur"    Number of the current position in the undo
+                                tree.
+                  "synced"      Non-zero when the last undo block was synced.
+                                This happens when waiting from input from the
+                                user.  See |undo-blocks|.
+                  "entries"     A list of dictionaries with information about
+                                undo blocks.
 
-		The first item in the "entries" list is the oldest undo item.
-		Each List item is a |Dictionary| with these items:
-		  "seq"		Undo sequence number.  Same as what appears in
-				|:undolist|.
-		  "time"	Timestamp when the change happened.  Use
-				|strftime()| to convert to something readable.
-		  "newhead"	Only appears in the item that is the last one
-				that was added.  This marks the last change
-				and where further changes will be added.
-		  "curhead"	Only appears in the item that is the last one
-				that was undone.  This marks the current
-				position in the undo tree, the block that will
-				be used by a redo command.  When nothing was
-				undone after the last change this item will
-				not appear anywhere.
-		  "save"	Only appears on the last block before a file
-				write.  The number is the write count.  The
-				first write has number 1, the last one the
-				"save_last" mentioned above.
-		  "alt"		Alternate entry.  This is again a List of undo
-				blocks.  Each item may again have an "alt"
-				item.
+                The first item in the "entries" list is the oldest undo item.
+                Each List item is a |Dictionary| with these items:
+                  "seq"         Undo sequence number.  Same as what appears in
+                                |:undolist|.
+                  "time"        Timestamp when the change happened.  Use
+                                |strftime()| to convert to something readable.
+                  "newhead"     Only appears in the item that is the last one
+                                that was added.  This marks the last change
+                                and where further changes will be added.
+                  "curhead"     Only appears in the item that is the last one
+                                that was undone.  This marks the current
+                                position in the undo tree, the block that will
+                                be used by a redo command.  When nothing was
+                                undone after the last change this item will
+                                not appear anywhere.
+                  "save"        Only appears on the last block before a file
+                                write.  The number is the write count.  The
+                                first write has number 1, the last one the
+                                "save_last" mentioned above.
+                  "alt"         Alternate entry.  This is again a List of undo
+                                blocks.  Each item may again have an "alt"
+                                item.
 
 uniq({list} [, {func} [, {dict}]])                                 *uniq()* *E882*
-		Remove second and succeeding copies of repeated adjacent
-		{list} items in-place.  Returns {list}.  If you want a list
-		to remain unmodified make a copy first: >vim
-			let newlist = uniq(copy(mylist))
-<		The default compare function uses the string representation of
-		each item.  For the use of {func} and {dict} see |sort()|.
+                Remove second and succeeding copies of repeated adjacent
+                {list} items in-place.  Returns {list}.  If you want a list
+                to remain unmodified make a copy first: >vim
+                        let newlist = uniq(copy(mylist))
+<                The default compare function uses the string representation of
+                each item.  For the use of {func} and {dict} see |sort()|.
 
-		Returns zero if {list} is not a |List|.
+                Returns zero if {list} is not a |List|.
 
 utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
-		Same as |charidx()| but returns the UTF-16 code unit index of
-		the byte at {idx} in {string} (after converting it to UTF-16).
+                Same as |charidx()| but returns the UTF-16 code unit index of
+                the byte at {idx} in {string} (after converting it to UTF-16).
 
-		When {charidx} is present and TRUE, {idx} is used as the
-		character index in the String {string} instead of as the byte
-		index.
-		An {idx} in the middle of a UTF-8 sequence is rounded
-		downwards to the beginning of that sequence.
+                When {charidx} is present and TRUE, {idx} is used as the
+                character index in the String {string} instead of as the byte
+                index.
+                An {idx} in the middle of a UTF-8 sequence is rounded
+                downwards to the beginning of that sequence.
 
-		Returns -1 if the arguments are invalid or if there are less
-		than {idx} bytes in {string}. If there are exactly {idx} bytes
-		the length of the string in UTF-16 code units is returned.
+                Returns -1 if the arguments are invalid or if there are less
+                than {idx} bytes in {string}. If there are exactly {idx} bytes
+                the length of the string in UTF-16 code units is returned.
 
-		See |byteidx()| and |byteidxcomp()| for getting the byte index
-		from the UTF-16 index and |charidx()| for getting the
-		character index from the UTF-16 index.
-		Refer to |string-offset-encoding| for more information.
-		Examples: >vim
-			echo utf16idx('a😊😊', 3)	" returns 2
-			echo utf16idx('a😊😊', 7)	" returns 4
-			echo utf16idx('a😊😊', 1, 0, 1)	" returns 2
-			echo utf16idx('a😊😊', 2, 0, 1)	" returns 4
-			echo utf16idx('aą́c', 6)		" returns 2
-			echo utf16idx('aą́c', 6, 1)	" returns 4
-			echo utf16idx('a😊😊', 9)	" returns -1
+                See |byteidx()| and |byteidxcomp()| for getting the byte index
+                from the UTF-16 index and |charidx()| for getting the
+                character index from the UTF-16 index.
+                Refer to |string-offset-encoding| for more information.
+                Examples: >vim
+                        echo utf16idx('a😊😊', 3)       " returns 2
+                        echo utf16idx('a😊😊', 7)       " returns 4
+                        echo utf16idx('a😊😊', 1, 0, 1) " returns 2
+                        echo utf16idx('a😊😊', 2, 0, 1) " returns 4
+                        echo utf16idx('aą́c', 6)         " returns 2
+                        echo utf16idx('aą́c', 6, 1)      " returns 4
+                        echo utf16idx('a😊😊', 9)       " returns -1
 <
-
 values({dict})                                                        *values()*
-		Return a |List| with all the values of {dict}.  The |List| is
-		in arbitrary order.  Also see |items()| and |keys()|.
-		Returns zero if {dict} is not a |Dict|.
+                Return a |List| with all the values of {dict}.  The |List| is
+                in arbitrary order.  Also see |items()| and |keys()|.
+                Returns zero if {dict} is not a |Dict|.
 
 virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
-		The result is a Number, which is the screen column of the file
-		position given with {expr}.  That is, the last screen position
-		occupied by the character at that position, when the screen
-		would be of unlimited width.  When there is a <Tab> at the
-		position, the returned Number will be the column at the end of
-		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
-		set to 8, it returns 8. |conceal| is ignored.
-		For the byte position use |col()|.
+                The result is a Number, which is the screen column of the file
+                position given with {expr}.  That is, the last screen position
+                occupied by the character at that position, when the screen
+                would be of unlimited width.  When there is a <Tab> at the
+                position, the returned Number will be the column at the end of
+                the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
+                set to 8, it returns 8. |conceal| is ignored.
+                For the byte position use |col()|.
 
-		For the use of {expr} see |col()|.
+                For the use of {expr} see |col()|.
 
-		When 'virtualedit' is used {expr} can be [lnum, col, off],
-		where "off" is the offset in screen columns from the start of
-		the character.  E.g., a position within a <Tab> or after the
-		last character.  When "off" is omitted zero is used.  When
-		Virtual editing is active in the current mode, a position
-		beyond the end of the line can be returned.  Also see
-		|'virtualedit'|
+                When 'virtualedit' is used {expr} can be [lnum, col, off],
+                where "off" is the offset in screen columns from the start of
+                the character.  E.g., a position within a <Tab> or after the
+                last character.  When "off" is omitted zero is used.  When
+                Virtual editing is active in the current mode, a position
+                beyond the end of the line can be returned.  Also see
+                |'virtualedit'|
 
-		The accepted positions are:
-		    .	    the cursor position
-		    $	    the end of the cursor line (the result is the
-			    number of displayed characters in the cursor line
-			    plus one)
-		    'x	    position of mark x (if the mark is not set, 0 is
-			    returned)
-		    v       In Visual mode: the start of the Visual area (the
-			    cursor is the end).  When not in Visual mode
-			    returns the cursor position.  Differs from |'<| in
-			    that it's updated right away.
+                The accepted positions are:
+                    .       the cursor position
+                    $       the end of the cursor line (the result is the
+                            number of displayed characters in the cursor line
+                            plus one)
+                    'x      position of mark x (if the mark is not set, 0 is
+                            returned)
+                    v       In Visual mode: the start of the Visual area (the
+                            cursor is the end).  When not in Visual mode
+                            returns the cursor position.  Differs from |'<| in
+                            that it's updated right away.
 
-		If {list} is present and non-zero then virtcol() returns a
-		List with the first and last screen position occupied by the
-		character.
+                If {list} is present and non-zero then virtcol() returns a
+                List with the first and last screen position occupied by the
+                character.
 
-		With the optional {winid} argument the values are obtained for
-		that window instead of the current window.
+                With the optional {winid} argument the values are obtained for
+                that window instead of the current window.
 
-		Note that only marks in the current file can be used.
-		Examples: >vim
-			" With text "foo^Lbar" and cursor on the "^L":
+                Note that only marks in the current file can be used.
+                Examples: >vim
+                        " With text "foo^Lbar" and cursor on the "^L":
 
-			echo virtcol(".")	" returns 5
-			echo virtcol(".", 1)	" returns [4, 5]
-			echo virtcol("$")	" returns 9
+                        echo virtcol(".")       " returns 5
+                        echo virtcol(".", 1)    " returns [4, 5]
+                        echo virtcol("$")       " returns 9
 
-			" With text "	  there", with 't at 'h':
+                        " With text "     there", with 't at 'h':
 
-			echo virtcol("'t")	" returns 6
-<		The first column is 1.  0 or [0, 0] is returned for an error.
-		A more advanced example that echoes the maximum length of
-		all lines: >vim
-		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+                        echo virtcol("'t")      " returns 6
+<                The first column is 1.  0 or [0, 0] is returned for an error.
+                A more advanced example that echoes the maximum length of
+                all lines: >vim
+                    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 
 virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
-		The result is a Number, which is the byte index of the
-		character in window {winid} at buffer line {lnum} and virtual
-		column {col}.
+                The result is a Number, which is the byte index of the
+                character in window {winid} at buffer line {lnum} and virtual
+                column {col}.
 
-		If buffer line {lnum} is an empty line, 0 is returned.
+                If buffer line {lnum} is an empty line, 0 is returned.
 
-		If {col} is greater than the last virtual column in line
-		{lnum}, then the byte index of the character at the last
-		virtual column is returned.
+                If {col} is greater than the last virtual column in line
+                {lnum}, then the byte index of the character at the last
+                virtual column is returned.
 
-		For a multi-byte character, the column number of the first
-		byte in the character is returned.
+                For a multi-byte character, the column number of the first
+                byte in the character is returned.
 
-		The {winid} argument can be the window number or the
-		|window-ID|. If this is zero, then the current window is used.
+                The {winid} argument can be the window number or the
+                |window-ID|. If this is zero, then the current window is used.
 
-		Returns -1 if the window {winid} doesn't exist or the buffer
-		line {lnum} or virtual column {col} is invalid.
+                Returns -1 if the window {winid} doesn't exist or the buffer
+                line {lnum} or virtual column {col} is invalid.
 
-		See also |screenpos()|, |virtcol()| and |col()|.
+                See also |screenpos()|, |virtcol()| and |col()|.
 
 visualmode([{expr}])                                              *visualmode()*
-		The result is a String, which describes the last Visual mode
-		used in the current buffer.  Initially it returns an empty
-		string, but once Visual mode has been used, it returns "v",
-		"V", or "<CTRL-V>" (a single CTRL-V character) for
-		character-wise, line-wise, or block-wise Visual mode
-		respectively.
-		Example: >vim
-			exe "normal " .. visualmode()
-<		This enters the same Visual mode as before.  It is also useful
-		in scripts if you wish to act differently depending on the
-		Visual mode that was used.
-		If Visual mode is active, use |mode()| to get the Visual mode
-		(e.g., in a |:vmap|).
-		If {expr} is supplied and it evaluates to a non-zero Number or
-		a non-empty String, then the Visual mode will be cleared and
-		the old value is returned.  See |non-zero-arg|.
+                The result is a String, which describes the last Visual mode
+                used in the current buffer.  Initially it returns an empty
+                string, but once Visual mode has been used, it returns "v",
+                "V", or "<CTRL-V>" (a single CTRL-V character) for
+                character-wise, line-wise, or block-wise Visual mode
+                respectively.
+                Example: >vim
+                        exe "normal " .. visualmode()
+<                This enters the same Visual mode as before.  It is also useful
+                in scripts if you wish to act differently depending on the
+                Visual mode that was used.
+                If Visual mode is active, use |mode()| to get the Visual mode
+                (e.g., in a |:vmap|).
+                If {expr} is supplied and it evaluates to a non-zero Number or
+                a non-empty String, then the Visual mode will be cleared and
+                the old value is returned.  See |non-zero-arg|.
 
 wait({timeout}, {condition} [, {interval}])                             *wait()*
-		Waits until {condition} evaluates to |TRUE|, where {condition}
-		is a |Funcref| or |string| containing an expression.
+                Waits until {condition} evaluates to |TRUE|, where {condition}
+                is a |Funcref| or |string| containing an expression.
 
-		{timeout} is the maximum waiting time in milliseconds, -1
-		means forever.
+                {timeout} is the maximum waiting time in milliseconds, -1
+                means forever.
 
-		Condition is evaluated on user events, internal events, and
-		every {interval} milliseconds (default: 200).
+                Condition is evaluated on user events, internal events, and
+                every {interval} milliseconds (default: 200).
 
-		Returns a status integer:
-			0 if the condition was satisfied before timeout
-			-1 if the timeout was exceeded
-			-2 if the function was interrupted (by |CTRL-C|)
-			-3 if an error occurred
+                Returns a status integer:
+                        0 if the condition was satisfied before timeout
+                        -1 if the timeout was exceeded
+                        -2 if the function was interrupted (by |CTRL-C|)
+                        -3 if an error occurred
 
 wildmenumode()                                                  *wildmenumode()*
-		Returns |TRUE| when the wildmenu is active and |FALSE|
-		otherwise.  See 'wildmenu' and 'wildmode'.
-		This can be used in mappings to handle the 'wildcharm' option
-		gracefully. (Makes only sense with |mapmode-c| mappings).
+                Returns |TRUE| when the wildmenu is active and |FALSE|
+                otherwise.  See 'wildmenu' and 'wildmode'.
+                This can be used in mappings to handle the 'wildcharm' option
+                gracefully. (Makes only sense with |mapmode-c| mappings).
 
-		For example to make <c-j> work like <down> in wildmode, use: >vim
-		    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
+                For example to make <c-j> work like <down> in wildmode, use: >vim
+                    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 <
-		(Note, this needs the 'wildcharm' option set appropriately).
+                (Note, this needs the 'wildcharm' option set appropriately).
 
 win_execute({id}, {command} [, {silent}])                        *win_execute()*
-		Like `execute()` but in the context of window {id}.
-		The window will temporarily be made the current window,
-		without triggering autocommands or changing directory.  When
-		executing {command} autocommands will be triggered, this may
-		have unexpected side effects.  Use `:noautocmd` if needed.
-		Example: >vim
-			call win_execute(winid, 'syntax enable')
-<		Doing the same with `setwinvar()` would not trigger
-		autocommands and not actually show syntax highlighting.
+                Like `execute()` but in the context of window {id}.
+                The window will temporarily be made the current window,
+                without triggering autocommands or changing directory.  When
+                executing {command} autocommands will be triggered, this may
+                have unexpected side effects.  Use `:noautocmd` if needed.
+                Example: >vim
+                        call win_execute(winid, 'syntax enable')
+<                Doing the same with `setwinvar()` would not trigger
+                autocommands and not actually show syntax highlighting.
 
-		When window {id} does not exist then no error is given and
-		an empty string is returned.
+                When window {id} does not exist then no error is given and
+                an empty string is returned.
 
 win_findbuf({bufnr})                                             *win_findbuf()*
-		Returns a |List| with |window-ID|s for windows that contain
-		buffer {bufnr}.  When there is none the list is empty.
+                Returns a |List| with |window-ID|s for windows that contain
+                buffer {bufnr}.  When there is none the list is empty.
 
 win_getid([{win} [, {tab}]])                                       *win_getid()*
-		Get the |window-ID| for the specified window.
-		When {win} is missing use the current window.
-		With {win} this is the window number.  The top window has
-		number 1.
-		Without {tab} use the current tab, otherwise the tab with
-		number {tab}.  The first tab has number one.
-		Return zero if the window cannot be found.
+                Get the |window-ID| for the specified window.
+                When {win} is missing use the current window.
+                With {win} this is the window number.  The top window has
+                number 1.
+                Without {tab} use the current tab, otherwise the tab with
+                number {tab}.  The first tab has number one.
+                Return zero if the window cannot be found.
 
 win_gettype([{nr}])                                              *win_gettype()*
-		Return the type of the window:
-			"autocmd"	autocommand window. Temporary window
-					used to execute autocommands.
-			"command"	command-line window |cmdwin|
-			(empty)		normal window
-			"loclist"	|location-list-window|
-			"popup"		floating window |api-floatwin|
-			"preview"	preview window |preview-window|
-			"quickfix"	|quickfix-window|
-			"unknown"	window {nr} not found
+                Return the type of the window:
+                        "autocmd"       autocommand window. Temporary window
+                                        used to execute autocommands.
+                        "command"       command-line window |cmdwin|
+                        (empty)         normal window
+                        "loclist"       |location-list-window|
+                        "popup"         floating window |api-floatwin|
+                        "preview"       preview window |preview-window|
+                        "quickfix"      |quickfix-window|
+                        "unknown"       window {nr} not found
 
-		When {nr} is omitted return the type of the current window.
-		When {nr} is given return the type of this window by number or
-		|window-ID|.
+                When {nr} is omitted return the type of the current window.
+                When {nr} is given return the type of this window by number or
+                |window-ID|.
 
-		Also see the 'buftype' option.
+                Also see the 'buftype' option.
 
 win_gotoid({expr})                                                *win_gotoid()*
-		Go to window with ID {expr}.  This may also change the current
-		tabpage.
-		Return TRUE if successful, FALSE if the window cannot be found.
+                Go to window with ID {expr}.  This may also change the current
+                tabpage.
+                Return TRUE if successful, FALSE if the window cannot be found.
 
 win_id2tabwin({expr})                                          *win_id2tabwin()*
-		Return a list with the tab number and window number of window
-		with ID {expr}: [tabnr, winnr].
-		Return [0, 0] if the window cannot be found.
+                Return a list with the tab number and window number of window
+                with ID {expr}: [tabnr, winnr].
+                Return [0, 0] if the window cannot be found.
 
 win_id2win({expr})                                                *win_id2win()*
-		Return the window number of window with ID {expr}.
-		Return 0 if the window cannot be found in the current tabpage.
+                Return the window number of window with ID {expr}.
+                Return 0 if the window cannot be found in the current tabpage.
 
 win_move_separator({nr}, {offset})                        *win_move_separator()*
-		Move window {nr}'s vertical separator (i.e., the right border)
-		by {offset} columns, as if being dragged by the mouse. {nr}
-		can be a window number or |window-ID|. A positive {offset}
-		moves right and a negative {offset} moves left. Moving a
-		window's vertical separator will change the width of the
-		window and the width of other windows adjacent to the vertical
-		separator. The magnitude of movement may be smaller than
-		specified (e.g., as a consequence of maintaining
-		'winminwidth'). Returns TRUE if the window can be found and
-		FALSE otherwise.
-		This will fail for the rightmost window and a full-width
-		window, since it has no separator on the right.
-		Only works for the current tab page. *E1308*
+                Move window {nr}'s vertical separator (i.e., the right border)
+                by {offset} columns, as if being dragged by the mouse. {nr}
+                can be a window number or |window-ID|. A positive {offset}
+                moves right and a negative {offset} moves left. Moving a
+                window's vertical separator will change the width of the
+                window and the width of other windows adjacent to the vertical
+                separator. The magnitude of movement may be smaller than
+                specified (e.g., as a consequence of maintaining
+                'winminwidth'). Returns TRUE if the window can be found and
+                FALSE otherwise.
+                This will fail for the rightmost window and a full-width
+                window, since it has no separator on the right.
+                Only works for the current tab page. *E1308*
 
 win_move_statusline({nr}, {offset})                      *win_move_statusline()*
-		Move window {nr}'s status line (i.e., the bottom border) by
-		{offset} rows, as if being dragged by the mouse. {nr} can be a
-		window number or |window-ID|. A positive {offset} moves down
-		and a negative {offset} moves up. Moving a window's status
-		line will change the height of the window and the height of
-		other windows adjacent to the status line. The magnitude of
-		movement may be smaller than specified (e.g., as a consequence
-		of maintaining 'winminheight'). Returns TRUE if the window can
-		be found and FALSE otherwise.
-		Only works for the current tab page.
+                Move window {nr}'s status line (i.e., the bottom border) by
+                {offset} rows, as if being dragged by the mouse. {nr} can be a
+                window number or |window-ID|. A positive {offset} moves down
+                and a negative {offset} moves up. Moving a window's status
+                line will change the height of the window and the height of
+                other windows adjacent to the status line. The magnitude of
+                movement may be smaller than specified (e.g., as a consequence
+                of maintaining 'winminheight'). Returns TRUE if the window can
+                be found and FALSE otherwise.
+                Only works for the current tab page.
 
 win_screenpos({nr})                                            *win_screenpos()*
-		Return the screen position of window {nr} as a list with two
-		numbers: [row, col].  The first window always has position
-		[1, 1], unless there is a tabline, then it is [2, 1].
-		{nr} can be the window number or the |window-ID|.  Use zero
-		for the current window.
-		Returns [0, 0] if the window cannot be found in the current
-		tabpage.
+                Return the screen position of window {nr} as a list with two
+                numbers: [row, col].  The first window always has position
+                [1, 1], unless there is a tabline, then it is [2, 1].
+                {nr} can be the window number or the |window-ID|.  Use zero
+                for the current window.
+                Returns [0, 0] if the window cannot be found in the current
+                tabpage.
 
 win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
-		Move the window {nr} to a new split of the window {target}.
-		This is similar to moving to {target}, creating a new window
-		using |:split| but having the same contents as window {nr}, and
-		then closing {nr}.
+                Move the window {nr} to a new split of the window {target}.
+                This is similar to moving to {target}, creating a new window
+                using |:split| but having the same contents as window {nr}, and
+                then closing {nr}.
 
-		Both {nr} and {target} can be window numbers or |window-ID|s.
-		Both must be in the current tab page.
+                Both {nr} and {target} can be window numbers or |window-ID|s.
+                Both must be in the current tab page.
 
-		Returns zero for success, non-zero for failure.
+                Returns zero for success, non-zero for failure.
 
-		{options} is a |Dictionary| with the following optional entries:
-		  "vertical"	When TRUE, the split is created vertically,
-				like with |:vsplit|.
-		  "rightbelow"	When TRUE, the split is made below or to the
-				right (if vertical).  When FALSE, it is done
-				above or to the left (if vertical).  When not
-				present, the values of 'splitbelow' and
-				'splitright' are used.
+                {options} is a |Dictionary| with the following optional entries:
+                  "vertical"    When TRUE, the split is created vertically,
+                                like with |:vsplit|.
+                  "rightbelow"  When TRUE, the split is made below or to the
+                                right (if vertical).  When FALSE, it is done
+                                above or to the left (if vertical).  When not
+                                present, the values of 'splitbelow' and
+                                'splitright' are used.
 
 winbufnr({nr})                                                      *winbufnr()*
-		The result is a Number, which is the number of the buffer
-		associated with window {nr}.  {nr} can be the window number or
-		the |window-ID|.
-		When {nr} is zero, the number of the buffer in the current
-		window is returned.
-		When window {nr} doesn't exist, -1 is returned.
-		Example: >vim
-		  echo "The file in the current window is " .. bufname(winbufnr(0))
+                The result is a Number, which is the number of the buffer
+                associated with window {nr}.  {nr} can be the window number or
+                the |window-ID|.
+                When {nr} is zero, the number of the buffer in the current
+                window is returned.
+                When window {nr} doesn't exist, -1 is returned.
+                Example: >vim
+                  echo "The file in the current window is " .. bufname(winbufnr(0))
 <
-
 wincol()                                                              *wincol()*
-		The result is a Number, which is the virtual column of the
-		cursor in the window.  This is counting screen cells from the
-		left side of the window.  The leftmost column is one.
+                The result is a Number, which is the virtual column of the
+                cursor in the window.  This is counting screen cells from the
+                left side of the window.  The leftmost column is one.
 
 windowsversion()                                              *windowsversion()*
-		The result is a String.  For MS-Windows it indicates the OS
-		version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
-		Windows XP is "5.1".  For non-MS-Windows systems the result is
-		an empty string.
+                The result is a String.  For MS-Windows it indicates the OS
+                version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
+                Windows XP is "5.1".  For non-MS-Windows systems the result is
+                an empty string.
 
 winheight({nr})                                                    *winheight()*
-		The result is a Number, which is the height of window {nr}.
-		{nr} can be the window number or the |window-ID|.
-		When {nr} is zero, the height of the current window is
-		returned.  When window {nr} doesn't exist, -1 is returned.
-		An existing window always has a height of zero or more.
-		This excludes any window toolbar line.
-		Examples: >vim
-		  echo "The current window has " .. winheight(0) .. " lines."
+                The result is a Number, which is the height of window {nr}.
+                {nr} can be the window number or the |window-ID|.
+                When {nr} is zero, the height of the current window is
+                returned.  When window {nr} doesn't exist, -1 is returned.
+                An existing window always has a height of zero or more.
+                This excludes any window toolbar line.
+                Examples: >vim
+                  echo "The current window has " .. winheight(0) .. " lines."
 
 winlayout([{tabnr}])                                               *winlayout()*
-		The result is a nested List containing the layout of windows
-		in a tabpage.
+                The result is a nested List containing the layout of windows
+                in a tabpage.
 
-		Without {tabnr} use the current tabpage, otherwise the tabpage
-		with number {tabnr}. If the tabpage {tabnr} is not found,
-		returns an empty list.
+                Without {tabnr} use the current tabpage, otherwise the tabpage
+                with number {tabnr}. If the tabpage {tabnr} is not found,
+                returns an empty list.
 
-		For a leaf window, it returns: >
-			["leaf", {winid}]
+                For a leaf window, it returns: >
+                        ["leaf", {winid}]
 <
-		For horizontally split windows, which form a column, it
-		returns: >
-			["col", [{nested list of windows}]]
-<		For vertically split windows, which form a row, it returns: >
-			["row", [{nested list of windows}]]
+                For horizontally split windows, which form a column, it
+                returns: >
+                        ["col", [{nested list of windows}]]
+<                For vertically split windows, which form a row, it returns: >
+                        ["row", [{nested list of windows}]]
 <
-		Example: >vim
-			" Only one window in the tab page
-			echo winlayout()
-<		 >
-			['leaf', 1000]
-<		 >vim
-			" Two horizontally split windows
-			echo winlayout()
-<		 >
-			['col', [['leaf', 1000], ['leaf', 1001]]]
-<		 >vim
-			" The second tab page, with three horizontally split
-			" windows, with two vertically split windows in the
-			" middle window
-			echo winlayout(2)
-<		 >
-			['col', [['leaf', 1002], ['row', [['leaf', 1003],
-					    ['leaf', 1001]]], ['leaf', 1000]]]
+                Example: >vim
+                        " Only one window in the tab page
+                        echo winlayout()
+<                 >
+                        ['leaf', 1000]
+<                 >vim
+                        " Two horizontally split windows
+                        echo winlayout()
+<                 >
+                        ['col', [['leaf', 1000], ['leaf', 1001]]]
+<                 >vim
+                        " The second tab page, with three horizontally split
+                        " windows, with two vertically split windows in the
+                        " middle window
+                        echo winlayout(2)
+<                 >
+                        ['col', [['leaf', 1002], ['row', [['leaf', 1003],
+                                            ['leaf', 1001]]], ['leaf', 1000]]]
 <
-
 winline()                                                            *winline()*
-		The result is a Number, which is the screen line of the cursor
-		in the window.  This is counting screen lines from the top of
-		the window.  The first line is one.
-		If the cursor was moved the view on the file will be updated
-		first, this may cause a scroll.
+                The result is a Number, which is the screen line of the cursor
+                in the window.  This is counting screen lines from the top of
+                the window.  The first line is one.
+                If the cursor was moved the view on the file will be updated
+                first, this may cause a scroll.
 
 winnr([{arg}])                                                         *winnr()*
-		The result is a Number, which is the number of the current
-		window.  The top window has number 1.
-		Returns zero for a popup window.
+                The result is a Number, which is the number of the current
+                window.  The top window has number 1.
+                Returns zero for a popup window.
 
-		The optional argument {arg} supports the following values:
-			$	the number of the last window (the window
-				count).
-			#	the number of the last accessed window (where
-				|CTRL-W_p| goes to).  If there is no previous
-				window or it is in another tab page 0 is
-				returned.
-			{N}j	the number of the Nth window below the
-				current window (where |CTRL-W_j| goes to).
-			{N}k	the number of the Nth window above the current
-				window (where |CTRL-W_k| goes to).
-			{N}h	the number of the Nth window left of the
-				current window (where |CTRL-W_h| goes to).
-			{N}l	the number of the Nth window right of the
-				current window (where |CTRL-W_l| goes to).
-		The number can be used with |CTRL-W_w| and ":wincmd w"
-		|:wincmd|.
-		When {arg} is invalid an error is given and zero is returned.
-		Also see |tabpagewinnr()| and |win_getid()|.
-		Examples: >vim
-			let window_count = winnr('$')
-			let prev_window = winnr('#')
-			let wnum = winnr('3k')
+                The optional argument {arg} supports the following values:
+                        $       the number of the last window (the window
+                                count).
+                        #       the number of the last accessed window (where
+                                |CTRL-W_p| goes to).  If there is no previous
+                                window or it is in another tab page 0 is
+                                returned.
+                        {N}j    the number of the Nth window below the
+                                current window (where |CTRL-W_j| goes to).
+                        {N}k    the number of the Nth window above the current
+                                window (where |CTRL-W_k| goes to).
+                        {N}h    the number of the Nth window left of the
+                                current window (where |CTRL-W_h| goes to).
+                        {N}l    the number of the Nth window right of the
+                                current window (where |CTRL-W_l| goes to).
+                The number can be used with |CTRL-W_w| and ":wincmd w"
+                |:wincmd|.
+                When {arg} is invalid an error is given and zero is returned.
+                Also see |tabpagewinnr()| and |win_getid()|.
+                Examples: >vim
+                        let window_count = winnr('$')
+                        let prev_window = winnr('#')
+                        let wnum = winnr('3k')
 
 winrestcmd()                                                      *winrestcmd()*
-		Returns a sequence of |:resize| commands that should restore
-		the current window sizes.  Only works properly when no windows
-		are opened or closed and the current window and tab page is
-		unchanged.
-		Example: >vim
-			let cmd = winrestcmd()
-			call MessWithWindowSizes()
-			exe cmd
+                Returns a sequence of |:resize| commands that should restore
+                the current window sizes.  Only works properly when no windows
+                are opened or closed and the current window and tab page is
+                unchanged.
+                Example: >vim
+                        let cmd = winrestcmd()
+                        call MessWithWindowSizes()
+                        exe cmd
 <
-
 winrestview({dict})                                              *winrestview()*
-		Uses the |Dictionary| returned by |winsaveview()| to restore
-		the view of the current window.
-		Note: The {dict} does not have to contain all values, that are
-		returned by |winsaveview()|. If values are missing, those
-		settings won't be restored. So you can use: >vim
-		    call winrestview({'curswant': 4})
+                Uses the |Dictionary| returned by |winsaveview()| to restore
+                the view of the current window.
+                Note: The {dict} does not have to contain all values, that are
+                returned by |winsaveview()|. If values are missing, those
+                settings won't be restored. So you can use: >vim
+                    call winrestview({'curswant': 4})
 <
-		This will only set the curswant value (the column the cursor
-		wants to move on vertical movements) of the cursor to column 5
-		(yes, that is 5), while all other settings will remain the
-		same. This is useful, if you set the cursor position manually.
+                This will only set the curswant value (the column the cursor
+                wants to move on vertical movements) of the cursor to column 5
+                (yes, that is 5), while all other settings will remain the
+                same. This is useful, if you set the cursor position manually.
 
-		If you have changed the values the result is unpredictable.
-		If the window size changed the result won't be the same.
+                If you have changed the values the result is unpredictable.
+                If the window size changed the result won't be the same.
 
 winsaveview()                                                    *winsaveview()*
-		Returns a |Dictionary| that contains information to restore
-		the view of the current window.  Use |winrestview()| to
-		restore the view.
-		This is useful if you have a mapping that jumps around in the
-		buffer and you want to go back to the original view.
-		This does not save fold information.  Use the 'foldenable'
-		option to temporarily switch off folding, so that folds are
-		not opened when moving around. This may have side effects.
-		The return value includes:
-			lnum		cursor line number
-			col		cursor column (Note: the first column
-					zero, as opposed to what |getcurpos()|
-					returns)
-			coladd		cursor column offset for 'virtualedit'
-			curswant	column for vertical movement (Note:
-					the first column is zero, as opposed
-					to what |getcurpos()| returns).  After
-					|$| command it will be a very large
-					number equal to |v:maxcol|.
-			topline		first line in the window
-			topfill		filler lines, only in diff mode
-			leftcol		first column displayed; only used when
-					'wrap' is off
-			skipcol		columns skipped
-		Note that no option values are saved.
+                Returns a |Dictionary| that contains information to restore
+                the view of the current window.  Use |winrestview()| to
+                restore the view.
+                This is useful if you have a mapping that jumps around in the
+                buffer and you want to go back to the original view.
+                This does not save fold information.  Use the 'foldenable'
+                option to temporarily switch off folding, so that folds are
+                not opened when moving around. This may have side effects.
+                The return value includes:
+                        lnum            cursor line number
+                        col             cursor column (Note: the first column
+                                        zero, as opposed to what |getcurpos()|
+                                        returns)
+                        coladd          cursor column offset for 'virtualedit'
+                        curswant        column for vertical movement (Note:
+                                        the first column is zero, as opposed
+                                        to what |getcurpos()| returns).  After
+                                        |$| command it will be a very large
+                                        number equal to |v:maxcol|.
+                        topline         first line in the window
+                        topfill         filler lines, only in diff mode
+                        leftcol         first column displayed; only used when
+                                        'wrap' is off
+                        skipcol         columns skipped
+                Note that no option values are saved.
 
 winwidth({nr})                                                      *winwidth()*
-		The result is a Number, which is the width of window {nr}.
-		{nr} can be the window number or the |window-ID|.
-		When {nr} is zero, the width of the current window is
-		returned.  When window {nr} doesn't exist, -1 is returned.
-		An existing window always has a width of zero or more.
-		Examples: >vim
-		  echo "The current window has " .. winwidth(0) .. " columns."
-		  if winwidth(0) <= 50
-		    50 wincmd |
-		  endif
-<		For getting the terminal or screen size, see the 'columns'
-		option.
+                The result is a Number, which is the width of window {nr}.
+                {nr} can be the window number or the |window-ID|.
+                When {nr} is zero, the width of the current window is
+                returned.  When window {nr} doesn't exist, -1 is returned.
+                An existing window always has a width of zero or more.
+                Examples: >vim
+                  echo "The current window has " .. winwidth(0) .. " columns."
+                  if winwidth(0) <= 50
+                    50 wincmd |
+                  endif
+<                For getting the terminal or screen size, see the 'columns'
+                option.
 
 wordcount()                                                        *wordcount()*
-		The result is a dictionary of byte/chars/word statistics for
-		the current buffer.  This is the same info as provided by
-		|g_CTRL-G|
-		The return value includes:
-			bytes		Number of bytes in the buffer
-			chars		Number of chars in the buffer
-			words		Number of words in the buffer
-			cursor_bytes    Number of bytes before cursor position
-					(not in Visual mode)
-			cursor_chars    Number of chars before cursor position
-					(not in Visual mode)
-			cursor_words    Number of words before cursor position
-					(not in Visual mode)
-			visual_bytes    Number of bytes visually selected
-					(only in Visual mode)
-			visual_chars    Number of chars visually selected
-					(only in Visual mode)
-			visual_words    Number of words visually selected
-					(only in Visual mode)
+                The result is a dictionary of byte/chars/word statistics for
+                the current buffer.  This is the same info as provided by
+                |g_CTRL-G|
+                The return value includes:
+                        bytes           Number of bytes in the buffer
+                        chars           Number of chars in the buffer
+                        words           Number of words in the buffer
+                        cursor_bytes    Number of bytes before cursor position
+                                        (not in Visual mode)
+                        cursor_chars    Number of chars before cursor position
+                                        (not in Visual mode)
+                        cursor_words    Number of words before cursor position
+                                        (not in Visual mode)
+                        visual_bytes    Number of bytes visually selected
+                                        (only in Visual mode)
+                        visual_chars    Number of chars visually selected
+                                        (only in Visual mode)
+                        visual_words    Number of words visually selected
+                                        (only in Visual mode)
 
 writefile({object}, {fname} [, {flags}])                           *writefile()*
-		When {object} is a |List| write it to file {fname}.  Each list
-		item is separated with a NL.  Each list item must be a String
-		or Number.
-		All NL characters are replaced with a NUL character.
-		Inserting CR characters needs to be done before passing {list}
-		to writefile().
+                When {object} is a |List| write it to file {fname}.  Each list
+                item is separated with a NL.  Each list item must be a String
+                or Number.
+                All NL characters are replaced with a NUL character.
+                Inserting CR characters needs to be done before passing {list}
+                to writefile().
 
-		When {object} is a |Blob| write the bytes to file {fname}
-		unmodified, also when binary mode is not specified.
+                When {object} is a |Blob| write the bytes to file {fname}
+                unmodified, also when binary mode is not specified.
 
-		{flags} must be a String.  These characters are recognized:
+                {flags} must be a String.  These characters are recognized:
 
-		'b'  Binary mode is used: There will not be a NL after the
-		     last list item.  An empty item at the end does cause the
-		     last line in the file to end in a NL.
+                'b'  Binary mode is used: There will not be a NL after the
+                     last list item.  An empty item at the end does cause the
+                     last line in the file to end in a NL.
 
-		'a'  Append mode is used, lines are appended to the file: >vim
-			call writefile(["foo"], "event.log", "a")
-			call writefile(["bar"], "event.log", "a")
+                'a'  Append mode is used, lines are appended to the file: >vim
+                        call writefile(["foo"], "event.log", "a")
+                        call writefile(["bar"], "event.log", "a")
 <
-		'D'  Delete the file when the current function ends.  This
-		     works like: >vim
-			defer delete({fname})
-<		     Fails when not in a function.  Also see |:defer|.
+                'D'  Delete the file when the current function ends.  This
+                     works like: >vim
+                        defer delete({fname})
+<                     Fails when not in a function.  Also see |:defer|.
 
-		's'  fsync() is called after writing the file.  This flushes
-		     the file to disk, if possible.  This takes more time but
-		     avoids losing the file if the system crashes.
+                's'  fsync() is called after writing the file.  This flushes
+                     the file to disk, if possible.  This takes more time but
+                     avoids losing the file if the system crashes.
 
-		'S'  fsync() is not called, even when 'fsync' is set.
+                'S'  fsync() is not called, even when 'fsync' is set.
 
-		     When {flags} does not contain "S" or "s" then fsync() is
-		     called if the 'fsync' option is set.
+                     When {flags} does not contain "S" or "s" then fsync() is
+                     called if the 'fsync' option is set.
 
-		An existing file is overwritten, if possible.
+                An existing file is overwritten, if possible.
 
-		When the write fails -1 is returned, otherwise 0.  There is an
-		error message if the file can't be created or when writing
-		fails.
+                When the write fails -1 is returned, otherwise 0.  There is an
+                error message if the file can't be created or when writing
+                fails.
 
-		Also see |readfile()|.
-		To copy a file byte for byte: >vim
-			let fl = readfile("foo", "b")
-			call writefile(fl, "foocopy", "b")
+                Also see |readfile()|.
+                To copy a file byte for byte: >vim
+                        let fl = readfile("foo", "b")
+                        call writefile(fl, "foocopy", "b")
 
 xor({expr}, {expr})                                                      *xor()*
-		Bitwise XOR on the two arguments.  The arguments are converted
-		to a number.  A List, Dict or Float argument causes an error.
-		Also see `and()` and `or()`.
-		Example: >vim
-			let bits = xor(bits, 0x80)
+                Bitwise XOR on the two arguments.  The arguments are converted
+                to a number.  A List, Dict or Float argument causes an error.
+                Also see `and()` and `or()`.
+                Example: >vim
+                        let bits = xor(bits, 0x80)
 <
-
 ==============================================================================
-2. Matching a pattern in a String			*string-match*
+2. Matching a pattern in a String                        *string-match*
 
 This is common between several functions. A regexp pattern as explained at
 |pattern| is normally used to find a match in the buffer lines.  When a

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,4 +1,4 @@
-*builtin.txt*    Nvim
+*builtin.txt*	 Nvim
 
 
 		  NVIM REFERENCE MANUAL
@@ -10,8929 +10,8929 @@ For functions grouped by what they are used for see |function-list|.
 
 				      Type |gO| to see the table of contents.
 ==============================================================================
-1. Details                                       *builtin-function-details*
+1. Details					 *builtin-function-details*
 
-abs({expr})                                                              *abs()*
-                Return the absolute value of {expr}.  When {expr} evaluates to
-                a |Float| abs() returns a |Float|.  When {expr} can be
-                converted to a |Number| abs() returns a |Number|.  Otherwise
-                abs() gives an error message and returns -1.
-                Examples: >vim
-                        echo abs(1.456)
-<                        1.456  >vim
-                        echo abs(-5.456)
-<                        5.456  >vim
-                        echo abs(-4)
-<                        4
+abs({expr})								 *abs()*
+		Return the absolute value of {expr}.  When {expr} evaluates to
+		a |Float| abs() returns a |Float|.  When {expr} can be
+		converted to a |Number| abs() returns a |Number|.  Otherwise
+		abs() gives an error message and returns -1.
+		Examples: >vim
+			echo abs(1.456)
+<			 1.456	>vim
+			echo abs(-5.456)
+<			 5.456	>vim
+			echo abs(-4)
+<			 4
 
-acos({expr})                                                            *acos()*
-                Return the arc cosine of {expr} measured in radians, as a
-                |Float| in the range of [0, pi].
-                {expr} must evaluate to a |Float| or a |Number| in the range
-                [-1, 1].
-                Returns NaN if {expr} is outside the range [-1, 1].  Returns
-                0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo acos(0)
-<                        1.570796 >vim
-                        echo acos(-0.5)
-<                        2.094395
+acos({expr})								*acos()*
+		Return the arc cosine of {expr} measured in radians, as a
+		|Float| in the range of [0, pi].
+		{expr} must evaluate to a |Float| or a |Number| in the range
+		[-1, 1].
+		Returns NaN if {expr} is outside the range [-1, 1].  Returns
+		0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo acos(0)
+<			 1.570796 >vim
+			echo acos(-0.5)
+<			 2.094395
 
-add({object}, {expr})                                                    *add()*
-                Append the item {expr} to |List| or |Blob| {object}.  Returns
-                the resulting |List| or |Blob|.  Examples: >vim
-                        let alist = add([1, 2, 3], item)
-                        call add(mylist, "woodstock")
-<                Note that when {expr} is a |List| it is appended as a single
-                item.  Use |extend()| to concatenate |Lists|.
-                When {object} is a |Blob| then {expr} must be a number.
-                Use |insert()| to add an item at another position.
-                Returns 1 if {object} is not a |List| or a |Blob|.
+add({object}, {expr})							 *add()*
+		Append the item {expr} to |List| or |Blob| {object}.  Returns
+		the resulting |List| or |Blob|.  Examples: >vim
+			let alist = add([1, 2, 3], item)
+			call add(mylist, "woodstock")
+<		 Note that when {expr} is a |List| it is appended as a single
+		item.  Use |extend()| to concatenate |Lists|.
+		When {object} is a |Blob| then {expr} must be a number.
+		Use |insert()| to add an item at another position.
+		Returns 1 if {object} is not a |List| or a |Blob|.
 
-and({expr}, {expr})                                                      *and()*
-                Bitwise AND on the two arguments.  The arguments are converted
-                to a number.  A List, Dict or Float argument causes an error.
-                Also see `or()` and `xor()`.
-                Example: >vim
-                        let flag = and(bits, 0x80)
+and({expr}, {expr})							 *and()*
+		Bitwise AND on the two arguments.  The arguments are converted
+		to a number.  A List, Dict or Float argument causes an error.
+		Also see `or()` and `xor()`.
+		Example: >vim
+			let flag = and(bits, 0x80)
 <
-api_info()                                                          *api_info()*
-                Returns Dictionary of |api-metadata|.
+api_info()							    *api_info()*
+		Returns Dictionary of |api-metadata|.
 
-                View it in a nice human-readable format: >vim
-                       lua vim.print(vim.fn.api_info())
+		View it in a nice human-readable format: >vim
+		       lua vim.print(vim.fn.api_info())
 <
-append({lnum}, {text})                                                *append()*
-                When {text} is a |List|: Append each item of the |List| as a
-                text line below line {lnum} in the current buffer.
-                Otherwise append {text} as one text line below line {lnum} in
-                the current buffer.
-                Any type of item is accepted and converted to a String.
-                {lnum} can be zero to insert a line before the first one.
-                {lnum} is used like with |getline()|.
-                Returns 1 for failure ({lnum} out of range or out of memory),
-                0 for success.  When {text} is an empty list zero is returned,
-                no matter the value of {lnum}.  Example: >vim
-                        let failed = append(line('$'), "# THE END")
-                        let failed = append(0, ["Chapter 1", "the beginning"])
+append({lnum}, {text})						      *append()*
+		When {text} is a |List|: Append each item of the |List| as a
+		text line below line {lnum} in the current buffer.
+		Otherwise append {text} as one text line below line {lnum} in
+		the current buffer.
+		Any type of item is accepted and converted to a String.
+		{lnum} can be zero to insert a line before the first one.
+		{lnum} is used like with |getline()|.
+		Returns 1 for failure ({lnum} out of range or out of memory),
+		0 for success.	When {text} is an empty list zero is returned,
+		no matter the value of {lnum}.	Example: >vim
+			let failed = append(line('$'), "# THE END")
+			let failed = append(0, ["Chapter 1", "the beginning"])
 <
-appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
-                Like |append()| but append the text in buffer {expr}.
+appendbufline({buf}, {lnum}, {text})			       *appendbufline()*
+		Like |append()| but append the text in buffer {expr}.
 
-                This function works only for loaded buffers. First call
-                |bufload()| if needed.
+		This function works only for loaded buffers. First call
+		|bufload()| if needed.
 
-                For the use of {buf}, see |bufname()|.
+		For the use of {buf}, see |bufname()|.
 
-                {lnum} is the line number to append below.  Note that using
-                |line()| would use the current buffer, not the one appending
-                to.  Use "$" to append at the end of the buffer.  Other string
-                values are not supported.
+		{lnum} is the line number to append below.  Note that using
+		|line()| would use the current buffer, not the one appending
+		to.  Use "$" to append at the end of the buffer.  Other string
+		values are not supported.
 
-                On success 0 is returned, on failure 1 is returned.
+		On success 0 is returned, on failure 1 is returned.
 
-                If {buf} is not a valid buffer or {lnum} is not valid, an
-                error message is given. Example: >vim
-                        let failed = appendbufline(13, 0, "# THE START")
-<                However, when {text} is an empty list then no error is given
-                for an invalid {lnum}, since {lnum} isn't actually used.
+		If {buf} is not a valid buffer or {lnum} is not valid, an
+		error message is given. Example: >vim
+			let failed = appendbufline(13, 0, "# THE START")
+<		 However, when {text} is an empty list then no error is given
+		for an invalid {lnum}, since {lnum} isn't actually used.
 
-argc([{winid}])                                                         *argc()*
-                The result is the number of files in the argument list.  See
-                |arglist|.
-                If {winid} is not supplied, the argument list of the current
-                window is used.
-                If {winid} is -1, the global argument list is used.
-                Otherwise {winid} specifies the window of which the argument
-                list is used: either the window number or the window ID.
-                Returns -1 if the {winid} argument is invalid.
+argc([{winid}])								*argc()*
+		The result is the number of files in the argument list.  See
+		|arglist|.
+		If {winid} is not supplied, the argument list of the current
+		window is used.
+		If {winid} is -1, the global argument list is used.
+		Otherwise {winid} specifies the window of which the argument
+		list is used: either the window number or the window ID.
+		Returns -1 if the {winid} argument is invalid.
 
-argidx()                                                              *argidx()*
-                The result is the current index in the argument list.  0 is
-                the first file.  argc() - 1 is the last one.  See |arglist|.
+argidx()							      *argidx()*
+		The result is the current index in the argument list.  0 is
+		the first file.  argc() - 1 is the last one.  See |arglist|.
 
-arglistid([{winnr} [, {tabnr}]])                                   *arglistid()*
-                Return the argument list ID.  This is a number which
-                identifies the argument list being used.  Zero is used for the
-                global argument list.  See |arglist|.
-                Returns -1 if the arguments are invalid.
+arglistid([{winnr} [, {tabnr}]])				   *arglistid()*
+		Return the argument list ID.  This is a number which
+		identifies the argument list being used.  Zero is used for the
+		global argument list.  See |arglist|.
+		Returns -1 if the arguments are invalid.
 
-                Without arguments use the current window.
-                With {winnr} only use this window in the current tab page.
-                With {winnr} and {tabnr} use the window in the specified tab
-                page.
-                {winnr} can be the window number or the |window-ID|.
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page.
+		{winnr} can be the window number or the |window-ID|.
 
-argv([{nr} [, {winid}]])                                                *argv()*
-                The result is the {nr}th file in the argument list.  See
-                |arglist|.  "argv(0)" is the first one.  Example: >vim
-                        let i = 0
-                        while i < argc()
-                          let f = escape(fnameescape(argv(i)), '.')
-                          exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
-                          let i = i + 1
-                        endwhile
-<                Without the {nr} argument, or when {nr} is -1, a |List| with
-                the whole |arglist| is returned.
+argv([{nr} [, {winid}]])						*argv()*
+		The result is the {nr}th file in the argument list.  See
+		|arglist|.  "argv(0)" is the first one.  Example: >vim
+			let i = 0
+			while i < argc()
+			  let f = escape(fnameescape(argv(i)), '.')
+			  exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
+			  let i = i + 1
+			endwhile
+<		 Without the {nr} argument, or when {nr} is -1, a |List| with
+		the whole |arglist| is returned.
 
-                The {winid} argument specifies the window ID, see |argc()|.
-                For the Vim command line arguments see |v:argv|.
+		The {winid} argument specifies the window ID, see |argc()|.
+		For the Vim command line arguments see |v:argv|.
 
-                Returns an empty string if {nr}th argument is not present in
-                the argument list.  Returns an empty List if the {winid}
-                argument is invalid.
+		Returns an empty string if {nr}th argument is not present in
+		the argument list.  Returns an empty List if the {winid}
+		argument is invalid.
 
-asin({expr})                                                            *asin()*
-                Return the arc sine of {expr} measured in radians, as a |Float|
-                in the range of [-pi/2, pi/2].
-                {expr} must evaluate to a |Float| or a |Number| in the range
-                [-1, 1].
-                Returns NaN if {expr} is outside the range [-1, 1].  Returns
-                0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo asin(0.8)
-<                        0.927295 >vim
-                        echo asin(-0.5)
-<                        -0.523599
+asin({expr})								*asin()*
+		Return the arc sine of {expr} measured in radians, as a |Float|
+		in the range of [-pi/2, pi/2].
+		{expr} must evaluate to a |Float| or a |Number| in the range
+		[-1, 1].
+		Returns NaN if {expr} is outside the range [-1, 1].  Returns
+		0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo asin(0.8)
+<			 0.927295 >vim
+			echo asin(-0.5)
+<			 -0.523599
 
-assert_beeps({cmd})                                             *assert_beeps()*
-                Run {cmd} and add an error message to |v:errors| if it does
-                NOT produce a beep or visual bell.
-                Also see |assert_fails()|, |assert_nobeep()| and
-                |assert-return|.
+assert_beeps({cmd})						*assert_beeps()*
+		Run {cmd} and add an error message to |v:errors| if it does
+		NOT produce a beep or visual bell.
+		Also see |assert_fails()|, |assert_nobeep()| and
+		|assert-return|.
 
-assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
-                When {expected} and {actual} are not equal an error message is
-                added to |v:errors| and 1 is returned.  Otherwise zero is
-                returned. |assert-return|
-                The error is in the form "Expected {expected} but got
-                {actual}".  When {msg} is present it is prefixed to that.
+assert_equal({expected}, {actual} [, {msg}])			*assert_equal()*
+		When {expected} and {actual} are not equal an error message is
+		added to |v:errors| and 1 is returned.	Otherwise zero is
+		returned. |assert-return|
+		The error is in the form "Expected {expected} but got
+		{actual}".  When {msg} is present it is prefixed to that.
 
-                There is no automatic conversion, the String "4" is different
-                from the Number 4.  And the number 4 is different from the
-                Float 4.0.  The value of 'ignorecase' is not used here, case
-                always matters.
-                Example: >vim
-                        assert_equal('foo', 'bar')
-<                Will result in a string to be added to |v:errors|:
-                        test.vim line 12: Expected 'foo' but got 'bar' ~
+		There is no automatic conversion, the String "4" is different
+		from the Number 4.  And the number 4 is different from the
+		Float 4.0.  The value of 'ignorecase' is not used here, case
+		always matters.
+		Example: >vim
+			assert_equal('foo', 'bar')
+<		 Will result in a string to be added to |v:errors|:
+			test.vim line 12: Expected 'foo' but got 'bar' ~
 
-assert_equalfile({fname-one}, {fname-two})                  *assert_equalfile()*
-                When the files {fname-one} and {fname-two} do not contain
-                exactly the same text an error message is added to |v:errors|.
-                Also see |assert-return|.
-                When {fname-one} or {fname-two} does not exist the error will
-                mention that.
+assert_equalfile({fname-one}, {fname-two})		    *assert_equalfile()*
+		When the files {fname-one} and {fname-two} do not contain
+		exactly the same text an error message is added to |v:errors|.
+		Also see |assert-return|.
+		When {fname-one} or {fname-two} does not exist the error will
+		mention that.
 
-assert_exception({error} [, {msg}])                         *assert_exception()*
-                When v:exception does not contain the string {error} an error
-                message is added to |v:errors|.  Also see |assert-return|.
-                This can be used to assert that a command throws an exception.
-                Using the error number, followed by a colon, avoids problems
-                with translations: >vim
-                        try
-                          commandthatfails
-                          call assert_false(1, 'command should have failed')
-                        catch
-                          call assert_exception('E492:')
-                        endtry
+assert_exception({error} [, {msg}])			    *assert_exception()*
+		When v:exception does not contain the string {error} an error
+		message is added to |v:errors|.  Also see |assert-return|.
+		This can be used to assert that a command throws an exception.
+		Using the error number, followed by a colon, avoids problems
+		with translations: >vim
+			try
+			  commandthatfails
+			  call assert_false(1, 'command should have failed')
+			catch
+			  call assert_exception('E492:')
+			endtry
 <
-                                                                *assert_fails()*
+								*assert_fails()*
 assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
-                Run {cmd} and add an error message to |v:errors| if it does
-                NOT produce an error or when {error} is not found in the
-                error message.  Also see |assert-return|.
+		Run {cmd} and add an error message to |v:errors| if it does
+		NOT produce an error or when {error} is not found in the
+		error message.	Also see |assert-return|.
 
-                When {error} is a string it must be found literally in the
-                first reported error. Most often this will be the error code,
-                including the colon, e.g. "E123:". >vim
-                        assert_fails('bad cmd', 'E987:')
+		When {error} is a string it must be found literally in the
+		first reported error. Most often this will be the error code,
+		including the colon, e.g. "E123:". >vim
+			assert_fails('bad cmd', 'E987:')
 <
-                When {error} is a |List| with one or two strings, these are
-                used as patterns.  The first pattern is matched against the
-                first reported error: >vim
-                        assert_fails('cmd', ['E987:.*expected bool'])
-<                The second pattern, if present, is matched against the last
-                reported error.  To only match the last error use an empty
-                string for the first error: >vim
-                        assert_fails('cmd', ['', 'E987:'])
+		When {error} is a |List| with one or two strings, these are
+		used as patterns.  The first pattern is matched against the
+		first reported error: >vim
+			assert_fails('cmd', ['E987:.*expected bool'])
+<		 The second pattern, if present, is matched against the last
+		reported error.  To only match the last error use an empty
+		string for the first error: >vim
+			assert_fails('cmd', ['', 'E987:'])
 <
-                If {msg} is empty then it is not used.  Do this to get the
-                default message when passing the {lnum} argument.
+		If {msg} is empty then it is not used.	Do this to get the
+		default message when passing the {lnum} argument.
 
-                When {lnum} is present and not negative, and the {error}
-                argument is present and matches, then this is compared with
-                the line number at which the error was reported. That can be
-                the line number in a function or in a script.
+		When {lnum} is present and not negative, and the {error}
+		argument is present and matches, then this is compared with
+		the line number at which the error was reported. That can be
+		the line number in a function or in a script.
 
-                When {context} is present it is used as a pattern and matched
-                against the context (script name or function name) where
-                {lnum} is located in.
+		When {context} is present it is used as a pattern and matched
+		against the context (script name or function name) where
+		{lnum} is located in.
 
-                Note that beeping is not considered an error, and some failing
-                commands only beep.  Use |assert_beeps()| for those.
+		Note that beeping is not considered an error, and some failing
+		commands only beep.  Use |assert_beeps()| for those.
 
-assert_false({actual} [, {msg}])                                *assert_false()*
-                When {actual} is not false an error message is added to
-                |v:errors|, like with |assert_equal()|.
-                The error is in the form "Expected False but got {actual}".
-                When {msg} is present it is prepended to that.
-                Also see |assert-return|.
+assert_false({actual} [, {msg}])				*assert_false()*
+		When {actual} is not false an error message is added to
+		|v:errors|, like with |assert_equal()|.
+		The error is in the form "Expected False but got {actual}".
+		When {msg} is present it is prepended to that.
+		Also see |assert-return|.
 
-                A value is false when it is zero. When {actual} is not a
-                number the assert fails.
+		A value is false when it is zero. When {actual} is not a
+		number the assert fails.
 
-assert_inrange({lower}, {upper}, {actual} [, {msg}])          *assert_inrange()*
-                This asserts number and |Float| values.  When {actual}  is lower
-                than {lower} or higher than {upper} an error message is added
-                to |v:errors|.  Also see |assert-return|.
-                The error is in the form "Expected range {lower} - {upper},
-                but got {actual}".  When {msg} is present it is prefixed to
-                that.
+assert_inrange({lower}, {upper}, {actual} [, {msg}])	      *assert_inrange()*
+		This asserts number and |Float| values.  When {actual}	is lower
+		than {lower} or higher than {upper} an error message is added
+		to |v:errors|.	Also see |assert-return|.
+		The error is in the form "Expected range {lower} - {upper},
+		but got {actual}".  When {msg} is present it is prefixed to
+		that.
 
-assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
-                When {pattern} does not match {actual} an error message is
-                added to |v:errors|.  Also see |assert-return|.
-                The error is in the form "Pattern {pattern} does not match
-                {actual}".  When {msg} is present it is prefixed to that.
+assert_match({pattern}, {actual} [, {msg}])			*assert_match()*
+		When {pattern} does not match {actual} an error message is
+		added to |v:errors|.  Also see |assert-return|.
+		The error is in the form "Pattern {pattern} does not match
+		{actual}".  When {msg} is present it is prefixed to that.
 
-                {pattern} is used as with |expr-=~|: The matching is always done
-                like 'magic' was set and 'cpoptions' is empty, no matter what
-                the actual value of 'magic' or 'cpoptions' is.
+		{pattern} is used as with |expr-=~|: The matching is always done
+		like 'magic' was set and 'cpoptions' is empty, no matter what
+		the actual value of 'magic' or 'cpoptions' is.
 
-                {actual} is used as a string, automatic conversion applies.
-                Use "^" and "$" to match with the start and end of the text.
-                Use both to match the whole text.
+		{actual} is used as a string, automatic conversion applies.
+		Use "^" and "$" to match with the start and end of the text.
+		Use both to match the whole text.
 
-                Example: >vim
-                        assert_match('^f.*o$', 'foobar')
-<                Will result in a string to be added to |v:errors|:
-                        test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+		Example: >vim
+			assert_match('^f.*o$', 'foobar')
+<		 Will result in a string to be added to |v:errors|:
+			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
-assert_nobeep({cmd})                                           *assert_nobeep()*
-                Run {cmd} and add an error message to |v:errors| if it
-                produces a beep or visual bell.
-                Also see |assert_beeps()|.
+assert_nobeep({cmd})					       *assert_nobeep()*
+		Run {cmd} and add an error message to |v:errors| if it
+		produces a beep or visual bell.
+		Also see |assert_beeps()|.
 
-assert_notequal({expected}, {actual} [, {msg}])              *assert_notequal()*
-                The opposite of `assert_equal()`: add an error message to
-                |v:errors| when {expected} and {actual} are equal.
-                Also see |assert-return|.
+assert_notequal({expected}, {actual} [, {msg}])		     *assert_notequal()*
+		The opposite of `assert_equal()`: add an error message to
+		|v:errors| when {expected} and {actual} are equal.
+		Also see |assert-return|.
 
-assert_notmatch({pattern}, {actual} [, {msg}])               *assert_notmatch()*
-                The opposite of `assert_match()`: add an error message to
-                |v:errors| when {pattern} matches {actual}.
-                Also see |assert-return|.
+assert_notmatch({pattern}, {actual} [, {msg}])		     *assert_notmatch()*
+		The opposite of `assert_match()`: add an error message to
+		|v:errors| when {pattern} matches {actual}.
+		Also see |assert-return|.
 
-assert_report({msg})                                           *assert_report()*
-                Report a test failure directly, using String {msg}.
-                Always returns one.
+assert_report({msg})					       *assert_report()*
+		Report a test failure directly, using String {msg}.
+		Always returns one.
 
-assert_true({actual} [, {msg}])                                  *assert_true()*
-                When {actual} is not true an error message is added to
-                |v:errors|, like with |assert_equal()|.
-                Also see |assert-return|.
-                A value is |TRUE| when it is a non-zero number or |v:true|.
-                When {actual} is not a number or |v:true| the assert fails.
-                When {msg} is given it precedes the default message.
+assert_true({actual} [, {msg}])					 *assert_true()*
+		When {actual} is not true an error message is added to
+		|v:errors|, like with |assert_equal()|.
+		Also see |assert-return|.
+		A value is |TRUE| when it is a non-zero number or |v:true|.
+		When {actual} is not a number or |v:true| the assert fails.
+		When {msg} is given it precedes the default message.
 
-atan({expr})                                                            *atan()*
-                Return the principal value of the arc tangent of {expr}, in
-                the range [-pi/2, +pi/2] radians, as a |Float|.
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo atan(100)
-<                        1.560797 >vim
-                        echo atan(-4.01)
-<                        -1.326405
+atan({expr})								*atan()*
+		Return the principal value of the arc tangent of {expr}, in
+		the range [-pi/2, +pi/2] radians, as a |Float|.
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo atan(100)
+<			 1.560797 >vim
+			echo atan(-4.01)
+<			 -1.326405
 
-atan2({expr1}, {expr2})                                                *atan2()*
-                Return the arc tangent of {expr1} / {expr2}, measured in
-                radians, as a |Float| in the range [-pi, pi].
-                {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
-                |Number|.
-                Examples: >vim
-                        echo atan2(-1, 1)
-<                        -0.785398 >vim
-                        echo atan2(1, -1)
-<                        2.356194
+atan2({expr1}, {expr2})						       *atan2()*
+		Return the arc tangent of {expr1} / {expr2}, measured in
+		radians, as a |Float| in the range [-pi, pi].
+		{expr1} and {expr2} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
+		|Number|.
+		Examples: >vim
+			echo atan2(-1, 1)
+<			 -0.785398 >vim
+			echo atan2(1, -1)
+<			 2.356194
 
-blob2list({blob})                                                  *blob2list()*
-                Return a List containing the number value of each byte in Blob
-                {blob}.  Examples: >vim
-                        blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
-                        blob2list(0z)           " returns []
-<                Returns an empty List on error.  |list2blob()| does the
-                opposite.
+blob2list({blob})						   *blob2list()*
+		Return a List containing the number value of each byte in Blob
+		{blob}.  Examples: >vim
+			blob2list(0z0102.0304)	" returns [1, 2, 3, 4]
+			blob2list(0z)		" returns []
+<		 Returns an empty List on error.  |list2blob()| does the
+		opposite.
 
-browse({save}, {title}, {initdir}, {default})                         *browse()*
-                Put up a file requester.  This only works when "has("browse")"
-                returns |TRUE| (only in some GUI versions).
-                The input fields are:
-                    {save}      when |TRUE|, select file to write
-                    {title}     title for the requester
-                    {initdir}   directory to start browsing in
-                    {default}   default file name
-                An empty string is returned when the "Cancel" button is hit,
-                something went wrong, or browsing is not possible.
+browse({save}, {title}, {initdir}, {default})			      *browse()*
+		Put up a file requester.  This only works when "has("browse")"
+		returns |TRUE| (only in some GUI versions).
+		The input fields are:
+		    {save}	when |TRUE|, select file to write
+		    {title}	title for the requester
+		    {initdir}	directory to start browsing in
+		    {default}	default file name
+		An empty string is returned when the "Cancel" button is hit,
+		something went wrong, or browsing is not possible.
 
-browsedir({title}, {initdir})                                      *browsedir()*
-                Put up a directory requester.  This only works when
-                "has("browse")" returns |TRUE| (only in some GUI versions).
-                On systems where a directory browser is not supported a file
-                browser is used.  In that case: select a file in the directory
-                to be used.
-                The input fields are:
-                    {title}     title for the requester
-                    {initdir}   directory to start browsing in
-                When the "Cancel" button is hit, something went wrong, or
-                browsing is not possible, an empty string is returned.
+browsedir({title}, {initdir})					   *browsedir()*
+		Put up a directory requester.  This only works when
+		"has("browse")" returns |TRUE| (only in some GUI versions).
+		On systems where a directory browser is not supported a file
+		browser is used.  In that case: select a file in the directory
+		to be used.
+		The input fields are:
+		    {title}	title for the requester
+		    {initdir}	directory to start browsing in
+		When the "Cancel" button is hit, something went wrong, or
+		browsing is not possible, an empty string is returned.
 
-bufadd({name})                                                        *bufadd()*
-                Add a buffer to the buffer list with name {name} (must be a
-                String).
-                If a buffer for file {name} already exists, return that buffer
-                number.  Otherwise return the buffer number of the newly
-                created buffer.  When {name} is an empty string then a new
-                buffer is always created.
-                The buffer will not have 'buflisted' set and not be loaded
-                yet.  To add some text to the buffer use this: >vim
-                        let bufnr = bufadd('someName')
-                        call bufload(bufnr)
-                        call setbufline(bufnr, 1, ['some', 'text'])
-<                Returns 0 on error.
+bufadd({name})							      *bufadd()*
+		Add a buffer to the buffer list with name {name} (must be a
+		String).
+		If a buffer for file {name} already exists, return that buffer
+		number.  Otherwise return the buffer number of the newly
+		created buffer.  When {name} is an empty string then a new
+		buffer is always created.
+		The buffer will not have 'buflisted' set and not be loaded
+		yet.  To add some text to the buffer use this: >vim
+			let bufnr = bufadd('someName')
+			call bufload(bufnr)
+			call setbufline(bufnr, 1, ['some', 'text'])
+<		 Returns 0 on error.
 
-bufexists({buf})                                                   *bufexists()*
-                The result is a Number, which is |TRUE| if a buffer called
-                {buf} exists.
-                If the {buf} argument is a number, buffer numbers are used.
-                Number zero is the alternate buffer for the current window.
+bufexists({buf})						   *bufexists()*
+		The result is a Number, which is |TRUE| if a buffer called
+		{buf} exists.
+		If the {buf} argument is a number, buffer numbers are used.
+		Number zero is the alternate buffer for the current window.
 
-                If the {buf} argument is a string it must match a buffer name
-                exactly.  The name can be:
-                - Relative to the current directory.
-                - A full path.
-                - The name of a buffer with 'buftype' set to "nofile".
-                - A URL name.
-                Unlisted buffers will be found.
-                Note that help files are listed by their short name in the
-                output of |:buffers|, but bufexists() requires using their
-                long name to be able to find them.
-                bufexists() may report a buffer exists, but to use the name
-                with a |:buffer| command you may need to use |expand()|.  Esp
-                for MS-Windows 8.3 names in the form "c:\DOCUME~1"
-                Use "bufexists(0)" to test for the existence of an alternate
-                file name.
+		If the {buf} argument is a string it must match a buffer name
+		exactly.  The name can be:
+		- Relative to the current directory.
+		- A full path.
+		- The name of a buffer with 'buftype' set to "nofile".
+		- A URL name.
+		Unlisted buffers will be found.
+		Note that help files are listed by their short name in the
+		output of |:buffers|, but bufexists() requires using their
+		long name to be able to find them.
+		bufexists() may report a buffer exists, but to use the name
+		with a |:buffer| command you may need to use |expand()|.  Esp
+		for MS-Windows 8.3 names in the form "c:\DOCUME~1"
+		Use "bufexists(0)" to test for the existence of an alternate
+		file name.
 
-buflisted({buf})                                                   *buflisted()*
-                The result is a Number, which is |TRUE| if a buffer called
-                {buf} exists and is listed (has the 'buflisted' option set).
-                The {buf} argument is used like with |bufexists()|.
+buflisted({buf})						   *buflisted()*
+		The result is a Number, which is |TRUE| if a buffer called
+		{buf} exists and is listed (has the 'buflisted' option set).
+		The {buf} argument is used like with |bufexists()|.
 
-bufload({buf})                                                       *bufload()*
-                Ensure the buffer {buf} is loaded.  When the buffer name
-                refers to an existing file then the file is read.  Otherwise
-                the buffer will be empty.  If the buffer was already loaded
-                then there is no change.  If the buffer is not related to a
-                file then no file is read (e.g., when 'buftype' is "nofile").
-                If there is an existing swap file for the file of the buffer,
-                there will be no dialog, the buffer will be loaded anyway.
-                The {buf} argument is used like with |bufexists()|.
+bufload({buf})							     *bufload()*
+		Ensure the buffer {buf} is loaded.  When the buffer name
+		refers to an existing file then the file is read.  Otherwise
+		the buffer will be empty.  If the buffer was already loaded
+		then there is no change.  If the buffer is not related to a
+		file then no file is read (e.g., when 'buftype' is "nofile").
+		If there is an existing swap file for the file of the buffer,
+		there will be no dialog, the buffer will be loaded anyway.
+		The {buf} argument is used like with |bufexists()|.
 
-bufloaded({buf})                                                   *bufloaded()*
-                The result is a Number, which is |TRUE| if a buffer called
-                {buf} exists and is loaded (shown in a window or hidden).
-                The {buf} argument is used like with |bufexists()|.
+bufloaded({buf})						   *bufloaded()*
+		The result is a Number, which is |TRUE| if a buffer called
+		{buf} exists and is loaded (shown in a window or hidden).
+		The {buf} argument is used like with |bufexists()|.
 
-bufname([{buf}])                                                     *bufname()*
-                The result is the name of a buffer.  Mostly as it is displayed
-                by the `:ls` command, but not using special names such as
-                "[No Name]".
-                If {buf} is omitted the current buffer is used.
-                If {buf} is a Number, that buffer number's name is given.
-                Number zero is the alternate buffer for the current window.
-                If {buf} is a String, it is used as a |file-pattern| to match
-                with the buffer names.  This is always done like 'magic' is
-                set and 'cpoptions' is empty.  When there is more than one
-                match an empty string is returned.
-                "" or "%" can be used for the current buffer, "#" for the
-                alternate buffer.
-                A full match is preferred, otherwise a match at the start, end
-                or middle of the buffer name is accepted.  If you only want a
-                full match then put "^" at the start and "$" at the end of the
-                pattern.
-                Listed buffers are found first.  If there is a single match
-                with a listed buffer, that one is returned.  Next unlisted
-                buffers are searched for.
-                If the {buf} is a String, but you want to use it as a buffer
-                number, force it to be a Number by adding zero to it: >vim
-                        echo bufname("3" + 0)
-<                If the buffer doesn't exist, or doesn't have a name, an empty
-                string is returned. >vim
-                        echo bufname("#")       " alternate buffer name
-                        echo bufname(3)         " name of buffer 3
-                        echo bufname("%")       " name of current buffer
-                        echo bufname("file2")   " name of buffer where "file2" matches.
+bufname([{buf}])						     *bufname()*
+		The result is the name of a buffer.  Mostly as it is displayed
+		by the `:ls` command, but not using special names such as
+		"[No Name]".
+		If {buf} is omitted the current buffer is used.
+		If {buf} is a Number, that buffer number's name is given.
+		Number zero is the alternate buffer for the current window.
+		If {buf} is a String, it is used as a |file-pattern| to match
+		with the buffer names.	This is always done like 'magic' is
+		set and 'cpoptions' is empty.  When there is more than one
+		match an empty string is returned.
+		"" or "%" can be used for the current buffer, "#" for the
+		alternate buffer.
+		A full match is preferred, otherwise a match at the start, end
+		or middle of the buffer name is accepted.  If you only want a
+		full match then put "^" at the start and "$" at the end of the
+		pattern.
+		Listed buffers are found first.  If there is a single match
+		with a listed buffer, that one is returned.  Next unlisted
+		buffers are searched for.
+		If the {buf} is a String, but you want to use it as a buffer
+		number, force it to be a Number by adding zero to it: >vim
+			echo bufname("3" + 0)
+<		 If the buffer doesn't exist, or doesn't have a name, an empty
+		string is returned. >vim
+			echo bufname("#")	" alternate buffer name
+			echo bufname(3)		" name of buffer 3
+			echo bufname("%")	" name of current buffer
+			echo bufname("file2")	" name of buffer where "file2" matches.
 <
-bufnr([{buf} [, {create}]])                                            *bufnr()*
-                The result is the number of a buffer, as it is displayed by
-                the `:ls` command.  For the use of {buf}, see |bufname()|
-                above.
-                If the buffer doesn't exist, -1 is returned.  Or, if the
-                {create} argument is present and TRUE, a new, unlisted,
-                buffer is created and its number is returned.
-                bufnr("$") is the last buffer: >vim
-                        let last_buffer = bufnr("$")
-<                The result is a Number, which is the highest buffer number
-                of existing buffers.  Note that not all buffers with a smaller
-                number necessarily exist, because ":bwipeout" may have removed
-                them.  Use bufexists() to test for the existence of a buffer.
+bufnr([{buf} [, {create}]])					       *bufnr()*
+		The result is the number of a buffer, as it is displayed by
+		the `:ls` command.  For the use of {buf}, see |bufname()|
+		above.
+		If the buffer doesn't exist, -1 is returned.  Or, if the
+		{create} argument is present and TRUE, a new, unlisted,
+		buffer is created and its number is returned.
+		bufnr("$") is the last buffer: >vim
+			let last_buffer = bufnr("$")
+<		 The result is a Number, which is the highest buffer number
+		of existing buffers.  Note that not all buffers with a smaller
+		number necessarily exist, because ":bwipeout" may have removed
+		them.  Use bufexists() to test for the existence of a buffer.
 
-bufwinid({buf})                                                     *bufwinid()*
-                The result is a Number, which is the |window-ID| of the first
-                window associated with buffer {buf}.  For the use of {buf},
-                see |bufname()| above.  If buffer {buf} doesn't exist or
-                there is no such window, -1 is returned.  Example: >vim
+bufwinid({buf})							    *bufwinid()*
+		The result is a Number, which is the |window-ID| of the first
+		window associated with buffer {buf}.  For the use of {buf},
+		see |bufname()| above.	If buffer {buf} doesn't exist or
+		there is no such window, -1 is returned.  Example: >vim
 
-                        echo "A window containing buffer 1 is " .. (bufwinid(1))
+			echo "A window containing buffer 1 is " .. (bufwinid(1))
 <
-                Only deals with the current tab page.  See |win_findbuf()| for
-                finding more.
+		Only deals with the current tab page.  See |win_findbuf()| for
+		finding more.
 
-bufwinnr({buf})                                                     *bufwinnr()*
-                Like |bufwinid()| but return the window number instead of the
-                |window-ID|.
-                If buffer {buf} doesn't exist or there is no such window, -1
-                is returned.  Example: >vim
+bufwinnr({buf})							    *bufwinnr()*
+		Like |bufwinid()| but return the window number instead of the
+		|window-ID|.
+		If buffer {buf} doesn't exist or there is no such window, -1
+		is returned.  Example: >vim
 
-                        echo "A window containing buffer 1 is " .. (bufwinnr(1))
+			echo "A window containing buffer 1 is " .. (bufwinnr(1))
 
-<                The number can be used with |CTRL-W_w| and ":wincmd w"
-                |:wincmd|.
+<		 The number can be used with |CTRL-W_w| and ":wincmd w"
+		|:wincmd|.
 
-byte2line({byte})                                                  *byte2line()*
-                Return the line number that contains the character at byte
-                count {byte} in the current buffer.  This includes the
-                end-of-line character, depending on the 'fileformat' option
-                for the current buffer.  The first character has byte count
-                one.
-                Also see |line2byte()|, |go| and |:goto|.
+byte2line({byte})						   *byte2line()*
+		Return the line number that contains the character at byte
+		count {byte} in the current buffer.  This includes the
+		end-of-line character, depending on the 'fileformat' option
+		for the current buffer.  The first character has byte count
+		one.
+		Also see |line2byte()|, |go| and |:goto|.
 
-                Returns -1 if the {byte} value is invalid.
+		Returns -1 if the {byte} value is invalid.
 
-byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
-                Return byte index of the {nr}th character in the String
-                {expr}.  Use zero for the first character, it then returns
-                zero.
-                If there are no multibyte characters the returned value is
-                equal to {nr}.
-                Composing characters are not counted separately, their byte
-                length is added to the preceding base character.  See
-                |byteidxcomp()| below for counting composing characters
-                separately.
-                When {utf16} is present and TRUE, {nr} is used as the UTF-16
-                index in the String {expr} instead of as the character index.
-                The UTF-16 index is the index in the string when it is encoded
-                with 16-bit words.  If the specified UTF-16 index is in the
-                middle of a character (e.g. in a 4-byte character), then the
-                byte index of the first byte in the character is returned.
-                Refer to |string-offset-encoding| for more information.
-                Example : >vim
-                        echo matchstr(str, ".", byteidx(str, 3))
-<                will display the fourth character.  Another way to do the
-                same: >vim
-                        let s = strpart(str, byteidx(str, 3))
-                        echo strpart(s, 0, byteidx(s, 1))
-<                Also see |strgetchar()| and |strcharpart()|.
+byteidx({expr}, {nr} [, {utf16}])				     *byteidx()*
+		Return byte index of the {nr}th character in the String
+		{expr}.  Use zero for the first character, it then returns
+		zero.
+		If there are no multibyte characters the returned value is
+		equal to {nr}.
+		Composing characters are not counted separately, their byte
+		length is added to the preceding base character.  See
+		|byteidxcomp()| below for counting composing characters
+		separately.
+		When {utf16} is present and TRUE, {nr} is used as the UTF-16
+		index in the String {expr} instead of as the character index.
+		The UTF-16 index is the index in the string when it is encoded
+		with 16-bit words.  If the specified UTF-16 index is in the
+		middle of a character (e.g. in a 4-byte character), then the
+		byte index of the first byte in the character is returned.
+		Refer to |string-offset-encoding| for more information.
+		Example : >vim
+			echo matchstr(str, ".", byteidx(str, 3))
+<		 will display the fourth character.  Another way to do the
+		same: >vim
+			let s = strpart(str, byteidx(str, 3))
+			echo strpart(s, 0, byteidx(s, 1))
+<		 Also see |strgetchar()| and |strcharpart()|.
 
-                If there are less than {nr} characters -1 is returned.
-                If there are exactly {nr} characters the length of the string
-                in bytes is returned.
-                See |charidx()| and |utf16idx()| for getting the character and
-                UTF-16 index respectively from the byte index.
-                Examples: >vim
-                        echo byteidx('a😊😊', 2)        " returns 5
-                        echo byteidx('a😊😊', 2, 1)     " returns 1
-                        echo byteidx('a😊😊', 3, 1)     " returns 5
+		If there are less than {nr} characters -1 is returned.
+		If there are exactly {nr} characters the length of the string
+		in bytes is returned.
+		See |charidx()| and |utf16idx()| for getting the character and
+		UTF-16 index respectively from the byte index.
+		Examples: >vim
+			echo byteidx('a😊😊', 2)	" returns 5
+			echo byteidx('a😊😊', 2, 1)	" returns 1
+			echo byteidx('a😊😊', 3, 1)	" returns 5
 <
-byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
-                Like byteidx(), except that a composing character is counted
-                as a separate character.  Example: >vim
-                        let s = 'e' .. nr2char(0x301)
-                        echo byteidx(s, 1)
-                        echo byteidxcomp(s, 1)
-                        echo byteidxcomp(s, 2)
-<                The first and third echo result in 3 ('e' plus composing
-                character is 3 bytes), the second echo results in 1 ('e' is
-                one byte).
+byteidxcomp({expr}, {nr} [, {utf16}])				 *byteidxcomp()*
+		Like byteidx(), except that a composing character is counted
+		as a separate character.  Example: >vim
+			let s = 'e' .. nr2char(0x301)
+			echo byteidx(s, 1)
+			echo byteidxcomp(s, 1)
+			echo byteidxcomp(s, 2)
+<		 The first and third echo result in 3 ('e' plus composing
+		character is 3 bytes), the second echo results in 1 ('e' is
+		one byte).
 
-call({func}, {arglist} [, {dict}])                                 *call()* *E699*
-                Call function {func} with the items in |List| {arglist} as
-                arguments.
-                {func} can either be a |Funcref| or the name of a function.
-                a:firstline and a:lastline are set to the cursor line.
-                Returns the return value of the called function.
-                {dict} is for functions with the "dict" attribute.  It will be
-                used to set the local variable "self". |Dictionary-function|
+call({func}, {arglist} [, {dict}])				   *call()* *E699*
+		Call function {func} with the items in |List| {arglist} as
+		arguments.
+		{func} can either be a |Funcref| or the name of a function.
+		a:firstline and a:lastline are set to the cursor line.
+		Returns the return value of the called function.
+		{dict} is for functions with the "dict" attribute.  It will be
+		used to set the local variable "self". |Dictionary-function|
 
-ceil({expr})                                                            *ceil()*
-                Return the smallest integral value greater than or equal to
-                {expr} as a |Float| (round up).
-                {expr} must evaluate to a |Float| or a |Number|.
-                Examples: >vim
-                        echo ceil(1.456)
-<                        2.0  >vim
-                        echo ceil(-5.456)
-<                        -5.0  >vim
-                        echo ceil(4.0)
-<                        4.0
+ceil({expr})								*ceil()*
+		Return the smallest integral value greater than or equal to
+		{expr} as a |Float| (round up).
+		{expr} must evaluate to a |Float| or a |Number|.
+		Examples: >vim
+			echo ceil(1.456)
+<			 2.0  >vim
+			echo ceil(-5.456)
+<			 -5.0  >vim
+			echo ceil(4.0)
+<			 4.0
 
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
-chanclose({id} [, {stream}])                                       *chanclose()*
-                Close a channel or a specific stream associated with it.
-                For a job, {stream} can be one of "stdin", "stdout",
-                "stderr" or "rpc" (closes stdin/stdout for a job started
-                with `"rpc":v:true`) If {stream} is omitted, all streams
-                are closed. If the channel is a pty, this will then close the
-                pty master, sending SIGHUP to the job process.
-                For a socket, there is only one stream, and {stream} should be
-                omitted.
+chanclose({id} [, {stream}])					   *chanclose()*
+		Close a channel or a specific stream associated with it.
+		For a job, {stream} can be one of "stdin", "stdout",
+		"stderr" or "rpc" (closes stdin/stdout for a job started
+		with `"rpc":v:true`) If {stream} is omitted, all streams
+		are closed. If the channel is a pty, this will then close the
+		pty master, sending SIGHUP to the job process.
+		For a socket, there is only one stream, and {stream} should be
+		omitted.
 
-changenr()                                                          *changenr()*
-                Return the number of the most recent change.  This is the same
-                number as what is displayed with |:undolist| and can be used
-                with the |:undo| command.
-                When a change was made it is the number of that change.  After
-                redo it is the number of the redone change.  After undo it is
-                one less than the number of the undone change.
-                Returns 0 if the undo list is empty.
+changenr()							    *changenr()*
+		Return the number of the most recent change.  This is the same
+		number as what is displayed with |:undolist| and can be used
+		with the |:undo| command.
+		When a change was made it is the number of that change.  After
+		redo it is the number of the redone change.  After undo it is
+		one less than the number of the undone change.
+		Returns 0 if the undo list is empty.
 
-chansend({id}, {data})                                              *chansend()*
-                Send data to channel {id}. For a job, it writes it to the
-                stdin of the process. For the stdio channel |channel-stdio|,
-                it writes to Nvim's stdout.  Returns the number of bytes
-                written if the write succeeded, 0 otherwise.
-                See |channel-bytes| for more information.
+chansend({id}, {data})						    *chansend()*
+		Send data to channel {id}. For a job, it writes it to the
+		stdin of the process. For the stdio channel |channel-stdio|,
+		it writes to Nvim's stdout.  Returns the number of bytes
+		written if the write succeeded, 0 otherwise.
+		See |channel-bytes| for more information.
 
-                {data} may be a string, string convertible, |Blob|, or a list.
-                If {data} is a list, the items will be joined by newlines; any
-                newlines in an item will be sent as NUL. To send a final
-                newline, include a final empty string. Example: >vim
-                        call chansend(id, ["abc", "123\n456", ""])
-<                will send "abc<NL>123<NUL>456<NL>".
+		{data} may be a string, string convertible, |Blob|, or a list.
+		If {data} is a list, the items will be joined by newlines; any
+		newlines in an item will be sent as NUL. To send a final
+		newline, include a final empty string. Example: >vim
+			call chansend(id, ["abc", "123\n456", ""])
+<		 will send "abc<NL>123<NUL>456<NL>".
 
-                chansend() writes raw data, not RPC messages.  If the channel
-                was created with `"rpc":v:true` then the channel expects RPC
-                messages, use |rpcnotify()| and |rpcrequest()| instead.
+		chansend() writes raw data, not RPC messages.  If the channel
+		was created with `"rpc":v:true` then the channel expects RPC
+		messages, use |rpcnotify()| and |rpcrequest()| instead.
 
-char2nr({string} [, {utf8}])                                         *char2nr()*
-                Return Number value of the first char in {string}.
-                Examples: >vim
-                        echo char2nr(" ")       " returns 32
-                        echo char2nr("ABC")     " returns 65
-                        echo char2nr("á")       " returns 225
-                        echo char2nr("á"[0])    " returns 195
-                        echo char2nr("\<M-x>")  " returns 128
-<                Non-ASCII characters are always treated as UTF-8 characters.
-                {utf8} is ignored, it exists only for backwards-compatibility.
-                A combining character is a separate character.
-                |nr2char()| does the opposite.
+char2nr({string} [, {utf8}])					     *char2nr()*
+		Return Number value of the first char in {string}.
+		Examples: >vim
+			echo char2nr(" ")	" returns 32
+			echo char2nr("ABC")	" returns 65
+			echo char2nr("á")	" returns 225
+			echo char2nr("á"[0])	" returns 195
+			echo char2nr("\<M-x>")	" returns 128
+<		 Non-ASCII characters are always treated as UTF-8 characters.
+		{utf8} is ignored, it exists only for backwards-compatibility.
+		A combining character is a separate character.
+		|nr2char()| does the opposite.
 
-                Returns 0 if {string} is not a |String|.
+		Returns 0 if {string} is not a |String|.
 
-charclass({string})                                                *charclass()*
-                Return the character class of the first character in {string}.
-                The character class is one of:
-                        0       blank
-                        1       punctuation
-                        2       word character
-                        3       emoji
-                        other   specific Unicode class
-                The class is used in patterns and word motions.
-                Returns 0 if {string} is not a |String|.
+charclass({string})						   *charclass()*
+		Return the character class of the first character in {string}.
+		The character class is one of:
+			0	blank
+			1	punctuation
+			2	word character
+			3	emoji
+			other	specific Unicode class
+		The class is used in patterns and word motions.
+		Returns 0 if {string} is not a |String|.
 
-charcol({expr} [, {winid}])                                          *charcol()*
-                Same as |col()| but returns the character index of the column
-                position given with {expr} instead of the byte position.
+charcol({expr} [, {winid}])					     *charcol()*
+		Same as |col()| but returns the character index of the column
+		position given with {expr} instead of the byte position.
 
-                Example:
-                With the cursor on '세' in line 5 with text "여보세요": >vim
-                        echo charcol('.')       " returns 3
-                        echo col('.')           " returns 7
+		Example:
+		With the cursor on '세' in line 5 with text "여보세요": >vim
+			echo charcol('.')	" returns 3
+			echo col('.')		" returns 7
 
-charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
-                Return the character index of the byte at {idx} in {string}.
-                The index of the first character is zero.
-                If there are no multibyte characters the returned value is
-                equal to {idx}.
+charidx({string}, {idx} [, {countcc} [, {utf16}]])		     *charidx()*
+		Return the character index of the byte at {idx} in {string}.
+		The index of the first character is zero.
+		If there are no multibyte characters the returned value is
+		equal to {idx}.
 
-                When {countcc} is omitted or |FALSE|, then composing characters
-                are not counted separately, their byte length is added to the
-                preceding base character.
-                When {countcc} is |TRUE|, then composing characters are
-                counted as separate characters.
+		When {countcc} is omitted or |FALSE|, then composing characters
+		are not counted separately, their byte length is added to the
+		preceding base character.
+		When {countcc} is |TRUE|, then composing characters are
+		counted as separate characters.
 
-                When {utf16} is present and TRUE, {idx} is used as the UTF-16
-                index in the String {expr} instead of as the byte index.
+		When {utf16} is present and TRUE, {idx} is used as the UTF-16
+		index in the String {expr} instead of as the byte index.
 
-                Returns -1 if the arguments are invalid or if there are less
-                than {idx} bytes. If there are exactly {idx} bytes the length
-                of the string in characters is returned.
+		Returns -1 if the arguments are invalid or if there are less
+		than {idx} bytes. If there are exactly {idx} bytes the length
+		of the string in characters is returned.
 
-                An error is given and -1 is returned if the first argument is
-                not a string, the second argument is not a number or when the
-                third argument is present and is not zero or one.
+		An error is given and -1 is returned if the first argument is
+		not a string, the second argument is not a number or when the
+		third argument is present and is not zero or one.
 
-                See |byteidx()| and |byteidxcomp()| for getting the byte index
-                from the character index and |utf16idx()| for getting the
-                UTF-16 index from the character index.
-                Refer to |string-offset-encoding| for more information.
-                Examples: >vim
-                        echo charidx('áb́ć', 3)          " returns 1
-                        echo charidx('áb́ć', 6, 1)       " returns 4
-                        echo charidx('áb́ć', 16)         " returns -1
-                        echo charidx('a😊😊', 4, 0, 1)  " returns 2
+		See |byteidx()| and |byteidxcomp()| for getting the byte index
+		from the character index and |utf16idx()| for getting the
+		UTF-16 index from the character index.
+		Refer to |string-offset-encoding| for more information.
+		Examples: >vim
+			echo charidx('áb́ć', 3)		" returns 1
+			echo charidx('áb́ć', 6, 1)	" returns 4
+			echo charidx('áb́ć', 16)		" returns -1
+			echo charidx('a😊😊', 4, 0, 1)	" returns 2
 <
-chdir({dir})                                                           *chdir()*
-                Change the current working directory to {dir}.  The scope of
-                the directory change depends on the directory of the current
-                window:
-                        - If the current window has a window-local directory
-                          (|:lcd|), then changes the window local directory.
-                        - Otherwise, if the current tabpage has a local
-                          directory (|:tcd|) then changes the tabpage local
-                          directory.
-                        - Otherwise, changes the global directory.
-                {dir} must be a String.
-                If successful, returns the previous working directory.  Pass
-                this to another chdir() to restore the directory.
-                On failure, returns an empty string.
+chdir({dir})							       *chdir()*
+		Change the current working directory to {dir}.	The scope of
+		the directory change depends on the directory of the current
+		window:
+			- If the current window has a window-local directory
+			  (|:lcd|), then changes the window local directory.
+			- Otherwise, if the current tabpage has a local
+			  directory (|:tcd|) then changes the tabpage local
+			  directory.
+			- Otherwise, changes the global directory.
+		{dir} must be a String.
+		If successful, returns the previous working directory.	Pass
+		this to another chdir() to restore the directory.
+		On failure, returns an empty string.
 
-                Example: >vim
-                        let save_dir = chdir(newdir)
-                        if save_dir != ""
-                           " ... do some work
-                           call chdir(save_dir)
-                        endif
+		Example: >vim
+			let save_dir = chdir(newdir)
+			if save_dir != ""
+			   " ... do some work
+			   call chdir(save_dir)
+			endif
 
-cindent({lnum})                                                      *cindent()*
-                Get the amount of indent for line {lnum} according the C
-                indenting rules, as with 'cindent'.
-                The indent is counted in spaces, the value of 'tabstop' is
-                relevant.  {lnum} is used just like in |getline()|.
-                When {lnum} is invalid -1 is returned.
-                See |C-indenting|.
+cindent({lnum})							     *cindent()*
+		Get the amount of indent for line {lnum} according the C
+		indenting rules, as with 'cindent'.
+		The indent is counted in spaces, the value of 'tabstop' is
+		relevant.  {lnum} is used just like in |getline()|.
+		When {lnum} is invalid -1 is returned.
+		See |C-indenting|.
 
-clearmatches([{win}])                                           *clearmatches()*
-                Clears all matches previously defined for the current window
-                by |matchadd()| and the |:match| commands.
-                If {win} is specified, use the window with this number or
-                window ID instead of the current window.
+clearmatches([{win}])						*clearmatches()*
+		Clears all matches previously defined for the current window
+		by |matchadd()| and the |:match| commands.
+		If {win} is specified, use the window with this number or
+		window ID instead of the current window.
 
-col({expr} [, {winid}])                                                  *col()*
-                The result is a Number, which is the byte index of the column
-                position given with {expr}.  The accepted positions are:
-                    .       the cursor position
-                    $       the end of the cursor line (the result is the
-                            number of bytes in the cursor line plus one)
-                    'x      position of mark x (if the mark is not set, 0 is
-                            returned)
-                    v       In Visual mode: the start of the Visual area (the
-                            cursor is the end).  When not in Visual mode
-                            returns the cursor position.  Differs from |'<| in
-                            that it's updated right away.
-                Additionally {expr} can be [lnum, col]: a |List| with the line
-                and column number. Most useful when the column is "$", to get
-                the last column of a specific line.  When "lnum" or "col" is
-                out of range then col() returns zero.
-                With the optional {winid} argument the values are obtained for
-                that window instead of the current window.
-                To get the line number use |line()|.  To get both use
-                |getpos()|.
-                For the screen column position use |virtcol()|.  For the
-                character position use |charcol()|.
-                Note that only marks in the current file can be used.
-                Examples: >vim
-                        echo col(".")                   " column of cursor
-                        echo col("$")                   " length of cursor line plus one
-                        echo col("'t")                  " column of mark t
-                        echo col("'" .. markname)       " column of mark markname
-<                The first column is 1.  Returns 0 if {expr} is invalid or when
-                the window with ID {winid} is not found.
-                For an uppercase mark the column may actually be in another
-                buffer.
-                For the cursor position, when 'virtualedit' is active, the
-                column is one higher if the cursor is after the end of the
-                line.  Also, when using a <Cmd> mapping the cursor isn't
-                moved, this can be used to obtain the column in Insert mode: >vim
-                        imap <F2> <Cmd>echo col(".").."\n"<CR>
+col({expr} [, {winid}])							 *col()*
+		The result is a Number, which is the byte index of the column
+		position given with {expr}.  The accepted positions are:
+		    .	    the cursor position
+		    $	    the end of the cursor line (the result is the
+			    number of bytes in the cursor line plus one)
+		    'x	    position of mark x (if the mark is not set, 0 is
+			    returned)
+		    v	    In Visual mode: the start of the Visual area (the
+			    cursor is the end).  When not in Visual mode
+			    returns the cursor position.  Differs from |'<| in
+			    that it's updated right away.
+		Additionally {expr} can be [lnum, col]: a |List| with the line
+		and column number. Most useful when the column is "$", to get
+		the last column of a specific line.  When "lnum" or "col" is
+		out of range then col() returns zero.
+		With the optional {winid} argument the values are obtained for
+		that window instead of the current window.
+		To get the line number use |line()|.  To get both use
+		|getpos()|.
+		For the screen column position use |virtcol()|.  For the
+		character position use |charcol()|.
+		Note that only marks in the current file can be used.
+		Examples: >vim
+			echo col(".")			" column of cursor
+			echo col("$")			" length of cursor line plus one
+			echo col("'t")			" column of mark t
+			echo col("'" .. markname)	" column of mark markname
+<		 The first column is 1.  Returns 0 if {expr} is invalid or when
+		the window with ID {winid} is not found.
+		For an uppercase mark the column may actually be in another
+		buffer.
+		For the cursor position, when 'virtualedit' is active, the
+		column is one higher if the cursor is after the end of the
+		line.  Also, when using a <Cmd> mapping the cursor isn't
+		moved, this can be used to obtain the column in Insert mode: >vim
+			imap <F2> <Cmd>echo col(".").."\n"<CR>
 
-complete({startcol}, {matches})                                *complete()* *E785*
-                Set the matches for Insert mode completion.
-                Can only be used in Insert mode.  You need to use a mapping
-                with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
-                or with an expression mapping.
-                {startcol} is the byte offset in the line where the completed
-                text start.  The text up to the cursor is the original text
-                that will be replaced by the matches.  Use col('.') for an
-                empty string.  "col('.') - 1" will replace one character by a
-                match.
-                {matches} must be a |List|.  Each |List| item is one match.
-                See |complete-items| for the kind of items that are possible.
-                "longest" in 'completeopt' is ignored.
-                Note that the after calling this function you need to avoid
-                inserting anything that would cause completion to stop.
-                The match can be selected with CTRL-N and CTRL-P as usual with
-                Insert mode completion.  The popup menu will appear if
-                specified, see |ins-completion-menu|.
-                Example: >vim
-                        inoremap <F5> <C-R>=ListMonths()<CR>
+complete({startcol}, {matches})				       *complete()* *E785*
+		Set the matches for Insert mode completion.
+		Can only be used in Insert mode.  You need to use a mapping
+		with CTRL-R = (see |i_CTRL-R|).  It does not work after CTRL-O
+		or with an expression mapping.
+		{startcol} is the byte offset in the line where the completed
+		text start.  The text up to the cursor is the original text
+		that will be replaced by the matches.  Use col('.') for an
+		empty string.  "col('.') - 1" will replace one character by a
+		match.
+		{matches} must be a |List|.  Each |List| item is one match.
+		See |complete-items| for the kind of items that are possible.
+		"longest" in 'completeopt' is ignored.
+		Note that the after calling this function you need to avoid
+		inserting anything that would cause completion to stop.
+		The match can be selected with CTRL-N and CTRL-P as usual with
+		Insert mode completion.  The popup menu will appear if
+		specified, see |ins-completion-menu|.
+		Example: >vim
+			inoremap <F5> <C-R>=ListMonths()<CR>
 
-                        func ListMonths()
-                          call complete(col('.'), ['January', 'February', 'March',
-                            \ 'April', 'May', 'June', 'July', 'August', 'September',
-                            \ 'October', 'November', 'December'])
-                          return ''
-                        endfunc
-<                This isn't very useful, but it shows how it works.  Note that
-                an empty string is returned to avoid a zero being inserted.
+			func ListMonths()
+			  call complete(col('.'), ['January', 'February', 'March',
+			    \ 'April', 'May', 'June', 'July', 'August', 'September',
+			    \ 'October', 'November', 'December'])
+			  return ''
+			endfunc
+<		 This isn't very useful, but it shows how it works.  Note that
+		an empty string is returned to avoid a zero being inserted.
 
-complete_add({expr})                                            *complete_add()*
-                Add {expr} to the list of matches.  Only to be used by the
-                function specified with the 'completefunc' option.
-                Returns 0 for failure (empty string or out of memory),
-                1 when the match was added, 2 when the match was already in
-                the list.
-                See |complete-functions| for an explanation of {expr}.  It is
-                the same as one item in the list that 'omnifunc' would return.
+complete_add({expr})						*complete_add()*
+		Add {expr} to the list of matches.  Only to be used by the
+		function specified with the 'completefunc' option.
+		Returns 0 for failure (empty string or out of memory),
+		1 when the match was added, 2 when the match was already in
+		the list.
+		See |complete-functions| for an explanation of {expr}.	It is
+		the same as one item in the list that 'omnifunc' would return.
 
-complete_check()                                              *complete_check()*
-                Check for a key typed while looking for completion matches.
-                This is to be used when looking for matches takes some time.
-                Returns |TRUE| when searching for matches is to be aborted,
-                zero otherwise.
-                Only to be used by the function specified with the
-                'completefunc' option.
+complete_check()					      *complete_check()*
+		Check for a key typed while looking for completion matches.
+		This is to be used when looking for matches takes some time.
+		Returns |TRUE| when searching for matches is to be aborted,
+		zero otherwise.
+		Only to be used by the function specified with the
+		'completefunc' option.
 
-complete_info([{what}])                                        *complete_info()*
-                Returns a |Dictionary| with information about Insert mode
-                completion.  See |ins-completion|.
-                The items are:
-                   mode         Current completion mode name string.
-                                See |complete_info_mode| for the values.
-                   pum_visible  |TRUE| if popup menu is visible.
-                                See |pumvisible()|.
-                   items        List of completion matches.  Each item is a
-                                dictionary containing the entries "word",
-                                "abbr", "menu", "kind", "info" and "user_data".
-                                See |complete-items|.
-                   selected     Selected item index.  First index is zero.
-                                Index is -1 if no item is selected (showing
-                                typed text only, or the last completion after
-                                no item is selected when using the <Up> or
-                                <Down> keys)
-                   inserted     Inserted string. [NOT IMPLEMENTED YET]
-                   preview_winid     Info floating preview window id.
-                   preview_bufnr     Info floating preview buffer id.
+complete_info([{what}])					       *complete_info()*
+		Returns a |Dictionary| with information about Insert mode
+		completion.  See |ins-completion|.
+		The items are:
+		   mode		Current completion mode name string.
+				See |complete_info_mode| for the values.
+		   pum_visible	|TRUE| if popup menu is visible.
+				See |pumvisible()|.
+		   items	List of completion matches.  Each item is a
+				dictionary containing the entries "word",
+				"abbr", "menu", "kind", "info" and "user_data".
+				See |complete-items|.
+		   selected	Selected item index.  First index is zero.
+				Index is -1 if no item is selected (showing
+				typed text only, or the last completion after
+				no item is selected when using the <Up> or
+				<Down> keys)
+		   inserted	Inserted string. [NOT IMPLEMENTED YET]
+		   preview_winid     Info floating preview window id.
+		   preview_bufnr     Info floating preview buffer id.
 
-                                                        *complete_info_mode*
-                mode values are:
-                   ""                Not in completion mode
-                   "keyword"         Keyword completion |i_CTRL-X_CTRL-N|
-                   "ctrl_x"          Just pressed CTRL-X |i_CTRL-X|
-                   "scroll"          Scrolling with |i_CTRL-X_CTRL-E| or
-                                     |i_CTRL-X_CTRL-Y|
-                   "whole_line"      Whole lines |i_CTRL-X_CTRL-L|
-                   "files"           File names |i_CTRL-X_CTRL-F|
-                   "tags"            Tags |i_CTRL-X_CTRL-]|
-                   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
-                   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
-                   "dictionary"      Dictionary |i_CTRL-X_CTRL-K|
-                   "thesaurus"       Thesaurus |i_CTRL-X_CTRL-T|
-                   "cmdline"         Vim Command line |i_CTRL-X_CTRL-V|
-                   "function"        User defined completion |i_CTRL-X_CTRL-U|
-                   "omni"            Omni completion |i_CTRL-X_CTRL-O|
-                   "spell"           Spelling suggestions |i_CTRL-X_s|
-                   "eval"            |complete()| completion
-                   "unknown"         Other internal modes
+							*complete_info_mode*
+		mode values are:
+		   ""		     Not in completion mode
+		   "keyword"	     Keyword completion |i_CTRL-X_CTRL-N|
+		   "ctrl_x"	     Just pressed CTRL-X |i_CTRL-X|
+		   "scroll"	     Scrolling with |i_CTRL-X_CTRL-E| or
+				     |i_CTRL-X_CTRL-Y|
+		   "whole_line"      Whole lines |i_CTRL-X_CTRL-L|
+		   "files"	     File names |i_CTRL-X_CTRL-F|
+		   "tags"	     Tags |i_CTRL-X_CTRL-]|
+		   "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
+		   "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
+		   "dictionary"      Dictionary |i_CTRL-X_CTRL-K|
+		   "thesaurus"	     Thesaurus |i_CTRL-X_CTRL-T|
+		   "cmdline"	     Vim Command line |i_CTRL-X_CTRL-V|
+		   "function"	     User defined completion |i_CTRL-X_CTRL-U|
+		   "omni"	     Omni completion |i_CTRL-X_CTRL-O|
+		   "spell"	     Spelling suggestions |i_CTRL-X_s|
+		   "eval"	     |complete()| completion
+		   "unknown"	     Other internal modes
 
-                If the optional {what} list argument is supplied, then only
-                the items listed in {what} are returned.  Unsupported items in
-                {what} are silently ignored.
+		If the optional {what} list argument is supplied, then only
+		the items listed in {what} are returned.  Unsupported items in
+		{what} are silently ignored.
 
-                To get the position and size of the popup menu, see
-                |pum_getpos()|. It's also available in |v:event| during the
-                |CompleteChanged| event.
+		To get the position and size of the popup menu, see
+		|pum_getpos()|. It's also available in |v:event| during the
+		|CompleteChanged| event.
 
-                Returns an empty |Dictionary| on error.
+		Returns an empty |Dictionary| on error.
 
-                Examples: >vim
-                        " Get all items
-                        call complete_info()
-                        " Get only 'mode'
-                        call complete_info(['mode'])
-                        " Get only 'mode' and 'pum_visible'
-                        call complete_info(['mode', 'pum_visible'])
+		Examples: >vim
+			" Get all items
+			call complete_info()
+			" Get only 'mode'
+			call complete_info(['mode'])
+			" Get only 'mode' and 'pum_visible'
+			call complete_info(['mode', 'pum_visible'])
 
-confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
-                confirm() offers the user a dialog, from which a choice can be
-                made.  It returns the number of the choice.  For the first
-                choice this is 1.
+confirm({msg} [, {choices} [, {default} [, {type}]]])		     *confirm()*
+		confirm() offers the user a dialog, from which a choice can be
+		made.  It returns the number of the choice.  For the first
+		choice this is 1.
 
-                {msg} is displayed in a dialog with {choices} as the
-                alternatives.  When {choices} is missing or empty, "&OK" is
-                used (and translated).
-                {msg} is a String, use '\n' to include a newline.  Only on
-                some systems the string is wrapped when it doesn't fit.
+		{msg} is displayed in a dialog with {choices} as the
+		alternatives.  When {choices} is missing or empty, "&OK" is
+		used (and translated).
+		{msg} is a String, use '\n' to include a newline.  Only on
+		some systems the string is wrapped when it doesn't fit.
 
-                {choices} is a String, with the individual choices separated
-                by '\n', e.g. >vim
-                        confirm("Save changes?", "&Yes\n&No\n&Cancel")
-<                The letter after the '&' is the shortcut key for that choice.
-                Thus you can type 'c' to select "Cancel".  The shortcut does
-                not need to be the first letter: >vim
-                        confirm("file has been modified", "&Save\nSave &All")
-<                For the console, the first letter of each choice is used as
-                the default shortcut key.  Case is ignored.
+		{choices} is a String, with the individual choices separated
+		by '\n', e.g. >vim
+			confirm("Save changes?", "&Yes\n&No\n&Cancel")
+<		 The letter after the '&' is the shortcut key for that choice.
+		Thus you can type 'c' to select "Cancel".  The shortcut does
+		not need to be the first letter: >vim
+			confirm("file has been modified", "&Save\nSave &All")
+<		 For the console, the first letter of each choice is used as
+		the default shortcut key.  Case is ignored.
 
-                The optional {type} String argument gives the type of dialog.
-                It can be one of these values: "Error", "Question", "Info",
-                "Warning" or "Generic".  Only the first character is relevant.
-                When {type} is omitted, "Generic" is used.
+		The optional {type} String argument gives the type of dialog.
+		It can be one of these values: "Error", "Question", "Info",
+		"Warning" or "Generic".  Only the first character is relevant.
+		When {type} is omitted, "Generic" is used.
 
-                The optional {type} argument gives the type of dialog.  This
-                is only used for the icon of the Win32 GUI.  It can be one of
-                these values: "Error", "Question", "Info", "Warning" or
-                "Generic".  Only the first character is relevant.
-                When {type} is omitted, "Generic" is used.
+		The optional {type} argument gives the type of dialog.	This
+		is only used for the icon of the Win32 GUI.  It can be one of
+		these values: "Error", "Question", "Info", "Warning" or
+		"Generic".  Only the first character is relevant.
+		When {type} is omitted, "Generic" is used.
 
-                If the user aborts the dialog by pressing <Esc>, CTRL-C,
-                or another valid interrupt key, confirm() returns 0.
+		If the user aborts the dialog by pressing <Esc>, CTRL-C,
+		or another valid interrupt key, confirm() returns 0.
 
-                An example: >vim
-                   let choice = confirm("What do you want?",
-                                        \ "&Apples\n&Oranges\n&Bananas", 2)
-                   if choice == 0
-                        echo "make up your mind!"
-                   elseif choice == 3
-                        echo "tasteful"
-                   else
-                        echo "I prefer bananas myself."
-                   endif
-<                In a GUI dialog, buttons are used.  The layout of the buttons
-                depends on the 'v' flag in 'guioptions'.  If it is included,
-                the buttons are always put vertically.  Otherwise,  confirm()
-                tries to put the buttons in one horizontal line.  If they
-                don't fit, a vertical layout is used anyway.  For some systems
-                the horizontal layout is always used.
+		An example: >vim
+		   let choice = confirm("What do you want?",
+					\ "&Apples\n&Oranges\n&Bananas", 2)
+		   if choice == 0
+			echo "make up your mind!"
+		   elseif choice == 3
+			echo "tasteful"
+		   else
+			echo "I prefer bananas myself."
+		   endif
+<		 In a GUI dialog, buttons are used.  The layout of the buttons
+		depends on the 'v' flag in 'guioptions'.  If it is included,
+		the buttons are always put vertically.	Otherwise,  confirm()
+		tries to put the buttons in one horizontal line.  If they
+		don't fit, a vertical layout is used anyway.  For some systems
+		the horizontal layout is always used.
 
-copy({expr})                                                            *copy()*
-                Make a copy of {expr}.  For Numbers and Strings this isn't
-                different from using {expr} directly.
-                When {expr} is a |List| a shallow copy is created.  This means
-                that the original |List| can be changed without changing the
-                copy, and vice versa.  But the items are identical, thus
-                changing an item changes the contents of both |Lists|.
-                A |Dictionary| is copied in a similar way as a |List|.
-                Also see |deepcopy()|.
+copy({expr})								*copy()*
+		Make a copy of {expr}.	For Numbers and Strings this isn't
+		different from using {expr} directly.
+		When {expr} is a |List| a shallow copy is created.  This means
+		that the original |List| can be changed without changing the
+		copy, and vice versa.  But the items are identical, thus
+		changing an item changes the contents of both |Lists|.
+		A |Dictionary| is copied in a similar way as a |List|.
+		Also see |deepcopy()|.
 
-cos({expr})                                                              *cos()*
-                Return the cosine of {expr}, measured in radians, as a |Float|.
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo cos(100)
-<                        0.862319 >vim
-                        echo cos(-4.01)
-<                        -0.646043
+cos({expr})								 *cos()*
+		Return the cosine of {expr}, measured in radians, as a |Float|.
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo cos(100)
+<			 0.862319 >vim
+			echo cos(-4.01)
+<			 -0.646043
 
-cosh({expr})                                                            *cosh()*
-                Return the hyperbolic cosine of {expr} as a |Float| in the range
-                [1, inf].
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo cosh(0.5)
-<                        1.127626 >vim
-                        echo cosh(-0.5)
-<                        -1.127626
+cosh({expr})								*cosh()*
+		Return the hyperbolic cosine of {expr} as a |Float| in the range
+		[1, inf].
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo cosh(0.5)
+<			 1.127626 >vim
+			echo cosh(-0.5)
+<			 -1.127626
 
-count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E706*
-                Return the number of times an item with value {expr} appears
-                in |String|, |List| or |Dictionary| {comp}.
+count({comp}, {expr} [, {ic} [, {start}]])			  *count()* *E706*
+		Return the number of times an item with value {expr} appears
+		in |String|, |List| or |Dictionary| {comp}.
 
-                If {start} is given then start with the item with this index.
-                {start} can only be used with a |List|.
+		If {start} is given then start with the item with this index.
+		{start} can only be used with a |List|.
 
-                When {ic} is given and it's |TRUE| then case is ignored.
+		When {ic} is given and it's |TRUE| then case is ignored.
 
-                When {comp} is a string then the number of not overlapping
-                occurrences of {expr} is returned. Zero is returned when
-                {expr} is an empty string.
+		When {comp} is a string then the number of not overlapping
+		occurrences of {expr} is returned. Zero is returned when
+		{expr} is an empty string.
 
-ctxget([{index}])                                                     *ctxget()*
-                Returns a |Dictionary| representing the |context| at {index}
-                from the top of the |context-stack| (see |context-dict|).
-                If {index} is not given, it is assumed to be 0 (i.e.: top).
+ctxget([{index}])						      *ctxget()*
+		Returns a |Dictionary| representing the |context| at {index}
+		from the top of the |context-stack| (see |context-dict|).
+		If {index} is not given, it is assumed to be 0 (i.e.: top).
 
-ctxpop()                                                              *ctxpop()*
-                Pops and restores the |context| at the top of the
-                |context-stack|.
+ctxpop()							      *ctxpop()*
+		Pops and restores the |context| at the top of the
+		|context-stack|.
 
-ctxpush([{types}])                                                   *ctxpush()*
-                Pushes the current editor state (|context|) on the
-                |context-stack|.
-                If {types} is given and is a |List| of |String|s, it specifies
-                which |context-types| to include in the pushed context.
-                Otherwise, all context types are included.
+ctxpush([{types}])						     *ctxpush()*
+		Pushes the current editor state (|context|) on the
+		|context-stack|.
+		If {types} is given and is a |List| of |String|s, it specifies
+		which |context-types| to include in the pushed context.
+		Otherwise, all context types are included.
 
-ctxset({context} [, {index}])                                         *ctxset()*
-                Sets the |context| at {index} from the top of the
-                |context-stack| to that represented by {context}.
-                {context} is a Dictionary with context data (|context-dict|).
-                If {index} is not given, it is assumed to be 0 (i.e.: top).
+ctxset({context} [, {index}])					      *ctxset()*
+		Sets the |context| at {index} from the top of the
+		|context-stack| to that represented by {context}.
+		{context} is a Dictionary with context data (|context-dict|).
+		If {index} is not given, it is assumed to be 0 (i.e.: top).
 
-ctxsize()                                                            *ctxsize()*
-                Returns the size of the |context-stack|.
+ctxsize()							     *ctxsize()*
+		Returns the size of the |context-stack|.
 
 cursor({lnum}, {col} [, {off}])
-cursor({list})                                                        *cursor()*
-                Positions the cursor at the column (byte count) {col} in the
-                line {lnum}.  The first column is one.
+cursor({list})							      *cursor()*
+		Positions the cursor at the column (byte count) {col} in the
+		line {lnum}.  The first column is one.
 
-                When there is one argument {list} this is used as a |List|
-                with two, three or four item:
-                        [{lnum}, {col}]
-                        [{lnum}, {col}, {off}]
-                        [{lnum}, {col}, {off}, {curswant}]
-                This is like the return value of |getpos()| or |getcurpos()|,
-                but without the first item.
+		When there is one argument {list} this is used as a |List|
+		with two, three or four item:
+			[{lnum}, {col}]
+			[{lnum}, {col}, {off}]
+			[{lnum}, {col}, {off}, {curswant}]
+		This is like the return value of |getpos()| or |getcurpos()|,
+		but without the first item.
 
-                To position the cursor using {col} as the character count, use
-                |setcursorcharpos()|.
+		To position the cursor using {col} as the character count, use
+		|setcursorcharpos()|.
 
-                Does not change the jumplist.
-                {lnum} is used like with |getline()|, except that if {lnum} is
-                zero, the cursor will stay in the current line.
-                If {lnum} is greater than the number of lines in the buffer,
-                the cursor will be positioned at the last line in the buffer.
-                If {col} is greater than the number of bytes in the line,
-                the cursor will be positioned at the last character in the
-                line.
-                If {col} is zero, the cursor will stay in the current column.
-                If {curswant} is given it is used to set the preferred column
-                for vertical movement.  Otherwise {col} is used.
+		Does not change the jumplist.
+		{lnum} is used like with |getline()|, except that if {lnum} is
+		zero, the cursor will stay in the current line.
+		If {lnum} is greater than the number of lines in the buffer,
+		the cursor will be positioned at the last line in the buffer.
+		If {col} is greater than the number of bytes in the line,
+		the cursor will be positioned at the last character in the
+		line.
+		If {col} is zero, the cursor will stay in the current column.
+		If {curswant} is given it is used to set the preferred column
+		for vertical movement.	Otherwise {col} is used.
 
-                When 'virtualedit' is used {off} specifies the offset in
-                screen columns from the start of the character.  E.g., a
-                position within a <Tab> or after the last character.
-                Returns 0 when the position could be set, -1 otherwise.
+		When 'virtualedit' is used {off} specifies the offset in
+		screen columns from the start of the character.  E.g., a
+		position within a <Tab> or after the last character.
+		Returns 0 when the position could be set, -1 otherwise.
 
-debugbreak({pid})                                                 *debugbreak()*
-                Specifically used to interrupt a program being debugged.  It
-                will cause process {pid} to get a SIGTRAP.  Behavior for other
-                processes is undefined. See |terminal-debug|.
-                (Sends a SIGINT to a process {pid} other than MS-Windows)
+debugbreak({pid})						  *debugbreak()*
+		Specifically used to interrupt a program being debugged.  It
+		will cause process {pid} to get a SIGTRAP.  Behavior for other
+		processes is undefined. See |terminal-debug|.
+		(Sends a SIGINT to a process {pid} other than MS-Windows)
 
-                Returns |TRUE| if successfully interrupted the program.
-                Otherwise returns |FALSE|.
+		Returns |TRUE| if successfully interrupted the program.
+		Otherwise returns |FALSE|.
 
-deepcopy({expr} [, {noref}])                                   *deepcopy()* *E698*
-                Make a copy of {expr}.  For Numbers and Strings this isn't
-                different from using {expr} directly.
-                When {expr} is a |List| a full copy is created.  This means
-                that the original |List| can be changed without changing the
-                copy, and vice versa.  When an item is a |List|, a copy for it
-                is made, recursively.  Thus changing an item in the copy does
-                not change the contents of the original |List|.
+deepcopy({expr} [, {noref}])				       *deepcopy()* *E698*
+		Make a copy of {expr}.	For Numbers and Strings this isn't
+		different from using {expr} directly.
+		When {expr} is a |List| a full copy is created.  This means
+		that the original |List| can be changed without changing the
+		copy, and vice versa.  When an item is a |List|, a copy for it
+		is made, recursively.  Thus changing an item in the copy does
+		not change the contents of the original |List|.
 
-                When {noref} is omitted or zero a contained |List| or
-                |Dictionary| is only copied once.  All references point to
-                this single copy.  With {noref} set to 1 every occurrence of a
-                |List| or |Dictionary| results in a new copy.  This also means
-                that a cyclic reference causes deepcopy() to fail.
-                                                                *E724*
-                Nesting is possible up to 100 levels.  When there is an item
-                that refers back to a higher level making a deep copy with
-                {noref} set to 1 will fail.
-                Also see |copy()|.
+		When {noref} is omitted or zero a contained |List| or
+		|Dictionary| is only copied once.  All references point to
+		this single copy.  With {noref} set to 1 every occurrence of a
+		|List| or |Dictionary| results in a new copy.  This also means
+		that a cyclic reference causes deepcopy() to fail.
+								*E724*
+		Nesting is possible up to 100 levels.  When there is an item
+		that refers back to a higher level making a deep copy with
+		{noref} set to 1 will fail.
+		Also see |copy()|.
 
-delete({fname} [, {flags}])                                           *delete()*
-                Without {flags} or with {flags} empty: Deletes the file by the
-                name {fname}.
+delete({fname} [, {flags}])					      *delete()*
+		Without {flags} or with {flags} empty: Deletes the file by the
+		name {fname}.
 
-                This also works when {fname} is a symbolic link.  The symbolic
-                link itself is deleted, not what it points to.
+		This also works when {fname} is a symbolic link.  The symbolic
+		link itself is deleted, not what it points to.
 
-                When {flags} is "d": Deletes the directory by the name
-                {fname}.  This fails when directory {fname} is not empty.
+		When {flags} is "d": Deletes the directory by the name
+		{fname}.  This fails when directory {fname} is not empty.
 
-                When {flags} is "rf": Deletes the directory by the name
-                {fname} and everything in it, recursively.  BE CAREFUL!
-                Note: on MS-Windows it is not possible to delete a directory
-                that is being used.
+		When {flags} is "rf": Deletes the directory by the name
+		{fname} and everything in it, recursively.  BE CAREFUL!
+		Note: on MS-Windows it is not possible to delete a directory
+		that is being used.
 
-                The result is a Number, which is 0/false if the delete
-                operation was successful and -1/true when the deletion failed
-                or partly failed.
+		The result is a Number, which is 0/false if the delete
+		operation was successful and -1/true when the deletion failed
+		or partly failed.
 
-deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
-                Delete lines {first} to {last} (inclusive) from buffer {buf}.
-                If {last} is omitted then delete line {first} only.
-                On success 0 is returned, on failure 1 is returned.
+deletebufline({buf}, {first} [, {last}])		       *deletebufline()*
+		Delete lines {first} to {last} (inclusive) from buffer {buf}.
+		If {last} is omitted then delete line {first} only.
+		On success 0 is returned, on failure 1 is returned.
 
-                This function works only for loaded buffers. First call
-                |bufload()| if needed.
+		This function works only for loaded buffers. First call
+		|bufload()| if needed.
 
-                For the use of {buf}, see |bufname()| above.
+		For the use of {buf}, see |bufname()| above.
 
-                {first} and {last} are used like with |getline()|. Note that
-                when using |line()| this refers to the current buffer. Use "$"
-                to refer to the last line in buffer {buf}.
+		{first} and {last} are used like with |getline()|. Note that
+		when using |line()| this refers to the current buffer. Use "$"
+		to refer to the last line in buffer {buf}.
 
-dictwatcheradd({dict}, {pattern}, {callback})                 *dictwatcheradd()*
-                Adds a watcher to a dictionary. A dictionary watcher is
-                identified by three components:
+dictwatcheradd({dict}, {pattern}, {callback})		      *dictwatcheradd()*
+		Adds a watcher to a dictionary. A dictionary watcher is
+		identified by three components:
 
-                - A dictionary({dict});
-                - A key pattern({pattern}).
-                - A function({callback}).
+		- A dictionary({dict});
+		- A key pattern({pattern}).
+		- A function({callback}).
 
-                After this is called, every change on {dict} and on keys
-                matching {pattern} will result in {callback} being invoked.
+		After this is called, every change on {dict} and on keys
+		matching {pattern} will result in {callback} being invoked.
 
-                For example, to watch all global variables: >vim
-                        silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
-                        function! OnDictChanged(d,k,z)
-                          echomsg string(a:k) string(a:z)
-                        endfunction
-                        call dictwatcheradd(g:, '*', 'OnDictChanged')
+		For example, to watch all global variables: >vim
+			silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
+			function! OnDictChanged(d,k,z)
+			  echomsg string(a:k) string(a:z)
+			endfunction
+			call dictwatcheradd(g:, '*', 'OnDictChanged')
 <
-                For now {pattern} only accepts very simple patterns that can
-                contain a "*" at the end of the string, in which case it will
-                match every key that begins with the substring before the "*".
-                That means if "*" is not the last character of {pattern}, only
-                keys that are exactly equal as {pattern} will be matched.
+		For now {pattern} only accepts very simple patterns that can
+		contain a "*" at the end of the string, in which case it will
+		match every key that begins with the substring before the "*".
+		That means if "*" is not the last character of {pattern}, only
+		keys that are exactly equal as {pattern} will be matched.
 
-                The {callback} receives three arguments:
+		The {callback} receives three arguments:
 
-                - The dictionary being watched.
-                - The key which changed.
-                - A dictionary containing the new and old values for the key.
+		- The dictionary being watched.
+		- The key which changed.
+		- A dictionary containing the new and old values for the key.
 
-                The type of change can be determined by examining the keys
-                present on the third argument:
+		The type of change can be determined by examining the keys
+		present on the third argument:
 
-                - If contains both `old` and `new`, the key was updated.
-                - If it contains only `new`, the key was added.
-                - If it contains only `old`, the key was deleted.
+		- If contains both `old` and `new`, the key was updated.
+		- If it contains only `new`, the key was added.
+		- If it contains only `old`, the key was deleted.
 
-                This function can be used by plugins to implement options with
-                validation and parsing logic.
+		This function can be used by plugins to implement options with
+		validation and parsing logic.
 
-dictwatcherdel({dict}, {pattern}, {callback})                 *dictwatcherdel()*
-                Removes a watcher added  with |dictwatcheradd()|. All three
-                arguments must match the ones passed to |dictwatcheradd()| in
-                order for the watcher to be successfully deleted.
+dictwatcherdel({dict}, {pattern}, {callback})		      *dictwatcherdel()*
+		Removes a watcher added  with |dictwatcheradd()|. All three
+		arguments must match the ones passed to |dictwatcheradd()| in
+		order for the watcher to be successfully deleted.
 
-did_filetype()                                                  *did_filetype()*
-                Returns |TRUE| when autocommands are being executed and the
-                FileType event has been triggered at least once.  Can be used
-                to avoid triggering the FileType event again in the scripts
-                that detect the file type. |FileType|
-                Returns |FALSE| when `:setf FALLBACK` was used.
-                When editing another file, the counter is reset, thus this
-                really checks if the FileType event has been triggered for the
-                current buffer.  This allows an autocommand that starts
-                editing another buffer to set 'filetype' and load a syntax
-                file.
+did_filetype()							*did_filetype()*
+		Returns |TRUE| when autocommands are being executed and the
+		FileType event has been triggered at least once.  Can be used
+		to avoid triggering the FileType event again in the scripts
+		that detect the file type. |FileType|
+		Returns |FALSE| when `:setf FALLBACK` was used.
+		When editing another file, the counter is reset, thus this
+		really checks if the FileType event has been triggered for the
+		current buffer.  This allows an autocommand that starts
+		editing another buffer to set 'filetype' and load a syntax
+		file.
 
-diff_filler({lnum})                                              *diff_filler()*
-                Returns the number of filler lines above line {lnum}.
-                These are the lines that were inserted at this point in
-                another diff'ed window.  These filler lines are shown in the
-                display but don't exist in the buffer.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
-                Returns 0 if the current window is not in diff mode.
+diff_filler({lnum})						 *diff_filler()*
+		Returns the number of filler lines above line {lnum}.
+		These are the lines that were inserted at this point in
+		another diff'ed window.  These filler lines are shown in the
+		display but don't exist in the buffer.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
+		Returns 0 if the current window is not in diff mode.
 
-diff_hlID({lnum}, {col})                                           *diff_hlID()*
-                Returns the highlight ID for diff mode at line {lnum} column
-                {col} (byte index).  When the current line does not have a
-                diff change zero is returned.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
-                {col} is 1 for the leftmost column, {lnum} is 1 for the first
-                line.
-                The highlight ID can be used with |synIDattr()| to obtain
-                syntax information about the highlighting.
+diff_hlID({lnum}, {col})					   *diff_hlID()*
+		Returns the highlight ID for diff mode at line {lnum} column
+		{col} (byte index).  When the current line does not have a
+		diff change zero is returned.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
+		{col} is 1 for the leftmost column, {lnum} is 1 for the first
+		line.
+		The highlight ID can be used with |synIDattr()| to obtain
+		syntax information about the highlighting.
 
-digraph_get({chars})                                       *digraph_get()* *E1214*
-                Return the digraph of {chars}.  This should be a string with
-                exactly two characters.  If {chars} are not just two
-                characters, or the digraph of {chars} does not exist, an error
-                is given and an empty string is returned.
+digraph_get({chars})					   *digraph_get()* *E1214*
+		Return the digraph of {chars}.	This should be a string with
+		exactly two characters.  If {chars} are not just two
+		characters, or the digraph of {chars} does not exist, an error
+		is given and an empty string is returned.
 
-                Also see |digraph_getlist()|.
+		Also see |digraph_getlist()|.
 
-                Examples: >vim
-                " Get a built-in digraph
-                echo digraph_get('00')          " Returns '∞'
+		Examples: >vim
+		" Get a built-in digraph
+		echo digraph_get('00')		" Returns '∞'
 
-                " Get a user-defined digraph
-                call digraph_set('aa', 'あ')
-                echo digraph_get('aa')          " Returns 'あ'
+		" Get a user-defined digraph
+		call digraph_set('aa', 'あ')
+		echo digraph_get('aa')		" Returns 'あ'
 <
-digraph_getlist([{listall}])                                 *digraph_getlist()*
-                Return a list of digraphs.  If the {listall} argument is given
-                and it is TRUE, return all digraphs, including the default
-                digraphs.  Otherwise, return only user-defined digraphs.
+digraph_getlist([{listall}])				     *digraph_getlist()*
+		Return a list of digraphs.  If the {listall} argument is given
+		and it is TRUE, return all digraphs, including the default
+		digraphs.  Otherwise, return only user-defined digraphs.
 
-                Also see |digraph_get()|.
+		Also see |digraph_get()|.
 
-                Examples: >vim
-                " Get user-defined digraphs
-                echo digraph_getlist()
+		Examples: >vim
+		" Get user-defined digraphs
+		echo digraph_getlist()
 
-                " Get all the digraphs, including default digraphs
-                echo digraph_getlist(1)
+		" Get all the digraphs, including default digraphs
+		echo digraph_getlist(1)
 <
-digraph_set({chars}, {digraph})                                  *digraph_set()*
-                Add digraph {chars} to the list.  {chars} must be a string
-                with two characters.  {digraph} is a string with one UTF-8
-                encoded character.  *E1215*
-                Be careful, composing characters are NOT ignored.  This
-                function is similar to |:digraphs| command, but useful to add
-                digraphs start with a white space.
+digraph_set({chars}, {digraph})					 *digraph_set()*
+		Add digraph {chars} to the list.  {chars} must be a string
+		with two characters.  {digraph} is a string with one UTF-8
+		encoded character.  *E1215*
+		Be careful, composing characters are NOT ignored.  This
+		function is similar to |:digraphs| command, but useful to add
+		digraphs start with a white space.
 
-                The function result is v:true if |digraph| is registered.  If
-                this fails an error message is given and v:false is returned.
+		The function result is v:true if |digraph| is registered.  If
+		this fails an error message is given and v:false is returned.
 
-                If you want to define multiple digraphs at once, you can use
-                |digraph_setlist()|.
+		If you want to define multiple digraphs at once, you can use
+		|digraph_setlist()|.
 
-                Example: >vim
-                        call digraph_set('  ', 'あ')
+		Example: >vim
+			call digraph_set('  ', 'あ')
 <
-                Can be used as a |method|: >vim
-                        GetString()->digraph_set('あ')
+		Can be used as a |method|: >vim
+			GetString()->digraph_set('あ')
 <
-digraph_setlist({digraphlist})                               *digraph_setlist()*
-                Similar to |digraph_set()| but this function can add multiple
-                digraphs at once.  {digraphlist} is a list composed of lists,
-                where each list contains two strings with {chars} and
-                {digraph} as in |digraph_set()|. *E1216*
-                Example: >vim
-                    call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
+digraph_setlist({digraphlist})				     *digraph_setlist()*
+		Similar to |digraph_set()| but this function can add multiple
+		digraphs at once.  {digraphlist} is a list composed of lists,
+		where each list contains two strings with {chars} and
+		{digraph} as in |digraph_set()|. *E1216*
+		Example: >vim
+		    call digraph_setlist([['aa', 'あ'], ['ii', 'い']])
 <
-                It is similar to the following: >vim
-                    for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
-                          call digraph_set(chars, digraph)
-                    endfor
-<                Except that the function returns after the first error,
-                following digraphs will not be added.
+		It is similar to the following: >vim
+		    for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
+			  call digraph_set(chars, digraph)
+		    endfor
+<		 Except that the function returns after the first error,
+		following digraphs will not be added.
 
-                Can be used as a |method|: >vim
-                    GetList()->digraph_setlist()
+		Can be used as a |method|: >vim
+		    GetList()->digraph_setlist()
 <
-empty({expr})                                                          *empty()*
-                Return the Number 1 if {expr} is empty, zero otherwise.
-                - A |List| or |Dictionary| is empty when it does not have any
-                  items.
-                - A |String| is empty when its length is zero.
-                - A |Number| and |Float| are empty when their value is zero.
-                - |v:false| and |v:null| are empty, |v:true| is not.
-                - A |Blob| is empty when its length is zero.
+empty({expr})							       *empty()*
+		Return the Number 1 if {expr} is empty, zero otherwise.
+		- A |List| or |Dictionary| is empty when it does not have any
+		  items.
+		- A |String| is empty when its length is zero.
+		- A |Number| and |Float| are empty when their value is zero.
+		- |v:false| and |v:null| are empty, |v:true| is not.
+		- A |Blob| is empty when its length is zero.
 
-environ()                                                            *environ()*
-                Return all of environment variables as dictionary. You can
-                check if an environment variable exists like this: >vim
-                        echo has_key(environ(), 'HOME')
-<                Note that the variable name may be CamelCase; to ignore case
-                use this: >vim
-                        echo index(keys(environ()), 'HOME', 0, 1) != -1
+environ()							     *environ()*
+		Return all of environment variables as dictionary. You can
+		check if an environment variable exists like this: >vim
+			echo has_key(environ(), 'HOME')
+<		 Note that the variable name may be CamelCase; to ignore case
+		use this: >vim
+			echo index(keys(environ()), 'HOME', 0, 1) != -1
 <
-escape({string}, {chars})                                             *escape()*
-                Escape the characters in {chars} that occur in {string} with a
-                backslash.  Example: >vim
-                        echo escape('c:\program files\vim', ' \')
-<                results in: >
-                        c:\\program\ files\\vim
-<                Also see |shellescape()| and |fnameescape()|.
+escape({string}, {chars})					      *escape()*
+		Escape the characters in {chars} that occur in {string} with a
+		backslash.  Example: >vim
+			echo escape('c:\program files\vim', ' \')
+<		 results in: >
+			c:\\program\ files\\vim
+<		 Also see |shellescape()| and |fnameescape()|.
 
-eval({string})                                                          *eval()*
-                Evaluate {string} and return the result.  Especially useful to
-                turn the result of |string()| back into the original value.
-                This works for Numbers, Floats, Strings, Blobs and composites
-                of them.  Also works for |Funcref|s that refer to existing
-                functions.
+eval({string})								*eval()*
+		Evaluate {string} and return the result.  Especially useful to
+		turn the result of |string()| back into the original value.
+		This works for Numbers, Floats, Strings, Blobs and composites
+		of them.  Also works for |Funcref|s that refer to existing
+		functions.
 
-eventhandler()                                                  *eventhandler()*
-                Returns 1 when inside an event handler.  That is that Vim got
-                interrupted while waiting for the user to type a character,
-                e.g., when dropping a file on Vim.  This means interactive
-                commands cannot be used.  Otherwise zero is returned.
+eventhandler()							*eventhandler()*
+		Returns 1 when inside an event handler.  That is that Vim got
+		interrupted while waiting for the user to type a character,
+		e.g., when dropping a file on Vim.  This means interactive
+		commands cannot be used.  Otherwise zero is returned.
 
-executable({expr})                                                *executable()*
-                This function checks if an executable with the name {expr}
-                exists.  {expr} must be the name of the program without any
-                arguments.
-                executable() uses the value of $PATH and/or the normal
-                searchpath for programs.                *PATHEXT*
-                On MS-Windows the ".exe", ".bat", etc. can optionally be
-                included.  Then the extensions in $PATHEXT are tried.  Thus if
-                "foo.exe" does not exist, "foo.exe.bat" can be found.  If
-                $PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
-                by itself can be used in $PATHEXT to try using the name
-                without an extension.  When 'shell' looks like a Unix shell,
-                then the name is also tried without adding an extension.
-                On MS-Windows it only checks if the file exists and is not a
-                directory, not if it's really executable.
-                On Windows an executable in the same directory as Vim is
-                always found (it is added to $PATH at |startup|).
-                The result is a Number:
-                        1       exists
-                        0       does not exist
-                        -1      not implemented on this system
-                |exepath()| can be used to get the full path of an executable.
+executable({expr})						  *executable()*
+		This function checks if an executable with the name {expr}
+		exists.  {expr} must be the name of the program without any
+		arguments.
+		executable() uses the value of $PATH and/or the normal
+		searchpath for programs.		*PATHEXT*
+		On MS-Windows the ".exe", ".bat", etc. can optionally be
+		included.  Then the extensions in $PATHEXT are tried.  Thus if
+		"foo.exe" does not exist, "foo.exe.bat" can be found.  If
+		$PATHEXT is not set then ".exe;.com;.bat;.cmd" is used.  A dot
+		by itself can be used in $PATHEXT to try using the name
+		without an extension.  When 'shell' looks like a Unix shell,
+		then the name is also tried without adding an extension.
+		On MS-Windows it only checks if the file exists and is not a
+		directory, not if it's really executable.
+		On Windows an executable in the same directory as Vim is
+		always found (it is added to $PATH at |startup|).
+		The result is a Number:
+			1	exists
+			0	does not exist
+			-1	not implemented on this system
+		|exepath()| can be used to get the full path of an executable.
 
-execute({command} [, {silent}])                                      *execute()*
-                Execute {command} and capture its output.
-                If {command} is a |String|, returns {command} output.
-                If {command} is a |List|, returns concatenated outputs.
-                Line continuations in {command} are not recognized.
-                Examples: >vim
-                        echo execute('echon "foo"')
-<                       foo >vim
-                        echo execute(['echon "foo"', 'echon "bar"'])
-<                       foobar
+execute({command} [, {silent}])					     *execute()*
+		Execute {command} and capture its output.
+		If {command} is a |String|, returns {command} output.
+		If {command} is a |List|, returns concatenated outputs.
+		Line continuations in {command} are not recognized.
+		Examples: >vim
+			echo execute('echon "foo"')
+<			foo >vim
+			echo execute(['echon "foo"', 'echon "bar"'])
+<			foobar
 
-                The optional {silent} argument can have these values:
-                        ""              no `:silent` used
-                        "silent"        `:silent` used
-                        "silent!"       `:silent!` used
-                The default is "silent".  Note that with "silent!", unlike
-                `:redir`, error messages are dropped.
+		The optional {silent} argument can have these values:
+			""		no `:silent` used
+			"silent"	`:silent` used
+			"silent!"	`:silent!` used
+		The default is "silent".  Note that with "silent!", unlike
+		`:redir`, error messages are dropped.
 
-                To get a list of lines use `split()` on the result: >vim
-                        execute('args')->split("\n")
+		To get a list of lines use `split()` on the result: >vim
+			execute('args')->split("\n")
 
-<                This function is not available in the |sandbox|.
-                Note: If nested, an outer execute() will not observe output of
-                the inner calls.
-                Note: Text attributes (highlights) are not captured.
-                To execute a command in another window than the current one
-                use `win_execute()`.
+<		 This function is not available in the |sandbox|.
+		Note: If nested, an outer execute() will not observe output of
+		the inner calls.
+		Note: Text attributes (highlights) are not captured.
+		To execute a command in another window than the current one
+		use `win_execute()`.
 
-exepath({expr})                                                      *exepath()*
-                Returns the full path of {expr} if it is an executable and
-                given as a (partial or full) path or is found in $PATH.
-                Returns empty string otherwise.
-                If {expr} starts with "./" the |current-directory| is used.
+exepath({expr})							     *exepath()*
+		Returns the full path of {expr} if it is an executable and
+		given as a (partial or full) path or is found in $PATH.
+		Returns empty string otherwise.
+		If {expr} starts with "./" the |current-directory| is used.
 
-exists({expr})                                                        *exists()*
-                The result is a Number, which is |TRUE| if {expr} is
-                defined, zero otherwise.
+exists({expr})							      *exists()*
+		The result is a Number, which is |TRUE| if {expr} is
+		defined, zero otherwise.
 
-                For checking for a supported feature use |has()|.
-                For checking if a file exists use |filereadable()|.
+		For checking for a supported feature use |has()|.
+		For checking if a file exists use |filereadable()|.
 
-                The {expr} argument is a string, which contains one of these:
-                        varname         internal variable (see
-                        dict.key        |internal-variables|).  Also works
-                        list[i]         for |curly-braces-names|, |Dictionary|
-                                        entries, |List| items, etc.
-                                        Beware that evaluating an index may
-                                        cause an error message for an invalid
-                                        expression.  E.g.: >vim
-                                           let l = [1, 2, 3]
-                                           echo exists("l[5]")
-<                                          0 >vim
-                                           echo exists("l[xx]")
-<                                          E121: Undefined variable: xx
-                                           0
-                        &option-name    Vim option (only checks if it exists,
-                                        not if it really works)
-                        +option-name    Vim option that works.
-                        $ENVNAME        environment variable (could also be
-                                        done by comparing with an empty
-                                        string)
-                        `*funcname`     built-in function (see |functions|)
-                                        or user defined function (see
-                                        |user-function|). Also works for a
-                                        variable that is a Funcref.
-                        :cmdname        Ex command: built-in command, user
-                                        command or command modifier |:command|.
-                                        Returns:
-                                        1  for match with start of a command
-                                        2  full match with a command
-                                        3  matches several user commands
-                                        To check for a supported command
-                                        always check the return value to be 2.
-                        :2match         The |:2match| command.
-                        :3match         The |:3match| command (but you
-                                        probably should not use it, it is
-                                        reserved for internal usage)
-                        #event          autocommand defined for this event
-                        #event#pattern  autocommand defined for this event and
-                                        pattern (the pattern is taken
-                                        literally and compared to the
-                                        autocommand patterns character by
-                                        character)
-                        #group          autocommand group exists
-                        #group#event    autocommand defined for this group and
-                                        event.
-                        #group#event#pattern
-                                        autocommand defined for this group,
-                                        event and pattern.
-                        ##event         autocommand for this event is
-                                        supported.
+		The {expr} argument is a string, which contains one of these:
+			varname		internal variable (see
+			dict.key	|internal-variables|).	Also works
+			list[i]		for |curly-braces-names|, |Dictionary|
+					entries, |List| items, etc.
+					Beware that evaluating an index may
+					cause an error message for an invalid
+					expression.  E.g.: >vim
+					   let l = [1, 2, 3]
+					   echo exists("l[5]")
+<					   0 >vim
+					   echo exists("l[xx]")
+<					   E121: Undefined variable: xx
+					   0
+			&option-name	Vim option (only checks if it exists,
+					not if it really works)
+			+option-name	Vim option that works.
+			$ENVNAME	environment variable (could also be
+					done by comparing with an empty
+					string)
+			`*funcname`	built-in function (see |functions|)
+					or user defined function (see
+					|user-function|). Also works for a
+					variable that is a Funcref.
+			:cmdname	Ex command: built-in command, user
+					command or command modifier |:command|.
+					Returns:
+					1  for match with start of a command
+					2  full match with a command
+					3  matches several user commands
+					To check for a supported command
+					always check the return value to be 2.
+			:2match		The |:2match| command.
+			:3match		The |:3match| command (but you
+					probably should not use it, it is
+					reserved for internal usage)
+			#event		autocommand defined for this event
+			#event#pattern	autocommand defined for this event and
+					pattern (the pattern is taken
+					literally and compared to the
+					autocommand patterns character by
+					character)
+			#group		autocommand group exists
+			#group#event	autocommand defined for this group and
+					event.
+			#group#event#pattern
+					autocommand defined for this group,
+					event and pattern.
+			##event		autocommand for this event is
+					supported.
 
-                Examples: >vim
-                        echo exists("&mouse")
-                        echo exists("$HOSTNAME")
-                        echo exists("*strftime")
-                        echo exists("*s:MyFunc")
-                        echo exists("*MyFunc")
-                        echo exists("bufcount")
-                        echo exists(":Make")
-                        echo exists("#CursorHold")
-                        echo exists("#BufReadPre#*.gz")
-                        echo exists("#filetypeindent")
-                        echo exists("#filetypeindent#FileType")
-                        echo exists("#filetypeindent#FileType#*")
-                        echo exists("##ColorScheme")
-<                There must be no space between the symbol (&/$/*/#) and the
-                name.
-                There must be no extra characters after the name, although in
-                a few cases this is ignored.  That may become stricter in the
-                future, thus don't count on it!
-                Working example: >vim
-                        echo exists(":make")
-<                NOT working example: >vim
-                        echo exists(":make install")
+		Examples: >vim
+			echo exists("&mouse")
+			echo exists("$HOSTNAME")
+			echo exists("*strftime")
+			echo exists("*s:MyFunc")
+			echo exists("*MyFunc")
+			echo exists("bufcount")
+			echo exists(":Make")
+			echo exists("#CursorHold")
+			echo exists("#BufReadPre#*.gz")
+			echo exists("#filetypeindent")
+			echo exists("#filetypeindent#FileType")
+			echo exists("#filetypeindent#FileType#*")
+			echo exists("##ColorScheme")
+<		 There must be no space between the symbol (&/$/*/#) and the
+		name.
+		There must be no extra characters after the name, although in
+		a few cases this is ignored.  That may become stricter in the
+		future, thus don't count on it!
+		Working example: >vim
+			echo exists(":make")
+<		 NOT working example: >vim
+			echo exists(":make install")
 
-<                Note that the argument must be a string, not the name of the
-                variable itself.  For example: >vim
-                        echo exists(bufcount)
-<                This doesn't check for existence of the "bufcount" variable,
-                but gets the value of "bufcount", and checks if that exists.
+<		 Note that the argument must be a string, not the name of the
+		variable itself.  For example: >vim
+			echo exists(bufcount)
+<		 This doesn't check for existence of the "bufcount" variable,
+		but gets the value of "bufcount", and checks if that exists.
 
-exp({expr})                                                              *exp()*
-                Return the exponential of {expr} as a |Float| in the range
-                [0, inf].
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo exp(2)
-<                        7.389056 >vim
-                        echo exp(-1)
-<                        0.367879
+exp({expr})								 *exp()*
+		Return the exponential of {expr} as a |Float| in the range
+		[0, inf].
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo exp(2)
+<			 7.389056 >vim
+			echo exp(-1)
+<			 0.367879
 
-expand({string} [, {nosuf} [, {list}]])                               *expand()*
-                Expand wildcards and the following special keywords in
-                {string}.  'wildignorecase' applies.
+expand({string} [, {nosuf} [, {list}]])				      *expand()*
+		Expand wildcards and the following special keywords in
+		{string}.  'wildignorecase' applies.
 
-                If {list} is given and it is |TRUE|, a List will be returned.
-                Otherwise the result is a String and when there are several
-                matches, they are separated by <NL> characters.
+		If {list} is given and it is |TRUE|, a List will be returned.
+		Otherwise the result is a String and when there are several
+		matches, they are separated by <NL> characters.
 
-                If the expansion fails, the result is an empty string.  A name
-                for a non-existing file is not included, unless {string} does
-                not start with '%', '#' or '<', see below.
+		If the expansion fails, the result is an empty string.	A name
+		for a non-existing file is not included, unless {string} does
+		not start with '%', '#' or '<', see below.
 
-                When {string} starts with '%', '#' or '<', the expansion is
-                done like for the |cmdline-special| variables with their
-                associated modifiers.  Here is a short overview:
+		When {string} starts with '%', '#' or '<', the expansion is
+		done like for the |cmdline-special| variables with their
+		associated modifiers.  Here is a short overview:
 
-                        %               current file name
-                        #               alternate file name
-                        #n              alternate file name n
-                        <cfile>         file name under the cursor
-                        <afile>         autocmd file name
-                        <abuf>          autocmd buffer number (as a String!)
-                        <amatch>        autocmd matched name
-                        <cexpr>         C expression under the cursor
-                        <sfile>         sourced script file or function name
-                        <slnum>         sourced script line number or function
-                                        line number
-                        <sflnum>        script file line number, also when in
-                                        a function
-                        <SID>           "<SNR>123_"  where "123" is the
-                                        current script ID  |<SID>|
-                        <script>        sourced script file, or script file
-                                        where the current function was defined
-                        <stack>         call stack
-                        <cword>         word under the cursor
-                        <cWORD>         WORD under the cursor
-                        <client>        the {clientid} of the last received
-                                        message
-                Modifiers:
-                        :p              expand to full path
-                        :h              head (last path component removed)
-                        :t              tail (last path component only)
-                        :r              root (one extension removed)
-                        :e              extension only
+			%		current file name
+			#		alternate file name
+			#n		alternate file name n
+			<cfile>		file name under the cursor
+			<afile>		autocmd file name
+			<abuf>		autocmd buffer number (as a String!)
+			<amatch>	autocmd matched name
+			<cexpr>		C expression under the cursor
+			<sfile>		sourced script file or function name
+			<slnum>		sourced script line number or function
+					line number
+			<sflnum>	script file line number, also when in
+					a function
+			<SID>		"<SNR>123_"  where "123" is the
+					current script ID  |<SID>|
+			<script>	sourced script file, or script file
+					where the current function was defined
+			<stack>		call stack
+			<cword>		word under the cursor
+			<cWORD>		WORD under the cursor
+			<client>	the {clientid} of the last received
+					message
+		Modifiers:
+			:p		expand to full path
+			:h		head (last path component removed)
+			:t		tail (last path component only)
+			:r		root (one extension removed)
+			:e		extension only
 
-                Example: >vim
-                        let &tags = expand("%:p:h") .. "/tags"
-<                Note that when expanding a string that starts with '%', '#' or
-                '<', any following text is ignored.  This does NOT work: >vim
-                        let doesntwork = expand("%:h.bak")
-<                Use this: >vim
-                        let doeswork = expand("%:h") .. ".bak"
-<                Also note that expanding "<cfile>" and others only returns the
-                referenced file name without further expansion.  If "<cfile>"
-                is "~/.cshrc", you need to do another expand() to have the
-                "~/" expanded into the path of the home directory: >vim
-                        echo expand(expand("<cfile>"))
+		Example: >vim
+			let &tags = expand("%:p:h") .. "/tags"
+<		 Note that when expanding a string that starts with '%', '#' or
+		'<', any following text is ignored.  This does NOT work: >vim
+			let doesntwork = expand("%:h.bak")
+<		 Use this: >vim
+			let doeswork = expand("%:h") .. ".bak"
+<		 Also note that expanding "<cfile>" and others only returns the
+		referenced file name without further expansion.  If "<cfile>"
+		is "~/.cshrc", you need to do another expand() to have the
+		"~/" expanded into the path of the home directory: >vim
+			echo expand(expand("<cfile>"))
 <
-                There cannot be white space between the variables and the
-                following modifier.  The |fnamemodify()| function can be used
-                to modify normal file names.
+		There cannot be white space between the variables and the
+		following modifier.  The |fnamemodify()| function can be used
+		to modify normal file names.
 
-                When using '%' or '#', and the current or alternate file name
-                is not defined, an empty string is used.  Using "%:p" in a
-                buffer with no name, results in the current directory, with a
-                '/' added.
-                When 'verbose' is set then expanding '%', '#' and <> items
-                will result in an error message if the argument cannot be
-                expanded.
+		When using '%' or '#', and the current or alternate file name
+		is not defined, an empty string is used.  Using "%:p" in a
+		buffer with no name, results in the current directory, with a
+		'/' added.
+		When 'verbose' is set then expanding '%', '#' and <> items
+		will result in an error message if the argument cannot be
+		expanded.
 
-                When {string} does not start with '%', '#' or '<', it is
-                expanded like a file name is expanded on the command line.
-                'suffixes' and 'wildignore' are used, unless the optional
-                {nosuf} argument is given and it is |TRUE|.
-                Names for non-existing files are included.  The "**" item can
-                be used to search in a directory tree.  For example, to find
-                all "README" files in the current directory and below: >vim
-                        echo expand("**/README")
+		When {string} does not start with '%', '#' or '<', it is
+		expanded like a file name is expanded on the command line.
+		'suffixes' and 'wildignore' are used, unless the optional
+		{nosuf} argument is given and it is |TRUE|.
+		Names for non-existing files are included.  The "**" item can
+		be used to search in a directory tree.	For example, to find
+		all "README" files in the current directory and below: >vim
+			echo expand("**/README")
 <
-                expand() can also be used to expand variables and environment
-                variables that are only known in a shell.  But this can be
-                slow, because a shell may be used to do the expansion.  See
-                |expr-env-expand|.
-                The expanded variable is still handled like a list of file
-                names.  When an environment variable cannot be expanded, it is
-                left unchanged.  Thus ":echo expand('$FOOBAR')" results in
-                "$FOOBAR".
+		expand() can also be used to expand variables and environment
+		variables that are only known in a shell.  But this can be
+		slow, because a shell may be used to do the expansion.	See
+		|expr-env-expand|.
+		The expanded variable is still handled like a list of file
+		names.	When an environment variable cannot be expanded, it is
+		left unchanged.  Thus ":echo expand('$FOOBAR')" results in
+		"$FOOBAR".
 
-                See |glob()| for finding existing files.  See |system()| for
-                getting the raw output of an external command.
+		See |glob()| for finding existing files.  See |system()| for
+		getting the raw output of an external command.
 
-expandcmd({string} [, {options}])                                  *expandcmd()*
-                Expand special items in String {string} like what is done for
-                an Ex command such as `:edit`.  This expands special keywords,
-                like with |expand()|, and environment variables, anywhere in
-                {string}.  "~user" and "~/path" are only expanded at the
-                start.
+expandcmd({string} [, {options}])				   *expandcmd()*
+		Expand special items in String {string} like what is done for
+		an Ex command such as `:edit`.	This expands special keywords,
+		like with |expand()|, and environment variables, anywhere in
+		{string}.  "~user" and "~/path" are only expanded at the
+		start.
 
-                The following items are supported in the {options} Dict
-                argument:
-                    errmsg      If set to TRUE, error messages are displayed
-                                if an error is encountered during expansion.
-                                By default, error messages are not displayed.
+		The following items are supported in the {options} Dict
+		argument:
+		    errmsg	If set to TRUE, error messages are displayed
+				if an error is encountered during expansion.
+				By default, error messages are not displayed.
 
-                Returns the expanded string.  If an error is encountered
-                during expansion, the unmodified {string} is returned.
+		Returns the expanded string.  If an error is encountered
+		during expansion, the unmodified {string} is returned.
 
-                Example: >vim
-                        echo expandcmd('make %<.o')
-<                 >
-                        make /path/runtime/doc/builtin.o
-<                 >vim
-                        echo expandcmd('make %<.o', {'errmsg': v:true})
+		Example: >vim
+			echo expandcmd('make %<.o')
+<		  >
+			make /path/runtime/doc/builtin.o
+<		  >vim
+			echo expandcmd('make %<.o', {'errmsg': v:true})
 <
-extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
-                {expr1} and {expr2} must be both |Lists| or both
-                |Dictionaries|.
+extend({expr1}, {expr2} [, {expr3}])				      *extend()*
+		{expr1} and {expr2} must be both |Lists| or both
+		|Dictionaries|.
 
-                If they are |Lists|: Append {expr2} to {expr1}.
-                If {expr3} is given insert the items of {expr2} before the
-                item with index {expr3} in {expr1}.  When {expr3} is zero
-                insert before the first item.  When {expr3} is equal to
-                len({expr1}) then {expr2} is appended.
-                Examples: >vim
-                        echo sort(extend(mylist, [7, 5]))
-                        call extend(mylist, [2, 3], 1)
-<                When {expr1} is the same List as {expr2} then the number of
-                items copied is equal to the original length of the List.
-                E.g., when {expr3} is 1 you get N new copies of the first item
-                (where N is the original length of the List).
-                Use |add()| to concatenate one item to a list.  To concatenate
-                two lists into a new list use the + operator: >vim
-                        let newlist = [1, 2, 3] + [4, 5]
+		If they are |Lists|: Append {expr2} to {expr1}.
+		If {expr3} is given insert the items of {expr2} before the
+		item with index {expr3} in {expr1}.  When {expr3} is zero
+		insert before the first item.  When {expr3} is equal to
+		len({expr1}) then {expr2} is appended.
+		Examples: >vim
+			echo sort(extend(mylist, [7, 5]))
+			call extend(mylist, [2, 3], 1)
+<		 When {expr1} is the same List as {expr2} then the number of
+		items copied is equal to the original length of the List.
+		E.g., when {expr3} is 1 you get N new copies of the first item
+		(where N is the original length of the List).
+		Use |add()| to concatenate one item to a list.	To concatenate
+		two lists into a new list use the + operator: >vim
+			let newlist = [1, 2, 3] + [4, 5]
 <
-                If they are |Dictionaries|:
-                Add all entries from {expr2} to {expr1}.
-                If a key exists in both {expr1} and {expr2} then {expr3} is
-                used to decide what to do:
-                {expr3} = "keep": keep the value of {expr1}
-                {expr3} = "force": use the value of {expr2}
-                {expr3} = "error": give an error message                *E737*
-                When {expr3} is omitted then "force" is assumed.
+		If they are |Dictionaries|:
+		Add all entries from {expr2} to {expr1}.
+		If a key exists in both {expr1} and {expr2} then {expr3} is
+		used to decide what to do:
+		{expr3} = "keep": keep the value of {expr1}
+		{expr3} = "force": use the value of {expr2}
+		{expr3} = "error": give an error message		*E737*
+		When {expr3} is omitted then "force" is assumed.
 
-                {expr1} is changed when {expr2} is not empty.  If necessary
-                make a copy of {expr1} first.
-                {expr2} remains unchanged.
-                When {expr1} is locked and {expr2} is not empty the operation
-                fails.
-                Returns {expr1}.  Returns 0 on error.
+		{expr1} is changed when {expr2} is not empty.  If necessary
+		make a copy of {expr1} first.
+		{expr2} remains unchanged.
+		When {expr1} is locked and {expr2} is not empty the operation
+		fails.
+		Returns {expr1}.  Returns 0 on error.
 
-extendnew({expr1}, {expr2} [, {expr3}])                            *extendnew()*
-                Like |extend()| but instead of adding items to {expr1} a new
-                List or Dictionary is created and returned.  {expr1} remains
-                unchanged.
+extendnew({expr1}, {expr2} [, {expr3}])				   *extendnew()*
+		Like |extend()| but instead of adding items to {expr1} a new
+		List or Dictionary is created and returned.  {expr1} remains
+		unchanged.
 
-feedkeys({string} [, {mode}])                                       *feedkeys()*
-                Characters in {string} are queued for processing as if they
-                come from a mapping or were typed by the user.
+feedkeys({string} [, {mode}])					    *feedkeys()*
+		Characters in {string} are queued for processing as if they
+		come from a mapping or were typed by the user.
 
-                By default the string is added to the end of the typeahead
-                buffer, thus if a mapping is still being executed the
-                characters come after them.  Use the 'i' flag to insert before
-                other characters, they will be executed next, before any
-                characters from a mapping.
+		By default the string is added to the end of the typeahead
+		buffer, thus if a mapping is still being executed the
+		characters come after them.  Use the 'i' flag to insert before
+		other characters, they will be executed next, before any
+		characters from a mapping.
 
-                The function does not wait for processing of keys contained in
-                {string}.
+		The function does not wait for processing of keys contained in
+		{string}.
 
-                To include special keys into {string}, use double-quotes
-                and "\..." notation |expr-quote|. For example,
-                feedkeys("\<CR>") simulates pressing of the <Enter> key. But
-                feedkeys('\<CR>') pushes 5 characters.
-                The |<Ignore>| keycode may be used to exit the
-                wait-for-character without doing anything.
+		To include special keys into {string}, use double-quotes
+		and "\..." notation |expr-quote|. For example,
+		feedkeys("\<CR>") simulates pressing of the <Enter> key. But
+		feedkeys('\<CR>') pushes 5 characters.
+		The |<Ignore>| keycode may be used to exit the
+		wait-for-character without doing anything.
 
-                {mode} is a String, which can contain these character flags:
-                'm'     Remap keys. This is default.  If {mode} is absent,
-                        keys are remapped.
-                'n'     Do not remap keys.
-                't'     Handle keys as if typed; otherwise they are handled as
-                        if coming from a mapping.  This matters for undo,
-                        opening folds, etc.
-                'i'     Insert the string instead of appending (see above).
-                'x'     Execute commands until typeahead is empty.  This is
-                        similar to using ":normal!".  You can call feedkeys()
-                        several times without 'x' and then one time with 'x'
-                        (possibly with an empty {string}) to execute all the
-                        typeahead.  Note that when Vim ends in Insert mode it
-                        will behave as if <Esc> is typed, to avoid getting
-                        stuck, waiting for a character to be typed before the
-                        script continues.
-                        Note that if you manage to call feedkeys() while
-                        executing commands, thus calling it recursively, then
-                        all typeahead will be consumed by the last call.
-                '!'     When used with 'x' will not end Insert mode. Can be
-                        used in a test when a timer is set to exit Insert mode
-                        a little later.  Useful for testing CursorHoldI.
+		{mode} is a String, which can contain these character flags:
+		'm'	Remap keys. This is default.  If {mode} is absent,
+			keys are remapped.
+		'n'	Do not remap keys.
+		't'	Handle keys as if typed; otherwise they are handled as
+			if coming from a mapping.  This matters for undo,
+			opening folds, etc.
+		'i'	Insert the string instead of appending (see above).
+		'x'	Execute commands until typeahead is empty.  This is
+			similar to using ":normal!".  You can call feedkeys()
+			several times without 'x' and then one time with 'x'
+			(possibly with an empty {string}) to execute all the
+			typeahead.  Note that when Vim ends in Insert mode it
+			will behave as if <Esc> is typed, to avoid getting
+			stuck, waiting for a character to be typed before the
+			script continues.
+			Note that if you manage to call feedkeys() while
+			executing commands, thus calling it recursively, then
+			all typeahead will be consumed by the last call.
+		'!'	When used with 'x' will not end Insert mode. Can be
+			used in a test when a timer is set to exit Insert mode
+			a little later.  Useful for testing CursorHoldI.
 
-                Return value is always 0.
+		Return value is always 0.
 
-filereadable({file})                                            *filereadable()*
-                The result is a Number, which is |TRUE| when a file with the
-                name {file} exists, and can be read.  If {file} doesn't exist,
-                or is a directory, the result is |FALSE|.  {file} is any
-                expression, which is used as a String.
-                If you don't care about the file being readable you can use
-                |glob()|.
-                {file} is used as-is, you may want to expand wildcards first: >vim
-                        echo filereadable('~/.vimrc')
-<                 >
-                        0
-<                 >vim
-                        echo filereadable(expand('~/.vimrc'))
-<                 >
-                        1
+filereadable({file})						*filereadable()*
+		The result is a Number, which is |TRUE| when a file with the
+		name {file} exists, and can be read.  If {file} doesn't exist,
+		or is a directory, the result is |FALSE|.  {file} is any
+		expression, which is used as a String.
+		If you don't care about the file being readable you can use
+		|glob()|.
+		{file} is used as-is, you may want to expand wildcards first: >vim
+			echo filereadable('~/.vimrc')
+<		  >
+			0
+<		  >vim
+			echo filereadable(expand('~/.vimrc'))
+<		  >
+			1
 <
-filewritable({file})                                            *filewritable()*
-                The result is a Number, which is 1 when a file with the
-                name {file} exists, and can be written.  If {file} doesn't
-                exist, or is not writable, the result is 0.  If {file} is a
-                directory, and we can write to it, the result is 2.
+filewritable({file})						*filewritable()*
+		The result is a Number, which is 1 when a file with the
+		name {file} exists, and can be written.  If {file} doesn't
+		exist, or is not writable, the result is 0.  If {file} is a
+		directory, and we can write to it, the result is 2.
 
-filter({expr1}, {expr2})                                              *filter()*
-                {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-                For each item in {expr1} evaluate {expr2} and when the result
-                is zero or false remove the item from the |List| or
-                |Dictionary|.  Similarly for each byte in a |Blob| and each
-                character in a |String|.
+filter({expr1}, {expr2})					      *filter()*
+		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
+		For each item in {expr1} evaluate {expr2} and when the result
+		is zero or false remove the item from the |List| or
+		|Dictionary|.  Similarly for each byte in a |Blob| and each
+		character in a |String|.
 
-                {expr2} must be a |string| or |Funcref|.
+		{expr2} must be a |string| or |Funcref|.
 
-                If {expr2} is a |string|, inside {expr2} |v:val| has the value
-                of the current item.  For a |Dictionary| |v:key| has the key
-                of the current item and for a |List| |v:key| has the index of
-                the current item.  For a |Blob| |v:key| has the index of the
-                current byte. For a |String| |v:key| has the index of the
-                current character.
-                Examples: >vim
-                        call filter(mylist, 'v:val !~ "OLD"')
-<                Removes the items where "OLD" appears. >vim
-                        call filter(mydict, 'v:key >= 8')
-<                Removes the items with a key below 8. >vim
-                        call filter(var, 0)
-<                Removes all the items, thus clears the |List| or |Dictionary|.
+		If {expr2} is a |string|, inside {expr2} |v:val| has the value
+		of the current item.  For a |Dictionary| |v:key| has the key
+		of the current item and for a |List| |v:key| has the index of
+		the current item.  For a |Blob| |v:key| has the index of the
+		current byte. For a |String| |v:key| has the index of the
+		current character.
+		Examples: >vim
+			call filter(mylist, 'v:val !~ "OLD"')
+<		 Removes the items where "OLD" appears. >vim
+			call filter(mydict, 'v:key >= 8')
+<		 Removes the items with a key below 8. >vim
+			call filter(var, 0)
+<		 Removes all the items, thus clears the |List| or |Dictionary|.
 
-                Note that {expr2} is the result of expression and is then
-                used as an expression again.  Often it is good to use a
-                |literal-string| to avoid having to double backslashes.
+		Note that {expr2} is the result of expression and is then
+		used as an expression again.  Often it is good to use a
+		|literal-string| to avoid having to double backslashes.
 
-                If {expr2} is a |Funcref| it must take two arguments:
-                        1. the key or the index of the current item.
-                        2. the value of the current item.
-                The function must return |TRUE| if the item should be kept.
-                Example that keeps the odd items of a list: >vim
-                        func Odd(idx, val)
-                          return a:idx % 2 == 1
-                        endfunc
-                        call filter(mylist, function('Odd'))
-<                It is shorter when using a |lambda|: >vim
-                        call filter(myList, {idx, val -> idx * val <= 42})
-<                If you do not use "val" you can leave it out: >vim
-                        call filter(myList, {idx -> idx % 2 == 1})
+		If {expr2} is a |Funcref| it must take two arguments:
+			1. the key or the index of the current item.
+			2. the value of the current item.
+		The function must return |TRUE| if the item should be kept.
+		Example that keeps the odd items of a list: >vim
+			func Odd(idx, val)
+			  return a:idx % 2 == 1
+			endfunc
+			call filter(mylist, function('Odd'))
+<		 It is shorter when using a |lambda|: >vim
+			call filter(myList, {idx, val -> idx * val <= 42})
+<		 If you do not use "val" you can leave it out: >vim
+			call filter(myList, {idx -> idx % 2 == 1})
 <
-                For a |List| and a |Dictionary| the operation is done
-                in-place.  If you want it to remain unmodified make a copy
-                first: >vim
-                        let l = filter(copy(mylist), 'v:val =~ "KEEP"')
+		For a |List| and a |Dictionary| the operation is done
+		in-place.  If you want it to remain unmodified make a copy
+		first: >vim
+			let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 
-<                Returns {expr1}, the |List| or |Dictionary| that was filtered,
-                or a new |Blob| or |String|.
-                When an error is encountered while evaluating {expr2} no
-                further items in {expr1} are processed.
-                When {expr2} is a Funcref errors inside a function are ignored,
-                unless it was defined with the "abort" flag.
+<		 Returns {expr1}, the |List| or |Dictionary| that was filtered,
+		or a new |Blob| or |String|.
+		When an error is encountered while evaluating {expr2} no
+		further items in {expr1} are processed.
+		When {expr2} is a Funcref errors inside a function are ignored,
+		unless it was defined with the "abort" flag.
 
-finddir({name} [, {path} [, {count}]])                               *finddir()*
-                Find directory {name} in {path}.  Supports both downwards and
-                upwards recursive directory searches.  See |file-searching|
-                for the syntax of {path}.
+finddir({name} [, {path} [, {count}]])				     *finddir()*
+		Find directory {name} in {path}.  Supports both downwards and
+		upwards recursive directory searches.  See |file-searching|
+		for the syntax of {path}.
 
-                Returns the path of the first found match.  When the found
-                directory is below the current directory a relative path is
-                returned.  Otherwise a full path is returned.
-                If {path} is omitted or empty then 'path' is used.
+		Returns the path of the first found match.  When the found
+		directory is below the current directory a relative path is
+		returned.  Otherwise a full path is returned.
+		If {path} is omitted or empty then 'path' is used.
 
-                If the optional {count} is given, find {count}'s occurrence of
-                {name} in {path} instead of the first one.
-                When {count} is negative return all the matches in a |List|.
+		If the optional {count} is given, find {count}'s occurrence of
+		{name} in {path} instead of the first one.
+		When {count} is negative return all the matches in a |List|.
 
-                Returns an empty string if the directory is not found.
+		Returns an empty string if the directory is not found.
 
-                This is quite similar to the ex-command `:find`.
+		This is quite similar to the ex-command `:find`.
 
-findfile({name} [, {path} [, {count}]])                             *findfile()*
-                Just like |finddir()|, but find a file instead of a directory.
-                Uses 'suffixesadd'.
-                Example: >vim
-                        echo findfile("tags.vim", ".;")
-<                Searches from the directory of the current file upwards until
-                it finds the file "tags.vim".
+findfile({name} [, {path} [, {count}]])				    *findfile()*
+		Just like |finddir()|, but find a file instead of a directory.
+		Uses 'suffixesadd'.
+		Example: >vim
+			echo findfile("tags.vim", ".;")
+<		 Searches from the directory of the current file upwards until
+		it finds the file "tags.vim".
 
-flatten({list} [, {maxdepth}])                                       *flatten()*
-                Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
-                the result is a |List| without nesting, as if {maxdepth} is
-                a very large number.
-                The {list} is changed in place, use |flattennew()| if you do
-                not want that.
-                                                                *E900*
-                {maxdepth} means how deep in nested lists changes are made.
-                {list} is not modified when {maxdepth} is 0.
-                {maxdepth} must be positive number.
+flatten({list} [, {maxdepth}])					     *flatten()*
+		Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
+		the result is a |List| without nesting, as if {maxdepth} is
+		a very large number.
+		The {list} is changed in place, use |flattennew()| if you do
+		not want that.
+								*E900*
+		{maxdepth} means how deep in nested lists changes are made.
+		{list} is not modified when {maxdepth} is 0.
+		{maxdepth} must be positive number.
 
-                If there is an error the number zero is returned.
+		If there is an error the number zero is returned.
 
-                Example: >vim
-                        echo flatten([1, [2, [3, 4]], 5])
-<                        [1, 2, 3, 4, 5] >vim
-                        echo flatten([1, [2, [3, 4]], 5], 1)
-<                        [1, 2, [3, 4], 5]
+		Example: >vim
+			echo flatten([1, [2, [3, 4]], 5])
+<			 [1, 2, 3, 4, 5] >vim
+			echo flatten([1, [2, [3, 4]], 5], 1)
+<			 [1, 2, [3, 4], 5]
 
-flattennew({list} [, {maxdepth}])                                 *flattennew()*
-                Like |flatten()| but first make a copy of {list}.
+flattennew({list} [, {maxdepth}])				  *flattennew()*
+		Like |flatten()| but first make a copy of {list}.
 
-float2nr({expr})                                                    *float2nr()*
-                Convert {expr} to a Number by omitting the part after the
-                decimal point.
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0 if {expr} is not a |Float| or a |Number|.
-                When the value of {expr} is out of range for a |Number| the
-                result is truncated to 0x7fffffff or -0x7fffffff (or when
-                64-bit Number support is enabled, 0x7fffffffffffffff or
-                -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
-                64-bit Number support is enabled, -0x8000000000000000).
-                Examples: >vim
-                        echo float2nr(3.95)
-<                        3  >vim
-                        echo float2nr(-23.45)
-<                        -23  >vim
-                        echo float2nr(1.0e100)
-<                        2147483647  (or 9223372036854775807) >vim
-                        echo float2nr(-1.0e150)
-<                        -2147483647 (or -9223372036854775807) >vim
-                        echo float2nr(1.0e-100)
-<                        0
+float2nr({expr})						    *float2nr()*
+		Convert {expr} to a Number by omitting the part after the
+		decimal point.
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0 if {expr} is not a |Float| or a |Number|.
+		When the value of {expr} is out of range for a |Number| the
+		result is truncated to 0x7fffffff or -0x7fffffff (or when
+		64-bit Number support is enabled, 0x7fffffffffffffff or
+		-0x7fffffffffffffff).  NaN results in -0x80000000 (or when
+		64-bit Number support is enabled, -0x8000000000000000).
+		Examples: >vim
+			echo float2nr(3.95)
+<			 3  >vim
+			echo float2nr(-23.45)
+<			 -23  >vim
+			echo float2nr(1.0e100)
+<			 2147483647  (or 9223372036854775807) >vim
+			echo float2nr(-1.0e150)
+<			 -2147483647 (or -9223372036854775807) >vim
+			echo float2nr(1.0e-100)
+<			 0
 
-floor({expr})                                                          *floor()*
-                Return the largest integral value less than or equal to
-                {expr} as a |Float| (round down).
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo floor(1.856)
-<                        1.0  >vim
-                        echo floor(-5.456)
-<                        -6.0  >vim
-                        echo floor(4.0)
-<                        4.0
+floor({expr})							       *floor()*
+		Return the largest integral value less than or equal to
+		{expr} as a |Float| (round down).
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo floor(1.856)
+<			 1.0  >vim
+			echo floor(-5.456)
+<			 -6.0  >vim
+			echo floor(4.0)
+<			 4.0
 
-fmod({expr1}, {expr2})                                                  *fmod()*
-                Return the remainder of {expr1} / {expr2}, even if the
-                division is not representable.  Returns {expr1} - i * {expr2}
-                for some integer i such that if {expr2} is non-zero, the
-                result has the same sign as {expr1} and magnitude less than
-                the magnitude of {expr2}.  If {expr2} is zero, the value
-                returned is zero.  The value returned is a |Float|.
-                {expr1} and {expr2} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
-                |Number|.
-                Examples: >vim
-                        echo fmod(12.33, 1.22)
-<                        0.13 >vim
-                        echo fmod(-12.33, 1.22)
-<                        -0.13
+fmod({expr1}, {expr2})							*fmod()*
+		Return the remainder of {expr1} / {expr2}, even if the
+		division is not representable.	Returns {expr1} - i * {expr2}
+		for some integer i such that if {expr2} is non-zero, the
+		result has the same sign as {expr1} and magnitude less than
+		the magnitude of {expr2}.  If {expr2} is zero, the value
+		returned is zero.  The value returned is a |Float|.
+		{expr1} and {expr2} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
+		|Number|.
+		Examples: >vim
+			echo fmod(12.33, 1.22)
+<			 0.13 >vim
+			echo fmod(-12.33, 1.22)
+<			 -0.13
 
-fnameescape({string})                                            *fnameescape()*
-                Escape {string} for use as file name command argument.  All
-                characters that have a special meaning, such as `'%'` and `'|'`
-                are escaped with a backslash.
-                For most systems the characters escaped are
-                " \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
-                appears in a filename, it depends on the value of 'isfname'.
-                A leading '+' and '>' is also escaped (special after |:edit|
-                and |:write|).  And a "-" by itself (special after |:cd|).
-                Returns an empty string on error.
-                Example: >vim
-                        let fname = '+some str%nge|name'
-                        exe "edit " .. fnameescape(fname)
-<                results in executing: >vim
-                        edit \+some\ str\%nge\|name
+fnameescape({string})						 *fnameescape()*
+		Escape {string} for use as file name command argument.	All
+		characters that have a special meaning, such as `'%'` and `'|'`
+		are escaped with a backslash.
+		For most systems the characters escaped are
+		" \t\n*?[{`$\\%#'\"|!<".  For systems where a backslash
+		appears in a filename, it depends on the value of 'isfname'.
+		A leading '+' and '>' is also escaped (special after |:edit|
+		and |:write|).	And a "-" by itself (special after |:cd|).
+		Returns an empty string on error.
+		Example: >vim
+			let fname = '+some str%nge|name'
+			exe "edit " .. fnameescape(fname)
+<		 results in executing: >vim
+			edit \+some\ str\%nge\|name
 <
-fnamemodify({fname}, {mods})                                     *fnamemodify()*
-                Modify file name {fname} according to {mods}.  {mods} is a
-                string of characters like it is used for file names on the
-                command line.  See |filename-modifiers|.
-                Example: >vim
-                        echo fnamemodify("main.c", ":p:h")
-<                results in: >
-                        /home/user/vim/vim/src
-<                If {mods} is empty or an unsupported modifier is used then
-                {fname} is returned.
-                When {fname} is empty then with {mods} ":h" returns ".", so
-                that `:cd` can be used with it.  This is different from
-                expand('%:h') without a buffer name, which returns an empty
-                string.
-                Note: Environment variables don't work in {fname}, use
-                |expand()| first then.
+fnamemodify({fname}, {mods})					 *fnamemodify()*
+		Modify file name {fname} according to {mods}.  {mods} is a
+		string of characters like it is used for file names on the
+		command line.  See |filename-modifiers|.
+		Example: >vim
+			echo fnamemodify("main.c", ":p:h")
+<		 results in: >
+			/home/user/vim/vim/src
+<		 If {mods} is empty or an unsupported modifier is used then
+		{fname} is returned.
+		When {fname} is empty then with {mods} ":h" returns ".", so
+		that `:cd` can be used with it.  This is different from
+		expand('%:h') without a buffer name, which returns an empty
+		string.
+		Note: Environment variables don't work in {fname}, use
+		|expand()| first then.
 
-foldclosed({lnum})                                                *foldclosed()*
-                The result is a Number.  If the line {lnum} is in a closed
-                fold, the result is the number of the first line in that fold.
-                If the line {lnum} is not in a closed fold, -1 is returned.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
+foldclosed({lnum})						  *foldclosed()*
+		The result is a Number.  If the line {lnum} is in a closed
+		fold, the result is the number of the first line in that fold.
+		If the line {lnum} is not in a closed fold, -1 is returned.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
 
-foldclosedend({lnum})                                          *foldclosedend()*
-                The result is a Number.  If the line {lnum} is in a closed
-                fold, the result is the number of the last line in that fold.
-                If the line {lnum} is not in a closed fold, -1 is returned.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
+foldclosedend({lnum})					       *foldclosedend()*
+		The result is a Number.  If the line {lnum} is in a closed
+		fold, the result is the number of the last line in that fold.
+		If the line {lnum} is not in a closed fold, -1 is returned.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
 
-foldlevel({lnum})                                                  *foldlevel()*
-                The result is a Number, which is the foldlevel of line {lnum}
-                in the current buffer.  For nested folds the deepest level is
-                returned.  If there is no fold at line {lnum}, zero is
-                returned.  It doesn't matter if the folds are open or closed.
-                When used while updating folds (from 'foldexpr') -1 is
-                returned for lines where folds are still to be updated and the
-                foldlevel is unknown.  As a special case the level of the
-                previous line is usually available.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
+foldlevel({lnum})						   *foldlevel()*
+		The result is a Number, which is the foldlevel of line {lnum}
+		in the current buffer.	For nested folds the deepest level is
+		returned.  If there is no fold at line {lnum}, zero is
+		returned.  It doesn't matter if the folds are open or closed.
+		When used while updating folds (from 'foldexpr') -1 is
+		returned for lines where folds are still to be updated and the
+		foldlevel is unknown.  As a special case the level of the
+		previous line is usually available.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
 
-foldtext()                                                          *foldtext()*
-                Returns a String, to be displayed for a closed fold.  This is
-                the default function used for the 'foldtext' option and should
-                only be called from evaluating 'foldtext'.  It uses the
-                |v:foldstart|, |v:foldend| and |v:folddashes| variables.
-                The returned string looks like this: >
-                        +-- 45 lines: abcdef
-<                The number of leading dashes depends on the foldlevel.  The
-                "45" is the number of lines in the fold.  "abcdef" is the text
-                in the first non-blank line of the fold.  Leading white space,
-                "//" or "/*" and the text from the 'foldmarker' and
-                'commentstring' options is removed.
-                When used to draw the actual foldtext, the rest of the line
-                will be filled with the fold char from the 'fillchars'
-                setting.
-                Returns an empty string when there is no fold.
+foldtext()							    *foldtext()*
+		Returns a String, to be displayed for a closed fold.  This is
+		the default function used for the 'foldtext' option and should
+		only be called from evaluating 'foldtext'.  It uses the
+		|v:foldstart|, |v:foldend| and |v:folddashes| variables.
+		The returned string looks like this: >
+			+-- 45 lines: abcdef
+<		 The number of leading dashes depends on the foldlevel.  The
+		"45" is the number of lines in the fold.  "abcdef" is the text
+		in the first non-blank line of the fold.  Leading white space,
+		"//" or "/*" and the text from the 'foldmarker' and
+		'commentstring' options is removed.
+		When used to draw the actual foldtext, the rest of the line
+		will be filled with the fold char from the 'fillchars'
+		setting.
+		Returns an empty string when there is no fold.
 
-foldtextresult({lnum})                                        *foldtextresult()*
-                Returns the text that is displayed for the closed fold at line
-                {lnum}.  Evaluates 'foldtext' in the appropriate context.
-                When there is no closed fold at {lnum} an empty string is
-                returned.
-                {lnum} is used like with |getline()|.  Thus "." is the current
-                line, "'m" mark m, etc.
-                Useful when exporting folded text, e.g., to HTML.
+foldtextresult({lnum})					      *foldtextresult()*
+		Returns the text that is displayed for the closed fold at line
+		{lnum}.  Evaluates 'foldtext' in the appropriate context.
+		When there is no closed fold at {lnum} an empty string is
+		returned.
+		{lnum} is used like with |getline()|.  Thus "." is the current
+		line, "'m" mark m, etc.
+		Useful when exporting folded text, e.g., to HTML.
 
 
-fullcommand({name})                                              *fullcommand()*
-                Get the full command name from a short abbreviated command
-                name; see |20.2| for details on command abbreviations.
+fullcommand({name})						 *fullcommand()*
+		Get the full command name from a short abbreviated command
+		name; see |20.2| for details on command abbreviations.
 
-                The string argument {name} may start with a `:` and can
-                include a [range], these are skipped and not returned.
-                Returns an empty string if a command doesn't exist or if it's
-                ambiguous (for user-defined commands).
+		The string argument {name} may start with a `:` and can
+		include a [range], these are skipped and not returned.
+		Returns an empty string if a command doesn't exist or if it's
+		ambiguous (for user-defined commands).
 
-                For example `fullcommand('s')`, `fullcommand('sub')`,
-                `fullcommand(':%substitute')` all return "substitute".
+		For example `fullcommand('s')`, `fullcommand('sub')`,
+		`fullcommand(':%substitute')` all return "substitute".
 
-funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
-                Just like |function()|, but the returned Funcref will lookup
-                the function by reference, not by name.  This matters when the
-                function {name} is redefined later.
+funcref({name} [, {arglist}] [, {dict}])			     *funcref()*
+		Just like |function()|, but the returned Funcref will lookup
+		the function by reference, not by name.  This matters when the
+		function {name} is redefined later.
 
-                Unlike |function()|, {name} must be an existing user function.
-                It only works for an autoloaded function if it has already
-                been loaded (to avoid mistakenly loading the autoload script
-                when only intending to use the function name, use |function()|
-                instead). {name} cannot be a builtin function.
-                Returns 0 on error.
+		Unlike |function()|, {name} must be an existing user function.
+		It only works for an autoloaded function if it has already
+		been loaded (to avoid mistakenly loading the autoload script
+		when only intending to use the function name, use |function()|
+		instead). {name} cannot be a builtin function.
+		Returns 0 on error.
 
-function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* *E923*
-                Return a |Funcref| variable that refers to function {name}.
-                {name} can be the name of a user defined function or an
-                internal function.
+function({name} [, {arglist}] [, {dict}])	  *function()* *partial* *E700* *E923*
+		Return a |Funcref| variable that refers to function {name}.
+		{name} can be the name of a user defined function or an
+		internal function.
 
-                {name} can also be a Funcref or a partial. When it is a
-                partial the dict stored in it will be used and the {dict}
-                argument is not allowed. E.g.: >vim
-                        let FuncWithArg = function(dict.Func, [arg])
-                        let Broken = function(dict.Func, [arg], dict)
+		{name} can also be a Funcref or a partial. When it is a
+		partial the dict stored in it will be used and the {dict}
+		argument is not allowed. E.g.: >vim
+			let FuncWithArg = function(dict.Func, [arg])
+			let Broken = function(dict.Func, [arg], dict)
 <
-                When using the Funcref the function will be found by {name},
-                also when it was redefined later. Use |funcref()| to keep the
-                same function.
+		When using the Funcref the function will be found by {name},
+		also when it was redefined later. Use |funcref()| to keep the
+		same function.
 
-                When {arglist} or {dict} is present this creates a partial.
-                That means the argument list and/or the dictionary is stored in
-                the Funcref and will be used when the Funcref is called.
+		When {arglist} or {dict} is present this creates a partial.
+		That means the argument list and/or the dictionary is stored in
+		the Funcref and will be used when the Funcref is called.
 
-                The arguments are passed to the function in front of other
-                arguments, but after any argument from |method|.  Example: >vim
-                        func Callback(arg1, arg2, name)
-                        "...
-                        endfunc
-                        let Partial = function('Callback', ['one', 'two'])
-                        "...
-                        call Partial('name')
-<                Invokes the function as with: >vim
-                        call Callback('one', 'two', 'name')
+		The arguments are passed to the function in front of other
+		arguments, but after any argument from |method|.  Example: >vim
+			func Callback(arg1, arg2, name)
+			"...
+			endfunc
+			let Partial = function('Callback', ['one', 'two'])
+			"...
+			call Partial('name')
+<		 Invokes the function as with: >vim
+			call Callback('one', 'two', 'name')
 
-<                With a |method|: >vim
-                        func Callback(one, two, three)
-                        "...
-                        endfunc
-                        let Partial = function('Callback', ['two'])
-                        "...
-                        eval 'one'->Partial('three')
-<                Invokes the function as with: >vim
-                        call Callback('one', 'two', 'three')
+<		 With a |method|: >vim
+			func Callback(one, two, three)
+			"...
+			endfunc
+			let Partial = function('Callback', ['two'])
+			"...
+			eval 'one'->Partial('three')
+<		 Invokes the function as with: >vim
+			call Callback('one', 'two', 'three')
 
-<                The function() call can be nested to add more arguments to the
-                Funcref.  The extra arguments are appended to the list of
-                arguments.  Example: >vim
-                        func Callback(arg1, arg2, name)
-                        "...
-                        endfunc
-                        let Func = function('Callback', ['one'])
-                        let Func2 = function(Func, ['two'])
-                        "...
-                        call Func2('name')
-<                Invokes the function as with: >vim
-                        call Callback('one', 'two', 'name')
+<		 The function() call can be nested to add more arguments to the
+		Funcref.  The extra arguments are appended to the list of
+		arguments.  Example: >vim
+			func Callback(arg1, arg2, name)
+			"...
+			endfunc
+			let Func = function('Callback', ['one'])
+			let Func2 = function(Func, ['two'])
+			"...
+			call Func2('name')
+<		 Invokes the function as with: >vim
+			call Callback('one', 'two', 'name')
 
-<                The Dictionary is only useful when calling a "dict" function.
-                In that case the {dict} is passed in as "self". Example: >vim
-                        function Callback() dict
-                           echo "called for " .. self.name
-                        endfunction
-                        "...
-                        let context = {"name": "example"}
-                        let Func = function('Callback', context)
-                        "...
-                        call Func()     " will echo: called for example
-<                The use of function() is not needed when there are no extra
-                arguments, these two are equivalent, if Callback() is defined
-                as context.Callback(): >vim
-                        let Func = function('Callback', context)
-                        let Func = context.Callback
+<		 The Dictionary is only useful when calling a "dict" function.
+		In that case the {dict} is passed in as "self". Example: >vim
+			function Callback() dict
+			   echo "called for " .. self.name
+			endfunction
+			"...
+			let context = {"name": "example"}
+			let Func = function('Callback', context)
+			"...
+			call Func()	" will echo: called for example
+<		 The use of function() is not needed when there are no extra
+		arguments, these two are equivalent, if Callback() is defined
+		as context.Callback(): >vim
+			let Func = function('Callback', context)
+			let Func = context.Callback
 
-<                The argument list and the Dictionary can be combined: >vim
-                        function Callback(arg1, count) dict
-                        "...
-                        endfunction
-                        let context = {"name": "example"}
-                        let Func = function('Callback', ['one'], context)
-                        "...
-                        call Func(500)
-<                Invokes the function as with: >vim
-                        call context.Callback('one', 500)
+<		 The argument list and the Dictionary can be combined: >vim
+			function Callback(arg1, count) dict
+			"...
+			endfunction
+			let context = {"name": "example"}
+			let Func = function('Callback', ['one'], context)
+			"...
+			call Func(500)
+<		 Invokes the function as with: >vim
+			call context.Callback('one', 500)
 <
-                Returns 0 on error.
+		Returns 0 on error.
 
-garbagecollect([{atexit}])                                    *garbagecollect()*
-                Cleanup unused |Lists| and |Dictionaries| that have circular
-                references.
+garbagecollect([{atexit}])				      *garbagecollect()*
+		Cleanup unused |Lists| and |Dictionaries| that have circular
+		references.
 
-                There is hardly ever a need to invoke this function, as it is
-                automatically done when Vim runs out of memory or is waiting
-                for the user to press a key after 'updatetime'.  Items without
-                circular references are always freed when they become unused.
-                This is useful if you have deleted a very big |List| and/or
-                |Dictionary| with circular references in a script that runs
-                for a long time.
+		There is hardly ever a need to invoke this function, as it is
+		automatically done when Vim runs out of memory or is waiting
+		for the user to press a key after 'updatetime'.  Items without
+		circular references are always freed when they become unused.
+		This is useful if you have deleted a very big |List| and/or
+		|Dictionary| with circular references in a script that runs
+		for a long time.
 
-                When the optional {atexit} argument is one, garbage
-                collection will also be done when exiting Vim, if it wasn't
-                done before.  This is useful when checking for memory leaks.
+		When the optional {atexit} argument is one, garbage
+		collection will also be done when exiting Vim, if it wasn't
+		done before.  This is useful when checking for memory leaks.
 
-                The garbage collection is not done immediately but only when
-                it's safe to perform.  This is when waiting for the user to
-                type a character.
+		The garbage collection is not done immediately but only when
+		it's safe to perform.  This is when waiting for the user to
+		type a character.
 
-get({list}, {idx} [, {default}])                                         *get()*
-                Get item {idx} from |List| {list}.  When this item is not
-                available return {default}.  Return zero when {default} is
-                omitted.
+get({list}, {idx} [, {default}])					 *get()*
+		Get item {idx} from |List| {list}.  When this item is not
+		available return {default}.  Return zero when {default} is
+		omitted.
 
 get({blob}, {idx} [, {default}])
-                Get byte {idx} from |Blob| {blob}.  When this byte is not
-                available return {default}.  Return -1 when {default} is
-                omitted.
+		Get byte {idx} from |Blob| {blob}.  When this byte is not
+		available return {default}.  Return -1 when {default} is
+		omitted.
 
 get({dict}, {key} [, {default}])
-                Get item with key {key} from |Dictionary| {dict}.  When this
-                item is not available return {default}.  Return zero when
-                {default} is omitted.  Useful example: >vim
-                        let val = get(g:, 'var_name', 'default')
-<                This gets the value of g:var_name if it exists, and uses
-                "default" when it does not exist.
+		Get item with key {key} from |Dictionary| {dict}.  When this
+		item is not available return {default}.  Return zero when
+		{default} is omitted.  Useful example: >vim
+			let val = get(g:, 'var_name', 'default')
+<		 This gets the value of g:var_name if it exists, and uses
+		"default" when it does not exist.
 
 get({func}, {what})
-                Get item {what} from Funcref {func}.  Possible values for
-                {what} are:
-                        "name"  The function name
-                        "func"  The function
-                        "dict"  The dictionary
-                        "args"  The list with arguments
-                Returns zero on error.
+		Get item {what} from Funcref {func}.  Possible values for
+		{what} are:
+			"name"	The function name
+			"func"	The function
+			"dict"	The dictionary
+			"args"	The list with arguments
+		Returns zero on error.
 
 getbufinfo([{buf}])
-getbufinfo([{dict}])                                              *getbufinfo()*
-                Get information about buffers as a List of Dictionaries.
+getbufinfo([{dict}])						  *getbufinfo()*
+		Get information about buffers as a List of Dictionaries.
 
-                Without an argument information about all the buffers is
-                returned.
+		Without an argument information about all the buffers is
+		returned.
 
-                When the argument is a |Dictionary| only the buffers matching
-                the specified criteria are returned.  The following keys can
-                be specified in {dict}:
-                        buflisted       include only listed buffers.
-                        bufloaded       include only loaded buffers.
-                        bufmodified     include only modified buffers.
+		When the argument is a |Dictionary| only the buffers matching
+		the specified criteria are returned.  The following keys can
+		be specified in {dict}:
+			buflisted	include only listed buffers.
+			bufloaded	include only loaded buffers.
+			bufmodified	include only modified buffers.
 
-                Otherwise, {buf} specifies a particular buffer to return
-                information for.  For the use of {buf}, see |bufname()|
-                above.  If the buffer is found the returned List has one item.
-                Otherwise the result is an empty list.
+		Otherwise, {buf} specifies a particular buffer to return
+		information for.  For the use of {buf}, see |bufname()|
+		above.	If the buffer is found the returned List has one item.
+		Otherwise the result is an empty list.
 
-                Each returned List item is a dictionary with the following
-                entries:
-                        bufnr           Buffer number.
-                        changed         TRUE if the buffer is modified.
-                        changedtick     Number of changes made to the buffer.
-                        hidden          TRUE if the buffer is hidden.
-                        lastused        Timestamp in seconds, like
-                                        |localtime()|, when the buffer was
-                                        last used.
-                        listed          TRUE if the buffer is listed.
-                        lnum            Line number used for the buffer when
-                                        opened in the current window.
-                                        Only valid if the buffer has been
-                                        displayed in the window in the past.
-                                        If you want the line number of the
-                                        last known cursor position in a given
-                                        window, use |line()|: >vim
-                                                echo line('.', {winid})
+		Each returned List item is a dictionary with the following
+		entries:
+			bufnr		Buffer number.
+			changed		TRUE if the buffer is modified.
+			changedtick	Number of changes made to the buffer.
+			hidden		TRUE if the buffer is hidden.
+			lastused	Timestamp in seconds, like
+					|localtime()|, when the buffer was
+					last used.
+			listed		TRUE if the buffer is listed.
+			lnum		Line number used for the buffer when
+					opened in the current window.
+					Only valid if the buffer has been
+					displayed in the window in the past.
+					If you want the line number of the
+					last known cursor position in a given
+					window, use |line()|: >vim
+						echo line('.', {winid})
 <
-                        linecount       Number of lines in the buffer (only
-                                        valid when loaded)
-                        loaded          TRUE if the buffer is loaded.
-                        name            Full path to the file in the buffer.
-                        signs           List of signs placed in the buffer.
-                                        Each list item is a dictionary with
-                                        the following fields:
-                                            id    sign identifier
-                                            lnum  line number
-                                            name  sign name
-                        variables       A reference to the dictionary with
-                                        buffer-local variables.
-                        windows         List of |window-ID|s that display this
-                                        buffer
+			linecount	Number of lines in the buffer (only
+					valid when loaded)
+			loaded		TRUE if the buffer is loaded.
+			name		Full path to the file in the buffer.
+			signs		List of signs placed in the buffer.
+					Each list item is a dictionary with
+					the following fields:
+					    id	  sign identifier
+					    lnum  line number
+					    name  sign name
+			variables	A reference to the dictionary with
+					buffer-local variables.
+			windows		List of |window-ID|s that display this
+					buffer
 
-                Examples: >vim
-                        for buf in getbufinfo()
-                            echo buf.name
-                        endfor
-                        for buf in getbufinfo({'buflisted':1})
-                            if buf.changed
-                                " ....
-                            endif
-                        endfor
+		Examples: >vim
+			for buf in getbufinfo()
+			    echo buf.name
+			endfor
+			for buf in getbufinfo({'buflisted':1})
+			    if buf.changed
+				" ....
+			    endif
+			endfor
 <
-                To get buffer-local options use: >vim
-                        getbufvar({bufnr}, '&option_name')
+		To get buffer-local options use: >vim
+			getbufvar({bufnr}, '&option_name')
 <
-getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
-                Return a |List| with the lines starting from {lnum} to {end}
-                (inclusive) in the buffer {buf}.  If {end} is omitted, a
-                |List| with only the line {lnum} is returned.  See
-                `getbufoneline()` for only getting the line.
+getbufline({buf}, {lnum} [, {end}])				  *getbufline()*
+		Return a |List| with the lines starting from {lnum} to {end}
+		(inclusive) in the buffer {buf}.  If {end} is omitted, a
+		|List| with only the line {lnum} is returned.  See
+		`getbufoneline()` for only getting the line.
 
-                For the use of {buf}, see |bufname()| above.
+		For the use of {buf}, see |bufname()| above.
 
-                For {lnum} and {end} "$" can be used for the last line of the
-                buffer.  Otherwise a number must be used.
+		For {lnum} and {end} "$" can be used for the last line of the
+		buffer.  Otherwise a number must be used.
 
-                When {lnum} is smaller than 1 or bigger than the number of
-                lines in the buffer, an empty |List| is returned.
+		When {lnum} is smaller than 1 or bigger than the number of
+		lines in the buffer, an empty |List| is returned.
 
-                When {end} is greater than the number of lines in the buffer,
-                it is treated as {end} is set to the number of lines in the
-                buffer.  When {end} is before {lnum} an empty |List| is
-                returned.
+		When {end} is greater than the number of lines in the buffer,
+		it is treated as {end} is set to the number of lines in the
+		buffer.  When {end} is before {lnum} an empty |List| is
+		returned.
 
-                This function works only for loaded buffers.  For unloaded and
-                non-existing buffers, an empty |List| is returned.
+		This function works only for loaded buffers.  For unloaded and
+		non-existing buffers, an empty |List| is returned.
 
-                Example: >vim
-                        let lines = getbufline(bufnr("myfile"), 1, "$")
+		Example: >vim
+			let lines = getbufline(bufnr("myfile"), 1, "$")
 
-getbufoneline({buf}, {lnum})                                   *getbufoneline()*
-                Just like `getbufline()` but only get one line and return it
-                as a string.
+getbufoneline({buf}, {lnum})				       *getbufoneline()*
+		Just like `getbufline()` but only get one line and return it
+		as a string.
 
-getbufvar({buf}, {varname} [, {def}])                              *getbufvar()*
-                The result is the value of option or local buffer variable
-                {varname} in buffer {buf}.  Note that the name without "b:"
-                must be used.
-                The {varname} argument is a string.
-                When {varname} is empty returns a |Dictionary| with all the
-                buffer-local variables.
-                When {varname} is equal to "&" returns a |Dictionary| with all
-                the buffer-local options.
-                Otherwise, when {varname} starts with "&" returns the value of
-                a buffer-local option.
-                This also works for a global or buffer-local option, but it
-                doesn't work for a global variable, window-local variable or
-                window-local option.
-                For the use of {buf}, see |bufname()| above.
-                When the buffer or variable doesn't exist {def} or an empty
-                string is returned, there is no error message.
-                Examples: >vim
-                        let bufmodified = getbufvar(1, "&mod")
-                        echo "todo myvar = " .. getbufvar("todo", "myvar")
+getbufvar({buf}, {varname} [, {def}])				   *getbufvar()*
+		The result is the value of option or local buffer variable
+		{varname} in buffer {buf}.  Note that the name without "b:"
+		must be used.
+		The {varname} argument is a string.
+		When {varname} is empty returns a |Dictionary| with all the
+		buffer-local variables.
+		When {varname} is equal to "&" returns a |Dictionary| with all
+		the buffer-local options.
+		Otherwise, when {varname} starts with "&" returns the value of
+		a buffer-local option.
+		This also works for a global or buffer-local option, but it
+		doesn't work for a global variable, window-local variable or
+		window-local option.
+		For the use of {buf}, see |bufname()| above.
+		When the buffer or variable doesn't exist {def} or an empty
+		string is returned, there is no error message.
+		Examples: >vim
+			let bufmodified = getbufvar(1, "&mod")
+			echo "todo myvar = " .. getbufvar("todo", "myvar")
 
-getcellwidths()                                                *getcellwidths()*
-                Returns a |List| of cell widths of character ranges overridden
-                by |setcellwidths()|.  The format is equal to the argument of
-                |setcellwidths()|.  If no character ranges have their cell
-                widths overridden, an empty List is returned.
+getcellwidths()						       *getcellwidths()*
+		Returns a |List| of cell widths of character ranges overridden
+		by |setcellwidths()|.  The format is equal to the argument of
+		|setcellwidths()|.  If no character ranges have their cell
+		widths overridden, an empty List is returned.
 
-getchangelist([{buf}])                                         *getchangelist()*
-                Returns the |changelist| for the buffer {buf}. For the use
-                of {buf}, see |bufname()| above. If buffer {buf} doesn't
-                exist, an empty list is returned.
+getchangelist([{buf}])					       *getchangelist()*
+		Returns the |changelist| for the buffer {buf}. For the use
+		of {buf}, see |bufname()| above. If buffer {buf} doesn't
+		exist, an empty list is returned.
 
-                The returned list contains two entries: a list with the change
-                locations and the current position in the list.  Each
-                entry in the change list is a dictionary with the following
-                entries:
-                        col             column number
-                        coladd          column offset for 'virtualedit'
-                        lnum            line number
-                If buffer {buf} is the current buffer, then the current
-                position refers to the position in the list. For other
-                buffers, it is set to the length of the list.
+		The returned list contains two entries: a list with the change
+		locations and the current position in the list.  Each
+		entry in the change list is a dictionary with the following
+		entries:
+			col		column number
+			coladd		column offset for 'virtualedit'
+			lnum		line number
+		If buffer {buf} is the current buffer, then the current
+		position refers to the position in the list. For other
+		buffers, it is set to the length of the list.
 
-getchar([expr])                                                      *getchar()*
-                Get a single character from the user or input stream.
-                If [expr] is omitted, wait until a character is available.
-                If [expr] is 0, only get a character when one is available.
-                        Return zero otherwise.
-                If [expr] is 1, only check if a character is available, it is
-                        not consumed.  Return zero if no character available.
-                If you prefer always getting a string use |getcharstr()|.
+getchar([expr])							     *getchar()*
+		Get a single character from the user or input stream.
+		If [expr] is omitted, wait until a character is available.
+		If [expr] is 0, only get a character when one is available.
+			Return zero otherwise.
+		If [expr] is 1, only check if a character is available, it is
+			not consumed.  Return zero if no character available.
+		If you prefer always getting a string use |getcharstr()|.
 
-                Without [expr] and when [expr] is 0 a whole character or
-                special key is returned.  If it is a single character, the
-                result is a Number.  Use |nr2char()| to convert it to a String.
-                Otherwise a String is returned with the encoded character.
-                For a special key it's a String with a sequence of bytes
-                starting with 0x80 (decimal: 128).  This is the same value as
-                the String "\<Key>", e.g., "\<Left>".  The returned value is
-                also a String when a modifier (shift, control, alt) was used
-                that is not included in the character.
+		Without [expr] and when [expr] is 0 a whole character or
+		special key is returned.  If it is a single character, the
+		result is a Number.  Use |nr2char()| to convert it to a String.
+		Otherwise a String is returned with the encoded character.
+		For a special key it's a String with a sequence of bytes
+		starting with 0x80 (decimal: 128).  This is the same value as
+		the String "\<Key>", e.g., "\<Left>".  The returned value is
+		also a String when a modifier (shift, control, alt) was used
+		that is not included in the character.
 
-                When [expr] is 0 and Esc is typed, there will be a short delay
-                while Vim waits to see if this is the start of an escape
-                sequence.
+		When [expr] is 0 and Esc is typed, there will be a short delay
+		while Vim waits to see if this is the start of an escape
+		sequence.
 
-                When [expr] is 1 only the first byte is returned.  For a
-                one-byte character it is the character itself as a number.
-                Use nr2char() to convert it to a String.
+		When [expr] is 1 only the first byte is returned.  For a
+		one-byte character it is the character itself as a number.
+		Use nr2char() to convert it to a String.
 
-                Use getcharmod() to obtain any additional modifiers.
+		Use getcharmod() to obtain any additional modifiers.
 
-                When the user clicks a mouse button, the mouse event will be
-                returned.  The position can then be found in |v:mouse_col|,
-                |v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
-                |getmousepos()| can also be used.  Mouse move events will be
-                ignored.
-                This example positions the mouse as it would normally happen: >vim
-                        let c = getchar()
-                        if c == "\<LeftMouse>" && v:mouse_win > 0
-                          exe v:mouse_win .. "wincmd w"
-                          exe v:mouse_lnum
-                          exe "normal " .. v:mouse_col .. "|"
-                        endif
+		When the user clicks a mouse button, the mouse event will be
+		returned.  The position can then be found in |v:mouse_col|,
+		|v:mouse_lnum|, |v:mouse_winid| and |v:mouse_win|.
+		|getmousepos()| can also be used.  Mouse move events will be
+		ignored.
+		This example positions the mouse as it would normally happen: >vim
+			let c = getchar()
+			if c == "\<LeftMouse>" && v:mouse_win > 0
+			  exe v:mouse_win .. "wincmd w"
+			  exe v:mouse_lnum
+			  exe "normal " .. v:mouse_col .. "|"
+			endif
 <
-                There is no prompt, you will somehow have to make clear to the
-                user that a character has to be typed.  The screen is not
-                redrawn, e.g. when resizing the window.
+		There is no prompt, you will somehow have to make clear to the
+		user that a character has to be typed.	The screen is not
+		redrawn, e.g. when resizing the window.
 
-                There is no mapping for the character.
-                Key codes are replaced, thus when the user presses the <Del>
-                key you get the code for the <Del> key, not the raw character
-                sequence.  Examples: >vim
-                        getchar() == "\<Del>"
-                        getchar() == "\<S-Left>"
-<                This example redefines "f" to ignore case: >vim
-                        nmap f :call FindChar()<CR>
-                        function FindChar()
-                          let c = nr2char(getchar())
-                          while col('.') < col('$') - 1
-                            normal l
-                            if getline('.')[col('.') - 1] ==? c
-                              break
-                            endif
-                          endwhile
-                        endfunction
+		There is no mapping for the character.
+		Key codes are replaced, thus when the user presses the <Del>
+		key you get the code for the <Del> key, not the raw character
+		sequence.  Examples: >vim
+			getchar() == "\<Del>"
+			getchar() == "\<S-Left>"
+<		 This example redefines "f" to ignore case: >vim
+			nmap f :call FindChar()<CR>
+			function FindChar()
+			  let c = nr2char(getchar())
+			  while col('.') < col('$') - 1
+			    normal l
+			    if getline('.')[col('.') - 1] ==? c
+			      break
+			    endif
+			  endwhile
+			endfunction
 <
-getcharmod()                                                      *getcharmod()*
-                The result is a Number which is the state of the modifiers for
-                the last obtained character with getchar() or in another way.
-                These values are added together:
-                        2       shift
-                        4       control
-                        8       alt (meta)
-                        16      meta (when it's different from ALT)
-                        32      mouse double click
-                        64      mouse triple click
-                        96      mouse quadruple click (== 32 + 64)
-                        128     command (Macintosh only)
-                Only the modifiers that have not been included in the
-                character itself are obtained.  Thus Shift-a results in "A"
-                without a modifier.  Returns 0 if no modifiers are used.
+getcharmod()							  *getcharmod()*
+		The result is a Number which is the state of the modifiers for
+		the last obtained character with getchar() or in another way.
+		These values are added together:
+			2	shift
+			4	control
+			8	alt (meta)
+			16	meta (when it's different from ALT)
+			32	mouse double click
+			64	mouse triple click
+			96	mouse quadruple click (== 32 + 64)
+			128	command (Macintosh only)
+		Only the modifiers that have not been included in the
+		character itself are obtained.	Thus Shift-a results in "A"
+		without a modifier.  Returns 0 if no modifiers are used.
 
-getcharpos({expr})                                                *getcharpos()*
-                Get the position for String {expr}. Same as |getpos()| but the
-                column number in the returned List is a character index
-                instead of a byte index.
-                If |getpos()| returns a very large column number, equal to
-                |v:maxcol|, then getcharpos() will return the character index
-                of the last character.
+getcharpos({expr})						  *getcharpos()*
+		Get the position for String {expr}. Same as |getpos()| but the
+		column number in the returned List is a character index
+		instead of a byte index.
+		If |getpos()| returns a very large column number, equal to
+		|v:maxcol|, then getcharpos() will return the character index
+		of the last character.
 
-                Example:
-                With the cursor on '세' in line 5 with text "여보세요": >vim
-                        getcharpos('.')         returns [0, 5, 3, 0]
-                        getpos('.')             returns [0, 5, 7, 0]
+		Example:
+		With the cursor on '세' in line 5 with text "여보세요": >vim
+			getcharpos('.')		returns [0, 5, 3, 0]
+			getpos('.')		returns [0, 5, 7, 0]
 <
-getcharsearch()                                                *getcharsearch()*
-                Return the current character search information as a {dict}
-                with the following entries:
+getcharsearch()						       *getcharsearch()*
+		Return the current character search information as a {dict}
+		with the following entries:
 
-                    char        character previously used for a character
-                                search (|t|, |f|, |T|, or |F|); empty string
-                                if no character search has been performed
-                    forward     direction of character search; 1 for forward,
-                                0 for backward
-                    until       type of character search; 1 for a |t| or |T|
-                                character search, 0 for an |f| or |F|
-                                character search
+		    char	character previously used for a character
+				search (|t|, |f|, |T|, or |F|); empty string
+				if no character search has been performed
+		    forward	direction of character search; 1 for forward,
+				0 for backward
+		    until	type of character search; 1 for a |t| or |T|
+				character search, 0 for an |f| or |F|
+				character search
 
-                This can be useful to always have |;| and |,| search
-                forward/backward regardless of the direction of the previous
-                character search: >vim
-                        nnoremap <expr> ; getcharsearch().forward ? ';' : ','
-                        nnoremap <expr> , getcharsearch().forward ? ',' : ';'
-<                Also see |setcharsearch()|.
+		This can be useful to always have |;| and |,| search
+		forward/backward regardless of the direction of the previous
+		character search: >vim
+			nnoremap <expr> ; getcharsearch().forward ? ';' : ','
+			nnoremap <expr> , getcharsearch().forward ? ',' : ';'
+<		 Also see |setcharsearch()|.
 
-getcharstr([expr])                                                *getcharstr()*
-                Get a single character from the user or input stream as a
-                string.
-                If [expr] is omitted, wait until a character is available.
-                If [expr] is 0 or false, only get a character when one is
-                        available.  Return an empty string otherwise.
-                If [expr] is 1 or true, only check if a character is
-                        available, it is not consumed.  Return an empty string
-                        if no character is available.
-                Otherwise this works like |getchar()|, except that a number
-                result is converted to a string.
+getcharstr([expr])						  *getcharstr()*
+		Get a single character from the user or input stream as a
+		string.
+		If [expr] is omitted, wait until a character is available.
+		If [expr] is 0 or false, only get a character when one is
+			available.  Return an empty string otherwise.
+		If [expr] is 1 or true, only check if a character is
+			available, it is not consumed.	Return an empty string
+			if no character is available.
+		Otherwise this works like |getchar()|, except that a number
+		result is converted to a string.
 
-getcmdcompltype()                                            *getcmdcompltype()*
-                Return the type of the current command-line completion.
-                Only works when the command line is being edited, thus
-                requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
-                See |:command-completion| for the return string.
-                Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-                |setcmdline()|.
-                Returns an empty string when completion is not defined.
+getcmdcompltype()					     *getcmdcompltype()*
+		Return the type of the current command-line completion.
+		Only works when the command line is being edited, thus
+		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
+		See |:command-completion| for the return string.
+		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
+		|setcmdline()|.
+		Returns an empty string when completion is not defined.
 
-getcmdline()                                                      *getcmdline()*
-                Return the current command-line.  Only works when the command
-                line is being edited, thus requires use of |c_CTRL-\_e| or
-                |c_CTRL-R_=|.
-                Example: >vim
-                        cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
-<                Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
-                |setcmdline()|.
-                Returns an empty string when entering a password or using
-                |inputsecret()|.
+getcmdline()							  *getcmdline()*
+		Return the current command-line.  Only works when the command
+		line is being edited, thus requires use of |c_CTRL-\_e| or
+		|c_CTRL-R_=|.
+		Example: >vim
+			cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
+<		 Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
+		|setcmdline()|.
+		Returns an empty string when entering a password or using
+		|inputsecret()|.
 
-getcmdpos()                                                        *getcmdpos()*
-                Return the position of the cursor in the command line as a
-                byte count.  The first column is 1.
-                Only works when editing the command line, thus requires use of
-                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-                Returns 0 otherwise.
-                Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-                |setcmdline()|.
+getcmdpos()							   *getcmdpos()*
+		Return the position of the cursor in the command line as a
+		byte count.  The first column is 1.
+		Only works when editing the command line, thus requires use of
+		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+		Returns 0 otherwise.
+		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
+		|setcmdline()|.
 
-getcmdscreenpos()                                            *getcmdscreenpos()*
-                Return the screen position of the cursor in the command line
-                as a byte count.  The first column is 1.
-                Instead of |getcmdpos()|, it adds the prompt position.
-                Only works when editing the command line, thus requires use of
-                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-                Returns 0 otherwise.
-                Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
-                |setcmdline()|.
+getcmdscreenpos()					     *getcmdscreenpos()*
+		Return the screen position of the cursor in the command line
+		as a byte count.  The first column is 1.
+		Instead of |getcmdpos()|, it adds the prompt position.
+		Only works when editing the command line, thus requires use of
+		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+		Returns 0 otherwise.
+		Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
+		|setcmdline()|.
 
-getcmdtype()                                                      *getcmdtype()*
-                Return the current command-line type. Possible return values
-                are:
-                    :   normal Ex command
-                    >   debug mode command |debug-mode|
-                    /   forward search command
-                    ?   backward search command
-                    @   |input()| command
-                    `-` |:insert| or |:append| command
-                    =   |i_CTRL-R_=|
-                Only works when editing the command line, thus requires use of
-                |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
-                Returns an empty string otherwise.
-                Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
+getcmdtype()							  *getcmdtype()*
+		Return the current command-line type. Possible return values
+		are:
+		    :	normal Ex command
+		    >	debug mode command |debug-mode|
+		    /	forward search command
+		    ?	backward search command
+		    @	|input()| command
+		    `-` |:insert| or |:append| command
+		    =	|i_CTRL-R_=|
+		Only works when editing the command line, thus requires use of
+		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
+		Returns an empty string otherwise.
+		Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 
-getcmdwintype()                                                *getcmdwintype()*
-                Return the current |command-line-window| type. Possible return
-                values are the same as |getcmdtype()|. Returns an empty string
-                when not in the command-line window.
+getcmdwintype()						       *getcmdwintype()*
+		Return the current |command-line-window| type. Possible return
+		values are the same as |getcmdtype()|. Returns an empty string
+		when not in the command-line window.
 
-getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
-                Return a list of command-line completion matches. The String
-                {type} argument specifies what for.  The following completion
-                types are supported:
+getcompletion({pat}, {type} [, {filtered}])		       *getcompletion()*
+		Return a list of command-line completion matches. The String
+		{type} argument specifies what for.  The following completion
+		types are supported:
 
-                arglist         file names in argument list
-                augroup         autocmd groups
-                buffer          buffer names
-                breakpoint      |:breakadd| and |:breakdel| suboptions
-                cmdline         |cmdline-completion| result
-                color           color schemes
-                command         Ex command
-                compiler        compilers
-                custom,{func}   custom completion, defined via {func}
-                customlist,{func} custom completion, defined via {func}
-                diff_buffer     |:diffget| and |:diffput| completion
-                dir             directory names
-                environment     environment variable names
-                event           autocommand events
-                expression      Vim expression
-                file            file and directory names
-                file_in_path    file and directory names in |'path'|
-                filetype        filetype names |'filetype'|
-                function        function name
-                help            help subjects
-                highlight       highlight groups
-                history         |:history| suboptions
-                locale          locale names (as output of locale -a)
-                mapclear        buffer argument
-                mapping         mapping name
-                menu            menus
-                messages        |:messages| suboptions
-                option          options
-                packadd         optional package |pack-add| names
-                runtime         |:runtime| completion
-                scriptnames     sourced script names |:scriptnames|
-                shellcmd        Shell command
-                sign            |:sign| suboptions
-                syntax          syntax file names |'syntax'|
-                syntime         |:syntime| suboptions
-                tag             tags
-                tag_listfiles   tags, file names
-                user            user names
-                var             user variables
+		arglist		file names in argument list
+		augroup		autocmd groups
+		buffer		buffer names
+		breakpoint	|:breakadd| and |:breakdel| suboptions
+		cmdline		|cmdline-completion| result
+		color		color schemes
+		command		Ex command
+		compiler	compilers
+		custom,{func}	custom completion, defined via {func}
+		customlist,{func} custom completion, defined via {func}
+		diff_buffer	|:diffget| and |:diffput| completion
+		dir		directory names
+		environment	environment variable names
+		event		autocommand events
+		expression	Vim expression
+		file		file and directory names
+		file_in_path	file and directory names in |'path'|
+		filetype	filetype names |'filetype'|
+		function	function name
+		help		help subjects
+		highlight	highlight groups
+		history		|:history| suboptions
+		locale		locale names (as output of locale -a)
+		mapclear	buffer argument
+		mapping		mapping name
+		menu		menus
+		messages	|:messages| suboptions
+		option		options
+		packadd		optional package |pack-add| names
+		runtime		|:runtime| completion
+		scriptnames	sourced script names |:scriptnames|
+		shellcmd	Shell command
+		sign		|:sign| suboptions
+		syntax		syntax file names |'syntax'|
+		syntime		|:syntime| suboptions
+		tag		tags
+		tag_listfiles	tags, file names
+		user		user names
+		var		user variables
 
-                If {pat} is an empty string, then all the matches are
-                returned.  Otherwise only items matching {pat} are returned.
-                See |wildcards| for the use of special characters in {pat}.
+		If {pat} is an empty string, then all the matches are
+		returned.  Otherwise only items matching {pat} are returned.
+		See |wildcards| for the use of special characters in {pat}.
 
-                If the optional {filtered} flag is set to 1, then 'wildignore'
-                is applied to filter the results.  Otherwise all the matches
-                are returned. The 'wildignorecase' option always applies.
+		If the optional {filtered} flag is set to 1, then 'wildignore'
+		is applied to filter the results.  Otherwise all the matches
+		are returned. The 'wildignorecase' option always applies.
 
-                If the 'wildoptions' option contains "fuzzy", then fuzzy
-                matching is used to get the completion matches. Otherwise
-                regular expression matching is used.  Thus this function
-                follows the user preference, what happens on the command line.
-                If you do not want this you can make 'wildoptions' empty
-                before calling getcompletion() and restore it afterwards.
+		If the 'wildoptions' option contains "fuzzy", then fuzzy
+		matching is used to get the completion matches. Otherwise
+		regular expression matching is used.  Thus this function
+		follows the user preference, what happens on the command line.
+		If you do not want this you can make 'wildoptions' empty
+		before calling getcompletion() and restore it afterwards.
 
-                If {type} is "cmdline", then the |cmdline-completion| result is
-                returned.  For example, to complete the possible values after
-                a ":call" command: >vim
-                        echo getcompletion('call ', 'cmdline')
+		If {type} is "cmdline", then the |cmdline-completion| result is
+		returned.  For example, to complete the possible values after
+		a ":call" command: >vim
+			echo getcompletion('call ', 'cmdline')
 <
-                If there are no matches, an empty list is returned.  An
-                invalid value for {type} produces an error.
+		If there are no matches, an empty list is returned.  An
+		invalid value for {type} produces an error.
 
-getcurpos([{winid}])                                               *getcurpos()*
-                Get the position of the cursor.  This is like getpos('.'), but
-                includes an extra "curswant" item in the list:
-                    [0, lnum, col, off, curswant] ~
-                The "curswant" number is the preferred column when moving the
-                cursor vertically.  After |$| command it will be a very large
-                number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
-                |getpos()|.
-                The first "bufnum" item is always zero. The byte position of
-                the cursor is returned in "col". To get the character
-                position, use |getcursorcharpos()|.
+getcurpos([{winid}])						   *getcurpos()*
+		Get the position of the cursor.  This is like getpos('.'), but
+		includes an extra "curswant" item in the list:
+		    [0, lnum, col, off, curswant] ~
+		The "curswant" number is the preferred column when moving the
+		cursor vertically.  After |$| command it will be a very large
+		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
+		|getpos()|.
+		The first "bufnum" item is always zero. The byte position of
+		the cursor is returned in "col". To get the character
+		position, use |getcursorcharpos()|.
 
-                The optional {winid} argument can specify the window.  It can
-                be the window number or the |window-ID|.  The last known
-                cursor position is returned, this may be invalid for the
-                current value of the buffer if it is not the current window.
-                If {winid} is invalid a list with zeroes is returned.
+		The optional {winid} argument can specify the window.  It can
+		be the window number or the |window-ID|.  The last known
+		cursor position is returned, this may be invalid for the
+		current value of the buffer if it is not the current window.
+		If {winid} is invalid a list with zeroes is returned.
 
-                This can be used to save and restore the cursor position: >vim
-                        let save_cursor = getcurpos()
-                        MoveTheCursorAround
-                        call setpos('.', save_cursor)
-<                Note that this only works within the window.  See
-                |winrestview()| for restoring more state.
+		This can be used to save and restore the cursor position: >vim
+			let save_cursor = getcurpos()
+			MoveTheCursorAround
+			call setpos('.', save_cursor)
+<		 Note that this only works within the window.  See
+		|winrestview()| for restoring more state.
 
-getcursorcharpos([{winid}])                                 *getcursorcharpos()*
-                Same as |getcurpos()| but the column number in the returned
-                List is a character index instead of a byte index.
+getcursorcharpos([{winid}])				    *getcursorcharpos()*
+		Same as |getcurpos()| but the column number in the returned
+		List is a character index instead of a byte index.
 
-                Example:
-                With the cursor on '보' in line 3 with text "여보세요": >vim
-                        getcursorcharpos()      " returns [0, 3, 2, 0, 3]
-                        getcurpos()             " returns [0, 3, 4, 0, 3]
+		Example:
+		With the cursor on '보' in line 3 with text "여보세요": >vim
+			getcursorcharpos()	" returns [0, 3, 2, 0, 3]
+			getcurpos()		" returns [0, 3, 4, 0, 3]
 <
-getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
-                With no arguments, returns the name of the effective
-                |current-directory|. With {winnr} or {tabnr} the working
-                directory of that scope is returned, and 'autochdir' is
-                ignored.
-                Tabs and windows are identified by their respective numbers,
-                0 means current tab or window. Missing tab number implies 0.
-                Thus the following are equivalent: >vim
-                        getcwd(0)
-                        getcwd(0, 0)
-<                If {winnr} is -1 it is ignored, only the tab is resolved.
-                {winnr} can be the window number or the |window-ID|.
-                If both {winnr} and {tabnr} are -1 the global working
-                directory is returned.
-                Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+getcwd([{winnr} [, {tabnr}]])					      *getcwd()*
+		With no arguments, returns the name of the effective
+		|current-directory|. With {winnr} or {tabnr} the working
+		directory of that scope is returned, and 'autochdir' is
+		ignored.
+		Tabs and windows are identified by their respective numbers,
+		0 means current tab or window. Missing tab number implies 0.
+		Thus the following are equivalent: >vim
+			getcwd(0)
+			getcwd(0, 0)
+<		 If {winnr} is -1 it is ignored, only the tab is resolved.
+		{winnr} can be the window number or the |window-ID|.
+		If both {winnr} and {tabnr} are -1 the global working
+		directory is returned.
+		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
-getenv({name})                                                        *getenv()*
-                Return the value of environment variable {name}.  The {name}
-                argument is a string, without a leading '$'.  Example: >vim
-                        myHome = getenv('HOME')
+getenv({name})							      *getenv()*
+		Return the value of environment variable {name}.  The {name}
+		argument is a string, without a leading '$'.  Example: >vim
+			myHome = getenv('HOME')
 
-<                When the variable does not exist |v:null| is returned.  That
-                is different from a variable set to an empty string.
-                See also |expr-env|.
+<		 When the variable does not exist |v:null| is returned.  That
+		is different from a variable set to an empty string.
+		See also |expr-env|.
 
-getfontname([{name}])                                            *getfontname()*
-                Without an argument returns the name of the normal font being
-                used.  Like what is used for the Normal highlight group
-                |hl-Normal|.
-                With an argument a check is done whether String {name} is a
-                valid font name.  If not then an empty string is returned.
-                Otherwise the actual font name is returned, or {name} if the
-                GUI does not support obtaining the real name.
-                Only works when the GUI is running, thus not in your vimrc or
-                gvimrc file.  Use the |GUIEnter| autocommand to use this
-                function just after the GUI has started.
+getfontname([{name}])						 *getfontname()*
+		Without an argument returns the name of the normal font being
+		used.  Like what is used for the Normal highlight group
+		|hl-Normal|.
+		With an argument a check is done whether String {name} is a
+		valid font name.  If not then an empty string is returned.
+		Otherwise the actual font name is returned, or {name} if the
+		GUI does not support obtaining the real name.
+		Only works when the GUI is running, thus not in your vimrc or
+		gvimrc file.  Use the |GUIEnter| autocommand to use this
+		function just after the GUI has started.
 
-getfperm({fname})                                                   *getfperm()*
-                The result is a String, which is the read, write, and execute
-                permissions of the given file {fname}.
-                If {fname} does not exist or its directory cannot be read, an
-                empty string is returned.
-                The result is of the form "rwxrwxrwx", where each group of
-                "rwx" flags represent, in turn, the permissions of the owner
-                of the file, the group the file belongs to, and other users.
-                If a user does not have a given permission the flag for this
-                is replaced with the string "-".  Examples: >vim
-                        echo getfperm("/etc/passwd")
-                        echo getfperm(expand("~/.config/nvim/init.vim"))
-<                This will hopefully (from a security point of view) display
-                the string "rw-r--r--" or even "rw-------".
+getfperm({fname})						    *getfperm()*
+		The result is a String, which is the read, write, and execute
+		permissions of the given file {fname}.
+		If {fname} does not exist or its directory cannot be read, an
+		empty string is returned.
+		The result is of the form "rwxrwxrwx", where each group of
+		"rwx" flags represent, in turn, the permissions of the owner
+		of the file, the group the file belongs to, and other users.
+		If a user does not have a given permission the flag for this
+		is replaced with the string "-".  Examples: >vim
+			echo getfperm("/etc/passwd")
+			echo getfperm(expand("~/.config/nvim/init.vim"))
+<		 This will hopefully (from a security point of view) display
+		the string "rw-r--r--" or even "rw-------".
 
-                For setting permissions use |setfperm()|.
+		For setting permissions use |setfperm()|.
 
-getfsize({fname})                                                   *getfsize()*
-                The result is a Number, which is the size in bytes of the
-                given file {fname}.
-                If {fname} is a directory, 0 is returned.
-                If the file {fname} can't be found, -1 is returned.
-                If the size of {fname} is too big to fit in a Number then -2
-                is returned.
+getfsize({fname})						    *getfsize()*
+		The result is a Number, which is the size in bytes of the
+		given file {fname}.
+		If {fname} is a directory, 0 is returned.
+		If the file {fname} can't be found, -1 is returned.
+		If the size of {fname} is too big to fit in a Number then -2
+		is returned.
 
-getftime({fname})                                                   *getftime()*
-                The result is a Number, which is the last modification time of
-                the given file {fname}.  The value is measured as seconds
-                since 1st Jan 1970, and may be passed to strftime().  See also
-                |localtime()| and |strftime()|.
-                If the file {fname} can't be found -1 is returned.
+getftime({fname})						    *getftime()*
+		The result is a Number, which is the last modification time of
+		the given file {fname}.  The value is measured as seconds
+		since 1st Jan 1970, and may be passed to strftime().  See also
+		|localtime()| and |strftime()|.
+		If the file {fname} can't be found -1 is returned.
 
-getftype({fname})                                                   *getftype()*
-                The result is a String, which is a description of the kind of
-                file of the given file {fname}.
-                If {fname} does not exist an empty string is returned.
-                Here is a table over different kinds of files and their
-                results:
-                        Normal file             "file"
-                        Directory               "dir"
-                        Symbolic link           "link"
-                        Block device            "bdev"
-                        Character device        "cdev"
-                        Socket                  "socket"
-                        FIFO                    "fifo"
-                        All other               "other"
-                Example: >vim
-                        getftype("/home")
-<                Note that a type such as "link" will only be returned on
-                systems that support it.  On some systems only "dir" and
-                "file" are returned.
+getftype({fname})						    *getftype()*
+		The result is a String, which is a description of the kind of
+		file of the given file {fname}.
+		If {fname} does not exist an empty string is returned.
+		Here is a table over different kinds of files and their
+		results:
+			Normal file		"file"
+			Directory		"dir"
+			Symbolic link		"link"
+			Block device		"bdev"
+			Character device	"cdev"
+			Socket			"socket"
+			FIFO			"fifo"
+			All other		"other"
+		Example: >vim
+			getftype("/home")
+<		 Note that a type such as "link" will only be returned on
+		systems that support it.  On some systems only "dir" and
+		"file" are returned.
 
-getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
-                Returns the |jumplist| for the specified window.
+getjumplist([{winnr} [, {tabnr}]])				 *getjumplist()*
+		Returns the |jumplist| for the specified window.
 
-                Without arguments use the current window.
-                With {winnr} only use this window in the current tab page.
-                {winnr} can also be a |window-ID|.
-                With {winnr} and {tabnr} use the window in the specified tab
-                page.  If {winnr} or {tabnr} is invalid, an empty list is
-                returned.
+		Without arguments use the current window.
+		With {winnr} only use this window in the current tab page.
+		{winnr} can also be a |window-ID|.
+		With {winnr} and {tabnr} use the window in the specified tab
+		page.  If {winnr} or {tabnr} is invalid, an empty list is
+		returned.
 
-                The returned list contains two entries: a list with the jump
-                locations and the last used jump position number in the list.
-                Each entry in the jump location list is a dictionary with
-                the following entries:
-                        bufnr           buffer number
-                        col             column number
-                        coladd          column offset for 'virtualedit'
-                        filename        filename if available
-                        lnum            line number
+		The returned list contains two entries: a list with the jump
+		locations and the last used jump position number in the list.
+		Each entry in the jump location list is a dictionary with
+		the following entries:
+			bufnr		buffer number
+			col		column number
+			coladd		column offset for 'virtualedit'
+			filename	filename if available
+			lnum		line number
 
-getline({lnum} [, {end}])                                            *getline()*
-                Without {end} the result is a String, which is line {lnum}
-                from the current buffer.  Example: >vim
-                        getline(1)
-<                When {lnum} is a String that doesn't start with a
-                digit, |line()| is called to translate the String into a Number.
-                To get the line under the cursor: >vim
-                        getline(".")
-<                When {lnum} is a number smaller than 1 or bigger than the
-                number of lines in the buffer, an empty string is returned.
+getline({lnum} [, {end}])					     *getline()*
+		Without {end} the result is a String, which is line {lnum}
+		from the current buffer.  Example: >vim
+			getline(1)
+<		 When {lnum} is a String that doesn't start with a
+		digit, |line()| is called to translate the String into a Number.
+		To get the line under the cursor: >vim
+			getline(".")
+<		 When {lnum} is a number smaller than 1 or bigger than the
+		number of lines in the buffer, an empty string is returned.
 
-                When {end} is given the result is a |List| where each item is
-                a line from the current buffer in the range {lnum} to {end},
-                including line {end}.
-                {end} is used in the same way as {lnum}.
-                Non-existing lines are silently omitted.
-                When {end} is before {lnum} an empty |List| is returned.
-                Example: >vim
-                        let start = line('.')
-                        let end = search("^$") - 1
-                        let lines = getline(start, end)
+		When {end} is given the result is a |List| where each item is
+		a line from the current buffer in the range {lnum} to {end},
+		including line {end}.
+		{end} is used in the same way as {lnum}.
+		Non-existing lines are silently omitted.
+		When {end} is before {lnum} an empty |List| is returned.
+		Example: >vim
+			let start = line('.')
+			let end = search("^$") - 1
+			let lines = getline(start, end)
 
-<                To get lines from another buffer see |getbufline()| and
-                |getbufoneline()|
+<		 To get lines from another buffer see |getbufline()| and
+		|getbufoneline()|
 
-getloclist({nr} [, {what}])                                       *getloclist()*
-                Returns a |List| with all the entries in the location list for
-                window {nr}.  {nr} can be the window number or the |window-ID|.
-                When {nr} is zero the current window is used.
+getloclist({nr} [, {what}])					  *getloclist()*
+		Returns a |List| with all the entries in the location list for
+		window {nr}.  {nr} can be the window number or the |window-ID|.
+		When {nr} is zero the current window is used.
 
-                For a location list window, the displayed location list is
-                returned.  For an invalid window number {nr}, an empty list is
-                returned. Otherwise, same as |getqflist()|.
+		For a location list window, the displayed location list is
+		returned.  For an invalid window number {nr}, an empty list is
+		returned. Otherwise, same as |getqflist()|.
 
-                If the optional {what} dictionary argument is supplied, then
-                returns the items listed in {what} as a dictionary. Refer to
-                |getqflist()| for the supported items in {what}.
+		If the optional {what} dictionary argument is supplied, then
+		returns the items listed in {what} as a dictionary. Refer to
+		|getqflist()| for the supported items in {what}.
 
-                In addition to the items supported by |getqflist()| in {what},
-                the following item is supported by |getloclist()|:
+		In addition to the items supported by |getqflist()| in {what},
+		the following item is supported by |getloclist()|:
 
-                        filewinid       id of the window used to display files
-                                        from the location list. This field is
-                                        applicable only when called from a
-                                        location list window. See
-                                        |location-list-file-window| for more
-                                        details.
+			filewinid	id of the window used to display files
+					from the location list. This field is
+					applicable only when called from a
+					location list window. See
+					|location-list-file-window| for more
+					details.
 
-                Returns a |Dictionary| with default values if there is no
-                location list for the window {nr}.
-                Returns an empty Dictionary if window {nr} does not exist.
+		Returns a |Dictionary| with default values if there is no
+		location list for the window {nr}.
+		Returns an empty Dictionary if window {nr} does not exist.
 
-                Examples (See also |getqflist-examples|): >vim
-                        echo getloclist(3, {'all': 0})
-                        echo getloclist(5, {'filewinid': 0})
+		Examples (See also |getqflist-examples|): >vim
+			echo getloclist(3, {'all': 0})
+			echo getloclist(5, {'filewinid': 0})
 <
-getmarklist([{buf}])                                             *getmarklist()*
-                Without the {buf} argument returns a |List| with information
-                about all the global marks. |mark|
+getmarklist([{buf}])						 *getmarklist()*
+		Without the {buf} argument returns a |List| with information
+		about all the global marks. |mark|
 
-                If the optional {buf} argument is specified, returns the
-                local marks defined in buffer {buf}.  For the use of {buf},
-                see |bufname()|.  If {buf} is invalid, an empty list is
-                returned.
+		If the optional {buf} argument is specified, returns the
+		local marks defined in buffer {buf}.  For the use of {buf},
+		see |bufname()|.  If {buf} is invalid, an empty list is
+		returned.
 
-                Each item in the returned List is a |Dict| with the following:
-                    mark   name of the mark prefixed by "'"
-                    pos    a |List| with the position of the mark:
-                                [bufnum, lnum, col, off]
-                           Refer to |getpos()| for more information.
-                    file   file name
+		Each item in the returned List is a |Dict| with the following:
+		    mark   name of the mark prefixed by "'"
+		    pos    a |List| with the position of the mark:
+				[bufnum, lnum, col, off]
+			   Refer to |getpos()| for more information.
+		    file   file name
 
-                Refer to |getpos()| for getting information about a specific
-                mark.
+		Refer to |getpos()| for getting information about a specific
+		mark.
 
-getmatches([{win}])                                               *getmatches()*
-                Returns a |List| with all matches previously defined for the
-                current window by |matchadd()| and the |:match| commands.
-                |getmatches()| is useful in combination with |setmatches()|,
-                as |setmatches()| can restore a list of matches saved by
-                |getmatches()|.
-                If {win} is specified, use the window with this number or
-                window ID instead of the current window.  If {win} is invalid,
-                an empty list is returned.
-                Example: >vim
-                        echo getmatches()
-<                 >
-                        [{"group": "MyGroup1", "pattern": "TODO",
-                        "priority": 10, "id": 1}, {"group": "MyGroup2",
-                        "pattern": "FIXME", "priority": 10, "id": 2}]
-<                 >vim
-                        let m = getmatches()
-                        call clearmatches()
-                        echo getmatches()
-<                 >
-                        []
-<                 >vim
-                        call setmatches(m)
-                        echo getmatches()
-<                 >
-                        [{"group": "MyGroup1", "pattern": "TODO",
-                        "priority": 10, "id": 1}, {"group": "MyGroup2",
-                        "pattern": "FIXME", "priority": 10, "id": 2}]
-<                 >vim
-                        unlet m
+getmatches([{win}])						  *getmatches()*
+		Returns a |List| with all matches previously defined for the
+		current window by |matchadd()| and the |:match| commands.
+		|getmatches()| is useful in combination with |setmatches()|,
+		as |setmatches()| can restore a list of matches saved by
+		|getmatches()|.
+		If {win} is specified, use the window with this number or
+		window ID instead of the current window.  If {win} is invalid,
+		an empty list is returned.
+		Example: >vim
+			echo getmatches()
+<		  >
+			[{"group": "MyGroup1", "pattern": "TODO",
+			"priority": 10, "id": 1}, {"group": "MyGroup2",
+			"pattern": "FIXME", "priority": 10, "id": 2}]
+<		  >vim
+			let m = getmatches()
+			call clearmatches()
+			echo getmatches()
+<		  >
+			[]
+<		  >vim
+			call setmatches(m)
+			echo getmatches()
+<		  >
+			[{"group": "MyGroup1", "pattern": "TODO",
+			"priority": 10, "id": 1}, {"group": "MyGroup2",
+			"pattern": "FIXME", "priority": 10, "id": 2}]
+<		  >vim
+			unlet m
 <
-getmousepos()                                                    *getmousepos()*
-                Returns a |Dictionary| with the last known position of the
-                mouse.  This can be used in a mapping for a mouse click.  The
-                items are:
-                        screenrow       screen row
-                        screencol       screen column
-                        winid           Window ID of the click
-                        winrow          row inside "winid"
-                        wincol          column inside "winid"
-                        line            text line inside "winid"
-                        column          text column inside "winid"
-                        coladd          offset (in screen columns) from the
-                                        start of the clicked char
-                All numbers are 1-based.
+getmousepos()							 *getmousepos()*
+		Returns a |Dictionary| with the last known position of the
+		mouse.	This can be used in a mapping for a mouse click.  The
+		items are:
+			screenrow	screen row
+			screencol	screen column
+			winid		Window ID of the click
+			winrow		row inside "winid"
+			wincol		column inside "winid"
+			line		text line inside "winid"
+			column		text column inside "winid"
+			coladd		offset (in screen columns) from the
+					start of the clicked char
+		All numbers are 1-based.
 
-                If not over a window, e.g. when in the command line, then only
-                "screenrow" and "screencol" are valid, the others are zero.
+		If not over a window, e.g. when in the command line, then only
+		"screenrow" and "screencol" are valid, the others are zero.
 
-                When on the status line below a window or the vertical
-                separator right of a window, the "line" and "column" values
-                are zero.
+		When on the status line below a window or the vertical
+		separator right of a window, the "line" and "column" values
+		are zero.
 
-                When the position is after the text then "column" is the
-                length of the text in bytes plus one.
+		When the position is after the text then "column" is the
+		length of the text in bytes plus one.
 
-                If the mouse is over a focusable floating window then that
-                window is used.
+		If the mouse is over a focusable floating window then that
+		window is used.
 
-                When using |getchar()| the Vim variables |v:mouse_lnum|,
-                |v:mouse_col| and |v:mouse_winid| also provide these values.
+		When using |getchar()| the Vim variables |v:mouse_lnum|,
+		|v:mouse_col| and |v:mouse_winid| also provide these values.
 
-getpid()                                                              *getpid()*
-                Return a Number which is the process ID of the Vim process.
-                This is a unique number, until Vim exits.
+getpid()							      *getpid()*
+		Return a Number which is the process ID of the Vim process.
+		This is a unique number, until Vim exits.
 
-getpos({expr})                                                        *getpos()*
-                Get the position for String {expr}.  For possible values of
-                {expr} see |line()|.  For getting the cursor position see
-                |getcurpos()|.
-                The result is a |List| with four numbers:
-                    [bufnum, lnum, col, off]
-                "bufnum" is zero, unless a mark like '0 or 'A is used, then it
-                is the buffer number of the mark.
-                "lnum" and "col" are the position in the buffer.  The first
-                column is 1.
-                The "off" number is zero, unless 'virtualedit' is used.  Then
-                it is the offset in screen columns from the start of the
-                character.  E.g., a position within a <Tab> or after the last
-                character.
-                Note that for '< and '> Visual mode matters: when it is "V"
-                (visual line mode) the column of '< is zero and the column of
-                '> is a large number equal to |v:maxcol|.
-                The column number in the returned List is the byte position
-                within the line. To get the character position in the line,
-                use |getcharpos()|.
-                A very large column number equal to |v:maxcol| can be returned,
-                in which case it means "after the end of the line".
-                If {expr} is invalid, returns a list with all zeros.
-                This can be used to save and restore the position of a mark: >vim
-                        let save_a_mark = getpos("'a")
-                        " ...
-                        call setpos("'a", save_a_mark)
-<                Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+getpos({expr})							      *getpos()*
+		Get the position for String {expr}.  For possible values of
+		{expr} see |line()|.  For getting the cursor position see
+		|getcurpos()|.
+		The result is a |List| with four numbers:
+		    [bufnum, lnum, col, off]
+		"bufnum" is zero, unless a mark like '0 or 'A is used, then it
+		is the buffer number of the mark.
+		"lnum" and "col" are the position in the buffer.  The first
+		column is 1.
+		The "off" number is zero, unless 'virtualedit' is used.  Then
+		it is the offset in screen columns from the start of the
+		character.  E.g., a position within a <Tab> or after the last
+		character.
+		Note that for '< and '> Visual mode matters: when it is "V"
+		(visual line mode) the column of '< is zero and the column of
+		'> is a large number equal to |v:maxcol|.
+		The column number in the returned List is the byte position
+		within the line. To get the character position in the line,
+		use |getcharpos()|.
+		A very large column number equal to |v:maxcol| can be returned,
+		in which case it means "after the end of the line".
+		If {expr} is invalid, returns a list with all zeros.
+		This can be used to save and restore the position of a mark: >vim
+			let save_a_mark = getpos("'a")
+			" ...
+			call setpos("'a", save_a_mark)
+<		 Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
-getqflist([{what}])                                                *getqflist()*
-                Returns a |List| with all the current quickfix errors.  Each
-                list item is a dictionary with these entries:
-                        bufnr   number of buffer that has the file name, use
-                                bufname() to get the name
-                        module  module name
-                        lnum    line number in the buffer (first line is 1)
-                        end_lnum
-                                end of line number if the item is multiline
-                        col     column number (first column is 1)
-                        end_col end of column number if the item has range
-                        vcol    |TRUE|: "col" is visual column
-                                |FALSE|: "col" is byte index
-                        nr      error number
-                        pattern search pattern used to locate the error
-                        text    description of the error
-                        type    type of the error, 'E', '1', etc.
-                        valid   |TRUE|: recognized error message
-                        user_data
-                                custom data associated with the item, can be
-                                any type.
+getqflist([{what}])						   *getqflist()*
+		Returns a |List| with all the current quickfix errors.	Each
+		list item is a dictionary with these entries:
+			bufnr	number of buffer that has the file name, use
+				bufname() to get the name
+			module	module name
+			lnum	line number in the buffer (first line is 1)
+			end_lnum
+				end of line number if the item is multiline
+			col	column number (first column is 1)
+			end_col end of column number if the item has range
+			vcol	|TRUE|: "col" is visual column
+				|FALSE|: "col" is byte index
+			nr	error number
+			pattern search pattern used to locate the error
+			text	description of the error
+			type	type of the error, 'E', '1', etc.
+			valid	|TRUE|: recognized error message
+			user_data
+				custom data associated with the item, can be
+				any type.
 
-                When there is no error list or it's empty, an empty list is
-                returned. Quickfix list entries with a non-existing buffer
-                number are returned with "bufnr" set to zero (Note: some
-                functions accept buffer number zero for the alternate buffer,
-                you may need to explicitly check for zero).
+		When there is no error list or it's empty, an empty list is
+		returned. Quickfix list entries with a non-existing buffer
+		number are returned with "bufnr" set to zero (Note: some
+		functions accept buffer number zero for the alternate buffer,
+		you may need to explicitly check for zero).
 
-                Useful application: Find pattern matches in multiple files and
-                do something with them: >vim
-                        vimgrep /theword/jg *.c
-                        for d in getqflist()
-                           echo bufname(d.bufnr) ':' d.lnum '=' d.text
-                        endfor
+		Useful application: Find pattern matches in multiple files and
+		do something with them: >vim
+			vimgrep /theword/jg *.c
+			for d in getqflist()
+			   echo bufname(d.bufnr) ':' d.lnum '=' d.text
+			endfor
 <
-                If the optional {what} dictionary argument is supplied, then
-                returns only the items listed in {what} as a dictionary. The
-                following string items are supported in {what}:
-                        changedtick     get the total number of changes made
-                                        to the list |quickfix-changedtick|
-                        context get the |quickfix-context|
-                        efm     errorformat to use when parsing "lines". If
-                                not present, then the 'errorformat' option
-                                value is used.
-                        id      get information for the quickfix list with
-                                |quickfix-ID|; zero means the id for the
-                                current list or the list specified by "nr"
-                        idx     get information for the quickfix entry at this
-                                index in the list specified by "id" or "nr".
-                                If set to zero, then uses the current entry.
-                                See |quickfix-index|
-                        items   quickfix list entries
-                        lines   parse a list of lines using 'efm' and return
-                                the resulting entries.  Only a |List| type is
-                                accepted.  The current quickfix list is not
-                                modified. See |quickfix-parse|.
-                        nr      get information for this quickfix list; zero
-                                means the current quickfix list and "$" means
-                                the last quickfix list
-                        qfbufnr number of the buffer displayed in the quickfix
-                                window. Returns 0 if the quickfix buffer is
-                                not present. See |quickfix-buffer|.
-                        size    number of entries in the quickfix list
-                        title   get the list title |quickfix-title|
-                        winid   get the quickfix |window-ID|
-                        all     all of the above quickfix properties
-                Non-string items in {what} are ignored. To get the value of a
-                particular item, set it to zero.
-                If "nr" is not present then the current quickfix list is used.
-                If both "nr" and a non-zero "id" are specified, then the list
-                specified by "id" is used.
-                To get the number of lists in the quickfix stack, set "nr" to
-                "$" in {what}. The "nr" value in the returned dictionary
-                contains the quickfix stack size.
-                When "lines" is specified, all the other items except "efm"
-                are ignored.  The returned dictionary contains the entry
-                "items" with the list of entries.
+		If the optional {what} dictionary argument is supplied, then
+		returns only the items listed in {what} as a dictionary. The
+		following string items are supported in {what}:
+			changedtick	get the total number of changes made
+					to the list |quickfix-changedtick|
+			context get the |quickfix-context|
+			efm	errorformat to use when parsing "lines". If
+				not present, then the 'errorformat' option
+				value is used.
+			id	get information for the quickfix list with
+				|quickfix-ID|; zero means the id for the
+				current list or the list specified by "nr"
+			idx	get information for the quickfix entry at this
+				index in the list specified by "id" or "nr".
+				If set to zero, then uses the current entry.
+				See |quickfix-index|
+			items	quickfix list entries
+			lines	parse a list of lines using 'efm' and return
+				the resulting entries.	Only a |List| type is
+				accepted.  The current quickfix list is not
+				modified. See |quickfix-parse|.
+			nr	get information for this quickfix list; zero
+				means the current quickfix list and "$" means
+				the last quickfix list
+			qfbufnr number of the buffer displayed in the quickfix
+				window. Returns 0 if the quickfix buffer is
+				not present. See |quickfix-buffer|.
+			size	number of entries in the quickfix list
+			title	get the list title |quickfix-title|
+			winid	get the quickfix |window-ID|
+			all	all of the above quickfix properties
+		Non-string items in {what} are ignored. To get the value of a
+		particular item, set it to zero.
+		If "nr" is not present then the current quickfix list is used.
+		If both "nr" and a non-zero "id" are specified, then the list
+		specified by "id" is used.
+		To get the number of lists in the quickfix stack, set "nr" to
+		"$" in {what}. The "nr" value in the returned dictionary
+		contains the quickfix stack size.
+		When "lines" is specified, all the other items except "efm"
+		are ignored.  The returned dictionary contains the entry
+		"items" with the list of entries.
 
-                The returned dictionary contains the following entries:
-                        changedtick     total number of changes made to the
-                                        list |quickfix-changedtick|
-                        context quickfix list context. See |quickfix-context|
-                                If not present, set to "".
-                        id      quickfix list ID |quickfix-ID|. If not
-                                present, set to 0.
-                        idx     index of the quickfix entry in the list. If not
-                                present, set to 0.
-                        items   quickfix list entries. If not present, set to
-                                an empty list.
-                        nr      quickfix list number. If not present, set to 0
-                        qfbufnr number of the buffer displayed in the quickfix
-                                window. If not present, set to 0.
-                        size    number of entries in the quickfix list. If not
-                                present, set to 0.
-                        title   quickfix list title text. If not present, set
-                                to "".
-                        winid   quickfix |window-ID|. If not present, set to 0
+		The returned dictionary contains the following entries:
+			changedtick	total number of changes made to the
+					list |quickfix-changedtick|
+			context quickfix list context. See |quickfix-context|
+				If not present, set to "".
+			id	quickfix list ID |quickfix-ID|. If not
+				present, set to 0.
+			idx	index of the quickfix entry in the list. If not
+				present, set to 0.
+			items	quickfix list entries. If not present, set to
+				an empty list.
+			nr	quickfix list number. If not present, set to 0
+			qfbufnr number of the buffer displayed in the quickfix
+				window. If not present, set to 0.
+			size	number of entries in the quickfix list. If not
+				present, set to 0.
+			title	quickfix list title text. If not present, set
+				to "".
+			winid	quickfix |window-ID|. If not present, set to 0
 
-                Examples (See also |getqflist-examples|): >vim
-                        echo getqflist({'all': 1})
-                        echo getqflist({'nr': 2, 'title': 1})
-                        echo getqflist({'lines' : ["F1:10:L10"]})
+		Examples (See also |getqflist-examples|): >vim
+			echo getqflist({'all': 1})
+			echo getqflist({'nr': 2, 'title': 1})
+			echo getqflist({'lines' : ["F1:10:L10"]})
 <
-getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
-                The result is a String, which is the contents of register
-                {regname}.  Example: >vim
-                        let cliptext = getreg('*')
-<                When register {regname} was not set the result is an empty
-                string.
-                The {regname} argument must be a string.
+getreg([{regname} [, 1 [, {list}]]])				      *getreg()*
+		The result is a String, which is the contents of register
+		{regname}.  Example: >vim
+			let cliptext = getreg('*')
+<		 When register {regname} was not set the result is an empty
+		string.
+		The {regname} argument must be a string.
 
-                getreg('=') returns the last evaluated value of the expression
-                register.  (For use in maps.)
-                getreg('=', 1) returns the expression itself, so that it can
-                be restored with |setreg()|.  For other registers the extra
-                argument is ignored, thus you can always give it.
+		getreg('=') returns the last evaluated value of the expression
+		register.  (For use in maps.)
+		getreg('=', 1) returns the expression itself, so that it can
+		be restored with |setreg()|.  For other registers the extra
+		argument is ignored, thus you can always give it.
 
-                If {list} is present and |TRUE|, the result type is changed
-                to |List|. Each list item is one text line. Use it if you care
-                about zero bytes possibly present inside register: without
-                third argument both NLs and zero bytes are represented as NLs
-                (see |NL-used-for-Nul|).
-                When the register was not set an empty list is returned.
+		If {list} is present and |TRUE|, the result type is changed
+		to |List|. Each list item is one text line. Use it if you care
+		about zero bytes possibly present inside register: without
+		third argument both NLs and zero bytes are represented as NLs
+		(see |NL-used-for-Nul|).
+		When the register was not set an empty list is returned.
 
-                If {regname} is not specified, |v:register| is used.
+		If {regname} is not specified, |v:register| is used.
 
-getreginfo([{regname}])                                           *getreginfo()*
-                Returns detailed information about register {regname} as a
-                Dictionary with the following entries:
-                        regcontents     List of lines contained in register
-                                        {regname}, like
-                                        getreg({regname}, 1, 1).
-                        regtype         the type of register {regname}, as in
-                                        |getregtype()|.
-                        isunnamed       Boolean flag, v:true if this register
-                                        is currently pointed to by the unnamed
-                                        register.
-                        points_to       for the unnamed register, gives the
-                                        single letter name of the register
-                                        currently pointed to (see |quotequote|).
-                                        For example, after deleting a line
-                                        with `dd`, this field will be "1",
-                                        which is the register that got the
-                                        deleted text.
+getreginfo([{regname}])						  *getreginfo()*
+		Returns detailed information about register {regname} as a
+		Dictionary with the following entries:
+			regcontents	List of lines contained in register
+					{regname}, like
+					getreg({regname}, 1, 1).
+			regtype		the type of register {regname}, as in
+					|getregtype()|.
+			isunnamed	Boolean flag, v:true if this register
+					is currently pointed to by the unnamed
+					register.
+			points_to	for the unnamed register, gives the
+					single letter name of the register
+					currently pointed to (see |quotequote|).
+					For example, after deleting a line
+					with `dd`, this field will be "1",
+					which is the register that got the
+					deleted text.
 
-                The {regname} argument is a string.  If {regname} is invalid
-                or not set, an empty Dictionary will be returned.
-                If {regname} is not specified, |v:register| is used.
-                The returned Dictionary can be passed to |setreg()|.
+		The {regname} argument is a string.  If {regname} is invalid
+		or not set, an empty Dictionary will be returned.
+		If {regname} is not specified, |v:register| is used.
+		The returned Dictionary can be passed to |setreg()|.
 
-getregtype([{regname}])                                           *getregtype()*
-                The result is a String, which is type of register {regname}.
-                The value will be one of:
-                    "v"                 for |charwise| text
-                    "V"                 for |linewise| text
-                    "<CTRL-V>{width}"   for |blockwise-visual| text
-                    ""                  for an empty or unknown register
-                <CTRL-V> is one character with value 0x16.
-                The {regname} argument is a string.  If {regname} is not
-                specified, |v:register| is used.
+getregtype([{regname}])						  *getregtype()*
+		The result is a String, which is type of register {regname}.
+		The value will be one of:
+		    "v"			for |charwise| text
+		    "V"			for |linewise| text
+		    "<CTRL-V>{width}"	for |blockwise-visual| text
+		    ""			for an empty or unknown register
+		<CTRL-V> is one character with value 0x16.
+		The {regname} argument is a string.  If {regname} is not
+		specified, |v:register| is used.
 
-getscriptinfo([{opts}])                                        *getscriptinfo()*
-                Returns a |List| with information about all the sourced Vim
-                scripts in the order they were sourced, like what
-                `:scriptnames` shows.
+getscriptinfo([{opts}])					       *getscriptinfo()*
+		Returns a |List| with information about all the sourced Vim
+		scripts in the order they were sourced, like what
+		`:scriptnames` shows.
 
-                The optional Dict argument {opts} supports the following
-                optional items:
-                    name        Script name match pattern. If specified,
-                                and "sid" is not specified, information about
-                                scripts with a name that match the pattern
-                                "name" are returned.
-                    sid         Script ID |<SID>|.  If specified, only
-                                information about the script with ID "sid" is
-                                returned and "name" is ignored.
+		The optional Dict argument {opts} supports the following
+		optional items:
+		    name	Script name match pattern. If specified,
+				and "sid" is not specified, information about
+				scripts with a name that match the pattern
+				"name" are returned.
+		    sid		Script ID |<SID>|.  If specified, only
+				information about the script with ID "sid" is
+				returned and "name" is ignored.
 
-                Each item in the returned List is a |Dict| with the following
-                items:
-                    autoload    Always set to FALSE.
-                    functions   List of script-local function names defined in
-                                the script.  Present only when a particular
-                                script is specified using the "sid" item in
-                                {opts}.
-                    name        Vim script file name.
-                    sid         Script ID |<SID>|.
-                    variables   A dictionary with the script-local variables.
-                                Present only when a particular script is
-                                specified using the "sid" item in {opts}.
-                                Note that this is a copy, the value of
-                                script-local variables cannot be changed using
-                                this dictionary.
-                    version     Vim script version, always 1
+		Each item in the returned List is a |Dict| with the following
+		items:
+		    autoload	Always set to FALSE.
+		    functions	List of script-local function names defined in
+				the script.  Present only when a particular
+				script is specified using the "sid" item in
+				{opts}.
+		    name	Vim script file name.
+		    sid		Script ID |<SID>|.
+		    variables	A dictionary with the script-local variables.
+				Present only when a particular script is
+				specified using the "sid" item in {opts}.
+				Note that this is a copy, the value of
+				script-local variables cannot be changed using
+				this dictionary.
+		    version	Vim script version, always 1
 
-                Examples: >vim
-                        echo getscriptinfo({'name': 'myscript'})
-                        echo getscriptinfo({'sid': 15}).variables
+		Examples: >vim
+			echo getscriptinfo({'name': 'myscript'})
+			echo getscriptinfo({'sid': 15}).variables
 <
-gettabinfo([{tabnr}])                                             *gettabinfo()*
-                If {tabnr} is not specified, then information about all the
-                tab pages is returned as a |List|. Each List item is a
-                |Dictionary|.  Otherwise, {tabnr} specifies the tab page
-                number and information about that one is returned.  If the tab
-                page does not exist an empty List is returned.
+gettabinfo([{tabnr}])						  *gettabinfo()*
+		If {tabnr} is not specified, then information about all the
+		tab pages is returned as a |List|. Each List item is a
+		|Dictionary|.  Otherwise, {tabnr} specifies the tab page
+		number and information about that one is returned.  If the tab
+		page does not exist an empty List is returned.
 
-                Each List item is a |Dictionary| with the following entries:
-                        tabnr           tab page number.
-                        variables       a reference to the dictionary with
-                                        tabpage-local variables
-                        windows         List of |window-ID|s in the tab page.
+		Each List item is a |Dictionary| with the following entries:
+			tabnr		tab page number.
+			variables	a reference to the dictionary with
+					tabpage-local variables
+			windows		List of |window-ID|s in the tab page.
 
-gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
-                Get the value of a tab-local variable {varname} in tab page
-                {tabnr}. |t:var|
-                Tabs are numbered starting with one.
-                The {varname} argument is a string.  When {varname} is empty a
-                dictionary with all tab-local variables is returned.
-                Note that the name without "t:" must be used.
-                When the tab or variable doesn't exist {def} or an empty
-                string is returned, there is no error message.
+gettabvar({tabnr}, {varname} [, {def}])				   *gettabvar()*
+		Get the value of a tab-local variable {varname} in tab page
+		{tabnr}. |t:var|
+		Tabs are numbered starting with one.
+		The {varname} argument is a string.  When {varname} is empty a
+		dictionary with all tab-local variables is returned.
+		Note that the name without "t:" must be used.
+		When the tab or variable doesn't exist {def} or an empty
+		string is returned, there is no error message.
 
-gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
-                Get the value of window-local variable {varname} in window
-                {winnr} in tab page {tabnr}.
-                The {varname} argument is a string.  When {varname} is empty a
-                dictionary with all window-local variables is returned.
-                When {varname} is equal to "&" get the values of all
-                window-local options in a |Dictionary|.
-                Otherwise, when {varname} starts with "&" get the value of a
-                window-local option.
-                Note that {varname} must be the name without "w:".
-                Tabs are numbered starting with one.  For the current tabpage
-                use |getwinvar()|.
-                {winnr} can be the window number or the |window-ID|.
-                When {winnr} is zero the current window is used.
-                This also works for a global option, buffer-local option and
-                window-local option, but it doesn't work for a global variable
-                or buffer-local variable.
-                When the tab, window or variable doesn't exist {def} or an
-                empty string is returned, there is no error message.
-                Examples: >vim
-                        let list_is_on = gettabwinvar(1, 2, '&list')
-                        echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
+gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])		*gettabwinvar()*
+		Get the value of window-local variable {varname} in window
+		{winnr} in tab page {tabnr}.
+		The {varname} argument is a string.  When {varname} is empty a
+		dictionary with all window-local variables is returned.
+		When {varname} is equal to "&" get the values of all
+		window-local options in a |Dictionary|.
+		Otherwise, when {varname} starts with "&" get the value of a
+		window-local option.
+		Note that {varname} must be the name without "w:".
+		Tabs are numbered starting with one.  For the current tabpage
+		use |getwinvar()|.
+		{winnr} can be the window number or the |window-ID|.
+		When {winnr} is zero the current window is used.
+		This also works for a global option, buffer-local option and
+		window-local option, but it doesn't work for a global variable
+		or buffer-local variable.
+		When the tab, window or variable doesn't exist {def} or an
+		empty string is returned, there is no error message.
+		Examples: >vim
+			let list_is_on = gettabwinvar(1, 2, '&list')
+			echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
 <
-                To obtain all window-local variables use: >vim
-                        gettabwinvar({tabnr}, {winnr}, '&')
+		To obtain all window-local variables use: >vim
+			gettabwinvar({tabnr}, {winnr}, '&')
 <
-gettagstack([{winnr}])                                           *gettagstack()*
-                The result is a Dict, which is the tag stack of window {winnr}.
-                {winnr} can be the window number or the |window-ID|.
-                When {winnr} is not specified, the current window is used.
-                When window {winnr} doesn't exist, an empty Dict is returned.
+gettagstack([{winnr}])						 *gettagstack()*
+		The result is a Dict, which is the tag stack of window {winnr}.
+		{winnr} can be the window number or the |window-ID|.
+		When {winnr} is not specified, the current window is used.
+		When window {winnr} doesn't exist, an empty Dict is returned.
 
-                The returned dictionary contains the following entries:
-                        curidx          Current index in the stack. When at
-                                        top of the stack, set to (length + 1).
-                                        Index of bottom of the stack is 1.
-                        items           List of items in the stack. Each item
-                                        is a dictionary containing the
-                                        entries described below.
-                        length          Number of entries in the stack.
+		The returned dictionary contains the following entries:
+			curidx		Current index in the stack. When at
+					top of the stack, set to (length + 1).
+					Index of bottom of the stack is 1.
+			items		List of items in the stack. Each item
+					is a dictionary containing the
+					entries described below.
+			length		Number of entries in the stack.
 
-                Each item in the stack is a dictionary with the following
-                entries:
-                        bufnr           buffer number of the current jump
-                        from            cursor position before the tag jump.
-                                        See |getpos()| for the format of the
-                                        returned list.
-                        matchnr         current matching tag number. Used when
-                                        multiple matching tags are found for a
-                                        name.
-                        tagname         name of the tag
+		Each item in the stack is a dictionary with the following
+		entries:
+			bufnr		buffer number of the current jump
+			from		cursor position before the tag jump.
+					See |getpos()| for the format of the
+					returned list.
+			matchnr		current matching tag number. Used when
+					multiple matching tags are found for a
+					name.
+			tagname		name of the tag
 
-                See |tagstack| for more information about the tag stack.
+		See |tagstack| for more information about the tag stack.
 
-gettext({text})                                                      *gettext()*
-                Translate String {text} if possible.
-                This is mainly for use in the distributed Vim scripts.  When
-                generating message translations the {text} is extracted by
-                xgettext, the translator can add the translated message in the
-                .po file and Vim will lookup the translation when gettext() is
-                called.
-                For {text} double quoted strings are preferred, because
-                xgettext does not understand escaping in single quoted
-                strings.
+gettext({text})							     *gettext()*
+		Translate String {text} if possible.
+		This is mainly for use in the distributed Vim scripts.	When
+		generating message translations the {text} is extracted by
+		xgettext, the translator can add the translated message in the
+		.po file and Vim will lookup the translation when gettext() is
+		called.
+		For {text} double quoted strings are preferred, because
+		xgettext does not understand escaping in single quoted
+		strings.
 
-getwininfo([{winid}])                                             *getwininfo()*
-                Returns information about windows as a |List| with Dictionaries.
+getwininfo([{winid}])						  *getwininfo()*
+		Returns information about windows as a |List| with Dictionaries.
 
-                If {winid} is given Information about the window with that ID
-                is returned, as a |List| with one item.  If the window does not
-                exist the result is an empty list.
+		If {winid} is given Information about the window with that ID
+		is returned, as a |List| with one item.  If the window does not
+		exist the result is an empty list.
 
-                Without {winid} information about all the windows in all the
-                tab pages is returned.
+		Without {winid} information about all the windows in all the
+		tab pages is returned.
 
-                Each List item is a |Dictionary| with the following entries:
-                        botline         last complete displayed buffer line
-                        bufnr           number of buffer in the window
-                        height          window height (excluding winbar)
-                        loclist         1 if showing a location list
-                        quickfix        1 if quickfix or location list window
-                        terminal        1 if a terminal window
-                        tabnr           tab page number
-                        topline         first displayed buffer line
-                        variables       a reference to the dictionary with
-                                        window-local variables
-                        width           window width
-                        winbar          1 if the window has a toolbar, 0
-                                        otherwise
-                        wincol          leftmost screen column of the window;
-                                        "col" from |win_screenpos()|
-                        textoff         number of columns occupied by any
-                                        'foldcolumn', 'signcolumn' and line
-                                        number in front of the text
-                        winid           |window-ID|
-                        winnr           window number
-                        winrow          topmost screen line of the window;
-                                        "row" from |win_screenpos()|
+		Each List item is a |Dictionary| with the following entries:
+			botline		last complete displayed buffer line
+			bufnr		number of buffer in the window
+			height		window height (excluding winbar)
+			loclist		1 if showing a location list
+			quickfix	1 if quickfix or location list window
+			terminal	1 if a terminal window
+			tabnr		tab page number
+			topline		first displayed buffer line
+			variables	a reference to the dictionary with
+					window-local variables
+			width		window width
+			winbar		1 if the window has a toolbar, 0
+					otherwise
+			wincol		leftmost screen column of the window;
+					"col" from |win_screenpos()|
+			textoff		number of columns occupied by any
+					'foldcolumn', 'signcolumn' and line
+					number in front of the text
+			winid		|window-ID|
+			winnr		window number
+			winrow		topmost screen line of the window;
+					"row" from |win_screenpos()|
 
-getwinpos([{timeout}])                                             *getwinpos()*
-                The result is a |List| with two numbers, the result of
-                |getwinposx()| and |getwinposy()| combined:
-                        [x-pos, y-pos]
-                {timeout} can be used to specify how long to wait in msec for
-                a response from the terminal.  When omitted 100 msec is used.
+getwinpos([{timeout}])						   *getwinpos()*
+		The result is a |List| with two numbers, the result of
+		|getwinposx()| and |getwinposy()| combined:
+			[x-pos, y-pos]
+		{timeout} can be used to specify how long to wait in msec for
+		a response from the terminal.  When omitted 100 msec is used.
 
-                Use a longer time for a remote terminal.
-                When using a value less than 10 and no response is received
-                within that time, a previously reported position is returned,
-                if available.  This can be used to poll for the position and
-                do some work in the meantime: >vim
-                        while 1
-                          let res = getwinpos(1)
-                          if res[0] >= 0
-                            break
-                          endif
-                          " Do some work here
-                        endwhile
+		Use a longer time for a remote terminal.
+		When using a value less than 10 and no response is received
+		within that time, a previously reported position is returned,
+		if available.  This can be used to poll for the position and
+		do some work in the meantime: >vim
+			while 1
+			  let res = getwinpos(1)
+			  if res[0] >= 0
+			    break
+			  endif
+			  " Do some work here
+			endwhile
 <
-getwinposx()                                                      *getwinposx()*
-                The result is a Number, which is the X coordinate in pixels of
-                the left hand side of the GUI Vim window.  The result will be
-                -1 if the information is not available.
-                The value can be used with `:winpos`.
+getwinposx()							  *getwinposx()*
+		The result is a Number, which is the X coordinate in pixels of
+		the left hand side of the GUI Vim window.  The result will be
+		-1 if the information is not available.
+		The value can be used with `:winpos`.
 
-getwinposy()                                                      *getwinposy()*
-                The result is a Number, which is the Y coordinate in pixels of
-                the top of the GUI Vim window.  The result will be -1 if the
-                information is not available.
-                The value can be used with `:winpos`.
+getwinposy()							  *getwinposy()*
+		The result is a Number, which is the Y coordinate in pixels of
+		the top of the GUI Vim window.	The result will be -1 if the
+		information is not available.
+		The value can be used with `:winpos`.
 
-getwinvar({winnr}, {varname} [, {def}])                            *getwinvar()*
-                Like |gettabwinvar()| for the current tabpage.
-                Examples: >vim
-                        let list_is_on = getwinvar(2, '&list')
-                        echo "myvar = " .. getwinvar(1, 'myvar')
+getwinvar({winnr}, {varname} [, {def}])				   *getwinvar()*
+		Like |gettabwinvar()| for the current tabpage.
+		Examples: >vim
+			let list_is_on = getwinvar(2, '&list')
+			echo "myvar = " .. getwinvar(1, 'myvar')
 
-glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
-                Expand the file wildcards in {expr}.  See |wildcards| for the
-                use of special characters.
+glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])			*glob()*
+		Expand the file wildcards in {expr}.  See |wildcards| for the
+		use of special characters.
 
-                Unless the optional {nosuf} argument is given and is |TRUE|,
-                the 'suffixes' and 'wildignore' options apply: Names matching
-                one of the patterns in 'wildignore' will be skipped and
-                'suffixes' affect the ordering of matches.
-                'wildignorecase' always applies.
+		Unless the optional {nosuf} argument is given and is |TRUE|,
+		the 'suffixes' and 'wildignore' options apply: Names matching
+		one of the patterns in 'wildignore' will be skipped and
+		'suffixes' affect the ordering of matches.
+		'wildignorecase' always applies.
 
-                When {list} is present and it is |TRUE| the result is a |List|
-                with all matching files. The advantage of using a List is,
-                you also get filenames containing newlines correctly.
-                Otherwise the result is a String and when there are several
-                matches, they are separated by <NL> characters.
+		When {list} is present and it is |TRUE| the result is a |List|
+		with all matching files. The advantage of using a List is,
+		you also get filenames containing newlines correctly.
+		Otherwise the result is a String and when there are several
+		matches, they are separated by <NL> characters.
 
-                If the expansion fails, the result is an empty String or List.
+		If the expansion fails, the result is an empty String or List.
 
-                You can also use |readdir()| if you need to do complicated
-                things, such as limiting the number of matches.
+		You can also use |readdir()| if you need to do complicated
+		things, such as limiting the number of matches.
 
-                A name for a non-existing file is not included.  A symbolic
-                link is only included if it points to an existing file.
-                However, when the {alllinks} argument is present and it is
-                |TRUE| then all symbolic links are included.
+		A name for a non-existing file is not included.  A symbolic
+		link is only included if it points to an existing file.
+		However, when the {alllinks} argument is present and it is
+		|TRUE| then all symbolic links are included.
 
-                For most systems backticks can be used to get files names from
-                any external command.  Example: >vim
-                        let tagfiles = glob("`find . -name tags -print`")
-                        let &tags = substitute(tagfiles, "\n", ",", "g")
-<                The result of the program inside the backticks should be one
-                item per line.  Spaces inside an item are allowed.
+		For most systems backticks can be used to get files names from
+		any external command.  Example: >vim
+			let tagfiles = glob("`find . -name tags -print`")
+			let &tags = substitute(tagfiles, "\n", ",", "g")
+<		 The result of the program inside the backticks should be one
+		item per line.	Spaces inside an item are allowed.
 
-                See |expand()| for expanding special Vim variables.  See
-                |system()| for getting the raw output of an external command.
+		See |expand()| for expanding special Vim variables.  See
+		|system()| for getting the raw output of an external command.
 
-glob2regpat({string})                                            *glob2regpat()*
-                Convert a file pattern, as used by glob(), into a search
-                pattern.  The result can be used to match with a string that
-                is a file name.  E.g. >vim
-                        if filename =~ glob2regpat('Make*.mak')
-                          " ...
-                        endif
-<                This is equivalent to: >vim
-                        if filename =~ '^Make.*\.mak$'
-                          " ...
-                        endif
-<                When {string} is an empty string the result is "^$", match an
-                empty string.
-                Note that the result depends on the system.  On MS-Windows
-                a backslash usually means a path separator.
+glob2regpat({string})						 *glob2regpat()*
+		Convert a file pattern, as used by glob(), into a search
+		pattern.  The result can be used to match with a string that
+		is a file name.  E.g. >vim
+			if filename =~ glob2regpat('Make*.mak')
+			  " ...
+			endif
+<		 This is equivalent to: >vim
+			if filename =~ '^Make.*\.mak$'
+			  " ...
+			endif
+<		 When {string} is an empty string the result is "^$", match an
+		empty string.
+		Note that the result depends on the system.  On MS-Windows
+		a backslash usually means a path separator.
 
-globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
-                Perform glob() for String {expr} on all directories in {path}
-                and concatenate the results.  Example: >vim
-                        echo globpath(&rtp, "syntax/c.vim")
+globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])	    *globpath()*
+		Perform glob() for String {expr} on all directories in {path}
+		and concatenate the results.  Example: >vim
+			echo globpath(&rtp, "syntax/c.vim")
 <
-                {path} is a comma-separated list of directory names.  Each
-                directory name is prepended to {expr} and expanded like with
-                |glob()|.  A path separator is inserted when needed.
-                To add a comma inside a directory name escape it with a
-                backslash.  Note that on MS-Windows a directory may have a
-                trailing backslash, remove it if you put a comma after it.
-                If the expansion fails for one of the directories, there is no
-                error message.
+		{path} is a comma-separated list of directory names.  Each
+		directory name is prepended to {expr} and expanded like with
+		|glob()|.  A path separator is inserted when needed.
+		To add a comma inside a directory name escape it with a
+		backslash.  Note that on MS-Windows a directory may have a
+		trailing backslash, remove it if you put a comma after it.
+		If the expansion fails for one of the directories, there is no
+		error message.
 
-                Unless the optional {nosuf} argument is given and is |TRUE|,
-                the 'suffixes' and 'wildignore' options apply: Names matching
-                one of the patterns in 'wildignore' will be skipped and
-                'suffixes' affect the ordering of matches.
+		Unless the optional {nosuf} argument is given and is |TRUE|,
+		the 'suffixes' and 'wildignore' options apply: Names matching
+		one of the patterns in 'wildignore' will be skipped and
+		'suffixes' affect the ordering of matches.
 
-                When {list} is present and it is |TRUE| the result is a |List|
-                with all matching files. The advantage of using a List is, you
-                also get filenames containing newlines correctly. Otherwise
-                the result is a String and when there are several matches,
-                they are separated by <NL> characters.  Example: >vim
-                        echo globpath(&rtp, "syntax/c.vim", 0, 1)
+		When {list} is present and it is |TRUE| the result is a |List|
+		with all matching files. The advantage of using a List is, you
+		also get filenames containing newlines correctly. Otherwise
+		the result is a String and when there are several matches,
+		they are separated by <NL> characters.	Example: >vim
+			echo globpath(&rtp, "syntax/c.vim", 0, 1)
 <
-                {allinks} is used as with |glob()|.
+		{allinks} is used as with |glob()|.
 
-                The "**" item can be used to search in a directory tree.
-                For example, to find all "README.txt" files in the directories
-                in 'runtimepath' and below: >vim
-                        echo globpath(&rtp, "**/README.txt")
-<                Upwards search and limiting the depth of "**" is not
-                supported, thus using 'path' will not always work properly.
+		The "**" item can be used to search in a directory tree.
+		For example, to find all "README.txt" files in the directories
+		in 'runtimepath' and below: >vim
+			echo globpath(&rtp, "**/README.txt")
+<		 Upwards search and limiting the depth of "**" is not
+		supported, thus using 'path' will not always work properly.
 
-has({feature})                                                           *has()*
-                Returns 1 if {feature} is supported, 0 otherwise.  The
-                {feature} argument is a feature name like "nvim-0.2.1" or
-                "win32", see below.  See also |exists()|.
+has({feature})								 *has()*
+		Returns 1 if {feature} is supported, 0 otherwise.  The
+		{feature} argument is a feature name like "nvim-0.2.1" or
+		"win32", see below.  See also |exists()|.
 
-                To get the system name use |vim.uv|.os_uname() in Lua: >lua
-                        print(vim.uv.os_uname().sysname)
+		To get the system name use |vim.uv|.os_uname() in Lua: >lua
+			print(vim.uv.os_uname().sysname)
 
-<                If the code has a syntax error then Vimscript may skip the
-                rest of the line.  Put |:if| and |:endif| on separate lines to
-                avoid the syntax error: >vim
-                        if has('feature')
-                          let x = this_breaks_without_the_feature()
-                        endif
+<		 If the code has a syntax error then Vimscript may skip the
+		rest of the line.  Put |:if| and |:endif| on separate lines to
+		avoid the syntax error: >vim
+			if has('feature')
+			  let x = this_breaks_without_the_feature()
+			endif
 <
-                Vim's compile-time feature-names (prefixed with "+") are not
-                recognized because Nvim is always compiled with all possible
-                features. |feature-compile|
+		Vim's compile-time feature-names (prefixed with "+") are not
+		recognized because Nvim is always compiled with all possible
+		features. |feature-compile|
 
-                Feature names can be:
-                1.  Nvim version. For example the "nvim-0.2.1" feature means
-                    that Nvim is version 0.2.1 or later: >vim
-                        if has("nvim-0.2.1")
-                          " ...
-                        endif
+		Feature names can be:
+		1.  Nvim version. For example the "nvim-0.2.1" feature means
+		    that Nvim is version 0.2.1 or later: >vim
+			if has("nvim-0.2.1")
+			  " ...
+			endif
 
-<                2.  Runtime condition or other pseudo-feature. For example the
-                    "win32" feature checks if the current system is Windows: >vim
-                        if has("win32")
-                          " ...
-                        endif
-<                                                       *feature-list*
-                    List of supported pseudo-feature names:
-                        acl             |ACL| support.
-                        bsd             BSD system (not macOS, use "mac" for that).
-                        clipboard       |clipboard| provider is available.
-                        fname_case      Case in file names matters (for Darwin and MS-Windows
-                                        this is not present).
-                        gui_running     Nvim has a GUI.
-                        iconv           Can use |iconv()| for conversion.
-                        linux           Linux system.
-                        mac             MacOS system.
-                        nvim            This is Nvim.
-                        python3         Legacy Vim |python3| interface. |has-python|
-                        pythonx         Legacy Vim |python_x| interface. |has-pythonx|
-                        sun             SunOS system.
-                        ttyin           input is a terminal (tty).
-                        ttyout          output is a terminal (tty).
-                        unix            Unix system.
-                        *vim_starting*  True during |startup|.
-                        win32           Windows system (32 or 64 bit).
-                        win64           Windows system (64 bit).
-                        wsl             WSL (Windows Subsystem for Linux) system.
+<		 2.  Runtime condition or other pseudo-feature. For example the
+		    "win32" feature checks if the current system is Windows: >vim
+			if has("win32")
+			  " ...
+			endif
+<							*feature-list*
+		    List of supported pseudo-feature names:
+			acl		|ACL| support.
+			bsd		BSD system (not macOS, use "mac" for that).
+			clipboard	|clipboard| provider is available.
+			fname_case	Case in file names matters (for Darwin and MS-Windows
+					this is not present).
+			gui_running	Nvim has a GUI.
+			iconv		Can use |iconv()| for conversion.
+			linux		Linux system.
+			mac		MacOS system.
+			nvim		This is Nvim.
+			python3		Legacy Vim |python3| interface. |has-python|
+			pythonx		Legacy Vim |python_x| interface. |has-pythonx|
+			sun		SunOS system.
+			ttyin		input is a terminal (tty).
+			ttyout		output is a terminal (tty).
+			unix		Unix system.
+			*vim_starting*	True during |startup|.
+			win32		Windows system (32 or 64 bit).
+			win64		Windows system (64 bit).
+			wsl		WSL (Windows Subsystem for Linux) system.
 
-                                                        *has-patch*
-                3.  Vim patch. For example the "patch123" feature means that
-                    Vim patch 123 at the current |v:version| was included: >vim
-                        if v:version > 602 || v:version == 602 && has("patch148")
-                          " ...
-                        endif
+							*has-patch*
+		3.  Vim patch. For example the "patch123" feature means that
+		    Vim patch 123 at the current |v:version| was included: >vim
+			if v:version > 602 || v:version == 602 && has("patch148")
+			  " ...
+			endif
 
-<                4.  Vim version. For example the "patch-7.4.237" feature means
-                    that Nvim is Vim-compatible to version 7.4.237 or later. >vim
-                        if has("patch-7.4.237")
-                          " ...
-                        endif
+<		 4.  Vim version. For example the "patch-7.4.237" feature means
+		    that Nvim is Vim-compatible to version 7.4.237 or later. >vim
+			if has("patch-7.4.237")
+			  " ...
+			endif
 <
-has_key({dict}, {key})                                               *has_key()*
-                The result is a Number, which is TRUE if |Dictionary| {dict}
-                has an entry with key {key}.  FALSE otherwise. The {key}
-                argument is a string.
+has_key({dict}, {key})						     *has_key()*
+		The result is a Number, which is TRUE if |Dictionary| {dict}
+		has an entry with key {key}.  FALSE otherwise. The {key}
+		argument is a string.
 
-haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
-                The result is a Number, which is 1 when the window has set a
-                local path via |:lcd| or when {winnr} is -1 and the tabpage
-                has set a local path via |:tcd|, otherwise 0.
+haslocaldir([{winnr} [, {tabnr}]])				 *haslocaldir()*
+		The result is a Number, which is 1 when the window has set a
+		local path via |:lcd| or when {winnr} is -1 and the tabpage
+		has set a local path via |:tcd|, otherwise 0.
 
-                Tabs and windows are identified by their respective numbers,
-                0 means current tab or window. Missing argument implies 0.
-                Thus the following are equivalent: >vim
-                        echo haslocaldir()
-                        echo haslocaldir(0)
-                        echo haslocaldir(0, 0)
-<                With {winnr} use that window in the current tabpage.
-                With {winnr} and {tabnr} use the window in that tabpage.
-                {winnr} can be the window number or the |window-ID|.
-                If {winnr} is -1 it is ignored, only the tab is resolved.
-                Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+		Tabs and windows are identified by their respective numbers,
+		0 means current tab or window. Missing argument implies 0.
+		Thus the following are equivalent: >vim
+			echo haslocaldir()
+			echo haslocaldir(0)
+			echo haslocaldir(0, 0)
+<		 With {winnr} use that window in the current tabpage.
+		With {winnr} and {tabnr} use the window in that tabpage.
+		{winnr} can be the window number or the |window-ID|.
+		If {winnr} is -1 it is ignored, only the tab is resolved.
+		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
-hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
-                The result is a Number, which is TRUE if there is a mapping
-                that contains {what} in somewhere in the rhs (what it is
-                mapped to) and this mapping exists in one of the modes
-                indicated by {mode}.
-                The arguments {what} and {mode} are strings.
-                When {abbr} is there and it is |TRUE| use abbreviations
-                instead of mappings.  Don't forget to specify Insert and/or
-                Command-line mode.
-                Both the global mappings and the mappings local to the current
-                buffer are checked for a match.
-                If no matching mapping is found FALSE is returned.
-                The following characters are recognized in {mode}:
-                        n       Normal mode
-                        v       Visual and Select mode
-                        x       Visual mode
-                        s       Select mode
-                        o       Operator-pending mode
-                        i       Insert mode
-                        l       Language-Argument ("r", "f", "t", etc.)
-                        c       Command-line mode
-                When {mode} is omitted, "nvo" is used.
+hasmapto({what} [, {mode} [, {abbr}]])				    *hasmapto()*
+		The result is a Number, which is TRUE if there is a mapping
+		that contains {what} in somewhere in the rhs (what it is
+		mapped to) and this mapping exists in one of the modes
+		indicated by {mode}.
+		The arguments {what} and {mode} are strings.
+		When {abbr} is there and it is |TRUE| use abbreviations
+		instead of mappings.  Don't forget to specify Insert and/or
+		Command-line mode.
+		Both the global mappings and the mappings local to the current
+		buffer are checked for a match.
+		If no matching mapping is found FALSE is returned.
+		The following characters are recognized in {mode}:
+			n	Normal mode
+			v	Visual and Select mode
+			x	Visual mode
+			s	Select mode
+			o	Operator-pending mode
+			i	Insert mode
+			l	Language-Argument ("r", "f", "t", etc.)
+			c	Command-line mode
+		When {mode} is omitted, "nvo" is used.
 
-                This function is useful to check if a mapping already exists
-                to a function in a Vim script.  Example: >vim
-                        if !hasmapto('\ABCdoit')
-                           map <Leader>d \ABCdoit
-                        endif
-<                This installs the mapping to "\ABCdoit" only if there isn't
-                already a mapping to "\ABCdoit".
+		This function is useful to check if a mapping already exists
+		to a function in a Vim script.	Example: >vim
+			if !hasmapto('\ABCdoit')
+			   map <Leader>d \ABCdoit
+			endif
+<		 This installs the mapping to "\ABCdoit" only if there isn't
+		already a mapping to "\ABCdoit".
 
-histadd({history}, {item})                                           *histadd()*
-                Add the String {item} to the history {history} which can be
-                one of:                                 *hist-names*
-                        "cmd"    or ":"   command line history
-                        "search" or "/"   search pattern history
-                        "expr"   or "="   typed expression history
-                        "input"  or "@"   input line history
-                        "debug"  or ">"   debug command history
-                        empty             the current or last used history
-                The {history} string does not need to be the whole name, one
-                character is sufficient.
-                If {item} does already exist in the history, it will be
-                shifted to become the newest entry.
-                The result is a Number: TRUE if the operation was successful,
-                otherwise FALSE is returned.
+histadd({history}, {item})					     *histadd()*
+		Add the String {item} to the history {history} which can be
+		one of:					*hist-names*
+			"cmd"	 or ":"   command line history
+			"search" or "/"   search pattern history
+			"expr"	 or "="   typed expression history
+			"input"  or "@"   input line history
+			"debug"  or ">"   debug command history
+			empty		  the current or last used history
+		The {history} string does not need to be the whole name, one
+		character is sufficient.
+		If {item} does already exist in the history, it will be
+		shifted to become the newest entry.
+		The result is a Number: TRUE if the operation was successful,
+		otherwise FALSE is returned.
 
-                Example: >vim
-                        call histadd("input", strftime("%Y %b %d"))
-                        let date=input("Enter date: ")
-<                This function is not available in the |sandbox|.
+		Example: >vim
+			call histadd("input", strftime("%Y %b %d"))
+			let date=input("Enter date: ")
+<		 This function is not available in the |sandbox|.
 
-histdel({history} [, {item}])                                        *histdel()*
-                Clear {history}, i.e. delete all its entries.  See |hist-names|
-                for the possible values of {history}.
+histdel({history} [, {item}])					     *histdel()*
+		Clear {history}, i.e. delete all its entries.  See |hist-names|
+		for the possible values of {history}.
 
-                If the parameter {item} evaluates to a String, it is used as a
-                regular expression.  All entries matching that expression will
-                be removed from the history (if there are any).
-                Upper/lowercase must match, unless "\c" is used |/\c|.
-                If {item} evaluates to a Number, it will be interpreted as
-                an index, see |:history-indexing|.  The respective entry will
-                be removed if it exists.
+		If the parameter {item} evaluates to a String, it is used as a
+		regular expression.  All entries matching that expression will
+		be removed from the history (if there are any).
+		Upper/lowercase must match, unless "\c" is used |/\c|.
+		If {item} evaluates to a Number, it will be interpreted as
+		an index, see |:history-indexing|.  The respective entry will
+		be removed if it exists.
 
-                The result is TRUE for a successful operation, otherwise FALSE
-                is returned.
+		The result is TRUE for a successful operation, otherwise FALSE
+		is returned.
 
-                Examples:
-                Clear expression register history: >vim
-                        call histdel("expr")
+		Examples:
+		Clear expression register history: >vim
+			call histdel("expr")
 <
-                Remove all entries starting with "*" from the search history: >vim
-                        call histdel("/", '^\*')
+		Remove all entries starting with "*" from the search history: >vim
+			call histdel("/", '^\*')
 <
-                The following three are equivalent: >vim
-                        call histdel("search", histnr("search"))
-                        call histdel("search", -1)
-                        call histdel("search", '^' .. histget("search", -1) .. '$')
+		The following three are equivalent: >vim
+			call histdel("search", histnr("search"))
+			call histdel("search", -1)
+			call histdel("search", '^' .. histget("search", -1) .. '$')
 <
-                To delete the last search pattern and use the last-but-one for
-                the "n" command and 'hlsearch': >vim
-                        call histdel("search", -1)
-                        let @/ = histget("search", -1)
+		To delete the last search pattern and use the last-but-one for
+		the "n" command and 'hlsearch': >vim
+			call histdel("search", -1)
+			let @/ = histget("search", -1)
 <
-histget({history} [, {index}])                                       *histget()*
-                The result is a String, the entry with Number {index} from
-                {history}.  See |hist-names| for the possible values of
-                {history}, and |:history-indexing| for {index}.  If there is
-                no such entry, an empty String is returned.  When {index} is
-                omitted, the most recent item from the history is used.
+histget({history} [, {index}])					     *histget()*
+		The result is a String, the entry with Number {index} from
+		{history}.  See |hist-names| for the possible values of
+		{history}, and |:history-indexing| for {index}.  If there is
+		no such entry, an empty String is returned.  When {index} is
+		omitted, the most recent item from the history is used.
 
-                Examples:
-                Redo the second last search from history. >vim
-                        execute '/' .. histget("search", -2)
+		Examples:
+		Redo the second last search from history. >vim
+			execute '/' .. histget("search", -2)
 
-<                Define an Ex command ":H {num}" that supports re-execution of
-                the {num}th entry from the output of |:history|. >vim
-                        command -nargs=1 H execute histget("cmd", 0+<args>)
+<		 Define an Ex command ":H {num}" that supports re-execution of
+		the {num}th entry from the output of |:history|. >vim
+			command -nargs=1 H execute histget("cmd", 0+<args>)
 <
-histnr({history})                                                     *histnr()*
-                The result is the Number of the current entry in {history}.
-                See |hist-names| for the possible values of {history}.
-                If an error occurred, -1 is returned.
+histnr({history})						      *histnr()*
+		The result is the Number of the current entry in {history}.
+		See |hist-names| for the possible values of {history}.
+		If an error occurred, -1 is returned.
 
-                Example: >vim
-                        let inp_index = histnr("expr")
+		Example: >vim
+			let inp_index = histnr("expr")
 
-hlID({name})                                                            *hlID()*
-                The result is a Number, which is the ID of the highlight group
-                with name {name}.  When the highlight group doesn't exist,
-                zero is returned.
-                This can be used to retrieve information about the highlight
-                group.  For example, to get the background color of the
-                "Comment" group: >vim
-                        echo synIDattr(synIDtrans(hlID("Comment")), "bg")
+hlID({name})								*hlID()*
+		The result is a Number, which is the ID of the highlight group
+		with name {name}.  When the highlight group doesn't exist,
+		zero is returned.
+		This can be used to retrieve information about the highlight
+		group.	For example, to get the background color of the
+		"Comment" group: >vim
+			echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 <
-hlexists({name})                                                    *hlexists()*
-                The result is a Number, which is TRUE if a highlight group
-                called {name} exists.  This is when the group has been
-                defined in some way.  Not necessarily when highlighting has
-                been defined for it, it may also have been used for a syntax
-                item.
+hlexists({name})						    *hlexists()*
+		The result is a Number, which is TRUE if a highlight group
+		called {name} exists.  This is when the group has been
+		defined in some way.  Not necessarily when highlighting has
+		been defined for it, it may also have been used for a syntax
+		item.
 
-hostname()                                                          *hostname()*
-                The result is a String, which is the name of the machine on
-                which Vim is currently running.  Machine names greater than
-                256 characters long are truncated.
+hostname()							    *hostname()*
+		The result is a String, which is the name of the machine on
+		which Vim is currently running.  Machine names greater than
+		256 characters long are truncated.
 
-iconv({string}, {from}, {to})                                          *iconv()*
-                The result is a String, which is the text {string} converted
-                from encoding {from} to encoding {to}.
-                When the conversion completely fails an empty string is
-                returned.  When some characters could not be converted they
-                are replaced with "?".
-                The encoding names are whatever the iconv() library function
-                can accept, see ":!man 3 iconv".
-                Note that Vim uses UTF-8 for all Unicode encodings, conversion
-                from/to UCS-2 is automatically changed to use UTF-8.  You
-                cannot use UCS-2 in a string anyway, because of the NUL bytes.
+iconv({string}, {from}, {to})					       *iconv()*
+		The result is a String, which is the text {string} converted
+		from encoding {from} to encoding {to}.
+		When the conversion completely fails an empty string is
+		returned.  When some characters could not be converted they
+		are replaced with "?".
+		The encoding names are whatever the iconv() library function
+		can accept, see ":!man 3 iconv".
+		Note that Vim uses UTF-8 for all Unicode encodings, conversion
+		from/to UCS-2 is automatically changed to use UTF-8.  You
+		cannot use UCS-2 in a string anyway, because of the NUL bytes.
 
-id({expr})                                                                *id()*
-                Returns a |String| which is a unique identifier of the
-                container type (|List|, |Dict|, |Blob| and |Partial|). It is
-                guaranteed that for the mentioned types `id(v1) ==# id(v2)`
-                returns true iff `type(v1) == type(v2) && v1 is v2`.
-                Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
-                `v:_null_blob` have the same `id()` with different types
-                because they are internally represented as NULL pointers.
-                `id()` returns a hexadecimal representanion of the pointers to
-                the containers (i.e. like `0x994a40`), same as `printf("%p",
-                {expr})`, but it is advised against counting on the exact
-                format of the return value.
+id({expr})								  *id()*
+		Returns a |String| which is a unique identifier of the
+		container type (|List|, |Dict|, |Blob| and |Partial|). It is
+		guaranteed that for the mentioned types `id(v1) ==# id(v2)`
+		returns true iff `type(v1) == type(v2) && v1 is v2`.
+		Note that `v:_null_string`, `v:_null_list`, `v:_null_dict` and
+		`v:_null_blob` have the same `id()` with different types
+		because they are internally represented as NULL pointers.
+		`id()` returns a hexadecimal representanion of the pointers to
+		the containers (i.e. like `0x994a40`), same as `printf("%p",
+		{expr})`, but it is advised against counting on the exact
+		format of the return value.
 
-                It is not guaranteed that `id(no_longer_existing_container)`
-                will not be equal to some other `id()`: new containers may
-                reuse identifiers of the garbage-collected ones.
+		It is not guaranteed that `id(no_longer_existing_container)`
+		will not be equal to some other `id()`: new containers may
+		reuse identifiers of the garbage-collected ones.
 
-indent({lnum})                                                        *indent()*
-                The result is a Number, which is indent of line {lnum} in the
-                current buffer.  The indent is counted in spaces, the value
-                of 'tabstop' is relevant.  {lnum} is used just like in
-                |getline()|.
-                When {lnum} is invalid -1 is returned.
+indent({lnum})							      *indent()*
+		The result is a Number, which is indent of line {lnum} in the
+		current buffer.  The indent is counted in spaces, the value
+		of 'tabstop' is relevant.  {lnum} is used just like in
+		|getline()|.
+		When {lnum} is invalid -1 is returned.
 
-index({object}, {expr} [, {start} [, {ic}]])                           *index()*
-                Find {expr} in {object} and return its index.  See
-                |indexof()| for using a lambda to select the item.
+index({object}, {expr} [, {start} [, {ic}]])			       *index()*
+		Find {expr} in {object} and return its index.  See
+		|indexof()| for using a lambda to select the item.
 
-                If {object} is a |List| return the lowest index where the item
-                has a value equal to {expr}.  There is no automatic
-                conversion, so the String "4" is different from the Number 4.
-                And the Number 4 is different from the Float 4.0.  The value
-                of 'ignorecase' is not used here, case matters as indicated by
-                the {ic} argument.
+		If {object} is a |List| return the lowest index where the item
+		has a value equal to {expr}.  There is no automatic
+		conversion, so the String "4" is different from the Number 4.
+		And the Number 4 is different from the Float 4.0.  The value
+		of 'ignorecase' is not used here, case matters as indicated by
+		the {ic} argument.
 
-                If {object} is a |Blob| return the lowest index where the byte
-                value is equal to {expr}.
+		If {object} is a |Blob| return the lowest index where the byte
+		value is equal to {expr}.
 
-                If {start} is given then start looking at the item with index
-                {start} (may be negative for an item relative to the end).
+		If {start} is given then start looking at the item with index
+		{start} (may be negative for an item relative to the end).
 
-                When {ic} is given and it is |TRUE|, ignore case.  Otherwise
-                case must match.
+		When {ic} is given and it is |TRUE|, ignore case.  Otherwise
+		case must match.
 
-                -1 is returned when {expr} is not found in {object}.
-                Example: >vim
-                        let idx = index(words, "the")
-                        if index(numbers, 123) >= 0
-                          " ...
-                        endif
+		-1 is returned when {expr} is not found in {object}.
+		Example: >vim
+			let idx = index(words, "the")
+			if index(numbers, 123) >= 0
+			  " ...
+			endif
 
-indexof({object}, {expr} [, {opts}])                                 *indexof()*
-                Returns the index of an item in {object} where {expr} is
-                v:true.  {object} must be a |List| or a |Blob|.
+indexof({object}, {expr} [, {opts}])				     *indexof()*
+		Returns the index of an item in {object} where {expr} is
+		v:true.  {object} must be a |List| or a |Blob|.
 
-                If {object} is a |List|, evaluate {expr} for each item in the
-                List until the expression is v:true and return the index of
-                this item.
+		If {object} is a |List|, evaluate {expr} for each item in the
+		List until the expression is v:true and return the index of
+		this item.
 
-                If {object} is a |Blob| evaluate {expr} for each byte in the
-                Blob until the expression is v:true and return the index of
-                this byte.
+		If {object} is a |Blob| evaluate {expr} for each byte in the
+		Blob until the expression is v:true and return the index of
+		this byte.
 
-                {expr} must be a |string| or |Funcref|.
+		{expr} must be a |string| or |Funcref|.
 
-                If {expr} is a |string|: If {object} is a |List|, inside
-                {expr} |v:key| has the index of the current List item and
-                |v:val| has the value of the item.  If {object} is a |Blob|,
-                inside {expr} |v:key| has the index of the current byte and
-                |v:val| has the byte value.
+		If {expr} is a |string|: If {object} is a |List|, inside
+		{expr} |v:key| has the index of the current List item and
+		|v:val| has the value of the item.  If {object} is a |Blob|,
+		inside {expr} |v:key| has the index of the current byte and
+		|v:val| has the byte value.
 
-                If {expr} is a |Funcref| it must take two arguments:
-                        1. the key or the index of the current item.
-                        2. the value of the current item.
-                The function must return |TRUE| if the item is found and the
-                search should stop.
+		If {expr} is a |Funcref| it must take two arguments:
+			1. the key or the index of the current item.
+			2. the value of the current item.
+		The function must return |TRUE| if the item is found and the
+		search should stop.
 
-                The optional argument {opts} is a Dict and supports the
-                following items:
-                    startidx    start evaluating {expr} at the item with this
-                                index; may be negative for an item relative to
-                                the end
-                Returns -1 when {expr} evaluates to v:false for all the items.
-                Example: >vim
-                        let l = [#{n: 10}, #{n: 20}, #{n: 30}]
-                        echo indexof(l, "v:val.n == 20")
-                        echo indexof(l, {i, v -> v.n == 30})
-                        echo indexof(l, "v:val.n == 20", #{startidx: 1})
+		The optional argument {opts} is a Dict and supports the
+		following items:
+		    startidx	start evaluating {expr} at the item with this
+				index; may be negative for an item relative to
+				the end
+		Returns -1 when {expr} evaluates to v:false for all the items.
+		Example: >vim
+			let l = [#{n: 10}, #{n: 20}, #{n: 30}]
+			echo indexof(l, "v:val.n == 20")
+			echo indexof(l, {i, v -> v.n == 30})
+			echo indexof(l, "v:val.n == 20", #{startidx: 1})
 
-input({prompt} [, {text} [, {completion}]])                            *input()*
+input({prompt} [, {text} [, {completion}]])			       *input()*
 
 input({opts})
-                The result is a String, which is whatever the user typed on
-                the command-line.  The {prompt} argument is either a prompt
-                string, or a blank string (for no prompt).  A '\n' can be used
-                in the prompt to start a new line.
+		The result is a String, which is whatever the user typed on
+		the command-line.  The {prompt} argument is either a prompt
+		string, or a blank string (for no prompt).  A '\n' can be used
+		in the prompt to start a new line.
 
-                In the second form it accepts a single dictionary with the
-                following keys, any of which may be omitted:
+		In the second form it accepts a single dictionary with the
+		following keys, any of which may be omitted:
 
-                Key           Default  Description ~
-                prompt        ""       Same as {prompt} in the first form.
-                default       ""       Same as {text} in the first form.
-                completion    nothing  Same as {completion} in the first form.
-                cancelreturn  ""       The value returned when the dialog is
-                                       cancelled.
-                highlight     nothing  Highlight handler: |Funcref|.
+		Key	      Default  Description ~
+		prompt	      ""       Same as {prompt} in the first form.
+		default       ""       Same as {text} in the first form.
+		completion    nothing  Same as {completion} in the first form.
+		cancelreturn  ""       The value returned when the dialog is
+				       cancelled.
+		highlight     nothing  Highlight handler: |Funcref|.
 
-                The highlighting set with |:echohl| is used for the prompt.
-                The input is entered just like a command-line, with the same
-                editing commands and mappings.  There is a separate history
-                for lines typed for input().
-                Example: >vim
-                        if input("Coffee or beer? ") == "beer"
-                          echo "Cheers!"
-                        endif
+		The highlighting set with |:echohl| is used for the prompt.
+		The input is entered just like a command-line, with the same
+		editing commands and mappings.	There is a separate history
+		for lines typed for input().
+		Example: >vim
+			if input("Coffee or beer? ") == "beer"
+			  echo "Cheers!"
+			endif
 <
-                If the optional {text} argument is present and not empty, this
-                is used for the default reply, as if the user typed this.
-                Example: >vim
-                        let color = input("Color? ", "white")
+		If the optional {text} argument is present and not empty, this
+		is used for the default reply, as if the user typed this.
+		Example: >vim
+			let color = input("Color? ", "white")
 
-<                The optional {completion} argument specifies the type of
-                completion supported for the input.  Without it completion is
-                not performed.  The supported completion types are the same as
-                that can be supplied to a user-defined command using the
-                "-complete=" argument.  Refer to |:command-completion| for
-                more information.  Example: >vim
-                        let fname = input("File: ", "", "file")
+<		 The optional {completion} argument specifies the type of
+		completion supported for the input.  Without it completion is
+		not performed.	The supported completion types are the same as
+		that can be supplied to a user-defined command using the
+		"-complete=" argument.	Refer to |:command-completion| for
+		more information.  Example: >vim
+			let fname = input("File: ", "", "file")
 
-<                                       *input()-highlight* *E5400* *E5402*
-                The optional `highlight` key allows specifying function which
-                will be used for highlighting user input.  This function
-                receives user input as its only argument and must return
-                a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
-                where
-                        hl_start_col is the first highlighted column,
-                        hl_end_col is the last highlighted column (+ 1!),
-                        hl_group is |:hi| group used for highlighting.
-                                              *E5403* *E5404* *E5405* *E5406*
-                Both hl_start_col and hl_end_col + 1 must point to the start
-                of the multibyte character (highlighting must not break
-                multibyte characters), hl_end_col + 1 may be equal to the
-                input length.  Start column must be in range [0, len(input)),
-                end column must be in range (hl_start_col, len(input)],
-                sections must be ordered so that next hl_start_col is greater
-                then or equal to previous hl_end_col.
+<					*input()-highlight* *E5400* *E5402*
+		The optional `highlight` key allows specifying function which
+		will be used for highlighting user input.  This function
+		receives user input as its only argument and must return
+		a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
+		where
+			hl_start_col is the first highlighted column,
+			hl_end_col is the last highlighted column (+ 1!),
+			hl_group is |:hi| group used for highlighting.
+					      *E5403* *E5404* *E5405* *E5406*
+		Both hl_start_col and hl_end_col + 1 must point to the start
+		of the multibyte character (highlighting must not break
+		multibyte characters), hl_end_col + 1 may be equal to the
+		input length.  Start column must be in range [0, len(input)),
+		end column must be in range (hl_start_col, len(input)],
+		sections must be ordered so that next hl_start_col is greater
+		then or equal to previous hl_end_col.
 
-                Example (try some input with parentheses): >vim
-                        highlight RBP1 guibg=Red ctermbg=red
-                        highlight RBP2 guibg=Yellow ctermbg=yellow
-                        highlight RBP3 guibg=Green ctermbg=green
-                        highlight RBP4 guibg=Blue ctermbg=blue
-                        let g:rainbow_levels = 4
-                        function! RainbowParens(cmdline)
-                          let ret = []
-                          let i = 0
-                          let lvl = 0
-                          while i < len(a:cmdline)
-                            if a:cmdline[i] is# '('
-                              call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-                              let lvl += 1
-                            elseif a:cmdline[i] is# ')'
-                              let lvl -= 1
-                              call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-                            endif
-                            let i += 1
-                          endwhile
-                          return ret
-                        endfunction
-                        call input({'prompt':'>','highlight':'RainbowParens'})
+		Example (try some input with parentheses): >vim
+			highlight RBP1 guibg=Red ctermbg=red
+			highlight RBP2 guibg=Yellow ctermbg=yellow
+			highlight RBP3 guibg=Green ctermbg=green
+			highlight RBP4 guibg=Blue ctermbg=blue
+			let g:rainbow_levels = 4
+			function! RainbowParens(cmdline)
+			  let ret = []
+			  let i = 0
+			  let lvl = 0
+			  while i < len(a:cmdline)
+			    if a:cmdline[i] is# '('
+			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+			      let lvl += 1
+			    elseif a:cmdline[i] is# ')'
+			      let lvl -= 1
+			      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+			    endif
+			    let i += 1
+			  endwhile
+			  return ret
+			endfunction
+			call input({'prompt':'>','highlight':'RainbowParens'})
 <
-                Highlight function is called at least once for each new
-                displayed input string, before command-line is redrawn.  It is
-                expected that function is pure for the duration of one input()
-                call, i.e. it produces the same output for the same input, so
-                output may be memoized.  Function is run like under |:silent|
-                modifier. If the function causes any errors, it will be
-                skipped for the duration of the current input() call.
+		Highlight function is called at least once for each new
+		displayed input string, before command-line is redrawn.  It is
+		expected that function is pure for the duration of one input()
+		call, i.e. it produces the same output for the same input, so
+		output may be memoized.  Function is run like under |:silent|
+		modifier. If the function causes any errors, it will be
+		skipped for the duration of the current input() call.
 
-                Highlighting is disabled if command-line contains arabic
-                characters.
+		Highlighting is disabled if command-line contains arabic
+		characters.
 
-                NOTE: This function must not be used in a startup file, for
-                the versions that only run in GUI mode (e.g., the Win32 GUI).
-                Note: When input() is called from within a mapping it will
-                consume remaining characters from that mapping, because a
-                mapping is handled like the characters were typed.
-                Use |inputsave()| before input() and |inputrestore()|
-                after input() to avoid that.  Another solution is to avoid
-                that further characters follow in the mapping, e.g., by using
-                |:execute| or |:normal|.
+		NOTE: This function must not be used in a startup file, for
+		the versions that only run in GUI mode (e.g., the Win32 GUI).
+		Note: When input() is called from within a mapping it will
+		consume remaining characters from that mapping, because a
+		mapping is handled like the characters were typed.
+		Use |inputsave()| before input() and |inputrestore()|
+		after input() to avoid that.  Another solution is to avoid
+		that further characters follow in the mapping, e.g., by using
+		|:execute| or |:normal|.
 
-                Example with a mapping: >vim
-                        nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
-                        function GetFoo()
-                          call inputsave()
-                          let g:Foo = input("enter search pattern: ")
-                          call inputrestore()
-                        endfunction
+		Example with a mapping: >vim
+			nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
+			function GetFoo()
+			  call inputsave()
+			  let g:Foo = input("enter search pattern: ")
+			  call inputrestore()
+			endfunction
 
-inputlist({textlist})                                              *inputlist()*
-                {textlist} must be a |List| of strings.  This |List| is
-                displayed, one string per line.  The user will be prompted to
-                enter a number, which is returned.
-                The user can also select an item by clicking on it with the
-                mouse, if the mouse is enabled in the command line ('mouse' is
-                "a" or includes "c").  For the first string 0 is returned.
-                When clicking above the first item a negative number is
-                returned.  When clicking on the prompt one more than the
-                length of {textlist} is returned.
-                Make sure {textlist} has less than 'lines' entries, otherwise
-                it won't work.  It's a good idea to put the entry number at
-                the start of the string.  And put a prompt in the first item.
-                Example: >vim
-                        let color = inputlist(['Select color:', '1. red',
-                                \ '2. green', '3. blue'])
+inputlist({textlist})						   *inputlist()*
+		{textlist} must be a |List| of strings.  This |List| is
+		displayed, one string per line.  The user will be prompted to
+		enter a number, which is returned.
+		The user can also select an item by clicking on it with the
+		mouse, if the mouse is enabled in the command line ('mouse' is
+		"a" or includes "c").  For the first string 0 is returned.
+		When clicking above the first item a negative number is
+		returned.  When clicking on the prompt one more than the
+		length of {textlist} is returned.
+		Make sure {textlist} has less than 'lines' entries, otherwise
+		it won't work.	It's a good idea to put the entry number at
+		the start of the string.  And put a prompt in the first item.
+		Example: >vim
+			let color = inputlist(['Select color:', '1. red',
+				\ '2. green', '3. blue'])
 
-inputrestore()                                                  *inputrestore()*
-                Restore typeahead that was saved with a previous |inputsave()|.
-                Should be called the same number of times inputsave() is
-                called.  Calling it more often is harmless though.
-                Returns TRUE when there is nothing to restore, FALSE otherwise.
+inputrestore()							*inputrestore()*
+		Restore typeahead that was saved with a previous |inputsave()|.
+		Should be called the same number of times inputsave() is
+		called.  Calling it more often is harmless though.
+		Returns TRUE when there is nothing to restore, FALSE otherwise.
 
-inputsave()                                                        *inputsave()*
-                Preserve typeahead (also from mappings) and clear it, so that
-                a following prompt gets input from the user.  Should be
-                followed by a matching inputrestore() after the prompt.  Can
-                be used several times, in which case there must be just as
-                many inputrestore() calls.
-                Returns TRUE when out of memory, FALSE otherwise.
+inputsave()							   *inputsave()*
+		Preserve typeahead (also from mappings) and clear it, so that
+		a following prompt gets input from the user.  Should be
+		followed by a matching inputrestore() after the prompt.  Can
+		be used several times, in which case there must be just as
+		many inputrestore() calls.
+		Returns TRUE when out of memory, FALSE otherwise.
 
-inputsecret({prompt} [, {text}])                                 *inputsecret()*
-                This function acts much like the |input()| function with but
-                two exceptions:
-                a) the user's response will be displayed as a sequence of
-                asterisks ("*") thereby keeping the entry secret, and
-                b) the user's response will not be recorded on the input
-                |history| stack.
-                The result is a String, which is whatever the user actually
-                typed on the command-line in response to the issued prompt.
-                NOTE: Command-line completion is not supported.
+inputsecret({prompt} [, {text}])				 *inputsecret()*
+		This function acts much like the |input()| function with but
+		two exceptions:
+		a) the user's response will be displayed as a sequence of
+		asterisks ("*") thereby keeping the entry secret, and
+		b) the user's response will not be recorded on the input
+		|history| stack.
+		The result is a String, which is whatever the user actually
+		typed on the command-line in response to the issued prompt.
+		NOTE: Command-line completion is not supported.
 
-insert({object}, {item} [, {idx}])                                    *insert()*
-                When {object} is a |List| or a |Blob| insert {item} at the start
-                of it.
+insert({object}, {item} [, {idx}])				      *insert()*
+		When {object} is a |List| or a |Blob| insert {item} at the start
+		of it.
 
-                If {idx} is specified insert {item} before the item with index
-                {idx}.  If {idx} is zero it goes before the first item, just
-                like omitting {idx}.  A negative {idx} is also possible, see
-                |list-index|.  -1 inserts just before the last item.
+		If {idx} is specified insert {item} before the item with index
+		{idx}.	If {idx} is zero it goes before the first item, just
+		like omitting {idx}.  A negative {idx} is also possible, see
+		|list-index|.  -1 inserts just before the last item.
 
-                Returns the resulting |List| or |Blob|.  Examples: >vim
-                        let mylist = insert([2, 3, 5], 1)
-                        call insert(mylist, 4, -1)
-                        call insert(mylist, 6, len(mylist))
-<                The last example can be done simpler with |add()|.
-                Note that when {item} is a |List| it is inserted as a single
-                item.  Use |extend()| to concatenate |Lists|.
+		Returns the resulting |List| or |Blob|.  Examples: >vim
+			let mylist = insert([2, 3, 5], 1)
+			call insert(mylist, 4, -1)
+			call insert(mylist, 6, len(mylist))
+<		 The last example can be done simpler with |add()|.
+		Note that when {item} is a |List| it is inserted as a single
+		item.  Use |extend()| to concatenate |Lists|.
 
-interrupt()                                                        *interrupt()*
-                Interrupt script execution.  It works more or less like the
-                user typing CTRL-C, most commands won't execute and control
-                returns to the user.  This is useful to abort execution
-                from lower down, e.g. in an autocommand.  Example: >vim
-                function s:check_typoname(file)
-                   if fnamemodify(a:file, ':t') == '['
-                       echomsg 'Maybe typo'
-                       call interrupt()
-                   endif
-                endfunction
-                au BufWritePre * call s:check_typoname(expand('<amatch>'))
+interrupt()							   *interrupt()*
+		Interrupt script execution.  It works more or less like the
+		user typing CTRL-C, most commands won't execute and control
+		returns to the user.  This is useful to abort execution
+		from lower down, e.g. in an autocommand.  Example: >vim
+		function s:check_typoname(file)
+		   if fnamemodify(a:file, ':t') == '['
+		       echomsg 'Maybe typo'
+		       call interrupt()
+		   endif
+		endfunction
+		au BufWritePre * call s:check_typoname(expand('<amatch>'))
 <
-invert({expr})                                                        *invert()*
-                Bitwise invert.  The argument is converted to a number.  A
-                List, Dict or Float argument causes an error.  Example: >vim
-                        let bits = invert(bits)
+invert({expr})							      *invert()*
+		Bitwise invert.  The argument is converted to a number.  A
+		List, Dict or Float argument causes an error.  Example: >vim
+			let bits = invert(bits)
 <
-isdirectory({directory})                                         *isdirectory()*
-                The result is a Number, which is |TRUE| when a directory
-                with the name {directory} exists.  If {directory} doesn't
-                exist, or isn't a directory, the result is |FALSE|.  {directory}
-                is any expression, which is used as a String.
+isdirectory({directory})					 *isdirectory()*
+		The result is a Number, which is |TRUE| when a directory
+		with the name {directory} exists.  If {directory} doesn't
+		exist, or isn't a directory, the result is |FALSE|.  {directory}
+		is any expression, which is used as a String.
 
-isinf({expr})                                                          *isinf()*
-                Return 1 if {expr} is a positive infinity, or -1 a negative
-                infinity, otherwise 0. >vim
-                        echo isinf(1.0 / 0.0)
-<                        1 >vim
-                        echo isinf(-1.0 / 0.0)
-<                        -1
+isinf({expr})							       *isinf()*
+		Return 1 if {expr} is a positive infinity, or -1 a negative
+		infinity, otherwise 0. >vim
+			echo isinf(1.0 / 0.0)
+<			 1 >vim
+			echo isinf(-1.0 / 0.0)
+<			 -1
 
-islocked({expr})                                               *islocked()* *E786*
-                The result is a Number, which is |TRUE| when {expr} is the
-                name of a locked variable.
-                The string argument {expr} must be the name of a variable,
-                |List| item or |Dictionary| entry, not the variable itself!
-                Example: >vim
-                        let alist = [0, ['a', 'b'], 2, 3]
-                        lockvar 1 alist
-                        echo islocked('alist')          " 1
-                        echo islocked('alist[1]')       " 0
+islocked({expr})					       *islocked()* *E786*
+		The result is a Number, which is |TRUE| when {expr} is the
+		name of a locked variable.
+		The string argument {expr} must be the name of a variable,
+		|List| item or |Dictionary| entry, not the variable itself!
+		Example: >vim
+			let alist = [0, ['a', 'b'], 2, 3]
+			lockvar 1 alist
+			echo islocked('alist')		" 1
+			echo islocked('alist[1]')	" 0
 
-<                When {expr} is a variable that does not exist you get an error
-                message.  Use |exists()| to check for existence.
+<		 When {expr} is a variable that does not exist you get an error
+		message.  Use |exists()| to check for existence.
 
-isnan({expr})                                                          *isnan()*
-                Return |TRUE| if {expr} is a float with value NaN. >vim
-                        echo isnan(0.0 / 0.0)
-<                        1
+isnan({expr})							       *isnan()*
+		Return |TRUE| if {expr} is a float with value NaN. >vim
+			echo isnan(0.0 / 0.0)
+<			 1
 
-items({dict})                                                          *items()*
-                Return a |List| with all the key-value pairs of {dict}.  Each
-                |List| item is a list with two items: the key of a {dict}
-                entry and the value of this entry.  The |List| is in arbitrary
-                order.  Also see |keys()| and |values()|.
-                Example: >vim
-                        for [key, value] in items(mydict)
-                           echo key .. ': ' .. value
-                        endfor
+items({dict})							       *items()*
+		Return a |List| with all the key-value pairs of {dict}.  Each
+		|List| item is a list with two items: the key of a {dict}
+		entry and the value of this entry.  The |List| is in arbitrary
+		order.	Also see |keys()| and |values()|.
+		Example: >vim
+			for [key, value] in items(mydict)
+			   echo key .. ': ' .. value
+			endfor
 
-jobpid({job})                                                         *jobpid()*
-                Return the PID (process id) of |job-id| {job}.
+jobpid({job})							      *jobpid()*
+		Return the PID (process id) of |job-id| {job}.
 
-jobresize({job}, {width}, {height})                                *jobresize()*
-                Resize the pseudo terminal window of |job-id| {job} to {width}
-                columns and {height} rows.
-                Fails if the job was not started with `"pty":v:true`.
+jobresize({job}, {width}, {height})				   *jobresize()*
+		Resize the pseudo terminal window of |job-id| {job} to {width}
+		columns and {height} rows.
+		Fails if the job was not started with `"pty":v:true`.
 
-jobstart({cmd} [, {opts}])                                          *jobstart()*
-                Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
+jobstart({cmd} [, {opts}])					    *jobstart()*
+		Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
 
-                Spawns {cmd} as a job.
-                If {cmd} is a List it runs directly (no 'shell').
-                If {cmd} is a String it runs in the 'shell', like this: >vim
-                  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
-<                (See |shell-unquoting| for details.)
+		Spawns {cmd} as a job.
+		If {cmd} is a List it runs directly (no 'shell').
+		If {cmd} is a String it runs in the 'shell', like this: >vim
+		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
+<		 (See |shell-unquoting| for details.)
 
-                Example: >vim
-                  call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
+		Example: >vim
+		  call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
 <
-                Returns |job-id| on success, 0 on invalid arguments (or job
-                table is full), -1 if {cmd}[0] or 'shell' is not executable.
-                The returned job-id is a valid |channel-id| representing the
-                job's stdio streams. Use |chansend()| (or |rpcnotify()| and
-                |rpcrequest()| if "rpc" was enabled) to send data to stdin and
-                |chanclose()| to close the streams without stopping the job.
+		Returns |job-id| on success, 0 on invalid arguments (or job
+		table is full), -1 if {cmd}[0] or 'shell' is not executable.
+		The returned job-id is a valid |channel-id| representing the
+		job's stdio streams. Use |chansend()| (or |rpcnotify()| and
+		|rpcrequest()| if "rpc" was enabled) to send data to stdin and
+		|chanclose()| to close the streams without stopping the job.
 
-                See |job-control| and |RPC|.
+		See |job-control| and |RPC|.
 
-                NOTE: on Windows if {cmd} is a List:
-                  - cmd[0] must be an executable (not a "built-in"). If it is
-                    in $PATH it can be called by name, without an extension: >vim
-                      call jobstart(['ping', 'neovim.io'])
-<                    If it is a full or partial path, extension is required: >vim
-                      call jobstart(['System32\ping.exe', 'neovim.io'])
-<                  - {cmd} is collapsed to a string of quoted args as expected
-                    by CommandLineToArgvW https://msdn.microsoft.com/bb776391
-                    unless cmd[0] is some form of "cmd.exe".
+		NOTE: on Windows if {cmd} is a List:
+		  - cmd[0] must be an executable (not a "built-in"). If it is
+		    in $PATH it can be called by name, without an extension: >vim
+		      call jobstart(['ping', 'neovim.io'])
+<		     If it is a full or partial path, extension is required: >vim
+		      call jobstart(['System32\ping.exe', 'neovim.io'])
+<		   - {cmd} is collapsed to a string of quoted args as expected
+		    by CommandLineToArgvW https://msdn.microsoft.com/bb776391
+		    unless cmd[0] is some form of "cmd.exe".
 
-                                                        *jobstart-env*
-                The job environment is initialized as follows:
-                  $NVIM                is set to |v:servername| of the parent Nvim
-                  $NVIM_LISTEN_ADDRESS is unset
-                  $NVIM_LOG_FILE       is unset
-                  $VIM                 is unset
-                  $VIMRUNTIME          is unset
-                You can set these with the `env` option.
+							*jobstart-env*
+		The job environment is initialized as follows:
+		  $NVIM		       is set to |v:servername| of the parent Nvim
+		  $NVIM_LISTEN_ADDRESS is unset
+		  $NVIM_LOG_FILE       is unset
+		  $VIM		       is unset
+		  $VIMRUNTIME	       is unset
+		You can set these with the `env` option.
 
-                                                        *jobstart-options*
-                {opts} is a dictionary with these keys:
-                  clear_env:  (boolean) `env` defines the job environment
-                              exactly, instead of merging current environment.
-                  cwd:        (string, default=|current-directory|) Working
-                              directory of the job.
-                  detach:     (boolean) Detach the job process: it will not be
-                              killed when Nvim exits. If the process exits
-                              before Nvim, `on_exit` will be invoked.
-                  env:        (dict) Map of environment variable name:value
-                              pairs extending (or replace with "clear_env")
-                              the current environment. |jobstart-env|
-                  height:     (number) Height of the `pty` terminal.
-                  |on_exit|:    (function) Callback invoked when the job exits.
-                  |on_stdout|:  (function) Callback invoked when the job emits
-                              stdout data.
-                  |on_stderr|:  (function) Callback invoked when the job emits
-                              stderr data.
-                  overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
-                              stdio passed to the child process. Only on
-                              MS-Windows; ignored on other platforms.
-                  pty:        (boolean) Connect the job to a new pseudo
-                              terminal, and its streams to the master file
-                              descriptor. `on_stdout` receives all output,
-                              `on_stderr` is ignored. |terminal-start|
-                  rpc:        (boolean) Use |msgpack-rpc| to communicate with
-                              the job over stdio. Then `on_stdout` is ignored,
-                              but `on_stderr` can still be used.
-                  stderr_buffered: (boolean) Collect data until EOF (stream closed)
-                              before invoking `on_stderr`. |channel-buffered|
-                  stdout_buffered: (boolean) Collect data until EOF (stream
-                              closed) before invoking `on_stdout`. |channel-buffered|
-                  stdin:      (string) Either "pipe" (default) to connect the
-                              job's stdin to a channel or "null" to disconnect
-                              stdin.
-                  width:      (number) Width of the `pty` terminal.
+							*jobstart-options*
+		{opts} is a dictionary with these keys:
+		  clear_env:  (boolean) `env` defines the job environment
+			      exactly, instead of merging current environment.
+		  cwd:	      (string, default=|current-directory|) Working
+			      directory of the job.
+		  detach:     (boolean) Detach the job process: it will not be
+			      killed when Nvim exits. If the process exits
+			      before Nvim, `on_exit` will be invoked.
+		  env:	      (dict) Map of environment variable name:value
+			      pairs extending (or replace with "clear_env")
+			      the current environment. |jobstart-env|
+		  height:     (number) Height of the `pty` terminal.
+		  |on_exit|:	(function) Callback invoked when the job exits.
+		  |on_stdout|:	(function) Callback invoked when the job emits
+			      stdout data.
+		  |on_stderr|:	(function) Callback invoked when the job emits
+			      stderr data.
+		  overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
+			      stdio passed to the child process. Only on
+			      MS-Windows; ignored on other platforms.
+		  pty:	      (boolean) Connect the job to a new pseudo
+			      terminal, and its streams to the master file
+			      descriptor. `on_stdout` receives all output,
+			      `on_stderr` is ignored. |terminal-start|
+		  rpc:	      (boolean) Use |msgpack-rpc| to communicate with
+			      the job over stdio. Then `on_stdout` is ignored,
+			      but `on_stderr` can still be used.
+		  stderr_buffered: (boolean) Collect data until EOF (stream closed)
+			      before invoking `on_stderr`. |channel-buffered|
+		  stdout_buffered: (boolean) Collect data until EOF (stream
+			      closed) before invoking `on_stdout`. |channel-buffered|
+		  stdin:      (string) Either "pipe" (default) to connect the
+			      job's stdin to a channel or "null" to disconnect
+			      stdin.
+		  width:      (number) Width of the `pty` terminal.
 
-                {opts} is passed as |self| dictionary to the callback; the
-                caller may set other keys to pass application-specific data.
+		{opts} is passed as |self| dictionary to the callback; the
+		caller may set other keys to pass application-specific data.
 
-                Returns:
-                  - |channel-id| on success
-                  - 0 on invalid arguments
-                  - -1 if {cmd}[0] is not executable.
-                See also |job-control|, |channel|, |msgpack-rpc|.
+		Returns:
+		  - |channel-id| on success
+		  - 0 on invalid arguments
+		  - -1 if {cmd}[0] is not executable.
+		See also |job-control|, |channel|, |msgpack-rpc|.
 
-jobstop({id})                                                        *jobstop()*
-                Stop |job-id| {id} by sending SIGTERM to the job process. If
-                the process does not terminate after a timeout then SIGKILL
-                will be sent. When the job terminates its |on_exit| handler
-                (if any) will be invoked.
-                See |job-control|.
+jobstop({id})							     *jobstop()*
+		Stop |job-id| {id} by sending SIGTERM to the job process. If
+		the process does not terminate after a timeout then SIGKILL
+		will be sent. When the job terminates its |on_exit| handler
+		(if any) will be invoked.
+		See |job-control|.
 
-                Returns 1 for valid job id, 0 for invalid id, including jobs have
-                exited or stopped.
+		Returns 1 for valid job id, 0 for invalid id, including jobs have
+		exited or stopped.
 
-jobwait({jobs} [, {timeout}])                                        *jobwait()*
-                Waits for jobs and their |on_exit| handlers to complete.
+jobwait({jobs} [, {timeout}])					     *jobwait()*
+		Waits for jobs and their |on_exit| handlers to complete.
 
-                {jobs} is a List of |job-id|s to wait for.
-                {timeout} is the maximum waiting time in milliseconds. If
-                omitted or -1, wait forever.
+		{jobs} is a List of |job-id|s to wait for.
+		{timeout} is the maximum waiting time in milliseconds. If
+		omitted or -1, wait forever.
 
-                Timeout of 0 can be used to check the status of a job: >vim
-                        let running = jobwait([{job-id}], 0)[0] == -1
+		Timeout of 0 can be used to check the status of a job: >vim
+			let running = jobwait([{job-id}], 0)[0] == -1
 <
-                During jobwait() callbacks for jobs not in the {jobs} list may
-                be invoked. The screen will not redraw unless |:redraw| is
-                invoked by a callback.
+		During jobwait() callbacks for jobs not in the {jobs} list may
+		be invoked. The screen will not redraw unless |:redraw| is
+		invoked by a callback.
 
-                Returns a list of len({jobs}) integers, where each integer is
-                the status of the corresponding job:
-                        Exit-code, if the job exited
-                        -1 if the timeout was exceeded
-                        -2 if the job was interrupted (by |CTRL-C|)
-                        -3 if the job-id is invalid
+		Returns a list of len({jobs}) integers, where each integer is
+		the status of the corresponding job:
+			Exit-code, if the job exited
+			-1 if the timeout was exceeded
+			-2 if the job was interrupted (by |CTRL-C|)
+			-3 if the job-id is invalid
 
-join({list} [, {sep}])                                                  *join()*
-                Join the items in {list} together into one String.
-                When {sep} is specified it is put in between the items.  If
-                {sep} is omitted a single space is used.
-                Note that {sep} is not added at the end.  You might want to
-                add it there too: >vim
-                        let lines = join(mylist, "\n") .. "\n"
-<                String items are used as-is.  |Lists| and |Dictionaries| are
-                converted into a string like with |string()|.
-                The opposite function is |split()|.
+join({list} [, {sep}])							*join()*
+		Join the items in {list} together into one String.
+		When {sep} is specified it is put in between the items.  If
+		{sep} is omitted a single space is used.
+		Note that {sep} is not added at the end.  You might want to
+		add it there too: >vim
+			let lines = join(mylist, "\n") .. "\n"
+<		 String items are used as-is.  |Lists| and |Dictionaries| are
+		converted into a string like with |string()|.
+		The opposite function is |split()|.
 
-json_decode({expr})                                              *json_decode()*
-                Convert {expr} from JSON object.  Accepts |readfile()|-style
-                list as the input, as well as regular string.  May output any
-                Vim value. In the following cases it will output
-                |msgpack-special-dict|:
-                1. Dictionary contains duplicate key.
-                2. String contains NUL byte.  Two special dictionaries: for
-                   dictionary and for string will be emitted in case string
-                   with NUL byte was a dictionary key.
+json_decode({expr})						 *json_decode()*
+		Convert {expr} from JSON object.  Accepts |readfile()|-style
+		list as the input, as well as regular string.  May output any
+		Vim value. In the following cases it will output
+		|msgpack-special-dict|:
+		1. Dictionary contains duplicate key.
+		2. String contains NUL byte.  Two special dictionaries: for
+		   dictionary and for string will be emitted in case string
+		   with NUL byte was a dictionary key.
 
-                Note: function treats its input as UTF-8 always.  The JSON
-                standard allows only a few encodings, of which UTF-8 is
-                recommended and the only one required to be supported.
-                Non-UTF-8 characters are an error.
+		Note: function treats its input as UTF-8 always.  The JSON
+		standard allows only a few encodings, of which UTF-8 is
+		recommended and the only one required to be supported.
+		Non-UTF-8 characters are an error.
 
-json_encode({expr})                                              *json_encode()*
-                Convert {expr} into a JSON string.  Accepts
-                |msgpack-special-dict| as the input.  Will not convert
-                |Funcref|s, mappings with non-string keys (can be created as
-                |msgpack-special-dict|), values with self-referencing
-                containers, strings which contain non-UTF-8 characters,
-                pseudo-UTF-8 strings which contain codepoints reserved for
-                surrogate pairs (such strings are not valid UTF-8 strings).
-                Non-printable characters are converted into "\u1234" escapes
-                or special escapes like "\t", other are dumped as-is.
-                |Blob|s are converted to arrays of the individual bytes.
+json_encode({expr})						 *json_encode()*
+		Convert {expr} into a JSON string.  Accepts
+		|msgpack-special-dict| as the input.  Will not convert
+		|Funcref|s, mappings with non-string keys (can be created as
+		|msgpack-special-dict|), values with self-referencing
+		containers, strings which contain non-UTF-8 characters,
+		pseudo-UTF-8 strings which contain codepoints reserved for
+		surrogate pairs (such strings are not valid UTF-8 strings).
+		Non-printable characters are converted into "\u1234" escapes
+		or special escapes like "\t", other are dumped as-is.
+		|Blob|s are converted to arrays of the individual bytes.
 
-keys({dict})                                                            *keys()*
-                Return a |List| with all the keys of {dict}.  The |List| is in
-                arbitrary order.  Also see |items()| and |values()|.
+keys({dict})								*keys()*
+		Return a |List| with all the keys of {dict}.  The |List| is in
+		arbitrary order.  Also see |items()| and |values()|.
 
-keytrans({string})                                                  *keytrans()*
-                Turn the internal byte representation of keys into a form that
-                can be used for |:map|.  E.g. >vim
-                        let xx = "\<C-Home>"
-                        echo keytrans(xx)
-<                       <C-Home>
+keytrans({string})						    *keytrans()*
+		Turn the internal byte representation of keys into a form that
+		can be used for |:map|.  E.g. >vim
+			let xx = "\<C-Home>"
+			echo keytrans(xx)
+<			<C-Home>
 
-len({expr})                                                         *len()* *E701*
-                The result is a Number, which is the length of the argument.
-                When {expr} is a String or a Number the length in bytes is
-                used, as with |strlen()|.
-                When {expr} is a |List| the number of items in the |List| is
-                returned.
-                When {expr} is a |Blob| the number of bytes is returned.
-                When {expr} is a |Dictionary| the number of entries in the
-                |Dictionary| is returned.
-                Otherwise an error is given and returns zero.
+len({expr})							    *len()* *E701*
+		The result is a Number, which is the length of the argument.
+		When {expr} is a String or a Number the length in bytes is
+		used, as with |strlen()|.
+		When {expr} is a |List| the number of items in the |List| is
+		returned.
+		When {expr} is a |Blob| the number of bytes is returned.
+		When {expr} is a |Dictionary| the number of entries in the
+		|Dictionary| is returned.
+		Otherwise an error is given and returns zero.
 
-libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E368*
-                Call function {funcname} in the run-time library {libname}
-                with single argument {argument}.
-                This is useful to call functions in a library that you
-                especially made to be used with Vim.  Since only one argument
-                is possible, calling standard library functions is rather
-                limited.
-                The result is the String returned by the function.  If the
-                function returns NULL, this will appear as an empty string ""
-                to Vim.
-                If the function returns a number, use libcallnr()!
-                If {argument} is a number, it is passed to the function as an
-                int; if {argument} is a string, it is passed as a
-                null-terminated string.
+libcall({libname}, {funcname}, {argument})		   *libcall()* *E364* *E368*
+		Call function {funcname} in the run-time library {libname}
+		with single argument {argument}.
+		This is useful to call functions in a library that you
+		especially made to be used with Vim.  Since only one argument
+		is possible, calling standard library functions is rather
+		limited.
+		The result is the String returned by the function.  If the
+		function returns NULL, this will appear as an empty string ""
+		to Vim.
+		If the function returns a number, use libcallnr()!
+		If {argument} is a number, it is passed to the function as an
+		int; if {argument} is a string, it is passed as a
+		null-terminated string.
 
-                libcall() allows you to write your own 'plug-in' extensions to
-                Vim without having to recompile the program.  It is NOT a
-                means to call system functions!  If you try to do so Vim will
-                very probably crash.
+		libcall() allows you to write your own 'plug-in' extensions to
+		Vim without having to recompile the program.  It is NOT a
+		means to call system functions!  If you try to do so Vim will
+		very probably crash.
 
-                For Win32, the functions you write must be placed in a DLL
-                and use the normal C calling convention (NOT Pascal which is
-                used in Windows System DLLs).  The function must take exactly
-                one parameter, either a character pointer or a long integer,
-                and must return a character pointer or NULL.  The character
-                pointer returned must point to memory that will remain valid
-                after the function has returned (e.g. in static data in the
-                DLL).  If it points to allocated memory, that memory will
-                leak away.  Using a static buffer in the function should work,
-                it's then freed when the DLL is unloaded.
+		For Win32, the functions you write must be placed in a DLL
+		and use the normal C calling convention (NOT Pascal which is
+		used in Windows System DLLs).  The function must take exactly
+		one parameter, either a character pointer or a long integer,
+		and must return a character pointer or NULL.  The character
+		pointer returned must point to memory that will remain valid
+		after the function has returned (e.g. in static data in the
+		DLL).  If it points to allocated memory, that memory will
+		leak away.  Using a static buffer in the function should work,
+		it's then freed when the DLL is unloaded.
 
-                WARNING: If the function returns a non-valid pointer, Vim may
-                crash!  This also happens if the function returns a number,
-                because Vim thinks it's a pointer.
-                For Win32 systems, {libname} should be the filename of the DLL
-                without the ".DLL" suffix.  A full path is only required if
-                the DLL is not in the usual places.
-                For Unix: When compiling your own plugins, remember that the
-                object code must be compiled as position-independent ('PIC').
-                Examples: >vim
-                        echo libcall("libc.so", "getenv", "HOME")
+		WARNING: If the function returns a non-valid pointer, Vim may
+		crash!	This also happens if the function returns a number,
+		because Vim thinks it's a pointer.
+		For Win32 systems, {libname} should be the filename of the DLL
+		without the ".DLL" suffix.  A full path is only required if
+		the DLL is not in the usual places.
+		For Unix: When compiling your own plugins, remember that the
+		object code must be compiled as position-independent ('PIC').
+		Examples: >vim
+			echo libcall("libc.so", "getenv", "HOME")
 
-libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
-                Just like |libcall()|, but used for a function that returns an
-                int instead of a string.
-                Examples: >vim
-                        echo libcallnr("/usr/lib/libc.so", "getpid", "")
-                        call libcallnr("libc.so", "printf", "Hello World!\n")
-                        call libcallnr("libc.so", "sleep", 10)
+libcallnr({libname}, {funcname}, {argument})			   *libcallnr()*
+		Just like |libcall()|, but used for a function that returns an
+		int instead of a string.
+		Examples: >vim
+			echo libcallnr("/usr/lib/libc.so", "getpid", "")
+			call libcallnr("libc.so", "printf", "Hello World!\n")
+			call libcallnr("libc.so", "sleep", 10)
 <
-line({expr} [, {winid}])                                                *line()*
-                The result is a Number, which is the line number of the file
-                position given with {expr}.  The {expr} argument is a string.
-                The accepted positions are:
-                    .       the cursor position
-                    $       the last line in the current buffer
-                    'x      position of mark x (if the mark is not set, 0 is
-                            returned)
-                    w0      first line visible in current window (one if the
-                            display isn't updated, e.g. in silent Ex mode)
-                    w$      last line visible in current window (this is one
-                            less than "w0" if no lines are visible)
-                    v       In Visual mode: the start of the Visual area (the
-                            cursor is the end).  When not in Visual mode
-                            returns the cursor position.  Differs from |'<| in
-                            that it's updated right away.
-                Note that a mark in another file can be used.  The line number
-                then applies to another buffer.
-                To get the column number use |col()|.  To get both use
-                |getpos()|.
-                With the optional {winid} argument the values are obtained for
-                that window instead of the current window.
-                Returns 0 for invalid values of {expr} and {winid}.
-                Examples: >vim
-                        echo line(".")                  " line number of the cursor
-                        echo line(".", winid)           " idem, in window "winid"
-                        echo line("'t")                 " line number of mark t
-                        echo line("'" .. marker)        " line number of mark marker
+line({expr} [, {winid}])						*line()*
+		The result is a Number, which is the line number of the file
+		position given with {expr}.  The {expr} argument is a string.
+		The accepted positions are:
+		    .	    the cursor position
+		    $	    the last line in the current buffer
+		    'x	    position of mark x (if the mark is not set, 0 is
+			    returned)
+		    w0	    first line visible in current window (one if the
+			    display isn't updated, e.g. in silent Ex mode)
+		    w$	    last line visible in current window (this is one
+			    less than "w0" if no lines are visible)
+		    v	    In Visual mode: the start of the Visual area (the
+			    cursor is the end).  When not in Visual mode
+			    returns the cursor position.  Differs from |'<| in
+			    that it's updated right away.
+		Note that a mark in another file can be used.  The line number
+		then applies to another buffer.
+		To get the column number use |col()|.  To get both use
+		|getpos()|.
+		With the optional {winid} argument the values are obtained for
+		that window instead of the current window.
+		Returns 0 for invalid values of {expr} and {winid}.
+		Examples: >vim
+			echo line(".")			" line number of the cursor
+			echo line(".", winid)		" idem, in window "winid"
+			echo line("'t")			" line number of mark t
+			echo line("'" .. marker)	" line number of mark marker
 <
-                To jump to the last known position when opening a file see
-                |last-position-jump|.
+		To jump to the last known position when opening a file see
+		|last-position-jump|.
 
-line2byte({lnum})                                                  *line2byte()*
-                Return the byte count from the start of the buffer for line
-                {lnum}.  This includes the end-of-line character, depending on
-                the 'fileformat' option for the current buffer.  The first
-                line returns 1. UTF-8 encoding is used, 'fileencoding' is
-                ignored.  This can also be used to get the byte count for the
-                line just below the last line: >vim
-                        echo line2byte(line("$") + 1)
-<                This is the buffer size plus one.  If 'fileencoding' is empty
-                it is the file size plus one.  {lnum} is used like with
-                |getline()|.  When {lnum} is invalid -1 is returned.
-                Also see |byte2line()|, |go| and |:goto|.
+line2byte({lnum})						   *line2byte()*
+		Return the byte count from the start of the buffer for line
+		{lnum}.  This includes the end-of-line character, depending on
+		the 'fileformat' option for the current buffer.  The first
+		line returns 1. UTF-8 encoding is used, 'fileencoding' is
+		ignored.  This can also be used to get the byte count for the
+		line just below the last line: >vim
+			echo line2byte(line("$") + 1)
+<		 This is the buffer size plus one.  If 'fileencoding' is empty
+		it is the file size plus one.  {lnum} is used like with
+		|getline()|.  When {lnum} is invalid -1 is returned.
+		Also see |byte2line()|, |go| and |:goto|.
 
-lispindent({lnum})                                                *lispindent()*
-                Get the amount of indent for line {lnum} according the lisp
-                indenting rules, as with 'lisp'.
-                The indent is counted in spaces, the value of 'tabstop' is
-                relevant.  {lnum} is used just like in |getline()|.
-                When {lnum} is invalid, -1 is returned.
+lispindent({lnum})						  *lispindent()*
+		Get the amount of indent for line {lnum} according the lisp
+		indenting rules, as with 'lisp'.
+		The indent is counted in spaces, the value of 'tabstop' is
+		relevant.  {lnum} is used just like in |getline()|.
+		When {lnum} is invalid, -1 is returned.
 
-list2blob({list})                                                  *list2blob()*
-                Return a Blob concatenating all the number values in {list}.
-                Examples: >vim
-                        echo list2blob([1, 2, 3, 4])    " returns 0z01020304
-                        echo list2blob([])              " returns 0z
-<                Returns an empty Blob on error.  If one of the numbers is
-                negative or more than 255 error *E1239* is given.
+list2blob({list})						   *list2blob()*
+		Return a Blob concatenating all the number values in {list}.
+		Examples: >vim
+			echo list2blob([1, 2, 3, 4])	" returns 0z01020304
+			echo list2blob([])		" returns 0z
+<		 Returns an empty Blob on error.  If one of the numbers is
+		negative or more than 255 error *E1239* is given.
 
-                |blob2list()| does the opposite.
+		|blob2list()| does the opposite.
 
-list2str({list} [, {utf8}])                                         *list2str()*
-                Convert each number in {list} to a character string can
-                concatenate them all.  Examples: >vim
-                        echo list2str([32])             " returns " "
-                        echo list2str([65, 66, 67])     " returns "ABC"
-<                The same can be done (slowly) with: >vim
-                        echo join(map(list, {nr, val -> nr2char(val)}), '')
-<                |str2list()| does the opposite.
+list2str({list} [, {utf8}])					    *list2str()*
+		Convert each number in {list} to a character string can
+		concatenate them all.  Examples: >vim
+			echo list2str([32])		" returns " "
+			echo list2str([65, 66, 67])	" returns "ABC"
+<		 The same can be done (slowly) with: >vim
+			echo join(map(list, {nr, val -> nr2char(val)}), '')
+<		 |str2list()| does the opposite.
 
-                UTF-8 encoding is always used, {utf8} option has no effect,
-                and exists only for backwards-compatibility.
-                With UTF-8 composing characters work as expected: >vim
-                        echo list2str([97, 769])        " returns "á"
+		UTF-8 encoding is always used, {utf8} option has no effect,
+		and exists only for backwards-compatibility.
+		With UTF-8 composing characters work as expected: >vim
+			echo list2str([97, 769])	" returns "á"
 <
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-localtime()                                                        *localtime()*
-                Return the current time, measured as seconds since 1st Jan
-                1970.  See also |strftime()|, |strptime()| and |getftime()|.
+localtime()							   *localtime()*
+		Return the current time, measured as seconds since 1st Jan
+		1970.  See also |strftime()|, |strptime()| and |getftime()|.
 
-log({expr})                                                              *log()*
-                Return the natural logarithm (base e) of {expr} as a |Float|.
-                {expr} must evaluate to a |Float| or a |Number| in the range
-                (0, inf].
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo log(10)
-<                        2.302585 >vim
-                        echo log(exp(5))
-<                        5.0
+log({expr})								 *log()*
+		Return the natural logarithm (base e) of {expr} as a |Float|.
+		{expr} must evaluate to a |Float| or a |Number| in the range
+		(0, inf].
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo log(10)
+<			 2.302585 >vim
+			echo log(exp(5))
+<			 5.0
 
-log10({expr})                                                          *log10()*
-                Return the logarithm of Float {expr} to base 10 as a |Float|.
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo log10(1000)
-<                        3.0 >vim
-                        echo log10(0.01)
-<                        -2.0
+log10({expr})							       *log10()*
+		Return the logarithm of Float {expr} to base 10 as a |Float|.
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo log10(1000)
+<			 3.0 >vim
+			echo log10(0.01)
+<			 -2.0
 
-luaeval({expr} [, {expr}])                                           *luaeval()*
-                Evaluate Lua expression {expr} and return its result converted
-                to Vim data structures. See |lua-eval| for more details.
+luaeval({expr} [, {expr}])					     *luaeval()*
+		Evaluate Lua expression {expr} and return its result converted
+		to Vim data structures. See |lua-eval| for more details.
 
-map({expr1}, {expr2})                                                    *map()*
-                {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
-                When {expr1} is a |List|| or |Dictionary|, replace each
-                item in {expr1} with the result of evaluating {expr2}.
-                For a |Blob| each byte is replaced.
-                For a |String|, each character, including composing
-                characters, is replaced.
-                If the item type changes you may want to use |mapnew()| to
-                create a new List or Dictionary.
+map({expr1}, {expr2})							 *map()*
+		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
+		When {expr1} is a |List|| or |Dictionary|, replace each
+		item in {expr1} with the result of evaluating {expr2}.
+		For a |Blob| each byte is replaced.
+		For a |String|, each character, including composing
+		characters, is replaced.
+		If the item type changes you may want to use |mapnew()| to
+		create a new List or Dictionary.
 
-                {expr2} must be a |String| or |Funcref|.
+		{expr2} must be a |String| or |Funcref|.
 
-                If {expr2} is a |String|, inside {expr2} |v:val| has the value
-                of the current item.  For a |Dictionary| |v:key| has the key
-                of the current item and for a |List| |v:key| has the index of
-                the current item.  For a |Blob| |v:key| has the index of the
-                current byte. For a |String| |v:key| has the index of the
-                current character.
-                Example: >vim
-                        call map(mylist, '"> " .. v:val .. " <"')
-<                This puts "> " before and " <" after each item in "mylist".
+		If {expr2} is a |String|, inside {expr2} |v:val| has the value
+		of the current item.  For a |Dictionary| |v:key| has the key
+		of the current item and for a |List| |v:key| has the index of
+		the current item.  For a |Blob| |v:key| has the index of the
+		current byte. For a |String| |v:key| has the index of the
+		current character.
+		Example: >vim
+			call map(mylist, '"> " .. v:val .. " <"')
+<		 This puts "> " before and " <" after each item in "mylist".
 
-                Note that {expr2} is the result of an expression and is then
-                used as an expression again.  Often it is good to use a
-                |literal-string| to avoid having to double backslashes.  You
-                still have to double ' quotes
+		Note that {expr2} is the result of an expression and is then
+		used as an expression again.  Often it is good to use a
+		|literal-string| to avoid having to double backslashes.  You
+		still have to double ' quotes
 
-                If {expr2} is a |Funcref| it is called with two arguments:
-                        1. The key or the index of the current item.
-                        2. the value of the current item.
-                The function must return the new value of the item. Example
-                that changes each value by "key-value": >vim
-                        func KeyValue(key, val)
-                          return a:key .. '-' .. a:val
-                        endfunc
-                        call map(myDict, function('KeyValue'))
-<                It is shorter when using a |lambda|: >vim
-                        call map(myDict, {key, val -> key .. '-' .. val})
-<                If you do not use "val" you can leave it out: >vim
-                        call map(myDict, {key -> 'item: ' .. key})
-<                If you do not use "key" you can use a short name: >vim
-                        call map(myDict, {_, val -> 'item: ' .. val})
+		If {expr2} is a |Funcref| it is called with two arguments:
+			1. The key or the index of the current item.
+			2. the value of the current item.
+		The function must return the new value of the item. Example
+		that changes each value by "key-value": >vim
+			func KeyValue(key, val)
+			  return a:key .. '-' .. a:val
+			endfunc
+			call map(myDict, function('KeyValue'))
+<		 It is shorter when using a |lambda|: >vim
+			call map(myDict, {key, val -> key .. '-' .. val})
+<		 If you do not use "val" you can leave it out: >vim
+			call map(myDict, {key -> 'item: ' .. key})
+<		 If you do not use "key" you can use a short name: >vim
+			call map(myDict, {_, val -> 'item: ' .. val})
 <
-                The operation is done in-place for a |List| and |Dictionary|.
-                If you want it to remain unmodified make a copy first: >vim
-                        let tlist = map(copy(mylist), ' v:val .. "\t"')
+		The operation is done in-place for a |List| and |Dictionary|.
+		If you want it to remain unmodified make a copy first: >vim
+			let tlist = map(copy(mylist), ' v:val .. "\t"')
 
-<                Returns {expr1}, the |List| or |Dictionary| that was filtered,
-                or a new |Blob| or |String|.
-                When an error is encountered while evaluating {expr2} no
-                further items in {expr1} are processed.
-                When {expr2} is a Funcref errors inside a function are ignored,
-                unless it was defined with the "abort" flag.
+<		 Returns {expr1}, the |List| or |Dictionary| that was filtered,
+		or a new |Blob| or |String|.
+		When an error is encountered while evaluating {expr2} no
+		further items in {expr1} are processed.
+		When {expr2} is a Funcref errors inside a function are ignored,
+		unless it was defined with the "abort" flag.
 
-maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
-                When {dict} is omitted or zero: Return the rhs of mapping
-                {name} in mode {mode}.  The returned String has special
-                characters translated like in the output of the ":map" command
-                listing. When {dict} is TRUE a dictionary is returned, see
-                below. To get a list of all mappings see |maplist()|.
+maparg({name} [, {mode} [, {abbr} [, {dict}]]])			      *maparg()*
+		When {dict} is omitted or zero: Return the rhs of mapping
+		{name} in mode {mode}.	The returned String has special
+		characters translated like in the output of the ":map" command
+		listing. When {dict} is TRUE a dictionary is returned, see
+		below. To get a list of all mappings see |maplist()|.
 
-                When there is no mapping for {name}, an empty String is
-                returned if {dict} is FALSE, otherwise returns an empty Dict.
-                When the mapping for {name} is empty, then "<Nop>" is
-                returned.
+		When there is no mapping for {name}, an empty String is
+		returned if {dict} is FALSE, otherwise returns an empty Dict.
+		When the mapping for {name} is empty, then "<Nop>" is
+		returned.
 
-                The {name} can have special key names, like in the ":map"
-                command.
+		The {name} can have special key names, like in the ":map"
+		command.
 
-                {mode} can be one of these strings:
-                        "n"     Normal
-                        "v"     Visual (including Select)
-                        "o"     Operator-pending
-                        "i"     Insert
-                        "c"     Cmd-line
-                        "s"     Select
-                        "x"     Visual
-                        "l"     langmap |language-mapping|
-                        "t"     Terminal
-                        ""      Normal, Visual and Operator-pending
-                When {mode} is omitted, the modes for "" are used.
+		{mode} can be one of these strings:
+			"n"	Normal
+			"v"	Visual (including Select)
+			"o"	Operator-pending
+			"i"	Insert
+			"c"	Cmd-line
+			"s"	Select
+			"x"	Visual
+			"l"	langmap |language-mapping|
+			"t"	Terminal
+			""	Normal, Visual and Operator-pending
+		When {mode} is omitted, the modes for "" are used.
 
-                When {abbr} is there and it is |TRUE| use abbreviations
-                instead of mappings.
+		When {abbr} is there and it is |TRUE| use abbreviations
+		instead of mappings.
 
-                When {dict} is there and it is |TRUE| return a dictionary
-                containing all the information of the mapping with the
-                following items:                        *mapping-dict*
-                  "lhs"      The {lhs} of the mapping as it would be typed
-                  "lhsraw"   The {lhs} of the mapping as raw bytes
-                  "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
-                              form, only present when it differs from "lhsraw"
-                  "rhs"      The {rhs} of the mapping as typed.
-                  "silent"   1 for a |:map-silent| mapping, else 0.
-                  "noremap"  1 if the {rhs} of the mapping is not remappable.
-                  "script"   1 if mapping was defined with <script>.
-                  "expr"     1 for an expression mapping (|:map-<expr>|).
-                  "buffer"   1 for a buffer local mapping (|:map-local|).
-                  "mode"     Modes for which the mapping is defined. In
-                             addition to the modes mentioned above, these
-                             characters will be used:
-                             " "     Normal, Visual and Operator-pending
-                             "!"     Insert and Commandline mode
-                                     (|mapmode-ic|)
-                  "sid"      The script local ID, used for <sid> mappings
-                             (|<SID>|).  Negative for special contexts.
-                  "scriptversion"  The version of the script, always 1.
-                  "lnum"     The line number in "sid", zero if unknown.
-                  "nowait"   Do not wait for other, longer mappings.
-                             (|:map-<nowait>|).
-                  "abbr"     True if this is an |abbreviation|.
-                  "mode_bits" Nvim's internal binary representation of "mode".
-                             |mapset()| ignores this; only "mode" is used.
-                             See |maplist()| for usage examples. The values
-                             are from src/nvim/state_defs.h and may change in
-                             the future.
+		When {dict} is there and it is |TRUE| return a dictionary
+		containing all the information of the mapping with the
+		following items:			*mapping-dict*
+		  "lhs"      The {lhs} of the mapping as it would be typed
+		  "lhsraw"   The {lhs} of the mapping as raw bytes
+		  "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
+			      form, only present when it differs from "lhsraw"
+		  "rhs"      The {rhs} of the mapping as typed.
+		  "silent"   1 for a |:map-silent| mapping, else 0.
+		  "noremap"  1 if the {rhs} of the mapping is not remappable.
+		  "script"   1 if mapping was defined with <script>.
+		  "expr"     1 for an expression mapping (|:map-<expr>|).
+		  "buffer"   1 for a buffer local mapping (|:map-local|).
+		  "mode"     Modes for which the mapping is defined. In
+			     addition to the modes mentioned above, these
+			     characters will be used:
+			     " "     Normal, Visual and Operator-pending
+			     "!"     Insert and Commandline mode
+				     (|mapmode-ic|)
+		  "sid"      The script local ID, used for <sid> mappings
+			     (|<SID>|).  Negative for special contexts.
+		  "scriptversion"  The version of the script, always 1.
+		  "lnum"     The line number in "sid", zero if unknown.
+		  "nowait"   Do not wait for other, longer mappings.
+			     (|:map-<nowait>|).
+		  "abbr"     True if this is an |abbreviation|.
+		  "mode_bits" Nvim's internal binary representation of "mode".
+			     |mapset()| ignores this; only "mode" is used.
+			     See |maplist()| for usage examples. The values
+			     are from src/nvim/state_defs.h and may change in
+			     the future.
 
-                The dictionary can be used to restore a mapping with
-                |mapset()|.
+		The dictionary can be used to restore a mapping with
+		|mapset()|.
 
-                The mappings local to the current buffer are checked first,
-                then the global mappings.
-                This function can be used to map a key even when it's already
-                mapped, and have it do the original mapping too.  Sketch: >vim
-                        exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+		The mappings local to the current buffer are checked first,
+		then the global mappings.
+		This function can be used to map a key even when it's already
+		mapped, and have it do the original mapping too.  Sketch: >vim
+			exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
-mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
-                Check if there is a mapping that matches with {name} in mode
-                {mode}.  See |maparg()| for {mode} and special names in
-                {name}.
-                When {abbr} is there and it is non-zero use abbreviations
-                instead of mappings.
-                A match happens with a mapping that starts with {name} and
-                with a mapping which is equal to the start of {name}.
+mapcheck({name} [, {mode} [, {abbr}]])				    *mapcheck()*
+		Check if there is a mapping that matches with {name} in mode
+		{mode}.  See |maparg()| for {mode} and special names in
+		{name}.
+		When {abbr} is there and it is non-zero use abbreviations
+		instead of mappings.
+		A match happens with a mapping that starts with {name} and
+		with a mapping which is equal to the start of {name}.
 
-                        matches mapping "a"     "ab"    "abc" ~
-                   mapcheck("a")        yes     yes      yes
-                   mapcheck("abc")      yes     yes      yes
-                   mapcheck("ax")       yes     no       no
-                   mapcheck("b")        no      no       no
+			matches mapping "a"	"ab"	"abc" ~
+		   mapcheck("a")	yes	yes	 yes
+		   mapcheck("abc")	yes	yes	 yes
+		   mapcheck("ax")	yes	no	 no
+		   mapcheck("b")	no	no	 no
 
-                The difference with maparg() is that mapcheck() finds a
-                mapping that matches with {name}, while maparg() only finds a
-                mapping for {name} exactly.
-                When there is no mapping that starts with {name}, an empty
-                String is returned.  If there is one, the RHS of that mapping
-                is returned.  If there are several mappings that start with
-                {name}, the RHS of one of them is returned.  This will be
-                "<Nop>" if the RHS is empty.
-                The mappings local to the current buffer are checked first,
-                then the global mappings.
-                This function can be used to check if a mapping can be added
-                without being ambiguous.  Example: >vim
-                        if mapcheck("_vv") == ""
-                           map _vv :set guifont=7x13<CR>
-                        endif
-<                This avoids adding the "_vv" mapping when there already is a
-                mapping for "_v" or for "_vvv".
+		The difference with maparg() is that mapcheck() finds a
+		mapping that matches with {name}, while maparg() only finds a
+		mapping for {name} exactly.
+		When there is no mapping that starts with {name}, an empty
+		String is returned.  If there is one, the RHS of that mapping
+		is returned.  If there are several mappings that start with
+		{name}, the RHS of one of them is returned.  This will be
+		"<Nop>" if the RHS is empty.
+		The mappings local to the current buffer are checked first,
+		then the global mappings.
+		This function can be used to check if a mapping can be added
+		without being ambiguous.  Example: >vim
+			if mapcheck("_vv") == ""
+			   map _vv :set guifont=7x13<CR>
+			endif
+<		 This avoids adding the "_vv" mapping when there already is a
+		mapping for "_v" or for "_vvv".
 
-maplist([{abbr}])                                                    *maplist()*
-                Returns a |List| of all mappings.  Each List item is a |Dict|,
-                the same as what is returned by |maparg()|, see
-                |mapping-dict|.  When {abbr} is there and it is |TRUE| use
-                abbreviations instead of mappings.
+maplist([{abbr}])						     *maplist()*
+		Returns a |List| of all mappings.  Each List item is a |Dict|,
+		the same as what is returned by |maparg()|, see
+		|mapping-dict|.  When {abbr} is there and it is |TRUE| use
+		abbreviations instead of mappings.
 
-                Example to show all mappings with "MultiMatch" in rhs: >vim
-                        echo maplist()->filter({_, m ->
-                                \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
-                                \ })
-<                It can be tricky to find mappings for particular |:map-modes|.
-                |mapping-dict|'s "mode_bits" can simplify this. For example,
-                the mode_bits for Normal, Insert or Command-line modes are
-                0x19. To find all the mappings available in those modes you
-                can do: >vim
-                        let saved_maps = []
-                        for m in maplist()
-                            if and(m.mode_bits, 0x19) != 0
-                                eval saved_maps->add(m)
-                            endif
-                        endfor
-                        echo saved_maps->mapnew({_, m -> m.lhs})
-<                The values of the mode_bits are defined in Nvim's
-                src/nvim/state_defs.h file and they can be discovered at
-                runtime using |:map-commands| and "maplist()". Example: >vim
-                        omap xyzzy <Nop>
-                        let op_bit = maplist()->filter(
-                            \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
-                        ounmap xyzzy
-                        echo printf("Operator-pending mode bit: 0x%x", op_bit)
+		Example to show all mappings with "MultiMatch" in rhs: >vim
+			echo maplist()->filter({_, m ->
+				\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
+				\ })
+<		 It can be tricky to find mappings for particular |:map-modes|.
+		|mapping-dict|'s "mode_bits" can simplify this. For example,
+		the mode_bits for Normal, Insert or Command-line modes are
+		0x19. To find all the mappings available in those modes you
+		can do: >vim
+			let saved_maps = []
+			for m in maplist()
+			    if and(m.mode_bits, 0x19) != 0
+				eval saved_maps->add(m)
+			    endif
+			endfor
+			echo saved_maps->mapnew({_, m -> m.lhs})
+<		 The values of the mode_bits are defined in Nvim's
+		src/nvim/state_defs.h file and they can be discovered at
+		runtime using |:map-commands| and "maplist()". Example: >vim
+			omap xyzzy <Nop>
+			let op_bit = maplist()->filter(
+			    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
+			ounmap xyzzy
+			echo printf("Operator-pending mode bit: 0x%x", op_bit)
 
-mapnew({expr1}, {expr2})                                              *mapnew()*
-                Like |map()| but instead of replacing items in {expr1} a new
-                List or Dictionary is created and returned.  {expr1} remains
-                unchanged.  Items can still be changed by {expr2}, if you
-                don't want that use |deepcopy()| first.
+mapnew({expr1}, {expr2})					      *mapnew()*
+		Like |map()| but instead of replacing items in {expr1} a new
+		List or Dictionary is created and returned.  {expr1} remains
+		unchanged.  Items can still be changed by {expr2}, if you
+		don't want that use |deepcopy()| first.
 
-mapset({mode}, {abbr}, {dict})                                        *mapset()*
-                Restore a mapping from a dictionary, possibly returned by
-                |maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
-                is true, is set on the current buffer; it is up to the caller
-                to ensure that the intended buffer is the current buffer. This
-                feature allows copying mappings from one buffer to another.
-                The dict.mode value may restore a single mapping that covers
-                more than one mode, like with mode values of '!', ' ', "nox",
-                or 'v'. *E1276*
+mapset({mode}, {abbr}, {dict})					      *mapset()*
+		Restore a mapping from a dictionary, possibly returned by
+		|maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
+		is true, is set on the current buffer; it is up to the caller
+		to ensure that the intended buffer is the current buffer. This
+		feature allows copying mappings from one buffer to another.
+		The dict.mode value may restore a single mapping that covers
+		more than one mode, like with mode values of '!', ' ', "nox",
+		or 'v'. *E1276*
 
-                In the first form, {mode} and {abbr} should be the same as
-                for the call to |maparg()|. *E460*
-                {mode} is used to define the mode in which the mapping is set,
-                not the "mode" entry in {dict}.
-                Example for saving and restoring a mapping: >vim
-                        let save_map = maparg('K', 'n', 0, 1)
-                        nnoremap K somethingelse
-                        " ...
-                        call mapset('n', 0, save_map)
-<                Note that if you are going to replace a map in several modes,
-                e.g. with `:map!`, you need to save/restore the mapping for
-                all of them, when they might differ.
+		In the first form, {mode} and {abbr} should be the same as
+		for the call to |maparg()|. *E460*
+		{mode} is used to define the mode in which the mapping is set,
+		not the "mode" entry in {dict}.
+		Example for saving and restoring a mapping: >vim
+			let save_map = maparg('K', 'n', 0, 1)
+			nnoremap K somethingelse
+			" ...
+			call mapset('n', 0, save_map)
+<		 Note that if you are going to replace a map in several modes,
+		e.g. with `:map!`, you need to save/restore the mapping for
+		all of them, when they might differ.
 
-                In the second form, with {dict} as the only argument, mode
-                and abbr are taken from the dict.
-                Example: >vim
-                        let save_maps = maplist()->filter(
-                                                \ {_, m -> m.lhs == 'K'})
-                        nnoremap K somethingelse
-                        cnoremap K somethingelse2
-                        " ...
-                        unmap K
-                        for d in save_maps
-                            call mapset(d)
-                        endfor
+		In the second form, with {dict} as the only argument, mode
+		and abbr are taken from the dict.
+		Example: >vim
+			let save_maps = maplist()->filter(
+						\ {_, m -> m.lhs == 'K'})
+			nnoremap K somethingelse
+			cnoremap K somethingelse2
+			" ...
+			unmap K
+			for d in save_maps
+			    call mapset(d)
+			endfor
 
-match({expr}, {pat} [, {start} [, {count}]])                           *match()*
-                When {expr} is a |List| then this returns the index of the
-                first item where {pat} matches.  Each item is used as a
-                String, |Lists| and |Dictionaries| are used as echoed.
+match({expr}, {pat} [, {start} [, {count}]])			       *match()*
+		When {expr} is a |List| then this returns the index of the
+		first item where {pat} matches.  Each item is used as a
+		String, |Lists| and |Dictionaries| are used as echoed.
 
-                Otherwise, {expr} is used as a String.  The result is a
-                Number, which gives the index (byte offset) in {expr} where
-                {pat} matches.
+		Otherwise, {expr} is used as a String.	The result is a
+		Number, which gives the index (byte offset) in {expr} where
+		{pat} matches.
 
-                A match at the first character or |List| item returns zero.
-                If there is no match -1 is returned.
+		A match at the first character or |List| item returns zero.
+		If there is no match -1 is returned.
 
-                For getting submatches see |matchlist()|.
-                Example: >vim
-                        echo match("testing", "ing")    " results in 4
-                        echo match([1, 'x'], '\a')      " results in 1
-<                See |string-match| for how {pat} is used.
-                                                                *strpbrk()*
-                Vim doesn't have a strpbrk() function.  But you can do: >vim
-                        let sepidx = match(line, '[.,;: \t]')
-<                                                               *strcasestr()*
-                Vim doesn't have a strcasestr() function.  But you can add
-                "\c" to the pattern to ignore case: >vim
-                        let idx = match(haystack, '\cneedle')
+		For getting submatches see |matchlist()|.
+		Example: >vim
+			echo match("testing", "ing")	" results in 4
+			echo match([1, 'x'], '\a')	" results in 1
+<		 See |string-match| for how {pat} is used.
+								*strpbrk()*
+		Vim doesn't have a strpbrk() function.	But you can do: >vim
+			let sepidx = match(line, '[.,;: \t]')
+<								*strcasestr()*
+		Vim doesn't have a strcasestr() function.  But you can add
+		"\c" to the pattern to ignore case: >vim
+			let idx = match(haystack, '\cneedle')
 <
-                If {start} is given, the search starts from byte index
-                {start} in a String or item {start} in a |List|.
-                The result, however, is still the index counted from the
-                first character/item.  Example: >vim
-                        echo match("testing", "ing", 2)
-<                result is again "4". >vim
-                        echo match("testing", "ing", 4)
-<                result is again "4". >vim
-                        echo match("testing", "t", 2)
-<                result is "3".
-                For a String, if {start} > 0 then it is like the string starts
-                {start} bytes later, thus "^" will match at {start}.  Except
-                when {count} is given, then it's like matches before the
-                {start} byte are ignored (this is a bit complicated to keep it
-                backwards compatible).
-                For a String, if {start} < 0, it will be set to 0.  For a list
-                the index is counted from the end.
-                If {start} is out of range ({start} > strlen({expr}) for a
-                String or {start} > len({expr}) for a |List|) -1 is returned.
+		If {start} is given, the search starts from byte index
+		{start} in a String or item {start} in a |List|.
+		The result, however, is still the index counted from the
+		first character/item.  Example: >vim
+			echo match("testing", "ing", 2)
+<		 result is again "4". >vim
+			echo match("testing", "ing", 4)
+<		 result is again "4". >vim
+			echo match("testing", "t", 2)
+<		 result is "3".
+		For a String, if {start} > 0 then it is like the string starts
+		{start} bytes later, thus "^" will match at {start}.  Except
+		when {count} is given, then it's like matches before the
+		{start} byte are ignored (this is a bit complicated to keep it
+		backwards compatible).
+		For a String, if {start} < 0, it will be set to 0.  For a list
+		the index is counted from the end.
+		If {start} is out of range ({start} > strlen({expr}) for a
+		String or {start} > len({expr}) for a |List|) -1 is returned.
 
-                When {count} is given use the {count}th match.  When a match
-                is found in a String the search for the next one starts one
-                character further.  Thus this example results in 1: >vim
-                        echo match("testing", "..", 0, 2)
-<                In a |List| the search continues in the next item.
-                Note that when {count} is added the way {start} works changes,
-                see above.
+		When {count} is given use the {count}th match.	When a match
+		is found in a String the search for the next one starts one
+		character further.  Thus this example results in 1: >vim
+			echo match("testing", "..", 0, 2)
+<		 In a |List| the search continues in the next item.
+		Note that when {count} is added the way {start} works changes,
+		see above.
 
-                See |pattern| for the patterns that are accepted.
-                The 'ignorecase' option is used to set the ignore-caseness of
-                the pattern.  'smartcase' is NOT used.  The matching is always
-                done like 'magic' is set and 'cpoptions' is empty.
-                Note that a match at the start is preferred, thus when the
-                pattern is using "*" (any number of matches) it tends to find
-                zero matches at the start instead of a number of matches
-                further down in the text.
+		See |pattern| for the patterns that are accepted.
+		The 'ignorecase' option is used to set the ignore-caseness of
+		the pattern.  'smartcase' is NOT used.	The matching is always
+		done like 'magic' is set and 'cpoptions' is empty.
+		Note that a match at the start is preferred, thus when the
+		pattern is using "*" (any number of matches) it tends to find
+		zero matches at the start instead of a number of matches
+		further down in the text.
 
-                                                *matchadd()* *E798* *E799* *E801* *E957*
+						*matchadd()* *E798* *E799* *E801* *E957*
 matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
-                Defines a pattern to be highlighted in the current window (a
-                "match").  It will be highlighted with {group}.  Returns an
-                identification number (ID), which can be used to delete the
-                match using |matchdelete()|.  The ID is bound to the window.
-                Matching is case sensitive and magic, unless case sensitivity
-                or magicness are explicitly overridden in {pattern}.  The
-                'magic', 'smartcase' and 'ignorecase' options are not used.
-                The "Conceal" value is special, it causes the match to be
-                concealed.
+		Defines a pattern to be highlighted in the current window (a
+		"match").  It will be highlighted with {group}.  Returns an
+		identification number (ID), which can be used to delete the
+		match using |matchdelete()|.  The ID is bound to the window.
+		Matching is case sensitive and magic, unless case sensitivity
+		or magicness are explicitly overridden in {pattern}.  The
+		'magic', 'smartcase' and 'ignorecase' options are not used.
+		The "Conceal" value is special, it causes the match to be
+		concealed.
 
-                The optional {priority} argument assigns a priority to the
-                match.  A match with a high priority will have its
-                highlighting overrule that of a match with a lower priority.
-                A priority is specified as an integer (negative numbers are no
-                exception).  If the {priority} argument is not specified, the
-                default priority is 10.  The priority of 'hlsearch' is zero,
-                hence all matches with a priority greater than zero will
-                overrule it.  Syntax highlighting (see 'syntax') is a separate
-                mechanism, and regardless of the chosen priority a match will
-                always overrule syntax highlighting.
+		The optional {priority} argument assigns a priority to the
+		match.	A match with a high priority will have its
+		highlighting overrule that of a match with a lower priority.
+		A priority is specified as an integer (negative numbers are no
+		exception).  If the {priority} argument is not specified, the
+		default priority is 10.  The priority of 'hlsearch' is zero,
+		hence all matches with a priority greater than zero will
+		overrule it.  Syntax highlighting (see 'syntax') is a separate
+		mechanism, and regardless of the chosen priority a match will
+		always overrule syntax highlighting.
 
-                The optional {id} argument allows the request for a specific
-                match ID.  If a specified ID is already taken, an error
-                message will appear and the match will not be added.  An ID
-                is specified as a positive integer (zero excluded).  IDs 1, 2
-                and 3 are reserved for |:match|, |:2match| and |:3match|,
-                respectively.  3 is reserved for use by the |matchparen|
-                plugin.
-                If the {id} argument is not specified or -1, |matchadd()|
-                automatically chooses a free ID, which is at least 1000.
+		The optional {id} argument allows the request for a specific
+		match ID.  If a specified ID is already taken, an error
+		message will appear and the match will not be added.  An ID
+		is specified as a positive integer (zero excluded).  IDs 1, 2
+		and 3 are reserved for |:match|, |:2match| and |:3match|,
+		respectively.  3 is reserved for use by the |matchparen|
+		plugin.
+		If the {id} argument is not specified or -1, |matchadd()|
+		automatically chooses a free ID, which is at least 1000.
 
-                The optional {dict} argument allows for further custom
-                values. Currently this is used to specify a match specific
-                conceal character that will be shown for |hl-Conceal|
-                highlighted matches. The dict can have the following members:
+		The optional {dict} argument allows for further custom
+		values. Currently this is used to specify a match specific
+		conceal character that will be shown for |hl-Conceal|
+		highlighted matches. The dict can have the following members:
 
-                        conceal     Special character to show instead of the
-                                    match (only for |hl-Conceal| highlighted
-                                    matches, see |:syn-cchar|)
-                        window      Instead of the current window use the
-                                    window with this number or window ID.
+			conceal     Special character to show instead of the
+				    match (only for |hl-Conceal| highlighted
+				    matches, see |:syn-cchar|)
+			window	    Instead of the current window use the
+				    window with this number or window ID.
 
-                The number of matches is not limited, as it is the case with
-                the |:match| commands.
+		The number of matches is not limited, as it is the case with
+		the |:match| commands.
 
-                Returns -1 on error.
+		Returns -1 on error.
 
-                Example: >vim
-                        highlight MyGroup ctermbg=green guibg=green
-                        let m = matchadd("MyGroup", "TODO")
-<                Deletion of the pattern: >vim
-                        call matchdelete(m)
+		Example: >vim
+			highlight MyGroup ctermbg=green guibg=green
+			let m = matchadd("MyGroup", "TODO")
+<		 Deletion of the pattern: >vim
+			call matchdelete(m)
 
-<                A list of matches defined by |matchadd()| and |:match| are
-                available from |getmatches()|.  All matches can be deleted in
-                one operation by |clearmatches()|.
+<		 A list of matches defined by |matchadd()| and |:match| are
+		available from |getmatches()|.	All matches can be deleted in
+		one operation by |clearmatches()|.
 
-matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
-                Same as |matchadd()|, but requires a list of positions {pos}
-                instead of a pattern. This command is faster than |matchadd()|
-                because it does not require to handle regular expressions and
-                sets buffer line boundaries to redraw screen. It is supposed
-                to be used when fast match additions and deletions are
-                required, for example to highlight matching parentheses.
-                                                        *E5030* *E5031*
-                {pos} is a list of positions.  Each position can be one of
-                these:
-                - A number.  This whole line will be highlighted.  The first
-                  line has number 1.
-                - A list with one number, e.g., [23]. The whole line with this
-                  number will be highlighted.
-                - A list with two numbers, e.g., [23, 11]. The first number is
-                  the line number, the second one is the column number (first
-                  column is 1, the value must correspond to the byte index as
-                  |col()| would return).  The character at this position will
-                  be highlighted.
-                - A list with three numbers, e.g., [23, 11, 3]. As above, but
-                  the third number gives the length of the highlight in bytes.
+matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])	 *matchaddpos()*
+		Same as |matchadd()|, but requires a list of positions {pos}
+		instead of a pattern. This command is faster than |matchadd()|
+		because it does not require to handle regular expressions and
+		sets buffer line boundaries to redraw screen. It is supposed
+		to be used when fast match additions and deletions are
+		required, for example to highlight matching parentheses.
+							*E5030* *E5031*
+		{pos} is a list of positions.  Each position can be one of
+		these:
+		- A number.  This whole line will be highlighted.  The first
+		  line has number 1.
+		- A list with one number, e.g., [23]. The whole line with this
+		  number will be highlighted.
+		- A list with two numbers, e.g., [23, 11]. The first number is
+		  the line number, the second one is the column number (first
+		  column is 1, the value must correspond to the byte index as
+		  |col()| would return).  The character at this position will
+		  be highlighted.
+		- A list with three numbers, e.g., [23, 11, 3]. As above, but
+		  the third number gives the length of the highlight in bytes.
 
-                Entries with zero and negative line numbers are silently
-                ignored, as well as entries with negative column numbers and
-                lengths.
+		Entries with zero and negative line numbers are silently
+		ignored, as well as entries with negative column numbers and
+		lengths.
 
-                Returns -1 on error.
+		Returns -1 on error.
 
-                Example: >vim
-                        highlight MyGroup ctermbg=green guibg=green
-                        let m = matchaddpos("MyGroup", [[23, 24], 34])
-<                Deletion of the pattern: >vim
-                        call matchdelete(m)
+		Example: >vim
+			highlight MyGroup ctermbg=green guibg=green
+			let m = matchaddpos("MyGroup", [[23, 24], 34])
+<		 Deletion of the pattern: >vim
+			call matchdelete(m)
 
-<                Matches added by |matchaddpos()| are returned by
-                |getmatches()|.
+<		 Matches added by |matchaddpos()| are returned by
+		|getmatches()|.
 
-matcharg({nr})                                                      *matcharg()*
-                Selects the {nr} match item, as set with a |:match|,
-                |:2match| or |:3match| command.
-                Return a |List| with two elements:
-                        The name of the highlight group used
-                        The pattern used.
-                When {nr} is not 1, 2 or 3 returns an empty |List|.
-                When there is no match item set returns ['', ''].
-                This is useful to save and restore a |:match|.
-                Highlighting matches using the |:match| commands are limited
-                to three matches. |matchadd()| does not have this limitation.
+matcharg({nr})							    *matcharg()*
+		Selects the {nr} match item, as set with a |:match|,
+		|:2match| or |:3match| command.
+		Return a |List| with two elements:
+			The name of the highlight group used
+			The pattern used.
+		When {nr} is not 1, 2 or 3 returns an empty |List|.
+		When there is no match item set returns ['', ''].
+		This is useful to save and restore a |:match|.
+		Highlighting matches using the |:match| commands are limited
+		to three matches. |matchadd()| does not have this limitation.
 
-matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E803*
-                Deletes a match with ID {id} previously defined by |matchadd()|
-                or one of the |:match| commands.  Returns 0 if successful,
-                otherwise -1.  See example for |matchadd()|.  All matches can
-                be deleted in one operation by |clearmatches()|.
-                If {win} is specified, use the window with this number or
-                window ID instead of the current window.
+matchdelete({id} [, {win}])			       *matchdelete()* *E802* *E803*
+		Deletes a match with ID {id} previously defined by |matchadd()|
+		or one of the |:match| commands.  Returns 0 if successful,
+		otherwise -1.  See example for |matchadd()|.  All matches can
+		be deleted in one operation by |clearmatches()|.
+		If {win} is specified, use the window with this number or
+		window ID instead of the current window.
 
-matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
-                Same as |match()|, but return the index of first character
-                after the match.  Example: >vim
-                        echo matchend("testing", "ing")
-<                results in "7".
-                                                        *strspn()* *strcspn()*
-                Vim doesn't have a strspn() or strcspn() function, but you can
-                do it with matchend(): >vim
-                        let span = matchend(line, '[a-zA-Z]')
-                        let span = matchend(line, '[^a-zA-Z]')
-<                Except that -1 is returned when there are no matches.
+matchend({expr}, {pat} [, {start} [, {count}]])			    *matchend()*
+		Same as |match()|, but return the index of first character
+		after the match.  Example: >vim
+			echo matchend("testing", "ing")
+<		 results in "7".
+							*strspn()* *strcspn()*
+		Vim doesn't have a strspn() or strcspn() function, but you can
+		do it with matchend(): >vim
+			let span = matchend(line, '[a-zA-Z]')
+			let span = matchend(line, '[^a-zA-Z]')
+<		 Except that -1 is returned when there are no matches.
 
-                The {start}, if given, has the same meaning as for |match()|. >vim
-                        echo matchend("testing", "ing", 2)
-<                results in "7". >vim
-                        echo matchend("testing", "ing", 5)
-<                result is "-1".
-                When {expr} is a |List| the result is equal to |match()|.
+		The {start}, if given, has the same meaning as for |match()|. >vim
+			echo matchend("testing", "ing", 2)
+<		 results in "7". >vim
+			echo matchend("testing", "ing", 5)
+<		 result is "-1".
+		When {expr} is a |List| the result is equal to |match()|.
 
-matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
-                If {list} is a list of strings, then returns a |List| with all
-                the strings in {list} that fuzzy match {str}. The strings in
-                the returned list are sorted based on the matching score.
+matchfuzzy({list}, {str} [, {dict}])				  *matchfuzzy()*
+		If {list} is a list of strings, then returns a |List| with all
+		the strings in {list} that fuzzy match {str}. The strings in
+		the returned list are sorted based on the matching score.
 
-                The optional {dict} argument always supports the following
-                items:
-                    matchseq    When this item is present return only matches
-                                that contain the characters in {str} in the
-                                given sequence.
-                    limit       Maximum number of matches in {list} to be
-                                returned.  Zero means no limit.
+		The optional {dict} argument always supports the following
+		items:
+		    matchseq	When this item is present return only matches
+				that contain the characters in {str} in the
+				given sequence.
+		    limit	Maximum number of matches in {list} to be
+				returned.  Zero means no limit.
 
-                If {list} is a list of dictionaries, then the optional {dict}
-                argument supports the following additional items:
-                    key         Key of the item which is fuzzy matched against
-                                {str}. The value of this item should be a
-                                string.
-                    text_cb     |Funcref| that will be called for every item
-                                in {list} to get the text for fuzzy matching.
-                                This should accept a dictionary item as the
-                                argument and return the text for that item to
-                                use for fuzzy matching.
+		If {list} is a list of dictionaries, then the optional {dict}
+		argument supports the following additional items:
+		    key		Key of the item which is fuzzy matched against
+				{str}. The value of this item should be a
+				string.
+		    text_cb	|Funcref| that will be called for every item
+				in {list} to get the text for fuzzy matching.
+				This should accept a dictionary item as the
+				argument and return the text for that item to
+				use for fuzzy matching.
 
-                {str} is treated as a literal string and regular expression
-                matching is NOT supported.  The maximum supported {str} length
-                is 256.
+		{str} is treated as a literal string and regular expression
+		matching is NOT supported.  The maximum supported {str} length
+		is 256.
 
-                When {str} has multiple words each separated by white space,
-                then the list of strings that have all the words is returned.
+		When {str} has multiple words each separated by white space,
+		then the list of strings that have all the words is returned.
 
-                If there are no matching strings or there is an error, then an
-                empty list is returned. If length of {str} is greater than
-                256, then returns an empty list.
+		If there are no matching strings or there is an error, then an
+		empty list is returned. If length of {str} is greater than
+		256, then returns an empty list.
 
-                When {limit} is given, matchfuzzy() will find up to this
-                number of matches in {list} and return them in sorted order.
+		When {limit} is given, matchfuzzy() will find up to this
+		number of matches in {list} and return them in sorted order.
 
-                Refer to |fuzzy-matching| for more information about fuzzy
-                matching strings.
+		Refer to |fuzzy-matching| for more information about fuzzy
+		matching strings.
 
-                Example: >vim
-                   echo matchfuzzy(["clay", "crow"], "cay")
-<                results in ["clay"]. >vim
-                   echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
-<                results in a list of buffer names fuzzy matching "ndl". >vim
-                   echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
-<                results in a list of buffer information dicts with buffer
-                names fuzzy matching "ndl". >vim
-                   echo getbufinfo()->matchfuzzy("spl",
-                                                \ {'text_cb' : {v -> v.name}})
-<                results in a list of buffer information dicts with buffer
-                names fuzzy matching "spl". >vim
-                   echo v:oldfiles->matchfuzzy("test")
-<                results in a list of file names fuzzy matching "test". >vim
-                   let l = readfile("buffer.c")->matchfuzzy("str")
-<                results in a list of lines in "buffer.c" fuzzy matching "str". >vim
-                   echo ['one two', 'two one']->matchfuzzy('two one')
-<                results in `['two one', 'one two']` . >vim
-                   echo ['one two', 'two one']->matchfuzzy('two one',
-                                                \ {'matchseq': 1})
-<                results in `['two one']`.
+		Example: >vim
+		   echo matchfuzzy(["clay", "crow"], "cay")
+<		 results in ["clay"]. >vim
+		   echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
+<		 results in a list of buffer names fuzzy matching "ndl". >vim
+		   echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
+<		 results in a list of buffer information dicts with buffer
+		names fuzzy matching "ndl". >vim
+		   echo getbufinfo()->matchfuzzy("spl",
+						\ {'text_cb' : {v -> v.name}})
+<		 results in a list of buffer information dicts with buffer
+		names fuzzy matching "spl". >vim
+		   echo v:oldfiles->matchfuzzy("test")
+<		 results in a list of file names fuzzy matching "test". >vim
+		   let l = readfile("buffer.c")->matchfuzzy("str")
+<		 results in a list of lines in "buffer.c" fuzzy matching "str". >vim
+		   echo ['one two', 'two one']->matchfuzzy('two one')
+<		 results in `['two one', 'one two']` . >vim
+		   echo ['one two', 'two one']->matchfuzzy('two one',
+						\ {'matchseq': 1})
+<		 results in `['two one']`.
 
-matchfuzzypos({list}, {str} [, {dict}])                        *matchfuzzypos()*
-                Same as |matchfuzzy()|, but returns the list of matched
-                strings, the list of character positions where characters
-                in {str} matches and a list of matching scores.  You can
-                use |byteidx()| to convert a character position to a byte
-                position.
+matchfuzzypos({list}, {str} [, {dict}])			       *matchfuzzypos()*
+		Same as |matchfuzzy()|, but returns the list of matched
+		strings, the list of character positions where characters
+		in {str} matches and a list of matching scores.  You can
+		use |byteidx()| to convert a character position to a byte
+		position.
 
-                If {str} matches multiple times in a string, then only the
-                positions for the best match is returned.
+		If {str} matches multiple times in a string, then only the
+		positions for the best match is returned.
 
-                If there are no matching strings or there is an error, then a
-                list with three empty list items is returned.
+		If there are no matching strings or there is an error, then a
+		list with three empty list items is returned.
 
-                Example: >vim
-                        echo matchfuzzypos(['testing'], 'tsg')
-<                results in [["testing"], [[0, 2, 6]], [99]] >vim
-                        echo matchfuzzypos(['clay', 'lacy'], 'la')
-<                results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
-                        echo [{'text': 'hello', 'id' : 10}]
-                                \ ->matchfuzzypos('ll', {'key' : 'text'})
-<                results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
+		Example: >vim
+			echo matchfuzzypos(['testing'], 'tsg')
+<		 results in [["testing"], [[0, 2, 6]], [99]] >vim
+			echo matchfuzzypos(['clay', 'lacy'], 'la')
+<		 results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
+			echo [{'text': 'hello', 'id' : 10}]
+				\ ->matchfuzzypos('ll', {'key' : 'text'})
+<		 results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 
-matchlist({expr}, {pat} [, {start} [, {count}]])                   *matchlist()*
-                Same as |match()|, but return a |List|.  The first item in the
-                list is the matched string, same as what matchstr() would
-                return.  Following items are submatches, like "\1", "\2", etc.
-                in |:substitute|.  When an optional submatch didn't match an
-                empty string is used.  Example: >vim
-                        echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
-<                Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
-                When there is no match an empty list is returned.
+matchlist({expr}, {pat} [, {start} [, {count}]])		   *matchlist()*
+		Same as |match()|, but return a |List|.  The first item in the
+		list is the matched string, same as what matchstr() would
+		return.  Following items are submatches, like "\1", "\2", etc.
+		in |:substitute|.  When an optional submatch didn't match an
+		empty string is used.  Example: >vim
+			echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
+<		 Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
+		When there is no match an empty list is returned.
 
-                You can pass in a List, but that is not very useful.
+		You can pass in a List, but that is not very useful.
 
-matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
-                Same as |match()|, but return the matched string.  Example: >vim
-                        echo matchstr("testing", "ing")
-<                results in "ing".
-                When there is no match "" is returned.
-                The {start}, if given, has the same meaning as for |match()|. >vim
-                        echo matchstr("testing", "ing", 2)
-<                results in "ing". >vim
-                        echo matchstr("testing", "ing", 5)
-<                result is "".
-                When {expr} is a |List| then the matching item is returned.
-                The type isn't changed, it's not necessarily a String.
+matchstr({expr}, {pat} [, {start} [, {count}]])			    *matchstr()*
+		Same as |match()|, but return the matched string.  Example: >vim
+			echo matchstr("testing", "ing")
+<		 results in "ing".
+		When there is no match "" is returned.
+		The {start}, if given, has the same meaning as for |match()|. >vim
+			echo matchstr("testing", "ing", 2)
+<		 results in "ing". >vim
+			echo matchstr("testing", "ing", 5)
+<		 result is "".
+		When {expr} is a |List| then the matching item is returned.
+		The type isn't changed, it's not necessarily a String.
 
-matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
-                Same as |matchstr()|, but return the matched string, the start
-                position and the end position of the match.  Example: >vim
-                        echo matchstrpos("testing", "ing")
-<                results in ["ing", 4, 7].
-                When there is no match ["", -1, -1] is returned.
-                The {start}, if given, has the same meaning as for |match()|. >vim
-                        echo matchstrpos("testing", "ing", 2)
-<                results in ["ing", 4, 7]. >vim
-                        echo matchstrpos("testing", "ing", 5)
-<                result is ["", -1, -1].
-                When {expr} is a |List| then the matching item, the index
-                of first item where {pat} matches, the start position and the
-                end position of the match are returned. >vim
-                        echo matchstrpos([1, '__x'], '\a')
-<                result is ["x", 1, 2, 3].
-                The type isn't changed, it's not necessarily a String.
+matchstrpos({expr}, {pat} [, {start} [, {count}]])		 *matchstrpos()*
+		Same as |matchstr()|, but return the matched string, the start
+		position and the end position of the match.  Example: >vim
+			echo matchstrpos("testing", "ing")
+<		 results in ["ing", 4, 7].
+		When there is no match ["", -1, -1] is returned.
+		The {start}, if given, has the same meaning as for |match()|. >vim
+			echo matchstrpos("testing", "ing", 2)
+<		 results in ["ing", 4, 7]. >vim
+			echo matchstrpos("testing", "ing", 5)
+<		 result is ["", -1, -1].
+		When {expr} is a |List| then the matching item, the index
+		of first item where {pat} matches, the start position and the
+		end position of the match are returned. >vim
+			echo matchstrpos([1, '__x'], '\a')
+<		 result is ["x", 1, 2, 3].
+		The type isn't changed, it's not necessarily a String.
 
-max({expr})                                                              *max()*
-                Return the maximum value of all items in {expr}. Example: >vim
-                        echo max([apples, pears, oranges])
+max({expr})								 *max()*
+		Return the maximum value of all items in {expr}. Example: >vim
+			echo max([apples, pears, oranges])
 
-<                {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
-                it returns the maximum of all values in the Dictionary.
-                If {expr} is neither a List nor a Dictionary, or one of the
-                items in {expr} cannot be used as a Number this results in
-                                an error.  An empty |List| or |Dictionary| results in zero.
+<		 {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+		it returns the maximum of all values in the Dictionary.
+		If {expr} is neither a List nor a Dictionary, or one of the
+		items in {expr} cannot be used as a Number this results in
+				an error.  An empty |List| or |Dictionary| results in zero.
 
-menu_get({path} [, {modes}])                                        *menu_get()*
-                Returns a |List| of |Dictionaries| describing |menus| (defined
-                by |:menu|, |:amenu|, …), including |hidden-menus|.
+menu_get({path} [, {modes}])					    *menu_get()*
+		Returns a |List| of |Dictionaries| describing |menus| (defined
+		by |:menu|, |:amenu|, …), including |hidden-menus|.
 
-                {path} matches a menu by name, or all menus if {path} is an
-                empty string.  Example: >vim
-                        echo menu_get('File','')
-                        echo menu_get('')
+		{path} matches a menu by name, or all menus if {path} is an
+		empty string.  Example: >vim
+			echo menu_get('File','')
+			echo menu_get('')
 <
-                {modes} is a string of zero or more modes (see |maparg()| or
-                |creating-menus| for the list of modes). "a" means "all".
+		{modes} is a string of zero or more modes (see |maparg()| or
+		|creating-menus| for the list of modes). "a" means "all".
 
-                Example: >vim
-                        nnoremenu &Test.Test inormal
-                        inoremenu Test.Test insert
-                        vnoremenu Test.Test x
-                        echo menu_get("")
+		Example: >vim
+			nnoremenu &Test.Test inormal
+			inoremenu Test.Test insert
+			vnoremenu Test.Test x
+			echo menu_get("")
 
-<                returns something like this: >
+<		 returns something like this: >
 
-                        [ {
-                          "hidden": 0,
-                          "name": "Test",
-                          "priority": 500,
-                          "shortcut": 84,
-                          "submenus": [ {
-                            "hidden": 0,
-                            "mappings": {
-                              i": {
-                                "enabled": 1,
-                                "noremap": 1,
-                                "rhs": "insert",
-                                "sid": 1,
-                                "silent": 0
-                              },
-                              n": { ... },
-                              s": { ... },
-                              v": { ... }
-                            },
-                            "name": "Test",
-                            "priority": 500,
-                            "shortcut": 0
-                          } ]
-                        } ]
+			[ {
+			  "hidden": 0,
+			  "name": "Test",
+			  "priority": 500,
+			  "shortcut": 84,
+			  "submenus": [ {
+			    "hidden": 0,
+			    "mappings": {
+			      i": {
+				"enabled": 1,
+				"noremap": 1,
+				"rhs": "insert",
+				"sid": 1,
+				"silent": 0
+			      },
+			      n": { ... },
+			      s": { ... },
+			      v": { ... }
+			    },
+			    "name": "Test",
+			    "priority": 500,
+			    "shortcut": 0
+			  } ]
+			} ]
 <
-menu_info({name} [, {mode}])                                       *menu_info()*
-                Return information about the specified menu {name} in
-                mode {mode}. The menu name should be specified without the
-                shortcut character ('&'). If {name} is "", then the top-level
-                menu names are returned.
+menu_info({name} [, {mode}])					   *menu_info()*
+		Return information about the specified menu {name} in
+		mode {mode}. The menu name should be specified without the
+		shortcut character ('&'). If {name} is "", then the top-level
+		menu names are returned.
 
-                {mode} can be one of these strings:
-                        "n"     Normal
-                        "v"     Visual (including Select)
-                        "o"     Operator-pending
-                        "i"     Insert
-                        "c"     Cmd-line
-                        "s"     Select
-                        "x"     Visual
-                        "t"     Terminal-Job
-                        ""      Normal, Visual and Operator-pending
-                        "!"     Insert and Cmd-line
-                When {mode} is omitted, the modes for "" are used.
+		{mode} can be one of these strings:
+			"n"	Normal
+			"v"	Visual (including Select)
+			"o"	Operator-pending
+			"i"	Insert
+			"c"	Cmd-line
+			"s"	Select
+			"x"	Visual
+			"t"	Terminal-Job
+			""	Normal, Visual and Operator-pending
+			"!"	Insert and Cmd-line
+		When {mode} is omitted, the modes for "" are used.
 
-                Returns a |Dictionary| containing the following items:
-                  accel         menu item accelerator text |menu-text|
-                  display       display name (name without '&')
-                  enabled       v:true if this menu item is enabled
-                                Refer to |:menu-enable|
-                  icon          name of the icon file (for toolbar)
-                                |toolbar-icon|
-                  iconidx       index of a built-in icon
-                  modes         modes for which the menu is defined. In
-                                addition to the modes mentioned above, these
-                                characters will be used:
-                                " "     Normal, Visual and Operator-pending
-                  name          menu item name.
-                  noremenu      v:true if the {rhs} of the menu item is not
-                                remappable else v:false.
-                  priority      menu order priority |menu-priority|
-                  rhs           right-hand-side of the menu item. The returned
-                                string has special characters translated like
-                                in the output of the ":menu" command listing.
-                                When the {rhs} of a menu item is empty, then
-                                "<Nop>" is returned.
-                  script        v:true if script-local remapping of {rhs} is
-                                allowed else v:false.  See |:menu-script|.
-                  shortcut      shortcut key (character after '&' in
-                                the menu name) |menu-shortcut|
-                  silent        v:true if the menu item is created
-                                with <silent> argument |:menu-silent|
-                  submenus      |List| containing the names of
-                                all the submenus.  Present only if the menu
-                                item has submenus.
+		Returns a |Dictionary| containing the following items:
+		  accel		menu item accelerator text |menu-text|
+		  display	display name (name without '&')
+		  enabled	v:true if this menu item is enabled
+				Refer to |:menu-enable|
+		  icon		name of the icon file (for toolbar)
+				|toolbar-icon|
+		  iconidx	index of a built-in icon
+		  modes		modes for which the menu is defined. In
+				addition to the modes mentioned above, these
+				characters will be used:
+				" "	Normal, Visual and Operator-pending
+		  name		menu item name.
+		  noremenu	v:true if the {rhs} of the menu item is not
+				remappable else v:false.
+		  priority	menu order priority |menu-priority|
+		  rhs		right-hand-side of the menu item. The returned
+				string has special characters translated like
+				in the output of the ":menu" command listing.
+				When the {rhs} of a menu item is empty, then
+				"<Nop>" is returned.
+		  script	v:true if script-local remapping of {rhs} is
+				allowed else v:false.  See |:menu-script|.
+		  shortcut	shortcut key (character after '&' in
+				the menu name) |menu-shortcut|
+		  silent	v:true if the menu item is created
+				with <silent> argument |:menu-silent|
+		  submenus	|List| containing the names of
+				all the submenus.  Present only if the menu
+				item has submenus.
 
-                Returns an empty dictionary if the menu item is not found.
+		Returns an empty dictionary if the menu item is not found.
 
-                Examples: >vim
-                        echo menu_info('Edit.Cut')
-                        echo menu_info('File.Save', 'n')
+		Examples: >vim
+			echo menu_info('Edit.Cut')
+			echo menu_info('File.Save', 'n')
 
-                        " Display the entire menu hierarchy in a buffer
-                        func ShowMenu(name, pfx)
-                          let m = menu_info(a:name)
-                          call append(line('$'), a:pfx .. m.display)
-                          for child in m->get('submenus', [])
-                            call ShowMenu(a:name .. '.' .. escape(child, '.'),
-                                                        \ a:pfx .. '    ')
-                          endfor
-                        endfunc
-                        new
-                        for topmenu in menu_info('').submenus
-                          call ShowMenu(topmenu, '')
-                        endfor
+			" Display the entire menu hierarchy in a buffer
+			func ShowMenu(name, pfx)
+			  let m = menu_info(a:name)
+			  call append(line('$'), a:pfx .. m.display)
+			  for child in m->get('submenus', [])
+			    call ShowMenu(a:name .. '.' .. escape(child, '.'),
+							\ a:pfx .. '	')
+			  endfor
+			endfunc
+			new
+			for topmenu in menu_info('').submenus
+			  call ShowMenu(topmenu, '')
+			endfor
 <
-min({expr})                                                              *min()*
-                Return the minimum value of all items in {expr}. Example: >vim
-                        echo min([apples, pears, oranges])
+min({expr})								 *min()*
+		Return the minimum value of all items in {expr}. Example: >vim
+			echo min([apples, pears, oranges])
 
-<                {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
-                it returns the minimum of all values in the Dictionary.
-                If {expr} is neither a List nor a Dictionary, or one of the
-                items in {expr} cannot be used as a Number this results in
-                an error.  An empty |List| or |Dictionary| results in zero.
+<		 {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+		it returns the minimum of all values in the Dictionary.
+		If {expr} is neither a List nor a Dictionary, or one of the
+		items in {expr} cannot be used as a Number this results in
+		an error.  An empty |List| or |Dictionary| results in zero.
 
-mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
-                Create directory {name}.
+mkdir({name} [, {flags} [, {prot}]])				  *mkdir()* *E739*
+		Create directory {name}.
 
-                When {flags} is present it must be a string.  An empty string
-                has no effect.
+		When {flags} is present it must be a string.  An empty string
+		has no effect.
 
-                If {flags} contains "p" then intermediate directories are
-                created as necessary.
+		If {flags} contains "p" then intermediate directories are
+		created as necessary.
 
-                If {flags} contains "D" then {name} is deleted at the end of
-                the current function, as with: >vim
-                        defer delete({name}, 'd')
+		If {flags} contains "D" then {name} is deleted at the end of
+		the current function, as with: >vim
+			defer delete({name}, 'd')
 <
-                If {flags} contains "R" then {name} is deleted recursively at
-                the end of the current function, as with: >vim
-                        defer delete({name}, 'rf')
-<                Note that when {name} has more than one part and "p" is used
-                some directories may already exist.  Only the first one that
-                is created and what it contains is scheduled to be deleted.
-                E.g. when using: >vim
-                        call mkdir('subdir/tmp/autoload', 'pR')
-<                and "subdir" already exists then "subdir/tmp" will be
-                scheduled for deletion, like with: >vim
-                        defer delete('subdir/tmp', 'rf')
+		If {flags} contains "R" then {name} is deleted recursively at
+		the end of the current function, as with: >vim
+			defer delete({name}, 'rf')
+<		 Note that when {name} has more than one part and "p" is used
+		some directories may already exist.  Only the first one that
+		is created and what it contains is scheduled to be deleted.
+		E.g. when using: >vim
+			call mkdir('subdir/tmp/autoload', 'pR')
+<		 and "subdir" already exists then "subdir/tmp" will be
+		scheduled for deletion, like with: >vim
+			defer delete('subdir/tmp', 'rf')
 <
-                If {prot} is given it is used to set the protection bits of
-                the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
-                the user, readable for others).  Use 0o700 to make it
-                unreadable for others.
+		If {prot} is given it is used to set the protection bits of
+		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
+		the user, readable for others).  Use 0o700 to make it
+		unreadable for others.
 
-                {prot} is applied for all parts of {name}.  Thus if you create
-                /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
-                        call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
+		{prot} is applied for all parts of {name}.  Thus if you create
+		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+			call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
-<                This function is not available in the |sandbox|.
+<		 This function is not available in the |sandbox|.
 
-                If you try to create an existing directory with {flags} set to
-                "p" mkdir() will silently exit.
+		If you try to create an existing directory with {flags} set to
+		"p" mkdir() will silently exit.
 
-                The function result is a Number, which is TRUE if the call was
-                successful or FALSE if the directory creation failed or partly
-                failed.
+		The function result is a Number, which is TRUE if the call was
+		successful or FALSE if the directory creation failed or partly
+		failed.
 
-mode([expr])                                                            *mode()*
-                Return a string that indicates the current mode.
-                If [expr] is supplied and it evaluates to a non-zero Number or
-                a non-empty String (|non-zero-arg|), then the full mode is
-                returned, otherwise only the first letter is returned.
-                Also see |state()|.
+mode([expr])								*mode()*
+		Return a string that indicates the current mode.
+		If [expr] is supplied and it evaluates to a non-zero Number or
+		a non-empty String (|non-zero-arg|), then the full mode is
+		returned, otherwise only the first letter is returned.
+		Also see |state()|.
 
-                   n        Normal
-                   no       Operator-pending
-                   nov      Operator-pending (forced charwise |o_v|)
-                   noV      Operator-pending (forced linewise |o_V|)
-                   noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
-                                CTRL-V is one character
-                   niI      Normal using |i_CTRL-O| in |Insert-mode|
-                   niR      Normal using |i_CTRL-O| in |Replace-mode|
-                   niV      Normal using |i_CTRL-O| in |Virtual-Replace-mode|
-                   nt       Normal in |terminal-emulator| (insert goes to
-                                Terminal mode)
-                   ntT      Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
-                   v        Visual by character
-                   vs       Visual by character using |v_CTRL-O| in Select mode
-                   V        Visual by line
-                   Vs       Visual by line using |v_CTRL-O| in Select mode
-                   CTRL-V   Visual blockwise
-                   CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
-                   s        Select by character
-                   S        Select by line
-                   CTRL-S   Select blockwise
-                   i        Insert
-                   ic       Insert mode completion |compl-generic|
-                   ix       Insert mode |i_CTRL-X| completion
-                   R        Replace |R|
-                   Rc       Replace mode completion |compl-generic|
-                   Rx       Replace mode |i_CTRL-X| completion
-                   Rv       Virtual Replace |gR|
-                   Rvc      Virtual Replace mode completion |compl-generic|
-                   Rvx      Virtual Replace mode |i_CTRL-X| completion
-                   c        Command-line editing
-                   cr       Command-line editing overstrike mode |c_<Insert>|
-                   cv       Vim Ex mode |gQ|
-                   cvr      Vim Ex mode while in overstrike mode |c_<Insert>|
-                   r        Hit-enter prompt
-                   rm       The -- more -- prompt
-                   r?       A |:confirm| query of some sort
-                   !        Shell or external command is executing
-                   t        Terminal mode: keys go to the job
+		   n	    Normal
+		   no	    Operator-pending
+		   nov	    Operator-pending (forced charwise |o_v|)
+		   noV	    Operator-pending (forced linewise |o_V|)
+		   noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
+				CTRL-V is one character
+		   niI	    Normal using |i_CTRL-O| in |Insert-mode|
+		   niR	    Normal using |i_CTRL-O| in |Replace-mode|
+		   niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
+		   nt	    Normal in |terminal-emulator| (insert goes to
+				Terminal mode)
+		   ntT	    Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
+		   v	    Visual by character
+		   vs	    Visual by character using |v_CTRL-O| in Select mode
+		   V	    Visual by line
+		   Vs	    Visual by line using |v_CTRL-O| in Select mode
+		   CTRL-V   Visual blockwise
+		   CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
+		   s	    Select by character
+		   S	    Select by line
+		   CTRL-S   Select blockwise
+		   i	    Insert
+		   ic	    Insert mode completion |compl-generic|
+		   ix	    Insert mode |i_CTRL-X| completion
+		   R	    Replace |R|
+		   Rc	    Replace mode completion |compl-generic|
+		   Rx	    Replace mode |i_CTRL-X| completion
+		   Rv	    Virtual Replace |gR|
+		   Rvc	    Virtual Replace mode completion |compl-generic|
+		   Rvx	    Virtual Replace mode |i_CTRL-X| completion
+		   c	    Command-line editing
+		   cr	    Command-line editing overstrike mode |c_<Insert>|
+		   cv	    Vim Ex mode |gQ|
+		   cvr	    Vim Ex mode while in overstrike mode |c_<Insert>|
+		   r	    Hit-enter prompt
+		   rm	    The -- more -- prompt
+		   r?	    A |:confirm| query of some sort
+		   !	    Shell or external command is executing
+		   t	    Terminal mode: keys go to the job
 
-                This is useful in the 'statusline' option or RPC calls. In
-                most other places it always returns "c" or "n".
-                Note that in the future more modes and more specific modes may
-                be added. It's better not to compare the whole string but only
-                the leading character(s).
-                Also see |visualmode()|.
+		This is useful in the 'statusline' option or RPC calls. In
+		most other places it always returns "c" or "n".
+		Note that in the future more modes and more specific modes may
+		be added. It's better not to compare the whole string but only
+		the leading character(s).
+		Also see |visualmode()|.
 
-msgpackdump({list} [, {type}])                                   *msgpackdump()*
-                Convert a list of Vimscript objects to msgpack. Returned value is a
-                |readfile()|-style list. When {type} contains "B", a |Blob| is
-                returned instead. Example: >vim
-                        call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
-<                or, using a |Blob|: >vim
-                        call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
+msgpackdump({list} [, {type}])					 *msgpackdump()*
+		Convert a list of Vimscript objects to msgpack. Returned value is a
+		|readfile()|-style list. When {type} contains "B", a |Blob| is
+		returned instead. Example: >vim
+			call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
+<		 or, using a |Blob|: >vim
+			call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
 <
-                This will write the single 0x80 byte to a `fname.mpack` file
-                (dictionary with zero items is represented by 0x80 byte in
-                messagepack).
+		This will write the single 0x80 byte to a `fname.mpack` file
+		(dictionary with zero items is represented by 0x80 byte in
+		messagepack).
 
-                Limitations:                            *E5004* *E5005*
-                1. |Funcref|s cannot be dumped.
-                2. Containers that reference themselves cannot be dumped.
-                3. Dictionary keys are always dumped as STR strings.
-                4. Other strings and |Blob|s are always dumped as BIN strings.
-                5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
+		Limitations:				*E5004* *E5005*
+		1. |Funcref|s cannot be dumped.
+		2. Containers that reference themselves cannot be dumped.
+		3. Dictionary keys are always dumped as STR strings.
+		4. Other strings and |Blob|s are always dumped as BIN strings.
+		5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
 
-msgpackparse({data})                                            *msgpackparse()*
-                Convert a |readfile()|-style list or a |Blob| to a list of
-                Vimscript objects.
-                Example: >vim
-                        let fname = expand('~/.config/nvim/shada/main.shada')
-                        let mpack = readfile(fname, 'b')
-                        let shada_objects = msgpackparse(mpack)
-<                This will read ~/.config/nvim/shada/main.shada file to
-                `shada_objects` list.
+msgpackparse({data})						*msgpackparse()*
+		Convert a |readfile()|-style list or a |Blob| to a list of
+		Vimscript objects.
+		Example: >vim
+			let fname = expand('~/.config/nvim/shada/main.shada')
+			let mpack = readfile(fname, 'b')
+			let shada_objects = msgpackparse(mpack)
+<		 This will read ~/.config/nvim/shada/main.shada file to
+		`shada_objects` list.
 
-                Limitations:
-                1. Mapping ordering is not preserved unless messagepack
-                   mapping is dumped using generic mapping
-                   (|msgpack-special-map|).
-                2. Since the parser aims to preserve all data untouched
-                   (except for 1.) some strings are parsed to
-                   |msgpack-special-dict| format which is not convenient to
-                   use.
-                                                        *msgpack-special-dict*
-                Some messagepack strings may be parsed to special
-                dictionaries. Special dictionaries are dictionaries which
+		Limitations:
+		1. Mapping ordering is not preserved unless messagepack
+		   mapping is dumped using generic mapping
+		   (|msgpack-special-map|).
+		2. Since the parser aims to preserve all data untouched
+		   (except for 1.) some strings are parsed to
+		   |msgpack-special-dict| format which is not convenient to
+		   use.
+							*msgpack-special-dict*
+		Some messagepack strings may be parsed to special
+		dictionaries. Special dictionaries are dictionaries which
 
-                1. Contain exactly two keys: `_TYPE` and `_VAL`.
-                2. `_TYPE` key is one of the types found in |v:msgpack_types|
-                   variable.
-                3. Value for `_VAL` has the following format (Key column
-                   contains name of the key from |v:msgpack_types|):
+		1. Contain exactly two keys: `_TYPE` and `_VAL`.
+		2. `_TYPE` key is one of the types found in |v:msgpack_types|
+		   variable.
+		3. Value for `_VAL` has the following format (Key column
+		   contains name of the key from |v:msgpack_types|):
 
-                Key     Value ~
-                nil     Zero, ignored when dumping.  Not returned by
-                        |msgpackparse()| since |v:null| was introduced.
-                boolean One or zero.  When dumping it is only checked that
-                        value is a |Number|.  Not returned by |msgpackparse()|
-                        since |v:true| and |v:false| were introduced.
-                integer |List| with four numbers: sign (-1 or 1), highest two
-                        bits, number with bits from 62nd to 31st, lowest 31
-                        bits. I.e. to get actual number one will need to use
-                        code like >
-                                _VAL[0] * ((_VAL[1] << 62)
-                                           & (_VAL[2] << 31)
-                                           & _VAL[3])
-<                       Special dictionary with this type will appear in
-                        |msgpackparse()| output under one of the following
-                        circumstances:
-                        1. |Number| is 32-bit and value is either above
-                           INT32_MAX or below INT32_MIN.
-                        2. |Number| is 64-bit and value is above INT64_MAX. It
-                           cannot possibly be below INT64_MIN because msgpack
-                           C parser does not support such values.
-                float   |Float|. This value cannot possibly appear in
-                        |msgpackparse()| output.
-                string  |readfile()|-style list of strings. This value will
-                        appear in |msgpackparse()| output if string contains
-                        zero byte or if string is a mapping key and mapping is
-                        being represented as special dictionary for other
-                        reasons.
-                binary  |String|, or |Blob| if binary string contains zero
-                        byte. This value cannot appear in |msgpackparse()|
-                        output since blobs were introduced.
-                array   |List|. This value cannot appear in |msgpackparse()|
-                        output.
-                                                        *msgpack-special-map*
-                map     |List| of |List|s with two items (key and value) each.
-                        This value will appear in |msgpackparse()| output if
-                        parsed mapping contains one of the following keys:
-                        1. Any key that is not a string (including keys which
-                           are binary strings).
-                        2. String with NUL byte inside.
-                        3. Duplicate key.
-                ext     |List| with two values: first is a signed integer
-                        representing extension type. Second is
-                        |readfile()|-style list of strings.
+		Key	Value ~
+		nil	Zero, ignored when dumping.  Not returned by
+			|msgpackparse()| since |v:null| was introduced.
+		boolean One or zero.  When dumping it is only checked that
+			value is a |Number|.  Not returned by |msgpackparse()|
+			since |v:true| and |v:false| were introduced.
+		integer |List| with four numbers: sign (-1 or 1), highest two
+			bits, number with bits from 62nd to 31st, lowest 31
+			bits. I.e. to get actual number one will need to use
+			code like >
+				_VAL[0] * ((_VAL[1] << 62)
+					   & (_VAL[2] << 31)
+					   & _VAL[3])
+<			Special dictionary with this type will appear in
+			|msgpackparse()| output under one of the following
+			circumstances:
+			1. |Number| is 32-bit and value is either above
+			   INT32_MAX or below INT32_MIN.
+			2. |Number| is 64-bit and value is above INT64_MAX. It
+			   cannot possibly be below INT64_MIN because msgpack
+			   C parser does not support such values.
+		float	|Float|. This value cannot possibly appear in
+			|msgpackparse()| output.
+		string	|readfile()|-style list of strings. This value will
+			appear in |msgpackparse()| output if string contains
+			zero byte or if string is a mapping key and mapping is
+			being represented as special dictionary for other
+			reasons.
+		binary	|String|, or |Blob| if binary string contains zero
+			byte. This value cannot appear in |msgpackparse()|
+			output since blobs were introduced.
+		array	|List|. This value cannot appear in |msgpackparse()|
+			output.
+							*msgpack-special-map*
+		map	|List| of |List|s with two items (key and value) each.
+			This value will appear in |msgpackparse()| output if
+			parsed mapping contains one of the following keys:
+			1. Any key that is not a string (including keys which
+			   are binary strings).
+			2. String with NUL byte inside.
+			3. Duplicate key.
+		ext	|List| with two values: first is a signed integer
+			representing extension type. Second is
+			|readfile()|-style list of strings.
 
-nextnonblank({lnum})                                            *nextnonblank()*
-                Return the line number of the first line at or below {lnum}
-                that is not blank.  Example: >vim
-                        if getline(nextnonblank(1)) =~ "Java" | endif
-<                When {lnum} is invalid or there is no non-blank line at or
-                below it, zero is returned.
-                {lnum} is used like with |getline()|.
-                See also |prevnonblank()|.
+nextnonblank({lnum})						*nextnonblank()*
+		Return the line number of the first line at or below {lnum}
+		that is not blank.  Example: >vim
+			if getline(nextnonblank(1)) =~ "Java" | endif
+<		 When {lnum} is invalid or there is no non-blank line at or
+		below it, zero is returned.
+		{lnum} is used like with |getline()|.
+		See also |prevnonblank()|.
 
-nr2char({expr} [, {utf8}])                                           *nr2char()*
-                Return a string with a single character, which has the number
-                value {expr}.  Examples: >vim
-                        echo nr2char(64)                " returns '@'
-                        echo nr2char(32)                " returns ' '
-<                Example for "utf-8": >vim
-                        echo nr2char(300)               " returns I with bow character
+nr2char({expr} [, {utf8}])					     *nr2char()*
+		Return a string with a single character, which has the number
+		value {expr}.  Examples: >vim
+			echo nr2char(64)		" returns '@'
+			echo nr2char(32)		" returns ' '
+<		 Example for "utf-8": >vim
+			echo nr2char(300)		" returns I with bow character
 <
-                UTF-8 encoding is always used, {utf8} option has no effect,
-                and exists only for backwards-compatibility.
-                Note that a NUL character in the file is specified with
-                nr2char(10), because NULs are represented with newline
-                characters.  nr2char(0) is a real NUL and terminates the
-                string, thus results in an empty string.
+		UTF-8 encoding is always used, {utf8} option has no effect,
+		and exists only for backwards-compatibility.
+		Note that a NUL character in the file is specified with
+		nr2char(10), because NULs are represented with newline
+		characters.  nr2char(0) is a real NUL and terminates the
+		string, thus results in an empty string.
 
-nvim_...({...})                                      *nvim_...()* *E5555* *eval-api*
-                Call nvim |api| functions. The type checking of arguments will
-                be stricter than for most other builtins. For instance,
-                if Integer is expected, a |Number| must be passed in, a
-                |String| will not be autoconverted.
-                Buffer numbers, as returned by |bufnr()| could be used as
-                first argument to nvim_buf_... functions.  All functions
-                expecting an object (buffer, window or tabpage) can
-                also take the numerical value 0 to indicate the current
-                (focused) object.
+nvim_...({...})					     *nvim_...()* *E5555* *eval-api*
+		Call nvim |api| functions. The type checking of arguments will
+		be stricter than for most other builtins. For instance,
+		if Integer is expected, a |Number| must be passed in, a
+		|String| will not be autoconverted.
+		Buffer numbers, as returned by |bufnr()| could be used as
+		first argument to nvim_buf_... functions.  All functions
+		expecting an object (buffer, window or tabpage) can
+		also take the numerical value 0 to indicate the current
+		(focused) object.
 
-or({expr}, {expr})                                                        *or()*
-                Bitwise OR on the two arguments.  The arguments are converted
-                to a number.  A List, Dict or Float argument causes an error.
-                Also see `and()` and `xor()`.
-                Example: >vim
-                        let bits = or(bits, 0x80)
+or({expr}, {expr})							  *or()*
+		Bitwise OR on the two arguments.  The arguments are converted
+		to a number.  A List, Dict or Float argument causes an error.
+		Also see `and()` and `xor()`.
+		Example: >vim
+			let bits = or(bits, 0x80)
 
-<                Rationale: The reason this is a function and not using the "|"
-                character like many languages, is that Vi has always used "|"
-                to separate commands.  In many places it would not be clear if
-                "|" is an operator or a command separator.
+<		 Rationale: The reason this is a function and not using the "|"
+		character like many languages, is that Vi has always used "|"
+		to separate commands.  In many places it would not be clear if
+		"|" is an operator or a command separator.
 
-pathshorten({path} [, {len}])                                    *pathshorten()*
-                Shorten directory names in the path {path} and return the
-                result.  The tail, the file name, is kept as-is.  The other
-                components in the path are reduced to {len} letters in length.
-                If {len} is omitted or smaller than 1 then 1 is used (single
-                letters).  Leading '~' and '.' characters are kept.  Examples: >vim
-                        echo pathshorten('~/.config/nvim/autoload/file1.vim')
-<                       ~/.c/n/a/file1.vim ~
+pathshorten({path} [, {len}])					 *pathshorten()*
+		Shorten directory names in the path {path} and return the
+		result.  The tail, the file name, is kept as-is.  The other
+		components in the path are reduced to {len} letters in length.
+		If {len} is omitted or smaller than 1 then 1 is used (single
+		letters).  Leading '~' and '.' characters are kept.  Examples: >vim
+			echo pathshorten('~/.config/nvim/autoload/file1.vim')
+<			~/.c/n/a/file1.vim ~
 >vim
-                        echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
-<                       ~/.co/nv/au/file2.vim ~
-                It doesn't matter if the path exists or not.
-                Returns an empty string on error.
+			echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
+<			~/.co/nv/au/file2.vim ~
+		It doesn't matter if the path exists or not.
+		Returns an empty string on error.
 
-perleval({expr})                                                    *perleval()*
-                Evaluate |perl| expression {expr} and return its result
-                converted to Vim data structures.
-                Numbers and strings are returned as they are (strings are
-                copied though).
-                Lists are represented as Vim |List| type.
-                Dictionaries are represented as Vim |Dictionary| type,
-                non-string keys result in error.
+perleval({expr})						    *perleval()*
+		Evaluate |perl| expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers and strings are returned as they are (strings are
+		copied though).
+		Lists are represented as Vim |List| type.
+		Dictionaries are represented as Vim |Dictionary| type,
+		non-string keys result in error.
 
-                Note: If you want an array or hash, {expr} must return a
-                reference to it.
-                Example: >vim
-                        echo perleval('[1 .. 4]')
-<                       [1, 2, 3, 4]
+		Note: If you want an array or hash, {expr} must return a
+		reference to it.
+		Example: >vim
+			echo perleval('[1 .. 4]')
+<			[1, 2, 3, 4]
 
-pow({x}, {y})                                                            *pow()*
-                Return the power of {x} to the exponent {y} as a |Float|.
-                {x} and {y} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo pow(3, 3)
-<                        27.0 >vim
-                        echo pow(2, 16)
-<                        65536.0 >vim
-                        echo pow(32, 0.20)
-<                        2.0
+pow({x}, {y})								 *pow()*
+		Return the power of {x} to the exponent {y} as a |Float|.
+		{x} and {y} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo pow(3, 3)
+<			 27.0 >vim
+			echo pow(2, 16)
+<			 65536.0 >vim
+			echo pow(32, 0.20)
+<			 2.0
 
-prevnonblank({lnum})                                            *prevnonblank()*
-                Return the line number of the first line at or above {lnum}
-                that is not blank.  Example: >vim
-                        let ind = indent(prevnonblank(v:lnum - 1))
-<                When {lnum} is invalid or there is no non-blank line at or
-                above it, zero is returned.
-                {lnum} is used like with |getline()|.
-                Also see |nextnonblank()|.
+prevnonblank({lnum})						*prevnonblank()*
+		Return the line number of the first line at or above {lnum}
+		that is not blank.  Example: >vim
+			let ind = indent(prevnonblank(v:lnum - 1))
+<		 When {lnum} is invalid or there is no non-blank line at or
+		above it, zero is returned.
+		{lnum} is used like with |getline()|.
+		Also see |nextnonblank()|.
 
-printf({fmt}, {expr1} ...)                                            *printf()*
-                Return a String with {fmt}, where "%" items are replaced by
-                the formatted form of their respective arguments.  Example: >vim
-                        echo printf("%4d: E%d %.30s", lnum, errno, msg)
-<                May result in:
-                        "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
+printf({fmt}, {expr1} ...)					      *printf()*
+		Return a String with {fmt}, where "%" items are replaced by
+		the formatted form of their respective arguments.  Example: >vim
+			echo printf("%4d: E%d %.30s", lnum, errno, msg)
+<		 May result in:
+			"  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 
-                When used as a |method| the base is passed as the second
-                argument: >vim
-                        Compute()->printf("result: %d")
+		When used as a |method| the base is passed as the second
+		argument: >vim
+			Compute()->printf("result: %d")
 <
-                You can use `call()` to pass the items as a list.
+		You can use `call()` to pass the items as a list.
 
-                Often used items are:
-                  %s    string
-                  %6S   string right-aligned in 6 display cells
-                  %6s   string right-aligned in 6 bytes
-                  %.9s  string truncated to 9 bytes
-                  %c    single byte
-                  %d    decimal number
-                  %5d   decimal number padded with spaces to 5 characters
-                  %b    binary number
-                  %08b  binary number padded with zeros to at least 8 characters
-                  %B    binary number using upper case letters
-                  %x    hex number
-                  %04x  hex number padded with zeros to at least 4 characters
-                  %X    hex number using upper case letters
-                  %o    octal number
-                  %f    floating point number as 12.23, inf, -inf or nan
-                  %F    floating point number as 12.23, INF, -INF or NAN
-                  %e    floating point number as 1.23e3, inf, -inf or nan
-                  %E    floating point number as 1.23E3, INF, -INF or NAN
-                  %g    floating point number, as %f or %e depending on value
-                  %G    floating point number, as %F or %E depending on value
-                  %%    the % character itself
-                  %p    representation of the pointer to the container
+		Often used items are:
+		  %s	string
+		  %6S	string right-aligned in 6 display cells
+		  %6s	string right-aligned in 6 bytes
+		  %.9s	string truncated to 9 bytes
+		  %c	single byte
+		  %d	decimal number
+		  %5d	decimal number padded with spaces to 5 characters
+		  %b	binary number
+		  %08b	binary number padded with zeros to at least 8 characters
+		  %B	binary number using upper case letters
+		  %x	hex number
+		  %04x	hex number padded with zeros to at least 4 characters
+		  %X	hex number using upper case letters
+		  %o	octal number
+		  %f	floating point number as 12.23, inf, -inf or nan
+		  %F	floating point number as 12.23, INF, -INF or NAN
+		  %e	floating point number as 1.23e3, inf, -inf or nan
+		  %E	floating point number as 1.23E3, INF, -INF or NAN
+		  %g	floating point number, as %f or %e depending on value
+		  %G	floating point number, as %F or %E depending on value
+		  %%	the % character itself
+		  %p	representation of the pointer to the container
 
-                Conversion specifications start with '%' and end with the
-                conversion type.  All other characters are copied unchanged to
-                the result.
+		Conversion specifications start with '%' and end with the
+		conversion type.  All other characters are copied unchanged to
+		the result.
 
-                The "%" starts a conversion specification.  The following
-                arguments appear in sequence:
+		The "%" starts a conversion specification.  The following
+		arguments appear in sequence:
 
-                        % [pos-argument] [flags] [field-width] [.precision] type
+			% [pos-argument] [flags] [field-width] [.precision] type
 
-                pos-argument
-                        At most one positional argument specifier. These
-                        take the form {n$}, where n is >= 1.
+		pos-argument
+			At most one positional argument specifier. These
+			take the form {n$}, where n is >= 1.
 
-                flags
-                        Zero or more of the following flags:
+		flags
+			Zero or more of the following flags:
 
-                    #         The value should be converted to an "alternate
-                              form".  For c, d, and s conversions, this option
-                              has no effect.  For o conversions, the precision
-                              of the number is increased to force the first
-                              character of the output string to a zero (except
-                              if a zero value is printed with an explicit
-                              precision of zero).
-                              For x and X conversions, a non-zero result has
-                              the string "0x" (or "0X" for X conversions)
-                              prepended to it.
+		    #	      The value should be converted to an "alternate
+			      form".  For c, d, and s conversions, this option
+			      has no effect.  For o conversions, the precision
+			      of the number is increased to force the first
+			      character of the output string to a zero (except
+			      if a zero value is printed with an explicit
+			      precision of zero).
+			      For x and X conversions, a non-zero result has
+			      the string "0x" (or "0X" for X conversions)
+			      prepended to it.
 
-                    0 (zero)  Zero padding.  For all conversions the converted
-                              value is padded on the left with zeros rather
-                              than blanks.  If a precision is given with a
-                              numeric conversion (d, o, x, and X), the 0 flag
-                              is ignored.
+		    0 (zero)  Zero padding.  For all conversions the converted
+			      value is padded on the left with zeros rather
+			      than blanks.  If a precision is given with a
+			      numeric conversion (d, o, x, and X), the 0 flag
+			      is ignored.
 
-                    -         A negative field width flag; the converted value
-                              is to be left adjusted on the field boundary.
-                              The converted value is padded on the right with
-                              blanks, rather than on the left with blanks or
-                              zeros.  A - overrides a 0 if both are given.
+		    -	      A negative field width flag; the converted value
+			      is to be left adjusted on the field boundary.
+			      The converted value is padded on the right with
+			      blanks, rather than on the left with blanks or
+			      zeros.  A - overrides a 0 if both are given.
 
-                    ' ' (space)  A blank should be left before a positive
-                              number produced by a signed conversion (d).
+		    ' ' (space)  A blank should be left before a positive
+			      number produced by a signed conversion (d).
 
-                    +         A sign must always be placed before a number
-                              produced by a signed conversion.  A + overrides
-                              a space if both are used.
+		    +	      A sign must always be placed before a number
+			      produced by a signed conversion.	A + overrides
+			      a space if both are used.
 
-                field-width
-                        An optional decimal digit string specifying a minimum
-                        field width.  If the converted value has fewer bytes
-                        than the field width, it will be padded with spaces on
-                        the left (or right, if the left-adjustment flag has
-                        been given) to fill out the field width.  For the S
-                        conversion the count is in cells.
+		field-width
+			An optional decimal digit string specifying a minimum
+			field width.  If the converted value has fewer bytes
+			than the field width, it will be padded with spaces on
+			the left (or right, if the left-adjustment flag has
+			been given) to fill out the field width.  For the S
+			conversion the count is in cells.
 
-                .precision
-                        An optional precision, in the form of a period '.'
-                        followed by an optional digit string.  If the digit
-                        string is omitted, the precision is taken as zero.
-                        This gives the minimum number of digits to appear for
-                        d, o, x, and X conversions, the maximum number of
-                        bytes to be printed from a string for s conversions,
-                        or the maximum number of cells to be printed from a
-                        string for S conversions.
-                        For floating point it is the number of digits after
-                        the decimal point.
+		.precision
+			An optional precision, in the form of a period '.'
+			followed by an optional digit string.  If the digit
+			string is omitted, the precision is taken as zero.
+			This gives the minimum number of digits to appear for
+			d, o, x, and X conversions, the maximum number of
+			bytes to be printed from a string for s conversions,
+			or the maximum number of cells to be printed from a
+			string for S conversions.
+			For floating point it is the number of digits after
+			the decimal point.
 
-                type
-                        A character that specifies the type of conversion to
-                        be applied, see below.
+		type
+			A character that specifies the type of conversion to
+			be applied, see below.
 
-                A field width or precision, or both, may be indicated by an
-                asterisk "*" instead of a digit string.  In this case, a
-                Number argument supplies the field width or precision.  A
-                negative field width is treated as a left adjustment flag
-                followed by a positive field width; a negative precision is
-                treated as though it were missing.  Example: >vim
-                        echo printf("%d: %.*s", nr, width, line)
-<                This limits the length of the text used from "line" to
-                "width" bytes.
+		A field width or precision, or both, may be indicated by an
+		asterisk "*" instead of a digit string.  In this case, a
+		Number argument supplies the field width or precision.	A
+		negative field width is treated as a left adjustment flag
+		followed by a positive field width; a negative precision is
+		treated as though it were missing.  Example: >vim
+			echo printf("%d: %.*s", nr, width, line)
+<		 This limits the length of the text used from "line" to
+		"width" bytes.
 
-                If the argument to be formatted is specified using a
-                positional argument specifier, and a '*' is used to indicate
-                that a number argument is to be used to specify the width or
-                precision, the argument(s) to be used must also be specified
-                using a {n$} positional argument specifier. See |printf-$|.
+		If the argument to be formatted is specified using a
+		positional argument specifier, and a '*' is used to indicate
+		that a number argument is to be used to specify the width or
+		precision, the argument(s) to be used must also be specified
+		using a {n$} positional argument specifier. See |printf-$|.
 
-                The conversion specifiers and their meanings are:
+		The conversion specifiers and their meanings are:
 
-                                *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
-                dbBoxX  The Number argument is converted to signed decimal (d),
-                        unsigned binary (b and B), unsigned octal (o), or
-                        unsigned hexadecimal (x and X) notation.  The letters
-                        "abcdef" are used for x conversions; the letters
-                        "ABCDEF" are used for X conversions.  The precision, if
-                        any, gives the minimum number of digits that must
-                        appear; if the converted value requires fewer digits, it
-                        is padded on the left with zeros.  In no case does a
-                        non-existent or small field width cause truncation of a
-                        numeric field; if the result of a conversion is wider
-                        than the field width, the field is expanded to contain
-                        the conversion result.
-                        The 'h' modifier indicates the argument is 16 bits.
-                        The 'l' modifier indicates the argument is a long
-                        integer.  The size will be 32 bits or 64 bits
-                        depending on your platform.
-                        The "ll" modifier indicates the argument is 64 bits.
-                        The b and B conversion specifiers never take a width
-                        modifier and always assume their argument is a 64 bit
-                        integer.
-                        Generally, these modifiers are not useful. They are
-                        ignored when type is known from the argument.
+				*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
+		dbBoxX	The Number argument is converted to signed decimal (d),
+			unsigned binary (b and B), unsigned octal (o), or
+			unsigned hexadecimal (x and X) notation.  The letters
+			"abcdef" are used for x conversions; the letters
+			"ABCDEF" are used for X conversions.  The precision, if
+			any, gives the minimum number of digits that must
+			appear; if the converted value requires fewer digits, it
+			is padded on the left with zeros.  In no case does a
+			non-existent or small field width cause truncation of a
+			numeric field; if the result of a conversion is wider
+			than the field width, the field is expanded to contain
+			the conversion result.
+			The 'h' modifier indicates the argument is 16 bits.
+			The 'l' modifier indicates the argument is a long
+			integer.  The size will be 32 bits or 64 bits
+			depending on your platform.
+			The "ll" modifier indicates the argument is 64 bits.
+			The b and B conversion specifiers never take a width
+			modifier and always assume their argument is a 64 bit
+			integer.
+			Generally, these modifiers are not useful. They are
+			ignored when type is known from the argument.
 
-                i       alias for d
-                D       alias for ld
-                U       alias for lu
-                O       alias for lo
+		i	alias for d
+		D	alias for ld
+		U	alias for lu
+		O	alias for lo
 
-                                                        *printf-c*
-                c       The Number argument is converted to a byte, and the
-                        resulting character is written.
+							*printf-c*
+		c	The Number argument is converted to a byte, and the
+			resulting character is written.
 
-                                                        *printf-s*
-                s       The text of the String argument is used.  If a
-                        precision is specified, no more bytes than the number
-                        specified are used.
-                        If the argument is not a String type, it is
-                        automatically converted to text with the same format
-                        as ":echo".
-                                                        *printf-S*
-                S       The text of the String argument is used.  If a
-                        precision is specified, no more display cells than the
-                        number specified are used.
+							*printf-s*
+		s	The text of the String argument is used.  If a
+			precision is specified, no more bytes than the number
+			specified are used.
+			If the argument is not a String type, it is
+			automatically converted to text with the same format
+			as ":echo".
+							*printf-S*
+		S	The text of the String argument is used.  If a
+			precision is specified, no more display cells than the
+			number specified are used.
 
-                                                        *printf-f* *E807*
-                f F     The Float argument is converted into a string of the
-                        form 123.456.  The precision specifies the number of
-                        digits after the decimal point.  When the precision is
-                        zero the decimal point is omitted.  When the precision
-                        is not specified 6 is used.  A really big number
-                        (out of range or dividing by zero) results in "inf"
-                         or "-inf" with %f (INF or -INF with %F).
-                         "0.0 / 0.0" results in "nan" with %f (NAN with %F).
-                        Example: >vim
-                                echo printf("%.2f", 12.115)
-<                               12.12
-                        Note that roundoff depends on the system libraries.
-                        Use |round()| when in doubt.
+							*printf-f* *E807*
+		f F	The Float argument is converted into a string of the
+			form 123.456.  The precision specifies the number of
+			digits after the decimal point.  When the precision is
+			zero the decimal point is omitted.  When the precision
+			is not specified 6 is used.  A really big number
+			(out of range or dividing by zero) results in "inf"
+			 or "-inf" with %f (INF or -INF with %F).
+			 "0.0 / 0.0" results in "nan" with %f (NAN with %F).
+			Example: >vim
+				echo printf("%.2f", 12.115)
+<				12.12
+			Note that roundoff depends on the system libraries.
+			Use |round()| when in doubt.
 
-                                                        *printf-e* *printf-E*
-                e E     The Float argument is converted into a string of the
-                        form 1.234e+03 or 1.234E+03 when using 'E'.  The
-                        precision specifies the number of digits after the
-                        decimal point, like with 'f'.
+							*printf-e* *printf-E*
+		e E	The Float argument is converted into a string of the
+			form 1.234e+03 or 1.234E+03 when using 'E'.  The
+			precision specifies the number of digits after the
+			decimal point, like with 'f'.
 
-                                                        *printf-g* *printf-G*
-                g G     The Float argument is converted like with 'f' if the
-                        value is between 0.001 (inclusive) and 10000000.0
-                        (exclusive).  Otherwise 'e' is used for 'g' and 'E'
-                        for 'G'.  When no precision is specified superfluous
-                        zeroes and '+' signs are removed, except for the zero
-                        immediately after the decimal point.  Thus 10000000.0
-                        results in 1.0e7.
+							*printf-g* *printf-G*
+		g G	The Float argument is converted like with 'f' if the
+			value is between 0.001 (inclusive) and 10000000.0
+			(exclusive).  Otherwise 'e' is used for 'g' and 'E'
+			for 'G'.  When no precision is specified superfluous
+			zeroes and '+' signs are removed, except for the zero
+			immediately after the decimal point.  Thus 10000000.0
+			results in 1.0e7.
 
-                                                        *printf-%*
-                %       A '%' is written.  No argument is converted.  The
-                        complete conversion specification is "%%".
+							*printf-%*
+		%	A '%' is written.  No argument is converted.  The
+			complete conversion specification is "%%".
 
-                When a Number argument is expected a String argument is also
-                accepted and automatically converted.
-                When a Float or String argument is expected a Number argument
-                is also accepted and automatically converted.
-                Any other argument type results in an error message.
+		When a Number argument is expected a String argument is also
+		accepted and automatically converted.
+		When a Float or String argument is expected a Number argument
+		is also accepted and automatically converted.
+		Any other argument type results in an error message.
 
-                                                        *E766* *E767*
-                The number of {exprN} arguments must exactly match the number
-                of "%" items.  If there are not sufficient or too many
-                arguments an error is given.  Up to 18 arguments can be used.
+							*E766* *E767*
+		The number of {exprN} arguments must exactly match the number
+		of "%" items.  If there are not sufficient or too many
+		arguments an error is given.  Up to 18 arguments can be used.
 
-                                                        *printf-$*
-                In certain languages, error and informative messages are
-                more readable when the order of words is different from the
-                corresponding message in English. To accommodate translations
-                having a different word order, positional arguments may be
-                used to indicate this. For instance: >vim
+							*printf-$*
+		In certain languages, error and informative messages are
+		more readable when the order of words is different from the
+		corresponding message in English. To accommodate translations
+		having a different word order, positional arguments may be
+		used to indicate this. For instance: >vim
 
-                    #, c-format
-                    msgid "%s returning %s"
-                    msgstr "waarde %2$s komt terug van %1$s"
+		    #, c-format
+		    msgid "%s returning %s"
+		    msgstr "waarde %2$s komt terug van %1$s"
 <
-                In this example, the sentence has its 2 string arguments
-                reversed in the output. >vim
+		In this example, the sentence has its 2 string arguments
+		reversed in the output. >vim
 
-                    echo printf(
-                        "In The Netherlands, vim's creator's name is: %1$s %2$s",
-                        "Bram", "Moolenaar")
-<                    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+		    echo printf(
+			"In The Netherlands, vim's creator's name is: %1$s %2$s",
+			"Bram", "Moolenaar")
+<		     In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
-                    echo printf(
-                        "In Belgium, vim's creator's name is: %2$s %1$s",
-                        "Bram", "Moolenaar")
-<                    In Belgium, vim's creator's name is: Moolenaar Bram
+		    echo printf(
+			"In Belgium, vim's creator's name is: %2$s %1$s",
+			"Bram", "Moolenaar")
+<		     In Belgium, vim's creator's name is: Moolenaar Bram
 
-                Width (and precision) can be specified using the '*' specifier.
-                In this case, you must specify the field width position in the
-                argument list. >vim
+		Width (and precision) can be specified using the '*' specifier.
+		In this case, you must specify the field width position in the
+		argument list. >vim
 
-                    echo printf("%1$*2$.*3$d", 1, 2, 3)
-<                    001 >vim
-                    echo printf("%2$*3$.*1$d", 1, 2, 3)
-<                      2 >vim
-                    echo printf("%3$*1$.*2$d", 1, 2, 3)
-<                    03 >vim
-                    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-<                    1.414
+		    echo printf("%1$*2$.*3$d", 1, 2, 3)
+<		     001 >vim
+		    echo printf("%2$*3$.*1$d", 1, 2, 3)
+<		       2 >vim
+		    echo printf("%3$*1$.*2$d", 1, 2, 3)
+<		     03 >vim
+		    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
+<		     1.414
 
-                You can mix specifying the width and/or precision directly
-                and via positional arguments: >vim
+		You can mix specifying the width and/or precision directly
+		and via positional arguments: >vim
 
-                    echo printf("%1$4.*2$f", 1.4142135, 6)
-<                    1.414214 >vim
-                    echo printf("%1$*2$.4f", 1.4142135, 6)
-<                    1.4142 >vim
-                    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-<                      1.41
+		    echo printf("%1$4.*2$f", 1.4142135, 6)
+<		     1.414214 >vim
+		    echo printf("%1$*2$.4f", 1.4142135, 6)
+<		     1.4142 >vim
+		    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
+<		       1.41
 
-                                                        *E1500*
-                You cannot mix positional and non-positional arguments: >vim
-                    echo printf("%s%1$s", "One", "Two")
-<                    E1500: Cannot mix positional and non-positional arguments:
-                    %s%1$s
+							*E1500*
+		You cannot mix positional and non-positional arguments: >vim
+		    echo printf("%s%1$s", "One", "Two")
+<		     E1500: Cannot mix positional and non-positional arguments:
+		    %s%1$s
 
-                                                        *E1501*
-                You cannot skip a positional argument in a format string: >vim
-                    echo printf("%3$s%1$s", "One", "Two", "Three")
-<                    E1501: format argument 2 unused in $-style format:
-                    %3$s%1$s
+							*E1501*
+		You cannot skip a positional argument in a format string: >vim
+		    echo printf("%3$s%1$s", "One", "Two", "Three")
+<		     E1501: format argument 2 unused in $-style format:
+		    %3$s%1$s
 
-                                                        *E1502*
-                You can re-use a [field-width] (or [precision]) argument: >vim
-                    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-<                    1 at width 2 is: 01
+							*E1502*
+		You can re-use a [field-width] (or [precision]) argument: >vim
+		    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
+<		     1 at width 2 is: 01
 
-                However, you can't use it as a different type: >vim
-                    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-<                    E1502: Positional argument 2 used as field width reused as
-                    different type: long int/int
+		However, you can't use it as a different type: >vim
+		    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
+<		     E1502: Positional argument 2 used as field width reused as
+		    different type: long int/int
 
-                                                        *E1503*
-                When a positional argument is used, but not the correct number
-                or arguments is given, an error is raised: >vim
-                    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-<                    E1503: Positional argument 3 out of bounds: %1$d at width
-                    %2$d is: %01$*2$.*3$d
+							*E1503*
+		When a positional argument is used, but not the correct number
+		or arguments is given, an error is raised: >vim
+		    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
+<		     E1503: Positional argument 3 out of bounds: %1$d at width
+		    %2$d is: %01$*2$.*3$d
 
-                Only the first error is reported: >vim
-                    echo printf("%01$*2$.*3$d %4$d", 1, 2)
-<                    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
-                    %4$d
+		Only the first error is reported: >vim
+		    echo printf("%01$*2$.*3$d %4$d", 1, 2)
+<		     E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+		    %4$d
 
-                                                        *E1504*
-                A positional argument can be used more than once: >vim
-                    echo printf("%1$s %2$s %1$s", "One", "Two")
-<                    One Two One
+							*E1504*
+		A positional argument can be used more than once: >vim
+		    echo printf("%1$s %2$s %1$s", "One", "Two")
+<		     One Two One
 
-                However, you can't use a different type the second time: >vim
-                    echo printf("%1$s %2$s %1$d", "One", "Two")
-<                    E1504: Positional argument 1 type used inconsistently:
-                    int/string
+		However, you can't use a different type the second time: >vim
+		    echo printf("%1$s %2$s %1$d", "One", "Two")
+<		     E1504: Positional argument 1 type used inconsistently:
+		    int/string
 
-                                                        *E1505*
-                Various other errors that lead to a format string being
-                wrongly formatted lead to: >vim
-                    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-<                    E1505: Invalid format specifier: %1$d at width %2$d is:
-                    %01$*2$.3$d
+							*E1505*
+		Various other errors that lead to a format string being
+		wrongly formatted lead to: >vim
+		    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
+<		     E1505: Invalid format specifier: %1$d at width %2$d is:
+		    %01$*2$.3$d
 
-                                                        *E1507*
-                This internal error indicates that the logic to parse a
-                positional format argument ran into a problem that couldn't be
-                otherwise reported.  Please file a bug against Vim if you run
-                into this, copying the exact format string and parameters that
-                were used.
+							*E1507*
+		This internal error indicates that the logic to parse a
+		positional format argument ran into a problem that couldn't be
+		otherwise reported.  Please file a bug against Vim if you run
+		into this, copying the exact format string and parameters that
+		were used.
 
-prompt_getprompt({buf})                                     *prompt_getprompt()*
-                Returns the effective prompt text for buffer {buf}.  {buf} can
-                be a buffer name or number.  See |prompt-buffer|.
+prompt_getprompt({buf})					    *prompt_getprompt()*
+		Returns the effective prompt text for buffer {buf}.  {buf} can
+		be a buffer name or number.  See |prompt-buffer|.
 
-                If the buffer doesn't exist or isn't a prompt buffer, an empty
-                string is returned.
+		If the buffer doesn't exist or isn't a prompt buffer, an empty
+		string is returned.
 
-prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
-                Set prompt callback for buffer {buf} to {expr}.  When {expr}
-                is an empty string the callback is removed.  This has only
-                effect if {buf} has 'buftype' set to "prompt".
+prompt_setcallback({buf}, {expr})			  *prompt_setcallback()*
+		Set prompt callback for buffer {buf} to {expr}.  When {expr}
+		is an empty string the callback is removed.  This has only
+		effect if {buf} has 'buftype' set to "prompt".
 
-                The callback is invoked when pressing Enter.  The current
-                buffer will always be the prompt buffer.  A new line for a
-                prompt is added before invoking the callback, thus the prompt
-                for which the callback was invoked will be in the last but one
-                line.
-                If the callback wants to add text to the buffer, it must
-                insert it above the last line, since that is where the current
-                prompt is.  This can also be done asynchronously.
-                The callback is invoked with one argument, which is the text
-                that was entered at the prompt.  This can be an empty string
-                if the user only typed Enter.
-                Example: >vim
-                   func s:TextEntered(text)
-                     if a:text == 'exit' || a:text == 'quit'
-                       stopinsert
-                       " Reset 'modified' to allow the buffer to be closed.
-                       " We assume there is nothing useful to be saved.
-                       set nomodified
-                       close
-                     else
-                       " Do something useful with "a:text".  In this example
-                       " we just repeat it.
-                       call append(line('$') - 1, 'Entered: "' .. a:text .. '"')
-                     endif
-                   endfunc
-                   call prompt_setcallback(bufnr(), function('s:TextEntered'))
+		The callback is invoked when pressing Enter.  The current
+		buffer will always be the prompt buffer.  A new line for a
+		prompt is added before invoking the callback, thus the prompt
+		for which the callback was invoked will be in the last but one
+		line.
+		If the callback wants to add text to the buffer, it must
+		insert it above the last line, since that is where the current
+		prompt is.  This can also be done asynchronously.
+		The callback is invoked with one argument, which is the text
+		that was entered at the prompt.  This can be an empty string
+		if the user only typed Enter.
+		Example: >vim
+		   func s:TextEntered(text)
+		     if a:text == 'exit' || a:text == 'quit'
+		       stopinsert
+		       " Reset 'modified' to allow the buffer to be closed.
+		       " We assume there is nothing useful to be saved.
+		       set nomodified
+		       close
+		     else
+		       " Do something useful with "a:text".  In this example
+		       " we just repeat it.
+		       call append(line('$') - 1, 'Entered: "' .. a:text .. '"')
+		     endif
+		   endfunc
+		   call prompt_setcallback(bufnr(), function('s:TextEntered'))
 
-prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
-                Set a callback for buffer {buf} to {expr}.  When {expr} is an
-                empty string the callback is removed.  This has only effect if
-                {buf} has 'buftype' set to "prompt".
+prompt_setinterrupt({buf}, {expr})			 *prompt_setinterrupt()*
+		Set a callback for buffer {buf} to {expr}.  When {expr} is an
+		empty string the callback is removed.  This has only effect if
+		{buf} has 'buftype' set to "prompt".
 
-                This callback will be invoked when pressing CTRL-C in Insert
-                mode.  Without setting a callback Vim will exit Insert mode,
-                as in any buffer.
+		This callback will be invoked when pressing CTRL-C in Insert
+		mode.  Without setting a callback Vim will exit Insert mode,
+		as in any buffer.
 
-prompt_setprompt({buf}, {text})                             *prompt_setprompt()*
-                Set prompt for buffer {buf} to {text}.  You most likely want
-                {text} to end in a space.
-                The result is only visible if {buf} has 'buftype' set to
-                "prompt".  Example: >vim
-                        call prompt_setprompt(bufnr(''), 'command: ')
+prompt_setprompt({buf}, {text})				    *prompt_setprompt()*
+		Set prompt for buffer {buf} to {text}.	You most likely want
+		{text} to end in a space.
+		The result is only visible if {buf} has 'buftype' set to
+		"prompt".  Example: >vim
+			call prompt_setprompt(bufnr(''), 'command: ')
 <
-pum_getpos()                                                      *pum_getpos()*
-                If the popup menu (see |ins-completion-menu|) is not visible,
-                returns an empty |Dictionary|, otherwise, returns a
-                |Dictionary| with the following keys:
-                        height          nr of items visible
-                        width           screen cells
-                        row             top screen row (0 first row)
-                        col             leftmost screen column (0 first col)
-                        size            total nr of items
-                        scrollbar       |TRUE| if scrollbar is visible
+pum_getpos()							  *pum_getpos()*
+		If the popup menu (see |ins-completion-menu|) is not visible,
+		returns an empty |Dictionary|, otherwise, returns a
+		|Dictionary| with the following keys:
+			height		nr of items visible
+			width		screen cells
+			row		top screen row (0 first row)
+			col		leftmost screen column (0 first col)
+			size		total nr of items
+			scrollbar	|TRUE| if scrollbar is visible
 
-                The values are the same as in |v:event| during |CompleteChanged|.
+		The values are the same as in |v:event| during |CompleteChanged|.
 
-pumvisible()                                                      *pumvisible()*
-                Returns non-zero when the popup menu is visible, zero
-                otherwise.  See |ins-completion-menu|.
-                This can be used to avoid some things that would remove the
-                popup menu.
+pumvisible()							  *pumvisible()*
+		Returns non-zero when the popup menu is visible, zero
+		otherwise.  See |ins-completion-menu|.
+		This can be used to avoid some things that would remove the
+		popup menu.
 
-py3eval({expr})                                                      *py3eval()*
-                Evaluate Python expression {expr} and return its result
-                converted to Vim data structures.
-                Numbers and strings are returned as they are (strings are
-                copied though, Unicode strings are additionally converted to
-                UTF-8).
-                Lists are represented as Vim |List| type.
-                Dictionaries are represented as Vim |Dictionary| type with
-                keys converted to strings.
+py3eval({expr})							     *py3eval()*
+		Evaluate Python expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers and strings are returned as they are (strings are
+		copied though, Unicode strings are additionally converted to
+		UTF-8).
+		Lists are represented as Vim |List| type.
+		Dictionaries are represented as Vim |Dictionary| type with
+		keys converted to strings.
 
-pyeval({expr})                                              *pyeval()* *E858* *E859*
-                Evaluate Python expression {expr} and return its result
-                converted to Vim data structures.
-                Numbers and strings are returned as they are (strings are
-                copied though).
-                Lists are represented as Vim |List| type.
-                Dictionaries are represented as Vim |Dictionary| type,
-                non-string keys result in error.
+pyeval({expr})						    *pyeval()* *E858* *E859*
+		Evaluate Python expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers and strings are returned as they are (strings are
+		copied though).
+		Lists are represented as Vim |List| type.
+		Dictionaries are represented as Vim |Dictionary| type,
+		non-string keys result in error.
 
-pyxeval({expr})                                                      *pyxeval()*
-                Evaluate Python expression {expr} and return its result
-                converted to Vim data structures.
-                Uses Python 2 or 3, see |python_x| and 'pyxversion'.
-                See also: |pyeval()|, |py3eval()|
+pyxeval({expr})							     *pyxeval()*
+		Evaluate Python expression {expr} and return its result
+		converted to Vim data structures.
+		Uses Python 2 or 3, see |python_x| and 'pyxversion'.
+		See also: |pyeval()|, |py3eval()|
 
-rand([{expr}])                                                          *rand()*
-                Return a pseudo-random Number generated with an xoshiro128**
-                algorithm using seed {expr}.  The returned number is 32 bits,
-                also on 64 bits systems, for consistency.
-                {expr} can be initialized by |srand()| and will be updated by
-                rand().  If {expr} is omitted, an internal seed value is used
-                and updated.
-                Returns -1 if {expr} is invalid.
+rand([{expr}])								*rand()*
+		Return a pseudo-random Number generated with an xoshiro128**
+		algorithm using seed {expr}.  The returned number is 32 bits,
+		also on 64 bits systems, for consistency.
+		{expr} can be initialized by |srand()| and will be updated by
+		rand().  If {expr} is omitted, an internal seed value is used
+		and updated.
+		Returns -1 if {expr} is invalid.
 
-                Examples: >vim
-                        echo rand()
-                        let seed = srand()
-                        echo rand(seed)
-                        echo rand(seed) % 16  " random number 0 - 15
+		Examples: >vim
+			echo rand()
+			let seed = srand()
+			echo rand(seed)
+			echo rand(seed) % 16  " random number 0 - 15
 <
-range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E727*
-                Returns a |List| with Numbers:
-                - If only {expr} is specified: [0, 1, ..., {expr} - 1]
-                - If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
-                - If {stride} is specified: [{expr}, {expr} + {stride}, ...,
-                  {max}] (increasing {expr} with {stride} each time, not
-                  producing a value past {max}).
-                When the maximum is one before the start the result is an
-                empty list.  When the maximum is more than one before the
-                start this is an error.
-                Examples: >vim
-                        echo range(4)           " [0, 1, 2, 3]
-                        echo range(2, 4)        " [2, 3, 4]
-                        echo range(2, 9, 3)     " [2, 5, 8]
-                        echo range(2, -2, -1)   " [2, 1, 0, -1, -2]
-                        echo range(0)           " []
-                        echo range(2, 0)        " error!
+range({expr} [, {max} [, {stride}]])			     *range()* *E726* *E727*
+		Returns a |List| with Numbers:
+		- If only {expr} is specified: [0, 1, ..., {expr} - 1]
+		- If {max} is specified: [{expr}, {expr} + 1, ..., {max}]
+		- If {stride} is specified: [{expr}, {expr} + {stride}, ...,
+		  {max}] (increasing {expr} with {stride} each time, not
+		  producing a value past {max}).
+		When the maximum is one before the start the result is an
+		empty list.  When the maximum is more than one before the
+		start this is an error.
+		Examples: >vim
+			echo range(4)		" [0, 1, 2, 3]
+			echo range(2, 4)	" [2, 3, 4]
+			echo range(2, 9, 3)	" [2, 5, 8]
+			echo range(2, -2, -1)	" [2, 1, 0, -1, -2]
+			echo range(0)		" []
+			echo range(2, 0)	" error!
 <
-readblob({fname} [, {offset} [, {size}]])                           *readblob()*
-                Read file {fname} in binary mode and return a |Blob|.
-                If {offset} is specified, read the file from the specified
-                offset.  If it is a negative value, it is used as an offset
-                from the end of the file.  E.g., to read the last 12 bytes: >vim
-                        echo readblob('file.bin', -12)
-<                If {size} is specified, only the specified size will be read.
-                E.g. to read the first 100 bytes of a file: >vim
-                        echo readblob('file.bin', 0, 100)
-<                If {size} is -1 or omitted, the whole data starting from
-                {offset} will be read.
-                This can be also used to read the data from a character device
-                on Unix when {size} is explicitly set.  Only if the device
-                supports seeking {offset} can be used.  Otherwise it should be
-                zero.  E.g. to read 10 bytes from a serial console: >vim
-                        echo readblob('/dev/ttyS0', 0, 10)
-<                When the file can't be opened an error message is given and
-                the result is an empty |Blob|.
-                When the offset is beyond the end of the file the result is an
-                empty blob.
-                When trying to read more bytes than are available the result
-                is truncated.
-                Also see |readfile()| and |writefile()|.
+readblob({fname} [, {offset} [, {size}]])			    *readblob()*
+		Read file {fname} in binary mode and return a |Blob|.
+		If {offset} is specified, read the file from the specified
+		offset.  If it is a negative value, it is used as an offset
+		from the end of the file.  E.g., to read the last 12 bytes: >vim
+			echo readblob('file.bin', -12)
+<		 If {size} is specified, only the specified size will be read.
+		E.g. to read the first 100 bytes of a file: >vim
+			echo readblob('file.bin', 0, 100)
+<		 If {size} is -1 or omitted, the whole data starting from
+		{offset} will be read.
+		This can be also used to read the data from a character device
+		on Unix when {size} is explicitly set.	Only if the device
+		supports seeking {offset} can be used.	Otherwise it should be
+		zero.  E.g. to read 10 bytes from a serial console: >vim
+			echo readblob('/dev/ttyS0', 0, 10)
+<		 When the file can't be opened an error message is given and
+		the result is an empty |Blob|.
+		When the offset is beyond the end of the file the result is an
+		empty blob.
+		When trying to read more bytes than are available the result
+		is truncated.
+		Also see |readfile()| and |writefile()|.
 
-readdir({directory} [, {expr}])                                      *readdir()*
-                Return a list with file and directory names in {directory}.
-                You can also use |glob()| if you don't need to do complicated
-                things, such as limiting the number of matches.
+readdir({directory} [, {expr}])					     *readdir()*
+		Return a list with file and directory names in {directory}.
+		You can also use |glob()| if you don't need to do complicated
+		things, such as limiting the number of matches.
 
-                When {expr} is omitted all entries are included.
-                When {expr} is given, it is evaluated to check what to do:
-                        If {expr} results in -1 then no further entries will
-                        be handled.
-                        If {expr} results in 0 then this entry will not be
-                        added to the list.
-                        If {expr} results in 1 then this entry will be added
-                        to the list.
-                Each time {expr} is evaluated |v:val| is set to the entry name.
-                When {expr} is a function the name is passed as the argument.
-                For example, to get a list of files ending in ".txt": >vim
-                  echo readdir(dirname, {n -> n =~ '.txt$'})
-<                To skip hidden and backup files: >vim
-                  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
+		When {expr} is omitted all entries are included.
+		When {expr} is given, it is evaluated to check what to do:
+			If {expr} results in -1 then no further entries will
+			be handled.
+			If {expr} results in 0 then this entry will not be
+			added to the list.
+			If {expr} results in 1 then this entry will be added
+			to the list.
+		Each time {expr} is evaluated |v:val| is set to the entry name.
+		When {expr} is a function the name is passed as the argument.
+		For example, to get a list of files ending in ".txt": >vim
+		  echo readdir(dirname, {n -> n =~ '.txt$'})
+<		 To skip hidden and backup files: >vim
+		  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 
-<                If you want to get a directory tree: >vim
-                  function! s:tree(dir)
-                      return {a:dir : map(readdir(a:dir),
-                      \ {_, x -> isdirectory(x) ?
-                      \          {x : s:tree(a:dir .. '/' .. x)} : x})}
-                  endfunction
-                  echo s:tree(".")
+<		 If you want to get a directory tree: >vim
+		  function! s:tree(dir)
+		      return {a:dir : map(readdir(a:dir),
+		      \ {_, x -> isdirectory(x) ?
+		      \		 {x : s:tree(a:dir .. '/' .. x)} : x})}
+		  endfunction
+		  echo s:tree(".")
 <
-                Returns an empty List on error.
+		Returns an empty List on error.
 
-readfile({fname} [, {type} [, {max}]])                              *readfile()*
-                Read file {fname} and return a |List|, each line of the file
-                as an item.  Lines are broken at NL characters.  Macintosh
-                files separated with CR will result in a single long line
-                (unless a NL appears somewhere).
-                All NUL characters are replaced with a NL character.
-                When {type} contains "b" binary mode is used:
-                - When the last line ends in a NL an extra empty list item is
-                  added.
-                - No CR characters are removed.
-                Otherwise:
-                - CR characters that appear before a NL are removed.
-                - Whether the last line ends in a NL or not does not matter.
-                - Any UTF-8 byte order mark is removed from the text.
-                When {max} is given this specifies the maximum number of lines
-                to be read.  Useful if you only want to check the first ten
-                lines of a file: >vim
-                        for line in readfile(fname, '', 10)
-                          if line =~ 'Date' | echo line | endif
-                        endfor
-<                When {max} is negative -{max} lines from the end of the file
-                are returned, or as many as there are.
-                When {max} is zero the result is an empty list.
-                Note that without {max} the whole file is read into memory.
-                Also note that there is no recognition of encoding.  Read a
-                file into a buffer if you need to.
-                Deprecated (use |readblob()| instead): When {type} contains
-                "B" a |Blob| is returned with the binary data of the file
-                unmodified.
-                When the file can't be opened an error message is given and
-                the result is an empty list.
-                Also see |writefile()|.
+readfile({fname} [, {type} [, {max}]])				    *readfile()*
+		Read file {fname} and return a |List|, each line of the file
+		as an item.  Lines are broken at NL characters.  Macintosh
+		files separated with CR will result in a single long line
+		(unless a NL appears somewhere).
+		All NUL characters are replaced with a NL character.
+		When {type} contains "b" binary mode is used:
+		- When the last line ends in a NL an extra empty list item is
+		  added.
+		- No CR characters are removed.
+		Otherwise:
+		- CR characters that appear before a NL are removed.
+		- Whether the last line ends in a NL or not does not matter.
+		- Any UTF-8 byte order mark is removed from the text.
+		When {max} is given this specifies the maximum number of lines
+		to be read.  Useful if you only want to check the first ten
+		lines of a file: >vim
+			for line in readfile(fname, '', 10)
+			  if line =~ 'Date' | echo line | endif
+			endfor
+<		 When {max} is negative -{max} lines from the end of the file
+		are returned, or as many as there are.
+		When {max} is zero the result is an empty list.
+		Note that without {max} the whole file is read into memory.
+		Also note that there is no recognition of encoding.  Read a
+		file into a buffer if you need to.
+		Deprecated (use |readblob()| instead): When {type} contains
+		"B" a |Blob| is returned with the binary data of the file
+		unmodified.
+		When the file can't be opened an error message is given and
+		the result is an empty list.
+		Also see |writefile()|.
 
-reduce({object}, {func} [, {initial}])                           *reduce()* *E998*
-                {func} is called for every item in {object}, which can be a
-                |String|, |List| or a |Blob|.  {func} is called with two
-                arguments: the result so far and current item.  After
-                processing all items the result is returned.
+reduce({object}, {func} [, {initial}])				 *reduce()* *E998*
+		{func} is called for every item in {object}, which can be a
+		|String|, |List| or a |Blob|.  {func} is called with two
+		arguments: the result so far and current item.	After
+		processing all items the result is returned.
 
-                {initial} is the initial result.  When omitted, the first item
-                in {object} is used and {func} is first called for the second
-                item.  If {initial} is not given and {object} is empty no
-                result can be computed, an E998 error is given.
+		{initial} is the initial result.  When omitted, the first item
+		in {object} is used and {func} is first called for the second
+		item.  If {initial} is not given and {object} is empty no
+		result can be computed, an E998 error is given.
 
-                Examples: >vim
-                        echo reduce([1, 3, 5], { acc, val -> acc + val })
-                        echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
-                        echo reduce(0z1122, { acc, val -> 2 * acc + val })
-                        echo reduce('xyz', { acc, val -> acc .. ',' .. val })
+		Examples: >vim
+			echo reduce([1, 3, 5], { acc, val -> acc + val })
+			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+			echo reduce(0z1122, { acc, val -> 2 * acc + val })
+			echo reduce('xyz', { acc, val -> acc .. ',' .. val })
 <
-reg_executing()                                                *reg_executing()*
-                Returns the single letter name of the register being executed.
-                Returns an empty string when no register is being executed.
-                See |@|.
+reg_executing()						       *reg_executing()*
+		Returns the single letter name of the register being executed.
+		Returns an empty string when no register is being executed.
+		See |@|.
 
-reg_recorded()                                                  *reg_recorded()*
-                Returns the single letter name of the last recorded register.
-                Returns an empty string when nothing was recorded yet.
-                See |q| and |Q|.
+reg_recorded()							*reg_recorded()*
+		Returns the single letter name of the last recorded register.
+		Returns an empty string when nothing was recorded yet.
+		See |q| and |Q|.
 
-reg_recording()                                                *reg_recording()*
-                Returns the single letter name of the register being recorded.
-                Returns an empty string when not recording.  See |q|.
+reg_recording()						       *reg_recording()*
+		Returns the single letter name of the register being recorded.
+		Returns an empty string when not recording.  See |q|.
 
 reltime()
 reltime({start})
-reltime({start}, {end})                                              *reltime()*
-                Return an item that represents a time value.  The item is a
-                list with items that depend on the system.
-                The item can be passed to |reltimestr()| to convert it to a
-                string or |reltimefloat()| to convert to a Float.
+reltime({start}, {end})						     *reltime()*
+		Return an item that represents a time value.  The item is a
+		list with items that depend on the system.
+		The item can be passed to |reltimestr()| to convert it to a
+		string or |reltimefloat()| to convert to a Float.
 
-                Without an argument it returns the current "relative time", an
-                implementation-defined value meaningful only when used as an
-                argument to |reltime()|, |reltimestr()| and |reltimefloat()|.
+		Without an argument it returns the current "relative time", an
+		implementation-defined value meaningful only when used as an
+		argument to |reltime()|, |reltimestr()| and |reltimefloat()|.
 
-                With one argument it returns the time passed since the time
-                specified in the argument.
-                With two arguments it returns the time passed between {start}
-                and {end}.
+		With one argument it returns the time passed since the time
+		specified in the argument.
+		With two arguments it returns the time passed between {start}
+		and {end}.
 
-                The {start} and {end} arguments must be values returned by
-                reltime().  Returns zero on error.
+		The {start} and {end} arguments must be values returned by
+		reltime().  Returns zero on error.
 
-                Note: |localtime()| returns the current (non-relative) time.
+		Note: |localtime()| returns the current (non-relative) time.
 
-reltimefloat({time})                                            *reltimefloat()*
-                Return a Float that represents the time value of {time}.
-                Unit of time is seconds.
-                Example:
-                        let start = reltime()
-                        call MyFunction()
-                        let seconds = reltimefloat(reltime(start))
-                See the note of reltimestr() about overhead.
-                Also see |profiling|.
-                If there is an error an empty string is returned
+reltimefloat({time})						*reltimefloat()*
+		Return a Float that represents the time value of {time}.
+		Unit of time is seconds.
+		Example:
+			let start = reltime()
+			call MyFunction()
+			let seconds = reltimefloat(reltime(start))
+		See the note of reltimestr() about overhead.
+		Also see |profiling|.
+		If there is an error an empty string is returned
 
-reltimestr({time})                                                *reltimestr()*
-                Return a String that represents the time value of {time}.
-                This is the number of seconds, a dot and the number of
-                microseconds.  Example: >vim
-                        let start = reltime()
-                        call MyFunction()
-                        echo reltimestr(reltime(start))
-<                Note that overhead for the commands will be added to the time.
-                Leading spaces are used to make the string align nicely.  You
-                can use split() to remove it. >vim
-                        echo split(reltimestr(reltime(start)))[0]
-<                Also see |profiling|.
-                If there is an error an empty string is returned
+reltimestr({time})						  *reltimestr()*
+		Return a String that represents the time value of {time}.
+		This is the number of seconds, a dot and the number of
+		microseconds.  Example: >vim
+			let start = reltime()
+			call MyFunction()
+			echo reltimestr(reltime(start))
+<		 Note that overhead for the commands will be added to the time.
+		Leading spaces are used to make the string align nicely.  You
+		can use split() to remove it. >vim
+			echo split(reltimestr(reltime(start)))[0]
+<		 Also see |profiling|.
+		If there is an error an empty string is returned
 
 remove({list}, {idx})
-remove({list}, {idx}, {end})                                          *remove()*
-                Without {end}: Remove the item at {idx} from |List| {list} and
-                return the item.
-                With {end}: Remove items from {idx} to {end} (inclusive) and
-                return a |List| with these items.  When {idx} points to the same
-                item as {end} a list with one item is returned.  When {end}
-                points to an item before {idx} this is an error.
-                See |list-index| for possible values of {idx} and {end}.
-                Returns zero on error.
-                Example: >vim
-                        echo "last item: " .. remove(mylist, -1)
-                        call remove(mylist, 0, 9)
+remove({list}, {idx}, {end})					      *remove()*
+		Without {end}: Remove the item at {idx} from |List| {list} and
+		return the item.
+		With {end}: Remove items from {idx} to {end} (inclusive) and
+		return a |List| with these items.  When {idx} points to the same
+		item as {end} a list with one item is returned.  When {end}
+		points to an item before {idx} this is an error.
+		See |list-index| for possible values of {idx} and {end}.
+		Returns zero on error.
+		Example: >vim
+			echo "last item: " .. remove(mylist, -1)
+			call remove(mylist, 0, 9)
 <
-                Use |delete()| to remove a file.
+		Use |delete()| to remove a file.
 
 remove({blob}, {idx})
 remove({blob}, {idx}, {end})
-                Without {end}: Remove the byte at {idx} from |Blob| {blob} and
-                return the byte.
-                With {end}: Remove bytes from {idx} to {end} (inclusive) and
-                return a |Blob| with these bytes.  When {idx} points to the same
-                byte as {end} a |Blob| with one byte is returned.  When {end}
-                points to a byte before {idx} this is an error.
-                Returns zero on error.
-                Example: >vim
-                        echo "last byte: " .. remove(myblob, -1)
-                        call remove(mylist, 0, 9)
+		Without {end}: Remove the byte at {idx} from |Blob| {blob} and
+		return the byte.
+		With {end}: Remove bytes from {idx} to {end} (inclusive) and
+		return a |Blob| with these bytes.  When {idx} points to the same
+		byte as {end} a |Blob| with one byte is returned.  When {end}
+		points to a byte before {idx} this is an error.
+		Returns zero on error.
+		Example: >vim
+			echo "last byte: " .. remove(myblob, -1)
+			call remove(mylist, 0, 9)
 <
 remove({dict}, {key})
-                Remove the entry from {dict} with key {key} and return it.
-                Example: >vim
-                        echo "removed " .. remove(dict, "one")
-<                If there is no {key} in {dict} this is an error.
-                Returns zero on error.
+		Remove the entry from {dict} with key {key} and return it.
+		Example: >vim
+			echo "removed " .. remove(dict, "one")
+<		 If there is no {key} in {dict} this is an error.
+		Returns zero on error.
 
-rename({from}, {to})                                                  *rename()*
-                Rename the file by the name {from} to the name {to}.  This
-                should also work to move files across file systems.  The
-                result is a Number, which is 0 if the file was renamed
-                successfully, and non-zero when the renaming failed.
-                NOTE: If {to} exists it is overwritten without warning.
-                This function is not available in the |sandbox|.
+rename({from}, {to})						      *rename()*
+		Rename the file by the name {from} to the name {to}.  This
+		should also work to move files across file systems.  The
+		result is a Number, which is 0 if the file was renamed
+		successfully, and non-zero when the renaming failed.
+		NOTE: If {to} exists it is overwritten without warning.
+		This function is not available in the |sandbox|.
 
-repeat({expr}, {count})                                               *repeat()*
-                Repeat {expr} {count} times and return the concatenated
-                result.  Example: >vim
-                        let separator = repeat('-', 80)
-<                When {count} is zero or negative the result is empty.
-                When {expr} is a |List| or a |Blob| the result is {expr}
-                concatenated {count} times.  Example: >vim
-                        let longlist = repeat(['a', 'b'], 3)
-<                Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+repeat({expr}, {count})						      *repeat()*
+		Repeat {expr} {count} times and return the concatenated
+		result.  Example: >vim
+			let separator = repeat('-', 80)
+<		 When {count} is zero or negative the result is empty.
+		When {expr} is a |List| or a |Blob| the result is {expr}
+		concatenated {count} times.  Example: >vim
+			let longlist = repeat(['a', 'b'], 3)
+<		 Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
-resolve({filename})                                             *resolve()* *E655*
-                On MS-Windows, when {filename} is a shortcut (a .lnk file),
-                returns the path the shortcut points to in a simplified form.
-                On Unix, repeat resolving symbolic links in all path
-                components of {filename} and return the simplified result.
-                To cope with link cycles, resolving of symbolic links is
-                stopped after 100 iterations.
-                On other systems, return the simplified {filename}.
-                The simplification step is done as by |simplify()|.
-                resolve() keeps a leading path component specifying the
-                current directory (provided the result is still a relative
-                path name) and also keeps a trailing path separator.
+resolve({filename})						*resolve()* *E655*
+		On MS-Windows, when {filename} is a shortcut (a .lnk file),
+		returns the path the shortcut points to in a simplified form.
+		On Unix, repeat resolving symbolic links in all path
+		components of {filename} and return the simplified result.
+		To cope with link cycles, resolving of symbolic links is
+		stopped after 100 iterations.
+		On other systems, return the simplified {filename}.
+		The simplification step is done as by |simplify()|.
+		resolve() keeps a leading path component specifying the
+		current directory (provided the result is still a relative
+		path name) and also keeps a trailing path separator.
 
-reverse({object})                                                    *reverse()*
-                Reverse the order of items in {object}.  {object} can be a
-                |List|, a |Blob| or a |String|.  For a List and a Blob the
-                items are reversed in-place and {object} is returned.
-                For a String a new String is returned.
-                Returns zero if {object} is not a List, Blob or a String.
-                If you want a List or Blob to remain unmodified make a copy
-                first: >vim
-                        let revlist = reverse(copy(mylist))
+reverse({object})						     *reverse()*
+		Reverse the order of items in {object}.  {object} can be a
+		|List|, a |Blob| or a |String|.  For a List and a Blob the
+		items are reversed in-place and {object} is returned.
+		For a String a new String is returned.
+		Returns zero if {object} is not a List, Blob or a String.
+		If you want a List or Blob to remain unmodified make a copy
+		first: >vim
+			let revlist = reverse(copy(mylist))
 <
-round({expr})                                                          *round()*
-                Round off {expr} to the nearest integral value and return it
-                as a |Float|.  If {expr} lies halfway between two integral
-                values, then use the larger one (away from zero).
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo round(0.456)
-<                        0.0  >vim
-                        echo round(4.5)
-<                        5.0 >vim
-                        echo round(-4.5)
-<                        -5.0
+round({expr})							       *round()*
+		Round off {expr} to the nearest integral value and return it
+		as a |Float|.  If {expr} lies halfway between two integral
+		values, then use the larger one (away from zero).
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo round(0.456)
+<			 0.0  >vim
+			echo round(4.5)
+<			 5.0 >vim
+			echo round(-4.5)
+<			 -5.0
 
-rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
-                Sends {event} to {channel} via |RPC| and returns immediately.
-                If {channel} is 0, the event is broadcast to all channels.
-                Example: >vim
-                        au VimLeave call rpcnotify(0, "leaving")
+rpcnotify({channel}, {event} [, {args}...])			   *rpcnotify()*
+		Sends {event} to {channel} via |RPC| and returns immediately.
+		If {channel} is 0, the event is broadcast to all channels.
+		Example: >vim
+			au VimLeave call rpcnotify(0, "leaving")
 <
-rpcrequest({channel}, {method} [, {args}...])                     *rpcrequest()*
-                Sends a request to {channel} to invoke {method} via
-                |RPC| and blocks until a response is received.
-                Example: >vim
-                        let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+rpcrequest({channel}, {method} [, {args}...])			  *rpcrequest()*
+		Sends a request to {channel} to invoke {method} via
+		|RPC| and blocks until a response is received.
+		Example: >vim
+			let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 <
-rpcstart({prog} [, {argv}])                                         *rpcstart()*
-                Deprecated. Replace  >vim
-                        let id = rpcstart('prog', ['arg1', 'arg2'])
-<                with >vim
-                        let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+rpcstart({prog} [, {argv}])					    *rpcstart()*
+		Deprecated. Replace  >vim
+			let id = rpcstart('prog', ['arg1', 'arg2'])
+<		 with >vim
+			let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 <
-rubyeval({expr})                                                    *rubyeval()*
-                Evaluate Ruby expression {expr} and return its result
-                converted to Vim data structures.
-                Numbers, floats and strings are returned as they are (strings
-                are copied though).
-                Arrays are represented as Vim |List| type.
-                Hashes are represented as Vim |Dictionary| type.
-                Other objects are represented as strings resulted from their
-                "Object#to_s" method.
+rubyeval({expr})						    *rubyeval()*
+		Evaluate Ruby expression {expr} and return its result
+		converted to Vim data structures.
+		Numbers, floats and strings are returned as they are (strings
+		are copied though).
+		Arrays are represented as Vim |List| type.
+		Hashes are represented as Vim |Dictionary| type.
+		Other objects are represented as strings resulted from their
+		"Object#to_s" method.
 
-screenattr({row}, {col})                                          *screenattr()*
-                Like |screenchar()|, but return the attribute.  This is a rather
-                arbitrary number that can only be used to compare to the
-                attribute at other positions.
-                Returns -1 when row or col is out of range.
+screenattr({row}, {col})					  *screenattr()*
+		Like |screenchar()|, but return the attribute.	This is a rather
+		arbitrary number that can only be used to compare to the
+		attribute at other positions.
+		Returns -1 when row or col is out of range.
 
-screenchar({row}, {col})                                          *screenchar()*
-                The result is a Number, which is the character at position
-                [row, col] on the screen.  This works for every possible
-                screen position, also status lines, window separators and the
-                command line.  The top left position is row one, column one
-                The character excludes composing characters.  For double-byte
-                encodings it may only be the first byte.
-                This is mainly to be used for testing.
-                Returns -1 when row or col is out of range.
+screenchar({row}, {col})					  *screenchar()*
+		The result is a Number, which is the character at position
+		[row, col] on the screen.  This works for every possible
+		screen position, also status lines, window separators and the
+		command line.  The top left position is row one, column one
+		The character excludes composing characters.  For double-byte
+		encodings it may only be the first byte.
+		This is mainly to be used for testing.
+		Returns -1 when row or col is out of range.
 
-screenchars({row}, {col})                                        *screenchars()*
-                The result is a |List| of Numbers.  The first number is the same
-                as what |screenchar()| returns.  Further numbers are
-                composing characters on top of the base character.
-                This is mainly to be used for testing.
-                Returns an empty List when row or col is out of range.
+screenchars({row}, {col})					 *screenchars()*
+		The result is a |List| of Numbers.  The first number is the same
+		as what |screenchar()| returns.  Further numbers are
+		composing characters on top of the base character.
+		This is mainly to be used for testing.
+		Returns an empty List when row or col is out of range.
 
-screencol()                                                        *screencol()*
-                The result is a Number, which is the current screen column of
-                the cursor. The leftmost column has number 1.
-                This function is mainly used for testing.
+screencol()							   *screencol()*
+		The result is a Number, which is the current screen column of
+		the cursor. The leftmost column has number 1.
+		This function is mainly used for testing.
 
-                Note: Always returns the current screen column, thus if used
-                in a command (e.g. ":echo screencol()") it will return the
-                column inside the command line, which is 1 when the command is
-                executed. To get the cursor position in the file use one of
-                the following mappings: >vim
-                        nnoremap <expr> GG ":echom " .. screencol() .. "\n"
-                        nnoremap <silent> GG :echom screencol()<CR>
-                        noremap GG <Cmd>echom screencol()<Cr>
+		Note: Always returns the current screen column, thus if used
+		in a command (e.g. ":echo screencol()") it will return the
+		column inside the command line, which is 1 when the command is
+		executed. To get the cursor position in the file use one of
+		the following mappings: >vim
+			nnoremap <expr> GG ":echom " .. screencol() .. "\n"
+			nnoremap <silent> GG :echom screencol()<CR>
+			noremap GG <Cmd>echom screencol()<Cr>
 <
-screenpos({winid}, {lnum}, {col})                                  *screenpos()*
-                The result is a Dict with the screen position of the text
-                character in window {winid} at buffer line {lnum} and column
-                {col}.  {col} is a one-based byte index.
-                The Dict has these members:
-                        row     screen row
-                        col     first screen column
-                        endcol  last screen column
-                        curscol cursor screen column
-                If the specified position is not visible, all values are zero.
-                The "endcol" value differs from "col" when the character
-                occupies more than one screen cell.  E.g. for a Tab "col" can
-                be 1 and "endcol" can be 8.
-                The "curscol" value is where the cursor would be placed.  For
-                a Tab it would be the same as "endcol", while for a double
-                width character it would be the same as "col".
-                The |conceal| feature is ignored here, the column numbers are
-                as if 'conceallevel' is zero.  You can set the cursor to the
-                right position and use |screencol()| to get the value with
-                |conceal| taken into account.
-                If the position is in a closed fold the screen position of the
-                first character is returned, {col} is not used.
-                Returns an empty Dict if {winid} is invalid.
+screenpos({winid}, {lnum}, {col})				   *screenpos()*
+		The result is a Dict with the screen position of the text
+		character in window {winid} at buffer line {lnum} and column
+		{col}.	{col} is a one-based byte index.
+		The Dict has these members:
+			row	screen row
+			col	first screen column
+			endcol	last screen column
+			curscol cursor screen column
+		If the specified position is not visible, all values are zero.
+		The "endcol" value differs from "col" when the character
+		occupies more than one screen cell.  E.g. for a Tab "col" can
+		be 1 and "endcol" can be 8.
+		The "curscol" value is where the cursor would be placed.  For
+		a Tab it would be the same as "endcol", while for a double
+		width character it would be the same as "col".
+		The |conceal| feature is ignored here, the column numbers are
+		as if 'conceallevel' is zero.  You can set the cursor to the
+		right position and use |screencol()| to get the value with
+		|conceal| taken into account.
+		If the position is in a closed fold the screen position of the
+		first character is returned, {col} is not used.
+		Returns an empty Dict if {winid} is invalid.
 
-screenrow()                                                        *screenrow()*
-                The result is a Number, which is the current screen row of the
-                cursor.  The top line has number one.
-                This function is mainly used for testing.
-                Alternatively you can use |winline()|.
+screenrow()							   *screenrow()*
+		The result is a Number, which is the current screen row of the
+		cursor.  The top line has number one.
+		This function is mainly used for testing.
+		Alternatively you can use |winline()|.
 
-                Note: Same restrictions as with |screencol()|.
+		Note: Same restrictions as with |screencol()|.
 
-screenstring({row}, {col})                                      *screenstring()*
-                The result is a String that contains the base character and
-                any composing characters at position [row, col] on the screen.
-                This is like |screenchars()| but returning a String with the
-                characters.
-                This is mainly to be used for testing.
-                Returns an empty String when row or col is out of range.
+screenstring({row}, {col})					*screenstring()*
+		The result is a String that contains the base character and
+		any composing characters at position [row, col] on the screen.
+		This is like |screenchars()| but returning a String with the
+		characters.
+		This is mainly to be used for testing.
+		Returns an empty String when row or col is out of range.
 
 search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
-                Search for regexp pattern {pattern}.  The search starts at the
-                cursor position (you can use |cursor()| to set it).
+		Search for regexp pattern {pattern}.  The search starts at the
+		cursor position (you can use |cursor()| to set it).
 
-                When a match has been found its line number is returned.
-                If there is no match a 0 is returned and the cursor doesn't
-                move.  No error message is given.
+		When a match has been found its line number is returned.
+		If there is no match a 0 is returned and the cursor doesn't
+		move.  No error message is given.
 
-                {flags} is a String, which can contain these character flags:
-                'b'     search Backward instead of forward
-                'c'     accept a match at the Cursor position
-                'e'     move to the End of the match
-                'n'     do Not move the cursor
-                'p'     return number of matching sub-Pattern (see below)
-                's'     Set the ' mark at the previous location of the cursor
-                'w'     Wrap around the end of the file
-                'W'     don't Wrap around the end of the file
-                'z'     start searching at the cursor column instead of Zero
-                If neither 'w' or 'W' is given, the 'wrapscan' option applies.
+		{flags} is a String, which can contain these character flags:
+		'b'	search Backward instead of forward
+		'c'	accept a match at the Cursor position
+		'e'	move to the End of the match
+		'n'	do Not move the cursor
+		'p'	return number of matching sub-Pattern (see below)
+		's'	Set the ' mark at the previous location of the cursor
+		'w'	Wrap around the end of the file
+		'W'	don't Wrap around the end of the file
+		'z'	start searching at the cursor column instead of Zero
+		If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
-                If the 's' flag is supplied, the ' mark is set, only if the
-                cursor is moved. The 's' flag cannot be combined with the 'n'
-                flag.
+		If the 's' flag is supplied, the ' mark is set, only if the
+		cursor is moved. The 's' flag cannot be combined with the 'n'
+		flag.
 
-                'ignorecase', 'smartcase' and 'magic' are used.
+		'ignorecase', 'smartcase' and 'magic' are used.
 
-                When the 'z' flag is not given, forward searching always
-                starts in column zero and then matches before the cursor are
-                skipped.  When the 'c' flag is present in 'cpo' the next
-                search starts after the match.  Without the 'c' flag the next
-                search starts one column after the start of the match.  This
-                matters for overlapping matches.  See |cpo-c|.  You can also
-                insert "\ze" to change where the match ends, see  |/\ze|.
+		When the 'z' flag is not given, forward searching always
+		starts in column zero and then matches before the cursor are
+		skipped.  When the 'c' flag is present in 'cpo' the next
+		search starts after the match.	Without the 'c' flag the next
+		search starts one column after the start of the match.	This
+		matters for overlapping matches.  See |cpo-c|.	You can also
+		insert "\ze" to change where the match ends, see  |/\ze|.
 
-                When searching backwards and the 'z' flag is given then the
-                search starts in column zero, thus no match in the current
-                line will be found (unless wrapping around the end of the
-                file).
+		When searching backwards and the 'z' flag is given then the
+		search starts in column zero, thus no match in the current
+		line will be found (unless wrapping around the end of the
+		file).
 
-                When the {stopline} argument is given then the search stops
-                after searching this line.  This is useful to restrict the
-                search to a range of lines.  Examples: >vim
-                        let match = search('(', 'b', line("w0"))
-                        let end = search('END', '', line("w$"))
-<                When {stopline} is used and it is not zero this also implies
-                that the search does not wrap around the end of the file.
-                A zero value is equal to not giving the argument.
+		When the {stopline} argument is given then the search stops
+		after searching this line.  This is useful to restrict the
+		search to a range of lines.  Examples: >vim
+			let match = search('(', 'b', line("w0"))
+			let end = search('END', '', line("w$"))
+<		 When {stopline} is used and it is not zero this also implies
+		that the search does not wrap around the end of the file.
+		A zero value is equal to not giving the argument.
 
-                When the {timeout} argument is given the search stops when
-                more than this many milliseconds have passed.  Thus when
-                {timeout} is 500 the search stops after half a second.
-                The value must not be negative.  A zero value is like not
-                giving the argument.
+		When the {timeout} argument is given the search stops when
+		more than this many milliseconds have passed.  Thus when
+		{timeout} is 500 the search stops after half a second.
+		The value must not be negative.  A zero value is like not
+		giving the argument.
 
-                If the {skip} expression is given it is evaluated with the
-                cursor positioned on the start of a match.  If it evaluates to
-                non-zero this match is skipped.  This can be used, for
-                example, to skip a match in a comment or a string.
-                {skip} can be a string, which is evaluated as an expression, a
-                function reference or a lambda.
-                When {skip} is omitted or empty, every match is accepted.
-                When evaluating {skip} causes an error the search is aborted
-                and -1 returned.
-                                                        *search()-sub-match*
-                With the 'p' flag the returned value is one more than the
-                first sub-match in \(\).  One if none of them matched but the
-                whole pattern did match.
-                To get the column number too use |searchpos()|.
+		If the {skip} expression is given it is evaluated with the
+		cursor positioned on the start of a match.  If it evaluates to
+		non-zero this match is skipped.  This can be used, for
+		example, to skip a match in a comment or a string.
+		{skip} can be a string, which is evaluated as an expression, a
+		function reference or a lambda.
+		When {skip} is omitted or empty, every match is accepted.
+		When evaluating {skip} causes an error the search is aborted
+		and -1 returned.
+							*search()-sub-match*
+		With the 'p' flag the returned value is one more than the
+		first sub-match in \(\).  One if none of them matched but the
+		whole pattern did match.
+		To get the column number too use |searchpos()|.
 
-                The cursor will be positioned at the match, unless the 'n'
-                flag is used.
+		The cursor will be positioned at the match, unless the 'n'
+		flag is used.
 
-                Example (goes over all files in the argument list): >vim
-                    let n = 1
-                    while n <= argc()       " loop over all files in arglist
-                      exe "argument " .. n
-                      " start at the last char in the file and wrap for the
-                      " first search to find match at start of file
-                      normal G$
-                      let flags = "w"
-                      while search("foo", flags) > 0
-                        s/foo/bar/g
-                        let flags = "W"
-                      endwhile
-                      update                " write the file if modified
-                      let n = n + 1
-                    endwhile
+		Example (goes over all files in the argument list): >vim
+		    let n = 1
+		    while n <= argc()	    " loop over all files in arglist
+		      exe "argument " .. n
+		      " start at the last char in the file and wrap for the
+		      " first search to find match at start of file
+		      normal G$
+		      let flags = "w"
+		      while search("foo", flags) > 0
+			s/foo/bar/g
+			let flags = "W"
+		      endwhile
+		      update		    " write the file if modified
+		      let n = n + 1
+		    endwhile
 <
-                Example for using some flags: >vim
-                    echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
-<                This will search for the keywords "if", "else", and "endif"
-                under or after the cursor.  Because of the 'p' flag, it
-                returns 1, 2, or 3 depending on which keyword is found, or 0
-                if the search fails.  With the cursor on the first word of the
-                line:
-                    if (foo == 0) | let foo = foo + 1 | endif ~
-                the function returns 1.  Without the 'c' flag, the function
-                finds the "endif" and returns 3.  The same thing happens
-                without the 'e' flag if the cursor is on the "f" of "if".
-                The 'n' flag tells the function not to move the cursor.
+		Example for using some flags: >vim
+		    echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
+<		 This will search for the keywords "if", "else", and "endif"
+		under or after the cursor.  Because of the 'p' flag, it
+		returns 1, 2, or 3 depending on which keyword is found, or 0
+		if the search fails.  With the cursor on the first word of the
+		line:
+		    if (foo == 0) | let foo = foo + 1 | endif ~
+		the function returns 1.  Without the 'c' flag, the function
+		finds the "endif" and returns 3.  The same thing happens
+		without the 'e' flag if the cursor is on the "f" of "if".
+		The 'n' flag tells the function not to move the cursor.
 
-searchcount([{options}])                                         *searchcount()*
-                Get or update the last search count, like what is displayed
-                without the "S" flag in 'shortmess'.  This works even if
-                'shortmess' does contain the "S" flag.
+searchcount([{options}])					 *searchcount()*
+		Get or update the last search count, like what is displayed
+		without the "S" flag in 'shortmess'.  This works even if
+		'shortmess' does contain the "S" flag.
 
-                This returns a |Dictionary|. The dictionary is empty if the
-                previous pattern was not set and "pattern" was not specified.
+		This returns a |Dictionary|. The dictionary is empty if the
+		previous pattern was not set and "pattern" was not specified.
 
-                  key           type            meaning ~
-                  current       |Number|        current position of match;
-                                                0 if the cursor position is
-                                                before the first match
-                  exact_match   |Boolean|       1 if "current" is matched on
-                                                "pos", otherwise 0
-                  total         |Number|        total count of matches found
-                  incomplete    |Number|        0: search was fully completed
-                                                1: recomputing was timed out
-                                                2: max count exceeded
+		  key		type		meaning ~
+		  current	|Number|	current position of match;
+						0 if the cursor position is
+						before the first match
+		  exact_match	|Boolean|	1 if "current" is matched on
+						"pos", otherwise 0
+		  total		|Number|	total count of matches found
+		  incomplete	|Number|	0: search was fully completed
+						1: recomputing was timed out
+						2: max count exceeded
 
-                For {options} see further down.
+		For {options} see further down.
 
-                To get the last search count when |n| or |N| was pressed, call
-                this function with `recompute: 0` . This sometimes returns
-                wrong information because |n| and |N|'s maximum count is 99.
-                If it exceeded 99 the result must be max count + 1 (100). If
-                you want to get correct information, specify `recompute: 1`: >vim
+		To get the last search count when |n| or |N| was pressed, call
+		this function with `recompute: 0` . This sometimes returns
+		wrong information because |n| and |N|'s maximum count is 99.
+		If it exceeded 99 the result must be max count + 1 (100). If
+		you want to get correct information, specify `recompute: 1`: >vim
 
-                        " result == maxcount + 1 (100) when many matches
-                        let result = searchcount(#{recompute: 0})
+			" result == maxcount + 1 (100) when many matches
+			let result = searchcount(#{recompute: 0})
 
-                        " Below returns correct result (recompute defaults
-                        " to 1)
-                        let result = searchcount()
+			" Below returns correct result (recompute defaults
+			" to 1)
+			let result = searchcount()
 <
-                The function is useful to add the count to 'statusline': >vim
-                        function! LastSearchCount() abort
-                          let result = searchcount(#{recompute: 0})
-                          if empty(result)
-                            return ''
-                          endif
-                          if result.incomplete ==# 1     " timed out
-                            return printf(' /%s [?/??]', @/)
-                          elseif result.incomplete ==# 2 " max count exceeded
-                            if result.total > result.maxcount &&
-                            \  result.current > result.maxcount
-                              return printf(' /%s [>%d/>%d]', @/,
-                              \             result.current, result.total)
-                            elseif result.total > result.maxcount
-                              return printf(' /%s [%d/>%d]', @/,
-                              \             result.current, result.total)
-                            endif
-                          endif
-                          return printf(' /%s [%d/%d]', @/,
-                          \             result.current, result.total)
-                        endfunction
-                        let &statusline ..= '%{LastSearchCount()}'
+		The function is useful to add the count to 'statusline': >vim
+			function! LastSearchCount() abort
+			  let result = searchcount(#{recompute: 0})
+			  if empty(result)
+			    return ''
+			  endif
+			  if result.incomplete ==# 1	 " timed out
+			    return printf(' /%s [?/??]', @/)
+			  elseif result.incomplete ==# 2 " max count exceeded
+			    if result.total > result.maxcount &&
+			    \  result.current > result.maxcount
+			      return printf(' /%s [>%d/>%d]', @/,
+			      \		    result.current, result.total)
+			    elseif result.total > result.maxcount
+			      return printf(' /%s [%d/>%d]', @/,
+			      \		    result.current, result.total)
+			    endif
+			  endif
+			  return printf(' /%s [%d/%d]', @/,
+			  \		result.current, result.total)
+			endfunction
+			let &statusline ..= '%{LastSearchCount()}'
 
-                        " Or if you want to show the count only when
-                        " 'hlsearch' was on
-                        " let &statusline ..=
-                        " \   '%{v:hlsearch ? LastSearchCount() : ""}'
+			" Or if you want to show the count only when
+			" 'hlsearch' was on
+			" let &statusline ..=
+			" \   '%{v:hlsearch ? LastSearchCount() : ""}'
 <
-                You can also update the search count, which can be useful in a
-                |CursorMoved| or |CursorMovedI| autocommand: >vim
+		You can also update the search count, which can be useful in a
+		|CursorMoved| or |CursorMovedI| autocommand: >vim
 
-                        autocmd CursorMoved,CursorMovedI *
-                          \ let s:searchcount_timer = timer_start(
-                          \   200, function('s:update_searchcount'))
-                        function! s:update_searchcount(timer) abort
-                          if a:timer ==# s:searchcount_timer
-                            call searchcount(#{
-                            \ recompute: 1, maxcount: 0, timeout: 100})
-                            redrawstatus
-                          endif
-                        endfunction
+			autocmd CursorMoved,CursorMovedI *
+			  \ let s:searchcount_timer = timer_start(
+			  \   200, function('s:update_searchcount'))
+			function! s:update_searchcount(timer) abort
+			  if a:timer ==# s:searchcount_timer
+			    call searchcount(#{
+			    \ recompute: 1, maxcount: 0, timeout: 100})
+			    redrawstatus
+			  endif
+			endfunction
 <
-                This can also be used to count matched texts with specified
-                pattern in the current buffer using "pattern":  >vim
+		This can also be used to count matched texts with specified
+		pattern in the current buffer using "pattern":	>vim
 
-                        " Count '\<foo\>' in this buffer
-                        " (Note that it also updates search count)
-                        let result = searchcount(#{pattern: '\<foo\>'})
+			" Count '\<foo\>' in this buffer
+			" (Note that it also updates search count)
+			let result = searchcount(#{pattern: '\<foo\>'})
 
-                        " To restore old search count by old pattern,
-                        " search again
-                        call searchcount()
+			" To restore old search count by old pattern,
+			" search again
+			call searchcount()
 <
-                {options} must be a |Dictionary|. It can contain:
-                  key           type            meaning ~
-                  recompute     |Boolean|         if |TRUE|, recompute the count
-                                                like |n| or |N| was executed.
-                                                otherwise returns the last
-                                                computed result (when |n| or
-                                                |N| was used when "S" is not
-                                                in 'shortmess', or this
-                                                function was called).
-                                                (default: |TRUE|)
-                  pattern       |String|          recompute if this was given
-                                                and different with |@/|.
-                                                this works as same as the
-                                                below command is executed
-                                                before calling this function >vim
-                                                  let @/ = pattern
-<                                               (default: |@/|)
-                  timeout       |Number|          0 or negative number is no
-                                                timeout. timeout milliseconds
-                                                for recomputing the result
-                                                (default: 0)
-                  maxcount      |Number|          0 or negative number is no
-                                                limit. max count of matched
-                                                text while recomputing the
-                                                result.  if search exceeded
-                                                total count, "total" value
-                                                becomes `maxcount + 1`
-                                                (default: 0)
-                  pos           |List|            `[lnum, col, off]` value
-                                                when recomputing the result.
-                                                this changes "current" result
-                                                value. see |cursor()|, |getpos()|
-                                                (default: cursor's position)
+		{options} must be a |Dictionary|. It can contain:
+		  key		type		meaning ~
+		  recompute	|Boolean|	  if |TRUE|, recompute the count
+						like |n| or |N| was executed.
+						otherwise returns the last
+						computed result (when |n| or
+						|N| was used when "S" is not
+						in 'shortmess', or this
+						function was called).
+						(default: |TRUE|)
+		  pattern	|String|	  recompute if this was given
+						and different with |@/|.
+						this works as same as the
+						below command is executed
+						before calling this function >vim
+						  let @/ = pattern
+<						(default: |@/|)
+		  timeout	|Number|	  0 or negative number is no
+						timeout. timeout milliseconds
+						for recomputing the result
+						(default: 0)
+		  maxcount	|Number|	  0 or negative number is no
+						limit. max count of matched
+						text while recomputing the
+						result.  if search exceeded
+						total count, "total" value
+						becomes `maxcount + 1`
+						(default: 0)
+		  pos		|List|		  `[lnum, col, off]` value
+						when recomputing the result.
+						this changes "current" result
+						value. see |cursor()|, |getpos()|
+						(default: cursor's position)
 
-searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
-                Search for the declaration of {name}.
+searchdecl({name} [, {global} [, {thisblock}]])			  *searchdecl()*
+		Search for the declaration of {name}.
 
-                With a non-zero {global} argument it works like |gD|, find
-                first match in the file.  Otherwise it works like |gd|, find
-                first match in the function.
+		With a non-zero {global} argument it works like |gD|, find
+		first match in the file.  Otherwise it works like |gd|, find
+		first match in the function.
 
-                With a non-zero {thisblock} argument matches in a {} block
-                that ends before the cursor position are ignored.  Avoids
-                finding variable declarations only valid in another scope.
+		With a non-zero {thisblock} argument matches in a {} block
+		that ends before the cursor position are ignored.  Avoids
+		finding variable declarations only valid in another scope.
 
-                Moves the cursor to the found match.
-                Returns zero for success, non-zero for failure.
-                Example: >vim
-                        if searchdecl('myvar') == 0
-                           echo getline('.')
-                        endif
+		Moves the cursor to the found match.
+		Returns zero for success, non-zero for failure.
+		Example: >vim
+			if searchdecl('myvar') == 0
+			   echo getline('.')
+			endif
 <
-                                                                  *searchpair()*
+								  *searchpair()*
 searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
-                Search for the match of a nested start-end pair.  This can be
-                used to find the "endif" that matches an "if", while other
-                if/endif pairs in between are ignored.
-                The search starts at the cursor.  The default is to search
-                forward, include 'b' in {flags} to search backward.
-                If a match is found, the cursor is positioned at it and the
-                line number is returned.  If no match is found 0 or -1 is
-                returned and the cursor doesn't move.  No error message is
-                given.
+		Search for the match of a nested start-end pair.  This can be
+		used to find the "endif" that matches an "if", while other
+		if/endif pairs in between are ignored.
+		The search starts at the cursor.  The default is to search
+		forward, include 'b' in {flags} to search backward.
+		If a match is found, the cursor is positioned at it and the
+		line number is returned.  If no match is found 0 or -1 is
+		returned and the cursor doesn't move.  No error message is
+		given.
 
-                {start}, {middle} and {end} are patterns, see |pattern|.  They
-                must not contain \( \) pairs.  Use of \%( \) is allowed.  When
-                {middle} is not empty, it is found when searching from either
-                direction, but only when not in a nested start-end pair.  A
-                typical use is: >vim
-                        echo searchpair('\<if\>', '\<else\>', '\<endif\>')
-<                By leaving {middle} empty the "else" is skipped.
+		{start}, {middle} and {end} are patterns, see |pattern|.  They
+		must not contain \( \) pairs.  Use of \%( \) is allowed.  When
+		{middle} is not empty, it is found when searching from either
+		direction, but only when not in a nested start-end pair.  A
+		typical use is: >vim
+			echo searchpair('\<if\>', '\<else\>', '\<endif\>')
+<		 By leaving {middle} empty the "else" is skipped.
 
-                {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
-                |search()|.  Additionally:
-                'r'     Repeat until no more matches found; will find the
-                        outer pair.  Implies the 'W' flag.
-                'm'     Return number of matches instead of line number with
-                        the match; will be > 1 when 'r' is used.
-                Note: it's nearly always a good idea to use the 'W' flag, to
-                avoid wrapping around the end of the file.
+		{flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
+		|search()|.  Additionally:
+		'r'	Repeat until no more matches found; will find the
+			outer pair.  Implies the 'W' flag.
+		'm'	Return number of matches instead of line number with
+			the match; will be > 1 when 'r' is used.
+		Note: it's nearly always a good idea to use the 'W' flag, to
+		avoid wrapping around the end of the file.
 
-                When a match for {start}, {middle} or {end} is found, the
-                {skip} expression is evaluated with the cursor positioned on
-                the start of the match.  It should return non-zero if this
-                match is to be skipped.  E.g., because it is inside a comment
-                or a string.
-                When {skip} is omitted or empty, every match is accepted.
-                When evaluating {skip} causes an error the search is aborted
-                and -1 returned.
-                {skip} can be a string, a lambda, a funcref or a partial.
-                Anything else makes the function fail.
+		When a match for {start}, {middle} or {end} is found, the
+		{skip} expression is evaluated with the cursor positioned on
+		the start of the match.  It should return non-zero if this
+		match is to be skipped.  E.g., because it is inside a comment
+		or a string.
+		When {skip} is omitted or empty, every match is accepted.
+		When evaluating {skip} causes an error the search is aborted
+		and -1 returned.
+		{skip} can be a string, a lambda, a funcref or a partial.
+		Anything else makes the function fail.
 
-                For {stopline} and {timeout} see |search()|.
+		For {stopline} and {timeout} see |search()|.
 
-                The value of 'ignorecase' is used.  'magic' is ignored, the
-                patterns are used like it's on.
+		The value of 'ignorecase' is used.  'magic' is ignored, the
+		patterns are used like it's on.
 
-                The search starts exactly at the cursor.  A match with
-                {start}, {middle} or {end} at the next character, in the
-                direction of searching, is the first one found.  Example: >vim
-                        if 1
-                          if 2
-                          endif 2
-                        endif 1
-<                When starting at the "if 2", with the cursor on the "i", and
-                searching forwards, the "endif 2" is found.  When starting on
-                the character just before the "if 2", the "endif 1" will be
-                found.  That's because the "if 2" will be found first, and
-                then this is considered to be a nested if/endif from "if 2" to
-                "endif 2".
-                When searching backwards and {end} is more than one character,
-                it may be useful to put "\zs" at the end of the pattern, so
-                that when the cursor is inside a match with the end it finds
-                the matching start.
+		The search starts exactly at the cursor.  A match with
+		{start}, {middle} or {end} at the next character, in the
+		direction of searching, is the first one found.  Example: >vim
+			if 1
+			  if 2
+			  endif 2
+			endif 1
+<		 When starting at the "if 2", with the cursor on the "i", and
+		searching forwards, the "endif 2" is found.  When starting on
+		the character just before the "if 2", the "endif 1" will be
+		found.	That's because the "if 2" will be found first, and
+		then this is considered to be a nested if/endif from "if 2" to
+		"endif 2".
+		When searching backwards and {end} is more than one character,
+		it may be useful to put "\zs" at the end of the pattern, so
+		that when the cursor is inside a match with the end it finds
+		the matching start.
 
-                Example, to find the "endif" command in a Vim script: >vim
+		Example, to find the "endif" command in a Vim script: >vim
 
-                        echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
-                        \ 'getline(".") =~ "^\\s*\""')
+			echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
+			\ 'getline(".") =~ "^\\s*\""')
 
-<                The cursor must be at or after the "if" for which a match is
-                to be found.  Note that single-quote strings are used to avoid
-                having to double the backslashes.  The skip expression only
-                catches comments at the start of a line, not after a command.
-                Also, a word "en" or "if" halfway through a line is considered
-                a match.
-                Another example, to search for the matching "{" of a "}": >vim
+<		 The cursor must be at or after the "if" for which a match is
+		to be found.  Note that single-quote strings are used to avoid
+		having to double the backslashes.  The skip expression only
+		catches comments at the start of a line, not after a command.
+		Also, a word "en" or "if" halfway through a line is considered
+		a match.
+		Another example, to search for the matching "{" of a "}": >vim
 
-                        echo searchpair('{', '', '}', 'bW')
+			echo searchpair('{', '', '}', 'bW')
 
-<                This works when the cursor is at or before the "}" for which a
-                match is to be found.  To reject matches that syntax
-                highlighting recognized as strings: >vim
+<		 This works when the cursor is at or before the "}" for which a
+		match is to be found.  To reject matches that syntax
+		highlighting recognized as strings: >vim
 
-                        echo searchpair('{', '', '}', 'bW',
-                             \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
+			echo searchpair('{', '', '}', 'bW',
+			     \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
 <
-                                                               *searchpairpos()*
+							       *searchpairpos()*
 searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
-                Same as |searchpair()|, but returns a |List| with the line and
-                column position of the match. The first element of the |List|
-                is the line number and the second element is the byte index of
-                the column position of the match.  If no match is found,
-                returns [0, 0]. >vim
+		Same as |searchpair()|, but returns a |List| with the line and
+		column position of the match. The first element of the |List|
+		is the line number and the second element is the byte index of
+		the column position of the match.  If no match is found,
+		returns [0, 0]. >vim
 
-                        let [lnum,col] = searchpairpos('{', '', '}', 'n')
+			let [lnum,col] = searchpairpos('{', '', '}', 'n')
 <
-                See |match-parens| for a bigger and more useful example.
+		See |match-parens| for a bigger and more useful example.
 
-                                                                   *searchpos()*
+								   *searchpos()*
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
-                Same as |search()|, but returns a |List| with the line and
-                column position of the match. The first element of the |List|
-                is the line number and the second element is the byte index of
-                the column position of the match. If no match is found,
-                returns [0, 0].
-                Example: >vim
-                        let [lnum, col] = searchpos('mypattern', 'n')
+		Same as |search()|, but returns a |List| with the line and
+		column position of the match. The first element of the |List|
+		is the line number and the second element is the byte index of
+		the column position of the match. If no match is found,
+		returns [0, 0].
+		Example: >vim
+			let [lnum, col] = searchpos('mypattern', 'n')
 
-<                When the 'p' flag is given then there is an extra item with
-                the sub-pattern match number |search()-sub-match|.  Example: >vim
-                        let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
-<                In this example "submatch" is 2 when a lowercase letter is
-                found |/\l|, 3 when an uppercase letter is found |/\u|.
+<		 When the 'p' flag is given then there is an extra item with
+		the sub-pattern match number |search()-sub-match|.  Example: >vim
+			let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
+<		 In this example "submatch" is 2 when a lowercase letter is
+		found |/\l|, 3 when an uppercase letter is found |/\u|.
 
-serverlist()                                                      *serverlist()*
-                Returns a list of server addresses, or empty if all servers
-                were stopped. |serverstart()| |serverstop()|
-                Example: >vim
-                        echo serverlist()
+serverlist()							  *serverlist()*
+		Returns a list of server addresses, or empty if all servers
+		were stopped. |serverstart()| |serverstop()|
+		Example: >vim
+			echo serverlist()
 <
-serverstart([{address}])                                         *serverstart()*
-                Opens a socket or named pipe at {address} and listens for
-                |RPC| messages. Clients can send |API| commands to the
-                returned address to control Nvim.
+serverstart([{address}])					 *serverstart()*
+		Opens a socket or named pipe at {address} and listens for
+		|RPC| messages. Clients can send |API| commands to the
+		returned address to control Nvim.
 
-                Returns the address string (which may differ from the
-                {address} argument, see below).
+		Returns the address string (which may differ from the
+		{address} argument, see below).
 
-                - If {address} has a colon (":") it is a TCP/IPv4/IPv6 address
-                  where the last ":" separates host and port (empty or zero
-                  assigns a random port).
-                - Else {address} is the path to a named pipe (except on Windows).
-                  - If {address} has no slashes ("/") it is treated as the
-                    "name" part of a generated path in this format: >vim
-                        stdpath("run").."/{name}.{pid}.{counter}"
-<                  - If {address} is omitted the name is "nvim". >vim
-                        echo serverstart()
-<                 >
-                        => /tmp/nvim.bram/oknANW/nvim.15430.5
+		- If {address} has a colon (":") it is a TCP/IPv4/IPv6 address
+		  where the last ":" separates host and port (empty or zero
+		  assigns a random port).
+		- Else {address} is the path to a named pipe (except on Windows).
+		  - If {address} has no slashes ("/") it is treated as the
+		    "name" part of a generated path in this format: >vim
+			stdpath("run").."/{name}.{pid}.{counter}"
+<		   - If {address} is omitted the name is "nvim". >vim
+			echo serverstart()
+<		  >
+			=> /tmp/nvim.bram/oknANW/nvim.15430.5
 <
-                Example bash command to list all Nvim servers: >bash
-                        ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
+		Example bash command to list all Nvim servers: >bash
+			ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
 
-<                Example named pipe: >vim
-                        if has('win32')
-                          echo serverstart('\\.\pipe\nvim-pipe-1234')
-                        else
-                          echo serverstart('nvim.sock')
-                        endif
+<		 Example named pipe: >vim
+			if has('win32')
+			  echo serverstart('\\.\pipe\nvim-pipe-1234')
+			else
+			  echo serverstart('nvim.sock')
+			endif
 <
-                Example TCP/IP address: >vim
-                        echo serverstart('::1:12345')
+		Example TCP/IP address: >vim
+			echo serverstart('::1:12345')
 <
-serverstop({address})                                             *serverstop()*
-                Closes the pipe or socket at {address}.
-                Returns TRUE if {address} is valid, else FALSE.
-                If |v:servername| is stopped it is set to the next available
-                address in |serverlist()|.
+serverstop({address})						  *serverstop()*
+		Closes the pipe or socket at {address}.
+		Returns TRUE if {address} is valid, else FALSE.
+		If |v:servername| is stopped it is set to the next available
+		address in |serverlist()|.
 
-setbufline({buf}, {lnum}, {text})                                 *setbufline()*
-                Set line {lnum} to {text} in buffer {buf}.  This works like
-                |setline()| for the specified buffer.
+setbufline({buf}, {lnum}, {text})				  *setbufline()*
+		Set line {lnum} to {text} in buffer {buf}.  This works like
+		|setline()| for the specified buffer.
 
-                This function works only for loaded buffers. First call
-                |bufload()| if needed.
+		This function works only for loaded buffers. First call
+		|bufload()| if needed.
 
-                To insert lines use |appendbufline()|.
+		To insert lines use |appendbufline()|.
 
-                {text} can be a string to set one line, or a List of strings
-                to set multiple lines.  If the List extends below the last
-                line then those lines are added.  If the List is empty then
-                nothing is changed and zero is returned.
+		{text} can be a string to set one line, or a List of strings
+		to set multiple lines.	If the List extends below the last
+		line then those lines are added.  If the List is empty then
+		nothing is changed and zero is returned.
 
-                For the use of {buf}, see |bufname()| above.
+		For the use of {buf}, see |bufname()| above.
 
-                {lnum} is used like with |setline()|.
-                Use "$" to refer to the last line in buffer {buf}.
-                When {lnum} is just below the last line the {text} will be
-                added below the last line.
-                On success 0 is returned, on failure 1 is returned.
+		{lnum} is used like with |setline()|.
+		Use "$" to refer to the last line in buffer {buf}.
+		When {lnum} is just below the last line the {text} will be
+		added below the last line.
+		On success 0 is returned, on failure 1 is returned.
 
-                If {buf} is not a valid buffer or {lnum} is not valid, an
-                error message is given.
+		If {buf} is not a valid buffer or {lnum} is not valid, an
+		error message is given.
 
-setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
-                Set option or local variable {varname} in buffer {buf} to
-                {val}.
-                This also works for a global or local window option, but it
-                doesn't work for a global or local window variable.
-                For a local window option the global value is unchanged.
-                For the use of {buf}, see |bufname()| above.
-                The {varname} argument is a string.
-                Note that the variable name without "b:" must be used.
-                Examples: >vim
-                        call setbufvar(1, "&mod", 1)
-                        call setbufvar("todo", "myvar", "foobar")
-<                This function is not available in the |sandbox|.
+setbufvar({buf}, {varname}, {val})				   *setbufvar()*
+		Set option or local variable {varname} in buffer {buf} to
+		{val}.
+		This also works for a global or local window option, but it
+		doesn't work for a global or local window variable.
+		For a local window option the global value is unchanged.
+		For the use of {buf}, see |bufname()| above.
+		The {varname} argument is a string.
+		Note that the variable name without "b:" must be used.
+		Examples: >vim
+			call setbufvar(1, "&mod", 1)
+			call setbufvar("todo", "myvar", "foobar")
+<		 This function is not available in the |sandbox|.
 
-setcellwidths({list})                                          *setcellwidths()*
-                Specify overrides for cell widths of character ranges.  This
-                tells Vim how wide characters are when displayed in the
-                terminal, counted in screen cells.  The values override
-                'ambiwidth'.  Example: >vim
-                   call setcellwidths([
-                                \ [0x111, 0x111, 1],
-                                \ [0x2194, 0x2199, 2],
-                                \ ])
+setcellwidths({list})					       *setcellwidths()*
+		Specify overrides for cell widths of character ranges.	This
+		tells Vim how wide characters are when displayed in the
+		terminal, counted in screen cells.  The values override
+		'ambiwidth'.  Example: >vim
+		   call setcellwidths([
+				\ [0x111, 0x111, 1],
+				\ [0x2194, 0x2199, 2],
+				\ ])
 
-<                The {list} argument is a List of Lists with each three
-                numbers: [{low}, {high}, {width}].      *E1109* *E1110*
-                {low} and {high} can be the same, in which case this refers to
-                one character.  Otherwise it is the range of characters from
-                {low} to {high} (inclusive).            *E1111* *E1114*
-                Only characters with value 0x80 and higher can be used.
+<		 The {list} argument is a List of Lists with each three
+		numbers: [{low}, {high}, {width}].	*E1109* *E1110*
+		{low} and {high} can be the same, in which case this refers to
+		one character.	Otherwise it is the range of characters from
+		{low} to {high} (inclusive).		*E1111* *E1114*
+		Only characters with value 0x80 and higher can be used.
 
-                {width} must be either 1 or 2, indicating the character width
-                in screen cells.                        *E1112*
-                An error is given if the argument is invalid, also when a
-                range overlaps with another.            *E1113*
+		{width} must be either 1 or 2, indicating the character width
+		in screen cells.			*E1112*
+		An error is given if the argument is invalid, also when a
+		range overlaps with another.		*E1113*
 
-                If the new value causes 'fillchars' or 'listchars' to become
-                invalid it is rejected and an error is given.
+		If the new value causes 'fillchars' or 'listchars' to become
+		invalid it is rejected and an error is given.
 
-                To clear the overrides pass an empty {list}: >vim
-                   call setcellwidths([])
+		To clear the overrides pass an empty {list}: >vim
+		   call setcellwidths([])
 
-<                You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
-                the effect for known emoji characters.  Move the cursor
-                through the text to check if the cell widths of your terminal
-                match with what Vim knows about each emoji.  If it doesn't
-                look right you need to adjust the {list} argument.
+<		 You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
+		the effect for known emoji characters.	Move the cursor
+		through the text to check if the cell widths of your terminal
+		match with what Vim knows about each emoji.  If it doesn't
+		look right you need to adjust the {list} argument.
 
-setcharpos({expr}, {list})                                        *setcharpos()*
-                Same as |setpos()| but uses the specified column number as the
-                character index instead of the byte index in the line.
+setcharpos({expr}, {list})					  *setcharpos()*
+		Same as |setpos()| but uses the specified column number as the
+		character index instead of the byte index in the line.
 
-                Example:
-                With the text "여보세요" in line 8: >vim
-                        call setcharpos('.', [0, 8, 4, 0])
-<                positions the cursor on the fourth character '요'. >vim
-                        call setpos('.', [0, 8, 4, 0])
-<                positions the cursor on the second character '보'.
+		Example:
+		With the text "여보세요" in line 8: >vim
+			call setcharpos('.', [0, 8, 4, 0])
+<		 positions the cursor on the fourth character '요'. >vim
+			call setpos('.', [0, 8, 4, 0])
+<		 positions the cursor on the second character '보'.
 
-setcharsearch({dict})                                          *setcharsearch()*
-                Set the current character search information to {dict},
-                which contains one or more of the following entries:
+setcharsearch({dict})					       *setcharsearch()*
+		Set the current character search information to {dict},
+		which contains one or more of the following entries:
 
-                    char        character which will be used for a subsequent
-                                |,| or |;| command; an empty string clears the
-                                character search
-                    forward     direction of character search; 1 for forward,
-                                0 for backward
-                    until       type of character search; 1 for a |t| or |T|
-                                character search, 0 for an |f| or |F|
-                                character search
+		    char	character which will be used for a subsequent
+				|,| or |;| command; an empty string clears the
+				character search
+		    forward	direction of character search; 1 for forward,
+				0 for backward
+		    until	type of character search; 1 for a |t| or |T|
+				character search, 0 for an |f| or |F|
+				character search
 
-                This can be useful to save/restore a user's character search
-                from a script: >vim
-                        let prevsearch = getcharsearch()
-                        " Perform a command which clobbers user's search
-                        call setcharsearch(prevsearch)
-<                Also see |getcharsearch()|.
+		This can be useful to save/restore a user's character search
+		from a script: >vim
+			let prevsearch = getcharsearch()
+			" Perform a command which clobbers user's search
+			call setcharsearch(prevsearch)
+<		 Also see |getcharsearch()|.
 
-setcmdline({str} [, {pos}])                                       *setcmdline()*
-                Set the command line to {str} and set the cursor position to
-                {pos}.
-                If {pos} is omitted, the cursor is positioned after the text.
-                Returns 0 when successful, 1 when not editing the command
-                line.
+setcmdline({str} [, {pos}])					  *setcmdline()*
+		Set the command line to {str} and set the cursor position to
+		{pos}.
+		If {pos} is omitted, the cursor is positioned after the text.
+		Returns 0 when successful, 1 when not editing the command
+		line.
 
-setcmdpos({pos})                                                   *setcmdpos()*
-                Set the cursor position in the command line to byte position
-                {pos}.  The first position is 1.
-                Use |getcmdpos()| to obtain the current position.
-                Only works while editing the command line, thus you must use
-                |c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
-                |c_CTRL-\_e| and |c_CTRL-R_CTRL-R| with '=' the position is
-                set after the command line is set to the expression.  For
-                |c_CTRL-R_=| it is set after evaluating the expression but
-                before inserting the resulting text.
-                When the number is too big the cursor is put at the end of the
-                line.  A number smaller than one has undefined results.
-                Returns 0 when successful, 1 when not editing the command
-                line.
+setcmdpos({pos})						   *setcmdpos()*
+		Set the cursor position in the command line to byte position
+		{pos}.	The first position is 1.
+		Use |getcmdpos()| to obtain the current position.
+		Only works while editing the command line, thus you must use
+		|c_CTRL-\_e|, |c_CTRL-R_=| or |c_CTRL-R_CTRL-R| with '='.  For
+		|c_CTRL-\_e| and |c_CTRL-R_CTRL-R| with '=' the position is
+		set after the command line is set to the expression.  For
+		|c_CTRL-R_=| it is set after evaluating the expression but
+		before inserting the resulting text.
+		When the number is too big the cursor is put at the end of the
+		line.  A number smaller than one has undefined results.
+		Returns 0 when successful, 1 when not editing the command
+		line.
 
 setcursorcharpos({lnum}, {col} [, {off}])
-setcursorcharpos({list})                                    *setcursorcharpos()*
-                Same as |cursor()| but uses the specified column number as the
-                character index instead of the byte index in the line.
+setcursorcharpos({list})				    *setcursorcharpos()*
+		Same as |cursor()| but uses the specified column number as the
+		character index instead of the byte index in the line.
 
-                Example:
-                With the text "여보세요" in line 4: >vim
-                        call setcursorcharpos(4, 3)
-<                positions the cursor on the third character '세'. >vim
-                        call cursor(4, 3)
-<                positions the cursor on the first character '여'.
+		Example:
+		With the text "여보세요" in line 4: >vim
+			call setcursorcharpos(4, 3)
+<		 positions the cursor on the third character '세'. >vim
+			call cursor(4, 3)
+<		 positions the cursor on the first character '여'.
 
-setenv({name}, {val})                                                 *setenv()*
-                Set environment variable {name} to {val}.  Example: >vim
-                        call setenv('HOME', '/home/myhome')
+setenv({name}, {val})						      *setenv()*
+		Set environment variable {name} to {val}.  Example: >vim
+			call setenv('HOME', '/home/myhome')
 
-<                When {val} is |v:null| the environment variable is deleted.
-                See also |expr-env|.
+<		 When {val} is |v:null| the environment variable is deleted.
+		See also |expr-env|.
 
-setfperm({fname}, {mode})                                     *setfperm()* *chmod*
-                Set the file permissions for {fname} to {mode}.
-                {mode} must be a string with 9 characters.  It is of the form
-                "rwxrwxrwx", where each group of "rwx" flags represent, in
-                turn, the permissions of the owner of the file, the group the
-                file belongs to, and other users.  A '-' character means the
-                permission is off, any other character means on.  Multi-byte
-                characters are not supported.
+setfperm({fname}, {mode})				      *setfperm()* *chmod*
+		Set the file permissions for {fname} to {mode}.
+		{mode} must be a string with 9 characters.  It is of the form
+		"rwxrwxrwx", where each group of "rwx" flags represent, in
+		turn, the permissions of the owner of the file, the group the
+		file belongs to, and other users.  A '-' character means the
+		permission is off, any other character means on.  Multi-byte
+		characters are not supported.
 
-                For example "rw-r-----" means read-write for the user,
-                readable by the group, not accessible by others.  "xx-x-----"
-                would do the same thing.
+		For example "rw-r-----" means read-write for the user,
+		readable by the group, not accessible by others.  "xx-x-----"
+		would do the same thing.
 
-                Returns non-zero for success, zero for failure.
+		Returns non-zero for success, zero for failure.
 
-                To read permissions see |getfperm()|.
+		To read permissions see |getfperm()|.
 
-setline({lnum}, {text})                                              *setline()*
-                Set line {lnum} of the current buffer to {text}.  To insert
-                lines use |append()|. To set lines in another buffer use
-                |setbufline()|.
+setline({lnum}, {text})						     *setline()*
+		Set line {lnum} of the current buffer to {text}.  To insert
+		lines use |append()|. To set lines in another buffer use
+		|setbufline()|.
 
-                {lnum} is used like with |getline()|.
-                When {lnum} is just below the last line the {text} will be
-                added below the last line.
-                {text} can be any type or a List of any type, each item is
-                converted to a String.  When {text} is an empty List then
-                nothing is changed and FALSE is returned.
+		{lnum} is used like with |getline()|.
+		When {lnum} is just below the last line the {text} will be
+		added below the last line.
+		{text} can be any type or a List of any type, each item is
+		converted to a String.	When {text} is an empty List then
+		nothing is changed and FALSE is returned.
 
-                If this succeeds, FALSE is returned.  If this fails (most likely
-                because {lnum} is invalid) TRUE is returned.
+		If this succeeds, FALSE is returned.  If this fails (most likely
+		because {lnum} is invalid) TRUE is returned.
 
-                Example: >vim
-                        call setline(5, strftime("%c"))
+		Example: >vim
+			call setline(5, strftime("%c"))
 
-<                When {text} is a |List| then line {lnum} and following lines
-                will be set to the items in the list.  Example: >vim
-                        call setline(5, ['aaa', 'bbb', 'ccc'])
-<                This is equivalent to: >vim
-                        for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
-                          call setline(n, l)
-                        endfor
+<		 When {text} is a |List| then line {lnum} and following lines
+		will be set to the items in the list.  Example: >vim
+			call setline(5, ['aaa', 'bbb', 'ccc'])
+<		 This is equivalent to: >vim
+			for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
+			  call setline(n, l)
+			endfor
 
-<                Note: The '[ and '] marks are not set.
+<		 Note: The '[ and '] marks are not set.
 
-setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
-                Create or replace or add to the location list for window {nr}.
-                {nr} can be the window number or the |window-ID|.
-                When {nr} is zero the current window is used.
+setloclist({nr}, {list} [, {action} [, {what}]])		  *setloclist()*
+		Create or replace or add to the location list for window {nr}.
+		{nr} can be the window number or the |window-ID|.
+		When {nr} is zero the current window is used.
 
-                For a location list window, the displayed location list is
-                modified.  For an invalid window number {nr}, -1 is returned.
-                Otherwise, same as |setqflist()|.
-                Also see |location-list|.
+		For a location list window, the displayed location list is
+		modified.  For an invalid window number {nr}, -1 is returned.
+		Otherwise, same as |setqflist()|.
+		Also see |location-list|.
 
-                For {action} see |setqflist-action|.
+		For {action} see |setqflist-action|.
 
-                If the optional {what} dictionary argument is supplied, then
-                only the items listed in {what} are set. Refer to |setqflist()|
-                for the list of supported keys in {what}.
+		If the optional {what} dictionary argument is supplied, then
+		only the items listed in {what} are set. Refer to |setqflist()|
+		for the list of supported keys in {what}.
 
-setmatches({list} [, {win}])                                      *setmatches()*
-                Restores a list of matches saved by |getmatches()| for the
-                current window.  Returns 0 if successful, otherwise -1.  All
-                current matches are cleared before the list is restored.  See
-                example for |getmatches()|.
-                If {win} is specified, use the window with this number or
-                window ID instead of the current window.
+setmatches({list} [, {win}])					  *setmatches()*
+		Restores a list of matches saved by |getmatches()| for the
+		current window.  Returns 0 if successful, otherwise -1.  All
+		current matches are cleared before the list is restored.  See
+		example for |getmatches()|.
+		If {win} is specified, use the window with this number or
+		window ID instead of the current window.
 
-setpos({expr}, {list})                                                *setpos()*
-                Set the position for String {expr}.  Possible values:
-                        .       the cursor
-                        'x      mark x
+setpos({expr}, {list})						      *setpos()*
+		Set the position for String {expr}.  Possible values:
+			.	the cursor
+			'x	mark x
 
-                {list} must be a |List| with four or five numbers:
-                    [bufnum, lnum, col, off]
-                    [bufnum, lnum, col, off, curswant]
+		{list} must be a |List| with four or five numbers:
+		    [bufnum, lnum, col, off]
+		    [bufnum, lnum, col, off, curswant]
 
-                "bufnum" is the buffer number.  Zero can be used for the
-                current buffer.  When setting an uppercase mark "bufnum" is
-                used for the mark position.  For other marks it specifies the
-                buffer to set the mark in.  You can use the |bufnr()| function
-                to turn a file name into a buffer number.
-                For setting the cursor and the ' mark "bufnum" is ignored,
-                since these are associated with a window, not a buffer.
-                Does not change the jumplist.
+		"bufnum" is the buffer number.	Zero can be used for the
+		current buffer.  When setting an uppercase mark "bufnum" is
+		used for the mark position.  For other marks it specifies the
+		buffer to set the mark in.  You can use the |bufnr()| function
+		to turn a file name into a buffer number.
+		For setting the cursor and the ' mark "bufnum" is ignored,
+		since these are associated with a window, not a buffer.
+		Does not change the jumplist.
 
-                "lnum" and "col" are the position in the buffer.  The first
-                column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
-                smaller than 1 then 1 is used. To use the character count
-                instead of the byte count, use |setcharpos()|.
+		"lnum" and "col" are the position in the buffer.  The first
+		column is 1.  Use a zero "lnum" to delete a mark.  If "col" is
+		smaller than 1 then 1 is used. To use the character count
+		instead of the byte count, use |setcharpos()|.
 
-                The "off" number is only used when 'virtualedit' is set. Then
-                it is the offset in screen columns from the start of the
-                character.  E.g., a position within a <Tab> or after the last
-                character.
+		The "off" number is only used when 'virtualedit' is set. Then
+		it is the offset in screen columns from the start of the
+		character.  E.g., a position within a <Tab> or after the last
+		character.
 
-                The "curswant" number is only used when setting the cursor
-                position.  It sets the preferred column for when moving the
-                cursor vertically.  When the "curswant" number is missing the
-                preferred column is not set.  When it is present and setting a
-                mark position it is not used.
+		The "curswant" number is only used when setting the cursor
+		position.  It sets the preferred column for when moving the
+		cursor vertically.  When the "curswant" number is missing the
+		preferred column is not set.  When it is present and setting a
+		mark position it is not used.
 
-                Note that for '< and '> changing the line number may result in
-                the marks to be effectively be swapped, so that '< is always
-                before '>.
+		Note that for '< and '> changing the line number may result in
+		the marks to be effectively be swapped, so that '< is always
+		before '>.
 
-                Returns 0 when the position could be set, -1 otherwise.
-                An error message is given if {expr} is invalid.
+		Returns 0 when the position could be set, -1 otherwise.
+		An error message is given if {expr} is invalid.
 
-                Also see |setcharpos()|, |getpos()| and |getcurpos()|.
+		Also see |setcharpos()|, |getpos()| and |getcurpos()|.
 
-                This does not restore the preferred column for moving
-                vertically; if you set the cursor position with this, |j| and
-                |k| motions will jump to previous columns!  Use |cursor()| to
-                also set the preferred column.  Also see the "curswant" key in
-                |winrestview()|.
+		This does not restore the preferred column for moving
+		vertically; if you set the cursor position with this, |j| and
+		|k| motions will jump to previous columns!  Use |cursor()| to
+		also set the preferred column.	Also see the "curswant" key in
+		|winrestview()|.
 
-setqflist({list} [, {action} [, {what}]])                          *setqflist()*
-                Create or replace or add to the quickfix list.
+setqflist({list} [, {action} [, {what}]])			   *setqflist()*
+		Create or replace or add to the quickfix list.
 
-                If the optional {what} dictionary argument is supplied, then
-                only the items listed in {what} are set. The first {list}
-                argument is ignored.  See below for the supported items in
-                {what}.
-                                                        *setqflist-what*
-                When {what} is not present, the items in {list} are used.  Each
-                item must be a dictionary.  Non-dictionary items in {list} are
-                ignored.  Each dictionary item can contain the following
-                entries:
+		If the optional {what} dictionary argument is supplied, then
+		only the items listed in {what} are set. The first {list}
+		argument is ignored.  See below for the supported items in
+		{what}.
+							*setqflist-what*
+		When {what} is not present, the items in {list} are used.  Each
+		item must be a dictionary.  Non-dictionary items in {list} are
+		ignored.  Each dictionary item can contain the following
+		entries:
 
-                    bufnr       buffer number; must be the number of a valid
-                                buffer
-                    filename    name of a file; only used when "bufnr" is not
-                                present or it is invalid.
-                    module      name of a module; if given it will be used in
-                                quickfix error window instead of the filename.
-                    lnum        line number in the file
-                    end_lnum    end of lines, if the item spans multiple lines
-                    pattern     search pattern used to locate the error
-                    col         column number
-                    vcol        when non-zero: "col" is visual column
-                                when zero: "col" is byte index
-                    end_col     end column, if the item spans multiple columns
-                    nr          error number
-                    text        description of the error
-                    type        single-character error type, 'E', 'W', etc.
-                    valid       recognized error message
-                    user_data
-                                custom data associated with the item, can be
-                                any type.
+		    bufnr	buffer number; must be the number of a valid
+				buffer
+		    filename	name of a file; only used when "bufnr" is not
+				present or it is invalid.
+		    module	name of a module; if given it will be used in
+				quickfix error window instead of the filename.
+		    lnum	line number in the file
+		    end_lnum	end of lines, if the item spans multiple lines
+		    pattern	search pattern used to locate the error
+		    col		column number
+		    vcol	when non-zero: "col" is visual column
+				when zero: "col" is byte index
+		    end_col	end column, if the item spans multiple columns
+		    nr		error number
+		    text	description of the error
+		    type	single-character error type, 'E', 'W', etc.
+		    valid	recognized error message
+		    user_data
+				custom data associated with the item, can be
+				any type.
 
-                The "col", "vcol", "nr", "type" and "text" entries are
-                optional.  Either "lnum" or "pattern" entry can be used to
-                locate a matching error line.
-                If the "filename" and "bufnr" entries are not present or
-                neither the "lnum" or "pattern" entries are present, then the
-                item will not be handled as an error line.
-                If both "pattern" and "lnum" are present then "pattern" will
-                be used.
-                If the "valid" entry is not supplied, then the valid flag is
-                set when "bufnr" is a valid buffer or "filename" exists.
-                If you supply an empty {list}, the quickfix list will be
-                cleared.
-                Note that the list is not exactly the same as what
-                |getqflist()| returns.
+		The "col", "vcol", "nr", "type" and "text" entries are
+		optional.  Either "lnum" or "pattern" entry can be used to
+		locate a matching error line.
+		If the "filename" and "bufnr" entries are not present or
+		neither the "lnum" or "pattern" entries are present, then the
+		item will not be handled as an error line.
+		If both "pattern" and "lnum" are present then "pattern" will
+		be used.
+		If the "valid" entry is not supplied, then the valid flag is
+		set when "bufnr" is a valid buffer or "filename" exists.
+		If you supply an empty {list}, the quickfix list will be
+		cleared.
+		Note that the list is not exactly the same as what
+		|getqflist()| returns.
 
-                {action} values:                *setqflist-action* *E927*
-                'a'     The items from {list} are added to the existing
-                        quickfix list. If there is no existing list, then a
-                        new list is created.
+		{action} values:		*setqflist-action* *E927*
+		'a'	The items from {list} are added to the existing
+			quickfix list. If there is no existing list, then a
+			new list is created.
 
-                'r'     The items from the current quickfix list are replaced
-                        with the items from {list}.  This can also be used to
-                        clear the list: >vim
-                                call setqflist([], 'r')
+		'r'	The items from the current quickfix list are replaced
+			with the items from {list}.  This can also be used to
+			clear the list: >vim
+				call setqflist([], 'r')
 <
-                'f'     All the quickfix lists in the quickfix stack are
-                        freed.
+		'f'	All the quickfix lists in the quickfix stack are
+			freed.
 
-                If {action} is not present or is set to ' ', then a new list
-                is created. The new quickfix list is added after the current
-                quickfix list in the stack and all the following lists are
-                freed. To add a new quickfix list at the end of the stack,
-                set "nr" in {what} to "$".
+		If {action} is not present or is set to ' ', then a new list
+		is created. The new quickfix list is added after the current
+		quickfix list in the stack and all the following lists are
+		freed. To add a new quickfix list at the end of the stack,
+		set "nr" in {what} to "$".
 
-                The following items can be specified in dictionary {what}:
-                    context     quickfix list context. See |quickfix-context|
-                    efm         errorformat to use when parsing text from
-                                "lines". If this is not present, then the
-                                'errorformat' option value is used.
-                                See |quickfix-parse|
-                    id          quickfix list identifier |quickfix-ID|
-                    idx         index of the current entry in the quickfix
-                                list specified by "id" or "nr". If set to '$',
-                                then the last entry in the list is set as the
-                                current entry.  See |quickfix-index|
-                    items       list of quickfix entries. Same as the {list}
-                                argument.
-                    lines       use 'errorformat' to parse a list of lines and
-                                add the resulting entries to the quickfix list
-                                {nr} or {id}.  Only a |List| value is supported.
-                                See |quickfix-parse|
-                    nr          list number in the quickfix stack; zero
-                                means the current quickfix list and "$" means
-                                the last quickfix list.
-                    quickfixtextfunc
-                                function to get the text to display in the
-                                quickfix window.  The value can be the name of
-                                a function or a funcref or a lambda.  Refer to
-                                |quickfix-window-function| for an explanation
-                                of how to write the function and an example.
-                    title       quickfix list title text. See |quickfix-title|
-                Unsupported keys in {what} are ignored.
-                If the "nr" item is not present, then the current quickfix list
-                is modified. When creating a new quickfix list, "nr" can be
-                set to a value one greater than the quickfix stack size.
-                When modifying a quickfix list, to guarantee that the correct
-                list is modified, "id" should be used instead of "nr" to
-                specify the list.
+		The following items can be specified in dictionary {what}:
+		    context	quickfix list context. See |quickfix-context|
+		    efm		errorformat to use when parsing text from
+				"lines". If this is not present, then the
+				'errorformat' option value is used.
+				See |quickfix-parse|
+		    id		quickfix list identifier |quickfix-ID|
+		    idx		index of the current entry in the quickfix
+				list specified by "id" or "nr". If set to '$',
+				then the last entry in the list is set as the
+				current entry.	See |quickfix-index|
+		    items	list of quickfix entries. Same as the {list}
+				argument.
+		    lines	use 'errorformat' to parse a list of lines and
+				add the resulting entries to the quickfix list
+				{nr} or {id}.  Only a |List| value is supported.
+				See |quickfix-parse|
+		    nr		list number in the quickfix stack; zero
+				means the current quickfix list and "$" means
+				the last quickfix list.
+		    quickfixtextfunc
+				function to get the text to display in the
+				quickfix window.  The value can be the name of
+				a function or a funcref or a lambda.  Refer to
+				|quickfix-window-function| for an explanation
+				of how to write the function and an example.
+		    title	quickfix list title text. See |quickfix-title|
+		Unsupported keys in {what} are ignored.
+		If the "nr" item is not present, then the current quickfix list
+		is modified. When creating a new quickfix list, "nr" can be
+		set to a value one greater than the quickfix stack size.
+		When modifying a quickfix list, to guarantee that the correct
+		list is modified, "id" should be used instead of "nr" to
+		specify the list.
 
-                Examples (See also |setqflist-examples|): >vim
-                   call setqflist([], 'r', {'title': 'My search'})
-                   call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
-                   call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
+		Examples (See also |setqflist-examples|): >vim
+		   call setqflist([], 'r', {'title': 'My search'})
+		   call setqflist([], 'r', {'nr': 2, 'title': 'Errors'})
+		   call setqflist([], 'a', {'id':qfid, 'lines':["F1:10:L10"]})
 <
-                Returns zero for success, -1 for failure.
+		Returns zero for success, -1 for failure.
 
-                This function can be used to create a quickfix list
-                independent of the 'errorformat' setting.  Use a command like
-                `:cc 1` to jump to the first position.
+		This function can be used to create a quickfix list
+		independent of the 'errorformat' setting.  Use a command like
+		`:cc 1` to jump to the first position.
 
-setreg({regname}, {value} [, {options}])                              *setreg()*
-                Set the register {regname} to {value}.
-                If {regname} is "" or "@", the unnamed register '"' is used.
-                The {regname} argument is a string.
+setreg({regname}, {value} [, {options}])			      *setreg()*
+		Set the register {regname} to {value}.
+		If {regname} is "" or "@", the unnamed register '"' is used.
+		The {regname} argument is a string.
 
-                {value} may be any value returned by |getreg()| or
-                |getreginfo()|, including a |List| or |Dict|.
-                If {options} contains "a" or {regname} is upper case,
-                then the value is appended.
+		{value} may be any value returned by |getreg()| or
+		|getreginfo()|, including a |List| or |Dict|.
+		If {options} contains "a" or {regname} is upper case,
+		then the value is appended.
 
-                {options} can also contain a register type specification:
-                    "c" or "v"        |charwise| mode
-                    "l" or "V"        |linewise| mode
-                    "b" or "<CTRL-V>" |blockwise-visual| mode
-                If a number immediately follows "b" or "<CTRL-V>" then this is
-                used as the width of the selection - if it is not specified
-                then the width of the block is set to the number of characters
-                in the longest line (counting a <Tab> as 1 character).
-                If {options} contains "u" or '"', then the unnamed register is
-                set to point to register {regname}.
+		{options} can also contain a register type specification:
+		    "c" or "v"	      |charwise| mode
+		    "l" or "V"	      |linewise| mode
+		    "b" or "<CTRL-V>" |blockwise-visual| mode
+		If a number immediately follows "b" or "<CTRL-V>" then this is
+		used as the width of the selection - if it is not specified
+		then the width of the block is set to the number of characters
+		in the longest line (counting a <Tab> as 1 character).
+		If {options} contains "u" or '"', then the unnamed register is
+		set to point to register {regname}.
 
-                If {options} contains no register settings, then the default
-                is to use character mode unless {value} ends in a <NL> for
-                string {value} and linewise mode for list {value}. Blockwise
-                mode is never selected automatically.
-                Returns zero for success, non-zero for failure.
+		If {options} contains no register settings, then the default
+		is to use character mode unless {value} ends in a <NL> for
+		string {value} and linewise mode for list {value}. Blockwise
+		mode is never selected automatically.
+		Returns zero for success, non-zero for failure.
 
-                                                        *E883*
-                Note: you may not use |List| containing more than one item to
-                      set search and expression registers. Lists containing no
-                      items act like empty strings.
+							*E883*
+		Note: you may not use |List| containing more than one item to
+		      set search and expression registers. Lists containing no
+		      items act like empty strings.
 
-                Examples: >vim
-                        call setreg(v:register, @*)
-                        call setreg('*', @%, 'ac')
-                        call setreg('a', "1\n2\n3", 'b5')
-                        call setreg('"', { 'points_to': 'a'})
+		Examples: >vim
+			call setreg(v:register, @*)
+			call setreg('*', @%, 'ac')
+			call setreg('a', "1\n2\n3", 'b5')
+			call setreg('"', { 'points_to': 'a'})
 
-<                This example shows using the functions to save and restore a
-                register: >vim
-                        let var_a = getreginfo()
-                        call setreg('a', var_a)
-<                or: >vim
-                        let var_a = getreg('a', 1, 1)
-                        let var_amode = getregtype('a')
-                        " ....
-                        call setreg('a', var_a, var_amode)
-<                Note: you may not reliably restore register value
-                without using the third argument to |getreg()| as without it
-                newlines are represented as newlines AND Nul bytes are
-                represented as newlines as well, see |NL-used-for-Nul|.
+<		 This example shows using the functions to save and restore a
+		register: >vim
+			let var_a = getreginfo()
+			call setreg('a', var_a)
+<		 or: >vim
+			let var_a = getreg('a', 1, 1)
+			let var_amode = getregtype('a')
+			" ....
+			call setreg('a', var_a, var_amode)
+<		 Note: you may not reliably restore register value
+		without using the third argument to |getreg()| as without it
+		newlines are represented as newlines AND Nul bytes are
+		represented as newlines as well, see |NL-used-for-Nul|.
 
-                You can also change the type of a register by appending
-                nothing: >vim
-                        call setreg('a', '', 'al')
+		You can also change the type of a register by appending
+		nothing: >vim
+			call setreg('a', '', 'al')
 
-settabvar({tabnr}, {varname}, {val})                               *settabvar()*
-                Set tab-local variable {varname} to {val} in tab page {tabnr}.
-                |t:var|
-                The {varname} argument is a string.
-                Note that the variable name without "t:" must be used.
-                Tabs are numbered starting with one.
-                This function is not available in the |sandbox|.
+settabvar({tabnr}, {varname}, {val})				   *settabvar()*
+		Set tab-local variable {varname} to {val} in tab page {tabnr}.
+		|t:var|
+		The {varname} argument is a string.
+		Note that the variable name without "t:" must be used.
+		Tabs are numbered starting with one.
+		This function is not available in the |sandbox|.
 
-settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
-                Set option or local variable {varname} in window {winnr} to
-                {val}.
-                Tabs are numbered starting with one.  For the current tabpage
-                use |setwinvar()|.
-                {winnr} can be the window number or the |window-ID|.
-                When {winnr} is zero the current window is used.
-                This also works for a global or local buffer option, but it
-                doesn't work for a global or local buffer variable.
-                For a local buffer option the global value is unchanged.
-                Note that the variable name without "w:" must be used.
-                Examples: >vim
-                        call settabwinvar(1, 1, "&list", 0)
-                        call settabwinvar(3, 2, "myvar", "foobar")
-<                This function is not available in the |sandbox|.
+settabwinvar({tabnr}, {winnr}, {varname}, {val})		*settabwinvar()*
+		Set option or local variable {varname} in window {winnr} to
+		{val}.
+		Tabs are numbered starting with one.  For the current tabpage
+		use |setwinvar()|.
+		{winnr} can be the window number or the |window-ID|.
+		When {winnr} is zero the current window is used.
+		This also works for a global or local buffer option, but it
+		doesn't work for a global or local buffer variable.
+		For a local buffer option the global value is unchanged.
+		Note that the variable name without "w:" must be used.
+		Examples: >vim
+			call settabwinvar(1, 1, "&list", 0)
+			call settabwinvar(3, 2, "myvar", "foobar")
+<		 This function is not available in the |sandbox|.
 
-settagstack({nr}, {dict} [, {action}])                           *settagstack()*
-                Modify the tag stack of the window {nr} using {dict}.
-                {nr} can be the window number or the |window-ID|.
+settagstack({nr}, {dict} [, {action}])				 *settagstack()*
+		Modify the tag stack of the window {nr} using {dict}.
+		{nr} can be the window number or the |window-ID|.
 
-                For a list of supported items in {dict}, refer to
-                |gettagstack()|. "curidx" takes effect before changing the tag
-                stack.
-                                                        *E962*
-                How the tag stack is modified depends on the {action}
-                argument:
-                - If {action} is not present or is set to 'r', then the tag
-                  stack is replaced.
-                - If {action} is set to 'a', then new entries from {dict} are
-                  pushed (added) onto the tag stack.
-                - If {action} is set to 't', then all the entries from the
-                  current entry in the tag stack or "curidx" in {dict} are
-                  removed and then new entries are pushed to the stack.
+		For a list of supported items in {dict}, refer to
+		|gettagstack()|. "curidx" takes effect before changing the tag
+		stack.
+							*E962*
+		How the tag stack is modified depends on the {action}
+		argument:
+		- If {action} is not present or is set to 'r', then the tag
+		  stack is replaced.
+		- If {action} is set to 'a', then new entries from {dict} are
+		  pushed (added) onto the tag stack.
+		- If {action} is set to 't', then all the entries from the
+		  current entry in the tag stack or "curidx" in {dict} are
+		  removed and then new entries are pushed to the stack.
 
-                The current index is set to one after the length of the tag
-                stack after the modification.
+		The current index is set to one after the length of the tag
+		stack after the modification.
 
-                Returns zero for success, -1 for failure.
+		Returns zero for success, -1 for failure.
 
-                Examples (for more examples see |tagstack-examples|):
-                    Empty the tag stack of window 3: >vim
-                        call settagstack(3, {'items' : []})
+		Examples (for more examples see |tagstack-examples|):
+		    Empty the tag stack of window 3: >vim
+			call settagstack(3, {'items' : []})
 
-<                    Save and restore the tag stack: >vim
-                        let stack = gettagstack(1003)
-                        " do something else
-                        call settagstack(1003, stack)
-                        unlet stack
+<		     Save and restore the tag stack: >vim
+			let stack = gettagstack(1003)
+			" do something else
+			call settagstack(1003, stack)
+			unlet stack
 <
-setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
-                Like |settabwinvar()| for the current tab page.
-                Examples: >vim
-                        call setwinvar(1, "&list", 0)
-                        call setwinvar(2, "myvar", "foobar")
+setwinvar({nr}, {varname}, {val})				   *setwinvar()*
+		Like |settabwinvar()| for the current tab page.
+		Examples: >vim
+			call setwinvar(1, "&list", 0)
+			call setwinvar(2, "myvar", "foobar")
 
-sha256({string})                                                      *sha256()*
-                Returns a String with 64 hex characters, which is the SHA256
-                checksum of {string}.
+sha256({string})						      *sha256()*
+		Returns a String with 64 hex characters, which is the SHA256
+		checksum of {string}.
 
-shellescape({string} [, {special}])                              *shellescape()*
-                Escape {string} for use as a shell command argument.
+shellescape({string} [, {special}])				 *shellescape()*
+		Escape {string} for use as a shell command argument.
 
-                On Windows when 'shellslash' is not set, encloses {string} in
-                double-quotes and doubles all double-quotes within {string}.
-                Otherwise encloses {string} in single-quotes and replaces all
-                "'" with "'\''".
+		On Windows when 'shellslash' is not set, encloses {string} in
+		double-quotes and doubles all double-quotes within {string}.
+		Otherwise encloses {string} in single-quotes and replaces all
+		"'" with "'\''".
 
-                If {special} is a |non-zero-arg|:
-                - Special items such as "!", "%", "#" and "<cword>" will be
-                  preceded by a backslash. The backslash will be removed again
-                  by the |:!| command.
-                - The <NL> character is escaped.
+		If {special} is a |non-zero-arg|:
+		- Special items such as "!", "%", "#" and "<cword>" will be
+		  preceded by a backslash. The backslash will be removed again
+		  by the |:!| command.
+		- The <NL> character is escaped.
 
-                If 'shell' contains "csh" in the tail:
-                - The "!" character will be escaped. This is because csh and
-                  tcsh use "!" for history replacement even in single-quotes.
-                - The <NL> character is escaped (twice if {special} is
-                  a |non-zero-arg|).
+		If 'shell' contains "csh" in the tail:
+		- The "!" character will be escaped. This is because csh and
+		  tcsh use "!" for history replacement even in single-quotes.
+		- The <NL> character is escaped (twice if {special} is
+		  a |non-zero-arg|).
 
-                If 'shell' contains "fish" in the tail, the "\" character will
-                be escaped because in fish it is used as an escape character
-                inside single quotes.
+		If 'shell' contains "fish" in the tail, the "\" character will
+		be escaped because in fish it is used as an escape character
+		inside single quotes.
 
-                Example of use with a |:!| command: >vim
-                    exe '!dir ' .. shellescape(expand('<cfile>'), 1)
-<                This results in a directory listing for the file under the
-                cursor.  Example of use with |system()|: >vim
-                    call system("chmod +w -- " .. shellescape(expand("%")))
-<                See also |::S|.
+		Example of use with a |:!| command: >vim
+		    exe '!dir ' .. shellescape(expand('<cfile>'), 1)
+<		 This results in a directory listing for the file under the
+		cursor.  Example of use with |system()|: >vim
+		    call system("chmod +w -- " .. shellescape(expand("%")))
+<		 See also |::S|.
 
-shiftwidth([{col}])                                               *shiftwidth()*
-                Returns the effective value of 'shiftwidth'. This is the
-                'shiftwidth' value unless it is zero, in which case it is the
-                'tabstop' value.  To be backwards compatible in indent
-                plugins, use this: >vim
-                        if exists('*shiftwidth')
-                          func s:sw()
-                            return shiftwidth()
-                          endfunc
-                        else
-                          func s:sw()
-                            return &sw
-                          endfunc
-                        endif
-<                And then use s:sw() instead of &sw.
+shiftwidth([{col}])						  *shiftwidth()*
+		Returns the effective value of 'shiftwidth'. This is the
+		'shiftwidth' value unless it is zero, in which case it is the
+		'tabstop' value.  To be backwards compatible in indent
+		plugins, use this: >vim
+			if exists('*shiftwidth')
+			  func s:sw()
+			    return shiftwidth()
+			  endfunc
+			else
+			  func s:sw()
+			    return &sw
+			  endfunc
+			endif
+<		 And then use s:sw() instead of &sw.
 
-                When there is one argument {col} this is used as column number
-                for which to return the 'shiftwidth' value. This matters for the
-                'vartabstop' feature. If no {col} argument is given, column 1
-                will be assumed.
+		When there is one argument {col} this is used as column number
+		for which to return the 'shiftwidth' value. This matters for the
+		'vartabstop' feature. If no {col} argument is given, column 1
+		will be assumed.
 
 sign_define({name} [, {dict}])
-sign_define({list})                                              *sign_define()*
-                Define a new sign named {name} or modify the attributes of an
-                existing sign.  This is similar to the |:sign-define| command.
+sign_define({list})						 *sign_define()*
+		Define a new sign named {name} or modify the attributes of an
+		existing sign.	This is similar to the |:sign-define| command.
 
-                Prefix {name} with a unique text to avoid name collisions.
-                There is no {group} like with placing signs.
+		Prefix {name} with a unique text to avoid name collisions.
+		There is no {group} like with placing signs.
 
-                The {name} can be a String or a Number.  The optional {dict}
-                argument specifies the sign attributes.  The following values
-                are supported:
-                   icon         full path to the bitmap file for the sign.
-                   linehl       highlight group used for the whole line the
-                                sign is placed in.
-                   numhl        highlight group used for the line number where
-                                the sign is placed.
-                   text         text that is displayed when there is no icon
-                                or the GUI is not being used.
-                   texthl       highlight group used for the text item
-                   culhl        highlight group used for the text item when
-                                the cursor is on the same line as the sign and
-                                'cursorline' is enabled.
+		The {name} can be a String or a Number.  The optional {dict}
+		argument specifies the sign attributes.  The following values
+		are supported:
+		   icon		full path to the bitmap file for the sign.
+		   linehl	highlight group used for the whole line the
+				sign is placed in.
+		   numhl	highlight group used for the line number where
+				the sign is placed.
+		   text		text that is displayed when there is no icon
+				or the GUI is not being used.
+		   texthl	highlight group used for the text item
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled.
 
-                If the sign named {name} already exists, then the attributes
-                of the sign are updated.
+		If the sign named {name} already exists, then the attributes
+		of the sign are updated.
 
-                The one argument {list} can be used to define a list of signs.
-                Each list item is a dictionary with the above items in {dict}
-                and a "name" item for the sign name.
+		The one argument {list} can be used to define a list of signs.
+		Each list item is a dictionary with the above items in {dict}
+		and a "name" item for the sign name.
 
-                Returns 0 on success and -1 on failure.  When the one argument
-                {list} is used, then returns a List of values one for each
-                defined sign.
+		Returns 0 on success and -1 on failure.  When the one argument
+		{list} is used, then returns a List of values one for each
+		defined sign.
 
-                Examples: >vim
-                        call sign_define("mySign", {
-                                \ "text" : "=>",
-                                \ "texthl" : "Error",
-                                \ "linehl" : "Search"})
-                        call sign_define([
-                                \ {'name' : 'sign1',
-                                \  'text' : '=>'},
-                                \ {'name' : 'sign2',
-                                \  'text' : '!!'}
-                                \ ])
+		Examples: >vim
+			call sign_define("mySign", {
+				\ "text" : "=>",
+				\ "texthl" : "Error",
+				\ "linehl" : "Search"})
+			call sign_define([
+				\ {'name' : 'sign1',
+				\  'text' : '=>'},
+				\ {'name' : 'sign2',
+				\  'text' : '!!'}
+				\ ])
 <
-sign_getdefined([{name}])                                    *sign_getdefined()*
-                Get a list of defined signs and their attributes.
-                This is similar to the |:sign-list| command.
+sign_getdefined([{name}])				     *sign_getdefined()*
+		Get a list of defined signs and their attributes.
+		This is similar to the |:sign-list| command.
 
-                If the {name} is not supplied, then a list of all the defined
-                signs is returned. Otherwise the attribute of the specified
-                sign is returned.
+		If the {name} is not supplied, then a list of all the defined
+		signs is returned. Otherwise the attribute of the specified
+		sign is returned.
 
-                Each list item in the returned value is a dictionary with the
-                following entries:
-                   icon         full path to the bitmap file of the sign
-                   linehl       highlight group used for the whole line the
-                                sign is placed in; not present if not set.
-                   name         name of the sign
-                   numhl        highlight group used for the line number where
-                                the sign is placed; not present if not set.
-                   text         text that is displayed when there is no icon
-                                or the GUI is not being used.
-                   texthl       highlight group used for the text item; not
-                                present if not set.
-                   culhl        highlight group used for the text item when
-                                the cursor is on the same line as the sign and
-                                'cursorline' is enabled; not present if not
-                                set.
+		Each list item in the returned value is a dictionary with the
+		following entries:
+		   icon		full path to the bitmap file of the sign
+		   linehl	highlight group used for the whole line the
+				sign is placed in; not present if not set.
+		   name		name of the sign
+		   numhl	highlight group used for the line number where
+				the sign is placed; not present if not set.
+		   text		text that is displayed when there is no icon
+				or the GUI is not being used.
+		   texthl	highlight group used for the text item; not
+				present if not set.
+		   culhl	highlight group used for the text item when
+				the cursor is on the same line as the sign and
+				'cursorline' is enabled; not present if not
+				set.
 
-                Returns an empty List if there are no signs and when {name} is
-                not found.
+		Returns an empty List if there are no signs and when {name} is
+		not found.
 
-                Examples: >vim
-                        " Get a list of all the defined signs
-                        echo sign_getdefined()
+		Examples: >vim
+			" Get a list of all the defined signs
+			echo sign_getdefined()
 
-                        " Get the attribute of the sign named mySign
-                        echo sign_getdefined("mySign")
+			" Get the attribute of the sign named mySign
+			echo sign_getdefined("mySign")
 <
-sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
-                Return a list of signs placed in a buffer or all the buffers.
-                This is similar to the |:sign-place-list| command.
+sign_getplaced([{buf} [, {dict}]])			      *sign_getplaced()*
+		Return a list of signs placed in a buffer or all the buffers.
+		This is similar to the |:sign-place-list| command.
 
-                If the optional buffer name {buf} is specified, then only the
-                list of signs placed in that buffer is returned.  For the use
-                of {buf}, see |bufname()|. The optional {dict} can contain
-                the following entries:
-                   group        select only signs in this group
-                   id           select sign with this identifier
-                   lnum         select signs placed in this line. For the use
-                                of {lnum}, see |line()|.
-                If {group} is "*", then signs in all the groups including the
-                global group are returned. If {group} is not supplied or is an
-                empty string, then only signs in the global group are
-                returned.  If no arguments are supplied, then signs in the
-                global group placed in all the buffers are returned.
-                See |sign-group|.
+		If the optional buffer name {buf} is specified, then only the
+		list of signs placed in that buffer is returned.  For the use
+		of {buf}, see |bufname()|. The optional {dict} can contain
+		the following entries:
+		   group	select only signs in this group
+		   id		select sign with this identifier
+		   lnum		select signs placed in this line. For the use
+				of {lnum}, see |line()|.
+		If {group} is "*", then signs in all the groups including the
+		global group are returned. If {group} is not supplied or is an
+		empty string, then only signs in the global group are
+		returned.  If no arguments are supplied, then signs in the
+		global group placed in all the buffers are returned.
+		See |sign-group|.
 
-                Each list item in the returned value is a dictionary with the
-                following entries:
-                        bufnr   number of the buffer with the sign
-                        signs   list of signs placed in {bufnr}. Each list
-                                item is a dictionary with the below listed
-                                entries
+		Each list item in the returned value is a dictionary with the
+		following entries:
+			bufnr	number of the buffer with the sign
+			signs	list of signs placed in {bufnr}. Each list
+				item is a dictionary with the below listed
+				entries
 
-                The dictionary for each sign contains the following entries:
-                        group    sign group. Set to '' for the global group.
-                        id       identifier of the sign
-                        lnum     line number where the sign is placed
-                        name     name of the defined sign
-                        priority sign priority
+		The dictionary for each sign contains the following entries:
+			group	 sign group. Set to '' for the global group.
+			id	 identifier of the sign
+			lnum	 line number where the sign is placed
+			name	 name of the defined sign
+			priority sign priority
 
-                The returned signs in a buffer are ordered by their line
-                number and priority.
+		The returned signs in a buffer are ordered by their line
+		number and priority.
 
-                Returns an empty list on failure or if there are no placed
-                signs.
+		Returns an empty list on failure or if there are no placed
+		signs.
 
-                Examples: >vim
-                        " Get a List of signs placed in eval.c in the
-                        " global group
-                        echo sign_getplaced("eval.c")
+		Examples: >vim
+			" Get a List of signs placed in eval.c in the
+			" global group
+			echo sign_getplaced("eval.c")
 
-                        " Get a List of signs in group 'g1' placed in eval.c
-                        echo sign_getplaced("eval.c", {'group' : 'g1'})
+			" Get a List of signs in group 'g1' placed in eval.c
+			echo sign_getplaced("eval.c", {'group' : 'g1'})
 
-                        " Get a List of signs placed at line 10 in eval.c
-                        echo sign_getplaced("eval.c", {'lnum' : 10})
+			" Get a List of signs placed at line 10 in eval.c
+			echo sign_getplaced("eval.c", {'lnum' : 10})
 
-                        " Get sign with identifier 10 placed in a.py
-                        echo sign_getplaced("a.py", {'id' : 10})
+			" Get sign with identifier 10 placed in a.py
+			echo sign_getplaced("a.py", {'id' : 10})
 
-                        " Get sign with id 20 in group 'g1' placed in a.py
-                        echo sign_getplaced("a.py", {'group' : 'g1',
-                                                        \  'id' : 20})
+			" Get sign with id 20 in group 'g1' placed in a.py
+			echo sign_getplaced("a.py", {'group' : 'g1',
+							\  'id' : 20})
 
-                        " Get a List of all the placed signs
-                        echo sign_getplaced()
+			" Get a List of all the placed signs
+			echo sign_getplaced()
 <
-sign_jump({id}, {group}, {buf})                                    *sign_jump()*
-                Open the buffer {buf} or jump to the window that contains
-                {buf} and position the cursor at sign {id} in group {group}.
-                This is similar to the |:sign-jump| command.
+sign_jump({id}, {group}, {buf})					   *sign_jump()*
+		Open the buffer {buf} or jump to the window that contains
+		{buf} and position the cursor at sign {id} in group {group}.
+		This is similar to the |:sign-jump| command.
 
-                If {group} is an empty string, then the global group is used.
-                For the use of {buf}, see |bufname()|.
+		If {group} is an empty string, then the global group is used.
+		For the use of {buf}, see |bufname()|.
 
-                Returns the line number of the sign. Returns -1 if the
-                arguments are invalid.
+		Returns the line number of the sign. Returns -1 if the
+		arguments are invalid.
 
-                Example: >vim
-                        " Jump to sign 10 in the current buffer
-                        call sign_jump(10, '', '')
+		Example: >vim
+			" Jump to sign 10 in the current buffer
+			call sign_jump(10, '', '')
 <
-sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
-                Place the sign defined as {name} at line {lnum} in file or
-                buffer {buf} and assign {id} and {group} to sign.  This is
-                similar to the |:sign-place| command.
+sign_place({id}, {group}, {name}, {buf} [, {dict}])		  *sign_place()*
+		Place the sign defined as {name} at line {lnum} in file or
+		buffer {buf} and assign {id} and {group} to sign.  This is
+		similar to the |:sign-place| command.
 
-                If the sign identifier {id} is zero, then a new identifier is
-                allocated.  Otherwise the specified number is used. {group} is
-                the sign group name. To use the global sign group, use an
-                empty string.  {group} functions as a namespace for {id}, thus
-                two groups can use the same IDs. Refer to |sign-identifier|
-                and |sign-group| for more information.
+		If the sign identifier {id} is zero, then a new identifier is
+		allocated.  Otherwise the specified number is used. {group} is
+		the sign group name. To use the global sign group, use an
+		empty string.  {group} functions as a namespace for {id}, thus
+		two groups can use the same IDs. Refer to |sign-identifier|
+		and |sign-group| for more information.
 
-                {name} refers to a defined sign.
-                {buf} refers to a buffer name or number. For the accepted
-                values, see |bufname()|.
+		{name} refers to a defined sign.
+		{buf} refers to a buffer name or number. For the accepted
+		values, see |bufname()|.
 
-                The optional {dict} argument supports the following entries:
-                        lnum            line number in the file or buffer
-                                        {buf} where the sign is to be placed.
-                                        For the accepted values, see |line()|.
-                        priority        priority of the sign. See
-                                        |sign-priority| for more information.
+		The optional {dict} argument supports the following entries:
+			lnum		line number in the file or buffer
+					{buf} where the sign is to be placed.
+					For the accepted values, see |line()|.
+			priority	priority of the sign. See
+					|sign-priority| for more information.
 
-                If the optional {dict} is not specified, then it modifies the
-                placed sign {id} in group {group} to use the defined sign
-                {name}.
+		If the optional {dict} is not specified, then it modifies the
+		placed sign {id} in group {group} to use the defined sign
+		{name}.
 
-                Returns the sign identifier on success and -1 on failure.
+		Returns the sign identifier on success and -1 on failure.
 
-                Examples: >vim
-                        " Place a sign named sign1 with id 5 at line 20 in
-                        " buffer json.c
-                        call sign_place(5, '', 'sign1', 'json.c',
-                                                        \ {'lnum' : 20})
+		Examples: >vim
+			" Place a sign named sign1 with id 5 at line 20 in
+			" buffer json.c
+			call sign_place(5, '', 'sign1', 'json.c',
+							\ {'lnum' : 20})
 
-                        " Updates sign 5 in buffer json.c to use sign2
-                        call sign_place(5, '', 'sign2', 'json.c')
+			" Updates sign 5 in buffer json.c to use sign2
+			call sign_place(5, '', 'sign2', 'json.c')
 
-                        " Place a sign named sign3 at line 30 in
-                        " buffer json.c with a new identifier
-                        let id = sign_place(0, '', 'sign3', 'json.c',
-                                                        \ {'lnum' : 30})
+			" Place a sign named sign3 at line 30 in
+			" buffer json.c with a new identifier
+			let id = sign_place(0, '', 'sign3', 'json.c',
+							\ {'lnum' : 30})
 
-                        " Place a sign named sign4 with id 10 in group 'g3'
-                        " at line 40 in buffer json.c with priority 90
-                        call sign_place(10, 'g3', 'sign4', 'json.c',
-                                        \ {'lnum' : 40, 'priority' : 90})
+			" Place a sign named sign4 with id 10 in group 'g3'
+			" at line 40 in buffer json.c with priority 90
+			call sign_place(10, 'g3', 'sign4', 'json.c',
+					\ {'lnum' : 40, 'priority' : 90})
 <
-sign_placelist({list})                                        *sign_placelist()*
-                Place one or more signs.  This is similar to the
-                |sign_place()| function.  The {list} argument specifies the
-                List of signs to place. Each list item is a dict with the
-                following sign attributes:
-                    buffer      Buffer name or number. For the accepted
-                                values, see |bufname()|.
-                    group       Sign group. {group} functions as a namespace
-                                for {id}, thus two groups can use the same
-                                IDs. If not specified or set to an empty
-                                string, then the global group is used.   See
-                                |sign-group| for more information.
-                    id          Sign identifier. If not specified or zero,
-                                then a new unique identifier is allocated.
-                                Otherwise the specified number is used. See
-                                |sign-identifier| for more information.
-                    lnum        Line number in the buffer where the sign is to
-                                be placed. For the accepted values, see
-                                |line()|.
-                    name        Name of the sign to place. See |sign_define()|
-                                for more information.
-                    priority    Priority of the sign. When multiple signs are
-                                placed on a line, the sign with the highest
-                                priority is used. If not specified, the
-                                default value of 10 is used. See
-                                |sign-priority| for more information.
+sign_placelist({list})					      *sign_placelist()*
+		Place one or more signs.  This is similar to the
+		|sign_place()| function.  The {list} argument specifies the
+		List of signs to place. Each list item is a dict with the
+		following sign attributes:
+		    buffer	Buffer name or number. For the accepted
+				values, see |bufname()|.
+		    group	Sign group. {group} functions as a namespace
+				for {id}, thus two groups can use the same
+				IDs. If not specified or set to an empty
+				string, then the global group is used.	 See
+				|sign-group| for more information.
+		    id		Sign identifier. If not specified or zero,
+				then a new unique identifier is allocated.
+				Otherwise the specified number is used. See
+				|sign-identifier| for more information.
+		    lnum	Line number in the buffer where the sign is to
+				be placed. For the accepted values, see
+				|line()|.
+		    name	Name of the sign to place. See |sign_define()|
+				for more information.
+		    priority	Priority of the sign. When multiple signs are
+				placed on a line, the sign with the highest
+				priority is used. If not specified, the
+				default value of 10 is used. See
+				|sign-priority| for more information.
 
-                If {id} refers to an existing sign, then the existing sign is
-                modified to use the specified {name} and/or {priority}.
+		If {id} refers to an existing sign, then the existing sign is
+		modified to use the specified {name} and/or {priority}.
 
-                Returns a List of sign identifiers. If failed to place a
-                sign, the corresponding list item is set to -1.
+		Returns a List of sign identifiers. If failed to place a
+		sign, the corresponding list item is set to -1.
 
-                Examples: >vim
-                        " Place sign s1 with id 5 at line 20 and id 10 at line
-                        " 30 in buffer a.c
-                        let [n1, n2] = sign_placelist([
-                                \ {'id' : 5,
-                                \  'name' : 's1',
-                                \  'buffer' : 'a.c',
-                                \  'lnum' : 20},
-                                \ {'id' : 10,
-                                \  'name' : 's1',
-                                \  'buffer' : 'a.c',
-                                \  'lnum' : 30}
-                                \ ])
+		Examples: >vim
+			" Place sign s1 with id 5 at line 20 and id 10 at line
+			" 30 in buffer a.c
+			let [n1, n2] = sign_placelist([
+				\ {'id' : 5,
+				\  'name' : 's1',
+				\  'buffer' : 'a.c',
+				\  'lnum' : 20},
+				\ {'id' : 10,
+				\  'name' : 's1',
+				\  'buffer' : 'a.c',
+				\  'lnum' : 30}
+				\ ])
 
-                        " Place sign s1 in buffer a.c at line 40 and 50
-                        " with auto-generated identifiers
-                        let [n1, n2] = sign_placelist([
-                                \ {'name' : 's1',
-                                \  'buffer' : 'a.c',
-                                \  'lnum' : 40},
-                                \ {'name' : 's1',
-                                \  'buffer' : 'a.c',
-                                \  'lnum' : 50}
-                                \ ])
+			" Place sign s1 in buffer a.c at line 40 and 50
+			" with auto-generated identifiers
+			let [n1, n2] = sign_placelist([
+				\ {'name' : 's1',
+				\  'buffer' : 'a.c',
+				\  'lnum' : 40},
+				\ {'name' : 's1',
+				\  'buffer' : 'a.c',
+				\  'lnum' : 50}
+				\ ])
 <
 sign_undefine([{name}])
-sign_undefine({list})                                          *sign_undefine()*
-                Deletes a previously defined sign {name}. This is similar to
-                the |:sign-undefine| command. If {name} is not supplied, then
-                deletes all the defined signs.
+sign_undefine({list})					       *sign_undefine()*
+		Deletes a previously defined sign {name}. This is similar to
+		the |:sign-undefine| command. If {name} is not supplied, then
+		deletes all the defined signs.
 
-                The one argument {list} can be used to undefine a list of
-                signs. Each list item is the name of a sign.
+		The one argument {list} can be used to undefine a list of
+		signs. Each list item is the name of a sign.
 
-                Returns 0 on success and -1 on failure.  For the one argument
-                {list} call, returns a list of values one for each undefined
-                sign.
+		Returns 0 on success and -1 on failure.  For the one argument
+		{list} call, returns a list of values one for each undefined
+		sign.
 
-                Examples: >vim
-                        " Delete a sign named mySign
-                        call sign_undefine("mySign")
+		Examples: >vim
+			" Delete a sign named mySign
+			call sign_undefine("mySign")
 
-                        " Delete signs 'sign1' and 'sign2'
-                        call sign_undefine(["sign1", "sign2"])
+			" Delete signs 'sign1' and 'sign2'
+			call sign_undefine(["sign1", "sign2"])
 
-                        " Delete all the signs
-                        call sign_undefine()
+			" Delete all the signs
+			call sign_undefine()
 <
-sign_unplace({group} [, {dict}])                                *sign_unplace()*
-                Remove a previously placed sign in one or more buffers.  This
-                is similar to the |:sign-unplace| command.
+sign_unplace({group} [, {dict}])				*sign_unplace()*
+		Remove a previously placed sign in one or more buffers.  This
+		is similar to the |:sign-unplace| command.
 
-                {group} is the sign group name. To use the global sign group,
-                use an empty string.  If {group} is set to "*", then all the
-                groups including the global group are used.
-                The signs in {group} are selected based on the entries in
-                {dict}.  The following optional entries in {dict} are
-                supported:
-                        buffer  buffer name or number. See |bufname()|.
-                        id      sign identifier
-                If {dict} is not supplied, then all the signs in {group} are
-                removed.
+		{group} is the sign group name. To use the global sign group,
+		use an empty string.  If {group} is set to "*", then all the
+		groups including the global group are used.
+		The signs in {group} are selected based on the entries in
+		{dict}.  The following optional entries in {dict} are
+		supported:
+			buffer	buffer name or number. See |bufname()|.
+			id	sign identifier
+		If {dict} is not supplied, then all the signs in {group} are
+		removed.
 
-                Returns 0 on success and -1 on failure.
+		Returns 0 on success and -1 on failure.
 
-                Examples: >vim
-                        " Remove sign 10 from buffer a.vim
-                        call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
+		Examples: >vim
+			" Remove sign 10 from buffer a.vim
+			call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
 
-                        " Remove sign 20 in group 'g1' from buffer 3
-                        call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
+			" Remove sign 20 in group 'g1' from buffer 3
+			call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
 
-                        " Remove all the signs in group 'g2' from buffer 10
-                        call sign_unplace('g2', {'buffer' : 10})
+			" Remove all the signs in group 'g2' from buffer 10
+			call sign_unplace('g2', {'buffer' : 10})
 
-                        " Remove sign 30 in group 'g3' from all the buffers
-                        call sign_unplace('g3', {'id' : 30})
+			" Remove sign 30 in group 'g3' from all the buffers
+			call sign_unplace('g3', {'id' : 30})
 
-                        " Remove all the signs placed in buffer 5
-                        call sign_unplace('*', {'buffer' : 5})
+			" Remove all the signs placed in buffer 5
+			call sign_unplace('*', {'buffer' : 5})
 
-                        " Remove the signs in group 'g4' from all the buffers
-                        call sign_unplace('g4')
+			" Remove the signs in group 'g4' from all the buffers
+			call sign_unplace('g4')
 
-                        " Remove sign 40 from all the buffers
-                        call sign_unplace('*', {'id' : 40})
+			" Remove sign 40 from all the buffers
+			call sign_unplace('*', {'id' : 40})
 
-                        " Remove all the placed signs from all the buffers
-                        call sign_unplace('*')
+			" Remove all the placed signs from all the buffers
+			call sign_unplace('*')
 
-sign_unplacelist({list})                                    *sign_unplacelist()*
-                Remove previously placed signs from one or more buffers.  This
-                is similar to the |sign_unplace()| function.
+sign_unplacelist({list})				    *sign_unplacelist()*
+		Remove previously placed signs from one or more buffers.  This
+		is similar to the |sign_unplace()| function.
 
-                The {list} argument specifies the List of signs to remove.
-                Each list item is a dict with the following sign attributes:
-                    buffer      buffer name or number. For the accepted
-                                values, see |bufname()|. If not specified,
-                                then the specified sign is removed from all
-                                the buffers.
-                    group       sign group name. If not specified or set to an
-                                empty string, then the global sign group is
-                                used. If set to "*", then all the groups
-                                including the global group are used.
-                    id          sign identifier. If not specified, then all
-                                the signs in the specified group are removed.
+		The {list} argument specifies the List of signs to remove.
+		Each list item is a dict with the following sign attributes:
+		    buffer	buffer name or number. For the accepted
+				values, see |bufname()|. If not specified,
+				then the specified sign is removed from all
+				the buffers.
+		    group	sign group name. If not specified or set to an
+				empty string, then the global sign group is
+				used. If set to "*", then all the groups
+				including the global group are used.
+		    id		sign identifier. If not specified, then all
+				the signs in the specified group are removed.
 
-                Returns a List where an entry is set to 0 if the corresponding
-                sign was successfully removed or -1 on failure.
+		Returns a List where an entry is set to 0 if the corresponding
+		sign was successfully removed or -1 on failure.
 
-                Example: >vim
-                        " Remove sign with id 10 from buffer a.vim and sign
-                        " with id 20 from buffer b.vim
-                        call sign_unplacelist([
-                                \ {'id' : 10, 'buffer' : "a.vim"},
-                                \ {'id' : 20, 'buffer' : 'b.vim'},
-                                \ ])
+		Example: >vim
+			" Remove sign with id 10 from buffer a.vim and sign
+			" with id 20 from buffer b.vim
+			call sign_unplacelist([
+				\ {'id' : 10, 'buffer' : "a.vim"},
+				\ {'id' : 20, 'buffer' : 'b.vim'},
+				\ ])
 <
-simplify({filename})                                                *simplify()*
-                Simplify the file name as much as possible without changing
-                the meaning.  Shortcuts (on MS-Windows) or symbolic links (on
-                Unix) are not resolved.  If the first path component in
-                {filename} designates the current directory, this will be
-                valid for the result as well.  A trailing path separator is
-                not removed either. On Unix "//path" is unchanged, but
-                "///path" is simplified to "/path" (this follows the Posix
-                standard).
-                Example: >vim
-                        simplify("./dir/.././/file/") == "./file/"
-<                Note: The combination "dir/.." is only removed if "dir" is
-                a searchable directory or does not exist.  On Unix, it is also
-                removed when "dir" is a symbolic link within the same
-                directory.  In order to resolve all the involved symbolic
-                links before simplifying the path name, use |resolve()|.
+simplify({filename})						    *simplify()*
+		Simplify the file name as much as possible without changing
+		the meaning.  Shortcuts (on MS-Windows) or symbolic links (on
+		Unix) are not resolved.  If the first path component in
+		{filename} designates the current directory, this will be
+		valid for the result as well.  A trailing path separator is
+		not removed either. On Unix "//path" is unchanged, but
+		"///path" is simplified to "/path" (this follows the Posix
+		standard).
+		Example: >vim
+			simplify("./dir/.././/file/") == "./file/"
+<		 Note: The combination "dir/.." is only removed if "dir" is
+		a searchable directory or does not exist.  On Unix, it is also
+		removed when "dir" is a symbolic link within the same
+		directory.  In order to resolve all the involved symbolic
+		links before simplifying the path name, use |resolve()|.
 
-sin({expr})                                                              *sin()*
-                Return the sine of {expr}, measured in radians, as a |Float|.
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo sin(100)
-<                        -0.506366 >vim
-                        echo sin(-4.01)
-<                        0.763301
+sin({expr})								 *sin()*
+		Return the sine of {expr}, measured in radians, as a |Float|.
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo sin(100)
+<			 -0.506366 >vim
+			echo sin(-4.01)
+<			 0.763301
 
-sinh({expr})                                                            *sinh()*
-                Return the hyperbolic sine of {expr} as a |Float| in the range
-                [-inf, inf].
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo sinh(0.5)
-<                       0.521095 >vim
-                        echo sinh(-0.9)
-<                       -1.026517
+sinh({expr})								*sinh()*
+		Return the hyperbolic sine of {expr} as a |Float| in the range
+		[-inf, inf].
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo sinh(0.5)
+<			0.521095 >vim
+			echo sinh(-0.9)
+<			-1.026517
 
-slice({expr}, {start} [, {end}])                                       *slice()*
-                Similar to using a |slice| "expr[start : end]", but "end" is
-                used exclusive.  And for a string the indexes are used as
-                character indexes instead of byte indexes.
-                Also, composing characters are not counted.
-                When {end} is omitted the slice continues to the last item.
-                When {end} is -1 the last item is omitted.
-                Returns an empty value if {start} or {end} are invalid.
+slice({expr}, {start} [, {end}])				       *slice()*
+		Similar to using a |slice| "expr[start : end]", but "end" is
+		used exclusive.  And for a string the indexes are used as
+		character indexes instead of byte indexes.
+		Also, composing characters are not counted.
+		When {end} is omitted the slice continues to the last item.
+		When {end} is -1 the last item is omitted.
+		Returns an empty value if {start} or {end} are invalid.
 
-sockconnect({mode}, {address} [, {opts}])                        *sockconnect()*
-                Connect a socket to an address. If {mode} is "pipe" then
-                {address} should be the path of a local domain socket (on
-                unix) or named pipe (on Windows). If {mode} is "tcp" then
-                {address} should be of the form "host:port" where the host
-                should be an ip address or host name, and port the port
-                number.
+sockconnect({mode}, {address} [, {opts}])			 *sockconnect()*
+		Connect a socket to an address. If {mode} is "pipe" then
+		{address} should be the path of a local domain socket (on
+		unix) or named pipe (on Windows). If {mode} is "tcp" then
+		{address} should be of the form "host:port" where the host
+		should be an ip address or host name, and port the port
+		number.
 
-                For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
-                |luv-tcp-handle|.
+		For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
+		|luv-tcp-handle|.
 
-                Returns a |channel| ID. Close the socket with |chanclose()|.
-                Use |chansend()| to send data over a bytes socket, and
-                |rpcrequest()| and |rpcnotify()| to communicate with a RPC
-                socket.
+		Returns a |channel| ID. Close the socket with |chanclose()|.
+		Use |chansend()| to send data over a bytes socket, and
+		|rpcrequest()| and |rpcnotify()| to communicate with a RPC
+		socket.
 
-                {opts} is an optional dictionary with these keys:
-                  |on_data| : callback invoked when data was read from socket
-                  data_buffered : read socket data in |channel-buffered| mode.
-                  rpc     : If set, |msgpack-rpc| will be used to communicate
-                            over the socket.
-                Returns:
-                  - The channel ID on success (greater than zero)
-                  - 0 on invalid arguments or connection failure.
+		{opts} is an optional dictionary with these keys:
+		  |on_data| : callback invoked when data was read from socket
+		  data_buffered : read socket data in |channel-buffered| mode.
+		  rpc	  : If set, |msgpack-rpc| will be used to communicate
+			    over the socket.
+		Returns:
+		  - The channel ID on success (greater than zero)
+		  - 0 on invalid arguments or connection failure.
 
-sort({list} [, {how} [, {dict}]])                                  *sort()* *E702*
-                Sort the items in {list} in-place.  Returns {list}.
+sort({list} [, {how} [, {dict}]])				   *sort()* *E702*
+		Sort the items in {list} in-place.  Returns {list}.
 
-                If you want a list to remain unmodified make a copy first: >vim
-                        let sortedlist = sort(copy(mylist))
+		If you want a list to remain unmodified make a copy first: >vim
+			let sortedlist = sort(copy(mylist))
 
-<                When {how} is omitted or is a string, then sort() uses the
-                string representation of each item to sort on.  Numbers sort
-                after Strings, |Lists| after Numbers.  For sorting text in the
-                current buffer use |:sort|.
+<		 When {how} is omitted or is a string, then sort() uses the
+		string representation of each item to sort on.	Numbers sort
+		after Strings, |Lists| after Numbers.  For sorting text in the
+		current buffer use |:sort|.
 
-                When {how} is given and it is 'i' then case is ignored.
-                For backwards compatibility, the value one can be used to
-                ignore case.  Zero means to not ignore case.
+		When {how} is given and it is 'i' then case is ignored.
+		For backwards compatibility, the value one can be used to
+		ignore case.  Zero means to not ignore case.
 
-                When {how} is given and it is 'l' then the current collation
-                locale is used for ordering. Implementation details: strcoll()
-                is used to compare strings. See |:language| check or set the
-                collation locale. |v:collate| can also be used to check the
-                current locale. Sorting using the locale typically ignores
-                case. Example: >vim
-                        " ö is sorted similarly to o with English locale.
-                        language collate en_US.UTF8
-                        echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<                        ['n', 'o', 'O', 'ö', 'p', 'z'] ~
+		When {how} is given and it is 'l' then the current collation
+		locale is used for ordering. Implementation details: strcoll()
+		is used to compare strings. See |:language| check or set the
+		collation locale. |v:collate| can also be used to check the
+		current locale. Sorting using the locale typically ignores
+		case. Example: >vim
+			" ö is sorted similarly to o with English locale.
+			language collate en_US.UTF8
+			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			 ['n', 'o', 'O', 'ö', 'p', 'z'] ~
 >vim
-                        " ö is sorted after z with Swedish locale.
-                        language collate sv_SE.UTF8
-                        echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<                        ['n', 'o', 'O', 'p', 'z', 'ö'] ~
-                This does not work properly on Mac.
+			" ö is sorted after z with Swedish locale.
+			language collate sv_SE.UTF8
+			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+<			 ['n', 'o', 'O', 'p', 'z', 'ö'] ~
+		This does not work properly on Mac.
 
-                When {how} is given and it is 'n' then all items will be
-                sorted numerical (Implementation detail: this uses the
-                strtod() function to parse numbers, Strings, Lists, Dicts and
-                Funcrefs will be considered as being 0).
+		When {how} is given and it is 'n' then all items will be
+		sorted numerical (Implementation detail: this uses the
+		strtod() function to parse numbers, Strings, Lists, Dicts and
+		Funcrefs will be considered as being 0).
 
-                When {how} is given and it is 'N' then all items will be
-                sorted numerical. This is like 'n' but a string containing
-                digits will be used as the number they represent.
+		When {how} is given and it is 'N' then all items will be
+		sorted numerical. This is like 'n' but a string containing
+		digits will be used as the number they represent.
 
-                When {how} is given and it is 'f' then all items will be
-                sorted numerical. All values must be a Number or a Float.
+		When {how} is given and it is 'f' then all items will be
+		sorted numerical. All values must be a Number or a Float.
 
-                When {how} is a |Funcref| or a function name, this function
-                is called to compare items.  The function is invoked with two
-                items as argument and must return zero if they are equal, 1 or
-                bigger if the first one sorts after the second one, -1 or
-                smaller if the first one sorts before the second one.
+		When {how} is a |Funcref| or a function name, this function
+		is called to compare items.  The function is invoked with two
+		items as argument and must return zero if they are equal, 1 or
+		bigger if the first one sorts after the second one, -1 or
+		smaller if the first one sorts before the second one.
 
-                {dict} is for functions with the "dict" attribute.  It will be
-                used to set the local variable "self". |Dictionary-function|
+		{dict} is for functions with the "dict" attribute.  It will be
+		used to set the local variable "self". |Dictionary-function|
 
-                The sort is stable, items which compare equal (as number or as
-                string) will keep their relative position. E.g., when sorting
-                on numbers, text strings will sort next to each other, in the
-                same order as they were originally.
+		The sort is stable, items which compare equal (as number or as
+		string) will keep their relative position. E.g., when sorting
+		on numbers, text strings will sort next to each other, in the
+		same order as they were originally.
 
 
-                Example: >vim
-                        func MyCompare(i1, i2)
-                           return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
-                        endfunc
-                        eval mylist->sort("MyCompare")
-<                A shorter compare version for this specific simple case, which
-                ignores overflow: >vim
-                        func MyCompare(i1, i2)
-                           return a:i1 - a:i2
-                        endfunc
-<                For a simple expression you can use a lambda: >vim
-                        eval mylist->sort({i1, i2 -> i1 - i2})
+		Example: >vim
+			func MyCompare(i1, i2)
+			   return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
+			endfunc
+			eval mylist->sort("MyCompare")
+<		 A shorter compare version for this specific simple case, which
+		ignores overflow: >vim
+			func MyCompare(i1, i2)
+			   return a:i1 - a:i2
+			endfunc
+<		 For a simple expression you can use a lambda: >vim
+			eval mylist->sort({i1, i2 -> i1 - i2})
 <
-soundfold({word})                                                  *soundfold()*
-                Return the sound-folded equivalent of {word}.  Uses the first
-                language in 'spelllang' for the current window that supports
-                soundfolding.  'spell' must be set.  When no sound folding is
-                possible the {word} is returned unmodified.
-                This can be used for making spelling suggestions.  Note that
-                the method can be quite slow.
+soundfold({word})						   *soundfold()*
+		Return the sound-folded equivalent of {word}.  Uses the first
+		language in 'spelllang' for the current window that supports
+		soundfolding.  'spell' must be set.  When no sound folding is
+		possible the {word} is returned unmodified.
+		This can be used for making spelling suggestions.  Note that
+		the method can be quite slow.
 
-spellbadword([{sentence}])                                      *spellbadword()*
-                Without argument: The result is the badly spelled word under
-                or after the cursor.  The cursor is moved to the start of the
-                bad word.  When no bad word is found in the cursor line the
-                result is an empty string and the cursor doesn't move.
+spellbadword([{sentence}])					*spellbadword()*
+		Without argument: The result is the badly spelled word under
+		or after the cursor.  The cursor is moved to the start of the
+		bad word.  When no bad word is found in the cursor line the
+		result is an empty string and the cursor doesn't move.
 
-                With argument: The result is the first word in {sentence} that
-                is badly spelled.  If there are no spelling mistakes the
-                result is an empty string.
+		With argument: The result is the first word in {sentence} that
+		is badly spelled.  If there are no spelling mistakes the
+		result is an empty string.
 
-                The return value is a list with two items:
-                - The badly spelled word or an empty string.
-                - The type of the spelling error:
-                        "bad"           spelling mistake
-                        "rare"          rare word
-                        "local"         word only valid in another region
-                        "caps"          word should start with Capital
-                Example: >vim
-                        echo spellbadword("the quik brown fox")
-<                        ['quik', 'bad'] ~
+		The return value is a list with two items:
+		- The badly spelled word or an empty string.
+		- The type of the spelling error:
+			"bad"		spelling mistake
+			"rare"		rare word
+			"local"		word only valid in another region
+			"caps"		word should start with Capital
+		Example: >vim
+			echo spellbadword("the quik brown fox")
+<			 ['quik', 'bad'] ~
 
-                The spelling information for the current window and the value
-                of 'spelllang' are used.
+		The spelling information for the current window and the value
+		of 'spelllang' are used.
 
-spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
-                Return a |List| with spelling suggestions to replace {word}.
-                When {max} is given up to this number of suggestions are
-                returned.  Otherwise up to 25 suggestions are returned.
+spellsuggest({word} [, {max} [, {capital}]])			*spellsuggest()*
+		Return a |List| with spelling suggestions to replace {word}.
+		When {max} is given up to this number of suggestions are
+		returned.  Otherwise up to 25 suggestions are returned.
 
-                When the {capital} argument is given and it's non-zero only
-                suggestions with a leading capital will be given.  Use this
-                after a match with 'spellcapcheck'.
+		When the {capital} argument is given and it's non-zero only
+		suggestions with a leading capital will be given.  Use this
+		after a match with 'spellcapcheck'.
 
-                {word} can be a badly spelled word followed by other text.
-                This allows for joining two words that were split.  The
-                suggestions also include the following text, thus you can
-                replace a line.
+		{word} can be a badly spelled word followed by other text.
+		This allows for joining two words that were split.  The
+		suggestions also include the following text, thus you can
+		replace a line.
 
-                {word} may also be a good word.  Similar words will then be
-                returned.  {word} itself is not included in the suggestions,
-                although it may appear capitalized.
+		{word} may also be a good word.  Similar words will then be
+		returned.  {word} itself is not included in the suggestions,
+		although it may appear capitalized.
 
-                The spelling information for the current window is used.  The
-                values of 'spelllang' and 'spellsuggest' are used.
+		The spelling information for the current window is used.  The
+		values of 'spelllang' and 'spellsuggest' are used.
 
-split({string} [, {pattern} [, {keepempty}]])                          *split()*
-                Make a |List| out of {string}.  When {pattern} is omitted or
-                empty each white-separated sequence of characters becomes an
-                item.
-                Otherwise the string is split where {pattern} matches,
-                removing the matched characters. 'ignorecase' is not used
-                here, add \c to ignore case. |/\c|
-                When the first or last item is empty it is omitted, unless the
-                {keepempty} argument is given and it's non-zero.
-                Other empty items are kept when {pattern} matches at least one
-                character or when {keepempty} is non-zero.
-                Example: >vim
-                        let words = split(getline('.'), '\W\+')
-<                To split a string in individual characters: >vim
-                        for c in split(mystring, '\zs') | endfor
-<                If you want to keep the separator you can also use '\zs' at
-                the end of the pattern: >vim
-                        echo split('abc:def:ghi', ':\zs')
-<                 >
-                        ['abc:', 'def:', 'ghi']
+split({string} [, {pattern} [, {keepempty}]])			       *split()*
+		Make a |List| out of {string}.	When {pattern} is omitted or
+		empty each white-separated sequence of characters becomes an
+		item.
+		Otherwise the string is split where {pattern} matches,
+		removing the matched characters. 'ignorecase' is not used
+		here, add \c to ignore case. |/\c|
+		When the first or last item is empty it is omitted, unless the
+		{keepempty} argument is given and it's non-zero.
+		Other empty items are kept when {pattern} matches at least one
+		character or when {keepempty} is non-zero.
+		Example: >vim
+			let words = split(getline('.'), '\W\+')
+<		 To split a string in individual characters: >vim
+			for c in split(mystring, '\zs') | endfor
+<		 If you want to keep the separator you can also use '\zs' at
+		the end of the pattern: >vim
+			echo split('abc:def:ghi', ':\zs')
+<		  >
+			['abc:', 'def:', 'ghi']
 <
-                Splitting a table where the first element can be empty: >vim
-                        let items = split(line, ':', 1)
-<                The opposite function is |join()|.
+		Splitting a table where the first element can be empty: >vim
+			let items = split(line, ':', 1)
+<		 The opposite function is |join()|.
 
-sqrt({expr})                                                            *sqrt()*
-                Return the non-negative square root of Float {expr} as a
-                |Float|.
-                {expr} must evaluate to a |Float| or a |Number|.  When {expr}
-                is negative the result is NaN (Not a Number).  Returns 0.0 if
-                {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo sqrt(100)
-<                        10.0 >vim
-                        echo sqrt(-4.01)
-<                        str2float("nan")
-                NaN may be different, it depends on system libraries.
+sqrt({expr})								*sqrt()*
+		Return the non-negative square root of Float {expr} as a
+		|Float|.
+		{expr} must evaluate to a |Float| or a |Number|.  When {expr}
+		is negative the result is NaN (Not a Number).  Returns 0.0 if
+		{expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo sqrt(100)
+<			 10.0 >vim
+			echo sqrt(-4.01)
+<			 str2float("nan")
+		NaN may be different, it depends on system libraries.
 
-srand([{expr}])                                                        *srand()*
-                Initialize seed used by |rand()|:
-                - If {expr} is not given, seed values are initialized by
-                  reading from /dev/urandom, if possible, or using time(NULL)
-                  a.k.a. epoch time otherwise; this only has second accuracy.
-                - If {expr} is given it must be a Number.  It is used to
-                  initialize the seed values.  This is useful for testing or
-                  when a predictable sequence is intended.
+srand([{expr}])							       *srand()*
+		Initialize seed used by |rand()|:
+		- If {expr} is not given, seed values are initialized by
+		  reading from /dev/urandom, if possible, or using time(NULL)
+		  a.k.a. epoch time otherwise; this only has second accuracy.
+		- If {expr} is given it must be a Number.  It is used to
+		  initialize the seed values.  This is useful for testing or
+		  when a predictable sequence is intended.
 
-                Examples: >vim
-                        let seed = srand()
-                        let seed = srand(userinput)
-                        echo rand(seed)
+		Examples: >vim
+			let seed = srand()
+			let seed = srand(userinput)
+			echo rand(seed)
 <
-state([{what}])                                                        *state()*
-                Return a string which contains characters indicating the
-                current state.  Mostly useful in callbacks that want to do
-                work that may not always be safe.  Roughly this works like:
-                - callback uses state() to check if work is safe to do.
-                  Yes: then do it right away.
-                  No:  add to work queue and add a |SafeState| autocommand.
-                - When SafeState is triggered and executes your autocommand,
-                  check with `state()` if the work can be done now, and if yes
-                  remove it from the queue and execute.
-                  Remove the autocommand if the queue is now empty.
-                Also see |mode()|.
+state([{what}])							       *state()*
+		Return a string which contains characters indicating the
+		current state.	Mostly useful in callbacks that want to do
+		work that may not always be safe.  Roughly this works like:
+		- callback uses state() to check if work is safe to do.
+		  Yes: then do it right away.
+		  No:  add to work queue and add a |SafeState| autocommand.
+		- When SafeState is triggered and executes your autocommand,
+		  check with `state()` if the work can be done now, and if yes
+		  remove it from the queue and execute.
+		  Remove the autocommand if the queue is now empty.
+		Also see |mode()|.
 
-                When {what} is given only characters in this string will be
-                added.  E.g, this checks if the screen has scrolled: >vim
-                        if state('s') == ''
-                           " screen has not scrolled
+		When {what} is given only characters in this string will be
+		added.	E.g, this checks if the screen has scrolled: >vim
+			if state('s') == ''
+			   " screen has not scrolled
 <
-                These characters indicate the state, generally indicating that
-                something is busy:
-                    m   halfway a mapping, :normal command, feedkeys() or
-                        stuffed command
-                    o   operator pending, e.g. after |d|
-                    a   Insert mode autocomplete active
-                    x   executing an autocommand
-                    S   not triggering SafeState, e.g. after |f| or a count
-                    c   callback invoked, including timer (repeats for
-                        recursiveness up to "ccc")
-                    s   screen has scrolled for messages
+		These characters indicate the state, generally indicating that
+		something is busy:
+		    m	halfway a mapping, :normal command, feedkeys() or
+			stuffed command
+		    o	operator pending, e.g. after |d|
+		    a	Insert mode autocomplete active
+		    x	executing an autocommand
+		    S	not triggering SafeState, e.g. after |f| or a count
+		    c	callback invoked, including timer (repeats for
+			recursiveness up to "ccc")
+		    s	screen has scrolled for messages
 
-stdioopen({opts})                                                  *stdioopen()*
-                With |--headless| this opens stdin and stdout as a |channel|.
-                May be called only once. See |channel-stdio|. stderr is not
-                handled by this function, see |v:stderr|.
+stdioopen({opts})						   *stdioopen()*
+		With |--headless| this opens stdin and stdout as a |channel|.
+		May be called only once. See |channel-stdio|. stderr is not
+		handled by this function, see |v:stderr|.
 
-                Close the stdio handles with |chanclose()|. Use |chansend()|
-                to send data to stdout, and |rpcrequest()| and |rpcnotify()|
-                to communicate over RPC.
+		Close the stdio handles with |chanclose()|. Use |chansend()|
+		to send data to stdout, and |rpcrequest()| and |rpcnotify()|
+		to communicate over RPC.
 
-                {opts} is a dictionary with these keys:
-                  |on_stdin| : callback invoked when stdin is written to.
-                  on_print : callback invoked when Nvim needs to print a
-                             message, with the message (whose type is string)
-                             as sole argument.
-                  stdin_buffered : read stdin in |channel-buffered| mode.
-                  rpc      : If set, |msgpack-rpc| will be used to communicate
-                             over stdio
-                Returns:
-                  - |channel-id| on success (value is always 1)
-                  - 0 on invalid arguments
+		{opts} is a dictionary with these keys:
+		  |on_stdin| : callback invoked when stdin is written to.
+		  on_print : callback invoked when Nvim needs to print a
+			     message, with the message (whose type is string)
+			     as sole argument.
+		  stdin_buffered : read stdin in |channel-buffered| mode.
+		  rpc	   : If set, |msgpack-rpc| will be used to communicate
+			     over stdio
+		Returns:
+		  - |channel-id| on success (value is always 1)
+		  - 0 on invalid arguments
 
-stdpath({what})                                                *stdpath()* *E6100*
-                Returns |standard-path| locations of various default files and
-                directories.
+stdpath({what})						       *stdpath()* *E6100*
+		Returns |standard-path| locations of various default files and
+		directories.
 
-                {what}       Type    Description ~
-                cache        String  Cache directory: arbitrary temporary
-                                     storage for plugins, etc.
-                config       String  User configuration directory. |init.vim|
-                                     is stored here.
-                config_dirs  List    Other configuration directories.
-                data         String  User data directory.
-                data_dirs    List    Other data directories.
-                log          String  Logs directory (for use by plugins too).
-                run          String  Run directory: temporary, local storage
-                                     for sockets, named pipes, etc.
-                state        String  Session state directory: storage for file
-                                     drafts, swap, undo, |shada|.
+		{what}	     Type    Description ~
+		cache	     String  Cache directory: arbitrary temporary
+				     storage for plugins, etc.
+		config	     String  User configuration directory. |init.vim|
+				     is stored here.
+		config_dirs  List    Other configuration directories.
+		data	     String  User data directory.
+		data_dirs    List    Other data directories.
+		log	     String  Logs directory (for use by plugins too).
+		run	     String  Run directory: temporary, local storage
+				     for sockets, named pipes, etc.
+		state	     String  Session state directory: storage for file
+				     drafts, swap, undo, |shada|.
 
-                Example: >vim
-                        echo stdpath("config")
+		Example: >vim
+			echo stdpath("config")
 <
-str2float({string} [, {quoted}])                                   *str2float()*
-                Convert String {string} to a Float.  This mostly works the
-                same as when using a floating point number in an expression,
-                see |floating-point-format|.  But it's a bit more permissive.
-                E.g., "1e40" is accepted, while in an expression you need to
-                write "1.0e40".  The hexadecimal form "0x123" is also
-                accepted, but not others, like binary or octal.
-                When {quoted} is present and non-zero then embedded single
-                quotes before the dot are ignored, thus "1'000.0" is a
-                thousand.
-                Text after the number is silently ignored.
-                The decimal point is always '.', no matter what the locale is
-                set to.  A comma ends the number: "12,345.67" is converted to
-                12.0.  You can strip out thousands separators with
-                |substitute()|: >vim
-                        let f = str2float(substitute(text, ',', '', 'g'))
+str2float({string} [, {quoted}])				   *str2float()*
+		Convert String {string} to a Float.  This mostly works the
+		same as when using a floating point number in an expression,
+		see |floating-point-format|.  But it's a bit more permissive.
+		E.g., "1e40" is accepted, while in an expression you need to
+		write "1.0e40".  The hexadecimal form "0x123" is also
+		accepted, but not others, like binary or octal.
+		When {quoted} is present and non-zero then embedded single
+		quotes before the dot are ignored, thus "1'000.0" is a
+		thousand.
+		Text after the number is silently ignored.
+		The decimal point is always '.', no matter what the locale is
+		set to.  A comma ends the number: "12,345.67" is converted to
+		12.0.  You can strip out thousands separators with
+		|substitute()|: >vim
+			let f = str2float(substitute(text, ',', '', 'g'))
 <
-                Returns 0.0 if the conversion fails.
+		Returns 0.0 if the conversion fails.
 
-str2list({string} [, {utf8}])                                       *str2list()*
-                Return a list containing the number values which represent
-                each character in String {string}.  Examples: >vim
-                        echo str2list(" ")              " returns [32]
-                        echo str2list("ABC")            " returns [65, 66, 67]
-<                |list2str()| does the opposite.
+str2list({string} [, {utf8}])					    *str2list()*
+		Return a list containing the number values which represent
+		each character in String {string}.  Examples: >vim
+			echo str2list(" ")		" returns [32]
+			echo str2list("ABC")		" returns [65, 66, 67]
+<		 |list2str()| does the opposite.
 
-                UTF-8 encoding is always used, {utf8} option has no effect,
-                and exists only for backwards-compatibility.
-                With UTF-8 composing characters are handled properly: >vim
-                        echo str2list("á")              " returns [97, 769]
+		UTF-8 encoding is always used, {utf8} option has no effect,
+		and exists only for backwards-compatibility.
+		With UTF-8 composing characters are handled properly: >vim
+			echo str2list("á")		" returns [97, 769]
 
-str2nr({string} [, {base}])                                           *str2nr()*
-                Convert string {string} to a number.
-                {base} is the conversion base, it can be 2, 8, 10 or 16.
-                When {quoted} is present and non-zero then embedded single
-                quotes are ignored, thus "1'000'000" is a million.
+str2nr({string} [, {base}])					      *str2nr()*
+		Convert string {string} to a number.
+		{base} is the conversion base, it can be 2, 8, 10 or 16.
+		When {quoted} is present and non-zero then embedded single
+		quotes are ignored, thus "1'000'000" is a million.
 
-                When {base} is omitted base 10 is used.  This also means that
-                a leading zero doesn't cause octal conversion to be used, as
-                with the default String to Number conversion.  Example: >vim
-                        let nr = str2nr('0123')
+		When {base} is omitted base 10 is used.  This also means that
+		a leading zero doesn't cause octal conversion to be used, as
+		with the default String to Number conversion.  Example: >vim
+			let nr = str2nr('0123')
 <
-                When {base} is 16 a leading "0x" or "0X" is ignored.  With a
-                different base the result will be zero. Similarly, when
-                {base} is 8 a leading "0", "0o" or "0O" is ignored, and when
-                {base} is 2 a leading "0b" or "0B" is ignored.
-                Text after the number is silently ignored.
+		When {base} is 16 a leading "0x" or "0X" is ignored.  With a
+		different base the result will be zero. Similarly, when
+		{base} is 8 a leading "0", "0o" or "0O" is ignored, and when
+		{base} is 2 a leading "0b" or "0B" is ignored.
+		Text after the number is silently ignored.
 
-                Returns 0 if {string} is empty or on error.
+		Returns 0 if {string} is empty or on error.
 
-strcharlen({string})                                              *strcharlen()*
-                The result is a Number, which is the number of characters
-                in String {string}.  Composing characters are ignored.
-                |strchars()| can count the number of characters, counting
-                composing characters separately.
+strcharlen({string})						  *strcharlen()*
+		The result is a Number, which is the number of characters
+		in String {string}.  Composing characters are ignored.
+		|strchars()| can count the number of characters, counting
+		composing characters separately.
 
-                Returns 0 if {string} is empty or on error.
+		Returns 0 if {string} is empty or on error.
 
-                Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
-strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
-                Like |strpart()| but using character index and length instead
-                of byte index and length.
-                When {skipcc} is omitted or zero, composing characters are
-                counted separately.
-                When {skipcc} set to 1, Composing characters are ignored,
-                similar to  |slice()|.
-                When a character index is used where a character does not
-                exist it is omitted and counted as one character.  For
-                example: >vim
-                        echo strcharpart('abc', -1, 2)
-<                results in 'a'.
+strcharpart({src}, {start} [, {len} [, {skipcc}]])		 *strcharpart()*
+		Like |strpart()| but using character index and length instead
+		of byte index and length.
+		When {skipcc} is omitted or zero, composing characters are
+		counted separately.
+		When {skipcc} set to 1, Composing characters are ignored,
+		similar to  |slice()|.
+		When a character index is used where a character does not
+		exist it is omitted and counted as one character.  For
+		example: >vim
+			echo strcharpart('abc', -1, 2)
+<		 results in 'a'.
 
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-strchars({string} [, {skipcc}])                                     *strchars()*
-                The result is a Number, which is the number of characters
-                in String {string}.
-                When {skipcc} is omitted or zero, composing characters are
-                counted separately.
-                When {skipcc} set to 1, Composing characters are ignored.
-                |strcharlen()| always does this.
+strchars({string} [, {skipcc}])					    *strchars()*
+		The result is a Number, which is the number of characters
+		in String {string}.
+		When {skipcc} is omitted or zero, composing characters are
+		counted separately.
+		When {skipcc} set to 1, Composing characters are ignored.
+		|strcharlen()| always does this.
 
-                Returns zero on error.
+		Returns zero on error.
 
-                Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
-                {skipcc} is only available after 7.4.755.  For backward
-                compatibility, you can define a wrapper function: >vim
-                    if has("patch-7.4.755")
-                      function s:strchars(str, skipcc)
-                        return strchars(a:str, a:skipcc)
-                      endfunction
-                    else
-                      function s:strchars(str, skipcc)
-                        if a:skipcc
-                          return strlen(substitute(a:str, ".", "x", "g"))
-                        else
-                          return strchars(a:str)
-                        endif
-                      endfunction
-                    endif
+		{skipcc} is only available after 7.4.755.  For backward
+		compatibility, you can define a wrapper function: >vim
+		    if has("patch-7.4.755")
+		      function s:strchars(str, skipcc)
+			return strchars(a:str, a:skipcc)
+		      endfunction
+		    else
+		      function s:strchars(str, skipcc)
+			if a:skipcc
+			  return strlen(substitute(a:str, ".", "x", "g"))
+			else
+			  return strchars(a:str)
+			endif
+		      endfunction
+		    endif
 <
-strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
-                The result is a Number, which is the number of display cells
-                String {string} occupies on the screen when it starts at {col}
-                (first column is zero).  When {col} is omitted zero is used.
-                Otherwise it is the screen column where to start.  This
-                matters for Tab characters.
-                The option settings of the current window are used.  This
-                matters for anything that's displayed differently, such as
-                'tabstop' and 'display'.
-                When {string} contains characters with East Asian Width Class
-                Ambiguous, this function's return value depends on 'ambiwidth'.
-                Returns zero on error.
-                Also see |strlen()|, |strwidth()| and |strchars()|.
+strdisplaywidth({string} [, {col}])			     *strdisplaywidth()*
+		The result is a Number, which is the number of display cells
+		String {string} occupies on the screen when it starts at {col}
+		(first column is zero).  When {col} is omitted zero is used.
+		Otherwise it is the screen column where to start.  This
+		matters for Tab characters.
+		The option settings of the current window are used.  This
+		matters for anything that's displayed differently, such as
+		'tabstop' and 'display'.
+		When {string} contains characters with East Asian Width Class
+		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Returns zero on error.
+		Also see |strlen()|, |strwidth()| and |strchars()|.
 
-strftime({format} [, {time}])                                       *strftime()*
-                The result is a String, which is a formatted date and time, as
-                specified by the {format} string.  The given {time} is used,
-                or the current time if no time is given.  The accepted
-                {format} depends on your system, thus this is not portable!
-                See the manual page of the C function strftime() for the
-                format.  The maximum length of the result is 80 characters.
-                See also |localtime()|, |getftime()| and |strptime()|.
-                The language can be changed with the |:language| command.
-                Examples: >vim
-                  echo strftime("%c")              " Sun Apr 27 11:49:23 1997
-                  echo strftime("%Y %b %d %X")     " 1997 Apr 27 11:53:25
-                  echo strftime("%y%m%d %T")       " 970427 11:53:55
-                  echo strftime("%H:%M")                   " 11:55
-                  echo strftime("%c", getftime("file.c"))
-                                                   " Show mod time of file.c.
+strftime({format} [, {time}])					    *strftime()*
+		The result is a String, which is a formatted date and time, as
+		specified by the {format} string.  The given {time} is used,
+		or the current time if no time is given.  The accepted
+		{format} depends on your system, thus this is not portable!
+		See the manual page of the C function strftime() for the
+		format.  The maximum length of the result is 80 characters.
+		See also |localtime()|, |getftime()| and |strptime()|.
+		The language can be changed with the |:language| command.
+		Examples: >vim
+		  echo strftime("%c")		   " Sun Apr 27 11:49:23 1997
+		  echo strftime("%Y %b %d %X")	   " 1997 Apr 27 11:53:25
+		  echo strftime("%y%m%d %T")	   " 970427 11:53:55
+		  echo strftime("%H:%M")		   " 11:55
+		  echo strftime("%c", getftime("file.c"))
+						   " Show mod time of file.c.
 
-strgetchar({str}, {index})                                        *strgetchar()*
-                Get a Number corresponding to the character at {index} in
-                {str}.  This uses a zero-based character index, not a byte
-                index.  Composing characters are considered separate
-                characters here.  Use |nr2char()| to convert the Number to a
-                String.
-                Returns -1 if {index} is invalid.
-                Also see |strcharpart()| and |strchars()|.
+strgetchar({str}, {index})					  *strgetchar()*
+		Get a Number corresponding to the character at {index} in
+		{str}.	This uses a zero-based character index, not a byte
+		index.	Composing characters are considered separate
+		characters here.  Use |nr2char()| to convert the Number to a
+		String.
+		Returns -1 if {index} is invalid.
+		Also see |strcharpart()| and |strchars()|.
 
-stridx({haystack}, {needle} [, {start}])                              *stridx()*
-                The result is a Number, which gives the byte index in
-                {haystack} of the first occurrence of the String {needle}.
-                If {start} is specified, the search starts at index {start}.
-                This can be used to find a second match: >vim
-                        let colon1 = stridx(line, ":")
-                        let colon2 = stridx(line, ":", colon1 + 1)
-<                The search is done case-sensitive.
-                For pattern searches use |match()|.
-                -1 is returned if the {needle} does not occur in {haystack}.
-                See also |strridx()|.
-                Examples: >vim
-                  echo stridx("An Example", "Example")     " 3
-                  echo stridx("Starting point", "Start")   " 0
-                  echo stridx("Starting point", "start")   " -1
-<                                               *strstr()* *strchr()*
-                stridx() works similar to the C function strstr().  When used
-                with a single character it works similar to strchr().
+stridx({haystack}, {needle} [, {start}])			      *stridx()*
+		The result is a Number, which gives the byte index in
+		{haystack} of the first occurrence of the String {needle}.
+		If {start} is specified, the search starts at index {start}.
+		This can be used to find a second match: >vim
+			let colon1 = stridx(line, ":")
+			let colon2 = stridx(line, ":", colon1 + 1)
+<		 The search is done case-sensitive.
+		For pattern searches use |match()|.
+		-1 is returned if the {needle} does not occur in {haystack}.
+		See also |strridx()|.
+		Examples: >vim
+		  echo stridx("An Example", "Example")	   " 3
+		  echo stridx("Starting point", "Start")   " 0
+		  echo stridx("Starting point", "start")   " -1
+<						*strstr()* *strchr()*
+		stridx() works similar to the C function strstr().  When used
+		with a single character it works similar to strchr().
 
-string({expr})                                                        *string()*
-                Return {expr} converted to a String.  If {expr} is a Number,
-                Float, String, Blob or a composition of them, then the result
-                can be parsed back with |eval()|.
-                        {expr} type     result ~
-                        String          'string'
-                        Number          123
-                        Float           123.123456 or 1.123456e8 or
-                                        `str2float('inf')`
-                        Funcref         `function('name')`
-                        Blob            0z00112233.44556677.8899
-                        List            [item, item]
-                        Dictionary      `{key: value, key: value}`
-                Note that in String values the ' character is doubled.
-                Also see |strtrans()|.
-                Note 2: Output format is mostly compatible with YAML, except
-                for infinite and NaN floating-point values representations
-                which use |str2float()|.  Strings are also dumped literally,
-                only single quote is escaped, which does not allow using YAML
-                for parsing back binary strings.  |eval()| should always work for
-                strings and floats though and this is the only official
-                method, use |msgpackdump()| or |json_encode()| if you need to
-                share data with other application.
+string({expr})							      *string()*
+		Return {expr} converted to a String.  If {expr} is a Number,
+		Float, String, Blob or a composition of them, then the result
+		can be parsed back with |eval()|.
+			{expr} type	result ~
+			String		'string'
+			Number		123
+			Float		123.123456 or 1.123456e8 or
+					`str2float('inf')`
+			Funcref		`function('name')`
+			Blob		0z00112233.44556677.8899
+			List		[item, item]
+			Dictionary	`{key: value, key: value}`
+		Note that in String values the ' character is doubled.
+		Also see |strtrans()|.
+		Note 2: Output format is mostly compatible with YAML, except
+		for infinite and NaN floating-point values representations
+		which use |str2float()|.  Strings are also dumped literally,
+		only single quote is escaped, which does not allow using YAML
+		for parsing back binary strings.  |eval()| should always work for
+		strings and floats though and this is the only official
+		method, use |msgpackdump()| or |json_encode()| if you need to
+		share data with other application.
 
-strlen({string})                                                      *strlen()*
-                The result is a Number, which is the length of the String
-                {string} in bytes.
-                If the argument is a Number it is first converted to a String.
-                For other types an error is given and zero is returned.
-                If you want to count the number of multibyte characters use
-                |strchars()|.
-                Also see |len()|, |strdisplaywidth()| and |strwidth()|.
+strlen({string})						      *strlen()*
+		The result is a Number, which is the length of the String
+		{string} in bytes.
+		If the argument is a Number it is first converted to a String.
+		For other types an error is given and zero is returned.
+		If you want to count the number of multibyte characters use
+		|strchars()|.
+		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
 
-strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
-                The result is a String, which is part of {src}, starting from
-                byte {start}, with the byte length {len}.
-                When {chars} is present and TRUE then {len} is the number of
-                characters positions (composing characters are not counted
-                separately, thus "1" means one base character and any
-                following composing characters).
-                To count {start} as characters instead of bytes use
-                |strcharpart()|.
+strpart({src}, {start} [, {len} [, {chars}]])			     *strpart()*
+		The result is a String, which is part of {src}, starting from
+		byte {start}, with the byte length {len}.
+		When {chars} is present and TRUE then {len} is the number of
+		characters positions (composing characters are not counted
+		separately, thus "1" means one base character and any
+		following composing characters).
+		To count {start} as characters instead of bytes use
+		|strcharpart()|.
 
-                When bytes are selected which do not exist, this doesn't
-                result in an error, the bytes are simply omitted.
-                If {len} is missing, the copy continues from {start} till the
-                end of the {src}. >vim
-                        echo strpart("abcdefg", 3, 2)    " returns 'de'
-                        echo strpart("abcdefg", -2, 4)   " returns 'ab'
-                        echo strpart("abcdefg", 5, 4)    " returns 'fg'
-                        echo strpart("abcdefg", 3)       " returns 'defg'
+		When bytes are selected which do not exist, this doesn't
+		result in an error, the bytes are simply omitted.
+		If {len} is missing, the copy continues from {start} till the
+		end of the {src}. >vim
+			echo strpart("abcdefg", 3, 2)	 " returns 'de'
+			echo strpart("abcdefg", -2, 4)	 " returns 'ab'
+			echo strpart("abcdefg", 5, 4)	 " returns 'fg'
+			echo strpart("abcdefg", 3)	 " returns 'defg'
 
-<                Note: To get the first character, {start} must be 0.  For
-                example, to get the character under the cursor: >vim
-                        strpart(getline("."), col(".") - 1, 1, v:true)
+<		 Note: To get the first character, {start} must be 0.  For
+		example, to get the character under the cursor: >vim
+			strpart(getline("."), col(".") - 1, 1, v:true)
 <
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-strptime({format}, {timestring})                                    *strptime()*
-                The result is a Number, which is a unix timestamp representing
-                the date and time in {timestring}, which is expected to match
-                the format specified in {format}.
+strptime({format}, {timestring})				    *strptime()*
+		The result is a Number, which is a unix timestamp representing
+		the date and time in {timestring}, which is expected to match
+		the format specified in {format}.
 
-                The accepted {format} depends on your system, thus this is not
-                portable!  See the manual page of the C function strptime()
-                for the format.  Especially avoid "%c".  The value of $TZ also
-                matters.
+		The accepted {format} depends on your system, thus this is not
+		portable!  See the manual page of the C function strptime()
+		for the format.  Especially avoid "%c".  The value of $TZ also
+		matters.
 
-                If the {timestring} cannot be parsed with {format} zero is
-                returned.  If you do not know the format of {timestring} you
-                can try different {format} values until you get a non-zero
-                result.
+		If the {timestring} cannot be parsed with {format} zero is
+		returned.  If you do not know the format of {timestring} you
+		can try different {format} values until you get a non-zero
+		result.
 
-                See also |strftime()|.
-                Examples: >vim
-                  echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
-<                  862156163 >vim
-                  echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
-<                  Sun Apr 27 11:53:55 1997 >vim
-                  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
-<                  Sun Apr 27 12:53:55 1997
+		See also |strftime()|.
+		Examples: >vim
+		  echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
+<		   862156163 >vim
+		  echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
+<		   Sun Apr 27 11:53:55 1997 >vim
+		  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
+<		   Sun Apr 27 12:53:55 1997
 
-strridx({haystack}, {needle} [, {start}])                            *strridx()*
-                The result is a Number, which gives the byte index in
-                {haystack} of the last occurrence of the String {needle}.
-                When {start} is specified, matches beyond this index are
-                ignored.  This can be used to find a match before a previous
-                match: >vim
-                        let lastcomma = strridx(line, ",")
-                        let comma2 = strridx(line, ",", lastcomma - 1)
-<                The search is done case-sensitive.
-                For pattern searches use |match()|.
-                -1 is returned if the {needle} does not occur in {haystack}.
-                If the {needle} is empty the length of {haystack} is returned.
-                See also |stridx()|.  Examples: >vim
-                  echo strridx("an angry armadillo", "an")           3
-<                                                       *strrchr()*
-                When used with a single character it works similar to the C
-                function strrchr().
+strridx({haystack}, {needle} [, {start}])			     *strridx()*
+		The result is a Number, which gives the byte index in
+		{haystack} of the last occurrence of the String {needle}.
+		When {start} is specified, matches beyond this index are
+		ignored.  This can be used to find a match before a previous
+		match: >vim
+			let lastcomma = strridx(line, ",")
+			let comma2 = strridx(line, ",", lastcomma - 1)
+<		 The search is done case-sensitive.
+		For pattern searches use |match()|.
+		-1 is returned if the {needle} does not occur in {haystack}.
+		If the {needle} is empty the length of {haystack} is returned.
+		See also |stridx()|.  Examples: >vim
+		  echo strridx("an angry armadillo", "an")	     3
+<							*strrchr()*
+		When used with a single character it works similar to the C
+		function strrchr().
 
-strtrans({string})                                                  *strtrans()*
-                The result is a String, which is {string} with all unprintable
-                characters translated into printable characters |'isprint'|.
-                Like they are shown in a window.  Example: >vim
-                        echo strtrans(@a)
-<                This displays a newline in register a as "^@" instead of
-                starting a new line.
+strtrans({string})						    *strtrans()*
+		The result is a String, which is {string} with all unprintable
+		characters translated into printable characters |'isprint'|.
+		Like they are shown in a window.  Example: >vim
+			echo strtrans(@a)
+<		 This displays a newline in register a as "^@" instead of
+		starting a new line.
 
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-strutf16len({string} [, {countcc}])                              *strutf16len()*
-                The result is a Number, which is the number of UTF-16 code
-                units in String {string} (after converting it to UTF-16).
+strutf16len({string} [, {countcc}])				 *strutf16len()*
+		The result is a Number, which is the number of UTF-16 code
+		units in String {string} (after converting it to UTF-16).
 
-                When {countcc} is TRUE, composing characters are counted
-                separately.
-                When {countcc} is omitted or FALSE, composing characters are
-                ignored.
+		When {countcc} is TRUE, composing characters are counted
+		separately.
+		When {countcc} is omitted or FALSE, composing characters are
+		ignored.
 
-                Returns zero on error.
+		Returns zero on error.
 
-                Also see |strlen()| and |strcharlen()|.
-                Examples: >vim
-                    echo strutf16len('a')               " returns 1
-                    echo strutf16len('©')               " returns 1
-                    echo strutf16len('😊')              " returns 2
-                    echo strutf16len('ą́')               " returns 1
-                    echo strutf16len('ą́', v:true)       " returns 3
+		Also see |strlen()| and |strcharlen()|.
+		Examples: >vim
+		    echo strutf16len('a')		" returns 1
+		    echo strutf16len('©')		" returns 1
+		    echo strutf16len('😊')		" returns 2
+		    echo strutf16len('ą́')		" returns 1
+		    echo strutf16len('ą́', v:true)	" returns 3
 <
-strwidth({string})                                                  *strwidth()*
-                The result is a Number, which is the number of display cells
-                String {string} occupies.  A Tab character is counted as one
-                cell, alternatively use |strdisplaywidth()|.
-                When {string} contains characters with East Asian Width Class
-                Ambiguous, this function's return value depends on 'ambiwidth'.
-                Returns zero on error.
-                Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
+strwidth({string})						    *strwidth()*
+		The result is a Number, which is the number of display cells
+		String {string} occupies.  A Tab character is counted as one
+		cell, alternatively use |strdisplaywidth()|.
+		When {string} contains characters with East Asian Width Class
+		Ambiguous, this function's return value depends on 'ambiwidth'.
+		Returns zero on error.
+		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
-submatch({nr} [, {list}])                                      *submatch()* *E935*
-                Only for an expression in a |:substitute| command or
-                substitute() function.
-                Returns the {nr}th submatch of the matched text.  When {nr}
-                is 0 the whole matched text is returned.
-                Note that a NL in the string can stand for a line break of a
-                multi-line match or a NUL character in the text.
-                Also see |sub-replace-expression|.
+submatch({nr} [, {list}])				       *submatch()* *E935*
+		Only for an expression in a |:substitute| command or
+		substitute() function.
+		Returns the {nr}th submatch of the matched text.  When {nr}
+		is 0 the whole matched text is returned.
+		Note that a NL in the string can stand for a line break of a
+		multi-line match or a NUL character in the text.
+		Also see |sub-replace-expression|.
 
-                If {list} is present and non-zero then submatch() returns
-                a list of strings, similar to |getline()| with two arguments.
-                NL characters in the text represent NUL characters in the
-                text.
-                Only returns more than one item for |:substitute|, inside
-                |substitute()| this list will always contain one or zero
-                items, since there are no real line breaks.
+		If {list} is present and non-zero then submatch() returns
+		a list of strings, similar to |getline()| with two arguments.
+		NL characters in the text represent NUL characters in the
+		text.
+		Only returns more than one item for |:substitute|, inside
+		|substitute()| this list will always contain one or zero
+		items, since there are no real line breaks.
 
-                When substitute() is used recursively only the submatches in
-                the current (deepest) call can be obtained.
+		When substitute() is used recursively only the submatches in
+		the current (deepest) call can be obtained.
 
-                Returns an empty string or list on error.
+		Returns an empty string or list on error.
 
-                Examples: >vim
-                        s/\d\+/\=submatch(0) + 1/
-                        echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
-<                This finds the first number in the line and adds one to it.
-                A line break is included as a newline character.
+		Examples: >vim
+			s/\d\+/\=submatch(0) + 1/
+			echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
+<		 This finds the first number in the line and adds one to it.
+		A line break is included as a newline character.
 
-substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
-                The result is a String, which is a copy of {string}, in which
-                the first match of {pat} is replaced with {sub}.
-                When {flags} is "g", all matches of {pat} in {string} are
-                replaced.  Otherwise {flags} should be "".
+substitute({string}, {pat}, {sub}, {flags})			  *substitute()*
+		The result is a String, which is a copy of {string}, in which
+		the first match of {pat} is replaced with {sub}.
+		When {flags} is "g", all matches of {pat} in {string} are
+		replaced.  Otherwise {flags} should be "".
 
-                This works like the ":substitute" command (without any flags).
-                But the matching with {pat} is always done like the 'magic'
-                option is set and 'cpoptions' is empty (to make scripts
-                portable).  'ignorecase' is still relevant, use |/\c| or |/\C|
-                if you want to ignore or match case and ignore 'ignorecase'.
-                'smartcase' is not used.  See |string-match| for how {pat} is
-                used.
+		This works like the ":substitute" command (without any flags).
+		But the matching with {pat} is always done like the 'magic'
+		option is set and 'cpoptions' is empty (to make scripts
+		portable).  'ignorecase' is still relevant, use |/\c| or |/\C|
+		if you want to ignore or match case and ignore 'ignorecase'.
+		'smartcase' is not used.  See |string-match| for how {pat} is
+		used.
 
-                A "~" in {sub} is not replaced with the previous {sub}.
-                Note that some codes in {sub} have a special meaning
-                |sub-replace-special|.  For example, to replace something with
-                "\n" (two characters), use "\\\\n" or '\\n'.
+		A "~" in {sub} is not replaced with the previous {sub}.
+		Note that some codes in {sub} have a special meaning
+		|sub-replace-special|.	For example, to replace something with
+		"\n" (two characters), use "\\\\n" or '\\n'.
 
-                When {pat} does not match in {string}, {string} is returned
-                unmodified.
+		When {pat} does not match in {string}, {string} is returned
+		unmodified.
 
-                Example: >vim
-                        let &path = substitute(&path, ",\\=[^,]*$", "", "")
-<                This removes the last component of the 'path' option. >vim
-                        echo substitute("testing", ".*", "\\U\\0", "")
-<                results in "TESTING".
+		Example: >vim
+			let &path = substitute(&path, ",\\=[^,]*$", "", "")
+<		 This removes the last component of the 'path' option. >vim
+			echo substitute("testing", ".*", "\\U\\0", "")
+<		 results in "TESTING".
 
-                When {sub} starts with "\=", the remainder is interpreted as
-                an expression. See |sub-replace-expression|.  Example: >vim
-                        echo substitute(s, '%\(\x\x\)',
-                           \ '\=nr2char("0x" .. submatch(1))', 'g')
+		When {sub} starts with "\=", the remainder is interpreted as
+		an expression. See |sub-replace-expression|.  Example: >vim
+			echo substitute(s, '%\(\x\x\)',
+			   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
-<                When {sub} is a Funcref that function is called, with one
-                optional argument.  Example: >vim
-                   echo substitute(s, '%\(\x\x\)', SubNr, 'g')
-<                The optional argument is a list which contains the whole
-                matched string and up to nine submatches, like what
-                |submatch()| returns.  Example: >vim
-                   echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
+<		 When {sub} is a Funcref that function is called, with one
+		optional argument.  Example: >vim
+		   echo substitute(s, '%\(\x\x\)', SubNr, 'g')
+<		 The optional argument is a list which contains the whole
+		matched string and up to nine submatches, like what
+		|submatch()| returns.  Example: >vim
+		   echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
 
-<                Returns an empty string on error.
+<		 Returns an empty string on error.
 
-swapfilelist()                                                  *swapfilelist()*
-                Returns a list of swap file names, like what "vim -r" shows.
-                See the |-r| command argument.  The 'directory' option is used
-                for the directories to inspect.  If you only want to get a
-                list of swap files in the current directory then temporarily
-                set 'directory' to a dot: >vim
-                        let save_dir = &directory
-                        let &directory = '.'
-                        let swapfiles = swapfilelist()
-                        let &directory = save_dir
+swapfilelist()							*swapfilelist()*
+		Returns a list of swap file names, like what "vim -r" shows.
+		See the |-r| command argument.	The 'directory' option is used
+		for the directories to inspect.  If you only want to get a
+		list of swap files in the current directory then temporarily
+		set 'directory' to a dot: >vim
+			let save_dir = &directory
+			let &directory = '.'
+			let swapfiles = swapfilelist()
+			let &directory = save_dir
 
-swapinfo({fname})                                                   *swapinfo()*
-                The result is a dictionary, which holds information about the
-                swapfile {fname}. The available fields are:
-                        version Vim version
-                        user    user name
-                        host    host name
-                        fname   original file name
-                        pid     PID of the Nvim process that created the swap
-                                file, or zero if not running.
-                        mtime   last modification time in seconds
-                        inode   Optional: INODE number of the file
-                        dirty   1 if file was modified, 0 if not
-                In case of failure an "error" item is added with the reason:
-                        Cannot open file: file not found or in accessible
-                        Cannot read file: cannot read first block
-                        Not a swap file: does not contain correct block ID
-                        Magic number mismatch: Info in first block is invalid
+swapinfo({fname})						    *swapinfo()*
+		The result is a dictionary, which holds information about the
+		swapfile {fname}. The available fields are:
+			version Vim version
+			user	user name
+			host	host name
+			fname	original file name
+			pid	PID of the Nvim process that created the swap
+				file, or zero if not running.
+			mtime	last modification time in seconds
+			inode	Optional: INODE number of the file
+			dirty	1 if file was modified, 0 if not
+		In case of failure an "error" item is added with the reason:
+			Cannot open file: file not found or in accessible
+			Cannot read file: cannot read first block
+			Not a swap file: does not contain correct block ID
+			Magic number mismatch: Info in first block is invalid
 
-swapname({buf})                                                     *swapname()*
-                The result is the swap file path of the buffer {buf}.
-                For the use of {buf}, see |bufname()| above.
-                If buffer {buf} is the current buffer, the result is equal to
-                |:swapname| (unless there is no swap file).
-                If buffer {buf} has no swap file, returns an empty string.
+swapname({buf})							    *swapname()*
+		The result is the swap file path of the buffer {buf}.
+		For the use of {buf}, see |bufname()| above.
+		If buffer {buf} is the current buffer, the result is equal to
+		|:swapname| (unless there is no swap file).
+		If buffer {buf} has no swap file, returns an empty string.
 
-synID({lnum}, {col}, {trans})                                          *synID()*
-                The result is a Number, which is the syntax ID at the position
-                {lnum} and {col} in the current window.
-                The syntax ID can be used with |synIDattr()| and
-                |synIDtrans()| to obtain syntax information about text.
+synID({lnum}, {col}, {trans})					       *synID()*
+		The result is a Number, which is the syntax ID at the position
+		{lnum} and {col} in the current window.
+		The syntax ID can be used with |synIDattr()| and
+		|synIDtrans()| to obtain syntax information about text.
 
-                {col} is 1 for the leftmost column, {lnum} is 1 for the first
-                line.  'synmaxcol' applies, in a longer line zero is returned.
-                Note that when the position is after the last character,
-                that's where the cursor can be in Insert mode, synID() returns
-                zero.  {lnum} is used like with |getline()|.
+		{col} is 1 for the leftmost column, {lnum} is 1 for the first
+		line.  'synmaxcol' applies, in a longer line zero is returned.
+		Note that when the position is after the last character,
+		that's where the cursor can be in Insert mode, synID() returns
+		zero.  {lnum} is used like with |getline()|.
 
-                When {trans} is |TRUE|, transparent items are reduced to the
-                item that they reveal.  This is useful when wanting to know
-                the effective color.  When {trans} is |FALSE|, the transparent
-                item is returned.  This is useful when wanting to know which
-                syntax item is effective (e.g. inside parens).
-                Warning: This function can be very slow.  Best speed is
-                obtained by going through the file in forward direction.
+		When {trans} is |TRUE|, transparent items are reduced to the
+		item that they reveal.	This is useful when wanting to know
+		the effective color.  When {trans} is |FALSE|, the transparent
+		item is returned.  This is useful when wanting to know which
+		syntax item is effective (e.g. inside parens).
+		Warning: This function can be very slow.  Best speed is
+		obtained by going through the file in forward direction.
 
-                Returns zero on error.
+		Returns zero on error.
 
-                Example (echoes the name of the syntax item under the cursor): >vim
-                        echo synIDattr(synID(line("."), col("."), 1), "name")
+		Example (echoes the name of the syntax item under the cursor): >vim
+			echo synIDattr(synID(line("."), col("."), 1), "name")
 <
-synIDattr({synID}, {what} [, {mode}])                              *synIDattr()*
-                The result is a String, which is the {what} attribute of
-                syntax ID {synID}.  This can be used to obtain information
-                about a syntax item.
-                {mode} can be "gui" or "cterm", to get the attributes
-                for that mode.  When {mode} is omitted, or an invalid value is
-                used, the attributes for the currently active highlighting are
-                used (GUI or cterm).
-                Use synIDtrans() to follow linked highlight groups.
-                {what}          result
-                "name"          the name of the syntax item
-                "fg"            foreground color (GUI: color name used to set
-                                the color, cterm: color number as a string,
-                                term: empty string)
-                "bg"            background color (as with "fg")
-                "font"          font name (only available in the GUI)
-                                |highlight-font|
-                "sp"            special color (as with "fg") |guisp|
-                "fg#"           like "fg", but for the GUI and the GUI is
-                                running the name in "#RRGGBB" form
-                "bg#"           like "fg#" for "bg"
-                "sp#"           like "fg#" for "sp"
-                "bold"          "1" if bold
-                "italic"        "1" if italic
-                "reverse"       "1" if reverse
-                "inverse"       "1" if inverse (= reverse)
-                "standout"      "1" if standout
-                "underline"     "1" if underlined
-                "undercurl"     "1" if undercurled
-                "underdouble"   "1" if double underlined
-                "underdotted"   "1" if dotted underlined
-                "underdashed"   "1" if dashed underlined
-                "strikethrough" "1" if struckthrough
-                "altfont"       "1" if alternative font
-                "nocombine"     "1" if nocombine
+synIDattr({synID}, {what} [, {mode}])				   *synIDattr()*
+		The result is a String, which is the {what} attribute of
+		syntax ID {synID}.  This can be used to obtain information
+		about a syntax item.
+		{mode} can be "gui" or "cterm", to get the attributes
+		for that mode.	When {mode} is omitted, or an invalid value is
+		used, the attributes for the currently active highlighting are
+		used (GUI or cterm).
+		Use synIDtrans() to follow linked highlight groups.
+		{what}		result
+		"name"		the name of the syntax item
+		"fg"		foreground color (GUI: color name used to set
+				the color, cterm: color number as a string,
+				term: empty string)
+		"bg"		background color (as with "fg")
+		"font"		font name (only available in the GUI)
+				|highlight-font|
+		"sp"		special color (as with "fg") |guisp|
+		"fg#"		like "fg", but for the GUI and the GUI is
+				running the name in "#RRGGBB" form
+		"bg#"		like "fg#" for "bg"
+		"sp#"		like "fg#" for "sp"
+		"bold"		"1" if bold
+		"italic"	"1" if italic
+		"reverse"	"1" if reverse
+		"inverse"	"1" if inverse (= reverse)
+		"standout"	"1" if standout
+		"underline"	"1" if underlined
+		"undercurl"	"1" if undercurled
+		"underdouble"	"1" if double underlined
+		"underdotted"	"1" if dotted underlined
+		"underdashed"	"1" if dashed underlined
+		"strikethrough" "1" if struckthrough
+		"altfont"	"1" if alternative font
+		"nocombine"	"1" if nocombine
 
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-                Example (echoes the color of the syntax item under the
-                cursor): >vim
-                        echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
+		Example (echoes the color of the syntax item under the
+		cursor): >vim
+			echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
 <
-                Can also be used as a |method|: >vim
-                        echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+		Can also be used as a |method|: >vim
+			echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
 <
-synIDtrans({synID})                                               *synIDtrans()*
-                The result is a Number, which is the translated syntax ID of
-                {synID}.  This is the syntax group ID of what is being used to
-                highlight the character.  Highlight links given with
-                ":highlight link" are followed.
+synIDtrans({synID})						  *synIDtrans()*
+		The result is a Number, which is the translated syntax ID of
+		{synID}.  This is the syntax group ID of what is being used to
+		highlight the character.  Highlight links given with
+		":highlight link" are followed.
 
-                Returns zero on error.
+		Returns zero on error.
 
-synconcealed({lnum}, {col})                                     *synconcealed()*
-                The result is a |List| with currently three items:
-                1. The first item in the list is 0 if the character at the
-                   position {lnum} and {col} is not part of a concealable
-                   region, 1 if it is.  {lnum} is used like with |getline()|.
-                2. The second item in the list is a string. If the first item
-                   is 1, the second item contains the text which will be
-                   displayed in place of the concealed text, depending on the
-                   current setting of 'conceallevel' and 'listchars'.
-                3. The third and final item in the list is a number
-                   representing the specific syntax region matched in the
-                   line. When the character is not concealed the value is
-                   zero. This allows detection of the beginning of a new
-                   concealable region if there are two consecutive regions
-                   with the same replacement character.  For an example, if
-                   the text is "123456" and both "23" and "45" are concealed
-                   and replaced by the character "X", then:
-                        call                    returns ~
-                        synconcealed(lnum, 1)   [0, '', 0]
-                        synconcealed(lnum, 2)   [1, 'X', 1]
-                        synconcealed(lnum, 3)   [1, 'X', 1]
-                        synconcealed(lnum, 4)   [1, 'X', 2]
-                        synconcealed(lnum, 5)   [1, 'X', 2]
-                        synconcealed(lnum, 6)   [0, '', 0]
+synconcealed({lnum}, {col})					*synconcealed()*
+		The result is a |List| with currently three items:
+		1. The first item in the list is 0 if the character at the
+		   position {lnum} and {col} is not part of a concealable
+		   region, 1 if it is.	{lnum} is used like with |getline()|.
+		2. The second item in the list is a string. If the first item
+		   is 1, the second item contains the text which will be
+		   displayed in place of the concealed text, depending on the
+		   current setting of 'conceallevel' and 'listchars'.
+		3. The third and final item in the list is a number
+		   representing the specific syntax region matched in the
+		   line. When the character is not concealed the value is
+		   zero. This allows detection of the beginning of a new
+		   concealable region if there are two consecutive regions
+		   with the same replacement character.  For an example, if
+		   the text is "123456" and both "23" and "45" are concealed
+		   and replaced by the character "X", then:
+			call			returns ~
+			synconcealed(lnum, 1)	[0, '', 0]
+			synconcealed(lnum, 2)	[1, 'X', 1]
+			synconcealed(lnum, 3)	[1, 'X', 1]
+			synconcealed(lnum, 4)	[1, 'X', 2]
+			synconcealed(lnum, 5)	[1, 'X', 2]
+			synconcealed(lnum, 6)	[0, '', 0]
 
-synstack({lnum}, {col})                                             *synstack()*
-                Return a |List|, which is the stack of syntax items at the
-                position {lnum} and {col} in the current window.  {lnum} is
-                used like with |getline()|.  Each item in the List is an ID
-                like what |synID()| returns.
-                The first item in the List is the outer region, following are
-                items contained in that one.  The last one is what |synID()|
-                returns, unless not the whole item is highlighted or it is a
-                transparent item.
-                This function is useful for debugging a syntax file.
-                Example that shows the syntax stack under the cursor: >vim
-                        for id in synstack(line("."), col("."))
-                           echo synIDattr(id, "name")
-                        endfor
-<                When the position specified with {lnum} and {col} is invalid
-                an empty list is returned.  The position just after the last
-                character in a line and the first column in an empty line are
-                valid positions.
+synstack({lnum}, {col})						    *synstack()*
+		Return a |List|, which is the stack of syntax items at the
+		position {lnum} and {col} in the current window.  {lnum} is
+		used like with |getline()|.  Each item in the List is an ID
+		like what |synID()| returns.
+		The first item in the List is the outer region, following are
+		items contained in that one.  The last one is what |synID()|
+		returns, unless not the whole item is highlighted or it is a
+		transparent item.
+		This function is useful for debugging a syntax file.
+		Example that shows the syntax stack under the cursor: >vim
+			for id in synstack(line("."), col("."))
+			   echo synIDattr(id, "name")
+			endfor
+<		 When the position specified with {lnum} and {col} is invalid
+		an empty list is returned.  The position just after the last
+		character in a line and the first column in an empty line are
+		valid positions.
 
-system({cmd} [, {input}])                                        *system()* *E677*
-                Note: Prefer |vim.system()| in Lua.
+system({cmd} [, {input}])					 *system()* *E677*
+		Note: Prefer |vim.system()| in Lua.
 
-                Gets the output of {cmd} as a |string| (|systemlist()| returns
-                a |List|) and sets |v:shell_error| to the error code.
-                {cmd} is treated as in |jobstart()|:
-                If {cmd} is a List it runs directly (no 'shell').
-                If {cmd} is a String it runs in the 'shell', like this: >vim
-                  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
+		Gets the output of {cmd} as a |string| (|systemlist()| returns
+		a |List|) and sets |v:shell_error| to the error code.
+		{cmd} is treated as in |jobstart()|:
+		If {cmd} is a List it runs directly (no 'shell').
+		If {cmd} is a String it runs in the 'shell', like this: >vim
+		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
 
-<                Not to be used for interactive commands.
+<		 Not to be used for interactive commands.
 
-                Result is a String, filtered to avoid platform-specific quirks:
-                - <CR><NL> is replaced with <NL>
-                - NUL characters are replaced with SOH (0x01)
+		Result is a String, filtered to avoid platform-specific quirks:
+		- <CR><NL> is replaced with <NL>
+		- NUL characters are replaced with SOH (0x01)
 
-                Example: >vim
-                    echo system(['ls', expand('%:h')])
+		Example: >vim
+		    echo system(['ls', expand('%:h')])
 
-<                If {input} is a string it is written to a pipe and passed as
-                stdin to the command.  The string is written as-is, line
-                separators are not changed.
-                If {input} is a |List| it is written to the pipe as
-                |writefile()| does with {binary} set to "b" (i.e. with
-                a newline between each list item, and newlines inside list
-                items converted to NULs).
-                When {input} is given and is a valid buffer id, the content of
-                the buffer is written to the file line by line, each line
-                terminated by NL (and NUL where the text has NL).
-                                                                *E5677*
-                Note: system() cannot write to or read from backgrounded ("&")
-                shell commands, e.g.: >vim
-                    echo system("cat - &", "foo")
-<                which is equivalent to: >
-                    $ echo foo | bash -c 'cat - &'
-<                The pipes are disconnected (unless overridden by shell
-                redirection syntax) before input can reach it. Use
-                |jobstart()| instead.
+<		 If {input} is a string it is written to a pipe and passed as
+		stdin to the command.  The string is written as-is, line
+		separators are not changed.
+		If {input} is a |List| it is written to the pipe as
+		|writefile()| does with {binary} set to "b" (i.e. with
+		a newline between each list item, and newlines inside list
+		items converted to NULs).
+		When {input} is given and is a valid buffer id, the content of
+		the buffer is written to the file line by line, each line
+		terminated by NL (and NUL where the text has NL).
+								*E5677*
+		Note: system() cannot write to or read from backgrounded ("&")
+		shell commands, e.g.: >vim
+		    echo system("cat - &", "foo")
+<		 which is equivalent to: >
+		    $ echo foo | bash -c 'cat - &'
+<		 The pipes are disconnected (unless overridden by shell
+		redirection syntax) before input can reach it. Use
+		|jobstart()| instead.
 
-                Note: Use |shellescape()| or |::S| with |expand()| or
-                |fnamemodify()| to escape special characters in a command
-                argument. 'shellquote' and 'shellxquote' must be properly
-                configured. Example: >vim
-                    echo system('ls '..shellescape(expand('%:h')))
-                    echo system('ls '..expand('%:h:S'))
+		Note: Use |shellescape()| or |::S| with |expand()| or
+		|fnamemodify()| to escape special characters in a command
+		argument. 'shellquote' and 'shellxquote' must be properly
+		configured. Example: >vim
+		    echo system('ls '..shellescape(expand('%:h')))
+		    echo system('ls '..expand('%:h:S'))
 
-<                Unlike ":!cmd" there is no automatic check for changed files.
-                Use |:checktime| to force a check.
+<		 Unlike ":!cmd" there is no automatic check for changed files.
+		Use |:checktime| to force a check.
 
-systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
-                Same as |system()|, but returns a |List| with lines (parts of
-                output separated by NL) with NULs transformed into NLs. Output
-                is the same as |readfile()| will output with {binary} argument
-                set to "b", except that a final newline is not preserved,
-                unless {keepempty} is non-zero.
-                Note that on MS-Windows you may get trailing CR characters.
+systemlist({cmd} [, {input} [, {keepempty}]])			  *systemlist()*
+		Same as |system()|, but returns a |List| with lines (parts of
+		output separated by NL) with NULs transformed into NLs. Output
+		is the same as |readfile()| will output with {binary} argument
+		set to "b", except that a final newline is not preserved,
+		unless {keepempty} is non-zero.
+		Note that on MS-Windows you may get trailing CR characters.
 
-                To see the difference between "echo hello" and "echo -n hello"
-                use |system()| and |split()|: >vim
-                        echo split(system('echo hello'), '\n', 1)
+		To see the difference between "echo hello" and "echo -n hello"
+		use |system()| and |split()|: >vim
+			echo split(system('echo hello'), '\n', 1)
 <
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-tabpagebuflist([{arg}])                                       *tabpagebuflist()*
-                The result is a |List|, where each item is the number of the
-                buffer associated with each window in the current tab page.
-                {arg} specifies the number of the tab page to be used. When
-                omitted the current tab page is used.
-                When {arg} is invalid the number zero is returned.
-                To get a list of all buffers in all tabs use this: >vim
-                        let buflist = []
-                        for i in range(tabpagenr('$'))
-                           call extend(buflist, tabpagebuflist(i + 1))
-                        endfor
-<                Note that a buffer may appear in more than one window.
+tabpagebuflist([{arg}])					      *tabpagebuflist()*
+		The result is a |List|, where each item is the number of the
+		buffer associated with each window in the current tab page.
+		{arg} specifies the number of the tab page to be used. When
+		omitted the current tab page is used.
+		When {arg} is invalid the number zero is returned.
+		To get a list of all buffers in all tabs use this: >vim
+			let buflist = []
+			for i in range(tabpagenr('$'))
+			   call extend(buflist, tabpagebuflist(i + 1))
+			endfor
+<		 Note that a buffer may appear in more than one window.
 
-tabpagenr([{arg}])                                                 *tabpagenr()*
-                The result is a Number, which is the number of the current
-                tab page.  The first tab page has number 1.
+tabpagenr([{arg}])						   *tabpagenr()*
+		The result is a Number, which is the number of the current
+		tab page.  The first tab page has number 1.
 
-                The optional argument {arg} supports the following values:
-                        $       the number of the last tab page (the tab page
-                                count).
-                        #       the number of the last accessed tab page
-                                (where |g<Tab>| goes to).  If there is no
-                                previous tab page, 0 is returned.
-                The number can be used with the |:tab| command.
+		The optional argument {arg} supports the following values:
+			$	the number of the last tab page (the tab page
+				count).
+			#	the number of the last accessed tab page
+				(where |g<Tab>| goes to).  If there is no
+				previous tab page, 0 is returned.
+		The number can be used with the |:tab| command.
 
-                Returns zero on error.
+		Returns zero on error.
 
-tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
-                Like |winnr()| but for tab page {tabarg}.
-                {tabarg} specifies the number of tab page to be used.
-                {arg} is used like with |winnr()|:
-                - When omitted the current window number is returned.  This is
-                  the window which will be used when going to this tab page.
-                - When "$" the number of windows is returned.
-                - When "#" the previous window nr is returned.
-                Useful examples: >vim
-                    tabpagewinnr(1)         " current window of tab page 1
-                    tabpagewinnr(4, '$')    " number of windows in tab page 4
-<                When {tabarg} is invalid zero is returned.
+tabpagewinnr({tabarg} [, {arg}])				*tabpagewinnr()*
+		Like |winnr()| but for tab page {tabarg}.
+		{tabarg} specifies the number of tab page to be used.
+		{arg} is used like with |winnr()|:
+		- When omitted the current window number is returned.  This is
+		  the window which will be used when going to this tab page.
+		- When "$" the number of windows is returned.
+		- When "#" the previous window nr is returned.
+		Useful examples: >vim
+		    tabpagewinnr(1)	    " current window of tab page 1
+		    tabpagewinnr(4, '$')    " number of windows in tab page 4
+<		 When {tabarg} is invalid zero is returned.
 
-tagfiles()                                                          *tagfiles()*
-                Returns a |List| with the file names used to search for tags
-                for the current buffer.  This is the 'tags' option expanded.
+tagfiles()							    *tagfiles()*
+		Returns a |List| with the file names used to search for tags
+		for the current buffer.  This is the 'tags' option expanded.
 
-taglist({expr} [, {filename}])                                       *taglist()*
-                Returns a |List| of tags matching the regular expression {expr}.
+taglist({expr} [, {filename}])					     *taglist()*
+		Returns a |List| of tags matching the regular expression {expr}.
 
-                If {filename} is passed it is used to prioritize the results
-                in the same way that |:tselect| does. See |tag-priority|.
-                {filename} should be the full path of the file.
+		If {filename} is passed it is used to prioritize the results
+		in the same way that |:tselect| does. See |tag-priority|.
+		{filename} should be the full path of the file.
 
-                Each list item is a dictionary with at least the following
-                entries:
-                        name            Name of the tag.
-                        filename        Name of the file where the tag is
-                                        defined.  It is either relative to the
-                                        current directory or a full path.
-                        cmd             Ex command used to locate the tag in
-                                        the file.
-                        kind            Type of the tag.  The value for this
-                                        entry depends on the language specific
-                                        kind values.  Only available when
-                                        using a tags file generated by
-                                        Universal/Exuberant ctags or hdrtag.
-                        static          A file specific tag.  Refer to
-                                        |static-tag| for more information.
-                More entries may be present, depending on the content of the
-                tags file: access, implementation, inherits and signature.
-                Refer to the ctags documentation for information about these
-                fields.  For C code the fields "struct", "class" and "enum"
-                may appear, they give the name of the entity the tag is
-                contained in.
+		Each list item is a dictionary with at least the following
+		entries:
+			name		Name of the tag.
+			filename	Name of the file where the tag is
+					defined.  It is either relative to the
+					current directory or a full path.
+			cmd		Ex command used to locate the tag in
+					the file.
+			kind		Type of the tag.  The value for this
+					entry depends on the language specific
+					kind values.  Only available when
+					using a tags file generated by
+					Universal/Exuberant ctags or hdrtag.
+			static		A file specific tag.  Refer to
+					|static-tag| for more information.
+		More entries may be present, depending on the content of the
+		tags file: access, implementation, inherits and signature.
+		Refer to the ctags documentation for information about these
+		fields.  For C code the fields "struct", "class" and "enum"
+		may appear, they give the name of the entity the tag is
+		contained in.
 
-                The ex-command "cmd" can be either an ex search pattern, a
-                line number or a line number followed by a byte number.
+		The ex-command "cmd" can be either an ex search pattern, a
+		line number or a line number followed by a byte number.
 
-                If there are no matching tags, then an empty list is returned.
+		If there are no matching tags, then an empty list is returned.
 
-                To get an exact tag match, the anchors '^' and '$' should be
-                used in {expr}.  This also make the function work faster.
-                Refer to |tag-regexp| for more information about the tag
-                search regular expression pattern.
+		To get an exact tag match, the anchors '^' and '$' should be
+		used in {expr}.  This also make the function work faster.
+		Refer to |tag-regexp| for more information about the tag
+		search regular expression pattern.
 
-                Refer to |'tags'| for information about how the tags file is
-                located by Vim. Refer to |tags-file-format| for the format of
-                the tags file generated by the different ctags tools.
+		Refer to |'tags'| for information about how the tags file is
+		located by Vim. Refer to |tags-file-format| for the format of
+		the tags file generated by the different ctags tools.
 
-tan({expr})                                                              *tan()*
-                Return the tangent of {expr}, measured in radians, as a |Float|
-                in the range [-inf, inf].
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo tan(10)
-<                        0.648361 >vim
-                        echo tan(-4.01)
-<                        -1.181502
+tan({expr})								 *tan()*
+		Return the tangent of {expr}, measured in radians, as a |Float|
+		in the range [-inf, inf].
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo tan(10)
+<			 0.648361 >vim
+			echo tan(-4.01)
+<			 -1.181502
 
-tanh({expr})                                                            *tanh()*
-                Return the hyperbolic tangent of {expr} as a |Float| in the
-                range [-1, 1].
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo tanh(0.5)
-<                        0.462117 >vim
-                        echo tanh(-1)
-<                        -0.761594
+tanh({expr})								*tanh()*
+		Return the hyperbolic tangent of {expr} as a |Float| in the
+		range [-1, 1].
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo tanh(0.5)
+<			 0.462117 >vim
+			echo tanh(-1)
+<			 -0.761594
 
-tempname()                                                          *tempname()*
-                Generates a (non-existent) filename located in the Nvim root
-                |tempdir|. Scripts can use the filename as a temporary file.
-                Example: >vim
-                        let tmpfile = tempname()
-                        exe "redir > " .. tmpfile
+tempname()							    *tempname()*
+		Generates a (non-existent) filename located in the Nvim root
+		|tempdir|. Scripts can use the filename as a temporary file.
+		Example: >vim
+			let tmpfile = tempname()
+			exe "redir > " .. tmpfile
 <
-termopen({cmd} [, {opts}])                                          *termopen()*
-                Spawns {cmd} in a new pseudo-terminal session connected
-                to the current (unmodified) buffer. Parameters and behavior
-                are the same as |jobstart()| except "pty", "width", "height",
-                and "TERM" are ignored: "height" and "width" are taken from
-                the current window. Note that termopen() implies a "pty" arg
-                to jobstart(), and thus has the implications documented at
-                |jobstart()|.
+termopen({cmd} [, {opts}])					    *termopen()*
+		Spawns {cmd} in a new pseudo-terminal session connected
+		to the current (unmodified) buffer. Parameters and behavior
+		are the same as |jobstart()| except "pty", "width", "height",
+		and "TERM" are ignored: "height" and "width" are taken from
+		the current window. Note that termopen() implies a "pty" arg
+		to jobstart(), and thus has the implications documented at
+		|jobstart()|.
 
-                Returns the same values as jobstart().
+		Returns the same values as jobstart().
 
-                Terminal environment is initialized as in |jobstart-env|,
-                except $TERM is set to "xterm-256color". Full behavior is
-                described in |terminal|.
+		Terminal environment is initialized as in |jobstart-env|,
+		except $TERM is set to "xterm-256color". Full behavior is
+		described in |terminal|.
 
-test_garbagecollect_now()                            *test_garbagecollect_now()*
-                Like |garbagecollect()|, but executed right away.  This must
-                only be called directly to avoid any structure to exist
-                internally, and |v:testing| must have been set before calling
-                any function.
+test_garbagecollect_now()			     *test_garbagecollect_now()*
+		Like |garbagecollect()|, but executed right away.  This must
+		only be called directly to avoid any structure to exist
+		internally, and |v:testing| must have been set before calling
+		any function.
 
 
-timer_info([{id}])                                                *timer_info()*
-                Return a list with information about timers.
-                When {id} is given only information about this timer is
-                returned.  When timer {id} does not exist an empty list is
-                returned.
-                When {id} is omitted information about all timers is returned.
+timer_info([{id}])						  *timer_info()*
+		Return a list with information about timers.
+		When {id} is given only information about this timer is
+		returned.  When timer {id} does not exist an empty list is
+		returned.
+		When {id} is omitted information about all timers is returned.
 
-                For each timer the information is stored in a |Dictionary| with
-                these items:
-                    "id"            the timer ID
-                    "time"          time the timer was started with
-                    "repeat"        number of times the timer will still fire;
-                                    -1 means forever
-                    "callback"      the callback
+		For each timer the information is stored in a |Dictionary| with
+		these items:
+		    "id"	    the timer ID
+		    "time"	    time the timer was started with
+		    "repeat"	    number of times the timer will still fire;
+				    -1 means forever
+		    "callback"	    the callback
 
-timer_pause({timer}, {paused})                                   *timer_pause()*
-                Pause or unpause a timer.  A paused timer does not invoke its
-                callback when its time expires.  Unpausing a timer may cause
-                the callback to be invoked almost immediately if enough time
-                has passed.
+timer_pause({timer}, {paused})					 *timer_pause()*
+		Pause or unpause a timer.  A paused timer does not invoke its
+		callback when its time expires.  Unpausing a timer may cause
+		the callback to be invoked almost immediately if enough time
+		has passed.
 
-                Pausing a timer is useful to avoid the callback to be called
-                for a short time.
+		Pausing a timer is useful to avoid the callback to be called
+		for a short time.
 
-                If {paused} evaluates to a non-zero Number or a non-empty
-                String, then the timer is paused, otherwise it is unpaused.
-                See |non-zero-arg|.
+		If {paused} evaluates to a non-zero Number or a non-empty
+		String, then the timer is paused, otherwise it is unpaused.
+		See |non-zero-arg|.
 
-timer_start({time}, {callback} [, {options}])              *timer_start()* *timer*
-                Create a timer and return the timer ID.
+timer_start({time}, {callback} [, {options}])		   *timer_start()* *timer*
+		Create a timer and return the timer ID.
 
-                {time} is the waiting time in milliseconds. This is the
-                minimum time before invoking the callback.  When the system is
-                busy or Vim is not waiting for input the time will be longer.
-                Zero can be used to execute the callback when Vim is back in
-                the main loop.
+		{time} is the waiting time in milliseconds. This is the
+		minimum time before invoking the callback.  When the system is
+		busy or Vim is not waiting for input the time will be longer.
+		Zero can be used to execute the callback when Vim is back in
+		the main loop.
 
-                {callback} is the function to call.  It can be the name of a
-                function or a |Funcref|.  It is called with one argument, which
-                is the timer ID.  The callback is only invoked when Vim is
-                waiting for input.
+		{callback} is the function to call.  It can be the name of a
+		function or a |Funcref|.  It is called with one argument, which
+		is the timer ID.  The callback is only invoked when Vim is
+		waiting for input.
 
-                {options} is a dictionary.  Supported entries:
-                   "repeat"     Number of times to repeat the callback.
-                                -1 means forever.  Default is 1.
-                                If the timer causes an error three times in a
-                                row the repeat is cancelled.
+		{options} is a dictionary.  Supported entries:
+		   "repeat"	Number of times to repeat the callback.
+				-1 means forever.  Default is 1.
+				If the timer causes an error three times in a
+				row the repeat is cancelled.
 
-                Returns -1 on error.
+		Returns -1 on error.
 
-                Example: >vim
-                        func MyHandler(timer)
-                          echo 'Handler called'
-                        endfunc
-                        let timer = timer_start(500, 'MyHandler',
-                                \ {'repeat': 3})
-<                This invokes MyHandler() three times at 500 msec intervals.
+		Example: >vim
+			func MyHandler(timer)
+			  echo 'Handler called'
+			endfunc
+			let timer = timer_start(500, 'MyHandler',
+				\ {'repeat': 3})
+<		 This invokes MyHandler() three times at 500 msec intervals.
 
-timer_stop({timer})                                               *timer_stop()*
-                Stop a timer.  The timer callback will no longer be invoked.
-                {timer} is an ID returned by timer_start(), thus it must be a
-                Number.  If {timer} does not exist there is no error.
+timer_stop({timer})						  *timer_stop()*
+		Stop a timer.  The timer callback will no longer be invoked.
+		{timer} is an ID returned by timer_start(), thus it must be a
+		Number.  If {timer} does not exist there is no error.
 
-timer_stopall()                                                *timer_stopall()*
-                Stop all timers.  The timer callbacks will no longer be
-                invoked.  Useful if some timers is misbehaving.  If there are
-                no timers there is no error.
+timer_stopall()						       *timer_stopall()*
+		Stop all timers.  The timer callbacks will no longer be
+		invoked.  Useful if some timers is misbehaving.  If there are
+		no timers there is no error.
 
-tolower({expr})                                                      *tolower()*
-                The result is a copy of the String given, with all uppercase
-                characters turned into lowercase (just like applying |gu| to
-                the string).  Returns an empty string on error.
+tolower({expr})							     *tolower()*
+		The result is a copy of the String given, with all uppercase
+		characters turned into lowercase (just like applying |gu| to
+		the string).  Returns an empty string on error.
 
-toupper({expr})                                                      *toupper()*
-                The result is a copy of the String given, with all lowercase
-                characters turned into uppercase (just like applying |gU| to
-                the string).  Returns an empty string on error.
+toupper({expr})							     *toupper()*
+		The result is a copy of the String given, with all lowercase
+		characters turned into uppercase (just like applying |gU| to
+		the string).  Returns an empty string on error.
 
-tr({src}, {fromstr}, {tostr})                                             *tr()*
-                The result is a copy of the {src} string with all characters
-                which appear in {fromstr} replaced by the character in that
-                position in the {tostr} string.  Thus the first character in
-                {fromstr} is translated into the first character in {tostr}
-                and so on.  Exactly like the unix "tr" command.
-                This code also deals with multibyte characters properly.
+tr({src}, {fromstr}, {tostr})						  *tr()*
+		The result is a copy of the {src} string with all characters
+		which appear in {fromstr} replaced by the character in that
+		position in the {tostr} string.  Thus the first character in
+		{fromstr} is translated into the first character in {tostr}
+		and so on.  Exactly like the unix "tr" command.
+		This code also deals with multibyte characters properly.
 
-                Returns an empty string on error.
+		Returns an empty string on error.
 
-                Examples: >vim
-                        echo tr("hello there", "ht", "HT")
-<                returns "Hello THere" >vim
-                        echo tr("<blob>", "<>", "{}")
-<                returns "{blob}"
+		Examples: >vim
+			echo tr("hello there", "ht", "HT")
+<		 returns "Hello THere" >vim
+			echo tr("<blob>", "<>", "{}")
+<		 returns "{blob}"
 
-trim({text} [, {mask} [, {dir}]])                                       *trim()*
-                Return {text} as a String where any character in {mask} is
-                removed from the beginning and/or end of {text}.
+trim({text} [, {mask} [, {dir}]])					*trim()*
+		Return {text} as a String where any character in {mask} is
+		removed from the beginning and/or end of {text}.
 
-                If {mask} is not given, or is an empty string, {mask} is all
-                characters up to 0x20, which includes Tab, space, NL and CR,
-                plus the non-breaking space character 0xa0.
+		If {mask} is not given, or is an empty string, {mask} is all
+		characters up to 0x20, which includes Tab, space, NL and CR,
+		plus the non-breaking space character 0xa0.
 
-                The optional {dir} argument specifies where to remove the
-                characters:
-                        0       remove from the beginning and end of {text}
-                        1       remove only at the beginning of {text}
-                        2       remove only at the end of {text}
-                When omitted both ends are trimmed.
+		The optional {dir} argument specifies where to remove the
+		characters:
+			0	remove from the beginning and end of {text}
+			1	remove only at the beginning of {text}
+			2	remove only at the end of {text}
+		When omitted both ends are trimmed.
 
-                This function deals with multibyte characters properly.
-                Returns an empty string on error.
+		This function deals with multibyte characters properly.
+		Returns an empty string on error.
 
-                Examples: >vim
-                        echo trim("   some text ")
-<                returns "some text" >vim
-                        echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
-<                returns "RESERVE_TAIL" >vim
-                        echo trim("rm<Xrm<>X>rrm", "rm<>")
-<                returns "Xrm<>X" (characters in the middle are not removed) >vim
-                        echo trim("  vim  ", " ", 2)
-<                returns "  vim"
+		Examples: >vim
+			echo trim("   some text ")
+<		 returns "some text" >vim
+			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
+<		 returns "RESERVE_TAIL" >vim
+			echo trim("rm<Xrm<>X>rrm", "rm<>")
+<		 returns "Xrm<>X" (characters in the middle are not removed) >vim
+			echo trim("  vim  ", " ", 2)
+<		 returns "  vim"
 
-trunc({expr})                                                          *trunc()*
-                Return the largest integral value with magnitude less than or
-                equal to {expr} as a |Float| (truncate towards zero).
-                {expr} must evaluate to a |Float| or a |Number|.
-                Returns 0.0 if {expr} is not a |Float| or a |Number|.
-                Examples: >vim
-                        echo trunc(1.456)
-<                        1.0  >vim
-                        echo trunc(-5.456)
-<                        -5.0  >vim
-                        echo trunc(4.0)
-<                        4.0
+trunc({expr})							       *trunc()*
+		Return the largest integral value with magnitude less than or
+		equal to {expr} as a |Float| (truncate towards zero).
+		{expr} must evaluate to a |Float| or a |Number|.
+		Returns 0.0 if {expr} is not a |Float| or a |Number|.
+		Examples: >vim
+			echo trunc(1.456)
+<			 1.0  >vim
+			echo trunc(-5.456)
+<			 -5.0  >vim
+			echo trunc(4.0)
+<			 4.0
 
-type({expr})                                                            *type()*
-                The result is a Number representing the type of {expr}.
-                Instead of using the number directly, it is better to use the
-                v:t_ variable that has the value:
-                        Number:     0  |v:t_number|
-                        String:     1  |v:t_string|
-                        Funcref:    2  |v:t_func|
-                        List:       3  |v:t_list|
-                        Dictionary: 4  |v:t_dict|
-                        Float:      5  |v:t_float|
-                        Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
-                        Null:       7  (|v:null|)
-                        Blob:      10  |v:t_blob|
-                For backward compatibility, this method can be used: >vim
-                        if type(myvar) == type(0) | endif
-                        if type(myvar) == type("") | endif
-                        if type(myvar) == type(function("tr")) | endif
-                        if type(myvar) == type([]) | endif
-                        if type(myvar) == type({}) | endif
-                        if type(myvar) == type(0.0) | endif
-                        if type(myvar) == type(v:true) | endif
-<                In place of checking for |v:null| type it is better to check
-                for |v:null| directly as it is the only value of this type: >vim
-                        if myvar is v:null | endif
-<                To check if the v:t_ variables exist use this: >vim
-                        if exists('v:t_number') | endif
+type({expr})								*type()*
+		The result is a Number representing the type of {expr}.
+		Instead of using the number directly, it is better to use the
+		v:t_ variable that has the value:
+			Number:     0  |v:t_number|
+			String:     1  |v:t_string|
+			Funcref:    2  |v:t_func|
+			List:	    3  |v:t_list|
+			Dictionary: 4  |v:t_dict|
+			Float:	    5  |v:t_float|
+			Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
+			Null:	    7  (|v:null|)
+			Blob:	   10  |v:t_blob|
+		For backward compatibility, this method can be used: >vim
+			if type(myvar) == type(0) | endif
+			if type(myvar) == type("") | endif
+			if type(myvar) == type(function("tr")) | endif
+			if type(myvar) == type([]) | endif
+			if type(myvar) == type({}) | endif
+			if type(myvar) == type(0.0) | endif
+			if type(myvar) == type(v:true) | endif
+<		 In place of checking for |v:null| type it is better to check
+		for |v:null| directly as it is the only value of this type: >vim
+			if myvar is v:null | endif
+<		 To check if the v:t_ variables exist use this: >vim
+			if exists('v:t_number') | endif
 
-undofile({name})                                                    *undofile()*
-                Return the name of the undo file that would be used for a file
-                with name {name} when writing.  This uses the 'undodir'
-                option, finding directories that exist.  It does not check if
-                the undo file exists.
-                {name} is always expanded to the full path, since that is what
-                is used internally.
-                If {name} is empty undofile() returns an empty string, since a
-                buffer without a file name will not write an undo file.
-                Useful in combination with |:wundo| and |:rundo|.
+undofile({name})						    *undofile()*
+		Return the name of the undo file that would be used for a file
+		with name {name} when writing.	This uses the 'undodir'
+		option, finding directories that exist.  It does not check if
+		the undo file exists.
+		{name} is always expanded to the full path, since that is what
+		is used internally.
+		If {name} is empty undofile() returns an empty string, since a
+		buffer without a file name will not write an undo file.
+		Useful in combination with |:wundo| and |:rundo|.
 
-undotree([{buf}])                                                   *undotree()*
-                Return the current state of the undo tree for the current
-                buffer, or for a specific buffer if {buf} is given.  The
-                result is a dictionary with the following items:
-                  "seq_last"    The highest undo sequence number used.
-                  "seq_cur"     The sequence number of the current position in
-                                the undo tree.  This differs from "seq_last"
-                                when some changes were undone.
-                  "time_cur"    Time last used for |:earlier| and related
-                                commands.  Use |strftime()| to convert to
-                                something readable.
-                  "save_last"   Number of the last file write.  Zero when no
-                                write yet.
-                  "save_cur"    Number of the current position in the undo
-                                tree.
-                  "synced"      Non-zero when the last undo block was synced.
-                                This happens when waiting from input from the
-                                user.  See |undo-blocks|.
-                  "entries"     A list of dictionaries with information about
-                                undo blocks.
+undotree([{buf}])						    *undotree()*
+		Return the current state of the undo tree for the current
+		buffer, or for a specific buffer if {buf} is given.  The
+		result is a dictionary with the following items:
+		  "seq_last"	The highest undo sequence number used.
+		  "seq_cur"	The sequence number of the current position in
+				the undo tree.	This differs from "seq_last"
+				when some changes were undone.
+		  "time_cur"	Time last used for |:earlier| and related
+				commands.  Use |strftime()| to convert to
+				something readable.
+		  "save_last"	Number of the last file write.	Zero when no
+				write yet.
+		  "save_cur"	Number of the current position in the undo
+				tree.
+		  "synced"	Non-zero when the last undo block was synced.
+				This happens when waiting from input from the
+				user.  See |undo-blocks|.
+		  "entries"	A list of dictionaries with information about
+				undo blocks.
 
-                The first item in the "entries" list is the oldest undo item.
-                Each List item is a |Dictionary| with these items:
-                  "seq"         Undo sequence number.  Same as what appears in
-                                |:undolist|.
-                  "time"        Timestamp when the change happened.  Use
-                                |strftime()| to convert to something readable.
-                  "newhead"     Only appears in the item that is the last one
-                                that was added.  This marks the last change
-                                and where further changes will be added.
-                  "curhead"     Only appears in the item that is the last one
-                                that was undone.  This marks the current
-                                position in the undo tree, the block that will
-                                be used by a redo command.  When nothing was
-                                undone after the last change this item will
-                                not appear anywhere.
-                  "save"        Only appears on the last block before a file
-                                write.  The number is the write count.  The
-                                first write has number 1, the last one the
-                                "save_last" mentioned above.
-                  "alt"         Alternate entry.  This is again a List of undo
-                                blocks.  Each item may again have an "alt"
-                                item.
+		The first item in the "entries" list is the oldest undo item.
+		Each List item is a |Dictionary| with these items:
+		  "seq"		Undo sequence number.  Same as what appears in
+				|:undolist|.
+		  "time"	Timestamp when the change happened.  Use
+				|strftime()| to convert to something readable.
+		  "newhead"	Only appears in the item that is the last one
+				that was added.  This marks the last change
+				and where further changes will be added.
+		  "curhead"	Only appears in the item that is the last one
+				that was undone.  This marks the current
+				position in the undo tree, the block that will
+				be used by a redo command.  When nothing was
+				undone after the last change this item will
+				not appear anywhere.
+		  "save"	Only appears on the last block before a file
+				write.	The number is the write count.	The
+				first write has number 1, the last one the
+				"save_last" mentioned above.
+		  "alt"		Alternate entry.  This is again a List of undo
+				blocks.  Each item may again have an "alt"
+				item.
 
-uniq({list} [, {func} [, {dict}]])                                 *uniq()* *E882*
-                Remove second and succeeding copies of repeated adjacent
-                {list} items in-place.  Returns {list}.  If you want a list
-                to remain unmodified make a copy first: >vim
-                        let newlist = uniq(copy(mylist))
-<                The default compare function uses the string representation of
-                each item.  For the use of {func} and {dict} see |sort()|.
+uniq({list} [, {func} [, {dict}]])				   *uniq()* *E882*
+		Remove second and succeeding copies of repeated adjacent
+		{list} items in-place.	Returns {list}.  If you want a list
+		to remain unmodified make a copy first: >vim
+			let newlist = uniq(copy(mylist))
+<		 The default compare function uses the string representation of
+		each item.  For the use of {func} and {dict} see |sort()|.
 
-                Returns zero if {list} is not a |List|.
+		Returns zero if {list} is not a |List|.
 
-utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
-                Same as |charidx()| but returns the UTF-16 code unit index of
-                the byte at {idx} in {string} (after converting it to UTF-16).
+utf16idx({string}, {idx} [, {countcc} [, {charidx}]])		    *utf16idx()*
+		Same as |charidx()| but returns the UTF-16 code unit index of
+		the byte at {idx} in {string} (after converting it to UTF-16).
 
-                When {charidx} is present and TRUE, {idx} is used as the
-                character index in the String {string} instead of as the byte
-                index.
-                An {idx} in the middle of a UTF-8 sequence is rounded
-                downwards to the beginning of that sequence.
+		When {charidx} is present and TRUE, {idx} is used as the
+		character index in the String {string} instead of as the byte
+		index.
+		An {idx} in the middle of a UTF-8 sequence is rounded
+		downwards to the beginning of that sequence.
 
-                Returns -1 if the arguments are invalid or if there are less
-                than {idx} bytes in {string}. If there are exactly {idx} bytes
-                the length of the string in UTF-16 code units is returned.
+		Returns -1 if the arguments are invalid or if there are less
+		than {idx} bytes in {string}. If there are exactly {idx} bytes
+		the length of the string in UTF-16 code units is returned.
 
-                See |byteidx()| and |byteidxcomp()| for getting the byte index
-                from the UTF-16 index and |charidx()| for getting the
-                character index from the UTF-16 index.
-                Refer to |string-offset-encoding| for more information.
-                Examples: >vim
-                        echo utf16idx('a😊😊', 3)       " returns 2
-                        echo utf16idx('a😊😊', 7)       " returns 4
-                        echo utf16idx('a😊😊', 1, 0, 1) " returns 2
-                        echo utf16idx('a😊😊', 2, 0, 1) " returns 4
-                        echo utf16idx('aą́c', 6)         " returns 2
-                        echo utf16idx('aą́c', 6, 1)      " returns 4
-                        echo utf16idx('a😊😊', 9)       " returns -1
+		See |byteidx()| and |byteidxcomp()| for getting the byte index
+		from the UTF-16 index and |charidx()| for getting the
+		character index from the UTF-16 index.
+		Refer to |string-offset-encoding| for more information.
+		Examples: >vim
+			echo utf16idx('a😊😊', 3)	" returns 2
+			echo utf16idx('a😊😊', 7)	" returns 4
+			echo utf16idx('a😊😊', 1, 0, 1) " returns 2
+			echo utf16idx('a😊😊', 2, 0, 1) " returns 4
+			echo utf16idx('aą́c', 6)		" returns 2
+			echo utf16idx('aą́c', 6, 1)	" returns 4
+			echo utf16idx('a😊😊', 9)	" returns -1
 <
-values({dict})                                                        *values()*
-                Return a |List| with all the values of {dict}.  The |List| is
-                in arbitrary order.  Also see |items()| and |keys()|.
-                Returns zero if {dict} is not a |Dict|.
+values({dict})							      *values()*
+		Return a |List| with all the values of {dict}.	The |List| is
+		in arbitrary order.  Also see |items()| and |keys()|.
+		Returns zero if {dict} is not a |Dict|.
 
-virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
-                The result is a Number, which is the screen column of the file
-                position given with {expr}.  That is, the last screen position
-                occupied by the character at that position, when the screen
-                would be of unlimited width.  When there is a <Tab> at the
-                position, the returned Number will be the column at the end of
-                the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
-                set to 8, it returns 8. |conceal| is ignored.
-                For the byte position use |col()|.
+virtcol({expr} [, {list} [, {winid}]])				     *virtcol()*
+		The result is a Number, which is the screen column of the file
+		position given with {expr}.  That is, the last screen position
+		occupied by the character at that position, when the screen
+		would be of unlimited width.  When there is a <Tab> at the
+		position, the returned Number will be the column at the end of
+		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
+		set to 8, it returns 8. |conceal| is ignored.
+		For the byte position use |col()|.
 
-                For the use of {expr} see |col()|.
+		For the use of {expr} see |col()|.
 
-                When 'virtualedit' is used {expr} can be [lnum, col, off],
-                where "off" is the offset in screen columns from the start of
-                the character.  E.g., a position within a <Tab> or after the
-                last character.  When "off" is omitted zero is used.  When
-                Virtual editing is active in the current mode, a position
-                beyond the end of the line can be returned.  Also see
-                |'virtualedit'|
+		When 'virtualedit' is used {expr} can be [lnum, col, off],
+		where "off" is the offset in screen columns from the start of
+		the character.	E.g., a position within a <Tab> or after the
+		last character.  When "off" is omitted zero is used.  When
+		Virtual editing is active in the current mode, a position
+		beyond the end of the line can be returned.  Also see
+		|'virtualedit'|
 
-                The accepted positions are:
-                    .       the cursor position
-                    $       the end of the cursor line (the result is the
-                            number of displayed characters in the cursor line
-                            plus one)
-                    'x      position of mark x (if the mark is not set, 0 is
-                            returned)
-                    v       In Visual mode: the start of the Visual area (the
-                            cursor is the end).  When not in Visual mode
-                            returns the cursor position.  Differs from |'<| in
-                            that it's updated right away.
+		The accepted positions are:
+		    .	    the cursor position
+		    $	    the end of the cursor line (the result is the
+			    number of displayed characters in the cursor line
+			    plus one)
+		    'x	    position of mark x (if the mark is not set, 0 is
+			    returned)
+		    v	    In Visual mode: the start of the Visual area (the
+			    cursor is the end).  When not in Visual mode
+			    returns the cursor position.  Differs from |'<| in
+			    that it's updated right away.
 
-                If {list} is present and non-zero then virtcol() returns a
-                List with the first and last screen position occupied by the
-                character.
+		If {list} is present and non-zero then virtcol() returns a
+		List with the first and last screen position occupied by the
+		character.
 
-                With the optional {winid} argument the values are obtained for
-                that window instead of the current window.
+		With the optional {winid} argument the values are obtained for
+		that window instead of the current window.
 
-                Note that only marks in the current file can be used.
-                Examples: >vim
-                        " With text "foo^Lbar" and cursor on the "^L":
+		Note that only marks in the current file can be used.
+		Examples: >vim
+			" With text "foo^Lbar" and cursor on the "^L":
 
-                        echo virtcol(".")       " returns 5
-                        echo virtcol(".", 1)    " returns [4, 5]
-                        echo virtcol("$")       " returns 9
+			echo virtcol(".")	" returns 5
+			echo virtcol(".", 1)	" returns [4, 5]
+			echo virtcol("$")	" returns 9
 
-                        " With text "     there", with 't at 'h':
+			" With text "	  there", with 't at 'h':
 
-                        echo virtcol("'t")      " returns 6
-<                The first column is 1.  0 or [0, 0] is returned for an error.
-                A more advanced example that echoes the maximum length of
-                all lines: >vim
-                    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+			echo virtcol("'t")	" returns 6
+<		 The first column is 1.  0 or [0, 0] is returned for an error.
+		A more advanced example that echoes the maximum length of
+		all lines: >vim
+		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 
-virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
-                The result is a Number, which is the byte index of the
-                character in window {winid} at buffer line {lnum} and virtual
-                column {col}.
+virtcol2col({winid}, {lnum}, {col})				 *virtcol2col()*
+		The result is a Number, which is the byte index of the
+		character in window {winid} at buffer line {lnum} and virtual
+		column {col}.
 
-                If buffer line {lnum} is an empty line, 0 is returned.
+		If buffer line {lnum} is an empty line, 0 is returned.
 
-                If {col} is greater than the last virtual column in line
-                {lnum}, then the byte index of the character at the last
-                virtual column is returned.
+		If {col} is greater than the last virtual column in line
+		{lnum}, then the byte index of the character at the last
+		virtual column is returned.
 
-                For a multi-byte character, the column number of the first
-                byte in the character is returned.
+		For a multi-byte character, the column number of the first
+		byte in the character is returned.
 
-                The {winid} argument can be the window number or the
-                |window-ID|. If this is zero, then the current window is used.
+		The {winid} argument can be the window number or the
+		|window-ID|. If this is zero, then the current window is used.
 
-                Returns -1 if the window {winid} doesn't exist or the buffer
-                line {lnum} or virtual column {col} is invalid.
+		Returns -1 if the window {winid} doesn't exist or the buffer
+		line {lnum} or virtual column {col} is invalid.
 
-                See also |screenpos()|, |virtcol()| and |col()|.
+		See also |screenpos()|, |virtcol()| and |col()|.
 
-visualmode([{expr}])                                              *visualmode()*
-                The result is a String, which describes the last Visual mode
-                used in the current buffer.  Initially it returns an empty
-                string, but once Visual mode has been used, it returns "v",
-                "V", or "<CTRL-V>" (a single CTRL-V character) for
-                character-wise, line-wise, or block-wise Visual mode
-                respectively.
-                Example: >vim
-                        exe "normal " .. visualmode()
-<                This enters the same Visual mode as before.  It is also useful
-                in scripts if you wish to act differently depending on the
-                Visual mode that was used.
-                If Visual mode is active, use |mode()| to get the Visual mode
-                (e.g., in a |:vmap|).
-                If {expr} is supplied and it evaluates to a non-zero Number or
-                a non-empty String, then the Visual mode will be cleared and
-                the old value is returned.  See |non-zero-arg|.
+visualmode([{expr}])						  *visualmode()*
+		The result is a String, which describes the last Visual mode
+		used in the current buffer.  Initially it returns an empty
+		string, but once Visual mode has been used, it returns "v",
+		"V", or "<CTRL-V>" (a single CTRL-V character) for
+		character-wise, line-wise, or block-wise Visual mode
+		respectively.
+		Example: >vim
+			exe "normal " .. visualmode()
+<		 This enters the same Visual mode as before.  It is also useful
+		in scripts if you wish to act differently depending on the
+		Visual mode that was used.
+		If Visual mode is active, use |mode()| to get the Visual mode
+		(e.g., in a |:vmap|).
+		If {expr} is supplied and it evaluates to a non-zero Number or
+		a non-empty String, then the Visual mode will be cleared and
+		the old value is returned.  See |non-zero-arg|.
 
-wait({timeout}, {condition} [, {interval}])                             *wait()*
-                Waits until {condition} evaluates to |TRUE|, where {condition}
-                is a |Funcref| or |string| containing an expression.
+wait({timeout}, {condition} [, {interval}])				*wait()*
+		Waits until {condition} evaluates to |TRUE|, where {condition}
+		is a |Funcref| or |string| containing an expression.
 
-                {timeout} is the maximum waiting time in milliseconds, -1
-                means forever.
+		{timeout} is the maximum waiting time in milliseconds, -1
+		means forever.
 
-                Condition is evaluated on user events, internal events, and
-                every {interval} milliseconds (default: 200).
+		Condition is evaluated on user events, internal events, and
+		every {interval} milliseconds (default: 200).
 
-                Returns a status integer:
-                        0 if the condition was satisfied before timeout
-                        -1 if the timeout was exceeded
-                        -2 if the function was interrupted (by |CTRL-C|)
-                        -3 if an error occurred
+		Returns a status integer:
+			0 if the condition was satisfied before timeout
+			-1 if the timeout was exceeded
+			-2 if the function was interrupted (by |CTRL-C|)
+			-3 if an error occurred
 
-wildmenumode()                                                  *wildmenumode()*
-                Returns |TRUE| when the wildmenu is active and |FALSE|
-                otherwise.  See 'wildmenu' and 'wildmode'.
-                This can be used in mappings to handle the 'wildcharm' option
-                gracefully. (Makes only sense with |mapmode-c| mappings).
+wildmenumode()							*wildmenumode()*
+		Returns |TRUE| when the wildmenu is active and |FALSE|
+		otherwise.  See 'wildmenu' and 'wildmode'.
+		This can be used in mappings to handle the 'wildcharm' option
+		gracefully. (Makes only sense with |mapmode-c| mappings).
 
-                For example to make <c-j> work like <down> in wildmode, use: >vim
-                    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
+		For example to make <c-j> work like <down> in wildmode, use: >vim
+		    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 <
-                (Note, this needs the 'wildcharm' option set appropriately).
+		(Note, this needs the 'wildcharm' option set appropriately).
 
-win_execute({id}, {command} [, {silent}])                        *win_execute()*
-                Like `execute()` but in the context of window {id}.
-                The window will temporarily be made the current window,
-                without triggering autocommands or changing directory.  When
-                executing {command} autocommands will be triggered, this may
-                have unexpected side effects.  Use `:noautocmd` if needed.
-                Example: >vim
-                        call win_execute(winid, 'syntax enable')
-<                Doing the same with `setwinvar()` would not trigger
-                autocommands and not actually show syntax highlighting.
+win_execute({id}, {command} [, {silent}])			 *win_execute()*
+		Like `execute()` but in the context of window {id}.
+		The window will temporarily be made the current window,
+		without triggering autocommands or changing directory.	When
+		executing {command} autocommands will be triggered, this may
+		have unexpected side effects.  Use `:noautocmd` if needed.
+		Example: >vim
+			call win_execute(winid, 'syntax enable')
+<		 Doing the same with `setwinvar()` would not trigger
+		autocommands and not actually show syntax highlighting.
 
-                When window {id} does not exist then no error is given and
-                an empty string is returned.
+		When window {id} does not exist then no error is given and
+		an empty string is returned.
 
-win_findbuf({bufnr})                                             *win_findbuf()*
-                Returns a |List| with |window-ID|s for windows that contain
-                buffer {bufnr}.  When there is none the list is empty.
+win_findbuf({bufnr})						 *win_findbuf()*
+		Returns a |List| with |window-ID|s for windows that contain
+		buffer {bufnr}.  When there is none the list is empty.
 
-win_getid([{win} [, {tab}]])                                       *win_getid()*
-                Get the |window-ID| for the specified window.
-                When {win} is missing use the current window.
-                With {win} this is the window number.  The top window has
-                number 1.
-                Without {tab} use the current tab, otherwise the tab with
-                number {tab}.  The first tab has number one.
-                Return zero if the window cannot be found.
+win_getid([{win} [, {tab}]])					   *win_getid()*
+		Get the |window-ID| for the specified window.
+		When {win} is missing use the current window.
+		With {win} this is the window number.  The top window has
+		number 1.
+		Without {tab} use the current tab, otherwise the tab with
+		number {tab}.  The first tab has number one.
+		Return zero if the window cannot be found.
 
-win_gettype([{nr}])                                              *win_gettype()*
-                Return the type of the window:
-                        "autocmd"       autocommand window. Temporary window
-                                        used to execute autocommands.
-                        "command"       command-line window |cmdwin|
-                        (empty)         normal window
-                        "loclist"       |location-list-window|
-                        "popup"         floating window |api-floatwin|
-                        "preview"       preview window |preview-window|
-                        "quickfix"      |quickfix-window|
-                        "unknown"       window {nr} not found
+win_gettype([{nr}])						 *win_gettype()*
+		Return the type of the window:
+			"autocmd"	autocommand window. Temporary window
+					used to execute autocommands.
+			"command"	command-line window |cmdwin|
+			(empty)		normal window
+			"loclist"	|location-list-window|
+			"popup"		floating window |api-floatwin|
+			"preview"	preview window |preview-window|
+			"quickfix"	|quickfix-window|
+			"unknown"	window {nr} not found
 
-                When {nr} is omitted return the type of the current window.
-                When {nr} is given return the type of this window by number or
-                |window-ID|.
+		When {nr} is omitted return the type of the current window.
+		When {nr} is given return the type of this window by number or
+		|window-ID|.
 
-                Also see the 'buftype' option.
+		Also see the 'buftype' option.
 
-win_gotoid({expr})                                                *win_gotoid()*
-                Go to window with ID {expr}.  This may also change the current
-                tabpage.
-                Return TRUE if successful, FALSE if the window cannot be found.
+win_gotoid({expr})						  *win_gotoid()*
+		Go to window with ID {expr}.  This may also change the current
+		tabpage.
+		Return TRUE if successful, FALSE if the window cannot be found.
 
-win_id2tabwin({expr})                                          *win_id2tabwin()*
-                Return a list with the tab number and window number of window
-                with ID {expr}: [tabnr, winnr].
-                Return [0, 0] if the window cannot be found.
+win_id2tabwin({expr})					       *win_id2tabwin()*
+		Return a list with the tab number and window number of window
+		with ID {expr}: [tabnr, winnr].
+		Return [0, 0] if the window cannot be found.
 
-win_id2win({expr})                                                *win_id2win()*
-                Return the window number of window with ID {expr}.
-                Return 0 if the window cannot be found in the current tabpage.
+win_id2win({expr})						  *win_id2win()*
+		Return the window number of window with ID {expr}.
+		Return 0 if the window cannot be found in the current tabpage.
 
-win_move_separator({nr}, {offset})                        *win_move_separator()*
-                Move window {nr}'s vertical separator (i.e., the right border)
-                by {offset} columns, as if being dragged by the mouse. {nr}
-                can be a window number or |window-ID|. A positive {offset}
-                moves right and a negative {offset} moves left. Moving a
-                window's vertical separator will change the width of the
-                window and the width of other windows adjacent to the vertical
-                separator. The magnitude of movement may be smaller than
-                specified (e.g., as a consequence of maintaining
-                'winminwidth'). Returns TRUE if the window can be found and
-                FALSE otherwise.
-                This will fail for the rightmost window and a full-width
-                window, since it has no separator on the right.
-                Only works for the current tab page. *E1308*
+win_move_separator({nr}, {offset})			  *win_move_separator()*
+		Move window {nr}'s vertical separator (i.e., the right border)
+		by {offset} columns, as if being dragged by the mouse. {nr}
+		can be a window number or |window-ID|. A positive {offset}
+		moves right and a negative {offset} moves left. Moving a
+		window's vertical separator will change the width of the
+		window and the width of other windows adjacent to the vertical
+		separator. The magnitude of movement may be smaller than
+		specified (e.g., as a consequence of maintaining
+		'winminwidth'). Returns TRUE if the window can be found and
+		FALSE otherwise.
+		This will fail for the rightmost window and a full-width
+		window, since it has no separator on the right.
+		Only works for the current tab page. *E1308*
 
-win_move_statusline({nr}, {offset})                      *win_move_statusline()*
-                Move window {nr}'s status line (i.e., the bottom border) by
-                {offset} rows, as if being dragged by the mouse. {nr} can be a
-                window number or |window-ID|. A positive {offset} moves down
-                and a negative {offset} moves up. Moving a window's status
-                line will change the height of the window and the height of
-                other windows adjacent to the status line. The magnitude of
-                movement may be smaller than specified (e.g., as a consequence
-                of maintaining 'winminheight'). Returns TRUE if the window can
-                be found and FALSE otherwise.
-                Only works for the current tab page.
+win_move_statusline({nr}, {offset})			 *win_move_statusline()*
+		Move window {nr}'s status line (i.e., the bottom border) by
+		{offset} rows, as if being dragged by the mouse. {nr} can be a
+		window number or |window-ID|. A positive {offset} moves down
+		and a negative {offset} moves up. Moving a window's status
+		line will change the height of the window and the height of
+		other windows adjacent to the status line. The magnitude of
+		movement may be smaller than specified (e.g., as a consequence
+		of maintaining 'winminheight'). Returns TRUE if the window can
+		be found and FALSE otherwise.
+		Only works for the current tab page.
 
-win_screenpos({nr})                                            *win_screenpos()*
-                Return the screen position of window {nr} as a list with two
-                numbers: [row, col].  The first window always has position
-                [1, 1], unless there is a tabline, then it is [2, 1].
-                {nr} can be the window number or the |window-ID|.  Use zero
-                for the current window.
-                Returns [0, 0] if the window cannot be found in the current
-                tabpage.
+win_screenpos({nr})					       *win_screenpos()*
+		Return the screen position of window {nr} as a list with two
+		numbers: [row, col].  The first window always has position
+		[1, 1], unless there is a tabline, then it is [2, 1].
+		{nr} can be the window number or the |window-ID|.  Use zero
+		for the current window.
+		Returns [0, 0] if the window cannot be found in the current
+		tabpage.
 
-win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
-                Move the window {nr} to a new split of the window {target}.
-                This is similar to moving to {target}, creating a new window
-                using |:split| but having the same contents as window {nr}, and
-                then closing {nr}.
+win_splitmove({nr}, {target} [, {options}])		       *win_splitmove()*
+		Move the window {nr} to a new split of the window {target}.
+		This is similar to moving to {target}, creating a new window
+		using |:split| but having the same contents as window {nr}, and
+		then closing {nr}.
 
-                Both {nr} and {target} can be window numbers or |window-ID|s.
-                Both must be in the current tab page.
+		Both {nr} and {target} can be window numbers or |window-ID|s.
+		Both must be in the current tab page.
 
-                Returns zero for success, non-zero for failure.
+		Returns zero for success, non-zero for failure.
 
-                {options} is a |Dictionary| with the following optional entries:
-                  "vertical"    When TRUE, the split is created vertically,
-                                like with |:vsplit|.
-                  "rightbelow"  When TRUE, the split is made below or to the
-                                right (if vertical).  When FALSE, it is done
-                                above or to the left (if vertical).  When not
-                                present, the values of 'splitbelow' and
-                                'splitright' are used.
+		{options} is a |Dictionary| with the following optional entries:
+		  "vertical"	When TRUE, the split is created vertically,
+				like with |:vsplit|.
+		  "rightbelow"	When TRUE, the split is made below or to the
+				right (if vertical).  When FALSE, it is done
+				above or to the left (if vertical).  When not
+				present, the values of 'splitbelow' and
+				'splitright' are used.
 
-winbufnr({nr})                                                      *winbufnr()*
-                The result is a Number, which is the number of the buffer
-                associated with window {nr}.  {nr} can be the window number or
-                the |window-ID|.
-                When {nr} is zero, the number of the buffer in the current
-                window is returned.
-                When window {nr} doesn't exist, -1 is returned.
-                Example: >vim
-                  echo "The file in the current window is " .. bufname(winbufnr(0))
+winbufnr({nr})							    *winbufnr()*
+		The result is a Number, which is the number of the buffer
+		associated with window {nr}.  {nr} can be the window number or
+		the |window-ID|.
+		When {nr} is zero, the number of the buffer in the current
+		window is returned.
+		When window {nr} doesn't exist, -1 is returned.
+		Example: >vim
+		  echo "The file in the current window is " .. bufname(winbufnr(0))
 <
-wincol()                                                              *wincol()*
-                The result is a Number, which is the virtual column of the
-                cursor in the window.  This is counting screen cells from the
-                left side of the window.  The leftmost column is one.
+wincol()							      *wincol()*
+		The result is a Number, which is the virtual column of the
+		cursor in the window.  This is counting screen cells from the
+		left side of the window.  The leftmost column is one.
 
-windowsversion()                                              *windowsversion()*
-                The result is a String.  For MS-Windows it indicates the OS
-                version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
-                Windows XP is "5.1".  For non-MS-Windows systems the result is
-                an empty string.
+windowsversion()					      *windowsversion()*
+		The result is a String.  For MS-Windows it indicates the OS
+		version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
+		Windows XP is "5.1".  For non-MS-Windows systems the result is
+		an empty string.
 
-winheight({nr})                                                    *winheight()*
-                The result is a Number, which is the height of window {nr}.
-                {nr} can be the window number or the |window-ID|.
-                When {nr} is zero, the height of the current window is
-                returned.  When window {nr} doesn't exist, -1 is returned.
-                An existing window always has a height of zero or more.
-                This excludes any window toolbar line.
-                Examples: >vim
-                  echo "The current window has " .. winheight(0) .. " lines."
+winheight({nr})							   *winheight()*
+		The result is a Number, which is the height of window {nr}.
+		{nr} can be the window number or the |window-ID|.
+		When {nr} is zero, the height of the current window is
+		returned.  When window {nr} doesn't exist, -1 is returned.
+		An existing window always has a height of zero or more.
+		This excludes any window toolbar line.
+		Examples: >vim
+		  echo "The current window has " .. winheight(0) .. " lines."
 
-winlayout([{tabnr}])                                               *winlayout()*
-                The result is a nested List containing the layout of windows
-                in a tabpage.
+winlayout([{tabnr}])						   *winlayout()*
+		The result is a nested List containing the layout of windows
+		in a tabpage.
 
-                Without {tabnr} use the current tabpage, otherwise the tabpage
-                with number {tabnr}. If the tabpage {tabnr} is not found,
-                returns an empty list.
+		Without {tabnr} use the current tabpage, otherwise the tabpage
+		with number {tabnr}. If the tabpage {tabnr} is not found,
+		returns an empty list.
 
-                For a leaf window, it returns: >
-                        ["leaf", {winid}]
+		For a leaf window, it returns: >
+			["leaf", {winid}]
 <
-                For horizontally split windows, which form a column, it
-                returns: >
-                        ["col", [{nested list of windows}]]
-<                For vertically split windows, which form a row, it returns: >
-                        ["row", [{nested list of windows}]]
+		For horizontally split windows, which form a column, it
+		returns: >
+			["col", [{nested list of windows}]]
+<		 For vertically split windows, which form a row, it returns: >
+			["row", [{nested list of windows}]]
 <
-                Example: >vim
-                        " Only one window in the tab page
-                        echo winlayout()
-<                 >
-                        ['leaf', 1000]
-<                 >vim
-                        " Two horizontally split windows
-                        echo winlayout()
-<                 >
-                        ['col', [['leaf', 1000], ['leaf', 1001]]]
-<                 >vim
-                        " The second tab page, with three horizontally split
-                        " windows, with two vertically split windows in the
-                        " middle window
-                        echo winlayout(2)
-<                 >
-                        ['col', [['leaf', 1002], ['row', [['leaf', 1003],
-                                            ['leaf', 1001]]], ['leaf', 1000]]]
+		Example: >vim
+			" Only one window in the tab page
+			echo winlayout()
+<		  >
+			['leaf', 1000]
+<		  >vim
+			" Two horizontally split windows
+			echo winlayout()
+<		  >
+			['col', [['leaf', 1000], ['leaf', 1001]]]
+<		  >vim
+			" The second tab page, with three horizontally split
+			" windows, with two vertically split windows in the
+			" middle window
+			echo winlayout(2)
+<		  >
+			['col', [['leaf', 1002], ['row', [['leaf', 1003],
+					    ['leaf', 1001]]], ['leaf', 1000]]]
 <
-winline()                                                            *winline()*
-                The result is a Number, which is the screen line of the cursor
-                in the window.  This is counting screen lines from the top of
-                the window.  The first line is one.
-                If the cursor was moved the view on the file will be updated
-                first, this may cause a scroll.
+winline()							     *winline()*
+		The result is a Number, which is the screen line of the cursor
+		in the window.	This is counting screen lines from the top of
+		the window.  The first line is one.
+		If the cursor was moved the view on the file will be updated
+		first, this may cause a scroll.
 
-winnr([{arg}])                                                         *winnr()*
-                The result is a Number, which is the number of the current
-                window.  The top window has number 1.
-                Returns zero for a popup window.
+winnr([{arg}])							       *winnr()*
+		The result is a Number, which is the number of the current
+		window.  The top window has number 1.
+		Returns zero for a popup window.
 
-                The optional argument {arg} supports the following values:
-                        $       the number of the last window (the window
-                                count).
-                        #       the number of the last accessed window (where
-                                |CTRL-W_p| goes to).  If there is no previous
-                                window or it is in another tab page 0 is
-                                returned.
-                        {N}j    the number of the Nth window below the
-                                current window (where |CTRL-W_j| goes to).
-                        {N}k    the number of the Nth window above the current
-                                window (where |CTRL-W_k| goes to).
-                        {N}h    the number of the Nth window left of the
-                                current window (where |CTRL-W_h| goes to).
-                        {N}l    the number of the Nth window right of the
-                                current window (where |CTRL-W_l| goes to).
-                The number can be used with |CTRL-W_w| and ":wincmd w"
-                |:wincmd|.
-                When {arg} is invalid an error is given and zero is returned.
-                Also see |tabpagewinnr()| and |win_getid()|.
-                Examples: >vim
-                        let window_count = winnr('$')
-                        let prev_window = winnr('#')
-                        let wnum = winnr('3k')
+		The optional argument {arg} supports the following values:
+			$	the number of the last window (the window
+				count).
+			#	the number of the last accessed window (where
+				|CTRL-W_p| goes to).  If there is no previous
+				window or it is in another tab page 0 is
+				returned.
+			{N}j	the number of the Nth window below the
+				current window (where |CTRL-W_j| goes to).
+			{N}k	the number of the Nth window above the current
+				window (where |CTRL-W_k| goes to).
+			{N}h	the number of the Nth window left of the
+				current window (where |CTRL-W_h| goes to).
+			{N}l	the number of the Nth window right of the
+				current window (where |CTRL-W_l| goes to).
+		The number can be used with |CTRL-W_w| and ":wincmd w"
+		|:wincmd|.
+		When {arg} is invalid an error is given and zero is returned.
+		Also see |tabpagewinnr()| and |win_getid()|.
+		Examples: >vim
+			let window_count = winnr('$')
+			let prev_window = winnr('#')
+			let wnum = winnr('3k')
 
-winrestcmd()                                                      *winrestcmd()*
-                Returns a sequence of |:resize| commands that should restore
-                the current window sizes.  Only works properly when no windows
-                are opened or closed and the current window and tab page is
-                unchanged.
-                Example: >vim
-                        let cmd = winrestcmd()
-                        call MessWithWindowSizes()
-                        exe cmd
+winrestcmd()							  *winrestcmd()*
+		Returns a sequence of |:resize| commands that should restore
+		the current window sizes.  Only works properly when no windows
+		are opened or closed and the current window and tab page is
+		unchanged.
+		Example: >vim
+			let cmd = winrestcmd()
+			call MessWithWindowSizes()
+			exe cmd
 <
-winrestview({dict})                                              *winrestview()*
-                Uses the |Dictionary| returned by |winsaveview()| to restore
-                the view of the current window.
-                Note: The {dict} does not have to contain all values, that are
-                returned by |winsaveview()|. If values are missing, those
-                settings won't be restored. So you can use: >vim
-                    call winrestview({'curswant': 4})
+winrestview({dict})						 *winrestview()*
+		Uses the |Dictionary| returned by |winsaveview()| to restore
+		the view of the current window.
+		Note: The {dict} does not have to contain all values, that are
+		returned by |winsaveview()|. If values are missing, those
+		settings won't be restored. So you can use: >vim
+		    call winrestview({'curswant': 4})
 <
-                This will only set the curswant value (the column the cursor
-                wants to move on vertical movements) of the cursor to column 5
-                (yes, that is 5), while all other settings will remain the
-                same. This is useful, if you set the cursor position manually.
+		This will only set the curswant value (the column the cursor
+		wants to move on vertical movements) of the cursor to column 5
+		(yes, that is 5), while all other settings will remain the
+		same. This is useful, if you set the cursor position manually.
 
-                If you have changed the values the result is unpredictable.
-                If the window size changed the result won't be the same.
+		If you have changed the values the result is unpredictable.
+		If the window size changed the result won't be the same.
 
-winsaveview()                                                    *winsaveview()*
-                Returns a |Dictionary| that contains information to restore
-                the view of the current window.  Use |winrestview()| to
-                restore the view.
-                This is useful if you have a mapping that jumps around in the
-                buffer and you want to go back to the original view.
-                This does not save fold information.  Use the 'foldenable'
-                option to temporarily switch off folding, so that folds are
-                not opened when moving around. This may have side effects.
-                The return value includes:
-                        lnum            cursor line number
-                        col             cursor column (Note: the first column
-                                        zero, as opposed to what |getcurpos()|
-                                        returns)
-                        coladd          cursor column offset for 'virtualedit'
-                        curswant        column for vertical movement (Note:
-                                        the first column is zero, as opposed
-                                        to what |getcurpos()| returns).  After
-                                        |$| command it will be a very large
-                                        number equal to |v:maxcol|.
-                        topline         first line in the window
-                        topfill         filler lines, only in diff mode
-                        leftcol         first column displayed; only used when
-                                        'wrap' is off
-                        skipcol         columns skipped
-                Note that no option values are saved.
+winsaveview()							 *winsaveview()*
+		Returns a |Dictionary| that contains information to restore
+		the view of the current window.  Use |winrestview()| to
+		restore the view.
+		This is useful if you have a mapping that jumps around in the
+		buffer and you want to go back to the original view.
+		This does not save fold information.  Use the 'foldenable'
+		option to temporarily switch off folding, so that folds are
+		not opened when moving around. This may have side effects.
+		The return value includes:
+			lnum		cursor line number
+			col		cursor column (Note: the first column
+					zero, as opposed to what |getcurpos()|
+					returns)
+			coladd		cursor column offset for 'virtualedit'
+			curswant	column for vertical movement (Note:
+					the first column is zero, as opposed
+					to what |getcurpos()| returns).  After
+					|$| command it will be a very large
+					number equal to |v:maxcol|.
+			topline		first line in the window
+			topfill		filler lines, only in diff mode
+			leftcol		first column displayed; only used when
+					'wrap' is off
+			skipcol		columns skipped
+		Note that no option values are saved.
 
-winwidth({nr})                                                      *winwidth()*
-                The result is a Number, which is the width of window {nr}.
-                {nr} can be the window number or the |window-ID|.
-                When {nr} is zero, the width of the current window is
-                returned.  When window {nr} doesn't exist, -1 is returned.
-                An existing window always has a width of zero or more.
-                Examples: >vim
-                  echo "The current window has " .. winwidth(0) .. " columns."
-                  if winwidth(0) <= 50
-                    50 wincmd |
-                  endif
-<                For getting the terminal or screen size, see the 'columns'
-                option.
+winwidth({nr})							    *winwidth()*
+		The result is a Number, which is the width of window {nr}.
+		{nr} can be the window number or the |window-ID|.
+		When {nr} is zero, the width of the current window is
+		returned.  When window {nr} doesn't exist, -1 is returned.
+		An existing window always has a width of zero or more.
+		Examples: >vim
+		  echo "The current window has " .. winwidth(0) .. " columns."
+		  if winwidth(0) <= 50
+		    50 wincmd |
+		  endif
+<		 For getting the terminal or screen size, see the 'columns'
+		option.
 
-wordcount()                                                        *wordcount()*
-                The result is a dictionary of byte/chars/word statistics for
-                the current buffer.  This is the same info as provided by
-                |g_CTRL-G|
-                The return value includes:
-                        bytes           Number of bytes in the buffer
-                        chars           Number of chars in the buffer
-                        words           Number of words in the buffer
-                        cursor_bytes    Number of bytes before cursor position
-                                        (not in Visual mode)
-                        cursor_chars    Number of chars before cursor position
-                                        (not in Visual mode)
-                        cursor_words    Number of words before cursor position
-                                        (not in Visual mode)
-                        visual_bytes    Number of bytes visually selected
-                                        (only in Visual mode)
-                        visual_chars    Number of chars visually selected
-                                        (only in Visual mode)
-                        visual_words    Number of words visually selected
-                                        (only in Visual mode)
+wordcount()							   *wordcount()*
+		The result is a dictionary of byte/chars/word statistics for
+		the current buffer.  This is the same info as provided by
+		|g_CTRL-G|
+		The return value includes:
+			bytes		Number of bytes in the buffer
+			chars		Number of chars in the buffer
+			words		Number of words in the buffer
+			cursor_bytes	Number of bytes before cursor position
+					(not in Visual mode)
+			cursor_chars	Number of chars before cursor position
+					(not in Visual mode)
+			cursor_words	Number of words before cursor position
+					(not in Visual mode)
+			visual_bytes	Number of bytes visually selected
+					(only in Visual mode)
+			visual_chars	Number of chars visually selected
+					(only in Visual mode)
+			visual_words	Number of words visually selected
+					(only in Visual mode)
 
-writefile({object}, {fname} [, {flags}])                           *writefile()*
-                When {object} is a |List| write it to file {fname}.  Each list
-                item is separated with a NL.  Each list item must be a String
-                or Number.
-                All NL characters are replaced with a NUL character.
-                Inserting CR characters needs to be done before passing {list}
-                to writefile().
+writefile({object}, {fname} [, {flags}])			   *writefile()*
+		When {object} is a |List| write it to file {fname}.  Each list
+		item is separated with a NL.  Each list item must be a String
+		or Number.
+		All NL characters are replaced with a NUL character.
+		Inserting CR characters needs to be done before passing {list}
+		to writefile().
 
-                When {object} is a |Blob| write the bytes to file {fname}
-                unmodified, also when binary mode is not specified.
+		When {object} is a |Blob| write the bytes to file {fname}
+		unmodified, also when binary mode is not specified.
 
-                {flags} must be a String.  These characters are recognized:
+		{flags} must be a String.  These characters are recognized:
 
-                'b'  Binary mode is used: There will not be a NL after the
-                     last list item.  An empty item at the end does cause the
-                     last line in the file to end in a NL.
+		'b'  Binary mode is used: There will not be a NL after the
+		     last list item.  An empty item at the end does cause the
+		     last line in the file to end in a NL.
 
-                'a'  Append mode is used, lines are appended to the file: >vim
-                        call writefile(["foo"], "event.log", "a")
-                        call writefile(["bar"], "event.log", "a")
+		'a'  Append mode is used, lines are appended to the file: >vim
+			call writefile(["foo"], "event.log", "a")
+			call writefile(["bar"], "event.log", "a")
 <
-                'D'  Delete the file when the current function ends.  This
-                     works like: >vim
-                        defer delete({fname})
-<                     Fails when not in a function.  Also see |:defer|.
+		'D'  Delete the file when the current function ends.  This
+		     works like: >vim
+			defer delete({fname})
+<		      Fails when not in a function.  Also see |:defer|.
 
-                's'  fsync() is called after writing the file.  This flushes
-                     the file to disk, if possible.  This takes more time but
-                     avoids losing the file if the system crashes.
+		's'  fsync() is called after writing the file.	This flushes
+		     the file to disk, if possible.  This takes more time but
+		     avoids losing the file if the system crashes.
 
-                'S'  fsync() is not called, even when 'fsync' is set.
+		'S'  fsync() is not called, even when 'fsync' is set.
 
-                     When {flags} does not contain "S" or "s" then fsync() is
-                     called if the 'fsync' option is set.
+		     When {flags} does not contain "S" or "s" then fsync() is
+		     called if the 'fsync' option is set.
 
-                An existing file is overwritten, if possible.
+		An existing file is overwritten, if possible.
 
-                When the write fails -1 is returned, otherwise 0.  There is an
-                error message if the file can't be created or when writing
-                fails.
+		When the write fails -1 is returned, otherwise 0.  There is an
+		error message if the file can't be created or when writing
+		fails.
 
-                Also see |readfile()|.
-                To copy a file byte for byte: >vim
-                        let fl = readfile("foo", "b")
-                        call writefile(fl, "foocopy", "b")
+		Also see |readfile()|.
+		To copy a file byte for byte: >vim
+			let fl = readfile("foo", "b")
+			call writefile(fl, "foocopy", "b")
 
-xor({expr}, {expr})                                                      *xor()*
-                Bitwise XOR on the two arguments.  The arguments are converted
-                to a number.  A List, Dict or Float argument causes an error.
-                Also see `and()` and `or()`.
-                Example: >vim
-                        let bits = xor(bits, 0x80)
+xor({expr}, {expr})							 *xor()*
+		Bitwise XOR on the two arguments.  The arguments are converted
+		to a number.  A List, Dict or Float argument causes an error.
+		Also see `and()` and `or()`.
+		Example: >vim
+			let bits = xor(bits, 0x80)
 <
 ==============================================================================
-2. Matching a pattern in a String                        *string-match*
+2. Matching a pattern in a String			 *string-match*
 
 This is common between several functions. A regexp pattern as explained at
 |pattern| is normally used to find a match in the buffer lines.  When a

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -19,11 +19,11 @@ abs({expr})								 *abs()*
 		abs() gives an error message and returns -1.
 		Examples: >vim
 			echo abs(1.456)
-<			 1.456	>vim
+<			1.456  >vim
 			echo abs(-5.456)
-<			 5.456	>vim
+<			5.456  >vim
 			echo abs(-4)
-<			 4
+<			4
 
 acos({expr})								*acos()*
 		Return the arc cosine of {expr} measured in radians, as a
@@ -34,16 +34,16 @@ acos({expr})								*acos()*
 		0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo acos(0)
-<			 1.570796 >vim
+<			1.570796 >vim
 			echo acos(-0.5)
-<			 2.094395
+<			2.094395
 
 add({object}, {expr})							 *add()*
 		Append the item {expr} to |List| or |Blob| {object}.  Returns
 		the resulting |List| or |Blob|.  Examples: >vim
 			let alist = add([1, 2, 3], item)
 			call add(mylist, "woodstock")
-<		 Note that when {expr} is a |List| it is appended as a single
+<		Note that when {expr} is a |List| it is appended as a single
 		item.  Use |extend()| to concatenate |Lists|.
 		When {object} is a |Blob| then {expr} must be a number.
 		Use |insert()| to add an item at another position.
@@ -94,7 +94,7 @@ appendbufline({buf}, {lnum}, {text})			       *appendbufline()*
 		If {buf} is not a valid buffer or {lnum} is not valid, an
 		error message is given. Example: >vim
 			let failed = appendbufline(13, 0, "# THE START")
-<		 However, when {text} is an empty list then no error is given
+<		However, when {text} is an empty list then no error is given
 		for an invalid {lnum}, since {lnum} isn't actually used.
 
 argc([{winid}])								*argc()*
@@ -132,7 +132,7 @@ argv([{nr} [, {winid}]])						*argv()*
 			  exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
 			  let i = i + 1
 			endwhile
-<		 Without the {nr} argument, or when {nr} is -1, a |List| with
+<		Without the {nr} argument, or when {nr} is -1, a |List| with
 		the whole |arglist| is returned.
 
 		The {winid} argument specifies the window ID, see |argc()|.
@@ -151,9 +151,9 @@ asin({expr})								*asin()*
 		0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo asin(0.8)
-<			 0.927295 >vim
+<			0.927295 >vim
 			echo asin(-0.5)
-<			 -0.523599
+<			-0.523599
 
 assert_beeps({cmd})						*assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does
@@ -174,7 +174,7 @@ assert_equal({expected}, {actual} [, {msg}])			*assert_equal()*
 		always matters.
 		Example: >vim
 			assert_equal('foo', 'bar')
-<		 Will result in a string to be added to |v:errors|:
+<		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Expected 'foo' but got 'bar' ~
 
 assert_equalfile({fname-one}, {fname-two})		    *assert_equalfile()*
@@ -212,7 +212,7 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		used as patterns.  The first pattern is matched against the
 		first reported error: >vim
 			assert_fails('cmd', ['E987:.*expected bool'])
-<		 The second pattern, if present, is matched against the last
+<		The second pattern, if present, is matched against the last
 		reported error.  To only match the last error use an empty
 		string for the first error: >vim
 			assert_fails('cmd', ['', 'E987:'])
@@ -266,7 +266,7 @@ assert_match({pattern}, {actual} [, {msg}])			*assert_match()*
 
 		Example: >vim
 			assert_match('^f.*o$', 'foobar')
-<		 Will result in a string to be added to |v:errors|:
+<		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
 assert_nobeep({cmd})					       *assert_nobeep()*
@@ -303,9 +303,9 @@ atan({expr})								*atan()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo atan(100)
-<			 1.560797 >vim
+<			1.560797 >vim
 			echo atan(-4.01)
-<			 -1.326405
+<			-1.326405
 
 atan2({expr1}, {expr2})						       *atan2()*
 		Return the arc tangent of {expr1} / {expr2}, measured in
@@ -315,16 +315,16 @@ atan2({expr1}, {expr2})						       *atan2()*
 		|Number|.
 		Examples: >vim
 			echo atan2(-1, 1)
-<			 -0.785398 >vim
+<			-0.785398 >vim
 			echo atan2(1, -1)
-<			 2.356194
+<			2.356194
 
 blob2list({blob})						   *blob2list()*
 		Return a List containing the number value of each byte in Blob
 		{blob}.  Examples: >vim
 			blob2list(0z0102.0304)	" returns [1, 2, 3, 4]
 			blob2list(0z)		" returns []
-<		 Returns an empty List on error.  |list2blob()| does the
+<		Returns an empty List on error.  |list2blob()| does the
 		opposite.
 
 browse({save}, {title}, {initdir}, {default})			      *browse()*
@@ -362,7 +362,7 @@ bufadd({name})							      *bufadd()*
 			let bufnr = bufadd('someName')
 			call bufload(bufnr)
 			call setbufline(bufnr, 1, ['some', 'text'])
-<		 Returns 0 on error.
+<		Returns 0 on error.
 
 bufexists({buf})						   *bufexists()*
 		The result is a Number, which is |TRUE| if a buffer called
@@ -429,7 +429,7 @@ bufname([{buf}])						     *bufname()*
 		If the {buf} is a String, but you want to use it as a buffer
 		number, force it to be a Number by adding zero to it: >vim
 			echo bufname("3" + 0)
-<		 If the buffer doesn't exist, or doesn't have a name, an empty
+<		If the buffer doesn't exist, or doesn't have a name, an empty
 		string is returned. >vim
 			echo bufname("#")	" alternate buffer name
 			echo bufname(3)		" name of buffer 3
@@ -445,7 +445,7 @@ bufnr([{buf} [, {create}]])					       *bufnr()*
 		buffer is created and its number is returned.
 		bufnr("$") is the last buffer: >vim
 			let last_buffer = bufnr("$")
-<		 The result is a Number, which is the highest buffer number
+<		The result is a Number, which is the highest buffer number
 		of existing buffers.  Note that not all buffers with a smaller
 		number necessarily exist, because ":bwipeout" may have removed
 		them.  Use bufexists() to test for the existence of a buffer.
@@ -469,7 +469,7 @@ bufwinnr({buf})							    *bufwinnr()*
 
 			echo "A window containing buffer 1 is " .. (bufwinnr(1))
 
-<		 The number can be used with |CTRL-W_w| and ":wincmd w"
+<		The number can be used with |CTRL-W_w| and ":wincmd w"
 		|:wincmd|.
 
 byte2line({byte})						   *byte2line()*
@@ -501,11 +501,11 @@ byteidx({expr}, {nr} [, {utf16}])				     *byteidx()*
 		Refer to |string-offset-encoding| for more information.
 		Example : >vim
 			echo matchstr(str, ".", byteidx(str, 3))
-<		 will display the fourth character.  Another way to do the
+<		will display the fourth character.  Another way to do the
 		same: >vim
 			let s = strpart(str, byteidx(str, 3))
 			echo strpart(s, 0, byteidx(s, 1))
-<		 Also see |strgetchar()| and |strcharpart()|.
+<		Also see |strgetchar()| and |strcharpart()|.
 
 		If there are less than {nr} characters -1 is returned.
 		If there are exactly {nr} characters the length of the string
@@ -524,7 +524,7 @@ byteidxcomp({expr}, {nr} [, {utf16}])				 *byteidxcomp()*
 			echo byteidx(s, 1)
 			echo byteidxcomp(s, 1)
 			echo byteidxcomp(s, 2)
-<		 The first and third echo result in 3 ('e' plus composing
+<		The first and third echo result in 3 ('e' plus composing
 		character is 3 bytes), the second echo results in 1 ('e' is
 		one byte).
 
@@ -543,11 +543,11 @@ ceil({expr})								*ceil()*
 		{expr} must evaluate to a |Float| or a |Number|.
 		Examples: >vim
 			echo ceil(1.456)
-<			 2.0  >vim
+<			2.0  >vim
 			echo ceil(-5.456)
-<			 -5.0  >vim
+<			-5.0  >vim
 			echo ceil(4.0)
-<			 4.0
+<			4.0
 
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
@@ -582,7 +582,7 @@ chansend({id}, {data})						    *chansend()*
 		newlines in an item will be sent as NUL. To send a final
 		newline, include a final empty string. Example: >vim
 			call chansend(id, ["abc", "123\n456", ""])
-<		 will send "abc<NL>123<NUL>456<NL>".
+<		will send "abc<NL>123<NUL>456<NL>".
 
 		chansend() writes raw data, not RPC messages.  If the channel
 		was created with `"rpc":v:true` then the channel expects RPC
@@ -596,7 +596,7 @@ char2nr({string} [, {utf8}])					     *char2nr()*
 			echo char2nr("á")	" returns 225
 			echo char2nr("á"[0])	" returns 195
 			echo char2nr("\<M-x>")	" returns 128
-<		 Non-ASCII characters are always treated as UTF-8 characters.
+<		Non-ASCII characters are always treated as UTF-8 characters.
 		{utf8} is ignored, it exists only for backwards-compatibility.
 		A combining character is a separate character.
 		|nr2char()| does the opposite.
@@ -720,7 +720,7 @@ col({expr} [, {winid}])							 *col()*
 			echo col("$")			" length of cursor line plus one
 			echo col("'t")			" column of mark t
 			echo col("'" .. markname)	" column of mark markname
-<		 The first column is 1.  Returns 0 if {expr} is invalid or when
+<		The first column is 1.	Returns 0 if {expr} is invalid or when
 		the window with ID {winid} is not found.
 		For an uppercase mark the column may actually be in another
 		buffer.
@@ -757,7 +757,7 @@ complete({startcol}, {matches})				       *complete()* *E785*
 			    \ 'October', 'November', 'December'])
 			  return ''
 			endfunc
-<		 This isn't very useful, but it shows how it works.  Note that
+<		This isn't very useful, but it shows how it works.  Note that
 		an empty string is returned to avoid a zero being inserted.
 
 complete_add({expr})						*complete_add()*
@@ -851,11 +851,11 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])		     *confirm()*
 		{choices} is a String, with the individual choices separated
 		by '\n', e.g. >vim
 			confirm("Save changes?", "&Yes\n&No\n&Cancel")
-<		 The letter after the '&' is the shortcut key for that choice.
+<		The letter after the '&' is the shortcut key for that choice.
 		Thus you can type 'c' to select "Cancel".  The shortcut does
 		not need to be the first letter: >vim
 			confirm("file has been modified", "&Save\nSave &All")
-<		 For the console, the first letter of each choice is used as
+<		For the console, the first letter of each choice is used as
 		the default shortcut key.  Case is ignored.
 
 		The optional {type} String argument gives the type of dialog.
@@ -882,7 +882,7 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])		     *confirm()*
 		   else
 			echo "I prefer bananas myself."
 		   endif
-<		 In a GUI dialog, buttons are used.  The layout of the buttons
+<		In a GUI dialog, buttons are used.  The layout of the buttons
 		depends on the 'v' flag in 'guioptions'.  If it is included,
 		the buttons are always put vertically.	Otherwise,  confirm()
 		tries to put the buttons in one horizontal line.  If they
@@ -905,9 +905,9 @@ cos({expr})								 *cos()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo cos(100)
-<			 0.862319 >vim
+<			0.862319 >vim
 			echo cos(-4.01)
-<			 -0.646043
+<			-0.646043
 
 cosh({expr})								*cosh()*
 		Return the hyperbolic cosine of {expr} as a |Float| in the range
@@ -916,9 +916,9 @@ cosh({expr})								*cosh()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo cosh(0.5)
-<			 1.127626 >vim
+<			1.127626 >vim
 			echo cosh(-0.5)
-<			 -1.127626
+<			-1.127626
 
 count({comp}, {expr} [, {ic} [, {start}]])			  *count()* *E706*
 		Return the number of times an item with value {expr} appears
@@ -1192,7 +1192,7 @@ digraph_setlist({digraphlist})				     *digraph_setlist()*
 		    for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
 			  call digraph_set(chars, digraph)
 		    endfor
-<		 Except that the function returns after the first error,
+<		Except that the function returns after the first error,
 		following digraphs will not be added.
 
 		Can be used as a |method|: >vim
@@ -1211,7 +1211,7 @@ environ()							     *environ()*
 		Return all of environment variables as dictionary. You can
 		check if an environment variable exists like this: >vim
 			echo has_key(environ(), 'HOME')
-<		 Note that the variable name may be CamelCase; to ignore case
+<		Note that the variable name may be CamelCase; to ignore case
 		use this: >vim
 			echo index(keys(environ()), 'HOME', 0, 1) != -1
 <
@@ -1219,9 +1219,9 @@ escape({string}, {chars})					      *escape()*
 		Escape the characters in {chars} that occur in {string} with a
 		backslash.  Example: >vim
 			echo escape('c:\program files\vim', ' \')
-<		 results in: >
+<		results in: >
 			c:\\program\ files\\vim
-<		 Also see |shellescape()| and |fnameescape()|.
+<		Also see |shellescape()| and |fnameescape()|.
 
 eval({string})								*eval()*
 		Evaluate {string} and return the result.  Especially useful to
@@ -1266,9 +1266,9 @@ execute({command} [, {silent}])					     *execute()*
 		Line continuations in {command} are not recognized.
 		Examples: >vim
 			echo execute('echon "foo"')
-<			foo >vim
+<		       foo >vim
 			echo execute(['echon "foo"', 'echon "bar"'])
-<			foobar
+<		       foobar
 
 		The optional {silent} argument can have these values:
 			""		no `:silent` used
@@ -1280,7 +1280,7 @@ execute({command} [, {silent}])					     *execute()*
 		To get a list of lines use `split()` on the result: >vim
 			execute('args')->split("\n")
 
-<		 This function is not available in the |sandbox|.
+<		This function is not available in the |sandbox|.
 		Note: If nested, an outer execute() will not observe output of
 		the inner calls.
 		Note: Text attributes (highlights) are not captured.
@@ -1310,9 +1310,9 @@ exists({expr})							      *exists()*
 					expression.  E.g.: >vim
 					   let l = [1, 2, 3]
 					   echo exists("l[5]")
-<					   0 >vim
+<					  0 >vim
 					   echo exists("l[xx]")
-<					   E121: Undefined variable: xx
+<					  E121: Undefined variable: xx
 					   0
 			&option-name	Vim option (only checks if it exists,
 					not if it really works)
@@ -1365,20 +1365,20 @@ exists({expr})							      *exists()*
 			echo exists("#filetypeindent#FileType")
 			echo exists("#filetypeindent#FileType#*")
 			echo exists("##ColorScheme")
-<		 There must be no space between the symbol (&/$/*/#) and the
+<		There must be no space between the symbol (&/$/*/#) and the
 		name.
 		There must be no extra characters after the name, although in
 		a few cases this is ignored.  That may become stricter in the
 		future, thus don't count on it!
 		Working example: >vim
 			echo exists(":make")
-<		 NOT working example: >vim
+<		NOT working example: >vim
 			echo exists(":make install")
 
-<		 Note that the argument must be a string, not the name of the
+<		Note that the argument must be a string, not the name of the
 		variable itself.  For example: >vim
 			echo exists(bufcount)
-<		 This doesn't check for existence of the "bufcount" variable,
+<		This doesn't check for existence of the "bufcount" variable,
 		but gets the value of "bufcount", and checks if that exists.
 
 exp({expr})								 *exp()*
@@ -1388,9 +1388,9 @@ exp({expr})								 *exp()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo exp(2)
-<			 7.389056 >vim
+<			7.389056 >vim
 			echo exp(-1)
-<			 0.367879
+<			0.367879
 
 expand({string} [, {nosuf} [, {list}]])				      *expand()*
 		Expand wildcards and the following special keywords in
@@ -1439,12 +1439,12 @@ expand({string} [, {nosuf} [, {list}]])				      *expand()*
 
 		Example: >vim
 			let &tags = expand("%:p:h") .. "/tags"
-<		 Note that when expanding a string that starts with '%', '#' or
+<		Note that when expanding a string that starts with '%', '#' or
 		'<', any following text is ignored.  This does NOT work: >vim
 			let doesntwork = expand("%:h.bak")
-<		 Use this: >vim
+<		Use this: >vim
 			let doeswork = expand("%:h") .. ".bak"
-<		 Also note that expanding "<cfile>" and others only returns the
+<		Also note that expanding "<cfile>" and others only returns the
 		referenced file name without further expansion.  If "<cfile>"
 		is "~/.cshrc", you need to do another expand() to have the
 		"~/" expanded into the path of the home directory: >vim
@@ -1501,9 +1501,9 @@ expandcmd({string} [, {options}])				   *expandcmd()*
 
 		Example: >vim
 			echo expandcmd('make %<.o')
-<		  >
+<		 >
 			make /path/runtime/doc/builtin.o
-<		  >vim
+<		 >vim
 			echo expandcmd('make %<.o', {'errmsg': v:true})
 <
 extend({expr1}, {expr2} [, {expr3}])				      *extend()*
@@ -1518,7 +1518,7 @@ extend({expr1}, {expr2} [, {expr3}])				      *extend()*
 		Examples: >vim
 			echo sort(extend(mylist, [7, 5]))
 			call extend(mylist, [2, 3], 1)
-<		 When {expr1} is the same List as {expr2} then the number of
+<		When {expr1} is the same List as {expr2} then the number of
 		items copied is equal to the original length of the List.
 		E.g., when {expr3} is 1 you get N new copies of the first item
 		(where N is the original length of the List).
@@ -1601,11 +1601,11 @@ filereadable({file})						*filereadable()*
 		|glob()|.
 		{file} is used as-is, you may want to expand wildcards first: >vim
 			echo filereadable('~/.vimrc')
-<		  >
+<		 >
 			0
-<		  >vim
+<		 >vim
 			echo filereadable(expand('~/.vimrc'))
-<		  >
+<		 >
 			1
 <
 filewritable({file})						*filewritable()*
@@ -1631,11 +1631,11 @@ filter({expr1}, {expr2})					      *filter()*
 		current character.
 		Examples: >vim
 			call filter(mylist, 'v:val !~ "OLD"')
-<		 Removes the items where "OLD" appears. >vim
+<		Removes the items where "OLD" appears. >vim
 			call filter(mydict, 'v:key >= 8')
-<		 Removes the items with a key below 8. >vim
+<		Removes the items with a key below 8. >vim
 			call filter(var, 0)
-<		 Removes all the items, thus clears the |List| or |Dictionary|.
+<		Removes all the items, thus clears the |List| or |Dictionary|.
 
 		Note that {expr2} is the result of expression and is then
 		used as an expression again.  Often it is good to use a
@@ -1650,9 +1650,9 @@ filter({expr1}, {expr2})					      *filter()*
 			  return a:idx % 2 == 1
 			endfunc
 			call filter(mylist, function('Odd'))
-<		 It is shorter when using a |lambda|: >vim
+<		It is shorter when using a |lambda|: >vim
 			call filter(myList, {idx, val -> idx * val <= 42})
-<		 If you do not use "val" you can leave it out: >vim
+<		If you do not use "val" you can leave it out: >vim
 			call filter(myList, {idx -> idx % 2 == 1})
 <
 		For a |List| and a |Dictionary| the operation is done
@@ -1660,7 +1660,7 @@ filter({expr1}, {expr2})					      *filter()*
 		first: >vim
 			let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 
-<		 Returns {expr1}, the |List| or |Dictionary| that was filtered,
+<		Returns {expr1}, the |List| or |Dictionary| that was filtered,
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
@@ -1690,7 +1690,7 @@ findfile({name} [, {path} [, {count}]])				    *findfile()*
 		Uses 'suffixesadd'.
 		Example: >vim
 			echo findfile("tags.vim", ".;")
-<		 Searches from the directory of the current file upwards until
+<		Searches from the directory of the current file upwards until
 		it finds the file "tags.vim".
 
 flatten({list} [, {maxdepth}])					     *flatten()*
@@ -1708,9 +1708,9 @@ flatten({list} [, {maxdepth}])					     *flatten()*
 
 		Example: >vim
 			echo flatten([1, [2, [3, 4]], 5])
-<			 [1, 2, 3, 4, 5] >vim
+<			[1, 2, 3, 4, 5] >vim
 			echo flatten([1, [2, [3, 4]], 5], 1)
-<			 [1, 2, [3, 4], 5]
+<			[1, 2, [3, 4], 5]
 
 flattennew({list} [, {maxdepth}])				  *flattennew()*
 		Like |flatten()| but first make a copy of {list}.
@@ -1727,15 +1727,15 @@ float2nr({expr})						    *float2nr()*
 		64-bit Number support is enabled, -0x8000000000000000).
 		Examples: >vim
 			echo float2nr(3.95)
-<			 3  >vim
+<			3  >vim
 			echo float2nr(-23.45)
-<			 -23  >vim
+<			-23  >vim
 			echo float2nr(1.0e100)
-<			 2147483647  (or 9223372036854775807) >vim
+<			2147483647  (or 9223372036854775807) >vim
 			echo float2nr(-1.0e150)
-<			 -2147483647 (or -9223372036854775807) >vim
+<			-2147483647 (or -9223372036854775807) >vim
 			echo float2nr(1.0e-100)
-<			 0
+<			0
 
 floor({expr})							       *floor()*
 		Return the largest integral value less than or equal to
@@ -1744,11 +1744,11 @@ floor({expr})							       *floor()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo floor(1.856)
-<			 1.0  >vim
+<			1.0  >vim
 			echo floor(-5.456)
-<			 -6.0  >vim
+<			-6.0  >vim
 			echo floor(4.0)
-<			 4.0
+<			4.0
 
 fmod({expr1}, {expr2})							*fmod()*
 		Return the remainder of {expr1} / {expr2}, even if the
@@ -1762,9 +1762,9 @@ fmod({expr1}, {expr2})							*fmod()*
 		|Number|.
 		Examples: >vim
 			echo fmod(12.33, 1.22)
-<			 0.13 >vim
+<			0.13 >vim
 			echo fmod(-12.33, 1.22)
-<			 -0.13
+<			-0.13
 
 fnameescape({string})						 *fnameescape()*
 		Escape {string} for use as file name command argument.	All
@@ -1779,7 +1779,7 @@ fnameescape({string})						 *fnameescape()*
 		Example: >vim
 			let fname = '+some str%nge|name'
 			exe "edit " .. fnameescape(fname)
-<		 results in executing: >vim
+<		results in executing: >vim
 			edit \+some\ str\%nge\|name
 <
 fnamemodify({fname}, {mods})					 *fnamemodify()*
@@ -1788,9 +1788,9 @@ fnamemodify({fname}, {mods})					 *fnamemodify()*
 		command line.  See |filename-modifiers|.
 		Example: >vim
 			echo fnamemodify("main.c", ":p:h")
-<		 results in: >
+<		results in: >
 			/home/user/vim/vim/src
-<		 If {mods} is empty or an unsupported modifier is used then
+<		If {mods} is empty or an unsupported modifier is used then
 		{fname} is returned.
 		When {fname} is empty then with {mods} ":h" returns ".", so
 		that `:cd` can be used with it.  This is different from
@@ -1832,7 +1832,7 @@ foldtext()							    *foldtext()*
 		|v:foldstart|, |v:foldend| and |v:folddashes| variables.
 		The returned string looks like this: >
 			+-- 45 lines: abcdef
-<		 The number of leading dashes depends on the foldlevel.  The
+<		The number of leading dashes depends on the foldlevel.	The
 		"45" is the number of lines in the fold.  "abcdef" is the text
 		in the first non-blank line of the fold.  Leading white space,
 		"//" or "/*" and the text from the 'foldmarker' and
@@ -1903,20 +1903,20 @@ function({name} [, {arglist}] [, {dict}])	  *function()* *partial* *E700* *E923*
 			let Partial = function('Callback', ['one', 'two'])
 			"...
 			call Partial('name')
-<		 Invokes the function as with: >vim
+<		Invokes the function as with: >vim
 			call Callback('one', 'two', 'name')
 
-<		 With a |method|: >vim
+<		With a |method|: >vim
 			func Callback(one, two, three)
 			"...
 			endfunc
 			let Partial = function('Callback', ['two'])
 			"...
 			eval 'one'->Partial('three')
-<		 Invokes the function as with: >vim
+<		Invokes the function as with: >vim
 			call Callback('one', 'two', 'three')
 
-<		 The function() call can be nested to add more arguments to the
+<		The function() call can be nested to add more arguments to the
 		Funcref.  The extra arguments are appended to the list of
 		arguments.  Example: >vim
 			func Callback(arg1, arg2, name)
@@ -1926,10 +1926,10 @@ function({name} [, {arglist}] [, {dict}])	  *function()* *partial* *E700* *E923*
 			let Func2 = function(Func, ['two'])
 			"...
 			call Func2('name')
-<		 Invokes the function as with: >vim
+<		Invokes the function as with: >vim
 			call Callback('one', 'two', 'name')
 
-<		 The Dictionary is only useful when calling a "dict" function.
+<		The Dictionary is only useful when calling a "dict" function.
 		In that case the {dict} is passed in as "self". Example: >vim
 			function Callback() dict
 			   echo "called for " .. self.name
@@ -1939,13 +1939,13 @@ function({name} [, {arglist}] [, {dict}])	  *function()* *partial* *E700* *E923*
 			let Func = function('Callback', context)
 			"...
 			call Func()	" will echo: called for example
-<		 The use of function() is not needed when there are no extra
+<		The use of function() is not needed when there are no extra
 		arguments, these two are equivalent, if Callback() is defined
 		as context.Callback(): >vim
 			let Func = function('Callback', context)
 			let Func = context.Callback
 
-<		 The argument list and the Dictionary can be combined: >vim
+<		The argument list and the Dictionary can be combined: >vim
 			function Callback(arg1, count) dict
 			"...
 			endfunction
@@ -1953,7 +1953,7 @@ function({name} [, {arglist}] [, {dict}])	  *function()* *partial* *E700* *E923*
 			let Func = function('Callback', ['one'], context)
 			"...
 			call Func(500)
-<		 Invokes the function as with: >vim
+<		Invokes the function as with: >vim
 			call context.Callback('one', 500)
 <
 		Returns 0 on error.
@@ -1993,7 +1993,7 @@ get({dict}, {key} [, {default}])
 		item is not available return {default}.  Return zero when
 		{default} is omitted.  Useful example: >vim
 			let val = get(g:, 'var_name', 'default')
-<		 This gets the value of g:var_name if it exists, and uses
+<		This gets the value of g:var_name if it exists, and uses
 		"default" when it does not exist.
 
 get({func}, {what})
@@ -2195,7 +2195,7 @@ getchar([expr])							     *getchar()*
 		sequence.  Examples: >vim
 			getchar() == "\<Del>"
 			getchar() == "\<S-Left>"
-<		 This example redefines "f" to ignore case: >vim
+<		This example redefines "f" to ignore case: >vim
 			nmap f :call FindChar()<CR>
 			function FindChar()
 			  let c = nr2char(getchar())
@@ -2254,7 +2254,7 @@ getcharsearch()						       *getcharsearch()*
 		character search: >vim
 			nnoremap <expr> ; getcharsearch().forward ? ';' : ','
 			nnoremap <expr> , getcharsearch().forward ? ',' : ';'
-<		 Also see |setcharsearch()|.
+<		Also see |setcharsearch()|.
 
 getcharstr([expr])						  *getcharstr()*
 		Get a single character from the user or input stream as a
@@ -2283,7 +2283,7 @@ getcmdline()							  *getcmdline()*
 		|c_CTRL-R_=|.
 		Example: >vim
 			cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
-<		 Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
+<		Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
 		|setcmdline()|.
 		Returns an empty string when entering a password or using
 		|inputsecret()|.
@@ -2417,7 +2417,7 @@ getcurpos([{winid}])						   *getcurpos()*
 			let save_cursor = getcurpos()
 			MoveTheCursorAround
 			call setpos('.', save_cursor)
-<		 Note that this only works within the window.  See
+<		Note that this only works within the window.  See
 		|winrestview()| for restoring more state.
 
 getcursorcharpos([{winid}])				    *getcursorcharpos()*
@@ -2439,7 +2439,7 @@ getcwd([{winnr} [, {tabnr}]])					      *getcwd()*
 		Thus the following are equivalent: >vim
 			getcwd(0)
 			getcwd(0, 0)
-<		 If {winnr} is -1 it is ignored, only the tab is resolved.
+<		If {winnr} is -1 it is ignored, only the tab is resolved.
 		{winnr} can be the window number or the |window-ID|.
 		If both {winnr} and {tabnr} are -1 the global working
 		directory is returned.
@@ -2450,7 +2450,7 @@ getenv({name})							      *getenv()*
 		argument is a string, without a leading '$'.  Example: >vim
 			myHome = getenv('HOME')
 
-<		 When the variable does not exist |v:null| is returned.  That
+<		When the variable does not exist |v:null| is returned.	That
 		is different from a variable set to an empty string.
 		See also |expr-env|.
 
@@ -2478,7 +2478,7 @@ getfperm({fname})						    *getfperm()*
 		is replaced with the string "-".  Examples: >vim
 			echo getfperm("/etc/passwd")
 			echo getfperm(expand("~/.config/nvim/init.vim"))
-<		 This will hopefully (from a security point of view) display
+<		This will hopefully (from a security point of view) display
 		the string "rw-r--r--" or even "rw-------".
 
 		For setting permissions use |setfperm()|.
@@ -2514,7 +2514,7 @@ getftype({fname})						    *getftype()*
 			All other		"other"
 		Example: >vim
 			getftype("/home")
-<		 Note that a type such as "link" will only be returned on
+<		Note that a type such as "link" will only be returned on
 		systems that support it.  On some systems only "dir" and
 		"file" are returned.
 
@@ -2542,11 +2542,11 @@ getline({lnum} [, {end}])					     *getline()*
 		Without {end} the result is a String, which is line {lnum}
 		from the current buffer.  Example: >vim
 			getline(1)
-<		 When {lnum} is a String that doesn't start with a
+<		When {lnum} is a String that doesn't start with a
 		digit, |line()| is called to translate the String into a Number.
 		To get the line under the cursor: >vim
 			getline(".")
-<		 When {lnum} is a number smaller than 1 or bigger than the
+<		When {lnum} is a number smaller than 1 or bigger than the
 		number of lines in the buffer, an empty string is returned.
 
 		When {end} is given the result is a |List| where each item is
@@ -2560,7 +2560,7 @@ getline({lnum} [, {end}])					     *getline()*
 			let end = search("^$") - 1
 			let lines = getline(start, end)
 
-<		 To get lines from another buffer see |getbufline()| and
+<		To get lines from another buffer see |getbufline()| and
 		|getbufoneline()|
 
 getloclist({nr} [, {what}])					  *getloclist()*
@@ -2624,24 +2624,24 @@ getmatches([{win}])						  *getmatches()*
 		an empty list is returned.
 		Example: >vim
 			echo getmatches()
-<		  >
+<		 >
 			[{"group": "MyGroup1", "pattern": "TODO",
 			"priority": 10, "id": 1}, {"group": "MyGroup2",
 			"pattern": "FIXME", "priority": 10, "id": 2}]
-<		  >vim
+<		 >vim
 			let m = getmatches()
 			call clearmatches()
 			echo getmatches()
-<		  >
+<		 >
 			[]
-<		  >vim
+<		 >vim
 			call setmatches(m)
 			echo getmatches()
-<		  >
+<		 >
 			[{"group": "MyGroup1", "pattern": "TODO",
 			"priority": 10, "id": 1}, {"group": "MyGroup2",
 			"pattern": "FIXME", "priority": 10, "id": 2}]
-<		  >vim
+<		 >vim
 			unlet m
 <
 getmousepos()							 *getmousepos()*
@@ -2706,7 +2706,7 @@ getpos({expr})							      *getpos()*
 			let save_a_mark = getpos("'a")
 			" ...
 			call setpos("'a", save_a_mark)
-<		 Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+<		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
 getqflist([{what}])						   *getqflist()*
 		Returns a |List| with all the current quickfix errors.	Each
@@ -2815,7 +2815,7 @@ getreg([{regname} [, 1 [, {list}]]])				      *getreg()*
 		The result is a String, which is the contents of register
 		{regname}.  Example: >vim
 			let cliptext = getreg('*')
-<		 When register {regname} was not set the result is an empty
+<		When register {regname} was not set the result is an empty
 		string.
 		The {regname} argument must be a string.
 
@@ -3095,7 +3095,7 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])			*glob()*
 		any external command.  Example: >vim
 			let tagfiles = glob("`find . -name tags -print`")
 			let &tags = substitute(tagfiles, "\n", ",", "g")
-<		 The result of the program inside the backticks should be one
+<		The result of the program inside the backticks should be one
 		item per line.	Spaces inside an item are allowed.
 
 		See |expand()| for expanding special Vim variables.  See
@@ -3108,11 +3108,11 @@ glob2regpat({string})						 *glob2regpat()*
 			if filename =~ glob2regpat('Make*.mak')
 			  " ...
 			endif
-<		 This is equivalent to: >vim
+<		This is equivalent to: >vim
 			if filename =~ '^Make.*\.mak$'
 			  " ...
 			endif
-<		 When {string} is an empty string the result is "^$", match an
+<		When {string} is an empty string the result is "^$", match an
 		empty string.
 		Note that the result depends on the system.  On MS-Windows
 		a backslash usually means a path separator.
@@ -3149,7 +3149,7 @@ globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])	    *globpath()*
 		For example, to find all "README.txt" files in the directories
 		in 'runtimepath' and below: >vim
 			echo globpath(&rtp, "**/README.txt")
-<		 Upwards search and limiting the depth of "**" is not
+<		Upwards search and limiting the depth of "**" is not
 		supported, thus using 'path' will not always work properly.
 
 has({feature})								 *has()*
@@ -3160,7 +3160,7 @@ has({feature})								 *has()*
 		To get the system name use |vim.uv|.os_uname() in Lua: >lua
 			print(vim.uv.os_uname().sysname)
 
-<		 If the code has a syntax error then Vimscript may skip the
+<		If the code has a syntax error then Vimscript may skip the
 		rest of the line.  Put |:if| and |:endif| on separate lines to
 		avoid the syntax error: >vim
 			if has('feature')
@@ -3178,12 +3178,12 @@ has({feature})								 *has()*
 			  " ...
 			endif
 
-<		 2.  Runtime condition or other pseudo-feature. For example the
+<		2.  Runtime condition or other pseudo-feature. For example the
 		    "win32" feature checks if the current system is Windows: >vim
 			if has("win32")
 			  " ...
 			endif
-<							*feature-list*
+<						       *feature-list*
 		    List of supported pseudo-feature names:
 			acl		|ACL| support.
 			bsd		BSD system (not macOS, use "mac" for that).
@@ -3213,7 +3213,7 @@ has({feature})								 *has()*
 			  " ...
 			endif
 
-<		 4.  Vim version. For example the "patch-7.4.237" feature means
+<		4.  Vim version. For example the "patch-7.4.237" feature means
 		    that Nvim is Vim-compatible to version 7.4.237 or later. >vim
 			if has("patch-7.4.237")
 			  " ...
@@ -3235,7 +3235,7 @@ haslocaldir([{winnr} [, {tabnr}]])				 *haslocaldir()*
 			echo haslocaldir()
 			echo haslocaldir(0)
 			echo haslocaldir(0, 0)
-<		 With {winnr} use that window in the current tabpage.
+<		With {winnr} use that window in the current tabpage.
 		With {winnr} and {tabnr} use the window in that tabpage.
 		{winnr} can be the window number or the |window-ID|.
 		If {winnr} is -1 it is ignored, only the tab is resolved.
@@ -3269,7 +3269,7 @@ hasmapto({what} [, {mode} [, {abbr}]])				    *hasmapto()*
 			if !hasmapto('\ABCdoit')
 			   map <Leader>d \ABCdoit
 			endif
-<		 This installs the mapping to "\ABCdoit" only if there isn't
+<		This installs the mapping to "\ABCdoit" only if there isn't
 		already a mapping to "\ABCdoit".
 
 histadd({history}, {item})					     *histadd()*
@@ -3291,7 +3291,7 @@ histadd({history}, {item})					     *histadd()*
 		Example: >vim
 			call histadd("input", strftime("%Y %b %d"))
 			let date=input("Enter date: ")
-<		 This function is not available in the |sandbox|.
+<		This function is not available in the |sandbox|.
 
 histdel({history} [, {item}])					     *histdel()*
 		Clear {history}, i.e. delete all its entries.  See |hist-names|
@@ -3336,7 +3336,7 @@ histget({history} [, {index}])					     *histget()*
 		Redo the second last search from history. >vim
 			execute '/' .. histget("search", -2)
 
-<		 Define an Ex command ":H {num}" that supports re-execution of
+<		Define an Ex command ":H {num}" that supports re-execution of
 		the {num}th entry from the output of |:history|. >vim
 			command -nargs=1 H execute histget("cmd", 0+<args>)
 <
@@ -3503,7 +3503,7 @@ input({opts})
 		Example: >vim
 			let color = input("Color? ", "white")
 
-<		 The optional {completion} argument specifies the type of
+<		The optional {completion} argument specifies the type of
 		completion supported for the input.  Without it completion is
 		not performed.	The supported completion types are the same as
 		that can be supplied to a user-defined command using the
@@ -3511,7 +3511,7 @@ input({opts})
 		more information.  Example: >vim
 			let fname = input("File: ", "", "file")
 
-<					*input()-highlight* *E5400* *E5402*
+<				       *input()-highlight* *E5400* *E5402*
 		The optional `highlight` key allows specifying function which
 		will be used for highlighting user input.  This function
 		receives user input as its only argument and must return
@@ -3637,7 +3637,7 @@ insert({object}, {item} [, {idx}])				      *insert()*
 			let mylist = insert([2, 3, 5], 1)
 			call insert(mylist, 4, -1)
 			call insert(mylist, 6, len(mylist))
-<		 The last example can be done simpler with |add()|.
+<		The last example can be done simpler with |add()|.
 		Note that when {item} is a |List| it is inserted as a single
 		item.  Use |extend()| to concatenate |Lists|.
 
@@ -3669,9 +3669,9 @@ isinf({expr})							       *isinf()*
 		Return 1 if {expr} is a positive infinity, or -1 a negative
 		infinity, otherwise 0. >vim
 			echo isinf(1.0 / 0.0)
-<			 1 >vim
+<			1 >vim
 			echo isinf(-1.0 / 0.0)
-<			 -1
+<			-1
 
 islocked({expr})					       *islocked()* *E786*
 		The result is a Number, which is |TRUE| when {expr} is the
@@ -3684,13 +3684,13 @@ islocked({expr})					       *islocked()* *E786*
 			echo islocked('alist')		" 1
 			echo islocked('alist[1]')	" 0
 
-<		 When {expr} is a variable that does not exist you get an error
+<		When {expr} is a variable that does not exist you get an error
 		message.  Use |exists()| to check for existence.
 
 isnan({expr})							       *isnan()*
 		Return |TRUE| if {expr} is a float with value NaN. >vim
 			echo isnan(0.0 / 0.0)
-<			 1
+<			1
 
 items({dict})							       *items()*
 		Return a |List| with all the key-value pairs of {dict}.  Each
@@ -3717,7 +3717,7 @@ jobstart({cmd} [, {opts}])					    *jobstart()*
 		If {cmd} is a List it runs directly (no 'shell').
 		If {cmd} is a String it runs in the 'shell', like this: >vim
 		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
-<		 (See |shell-unquoting| for details.)
+<		(See |shell-unquoting| for details.)
 
 		Example: >vim
 		  call jobstart('nvim -h', {'on_stdout':{j,d,e->append(line('.'),d)}})
@@ -3735,9 +3735,9 @@ jobstart({cmd} [, {opts}])					    *jobstart()*
 		  - cmd[0] must be an executable (not a "built-in"). If it is
 		    in $PATH it can be called by name, without an extension: >vim
 		      call jobstart(['ping', 'neovim.io'])
-<		     If it is a full or partial path, extension is required: >vim
+<		    If it is a full or partial path, extension is required: >vim
 		      call jobstart(['System32\ping.exe', 'neovim.io'])
-<		   - {cmd} is collapsed to a string of quoted args as expected
+<		  - {cmd} is collapsed to a string of quoted args as expected
 		    by CommandLineToArgvW https://msdn.microsoft.com/bb776391
 		    unless cmd[0] is some form of "cmd.exe".
 
@@ -3834,7 +3834,7 @@ join({list} [, {sep}])							*join()*
 		Note that {sep} is not added at the end.  You might want to
 		add it there too: >vim
 			let lines = join(mylist, "\n") .. "\n"
-<		 String items are used as-is.  |Lists| and |Dictionaries| are
+<		String items are used as-is.  |Lists| and |Dictionaries| are
 		converted into a string like with |string()|.
 		The opposite function is |split()|.
 
@@ -3874,7 +3874,7 @@ keytrans({string})						    *keytrans()*
 		can be used for |:map|.  E.g. >vim
 			let xx = "\<C-Home>"
 			echo keytrans(xx)
-<			<C-Home>
+<		       <C-Home>
 
 len({expr})							    *len()* *E701*
 		The result is a Number, which is the length of the argument.
@@ -3977,7 +3977,7 @@ line2byte({lnum})						   *line2byte()*
 		ignored.  This can also be used to get the byte count for the
 		line just below the last line: >vim
 			echo line2byte(line("$") + 1)
-<		 This is the buffer size plus one.  If 'fileencoding' is empty
+<		This is the buffer size plus one.  If 'fileencoding' is empty
 		it is the file size plus one.  {lnum} is used like with
 		|getline()|.  When {lnum} is invalid -1 is returned.
 		Also see |byte2line()|, |go| and |:goto|.
@@ -3994,7 +3994,7 @@ list2blob({list})						   *list2blob()*
 		Examples: >vim
 			echo list2blob([1, 2, 3, 4])	" returns 0z01020304
 			echo list2blob([])		" returns 0z
-<		 Returns an empty Blob on error.  If one of the numbers is
+<		Returns an empty Blob on error.  If one of the numbers is
 		negative or more than 255 error *E1239* is given.
 
 		|blob2list()| does the opposite.
@@ -4004,9 +4004,9 @@ list2str({list} [, {utf8}])					    *list2str()*
 		concatenate them all.  Examples: >vim
 			echo list2str([32])		" returns " "
 			echo list2str([65, 66, 67])	" returns "ABC"
-<		 The same can be done (slowly) with: >vim
+<		The same can be done (slowly) with: >vim
 			echo join(map(list, {nr, val -> nr2char(val)}), '')
-<		 |str2list()| does the opposite.
+<		|str2list()| does the opposite.
 
 		UTF-8 encoding is always used, {utf8} option has no effect,
 		and exists only for backwards-compatibility.
@@ -4026,9 +4026,9 @@ log({expr})								 *log()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo log(10)
-<			 2.302585 >vim
+<			2.302585 >vim
 			echo log(exp(5))
-<			 5.0
+<			5.0
 
 log10({expr})							       *log10()*
 		Return the logarithm of Float {expr} to base 10 as a |Float|.
@@ -4036,9 +4036,9 @@ log10({expr})							       *log10()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo log10(1000)
-<			 3.0 >vim
+<			3.0 >vim
 			echo log10(0.01)
-<			 -2.0
+<			-2.0
 
 luaeval({expr} [, {expr}])					     *luaeval()*
 		Evaluate Lua expression {expr} and return its result converted
@@ -4064,7 +4064,7 @@ map({expr1}, {expr2})							 *map()*
 		current character.
 		Example: >vim
 			call map(mylist, '"> " .. v:val .. " <"')
-<		 This puts "> " before and " <" after each item in "mylist".
+<		This puts "> " before and " <" after each item in "mylist".
 
 		Note that {expr2} is the result of an expression and is then
 		used as an expression again.  Often it is good to use a
@@ -4080,18 +4080,18 @@ map({expr1}, {expr2})							 *map()*
 			  return a:key .. '-' .. a:val
 			endfunc
 			call map(myDict, function('KeyValue'))
-<		 It is shorter when using a |lambda|: >vim
+<		It is shorter when using a |lambda|: >vim
 			call map(myDict, {key, val -> key .. '-' .. val})
-<		 If you do not use "val" you can leave it out: >vim
+<		If you do not use "val" you can leave it out: >vim
 			call map(myDict, {key -> 'item: ' .. key})
-<		 If you do not use "key" you can use a short name: >vim
+<		If you do not use "key" you can use a short name: >vim
 			call map(myDict, {_, val -> 'item: ' .. val})
 <
 		The operation is done in-place for a |List| and |Dictionary|.
 		If you want it to remain unmodified make a copy first: >vim
 			let tlist = map(copy(mylist), ' v:val .. "\t"')
 
-<		 Returns {expr1}, the |List| or |Dictionary| that was filtered,
+<		Returns {expr1}, the |List| or |Dictionary| that was filtered,
 		or a new |Blob| or |String|.
 		When an error is encountered while evaluating {expr2} no
 		further items in {expr1} are processed.
@@ -4200,7 +4200,7 @@ mapcheck({name} [, {mode} [, {abbr}]])				    *mapcheck()*
 			if mapcheck("_vv") == ""
 			   map _vv :set guifont=7x13<CR>
 			endif
-<		 This avoids adding the "_vv" mapping when there already is a
+<		This avoids adding the "_vv" mapping when there already is a
 		mapping for "_v" or for "_vvv".
 
 maplist([{abbr}])						     *maplist()*
@@ -4213,7 +4213,7 @@ maplist([{abbr}])						     *maplist()*
 			echo maplist()->filter({_, m ->
 				\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
 				\ })
-<		 It can be tricky to find mappings for particular |:map-modes|.
+<		It can be tricky to find mappings for particular |:map-modes|.
 		|mapping-dict|'s "mode_bits" can simplify this. For example,
 		the mode_bits for Normal, Insert or Command-line modes are
 		0x19. To find all the mappings available in those modes you
@@ -4225,7 +4225,7 @@ maplist([{abbr}])						     *maplist()*
 			    endif
 			endfor
 			echo saved_maps->mapnew({_, m -> m.lhs})
-<		 The values of the mode_bits are defined in Nvim's
+<		The values of the mode_bits are defined in Nvim's
 		src/nvim/state_defs.h file and they can be discovered at
 		runtime using |:map-commands| and "maplist()". Example: >vim
 			omap xyzzy <Nop>
@@ -4259,7 +4259,7 @@ mapset({mode}, {abbr}, {dict})					      *mapset()*
 			nnoremap K somethingelse
 			" ...
 			call mapset('n', 0, save_map)
-<		 Note that if you are going to replace a map in several modes,
+<		Note that if you are going to replace a map in several modes,
 		e.g. with `:map!`, you need to save/restore the mapping for
 		all of them, when they might differ.
 
@@ -4292,11 +4292,11 @@ match({expr}, {pat} [, {start} [, {count}]])			       *match()*
 		Example: >vim
 			echo match("testing", "ing")	" results in 4
 			echo match([1, 'x'], '\a')	" results in 1
-<		 See |string-match| for how {pat} is used.
+<		See |string-match| for how {pat} is used.
 								*strpbrk()*
 		Vim doesn't have a strpbrk() function.	But you can do: >vim
 			let sepidx = match(line, '[.,;: \t]')
-<								*strcasestr()*
+<							       *strcasestr()*
 		Vim doesn't have a strcasestr() function.  But you can add
 		"\c" to the pattern to ignore case: >vim
 			let idx = match(haystack, '\cneedle')
@@ -4306,11 +4306,11 @@ match({expr}, {pat} [, {start} [, {count}]])			       *match()*
 		The result, however, is still the index counted from the
 		first character/item.  Example: >vim
 			echo match("testing", "ing", 2)
-<		 result is again "4". >vim
+<		result is again "4". >vim
 			echo match("testing", "ing", 4)
-<		 result is again "4". >vim
+<		result is again "4". >vim
 			echo match("testing", "t", 2)
-<		 result is "3".
+<		result is "3".
 		For a String, if {start} > 0 then it is like the string starts
 		{start} bytes later, thus "^" will match at {start}.  Except
 		when {count} is given, then it's like matches before the
@@ -4325,7 +4325,7 @@ match({expr}, {pat} [, {start} [, {count}]])			       *match()*
 		is found in a String the search for the next one starts one
 		character further.  Thus this example results in 1: >vim
 			echo match("testing", "..", 0, 2)
-<		 In a |List| the search continues in the next item.
+<		In a |List| the search continues in the next item.
 		Note that when {count} is added the way {start} works changes,
 		see above.
 
@@ -4390,10 +4390,10 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		Example: >vim
 			highlight MyGroup ctermbg=green guibg=green
 			let m = matchadd("MyGroup", "TODO")
-<		 Deletion of the pattern: >vim
+<		Deletion of the pattern: >vim
 			call matchdelete(m)
 
-<		 A list of matches defined by |matchadd()| and |:match| are
+<		A list of matches defined by |matchadd()| and |:match| are
 		available from |getmatches()|.	All matches can be deleted in
 		one operation by |clearmatches()|.
 
@@ -4428,10 +4428,10 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])	 *matchaddpos()*
 		Example: >vim
 			highlight MyGroup ctermbg=green guibg=green
 			let m = matchaddpos("MyGroup", [[23, 24], 34])
-<		 Deletion of the pattern: >vim
+<		Deletion of the pattern: >vim
 			call matchdelete(m)
 
-<		 Matches added by |matchaddpos()| are returned by
+<		Matches added by |matchaddpos()| are returned by
 		|getmatches()|.
 
 matcharg({nr})							    *matcharg()*
@@ -4458,19 +4458,19 @@ matchend({expr}, {pat} [, {start} [, {count}]])			    *matchend()*
 		Same as |match()|, but return the index of first character
 		after the match.  Example: >vim
 			echo matchend("testing", "ing")
-<		 results in "7".
+<		results in "7".
 							*strspn()* *strcspn()*
 		Vim doesn't have a strspn() or strcspn() function, but you can
 		do it with matchend(): >vim
 			let span = matchend(line, '[a-zA-Z]')
 			let span = matchend(line, '[^a-zA-Z]')
-<		 Except that -1 is returned when there are no matches.
+<		Except that -1 is returned when there are no matches.
 
 		The {start}, if given, has the same meaning as for |match()|. >vim
 			echo matchend("testing", "ing", 2)
-<		 results in "7". >vim
+<		results in "7". >vim
 			echo matchend("testing", "ing", 5)
-<		 result is "-1".
+<		result is "-1".
 		When {expr} is a |List| the result is equal to |match()|.
 
 matchfuzzy({list}, {str} [, {dict}])				  *matchfuzzy()*
@@ -4516,25 +4516,25 @@ matchfuzzy({list}, {str} [, {dict}])				  *matchfuzzy()*
 
 		Example: >vim
 		   echo matchfuzzy(["clay", "crow"], "cay")
-<		 results in ["clay"]. >vim
+<		results in ["clay"]. >vim
 		   echo getbufinfo()->map({_, v -> v.name})->matchfuzzy("ndl")
-<		 results in a list of buffer names fuzzy matching "ndl". >vim
+<		results in a list of buffer names fuzzy matching "ndl". >vim
 		   echo getbufinfo()->matchfuzzy("ndl", {'key' : 'name'})
-<		 results in a list of buffer information dicts with buffer
+<		results in a list of buffer information dicts with buffer
 		names fuzzy matching "ndl". >vim
 		   echo getbufinfo()->matchfuzzy("spl",
 						\ {'text_cb' : {v -> v.name}})
-<		 results in a list of buffer information dicts with buffer
+<		results in a list of buffer information dicts with buffer
 		names fuzzy matching "spl". >vim
 		   echo v:oldfiles->matchfuzzy("test")
-<		 results in a list of file names fuzzy matching "test". >vim
+<		results in a list of file names fuzzy matching "test". >vim
 		   let l = readfile("buffer.c")->matchfuzzy("str")
-<		 results in a list of lines in "buffer.c" fuzzy matching "str". >vim
+<		results in a list of lines in "buffer.c" fuzzy matching "str". >vim
 		   echo ['one two', 'two one']->matchfuzzy('two one')
-<		 results in `['two one', 'one two']` . >vim
+<		results in `['two one', 'one two']` . >vim
 		   echo ['one two', 'two one']->matchfuzzy('two one',
 						\ {'matchseq': 1})
-<		 results in `['two one']`.
+<		results in `['two one']`.
 
 matchfuzzypos({list}, {str} [, {dict}])			       *matchfuzzypos()*
 		Same as |matchfuzzy()|, but returns the list of matched
@@ -4551,12 +4551,12 @@ matchfuzzypos({list}, {str} [, {dict}])			       *matchfuzzypos()*
 
 		Example: >vim
 			echo matchfuzzypos(['testing'], 'tsg')
-<		 results in [["testing"], [[0, 2, 6]], [99]] >vim
+<		results in [["testing"], [[0, 2, 6]], [99]] >vim
 			echo matchfuzzypos(['clay', 'lacy'], 'la')
-<		 results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
+<		results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
 			echo [{'text': 'hello', 'id' : 10}]
 				\ ->matchfuzzypos('ll', {'key' : 'text'})
-<		 results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
+<		results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 
 matchlist({expr}, {pat} [, {start} [, {count}]])		   *matchlist()*
 		Same as |match()|, but return a |List|.  The first item in the
@@ -4565,7 +4565,7 @@ matchlist({expr}, {pat} [, {start} [, {count}]])		   *matchlist()*
 		in |:substitute|.  When an optional submatch didn't match an
 		empty string is used.  Example: >vim
 			echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
-<		 Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
+<		Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
 		When there is no match an empty list is returned.
 
 		You can pass in a List, but that is not very useful.
@@ -4573,13 +4573,13 @@ matchlist({expr}, {pat} [, {start} [, {count}]])		   *matchlist()*
 matchstr({expr}, {pat} [, {start} [, {count}]])			    *matchstr()*
 		Same as |match()|, but return the matched string.  Example: >vim
 			echo matchstr("testing", "ing")
-<		 results in "ing".
+<		results in "ing".
 		When there is no match "" is returned.
 		The {start}, if given, has the same meaning as for |match()|. >vim
 			echo matchstr("testing", "ing", 2)
-<		 results in "ing". >vim
+<		results in "ing". >vim
 			echo matchstr("testing", "ing", 5)
-<		 result is "".
+<		result is "".
 		When {expr} is a |List| then the matching item is returned.
 		The type isn't changed, it's not necessarily a String.
 
@@ -4587,25 +4587,25 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])		 *matchstrpos()*
 		Same as |matchstr()|, but return the matched string, the start
 		position and the end position of the match.  Example: >vim
 			echo matchstrpos("testing", "ing")
-<		 results in ["ing", 4, 7].
+<		results in ["ing", 4, 7].
 		When there is no match ["", -1, -1] is returned.
 		The {start}, if given, has the same meaning as for |match()|. >vim
 			echo matchstrpos("testing", "ing", 2)
-<		 results in ["ing", 4, 7]. >vim
+<		results in ["ing", 4, 7]. >vim
 			echo matchstrpos("testing", "ing", 5)
-<		 result is ["", -1, -1].
+<		result is ["", -1, -1].
 		When {expr} is a |List| then the matching item, the index
 		of first item where {pat} matches, the start position and the
 		end position of the match are returned. >vim
 			echo matchstrpos([1, '__x'], '\a')
-<		 result is ["x", 1, 2, 3].
+<		result is ["x", 1, 2, 3].
 		The type isn't changed, it's not necessarily a String.
 
 max({expr})								 *max()*
 		Return the maximum value of all items in {expr}. Example: >vim
 			echo max([apples, pears, oranges])
 
-<		 {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+<		{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
 		it returns the maximum of all values in the Dictionary.
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
@@ -4629,7 +4629,7 @@ menu_get({path} [, {modes}])					    *menu_get()*
 			vnoremenu Test.Test x
 			echo menu_get("")
 
-<		 returns something like this: >
+<		returns something like this: >
 
 			[ {
 			  "hidden": 0,
@@ -4730,7 +4730,7 @@ min({expr})								 *min()*
 		Return the minimum value of all items in {expr}. Example: >vim
 			echo min([apples, pears, oranges])
 
-<		 {expr} can be a |List| or a |Dictionary|.  For a Dictionary,
+<		{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
 		it returns the minimum of all values in the Dictionary.
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
@@ -4752,12 +4752,12 @@ mkdir({name} [, {flags} [, {prot}]])				  *mkdir()* *E739*
 		If {flags} contains "R" then {name} is deleted recursively at
 		the end of the current function, as with: >vim
 			defer delete({name}, 'rf')
-<		 Note that when {name} has more than one part and "p" is used
+<		Note that when {name} has more than one part and "p" is used
 		some directories may already exist.  Only the first one that
 		is created and what it contains is scheduled to be deleted.
 		E.g. when using: >vim
 			call mkdir('subdir/tmp/autoload', 'pR')
-<		 and "subdir" already exists then "subdir/tmp" will be
+<		and "subdir" already exists then "subdir/tmp" will be
 		scheduled for deletion, like with: >vim
 			defer delete('subdir/tmp', 'rf')
 <
@@ -4770,7 +4770,7 @@ mkdir({name} [, {flags} [, {prot}]])				  *mkdir()* *E739*
 		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
 			call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
-<		 This function is not available in the |sandbox|.
+<		This function is not available in the |sandbox|.
 
 		If you try to create an existing directory with {flags} set to
 		"p" mkdir() will silently exit.
@@ -4838,7 +4838,7 @@ msgpackdump({list} [, {type}])					 *msgpackdump()*
 		|readfile()|-style list. When {type} contains "B", a |Blob| is
 		returned instead. Example: >vim
 			call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
-<		 or, using a |Blob|: >vim
+<		or, using a |Blob|: >vim
 			call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
 <
 		This will write the single 0x80 byte to a `fname.mpack` file
@@ -4859,7 +4859,7 @@ msgpackparse({data})						*msgpackparse()*
 			let fname = expand('~/.config/nvim/shada/main.shada')
 			let mpack = readfile(fname, 'b')
 			let shada_objects = msgpackparse(mpack)
-<		 This will read ~/.config/nvim/shada/main.shada file to
+<		This will read ~/.config/nvim/shada/main.shada file to
 		`shada_objects` list.
 
 		Limitations:
@@ -4893,7 +4893,7 @@ msgpackparse({data})						*msgpackparse()*
 				_VAL[0] * ((_VAL[1] << 62)
 					   & (_VAL[2] << 31)
 					   & _VAL[3])
-<			Special dictionary with this type will appear in
+<		       Special dictionary with this type will appear in
 			|msgpackparse()| output under one of the following
 			circumstances:
 			1. |Number| is 32-bit and value is either above
@@ -4929,7 +4929,7 @@ nextnonblank({lnum})						*nextnonblank()*
 		Return the line number of the first line at or below {lnum}
 		that is not blank.  Example: >vim
 			if getline(nextnonblank(1)) =~ "Java" | endif
-<		 When {lnum} is invalid or there is no non-blank line at or
+<		When {lnum} is invalid or there is no non-blank line at or
 		below it, zero is returned.
 		{lnum} is used like with |getline()|.
 		See also |prevnonblank()|.
@@ -4939,7 +4939,7 @@ nr2char({expr} [, {utf8}])					     *nr2char()*
 		value {expr}.  Examples: >vim
 			echo nr2char(64)		" returns '@'
 			echo nr2char(32)		" returns ' '
-<		 Example for "utf-8": >vim
+<		Example for "utf-8": >vim
 			echo nr2char(300)		" returns I with bow character
 <
 		UTF-8 encoding is always used, {utf8} option has no effect,
@@ -4967,7 +4967,7 @@ or({expr}, {expr})							  *or()*
 		Example: >vim
 			let bits = or(bits, 0x80)
 
-<		 Rationale: The reason this is a function and not using the "|"
+<		Rationale: The reason this is a function and not using the "|"
 		character like many languages, is that Vi has always used "|"
 		to separate commands.  In many places it would not be clear if
 		"|" is an operator or a command separator.
@@ -4979,10 +4979,10 @@ pathshorten({path} [, {len}])					 *pathshorten()*
 		If {len} is omitted or smaller than 1 then 1 is used (single
 		letters).  Leading '~' and '.' characters are kept.  Examples: >vim
 			echo pathshorten('~/.config/nvim/autoload/file1.vim')
-<			~/.c/n/a/file1.vim ~
+<		       ~/.c/n/a/file1.vim ~
 >vim
 			echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
-<			~/.co/nv/au/file2.vim ~
+<		       ~/.co/nv/au/file2.vim ~
 		It doesn't matter if the path exists or not.
 		Returns an empty string on error.
 
@@ -4999,7 +4999,7 @@ perleval({expr})						    *perleval()*
 		reference to it.
 		Example: >vim
 			echo perleval('[1 .. 4]')
-<			[1, 2, 3, 4]
+<		       [1, 2, 3, 4]
 
 pow({x}, {y})								 *pow()*
 		Return the power of {x} to the exponent {y} as a |Float|.
@@ -5007,17 +5007,17 @@ pow({x}, {y})								 *pow()*
 		Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo pow(3, 3)
-<			 27.0 >vim
+<			27.0 >vim
 			echo pow(2, 16)
-<			 65536.0 >vim
+<			65536.0 >vim
 			echo pow(32, 0.20)
-<			 2.0
+<			2.0
 
 prevnonblank({lnum})						*prevnonblank()*
 		Return the line number of the first line at or above {lnum}
 		that is not blank.  Example: >vim
 			let ind = indent(prevnonblank(v:lnum - 1))
-<		 When {lnum} is invalid or there is no non-blank line at or
+<		When {lnum} is invalid or there is no non-blank line at or
 		above it, zero is returned.
 		{lnum} is used like with |getline()|.
 		Also see |nextnonblank()|.
@@ -5026,7 +5026,7 @@ printf({fmt}, {expr1} ...)					      *printf()*
 		Return a String with {fmt}, where "%" items are replaced by
 		the formatted form of their respective arguments.  Example: >vim
 			echo printf("%4d: E%d %.30s", lnum, errno, msg)
-<		 May result in:
+<		May result in:
 			"  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 
 		When used as a |method| the base is passed as the second
@@ -5136,7 +5136,7 @@ printf({fmt}, {expr1} ...)					      *printf()*
 		followed by a positive field width; a negative precision is
 		treated as though it were missing.  Example: >vim
 			echo printf("%d: %.*s", nr, width, line)
-<		 This limits the length of the text used from "line" to
+<		This limits the length of the text used from "line" to
 		"width" bytes.
 
 		If the argument to be formatted is specified using a
@@ -5203,7 +5203,7 @@ printf({fmt}, {expr1} ...)					      *printf()*
 			 "0.0 / 0.0" results in "nan" with %f (NAN with %F).
 			Example: >vim
 				echo printf("%.2f", 12.115)
-<				12.12
+<			       12.12
 			Note that roundoff depends on the system libraries.
 			Use |round()| when in doubt.
 
@@ -5254,85 +5254,85 @@ printf({fmt}, {expr1} ...)					      *printf()*
 		    echo printf(
 			"In The Netherlands, vim's creator's name is: %1$s %2$s",
 			"Bram", "Moolenaar")
-<		     In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
+<		    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
 		    echo printf(
 			"In Belgium, vim's creator's name is: %2$s %1$s",
 			"Bram", "Moolenaar")
-<		     In Belgium, vim's creator's name is: Moolenaar Bram
+<		    In Belgium, vim's creator's name is: Moolenaar Bram
 
 		Width (and precision) can be specified using the '*' specifier.
 		In this case, you must specify the field width position in the
 		argument list. >vim
 
 		    echo printf("%1$*2$.*3$d", 1, 2, 3)
-<		     001 >vim
+<		    001 >vim
 		    echo printf("%2$*3$.*1$d", 1, 2, 3)
-<		       2 >vim
+<		      2 >vim
 		    echo printf("%3$*1$.*2$d", 1, 2, 3)
-<		     03 >vim
+<		    03 >vim
 		    echo printf("%1$*2$.*3$g", 1.4142, 2, 3)
-<		     1.414
+<		    1.414
 
 		You can mix specifying the width and/or precision directly
 		and via positional arguments: >vim
 
 		    echo printf("%1$4.*2$f", 1.4142135, 6)
-<		     1.414214 >vim
+<		    1.414214 >vim
 		    echo printf("%1$*2$.4f", 1.4142135, 6)
-<		     1.4142 >vim
+<		    1.4142 >vim
 		    echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
-<		       1.41
+<		      1.41
 
 							*E1500*
 		You cannot mix positional and non-positional arguments: >vim
 		    echo printf("%s%1$s", "One", "Two")
-<		     E1500: Cannot mix positional and non-positional arguments:
+<		    E1500: Cannot mix positional and non-positional arguments:
 		    %s%1$s
 
 							*E1501*
 		You cannot skip a positional argument in a format string: >vim
 		    echo printf("%3$s%1$s", "One", "Two", "Three")
-<		     E1501: format argument 2 unused in $-style format:
+<		    E1501: format argument 2 unused in $-style format:
 		    %3$s%1$s
 
 							*E1502*
 		You can re-use a [field-width] (or [precision]) argument: >vim
 		    echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
-<		     1 at width 2 is: 01
+<		    1 at width 2 is: 01
 
 		However, you can't use it as a different type: >vim
 		    echo printf("%1$d at width %2$ld is: %01$*2$d", 1, 2)
-<		     E1502: Positional argument 2 used as field width reused as
+<		    E1502: Positional argument 2 used as field width reused as
 		    different type: long int/int
 
 							*E1503*
 		When a positional argument is used, but not the correct number
 		or arguments is given, an error is raised: >vim
 		    echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
-<		     E1503: Positional argument 3 out of bounds: %1$d at width
+<		    E1503: Positional argument 3 out of bounds: %1$d at width
 		    %2$d is: %01$*2$.*3$d
 
 		Only the first error is reported: >vim
 		    echo printf("%01$*2$.*3$d %4$d", 1, 2)
-<		     E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
+<		    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
 		    %4$d
 
 							*E1504*
 		A positional argument can be used more than once: >vim
 		    echo printf("%1$s %2$s %1$s", "One", "Two")
-<		     One Two One
+<		    One Two One
 
 		However, you can't use a different type the second time: >vim
 		    echo printf("%1$s %2$s %1$d", "One", "Two")
-<		     E1504: Positional argument 1 type used inconsistently:
+<		    E1504: Positional argument 1 type used inconsistently:
 		    int/string
 
 							*E1505*
 		Various other errors that lead to a format string being
 		wrongly formatted lead to: >vim
 		    echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
-<		     E1505: Invalid format specifier: %1$d at width %2$d is:
+<		    E1505: Invalid format specifier: %1$d at width %2$d is:
 		    %01$*2$.3$d
 
 							*E1507*
@@ -5480,17 +5480,17 @@ readblob({fname} [, {offset} [, {size}]])			    *readblob()*
 		offset.  If it is a negative value, it is used as an offset
 		from the end of the file.  E.g., to read the last 12 bytes: >vim
 			echo readblob('file.bin', -12)
-<		 If {size} is specified, only the specified size will be read.
+<		If {size} is specified, only the specified size will be read.
 		E.g. to read the first 100 bytes of a file: >vim
 			echo readblob('file.bin', 0, 100)
-<		 If {size} is -1 or omitted, the whole data starting from
+<		If {size} is -1 or omitted, the whole data starting from
 		{offset} will be read.
 		This can be also used to read the data from a character device
 		on Unix when {size} is explicitly set.	Only if the device
 		supports seeking {offset} can be used.	Otherwise it should be
 		zero.  E.g. to read 10 bytes from a serial console: >vim
 			echo readblob('/dev/ttyS0', 0, 10)
-<		 When the file can't be opened an error message is given and
+<		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
 		When the offset is beyond the end of the file the result is an
 		empty blob.
@@ -5515,10 +5515,10 @@ readdir({directory} [, {expr}])					     *readdir()*
 		When {expr} is a function the name is passed as the argument.
 		For example, to get a list of files ending in ".txt": >vim
 		  echo readdir(dirname, {n -> n =~ '.txt$'})
-<		 To skip hidden and backup files: >vim
+<		To skip hidden and backup files: >vim
 		  echo readdir(dirname, {n -> n !~ '^\.\|\~$'})
 
-<		 If you want to get a directory tree: >vim
+<		If you want to get a directory tree: >vim
 		  function! s:tree(dir)
 		      return {a:dir : map(readdir(a:dir),
 		      \ {_, x -> isdirectory(x) ?
@@ -5548,7 +5548,7 @@ readfile({fname} [, {type} [, {max}]])				    *readfile()*
 			for line in readfile(fname, '', 10)
 			  if line =~ 'Date' | echo line | endif
 			endfor
-<		 When {max} is negative -{max} lines from the end of the file
+<		When {max} is negative -{max} lines from the end of the file
 		are returned, or as many as there are.
 		When {max} is zero the result is an empty list.
 		Note that without {max} the whole file is read into memory.
@@ -5632,11 +5632,11 @@ reltimestr({time})						  *reltimestr()*
 			let start = reltime()
 			call MyFunction()
 			echo reltimestr(reltime(start))
-<		 Note that overhead for the commands will be added to the time.
+<		Note that overhead for the commands will be added to the time.
 		Leading spaces are used to make the string align nicely.  You
 		can use split() to remove it. >vim
 			echo split(reltimestr(reltime(start)))[0]
-<		 Also see |profiling|.
+<		Also see |profiling|.
 		If there is an error an empty string is returned
 
 remove({list}, {idx})
@@ -5672,7 +5672,7 @@ remove({dict}, {key})
 		Remove the entry from {dict} with key {key} and return it.
 		Example: >vim
 			echo "removed " .. remove(dict, "one")
-<		 If there is no {key} in {dict} this is an error.
+<		If there is no {key} in {dict} this is an error.
 		Returns zero on error.
 
 rename({from}, {to})						      *rename()*
@@ -5687,11 +5687,11 @@ repeat({expr}, {count})						      *repeat()*
 		Repeat {expr} {count} times and return the concatenated
 		result.  Example: >vim
 			let separator = repeat('-', 80)
-<		 When {count} is zero or negative the result is empty.
+<		When {count} is zero or negative the result is empty.
 		When {expr} is a |List| or a |Blob| the result is {expr}
 		concatenated {count} times.  Example: >vim
 			let longlist = repeat(['a', 'b'], 3)
-<		 Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+<		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
 resolve({filename})						*resolve()* *E655*
 		On MS-Windows, when {filename} is a shortcut (a .lnk file),
@@ -5724,11 +5724,11 @@ round({expr})							       *round()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo round(0.456)
-<			 0.0  >vim
+<			0.0  >vim
 			echo round(4.5)
-<			 5.0 >vim
+<			5.0 >vim
 			echo round(-4.5)
-<			 -5.0
+<			-5.0
 
 rpcnotify({channel}, {event} [, {args}...])			   *rpcnotify()*
 		Sends {event} to {channel} via |RPC| and returns immediately.
@@ -5745,7 +5745,7 @@ rpcrequest({channel}, {method} [, {args}...])			  *rpcrequest()*
 rpcstart({prog} [, {argv}])					    *rpcstart()*
 		Deprecated. Replace  >vim
 			let id = rpcstart('prog', ['arg1', 'arg2'])
-<		 with >vim
+<		with >vim
 			let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 <
 rubyeval({expr})						    *rubyeval()*
@@ -5879,7 +5879,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		search to a range of lines.  Examples: >vim
 			let match = search('(', 'b', line("w0"))
 			let end = search('END', '', line("w$"))
-<		 When {stopline} is used and it is not zero this also implies
+<		When {stopline} is used and it is not zero this also implies
 		that the search does not wrap around the end of the file.
 		A zero value is equal to not giving the argument.
 
@@ -5925,7 +5925,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 <
 		Example for using some flags: >vim
 		    echo search('\<if\|\(else\)\|\(endif\)', 'ncpe')
-<		 This will search for the keywords "if", "else", and "endif"
+<		This will search for the keywords "if", "else", and "endif"
 		under or after the cursor.  Because of the 'p' flag, it
 		returns 1, 2, or 3 depending on which keyword is found, or 0
 		if the search fails.  With the cursor on the first word of the
@@ -6039,7 +6039,7 @@ searchcount([{options}])					 *searchcount()*
 						below command is executed
 						before calling this function >vim
 						  let @/ = pattern
-<						(default: |@/|)
+<					       (default: |@/|)
 		  timeout	|Number|	  0 or negative number is no
 						timeout. timeout milliseconds
 						for recomputing the result
@@ -6093,7 +6093,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
 		direction, but only when not in a nested start-end pair.  A
 		typical use is: >vim
 			echo searchpair('\<if\>', '\<else\>', '\<endif\>')
-<		 By leaving {middle} empty the "else" is skipped.
+<		By leaving {middle} empty the "else" is skipped.
 
 		{flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
 		|search()|.  Additionally:
@@ -6127,7 +6127,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
 			  if 2
 			  endif 2
 			endif 1
-<		 When starting at the "if 2", with the cursor on the "i", and
+<		When starting at the "if 2", with the cursor on the "i", and
 		searching forwards, the "endif 2" is found.  When starting on
 		the character just before the "if 2", the "endif 1" will be
 		found.	That's because the "if 2" will be found first, and
@@ -6143,7 +6143,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
 			echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
 			\ 'getline(".") =~ "^\\s*\""')
 
-<		 The cursor must be at or after the "if" for which a match is
+<		The cursor must be at or after the "if" for which a match is
 		to be found.  Note that single-quote strings are used to avoid
 		having to double the backslashes.  The skip expression only
 		catches comments at the start of a line, not after a command.
@@ -6153,7 +6153,7 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
 
 			echo searchpair('{', '', '}', 'bW')
 
-<		 This works when the cursor is at or before the "}" for which a
+<		This works when the cursor is at or before the "}" for which a
 		match is to be found.  To reject matches that syntax
 		highlighting recognized as strings: >vim
 
@@ -6182,10 +6182,10 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		Example: >vim
 			let [lnum, col] = searchpos('mypattern', 'n')
 
-<		 When the 'p' flag is given then there is an extra item with
+<		When the 'p' flag is given then there is an extra item with
 		the sub-pattern match number |search()-sub-match|.  Example: >vim
 			let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
-<		 In this example "submatch" is 2 when a lowercase letter is
+<		In this example "submatch" is 2 when a lowercase letter is
 		found |/\l|, 3 when an uppercase letter is found |/\u|.
 
 serverlist()							  *serverlist()*
@@ -6209,15 +6209,15 @@ serverstart([{address}])					 *serverstart()*
 		  - If {address} has no slashes ("/") it is treated as the
 		    "name" part of a generated path in this format: >vim
 			stdpath("run").."/{name}.{pid}.{counter}"
-<		   - If {address} is omitted the name is "nvim". >vim
+<		  - If {address} is omitted the name is "nvim". >vim
 			echo serverstart()
-<		  >
+<		 >
 			=> /tmp/nvim.bram/oknANW/nvim.15430.5
 <
 		Example bash command to list all Nvim servers: >bash
 			ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
 
-<		 Example named pipe: >vim
+<		Example named pipe: >vim
 			if has('win32')
 			  echo serverstart('\\.\pipe\nvim-pipe-1234')
 			else
@@ -6270,7 +6270,7 @@ setbufvar({buf}, {varname}, {val})				   *setbufvar()*
 		Examples: >vim
 			call setbufvar(1, "&mod", 1)
 			call setbufvar("todo", "myvar", "foobar")
-<		 This function is not available in the |sandbox|.
+<		This function is not available in the |sandbox|.
 
 setcellwidths({list})					       *setcellwidths()*
 		Specify overrides for cell widths of character ranges.	This
@@ -6282,7 +6282,7 @@ setcellwidths({list})					       *setcellwidths()*
 				\ [0x2194, 0x2199, 2],
 				\ ])
 
-<		 The {list} argument is a List of Lists with each three
+<		The {list} argument is a List of Lists with each three
 		numbers: [{low}, {high}, {width}].	*E1109* *E1110*
 		{low} and {high} can be the same, in which case this refers to
 		one character.	Otherwise it is the range of characters from
@@ -6300,7 +6300,7 @@ setcellwidths({list})					       *setcellwidths()*
 		To clear the overrides pass an empty {list}: >vim
 		   call setcellwidths([])
 
-<		 You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
+<		You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
 		the effect for known emoji characters.	Move the cursor
 		through the text to check if the cell widths of your terminal
 		match with what Vim knows about each emoji.  If it doesn't
@@ -6313,9 +6313,9 @@ setcharpos({expr}, {list})					  *setcharpos()*
 		Example:
 		With the text "여보세요" in line 8: >vim
 			call setcharpos('.', [0, 8, 4, 0])
-<		 positions the cursor on the fourth character '요'. >vim
+<		positions the cursor on the fourth character '요'. >vim
 			call setpos('.', [0, 8, 4, 0])
-<		 positions the cursor on the second character '보'.
+<		positions the cursor on the second character '보'.
 
 setcharsearch({dict})					       *setcharsearch()*
 		Set the current character search information to {dict},
@@ -6335,7 +6335,7 @@ setcharsearch({dict})					       *setcharsearch()*
 			let prevsearch = getcharsearch()
 			" Perform a command which clobbers user's search
 			call setcharsearch(prevsearch)
-<		 Also see |getcharsearch()|.
+<		Also see |getcharsearch()|.
 
 setcmdline({str} [, {pos}])					  *setcmdline()*
 		Set the command line to {str} and set the cursor position to
@@ -6367,15 +6367,15 @@ setcursorcharpos({list})				    *setcursorcharpos()*
 		Example:
 		With the text "여보세요" in line 4: >vim
 			call setcursorcharpos(4, 3)
-<		 positions the cursor on the third character '세'. >vim
+<		positions the cursor on the third character '세'. >vim
 			call cursor(4, 3)
-<		 positions the cursor on the first character '여'.
+<		positions the cursor on the first character '여'.
 
 setenv({name}, {val})						      *setenv()*
 		Set environment variable {name} to {val}.  Example: >vim
 			call setenv('HOME', '/home/myhome')
 
-<		 When {val} is |v:null| the environment variable is deleted.
+<		When {val} is |v:null| the environment variable is deleted.
 		See also |expr-env|.
 
 setfperm({fname}, {mode})				      *setfperm()* *chmod*
@@ -6413,15 +6413,15 @@ setline({lnum}, {text})						     *setline()*
 		Example: >vim
 			call setline(5, strftime("%c"))
 
-<		 When {text} is a |List| then line {lnum} and following lines
+<		When {text} is a |List| then line {lnum} and following lines
 		will be set to the items in the list.  Example: >vim
 			call setline(5, ['aaa', 'bbb', 'ccc'])
-<		 This is equivalent to: >vim
+<		This is equivalent to: >vim
 			for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
 			  call setline(n, l)
 			endfor
 
-<		 Note: The '[ and '] marks are not set.
+<		Note: The '[ and '] marks are not set.
 
 setloclist({nr}, {list} [, {action} [, {what}]])		  *setloclist()*
 		Create or replace or add to the location list for window {nr}.
@@ -6648,16 +6648,16 @@ setreg({regname}, {value} [, {options}])			      *setreg()*
 			call setreg('a', "1\n2\n3", 'b5')
 			call setreg('"', { 'points_to': 'a'})
 
-<		 This example shows using the functions to save and restore a
+<		This example shows using the functions to save and restore a
 		register: >vim
 			let var_a = getreginfo()
 			call setreg('a', var_a)
-<		 or: >vim
+<		or: >vim
 			let var_a = getreg('a', 1, 1)
 			let var_amode = getregtype('a')
 			" ....
 			call setreg('a', var_a, var_amode)
-<		 Note: you may not reliably restore register value
+<		Note: you may not reliably restore register value
 		without using the third argument to |getreg()| as without it
 		newlines are represented as newlines AND Nul bytes are
 		represented as newlines as well, see |NL-used-for-Nul|.
@@ -6688,7 +6688,7 @@ settabwinvar({tabnr}, {winnr}, {varname}, {val})		*settabwinvar()*
 		Examples: >vim
 			call settabwinvar(1, 1, "&list", 0)
 			call settabwinvar(3, 2, "myvar", "foobar")
-<		 This function is not available in the |sandbox|.
+<		This function is not available in the |sandbox|.
 
 settagstack({nr}, {dict} [, {action}])				 *settagstack()*
 		Modify the tag stack of the window {nr} using {dict}.
@@ -6717,7 +6717,7 @@ settagstack({nr}, {dict} [, {action}])				 *settagstack()*
 		    Empty the tag stack of window 3: >vim
 			call settagstack(3, {'items' : []})
 
-<		     Save and restore the tag stack: >vim
+<		    Save and restore the tag stack: >vim
 			let stack = gettagstack(1003)
 			" do something else
 			call settagstack(1003, stack)
@@ -6759,10 +6759,10 @@ shellescape({string} [, {special}])				 *shellescape()*
 
 		Example of use with a |:!| command: >vim
 		    exe '!dir ' .. shellescape(expand('<cfile>'), 1)
-<		 This results in a directory listing for the file under the
+<		This results in a directory listing for the file under the
 		cursor.  Example of use with |system()|: >vim
 		    call system("chmod +w -- " .. shellescape(expand("%")))
-<		 See also |::S|.
+<		See also |::S|.
 
 shiftwidth([{col}])						  *shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
@@ -6778,7 +6778,7 @@ shiftwidth([{col}])						  *shiftwidth()*
 			    return &sw
 			  endfunc
 			endif
-<		 And then use s:sw() instead of &sw.
+<		And then use s:sw() instead of &sw.
 
 		When there is one argument {col} this is used as column number
 		for which to return the 'shiftwidth' value. This matters for the
@@ -7151,7 +7151,7 @@ simplify({filename})						    *simplify()*
 		standard).
 		Example: >vim
 			simplify("./dir/.././/file/") == "./file/"
-<		 Note: The combination "dir/.." is only removed if "dir" is
+<		Note: The combination "dir/.." is only removed if "dir" is
 		a searchable directory or does not exist.  On Unix, it is also
 		removed when "dir" is a symbolic link within the same
 		directory.  In order to resolve all the involved symbolic
@@ -7163,9 +7163,9 @@ sin({expr})								 *sin()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo sin(100)
-<			 -0.506366 >vim
+<			-0.506366 >vim
 			echo sin(-4.01)
-<			 0.763301
+<			0.763301
 
 sinh({expr})								*sinh()*
 		Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -7174,9 +7174,9 @@ sinh({expr})								*sinh()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo sinh(0.5)
-<			0.521095 >vim
+<		       0.521095 >vim
 			echo sinh(-0.9)
-<			-1.026517
+<		       -1.026517
 
 slice({expr}, {start} [, {end}])				       *slice()*
 		Similar to using a |slice| "expr[start : end]", but "end" is
@@ -7218,7 +7218,7 @@ sort({list} [, {how} [, {dict}]])				   *sort()* *E702*
 		If you want a list to remain unmodified make a copy first: >vim
 			let sortedlist = sort(copy(mylist))
 
-<		 When {how} is omitted or is a string, then sort() uses the
+<		When {how} is omitted or is a string, then sort() uses the
 		string representation of each item to sort on.	Numbers sort
 		after Strings, |Lists| after Numbers.  For sorting text in the
 		current buffer use |:sort|.
@@ -7236,12 +7236,12 @@ sort({list} [, {how} [, {dict}]])				   *sort()* *E702*
 			" ö is sorted similarly to o with English locale.
 			language collate en_US.UTF8
 			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<			 ['n', 'o', 'O', 'ö', 'p', 'z'] ~
+<			['n', 'o', 'O', 'ö', 'p', 'z'] ~
 >vim
 			" ö is sorted after z with Swedish locale.
 			language collate sv_SE.UTF8
 			echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-<			 ['n', 'o', 'O', 'p', 'z', 'ö'] ~
+<			['n', 'o', 'O', 'p', 'z', 'ö'] ~
 		This does not work properly on Mac.
 
 		When {how} is given and it is 'n' then all items will be
@@ -7276,12 +7276,12 @@ sort({list} [, {how} [, {dict}]])				   *sort()* *E702*
 			   return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
 			endfunc
 			eval mylist->sort("MyCompare")
-<		 A shorter compare version for this specific simple case, which
+<		A shorter compare version for this specific simple case, which
 		ignores overflow: >vim
 			func MyCompare(i1, i2)
 			   return a:i1 - a:i2
 			endfunc
-<		 For a simple expression you can use a lambda: >vim
+<		For a simple expression you can use a lambda: >vim
 			eval mylist->sort({i1, i2 -> i1 - i2})
 <
 soundfold({word})						   *soundfold()*
@@ -7311,7 +7311,7 @@ spellbadword([{sentence}])					*spellbadword()*
 			"caps"		word should start with Capital
 		Example: >vim
 			echo spellbadword("the quik brown fox")
-<			 ['quik', 'bad'] ~
+<			['quik', 'bad'] ~
 
 		The spelling information for the current window and the value
 		of 'spelllang' are used.
@@ -7350,17 +7350,17 @@ split({string} [, {pattern} [, {keepempty}]])			       *split()*
 		character or when {keepempty} is non-zero.
 		Example: >vim
 			let words = split(getline('.'), '\W\+')
-<		 To split a string in individual characters: >vim
+<		To split a string in individual characters: >vim
 			for c in split(mystring, '\zs') | endfor
-<		 If you want to keep the separator you can also use '\zs' at
+<		If you want to keep the separator you can also use '\zs' at
 		the end of the pattern: >vim
 			echo split('abc:def:ghi', ':\zs')
-<		  >
+<		 >
 			['abc:', 'def:', 'ghi']
 <
 		Splitting a table where the first element can be empty: >vim
 			let items = split(line, ':', 1)
-<		 The opposite function is |join()|.
+<		The opposite function is |join()|.
 
 sqrt({expr})								*sqrt()*
 		Return the non-negative square root of Float {expr} as a
@@ -7370,9 +7370,9 @@ sqrt({expr})								*sqrt()*
 		{expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo sqrt(100)
-<			 10.0 >vim
+<			10.0 >vim
 			echo sqrt(-4.01)
-<			 str2float("nan")
+<			str2float("nan")
 		NaN may be different, it depends on system libraries.
 
 srand([{expr}])							       *srand()*
@@ -7485,7 +7485,7 @@ str2list({string} [, {utf8}])					    *str2list()*
 		each character in String {string}.  Examples: >vim
 			echo str2list(" ")		" returns [32]
 			echo str2list("ABC")		" returns [65, 66, 67]
-<		 |list2str()| does the opposite.
+<		|list2str()| does the opposite.
 
 		UTF-8 encoding is always used, {utf8} option has no effect,
 		and exists only for backwards-compatibility.
@@ -7532,7 +7532,7 @@ strcharpart({src}, {start} [, {len} [, {skipcc}]])		 *strcharpart()*
 		exist it is omitted and counted as one character.  For
 		example: >vim
 			echo strcharpart('abc', -1, 2)
-<		 results in 'a'.
+<		results in 'a'.
 
 		Returns an empty string on error.
 
@@ -7611,7 +7611,7 @@ stridx({haystack}, {needle} [, {start}])			      *stridx()*
 		This can be used to find a second match: >vim
 			let colon1 = stridx(line, ":")
 			let colon2 = stridx(line, ":", colon1 + 1)
-<		 The search is done case-sensitive.
+<		The search is done case-sensitive.
 		For pattern searches use |match()|.
 		-1 is returned if the {needle} does not occur in {haystack}.
 		See also |strridx()|.
@@ -7619,7 +7619,7 @@ stridx({haystack}, {needle} [, {start}])			      *stridx()*
 		  echo stridx("An Example", "Example")	   " 3
 		  echo stridx("Starting point", "Start")   " 0
 		  echo stridx("Starting point", "start")   " -1
-<						*strstr()* *strchr()*
+<					       *strstr()* *strchr()*
 		stridx() works similar to the C function strstr().  When used
 		with a single character it works similar to strchr().
 
@@ -7675,7 +7675,7 @@ strpart({src}, {start} [, {len} [, {chars}]])			     *strpart()*
 			echo strpart("abcdefg", 5, 4)	 " returns 'fg'
 			echo strpart("abcdefg", 3)	 " returns 'defg'
 
-<		 Note: To get the first character, {start} must be 0.  For
+<		Note: To get the first character, {start} must be 0.  For
 		example, to get the character under the cursor: >vim
 			strpart(getline("."), col(".") - 1, 1, v:true)
 <
@@ -7699,11 +7699,11 @@ strptime({format}, {timestring})				    *strptime()*
 		See also |strftime()|.
 		Examples: >vim
 		  echo strptime("%Y %b %d %X", "1997 Apr 27 11:49:23")
-<		   862156163 >vim
+<		  862156163 >vim
 		  echo strftime("%c", strptime("%y%m%d %T", "970427 11:53:55"))
-<		   Sun Apr 27 11:53:55 1997 >vim
+<		  Sun Apr 27 11:53:55 1997 >vim
 		  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
-<		   Sun Apr 27 12:53:55 1997
+<		  Sun Apr 27 12:53:55 1997
 
 strridx({haystack}, {needle} [, {start}])			     *strridx()*
 		The result is a Number, which gives the byte index in
@@ -7713,13 +7713,13 @@ strridx({haystack}, {needle} [, {start}])			     *strridx()*
 		match: >vim
 			let lastcomma = strridx(line, ",")
 			let comma2 = strridx(line, ",", lastcomma - 1)
-<		 The search is done case-sensitive.
+<		The search is done case-sensitive.
 		For pattern searches use |match()|.
 		-1 is returned if the {needle} does not occur in {haystack}.
 		If the {needle} is empty the length of {haystack} is returned.
 		See also |stridx()|.  Examples: >vim
 		  echo strridx("an angry armadillo", "an")	     3
-<							*strrchr()*
+<						       *strrchr()*
 		When used with a single character it works similar to the C
 		function strrchr().
 
@@ -7728,7 +7728,7 @@ strtrans({string})						    *strtrans()*
 		characters translated into printable characters |'isprint'|.
 		Like they are shown in a window.  Example: >vim
 			echo strtrans(@a)
-<		 This displays a newline in register a as "^@" instead of
+<		This displays a newline in register a as "^@" instead of
 		starting a new line.
 
 		Returns an empty string on error.
@@ -7786,7 +7786,7 @@ submatch({nr} [, {list}])				       *submatch()* *E935*
 		Examples: >vim
 			s/\d\+/\=submatch(0) + 1/
 			echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
-<		 This finds the first number in the line and adds one to it.
+<		This finds the first number in the line and adds one to it.
 		A line break is included as a newline character.
 
 substitute({string}, {pat}, {sub}, {flags})			  *substitute()*
@@ -7813,24 +7813,24 @@ substitute({string}, {pat}, {sub}, {flags})			  *substitute()*
 
 		Example: >vim
 			let &path = substitute(&path, ",\\=[^,]*$", "", "")
-<		 This removes the last component of the 'path' option. >vim
+<		This removes the last component of the 'path' option. >vim
 			echo substitute("testing", ".*", "\\U\\0", "")
-<		 results in "TESTING".
+<		results in "TESTING".
 
 		When {sub} starts with "\=", the remainder is interpreted as
 		an expression. See |sub-replace-expression|.  Example: >vim
 			echo substitute(s, '%\(\x\x\)',
 			   \ '\=nr2char("0x" .. submatch(1))', 'g')
 
-<		 When {sub} is a Funcref that function is called, with one
+<		When {sub} is a Funcref that function is called, with one
 		optional argument.  Example: >vim
 		   echo substitute(s, '%\(\x\x\)', SubNr, 'g')
-<		 The optional argument is a list which contains the whole
+<		The optional argument is a list which contains the whole
 		matched string and up to nine submatches, like what
 		|submatch()| returns.  Example: >vim
 		   echo substitute(s, '%\(\x\x\)', {m -> '0x' .. m[1]}, 'g')
 
-<		 Returns an empty string on error.
+<		Returns an empty string on error.
 
 swapfilelist()							*swapfilelist()*
 		Returns a list of swap file names, like what "vim -r" shows.
@@ -7985,7 +7985,7 @@ synstack({lnum}, {col})						    *synstack()*
 			for id in synstack(line("."), col("."))
 			   echo synIDattr(id, "name")
 			endfor
-<		 When the position specified with {lnum} and {col} is invalid
+<		When the position specified with {lnum} and {col} is invalid
 		an empty list is returned.  The position just after the last
 		character in a line and the first column in an empty line are
 		valid positions.
@@ -8000,7 +8000,7 @@ system({cmd} [, {input}])					 *system()* *E677*
 		If {cmd} is a String it runs in the 'shell', like this: >vim
 		  call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
 
-<		 Not to be used for interactive commands.
+<		Not to be used for interactive commands.
 
 		Result is a String, filtered to avoid platform-specific quirks:
 		- <CR><NL> is replaced with <NL>
@@ -8009,7 +8009,7 @@ system({cmd} [, {input}])					 *system()* *E677*
 		Example: >vim
 		    echo system(['ls', expand('%:h')])
 
-<		 If {input} is a string it is written to a pipe and passed as
+<		If {input} is a string it is written to a pipe and passed as
 		stdin to the command.  The string is written as-is, line
 		separators are not changed.
 		If {input} is a |List| it is written to the pipe as
@@ -8023,9 +8023,9 @@ system({cmd} [, {input}])					 *system()* *E677*
 		Note: system() cannot write to or read from backgrounded ("&")
 		shell commands, e.g.: >vim
 		    echo system("cat - &", "foo")
-<		 which is equivalent to: >
+<		which is equivalent to: >
 		    $ echo foo | bash -c 'cat - &'
-<		 The pipes are disconnected (unless overridden by shell
+<		The pipes are disconnected (unless overridden by shell
 		redirection syntax) before input can reach it. Use
 		|jobstart()| instead.
 
@@ -8036,7 +8036,7 @@ system({cmd} [, {input}])					 *system()* *E677*
 		    echo system('ls '..shellescape(expand('%:h')))
 		    echo system('ls '..expand('%:h:S'))
 
-<		 Unlike ":!cmd" there is no automatic check for changed files.
+<		Unlike ":!cmd" there is no automatic check for changed files.
 		Use |:checktime| to force a check.
 
 systemlist({cmd} [, {input} [, {keepempty}]])			  *systemlist()*
@@ -8064,7 +8064,7 @@ tabpagebuflist([{arg}])					      *tabpagebuflist()*
 			for i in range(tabpagenr('$'))
 			   call extend(buflist, tabpagebuflist(i + 1))
 			endfor
-<		 Note that a buffer may appear in more than one window.
+<		Note that a buffer may appear in more than one window.
 
 tabpagenr([{arg}])						   *tabpagenr()*
 		The result is a Number, which is the number of the current
@@ -8091,7 +8091,7 @@ tabpagewinnr({tabarg} [, {arg}])				*tabpagewinnr()*
 		Useful examples: >vim
 		    tabpagewinnr(1)	    " current window of tab page 1
 		    tabpagewinnr(4, '$')    " number of windows in tab page 4
-<		 When {tabarg} is invalid zero is returned.
+<		When {tabarg} is invalid zero is returned.
 
 tagfiles()							    *tagfiles()*
 		Returns a |List| with the file names used to search for tags
@@ -8147,9 +8147,9 @@ tan({expr})								 *tan()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo tan(10)
-<			 0.648361 >vim
+<			0.648361 >vim
 			echo tan(-4.01)
-<			 -1.181502
+<			-1.181502
 
 tanh({expr})								*tanh()*
 		Return the hyperbolic tangent of {expr} as a |Float| in the
@@ -8158,9 +8158,9 @@ tanh({expr})								*tanh()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo tanh(0.5)
-<			 0.462117 >vim
+<			0.462117 >vim
 			echo tanh(-1)
-<			 -0.761594
+<			-0.761594
 
 tempname()							    *tempname()*
 		Generates a (non-existent) filename located in the Nvim root
@@ -8247,7 +8247,7 @@ timer_start({time}, {callback} [, {options}])		   *timer_start()* *timer*
 			endfunc
 			let timer = timer_start(500, 'MyHandler',
 				\ {'repeat': 3})
-<		 This invokes MyHandler() three times at 500 msec intervals.
+<		This invokes MyHandler() three times at 500 msec intervals.
 
 timer_stop({timer})						  *timer_stop()*
 		Stop a timer.  The timer callback will no longer be invoked.
@@ -8281,9 +8281,9 @@ tr({src}, {fromstr}, {tostr})						  *tr()*
 
 		Examples: >vim
 			echo tr("hello there", "ht", "HT")
-<		 returns "Hello THere" >vim
+<		returns "Hello THere" >vim
 			echo tr("<blob>", "<>", "{}")
-<		 returns "{blob}"
+<		returns "{blob}"
 
 trim({text} [, {mask} [, {dir}]])					*trim()*
 		Return {text} as a String where any character in {mask} is
@@ -8305,13 +8305,13 @@ trim({text} [, {mask} [, {dir}]])					*trim()*
 
 		Examples: >vim
 			echo trim("   some text ")
-<		 returns "some text" >vim
+<		returns "some text" >vim
 			echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
-<		 returns "RESERVE_TAIL" >vim
+<		returns "RESERVE_TAIL" >vim
 			echo trim("rm<Xrm<>X>rrm", "rm<>")
-<		 returns "Xrm<>X" (characters in the middle are not removed) >vim
+<		returns "Xrm<>X" (characters in the middle are not removed) >vim
 			echo trim("  vim  ", " ", 2)
-<		 returns "  vim"
+<		returns "  vim"
 
 trunc({expr})							       *trunc()*
 		Return the largest integral value with magnitude less than or
@@ -8320,11 +8320,11 @@ trunc({expr})							       *trunc()*
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 		Examples: >vim
 			echo trunc(1.456)
-<			 1.0  >vim
+<			1.0  >vim
 			echo trunc(-5.456)
-<			 -5.0  >vim
+<			-5.0  >vim
 			echo trunc(4.0)
-<			 4.0
+<			4.0
 
 type({expr})								*type()*
 		The result is a Number representing the type of {expr}.
@@ -8347,10 +8347,10 @@ type({expr})								*type()*
 			if type(myvar) == type({}) | endif
 			if type(myvar) == type(0.0) | endif
 			if type(myvar) == type(v:true) | endif
-<		 In place of checking for |v:null| type it is better to check
+<		In place of checking for |v:null| type it is better to check
 		for |v:null| directly as it is the only value of this type: >vim
 			if myvar is v:null | endif
-<		 To check if the v:t_ variables exist use this: >vim
+<		To check if the v:t_ variables exist use this: >vim
 			if exists('v:t_number') | endif
 
 undofile({name})						    *undofile()*
@@ -8413,7 +8413,7 @@ uniq({list} [, {func} [, {dict}]])				   *uniq()* *E882*
 		{list} items in-place.	Returns {list}.  If you want a list
 		to remain unmodified make a copy first: >vim
 			let newlist = uniq(copy(mylist))
-<		 The default compare function uses the string representation of
+<		The default compare function uses the string representation of
 		each item.  For the use of {func} and {dict} see |sort()|.
 
 		Returns zero if {list} is not a |List|.
@@ -8500,7 +8500,7 @@ virtcol({expr} [, {list} [, {winid}]])				     *virtcol()*
 			" With text "	  there", with 't at 'h':
 
 			echo virtcol("'t")	" returns 6
-<		 The first column is 1.  0 or [0, 0] is returned for an error.
+<		The first column is 1.	0 or [0, 0] is returned for an error.
 		A more advanced example that echoes the maximum length of
 		all lines: >vim
 		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
@@ -8536,7 +8536,7 @@ visualmode([{expr}])						  *visualmode()*
 		respectively.
 		Example: >vim
 			exe "normal " .. visualmode()
-<		 This enters the same Visual mode as before.  It is also useful
+<		This enters the same Visual mode as before.  It is also useful
 		in scripts if you wish to act differently depending on the
 		Visual mode that was used.
 		If Visual mode is active, use |mode()| to get the Visual mode
@@ -8580,7 +8580,7 @@ win_execute({id}, {command} [, {silent}])			 *win_execute()*
 		have unexpected side effects.  Use `:noautocmd` if needed.
 		Example: >vim
 			call win_execute(winid, 'syntax enable')
-<		 Doing the same with `setwinvar()` would not trigger
+<		Doing the same with `setwinvar()` would not trigger
 		autocommands and not actually show syntax highlighting.
 
 		When window {id} does not exist then no error is given and
@@ -8732,25 +8732,25 @@ winlayout([{tabnr}])						   *winlayout()*
 		For horizontally split windows, which form a column, it
 		returns: >
 			["col", [{nested list of windows}]]
-<		 For vertically split windows, which form a row, it returns: >
+<		For vertically split windows, which form a row, it returns: >
 			["row", [{nested list of windows}]]
 <
 		Example: >vim
 			" Only one window in the tab page
 			echo winlayout()
-<		  >
+<		 >
 			['leaf', 1000]
-<		  >vim
+<		 >vim
 			" Two horizontally split windows
 			echo winlayout()
-<		  >
+<		 >
 			['col', [['leaf', 1000], ['leaf', 1001]]]
-<		  >vim
+<		 >vim
 			" The second tab page, with three horizontally split
 			" windows, with two vertically split windows in the
 			" middle window
 			echo winlayout(2)
-<		  >
+<		 >
 			['col', [['leaf', 1002], ['row', [['leaf', 1003],
 					    ['leaf', 1001]]], ['leaf', 1000]]]
 <
@@ -8854,7 +8854,7 @@ winwidth({nr})							    *winwidth()*
 		  if winwidth(0) <= 50
 		    50 wincmd |
 		  endif
-<		 For getting the terminal or screen size, see the 'columns'
+<		For getting the terminal or screen size, see the 'columns'
 		option.
 
 wordcount()							   *wordcount()*
@@ -8902,7 +8902,7 @@ writefile({object}, {fname} [, {flags}])			   *writefile()*
 		'D'  Delete the file when the current function ends.  This
 		     works like: >vim
 			defer delete({fname})
-<		      Fails when not in a function.  Also see |:defer|.
+<		     Fails when not in a function.  Also see |:defer|.
 
 		's'  fsync() is called after writing the file.	This flushes
 		     the file to disk, if possible.  This takes more time but

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -622,6698 +622,6695 @@ supported use something like this: >
 							*E355*
 A jump table for the options with a short description can be found at |Q_op|.
 
-			*'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
-'allowrevins' 'ari'	boolean	(default off)
-			global
-	Allow CTRL-_ in Insert and Command-line mode.  This is default off, to
-	avoid that users that accidentally type CTRL-_ instead of SHIFT-_ get
-	into reverse Insert mode, and don't know how to get out.  See
-	'revins'.
+                                   *'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
+'allowrevins' 'ari'     boolean (default off)
+                        global
+        Allow CTRL-_ in Insert and Command-line mode.  This is default off, to
+        avoid that users that accidentally type CTRL-_ instead of SHIFT-_ get
+        into reverse Insert mode, and don't know how to get out.  See
+        'revins'.
 
-						*'ambiwidth'* *'ambw'*
-'ambiwidth' 'ambw'	string	(default "single")
-			global
-	Tells Vim what to do with characters with East Asian Width Class
-	Ambiguous (such as Euro, Registered Sign, Copyright Sign, Greek
-	letters, Cyrillic letters).
+                                                            *'ambiwidth'* *'ambw'*
+'ambiwidth' 'ambw'      string (default "single")
+                        global
+        Tells Vim what to do with characters with East Asian Width Class
+        Ambiguous (such as Euro, Registered Sign, Copyright Sign, Greek
+        letters, Cyrillic letters).
 
-	There are currently two possible values:
-	"single":	Use the same width as characters in US-ASCII.  This is
-			expected by most users.
-	"double":	Use twice the width of ASCII characters.
-							*E834* *E835*
-	The value "double" cannot be used if 'listchars' or 'fillchars'
-	contains a character that would be double width.  These errors may
-	also be given when calling setcellwidths().
+        There are currently two possible values:
+        "single":       Use the same width as characters in US-ASCII.  This is
+                        expected by most users.
+        "double":       Use twice the width of ASCII characters.
+                                                        *E834* *E835*
+        The value "double" cannot be used if 'listchars' or 'fillchars'
+        contains a character that would be double width.  These errors may
+        also be given when calling setcellwidths().
 
-	The values are overruled for characters specified with
-	|setcellwidths()|.
+        The values are overruled for characters specified with
+        |setcellwidths()|.
 
-	There are a number of CJK fonts for which the width of glyphs for
-	those characters are solely based on how many octets they take in
-	legacy/traditional CJK encodings.  In those encodings, Euro,
-	Registered sign, Greek/Cyrillic letters are represented by two octets,
-	therefore those fonts have "wide" glyphs for them.  This is also
-	true of some line drawing characters used to make tables in text
-	file.  Therefore, when a CJK font is used for GUI Vim or
-	Vim is running inside a terminal (emulators) that uses a CJK font
-	(or Vim is run inside an xterm invoked with "-cjkwidth" option.),
-	this option should be set to "double" to match the width perceived
-	by Vim with the width of glyphs in the font.  Perhaps it also has
-	to be set to "double" under CJK MS-Windows when the system locale is
-	set to one of CJK locales.  See Unicode Standard Annex #11
-	(https://www.unicode.org/reports/tr11).
+        There are a number of CJK fonts for which the width of glyphs for
+        those characters are solely based on how many octets they take in
+        legacy/traditional CJK encodings.  In those encodings, Euro,
+        Registered sign, Greek/Cyrillic letters are represented by two octets,
+        therefore those fonts have "wide" glyphs for them.  This is also
+        true of some line drawing characters used to make tables in text
+        file.  Therefore, when a CJK font is used for GUI Vim or
+        Vim is running inside a terminal (emulators) that uses a CJK font
+        (or Vim is run inside an xterm invoked with "-cjkwidth" option.),
+        this option should be set to "double" to match the width perceived
+        by Vim with the width of glyphs in the font.  Perhaps it also has
+        to be set to "double" under CJK MS-Windows when the system locale is
+        set to one of CJK locales.  See Unicode Standard Annex #11
+        (https://www.unicode.org/reports/tr11).
 
-				*'arabic'* *'arab'* *'noarabic'* *'noarab'*
-'arabic' 'arab'		boolean	(default off)
-			local to window
-	This option can be set to start editing Arabic text.
-	Setting this option will:
-	- Set the 'rightleft' option, unless 'termbidi' is set.
-	- Set the 'arabicshape' option, unless 'termbidi' is set.
-	- Set the 'keymap' option to "arabic"; in Insert mode CTRL-^ toggles
-	  between typing English and Arabic key mapping.
-	- Set the 'delcombine' option
+                                           *'arabic'* *'arab'* *'noarabic'* *'noarab'*
+'arabic' 'arab'         boolean (default off)
+                        local to window
+        This option can be set to start editing Arabic text.
+        Setting this option will:
+        - Set the 'rightleft' option, unless 'termbidi' is set.
+        - Set the 'arabicshape' option, unless 'termbidi' is set.
+        - Set the 'keymap' option to "arabic"; in Insert mode CTRL-^ toggles
+          between typing English and Arabic key mapping.
+        - Set the 'delcombine' option
 
-	Resetting this option will:
-	- Reset the 'rightleft' option.
-	- Disable the use of 'keymap' (without changing its value).
-	Note that 'arabicshape' and 'delcombine' are not reset (it is a global
-	option).
-	Also see |arabic.txt|.
+        Resetting this option will:
+        - Reset the 'rightleft' option.
+        - Disable the use of 'keymap' (without changing its value).
+        Note that 'arabicshape' and 'delcombine' are not reset (it is a global
+        option).
+        Also see |arabic.txt|.
 
-		*'arabicshape'* *'arshape'* *'noarabicshape'* *'noarshape'*
-'arabicshape' 'arshape'	boolean	(default on)
-			global
-	When on and 'termbidi' is off, the required visual character
-	corrections that need to take place for displaying the Arabic language
-	take effect.  Shaping, in essence, gets enabled; the term is a broad
-	one which encompasses:
-	  a) the changing/morphing of characters based on their location
-	     within a word (initial, medial, final and stand-alone).
-	  b) the enabling of the ability to compose characters
-	  c) the enabling of the required combining of some characters
-	When disabled the display shows each character's true stand-alone
-	form.
-	Arabic is a complex language which requires other settings, for
-	further details see |arabic.txt|.
+                           *'arabicshape'* *'arshape'* *'noarabicshape'* *'noarshape'*
+'arabicshape' 'arshape' boolean (default on)
+                        global
+        When on and 'termbidi' is off, the required visual character
+        corrections that need to take place for displaying the Arabic language
+        take effect.  Shaping, in essence, gets enabled; the term is a broad
+        one which encompasses:
+          a) the changing/morphing of characters based on their location
+             within a word (initial, medial, final and stand-alone).
+          b) the enabling of the ability to compose characters
+          c) the enabling of the required combining of some characters
+        When disabled the display shows each character's true stand-alone
+        form.
+        Arabic is a complex language which requires other settings, for
+        further details see |arabic.txt|.
 
-			*'autochdir'* *'acd'* *'noautochdir'* *'noacd'*
-'autochdir' 'acd'	boolean	(default off)
-			global
-	When on, Vim will change the current working directory whenever you
-	open a file, switch buffers, delete a buffer or open/close a window.
-	It will change to the directory containing the file which was opened
-	or selected.  When a buffer has no name it also has no directory, thus
-	the current directory won't change when navigating to it.
-	Note: When this option is on some plugins may not work.
+                                       *'autochdir'* *'acd'* *'noautochdir'* *'noacd'*
+'autochdir' 'acd'       boolean (default off)
+                        global
+        When on, Vim will change the current working directory whenever you
+        open a file, switch buffers, delete a buffer or open/close a window.
+        It will change to the directory containing the file which was opened
+        or selected.  When a buffer has no name it also has no directory, thus
+        the current directory won't change when navigating to it.
+        Note: When this option is on some plugins may not work.
 
-			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
-'autoindent' 'ai'	boolean	(default on)
-			local to buffer
-	Copy indent from current line when starting a new line (typing <CR>
-	in Insert mode or when using the "o" or "O" command).  If you do not
-	type anything on the new line except <BS> or CTRL-D and then type
-	<Esc>, CTRL-O or <CR>, the indent is deleted again.  Moving the cursor
-	to another line has the same effect, unless the 'I' flag is included
-	in 'cpoptions'.
-	When autoindent is on, formatting (with the "gq" command or when you
-	reach 'textwidth' in Insert mode) uses the indentation of the first
-	line.
-	When 'smartindent' or 'cindent' is on the indent is changed in
-	a different way.
+                                       *'autoindent'* *'ai'* *'noautoindent'* *'noai'*
+'autoindent' 'ai'       boolean (default on)
+                        local to buffer
+        Copy indent from current line when starting a new line (typing <CR>
+        in Insert mode or when using the "o" or "O" command).  If you do not
+        type anything on the new line except <BS> or CTRL-D and then type
+        <Esc>, CTRL-O or <CR>, the indent is deleted again.  Moving the cursor
+        to another line has the same effect, unless the 'I' flag is included
+        in 'cpoptions'.
+        When autoindent is on, formatting (with the "gq" command or when you
+        reach 'textwidth' in Insert mode) uses the indentation of the first
+        line.
+        When 'smartindent' or 'cindent' is on the indent is changed in
+        a different way.
 
-				*'autoread'* *'ar'* *'noautoread'* *'noar'*
-'autoread' 'ar'		boolean	(default on)
-			global or local to buffer |global-local|
-	When a file has been detected to have been changed outside of Vim and
-	it has not been changed inside of Vim, automatically read it again.
-	When the file has been deleted this is not done, so you have the text
-	from before it was deleted.  When it appears again then it is read.
-	|timestamp|
-	If this option has a local value, use this command to switch back to
-	using the global value: >vim
-		set autoread<
+                                           *'autoread'* *'ar'* *'noautoread'* *'noar'*
+'autoread' 'ar'         boolean (default on)
+                        global or local to buffer |global-local|
+        When a file has been detected to have been changed outside of Vim and
+        it has not been changed inside of Vim, automatically read it again.
+        When the file has been deleted this is not done, so you have the text
+        from before it was deleted.  When it appears again then it is read.
+        |timestamp|
+        If this option has a local value, use this command to switch back to
+        using the global value: >vim
+                set autoread<
 <
 
-				*'autowrite'* *'aw'* *'noautowrite'* *'noaw'*
-'autowrite' 'aw'	boolean	(default off)
-			global
-	Write the contents of the file, if it has been modified, on each
-	`:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
-	`:suspend`, `:tag`, `:!`, `:make`, CTRL-] and CTRL-^ command; and when
-	a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
-	to another file.
-	A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is
-	set to "hide" and `:next` is used.
-	Note that for some commands the 'autowrite' option is not used, see
-	'autowriteall' for that.
-	Some buffers will not be written, specifically when 'buftype' is
-	"nowrite", "nofile", "terminal" or "prompt".
-	USE WITH CARE: If you make temporary changes to a buffer that you
-	don't want to be saved this option may cause it to be saved anyway.
-	Renaming the buffer with ":file {name}" may help avoid this.
+                                         *'autowrite'* *'aw'* *'noautowrite'* *'noaw'*
+'autowrite' 'aw'        boolean (default off)
+                        global
+        Write the contents of the file, if it has been modified, on each
+        `:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
+        `:suspend`, `:tag`, `:!`, `:make`, CTRL-] and CTRL-^ command; and when
+        a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
+        to another file.
+        A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is
+        set to "hide" and `:next` is used.
+        Note that for some commands the 'autowrite' option is not used, see
+        'autowriteall' for that.
+        Some buffers will not be written, specifically when 'buftype' is
+        "nowrite", "nofile", "terminal" or "prompt".
+        USE WITH CARE: If you make temporary changes to a buffer that you
+        don't want to be saved this option may cause it to be saved anyway.
+        Renaming the buffer with ":file {name}" may help avoid this.
 
-			*'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
-'autowriteall' 'awa'	boolean	(default off)
-			global
-	Like 'autowrite', but also used for commands ":edit", ":enew", ":quit",
-	":qall", ":exit", ":xit", ":recover" and closing the Vim window.
-	Setting this option also implies that Vim behaves like 'autowrite' has
-	been set.
+                                 *'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
+'autowriteall' 'awa'    boolean (default off)
+                        global
+        Like 'autowrite', but also used for commands ":edit", ":enew", ":quit",
+        ":qall", ":exit", ":xit", ":recover" and closing the Vim window.
+        Setting this option also implies that Vim behaves like 'autowrite' has
+        been set.
 
-						*'background'* *'bg'*
-'background' 'bg'	string	(default "dark")
-			global
-	When set to "dark" or "light", adjusts the default color groups for
-	that background type.  The |TUI| or other UI sets this on startup
-	(triggering |OptionSet|) if it can detect the background color.
+                                                             *'background'* *'bg'*
+'background' 'bg'       string (default "dark")
+                        global
+        When set to "dark" or "light", adjusts the default color groups for
+        that background type.  The |TUI| or other UI sets this on startup
+        (triggering |OptionSet|) if it can detect the background color.
 
-	This option does NOT change the background color, it tells Nvim what
-	the "inherited" (terminal/GUI) background looks like.
-	See |:hi-normal| if you want to set the background color explicitly.
-						*g:colors_name*
-	When a color scheme is loaded (the "g:colors_name" variable is set)
-	changing 'background' will cause the color scheme to be reloaded.  If
-	the color scheme adjusts to the value of 'background' this will work.
-	However, if the color scheme sets 'background' itself the effect may
-	be undone.  First delete the "g:colors_name" variable when needed.
+        This option does NOT change the background color, it tells Nvim what
+        the "inherited" (terminal/GUI) background looks like.
+        See |:hi-normal| if you want to set the background color explicitly.
+                                                *g:colors_name*
+        When a color scheme is loaded (the "g:colors_name" variable is set)
+        changing 'background' will cause the color scheme to be reloaded.  If
+        the color scheme adjusts to the value of 'background' this will work.
+        However, if the color scheme sets 'background' itself the effect may
+        be undone.  First delete the "g:colors_name" variable when needed.
 
-	Normally this option would be set in the vimrc file.  Possibly
-	depending on the terminal name.  Example: >vim
-		if $TERM ==# "xterm"
-		  set background=dark
-		endif
-<	When this option is changed, the default settings for the highlight groups
-	will change.  To use other settings, place ":highlight" commands AFTER
-	the setting of the 'background' option.
+        Normally this option would be set in the vimrc file.  Possibly
+        depending on the terminal name.  Example: >vim
+                if $TERM ==# "xterm"
+                  set background=dark
+                endif
+<       When this option is changed, the default settings for the highlight groups
+        will change.  To use other settings, place ":highlight" commands AFTER
+        the setting of the 'background' option.
 
-						*'backspace'* *'bs'*
-'backspace' 'bs'	string	(default "indent,eol,start")
-			global
-	Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
-	mode.  This is a list of items, separated by commas.  Each item allows
-	a way to backspace over something:
-	value	effect	~
-	indent	allow backspacing over autoindent
-	eol	allow backspacing over line breaks (join lines)
-	start	allow backspacing over the start of insert; CTRL-W and CTRL-U
-		stop once at the start of insert.
-	nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
-		insert.
+                                                              *'backspace'* *'bs'*
+'backspace' 'bs'        string (default "indent,eol,start")
+                        global
+        Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
+        mode.  This is a list of items, separated by commas.  Each item allows
+        a way to backspace over something:
+        value   effect  ~
+        indent  allow backspacing over autoindent
+        eol     allow backspacing over line breaks (join lines)
+        start   allow backspacing over the start of insert; CTRL-W and CTRL-U
+                stop once at the start of insert.
+        nostop  like start, except CTRL-W and CTRL-U do not stop at the start of
+                insert.
 
-	When the value is empty, Vi compatible backspacing is used, none of
-	the ways mentioned for the items above are possible.
+        When the value is empty, Vi compatible backspacing is used, none of
+        the ways mentioned for the items above are possible.
 
-				*'backup'* *'bk'* *'nobackup'* *'nobk'*
-'backup' 'bk'		boolean	(default off)
-			global
-	Make a backup before overwriting a file.  Leave it around after the
-	file has been successfully written.  If you do not want to keep the
-	backup file, but you do want a backup while the file is being
-	written, reset this option and set the 'writebackup' option (this is
-	the default).  If you do not want a backup file at all reset both
-	options (use this if your file system is almost full).  See the
-	|backup-table| for more explanations.
-	When the 'backupskip' pattern matches, a backup is not made anyway.
-	When 'patchmode' is set, the backup may be renamed to become the
-	oldest version of a file.
+                                               *'backup'* *'bk'* *'nobackup'* *'nobk'*
+'backup' 'bk'           boolean (default off)
+                        global
+        Make a backup before overwriting a file.  Leave it around after the
+        file has been successfully written.  If you do not want to keep the
+        backup file, but you do want a backup while the file is being
+        written, reset this option and set the 'writebackup' option (this is
+        the default).  If you do not want a backup file at all reset both
+        options (use this if your file system is almost full).  See the
+        |backup-table| for more explanations.
+        When the 'backupskip' pattern matches, a backup is not made anyway.
+        When 'patchmode' is set, the backup may be renamed to become the
+        oldest version of a file.
 
-						*'backupcopy'* *'bkc'*
-'backupcopy' 'bkc'	string	(default "auto")
-			global or local to buffer |global-local|
-	When writing a file and a backup is made, this option tells how it's
-	done.  This is a comma-separated list of words.
+                                                            *'backupcopy'* *'bkc'*
+'backupcopy' 'bkc'      string (default "auto")
+                        global or local to buffer |global-local|
+        When writing a file and a backup is made, this option tells how it's
+        done.  This is a comma-separated list of words.
 
-	The main values are:
-	"yes"	make a copy of the file and overwrite the original one
-	"no"	rename the file and write a new one
-	"auto"	one of the previous, what works best
+        The main values are:
+        "yes"   make a copy of the file and overwrite the original one
+        "no"    rename the file and write a new one
+        "auto"  one of the previous, what works best
 
-	Extra values that can be combined with the ones above are:
-	"breaksymlink"	always break symlinks when writing
-	"breakhardlink"	always break hardlinks when writing
+        Extra values that can be combined with the ones above are:
+        "breaksymlink"  always break symlinks when writing
+        "breakhardlink" always break hardlinks when writing
 
-	Making a copy and overwriting the original file:
-	- Takes extra time to copy the file.
-	+ When the file has special attributes, is a (hard/symbolic) link or
-	  has a resource fork, all this is preserved.
-	- When the file is a link the backup will have the name of the link,
-	  not of the real file.
+        Making a copy and overwriting the original file:
+        - Takes extra time to copy the file.
+        + When the file has special attributes, is a (hard/symbolic) link or
+          has a resource fork, all this is preserved.
+        - When the file is a link the backup will have the name of the link,
+          not of the real file.
 
-	Renaming the file and writing a new one:
-	+ It's fast.
-	- Sometimes not all attributes of the file can be copied to the new
-	  file.
-	- When the file is a link the new file will not be a link.
+        Renaming the file and writing a new one:
+        + It's fast.
+        - Sometimes not all attributes of the file can be copied to the new
+          file.
+        - When the file is a link the new file will not be a link.
 
-	The "auto" value is the middle way: When Vim sees that renaming the
-	file is possible without side effects (the attributes can be passed on
-	and the file is not a link) that is used.  When problems are expected,
-	a copy will be made.
+        The "auto" value is the middle way: When Vim sees that renaming the
+        file is possible without side effects (the attributes can be passed on
+        and the file is not a link) that is used.  When problems are expected,
+        a copy will be made.
 
-	The "breaksymlink" and "breakhardlink" values can be used in
-	combination with any of "yes", "no" and "auto".  When included, they
-	force Vim to always break either symbolic or hard links by doing
-	exactly what the "no" option does, renaming the original file to
-	become the backup and writing a new file in its place.  This can be
-	useful for example in source trees where all the files are symbolic or
-	hard links and any changes should stay in the local source tree, not
-	be propagated back to the original source.
-							*crontab*
-	One situation where "no" and "auto" will cause problems: A program
-	that opens a file, invokes Vim to edit that file, and then tests if
-	the open file was changed (through the file descriptor) will check the
-	backup file instead of the newly created file.  "crontab -e" is an
-	example.
+        The "breaksymlink" and "breakhardlink" values can be used in
+        combination with any of "yes", "no" and "auto".  When included, they
+        force Vim to always break either symbolic or hard links by doing
+        exactly what the "no" option does, renaming the original file to
+        become the backup and writing a new file in its place.  This can be
+        useful for example in source trees where all the files are symbolic or
+        hard links and any changes should stay in the local source tree, not
+        be propagated back to the original source.
+                                                        *crontab*
+        One situation where "no" and "auto" will cause problems: A program
+        that opens a file, invokes Vim to edit that file, and then tests if
+        the open file was changed (through the file descriptor) will check the
+        backup file instead of the newly created file.  "crontab -e" is an
+        example.
 
-	When a copy is made, the original file is truncated and then filled
-	with the new text.  This means that protection bits, owner and
-	symbolic links of the original file are unmodified.  The backup file,
-	however, is a new file, owned by the user who edited the file.  The
-	group of the backup is set to the group of the original file.  If this
-	fails, the protection bits for the group are made the same as for
-	others.
+        When a copy is made, the original file is truncated and then filled
+        with the new text.  This means that protection bits, owner and
+        symbolic links of the original file are unmodified.  The backup file,
+        however, is a new file, owned by the user who edited the file.  The
+        group of the backup is set to the group of the original file.  If this
+        fails, the protection bits for the group are made the same as for
+        others.
 
-	When the file is renamed, this is the other way around: The backup has
-	the same attributes of the original file, and the newly written file
-	is owned by the current user.  When the file was a (hard/symbolic)
-	link, the new file will not!  That's why the "auto" value doesn't
-	rename when the file is a link.  The owner and group of the newly
-	written file will be set to the same ones as the original file, but
-	the system may refuse to do this.  In that case the "auto" value will
-	again not rename the file.
+        When the file is renamed, this is the other way around: The backup has
+        the same attributes of the original file, and the newly written file
+        is owned by the current user.  When the file was a (hard/symbolic)
+        link, the new file will not!  That's why the "auto" value doesn't
+        rename when the file is a link.  The owner and group of the newly
+        written file will be set to the same ones as the original file, but
+        the system may refuse to do this.  In that case the "auto" value will
+        again not rename the file.
 
-						*'backupdir'* *'bdir'*
-'backupdir' 'bdir'	string	(default ".,$XDG_STATE_HOME/nvim/backup//")
-			global
-	List of directories for the backup file, separated with commas.
-	- The backup file will be created in the first directory in the list
-	  where this is possible.  If none of the directories exist Nvim will
-	  attempt to create the last directory in the list.
-	- Empty means that no backup file will be created ('patchmode' is
-	  impossible!).  Writing may fail because of this.
-	- A directory "." means to put the backup file in the same directory
-	  as the edited file.
-	- A directory starting with "./" (or ".\" for MS-Windows) means to put
-	  the backup file relative to where the edited file is.  The leading
-	  "." is replaced with the path name of the edited file.
-	  ("." inside a directory name has no special meaning).
-	- Spaces after the comma are ignored, other spaces are considered part
-	  of the directory name.  To have a space at the start of a directory
-	  name, precede it with a backslash.
-	- To include a comma in a directory name precede it with a backslash.
-	- A directory name may end in an '/'.
-	- For Unix and Win32, if a directory ends in two path separators "//",
-	  the swap file name will be built from the complete path to the file
-	  with all path separators changed to percent '%' signs. This will
-	  ensure file name uniqueness in the backup directory.
-	  On Win32, it is also possible to end with "\\".  However, When a
-	  separating comma is following, you must use "//", since "\\" will
-	  include the comma in the file name. Therefore it is recommended to
-	  use '//', instead of '\\'.
-	- Environment variables are expanded |:set_env|.
-	- Careful with '\' characters, type one before a space, type two to
-	  get one in the option (see |option-backslash|), for example: >vim
-	    set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
+                                                            *'backupdir'* *'bdir'*
+'backupdir' 'bdir'      string (default ".,$XDG_STATE_HOME/nvim/backup//")
+                        global
+        List of directories for the backup file, separated with commas.
+        - The backup file will be created in the first directory in the list
+          where this is possible.  If none of the directories exist Nvim will
+          attempt to create the last directory in the list.
+        - Empty means that no backup file will be created ('patchmode' is
+          impossible!).  Writing may fail because of this.
+        - A directory "." means to put the backup file in the same directory
+          as the edited file.
+        - A directory starting with "./" (or ".\" for MS-Windows) means to put
+          the backup file relative to where the edited file is.  The leading
+          "." is replaced with the path name of the edited file.
+          ("." inside a directory name has no special meaning).
+        - Spaces after the comma are ignored, other spaces are considered part
+          of the directory name.  To have a space at the start of a directory
+          name, precede it with a backslash.
+        - To include a comma in a directory name precede it with a backslash.
+        - A directory name may end in an '/'.
+        - For Unix and Win32, if a directory ends in two path separators "//",
+          the swap file name will be built from the complete path to the file
+          with all path separators changed to percent '%' signs. This will
+          ensure file name uniqueness in the backup directory.
+          On Win32, it is also possible to end with "\\".  However, When a
+          separating comma is following, you must use "//", since "\\" will
+          include the comma in the file name. Therefore it is recommended to
+          use '//', instead of '\\'.
+        - Environment variables are expanded |:set_env|.
+        - Careful with '\' characters, type one before a space, type two to
+          get one in the option (see |option-backslash|), for example: >vim
+            set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 <
-	See also 'backup' and 'writebackup' options.
-	If you want to hide your backup files on Unix, consider this value: >vim
-		set backupdir=./.backup,~/.backup,.,/tmp
-<	You must create a ".backup" directory in each directory and in your
-	home directory for this to work properly.
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	directories from the list.  This avoids problems when a future version
-	uses another default.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'backupext'* *'bex'* *E589*
-'backupext' 'bex'	string	(default "~")
-			global
-	String which is appended to a file name to make the name of the
-	backup file.  The default is quite unusual, because this avoids
-	accidentally overwriting existing files with a backup file.  You might
-	prefer using ".bak", but make sure that you don't have files with
-	".bak" that you want to keep.
-	Only normal file name characters can be used; `/\*?[|<>` are illegal.
-
-	If you like to keep a lot of backups, you could use a BufWritePre
-	autocommand to change 'backupext' just before writing the file to
-	include a timestamp. >vim
-		au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
-<	Use 'backupdir' to put the backup in a different directory.
-
-						*'backupskip'* *'bsk'*
-'backupskip' 'bsk'	string	(default "$TMPDIR/*,$TMP/*,$TEMP/*"
-                                 Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
-                                 Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
-			global
-	A list of file patterns.  When one of the patterns matches with the
-	name of the file which is written, no backup file is created.  Both
-	the specified file name and the full path name of the file are used.
-	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
-	Watch out for special characters, see |option-backslash|.
-	When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
-	default value.  "/tmp/*" is only used for Unix.
-
-	WARNING: Not having a backup file means that when Vim fails to write
-	your buffer correctly and then, for whatever reason, Vim exits, you
-	lose both the original file and what you were writing.  Only disable
-	backups if you don't care about losing the file.
-
-	Note that environment variables are not expanded.  If you want to use
-	$HOME you must expand it explicitly, e.g.: >vim
-		let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
-
-<	Note that the default also makes sure that "crontab -e" works (when a
-	backup would be made by renaming the original file crontab won't see
-	the newly created file).  Also see 'backupcopy' and |crontab|.
-
-						*'belloff'* *'bo'*
-'belloff' 'bo'		string	(default "all")
-			global
-	Specifies for which events the bell will not be rung. It is a comma-
-	separated list of items. For each item that is present, the bell
-	will be silenced. This is most useful to specify specific events in
-	insert mode to be silenced.
-
-	item	    meaning when present	~
-	all	    All events.
-	backspace   When hitting <BS> or <Del> and deleting results in an
-		    error.
-	cursor	    Fail to move around using the cursor keys or
-		    <PageUp>/<PageDown> in |Insert-mode|.
-	complete    Error occurred when using |i_CTRL-X_CTRL-K| or
-		    |i_CTRL-X_CTRL-T|.
-	copy	    Cannot copy char from insert mode using |i_CTRL-Y| or
-		    |i_CTRL-E|.
-	ctrlg	    Unknown Char after <C-G> in Insert mode.
-	error	    Other Error occurred (e.g. try to join last line)
-		    (mostly used in |Normal-mode| or |Cmdline-mode|).
-	esc	    hitting <Esc> in |Normal-mode|.
-	hangul	    Ignored.
-	lang	    Calling the beep module for Lua/Mzscheme/TCL.
-	mess	    No output available for |g<|.
-	showmatch   Error occurred for 'showmatch' function.
-	operator    Empty region error |cpo-E|.
-	register    Unknown register after <C-R> in |Insert-mode|.
-	shell	    Bell from shell output |:!|.
-	spell	    Error happened on spell suggest.
-	wildmode    More matches in |cmdline-completion| available
-		    (depends on the 'wildmode' setting).
-
-	This is most useful to fine tune when in Insert mode the bell should
-	be rung. For Normal mode and Ex commands, the bell is often rung to
-	indicate that an error occurred. It can be silenced by adding the
-	"error" keyword.
-
-				*'binary'* *'bin'* *'nobinary'* *'nobin'*
-'binary' 'bin'		boolean	(default off)
-			local to buffer
-	This option should be set before editing a binary file.  You can also
-	use the |-b| Vim argument.  When this option is switched on a few
-	options will be changed (also when it already was on):
-		'textwidth'  will be set to 0
-		'wrapmargin' will be set to 0
-		'modeline'   will be off
-		'expandtab'  will be off
-	Also, 'fileformat' and 'fileformats' options will not be used, the
-	file is read and written like 'fileformat' was "unix" (a single <NL>
-	separates lines).
-	The 'fileencoding' and 'fileencodings' options will not be used, the
-	file is read without conversion.
-	NOTE: When you start editing a(nother) file while the 'bin' option is
-	on, settings from autocommands may change the settings again (e.g.,
-	'textwidth'), causing trouble when editing.  You might want to set
-	'bin' again when the file has been loaded.
-	The previous values of these options are remembered and restored when
-	'bin' is switched from on to off.  Each buffer has its own set of
-	saved option values.
-	To edit a file with 'binary' set you can use the |++bin| argument.
-	This avoids you have to do ":set bin", which would have effect for all
-	files you edit.
-	When writing a file the <EOL> for the last line is only written if
-	there was one in the original file (normally Vim appends an <EOL> to
-	the last line if there is none; this would make the file longer).  See
-	the 'endofline' option.
-
-						*'bomb'* *'nobomb'*
-'bomb'			boolean	(default off)
-			local to buffer
-	When writing a file and the following conditions are met, a BOM (Byte
-	Order Mark) is prepended to the file:
-	- this option is on
-	- the 'binary' option is off
-	- 'fileencoding' is "utf-8", "ucs-2", "ucs-4" or one of the little/big
-	  endian variants.
-	Some applications use the BOM to recognize the encoding of the file.
-	Often used for UCS-2 files on MS-Windows.  For other applications it
-	causes trouble, for example: "cat file1 file2" makes the BOM of file2
-	appear halfway through the resulting file.  Gcc doesn't accept a BOM.
-	When Vim reads a file and 'fileencodings' starts with "ucs-bom", a
-	check for the presence of the BOM is done and 'bomb' set accordingly.
-	Unless 'binary' is set, it is removed from the first line, so that you
-	don't see it when editing.  When you don't change the options, the BOM
-	will be restored when writing the file.
-
-						*'breakat'* *'brk'*
-'breakat' 'brk'		string	(default " ^I!@*-+;:,./?")
-			global
-	This option lets you choose which characters might cause a line
-	break if 'linebreak' is on.  Only works for ASCII characters.
-
-			*'breakindent'* *'bri'* *'nobreakindent'* *'nobri'*
-'breakindent' 'bri'	boolean	(default off)
-			local to window
-	Every wrapped line will continue visually indented (same amount of
-	space as the beginning of that line), thus preserving horizontal blocks
-	of text.
-
-					*'breakindentopt'* *'briopt'*
-'breakindentopt' 'briopt'	string	(default "")
-			local to window
-	Settings for 'breakindent'. It can consist of the following optional
-	items and must be separated by a comma:
-		min:{n}	    Minimum text width that will be kept after
-			    applying 'breakindent', even if the resulting
-			    text should normally be narrower. This prevents
-			    text indented almost to the right window border
-			    occupying lot of vertical space when broken.
-			    (default: 20)
-		shift:{n}   After applying 'breakindent', the wrapped line's
-			    beginning will be shifted by the given number of
-			    characters.  It permits dynamic French paragraph
-			    indentation (negative) or emphasizing the line
-			    continuation (positive).
-			    (default: 0)
-		sbr	    Display the 'showbreak' value before applying the
-			    additional indent.
-			    (default: off)
-		list:{n}    Adds an additional indent for lines that match a
-			    numbered or bulleted list (using the
-			    'formatlistpat' setting).
-		list:-1	    Uses the length of a match with 'formatlistpat'
-			    for indentation.
-			    (default: 0)
-		column:{n}  Indent at column {n}. Will overrule the other
-			    sub-options. Note: an additional indent may be
-			    added for the 'showbreak' setting.
-			    (default: off)
-
-						*'browsedir'* *'bsdir'*
-'browsedir' 'bsdir'	string	(default "last")
-			global
-	Which directory to use for the file browser:
-	   last		Use same directory as with last file browser, where a
-			file was opened or saved.
-	   buffer	Use the directory of the related buffer.
-	   current	Use the current directory.
-	   {path}	Use the specified directory
-
-						*'bufhidden'* *'bh'*
-'bufhidden' 'bh'	string	(default "")
-			local to buffer  |local-noglobal|
-	This option specifies what happens when a buffer is no longer
-	displayed in a window:
-	  <empty>	follow the global 'hidden' option
-	  hide		hide the buffer (don't unload it), even if 'hidden' is
-			not set
-	  unload	unload the buffer, even if 'hidden' is set; the
-			|:hide| command will also unload the buffer
-	  delete	delete the buffer from the buffer list, even if
-			'hidden' is set; the |:hide| command will also delete
-			the buffer, making it behave like |:bdelete|
-	  wipe		wipe the buffer from the buffer list, even if
-			'hidden' is set; the |:hide| command will also wipe
-			out the buffer, making it behave like |:bwipeout|
-
-	CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
-	are lost without a warning.  Also, these values may break autocommands
-	that switch between buffers temporarily.
-	This option is used together with 'buftype' and 'swapfile' to specify
-	special kinds of buffers.   See |special-buffers|.
-
-			*'buflisted'* *'bl'* *'nobuflisted'* *'nobl'* *E85*
-'buflisted' 'bl'	boolean	(default on)
-			local to buffer
-	When this option is set, the buffer shows up in the buffer list.  If
-	it is reset it is not used for ":bnext", "ls", the Buffers menu, etc.
-	This option is reset by Vim for buffers that are only used to remember
-	a file name or marks.  Vim sets it when starting to edit a buffer.
-	But not when moving to a buffer with ":buffer".
-
-						*'buftype'* *'bt'* *E382*
-'buftype' 'bt'		string	(default "")
-			local to buffer  |local-noglobal|
-	The value of this option specifies the type of a buffer:
-	  <empty>	normal buffer
-	  acwrite	buffer will always be written with |BufWriteCmd|s
-	  help		help buffer (do not set this manually)
-	  nofile	buffer is not related to a file, will not be written
-	  nowrite	buffer will not be written
-	  quickfix	list of errors |:cwindow| or locations |:lwindow|
-	  terminal	|terminal-emulator| buffer
-	  prompt	buffer where only the last line can be edited, meant
-			to be used by a plugin, see |prompt-buffer|
-
-	This option is used together with 'bufhidden' and 'swapfile' to
-	specify special kinds of buffers.   See |special-buffers|.
-	Also see |win_gettype()|, which returns the type of the window.
-
-	Be careful with changing this option, it can have many side effects!
-	One such effect is that Vim will not check the timestamp of the file,
-	if the file is changed by another program this will not be noticed.
-
-	A "quickfix" buffer is only used for the error list and the location
-	list.  This value is set by the |:cwindow| and |:lwindow| commands and
-	you are not supposed to change it.
-
-	"nofile" and "nowrite" buffers are similar:
-	both:		The buffer is not to be written to disk, ":w" doesn't
-			work (":w filename" does work though).
-	both:		The buffer is never considered to be |'modified'|.
-			There is no warning when the changes will be lost, for
-			example when you quit Vim.
-	both:		A swap file is only created when using too much memory
-			(when 'swapfile' has been reset there is never a swap
-			file).
-	nofile only:	The buffer name is fixed, it is not handled like a
-			file name.  It is not modified in response to a |:cd|
-			command.
-	both:		When using ":e bufname" and already editing "bufname"
-			the buffer is made empty and autocommands are
-			triggered as usual for |:edit|.
-							*E676*
-	"acwrite" implies that the buffer name is not related to a file, like
-	"nofile", but it will be written.  Thus, in contrast to "nofile" and
-	"nowrite", ":w" does work and a modified buffer can't be abandoned
-	without saving.  For writing there must be matching |BufWriteCmd|,
-	|FileWriteCmd| or |FileAppendCmd| autocommands.
-
-						*'casemap'* *'cmp'*
-'casemap' 'cmp'		string	(default "internal,keepascii")
-			global
-	Specifies details about changing the case of letters.  It may contain
-	these words, separated by a comma:
-	internal	Use internal case mapping functions, the current
-			locale does not change the case mapping. When
-			"internal" is omitted, the towupper() and towlower()
-			system library functions are used when available.
-	keepascii	For the ASCII characters (0x00 to 0x7f) use the US
-			case mapping, the current locale is not effective.
-			This probably only matters for Turkish.
-
-				*'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
-'cdhome' 'cdh'		boolean	(default off)
-			global
-	When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
-	current working directory to the |$HOME| directory like in Unix.
-	When off, those commands just print the current directory name.
-	On Unix this option has no effect.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'cdpath'* *'cd'* *E344* *E346*
-'cdpath' 'cd'		string	(default equivalent to $CDPATH or ",,")
-			global
-	This is a list of directories which will be searched when using the
-	|:cd|, |:tcd| and |:lcd| commands, provided that the directory being
-	searched for has a relative path, not an absolute part starting with
-	"/", "./" or "../", the 'cdpath' option is not used then.
-	The 'cdpath' option's value has the same form and semantics as
-	|'path'|.  Also see |file-searching|.
-	The default value is taken from $CDPATH, with a "," prepended to look
-	in the current directory first.
-	If the default value taken from $CDPATH is not what you want, include
-	a modified version of the following command in your vimrc file to
-	override it: >vim
-	  let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-	(parts of 'cdpath' can be passed to the shell to expand file names).
-
-							*'cedit'*
-'cedit'			string	(default CTRL-F)
-			global
-	The key used in Command-line Mode to open the command-line window.
-	Only non-printable keys are allowed.
-	The key can be specified as a single character, but it is difficult to
-	type.  The preferred way is to use the <> notation.  Examples: >vim
-		exe "set cedit=\<C-Y>"
-		exe "set cedit=\<Esc>"
-<	|Nvi| also has this option, but it only uses the first character.
-	See |cmdwin|.
-
-							*'channel'*
-'channel'		number	(default 0)
-			local to buffer
-	|channel| connected to the buffer, or 0 if no channel is connected.
-	In a |:terminal| buffer this is the terminal channel.
-	Read-only.
-
-				*'charconvert'* *'ccv'* *E202* *E214* *E513*
-'charconvert' 'ccv'	string	(default "")
-			global
-	An expression that is used for character encoding conversion.  It is
-	evaluated when a file that is to be read or has been written has a
-	different encoding from what is desired.
-	'charconvert' is not used when the internal iconv() function is
-	supported and is able to do the conversion.  Using iconv() is
-	preferred, because it is much faster.
-	'charconvert' is not used when reading stdin |--|, because there is no
-	file to convert from.  You will have to save the text in a file first.
-	The expression must return zero, false or an empty string for success,
-	non-zero or true for failure.
-	See |encoding-names| for possible encoding names.
-	Additionally, names given in 'fileencodings' and 'fileencoding' are
-	used.
-	Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
-	is done internally by Vim, 'charconvert' is not used for this.
-	Also used for Unicode conversion.
-	Example: >vim
-		set charconvert=CharConvert()
-		fun CharConvert()
-		  system("recode "
-			\ .. v:charconvert_from .. ".." .. v:charconvert_to
-			\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
-		  return v:shell_error
-		endfun
-<	The related Vim variables are:
-		v:charconvert_from	name of the current encoding
-		v:charconvert_to	name of the desired encoding
-		v:fname_in		name of the input file
-		v:fname_out		name of the output file
-	Note that v:fname_in and v:fname_out will never be the same.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-				*'cindent'* *'cin'* *'nocindent'* *'nocin'*
-'cindent' 'cin'		boolean	(default off)
-			local to buffer
-	Enables automatic C program indenting.  See 'cinkeys' to set the keys
-	that trigger reindenting in insert mode and 'cinoptions' to set your
-	preferred indent style.
-	If 'indentexpr' is not empty, it overrules 'cindent'.
-	If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
-	the "=" operator indents using this algorithm rather than calling an
-	external program.
-	See |C-indenting|.
-	When you don't like the way 'cindent' works, try the 'smartindent'
-	option or 'indentexpr'.
-
-						*'cinkeys'* *'cink'*
-'cinkeys' 'cink'	string	(default "0{,0},0),0],:,0#,!^F,o,O,e")
-			local to buffer
-	A list of keys that, when typed in Insert mode, cause reindenting of
-	the current line.  Only used if 'cindent' is on and 'indentexpr' is
-	empty.
-	For the format of this option see |cinkeys-format|.
-	See |C-indenting|.
-
-						*'cinoptions'* *'cino'*
-'cinoptions' 'cino'	string	(default "")
-			local to buffer
-	The 'cinoptions' affect the way 'cindent' reindents lines in a C
-	program.  See |cinoptions-values| for the values of this option, and
-	|C-indenting| for info on C indenting in general.
-
-					*'cinscopedecls'* *'cinsd'*
-'cinscopedecls' 'cinsd'	string	(default "public,protected,private")
-			local to buffer
-	Keywords that are interpreted as a C++ scope declaration by |cino-g|.
-	Useful e.g. for working with the Qt framework that defines additional
-	scope declarations "signals", "public slots" and "private slots": >vim
-		set cinscopedecls+=signals,public\ slots,private\ slots
-<
-
-						*'cinwords'* *'cinw'*
-'cinwords' 'cinw'	string	(default "if,else,while,do,for,switch")
-			local to buffer
-	These keywords start an extra indent in the next line when
-	'smartindent' or 'cindent' is set.  For 'cindent' this is only done at
-	an appropriate place (inside {}).
-	Note that 'ignorecase' isn't used for 'cinwords'.  If case doesn't
-	matter, include the keyword both the uppercase and lowercase:
-	"if,If,IF".
-
-						*'clipboard'* *'cb'*
-'clipboard' 'cb'	string	(default "")
-			global
-	This option is a list of comma-separated names.
-	These names are recognized:
-
-						*clipboard-unnamed*
-	unnamed		When included, Vim will use the clipboard register "*"
-			for all yank, delete, change and put operations which
-			would normally go to the unnamed register.  When a
-			register is explicitly specified, it will always be
-			used regardless of whether "unnamed" is in 'clipboard'
-			or not.  The clipboard register can always be
-			explicitly accessed using the "* notation.  Also see
-			|clipboard|.
-
-						*clipboard-unnamedplus*
-	unnamedplus	A variant of the "unnamed" flag which uses the
-			clipboard register "+" (|quoteplus|) instead of
-			register "*" for all yank, delete, change and put
-			operations which would normally go to the unnamed
-			register.  When "unnamed" is also included to the
-			option, yank and delete operations (but not put)
-			will additionally copy the text into register
-			"*". See |clipboard|.
-
-						*'cmdheight'* *'ch'*
-'cmdheight' 'ch'	number	(default 1)
-			global or local to tab page |global-local|
-	Number of screen lines to use for the command-line.  Helps avoiding
-	|hit-enter| prompts.
-	The value of this option is stored with the tab page, so that each tab
-	page can have a different value.
-
-	When 'cmdheight' is zero, there is no command-line unless it is being
-	used.  The command-line will cover the last line of the screen when
-	shown.
-
-	WARNING: `cmdheight=0` is considered experimental. Expect some
-	unwanted behaviour. Some 'shortmess' flags and similar
-	mechanism might fail to take effect, causing unwanted hit-enter
-	prompts.  Some informative messages, both from Nvim itself and
-	plugins, will not be displayed.
-
-						*'cmdwinheight'* *'cwh'*
-'cmdwinheight' 'cwh'	number	(default 7)
-			global
-	Number of screen lines to use for the command-line window. |cmdwin|
-
-						*'colorcolumn'* *'cc'*
-'colorcolumn' 'cc'	string	(default "")
-			local to window
-	'colorcolumn' is a comma-separated list of screen columns that are
-	highlighted with ColorColumn |hl-ColorColumn|.  Useful to align
-	text.  Will make screen redrawing slower.
-	The screen column can be an absolute number, or a number preceded with
-	'+' or '-', which is added to or subtracted from 'textwidth'. >vim
-
-		set cc=+1	  " highlight column after 'textwidth'
-		set cc=+1,+2,+3  " highlight three columns after 'textwidth'
-		hi ColorColumn ctermbg=lightgrey guibg=lightgrey
-<
-	When 'textwidth' is zero then the items with '-' and '+' are not used.
-	A maximum of 256 columns are highlighted.
-
-						*'columns'* *'co'* *E594*
-'columns' 'co'		number	(default 80 or terminal width)
-			global
-	Number of columns of the screen.  Normally this is set by the terminal
-	initialization and does not have to be set by hand.
-	When Vim is running in the GUI or in a resizable window, setting this
-	option will cause the window size to be changed.  When you only want
-	to use the size for the GUI, put the command in your |ginit.vim| file.
-	When you set this option and Vim is unable to change the physical
-	number of columns of the display, the display may be messed up.  For
-	the GUI it is always possible and Vim limits the number of columns to
-	what fits on the screen.  You can use this command to get the widest
-	window possible: >vim
-		set columns=9999
-<	Minimum value is 12, maximum value is 10000.
-
-					*'comments'* *'com'* *E524* *E525*
-'comments' 'com'	string	(default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
-			local to buffer
-	A comma-separated list of strings that can start a comment line.  See
-	|format-comments|.  See |option-backslash| about using backslashes to
-	insert a space.
-
-					*'commentstring'* *'cms'* *E537*
-'commentstring' 'cms'	string	(default "")
-			local to buffer
-	A template for a comment.  The "%s" in the value is replaced with the
-	comment text.  For example, C uses "/*%s*/". Currently only used to
-	add markers for folding, see |fold-marker|.
-
-						*'complete'* *'cpt'* *E535*
-'complete' 'cpt'	string	(default ".,w,b,u,t")
-			local to buffer
-	This option specifies how keyword completion |ins-completion| works
-	when CTRL-P or CTRL-N are used.  It is also used for whole-line
-	completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
-	and the places to scan.  It is a comma-separated list of flags:
-	.	scan the current buffer ('wrapscan' is ignored)
-	w	scan buffers from other windows
-	b	scan other loaded buffers that are in the buffer list
-	u	scan the unloaded buffers that are in the buffer list
-	U	scan the buffers that are not in the buffer list
-	k	scan the files given with the 'dictionary' option
-	kspell  use the currently active spell checking |spell|
-	k{dict}	scan the file {dict}.  Several "k" flags can be given,
-		patterns are valid too.  For example: >vim
-			set cpt=k/usr/dict/*,k~/spanish
-<	s	scan the files given with the 'thesaurus' option
-	s{tsr}	scan the file {tsr}.  Several "s" flags can be given, patterns
-		are valid too.
-	i	scan current and included files
-	d	scan current and included files for defined name or macro
-		|i_CTRL-X_CTRL-D|
-	]	tag completion
-	t	same as "]"
-	f	scan the buffer names (as opposed to buffer contents)
-
-	Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
-	not executed, this may lead to unexpected completions from some files
-	(gzipped files for example).  Unloaded buffers are not scanned for
-	whole-line completion.
-
-	As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
-	based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
-	|i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
-
-						*'completefunc'* *'cfu'*
-'completefunc' 'cfu'	string	(default "")
-			local to buffer
-	This option specifies a function to be used for Insert mode completion
-	with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
-	See |complete-functions| for an explanation of how the function is
-	invoked and what it should return.  The value can be the name of a
-	function, a |lambda| or a |Funcref|. See |option-value-function| for
-	more information.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'completeopt'* *'cot'*
-'completeopt' 'cot'	string	(default "menu,preview")
-			global
-	A comma-separated list of options for Insert mode completion
-	|ins-completion|.  The supported values are:
-
-	   menu	    Use a popup menu to show the possible completions.  The
-		    menu is only shown when there is more than one match and
-		    sufficient colors are available.  |ins-completion-menu|
-
-	   menuone  Use the popup menu also when there is only one match.
-		    Useful when there is additional information about the
-		    match, e.g., what file it comes from.
-
-	   longest  Only insert the longest common text of the matches.  If
-		    the menu is displayed you can use CTRL-L to add more
-		    characters.  Whether case is ignored depends on the kind
-		    of completion.  For buffer text the 'ignorecase' option is
-		    used.
-
-	   preview  Show extra information about the currently selected
-		    completion in the preview window.  Only works in
-		    combination with "menu" or "menuone".
-
-	   noinsert Do not insert any text for a match until the user selects
-		    a match from the menu. Only works in combination with
-		    "menu" or "menuone". No effect if "longest" is present.
-
-	   noselect Do not select a match in the menu, force the user to
-		    select one from the menu. Only works in combination with
-		    "menu" or "menuone".
-
-	   popup    Show extra information about the currently selected
-		    completion in a popup window.  Only works in combination
-		    with "menu" or "menuone".  Overrides "preview".
-
-						*'completeslash'* *'csl'*
-'completeslash' 'csl'	string	(default "")
-			local to buffer
-			only for MS-Windows
-	When this option is set it overrules 'shellslash' for completion:
-	- When this option is set to "slash", a forward slash is used for path
-	  completion in insert mode. This is useful when editing HTML tag, or
-	  Makefile with 'noshellslash' on MS-Windows.
-	- When this option is set to "backslash", backslash is used. This is
-	  useful when editing a batch file with 'shellslash' set on MS-Windows.
-	- When this option is empty, same character is used as for
-	  'shellslash'.
-	For Insert mode completion the buffer-local value is used.  For
-	command line completion the global value is used.
-
-					*'concealcursor'* *'cocu'*
-'concealcursor' 'cocu'	string	(default "")
-			local to window
-	Sets the modes in which text in the cursor line can also be concealed.
-	When the current mode is listed then concealing happens just like in
-	other lines.
-	  n		Normal mode
-	  v		Visual mode
-	  i		Insert mode
-	  c		Command line editing, for 'incsearch'
-
-	'v' applies to all lines in the Visual area, not only the cursor.
-	A useful value is "nc".  This is used in help files.  So long as you
-	are moving around text is concealed, but when starting to insert text
-	or selecting a Visual area the concealed text is displayed, so that
-	you can see what you are doing.
-	Keep in mind that the cursor position is not always where it's
-	displayed.  E.g., when moving vertically it may change column.
-
-						*'conceallevel'* *'cole'*
-'conceallevel' 'cole'	number	(default 0)
-			local to window
-	Determine how text with the "conceal" syntax attribute |:syn-conceal|
-	is shown:
-
-	Value		Effect ~
-	0		Text is shown normally
-	1		Each block of concealed text is replaced with one
-			character.  If the syntax item does not have a custom
-			replacement character defined (see |:syn-cchar|) the
-			character defined in 'listchars' is used.
-			It is highlighted with the "Conceal" highlight group.
-	2		Concealed text is completely hidden unless it has a
-			custom replacement character defined (see
-			|:syn-cchar|).
-	3		Concealed text is completely hidden.
-
-	Note: in the cursor line concealed text is not hidden, so that you can
-	edit and copy the text.  This can be changed with the 'concealcursor'
-	option.
-
-				*'confirm'* *'cf'* *'noconfirm'* *'nocf'*
-'confirm' 'cf'		boolean	(default off)
-			global
-	When 'confirm' is on, certain operations that would normally
-	fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
-	instead raise a dialog asking if you wish to save the current
-	file(s).  You can still use a ! to unconditionally |abandon| a buffer.
-	If 'confirm' is off you can still activate confirmation for one
-	command only (this is most useful in mappings) with the |:confirm|
-	command.
-	Also see the |confirm()| function and the 'v' flag in 'guioptions'.
-
-			*'copyindent'* *'ci'* *'nocopyindent'* *'noci'*
-'copyindent' 'ci'	boolean	(default off)
-			local to buffer
-	Copy the structure of the existing lines indent when autoindenting a
-	new line.  Normally the new indent is reconstructed by a series of
-	tabs followed by spaces as required (unless |'expandtab'| is enabled,
-	in which case only spaces are used).  Enabling this option makes the
-	new line copy whatever characters were used for indenting on the
-	existing line.  'expandtab' has no effect on these characters, a Tab
-	remains a Tab.  If the new indent is greater than on the existing
-	line, the remaining space is filled in the normal manner.
-	See 'preserveindent'.
-
-						*'cpoptions'* *'cpo'* *cpo*
-'cpoptions' 'cpo'	string	(default "aABceFs_")
-			global
-	A sequence of single character flags.  When a character is present
-	this indicates Vi-compatible behavior.  This is used for things where
-	not being Vi-compatible is mostly or sometimes preferred.
-	'cpoptions' stands for "compatible-options".
-	Commas can be added for readability.
-	To avoid problems with flags that are added in the future, use the
-	"+=" and "-=" feature of ":set" |add-option-flags|.
-
-	    contains	behavior	~
-								*cpo-a*
-		a	When included, a ":read" command with a file name
-			argument will set the alternate file name for the
-			current window.
-								*cpo-A*
-		A	When included, a ":write" command with a file name
-			argument will set the alternate file name for the
-			current window.
-								*cpo-b*
-		b	"\|" in a ":map" command is recognized as the end of
-			the map command.  The '\' is included in the mapping,
-			the text after the '|' is interpreted as the next
-			command.  Use a CTRL-V instead of a backslash to
-			include the '|' in the mapping.  Applies to all
-			mapping, abbreviation, menu and autocmd commands.
-			See also |map_bar|.
-								*cpo-B*
-		B	A backslash has no special meaning in mappings,
-			abbreviations, user commands and the "to" part of the
-			menu commands.  Remove this flag to be able to use a
-			backslash like a CTRL-V.  For example, the command
-			":map X \<Esc>" results in X being mapped to:
-				'B' included:	"\^["	 (^[ is a real <Esc>)
-				'B' excluded:	"<Esc>"  (5 characters)
-								*cpo-c*
-		c	Searching continues at the end of any match at the
-			cursor position, but not further than the start of the
-			next line.  When not present searching continues
-			one character from the cursor position.  With 'c'
-			"abababababab" only gets three matches when repeating
-			"/abab", without 'c' there are five matches.
-								*cpo-C*
-		C	Do not concatenate sourced lines that start with a
-			backslash.  See |line-continuation|.
-								*cpo-d*
-		d	Using "./" in the 'tags' option doesn't mean to use
-			the tags file relative to the current file, but the
-			tags file in the current directory.
-								*cpo-D*
-		D	Can't use CTRL-K to enter a digraph after Normal mode
-			commands with a character argument, like |r|, |f| and
-			|t|.
-								*cpo-e*
-		e	When executing a register with ":@r", always add a
-			<CR> to the last line, also when the register is not
-			linewise.  If this flag is not present, the register
-			is not linewise and the last line does not end in a
-			<CR>, then the last line is put on the command-line
-			and can be edited before hitting <CR>.
-								*cpo-E*
-		E	It is an error when using "y", "d", "c", "g~", "gu" or
-			"gU" on an Empty region.  The operators only work when
-			at least one character is to be operated on.  Example:
-			This makes "y0" fail in the first column.
-								*cpo-f*
-		f	When included, a ":read" command with a file name
-			argument will set the file name for the current buffer,
-			if the current buffer doesn't have a file name yet.
-								*cpo-F*
-		F	When included, a ":write" command with a file name
-			argument will set the file name for the current
-			buffer, if the current buffer doesn't have a file name
-			yet.  Also see |cpo-P|.
-								*cpo-i*
-		i	When included, interrupting the reading of a file will
-			leave it modified.
-								*cpo-I*
-		I	When moving the cursor up or down just after inserting
-			indent for 'autoindent', do not delete the indent.
-								*cpo-J*
-		J	A |sentence| has to be followed by two spaces after
-			the '.', '!' or '?'.  A <Tab> is not recognized as
-			white space.
-								*cpo-K*
-		K	Don't wait for a key code to complete when it is
-			halfway through a mapping.  This breaks mapping
-			<F1><F1> when only part of the second <F1> has been
-			read.  It enables cancelling the mapping by typing
-			<F1><Esc>.
-								*cpo-l*
-		l	Backslash in a [] range in a search pattern is taken
-			literally, only "\]", "\^", "\-" and "\\" are special.
-			See |/[]|
-			   'l' included: "/[ \t]"  finds <Space>, '\' and 't'
-			   'l' excluded: "/[ \t]"  finds <Space> and <Tab>
-								*cpo-L*
-		L	When the 'list' option is set, 'wrapmargin',
-			'textwidth', 'softtabstop' and Virtual Replace mode
-			(see |gR|) count a <Tab> as two characters, instead of
-			the normal behavior of a <Tab>.
-								*cpo-m*
-		m	When included, a showmatch will always wait half a
-			second.  When not included, a showmatch will wait half
-			a second or until a character is typed.  |'showmatch'|
-								*cpo-M*
-		M	When excluded, "%" matching will take backslashes into
-			account.  Thus in "( \( )" and "\( ( \)" the outer
-			parenthesis match.  When included "%" ignores
-			backslashes, which is Vi compatible.
-								*cpo-n*
-		n	When included, the column used for 'number' and
-			'relativenumber' will also be used for text of wrapped
-			lines.
-								*cpo-o*
-		o	Line offset to search command is not remembered for
-			next search.
-								*cpo-O*
-		O	Don't complain if a file is being overwritten, even
-			when it didn't exist when editing it.  This is a
-			protection against a file unexpectedly created by
-			someone else.  Vi didn't complain about this.
-								*cpo-p*
-		p	Vi compatible Lisp indenting.  When not present, a
-			slightly better algorithm is used.
-								*cpo-P*
-		P	When included, a ":write" command that appends to a
-			file will set the file name for the current buffer, if
-			the current buffer doesn't have a file name yet and
-			the 'F' flag is also included |cpo-F|.
-								*cpo-q*
-		q	When joining multiple lines leave the cursor at the
-			position where it would be when joining two lines.
-								*cpo-r*
-		r	Redo ("." command) uses "/" to repeat a search
-			command, instead of the actually used search string.
-								*cpo-R*
-		R	Remove marks from filtered lines.  Without this flag
-			marks are kept like |:keepmarks| was used.
-								*cpo-s*
-		s	Set buffer options when entering the buffer for the
-			first time.  This is like it is in Vim version 3.0.
-			And it is the default.  If not present the options are
-			set when the buffer is created.
-								*cpo-S*
-		S	Set buffer options always when entering a buffer
-			(except 'readonly', 'fileformat', 'filetype' and
-			'syntax').  This is the (most) Vi compatible setting.
-			The options are set to the values in the current
-			buffer.  When you change an option and go to another
-			buffer, the value is copied.  Effectively makes the
-			buffer options global to all buffers.
-
-			's'    'S'     copy buffer options
-			no     no      when buffer created
-			yes    no      when buffer first entered (default)
-			 X     yes     each time when buffer entered (vi comp.)
-								*cpo-t*
-		t	Search pattern for the tag command is remembered for
-			"n" command.  Otherwise Vim only puts the pattern in
-			the history for search pattern, but doesn't change the
-			last used search pattern.
-								*cpo-u*
-		u	Undo is Vi compatible.  See |undo-two-ways|.
-								*cpo-v*
-		v	Backspaced characters remain visible on the screen in
-			Insert mode.  Without this flag the characters are
-			erased from the screen right away.  With this flag the
-			screen newly typed text overwrites backspaced
-			characters.
-								*cpo-W*
-		W	Don't overwrite a readonly file.  When omitted, ":w!"
-			overwrites a readonly file, if possible.
-								*cpo-x*
-		x	<Esc> on the command-line executes the command-line.
-			The default in Vim is to abandon the command-line,
-			because <Esc> normally aborts a command.  |c_<Esc>|
-								*cpo-X*
-		X	When using a count with "R" the replaced text is
-			deleted only once.  Also when repeating "R" with "."
-			and a count.
-								*cpo-y*
-		y	A yank command can be redone with ".".  Think twice if
-			you really want to use this, it may break some
-			plugins, since most people expect "." to only repeat a
-			change.
-								*cpo-Z*
-		Z	When using "w!" while the 'readonly' option is set,
-			don't reset 'readonly'.
-								*cpo-!*
-		!	When redoing a filter command, use the last used
-			external command, whatever it was.  Otherwise the last
-			used -filter- command is used.
-								*cpo-$*
-		$	When making a change to one line, don't redisplay the
-			line, but put a '$' at the end of the changed text.
-			The changed text will be overwritten when you type the
-			new text.  The line is redisplayed if you type any
-			command that moves the cursor from the insertion
-			point.
-								*cpo-%*
-		%	Vi-compatible matching is done for the "%" command.
-			Does not recognize "#if", "#endif", etc.
-			Does not recognize "/*" and "*/".
-			Parens inside single and double quotes are also
-			counted, causing a string that contains a paren to
-			disturb the matching.  For example, in a line like
-			"if (strcmp("foo(", s))" the first paren does not
-			match the last one.  When this flag is not included,
-			parens inside single and double quotes are treated
-			specially.  When matching a paren outside of quotes,
-			everything inside quotes is ignored.  When matching a
-			paren inside quotes, it will find the matching one (if
-			there is one).  This works very well for C programs.
-			This flag is also used for other features, such as
-			C-indenting.
-								*cpo-+*
-		+	When included, a ":write file" command will reset the
-			'modified' flag of the buffer, even though the buffer
-			itself may still be different from its file.
-								*cpo->*
-		>	When appending to a register, put a line break before
-			the appended text.
-								*cpo-;*
-		;	When using |,| or |;| to repeat the last |t| search
-			and the cursor is right in front of the searched
-			character, the cursor won't move. When not included,
-			the cursor would skip over it and jump to the
-			following occurrence.
-								*cpo-_*
-		_	When using |cw| on a word, do not include the
-			whitespace following the word in the motion.
-
-			*'cursorbind'* *'crb'* *'nocursorbind'* *'nocrb'*
-'cursorbind' 'crb'	boolean	(default off)
-			local to window
-	When this option is set, as the cursor in the current
-	window moves other cursorbound windows (windows that also have
-	this option set) move their cursors to the corresponding line and
-	column.  This option is useful for viewing the
-	differences between two versions of a file (see 'diff'); in diff mode,
-	inserted and deleted lines (though not characters within a line) are
-	taken into account.
-
-			*'cursorcolumn'* *'cuc'* *'nocursorcolumn'* *'nocuc'*
-'cursorcolumn' 'cuc'	boolean	(default off)
-			local to window
-	Highlight the screen column of the cursor with CursorColumn
-	|hl-CursorColumn|.  Useful to align text.  Will make screen redrawing
-	slower.
-	If you only want the highlighting in the current window you can use
-	these autocommands: >vim
-		au WinLeave * set nocursorline nocursorcolumn
-		au WinEnter * set cursorline cursorcolumn
+        See also 'backup' and 'writebackup' options.
+        If you want to hide your backup files on Unix, consider this value: >vim
+                set backupdir=./.backup,~/.backup,.,/tmp
+<       You must create a ".backup" directory in each directory and in your
+        home directory for this to work properly.
+        The use of |:set+=| and |:set-=| is preferred when adding or removing
+        directories from the list.  This avoids problems when a future version
+        uses another default.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                        *'backupext'* *'bex'* *E589*
+'backupext' 'bex'       string (default "~")
+                        global
+        String which is appended to a file name to make the name of the
+        backup file.  The default is quite unusual, because this avoids
+        accidentally overwriting existing files with a backup file.  You might
+        prefer using ".bak", but make sure that you don't have files with
+        ".bak" that you want to keep.
+        Only normal file name characters can be used; `/\*?[|<>` are illegal.
+
+        If you like to keep a lot of backups, you could use a BufWritePre
+        autocommand to change 'backupext' just before writing the file to
+        include a timestamp. >vim
+                au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
+<       Use 'backupdir' to put the backup in a different directory.
+
+                                                            *'backupskip'* *'bsk'*
+'backupskip' 'bsk'      string (default "$TMPDIR/*,$TMP/*,$TEMP/*"
+                                        Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
+                                        Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
+                        global
+        A list of file patterns.  When one of the patterns matches with the
+        name of the file which is written, no backup file is created.  Both
+        the specified file name and the full path name of the file are used.
+        The pattern is used like with |:autocmd|, see |autocmd-pattern|.
+        Watch out for special characters, see |option-backslash|.
+        When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
+        default value.  "/tmp/*" is only used for Unix.
+
+        WARNING: Not having a backup file means that when Vim fails to write
+        your buffer correctly and then, for whatever reason, Vim exits, you
+        lose both the original file and what you were writing.  Only disable
+        backups if you don't care about losing the file.
+
+        Note that environment variables are not expanded.  If you want to use
+        $HOME you must expand it explicitly, e.g.: >vim
+                let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+
+<       Note that the default also makes sure that "crontab -e" works (when a
+        backup would be made by renaming the original file crontab won't see
+        the newly created file).  Also see 'backupcopy' and |crontab|.
+
+                                                                *'belloff'* *'bo'*
+'belloff' 'bo'          string (default "all")
+                        global
+        Specifies for which events the bell will not be rung. It is a comma-
+        separated list of items. For each item that is present, the bell
+        will be silenced. This is most useful to specify specific events in
+        insert mode to be silenced.
+
+        item        meaning when present        ~
+        all         All events.
+        backspace   When hitting <BS> or <Del> and deleting results in an
+                    error.
+        cursor      Fail to move around using the cursor keys or
+                    <PageUp>/<PageDown> in |Insert-mode|.
+        complete    Error occurred when using |i_CTRL-X_CTRL-K| or
+                    |i_CTRL-X_CTRL-T|.
+        copy        Cannot copy char from insert mode using |i_CTRL-Y| or
+                    |i_CTRL-E|.
+        ctrlg       Unknown Char after <C-G> in Insert mode.
+        error       Other Error occurred (e.g. try to join last line)
+                    (mostly used in |Normal-mode| or |Cmdline-mode|).
+        esc         hitting <Esc> in |Normal-mode|.
+        hangul      Ignored.
+        lang        Calling the beep module for Lua/Mzscheme/TCL.
+        mess        No output available for |g<|.
+        showmatch   Error occurred for 'showmatch' function.
+        operator    Empty region error |cpo-E|.
+        register    Unknown register after <C-R> in |Insert-mode|.
+        shell       Bell from shell output |:!|.
+        spell       Error happened on spell suggest.
+        wildmode    More matches in |cmdline-completion| available
+                    (depends on the 'wildmode' setting).
+
+        This is most useful to fine tune when in Insert mode the bell should
+        be rung. For Normal mode and Ex commands, the bell is often rung to
+        indicate that an error occurred. It can be silenced by adding the
+        "error" keyword.
+
+                                             *'binary'* *'bin'* *'nobinary'* *'nobin'*
+'binary' 'bin'          boolean (default off)
+                        local to buffer
+        This option should be set before editing a binary file.  You can also
+        use the |-b| Vim argument.  When this option is switched on a few
+        options will be changed (also when it already was on):
+                'textwidth'  will be set to 0
+                'wrapmargin' will be set to 0
+                'modeline'   will be off
+                'expandtab'  will be off
+        Also, 'fileformat' and 'fileformats' options will not be used, the
+        file is read and written like 'fileformat' was "unix" (a single <NL>
+        separates lines).
+        The 'fileencoding' and 'fileencodings' options will not be used, the
+        file is read without conversion.
+        NOTE: When you start editing a(nother) file while the 'bin' option is
+        on, settings from autocommands may change the settings again (e.g.,
+        'textwidth'), causing trouble when editing.  You might want to set
+        'bin' again when the file has been loaded.
+        The previous values of these options are remembered and restored when
+        'bin' is switched from on to off.  Each buffer has its own set of
+        saved option values.
+        To edit a file with 'binary' set you can use the |++bin| argument.
+        This avoids you have to do ":set bin", which would have effect for all
+        files you edit.
+        When writing a file the <EOL> for the last line is only written if
+        there was one in the original file (normally Vim appends an <EOL> to
+        the last line if there is none; this would make the file longer).  See
+        the 'endofline' option.
+
+                                                               *'bomb'* *'nobomb'*
+'bomb'                  boolean (default off)
+                        local to buffer
+        When writing a file and the following conditions are met, a BOM (Byte
+        Order Mark) is prepended to the file:
+        - this option is on
+        - the 'binary' option is off
+        - 'fileencoding' is "utf-8", "ucs-2", "ucs-4" or one of the little/big
+          endian variants.
+        Some applications use the BOM to recognize the encoding of the file.
+        Often used for UCS-2 files on MS-Windows.  For other applications it
+        causes trouble, for example: "cat file1 file2" makes the BOM of file2
+        appear halfway through the resulting file.  Gcc doesn't accept a BOM.
+        When Vim reads a file and 'fileencodings' starts with "ucs-bom", a
+        check for the presence of the BOM is done and 'bomb' set accordingly.
+        Unless 'binary' is set, it is removed from the first line, so that you
+        don't see it when editing.  When you don't change the options, the BOM
+        will be restored when writing the file.
+
+                                                               *'breakat'* *'brk'*
+'breakat' 'brk'         string (default " ^I!@*-+;:,./?")
+                        global
+        This option lets you choose which characters might cause a line
+        break if 'linebreak' is on.  Only works for ASCII characters.
+
+                                   *'breakindent'* *'bri'* *'nobreakindent'* *'nobri'*
+'breakindent' 'bri'     boolean (default off)
+                        local to window
+        Every wrapped line will continue visually indented (same amount of
+        space as the beginning of that line), thus preserving horizontal blocks
+        of text.
+
+                                                     *'breakindentopt'* *'briopt'*
+'breakindentopt' 'briopt' string (default "")
+                        local to window
+        Settings for 'breakindent'. It can consist of the following optional
+        items and must be separated by a comma:
+                min:{n}     Minimum text width that will be kept after
+                            applying 'breakindent', even if the resulting
+                            text should normally be narrower. This prevents
+                            text indented almost to the right window border
+                            occupying lot of vertical space when broken.
+                            (default: 20)
+                shift:{n}   After applying 'breakindent', the wrapped line's
+                            beginning will be shifted by the given number of
+                            characters.  It permits dynamic French paragraph
+                            indentation (negative) or emphasizing the line
+                            continuation (positive).
+                            (default: 0)
+                sbr         Display the 'showbreak' value before applying the
+                            additional indent.
+                            (default: off)
+                list:{n}    Adds an additional indent for lines that match a
+                            numbered or bulleted list (using the
+                            'formatlistpat' setting).
+                list:-1     Uses the length of a match with 'formatlistpat'
+                            for indentation.
+                            (default: 0)
+                column:{n}  Indent at column {n}. Will overrule the other
+                            sub-options. Note: an additional indent may be
+                            added for the 'showbreak' setting.
+                            (default: off)
+
+                                                           *'browsedir'* *'bsdir'*
+'browsedir' 'bsdir'     string (default "last")
+                        global
+        Which directory to use for the file browser:
+           last         Use same directory as with last file browser, where a
+                        file was opened or saved.
+           buffer       Use the directory of the related buffer.
+           current      Use the current directory.
+           {path}       Use the specified directory
+
+                                                              *'bufhidden'* *'bh'*
+'bufhidden' 'bh'        string (default "")
+                        local to buffer  |local-noglobal|
+        This option specifies what happens when a buffer is no longer
+        displayed in a window:
+          <empty>       follow the global 'hidden' option
+          hide          hide the buffer (don't unload it), even if 'hidden' is
+                        not set
+          unload        unload the buffer, even if 'hidden' is set; the
+                        |:hide| command will also unload the buffer
+          delete        delete the buffer from the buffer list, even if
+                        'hidden' is set; the |:hide| command will also delete
+                        the buffer, making it behave like |:bdelete|
+          wipe          wipe the buffer from the buffer list, even if
+                        'hidden' is set; the |:hide| command will also wipe
+                        out the buffer, making it behave like |:bwipeout|
+
+        CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
+        are lost without a warning.  Also, these values may break autocommands
+        that switch between buffers temporarily.
+        This option is used together with 'buftype' and 'swapfile' to specify
+        special kinds of buffers.   See |special-buffers|.
+
+                                     *'buflisted'* *'bl'* *'nobuflisted'* *'nobl'* *E85*
+'buflisted' 'bl'        boolean (default on)
+                        local to buffer
+        When this option is set, the buffer shows up in the buffer list.  If
+        it is reset it is not used for ":bnext", "ls", the Buffers menu, etc.
+        This option is reset by Vim for buffers that are only used to remember
+        a file name or marks.  Vim sets it when starting to edit a buffer.
+        But not when moving to a buffer with ":buffer".
+
+                                                           *'buftype'* *'bt'* *E382*
+'buftype' 'bt'          string (default "")
+                        local to buffer  |local-noglobal|
+        The value of this option specifies the type of a buffer:
+          <empty>       normal buffer
+          acwrite       buffer will always be written with |BufWriteCmd|s
+          help          help buffer (do not set this manually)
+          nofile        buffer is not related to a file, will not be written
+          nowrite       buffer will not be written
+          quickfix      list of errors |:cwindow| or locations |:lwindow|
+          terminal      |terminal-emulator| buffer
+          prompt        buffer where only the last line can be edited, meant
+                        to be used by a plugin, see |prompt-buffer|
+
+        This option is used together with 'bufhidden' and 'swapfile' to
+        specify special kinds of buffers.   See |special-buffers|.
+        Also see |win_gettype()|, which returns the type of the window.
+
+        Be careful with changing this option, it can have many side effects!
+        One such effect is that Vim will not check the timestamp of the file,
+        if the file is changed by another program this will not be noticed.
+
+        A "quickfix" buffer is only used for the error list and the location
+        list.  This value is set by the |:cwindow| and |:lwindow| commands and
+        you are not supposed to change it.
+
+        "nofile" and "nowrite" buffers are similar:
+        both:           The buffer is not to be written to disk, ":w" doesn't
+                        work (":w filename" does work though).
+        both:           The buffer is never considered to be |'modified'|.
+                        There is no warning when the changes will be lost, for
+                        example when you quit Vim.
+        both:           A swap file is only created when using too much memory
+                        (when 'swapfile' has been reset there is never a swap
+                        file).
+        nofile only:    The buffer name is fixed, it is not handled like a
+                        file name.  It is not modified in response to a |:cd|
+                        command.
+        both:           When using ":e bufname" and already editing "bufname"
+                        the buffer is made empty and autocommands are
+                        triggered as usual for |:edit|.
+                                                        *E676*
+        "acwrite" implies that the buffer name is not related to a file, like
+        "nofile", but it will be written.  Thus, in contrast to "nofile" and
+        "nowrite", ":w" does work and a modified buffer can't be abandoned
+        without saving.  For writing there must be matching |BufWriteCmd|,
+        |FileWriteCmd| or |FileAppendCmd| autocommands.
+
+                                                               *'casemap'* *'cmp'*
+'casemap' 'cmp'         string (default "internal,keepascii")
+                        global
+        Specifies details about changing the case of letters.  It may contain
+        these words, separated by a comma:
+        internal        Use internal case mapping functions, the current
+                        locale does not change the case mapping. When
+                        "internal" is omitted, the towupper() and towlower()
+                        system library functions are used when available.
+        keepascii       For the ASCII characters (0x00 to 0x7f) use the US
+                        case mapping, the current locale is not effective.
+                        This probably only matters for Turkish.
+
+                                             *'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
+'cdhome' 'cdh'          boolean (default off)
+                        global
+        When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
+        current working directory to the |$HOME| directory like in Unix.
+        When off, those commands just print the current directory name.
+        On Unix this option has no effect.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                       *'cdpath'* *'cd'* *E344* *E346*
+'cdpath' 'cd'           string (default equivalent to $CDPATH or ",,")
+                        global
+        This is a list of directories which will be searched when using the
+        |:cd|, |:tcd| and |:lcd| commands, provided that the directory being
+        searched for has a relative path, not an absolute part starting with
+        "/", "./" or "../", the 'cdpath' option is not used then.
+        The 'cdpath' option's value has the same form and semantics as
+        |'path'|.  Also see |file-searching|.
+        The default value is taken from $CDPATH, with a "," prepended to look
+        in the current directory first.
+        If the default value taken from $CDPATH is not what you want, include
+        a modified version of the following command in your vimrc file to
+        override it: >vim
+          let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
+<       This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+        (parts of 'cdpath' can be passed to the shell to expand file names).
+
+                                                                       *'cedit'*
+'cedit'                 string (default CTRL-F)
+                        global
+        The key used in Command-line Mode to open the command-line window.
+        Only non-printable keys are allowed.
+        The key can be specified as a single character, but it is difficult to
+        type.  The preferred way is to use the <> notation.  Examples: >vim
+                exe "set cedit=\<C-Y>"
+                exe "set cedit=\<Esc>"
+<       |Nvi| also has this option, but it only uses the first character.
+        See |cmdwin|.
+
+                                                                     *'channel'*
+'channel'               number (default 0)
+                        local to buffer
+        |channel| connected to the buffer, or 0 if no channel is connected.
+        In a |:terminal| buffer this is the terminal channel.
+        Read-only.
+
+                                            *'charconvert'* *'ccv'* *E202* *E214* *E513*
+'charconvert' 'ccv'     string (default "")
+                        global
+        An expression that is used for character encoding conversion.  It is
+        evaluated when a file that is to be read or has been written has a
+        different encoding from what is desired.
+        'charconvert' is not used when the internal iconv() function is
+        supported and is able to do the conversion.  Using iconv() is
+        preferred, because it is much faster.
+        'charconvert' is not used when reading stdin |--|, because there is no
+        file to convert from.  You will have to save the text in a file first.
+        The expression must return zero, false or an empty string for success,
+        non-zero or true for failure.
+        See |encoding-names| for possible encoding names.
+        Additionally, names given in 'fileencodings' and 'fileencoding' are
+        used.
+        Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
+        is done internally by Vim, 'charconvert' is not used for this.
+        Also used for Unicode conversion.
+        Example: >vim
+                set charconvert=CharConvert()
+                fun CharConvert()
+                  system("recode "
+                        \ .. v:charconvert_from .. ".." .. v:charconvert_to
+                        \ .. " <" .. v:fname_in .. " >" .. v:fname_out)
+                  return v:shell_error
+                endfun
+<       The related Vim variables are:
+                v:charconvert_from      name of the current encoding
+                v:charconvert_to        name of the desired encoding
+                v:fname_in              name of the input file
+                v:fname_out             name of the output file
+        Note that v:fname_in and v:fname_out will never be the same.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                           *'cindent'* *'cin'* *'nocindent'* *'nocin'*
+'cindent' 'cin'         boolean (default off)
+                        local to buffer
+        Enables automatic C program indenting.  See 'cinkeys' to set the keys
+        that trigger reindenting in insert mode and 'cinoptions' to set your
+        preferred indent style.
+        If 'indentexpr' is not empty, it overrules 'cindent'.
+        If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
+        the "=" operator indents using this algorithm rather than calling an
+        external program.
+        See |C-indenting|.
+        When you don't like the way 'cindent' works, try the 'smartindent'
+        option or 'indentexpr'.
+
+                                                              *'cinkeys'* *'cink'*
+'cinkeys' 'cink'        string (default "0{,0},0),0],:,0#,!^F,o,O,e")
+                        local to buffer
+        A list of keys that, when typed in Insert mode, cause reindenting of
+        the current line.  Only used if 'cindent' is on and 'indentexpr' is
+        empty.
+        For the format of this option see |cinkeys-format|.
+        See |C-indenting|.
+
+                                                           *'cinoptions'* *'cino'*
+'cinoptions' 'cino'     string (default "")
+                        local to buffer
+        The 'cinoptions' affect the way 'cindent' reindents lines in a C
+        program.  See |cinoptions-values| for the values of this option, and
+        |C-indenting| for info on C indenting in general.
+
+                                                       *'cinscopedecls'* *'cinsd'*
+'cinscopedecls' 'cinsd' string (default "public,protected,private")
+                        local to buffer
+        Keywords that are interpreted as a C++ scope declaration by |cino-g|.
+        Useful e.g. for working with the Qt framework that defines additional
+        scope declarations "signals", "public slots" and "private slots": >vim
+                set cinscopedecls+=signals,public\ slots,private\ slots
 <
 
-			*'cursorline'* *'cul'* *'nocursorline'* *'nocul'*
-'cursorline' 'cul'	boolean	(default off)
-			local to window
-	Highlight the text line of the cursor with CursorLine |hl-CursorLine|.
-	Useful to easily spot the cursor.  Will make screen redrawing slower.
-	When Visual mode is active the highlighting isn't used to make it
-	easier to see the selected text.
+                                                             *'cinwords'* *'cinw'*
+'cinwords' 'cinw'       string (default "if,else,while,do,for,switch")
+                        local to buffer
+        These keywords start an extra indent in the next line when
+        'smartindent' or 'cindent' is set.  For 'cindent' this is only done at
+        an appropriate place (inside {}).
+        Note that 'ignorecase' isn't used for 'cinwords'.  If case doesn't
+        matter, include the keyword both the uppercase and lowercase:
+        "if,If,IF".
 
-					*'cursorlineopt'* *'culopt'*
-'cursorlineopt' 'culopt'	string	(default "both")
-			local to window
-	Comma-separated list of settings for how 'cursorline' is displayed.
-	Valid values:
-	"line"		Highlight the text line of the cursor with
-			CursorLine |hl-CursorLine|.
-	"screenline"	Highlight only the screen line of the cursor with
-			CursorLine |hl-CursorLine|.
-	"number"	Highlight the line number of the cursor with
-			CursorLineNr |hl-CursorLineNr|.
+                                                              *'clipboard'* *'cb'*
+'clipboard' 'cb'        string (default "")
+                        global
+        This option is a list of comma-separated names.
+        These names are recognized:
 
-	Special value:
-	"both"		Alias for the values "line,number".
+                                                *clipboard-unnamed*
+        unnamed         When included, Vim will use the clipboard register "*"
+                        for all yank, delete, change and put operations which
+                        would normally go to the unnamed register.  When a
+                        register is explicitly specified, it will always be
+                        used regardless of whether "unnamed" is in 'clipboard'
+                        or not.  The clipboard register can always be
+                        explicitly accessed using the "* notation.  Also see
+                        |clipboard|.
 
-	"line" and "screenline" cannot be used together.
+                                                *clipboard-unnamedplus*
+        unnamedplus     A variant of the "unnamed" flag which uses the
+                        clipboard register "+" (|quoteplus|) instead of
+                        register "*" for all yank, delete, change and put
+                        operations which would normally go to the unnamed
+                        register.  When "unnamed" is also included to the
+                        option, yank and delete operations (but not put)
+                        will additionally copy the text into register
+                        "*". See |clipboard|.
 
-							*'debug'*
-'debug'			string	(default "")
-			global
-	These values can be used:
-	msg	Error messages that would otherwise be omitted will be given
-		anyway.
-	throw	Error messages that would otherwise be omitted will be given
-		anyway and also throw an exception and set |v:errmsg|.
-	beep	A message will be given when otherwise only a beep would be
-		produced.
-	The values can be combined, separated by a comma.
-	"msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
-	'indentexpr'.
+                                                              *'cmdheight'* *'ch'*
+'cmdheight' 'ch'        number (default 1)
+                        global or local to tab page |global-local|
+        Number of screen lines to use for the command-line.  Helps avoiding
+        |hit-enter| prompts.
+        The value of this option is stored with the tab page, so that each tab
+        page can have a different value.
 
-						*'define'* *'def'*
-'define' 'def'		string	(default "")
-			global or local to buffer |global-local|
-	Pattern to be used to find a macro definition.  It is a search
-	pattern, just like for the "/" command.  This option is used for the
-	commands like "[i" and "[d" |include-search|.  The 'isident' option is
-	used to recognize the defined name after the match: >
-		{match with 'define'}{non-ID chars}{defined name}{non-ID char}
-<	See |option-backslash| about inserting backslashes to include a space
-	or backslash.
-	For C++ this value would be useful, to include const type declarations: >
-		^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
-<	You can also use "\ze" just before the name and continue the pattern
-	to check what is following.  E.g. for Javascript, if a function is
-	defined with `func_name = function(args)`: >
-		^\s*\ze\i\+\s*=\s*function(
-<	If the function is defined with `func_name : function() {...`: >
-	        ^\s*\ze\i\+\s*[:]\s*(*function\s*(
-<	When using the ":set" command, you need to double the backslashes!
-	To avoid that use `:let` with a single quote string: >vim
-		let &l:define = '^\s*\ze\k\+\s*=\s*function('
+        When 'cmdheight' is zero, there is no command-line unless it is being
+        used.  The command-line will cover the last line of the screen when
+        shown.
+
+        WARNING: `cmdheight=0` is considered experimental. Expect some
+        unwanted behaviour. Some 'shortmess' flags and similar
+        mechanism might fail to take effect, causing unwanted hit-enter
+        prompts.  Some informative messages, both from Nvim itself and
+        plugins, will not be displayed.
+
+                                                          *'cmdwinheight'* *'cwh'*
+'cmdwinheight' 'cwh'    number (default 7)
+                        global
+        Number of screen lines to use for the command-line window. |cmdwin|
+
+                                                            *'colorcolumn'* *'cc'*
+'colorcolumn' 'cc'      string (default "")
+                        local to window
+        'colorcolumn' is a comma-separated list of screen columns that are
+        highlighted with ColorColumn |hl-ColorColumn|.  Useful to align
+        text.  Will make screen redrawing slower.
+        The screen column can be an absolute number, or a number preceded with
+        '+' or '-', which is added to or subtracted from 'textwidth'. >vim
+
+                set cc=+1         " highlight column after 'textwidth'
+                set cc=+1,+2,+3  " highlight three columns after 'textwidth'
+                hi ColorColumn ctermbg=lightgrey guibg=lightgrey
+<
+        When 'textwidth' is zero then the items with '-' and '+' are not used.
+        A maximum of 256 columns are highlighted.
+
+                                                           *'columns'* *'co'* *E594*
+'columns' 'co'          number (default 80 or terminal width)
+                        global
+        Number of columns of the screen.  Normally this is set by the terminal
+        initialization and does not have to be set by hand.
+        When Vim is running in the GUI or in a resizable window, setting this
+        option will cause the window size to be changed.  When you only want
+        to use the size for the GUI, put the command in your |ginit.vim| file.
+        When you set this option and Vim is unable to change the physical
+        number of columns of the display, the display may be messed up.  For
+        the GUI it is always possible and Vim limits the number of columns to
+        what fits on the screen.  You can use this command to get the widest
+        window possible: >vim
+                set columns=9999
+<       Minimum value is 12, maximum value is 10000.
+
+                                                    *'comments'* *'com'* *E524* *E525*
+'comments' 'com'        string (default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
+                        local to buffer
+        A comma-separated list of strings that can start a comment line.  See
+        |format-comments|.  See |option-backslash| about using backslashes to
+        insert a space.
+
+                                                    *'commentstring'* *'cms'* *E537*
+'commentstring' 'cms'   string (default "")
+                        local to buffer
+        A template for a comment.  The "%s" in the value is replaced with the
+        comment text.  For example, C uses "/*%s*/". Currently only used to
+        add markers for folding, see |fold-marker|.
+
+                                                         *'complete'* *'cpt'* *E535*
+'complete' 'cpt'        string (default ".,w,b,u,t")
+                        local to buffer
+        This option specifies how keyword completion |ins-completion| works
+        when CTRL-P or CTRL-N are used.  It is also used for whole-line
+        completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
+        and the places to scan.  It is a comma-separated list of flags:
+        .       scan the current buffer ('wrapscan' is ignored)
+        w       scan buffers from other windows
+        b       scan other loaded buffers that are in the buffer list
+        u       scan the unloaded buffers that are in the buffer list
+        U       scan the buffers that are not in the buffer list
+        k       scan the files given with the 'dictionary' option
+        kspell  use the currently active spell checking |spell|
+        k{dict} scan the file {dict}.  Several "k" flags can be given,
+                patterns are valid too.  For example: >vim
+                        set cpt=k/usr/dict/*,k~/spanish
+<       s       scan the files given with the 'thesaurus' option
+        s{tsr}  scan the file {tsr}.  Several "s" flags can be given, patterns
+                are valid too.
+        i       scan current and included files
+        d       scan current and included files for defined name or macro
+                |i_CTRL-X_CTRL-D|
+        ]       tag completion
+        t       same as "]"
+        f       scan the buffer names (as opposed to buffer contents)
+
+        Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
+        not executed, this may lead to unexpected completions from some files
+        (gzipped files for example).  Unloaded buffers are not scanned for
+        whole-line completion.
+
+        As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
+        based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
+        |i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
+
+                                                          *'completefunc'* *'cfu'*
+'completefunc' 'cfu'    string (default "")
+                        local to buffer
+        This option specifies a function to be used for Insert mode completion
+        with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
+        See |complete-functions| for an explanation of how the function is
+        invoked and what it should return.  The value can be the name of a
+        function, a |lambda| or a |Funcref|. See |option-value-function| for
+        more information.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                           *'completeopt'* *'cot'*
+'completeopt' 'cot'     string (default "menu,preview")
+                        global
+        A comma-separated list of options for Insert mode completion
+        |ins-completion|.  The supported values are:
+
+           menu     Use a popup menu to show the possible completions.  The
+                    menu is only shown when there is more than one match and
+                    sufficient colors are available.  |ins-completion-menu|
+
+           menuone  Use the popup menu also when there is only one match.
+                    Useful when there is additional information about the
+                    match, e.g., what file it comes from.
+
+           longest  Only insert the longest common text of the matches.  If
+                    the menu is displayed you can use CTRL-L to add more
+                    characters.  Whether case is ignored depends on the kind
+                    of completion.  For buffer text the 'ignorecase' option is
+                    used.
+
+           preview  Show extra information about the currently selected
+                    completion in the preview window.  Only works in
+                    combination with "menu" or "menuone".
+
+           noinsert Do not insert any text for a match until the user selects
+                    a match from the menu. Only works in combination with
+                    "menu" or "menuone". No effect if "longest" is present.
+
+           noselect Do not select a match in the menu, force the user to
+                    select one from the menu. Only works in combination with
+                    "menu" or "menuone".
+
+           popup    Show extra information about the currently selected
+                    completion in a popup window.  Only works in combination
+                    with "menu" or "menuone".  Overrides "preview".
+
+                                                         *'completeslash'* *'csl'*
+'completeslash' 'csl'   string (default "")
+                        local to buffer
+        only for MS-Windows
+        When this option is set it overrules 'shellslash' for completion:
+        - When this option is set to "slash", a forward slash is used for path
+        completion in insert mode. This is useful when editing HTML tag, or
+        Makefile with 'noshellslash' on MS-Windows.
+        - When this option is set to "backslash", backslash is used. This is
+        useful when editing a batch file with 'shellslash' set on MS-Windows.
+        - When this option is empty, same character is used as for
+        'shellslash'.
+        For Insert mode completion the buffer-local value is used.  For
+        command line completion the global value is used.
+
+                                                        *'concealcursor'* *'cocu'*
+'concealcursor' 'cocu'  string (default "")
+                        local to window
+        Sets the modes in which text in the cursor line can also be concealed.
+        When the current mode is listed then concealing happens just like in
+        other lines.
+          n             Normal mode
+          v             Visual mode
+          i             Insert mode
+          c             Command line editing, for 'incsearch'
+
+        'v' applies to all lines in the Visual area, not only the cursor.
+        A useful value is "nc".  This is used in help files.  So long as you
+        are moving around text is concealed, but when starting to insert text
+        or selecting a Visual area the concealed text is displayed, so that
+        you can see what you are doing.
+        Keep in mind that the cursor position is not always where it's
+        displayed.  E.g., when moving vertically it may change column.
+
+                                                         *'conceallevel'* *'cole'*
+'conceallevel' 'cole'   number (default 0)
+                        local to window
+        Determine how text with the "conceal" syntax attribute |:syn-conceal|
+        is shown:
+
+        Value           Effect ~
+        0               Text is shown normally
+        1               Each block of concealed text is replaced with one
+                        character.  If the syntax item does not have a custom
+                        replacement character defined (see |:syn-cchar|) the
+                        character defined in 'listchars' is used.
+                        It is highlighted with the "Conceal" highlight group.
+        2               Concealed text is completely hidden unless it has a
+                        custom replacement character defined (see
+                        |:syn-cchar|).
+        3               Concealed text is completely hidden.
+
+        Note: in the cursor line concealed text is not hidden, so that you can
+        edit and copy the text.  This can be changed with the 'concealcursor'
+        option.
+
+                                             *'confirm'* *'cf'* *'noconfirm'* *'nocf'*
+'confirm' 'cf'          boolean (default off)
+                        global
+        When 'confirm' is on, certain operations that would normally
+        fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
+        instead raise a dialog asking if you wish to save the current
+        file(s).  You can still use a ! to unconditionally |abandon| a buffer.
+        If 'confirm' is off you can still activate confirmation for one
+        command only (this is most useful in mappings) with the |:confirm|
+        command.
+        Also see the |confirm()| function and the 'v' flag in 'guioptions'.
+
+                                       *'copyindent'* *'ci'* *'nocopyindent'* *'noci'*
+'copyindent' 'ci'       boolean (default off)
+                        local to buffer
+        Copy the structure of the existing lines indent when autoindenting a
+        new line.  Normally the new indent is reconstructed by a series of
+        tabs followed by spaces as required (unless |'expandtab'| is enabled,
+        in which case only spaces are used).  Enabling this option makes the
+        new line copy whatever characters were used for indenting on the
+        existing line.  'expandtab' has no effect on these characters, a Tab
+        remains a Tab.  If the new indent is greater than on the existing
+        line, the remaining space is filled in the normal manner.
+        See 'preserveindent'.
+
+                                                         *'cpoptions'* *'cpo'* *cpo*
+'cpoptions' 'cpo'       string (default "aABceFs_")
+                        global
+        A sequence of single character flags.  When a character is present
+        this indicates Vi-compatible behavior.  This is used for things where
+        not being Vi-compatible is mostly or sometimes preferred.
+        'cpoptions' stands for "compatible-options".
+        Commas can be added for readability.
+        To avoid problems with flags that are added in the future, use the
+        "+=" and "-=" feature of ":set" |add-option-flags|.
+
+            contains    behavior        ~
+                                                                *cpo-a*
+                a       When included, a ":read" command with a file name
+                        argument will set the alternate file name for the
+                        current window.
+                                                                *cpo-A*
+                A       When included, a ":write" command with a file name
+                        argument will set the alternate file name for the
+                        current window.
+                                                                *cpo-b*
+                b       "\|" in a ":map" command is recognized as the end of
+                        the map command.  The '\' is included in the mapping,
+                        the text after the '|' is interpreted as the next
+                        command.  Use a CTRL-V instead of a backslash to
+                        include the '|' in the mapping.  Applies to all
+                        mapping, abbreviation, menu and autocmd commands.
+                        See also |map_bar|.
+                                                                *cpo-B*
+                B       A backslash has no special meaning in mappings,
+                        abbreviations, user commands and the "to" part of the
+                        menu commands.  Remove this flag to be able to use a
+                        backslash like a CTRL-V.  For example, the command
+                        ":map X \<Esc>" results in X being mapped to:
+                                'B' included:   "\^["    (^[ is a real <Esc>)
+                                'B' excluded:   "<Esc>"  (5 characters)
+                                                                *cpo-c*
+                c       Searching continues at the end of any match at the
+                        cursor position, but not further than the start of the
+                        next line.  When not present searching continues
+                        one character from the cursor position.  With 'c'
+                        "abababababab" only gets three matches when repeating
+                        "/abab", without 'c' there are five matches.
+                                                                *cpo-C*
+                C       Do not concatenate sourced lines that start with a
+                        backslash.  See |line-continuation|.
+                                                                *cpo-d*
+                d       Using "./" in the 'tags' option doesn't mean to use
+                        the tags file relative to the current file, but the
+                        tags file in the current directory.
+                                                                *cpo-D*
+                D       Can't use CTRL-K to enter a digraph after Normal mode
+                        commands with a character argument, like |r|, |f| and
+                        |t|.
+                                                                *cpo-e*
+                e       When executing a register with ":@r", always add a
+                        <CR> to the last line, also when the register is not
+                        linewise.  If this flag is not present, the register
+                        is not linewise and the last line does not end in a
+                        <CR>, then the last line is put on the command-line
+                        and can be edited before hitting <CR>.
+                                                                *cpo-E*
+                E       It is an error when using "y", "d", "c", "g~", "gu" or
+                        "gU" on an Empty region.  The operators only work when
+                        at least one character is to be operated on.  Example:
+                        This makes "y0" fail in the first column.
+                                                                *cpo-f*
+                f       When included, a ":read" command with a file name
+                        argument will set the file name for the current buffer,
+                        if the current buffer doesn't have a file name yet.
+                                                                *cpo-F*
+                F       When included, a ":write" command with a file name
+                        argument will set the file name for the current
+                        buffer, if the current buffer doesn't have a file name
+                        yet.  Also see |cpo-P|.
+                                                                *cpo-i*
+                i       When included, interrupting the reading of a file will
+                        leave it modified.
+                                                                *cpo-I*
+                I       When moving the cursor up or down just after inserting
+                        indent for 'autoindent', do not delete the indent.
+                                                                *cpo-J*
+                J       A |sentence| has to be followed by two spaces after
+                        the '.', '!' or '?'.  A <Tab> is not recognized as
+                        white space.
+                                                                *cpo-K*
+                K       Don't wait for a key code to complete when it is
+                        halfway through a mapping.  This breaks mapping
+                        <F1><F1> when only part of the second <F1> has been
+                        read.  It enables cancelling the mapping by typing
+                        <F1><Esc>.
+                                                                *cpo-l*
+                l       Backslash in a [] range in a search pattern is taken
+                        literally, only "\]", "\^", "\-" and "\\" are special.
+                        See |/[]|
+                           'l' included: "/[ \t]"  finds <Space>, '\' and 't'
+                           'l' excluded: "/[ \t]"  finds <Space> and <Tab>
+                                                                *cpo-L*
+                L       When the 'list' option is set, 'wrapmargin',
+                        'textwidth', 'softtabstop' and Virtual Replace mode
+                        (see |gR|) count a <Tab> as two characters, instead of
+                        the normal behavior of a <Tab>.
+                                                                *cpo-m*
+                m       When included, a showmatch will always wait half a
+                        second.  When not included, a showmatch will wait half
+                        a second or until a character is typed.  |'showmatch'|
+                                                                *cpo-M*
+                M       When excluded, "%" matching will take backslashes into
+                        account.  Thus in "( \( )" and "\( ( \)" the outer
+                        parenthesis match.  When included "%" ignores
+                        backslashes, which is Vi compatible.
+                                                                *cpo-n*
+                n       When included, the column used for 'number' and
+                        'relativenumber' will also be used for text of wrapped
+                        lines.
+                                                                *cpo-o*
+                o       Line offset to search command is not remembered for
+                        next search.
+                                                                *cpo-O*
+                O       Don't complain if a file is being overwritten, even
+                        when it didn't exist when editing it.  This is a
+                        protection against a file unexpectedly created by
+                        someone else.  Vi didn't complain about this.
+                                                                *cpo-p*
+                p       Vi compatible Lisp indenting.  When not present, a
+                        slightly better algorithm is used.
+                                                                *cpo-P*
+                P       When included, a ":write" command that appends to a
+                        file will set the file name for the current buffer, if
+                        the current buffer doesn't have a file name yet and
+                        the 'F' flag is also included |cpo-F|.
+                                                                *cpo-q*
+                q       When joining multiple lines leave the cursor at the
+                        position where it would be when joining two lines.
+                                                                *cpo-r*
+                r       Redo ("." command) uses "/" to repeat a search
+                        command, instead of the actually used search string.
+                                                                *cpo-R*
+                R       Remove marks from filtered lines.  Without this flag
+                        marks are kept like |:keepmarks| was used.
+                                                                *cpo-s*
+                s       Set buffer options when entering the buffer for the
+                        first time.  This is like it is in Vim version 3.0.
+                        And it is the default.  If not present the options are
+                        set when the buffer is created.
+                                                                *cpo-S*
+                S       Set buffer options always when entering a buffer
+                        (except 'readonly', 'fileformat', 'filetype' and
+                        'syntax').  This is the (most) Vi compatible setting.
+                        The options are set to the values in the current
+                        buffer.  When you change an option and go to another
+                        buffer, the value is copied.  Effectively makes the
+                        buffer options global to all buffers.
+
+                        's'    'S'     copy buffer options
+                        no     no      when buffer created
+                        yes    no      when buffer first entered (default)
+                         X     yes     each time when buffer entered (vi comp.)
+                                                                *cpo-t*
+                t       Search pattern for the tag command is remembered for
+                        "n" command.  Otherwise Vim only puts the pattern in
+                        the history for search pattern, but doesn't change the
+                        last used search pattern.
+                                                                *cpo-u*
+                u       Undo is Vi compatible.  See |undo-two-ways|.
+                                                                *cpo-v*
+                v       Backspaced characters remain visible on the screen in
+                        Insert mode.  Without this flag the characters are
+                        erased from the screen right away.  With this flag the
+                        screen newly typed text overwrites backspaced
+                        characters.
+                                                                *cpo-W*
+                W       Don't overwrite a readonly file.  When omitted, ":w!"
+                        overwrites a readonly file, if possible.
+                                                                *cpo-x*
+                x       <Esc> on the command-line executes the command-line.
+                        The default in Vim is to abandon the command-line,
+                        because <Esc> normally aborts a command.  |c_<Esc>|
+                                                                *cpo-X*
+                X       When using a count with "R" the replaced text is
+                        deleted only once.  Also when repeating "R" with "."
+                        and a count.
+                                                                *cpo-y*
+                y       A yank command can be redone with ".".  Think twice if
+                        you really want to use this, it may break some
+                        plugins, since most people expect "." to only repeat a
+                        change.
+                                                                *cpo-Z*
+                Z       When using "w!" while the 'readonly' option is set,
+                        don't reset 'readonly'.
+                                                                *cpo-!*
+                !       When redoing a filter command, use the last used
+                        external command, whatever it was.  Otherwise the last
+                        used -filter- command is used.
+                                                                *cpo-$*
+                $       When making a change to one line, don't redisplay the
+                        line, but put a '$' at the end of the changed text.
+                        The changed text will be overwritten when you type the
+                        new text.  The line is redisplayed if you type any
+                        command that moves the cursor from the insertion
+                        point.
+                                                                *cpo-%*
+                %       Vi-compatible matching is done for the "%" command.
+                        Does not recognize "#if", "#endif", etc.
+                        Does not recognize "/*" and "*/".
+                        Parens inside single and double quotes are also
+                        counted, causing a string that contains a paren to
+                        disturb the matching.  For example, in a line like
+                        "if (strcmp("foo(", s))" the first paren does not
+                        match the last one.  When this flag is not included,
+                        parens inside single and double quotes are treated
+                        specially.  When matching a paren outside of quotes,
+                        everything inside quotes is ignored.  When matching a
+                        paren inside quotes, it will find the matching one (if
+                        there is one).  This works very well for C programs.
+                        This flag is also used for other features, such as
+                        C-indenting.
+                                                                *cpo-+*
+                +       When included, a ":write file" command will reset the
+                        'modified' flag of the buffer, even though the buffer
+                        itself may still be different from its file.
+                                                                *cpo->*
+                >       When appending to a register, put a line break before
+                        the appended text.
+                                                                *cpo-;*
+                ;       When using |,| or |;| to repeat the last |t| search
+                        and the cursor is right in front of the searched
+                        character, the cursor won't move. When not included,
+                        the cursor would skip over it and jump to the
+                        following occurrence.
+                                                                *cpo-_*
+                _       When using |cw| on a word, do not include the
+                        whitespace following the word in the motion.
+
+                                     *'cursorbind'* *'crb'* *'nocursorbind'* *'nocrb'*
+'cursorbind' 'crb'      boolean (default off)
+                        local to window
+        When this option is set, as the cursor in the current
+        window moves other cursorbound windows (windows that also have
+        this option set) move their cursors to the corresponding line and
+        column.  This option is useful for viewing the
+        differences between two versions of a file (see 'diff'); in diff mode,
+        inserted and deleted lines (though not characters within a line) are
+        taken into account.
+
+                                 *'cursorcolumn'* *'cuc'* *'nocursorcolumn'* *'nocuc'*
+'cursorcolumn' 'cuc'    boolean (default off)
+                        local to window
+        Highlight the screen column of the cursor with CursorColumn
+        |hl-CursorColumn|.  Useful to align text.  Will make screen redrawing
+        slower.
+        If you only want the highlighting in the current window you can use
+        these autocommands: >vim
+                au WinLeave * set nocursorline nocursorcolumn
+                au WinEnter * set cursorline cursorcolumn
 <
 
-			*'delcombine'* *'deco'* *'nodelcombine'* *'nodeco'*
-'delcombine' 'deco'	boolean	(default off)
-			global
-	If editing Unicode and this option is set, backspace and Normal mode
-	"x" delete each combining character on its own.  When it is off (the
-	default) the character along with its combining characters are
-	deleted.
-	Note: When 'delcombine' is set "xx" may work differently from "2x"!
+                                     *'cursorline'* *'cul'* *'nocursorline'* *'nocul'*
+'cursorline' 'cul'      boolean (default off)
+                        local to window
+        Highlight the text line of the cursor with CursorLine |hl-CursorLine|.
+        Useful to easily spot the cursor.  Will make screen redrawing slower.
+        When Visual mode is active the highlighting isn't used to make it
+        easier to see the selected text.
 
-	This is useful for Arabic, Hebrew and many other languages where one
-	may have combining characters overtop of base characters, and want
-	to remove only the combining ones.
+                                                      *'cursorlineopt'* *'culopt'*
+'cursorlineopt' 'culopt' string (default "both")
+                        local to window
+        Comma-separated list of settings for how 'cursorline' is displayed.
+        Valid values:
+        "line"          Highlight the text line of the cursor with
+                        CursorLine |hl-CursorLine|.
+        "screenline"    Highlight only the screen line of the cursor with
+                        CursorLine |hl-CursorLine|.
+        "number"        Highlight the line number of the cursor with
+                        CursorLineNr |hl-CursorLineNr|.
 
-						*'dictionary'* *'dict'*
-'dictionary' 'dict'	string	(default "")
-			global or local to buffer |global-local|
-	List of file names, separated by commas, that are used to lookup words
-	for keyword completion commands |i_CTRL-X_CTRL-K|.  Each file should
-	contain a list of words.  This can be one word per line, or several
-	words per line, separated by non-keyword characters (white space is
-	preferred).  Maximum line length is 510 bytes.
+        Special value:
+        "both"          Alias for the values "line,number".
 
-	When this option is empty or an entry "spell" is present, and spell
-	checking is enabled, words in the word lists for the currently active
-	'spelllang' are used. See |spell|.
+        "line" and "screenline" cannot be used together.
 
-	To include a comma in a file name precede it with a backslash.  Spaces
-	after a comma are ignored, otherwise spaces are included in the file
-	name.  See |option-backslash| about using backslashes.
-	This has nothing to do with the |Dictionary| variable type.
-	Where to find a list of words?
-	- BSD/macOS include the "/usr/share/dict/words" file.
-	- Try "apt install spell" to get the "/usr/share/dict/words" file on
-	  apt-managed systems (Debian/Ubuntu).
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	directories from the list.  This avoids problems when a future version
-	uses another default.
-	Backticks cannot be used in this option for security reasons.
+                                                                       *'debug'*
+'debug'                 string (default "")
+                        global
+        These values can be used:
+        msg     Error messages that would otherwise be omitted will be given
+                anyway.
+        throw   Error messages that would otherwise be omitted will be given
+                anyway and also throw an exception and set |v:errmsg|.
+        beep    A message will be given when otherwise only a beep would be
+                produced.
+        The values can be combined, separated by a comma.
+        "msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
+        'indentexpr'.
 
-						*'diff'* *'nodiff'*
-'diff'			boolean	(default off)
-			local to window
-	Join the current window in the group of windows that shows differences
-	between files.  See |diff-mode|.
-
-						*'diffexpr'* *'dex'*
-'diffexpr' 'dex'	string	(default "")
-			global
-	Expression which is evaluated to obtain a diff file (either ed-style
-	or unified-style) from two versions of a file.  See |diff-diffexpr|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'diffopt'* *'dip'*
-'diffopt' 'dip'		string	(default "internal,filler,closeoff")
-			global
-	Option settings for diff mode.  It can consist of the following items.
-	All are optional.  Items must be separated by a comma.
-
-		filler		Show filler lines, to keep the text
-				synchronized with a window that has inserted
-				lines at the same position.  Mostly useful
-				when windows are side-by-side and 'scrollbind'
-				is set.
-
-		context:{n}	Use a context of {n} lines between a change
-				and a fold that contains unchanged lines.
-				When omitted a context of six lines is used.
-				When using zero the context is actually one,
-				since folds require a line in between, also
-				for a deleted line. Set it to a very large
-				value (999999) to disable folding completely.
-				See |fold-diff|.
-
-		iblank		Ignore changes where lines are all blank.  Adds
-				the "-B" flag to the "diff" command if
-				'diffexpr' is empty.  Check the documentation
-				of the "diff" command for what this does
-				exactly.
-				NOTE: the diff windows will get out of sync,
-				because no differences between blank lines are
-				taken into account.
-
-		icase		Ignore changes in case of text.  "a" and "A"
-				are considered the same.  Adds the "-i" flag
-				to the "diff" command if 'diffexpr' is empty.
-
-		iwhite		Ignore changes in amount of white space.  Adds
-				the "-b" flag to the "diff" command if
-				'diffexpr' is empty.  Check the documentation
-				of the "diff" command for what this does
-				exactly.  It should ignore adding trailing
-				white space, but not leading white space.
-
-		iwhiteall	Ignore all white space changes.  Adds
-				the "-w" flag to the "diff" command if
-				'diffexpr' is empty.  Check the documentation
-				of the "diff" command for what this does
-				exactly.
-
-		iwhiteeol	Ignore white space changes at end of line.
-				Adds the "-Z" flag to the "diff" command if
-				'diffexpr' is empty.  Check the documentation
-				of the "diff" command for what this does
-				exactly.
-
-		horizontal	Start diff mode with horizontal splits (unless
-				explicitly specified otherwise).
-
-		vertical	Start diff mode with vertical splits (unless
-				explicitly specified otherwise).
-
-		closeoff	When a window is closed where 'diff' is set
-				and there is only one window remaining in the
-				same tab page with 'diff' set, execute
-				`:diffoff` in that window.  This undoes a
-				`:diffsplit` command.
-
-		hiddenoff	Do not use diff mode for a buffer when it
-				becomes hidden.
-
-		foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
-				starting diff mode.  Without this 2 is used.
-
-		followwrap	Follow the 'wrap' option and leave as it is.
-
-		internal	Use the internal diff library.  This is
-				ignored when 'diffexpr' is set.  *E960*
-				When running out of memory when writing a
-				buffer this item will be ignored for diffs
-				involving that buffer.  Set the 'verbose'
-				option to see when this happens.
-
-		indent-heuristic
-				Use the indent heuristic for the internal
-				diff library.
-
-		linematch:{n}   Enable a second stage diff on each generated
-				hunk in order to align lines. When the total
-				number of lines in a hunk exceeds {n}, the
-				second stage diff will not be performed as
-				very large hunks can cause noticeable lag. A
-				recommended setting is "linematch:60", as this
-				will enable alignment for a 2 buffer diff with
-				hunks of up to 30 lines each, or a 3 buffer
-				diff with hunks of up to 20 lines each.
-
-		algorithm:{text} Use the specified diff algorithm with the
-				internal diff engine. Currently supported
-				algorithms are:
-				myers      the default algorithm
-				minimal    spend extra time to generate the
-					   smallest possible diff
-				patience   patience diff algorithm
-				histogram  histogram diff algorithm
-
-	Examples: >vim
-		set diffopt=internal,filler,context:4
-		set diffopt=
-		set diffopt=internal,filler,foldcolumn:3
-		set diffopt-=internal  " do NOT use the internal diff parser
+                                                                *'define'* *'def'*
+'define' 'def'          string (default "")
+                        global or local to buffer |global-local|
+        Pattern to be used to find a macro definition.  It is a search
+        pattern, just like for the "/" command.  This option is used for the
+        commands like "[i" and "[d" |include-search|.  The 'isident' option is
+        used to recognize the defined name after the match: >
+                {match with 'define'}{non-ID chars}{defined name}{non-ID char}
+<       See |option-backslash| about inserting backslashes to include a space
+        or backslash.
+        For C++ this value would be useful, to include const type declarations: >
+                ^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
+<       You can also use "\ze" just before the name and continue the pattern
+        to check what is following.  E.g. for Javascript, if a function is
+        defined with `func_name = function(args)`: >
+                ^\s*\ze\i\+\s*=\s*function(
+<       If the function is defined with `func_name : function() {...`: >
+                ^\s*\ze\i\+\s*[:]\s*(*function\s*(
+<       When using the ":set" command, you need to double the backslashes!
+        To avoid that use `:let` with a single quote string: >vim
+                let &l:define = '^\s*\ze\k\+\s*=\s*function('
 <
 
-				*'digraph'* *'dg'* *'nodigraph'* *'nodg'*
-'digraph' 'dg'		boolean	(default off)
-			global
-	Enable the entering of digraphs in Insert mode with {char1} <BS>
-	{char2}.  See |digraphs|.
+                                   *'delcombine'* *'deco'* *'nodelcombine'* *'nodeco'*
+'delcombine' 'deco'     boolean (default off)
+                        global
+        If editing Unicode and this option is set, backspace and Normal mode
+        "x" delete each combining character on its own.  When it is off (the
+        default) the character along with its combining characters are
+        deleted.
+        Note: When 'delcombine' is set "xx" may work differently from "2x"!
 
-						*'directory'* *'dir'*
-'directory' 'dir'	string	(default "$XDG_STATE_HOME/nvim/swap//")
-			global
-	List of directory names for the swap file, separated with commas.
+        This is useful for Arabic, Hebrew and many other languages where one
+        may have combining characters overtop of base characters, and want
+        to remove only the combining ones.
 
-	Possible items:
-	- The swap file will be created in the first directory where this is
-	  possible.  If it is not possible in any directory, but last
-	  directory listed in the option does not exist, it is created.
-	- Empty means that no swap file will be used (recovery is
-	  impossible!) and no |E303| error will be given.
-	- A directory "." means to put the swap file in the same directory as
-	  the edited file.  On Unix, a dot is prepended to the file name, so
-	  it doesn't show in a directory listing.  On MS-Windows the "hidden"
-	  attribute is set and a dot prepended if possible.
-	- A directory starting with "./" (or ".\" for MS-Windows) means to put
-	  the swap file relative to where the edited file is.  The leading "."
-	  is replaced with the path name of the edited file.
-	- For Unix and Win32, if a directory ends in two path separators "//",
-	  the swap file name will be built from the complete path to the file
-	  with all path separators replaced by percent '%' signs (including
-	  the colon following the drive letter on Win32). This will ensure
-	  file name uniqueness in the preserve directory.
-	  On Win32, it is also possible to end with "\\".  However, When a
-	  separating comma is following, you must use "//", since "\\" will
-	  include the comma in the file name. Therefore it is recommended to
-	  use '//', instead of '\\'.
-	- Spaces after the comma are ignored, other spaces are considered part
-	  of the directory name.  To have a space at the start of a directory
-	  name, precede it with a backslash.
-	- To include a comma in a directory name precede it with a backslash.
-	- A directory name may end in an ':' or '/'.
-	- Environment variables are expanded |:set_env|.
-	- Careful with '\' characters, type one before a space, type two to
-	  get one in the option (see |option-backslash|), for example: >vim
-	    set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
-<
-	Editing the same file twice will result in a warning.  Using "/tmp" on
-	is discouraged: if the system crashes you lose the swap file. And
-	others on the computer may be able to see the files.
-	Use |:set+=| and |:set-=| when adding or removing directories from the
-	list, this avoids problems if the Nvim default is changed.
+                                                           *'dictionary'* *'dict'*
+'dictionary' 'dict'     string (default "")
+                        global or local to buffer |global-local|
+        List of file names, separated by commas, that are used to lookup words
+        for keyword completion commands |i_CTRL-X_CTRL-K|.  Each file should
+        contain a list of words.  This can be one word per line, or several
+        words per line, separated by non-keyword characters (white space is
+        preferred).  Maximum line length is 510 bytes.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+        When this option is empty or an entry "spell" is present, and spell
+        checking is enabled, words in the word lists for the currently active
+        'spelllang' are used. See |spell|.
 
-						*'display'* *'dy'*
-'display' 'dy'		string	(default "lastline")
-			global
-	Change the way text is displayed.  This is a comma-separated list of
-	flags:
-	lastline	When included, as much as possible of the last line
-			in a window will be displayed.  "@@@" is put in the
-			last columns of the last screen line to indicate the
-			rest of the line is not displayed.
-	truncate	Like "lastline", but "@@@" is displayed in the first
-			column of the last screen line.  Overrules "lastline".
-	uhex		Show unprintable characters hexadecimal as <xx>
-			instead of using ^C and ~C.
-	msgsep		Obsolete flag. Allowed but takes no effect. |msgsep|
+        To include a comma in a file name precede it with a backslash.  Spaces
+        after a comma are ignored, otherwise spaces are included in the file
+        name.  See |option-backslash| about using backslashes.
+        This has nothing to do with the |Dictionary| variable type.
+        Where to find a list of words?
+        - BSD/macOS include the "/usr/share/dict/words" file.
+        - Try "apt install spell" to get the "/usr/share/dict/words" file on
+          apt-managed systems (Debian/Ubuntu).
+        The use of |:set+=| and |:set-=| is preferred when adding or removing
+        directories from the list.  This avoids problems when a future version
+        uses another default.
+        Backticks cannot be used in this option for security reasons.
 
-	When neither "lastline" nor "truncate" is included, a last line that
-	doesn't fit is replaced with "@" lines.
+                                                               *'diff'* *'nodiff'*
+'diff'                  boolean (default off)
+                        local to window
+        Join the current window in the group of windows that shows differences
+        between files.  See |diff-mode|.
 
-	The "@" character can be changed by setting the "lastline" item in
-	'fillchars'.  The character is highlighted with |hl-NonText|.
+                                                              *'diffexpr'* *'dex'*
+'diffexpr' 'dex'        string (default "")
+                        global
+        Expression which is evaluated to obtain a diff file (either ed-style
+        or unified-style) from two versions of a file.  See |diff-diffexpr|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'eadirection'* *'ead'*
-'eadirection' 'ead'	string	(default "both")
-			global
-	Tells when the 'equalalways' option applies:
-		ver	vertically, width of windows is not affected
-		hor	horizontally, height of windows is not affected
-		both	width and height of windows is affected
+                                                               *'diffopt'* *'dip'*
+'diffopt' 'dip'         string (default "internal,filler,closeoff")
+                        global
+        Option settings for diff mode.  It can consist of the following items.
+        All are optional.  Items must be separated by a comma.
 
-				*'emoji'* *'emo'* *'noemoji'* *'noemo'*
-'emoji' 'emo'		boolean	(default on)
-			global
-	When on all Unicode emoji characters are considered to be full width.
-	This excludes "text emoji" characters, which are normally displayed as
-	single width.  Unfortunately there is no good specification for this
-	and it has been determined on trial-and-error basis.  Use the
-	|setcellwidths()| function to change the behavior.
+                filler          Show filler lines, to keep the text
+                                synchronized with a window that has inserted
+                                lines at the same position.  Mostly useful
+                                when windows are side-by-side and 'scrollbind'
+                                is set.
 
-						*'encoding'* *'enc'*
-'encoding' 'enc'	string	(default "utf-8")
-			global
-	String-encoding used internally and for |RPC| communication.
-	Always UTF-8.
+                context:{n}     Use a context of {n} lines between a change
+                                and a fold that contains unchanged lines.
+                                When omitted a context of six lines is used.
+                                When using zero the context is actually one,
+                                since folds require a line in between, also
+                                for a deleted line. Set it to a very large
+                                value (999999) to disable folding completely.
+                                See |fold-diff|.
 
-	See 'fileencoding' to control file-content encoding.
+                iblank          Ignore changes where lines are all blank.  Adds
+                                the "-B" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
+                                NOTE: the diff windows will get out of sync,
+                                because no differences between blank lines are
+                                taken into account.
 
-			*'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
-'endoffile' 'eof'	boolean	(default off)
-			local to buffer
-	Indicates that a CTRL-Z character was found at the end of the file
-	when reading it.  Normally only happens when 'fileformat' is "dos".
-	When writing a file and this option is off and the 'binary' option
-	is on, or 'fixeol' option is off, no CTRL-Z will be written at the
-	end of the file.
-	See |eol-and-eof| for example settings.
+                icase           Ignore changes in case of text.  "a" and "A"
+                                are considered the same.  Adds the "-i" flag
+                                to the "diff" command if 'diffexpr' is empty.
 
-			*'endofline'* *'eol'* *'noendofline'* *'noeol'*
-'endofline' 'eol'	boolean	(default on)
-			local to buffer
-	When writing a file and this option is off and the 'binary' option
-	is on, or 'fixeol' option is off, no <EOL> will be written for the
-	last line in the file.  This option is automatically set or reset when
-	starting to edit a new file, depending on whether file has an <EOL>
-	for the last line in the file.  Normally you don't have to set or
-	reset this option.
-	When 'binary' is off and 'fixeol' is on the value is not used when
-	writing the file.  When 'binary' is on or 'fixeol' is off it is used
-	to remember the presence of a <EOL> for the last line in the file, so
-	that when you write the file the situation from the original file can
-	be kept.  But you can change it if you want to.
-	See |eol-and-eof| for example settings.
+                iwhite          Ignore changes in amount of white space.  Adds
+                                the "-b" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.  It should ignore adding trailing
+                                white space, but not leading white space.
 
-			*'equalalways'* *'ea'* *'noequalalways'* *'noea'*
-'equalalways' 'ea'	boolean	(default on)
-			global
-	When on, all the windows are automatically made the same size after
-	splitting or closing a window.  This also happens the moment the
-	option is switched on.  When off, splitting a window will reduce the
-	size of the current window and leave the other windows the same.  When
-	closing a window the extra lines are given to the window next to it
-	(depending on 'splitbelow' and 'splitright').
-	When mixing vertically and horizontally split windows, a minimal size
-	is computed and some windows may be larger if there is room.  The
-	'eadirection' option tells in which direction the size is affected.
-	Changing the height and width of a window can be avoided by setting
-	'winfixheight' and 'winfixwidth', respectively.
-	If a window size is specified when creating a new window sizes are
-	currently not equalized (it's complicated, but may be implemented in
-	the future).
+                iwhiteall       Ignore all white space changes.  Adds
+                                the "-w" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
 
-						*'equalprg'* *'ep'*
-'equalprg' 'ep'		string	(default "")
-			global or local to buffer |global-local|
-	External program to use for "=" command.  When this option is empty
-	the internal formatting functions are used; either 'lisp', 'cindent'
-	or 'indentexpr'.
-	Environment variables are expanded |:set_env|.  See |option-backslash|
-	about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                iwhiteeol       Ignore white space changes at end of line.
+                                Adds the "-Z" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
 
-			*'errorbells'* *'eb'* *'noerrorbells'* *'noeb'*
-'errorbells' 'eb'	boolean	(default off)
-			global
-	Ring the bell (beep or screen flash) for error messages.  This only
-	makes a difference for error messages, the bell will be used always
-	for a lot of errors without a message (e.g., hitting <Esc> in Normal
-	mode).  See 'visualbell' to make the bell behave like a screen flash
-	or do nothing. See 'belloff' to finetune when to ring the bell.
+                horizontal      Start diff mode with horizontal splits (unless
+                                explicitly specified otherwise).
 
-						*'errorfile'* *'ef'*
-'errorfile' 'ef'	string	(default "errors.err")
-			global
-	Name of the errorfile for the QuickFix mode (see |:cf|).
-	When the "-q" command-line argument is used, 'errorfile' is set to the
-	following argument.  See |-q|.
-	NOT used for the ":make" command.  See 'makeef' for that.
-	Environment variables are expanded |:set_env|.
-	See |option-backslash| about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                vertical        Start diff mode with vertical splits (unless
+                                explicitly specified otherwise).
 
-						*'errorformat'* *'efm'*
-'errorformat' 'efm'	string	(default is very long)
-			global or local to buffer |global-local|
-	Scanf-like description of the format for the lines in the error file
-	(see |errorformat|).
+                closeoff        When a window is closed where 'diff' is set
+                                and there is only one window remaining in the
+                                same tab page with 'diff' set, execute
+                                `:diffoff` in that window.  This undoes a
+                                `:diffsplit` command.
 
-						*'eventignore'* *'ei'*
-'eventignore' 'ei'	string	(default "")
-			global
-	A list of autocommand event names, which are to be ignored.
-	When set to "all" or when "all" is one of the items, all autocommand
-	events are ignored, autocommands will not be executed.
-	Otherwise this is a comma-separated list of event names.  Example: >vim
-	    set ei=WinEnter,WinLeave
+                hiddenoff       Do not use diff mode for a buffer when it
+                                becomes hidden.
+
+                foldcolumn:{n}  Set the 'foldcolumn' option to {n} when
+                                starting diff mode.  Without this 2 is used.
+
+                followwrap      Follow the 'wrap' option and leave as it is.
+
+                internal        Use the internal diff library.  This is
+                                ignored when 'diffexpr' is set.  *E960*
+                                When running out of memory when writing a
+                                buffer this item will be ignored for diffs
+                                involving that buffer.  Set the 'verbose'
+                                option to see when this happens.
+
+                indent-heuristic
+                                Use the indent heuristic for the internal
+                                diff library.
+
+                linematch:{n}   Enable a second stage diff on each generated
+                                hunk in order to align lines. When the total
+                                number of lines in a hunk exceeds {n}, the
+                                second stage diff will not be performed as
+                                very large hunks can cause noticeable lag. A
+                                recommended setting is "linematch:60", as this
+                                will enable alignment for a 2 buffer diff with
+                                hunks of up to 30 lines each, or a 3 buffer
+                                diff with hunks of up to 20 lines each.
+
+                algorithm:{text} Use the specified diff algorithm with the
+                                internal diff engine. Currently supported
+                                algorithms are:
+                                myers      the default algorithm
+                                minimal    spend extra time to generate the
+                                           smallest possible diff
+                                patience   patience diff algorithm
+                                histogram  histogram diff algorithm
+
+        Examples: >vim
+                set diffopt=internal,filler,context:4
+                set diffopt=
+                set diffopt=internal,filler,foldcolumn:3
+                set diffopt-=internal  " do NOT use the internal diff parser
 <
 
-				*'expandtab'* *'et'* *'noexpandtab'* *'noet'*
-'expandtab' 'et'	boolean	(default off)
-			local to buffer
-	In Insert mode: Use the appropriate number of spaces to insert a
-	<Tab>.  Spaces are used in indents with the '>' and '<' commands and
-	when 'autoindent' is on.  To insert a real tab when 'expandtab' is
-	on, use CTRL-V<Tab>.  See also |:retab| and |ins-expandtab|.
+                                             *'digraph'* *'dg'* *'nodigraph'* *'nodg'*
+'digraph' 'dg'          boolean (default off)
+                        global
+        Enable the entering of digraphs in Insert mode with {char1} <BS>
+        {char2}.  See |digraphs|.
 
-					*'exrc'* *'ex'* *'noexrc'* *'noex'*
-'exrc' 'ex'		boolean	(default off)
-			global
-	Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
-	current directory, if the file is in the |trust| list. Use |:trust| to
-	manage trusted files. See also |vim.secure.read()|.
+                                                             *'directory'* *'dir'*
+'directory' 'dir'       string (default "$XDG_STATE_HOME/nvim/swap//")
+                        global
+        List of directory names for the swap file, separated with commas.
 
-	Compare 'exrc' to |editorconfig|:
-	- 'exrc' can execute any code; editorconfig only specifies settings.
-	- 'exrc' is Nvim-specific; editorconfig works in other editors.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'fileencoding'* *'fenc'* *E213*
-'fileencoding' 'fenc'	string	(default "")
-			local to buffer
-	File-content encoding for the current buffer. Conversion is done with
-	iconv() or as specified with 'charconvert'.
-
-	When 'fileencoding' is not UTF-8, conversion will be done when
-	writing the file.  For reading see below.
-	When 'fileencoding' is empty, the file will be saved with UTF-8
-	encoding (no conversion when reading or writing a file).
-
-	WARNING: Conversion to a non-Unicode encoding can cause loss of
-	information!
-
-	See |encoding-names| for the possible values.  Additionally, values may be
-	specified that can be handled by the converter, see
-	|mbyte-conversion|.
-
-	When reading a file 'fileencoding' will be set from 'fileencodings'.
-	To read a file in a certain encoding it won't work by setting
-	'fileencoding', use the |++enc| argument.  One exception: when
-	'fileencodings' is empty the value of 'fileencoding' is used.
-	For a new file the global value of 'fileencoding' is used.
-
-	Prepending "8bit-" and "2byte-" has no meaning here, they are ignored.
-	When the option is set, the value is converted to lowercase.  Thus
-	you can set it with uppercase values too.  '_' characters are
-	replaced with '-'.  If a name is recognized from the list at
-	|encoding-names|, it is replaced by the standard name.  For example
-	"ISO8859-2" becomes "iso-8859-2".
-
-	When this option is set, after starting to edit a file, the 'modified'
-	option is set, because the file would be different when written.
-
-	Keep in mind that changing 'fenc' from a modeline happens
-	AFTER the text has been read, thus it applies to when the file will be
-	written.  If you do set 'fenc' in a modeline, you might want to set
-	'nomodified' to avoid not being able to ":q".
-
-	This option cannot be changed when 'modifiable' is off.
-
-					*'fileencodings'* *'fencs'*
-'fileencodings' 'fencs'	string	(default "ucs-bom,utf-8,default,latin1")
-			global
-	This is a list of character encodings considered when starting to edit
-	an existing file.  When a file is read, Vim tries to use the first
-	mentioned character encoding.  If an error is detected, the next one
-	in the list is tried.  When an encoding is found that works,
-	'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
-	an empty string, which means that UTF-8 is used.
-		WARNING: Conversion can cause loss of information! You can use
-		the |++bad| argument to specify what is done with characters
-		that can't be converted.
-	For an empty file or a file with only ASCII characters most encodings
-	will work and the first entry of 'fileencodings' will be used (except
-	"ucs-bom", which requires the BOM to be present).  If you prefer
-	another encoding use an BufReadPost autocommand event to test if your
-	preferred encoding is to be used.  Example: >vim
-		au BufReadPost * if search('\S', 'w') == 0 |
-			\ set fenc=iso-2022-jp | endif
-<	This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
-	non-blank characters.
-	When the |++enc| argument is used then the value of 'fileencodings' is
-	not used.
-	Note that 'fileencodings' is not used for a new file, the global value
-	of 'fileencoding' is used instead.  You can set it with: >vim
-		setglobal fenc=iso-8859-2
-<	This means that a non-existing file may get a different encoding than
-	an empty file.
-	The special value "ucs-bom" can be used to check for a Unicode BOM
-	(Byte Order Mark) at the start of the file.  It must not be preceded
-	by "utf-8" or another Unicode encoding for this to work properly.
-	An entry for an 8-bit encoding (e.g., "latin1") should be the last,
-	because Vim cannot detect an error, thus the encoding is always
-	accepted.
-	The special value "default" can be used for the encoding from the
-	environment.  It is useful when your environment uses a non-latin1
-	encoding, such as Russian.
-	When a file contains an illegal UTF-8 byte sequence it won't be
-	recognized as "utf-8".  You can use the |8g8| command to find the
-	illegal byte sequence.
-	WRONG VALUES:			WHAT'S WRONG:
-		latin1,utf-8		"latin1" will always be used
-		utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
-					file
-		cp1250,latin1		"cp1250" will always be used
-	If 'fileencodings' is empty, 'fileencoding' is not modified.
-	See 'fileencoding' for the possible values.
-	Setting this option does not have an effect until the next time a file
-	is read.
-
-						*'fileformat'* *'ff'*
-'fileformat' 'ff'	string	(default Windows: "dos", Unix: "unix")
-			local to buffer
-	This gives the <EOL> of the current buffer, which is used for
-	reading/writing the buffer from/to a file:
-	    dos	    <CR><NL>
-	    unix    <NL>
-	    mac	    <CR>
-	When "dos" is used, CTRL-Z at the end of a file is ignored.
-	See |file-formats| and |file-read|.
-	For the character encoding of the file see 'fileencoding'.
-	When 'binary' is set, the value of 'fileformat' is ignored, file I/O
-	works like it was set to "unix".
-	This option is set automatically when starting to edit a file and
-	'fileformats' is not empty and 'binary' is off.
-	When this option is set, after starting to edit a file, the 'modified'
-	option is set, because the file would be different when written.
-	This option cannot be changed when 'modifiable' is off.
-
-						*'fileformats'* *'ffs'*
-'fileformats' 'ffs'	string	(default Windows: "dos,unix", Unix: "unix,dos")
-			global
-	This gives the end-of-line (<EOL>) formats that will be tried when
-	starting to edit a new buffer and when reading a file into an existing
-	buffer:
-	- When empty, the format defined with 'fileformat' will be used
-	  always.  It is not set automatically.
-	- When set to one name, that format will be used whenever a new buffer
-	  is opened.  'fileformat' is set accordingly for that buffer.  The
-	  'fileformats' name will be used when a file is read into an existing
-	  buffer, no matter what 'fileformat' for that buffer is set to.
-	- When more than one name is present, separated by commas, automatic
-	  <EOL> detection will be done when reading a file.  When starting to
-	  edit a file, a check is done for the <EOL>:
-	  1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
-	     'fileformat' is set to "dos".
-	  2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
-	     is set to "unix".  Note that when a <NL> is found without a
-	     preceding <CR>, "unix" is preferred over "dos".
-	  3. If 'fileformat' has not yet been set, and if a <CR> is found, and
-	     if 'fileformats' includes "mac", 'fileformat' is set to "mac".
-	     This means that "mac" is only chosen when:
-	      "unix" is not present or no <NL> is found in the file, and
-	      "dos" is not present or no <CR><NL> is found in the file.
-	     Except: if "unix" was chosen, but there is a <CR> before
-	     the first <NL>, and there appear to be more <CR>s than <NL>s in
-	     the first few lines, "mac" is used.
-	  4. If 'fileformat' is still not set, the first name from
-	     'fileformats' is used.
-	  When reading a file into an existing buffer, the same is done, but
-	  this happens like 'fileformat' has been set appropriately for that
-	  file only, the option is not changed.
-	When 'binary' is set, the value of 'fileformats' is not used.
-
-	When Vim starts up with an empty buffer the first item is used.  You
-	can overrule this by setting 'fileformat' in your .vimrc.
-
-	For systems with a Dos-like <EOL> (<CR><NL>), when reading files that
-	are ":source"ed and for vimrc files, automatic <EOL> detection may be
-	done:
-	- When 'fileformats' is empty, there is no automatic detection.  Dos
-	  format will be used.
-	- When 'fileformats' is set to one or more names, automatic detection
-	  is done.  This is based on the first <NL> in the file: If there is a
-	  <CR> in front of it, Dos format is used, otherwise Unix format is
-	  used.
-	Also see |file-formats|.
-
-		*'fileignorecase'* *'fic'* *'nofileignorecase'* *'nofic'*
-'fileignorecase' 'fic'	boolean	(default on for systems where case in file
-                                 names is normally ignored)
-			global
-	When set case is ignored when using file names and directories.
-	See 'wildignorecase' for only ignoring case when doing completion.
-
-						*'filetype'* *'ft'*
-'filetype' 'ft'		string	(default "")
-			local to buffer  |local-noglobal|
-	When this option is set, the FileType autocommand event is triggered.
-	All autocommands that match with the value of this option will be
-	executed.  Thus the value of 'filetype' is used in place of the file
-	name.
-	Otherwise this option does not always reflect the current file type.
-	This option is normally set when the file type is detected.  To enable
-	this use the ":filetype on" command. |:filetype|
-	Setting this option to a different value is most useful in a modeline,
-	for a file for which the file type is not automatically recognized.
-	Example, for in an IDL file: >c
-		/* vim: set filetype=idl : */
-<	|FileType| |filetypes|
-	When a dot appears in the value then this separates two filetype
-	names.  Example: >c
-		/* vim: set filetype=c.doxygen : */
-<	This will use the "c" filetype first, then the "doxygen" filetype.
-	This works both for filetype plugins and for syntax files.  More than
-	one dot may appear.
-	This option is not copied to another buffer, independent of the 's' or
-	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, `/\*?[|<>` are illegal.
-
-						*'fillchars'* *'fcs'*
-'fillchars' 'fcs'	string	(default "")
-			global or local to window |global-local|
-	Characters to fill the statuslines, vertical separators and special
-	lines in the window.
-	It is a comma-separated list of items.  Each item has a name, a colon
-	and the value of that item:
-
-	  item		default		Used for ~
-	  stl		' '		statusline of the current window
-	  stlnc		' '		statusline of the non-current windows
-	  wbr		' '		window bar
-	  horiz		'─' or '-'	horizontal separators |:split|
-	  horizup	'┴' or '-'	upwards facing horizontal separator
-	  horizdown	'┬' or '-'	downwards facing horizontal separator
-	  vert		'│' or '|'	vertical separators |:vsplit|
-	  vertleft	'┤' or '|'	left facing vertical separator
-	  vertright	'├' or '|'	right facing vertical separator
-	  verthoriz	'┼' or '+'	overlapping vertical and horizontal
-					separator
-	  fold		'·' or '-'	filling 'foldtext'
-	  foldopen	'-'		mark the beginning of a fold
-	  foldclose	'+'		show a closed fold
-	  foldsep	'│' or '|'      open fold middle marker
-	  diff		'-'		deleted lines of the 'diff' option
-	  msgsep	' '		message separator 'display'
-	  eob		'~'		empty lines at the end of a buffer
-	  lastline	'@'		'display' contains lastline/truncate
-
-	Any one that is omitted will fall back to the default.
-
-	Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
-	"verthoriz" are only used when 'laststatus' is 3, since only vertical
-	window separators are used otherwise.
-
-	If 'ambiwidth' is "double" then "horiz", "horizup", "horizdown",
-	"vert", "vertleft", "vertright", "verthoriz", "foldsep" and "fold"
-	default to single-byte alternatives.
-
-	Example: >vim
-	    set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
+        Possible items:
+        - The swap file will be created in the first directory where this is
+          possible.  If it is not possible in any directory, but last
+          directory listed in the option does not exist, it is created.
+        - Empty means that no swap file will be used (recovery is
+          impossible!) and no |E303| error will be given.
+        - A directory "." means to put the swap file in the same directory as
+          the edited file.  On Unix, a dot is prepended to the file name, so
+          it doesn't show in a directory listing.  On MS-Windows the "hidden"
+          attribute is set and a dot prepended if possible.
+        - A directory starting with "./" (or ".\" for MS-Windows) means to put
+          the swap file relative to where the edited file is.  The leading "."
+          is replaced with the path name of the edited file.
+        - For Unix and Win32, if a directory ends in two path separators "//",
+          the swap file name will be built from the complete path to the file
+          with all path separators replaced by percent '%' signs (including
+          the colon following the drive letter on Win32). This will ensure
+          file name uniqueness in the preserve directory.
+          On Win32, it is also possible to end with "\\".  However, When a
+          separating comma is following, you must use "//", since "\\" will
+          include the comma in the file name. Therefore it is recommended to
+          use '//', instead of '\\'.
+        - Spaces after the comma are ignored, other spaces are considered part
+          of the directory name.  To have a space at the start of a directory
+          name, precede it with a backslash.
+        - To include a comma in a directory name precede it with a backslash.
+        - A directory name may end in an ':' or '/'.
+        - Environment variables are expanded |:set_env|.
+        - Careful with '\' characters, type one before a space, type two to
+          get one in the option (see |option-backslash|), for example: >vim
+            set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 <
-	For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
-	single-byte and multibyte characters are supported.  But double-width
-	characters are not supported.
+        Editing the same file twice will result in a warning.  Using "/tmp" on
+        is discouraged: if the system crashes you lose the swap file. And
+        others on the computer may be able to see the files.
+        Use |:set+=| and |:set-=| when adding or removing directories from the
+        list, this avoids problems if the Nvim default is changed.
 
-	The highlighting used for these items:
-	  item		highlight group ~
-	  stl		StatusLine		|hl-StatusLine|
-	  stlnc		StatusLineNC		|hl-StatusLineNC|
-	  wbr		WinBar			|hl-WinBar| or |hl-WinBarNC|
-	  horiz		WinSeparator		|hl-WinSeparator|
-	  horizup	WinSeparator		|hl-WinSeparator|
-	  horizdown	WinSeparator		|hl-WinSeparator|
-	  vert		WinSeparator		|hl-WinSeparator|
-	  vertleft	WinSeparator		|hl-WinSeparator|
-	  vertright	WinSeparator		|hl-WinSeparator|
-	  verthoriz	WinSeparator		|hl-WinSeparator|
-	  fold		Folded			|hl-Folded|
-	  diff		DiffDelete		|hl-DiffDelete|
-	  eob		EndOfBuffer		|hl-EndOfBuffer|
-	  lastline	NonText			|hl-NonText|
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
-'fixendofline' 'fixeol'	boolean	(default on)
-			local to buffer
-	When writing a file and this option is on, <EOL> at the end of file
-	will be restored if missing.  Turn this option off if you want to
-	preserve the situation from the original file.
-	When the 'binary' option is set the value of this option doesn't
-	matter.
-	See the 'endofline' option.
-	See |eol-and-eof| for example settings.
+                                                                *'display'* *'dy'*
+'display' 'dy'          string (default "lastline")
+                        global
+        Change the way text is displayed.  This is a comma-separated list of
+        flags:
+        lastline        When included, as much as possible of the last line
+                        in a window will be displayed.  "@@@" is put in the
+                        last columns of the last screen line to indicate the
+                        rest of the line is not displayed.
+        truncate        Like "lastline", but "@@@" is displayed in the first
+                        column of the last screen line.  Overrules "lastline".
+        uhex            Show unprintable characters hexadecimal as <xx>
+                        instead of using ^C and ~C.
+        msgsep          Obsolete flag. Allowed but takes no effect. |msgsep|
 
-						*'foldclose'* *'fcl'*
-'foldclose' 'fcl'	string	(default "")
-			global
-	When set to "all", a fold is closed when the cursor isn't in it and
-	its level is higher than 'foldlevel'.  Useful if you want folds to
-	automatically close when moving out of them.
+        When neither "lastline" nor "truncate" is included, a last line that
+        doesn't fit is replaced with "@" lines.
 
-						*'foldcolumn'* *'fdc'*
-'foldcolumn' 'fdc'	string	(default "0")
-			local to window
-	When and how to draw the foldcolumn. Valid values are:
-	    "auto":       resize to the minimum amount of folds to display.
-	    "auto:[1-9]": resize to accommodate multiple folds up to the
-			  selected level
-	    "0":          to disable foldcolumn
-	    "[1-9]":      to display a fixed number of columns
-	See |folding|.
+        The "@" character can be changed by setting the "lastline" item in
+        'fillchars'.  The character is highlighted with |hl-NonText|.
 
-			*'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*
-'foldenable' 'fen'	boolean	(default on)
-			local to window
-	When off, all folds are open.  This option can be used to quickly
-	switch between showing all text unfolded and viewing the text with
-	folds (including manually opened or closed folds).  It can be toggled
-	with the |zi| command.  The 'foldcolumn' will remain blank when
-	'foldenable' is off.
-	This option is set by commands that create a new fold or close a fold.
-	See |folding|.
+                                                           *'eadirection'* *'ead'*
+'eadirection' 'ead'     string (default "both")
+                        global
+        Tells when the 'equalalways' option applies:
+                ver     vertically, width of windows is not affected
+                hor     horizontally, height of windows is not affected
+                both    width and height of windows is affected
 
-						*'foldexpr'* *'fde'*
-'foldexpr' 'fde'	string	(default "0")
-			local to window
-	The expression used for when 'foldmethod' is "expr".  It is evaluated
-	for each line to obtain its fold level.  The context is set to the
-	script where 'foldexpr' was set, script-local items can be accessed.
-	See |fold-expr| for the usage.
+                                               *'emoji'* *'emo'* *'noemoji'* *'noemo'*
+'emoji' 'emo'           boolean (default on)
+                        global
+        When on all Unicode emoji characters are considered to be full width.
+        This excludes "text emoji" characters, which are normally displayed as
+        single width.  Unfortunately there is no good specification for this
+        and it has been determined on trial-and-error basis.  Use the
+        |setcellwidths()| function to change the behavior.
 
-	The expression will be evaluated in the |sandbox| if set from a
-	modeline, see |sandbox-option|.
-	This option can't be set from a |modeline| when the 'diff' option is
-	on or the 'modelineexpr' option is off.
+                                                              *'encoding'* *'enc'*
+'encoding' 'enc'        string (default "utf-8")
+                        global
+        String-encoding used internally and for |RPC| communication.
+        Always UTF-8.
 
-	It is not allowed to change text or jump to another window while
-	evaluating 'foldexpr' |textlock|.
+        See 'fileencoding' to control file-content encoding.
 
-						*'foldignore'* *'fdi'*
-'foldignore' 'fdi'	string	(default "#")
-			local to window
-	Used only when 'foldmethod' is "indent".  Lines starting with
-	characters in 'foldignore' will get their fold level from surrounding
-	lines.  White space is skipped before checking for this character.
-	The default "#" works well for C programs.  See |fold-indent|.
+                                       *'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
+'endoffile' 'eof'       boolean (default off)
+                        local to buffer
+        Indicates that a CTRL-Z character was found at the end of the file
+        when reading it.  Normally only happens when 'fileformat' is "dos".
+        When writing a file and this option is off and the 'binary' option
+        is on, or 'fixeol' option is off, no CTRL-Z will be written at the
+        end of the file.
+        See |eol-and-eof| for example settings.
 
-						*'foldlevel'* *'fdl'*
-'foldlevel' 'fdl'	number	(default 0)
-			local to window
-	Sets the fold level: Folds with a higher level will be closed.
-	Setting this option to zero will close all folds.  Higher numbers will
-	close fewer folds.
-	This option is set by commands like |zm|, |zM| and |zR|.
-	See |fold-foldlevel|.
+                                       *'endofline'* *'eol'* *'noendofline'* *'noeol'*
+'endofline' 'eol'       boolean (default on)
+                        local to buffer
+        When writing a file and this option is off and the 'binary' option
+        is on, or 'fixeol' option is off, no <EOL> will be written for the
+        last line in the file.  This option is automatically set or reset when
+        starting to edit a new file, depending on whether file has an <EOL>
+        for the last line in the file.  Normally you don't have to set or
+        reset this option.
+        When 'binary' is off and 'fixeol' is on the value is not used when
+        writing the file.  When 'binary' is on or 'fixeol' is off it is used
+        to remember the presence of a <EOL> for the last line in the file, so
+        that when you write the file the situation from the original file can
+        be kept.  But you can change it if you want to.
+        See |eol-and-eof| for example settings.
 
-					*'foldlevelstart'* *'fdls'*
-'foldlevelstart' 'fdls'	number	(default -1)
-			global
-	Sets 'foldlevel' when starting to edit another buffer in a window.
-	Useful to always start editing with all folds closed (value zero),
-	some folds closed (one) or no folds closed (99).
-	This is done before reading any modeline, thus a setting in a modeline
-	overrules this option.  Starting to edit a file for |diff-mode| also
-	ignores this option and closes all folds.
-	It is also done before BufReadPre autocommands, to allow an autocmd to
-	overrule the 'foldlevel' value for specific files.
-	When the value is negative, it is not used.
+                                     *'equalalways'* *'ea'* *'noequalalways'* *'noea'*
+'equalalways' 'ea'      boolean (default on)
+                        global
+        When on, all the windows are automatically made the same size after
+        splitting or closing a window.  This also happens the moment the
+        option is switched on.  When off, splitting a window will reduce the
+        size of the current window and leave the other windows the same.  When
+        closing a window the extra lines are given to the window next to it
+        (depending on 'splitbelow' and 'splitright').
+        When mixing vertically and horizontally split windows, a minimal size
+        is computed and some windows may be larger if there is room.  The
+        'eadirection' option tells in which direction the size is affected.
+        Changing the height and width of a window can be avoided by setting
+        'winfixheight' and 'winfixwidth', respectively.
+        If a window size is specified when creating a new window sizes are
+        currently not equalized (it's complicated, but may be implemented in
+        the future).
 
-					*'foldmarker'* *'fmr'* *E536*
-'foldmarker' 'fmr'	string	(default "{{{,}}}")
-			local to window
-	The start and end marker used when 'foldmethod' is "marker".  There
-	must be one comma, which separates the start and end marker.  The
-	marker is a literal string (a regular expression would be too slow).
-	See |fold-marker|.
+                                                               *'equalprg'* *'ep'*
+'equalprg' 'ep'         string (default "")
+                        global or local to buffer |global-local|
+        External program to use for "=" command.  When this option is empty
+        the internal formatting functions are used; either 'lisp', 'cindent'
+        or 'indentexpr'.
+        Environment variables are expanded |:set_env|.  See |option-backslash|
+        about including spaces and backslashes.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'foldmethod'* *'fdm'*
-'foldmethod' 'fdm'	string	(default "manual")
-			local to window
-	The kind of folding used for the current window.  Possible values:
-	|fold-manual|	manual	    Folds are created manually.
-	|fold-indent|	indent	    Lines with equal indent form a fold.
-	|fold-expr|	expr	    'foldexpr' gives the fold level of a line.
-	|fold-marker|	marker	    Markers are used to specify folds.
-	|fold-syntax|	syntax	    Syntax highlighting items specify folds.
-	|fold-diff|	diff	    Fold text that is not changed.
+                                       *'errorbells'* *'eb'* *'noerrorbells'* *'noeb'*
+'errorbells' 'eb'       boolean (default off)
+                        global
+        Ring the bell (beep or screen flash) for error messages.  This only
+        makes a difference for error messages, the bell will be used always
+        for a lot of errors without a message (e.g., hitting <Esc> in Normal
+        mode).  See 'visualbell' to make the bell behave like a screen flash
+        or do nothing. See 'belloff' to finetune when to ring the bell.
 
-						*'foldminlines'* *'fml'*
-'foldminlines' 'fml'	number	(default 1)
-			local to window
-	Sets the number of screen lines above which a fold can be displayed
-	closed.  Also for manually closed folds.  With the default value of
-	one a fold can only be closed if it takes up two or more screen lines.
-	Set to zero to be able to close folds of just one screen line.
-	Note that this only has an effect on what is displayed.  After using
-	"zc" to close a fold, which is displayed open because it's smaller
-	than 'foldminlines', a following "zc" may close a containing fold.
+                                                              *'errorfile'* *'ef'*
+'errorfile' 'ef'        string (default "errors.err")
+                        global
+        Name of the errorfile for the QuickFix mode (see |:cf|).
+        When the "-q" command-line argument is used, 'errorfile' is set to the
+        following argument.  See |-q|.
+        NOT used for the ":make" command.  See 'makeef' for that.
+        Environment variables are expanded |:set_env|.
+        See |option-backslash| about including spaces and backslashes.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'foldnestmax'* *'fdn'*
-'foldnestmax' 'fdn'	number	(default 20)
-			local to window
-	Sets the maximum nesting of folds for the "indent" and "syntax"
-	methods.  This avoids that too many folds will be created.  Using more
-	than 20 doesn't work, because the internal limit is 20.
+                                                           *'errorformat'* *'efm'*
+'errorformat' 'efm'     string (default is very long)
+                        global or local to buffer |global-local|
+        Scanf-like description of the format for the lines in the error file
+        (see |errorformat|).
 
-						*'foldopen'* *'fdo'*
-'foldopen' 'fdo'	string	(default "block,hor,mark,percent,quickfix,search,tag,undo")
-			global
-	Specifies for which type of commands folds will be opened, if the
-	command moves the cursor into a closed fold.  It is a comma-separated
-	list of items.
-	NOTE: When the command is part of a mapping this option is not used.
-	Add the |zv| command to the mapping to get the same effect.
-	(rationale: the mapping may want to control opening folds itself)
-
-		item		commands ~
-		all		any
-		block		(, {, [[, [{, etc.
-		hor		horizontal movements: "l", "w", "fx", etc.
-		insert		any command in Insert mode
-		jump		far jumps: "G", "gg", etc.
-		mark		jumping to a mark: "'m", CTRL-O, etc.
-		percent		"%"
-		quickfix	":cn", ":crew", ":make", etc.
-		search		search for a pattern: "/", "n", "*", "gd", etc.
-				(not for a search pattern in a ":" command)
-				Also for |[s| and |]s|.
-		tag		jumping to a tag: ":ta", CTRL-T, etc.
-		undo		undo or redo: "u" and CTRL-R
-	When a movement command is used for an operator (e.g., "dl" or "y%")
-	this option is not used.  This means the operator will include the
-	whole closed fold.
-	Note that vertical movements are not here, because it would make it
-	very difficult to move onto a closed fold.
-	In insert mode the folds containing the cursor will always be open
-	when text is inserted.
-	To close folds you can re-apply 'foldlevel' with the |zx| command or
-	set the 'foldclose' option to "all".
-
-						*'foldtext'* *'fdt'*
-'foldtext' 'fdt'	string	(default "foldtext()")
-			local to window
-	An expression which is used to specify the text displayed for a closed
-	fold.  The context is set to the script where 'foldexpr' was set,
-	script-local items can be accessed.  See |fold-foldtext| for the
-	usage.
-
-	The expression will be evaluated in the |sandbox| if set from a
-	modeline, see |sandbox-option|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	It is not allowed to change text or jump to another window while
-	evaluating 'foldtext' |textlock|.
-
-						*'formatexpr'* *'fex'*
-'formatexpr' 'fex'	string	(default "")
-			local to buffer
-	Expression which is evaluated to format a range of lines for the |gq|
-	operator or automatic formatting (see 'formatoptions').  When this
-	option is empty 'formatprg' is used.
-
-	The |v:lnum|  variable holds the first line to be formatted.
-	The |v:count| variable holds the number of lines to be formatted.
-	The |v:char|  variable holds the character that is going to be
-		      inserted if the expression is being evaluated due to
-		      automatic formatting.  This can be empty.  Don't insert
-		      it yet!
-
-	Example: >vim
-		set formatexpr=mylang#Format()
-<	This will invoke the mylang#Format() function in the
-	autoload/mylang.vim file in 'runtimepath'. |autoload|
-
-	The expression is also evaluated when 'textwidth' is set and adding
-	text beyond that limit.  This happens under the same conditions as
-	when internal formatting is used.  Make sure the cursor is kept in the
-	same spot relative to the text then!  The |mode()| function will
-	return "i" or "R" in this situation.
-
-	When the expression evaluates to non-zero Vim will fall back to using
-	the internal format mechanism.
-
-	If the expression starts with s: or |<SID>|, then it is replaced with
-	the script ID (|local-function|). Example: >vim
-		set formatexpr=s:MyFormatExpr()
-		set formatexpr=<SID>SomeFormatExpr()
-<	Otherwise, the expression is evaluated in the context of the script
-	where the option was set, thus script-local items are available.
-
-	The expression will be evaluated in the |sandbox| when set from a
-	modeline, see |sandbox-option|.  That stops the option from working,
-	since changing the buffer text is not allowed.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-	NOTE: This option is set to "" when 'compatible' is set.
-
-						*'formatlistpat'* *'flp'*
-'formatlistpat' 'flp'	string	(default "^\s*\d\+[\]:.)}\t ]\s*")
-			local to buffer
-	A pattern that is used to recognize a list header.  This is used for
-	the "n" flag in 'formatoptions'.
-	The pattern must match exactly the text that will be the indent for
-	the line below it.  You can use |/\ze| to mark the end of the match
-	while still checking more characters.  There must be a character
-	following the pattern, when it matches the whole line it is handled
-	like there is no match.
-	The default recognizes a number, followed by an optional punctuation
-	character and white space.
-
-						*'formatoptions'* *'fo'*
-'formatoptions' 'fo'	string	(default "tcqj")
-			local to buffer
-	This is a sequence of letters which describes how automatic
-	formatting is to be done.
-	See |fo-table| for possible values and |gq| for how to format text.
-	Commas can be inserted for readability.
-	To avoid problems with flags that are added in the future, use the
-	"+=" and "-=" feature of ":set" |add-option-flags|.
-
-						*'formatprg'* *'fp'*
-'formatprg' 'fp'	string	(default "")
-			global or local to buffer |global-local|
-	The name of an external program that will be used to format the lines
-	selected with the |gq| operator.  The program must take the input on
-	stdin and produce the output on stdout.  The Unix program "fmt" is
-	such a program.
-	If the 'formatexpr' option is not empty it will be used instead.
-	Otherwise, if 'formatprg' option is an empty string, the internal
-	format function will be used |C-indenting|.
-	Environment variables are expanded |:set_env|.  See |option-backslash|
-	about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'fsync'* *'fs'* *'nofsync'* *'nofs'*
-'fsync' 'fs'		boolean	(default on)
-			global
-	When on, the OS function fsync() will be called after saving a file
-	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
-	This flushes the file to disk, ensuring that it is safely written.
-	Slow on some systems: writing buffers, quitting Nvim, and other
-	operations may sometimes take a few seconds.
-
-	Files are ALWAYS flushed ('fsync' is ignored) when:
-	- |CursorHold| event is triggered
-	- |:preserve| is called
-	- system signals low battery life
-	- Nvim exits abnormally
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-				*'gdefault'* *'gd'* *'nogdefault'* *'nogd'*
-'gdefault' 'gd'		boolean	(default off)
-			global
-	When on, the ":substitute" flag 'g' is default on.  This means that
-	all matches in a line are substituted instead of one.  When a 'g' flag
-	is given to a ":substitute" command, this will toggle the substitution
-	of all or one match.  See |complex-change|.
-
-		command		'gdefault' on	'gdefault' off	~
-		:s///		  subst. all	  subst. one
-		:s///g		  subst. one	  subst. all
-		:s///gg		  subst. all	  subst. one
-
-	NOTE: Setting this option may break plugins that rely on the default
-	behavior of the 'g' flag. This will also make the 'g' flag have the
-	opposite effect of that documented in |:s_g|.
-
-						*'grepformat'* *'gfm'*
-'grepformat' 'gfm'	string	(default "%f:%l:%m,%f:%l%m,%f  %l%m")
-			global
-	Format to recognize for the ":grep" command output.
-	This is a scanf-like string that uses the same format as the
-	'errorformat' option: see |errorformat|.
-
-						*'grepprg'* *'gp'*
-'grepprg' 'gp'		string	(default "grep -n ",
-                                 Unix: "grep -n $* /dev/null")
-			global or local to buffer |global-local|
-	Program to use for the |:grep| command.  This option may contain '%'
-	and '#' characters, which are expanded like when used in a command-
-	line.  The placeholder "$*" is allowed to specify where the arguments
-	will be included.  Environment variables are expanded |:set_env|.  See
-	|option-backslash| about including spaces and backslashes.
-	When your "grep" accepts the "-H" argument, use this to make ":grep"
-	also work well with a single file: >vim
-		set grepprg=grep\ -nH
-<	Special value: When 'grepprg' is set to "internal" the |:grep| command
-	works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
-	|:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
-	See also the section |:make_makeprg|, since most of the comments there
-	apply equally to 'grepprg'.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-				*'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
-'guicursor' 'gcr'	string	(default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")
-			global
-	Configures the cursor style for each mode. Works in the GUI and many
-	terminals.  See |tui-cursor-shape|.
-
-	To disable cursor-styling, reset the option: >vim
-		set guicursor=
-
-<	To enable mode shapes, "Cursor" highlight, and blinking: >vim
-		set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
-		  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
-		  \,sm:block-blinkwait175-blinkoff150-blinkon175
-
-<	The option is a comma-separated list of parts.  Each part consists of a
-	mode-list and an argument-list:
-		mode-list:argument-list,mode-list:argument-list,..
-	The mode-list is a dash separated list of these modes:
-		n	Normal mode
-		v	Visual mode
-		ve	Visual mode with 'selection' "exclusive" (same as 'v',
-			if not specified)
-		o	Operator-pending mode
-		i	Insert mode
-		r	Replace mode
-		c	Command-line Normal (append) mode
-		ci	Command-line Insert mode
-		cr	Command-line Replace mode
-		sm	showmatch in Insert mode
-		a	all modes
-	The argument-list is a dash separated list of these arguments:
-		hor{N}	horizontal bar, {N} percent of the character height
-		ver{N}	vertical bar, {N} percent of the character width
-		block	block cursor, fills the whole character
-			- Only one of the above three should be present.
-			- Default is "block" for each mode.
-		blinkwait{N}				*cursor-blinking*
-		blinkon{N}
-		blinkoff{N}
-			blink times for cursor: blinkwait is the delay before
-			the cursor starts blinking, blinkon is the time that
-			the cursor is shown and blinkoff is the time that the
-			cursor is not shown.  Times are in msec.  When one of
-			the numbers is zero, there is no blinking. E.g.: >vim
-				set guicursor=n:blinkon0
-<			- Default is "blinkon0" for each mode.
-		{group-name}
-			Highlight group that decides the color and font of the
-			cursor.
-			In the |TUI|:
-			- |inverse|/reverse and no group-name are interpreted
-			  as "host-terminal default cursor colors" which
-			  typically means "inverted bg and fg colors".
-			- |ctermfg| and |guifg| are ignored.
-		{group-name}/{group-name}
-			Two highlight group names, the first is used when
-			no language mappings are used, the other when they
-			are. |language-mapping|
-
-	Examples of parts:
-	   n-c-v:block-nCursor	In Normal, Command-line and Visual mode, use a
-				block cursor with colors from the "nCursor"
-				highlight group
-	   n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
-				In Normal et al. modes, use a block cursor
-				with the default colors defined by the host
-				terminal.  In Insert-like modes, use
-				a vertical bar cursor with colors from
-				"Cursor" highlight group.  In Replace-like
-				modes, use an underline cursor with
-				default colors.
-	   i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
-				In Insert and Command-line Insert mode, use a
-				30% vertical bar cursor with colors from the
-				"iCursor" highlight group.  Blink a bit
-				faster.
-
-	The 'a' mode is different.  It will set the given argument-list for
-	all modes.  It does not reset anything to defaults.  This can be used
-	to do a common setting for all modes.  For example, to switch off
-	blinking: "a:blinkon0"
-
-	Examples of cursor highlighting: >vim
-	    highlight Cursor gui=reverse guifg=NONE guibg=NONE
-	    highlight Cursor gui=NONE guifg=bg guibg=fg
+                                                            *'eventignore'* *'ei'*
+'eventignore' 'ei'      string (default "")
+                        global
+        A list of autocommand event names, which are to be ignored.
+        When set to "all" or when "all" is one of the items, all autocommand
+        events are ignored, autocommands will not be executed.
+        Otherwise this is a comma-separated list of event names.  Example: >vim
+            set ei=WinEnter,WinLeave
 <
 
-					*'guifont'* *'gfn'* *E235* *E596*
-'guifont' 'gfn'		string	(default "")
-			global
-	This is a list of fonts which will be used for the GUI version of Vim.
-	In its simplest form the value is just one font name.  When
-	the font cannot be found you will get an error message.  To try other
-	font names a list can be specified, font names separated with commas.
-	The first valid font is used.
+                                         *'expandtab'* *'et'* *'noexpandtab'* *'noet'*
+'expandtab' 'et'        boolean (default off)
+                        local to buffer
+        In Insert mode: Use the appropriate number of spaces to insert a
+        <Tab>.  Spaces are used in indents with the '>' and '<' commands and
+        when 'autoindent' is on.  To insert a real tab when 'expandtab' is
+        on, use CTRL-V<Tab>.  See also |:retab| and |ins-expandtab|.
 
-	Spaces after a comma are ignored.  To include a comma in a font name
-	precede it with a backslash.  Setting an option requires an extra
-	backslash before a space and a backslash.  See also
-	|option-backslash|.  For example: >vim
-	    set guifont=Screen15,\ 7x13,font\\,with\\,commas
-<	will make Vim try to use the font "Screen15" first, and if it fails it
-	will try to use "7x13" and then "font,with,commas" instead.
+                                                   *'exrc'* *'ex'* *'noexrc'* *'noex'*
+'exrc' 'ex'             boolean (default off)
+                        global
+        Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
+        current directory, if the file is in the |trust| list. Use |:trust| to
+        manage trusted files. See also |vim.secure.read()|.
 
-	If none of the fonts can be loaded, Vim will keep the current setting.
-	If an empty font list is given, Vim will try using other resource
-	settings (for X, it will use the Vim.font resource), and finally it
-	will try some builtin default which should always be there ("7x13" in
-	the case of X).  The font names given should be "normal" fonts.  Vim
-	will try to find the related bold and italic fonts.
+        Compare 'exrc' to |editorconfig|:
+        - 'exrc' can execute any code; editorconfig only specifies settings.
+        - 'exrc' is Nvim-specific; editorconfig works in other editors.
 
-	For Win32 and Mac OS: >vim
-	    set guifont=*
-<	will bring up a font requester, where you can pick the font you want.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-	The font name depends on the GUI used.
+                                                    *'fileencoding'* *'fenc'* *E213*
+'fileencoding' 'fenc'   string (default "")
+                        local to buffer
+        File-content encoding for the current buffer. Conversion is done with
+        iconv() or as specified with 'charconvert'.
 
-	For Mac OSX you can use something like this: >vim
-	    set guifont=Monaco:h10
-<								*E236*
-	Note that the fonts must be mono-spaced (all characters have the same
-	width).
+        When 'fileencoding' is not UTF-8, conversion will be done when
+        writing the file.  For reading see below.
+        When 'fileencoding' is empty, the file will be saved with UTF-8
+        encoding (no conversion when reading or writing a file).
 
-	To preview a font on X11, you might be able to use the "xfontsel"
-	program.  The "xlsfonts" program gives a list of all available fonts.
+        WARNING: Conversion to a non-Unicode encoding can cause loss of
+        information!
 
-	For the Win32 GUI					*E244* *E245*
-	- takes these options in the font name:
-		hXX - height is XX (points, can be floating-point)
-		wXX - width is XX (points, can be floating-point)
-		b   - bold
-		i   - italic
-		u   - underline
-		s   - strikeout
-		cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
-		      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
-		      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
-		      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
-		      Normally you would use "cDEFAULT".
+        See |encoding-names| for the possible values.  Additionally, values may be
+        specified that can be handled by the converter, see
+        |mbyte-conversion|.
 
-	  Use a ':' to separate the options.
-	- A '_' can be used in the place of a space, so you don't need to use
-	  backslashes to escape the spaces.
-	- Examples: >vim
-	    set guifont=courier_new:h12:w5:b:cRUSSIAN
-	    set guifont=Andale_Mono:h7.5:w4.5
+        When reading a file 'fileencoding' will be set from 'fileencodings'.
+        To read a file in a certain encoding it won't work by setting
+        'fileencoding', use the |++enc| argument.  One exception: when
+        'fileencodings' is empty the value of 'fileencoding' is used.
+        For a new file the global value of 'fileencoding' is used.
+
+        Prepending "8bit-" and "2byte-" has no meaning here, they are ignored.
+        When the option is set, the value is converted to lowercase.  Thus
+        you can set it with uppercase values too.  '_' characters are
+        replaced with '-'.  If a name is recognized from the list at
+        |encoding-names|, it is replaced by the standard name.  For example
+        "ISO8859-2" becomes "iso-8859-2".
+
+        When this option is set, after starting to edit a file, the 'modified'
+        option is set, because the file would be different when written.
+
+        Keep in mind that changing 'fenc' from a modeline happens
+        AFTER the text has been read, thus it applies to when the file will be
+        written.  If you do set 'fenc' in a modeline, you might want to set
+        'nomodified' to avoid not being able to ":q".
+
+        This option cannot be changed when 'modifiable' is off.
+
+                                                       *'fileencodings'* *'fencs'*
+'fileencodings' 'fencs' string (default "ucs-bom,utf-8,default,latin1")
+                        global
+        This is a list of character encodings considered when starting to edit
+        an existing file.  When a file is read, Vim tries to use the first
+        mentioned character encoding.  If an error is detected, the next one
+        in the list is tried.  When an encoding is found that works,
+        'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
+        an empty string, which means that UTF-8 is used.
+                WARNING: Conversion can cause loss of information! You can use
+                the |++bad| argument to specify what is done with characters
+                that can't be converted.
+        For an empty file or a file with only ASCII characters most encodings
+        will work and the first entry of 'fileencodings' will be used (except
+        "ucs-bom", which requires the BOM to be present).  If you prefer
+        another encoding use an BufReadPost autocommand event to test if your
+        preferred encoding is to be used.  Example: >vim
+                au BufReadPost * if search('\S', 'w') == 0 |
+                        \ set fenc=iso-2022-jp | endif
+<       This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
+        non-blank characters.
+        When the |++enc| argument is used then the value of 'fileencodings' is
+        not used.
+        Note that 'fileencodings' is not used for a new file, the global value
+        of 'fileencoding' is used instead.  You can set it with: >vim
+                setglobal fenc=iso-8859-2
+<       This means that a non-existing file may get a different encoding than
+        an empty file.
+        The special value "ucs-bom" can be used to check for a Unicode BOM
+        (Byte Order Mark) at the start of the file.  It must not be preceded
+        by "utf-8" or another Unicode encoding for this to work properly.
+        An entry for an 8-bit encoding (e.g., "latin1") should be the last,
+        because Vim cannot detect an error, thus the encoding is always
+        accepted.
+        The special value "default" can be used for the encoding from the
+        environment.  It is useful when your environment uses a non-latin1
+        encoding, such as Russian.
+        When a file contains an illegal UTF-8 byte sequence it won't be
+        recognized as "utf-8".  You can use the |8g8| command to find the
+        illegal byte sequence.
+        WRONG VALUES:                   WHAT'S WRONG:
+                latin1,utf-8            "latin1" will always be used
+                utf-8,ucs-bom,latin1    BOM won't be recognized in an utf-8
+                                        file
+                cp1250,latin1           "cp1250" will always be used
+        If 'fileencodings' is empty, 'fileencoding' is not modified.
+        See 'fileencoding' for the possible values.
+        Setting this option does not have an effect until the next time a file
+        is read.
+
+                                                             *'fileformat'* *'ff'*
+'fileformat' 'ff'       string (default Windows: "dos", Unix: "unix")
+                        local to buffer
+        This gives the <EOL> of the current buffer, which is used for
+        reading/writing the buffer from/to a file:
+            dos     <CR><NL>
+            unix    <NL>
+            mac     <CR>
+        When "dos" is used, CTRL-Z at the end of a file is ignored.
+        See |file-formats| and |file-read|.
+        For the character encoding of the file see 'fileencoding'.
+        When 'binary' is set, the value of 'fileformat' is ignored, file I/O
+        works like it was set to "unix".
+        This option is set automatically when starting to edit a file and
+        'fileformats' is not empty and 'binary' is off.
+        When this option is set, after starting to edit a file, the 'modified'
+        option is set, because the file would be different when written.
+        This option cannot be changed when 'modifiable' is off.
+
+                                                           *'fileformats'* *'ffs'*
+'fileformats' 'ffs'     string (default Windows: "dos,unix", Unix: "unix,dos")
+                        global
+        This gives the end-of-line (<EOL>) formats that will be tried when
+        starting to edit a new buffer and when reading a file into an existing
+        buffer:
+        - When empty, the format defined with 'fileformat' will be used
+          always.  It is not set automatically.
+        - When set to one name, that format will be used whenever a new buffer
+          is opened.  'fileformat' is set accordingly for that buffer.  The
+          'fileformats' name will be used when a file is read into an existing
+          buffer, no matter what 'fileformat' for that buffer is set to.
+        - When more than one name is present, separated by commas, automatic
+          <EOL> detection will be done when reading a file.  When starting to
+          edit a file, a check is done for the <EOL>:
+          1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
+             'fileformat' is set to "dos".
+          2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
+             is set to "unix".  Note that when a <NL> is found without a
+             preceding <CR>, "unix" is preferred over "dos".
+          3. If 'fileformat' has not yet been set, and if a <CR> is found, and
+             if 'fileformats' includes "mac", 'fileformat' is set to "mac".
+             This means that "mac" is only chosen when:
+              "unix" is not present or no <NL> is found in the file, and
+              "dos" is not present or no <CR><NL> is found in the file.
+             Except: if "unix" was chosen, but there is a <CR> before
+             the first <NL>, and there appear to be more <CR>s than <NL>s in
+             the first few lines, "mac" is used.
+          4. If 'fileformat' is still not set, the first name from
+             'fileformats' is used.
+          When reading a file into an existing buffer, the same is done, but
+          this happens like 'fileformat' has been set appropriately for that
+          file only, the option is not changed.
+        When 'binary' is set, the value of 'fileformats' is not used.
+
+        When Vim starts up with an empty buffer the first item is used.  You
+        can overrule this by setting 'fileformat' in your .vimrc.
+
+        For systems with a Dos-like <EOL> (<CR><NL>), when reading files that
+        are ":source"ed and for vimrc files, automatic <EOL> detection may be
+        done:
+        - When 'fileformats' is empty, there is no automatic detection.  Dos
+          format will be used.
+        - When 'fileformats' is set to one or more names, automatic detection
+          is done.  This is based on the first <NL> in the file: If there is a
+          <CR> in front of it, Dos format is used, otherwise Unix format is
+          used.
+        Also see |file-formats|.
+
+                             *'fileignorecase'* *'fic'* *'nofileignorecase'* *'nofic'*
+'fileignorecase' 'fic'  boolean (default on for systems where case in file
+                                         names is normally ignored)
+                        global
+        When set case is ignored when using file names and directories.
+        See 'wildignorecase' for only ignoring case when doing completion.
+
+                                                               *'filetype'* *'ft'*
+'filetype' 'ft'         string (default "")
+                        local to buffer  |local-noglobal|
+        When this option is set, the FileType autocommand event is triggered.
+        All autocommands that match with the value of this option will be
+        executed.  Thus the value of 'filetype' is used in place of the file
+        name.
+        Otherwise this option does not always reflect the current file type.
+        This option is normally set when the file type is detected.  To enable
+        this use the ":filetype on" command. |:filetype|
+        Setting this option to a different value is most useful in a modeline,
+        for a file for which the file type is not automatically recognized.
+        Example, for in an IDL file: >c
+                /* vim: set filetype=idl : */
+<       |FileType| |filetypes|
+        When a dot appears in the value then this separates two filetype
+        names.  Example: >c
+                /* vim: set filetype=c.doxygen : */
+<       This will use the "c" filetype first, then the "doxygen" filetype.
+        This works both for filetype plugins and for syntax files.  More than
+        one dot may appear.
+        This option is not copied to another buffer, independent of the 's' or
+        'S' flag in 'cpoptions'.
+        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+
+                                                             *'fillchars'* *'fcs'*
+'fillchars' 'fcs'       string (default "")
+                        global or local to window |global-local|
+        Characters to fill the statuslines, vertical separators and special
+        lines in the window.
+        It is a comma-separated list of items.  Each item has a name, a colon
+        and the value of that item:
+
+          item          default         Used for ~
+          stl           ' '             statusline of the current window
+          stlnc         ' '             statusline of the non-current windows
+          wbr           ' '             window bar
+          horiz         '─' or '-'      horizontal separators |:split|
+          horizup       '┴' or '-'      upwards facing horizontal separator
+          horizdown     '┬' or '-'      downwards facing horizontal separator
+          vert          '│' or '|'      vertical separators |:vsplit|
+          vertleft      '┤' or '|'      left facing vertical separator
+          vertright     '├' or '|'      right facing vertical separator
+          verthoriz     '┼' or '+'      overlapping vertical and horizontal
+                                        separator
+          fold          '·' or '-'      filling 'foldtext'
+          foldopen      '-'             mark the beginning of a fold
+          foldclose     '+'             show a closed fold
+          foldsep       '│' or '|'      open fold middle marker
+          diff          '-'             deleted lines of the 'diff' option
+          msgsep        ' '             message separator 'display'
+          eob           '~'             empty lines at the end of a buffer
+          lastline      '@'             'display' contains lastline/truncate
+
+        Any one that is omitted will fall back to the default.
+
+        Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
+        "verthoriz" are only used when 'laststatus' is 3, since only vertical
+        window separators are used otherwise.
+
+        If 'ambiwidth' is "double" then "horiz", "horizup", "horizdown",
+        "vert", "vertleft", "vertright", "verthoriz", "foldsep" and "fold"
+        default to single-byte alternatives.
+
+        Example: >vim
+            set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
+<
+        For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
+        single-byte and multibyte characters are supported.  But double-width
+        characters are not supported.
+
+        The highlighting used for these items:
+          item          highlight group ~
+          stl           StatusLine              |hl-StatusLine|
+          stlnc         StatusLineNC            |hl-StatusLineNC|
+          wbr           WinBar                  |hl-WinBar| or |hl-WinBarNC|
+          horiz         WinSeparator            |hl-WinSeparator|
+          horizup       WinSeparator            |hl-WinSeparator|
+          horizdown     WinSeparator            |hl-WinSeparator|
+          vert          WinSeparator            |hl-WinSeparator|
+          vertleft      WinSeparator            |hl-WinSeparator|
+          vertright     WinSeparator            |hl-WinSeparator|
+          verthoriz     WinSeparator            |hl-WinSeparator|
+          fold          Folded                  |hl-Folded|
+          diff          DiffDelete              |hl-DiffDelete|
+          eob           EndOfBuffer             |hl-EndOfBuffer|
+          lastline      NonText                 |hl-NonText|
+
+                           *'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
+'fixendofline' 'fixeol' boolean (default on)
+                        local to buffer
+        When writing a file and this option is on, <EOL> at the end of file
+        will be restored if missing.  Turn this option off if you want to
+        preserve the situation from the original file.
+        When the 'binary' option is set the value of this option doesn't
+        matter.
+        See the 'endofline' option.
+        See |eol-and-eof| for example settings.
+
+                                                             *'foldclose'* *'fcl'*
+'foldclose' 'fcl'       string (default "")
+                        global
+        When set to "all", a fold is closed when the cursor isn't in it and
+        its level is higher than 'foldlevel'.  Useful if you want folds to
+        automatically close when moving out of them.
+
+                                                            *'foldcolumn'* *'fdc'*
+'foldcolumn' 'fdc'      string (default "0")
+                        local to window
+        When and how to draw the foldcolumn. Valid values are:
+            "auto":       resize to the minimum amount of folds to display.
+            "auto:[1-9]": resize to accommodate multiple folds up to the
+                          selected level
+            "0":          to disable foldcolumn
+            "[1-9]":      to display a fixed number of columns
+        See |folding|.
+
+                                     *'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*
+'foldenable' 'fen'      boolean (default on)
+                        local to window
+        When off, all folds are open.  This option can be used to quickly
+        switch between showing all text unfolded and viewing the text with
+        folds (including manually opened or closed folds).  It can be toggled
+        with the |zi| command.  The 'foldcolumn' will remain blank when
+        'foldenable' is off.
+        This option is set by commands that create a new fold or close a fold.
+        See |folding|.
+
+                                                              *'foldexpr'* *'fde'*
+'foldexpr' 'fde'        string (default "0")
+                        local to window
+        The expression used for when 'foldmethod' is "expr".  It is evaluated
+        for each line to obtain its fold level.  The context is set to the
+        script where 'foldexpr' was set, script-local items can be accessed.
+        See |fold-expr| for the usage.
+
+        The expression will be evaluated in the |sandbox| if set from a
+        modeline, see |sandbox-option|.
+        This option can't be set from a |modeline| when the 'diff' option is
+        on or the 'modelineexpr' option is off.
+
+        It is not allowed to change text or jump to another window while
+        evaluating 'foldexpr' |textlock|.
+
+                                                            *'foldignore'* *'fdi'*
+'foldignore' 'fdi'      string (default "#")
+                        local to window
+        Used only when 'foldmethod' is "indent".  Lines starting with
+        characters in 'foldignore' will get their fold level from surrounding
+        lines.  White space is skipped before checking for this character.
+        The default "#" works well for C programs.  See |fold-indent|.
+
+                                                             *'foldlevel'* *'fdl'*
+'foldlevel' 'fdl'       number (default 0)
+                        local to window
+        Sets the fold level: Folds with a higher level will be closed.
+        Setting this option to zero will close all folds.  Higher numbers will
+        close fewer folds.
+        This option is set by commands like |zm|, |zM| and |zR|.
+        See |fold-foldlevel|.
+
+                                                       *'foldlevelstart'* *'fdls'*
+'foldlevelstart' 'fdls' number (default -1)
+                        global
+        Sets 'foldlevel' when starting to edit another buffer in a window.
+        Useful to always start editing with all folds closed (value zero),
+        some folds closed (one) or no folds closed (99).
+        This is done before reading any modeline, thus a setting in a modeline
+        overrules this option.  Starting to edit a file for |diff-mode| also
+        ignores this option and closes all folds.
+        It is also done before BufReadPre autocommands, to allow an autocmd to
+        overrule the 'foldlevel' value for specific files.
+        When the value is negative, it is not used.
+
+                                                       *'foldmarker'* *'fmr'* *E536*
+'foldmarker' 'fmr'      string (default "{{{,}}}")
+                        local to window
+        The start and end marker used when 'foldmethod' is "marker".  There
+        must be one comma, which separates the start and end marker.  The
+        marker is a literal string (a regular expression would be too slow).
+        See |fold-marker|.
+
+                                                            *'foldmethod'* *'fdm'*
+'foldmethod' 'fdm'      string (default "manual")
+                        local to window
+        The kind of folding used for the current window.  Possible values:
+        |fold-manual|   manual      Folds are created manually.
+        |fold-indent|   indent      Lines with equal indent form a fold.
+        |fold-expr|     expr        'foldexpr' gives the fold level of a line.
+        |fold-marker|   marker      Markers are used to specify folds.
+        |fold-syntax|   syntax      Syntax highlighting items specify folds.
+        |fold-diff|     diff        Fold text that is not changed.
+
+                                                          *'foldminlines'* *'fml'*
+'foldminlines' 'fml'    number (default 1)
+                        local to window
+        Sets the number of screen lines above which a fold can be displayed
+        closed.  Also for manually closed folds.  With the default value of
+        one a fold can only be closed if it takes up two or more screen lines.
+        Set to zero to be able to close folds of just one screen line.
+        Note that this only has an effect on what is displayed.  After using
+        "zc" to close a fold, which is displayed open because it's smaller
+        than 'foldminlines', a following "zc" may close a containing fold.
+
+                                                           *'foldnestmax'* *'fdn'*
+'foldnestmax' 'fdn'     number (default 20)
+                        local to window
+        Sets the maximum nesting of folds for the "indent" and "syntax"
+        methods.  This avoids that too many folds will be created.  Using more
+        than 20 doesn't work, because the internal limit is 20.
+
+                                                              *'foldopen'* *'fdo'*
+'foldopen' 'fdo'        string (default "block,hor,mark,percent,quickfix,search,tag,undo")
+                        global
+        Specifies for which type of commands folds will be opened, if the
+        command moves the cursor into a closed fold.  It is a comma-separated
+        list of items.
+        NOTE: When the command is part of a mapping this option is not used.
+        Add the |zv| command to the mapping to get the same effect.
+        (rationale: the mapping may want to control opening folds itself)
+
+                item            commands ~
+                all             any
+                block           (, {, [[, [{, etc.
+                hor             horizontal movements: "l", "w", "fx", etc.
+                insert          any command in Insert mode
+                jump            far jumps: "G", "gg", etc.
+                mark            jumping to a mark: "'m", CTRL-O, etc.
+                percent         "%"
+                quickfix        ":cn", ":crew", ":make", etc.
+                search          search for a pattern: "/", "n", "*", "gd", etc.
+                                (not for a search pattern in a ":" command)
+                                Also for |[s| and |]s|.
+                tag             jumping to a tag: ":ta", CTRL-T, etc.
+                undo            undo or redo: "u" and CTRL-R
+        When a movement command is used for an operator (e.g., "dl" or "y%")
+        this option is not used.  This means the operator will include the
+        whole closed fold.
+        Note that vertical movements are not here, because it would make it
+        very difficult to move onto a closed fold.
+        In insert mode the folds containing the cursor will always be open
+        when text is inserted.
+        To close folds you can re-apply 'foldlevel' with the |zx| command or
+        set the 'foldclose' option to "all".
+
+                                                              *'foldtext'* *'fdt'*
+'foldtext' 'fdt'        string (default "foldtext()")
+                        local to window
+        An expression which is used to specify the text displayed for a closed
+        fold.  The context is set to the script where 'foldexpr' was set,
+        script-local items can be accessed.  See |fold-foldtext| for the
+        usage.
+
+        The expression will be evaluated in the |sandbox| if set from a
+        modeline, see |sandbox-option|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        It is not allowed to change text or jump to another window while
+        evaluating 'foldtext' |textlock|.
+
+                                                            *'formatexpr'* *'fex'*
+'formatexpr' 'fex'      string (default "")
+                        local to buffer
+        Expression which is evaluated to format a range of lines for the |gq|
+        operator or automatic formatting (see 'formatoptions').  When this
+        option is empty 'formatprg' is used.
+
+        The |v:lnum|  variable holds the first line to be formatted.
+        The |v:count| variable holds the number of lines to be formatted.
+        The |v:char|  variable holds the character that is going to be
+                      inserted if the expression is being evaluated due to
+                      automatic formatting.  This can be empty.  Don't insert
+                      it yet!
+
+        Example: >vim
+                set formatexpr=mylang#Format()
+<       This will invoke the mylang#Format() function in the
+        autoload/mylang.vim file in 'runtimepath'. |autoload|
+
+        The expression is also evaluated when 'textwidth' is set and adding
+        text beyond that limit.  This happens under the same conditions as
+        when internal formatting is used.  Make sure the cursor is kept in the
+        same spot relative to the text then!  The |mode()| function will
+        return "i" or "R" in this situation.
+
+        When the expression evaluates to non-zero Vim will fall back to using
+        the internal format mechanism.
+
+        If the expression starts with s: or |<SID>|, then it is replaced with
+        the script ID (|local-function|). Example: >vim
+                set formatexpr=s:MyFormatExpr()
+                set formatexpr=<SID>SomeFormatExpr()
+<       Otherwise, the expression is evaluated in the context of the script
+        where the option was set, thus script-local items are available.
+
+        The expression will be evaluated in the |sandbox| when set from a
+        modeline, see |sandbox-option|.  That stops the option from working,
+        since changing the buffer text is not allowed.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+        NOTE: This option is set to "" when 'compatible' is set.
+
+                                                         *'formatlistpat'* *'flp'*
+'formatlistpat' 'flp'   string (default "^\s*\d\+[\]:.)}\t ]\s*")
+                        local to buffer
+        A pattern that is used to recognize a list header.  This is used for
+        the "n" flag in 'formatoptions'.
+        The pattern must match exactly the text that will be the indent for
+        the line below it.  You can use |/\ze| to mark the end of the match
+        while still checking more characters.  There must be a character
+        following the pattern, when it matches the whole line it is handled
+        like there is no match.
+        The default recognizes a number, followed by an optional punctuation
+        character and white space.
+
+                                                          *'formatoptions'* *'fo'*
+'formatoptions' 'fo'    string (default "tcqj")
+                        local to buffer
+        This is a sequence of letters which describes how automatic
+        formatting is to be done.
+        See |fo-table| for possible values and |gq| for how to format text.
+        Commas can be inserted for readability.
+        To avoid problems with flags that are added in the future, use the
+        "+=" and "-=" feature of ":set" |add-option-flags|.
+
+                                                              *'formatprg'* *'fp'*
+'formatprg' 'fp'        string (default "")
+                        global or local to buffer |global-local|
+        The name of an external program that will be used to format the lines
+        selected with the |gq| operator.  The program must take the input on
+        stdin and produce the output on stdout.  The Unix program "fmt" is
+        such a program.
+        If the 'formatexpr' option is not empty it will be used instead.
+        Otherwise, if 'formatprg' option is an empty string, the internal
+        format function will be used |C-indenting|.
+        Environment variables are expanded |:set_env|.  See |option-backslash|
+        about including spaces and backslashes.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                 *'fsync'* *'fs'* *'nofsync'* *'nofs'*
+'fsync' 'fs'            boolean (default on)
+                        global
+        When on, the OS function fsync() will be called after saving a file
+        (|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
+        This flushes the file to disk, ensuring that it is safely written.
+        Slow on some systems: writing buffers, quitting Nvim, and other
+        operations may sometimes take a few seconds.
+
+        Files are ALWAYS flushed ('fsync' is ignored) when:
+        - |CursorHold| event is triggered
+        - |:preserve| is called
+        - system signals low battery life
+        - Nvim exits abnormally
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                           *'gdefault'* *'gd'* *'nogdefault'* *'nogd'*
+'gdefault' 'gd'         boolean (default off)
+                        global
+        When on, the ":substitute" flag 'g' is default on.  This means that
+        all matches in a line are substituted instead of one.  When a 'g' flag
+        is given to a ":substitute" command, this will toggle the substitution
+        of all or one match.  See |complex-change|.
+
+                command         'gdefault' on   'gdefault' off  ~
+                :s///             subst. all      subst. one
+                :s///g            subst. one      subst. all
+                :s///gg           subst. all      subst. one
+
+        NOTE: Setting this option may break plugins that rely on the default
+        behavior of the 'g' flag. This will also make the 'g' flag have the
+        opposite effect of that documented in |:s_g|.
+
+                                                            *'grepformat'* *'gfm'*
+'grepformat' 'gfm'      string (default "%f:%l:%m,%f:%l%m,%f  %l%m")
+                        global
+        Format to recognize for the ":grep" command output.
+        This is a scanf-like string that uses the same format as the
+        'errorformat' option: see |errorformat|.
+
+                                                                *'grepprg'* *'gp'*
+'grepprg' 'gp'          string (default "grep -n ",
+                                         Unix: "grep -n $* /dev/null")
+                        global or local to buffer |global-local|
+        Program to use for the |:grep| command.  This option may contain '%'
+        and '#' characters, which are expanded like when used in a command-
+        line.  The placeholder "$*" is allowed to specify where the arguments
+        will be included.  Environment variables are expanded |:set_env|.  See
+        |option-backslash| about including spaces and backslashes.
+        When your "grep" accepts the "-H" argument, use this to make ":grep"
+        also work well with a single file: >vim
+                set grepprg=grep\ -nH
+<       Special value: When 'grepprg' is set to "internal" the |:grep| command
+        works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
+        |:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
+        See also the section |:make_makeprg|, since most of the comments there
+        apply equally to 'grepprg'.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                         *'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
+'guicursor' 'gcr'       string (default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")
+                        global
+        Configures the cursor style for each mode. Works in the GUI and many
+        terminals.  See |tui-cursor-shape|.
+
+        To disable cursor-styling, reset the option: >vim
+                set guicursor=
+
+<       To enable mode shapes, "Cursor" highlight, and blinking: >vim
+                set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
+                  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
+                  \,sm:block-blinkwait175-blinkoff150-blinkon175
+
+<       The option is a comma-separated list of parts.  Each part consists of a
+        mode-list and an argument-list:
+                mode-list:argument-list,mode-list:argument-list,..
+        The mode-list is a dash separated list of these modes:
+                n       Normal mode
+                v       Visual mode
+                ve      Visual mode with 'selection' "exclusive" (same as 'v',
+                        if not specified)
+                o       Operator-pending mode
+                i       Insert mode
+                r       Replace mode
+                c       Command-line Normal (append) mode
+                ci      Command-line Insert mode
+                cr      Command-line Replace mode
+                sm      showmatch in Insert mode
+                a       all modes
+        The argument-list is a dash separated list of these arguments:
+                hor{N}  horizontal bar, {N} percent of the character height
+                ver{N}  vertical bar, {N} percent of the character width
+                block   block cursor, fills the whole character
+                        - Only one of the above three should be present.
+                        - Default is "block" for each mode.
+                blinkwait{N}                            *cursor-blinking*
+                blinkon{N}
+                blinkoff{N}
+                        blink times for cursor: blinkwait is the delay before
+                        the cursor starts blinking, blinkon is the time that
+                        the cursor is shown and blinkoff is the time that the
+                        cursor is not shown.  Times are in msec.  When one of
+                        the numbers is zero, there is no blinking. E.g.: >vim
+                                set guicursor=n:blinkon0
+<                       - Default is "blinkon0" for each mode.
+                {group-name}
+                        Highlight group that decides the color and font of the
+                        cursor.
+                        In the |TUI|:
+                        - |inverse|/reverse and no group-name are interpreted
+                          as "host-terminal default cursor colors" which
+                          typically means "inverted bg and fg colors".
+                        - |ctermfg| and |guifg| are ignored.
+                {group-name}/{group-name}
+                        Two highlight group names, the first is used when
+                        no language mappings are used, the other when they
+                        are. |language-mapping|
+
+        Examples of parts:
+           n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
+                                block cursor with colors from the "nCursor"
+                                highlight group
+           n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
+                                In Normal et al. modes, use a block cursor
+                                with the default colors defined by the host
+                                terminal.  In Insert-like modes, use
+                                a vertical bar cursor with colors from
+                                "Cursor" highlight group.  In Replace-like
+                                modes, use an underline cursor with
+                                default colors.
+           i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
+                                In Insert and Command-line Insert mode, use a
+                                30% vertical bar cursor with colors from the
+                                "iCursor" highlight group.  Blink a bit
+                                faster.
+
+        The 'a' mode is different.  It will set the given argument-list for
+        all modes.  It does not reset anything to defaults.  This can be used
+        to do a common setting for all modes.  For example, to switch off
+        blinking: "a:blinkon0"
+
+        Examples of cursor highlighting: >vim
+            highlight Cursor gui=reverse guifg=NONE guibg=NONE
+            highlight Cursor gui=NONE guifg=bg guibg=fg
 <
 
-				*'guifontwide'* *'gfw'* *E231* *E533* *E534*
-'guifontwide' 'gfw'	string	(default "")
-			global
-	Comma-separated list of fonts to be used for double-width characters.
-	The first font that can be loaded is used.
-	Note: The size of these fonts must be exactly twice as wide as the one
-	specified with 'guifont' and the same height.
+                                                     *'guifont'* *'gfn'* *E235* *E596*
+'guifont' 'gfn'         string (default "")
+                        global
+        This is a list of fonts which will be used for the GUI version of Vim.
+        In its simplest form the value is just one font name.  When
+        the font cannot be found you will get an error message.  To try other
+        font names a list can be specified, font names separated with commas.
+        The first valid font is used.
 
-	When 'guifont' has a valid font and 'guifontwide' is empty Vim will
-	attempt to set 'guifontwide' to a matching double-width font.
+        Spaces after a comma are ignored.  To include a comma in a font name
+        precede it with a backslash.  Setting an option requires an extra
+        backslash before a space and a backslash.  See also
+        |option-backslash|.  For example: >vim
+            set guifont=Screen15,\ 7x13,font\\,with\\,commas
+<       will make Vim try to use the font "Screen15" first, and if it fails it
+        will try to use "7x13" and then "font,with,commas" instead.
 
-						*'guioptions'* *'go'*
-'guioptions' 'go'	string	(default "egmrLT"   (MS-Windows))
-			global
-	This option only has an effect in the GUI version of Vim.  It is a
-	sequence of letters which describes what components and options of the
-	GUI should be used.
-	To avoid problems with flags that are added in the future, use the
-	"+=" and "-=" feature of ":set" |add-option-flags|.
+        If none of the fonts can be loaded, Vim will keep the current setting.
+        If an empty font list is given, Vim will try using other resource
+        settings (for X, it will use the Vim.font resource), and finally it
+        will try some builtin default which should always be there ("7x13" in
+        the case of X).  The font names given should be "normal" fonts.  Vim
+        will try to find the related bold and italic fonts.
 
-	Valid letters are as follows:
-							*guioptions_a* *'go-a'*
-	  'a'	Autoselect:  If present, then whenever VISUAL mode is started,
-		or the Visual area extended, Vim tries to become the owner of
-		the windowing system's global selection.  This means that the
-		Visually highlighted text is available for pasting into other
-		applications as well as into Vim itself.  When the Visual mode
-		ends, possibly due to an operation on the text, or when an
-		application wants to paste the selection, the highlighted text
-		is automatically yanked into the "* selection register.
-		Thus the selection is still available for pasting into other
-		applications after the VISUAL mode has ended.
-		    If not present, then Vim won't become the owner of the
-		windowing system's global selection unless explicitly told to
-		by a yank or delete operation for the "* register.
-		The same applies to the modeless selection.
-								*'go-P'*
-	  'P'	Like autoselect but using the "+ register instead of the "*
-		register.
-								*'go-A'*
-	  'A'	Autoselect for the modeless selection.  Like 'a', but only
-		applies to the modeless selection.
+        For Win32 and Mac OS: >vim
+            set guifont=*
+<       will bring up a font requester, where you can pick the font you want.
 
-		    'guioptions'   autoselect Visual  autoselect modeless ~
-			 ""		 -			 -
-			 "a"		yes			yes
-			 "A"		 -			yes
-			 "aA"		yes			yes
+        The font name depends on the GUI used.
 
-								*'go-c'*
-	  'c'	Use console dialogs instead of popup dialogs for simple
-		choices.
-								*'go-d'*
-	  'd'	Use dark theme variant if available.
-								*'go-e'*
-	  'e'	Add tab pages when indicated with 'showtabline'.
-		'guitablabel' can be used to change the text in the labels.
-		When 'e' is missing a non-GUI tab pages line may be used.
-		The GUI tabs are only supported on some systems, currently
-		Mac OS/X and MS-Windows.
-								*'go-i'*
-	  'i'	Use a Vim icon.
-								*'go-m'*
-	  'm'	Menu bar is present.
-								*'go-M'*
-	  'M'	The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
-		that this flag must be added in the vimrc file, before
-		switching on syntax or filetype recognition (when the |gvimrc|
-		file is sourced the system menu has already been loaded; the
-		`:syntax on` and `:filetype on` commands load the menu too).
-								*'go-g'*
-	  'g'	Grey menu items: Make menu items that are not active grey.  If
-		'g' is not included inactive menu items are not shown at all.
-								*'go-T'*
-	  'T'	Include Toolbar.  Currently only in Win32 GUI.
-								*'go-r'*
-	  'r'	Right-hand scrollbar is always present.
-								*'go-R'*
-	  'R'	Right-hand scrollbar is present when there is a vertically
-		split window.
-								*'go-l'*
-	  'l'	Left-hand scrollbar is always present.
-								*'go-L'*
-	  'L'	Left-hand scrollbar is present when there is a vertically
-		split window.
-								*'go-b'*
-	  'b'	Bottom (horizontal) scrollbar is present.  Its size depends on
-		the longest visible line, or on the cursor line if the 'h'
-		flag is included. |gui-horiz-scroll|
-								*'go-h'*
-	  'h'	Limit horizontal scrollbar size to the length of the cursor
-		line.  Reduces computations. |gui-horiz-scroll|
+        For Mac OSX you can use something like this: >vim
+            set guifont=Monaco:h10
+<                                                               *E236*
+        Note that the fonts must be mono-spaced (all characters have the same
+        width).
 
-	And yes, you may even have scrollbars on the left AND the right if
-	you really want to :-).  See |gui-scrollbars| for more information.
+        To preview a font on X11, you might be able to use the "xfontsel"
+        program.  The "xlsfonts" program gives a list of all available fonts.
 
-								*'go-v'*
-	  'v'	Use a vertical button layout for dialogs.  When not included,
-		a horizontal layout is preferred, but when it doesn't fit a
-		vertical layout is used anyway.  Not supported in GTK 3.
-								*'go-p'*
-	  'p'	Use Pointer callbacks for X11 GUI.  This is required for some
-		window managers.  If the cursor is not blinking or hollow at
-		the right moment, try adding this flag.  This must be done
-		before starting the GUI.  Set it in your |gvimrc|.  Adding or
-		removing it after the GUI has started has no effect.
-								*'go-k'*
-	  'k'	Keep the GUI window size when adding/removing a scrollbar, or
-		toolbar, tabline, etc.  Instead, the behavior is similar to
-		when the window is maximized and will adjust 'lines' and
-		'columns' to fit to the window.  Without the 'k' flag Vim will
-		try to keep 'lines' and 'columns' the same when adding and
-		removing GUI components.
+        For the Win32 GUI                                       *E244* *E245*
+        - takes these options in the font name:
+                hXX - height is XX (points, can be floating-point)
+                wXX - width is XX (points, can be floating-point)
+                b   - bold
+                i   - italic
+                u   - underline
+                s   - strikeout
+                cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
+                      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
+                      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
+                      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
+                      Normally you would use "cDEFAULT".
 
-						*'guitablabel'* *'gtl'*
-'guitablabel' 'gtl'	string	(default "")
-			global
-	When non-empty describes the text to use in a label of the GUI tab
-	pages line.  When empty and when the result is empty Vim will use a
-	default label.  See |setting-guitablabel| for more info.
-
-	The format of this option is like that of 'statusline'.
-	'guitabtooltip' is used for the tooltip, see below.
-	The expression will be evaluated in the |sandbox| when set from a
-	modeline, see |sandbox-option|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	Only used when the GUI tab pages line is displayed.  'e' must be
-	present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
-	used.
-
-						*'guitabtooltip'* *'gtt'*
-'guitabtooltip' 'gtt'	string	(default "")
-			global
-	When non-empty describes the text to use in a tooltip for the GUI tab
-	pages line.  When empty Vim will use a default tooltip.
-	This option is otherwise just like 'guitablabel' above.
-	You can include a line break.  Simplest method is to use |:let|: >vim
-		let &guitabtooltip = "line one\nline two"
+          Use a ':' to separate the options.
+        - A '_' can be used in the place of a space, so you don't need to use
+          backslashes to escape the spaces.
+        - Examples: >vim
+            set guifont=courier_new:h12:w5:b:cRUSSIAN
+            set guifont=Andale_Mono:h7.5:w4.5
 <
 
-						*'helpfile'* *'hf'*
-'helpfile' 'hf'		string	(default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
-                                         (others) "$VIMRUNTIME/doc/help.txt")
-			global
-	Name of the main help file.  All distributed help files should be
-	placed together in one directory.  Additionally, all "doc" directories
-	in 'runtimepath' will be used.
-	Environment variables are expanded |:set_env|.  For example:
-	"$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
-	tried.  Also see |$VIMRUNTIME| and |option-backslash| about including
-	spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'helpheight'* *'hh'*
-'helpheight' 'hh'	number	(default 20)
-			global
-	Minimal initial height of the help window when it is opened with the
-	":help" command.  The initial height of the help window is half of the
-	current window, or (when the 'ea' option is on) the same as other
-	windows.  When the height is less than 'helpheight', the height is
-	set to 'helpheight'.  Set to zero to disable.
-
-						*'helplang'* *'hlg'*
-'helplang' 'hlg'	string	(default messages language or empty)
-			global
-	Comma-separated list of languages.  Vim will use the first language
-	for which the desired help can be found.  The English help will always
-	be used as a last resort.  You can add "en" to prefer English over
-	another language, but that will only find tags that exist in that
-	language and not in the English help.
-	Example: >vim
-		set helplang=de,it
-<	This will first search German, then Italian and finally English help
-	files.
-	When using |CTRL-]| and ":help!" in a non-English help file Vim will
-	try to find the tag in the current language before using this option.
-	See |help-translated|.
-
-				*'hidden'* *'hid'* *'nohidden'* *'nohid'*
-'hidden' 'hid'		boolean	(default on)
-			global
-	When off a buffer is unloaded (including loss of undo information)
-	when it is |abandon|ed.  When on a buffer becomes hidden when it is
-	|abandon|ed.  A buffer displayed in another window does not become
-	hidden, of course.
-
-	Commands that move through the buffer list sometimes hide a buffer
-	although the 'hidden' option is off when these three are true:
-	- the buffer is modified
-	- 'autowrite' is off or writing is not possible
-	- the '!' flag was used
-	Also see |windows|.
-
-	To hide a specific buffer use the 'bufhidden' option.
-	'hidden' is set for one command with ":hide {command}" |:hide|.
-
-						*'history'* *'hi'*
-'history' 'hi'		number	(default 10000)
-			global
-	A history of ":" commands, and a history of previous search patterns
-	is remembered.  This option decides how many entries may be stored in
-	each of these histories (see |cmdline-editing|).
-	The maximum value is 10000.
-
-				*'hlsearch'* *'hls'* *'nohlsearch'* *'nohls'*
-'hlsearch' 'hls'	boolean	(default on)
-			global
-	When there is a previous search pattern, highlight all its matches.
-	The |hl-Search| highlight group determines the highlighting for all
-	matches not under the cursor while the |hl-CurSearch| highlight group
-	(if defined) determines the highlighting for the match under the
-	cursor. If |hl-CurSearch| is not defined, then |hl-Search| is used for
-	both. Note that only the matching text is highlighted, any offsets
-	are not applied.
-	See also: 'incsearch' and |:match|.
-	When you get bored looking at the highlighted matches, you can turn it
-	off with |:nohlsearch|.  This does not change the option value, as
-	soon as you use a search command, the highlighting comes back.
-	'redrawtime' specifies the maximum time spent on finding matches.
-	When the search pattern can match an end-of-line, Vim will try to
-	highlight all of the matched text.  However, this depends on where the
-	search starts.  This will be the first line in the window or the first
-	line below a closed fold.  A match in a previous line which is not
-	drawn may not continue in a newly drawn line.
-	You can specify whether the highlight status is restored on startup
-	with the 'h' flag in 'shada' |shada-h|.
-
-						*'icon'* *'noicon'*
-'icon'			boolean	(default off, on when title can be restored)
-			global
-	When on, the icon text of the window will be set to the value of
-	'iconstring' (if it is not empty), or to the name of the file
-	currently being edited.  Only the last part of the name is used.
-	Overridden by the 'iconstring' option.
-	Only works if the terminal supports setting window icons.
-
-							*'iconstring'*
-'iconstring'		string	(default "")
-			global
-	When this option is not empty, it will be used for the icon text of
-	the window.  This happens only when the 'icon' option is on.
-	Only works if the terminal supports setting window icon text
-	When this option contains printf-style '%' items, they will be
-	expanded according to the rules used for 'statusline'.  See
-	'titlestring' for example settings.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-			*'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
-'ignorecase' 'ic'	boolean	(default off)
-			global
-	Ignore case in search patterns, |cmdline-completion|, when
-	searching in the tags file, and |expr-==|.
-	Also see 'smartcase' and 'tagcase'.
-	Can be overruled by using "\c" or "\C" in the pattern, see
-	|/ignorecase|.
-
-			*'imcmdline'* *'imc'* *'noimcmdline'* *'noimc'*
-'imcmdline' 'imc'	boolean	(default off)
-			global
-	When set the Input Method is always on when starting to edit a command
-	line, unless entering a search pattern (see 'imsearch' for that).
-	Setting this option is useful when your input method allows entering
-	English characters directly, e.g., when it's used to type accented
-	characters with dead keys.
-
-			*'imdisable'* *'imd'* *'noimdisable'* *'noimd'*
-'imdisable' 'imd'	boolean	(default off, on for some systems (SGI))
-			global
-	When set the Input Method is never used.  This is useful to disable
-	the IM when it doesn't work properly.
-	Currently this option is on by default for SGI/IRIX machines.  This
-	may change in later releases.
-
-						*'iminsert'* *'imi'*
-'iminsert' 'imi'	number	(default 0)
-			local to buffer
-	Specifies whether :lmap or an Input Method (IM) is to be used in
-	Insert mode.  Valid values:
-		0	:lmap is off and IM is off
-		1	:lmap is ON and IM is off
-		2	:lmap is off and IM is ON
-	To always reset the option to zero when leaving Insert mode with <Esc>
-	this can be used: >vim
-		inoremap <ESC> <ESC>:set iminsert=0<CR>
-<	This makes :lmap and IM turn off automatically when leaving Insert
-	mode.
-	Note that this option changes when using CTRL-^ in Insert mode
-	|i_CTRL-^|.
-	The value is set to 1 when setting 'keymap' to a valid keymap name.
-	It is also used for the argument of commands like "r" and "f".
-
-						*'imsearch'* *'ims'*
-'imsearch' 'ims'	number	(default -1)
-			local to buffer
-	Specifies whether :lmap or an Input Method (IM) is to be used when
-	entering a search pattern.  Valid values:
-		-1	the value of 'iminsert' is used, makes it look like
-			'iminsert' is also used when typing a search pattern
-		0	:lmap is off and IM is off
-		1	:lmap is ON and IM is off
-		2	:lmap is off and IM is ON
-	Note that this option changes when using CTRL-^ in Command-line mode
-	|c_CTRL-^|.
-	The value is set to 1 when it is not -1 and setting the 'keymap'
-	option to a valid keymap name.
-
-						*'inccommand'* *'icm'*
-'inccommand' 'icm'	string	(default "nosplit")
-			global
-	When nonempty, shows the effects of |:substitute|, |:smagic|,
-	|:snomagic| and user commands with the |:command-preview| flag as you
-	type.
-
-	Possible values:
-		nosplit	Shows the effects of a command incrementally in the
-			buffer.
-		split	Like "nosplit", but also shows partial off-screen
-			results in a preview window.
-
-	If the preview for built-in commands is too slow (exceeds
-	'redrawtime') then 'inccommand' is automatically disabled until
-	|Command-line-mode| is done.
-
-						*'include'* *'inc'*
-'include' 'inc'		string	(default "")
-			global or local to buffer |global-local|
-	Pattern to be used to find an include command.  It is a search
-	pattern, just like for the "/" command (See |pattern|).  This option
-	is used for the commands "[i", "]I", "[d", etc.
-	Normally the 'isfname' option is used to recognize the file name that
-	comes after the matched pattern.  But if "\zs" appears in the pattern
-	then the text matched from "\zs" to the end, or until "\ze" if it
-	appears, is used as the file name.  Use this to include characters
-	that are not in 'isfname', such as a space.  You can then use
-	'includeexpr' to process the matched text.
-	See |option-backslash| about including spaces and backslashes.
-
-						*'includeexpr'* *'inex'*
-'includeexpr' 'inex'	string	(default "")
-			local to buffer
-	Expression to be used to transform the string found with the 'include'
-	option to a file name.  Mostly useful to change "." to "/" for Java: >vim
-		setlocal includeexpr=substitute(v:fname,'\\.','/','g')
-<	The "v:fname" variable will be set to the file name that was detected.
-	Note the double backslash: the `:set` command first halves them, then
-	one remains in the value, where "\." matches a dot literally.  For
-	simple character replacements `tr()` avoids the need for escaping: >vim
-		setlocal includeexpr=tr(v:fname,'.','/')
-<
-	Also used for the |gf| command if an unmodified file name can't be
-	found.  Allows doing "gf" on the name after an 'include' statement.
-	Also used for |<cfile>|.
-
-	If the expression starts with s: or |<SID>|, then it is replaced with
-	the script ID (|local-function|). Example: >vim
-		setlocal includeexpr=s:MyIncludeExpr(v:fname)
-		setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
-<	Otherwise, the expression is evaluated in the context of the script
-	where the option was set, thus script-local items are available.
-
-	The expression will be evaluated in the |sandbox| when set from a
-	modeline, see |sandbox-option|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	It is not allowed to change text or jump to another window while
-	evaluating 'includeexpr' |textlock|.
-
-				*'incsearch'* *'is'* *'noincsearch'* *'nois'*
-'incsearch' 'is'	boolean	(default on)
-			global
-	While typing a search command, show where the pattern, as it was typed
-	so far, matches.  The matched string is highlighted.  If the pattern
-	is invalid or not found, nothing is shown.  The screen will be updated
-	often, this is only useful on fast terminals.
-	Note that the match will be shown, but the cursor will return to its
-	original position when no match is found and when pressing <Esc>.  You
-	still need to finish the search command with <Enter> to move the
-	cursor to the match.
-	You can use the CTRL-G and CTRL-T keys to move to the next and
-	previous match. |c_CTRL-G| |c_CTRL-T|
-	Vim only searches for about half a second.  With a complicated
-	pattern and/or a lot of text the match may not be found.  This is to
-	avoid that Vim hangs while you are typing the pattern.
-	The |hl-IncSearch| highlight group determines the highlighting.
-	When 'hlsearch' is on, all matched strings are highlighted too while
-	typing a search command. See also: 'hlsearch'.
-	If you don't want to turn 'hlsearch' on, but want to highlight all
-	matches while searching, you can turn on and off 'hlsearch' with
-	autocmd.  Example: >vim
-		augroup vimrc-incsearch-highlight
-		  autocmd!
-		  autocmd CmdlineEnter /,\? :set hlsearch
-		  autocmd CmdlineLeave /,\? :set nohlsearch
-		augroup END
-<
-	CTRL-L can be used to add one character from after the current match
-	to the command line.  If 'ignorecase' and 'smartcase' are set and the
-	command line has no uppercase characters, the added character is
-	converted to lowercase.
-	CTRL-R CTRL-W can be used to add the word at the end of the current
-	match, excluding the characters that were already typed.
-
-						*'indentexpr'* *'inde'*
-'indentexpr' 'inde'	string	(default "")
-			local to buffer
-	Expression which is evaluated to obtain the proper indent for a line.
-	It is used when a new line is created, for the |=| operator and
-	in Insert mode as specified with the 'indentkeys' option.
-	When this option is not empty, it overrules the 'cindent' and
-	'smartindent' indenting.  When 'lisp' is set, this option is
-	is only used when 'lispoptions' contains "expr:1".
-	The expression is evaluated with |v:lnum| set to the line number for
-	which the indent is to be computed.  The cursor is also in this line
-	when the expression is evaluated (but it may be moved around).
-
-	If the expression starts with s: or |<SID>|, then it is replaced with
-	the script ID (|local-function|). Example: >vim
-		set indentexpr=s:MyIndentExpr()
-		set indentexpr=<SID>SomeIndentExpr()
-<	Otherwise, the expression is evaluated in the context of the script
-	where the option was set, thus script-local items are available.
-
-	The expression must return the number of spaces worth of indent.  It
-	can return "-1" to keep the current indent (this means 'autoindent' is
-	used for the indent).
-	Functions useful for computing the indent are |indent()|, |cindent()|
-	and |lispindent()|.
-	The evaluation of the expression must not have side effects!  It must
-	not change the text, jump to another window, etc.  Afterwards the
-	cursor position is always restored, thus the cursor may be moved.
-	Normally this option would be set to call a function: >vim
-		set indentexpr=GetMyIndent()
-<	Error messages will be suppressed, unless the 'debug' option contains
-	"msg".
-	See |indent-expression|.
-
-	The expression will be evaluated in the |sandbox| when set from a
-	modeline, see |sandbox-option|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	It is not allowed to change text or jump to another window while
-	evaluating 'indentexpr' |textlock|.
-
-						*'indentkeys'* *'indk'*
-'indentkeys' 'indk'	string	(default "0{,0},0),0],:,0#,!^F,o,O,e")
-			local to buffer
-	A list of keys that, when typed in Insert mode, cause reindenting of
-	the current line.  Only happens if 'indentexpr' isn't empty.
-	The format is identical to 'cinkeys', see |indentkeys-format|.
-	See |C-indenting| and |indent-expression|.
-
-			*'infercase'* *'inf'* *'noinfercase'* *'noinf'*
-'infercase' 'inf'	boolean	(default off)
-			local to buffer
-	When doing keyword completion in insert mode |ins-completion|, and
-	'ignorecase' is also on, the case of the match is adjusted depending
-	on the typed text.  If the typed text contains a lowercase letter
-	where the match has an upper case letter, the completed part is made
-	lowercase.  If the typed text has no lowercase letters and the match
-	has a lowercase letter where the typed text has an uppercase letter,
-	and there is a letter before it, the completed part is made uppercase.
-	With 'noinfercase' the match is used as-is.
-
-						*'isfname'* *'isf'*
-'isfname' 'isf'		string	(default for Windows:
-                             "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
-                            otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,=")
-			global
-	The characters specified by this option are included in file names and
-	path names.  Filenames are used for commands like "gf", "[i" and in
-	the tags file.  It is also used for "\f" in a |pattern|.
-	Multi-byte characters 256 and above are always included, only the
-	characters up to 255 are specified with this option.
-	For UTF-8 the characters 0xa0 to 0xff are included as well.
-	Think twice before adding white space to this option.  Although a
-	space may appear inside a file name, the effect will be that Vim
-	doesn't know where a file name starts or ends when doing completion.
-	It most likely works better without a space in 'isfname'.
-
-	Note that on systems using a backslash as path separator, Vim tries to
-	do its best to make it work as you would expect.  That is a bit
-	tricky, since Vi originally used the backslash to escape special
-	characters.  Vim will not remove a backslash in front of a normal file
-	name character on these systems, but it will on Unix and alikes.  The
-	'&' and '^' are not included by default, because these are special for
-	cmd.exe.
-
-	The format of this option is a list of parts, separated with commas.
-	Each part can be a single character number or a range.  A range is two
-	character numbers with '-' in between.  A character number can be a
-	decimal number between 0 and 255 or the ASCII character itself (does
-	not work for digits).  Example:
-		"_,-,128-140,#-43"	(include '_' and '-' and the range
-					128 to 140 and '#' to 43)
-	If a part starts with '^', the following character number or range
-	will be excluded from the option.  The option is interpreted from left
-	to right.  Put the excluded character after the range where it is
-	included.  To include '^' itself use it as the last character of the
-	option or the end of a range.  Example:
-		"^a-z,#,^"	(exclude 'a' to 'z', include '#' and '^')
-	If the character is '@', all characters where isalpha() returns TRUE
-	are included.  Normally these are the characters a to z and A to Z,
-	plus accented characters.  To include '@' itself use "@-@".  Examples:
-		"@,^a-z"	All alphabetic characters, excluding lower
-				case ASCII letters.
-		"a-z,A-Z,@-@"	All letters plus the '@' character.
-	A comma can be included by using it where a character number is
-	expected.  Example:
-		"48-57,,,_"	Digits, comma and underscore.
-	A comma can be excluded by prepending a '^'.  Example:
-		" -~,^,,9"	All characters from space to '~', excluding
-				comma, plus <Tab>.
-	See |option-backslash| about including spaces and backslashes.
-
-						*'isident'* *'isi'*
-'isident' 'isi'		string	(default for Windows:
-                                           "@,48-57,_,128-167,224-235"
-                                otherwise: "@,48-57,_,192-255")
-			global
-	The characters given by this option are included in identifiers.
-	Identifiers are used in recognizing environment variables and after a
-	match of the 'define' option.  It is also used for "\i" in a
-	|pattern|.  See 'isfname' for a description of the format of this
-	option.  For '@' only characters up to 255 are used.
-	Careful: If you change this option, it might break expanding
-	environment variables.  E.g., when '/' is included and Vim tries to
-	expand "$HOME/.local/state/nvim/shada/main.shada".  Maybe you should
-	change 'iskeyword' instead.
-
-						*'iskeyword'* *'isk'*
-'iskeyword' 'isk'	string	(default "@,48-57,_,192-255")
-			local to buffer
-	Keywords are used in searching and recognizing with many commands:
-	"w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.  See
-	'isfname' for a description of the format of this option.  For '@'
-	characters above 255 check the "word" character class (any character
-	that is not white space or punctuation).
-	For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
-	For a help file it is set to all non-blank printable characters except
-	"*", '"' and '|' (so that CTRL-] on a command finds the help for that
-	command).
-	When the 'lisp' option is on the '-' character is always included.
-	This option also influences syntax highlighting, unless the syntax
-	uses |:syn-iskeyword|.
-
-						*'isprint'* *'isp'*
-'isprint' 'isp'		string	(default "@,161-255")
-			global
-	The characters given by this option are displayed directly on the
-	screen.  It is also used for "\p" in a |pattern|.  The characters from
-	space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
-	even when they are not included in 'isprint' or excluded.  See
-	'isfname' for a description of the format of this option.
-
-	Non-printable characters are displayed with two characters:
-		  0 -  31	"^@" - "^_"
-		 32 - 126	always single characters
-		   127		"^?"
-		128 - 159	"~@" - "~_"
-		160 - 254	"| " - "|~"
-		   255		"~?"
-	Illegal bytes from 128 to 255 (invalid UTF-8) are
-	displayed as <xx>, with the hexadecimal value of the byte.
-	When 'display' contains "uhex" all unprintable characters are
-	displayed as <xx>.
-	The SpecialKey highlighting will be used for unprintable characters.
-	|hl-SpecialKey|
-
-	Multi-byte characters 256 and above are always included, only the
-	characters up to 255 are specified with this option.  When a character
-	is printable but it is not available in the current font, a
-	replacement character will be shown.
-	Unprintable and zero-width Unicode characters are displayed as <xxxx>.
-	There is no option to specify these characters.
-
-			*'joinspaces'* *'js'* *'nojoinspaces'* *'nojs'*
-'joinspaces' 'js'	boolean	(default off)
-			global
-	Insert two spaces after a '.', '?' and '!' with a join command.
-	Otherwise only one space is inserted.
-
-						*'jumpoptions'* *'jop'*
-'jumpoptions' 'jop'	string	(default "")
-			global
-	List of words that change the behavior of the |jumplist|.
-	  stack         Make the jumplist behave like the tagstack.
-			Relative location of entries in the jumplist is
-			preserved at the cost of discarding subsequent entries
-			when navigating backwards in the jumplist and then
-			jumping to a location.  |jumplist-stack|
-
-	  view          When moving through the jumplist, |changelist|,
-			|alternate-file| or using |mark-motions| try to
-			restore the |mark-view| in which the action occurred.
-
-						*'keymap'* *'kmp'*
-'keymap' 'kmp'		string	(default "")
-			local to buffer
-	Name of a keyboard mapping.  See |mbyte-keymap|.
-	Setting this option to a valid keymap name has the side effect of
-	setting 'iminsert' to one, so that the keymap becomes effective.
-	'imsearch' is also set to one, unless it was -1
-	Only normal file name characters can be used, `/\*?[|<>` are illegal.
-
-						*'keymodel'* *'km'*
-'keymodel' 'km'		string	(default "")
-			global
-	List of comma-separated words, which enable special things that keys
-	can do.  These values can be used:
-	   startsel	Using a shifted special key starts selection (either
-			Select mode or Visual mode, depending on "key" being
-			present in 'selectmode').
-	   stopsel	Using a not-shifted special key stops selection.
-	Special keys in this context are the cursor keys, <End>, <Home>,
-	<PageUp> and <PageDown>.
-
-						*'keywordprg'* *'kp'*
-'keywordprg' 'kp'	string	(default ":Man", Windows: ":help")
-			global or local to buffer |global-local|
-	Program to use for the |K| command.  Environment variables are
-	expanded |:set_env|.  ":help" may be used to access the Vim internal
-	help.  (Note that previously setting the global option to the empty
-	value did this, which is now deprecated.)
-	When the first character is ":", the command is invoked as a Vim
-	Ex command prefixed with [count].
-	When "man" or "man -s" is used, Vim will automatically translate
-	a [count] for the "K" command to a section number.
-	See |option-backslash| about including spaces and backslashes.
-	Example: >vim
-		set keywordprg=man\ -s
-		set keywordprg=:Man
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'langmap'* *'lmap'* *E357* *E358*
-'langmap' 'lmap'	string	(default "")
-			global
-	This option allows switching your keyboard into a special language
-	mode.  When you are typing text in Insert mode the characters are
-	inserted directly.  When in Normal mode the 'langmap' option takes
-	care of translating these special characters to the original meaning
-	of the key.  This means you don't have to change the keyboard mode to
-	be able to execute Normal mode commands.
-	This is the opposite of the 'keymap' option, where characters are
-	mapped in Insert mode.
-	Also consider setting 'langremap' to off, to prevent 'langmap' from
-	applying to characters resulting from a mapping.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-	Example (for Greek, in UTF-8):				*greek*  >vim
-	    set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
-<	Example (exchanges meaning of z and y for commands): >vim
-	    set langmap=zy,yz,ZY,YZ
-<
-	The 'langmap' option is a list of parts, separated with commas.  Each
-	part can be in one of two forms:
-	1.  A list of pairs.  Each pair is a "from" character immediately
-	    followed by the "to" character.  Examples: "aA", "aAbBcC".
-	2.  A list of "from" characters, a semi-colon and a list of "to"
-	    characters.  Example: "abc;ABC"
-	Example: "aA,fgh;FGH,cCdDeE"
-	Special characters need to be preceded with a backslash.  These are
-	";", ',', '"', '|' and backslash itself.
-
-	This will allow you to activate vim actions without having to switch
-	back and forth between the languages.  Your language characters will
-	be understood as normal vim English characters (according to the
-	langmap mappings) in the following cases:
-	 o Normal/Visual mode (commands, buffer/register names, user mappings)
-	 o Insert/Replace Mode: Register names after CTRL-R
-	 o Insert/Replace Mode: Mappings
-	Characters entered in Command-line mode will NOT be affected by
-	this option.   Note that this option can be changed at any time
-	allowing to switch between mappings for different languages/encodings.
-	Use a mapping to avoid having to type it each time!
-
-						*'langmenu'* *'lm'*
-'langmenu' 'lm'		string	(default "")
-			global
-	Language to use for menu translation.  Tells which file is loaded
-	from the "lang" directory in 'runtimepath': >vim
-		"lang/menu_" .. &langmenu .. ".vim"
-<	(without the spaces).  For example, to always use the Dutch menus, no
-	matter what $LANG is set to: >vim
-		set langmenu=nl_NL.ISO_8859-1
-<	When 'langmenu' is empty, |v:lang| is used.
-	Only normal file name characters can be used, `/\*?[|<>` are illegal.
-	If your $LANG is set to a non-English language but you do want to use
-	the English menus: >vim
-		set langmenu=none
-<	This option must be set before loading menus, switching on filetype
-	detection or syntax highlighting.  Once the menus are defined setting
-	this option has no effect.  But you could do this: >vim
-		source $VIMRUNTIME/delmenu.vim
-		set langmenu=de_DE.ISO_8859-1
-		source $VIMRUNTIME/menu.vim
-<	Warning: This deletes all menus that you defined yourself!
-
-			*'langremap'* *'lrm'* *'nolangremap'* *'nolrm'*
-'langremap' 'lrm'	boolean	(default off)
-			global
-	When off, setting 'langmap' does not apply to characters resulting from
-	a mapping.  If setting 'langmap' disables some of your mappings, make
-	sure this option is off.
-
-						*'laststatus'* *'ls'*
-'laststatus' 'ls'	number	(default 2)
-			global
-	The value of this option influences when the last window will have a
-	status line:
-		0: never
-		1: only if there are at least two windows
-		2: always
-		3: always and ONLY the last window
-	The screen looks nicer with a status line if you have several
-	windows, but it takes another screen line. |status-line|
-
-			*'lazyredraw'* *'lz'* *'nolazyredraw'* *'nolz'*
-'lazyredraw' 'lz'	boolean	(default off)
-			global
-	When this option is set, the screen will not be redrawn while
-	executing macros, registers and other commands that have not been
-	typed.  Also, updating the window title is postponed.  To force an
-	update use |:redraw|.
-	This may occasionally cause display errors.  It is only meant to be set
-	temporarily when performing an operation where redrawing may cause
-	flickering or cause a slow down.
-
-			*'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
-'linebreak' 'lbr'	boolean	(default off)
-			local to window
-	If on, Vim will wrap long lines at a character in 'breakat' rather
-	than at the last character that fits on the screen.  Unlike
-	'wrapmargin' and 'textwidth', this does not insert <EOL>s in the file,
-	it only affects the way the file is displayed, not its contents.
-	If 'breakindent' is set, line is visually indented. Then, the value
-	of 'showbreak' is used to put in front of wrapped lines. This option
-	is not used when the 'wrap' option is off.
-	Note that <Tab> characters after an <EOL> are mostly not displayed
-	with the right amount of white space.
-
-							*'lines'* *E593*
-'lines'			number	(default 24 or terminal height)
-			global
-	Number of lines of the Vim window.
-	Normally you don't need to set this.  It is done automatically by the
-	terminal initialization code.
-	When Vim is running in the GUI or in a resizable window, setting this
-	option will cause the window size to be changed.  When you only want
-	to use the size for the GUI, put the command in your |gvimrc| file.
-	Vim limits the number of lines to what fits on the screen.  You can
-	use this command to get the tallest window possible: >vim
-		set lines=999
-<	Minimum value is 2, maximum value is 1000.
-
-						*'linespace'* *'lsp'*
-'linespace' 'lsp'	number	(default 0)
-			global
-			only in the GUI
-	Number of pixel lines inserted between characters.  Useful if the font
-	uses the full character cell height, making lines touch each other.
-	When non-zero there is room for underlining.
-	With some fonts there can be too much room between lines (to have
-	space for ascents and descents).  Then it makes sense to set
-	'linespace' to a negative value.  This may cause display problems
-	though!
-
-						*'lisp'* *'nolisp'*
-'lisp'			boolean	(default off)
-			local to buffer
-	Lisp mode: When <Enter> is typed in insert mode set the indent for
-	the next line to Lisp standards (well, sort of).  Also happens with
-	"cc" or "S".  'autoindent' must also be on for this to work.  The 'p'
-	flag in 'cpoptions' changes the method of indenting: Vi compatible or
-	better.  Also see 'lispwords'.
-	The '-' character is included in keyword characters.  Redefines the
-	"=" operator to use this same indentation algorithm rather than
-	calling an external program if 'equalprg' is empty.
-
-						*'lispoptions'* *'lop'*
-'lispoptions' 'lop'	string	(default "")
-			local to buffer
-	Comma-separated list of items that influence the Lisp indenting when
-	enabled with the |'lisp'| option.  Currently only one item is
-	supported:
-		expr:1	use 'indentexpr' for Lisp indenting when it is set
-		expr:0	do not use 'indentexpr' for Lisp indenting (default)
-	Note that when using 'indentexpr' the `=` operator indents all the
-	lines, otherwise the first line is not indented (Vi-compatible).
-
-						*'lispwords'* *'lw'*
-'lispwords' 'lw'	string	(default is very long)
-			global or local to buffer |global-local|
-	Comma-separated list of words that influence the Lisp indenting when
-	enabled with the |'lisp'| option.
-
-						*'list'* *'nolist'*
-'list'			boolean	(default off)
-			local to window
-	List mode: By default, show tabs as ">", trailing spaces as "-", and
-	non-breakable space characters as "+". Useful to see the difference
-	between tabs and spaces and for trailing blanks. Further changed by
-	the 'listchars' option.
-
-	The cursor is displayed at the start of the space a Tab character
-	occupies, not at the end as usual in Normal mode.  To get this cursor
-	position while displaying Tabs with spaces, use: >vim
-		set list lcs=tab:\ \
-<
-	Note that list mode will also affect formatting (set with 'textwidth'
-	or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
-	changing the way tabs are displayed.
-
-						*'listchars'* *'lcs'*
-'listchars' 'lcs'	string	(default "tab:> ,trail:-,nbsp:+")
-			global or local to window |global-local|
-	Strings to use in 'list' mode and for the |:list| command.  It is a
-	comma-separated list of string settings.
-
-							*lcs-eol*
-	  eol:c		Character to show at the end of each line.  When
-			omitted, there is no extra character at the end of the
-			line.
-							*lcs-tab*
-	  tab:xy[z]	Two or three characters to be used to show a tab.
-			The third character is optional.
-
-	  tab:xy	The 'x' is always used, then 'y' as many times as will
-			fit.  Thus "tab:>-" displays: >
-				>
-				>-
-				>--
-				etc.
-<
-	  tab:xyz	The 'z' is always used, then 'x' is prepended, and
-			then 'y' is used as many times as will fit.  Thus
-			"tab:<->" displays: >
-				>
-				<>
-				<->
-				<-->
-				etc.
-<
-			When "tab:" is omitted, a tab is shown as ^I.
-							*lcs-space*
-	  space:c	Character to show for a space.  When omitted, spaces
-			are left blank.
-							*lcs-multispace*
-	  multispace:c...
-			One or more characters to use cyclically to show for
-			multiple consecutive spaces.  Overrides the "space"
-			setting, except for single spaces.  When omitted, the
-			"space" setting is used.  For example,
-			`:set listchars=multispace:---+` shows ten consecutive
-			spaces as: >
-				---+---+--
-<
-							*lcs-lead*
-	  lead:c	Character to show for leading spaces.  When omitted,
-			leading spaces are blank.  Overrides the "space" and
-			"multispace" settings for leading spaces.  You can
-			combine it with "tab:", for example: >vim
-				set listchars+=tab:>-,lead:.
-<
-							*lcs-leadmultispace*
-	  leadmultispace:c...
-			Like the |lcs-multispace| value, but for leading
-			spaces only.  Also overrides |lcs-lead| for leading
-			multiple spaces.
-			`:set listchars=leadmultispace:---+` shows ten
-			consecutive leading spaces as: >
-				---+---+--XXX
-<
-			Where "XXX" denotes the first non-blank characters in
-			the line.
-							*lcs-trail*
-	  trail:c	Character to show for trailing spaces.  When omitted,
-			trailing spaces are blank.  Overrides the "space" and
-			"multispace" settings for trailing spaces.
-							*lcs-extends*
-	  extends:c	Character to show in the last column, when 'wrap' is
-			off and the line continues beyond the right of the
-			screen.
-							*lcs-precedes*
-	  precedes:c	Character to show in the first visible column of the
-			physical line, when there is text preceding the
-			character visible in the first column.
-							*lcs-conceal*
-	  conceal:c	Character to show in place of concealed text, when
-			'conceallevel' is set to 1.  A space when omitted.
-							*lcs-nbsp*
-	  nbsp:c	Character to show for a non-breakable space character
-			(0xA0 (160 decimal) and U+202F).  Left blank when
-			omitted.
-
-	The characters ':' and ',' should not be used.  UTF-8 characters can
-	be used.  All characters must be single width.
-
-	Each character can be specified as hex: >vim
-		set listchars=eol:\\x24
-		set listchars=eol:\\u21b5
-		set listchars=eol:\\U000021b5
-<	Note that a double backslash is used.  The number of hex characters
-	must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
-
-	Examples: >vim
-	    set lcs=tab:>-,trail:-
-	    set lcs=tab:>-,eol:<,nbsp:%
-	    set lcs=extends:>,precedes:<
-<	|hl-NonText| highlighting will be used for "eol", "extends" and
-	"precedes". |hl-Whitespace| for "nbsp", "space", "tab", "multispace",
-	"lead" and "trail".
-
-			*'loadplugins'* *'lpl'* *'noloadplugins'* *'nolpl'*
-'loadplugins' 'lpl'	boolean	(default on)
-			global
-	When on the plugin scripts are loaded when starting up |load-plugins|.
-	This option can be reset in your |vimrc| file to disable the loading
-	of plugins.
-	Note that using the "-u NONE" and "--noplugin" command line arguments
-	reset this option. |-u| |--noplugin|
-
-						*'magic'* *'nomagic'*
-'magic'			boolean	(default on)
-			global
-	Changes the special characters that can be used in search patterns.
-	See |pattern|.
-	WARNING: Switching this option off most likely breaks plugins!  That
-	is because many patterns assume it's on and will fail when it's off.
-	Only switch it off when working with old Vi scripts.  In any other
-	situation write patterns that work when 'magic' is on.  Include "\M"
-	when you want to |/\M|.
-
-						*'makeef'* *'mef'*
-'makeef' 'mef'		string	(default "")
-			global
-	Name of the errorfile for the |:make| command (see |:make_makeprg|)
-	and the |:grep| command.
-	When it is empty, an internally generated temp file will be used.
-	When "##" is included, it is replaced by a number to make the name
-	unique.  This makes sure that the ":make" command doesn't overwrite an
-	existing file.
-	NOT used for the ":cf" command.  See 'errorfile' for that.
-	Environment variables are expanded |:set_env|.
-	See |option-backslash| about including spaces and backslashes.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'makeencoding'* *'menc'*
-'makeencoding' 'menc'	string	(default "")
-			global or local to buffer |global-local|
-	Encoding used for reading the output of external commands.  When empty,
-	encoding is not converted.
-	This is used for `:make`, `:lmake`, `:grep`, `:lgrep`, `:grepadd`,
-	`:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
-	and `:laddfile`.
-
-	This would be mostly useful when you use MS-Windows.  If iconv is
-	enabled, setting 'makeencoding' to "char" has the same effect as
-	setting to the system locale encoding.  Example: >vim
-		set makeencoding=char	" system locale is used
+                                            *'guifontwide'* *'gfw'* *E231* *E533* *E534*
+'guifontwide' 'gfw'     string (default "")
+                        global
+        Comma-separated list of fonts to be used for double-width characters.
+        The first font that can be loaded is used.
+        Note: The size of these fonts must be exactly twice as wide as the one
+        specified with 'guifont' and the same height.
+
+        When 'guifont' has a valid font and 'guifontwide' is empty Vim will
+        attempt to set 'guifontwide' to a matching double-width font.
+
+                                                             *'guioptions'* *'go'*
+'guioptions' 'go'       string (default "egmrLT"   (MS-Windows))
+                        global
+        This option only has an effect in the GUI version of Vim.  It is a
+        sequence of letters which describes what components and options of the
+        GUI should be used.
+        To avoid problems with flags that are added in the future, use the
+        "+=" and "-=" feature of ":set" |add-option-flags|.
+
+        Valid letters are as follows:
+                                                        *guioptions_a* *'go-a'*
+          'a'   Autoselect:  If present, then whenever VISUAL mode is started,
+                or the Visual area extended, Vim tries to become the owner of
+                the windowing system's global selection.  This means that the
+                Visually highlighted text is available for pasting into other
+                applications as well as into Vim itself.  When the Visual mode
+                ends, possibly due to an operation on the text, or when an
+                application wants to paste the selection, the highlighted text
+                is automatically yanked into the "* selection register.
+                Thus the selection is still available for pasting into other
+                applications after the VISUAL mode has ended.
+                    If not present, then Vim won't become the owner of the
+                windowing system's global selection unless explicitly told to
+                by a yank or delete operation for the "* register.
+                The same applies to the modeless selection.
+                                                                *'go-P'*
+          'P'   Like autoselect but using the "+ register instead of the "*
+                register.
+                                                                *'go-A'*
+          'A'   Autoselect for the modeless selection.  Like 'a', but only
+                applies to the modeless selection.
+
+                    'guioptions'   autoselect Visual  autoselect modeless ~
+                         ""              -                       -
+                         "a"            yes                     yes
+                         "A"             -                      yes
+                         "aA"           yes                     yes
+
+                                                                *'go-c'*
+          'c'   Use console dialogs instead of popup dialogs for simple
+                choices.
+                                                                *'go-d'*
+          'd'   Use dark theme variant if available.
+                                                                *'go-e'*
+          'e'   Add tab pages when indicated with 'showtabline'.
+                'guitablabel' can be used to change the text in the labels.
+                When 'e' is missing a non-GUI tab pages line may be used.
+                The GUI tabs are only supported on some systems, currently
+                Mac OS/X and MS-Windows.
+                                                                *'go-i'*
+          'i'   Use a Vim icon.
+                                                                *'go-m'*
+          'm'   Menu bar is present.
+                                                                *'go-M'*
+          'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
+                that this flag must be added in the vimrc file, before
+                switching on syntax or filetype recognition (when the |gvimrc|
+                file is sourced the system menu has already been loaded; the
+                `:syntax on` and `:filetype on` commands load the menu too).
+                                                                *'go-g'*
+          'g'   Grey menu items: Make menu items that are not active grey.  If
+                'g' is not included inactive menu items are not shown at all.
+                                                                *'go-T'*
+          'T'   Include Toolbar.  Currently only in Win32 GUI.
+                                                                *'go-r'*
+          'r'   Right-hand scrollbar is always present.
+                                                                *'go-R'*
+          'R'   Right-hand scrollbar is present when there is a vertically
+                split window.
+                                                                *'go-l'*
+          'l'   Left-hand scrollbar is always present.
+                                                                *'go-L'*
+          'L'   Left-hand scrollbar is present when there is a vertically
+                split window.
+                                                                *'go-b'*
+          'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
+                the longest visible line, or on the cursor line if the 'h'
+                flag is included. |gui-horiz-scroll|
+                                                                *'go-h'*
+          'h'   Limit horizontal scrollbar size to the length of the cursor
+                line.  Reduces computations. |gui-horiz-scroll|
+
+        And yes, you may even have scrollbars on the left AND the right if
+        you really want to :-).  See |gui-scrollbars| for more information.
+
+                                                                *'go-v'*
+          'v'   Use a vertical button layout for dialogs.  When not included,
+                a horizontal layout is preferred, but when it doesn't fit a
+                vertical layout is used anyway.  Not supported in GTK 3.
+                                                                *'go-p'*
+          'p'   Use Pointer callbacks for X11 GUI.  This is required for some
+                window managers.  If the cursor is not blinking or hollow at
+                the right moment, try adding this flag.  This must be done
+                before starting the GUI.  Set it in your |gvimrc|.  Adding or
+                removing it after the GUI has started has no effect.
+                                                                *'go-k'*
+          'k'   Keep the GUI window size when adding/removing a scrollbar, or
+                toolbar, tabline, etc.  Instead, the behavior is similar to
+                when the window is maximized and will adjust 'lines' and
+                'columns' to fit to the window.  Without the 'k' flag Vim will
+                try to keep 'lines' and 'columns' the same when adding and
+                removing GUI components.
+
+                                                           *'guitablabel'* *'gtl'*
+'guitablabel' 'gtl'     string (default "")
+                        global
+        When non-empty describes the text to use in a label of the GUI tab
+        pages line.  When empty and when the result is empty Vim will use a
+        default label.  See |setting-guitablabel| for more info.
+
+        The format of this option is like that of 'statusline'.
+        'guitabtooltip' is used for the tooltip, see below.
+        The expression will be evaluated in the |sandbox| when set from a
+        modeline, see |sandbox-option|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        Only used when the GUI tab pages line is displayed.  'e' must be
+        present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
+        used.
+
+                                                         *'guitabtooltip'* *'gtt'*
+'guitabtooltip' 'gtt'   string (default "")
+                        global
+        When non-empty describes the text to use in a tooltip for the GUI tab
+        pages line.  When empty Vim will use a default tooltip.
+        This option is otherwise just like 'guitablabel' above.
+        You can include a line break.  Simplest method is to use |:let|: >vim
+                let &guitabtooltip = "line one\nline two"
 <
 
-						*'makeprg'* *'mp'*
-'makeprg' 'mp'		string	(default "make")
-			global or local to buffer |global-local|
-	Program to use for the ":make" command.  See |:make_makeprg|.
-	This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
-	which are expanded to the current and alternate file name.  Use |::S|
-	to escape file names in case they contain special characters.
-	Environment variables are expanded |:set_env|.  See |option-backslash|
-	about including spaces and backslashes.
-	Note that a '|' must be escaped twice: once for ":set" and once for
-	the interpretation of a command.  When you use a filter called
-	"myfilter" do it like this: >vim
-	    set makeprg=gmake\ \\\|\ myfilter
-<	The placeholder "$*" can be given (even multiple times) to specify
-	where the arguments will be included, for example: >vim
-	    set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                               *'helpfile'* *'hf'*
+'helpfile' 'hf'         string (default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
+                                        (others) "$VIMRUNTIME/doc/help.txt")
+                        global
+        Name of the main help file.  All distributed help files should be
+        placed together in one directory.  Additionally, all "doc" directories
+        in 'runtimepath' will be used.
+        Environment variables are expanded |:set_env|.  For example:
+        "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
+        tried.  Also see |$VIMRUNTIME| and |option-backslash| about including
+        spaces and backslashes.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'matchpairs'* *'mps'*
-'matchpairs' 'mps'	string	(default "(:),{:},[:]")
-			local to buffer
-	Characters that form pairs.  The |%| command jumps from one to the
-	other.
-	Only character pairs are allowed that are different, thus you cannot
-	jump between two double quotes.
-	The characters must be separated by a colon.
-	The pairs must be separated by a comma.  Example for including '<' and
-	'>' (for HTML): >vim
-		set mps+=<:>
+                                                             *'helpheight'* *'hh'*
+'helpheight' 'hh'       number (default 20)
+                        global
+        Minimal initial height of the help window when it is opened with the
+        ":help" command.  The initial height of the help window is half of the
+        current window, or (when the 'ea' option is on) the same as other
+        windows.  When the height is less than 'helpheight', the height is
+        set to 'helpheight'.  Set to zero to disable.
 
-<	A more exotic example, to jump between the '=' and ';' in an
-	assignment, useful for languages like C and Java: >vim
-		au FileType c,cpp,java set mps+==:;
+                                                              *'helplang'* *'hlg'*
+'helplang' 'hlg'        string (default messages language or empty)
+                        global
+        Comma-separated list of languages.  Vim will use the first language
+        for which the desired help can be found.  The English help will always
+        be used as a last resort.  You can add "en" to prefer English over
+        another language, but that will only find tags that exist in that
+        language and not in the English help.
+        Example: >vim
+                set helplang=de,it
+<       This will first search German, then Italian and finally English help
+        files.
+        When using |CTRL-]| and ":help!" in a non-English help file Vim will
+        try to find the tag in the current language before using this option.
+        See |help-translated|.
 
-<	For a more advanced way of using "%", see the matchit.vim plugin in
-	the $VIMRUNTIME/plugin directory. |add-local-help|
+                                             *'hidden'* *'hid'* *'nohidden'* *'nohid'*
+'hidden' 'hid'          boolean (default on)
+                        global
+        When off a buffer is unloaded (including loss of undo information)
+        when it is |abandon|ed.  When on a buffer becomes hidden when it is
+        |abandon|ed.  A buffer displayed in another window does not become
+        hidden, of course.
 
-						*'matchtime'* *'mat'*
-'matchtime' 'mat'	number	(default 5)
-			global
-	Tenths of a second to show the matching paren, when 'showmatch' is
-	set.  Note that this is not in milliseconds, like other options that
-	set a time.  This is to be compatible with Nvi.
+        Commands that move through the buffer list sometimes hide a buffer
+        although the 'hidden' option is off when these three are true:
+        - the buffer is modified
+        - 'autowrite' is off or writing is not possible
+        - the '!' flag was used
+        Also see |windows|.
 
-						*'maxfuncdepth'* *'mfd'*
-'maxfuncdepth' 'mfd'	number	(default 100)
-			global
-	Maximum depth of function calls for user functions.  This normally
-	catches endless recursion.  When using a recursive function with
-	more depth, set 'maxfuncdepth' to a bigger number.  But this will use
-	more memory, there is the danger of failing when memory is exhausted.
-	Increasing this limit above 200 also changes the maximum for Ex
-	command recursion, see |E169|.
-	See also |:function|.
-	Also used for maximum depth of callback functions.
+        To hide a specific buffer use the 'bufhidden' option.
+        'hidden' is set for one command with ":hide {command}" |:hide|.
 
-					*'maxmapdepth'* *'mmd'* *E223*
-'maxmapdepth' 'mmd'	number	(default 1000)
-			global
-	Maximum number of times a mapping is done without resulting in a
-	character to be used.  This normally catches endless mappings, like
-	":map x y" with ":map y x".  It still does not catch ":map g wg",
-	because the 'w' is used before the next mapping is done.  See also
-	|key-mapping|.
+                                                                *'history'* *'hi'*
+'history' 'hi'          number (default 10000)
+                        global
+        A history of ":" commands, and a history of previous search patterns
+        is remembered.  This option decides how many entries may be stored in
+        each of these histories (see |cmdline-editing|).
+        The maximum value is 10000.
 
-						*'maxmempattern'* *'mmp'*
-'maxmempattern' 'mmp'	number	(default 1000)
-			global
-	Maximum amount of memory (in Kbyte) to use for pattern matching.
-	The maximum value is about 2000000.  Use this to work without a limit.
-							*E363*
-	When Vim runs into the limit it gives an error message and mostly
-	behaves like CTRL-C was typed.
-	Running into the limit often means that the pattern is very
-	inefficient or too complex.  This may already happen with the pattern
-	"\(.\)*" on a very long line.  ".*" works much better.
-	Might also happen on redraw, when syntax rules try to match a complex
-	text structure.
-	Vim may run out of memory before hitting the 'maxmempattern' limit, in
-	which case you get an "Out of memory" error instead.
+                                         *'hlsearch'* *'hls'* *'nohlsearch'* *'nohls'*
+'hlsearch' 'hls'        boolean (default on)
+                        global
+        When there is a previous search pattern, highlight all its matches.
+        The |hl-Search| highlight group determines the highlighting for all
+        matches not under the cursor while the |hl-CurSearch| highlight group
+        (if defined) determines the highlighting for the match under the
+        cursor. If |hl-CurSearch| is not defined, then |hl-Search| is used for
+        both. Note that only the matching text is highlighted, any offsets
+        are not applied.
+        See also: 'incsearch' and |:match|.
+        When you get bored looking at the highlighted matches, you can turn it
+        off with |:nohlsearch|.  This does not change the option value, as
+        soon as you use a search command, the highlighting comes back.
+        'redrawtime' specifies the maximum time spent on finding matches.
+        When the search pattern can match an end-of-line, Vim will try to
+        highlight all of the matched text.  However, this depends on where the
+        search starts.  This will be the first line in the window or the first
+        line below a closed fold.  A match in a previous line which is not
+        drawn may not continue in a newly drawn line.
+        You can specify whether the highlight status is restored on startup
+        with the 'h' flag in 'shada' |shada-h|.
 
-						*'menuitems'* *'mis'*
-'menuitems' 'mis'	number	(default 25)
-			global
-	Maximum number of items to use in a menu.  Used for menus that are
-	generated from a list of items, e.g., the Buffers menu.  Changing this
-	option has no direct effect, the menu must be refreshed first.
+                                                               *'icon'* *'noicon'*
+'icon'                  boolean (default off, on when title can be restored)
+                        global
+        When on, the icon text of the window will be set to the value of
+        'iconstring' (if it is not empty), or to the name of the file
+        currently being edited.  Only the last part of the name is used.
+        Overridden by the 'iconstring' option.
+        Only works if the terminal supports setting window icons.
 
-						*'mkspellmem'* *'msm'*
-'mkspellmem' 'msm'	string	(default "460000,2000,500")
-			global
-	Parameters for |:mkspell|.  This tunes when to start compressing the
-	word tree.  Compression can be slow when there are many words, but
-	it's needed to avoid running out of memory.  The amount of memory used
-	per word depends very much on how similar the words are, that's why
-	this tuning is complicated.
+                                                                  *'iconstring'*
+'iconstring'            string (default "")
+                        global
+        When this option is not empty, it will be used for the icon text of
+        the window.  This happens only when the 'icon' option is on.
+        Only works if the terminal supports setting window icon text
+        When this option contains printf-style '%' items, they will be
+        expanded according to the rules used for 'statusline'.  See
+        'titlestring' for example settings.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
 
-	There are three numbers, separated by commas: >
-		{start},{inc},{added}
+                                       *'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
+'ignorecase' 'ic'       boolean (default off)
+                        global
+        Ignore case in search patterns, |cmdline-completion|, when
+        searching in the tags file, and |expr-==|.
+        Also see 'smartcase' and 'tagcase'.
+        Can be overruled by using "\c" or "\C" in the pattern, see
+        |/ignorecase|.
+
+                                       *'imcmdline'* *'imc'* *'noimcmdline'* *'noimc'*
+'imcmdline' 'imc'       boolean (default off)
+                        global
+        When set the Input Method is always on when starting to edit a command
+        line, unless entering a search pattern (see 'imsearch' for that).
+        Setting this option is useful when your input method allows entering
+        English characters directly, e.g., when it's used to type accented
+        characters with dead keys.
+
+                                       *'imdisable'* *'imd'* *'noimdisable'* *'noimd'*
+'imdisable' 'imd'       boolean (default off, on for some systems (SGI))
+                        global
+        When set the Input Method is never used.  This is useful to disable
+        the IM when it doesn't work properly.
+        Currently this option is on by default for SGI/IRIX machines.  This
+        may change in later releases.
+
+                                                              *'iminsert'* *'imi'*
+'iminsert' 'imi'        number (default 0)
+                        local to buffer
+        Specifies whether :lmap or an Input Method (IM) is to be used in
+        Insert mode.  Valid values:
+                0       :lmap is off and IM is off
+                1       :lmap is ON and IM is off
+                2       :lmap is off and IM is ON
+        To always reset the option to zero when leaving Insert mode with <Esc>
+        this can be used: >vim
+                inoremap <ESC> <ESC>:set iminsert=0<CR>
+<       This makes :lmap and IM turn off automatically when leaving Insert
+        mode.
+        Note that this option changes when using CTRL-^ in Insert mode
+        |i_CTRL-^|.
+        The value is set to 1 when setting 'keymap' to a valid keymap name.
+        It is also used for the argument of commands like "r" and "f".
+
+                                                              *'imsearch'* *'ims'*
+'imsearch' 'ims'        number (default -1)
+                        local to buffer
+        Specifies whether :lmap or an Input Method (IM) is to be used when
+        entering a search pattern.  Valid values:
+                -1      the value of 'iminsert' is used, makes it look like
+                        'iminsert' is also used when typing a search pattern
+                0       :lmap is off and IM is off
+                1       :lmap is ON and IM is off
+                2       :lmap is off and IM is ON
+        Note that this option changes when using CTRL-^ in Command-line mode
+        |c_CTRL-^|.
+        The value is set to 1 when it is not -1 and setting the 'keymap'
+        option to a valid keymap name.
+
+                                                            *'inccommand'* *'icm'*
+'inccommand' 'icm'      string (default "nosplit")
+                        global
+        When nonempty, shows the effects of |:substitute|, |:smagic|,
+        |:snomagic| and user commands with the |:command-preview| flag as you
+        type.
+
+        Possible values:
+                nosplit Shows the effects of a command incrementally in the
+                        buffer.
+                split   Like "nosplit", but also shows partial off-screen
+                        results in a preview window.
+
+        If the preview for built-in commands is too slow (exceeds
+        'redrawtime') then 'inccommand' is automatically disabled until
+        |Command-line-mode| is done.
+
+                                                               *'include'* *'inc'*
+'include' 'inc'         string (default "")
+                        global or local to buffer |global-local|
+        Pattern to be used to find an include command.  It is a search
+        pattern, just like for the "/" command (See |pattern|).  This option
+        is used for the commands "[i", "]I", "[d", etc.
+        Normally the 'isfname' option is used to recognize the file name that
+        comes after the matched pattern.  But if "\zs" appears in the pattern
+        then the text matched from "\zs" to the end, or until "\ze" if it
+        appears, is used as the file name.  Use this to include characters
+        that are not in 'isfname', such as a space.  You can then use
+        'includeexpr' to process the matched text.
+        See |option-backslash| about including spaces and backslashes.
+
+                                                          *'includeexpr'* *'inex'*
+'includeexpr' 'inex'    string (default "")
+                        local to buffer
+        Expression to be used to transform the string found with the 'include'
+        option to a file name.  Mostly useful to change "." to "/" for Java: >vim
+                setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+<       The "v:fname" variable will be set to the file name that was detected.
+        Note the double backslash: the `:set` command first halves them, then
+        one remains in the value, where "\." matches a dot literally.  For
+        simple character replacements `tr()` avoids the need for escaping: >vim
+                setlocal includeexpr=tr(v:fname,'.','/')
 <
-	For most languages the uncompressed word tree fits in memory.  {start}
-	gives the amount of memory in Kbyte that can be used before any
-	compression is done.  It should be a bit smaller than the amount of
-	memory that is available to Vim.
+        Also used for the |gf| command if an unmodified file name can't be
+        found.  Allows doing "gf" on the name after an 'include' statement.
+        Also used for |<cfile>|.
 
-	When going over the {start} limit the {inc} number specifies the
-	amount of memory in Kbyte that can be allocated before another
-	compression is done.  A low number means compression is done after
-	less words are added, which is slow.  A high number means more memory
-	will be allocated.
+        If the expression starts with s: or |<SID>|, then it is replaced with
+        the script ID (|local-function|). Example: >vim
+                setlocal includeexpr=s:MyIncludeExpr(v:fname)
+                setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
+<       Otherwise, the expression is evaluated in the context of the script
+        where the option was set, thus script-local items are available.
 
-	After doing compression, {added} times 1024 words can be added before
-	the {inc} limit is ignored and compression is done when any extra
-	amount of memory is needed.  A low number means there is a smaller
-	chance of hitting the {inc} limit, less memory is used but it's
-	slower.
+        The expression will be evaluated in the |sandbox| when set from a
+        modeline, see |sandbox-option|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
 
-	The languages for which these numbers are important are Italian and
-	Hungarian.  The default works for when you have about 512 Mbyte.  If
-	you have 1 Gbyte you could use: >vim
-		set mkspellmem=900000,3000,800
-<	If you have less than 512 Mbyte |:mkspell| may fail for some
-	languages, no matter what you set 'mkspellmem' to.
+        It is not allowed to change text or jump to another window while
+        evaluating 'includeexpr' |textlock|.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-				*'modeline'* *'ml'* *'nomodeline'* *'noml'*
-'modeline' 'ml'		boolean	(default on (off for root))
-			local to buffer
-	If 'modeline' is on 'modelines' gives the number of lines that is
-	checked for set commands.  If 'modeline' is off or 'modelines' is zero
-	no lines are checked.  See |modeline|.
-
-			*'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
-'modelineexpr' 'mle'	boolean	(default off)
-			global
-	When on allow some options that are an expression to be set in the
-	modeline.  Check the option for whether it is affected by
-	'modelineexpr'.  Also see |modeline|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'modelines'* *'mls'*
-'modelines' 'mls'	number	(default 5)
-			global
-	If 'modeline' is on 'modelines' gives the number of lines that is
-	checked for set commands.  If 'modeline' is off or 'modelines' is zero
-	no lines are checked.  See |modeline|.
-
-
-			*'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
-'modifiable' 'ma'	boolean	(default on)
-			local to buffer
-	When off the buffer contents cannot be changed.  The 'fileformat' and
-	'fileencoding' options also can't be changed.
-	Can be reset on startup with the |-M| command line argument.
-
-				*'modified'* *'mod'* *'nomodified'* *'nomod'*
-'modified' 'mod'	boolean	(default off)
-			local to buffer  |local-noglobal|
-	When on, the buffer is considered to be modified.  This option is set
-	when:
-	1. A change was made to the text since it was last written.  Using the
-	   |undo| command to go back to the original text will reset the
-	   option.  But undoing changes that were made before writing the
-	   buffer will set the option again, since the text is different from
-	   when it was written.
-	2. 'fileformat' or 'fileencoding' is different from its original
-	   value.  The original value is set when the buffer is read or
-	   written.  A ":set nomodified" command also resets the original
-	   values to the current values and the 'modified' option will be
-	   reset.
-	   Similarly for 'eol' and 'bomb'.
-	This option is not set when a change is made to the buffer as the
-	result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
-	FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
-	an explanation.
-	When 'buftype' is "nowrite" or "nofile" this option may be set, but
-	will be ignored.
-	Note that the text may actually be the same, e.g. 'modified' is set
-	when using "rA" on an "A".
-
-						*'more'* *'nomore'*
-'more'			boolean	(default on)
-			global
-	When on, listings pause when the whole screen is filled.  You will get
-	the |more-prompt|.  When this option is off there are no pauses, the
-	listing continues until finished.
-
-							*'mouse'*
-'mouse'			string	(default "nvi")
-			global
-	Enables mouse support. For example, to enable the mouse in Normal mode
-	and Visual mode: >vim
-		set mouse=nv
+                                         *'incsearch'* *'is'* *'noincsearch'* *'nois'*
+'incsearch' 'is'        boolean (default on)
+                        global
+        While typing a search command, show where the pattern, as it was typed
+        so far, matches.  The matched string is highlighted.  If the pattern
+        is invalid or not found, nothing is shown.  The screen will be updated
+        often, this is only useful on fast terminals.
+        Note that the match will be shown, but the cursor will return to its
+        original position when no match is found and when pressing <Esc>.  You
+        still need to finish the search command with <Enter> to move the
+        cursor to the match.
+        You can use the CTRL-G and CTRL-T keys to move to the next and
+        previous match. |c_CTRL-G| |c_CTRL-T|
+        Vim only searches for about half a second.  With a complicated
+        pattern and/or a lot of text the match may not be found.  This is to
+        avoid that Vim hangs while you are typing the pattern.
+        The |hl-IncSearch| highlight group determines the highlighting.
+        When 'hlsearch' is on, all matched strings are highlighted too while
+        typing a search command. See also: 'hlsearch'.
+        If you don't want to turn 'hlsearch' on, but want to highlight all
+        matches while searching, you can turn on and off 'hlsearch' with
+        autocmd.  Example: >vim
+                augroup vimrc-incsearch-highlight
+                  autocmd!
+                  autocmd CmdlineEnter /,\? :set hlsearch
+                  autocmd CmdlineLeave /,\? :set nohlsearch
+                augroup END
 <
-	To temporarily disable mouse support, hold the shift key while using
-	the mouse.
+        CTRL-L can be used to add one character from after the current match
+        to the command line.  If 'ignorecase' and 'smartcase' are set and the
+        command line has no uppercase characters, the added character is
+        converted to lowercase.
+        CTRL-R CTRL-W can be used to add the word at the end of the current
+        match, excluding the characters that were already typed.
 
-	Mouse support can be enabled for different modes:
-		n	Normal mode
-		v	Visual mode
-		i	Insert mode
-		c	Command-line mode
-		h	all previous modes when editing a help file
-		a	all previous modes
-		r	for |hit-enter| and |more-prompt| prompt
+                                                           *'indentexpr'* *'inde'*
+'indentexpr' 'inde'     string (default "")
+                        local to buffer
+        Expression which is evaluated to obtain the proper indent for a line.
+        It is used when a new line is created, for the |=| operator and
+        in Insert mode as specified with the 'indentkeys' option.
+        When this option is not empty, it overrules the 'cindent' and
+        'smartindent' indenting.  When 'lisp' is set, this option is
+        is only used when 'lispoptions' contains "expr:1".
+        The expression is evaluated with |v:lnum| set to the line number for
+        which the indent is to be computed.  The cursor is also in this line
+        when the expression is evaluated (but it may be moved around).
 
-	Left-click anywhere in a text buffer to place the cursor there.  This
-	works with operators too, e.g. type |d| then left-click to delete text
-	from the current cursor position to the position where you clicked.
+        If the expression starts with s: or |<SID>|, then it is replaced with
+        the script ID (|local-function|). Example: >vim
+                set indentexpr=s:MyIndentExpr()
+                set indentexpr=<SID>SomeIndentExpr()
+<       Otherwise, the expression is evaluated in the context of the script
+        where the option was set, thus script-local items are available.
 
-	Drag the |status-line| or vertical separator of a window to resize it.
+        The expression must return the number of spaces worth of indent.  It
+        can return "-1" to keep the current indent (this means 'autoindent' is
+        used for the indent).
+        Functions useful for computing the indent are |indent()|, |cindent()|
+        and |lispindent()|.
+        The evaluation of the expression must not have side effects!  It must
+        not change the text, jump to another window, etc.  Afterwards the
+        cursor position is always restored, thus the cursor may be moved.
+        Normally this option would be set to call a function: >vim
+                set indentexpr=GetMyIndent()
+<       Error messages will be suppressed, unless the 'debug' option contains
+        "msg".
+        See |indent-expression|.
 
-	If enabled for "v" (Visual mode) then double-click selects word-wise,
-	triple-click makes it line-wise, and quadruple-click makes it
-	rectangular block-wise.
+        The expression will be evaluated in the |sandbox| when set from a
+        modeline, see |sandbox-option|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
 
-	For scrolling with a mouse wheel see |scroll-mouse-wheel|.
+        It is not allowed to change text or jump to another window while
+        evaluating 'indentexpr' |textlock|.
 
-	Note: When enabling the mouse in a terminal, copy/paste will use the
-	"* register if possible. See also 'clipboard'.
+                                                           *'indentkeys'* *'indk'*
+'indentkeys' 'indk'     string (default "0{,0},0),0],:,0#,!^F,o,O,e")
+                        local to buffer
+        A list of keys that, when typed in Insert mode, cause reindenting of
+        the current line.  Only happens if 'indentexpr' isn't empty.
+        The format is identical to 'cinkeys', see |indentkeys-format|.
+        See |C-indenting| and |indent-expression|.
 
-	Related options:
-	'mousefocus'	window focus follows mouse pointer
-	'mousemodel'	what mouse button does which action
-	'mousehide'	hide mouse pointer while typing text
-	'selectmode'	whether to start Select mode or Visual mode
+                                       *'infercase'* *'inf'* *'noinfercase'* *'noinf'*
+'infercase' 'inf'       boolean (default off)
+                        local to buffer
+        When doing keyword completion in insert mode |ins-completion|, and
+        'ignorecase' is also on, the case of the match is adjusted depending
+        on the typed text.  If the typed text contains a lowercase letter
+        where the match has an upper case letter, the completed part is made
+        lowercase.  If the typed text has no lowercase letters and the match
+        has a lowercase letter where the typed text has an uppercase letter,
+        and there is a letter before it, the completed part is made uppercase.
+        With 'noinfercase' the match is used as-is.
 
-		*'mousefocus'* *'mousef'* *'nomousefocus'* *'nomousef'*
-'mousefocus' 'mousef'	boolean	(default off)
-			global
-	The window that the mouse pointer is on is automatically activated.
-	When changing the window layout or window focus in another way, the
-	mouse pointer is moved to the window with keyboard focus.  Off is the
-	default because it makes using the pull down menus a little goofy, as
-	a pointer transit may activate a window unintentionally.
+                                                               *'isfname'* *'isf'*
+'isfname' 'isf'         string (default for Windows: "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
+                                        otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,=")
+                        global
+        The characters specified by this option are included in file names and
+        path names.  Filenames are used for commands like "gf", "[i" and in
+        the tags file.  It is also used for "\f" in a |pattern|.
+        Multi-byte characters 256 and above are always included, only the
+        characters up to 255 are specified with this option.
+        For UTF-8 the characters 0xa0 to 0xff are included as well.
+        Think twice before adding white space to this option.  Although a
+        space may appear inside a file name, the effect will be that Vim
+        doesn't know where a file name starts or ends when doing completion.
+        It most likely works better without a space in 'isfname'.
 
-				*'mousehide'* *'mh'* *'nomousehide'* *'nomh'*
-'mousehide' 'mh'	boolean	(default on)
-			global
-			only in the GUI
-	When on, the mouse pointer is hidden when characters are typed.
-	The mouse pointer is restored when the mouse is moved.
+        Note that on systems using a backslash as path separator, Vim tries to
+        do its best to make it work as you would expect.  That is a bit
+        tricky, since Vi originally used the backslash to escape special
+        characters.  Vim will not remove a backslash in front of a normal file
+        name character on these systems, but it will on Unix and alikes.  The
+        '&' and '^' are not included by default, because these are special for
+        cmd.exe.
 
-						*'mousemodel'* *'mousem'*
-'mousemodel' 'mousem'	string	(default "popup_setpos")
-			global
-	Sets the model to use for the mouse.  The name mostly specifies what
-	the right mouse button is used for:
-	   extend	Right mouse button extends a selection.  This works
-			like in an xterm.
-	   popup	Right mouse button pops up a menu.  The shifted left
-			mouse button extends a selection.  This works like
-			with Microsoft Windows.
-	   popup_setpos Like "popup", but the cursor will be moved to the
-			position where the mouse was clicked, and thus the
-			selected operation will act upon the clicked object.
-			If clicking inside a selection, that selection will
-			be acted upon, i.e. no cursor move.  This implies of
-			course, that right clicking outside a selection will
-			end Visual mode.
-	Overview of what button does what for each model:
-	mouse		    extend		popup(_setpos) ~
-	left click	    place cursor	place cursor
-	left drag	    start selection	start selection
-	shift-left	    search word		extend selection
-	right click	    extend selection	popup menu (place cursor)
-	right drag	    extend selection	-
-	middle click	    paste		paste
+        The format of this option is a list of parts, separated with commas.
+        Each part can be a single character number or a range.  A range is two
+        character numbers with '-' in between.  A character number can be a
+        decimal number between 0 and 255 or the ASCII character itself (does
+        not work for digits).  Example:
+                "_,-,128-140,#-43"      (include '_' and '-' and the range
+                                        128 to 140 and '#' to 43)
+        If a part starts with '^', the following character number or range
+        will be excluded from the option.  The option is interpreted from left
+        to right.  Put the excluded character after the range where it is
+        included.  To include '^' itself use it as the last character of the
+        option or the end of a range.  Example:
+                "^a-z,#,^"      (exclude 'a' to 'z', include '#' and '^')
+        If the character is '@', all characters where isalpha() returns TRUE
+        are included.  Normally these are the characters a to z and A to Z,
+        plus accented characters.  To include '@' itself use "@-@".  Examples:
+                "@,^a-z"        All alphabetic characters, excluding lower
+                                case ASCII letters.
+                "a-z,A-Z,@-@"   All letters plus the '@' character.
+        A comma can be included by using it where a character number is
+        expected.  Example:
+                "48-57,,,_"     Digits, comma and underscore.
+        A comma can be excluded by prepending a '^'.  Example:
+                " -~,^,,9"      All characters from space to '~', excluding
+                                comma, plus <Tab>.
+        See |option-backslash| about including spaces and backslashes.
 
-	In the "popup" model the right mouse button produces a pop-up menu.
-	Nvim creates a default |popup-menu| but you can redefine it.
+                                                               *'isident'* *'isi'*
+'isident' 'isi'         string (default for Windows: "@,48-57,_,128-167,224-235"
+                                        otherwise: "@,48-57,_,192-255")
+                        global
+        The characters given by this option are included in identifiers.
+        Identifiers are used in recognizing environment variables and after a
+        match of the 'define' option.  It is also used for "\i" in a
+        |pattern|.  See 'isfname' for a description of the format of this
+        option.  For '@' only characters up to 255 are used.
+        Careful: If you change this option, it might break expanding
+        environment variables.  E.g., when '/' is included and Vim tries to
+        expand "$HOME/.local/state/nvim/shada/main.shada".  Maybe you should
+        change 'iskeyword' instead.
 
-	Note that you can further refine the meaning of buttons with mappings.
-	See |mouse-overview|.  But mappings are NOT used for modeless selection.
+                                                             *'iskeyword'* *'isk'*
+'iskeyword' 'isk'       string (default "@,48-57,_,192-255")
+                        local to buffer
+        Keywords are used in searching and recognizing with many commands:
+        "w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.  See
+        'isfname' for a description of the format of this option.  For '@'
+        characters above 255 check the "word" character class (any character
+        that is not white space or punctuation).
+        For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
+        For a help file it is set to all non-blank printable characters except
+        "*", '"' and '|' (so that CTRL-] on a command finds the help for that
+        command).
+        When the 'lisp' option is on the '-' character is always included.
+        This option also influences syntax highlighting, unless the syntax
+        uses |:syn-iskeyword|.
 
-	Example: >vim
-	    map <S-LeftMouse>     <RightMouse>
-	    map <S-LeftDrag>      <RightDrag>
-	    map <S-LeftRelease>   <RightRelease>
-	    map <2-S-LeftMouse>   <2-RightMouse>
-	    map <2-S-LeftDrag>    <2-RightDrag>
-	    map <2-S-LeftRelease> <2-RightRelease>
-	    map <3-S-LeftMouse>   <3-RightMouse>
-	    map <3-S-LeftDrag>    <3-RightDrag>
-	    map <3-S-LeftRelease> <3-RightRelease>
-	    map <4-S-LeftMouse>   <4-RightMouse>
-	    map <4-S-LeftDrag>    <4-RightDrag>
-	    map <4-S-LeftRelease> <4-RightRelease>
+                                                               *'isprint'* *'isp'*
+'isprint' 'isp'         string (default "@,161-255")
+                        global
+        The characters given by this option are displayed directly on the
+        screen.  It is also used for "\p" in a |pattern|.  The characters from
+        space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
+        even when they are not included in 'isprint' or excluded.  See
+        'isfname' for a description of the format of this option.
+
+        Non-printable characters are displayed with two characters:
+                  0 -  31       "^@" - "^_"
+                 32 - 126       always single characters
+                   127          "^?"
+                128 - 159       "~@" - "~_"
+                160 - 254       "| " - "|~"
+                   255          "~?"
+        Illegal bytes from 128 to 255 (invalid UTF-8) are
+        displayed as <xx>, with the hexadecimal value of the byte.
+        When 'display' contains "uhex" all unprintable characters are
+        displayed as <xx>.
+        The SpecialKey highlighting will be used for unprintable characters.
+        |hl-SpecialKey|
+
+        Multi-byte characters 256 and above are always included, only the
+        characters up to 255 are specified with this option.  When a character
+        is printable but it is not available in the current font, a
+        replacement character will be shown.
+        Unprintable and zero-width Unicode characters are displayed as <xxxx>.
+        There is no option to specify these characters.
+
+                                       *'joinspaces'* *'js'* *'nojoinspaces'* *'nojs'*
+'joinspaces' 'js'       boolean (default off)
+                        global
+        Insert two spaces after a '.', '?' and '!' with a join command.
+        Otherwise only one space is inserted.
+
+                                                           *'jumpoptions'* *'jop'*
+'jumpoptions' 'jop'     string (default "")
+                        global
+        List of words that change the behavior of the |jumplist|.
+          stack         Make the jumplist behave like the tagstack.
+                        Relative location of entries in the jumplist is
+                        preserved at the cost of discarding subsequent entries
+                        when navigating backwards in the jumplist and then
+                        jumping to a location.  |jumplist-stack|
+
+          view          When moving through the jumplist, |changelist|,
+                        |alternate-file| or using |mark-motions| try to
+                        restore the |mark-view| in which the action occurred.
+
+                                                                *'keymap'* *'kmp'*
+'keymap' 'kmp'          string (default "")
+                        local to buffer
+        Name of a keyboard mapping.  See |mbyte-keymap|.
+        Setting this option to a valid keymap name has the side effect of
+        setting 'iminsert' to one, so that the keymap becomes effective.
+        'imsearch' is also set to one, unless it was -1
+        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+
+                                                               *'keymodel'* *'km'*
+'keymodel' 'km'         string (default "")
+                        global
+        List of comma-separated words, which enable special things that keys
+        can do.  These values can be used:
+           startsel     Using a shifted special key starts selection (either
+                        Select mode or Visual mode, depending on "key" being
+                        present in 'selectmode').
+           stopsel      Using a not-shifted special key stops selection.
+        Special keys in this context are the cursor keys, <End>, <Home>,
+        <PageUp> and <PageDown>.
+
+                                                             *'keywordprg'* *'kp'*
+'keywordprg' 'kp'       string (default ":Man", Windows: ":help")
+                        global or local to buffer |global-local|
+        Program to use for the |K| command.  Environment variables are
+        expanded |:set_env|.  ":help" may be used to access the Vim internal
+        help.  (Note that previously setting the global option to the empty
+        value did this, which is now deprecated.)
+        When the first character is ":", the command is invoked as a Vim
+        Ex command prefixed with [count].
+        When "man" or "man -s" is used, Vim will automatically translate
+        a [count] for the "K" command to a section number.
+        See |option-backslash| about including spaces and backslashes.
+        Example: >vim
+                set keywordprg=man\ -s
+                set keywordprg=:Man
+<       This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                    *'langmap'* *'lmap'* *E357* *E358*
+'langmap' 'lmap'        string (default "")
+                        global
+        This option allows switching your keyboard into a special language
+        mode.  When you are typing text in Insert mode the characters are
+        inserted directly.  When in Normal mode the 'langmap' option takes
+        care of translating these special characters to the original meaning
+        of the key.  This means you don't have to change the keyboard mode to
+        be able to execute Normal mode commands.
+        This is the opposite of the 'keymap' option, where characters are
+        mapped in Insert mode.
+        Also consider setting 'langremap' to off, to prevent 'langmap' from
+        applying to characters resulting from a mapping.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+        Example (for Greek, in UTF-8):                          *greek*  >vim
+            set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
+<       Example (exchanges meaning of z and y for commands): >vim
+            set langmap=zy,yz,ZY,YZ
 <
-	Mouse commands requiring the CTRL modifier can be simulated by typing
-	the "g" key before using the mouse:
-	    "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
-	    "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
+        The 'langmap' option is a list of parts, separated with commas.  Each
+        part can be in one of two forms:
+        1.  A list of pairs.  Each pair is a "from" character immediately
+            followed by the "to" character.  Examples: "aA", "aAbBcC".
+        2.  A list of "from" characters, a semi-colon and a list of "to"
+            characters.  Example: "abc;ABC"
+        Example: "aA,fgh;FGH,cCdDeE"
+        Special characters need to be preceded with a backslash.  These are
+        ";", ',', '"', '|' and backslash itself.
 
-	*'mousemoveevent'* *'mousemev'* *'nomousemoveevent'* *'nomousemev'*
-'mousemoveevent' 'mousemev'	boolean	(default off)
-			global
-	When on, mouse move events are delivered to the input queue and are
-	available for mapping. The default, off, avoids the mouse movement
-	overhead except when needed.
-	Warning: Setting this option can make pending mappings to be aborted
-	when the mouse is moved.
+        This will allow you to activate vim actions without having to switch
+        back and forth between the languages.  Your language characters will
+        be understood as normal vim English characters (according to the
+        langmap mappings) in the following cases:
+         o Normal/Visual mode (commands, buffer/register names, user mappings)
+         o Insert/Replace Mode: Register names after CTRL-R
+         o Insert/Replace Mode: Mappings
+        Characters entered in Command-line mode will NOT be affected by
+        this option.   Note that this option can be changed at any time
+        allowing to switch between mappings for different languages/encodings.
+        Use a mapping to avoid having to type it each time!
 
-						*'mousescroll'* *E5080*
-'mousescroll'		string	(default "ver:3,hor:6")
-			global
-	This option controls the number of lines / columns to scroll by when
-	scrolling with a mouse wheel (|scroll-mouse-wheel|). The option is
-	a comma-separated list. Each part consists of a direction and a count
-	as follows:
-		direction:count,direction:count
-	Direction is one of either "hor" or "ver". "hor" controls horizontal
-	scrolling and "ver" controls vertical scrolling. Count sets the amount
-	to scroll by for the given direction, it should be a non negative
-	integer. Each direction should be set at most once. If a direction
-	is omitted, a default value is used (6 for horizontal scrolling and 3
-	for vertical scrolling). You can disable mouse scrolling by using
-	a count of 0.
+                                                               *'langmenu'* *'lm'*
+'langmenu' 'lm'         string (default "")
+                        global
+        Language to use for menu translation.  Tells which file is loaded
+        from the "lang" directory in 'runtimepath': >vim
+                "lang/menu_" .. &langmenu .. ".vim"
+<       (without the spaces).  For example, to always use the Dutch menus, no
+        matter what $LANG is set to: >vim
+                set langmenu=nl_NL.ISO_8859-1
+<       When 'langmenu' is empty, |v:lang| is used.
+        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+        If your $LANG is set to a non-English language but you do want to use
+        the English menus: >vim
+                set langmenu=none
+<       This option must be set before loading menus, switching on filetype
+        detection or syntax highlighting.  Once the menus are defined setting
+        this option has no effect.  But you could do this: >vim
+                source $VIMRUNTIME/delmenu.vim
+                set langmenu=de_DE.ISO_8859-1
+                source $VIMRUNTIME/menu.vim
+<       Warning: This deletes all menus that you defined yourself!
 
-	Example: >vim
-		set mousescroll=ver:5,hor:2
-<	Will make Nvim scroll 5 lines at a time when scrolling vertically, and
-	scroll 2 columns at a time when scrolling horizontally.
+                                       *'langremap'* *'lrm'* *'nolangremap'* *'nolrm'*
+'langremap' 'lrm'       boolean (default off)
+                        global
+        When off, setting 'langmap' does not apply to characters resulting from
+        a mapping.  If setting 'langmap' disables some of your mappings, make
+        sure this option is off.
 
-					*'mouseshape'* *'mouses'* *E547*
-'mouseshape' 'mouses'	string	(default "i:beam,r:beam,s:updown,sd:cross,
-                                        m:no,ml:up-arrow,v:rightup-arrow")
-			global
-	This option tells Vim what the mouse pointer should look like in
-	different modes.  The option is a comma-separated list of parts, much
-	like used for 'guicursor'.  Each part consist of a mode/location-list
-	and an argument-list:
-		mode-list:shape,mode-list:shape,..
-	The mode-list is a dash separated list of these modes/locations:
-			In a normal window: ~
-		n	Normal mode
-		v	Visual mode
-		ve	Visual mode with 'selection' "exclusive" (same as 'v',
-			if not specified)
-		o	Operator-pending mode
-		i	Insert mode
-		r	Replace mode
+                                                             *'laststatus'* *'ls'*
+'laststatus' 'ls'       number (default 2)
+                        global
+        The value of this option influences when the last window will have a
+        status line:
+                0: never
+                1: only if there are at least two windows
+                2: always
+                3: always and ONLY the last window
+        The screen looks nicer with a status line if you have several
+        windows, but it takes another screen line. |status-line|
 
-			Others: ~
-		c	appending to the command-line
-		ci	inserting in the command-line
-		cr	replacing in the command-line
-		m	at the 'Hit ENTER' or 'More' prompts
-		ml	idem, but cursor in the last line
-		e	any mode, pointer below last window
-		s	any mode, pointer on a status line
-		sd	any mode, while dragging a status line
-		vs	any mode, pointer on a vertical separator line
-		vd	any mode, while dragging a vertical separator line
-		a	everywhere
+                                       *'lazyredraw'* *'lz'* *'nolazyredraw'* *'nolz'*
+'lazyredraw' 'lz'       boolean (default off)
+                        global
+        When this option is set, the screen will not be redrawn while
+        executing macros, registers and other commands that have not been
+        typed.  Also, updating the window title is postponed.  To force an
+        update use |:redraw|.
+        This may occasionally cause display errors.  It is only meant to be set
+        temporarily when performing an operation where redrawing may cause
+        flickering or cause a slow down.
 
-	The shape is one of the following:
-	avail	name		looks like ~
-	w x	arrow		Normal mouse pointer
-	w x	blank		no pointer at all (use with care!)
-	w x	beam		I-beam
-	w x	updown		up-down sizing arrows
-	w x	leftright	left-right sizing arrows
-	w x	busy		The system's usual busy pointer
-	w x	no		The system's usual "no input" pointer
-	  x	udsizing	indicates up-down resizing
-	  x	lrsizing	indicates left-right resizing
-	  x	crosshair	like a big thin +
-	  x	hand1		black hand
-	  x	hand2		white hand
-	  x	pencil		what you write with
-	  x	question	big ?
-	  x	rightup-arrow	arrow pointing right-up
-	w x	up-arrow	arrow pointing up
-	  x	<number>	any X11 pointer number (see X11/cursorfont.h)
+                                       *'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
+'linebreak' 'lbr'       boolean (default off)
+                        local to window
+        If on, Vim will wrap long lines at a character in 'breakat' rather
+        than at the last character that fits on the screen.  Unlike
+        'wrapmargin' and 'textwidth', this does not insert <EOL>s in the file,
+        it only affects the way the file is displayed, not its contents.
+        If 'breakindent' is set, line is visually indented. Then, the value
+        of 'showbreak' is used to put in front of wrapped lines. This option
+        is not used when the 'wrap' option is off.
+        Note that <Tab> characters after an <EOL> are mostly not displayed
+        with the right amount of white space.
 
-	The "avail" column contains a 'w' if the shape is available for Win32,
-	x for X11.
-	Any modes not specified or shapes not available use the normal mouse
-	pointer.
+                                                                  *'lines'* *E593*
+'lines'                 number (default 24 or terminal height)
+                        global
+        Number of lines of the Vim window.
+        Normally you don't need to set this.  It is done automatically by the
+        terminal initialization code.
+        When Vim is running in the GUI or in a resizable window, setting this
+        option will cause the window size to be changed.  When you only want
+        to use the size for the GUI, put the command in your |gvimrc| file.
+        Vim limits the number of lines to what fits on the screen.  You can
+        use this command to get the tallest window possible: >vim
+                set lines=999
+<       Minimum value is 2, maximum value is 1000.
 
-	Example: >vim
-		set mouseshape=s:udsizing,m:no
-<	will make the mouse turn to a sizing arrow over the status lines and
-	indicate no input when the hit-enter prompt is displayed (since
-	clicking the mouse has no effect in this state.)
+                                                             *'linespace'* *'lsp'*
+'linespace' 'lsp'       number (default 0)
+                        global
+        only in the GUI
+        Number of pixel lines inserted between characters.  Useful if the font
+        uses the full character cell height, making lines touch each other.
+        When non-zero there is room for underlining.
+        With some fonts there can be too much room between lines (to have
+        space for ascents and descents).  Then it makes sense to set
+        'linespace' to a negative value.  This may cause display problems
+        though!
 
-						*'mousetime'* *'mouset'*
-'mousetime' 'mouset'	number	(default 500)
-			global
-	Defines the maximum time in msec between two mouse clicks for the
-	second click to be recognized as a multi click.
+                                                               *'lisp'* *'nolisp'*
+'lisp'                  boolean (default off)
+                        local to buffer
+        Lisp mode: When <Enter> is typed in insert mode set the indent for
+        the next line to Lisp standards (well, sort of).  Also happens with
+        "cc" or "S".  'autoindent' must also be on for this to work.  The 'p'
+        flag in 'cpoptions' changes the method of indenting: Vi compatible or
+        better.  Also see 'lispwords'.
+        The '-' character is included in keyword characters.  Redefines the
+        "=" operator to use this same indentation algorithm rather than
+        calling an external program if 'equalprg' is empty.
 
-						*'nrformats'* *'nf'*
-'nrformats' 'nf'	string	(default "bin,hex")
-			local to buffer
-	This defines what bases Vim will consider for numbers when using the
-	CTRL-A and CTRL-X commands for adding to and subtracting from a number
-	respectively; see |CTRL-A| for more info on these commands.
-	alpha	If included, single alphabetical characters will be
-		incremented or decremented.  This is useful for a list with a
-		letter index a), b), etc.		*octal-nrformats*
-	octal	If included, numbers that start with a zero will be considered
-		to be octal.  Example: Using CTRL-A on "007" results in "010".
-	hex	If included, numbers starting with "0x" or "0X" will be
-		considered to be hexadecimal.  Example: Using CTRL-X on
-		"0x100" results in "0x0ff".
-	bin	If included, numbers starting with "0b" or "0B" will be
-		considered to be binary.  Example: Using CTRL-X on
-		"0b1000" subtracts one, resulting in "0b0111".
-	unsigned    If included, numbers are recognized as unsigned. Thus a
-		leading dash or negative sign won't be considered as part of
-		the number.  Examples:
-		    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
-		    (without "unsigned" it would become "9-2021").
-		    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
-		    (without "unsigned" it would become "9-2019").
-		    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
-		    (2^64 - 1) has no effect, overflow is prevented.
-	Numbers which simply begin with a digit in the range 1-9 are always
-	considered decimal.  This also happens for numbers that are not
-	recognized as octal or hex.
+                                                           *'lispoptions'* *'lop'*
+'lispoptions' 'lop'     string (default "")
+                        local to buffer
+        Comma-separated list of items that influence the Lisp indenting when
+        enabled with the |'lisp'| option.  Currently only one item is
+        supported:
+                expr:1  use 'indentexpr' for Lisp indenting when it is set
+                expr:0  do not use 'indentexpr' for Lisp indenting (default)
+        Note that when using 'indentexpr' the `=` operator indents all the
+        lines, otherwise the first line is not indented (Vi-compatible).
 
-				*'number'* *'nu'* *'nonumber'* *'nonu'*
-'number' 'nu'		boolean	(default off)
-			local to window
-	Print the line number in front of each line.  When the 'n' option is
-	excluded from 'cpoptions' a wrapped line will not use the column of
-	line numbers.
-	Use the 'numberwidth' option to adjust the room for the line number.
-	When a long, wrapped line doesn't start with the first character, '-'
-	characters are put before the number.
-	For highlighting see |hl-LineNr|, |hl-CursorLineNr|, and the
-	|:sign-define| "numhl" argument.
-						*number_relativenumber*
-	The 'relativenumber' option changes the displayed number to be
-	relative to the cursor.  Together with 'number' there are these
-	four combinations (cursor in line 3):
+                                                              *'lispwords'* *'lw'*
+'lispwords' 'lw'        string (default is very long)
+                        global or local to buffer |global-local|
+        Comma-separated list of words that influence the Lisp indenting when
+        enabled with the |'lisp'| option.
 
-		'nonu'          'nu'            'nonu'          'nu'
-		'nornu'         'nornu'         'rnu'           'rnu'
-	>
-	    |apple          |  1 apple      |  2 apple      |  2 apple
-	    |pear           |  2 pear       |  1 pear       |  1 pear
-	    |nobody         |  3 nobody     |  0 nobody     |3   nobody
-	    |there          |  4 there      |  1 there      |  1 there
+                                                               *'list'* *'nolist'*
+'list'                  boolean (default off)
+                        local to window
+        List mode: By default, show tabs as ">", trailing spaces as "-", and
+        non-breakable space characters as "+". Useful to see the difference
+        between tabs and spaces and for trailing blanks. Further changed by
+        the 'listchars' option.
+
+        The cursor is displayed at the start of the space a Tab character
+        occupies, not at the end as usual in Normal mode.  To get this cursor
+        position while displaying Tabs with spaces, use: >vim
+                set list lcs=tab:\ \
 <
+        Note that list mode will also affect formatting (set with 'textwidth'
+        or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
+        changing the way tabs are displayed.
 
-						*'numberwidth'* *'nuw'*
-'numberwidth' 'nuw'	number	(default 4)
-			local to window
-	Minimal number of columns to use for the line number.  Only relevant
-	when the 'number' or 'relativenumber' option is set or printing lines
-	with a line number. Since one space is always between the number and
-	the text, there is one less character for the number itself.
-	The value is the minimum width.  A bigger width is used when needed to
-	fit the highest line number in the buffer respectively the number of
-	rows in the window, depending on whether 'number' or 'relativenumber'
-	is set. Thus with the Vim default of 4 there is room for a line number
-	up to 999. When the buffer has 1000 lines five columns will be used.
-	The minimum value is 1, the maximum value is 20.
+                                                             *'listchars'* *'lcs'*
+'listchars' 'lcs'       string (default "tab:> ,trail:-,nbsp:+")
+                        global or local to window |global-local|
+        Strings to use in 'list' mode and for the |:list| command.  It is a
+        comma-separated list of string settings.
 
-						*'omnifunc'* *'ofu'*
-'omnifunc' 'ofu'	string	(default "")
-			local to buffer
-	This option specifies a function to be used for Insert mode omni
-	completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
-	See |complete-functions| for an explanation of how the function is
-	invoked and what it should return.  The value can be the name of a
-	function, a |lambda| or a |Funcref|. See |option-value-function| for
-	more information.
-	This option is usually set by a filetype plugin:
-	|:filetype-plugin-on|
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                        *lcs-eol*
+          eol:c         Character to show at the end of each line.  When
+                        omitted, there is no extra character at the end of the
+                        line.
+                                                        *lcs-tab*
+          tab:xy[z]     Two or three characters to be used to show a tab.
+                        The third character is optional.
 
-			*'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
-'opendevice' 'odev'	boolean	(default off)
-			global
-			only for Windows
-	Enable reading and writing from devices.  This may get Vim stuck on a
-	device that can be opened but doesn't actually do the I/O.  Therefore
-	it is off by default.
-	Note that on Windows editing "aux.h", "lpt1.txt" and the like also
-	result in editing a device.
-
-					*'operatorfunc'* *'opfunc'*
-'operatorfunc' 'opfunc'	string	(default "")
-			global
-	This option specifies a function to be called by the |g@| operator.
-	See |:map-operator| for more info and an example.  The value can be
-	the name of a function, a |lambda| or a |Funcref|. See
-	|option-value-function| for more information.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'packpath'* *'pp'*
-'packpath' 'pp'		string	(default see 'runtimepath')
-			global
-	Directories used to find packages.
-	See |packages| and |packages-runtimepath|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'paragraphs'* *'para'*
-'paragraphs' 'para'	string	(default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
-			global
-	Specifies the nroff macros that separate paragraphs.  These are pairs
-	of two letters (see |object-motions|).
-
-						*'patchexpr'* *'pex'*
-'patchexpr' 'pex'	string	(default "")
-			global
-	Expression which is evaluated to apply a patch to a file and generate
-	the resulting new version of the file.  See |diff-patchexpr|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-					*'patchmode'* *'pm'* *E205* *E206*
-'patchmode' 'pm'	string	(default "")
-			global
-	When non-empty the oldest version of a file is kept.  This can be used
-	to keep the original version of a file if you are changing files in a
-	source distribution.  Only the first time that a file is written a
-	copy of the original file will be kept.  The name of the copy is the
-	name of the original file with the string in the 'patchmode' option
-	appended.  This option should start with a dot.  Use a string like
-	".orig" or ".org".  'backupdir' must not be empty for this to work
-	(Detail: The backup file is renamed to the patchmode file after the
-	new file has been successfully written, that's why it must be possible
-	to write a backup file).  If there was no file to be backed up, an
-	empty file is created.
-	When the 'backupskip' pattern matches, a patchmode file is not made.
-	Using 'patchmode' for compressed files appends the extension at the
-	end (e.g., "file.gz.orig"), thus the resulting name isn't always
-	recognized as a compressed file.
-	Only normal file name characters can be used, `/\*?[|<>` are illegal.
-
-				*'path'* *'pa'* *E343* *E345* *E347* *E854*
-'path' 'pa'		string	(default ".,,")
-			global or local to buffer |global-local|
-	This is a list of directories which will be searched when using the
-	|gf|, [f, ]f, ^Wf, |:find|, |:sfind|, |:tabfind| and other commands,
-	provided that the file being searched for has a relative path (not
-	starting with "/", "./" or "../").  The directories in the 'path'
-	option may be relative or absolute.
-	- Use commas to separate directory names: >vim
-		set path=.,/usr/local/include,/usr/include
-<	- Spaces can also be used to separate directory names.  To have a
-	  space in a directory name, precede it with an extra backslash, and
-	  escape the space: >vim
-		set path=.,/dir/with\\\ space
-<	- To include a comma in a directory name precede it with an extra
-	  backslash: >vim
-		set path=.,/dir/with\\,comma
-<	- To search relative to the directory of the current file, use: >vim
-		set path=.
-<	- To search in the current directory use an empty string between two
-	  commas: >vim
-		set path=,,
-<	- A directory name may end in a ':' or '/'.
-	- Environment variables are expanded |:set_env|.
-	- When using |netrw.vim| URLs can be used.  For example, adding
-	  "https://www.vim.org" will make ":find index.html" work.
-	- Search upwards and downwards in a directory tree using "*", "**" and
-	  ";".  See |file-searching| for info and syntax.
-	- Careful with '\' characters, type two to get one in the option: >vim
-		set path=.,c:\\include
-<	  Or just use '/' instead: >vim
-		set path=.,c:/include
-<	Don't forget "." or files won't even be found in the same directory as
-	the file!
-	The maximum length is limited.  How much depends on the system, mostly
-	it is something like 256 or 1024 characters.
-	You can check if all the include files are found, using the value of
-	'path', see |:checkpath|.
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	directories from the list.  This avoids problems when a future version
-	uses another default.  To remove the current directory use: >vim
-		set path-=
-<	To add the current directory use: >vim
-		set path+=
-<	To use an environment variable, you probably need to replace the
-	separator.  Here is an example to append $INCL, in which directory
-	names are separated with a semi-colon: >vim
-		let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
-<	Replace the ';' with a ':' or whatever separator is used.  Note that
-	this doesn't work when $INCL contains a comma or white space.
-
-		*'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
-'preserveindent' 'pi'	boolean	(default off)
-			local to buffer
-	When changing the indent of the current line, preserve as much of the
-	indent structure as possible.  Normally the indent is replaced by a
-	series of tabs followed by spaces as required (unless |'expandtab'| is
-	enabled, in which case only spaces are used).  Enabling this option
-	means the indent will preserve as many existing characters as possible
-	for indenting, and only add additional tabs or spaces as required.
-	'expandtab' does not apply to the preserved white space, a Tab remains
-	a Tab.
-	NOTE: When using ">>" multiple times the resulting indent is a mix of
-	tabs and spaces.  You might not like this.
-	Also see 'copyindent'.
-	Use |:retab| to clean up white space.
-
-						*'previewheight'* *'pvh'*
-'previewheight' 'pvh'	number	(default 12)
-			global
-	Default height for a preview window.  Used for |:ptag| and associated
-	commands.  Used for |CTRL-W_}| when no count is given.
-
-		*'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
-'previewwindow' 'pvw'	boolean	(default off)
-			local to window  |local-noglobal|
-	Identifies the preview window.  Only one window can have this option
-	set.  It's normally not set directly, but by using one of the commands
-	|:ptag|, |:pedit|, etc.
-
-						*'pumblend'* *'pb'*
-'pumblend' 'pb'		number	(default 0)
-			global
-	Enables pseudo-transparency for the |popup-menu|. Valid values are in
-	the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
-	transparent background. Values between 0-30 are typically most useful.
-
-	It is possible to override the level for individual highlights within
-	the popupmenu using |highlight-blend|. For instance, to enable
-	transparency but force the current selected element to be fully opaque: >vim
-
-		set pumblend=15
-		hi PmenuSel blend=0
+          tab:xy        The 'x' is always used, then 'y' as many times as will
+                        fit.  Thus "tab:>-" displays: >
+                                >
+                                >-
+                                >--
+                                etc.
 <
-	UI-dependent. Works best with RGB colors. 'termguicolors'
+          tab:xyz       The 'z' is always used, then 'x' is prepended, and
+                        then 'y' is used as many times as will fit.  Thus
+                        "tab:<->" displays: >
+                                >
+                                <>
+                                <->
+                                <-->
+                                etc.
+<
+                        When "tab:" is omitted, a tab is shown as ^I.
+                                                        *lcs-space*
+          space:c       Character to show for a space.  When omitted, spaces
+                        are left blank.
+                                                        *lcs-multispace*
+          multispace:c...
+                        One or more characters to use cyclically to show for
+                        multiple consecutive spaces.  Overrides the "space"
+                        setting, except for single spaces.  When omitted, the
+                        "space" setting is used.  For example,
+                        `:set listchars=multispace:---+` shows ten consecutive
+                        spaces as: >
+                                ---+---+--
+<
+                                                        *lcs-lead*
+          lead:c        Character to show for leading spaces.  When omitted,
+                        leading spaces are blank.  Overrides the "space" and
+                        "multispace" settings for leading spaces.  You can
+                        combine it with "tab:", for example: >vim
+                                set listchars+=tab:>-,lead:.
+<
+                                                        *lcs-leadmultispace*
+          leadmultispace:c...
+                        Like the |lcs-multispace| value, but for leading
+                        spaces only.  Also overrides |lcs-lead| for leading
+                        multiple spaces.
+                        `:set listchars=leadmultispace:---+` shows ten
+                        consecutive leading spaces as: >
+                                ---+---+--XXX
+<
+                        Where "XXX" denotes the first non-blank characters in
+                        the line.
+                                                        *lcs-trail*
+          trail:c       Character to show for trailing spaces.  When omitted,
+                        trailing spaces are blank.  Overrides the "space" and
+                        "multispace" settings for trailing spaces.
+                                                        *lcs-extends*
+          extends:c     Character to show in the last column, when 'wrap' is
+                        off and the line continues beyond the right of the
+                        screen.
+                                                        *lcs-precedes*
+          precedes:c    Character to show in the first visible column of the
+                        physical line, when there is text preceding the
+                        character visible in the first column.
+                                                        *lcs-conceal*
+          conceal:c     Character to show in place of concealed text, when
+                        'conceallevel' is set to 1.  A space when omitted.
+                                                        *lcs-nbsp*
+          nbsp:c        Character to show for a non-breakable space character
+                        (0xA0 (160 decimal) and U+202F).  Left blank when
+                        omitted.
 
-						*'pumheight'* *'ph'*
-'pumheight' 'ph'	number	(default 0)
-			global
-	Maximum number of items to show in the popup menu
-	(|ins-completion-menu|). Zero means "use available screen space".
+        The characters ':' and ',' should not be used.  UTF-8 characters can
+        be used.  All characters must be single width.
 
-						*'pumwidth'* *'pw'*
-'pumwidth' 'pw'		number	(default 15)
-			global
-	Minimum width for the popup menu (|ins-completion-menu|).  If the
-	cursor column + 'pumwidth' exceeds screen width, the popup menu is
-	nudged to fit on the screen.
+        Each character can be specified as hex: >vim
+                set listchars=eol:\\x24
+                set listchars=eol:\\u21b5
+                set listchars=eol:\\U000021b5
+<       Note that a double backslash is used.  The number of hex characters
+        must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
 
-						*'pyxversion'* *'pyx'*
-'pyxversion' 'pyx'	number	(default 3)
-			global
-	Specifies the python version used for pyx* functions and commands
-	|python_x|.  As only Python 3 is supported, this always has the value
-	`3`. Setting any other value is an error.
+        Examples: >vim
+            set lcs=tab:>-,trail:-
+            set lcs=tab:>-,eol:<,nbsp:%
+            set lcs=extends:>,precedes:<
+<       |hl-NonText| highlighting will be used for "eol", "extends" and
+        "precedes". |hl-Whitespace| for "nbsp", "space", "tab", "multispace",
+        "lead" and "trail".
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                   *'loadplugins'* *'lpl'* *'noloadplugins'* *'nolpl'*
+'loadplugins' 'lpl'     boolean (default on)
+                        global
+        When on the plugin scripts are loaded when starting up |load-plugins|.
+        This option can be reset in your |vimrc| file to disable the loading
+        of plugins.
+        Note that using the "-u NONE" and "--noplugin" command line arguments
+        reset this option. |-u| |--noplugin|
 
-					*'quickfixtextfunc'* *'qftf'*
-'quickfixtextfunc' 'qftf'	string	(default "")
-			global
-	This option specifies a function to be used to get the text to display
-	in the quickfix and location list windows.  This can be used to
-	customize the information displayed in the quickfix or location window
-	for each entry in the corresponding quickfix or location list.  See
-	|quickfix-window-function| for an explanation of how to write the
-	function and an example.  The value can be the name of a function, a
-	|lambda| or a |Funcref|. See |option-value-function| for more
-	information.
+                                                             *'magic'* *'nomagic'*
+'magic'                 boolean (default on)
+                        global
+        Changes the special characters that can be used in search patterns.
+        See |pattern|.
+        WARNING: Switching this option off most likely breaks plugins!  That
+        is because many patterns assume it's on and will fail when it's off.
+        Only switch it off when working with old Vi scripts.  In any other
+        situation write patterns that work when 'magic' is on.  Include "\M"
+        when you want to |/\M|.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                                *'makeef'* *'mef'*
+'makeef' 'mef'          string (default "")
+                        global
+        Name of the errorfile for the |:make| command (see |:make_makeprg|)
+        and the |:grep| command.
+        When it is empty, an internally generated temp file will be used.
+        When "##" is included, it is replaced by a number to make the name
+        unique.  This makes sure that the ":make" command doesn't overwrite an
+        existing file.
+        NOT used for the ":cf" command.  See 'errorfile' for that.
+        Environment variables are expanded |:set_env|.
+        See |option-backslash| about including spaces and backslashes.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'quoteescape'* *'qe'*
-'quoteescape' 'qe'	string	(default "\")
-			local to buffer
-	The characters that are used to escape quotes in a string.  Used for
-	objects like a', a" and a` |a'|.
-	When one of the characters in this option is found inside a string,
-	the following character will be skipped.  The default value makes the
-	text "foo\"bar\\" considered to be one string.
+                                                         *'makeencoding'* *'menc'*
+'makeencoding' 'menc'   string (default "")
+                        global or local to buffer |global-local|
+        Encoding used for reading the output of external commands.  When empty,
+        encoding is not converted.
+        This is used for `:make`, `:lmake`, `:grep`, `:lgrep`, `:grepadd`,
+        `:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
+        and `:laddfile`.
 
-				*'readonly'* *'ro'* *'noreadonly'* *'noro'*
-'readonly' 'ro'		boolean	(default off)
-			local to buffer  |local-noglobal|
-	If on, writes fail unless you use a '!'.  Protects you from
-	accidentally overwriting a file.  Default on when Vim is started
-	in read-only mode ("vim -R") or when the executable is called "view".
-	When using ":w!" the 'readonly' option is reset for the current
-	buffer, unless the 'Z' flag is in 'cpoptions'.
-	When using the ":view" command the 'readonly' option is set for the
-	newly edited buffer.
-	See 'modifiable' for disallowing changes to the buffer.
-
-						*'redrawdebug'* *'rdb'*
-'redrawdebug' 'rdb'	string	(default "")
-			global
-	Flags to change the way redrawing works, for debugging purposes.
-	Most useful with 'writedelay' set to some reasonable value.
-	Supports the following flags:
-	    compositor	Indicate each redraw event handled by the compositor
-			by briefly flashing the redrawn regions in colors
-			indicating the redraw type. These are the highlight
-			groups used (and their default colors):
-		RedrawDebugNormal   gui=reverse   normal redraw passed through
-		RedrawDebugClear    guibg=Yellow  clear event passed through
-		RedrawDebugComposed guibg=Green   redraw event modified by the
-						  compositor (due to
-						  overlapping grids, etc)
-		RedrawDebugRecompose guibg=Red    redraw generated by the
-						  compositor itself, due to a
-						  grid being moved or deleted.
-	    line	introduce a delay after each line drawn on the screen.
-			When using the TUI or another single-grid UI, "compositor"
-			gives more information and should be preferred (every
-			line is processed as a separate event by the compositor)
-	    flush	introduce a delay after each "flush" event.
-	    nothrottle	Turn off throttling of the message grid. This is an
-			optimization that joins many small scrolls to one
-			larger scroll when drawing the message area (with
-			'display' msgsep flag active).
-	    invalid	Enable stricter checking (abort) of inconsistencies
-			of the internal screen state. This is mostly
-			useful when running nvim inside a debugger (and
-			the test suite).
-	    nodelta	Send all internally redrawn cells to the UI, even if
-			they are unchanged from the already displayed state.
-
-						*'redrawtime'* *'rdt'*
-'redrawtime' 'rdt'	number	(default 2000)
-			global
-	Time in milliseconds for redrawing the display.  Applies to
-	'hlsearch', 'inccommand', |:match| highlighting and syntax
-	highlighting.
-	When redrawing takes more than this many milliseconds no further
-	matches will be highlighted.
-	For syntax highlighting the time applies per window.  When over the
-	limit syntax highlighting is disabled until |CTRL-L| is used.
-	This is used to avoid that Vim hangs when using a very complicated
-	pattern.
-
-						*'regexpengine'* *'re'*
-'regexpengine' 're'	number	(default 0)
-			global
-	This selects the default regexp engine. |two-engines|
-	The possible values are:
-		0	automatic selection
-		1	old engine
-		2	NFA engine
-	Note that when using the NFA engine and the pattern contains something
-	that is not supported the pattern will not match.  This is only useful
-	for debugging the regexp engine.
-	Using automatic selection enables Vim to switch the engine, if the
-	default engine becomes too costly.  E.g., when the NFA engine uses too
-	many states.  This should prevent Vim from hanging on a combination of
-	a complex pattern with long text.
-
-		*'relativenumber'* *'rnu'* *'norelativenumber'* *'nornu'*
-'relativenumber' 'rnu'	boolean	(default off)
-			local to window
-	Show the line number relative to the line with the cursor in front of
-	each line. Relative line numbers help you use the |count| you can
-	precede some vertical motion commands (e.g. j k + -) with, without
-	having to calculate it yourself. Especially useful in combination with
-	other commands (e.g. y d c < > gq gw =).
-	When the 'n' option is excluded from 'cpoptions' a wrapped
-	line will not use the column of line numbers.
-	The 'numberwidth' option can be used to set the room used for the line
-	number.
-	When a long, wrapped line doesn't start with the first character, '-'
-	characters are put before the number.
-	See |hl-LineNr|  and |hl-CursorLineNr| for the highlighting used for
-	the number.
-
-	The number in front of the cursor line also depends on the value of
-	'number', see |number_relativenumber| for all combinations of the two
-	options.
-
-							*'report'*
-'report'		number	(default 2)
-			global
-	Threshold for reporting number of lines changed.  When the number of
-	changed lines is more than 'report' a message will be given for most
-	":" commands.  If you want it always, set 'report' to 0.
-	For the ":substitute" command the number of substitutions is used
-	instead of the number of lines.
-
-				*'revins'* *'ri'* *'norevins'* *'nori'*
-'revins' 'ri'		boolean	(default off)
-			global
-	Inserting characters in Insert mode will work backwards.  See "typing
-	backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
-	command in Insert mode, when 'allowrevins' is set.
-
-				*'rightleft'* *'rl'* *'norightleft'* *'norl'*
-'rightleft' 'rl'	boolean	(default off)
-			local to window
-	When on, display orientation becomes right-to-left, i.e., characters
-	that are stored in the file appear from the right to the left.
-	Using this option, it is possible to edit files for languages that
-	are written from the right to the left such as Hebrew and Arabic.
-	This option is per window, so it is possible to edit mixed files
-	simultaneously, or to view the same file in both ways (this is
-	useful whenever you have a mixed text file with both right-to-left
-	and left-to-right strings so that both sets are displayed properly
-	in different windows).  Also see |rileft.txt|.
-
-						*'rightleftcmd'* *'rlc'*
-'rightleftcmd' 'rlc'	string	(default "search")
-			local to window
-	Each word in this option enables the command line editing to work in
-	right-to-left mode for a group of commands:
-
-		search		"/" and "?" commands
-
-	This is useful for languages such as Hebrew, Arabic and Farsi.
-	The 'rightleft' option must be set for 'rightleftcmd' to take effect.
-
-					*'ruler'* *'ru'* *'noruler'* *'noru'*
-'ruler' 'ru'		boolean	(default on)
-			global
-	Show the line and column number of the cursor position, separated by a
-	comma.  When there is room, the relative position of the displayed
-	text in the file is shown on the far right:
-		Top	first line is visible
-		Bot	last line is visible
-		All	first and last line are visible
-		45%	relative position in the file
-	If 'rulerformat' is set, it will determine the contents of the ruler.
-	Each window has its own ruler.  If a window has a status line, the
-	ruler is shown there.  If a window doesn't have a status line and
-	'cmdheight' is zero, the ruler is not shown.  Otherwise it is shown in
-	the last line of the screen.  If the statusline is given by
-	'statusline' (i.e. not empty), this option takes precedence over
-	'ruler' and 'rulerformat'.
-	If the number of characters displayed is different from the number of
-	bytes in the text (e.g., for a TAB or a multibyte character), both
-	the text column (byte number) and the screen column are shown,
-	separated with a dash.
-	For an empty line "0-1" is shown.
-	For an empty buffer the line number will also be zero: "0,0-1".
-	If you don't want to see the ruler all the time but want to know where
-	you are, use "g CTRL-G" |g_CTRL-G|.
-
-						*'rulerformat'* *'ruf'*
-'rulerformat' 'ruf'	string	(default "")
-			global
-	When this option is not empty, it determines the content of the ruler
-	string, as displayed for the 'ruler' option.
-	The format of this option is like that of 'statusline'.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	The default ruler width is 17 characters.  To make the ruler 15
-	characters wide, put "%15(" at the start and "%)" at the end.
-	Example: >vim
-		set rulerformat=%15(%c%V\ %p%%%)
+        This would be mostly useful when you use MS-Windows.  If iconv is
+        enabled, setting 'makeencoding' to "char" has the same effect as
+        setting to the system locale encoding.  Example: >vim
+                set makeencoding=char   " system locale is used
 <
 
-					*'runtimepath'* *'rtp'* *vimfiles*
-'runtimepath' 'rtp'	string	(default "$XDG_CONFIG_HOME/nvim,
-                                               $XDG_CONFIG_DIRS[1]/nvim,
-                                               $XDG_CONFIG_DIRS[2]/nvim,
-                                               …
-                                               $XDG_DATA_HOME/nvim[-data]/site,
-                                               $XDG_DATA_DIRS[1]/nvim/site,
-                                               $XDG_DATA_DIRS[2]/nvim/site,
-                                               …
-                                               $VIMRUNTIME,
-                                               …
-                                               $XDG_DATA_DIRS[2]/nvim/site/after,
-                                               $XDG_DATA_DIRS[1]/nvim/site/after,
-                                               $XDG_DATA_HOME/nvim[-data]/site/after,
-                                               …
-                                               $XDG_CONFIG_DIRS[2]/nvim/after,
-                                               $XDG_CONFIG_DIRS[1]/nvim/after,
-                                               $XDG_CONFIG_HOME/nvim/after")
-			global
-	List of directories to be searched for these runtime files:
-	  filetype.lua	filetypes |new-filetype|
-	  autoload/	automatically loaded scripts |autoload-functions|
-	  colors/	color scheme files |:colorscheme|
-	  compiler/	compiler files |:compiler|
-	  doc/		documentation |write-local-help|
-	  ftplugin/	filetype plugins |write-filetype-plugin|
-	  indent/	indent scripts |indent-expression|
-	  keymap/	key mapping files |mbyte-keymap|
-	  lang/		menu translations |:menutrans|
-	  lua/		|Lua| plugins
-	  menu.vim	GUI menus |menu.vim|
-	  pack/		packages |:packadd|
-	  parser/	|treesitter| syntax parsers
-	  plugin/	plugin scripts |write-plugin|
-	  queries/	|treesitter| queries
-	  rplugin/	|remote-plugin| scripts
-	  spell/	spell checking files |spell|
-	  syntax/	syntax files |mysyntaxfile|
-	  tutor/	tutorial files |:Tutor|
+                                                                *'makeprg'* *'mp'*
+'makeprg' 'mp'          string (default "make")
+                        global or local to buffer |global-local|
+        Program to use for the ":make" command.  See |:make_makeprg|.
+        This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
+        which are expanded to the current and alternate file name.  Use |::S|
+        to escape file names in case they contain special characters.
+        Environment variables are expanded |:set_env|.  See |option-backslash|
+        about including spaces and backslashes.
+        Note that a '|' must be escaped twice: once for ":set" and once for
+        the interpretation of a command.  When you use a filter called
+        "myfilter" do it like this: >vim
+            set makeprg=gmake\ \\\|\ myfilter
+<       The placeholder "$*" can be given (even multiple times) to specify
+        where the arguments will be included, for example: >vim
+            set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
+<       This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-	And any other file searched for with the |:runtime| command.
+                                                            *'matchpairs'* *'mps'*
+'matchpairs' 'mps'      string (default "(:),{:},[:]")
+                        local to buffer
+        Characters that form pairs.  The |%| command jumps from one to the
+        other.
+        Only character pairs are allowed that are different, thus you cannot
+        jump between two double quotes.
+        The characters must be separated by a colon.
+        The pairs must be separated by a comma.  Example for including '<' and
+        '>' (for HTML): >vim
+                set mps+=<:>
 
-	Defaults are setup to search these locations:
-	1. Your home directory, for personal preferences.
-	   Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
-	2. Directories which must contain configuration files according to
-	   |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
-	   preferences from system administrator.
-	3. Data home directory, for plugins installed by user.
-	   Given by `stdpath("data")/site`.  |$XDG_DATA_HOME|
-	4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
-	   This is for plugins which were installed by system administrator,
-	   but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
-	   to /usr/local/share/:/usr/share/, so system administrators are
-	   expected to install site plugins to /usr/share/nvim/site.
-	5. Session state directory, for state data such as swap, backupdir,
-	   viewdir, undodir, etc.
-	   Given by `stdpath("state")`.  |$XDG_STATE_HOME|
-	6. $VIMRUNTIME, for files distributed with Nvim.
-							*after-directory*
-	7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
-	   ordering.  This is for preferences to overrule or add to the
-	   distributed defaults or system-wide settings (rarely needed).
+<       A more exotic example, to jump between the '=' and ';' in an
+        assignment, useful for languages like C and Java: >vim
+                au FileType c,cpp,java set mps+==:;
 
-							*packages-runtimepath*
-	"start" packages will also be searched (|runtime-search-path|) for
-	runtime files after these, though such packages are not explicitly
-	reported in &runtimepath. But "opt" packages are explicitly added to
-	&runtimepath by |:packadd|.
+<       For a more advanced way of using "%", see the matchit.vim plugin in
+        the $VIMRUNTIME/plugin directory. |add-local-help|
 
-	Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
-	wildcards are allowed, but can significantly slow down searching for
-	runtime files.  For speed, use as few items as possible and avoid
-	wildcards.
-	See |:runtime|.
-	Example: >vim
-		set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
-<	This will use the directory "~/vimruntime" first (containing your
-	personal Nvim runtime files), then "/mygroup/vim", and finally
-	"$VIMRUNTIME" (the default runtime files).
-	You can put a directory before $VIMRUNTIME to find files which replace
-	distributed runtime files.  You can put a directory after $VIMRUNTIME
-	to find files which add to distributed runtime files.
+                                                             *'matchtime'* *'mat'*
+'matchtime' 'mat'       number (default 5)
+                        global
+        Tenths of a second to show the matching paren, when 'showmatch' is
+        set.  Note that this is not in milliseconds, like other options that
+        set a time.  This is to be compatible with Nvi.
 
-	With |--clean| the home directory entries are not included.
+                                                          *'maxfuncdepth'* *'mfd'*
+'maxfuncdepth' 'mfd'    number (default 100)
+                        global
+        Maximum depth of function calls for user functions.  This normally
+        catches endless recursion.  When using a recursive function with
+        more depth, set 'maxfuncdepth' to a bigger number.  But this will use
+        more memory, there is the danger of failing when memory is exhausted.
+        Increasing this limit above 200 also changes the maximum for Ex
+        command recursion, see |E169|.
+        See also |:function|.
+        Also used for maximum depth of callback functions.
 
-						*'scroll'* *'scr'*
-'scroll' 'scr'		number	(default half the window height)
-			local to window  |local-noglobal|
-	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
-	set to half the number of lines in the window when the window size
-	changes.  This may happen when enabling the |status-line| or
-	'tabline' option after setting the 'scroll' option.
-	If you give a count to the CTRL-U or CTRL-D command it will
-	be used as the new value for 'scroll'.  Reset to half the window
-	height with ":set scroll=0".
+                                                      *'maxmapdepth'* *'mmd'* *E223*
+'maxmapdepth' 'mmd'     number (default 1000)
+                        global
+        Maximum number of times a mapping is done without resulting in a
+        character to be used.  This normally catches endless mappings, like
+        ":map x y" with ":map y x".  It still does not catch ":map g wg",
+        because the 'w' is used before the next mapping is done.  See also
+        |key-mapping|.
 
-						*'scrollback'* *'scbk'*
-'scrollback' 'scbk'	number	(default 10000)
-			local to buffer
-	Maximum number of lines kept beyond the visible screen. Lines at the
-	top are deleted if new lines exceed this limit.
-	Minimum is 1, maximum is 100000.
-	Only in |terminal| buffers.
+                                                         *'maxmempattern'* *'mmp'*
+'maxmempattern' 'mmp'   number (default 1000)
+                        global
+        Maximum amount of memory (in Kbyte) to use for pattern matching.
+        The maximum value is about 2000000.  Use this to work without a limit.
+                                                        *E363*
+        When Vim runs into the limit it gives an error message and mostly
+        behaves like CTRL-C was typed.
+        Running into the limit often means that the pattern is very
+        inefficient or too complex.  This may already happen with the pattern
+        "\(.\)*" on a very long line.  ".*" works much better.
+        Might also happen on redraw, when syntax rules try to match a complex
+        text structure.
+        Vim may run out of memory before hitting the 'maxmempattern' limit, in
+        which case you get an "Out of memory" error instead.
 
-	Note: Lines that are not visible and kept in scrollback are not
-	reflown when the terminal buffer is resized horizontally.
+                                                             *'menuitems'* *'mis'*
+'menuitems' 'mis'       number (default 25)
+                        global
+        Maximum number of items to use in a menu.  Used for menus that are
+        generated from a list of items, e.g., the Buffers menu.  Changing this
+        option has no direct effect, the menu must be refreshed first.
 
-			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
-'scrollbind' 'scb'	boolean	(default off)
-			local to window
-	See also |scroll-binding|.  When this option is set, scrolling the
-	current window also scrolls other scrollbind windows (windows that
-	also have this option set).  This option is useful for viewing the
-	differences between two versions of a file, see 'diff'.
-	See |'scrollopt'| for options that determine how this option should be
-	interpreted.
-	This option is mostly reset when splitting a window to edit another
-	file.  This means that ":split | edit file" results in two windows
-	with scroll-binding, but ":split file" does not.
+                                                            *'mkspellmem'* *'msm'*
+'mkspellmem' 'msm'      string (default "460000,2000,500")
+                        global
+        Parameters for |:mkspell|.  This tunes when to start compressing the
+        word tree.  Compression can be slow when there are many words, but
+        it's needed to avoid running out of memory.  The amount of memory used
+        per word depends very much on how similar the words are, that's why
+        this tuning is complicated.
 
-						*'scrolljump'* *'sj'*
-'scrolljump' 'sj'	number	(default 1)
-			global
-	Minimal number of lines to scroll when the cursor gets off the
-	screen (e.g., with "j").  Not used for scroll commands (e.g., CTRL-E,
-	CTRL-D).  Useful if your terminal scrolls very slowly.
-	When set to a negative number from -1 to -100 this is used as the
-	percentage of the window height.  Thus -50 scrolls half the window
-	height.
-
-						*'scrolloff'* *'so'*
-'scrolloff' 'so'	number	(default 0)
-			global or local to window |global-local|
-	Minimal number of screen lines to keep above and below the cursor.
-	This will make some context visible around where you are working.  If
-	you set it to a very large value (999) the cursor line will always be
-	in the middle of the window (except at the start or end of the file or
-	when long lines wrap).
-	After using the local value, go back the global value with one of
-	these two: >vim
-		setlocal scrolloff<
-		setlocal scrolloff=-1
-<	For scrolling horizontally see 'sidescrolloff'.
-
-						*'scrollopt'* *'sbo'*
-'scrollopt' 'sbo'	string	(default "ver,jump")
-			global
-	This is a comma-separated list of words that specifies how
-	'scrollbind' windows should behave.  'sbo' stands for ScrollBind
-	Options.
-	The following words are available:
-	    ver		Bind vertical scrolling for 'scrollbind' windows
-	    hor		Bind horizontal scrolling for 'scrollbind' windows
-	    jump	Applies to the offset between two windows for vertical
-			scrolling.  This offset is the difference in the first
-			displayed line of the bound windows.  When moving
-			around in a window, another 'scrollbind' window may
-			reach a position before the start or after the end of
-			the buffer.  The offset is not changed though, when
-			moving back the 'scrollbind' window will try to scroll
-			to the desired position when possible.
-			When now making that window the current one, two
-			things can be done with the relative offset:
-			1. When "jump" is not included, the relative offset is
-			   adjusted for the scroll position in the new current
-			   window.  When going back to the other window, the
-			   new relative offset will be used.
-			2. When "jump" is included, the other windows are
-			   scrolled to keep the same relative offset.  When
-			   going back to the other window, it still uses the
-			   same relative offset.
-	Also see |scroll-binding|.
-	When 'diff' mode is active there always is vertical scroll binding,
-	even when "ver" isn't there.
-
-						*'sections'* *'sect'*
-'sections' 'sect'	string	(default "SHNHH HUnhsh")
-			global
-	Specifies the nroff macros that separate sections.  These are pairs of
-	two letters (See |object-motions|).  The default makes a section start
-	at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
-
-						*'selection'* *'sel'*
-'selection' 'sel'	string	(default "inclusive")
-			global
-	This option defines the behavior of the selection.  It is only used
-	in Visual and Select mode.
-	Possible values:
-	   value	past line     inclusive ~
-	   old		   no		yes
-	   inclusive	   yes		yes
-	   exclusive	   yes		no
-	"past line" means that the cursor is allowed to be positioned one
-	character past the line.
-	"inclusive" means that the last character of the selection is included
-	in an operation.  For example, when "x" is used to delete the
-	selection.
-	When "old" is used and 'virtualedit' allows the cursor to move past
-	the end of line the line break still isn't included.
-	Note that when "exclusive" is used and selecting from the end
-	backwards, you cannot include the last character of a line, when
-	starting in Normal mode and 'virtualedit' empty.
-
-						*'selectmode'* *'slm'*
-'selectmode' 'slm'	string	(default "")
-			global
-	This is a comma-separated list of words, which specifies when to start
-	Select mode instead of Visual mode, when a selection is started.
-	Possible values:
-	   mouse	when using the mouse
-	   key		when using shifted special keys
-	   cmd		when using "v", "V" or CTRL-V
-	See |Select-mode|.
-
-					*'sessionoptions'* *'ssop'*
-'sessionoptions' 'ssop'	string	(default "blank,buffers,curdir,folds,help,tabpages,winsize,terminal")
-			global
-	Changes the effect of the |:mksession| command.  It is a comma-
-	separated list of words.  Each word enables saving and restoring
-	something:
-	   word		save and restore ~
-	   blank	empty windows
-	   buffers	hidden and unloaded buffers, not just those in windows
-	   curdir	the current directory
-	   folds	manually created folds, opened/closed folds and local
-			fold options
-	   globals	global variables that start with an uppercase letter
-			and contain at least one lowercase letter.  Only
-			String and Number types are stored.
-	   help		the help window
-	   localoptions	options and mappings local to a window or buffer (not
-			global values for local options)
-	   options	all options and mappings (also global values for local
-			options)
-	   skiprtp	exclude 'runtimepath' and 'packpath' from the options
-	   resize	size of the Vim window: 'lines' and 'columns'
-	   sesdir	the directory in which the session file is located
-			will become the current directory (useful with
-			projects accessed over a network from different
-			systems)
-	   tabpages	all tab pages; without this only the current tab page
-			is restored, so that you can make a session for each
-			tab page separately
-	   terminal	include terminal windows where the command can be
-			restored
-	   winpos	position of the whole Vim window
-	   winsize	window sizes
-	   slash	|deprecated| Always enabled. Uses "/" in filenames.
-	   unix		|deprecated| Always enabled. Uses "\n" line endings.
-
-	Don't include both "curdir" and "sesdir". When neither is included
-	filenames are stored as absolute paths.
-	If you leave out "options" many things won't work well after restoring
-	the session.
-
-					*'shada'* *'sd'* *E526* *E527* *E528*
-'shada' 'sd'		string	(default for
-                                   Win32:  !,'100,<50,s10,h,rA:,rB:
-                                   others: !,'100,<50,s10,h)
-			global
-	When non-empty, the shada file is read upon startup and written
-	when exiting Vim (see |shada-file|).  The string should be a comma-
-	separated list of parameters, each consisting of a single character
-	identifying the particular parameter, followed by a number or string
-	which specifies the value of that parameter.  If a particular
-	character is left out, then the default value is used for that
-	parameter.  The following is a list of the identifying characters and
-	the effect of their value.
-	CHAR	VALUE	~
-							*shada-!*
-	!	When included, save and restore global variables that start
-		with an uppercase letter, and don't contain a lowercase
-		letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
-		and "_K_L_M" are not.  Nested List and Dict items may not be
-		read back correctly, you end up with an empty item.
-							*shada-quote*
-	"	Maximum number of lines saved for each register.  Old name of
-		the '<' item, with the disadvantage that you need to put a
-		backslash before the ", otherwise it will be recognized as the
-		start of a comment!
-							*shada-%*
-	%	When included, save and restore the buffer list.  If Vim is
-		started with a file name argument, the buffer list is not
-		restored.  If Vim is started without a file name argument, the
-		buffer list is restored from the shada file.  Quickfix
-		('buftype'), unlisted ('buflisted'), unnamed and buffers on
-		removable media (|shada-r|) are not saved.
-		When followed by a number, the number specifies the maximum
-		number of buffers that are stored.  Without a number all
-		buffers are stored.
-							*shada-'*
-	'	Maximum number of previously edited files for which the marks
-		are remembered.  This parameter must always be included when
-		'shada' is non-empty.
-		Including this item also means that the |jumplist| and the
-		|changelist| are stored in the shada file.
-							*shada-/*
-	/	Maximum number of items in the search pattern history to be
-		saved.  If non-zero, then the previous search and substitute
-		patterns are also saved.  When not included, the value of
-		'history' is used.
-							*shada-:*
-	:	Maximum number of items in the command-line history to be
-		saved.  When not included, the value of 'history' is used.
-							*shada-<*
-	<	Maximum number of lines saved for each register.  If zero then
-		registers are not saved.  When not included, all lines are
-		saved.  '"' is the old name for this item.
-		Also see the 's' item below: limit specified in KiB.
-							*shada-@*
-	@	Maximum number of items in the input-line history to be
-		saved.  When not included, the value of 'history' is used.
-							*shada-c*
-	c	Dummy option, kept for compatibility reasons.  Has no actual
-		effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
-		to UTF-8 as well.
-							*shada-f*
-	f	Whether file marks need to be stored.  If zero, file marks ('0
-		to '9, 'A to 'Z) are not stored.  When not present or when
-		non-zero, they are all stored.  '0 is used for the current
-		cursor position (when exiting or when doing |:wshada|).
-							*shada-h*
-	h	Disable the effect of 'hlsearch' when loading the shada
-		file.  When not included, it depends on whether ":nohlsearch"
-		has been used since the last search command.
-							*shada-n*
-	n	Name of the shada file.  The name must immediately follow
-		the 'n'.  Must be at the end of the option!  If the
-		'shadafile' option is set, that file name overrides the one
-		given here with 'shada'.  Environment variables are
-		expanded when opening the file, not when setting the option.
-							*shada-r*
-	r	Removable media.  The argument is a string (up to the next
-		',').  This parameter can be given several times.  Each
-		specifies the start of a path for which no marks will be
-		stored.  This is to avoid removable media.  For Windows you
-		could use "ra:,rb:".  You can also use it for temp files,
-		e.g., for Unix: "r/tmp".  Case is ignored.
-							*shada-s*
-	s	Maximum size of an item contents in KiB.  If zero then nothing
-		is saved.  Unlike Vim this applies to all items, except for
-		the buffer list and header.  Full item size is off by three
-		unsigned integers: with `s10` maximum item size may be 1 byte
-		(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
-		integer) + 3 bytes (item size: up to 16-bit integer because
-		2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
-		contents size) = 10253 bytes.
-
-	Example: >vim
-	    set shada='50,<1000,s100,:0,n~/nvim/shada
+        There are three numbers, separated by commas: >
+                {start},{inc},{added}
 <
-	'50		Marks will be remembered for the last 50 files you
-			edited.
-	<1000		Contents of registers (up to 1000 lines each) will be
-			remembered.
-	s100		Items with contents occupying more then 100 KiB are
-			skipped.
-	:0		Command-line history will not be saved.
-	n~/nvim/shada	The name of the file to use is "~/nvim/shada".
-	no /		Since '/' is not specified, the default will be used,
-			that is, save all of the search history, and also the
-			previous search and substitute patterns.
-	no %		The buffer list will not be saved nor read back.
-	no h		'hlsearch' highlighting will be restored.
+        For most languages the uncompressed word tree fits in memory.  {start}
+        gives the amount of memory in Kbyte that can be used before any
+        compression is done.  It should be a bit smaller than the amount of
+        memory that is available to Vim.
 
-	When setting 'shada' from an empty value you can use |:rshada| to
-	load the contents of the file, this is not done automatically.
+        When going over the {start} limit the {inc} number specifies the
+        amount of memory in Kbyte that can be allocated before another
+        compression is done.  A low number means compression is done after
+        less words are added, which is slow.  A high number means more memory
+        will be allocated.
 
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+        After doing compression, {added} times 1024 words can be added before
+        the {inc} limit is ignored and compression is done when any extra
+        amount of memory is needed.  A low number means there is a smaller
+        chance of hitting the {inc} limit, less memory is used but it's
+        slower.
 
-						*'shadafile'* *'sdf'*
-'shadafile' 'sdf'	string	(default "")
-			global
-	When non-empty, overrides the file name used for |shada| (viminfo).
-	When equal to "NONE" no shada file will be read or written.
-	This option can be set with the |-i| command line flag.  The |--clean|
-	command line flag sets it to "NONE".
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+        The languages for which these numbers are important are Italian and
+        Hungarian.  The default works for when you have about 512 Mbyte.  If
+        you have 1 Gbyte you could use: >vim
+                set mkspellmem=900000,3000,800
+<       If you have less than 512 Mbyte |:mkspell| may fail for some
+        languages, no matter what you set 'mkspellmem' to.
 
-						*'shell'* *'sh'* *E91*
-'shell' 'sh'		string	(default $SHELL or "sh", Win32: "cmd.exe")
-			global
-	Name of the shell to use for ! and :! commands.  When changing the
-	value also check these options: 'shellpipe', 'shellslash'
-	'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
-	It is allowed to give an argument to the command, e.g.  "csh -f".
-	See |option-backslash| about including spaces and backslashes.
-	Environment variables are expanded |:set_env|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-	If the name of the shell contains a space, you need to enclose it in
-	quotes.  Example with quotes: >vim
-		set shell=\"c:\program\ files\unix\sh.exe\"\ -f
-<	Note the backslash before each quote (to avoid starting a comment) and
-	each space (to avoid ending the option value), so better use |:let-&|
-	like this: >vim
-		let &shell='"C:\Program Files\unix\sh.exe" -f'
-<	Also note that the "-f" is not inside the quotes, because it is not
-	part of the command name.
-							*shell-unquoting*
-	Rules regarding quotes:
-	1. Option is split on space and tab characters that are not inside
-	   quotes: "abc def" runs shell named "abc" with additional argument
-	   "def", '"abc def"' runs shell named "abc def" with no additional
-	   arguments (here and below: additional means “additional to
-	   'shellcmdflag'”).
-	2. Quotes in option may be present in any position and any number:
-	   '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
-	   to just "abc".
-	3. Inside quotes backslash preceding backslash means one backslash.
-	   Backslash preceding quote means one quote. Backslash preceding
-	   anything else means backslash and next character literally:
-	   '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
-	   'a"b', '"a\b"' is the same as "a\b" again.
-	4. Outside of quotes backslash always means itself, it cannot be used
-	   to escape quote: 'a\"b"' is the same as "a\b".
-	Note that such processing is done after |:set| did its own round of
-	unescaping, so to keep yourself sane use |:let-&| like shown above.
-							*shell-powershell*
-	To use PowerShell: >vim
-		let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-		let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
-		let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-		let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
-		set shellquote= shellxquote=
+                                           *'modeline'* *'ml'* *'nomodeline'* *'noml'*
+'modeline' 'ml'         boolean (default on (off for root))
+                        local to buffer
+        If 'modeline' is on 'modelines' gives the number of lines that is
+        checked for set commands.  If 'modeline' is off or 'modelines' is zero
+        no lines are checked.  See |modeline|.
 
-<	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                 *'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
+'modelineexpr' 'mle'    boolean (default off)
+                        global
+        When on allow some options that are an expression to be set in the
+        modeline.  Check the option for whether it is affected by
+        'modelineexpr'.  Also see |modeline|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'shellcmdflag'* *'shcf'*
-'shellcmdflag' 'shcf'	string	(default "-c"; Windows: "/s /c")
-			global
-	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-	`bash.exe -c ls` or `cmd.exe /s /c "dir"`.  For MS-Windows, the
-	default is set according to the value of 'shell', to reduce the need
-	to set this option by the user.
-	On Unix it can have more than one flag.  Each white space separated
-	part is passed as an argument to the shell command.
-	See |option-backslash| about including spaces and backslashes.
-	See |shell-unquoting| which talks about separating this option into
-	multiple arguments.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                             *'modelines'* *'mls'*
+'modelines' 'mls'       number (default 5)
+                        global
+        If 'modeline' is on 'modelines' gives the number of lines that is
+        checked for set commands.  If 'modeline' is off or 'modelines' is zero
+        no lines are checked.  See |modeline|.
 
-						*'shellpipe'* *'sp'*
-'shellpipe' 'sp'	string	(default ">", "| tee", "|& tee" or "2>&1| tee")
-			global
-	String to be used to put the output of the ":make" command in the
-	error file.  See also |:make_makeprg|.  See |option-backslash| about
-	including spaces and backslashes.
-	The name of the temporary file can be represented by "%s" if necessary
-	(the file name is appended automatically if no %s appears in the value
-	of this option).
-	For MS-Windows the default is "2>&1| tee".  The stdout and stderr are
-	saved in a file and echoed to the screen.
-	For Unix the default is "| tee".  The stdout of the compiler is saved
-	in a file and echoed to the screen.  If the 'shell' option is "csh" or
-	"tcsh" after initializations, the default becomes "|& tee".  If the
-	'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
-	"bash", "fish", "ash" or "dash" the default becomes "2>&1| tee".  This
-	means that stderr is also included.  Before using the 'shell' option a
-	path is removed, thus "/bin/sh" uses "sh".
-	The initialization of this option is done after reading the vimrc
-	and the other initializations, so that when the 'shell' option is set
-	there, the 'shellpipe' option changes automatically, unless it was
-	explicitly set before.
-	When 'shellpipe' is set to an empty string, no redirection of the
-	":make" output will be done.  This is useful if you use a 'makeprg'
-	that writes to 'makeef' by itself.  If you want no piping, but do
-	want to include the 'makeef', set 'shellpipe' to a single space.
-	Don't forget to precede the space with a backslash: ":set sp=\ ".
-	In the future pipes may be used for filtering and this option will
-	become obsolete (at least for Unix).
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
 
-						*'shellquote'* *'shq'*
-'shellquote' 'shq'	string	(default ""; Windows, when 'shell'
+                                   *'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
+'modifiable' 'ma'       boolean (default on)
+                        local to buffer
+        When off the buffer contents cannot be changed.  The 'fileformat' and
+        'fileencoding' options also can't be changed.
+        Can be reset on startup with the |-M| command line argument.
+
+                                         *'modified'* *'mod'* *'nomodified'* *'nomod'*
+'modified' 'mod'        boolean (default off)
+                        local to buffer  |local-noglobal|
+        When on, the buffer is considered to be modified.  This option is set
+        when:
+        1. A change was made to the text since it was last written.  Using the
+           |undo| command to go back to the original text will reset the
+           option.  But undoing changes that were made before writing the
+           buffer will set the option again, since the text is different from
+           when it was written.
+        2. 'fileformat' or 'fileencoding' is different from its original
+           value.  The original value is set when the buffer is read or
+           written.  A ":set nomodified" command also resets the original
+           values to the current values and the 'modified' option will be
+           reset.
+           Similarly for 'eol' and 'bomb'.
+        This option is not set when a change is made to the buffer as the
+        result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
+        FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
+        an explanation.
+        When 'buftype' is "nowrite" or "nofile" this option may be set, but
+        will be ignored.
+        Note that the text may actually be the same, e.g. 'modified' is set
+        when using "rA" on an "A".
+
+                                                               *'more'* *'nomore'*
+'more'                  boolean (default on)
+                        global
+        When on, listings pause when the whole screen is filled.  You will get
+        the |more-prompt|.  When this option is off there are no pauses, the
+        listing continues until finished.
+
+                                                                       *'mouse'*
+'mouse'                 string (default "nvi")
+                        global
+        Enables mouse support. For example, to enable the mouse in Normal mode
+        and Visual mode: >vim
+                set mouse=nv
+<
+        To temporarily disable mouse support, hold the shift key while using
+        the mouse.
+
+        Mouse support can be enabled for different modes:
+                n       Normal mode
+                v       Visual mode
+                i       Insert mode
+                c       Command-line mode
+                h       all previous modes when editing a help file
+                a       all previous modes
+                r       for |hit-enter| and |more-prompt| prompt
+
+        Left-click anywhere in a text buffer to place the cursor there.  This
+        works with operators too, e.g. type |d| then left-click to delete text
+        from the current cursor position to the position where you clicked.
+
+        Drag the |status-line| or vertical separator of a window to resize it.
+
+        If enabled for "v" (Visual mode) then double-click selects word-wise,
+        triple-click makes it line-wise, and quadruple-click makes it
+        rectangular block-wise.
+
+        For scrolling with a mouse wheel see |scroll-mouse-wheel|.
+
+        Note: When enabling the mouse in a terminal, copy/paste will use the
+        "* register if possible. See also 'clipboard'.
+
+        Related options:
+        'mousefocus'    window focus follows mouse pointer
+        'mousemodel'    what mouse button does which action
+        'mousehide'     hide mouse pointer while typing text
+        'selectmode'    whether to start Select mode or Visual mode
+
+                               *'mousefocus'* *'mousef'* *'nomousefocus'* *'nomousef'*
+'mousefocus' 'mousef'   boolean (default off)
+                        global
+        The window that the mouse pointer is on is automatically activated.
+        When changing the window layout or window focus in another way, the
+        mouse pointer is moved to the window with keyboard focus.  Off is the
+        default because it makes using the pull down menus a little goofy, as
+        a pointer transit may activate a window unintentionally.
+
+                                         *'mousehide'* *'mh'* *'nomousehide'* *'nomh'*
+'mousehide' 'mh'        boolean (default on)
+                        global
+        only in the GUI
+        When on, the mouse pointer is hidden when characters are typed.
+        The mouse pointer is restored when the mouse is moved.
+
+                                                         *'mousemodel'* *'mousem'*
+'mousemodel' 'mousem'   string (default "popup_setpos")
+                        global
+        Sets the model to use for the mouse.  The name mostly specifies what
+        the right mouse button is used for:
+           extend       Right mouse button extends a selection.  This works
+                        like in an xterm.
+           popup        Right mouse button pops up a menu.  The shifted left
+                        mouse button extends a selection.  This works like
+                        with Microsoft Windows.
+           popup_setpos Like "popup", but the cursor will be moved to the
+                        position where the mouse was clicked, and thus the
+                        selected operation will act upon the clicked object.
+                        If clicking inside a selection, that selection will
+                        be acted upon, i.e. no cursor move.  This implies of
+                        course, that right clicking outside a selection will
+                        end Visual mode.
+        Overview of what button does what for each model:
+        mouse               extend              popup(_setpos) ~
+        left click          place cursor        place cursor
+        left drag           start selection     start selection
+        shift-left          search word         extend selection
+        right click         extend selection    popup menu (place cursor)
+        right drag          extend selection    -
+        middle click        paste               paste
+
+        In the "popup" model the right mouse button produces a pop-up menu.
+        Nvim creates a default |popup-menu| but you can redefine it.
+
+        Note that you can further refine the meaning of buttons with mappings.
+        See |mouse-overview|.  But mappings are NOT used for modeless selection.
+
+        Example: >vim
+            map <S-LeftMouse>     <RightMouse>
+            map <S-LeftDrag>      <RightDrag>
+            map <S-LeftRelease>   <RightRelease>
+            map <2-S-LeftMouse>   <2-RightMouse>
+            map <2-S-LeftDrag>    <2-RightDrag>
+            map <2-S-LeftRelease> <2-RightRelease>
+            map <3-S-LeftMouse>   <3-RightMouse>
+            map <3-S-LeftDrag>    <3-RightDrag>
+            map <3-S-LeftRelease> <3-RightRelease>
+            map <4-S-LeftMouse>   <4-RightMouse>
+            map <4-S-LeftDrag>    <4-RightDrag>
+            map <4-S-LeftRelease> <4-RightRelease>
+<
+        Mouse commands requiring the CTRL modifier can be simulated by typing
+        the "g" key before using the mouse:
+            "g<LeftMouse>"  is "<C-LeftMouse>   (jump to tag under mouse click)
+            "g<RightMouse>" is "<C-RightMouse>  ("CTRL-T")
+
+                   *'mousemoveevent'* *'mousemev'* *'nomousemoveevent'* *'nomousemev'*
+'mousemoveevent' 'mousemev' boolean (default off)
+                        global
+        When on, mouse move events are delivered to the input queue and are
+        available for mapping. The default, off, avoids the mouse movement
+        overhead except when needed.
+        Warning: Setting this option can make pending mappings to be aborted
+        when the mouse is moved.
+
+                                                           *'mousescroll'* *E5080*
+'mousescroll'           string (default "ver:3,hor:6")
+                        global
+        This option controls the number of lines / columns to scroll by when
+        scrolling with a mouse wheel (|scroll-mouse-wheel|). The option is
+        a comma-separated list. Each part consists of a direction and a count
+        as follows:
+                direction:count,direction:count
+        Direction is one of either "hor" or "ver". "hor" controls horizontal
+        scrolling and "ver" controls vertical scrolling. Count sets the amount
+        to scroll by for the given direction, it should be a non negative
+        integer. Each direction should be set at most once. If a direction
+        is omitted, a default value is used (6 for horizontal scrolling and 3
+        for vertical scrolling). You can disable mouse scrolling by using
+        a count of 0.
+
+        Example: >vim
+                set mousescroll=ver:5,hor:2
+<       Will make Nvim scroll 5 lines at a time when scrolling vertically, and
+        scroll 2 columns at a time when scrolling horizontally.
+
+                                                    *'mouseshape'* *'mouses'* *E547*
+'mouseshape' 'mouses'   string (default "i:beam,r:beam,s:updown,sd:cross,
+                                         m:no,ml:up-arrow,v:rightup-arrow")
+                        global
+        This option tells Vim what the mouse pointer should look like in
+        different modes.  The option is a comma-separated list of parts, much
+        like used for 'guicursor'.  Each part consist of a mode/location-list
+        and an argument-list:
+                mode-list:shape,mode-list:shape,..
+        The mode-list is a dash separated list of these modes/locations:
+                        In a normal window: ~
+                n       Normal mode
+                v       Visual mode
+                ve      Visual mode with 'selection' "exclusive" (same as 'v',
+                        if not specified)
+                o       Operator-pending mode
+                i       Insert mode
+                r       Replace mode
+
+                        Others: ~
+                c       appending to the command-line
+                ci      inserting in the command-line
+                cr      replacing in the command-line
+                m       at the 'Hit ENTER' or 'More' prompts
+                ml      idem, but cursor in the last line
+                e       any mode, pointer below last window
+                s       any mode, pointer on a status line
+                sd      any mode, while dragging a status line
+                vs      any mode, pointer on a vertical separator line
+                vd      any mode, while dragging a vertical separator line
+                a       everywhere
+
+        The shape is one of the following:
+        avail   name            looks like ~
+        w x     arrow           Normal mouse pointer
+        w x     blank           no pointer at all (use with care!)
+        w x     beam            I-beam
+        w x     updown          up-down sizing arrows
+        w x     leftright       left-right sizing arrows
+        w x     busy            The system's usual busy pointer
+        w x     no              The system's usual "no input" pointer
+          x     udsizing        indicates up-down resizing
+          x     lrsizing        indicates left-right resizing
+          x     crosshair       like a big thin +
+          x     hand1           black hand
+          x     hand2           white hand
+          x     pencil          what you write with
+          x     question        big ?
+          x     rightup-arrow   arrow pointing right-up
+        w x     up-arrow        arrow pointing up
+          x     <number>        any X11 pointer number (see X11/cursorfont.h)
+
+        The "avail" column contains a 'w' if the shape is available for Win32,
+        x for X11.
+        Any modes not specified or shapes not available use the normal mouse
+        pointer.
+
+        Example: >vim
+                set mouseshape=s:udsizing,m:no
+<       will make the mouse turn to a sizing arrow over the status lines and
+        indicate no input when the hit-enter prompt is displayed (since
+        clicking the mouse has no effect in this state.)
+
+                                                          *'mousetime'* *'mouset'*
+'mousetime' 'mouset'    number (default 500)
+                        global
+        Defines the maximum time in msec between two mouse clicks for the
+        second click to be recognized as a multi click.
+
+                                                              *'nrformats'* *'nf'*
+'nrformats' 'nf'        string (default "bin,hex")
+                        local to buffer
+        This defines what bases Vim will consider for numbers when using the
+        CTRL-A and CTRL-X commands for adding to and subtracting from a number
+        respectively; see |CTRL-A| for more info on these commands.
+        alpha   If included, single alphabetical characters will be
+                incremented or decremented.  This is useful for a list with a
+                letter index a), b), etc.               *octal-nrformats*
+        octal   If included, numbers that start with a zero will be considered
+                to be octal.  Example: Using CTRL-A on "007" results in "010".
+        hex     If included, numbers starting with "0x" or "0X" will be
+                considered to be hexadecimal.  Example: Using CTRL-X on
+                "0x100" results in "0x0ff".
+        bin     If included, numbers starting with "0b" or "0B" will be
+                considered to be binary.  Example: Using CTRL-X on
+                "0b1000" subtracts one, resulting in "0b0111".
+        unsigned    If included, numbers are recognized as unsigned. Thus a
+                leading dash or negative sign won't be considered as part of
+                the number.  Examples:
+                    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
+                    (without "unsigned" it would become "9-2021").
+                    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
+                    (without "unsigned" it would become "9-2019").
+                    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
+                    (2^64 - 1) has no effect, overflow is prevented.
+        Numbers which simply begin with a digit in the range 1-9 are always
+        considered decimal.  This also happens for numbers that are not
+        recognized as octal or hex.
+
+                                               *'number'* *'nu'* *'nonumber'* *'nonu'*
+'number' 'nu'           boolean (default off)
+                        local to window
+        Print the line number in front of each line.  When the 'n' option is
+        excluded from 'cpoptions' a wrapped line will not use the column of
+        line numbers.
+        Use the 'numberwidth' option to adjust the room for the line number.
+        When a long, wrapped line doesn't start with the first character, '-'
+        characters are put before the number.
+        For highlighting see |hl-LineNr|, |hl-CursorLineNr|, and the
+        |:sign-define| "numhl" argument.
+                                                *number_relativenumber*
+        The 'relativenumber' option changes the displayed number to be
+        relative to the cursor.  Together with 'number' there are these
+        four combinations (cursor in line 3):
+
+                'nonu'          'nu'            'nonu'          'nu'
+                'nornu'         'nornu'         'rnu'           'rnu'
+        >
+            |apple          |  1 apple      |  2 apple      |  2 apple
+            |pear           |  2 pear       |  1 pear       |  1 pear
+            |nobody         |  3 nobody     |  0 nobody     |3   nobody
+            |there          |  4 there      |  1 there      |  1 there
+<
+
+                                                           *'numberwidth'* *'nuw'*
+'numberwidth' 'nuw'     number (default 4)
+                        local to window
+        Minimal number of columns to use for the line number.  Only relevant
+        when the 'number' or 'relativenumber' option is set or printing lines
+        with a line number. Since one space is always between the number and
+        the text, there is one less character for the number itself.
+        The value is the minimum width.  A bigger width is used when needed to
+        fit the highest line number in the buffer respectively the number of
+        rows in the window, depending on whether 'number' or 'relativenumber'
+        is set. Thus with the Vim default of 4 there is room for a line number
+        up to 999. When the buffer has 1000 lines five columns will be used.
+        The minimum value is 1, the maximum value is 20.
+
+                                                              *'omnifunc'* *'ofu'*
+'omnifunc' 'ofu'        string (default "")
+                        local to buffer
+        This option specifies a function to be used for Insert mode omni
+        completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
+        See |complete-functions| for an explanation of how the function is
+        invoked and what it should return.  The value can be the name of a
+        function, a |lambda| or a |Funcref|. See |option-value-function| for
+        more information.
+        This option is usually set by a filetype plugin:
+        |:filetype-plugin-on|
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                   *'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
+'opendevice' 'odev'     boolean (default off)
+                        global
+        only for Windows
+        Enable reading and writing from devices.  This may get Vim stuck on a
+        device that can be opened but doesn't actually do the I/O.  Therefore
+        it is off by default.
+        Note that on Windows editing "aux.h", "lpt1.txt" and the like also
+        result in editing a device.
+
+                                                       *'operatorfunc'* *'opfunc'*
+'operatorfunc' 'opfunc' string (default "")
+                        global
+        This option specifies a function to be called by the |g@| operator.
+        See |:map-operator| for more info and an example.  The value can be
+        the name of a function, a |lambda| or a |Funcref|. See
+        |option-value-function| for more information.
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                               *'packpath'* *'pp'*
+'packpath' 'pp'         string (default see 'runtimepath')
+                        global
+        Directories used to find packages.
+        See |packages| and |packages-runtimepath|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                           *'paragraphs'* *'para'*
+'paragraphs' 'para'     string (default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
+                        global
+        Specifies the nroff macros that separate paragraphs.  These are pairs
+        of two letters (see |object-motions|).
+
+                                                             *'patchexpr'* *'pex'*
+'patchexpr' 'pex'       string (default "")
+                        global
+        Expression which is evaluated to apply a patch to a file and generate
+        the resulting new version of the file.  See |diff-patchexpr|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                    *'patchmode'* *'pm'* *E205* *E206*
+'patchmode' 'pm'        string (default "")
+                        global
+        When non-empty the oldest version of a file is kept.  This can be used
+        to keep the original version of a file if you are changing files in a
+        source distribution.  Only the first time that a file is written a
+        copy of the original file will be kept.  The name of the copy is the
+        name of the original file with the string in the 'patchmode' option
+        appended.  This option should start with a dot.  Use a string like
+        ".orig" or ".org".  'backupdir' must not be empty for this to work
+        (Detail: The backup file is renamed to the patchmode file after the
+        new file has been successfully written, that's why it must be possible
+        to write a backup file).  If there was no file to be backed up, an
+        empty file is created.
+        When the 'backupskip' pattern matches, a patchmode file is not made.
+        Using 'patchmode' for compressed files appends the extension at the
+        end (e.g., "file.gz.orig"), thus the resulting name isn't always
+        recognized as a compressed file.
+        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+
+                                               *'path'* *'pa'* *E343* *E345* *E347* *E854*
+'path' 'pa'             string (default ".,,")
+                        global or local to buffer |global-local|
+        This is a list of directories which will be searched when using the
+        |gf|, [f, ]f, ^Wf, |:find|, |:sfind|, |:tabfind| and other commands,
+        provided that the file being searched for has a relative path (not
+        starting with "/", "./" or "../").  The directories in the 'path'
+        option may be relative or absolute.
+        - Use commas to separate directory names: >vim
+                set path=.,/usr/local/include,/usr/include
+<       - Spaces can also be used to separate directory names.  To have a
+          space in a directory name, precede it with an extra backslash, and
+          escape the space: >vim
+                set path=.,/dir/with\\\ space
+<       - To include a comma in a directory name precede it with an extra
+          backslash: >vim
+                set path=.,/dir/with\\,comma
+<       - To search relative to the directory of the current file, use: >vim
+                set path=.
+<       - To search in the current directory use an empty string between two
+          commas: >vim
+                set path=,,
+<       - A directory name may end in a ':' or '/'.
+        - Environment variables are expanded |:set_env|.
+        - When using |netrw.vim| URLs can be used.  For example, adding
+          "https://www.vim.org" will make ":find index.html" work.
+        - Search upwards and downwards in a directory tree using "*", "**" and
+          ";".  See |file-searching| for info and syntax.
+        - Careful with '\' characters, type two to get one in the option: >vim
+                set path=.,c:\\include
+<         Or just use '/' instead: >vim
+                set path=.,c:/include
+<       Don't forget "." or files won't even be found in the same directory as
+        the file!
+        The maximum length is limited.  How much depends on the system, mostly
+        it is something like 256 or 1024 characters.
+        You can check if all the include files are found, using the value of
+        'path', see |:checkpath|.
+        The use of |:set+=| and |:set-=| is preferred when adding or removing
+        directories from the list.  This avoids problems when a future version
+        uses another default.  To remove the current directory use: >vim
+                set path-=
+<       To add the current directory use: >vim
+                set path+=
+<       To use an environment variable, you probably need to replace the
+        separator.  Here is an example to append $INCL, in which directory
+        names are separated with a semi-colon: >vim
+                let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
+<       Replace the ';' with a ':' or whatever separator is used.  Note that
+        this doesn't work when $INCL contains a comma or white space.
+
+                               *'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
+'preserveindent' 'pi'   boolean (default off)
+                        local to buffer
+        When changing the indent of the current line, preserve as much of the
+        indent structure as possible.  Normally the indent is replaced by a
+        series of tabs followed by spaces as required (unless |'expandtab'| is
+        enabled, in which case only spaces are used).  Enabling this option
+        means the indent will preserve as many existing characters as possible
+        for indenting, and only add additional tabs or spaces as required.
+        'expandtab' does not apply to the preserved white space, a Tab remains
+        a Tab.
+        NOTE: When using ">>" multiple times the resulting indent is a mix of
+        tabs and spaces.  You might not like this.
+        Also see 'copyindent'.
+        Use |:retab| to clean up white space.
+
+                                                         *'previewheight'* *'pvh'*
+'previewheight' 'pvh'   number (default 12)
+                        global
+        Default height for a preview window.  Used for |:ptag| and associated
+        commands.  Used for |CTRL-W_}| when no count is given.
+
+                          *'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
+'previewwindow' 'pvw'   boolean (default off)
+                        local to window  |local-noglobal|
+        Identifies the preview window.  Only one window can have this option
+        set.  It's normally not set directly, but by using one of the commands
+        |:ptag|, |:pedit|, etc.
+
+                                                               *'pumblend'* *'pb'*
+'pumblend' 'pb'         number (default 0)
+                        global
+        Enables pseudo-transparency for the |popup-menu|. Valid values are in
+        the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
+        transparent background. Values between 0-30 are typically most useful.
+
+        It is possible to override the level for individual highlights within
+        the popupmenu using |highlight-blend|. For instance, to enable
+        transparency but force the current selected element to be fully opaque: >vim
+
+                set pumblend=15
+                hi PmenuSel blend=0
+<
+        UI-dependent. Works best with RGB colors. 'termguicolors'
+
+                                                              *'pumheight'* *'ph'*
+'pumheight' 'ph'        number (default 0)
+                        global
+        Maximum number of items to show in the popup menu
+        (|ins-completion-menu|). Zero means "use available screen space".
+
+                                                               *'pumwidth'* *'pw'*
+'pumwidth' 'pw'         number (default 15)
+                        global
+        Minimum width for the popup menu (|ins-completion-menu|).  If the
+        cursor column + 'pumwidth' exceeds screen width, the popup menu is
+        nudged to fit on the screen.
+
+                                                            *'pyxversion'* *'pyx'*
+'pyxversion' 'pyx'      number (default 3)
+                        global
+        Specifies the python version used for pyx* functions and commands
+        |python_x|.  As only Python 3 is supported, this always has the value
+        `3`. Setting any other value is an error.
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                     *'quickfixtextfunc'* *'qftf'*
+'quickfixtextfunc' 'qftf' string (default "")
+                        global
+        This option specifies a function to be used to get the text to display
+        in the quickfix and location list windows.  This can be used to
+        customize the information displayed in the quickfix or location window
+        for each entry in the corresponding quickfix or location list.  See
+        |quickfix-window-function| for an explanation of how to write the
+        function and an example.  The value can be the name of a function, a
+        |lambda| or a |Funcref|. See |option-value-function| for more
+        information.
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                            *'quoteescape'* *'qe'*
+'quoteescape' 'qe'      string (default "\")
+                        local to buffer
+        The characters that are used to escape quotes in a string.  Used for
+        objects like a', a" and a` |a'|.
+        When one of the characters in this option is found inside a string,
+        the following character will be skipped.  The default value makes the
+        text "foo\"bar\\" considered to be one string.
+
+                                           *'readonly'* *'ro'* *'noreadonly'* *'noro'*
+'readonly' 'ro'         boolean (default off)
+                        local to buffer  |local-noglobal|
+        If on, writes fail unless you use a '!'.  Protects you from
+        accidentally overwriting a file.  Default on when Vim is started
+        in read-only mode ("vim -R") or when the executable is called "view".
+        When using ":w!" the 'readonly' option is reset for the current
+        buffer, unless the 'Z' flag is in 'cpoptions'.
+        When using the ":view" command the 'readonly' option is set for the
+        newly edited buffer.
+        See 'modifiable' for disallowing changes to the buffer.
+
+                                                           *'redrawdebug'* *'rdb'*
+'redrawdebug' 'rdb'     string (default "")
+                        global
+        Flags to change the way redrawing works, for debugging purposes.
+        Most useful with 'writedelay' set to some reasonable value.
+        Supports the following flags:
+            compositor  Indicate each redraw event handled by the compositor
+                        by briefly flashing the redrawn regions in colors
+                        indicating the redraw type. These are the highlight
+                        groups used (and their default colors):
+                RedrawDebugNormal   gui=reverse   normal redraw passed through
+                RedrawDebugClear    guibg=Yellow  clear event passed through
+                RedrawDebugComposed guibg=Green   redraw event modified by the
+                                                  compositor (due to
+                                                  overlapping grids, etc)
+                RedrawDebugRecompose guibg=Red    redraw generated by the
+                                                  compositor itself, due to a
+                                                  grid being moved or deleted.
+            line        introduce a delay after each line drawn on the screen.
+                        When using the TUI or another single-grid UI, "compositor"
+                        gives more information and should be preferred (every
+                        line is processed as a separate event by the compositor)
+            flush       introduce a delay after each "flush" event.
+            nothrottle  Turn off throttling of the message grid. This is an
+                        optimization that joins many small scrolls to one
+                        larger scroll when drawing the message area (with
+                        'display' msgsep flag active).
+            invalid     Enable stricter checking (abort) of inconsistencies
+                        of the internal screen state. This is mostly
+                        useful when running nvim inside a debugger (and
+                        the test suite).
+            nodelta     Send all internally redrawn cells to the UI, even if
+                        they are unchanged from the already displayed state.
+
+                                                            *'redrawtime'* *'rdt'*
+'redrawtime' 'rdt'      number (default 2000)
+                        global
+        Time in milliseconds for redrawing the display.  Applies to
+        'hlsearch', 'inccommand', |:match| highlighting and syntax
+        highlighting.
+        When redrawing takes more than this many milliseconds no further
+        matches will be highlighted.
+        For syntax highlighting the time applies per window.  When over the
+        limit syntax highlighting is disabled until |CTRL-L| is used.
+        This is used to avoid that Vim hangs when using a very complicated
+        pattern.
+
+                                                           *'regexpengine'* *'re'*
+'regexpengine' 're'     number (default 0)
+                        global
+        This selects the default regexp engine. |two-engines|
+        The possible values are:
+                0       automatic selection
+                1       old engine
+                2       NFA engine
+        Note that when using the NFA engine and the pattern contains something
+        that is not supported the pattern will not match.  This is only useful
+        for debugging the regexp engine.
+        Using automatic selection enables Vim to switch the engine, if the
+        default engine becomes too costly.  E.g., when the NFA engine uses too
+        many states.  This should prevent Vim from hanging on a combination of
+        a complex pattern with long text.
+
+                             *'relativenumber'* *'rnu'* *'norelativenumber'* *'nornu'*
+'relativenumber' 'rnu'  boolean (default off)
+                        local to window
+        Show the line number relative to the line with the cursor in front of
+        each line. Relative line numbers help you use the |count| you can
+        precede some vertical motion commands (e.g. j k + -) with, without
+        having to calculate it yourself. Especially useful in combination with
+        other commands (e.g. y d c < > gq gw =).
+        When the 'n' option is excluded from 'cpoptions' a wrapped
+        line will not use the column of line numbers.
+        The 'numberwidth' option can be used to set the room used for the line
+        number.
+        When a long, wrapped line doesn't start with the first character, '-'
+        characters are put before the number.
+        See |hl-LineNr|  and |hl-CursorLineNr| for the highlighting used for
+        the number.
+
+        The number in front of the cursor line also depends on the value of
+        'number', see |number_relativenumber| for all combinations of the two
+        options.
+
+                                                                      *'report'*
+'report'                number (default 2)
+                        global
+        Threshold for reporting number of lines changed.  When the number of
+        changed lines is more than 'report' a message will be given for most
+        ":" commands.  If you want it always, set 'report' to 0.
+        For the ":substitute" command the number of substitutions is used
+        instead of the number of lines.
+
+                                               *'revins'* *'ri'* *'norevins'* *'nori'*
+'revins' 'ri'           boolean (default off)
+                        global
+        Inserting characters in Insert mode will work backwards.  See "typing
+        backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
+        command in Insert mode, when 'allowrevins' is set.
+
+                                         *'rightleft'* *'rl'* *'norightleft'* *'norl'*
+'rightleft' 'rl'        boolean (default off)
+                        local to window
+        When on, display orientation becomes right-to-left, i.e., characters
+        that are stored in the file appear from the right to the left.
+        Using this option, it is possible to edit files for languages that
+        are written from the right to the left such as Hebrew and Arabic.
+        This option is per window, so it is possible to edit mixed files
+        simultaneously, or to view the same file in both ways (this is
+        useful whenever you have a mixed text file with both right-to-left
+        and left-to-right strings so that both sets are displayed properly
+        in different windows).  Also see |rileft.txt|.
+
+                                                          *'rightleftcmd'* *'rlc'*
+'rightleftcmd' 'rlc'    string (default "search")
+                        local to window
+        Each word in this option enables the command line editing to work in
+        right-to-left mode for a group of commands:
+
+                search          "/" and "?" commands
+
+        This is useful for languages such as Hebrew, Arabic and Farsi.
+        The 'rightleft' option must be set for 'rightleftcmd' to take effect.
+
+                                                 *'ruler'* *'ru'* *'noruler'* *'noru'*
+'ruler' 'ru'            boolean (default on)
+                        global
+        Show the line and column number of the cursor position, separated by a
+        comma.  When there is room, the relative position of the displayed
+        text in the file is shown on the far right:
+                Top     first line is visible
+                Bot     last line is visible
+                All     first and last line are visible
+                45%     relative position in the file
+        If 'rulerformat' is set, it will determine the contents of the ruler.
+        Each window has its own ruler.  If a window has a status line, the
+        ruler is shown there.  If a window doesn't have a status line and
+        'cmdheight' is zero, the ruler is not shown.  Otherwise it is shown in
+        the last line of the screen.  If the statusline is given by
+        'statusline' (i.e. not empty), this option takes precedence over
+        'ruler' and 'rulerformat'.
+        If the number of characters displayed is different from the number of
+        bytes in the text (e.g., for a TAB or a multibyte character), both
+        the text column (byte number) and the screen column are shown,
+        separated with a dash.
+        For an empty line "0-1" is shown.
+        For an empty buffer the line number will also be zero: "0,0-1".
+        If you don't want to see the ruler all the time but want to know where
+        you are, use "g CTRL-G" |g_CTRL-G|.
+
+                                                           *'rulerformat'* *'ruf'*
+'rulerformat' 'ruf'     string (default "")
+                        global
+        When this option is not empty, it determines the content of the ruler
+        string, as displayed for the 'ruler' option.
+        The format of this option is like that of 'statusline'.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        The default ruler width is 17 characters.  To make the ruler 15
+        characters wide, put "%15(" at the start and "%)" at the end.
+        Example: >vim
+                set rulerformat=%15(%c%V\ %p%%%)
+<
+
+                                                  *'runtimepath'* *'rtp'* *vimfiles*
+'runtimepath' 'rtp'     string (default "$XDG_CONFIG_HOME/nvim,
+                                         $XDG_CONFIG_DIRS[1]/nvim,
+                                         $XDG_CONFIG_DIRS[2]/nvim,
+                                         …
+                                         $XDG_DATA_HOME/nvim[-data]/site,
+                                         $XDG_DATA_DIRS[1]/nvim/site,
+                                         $XDG_DATA_DIRS[2]/nvim/site,
+                                         …
+                                         $VIMRUNTIME,
+                                         …
+                                         $XDG_DATA_DIRS[2]/nvim/site/after,
+                                         $XDG_DATA_DIRS[1]/nvim/site/after,
+                                         $XDG_DATA_HOME/nvim[-data]/site/after,
+                                         …
+                                         $XDG_CONFIG_DIRS[2]/nvim/after,
+                                         $XDG_CONFIG_DIRS[1]/nvim/after,
+                                         $XDG_CONFIG_HOME/nvim/after")
+                        global
+        List of directories to be searched for these runtime files:
+          filetype.lua  filetypes |new-filetype|
+          autoload/     automatically loaded scripts |autoload-functions|
+          colors/       color scheme files |:colorscheme|
+          compiler/     compiler files |:compiler|
+          doc/          documentation |write-local-help|
+          ftplugin/     filetype plugins |write-filetype-plugin|
+          indent/       indent scripts |indent-expression|
+          keymap/       key mapping files |mbyte-keymap|
+          lang/         menu translations |:menutrans|
+          lua/          |Lua| plugins
+          menu.vim      GUI menus |menu.vim|
+          pack/         packages |:packadd|
+          parser/       |treesitter| syntax parsers
+          plugin/       plugin scripts |write-plugin|
+          queries/      |treesitter| queries
+          rplugin/      |remote-plugin| scripts
+          spell/        spell checking files |spell|
+          syntax/       syntax files |mysyntaxfile|
+          tutor/        tutorial files |:Tutor|
+
+        And any other file searched for with the |:runtime| command.
+
+        Defaults are setup to search these locations:
+        1. Your home directory, for personal preferences.
+           Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
+        2. Directories which must contain configuration files according to
+           |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
+           preferences from system administrator.
+        3. Data home directory, for plugins installed by user.
+           Given by `stdpath("data")/site`.  |$XDG_DATA_HOME|
+        4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
+           This is for plugins which were installed by system administrator,
+           but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
+           to /usr/local/share/:/usr/share/, so system administrators are
+           expected to install site plugins to /usr/share/nvim/site.
+        5. Session state directory, for state data such as swap, backupdir,
+           viewdir, undodir, etc.
+           Given by `stdpath("state")`.  |$XDG_STATE_HOME|
+        6. $VIMRUNTIME, for files distributed with Nvim.
+                                                        *after-directory*
+        7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
+           ordering.  This is for preferences to overrule or add to the
+           distributed defaults or system-wide settings (rarely needed).
+
+                                                        *packages-runtimepath*
+        "start" packages will also be searched (|runtime-search-path|) for
+        runtime files after these, though such packages are not explicitly
+        reported in &runtimepath. But "opt" packages are explicitly added to
+        &runtimepath by |:packadd|.
+
+        Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
+        wildcards are allowed, but can significantly slow down searching for
+        runtime files.  For speed, use as few items as possible and avoid
+        wildcards.
+        See |:runtime|.
+        Example: >vim
+                set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
+<       This will use the directory "~/vimruntime" first (containing your
+        personal Nvim runtime files), then "/mygroup/vim", and finally
+        "$VIMRUNTIME" (the default runtime files).
+        You can put a directory before $VIMRUNTIME to find files which replace
+        distributed runtime files.  You can put a directory after $VIMRUNTIME
+        to find files which add to distributed runtime files.
+
+        With |--clean| the home directory entries are not included.
+
+                                                                *'scroll'* *'scr'*
+'scroll' 'scr'          number (default half the window height)
+                        local to window  |local-noglobal|
+        Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
+        set to half the number of lines in the window when the window size
+        changes.  This may happen when enabling the |status-line| or
+        'tabline' option after setting the 'scroll' option.
+        If you give a count to the CTRL-U or CTRL-D command it will
+        be used as the new value for 'scroll'.  Reset to half the window
+        height with ":set scroll=0".
+
+                                                           *'scrollback'* *'scbk'*
+'scrollback' 'scbk'     number (default 10000)
+                        local to buffer
+        Maximum number of lines kept beyond the visible screen. Lines at the
+        top are deleted if new lines exceed this limit.
+        Minimum is 1, maximum is 100000.
+        Only in |terminal| buffers.
+
+        Note: Lines that are not visible and kept in scrollback are not
+        reflown when the terminal buffer is resized horizontally.
+
+                                     *'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
+'scrollbind' 'scb'      boolean (default off)
+                        local to window
+        See also |scroll-binding|.  When this option is set, scrolling the
+        current window also scrolls other scrollbind windows (windows that
+        also have this option set).  This option is useful for viewing the
+        differences between two versions of a file, see 'diff'.
+        See |'scrollopt'| for options that determine how this option should be
+        interpreted.
+        This option is mostly reset when splitting a window to edit another
+        file.  This means that ":split | edit file" results in two windows
+        with scroll-binding, but ":split file" does not.
+
+                                                             *'scrolljump'* *'sj'*
+'scrolljump' 'sj'       number (default 1)
+                        global
+        Minimal number of lines to scroll when the cursor gets off the
+        screen (e.g., with "j").  Not used for scroll commands (e.g., CTRL-E,
+        CTRL-D).  Useful if your terminal scrolls very slowly.
+        When set to a negative number from -1 to -100 this is used as the
+        percentage of the window height.  Thus -50 scrolls half the window
+        height.
+
+                                                              *'scrolloff'* *'so'*
+'scrolloff' 'so'        number (default 0)
+                        global or local to window |global-local|
+        Minimal number of screen lines to keep above and below the cursor.
+        This will make some context visible around where you are working.  If
+        you set it to a very large value (999) the cursor line will always be
+        in the middle of the window (except at the start or end of the file or
+        when long lines wrap).
+        After using the local value, go back the global value with one of
+        these two: >vim
+                setlocal scrolloff<
+                setlocal scrolloff=-1
+<       For scrolling horizontally see 'sidescrolloff'.
+
+                                                             *'scrollopt'* *'sbo'*
+'scrollopt' 'sbo'       string (default "ver,jump")
+                        global
+        This is a comma-separated list of words that specifies how
+        'scrollbind' windows should behave.  'sbo' stands for ScrollBind
+        Options.
+        The following words are available:
+            ver         Bind vertical scrolling for 'scrollbind' windows
+            hor         Bind horizontal scrolling for 'scrollbind' windows
+            jump        Applies to the offset between two windows for vertical
+                        scrolling.  This offset is the difference in the first
+                        displayed line of the bound windows.  When moving
+                        around in a window, another 'scrollbind' window may
+                        reach a position before the start or after the end of
+                        the buffer.  The offset is not changed though, when
+                        moving back the 'scrollbind' window will try to scroll
+                        to the desired position when possible.
+                        When now making that window the current one, two
+                        things can be done with the relative offset:
+                        1. When "jump" is not included, the relative offset is
+                           adjusted for the scroll position in the new current
+                           window.  When going back to the other window, the
+                           new relative offset will be used.
+                        2. When "jump" is included, the other windows are
+                           scrolled to keep the same relative offset.  When
+                           going back to the other window, it still uses the
+                           same relative offset.
+        Also see |scroll-binding|.
+        When 'diff' mode is active there always is vertical scroll binding,
+        even when "ver" isn't there.
+
+                                                             *'sections'* *'sect'*
+'sections' 'sect'       string (default "SHNHH HUnhsh")
+                        global
+        Specifies the nroff macros that separate sections.  These are pairs of
+        two letters (See |object-motions|).  The default makes a section start
+        at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
+
+                                                             *'selection'* *'sel'*
+'selection' 'sel'       string (default "inclusive")
+                        global
+        This option defines the behavior of the selection.  It is only used
+        in Visual and Select mode.
+        Possible values:
+           value        past line     inclusive ~
+           old             no           yes
+           inclusive       yes          yes
+           exclusive       yes          no
+        "past line" means that the cursor is allowed to be positioned one
+        character past the line.
+        "inclusive" means that the last character of the selection is included
+        in an operation.  For example, when "x" is used to delete the
+        selection.
+        When "old" is used and 'virtualedit' allows the cursor to move past
+        the end of line the line break still isn't included.
+        Note that when "exclusive" is used and selecting from the end
+        backwards, you cannot include the last character of a line, when
+        starting in Normal mode and 'virtualedit' empty.
+
+                                                            *'selectmode'* *'slm'*
+'selectmode' 'slm'      string (default "")
+                        global
+        This is a comma-separated list of words, which specifies when to start
+        Select mode instead of Visual mode, when a selection is started.
+        Possible values:
+           mouse        when using the mouse
+           key          when using shifted special keys
+           cmd          when using "v", "V" or CTRL-V
+        See |Select-mode|.
+
+                                                       *'sessionoptions'* *'ssop'*
+'sessionoptions' 'ssop' string (default "blank,buffers,curdir,folds,help,tabpages,winsize,terminal")
+                        global
+        Changes the effect of the |:mksession| command.  It is a comma-
+        separated list of words.  Each word enables saving and restoring
+        something:
+           word         save and restore ~
+           blank        empty windows
+           buffers      hidden and unloaded buffers, not just those in windows
+           curdir       the current directory
+           folds        manually created folds, opened/closed folds and local
+                        fold options
+           globals      global variables that start with an uppercase letter
+                        and contain at least one lowercase letter.  Only
+                        String and Number types are stored.
+           help         the help window
+           localoptions options and mappings local to a window or buffer (not
+                        global values for local options)
+           options      all options and mappings (also global values for local
+                        options)
+           skiprtp      exclude 'runtimepath' and 'packpath' from the options
+           resize       size of the Vim window: 'lines' and 'columns'
+           sesdir       the directory in which the session file is located
+                        will become the current directory (useful with
+                        projects accessed over a network from different
+                        systems)
+           tabpages     all tab pages; without this only the current tab page
+                        is restored, so that you can make a session for each
+                        tab page separately
+           terminal     include terminal windows where the command can be
+                        restored
+           winpos       position of the whole Vim window
+           winsize      window sizes
+           slash        |deprecated| Always enabled. Uses "/" in filenames.
+           unix         |deprecated| Always enabled. Uses "\n" line endings.
+
+        Don't include both "curdir" and "sesdir". When neither is included
+        filenames are stored as absolute paths.
+        If you leave out "options" many things won't work well after restoring
+        the session.
+
+                                                   *'shada'* *'sd'* *E526* *E527* *E528*
+'shada' 'sd'            string (default for Win32:  !,'100,<50,s10,h,rA:,rB:
+                                            others: !,'100,<50,s10,h)
+                        global
+        When non-empty, the shada file is read upon startup and written
+        when exiting Vim (see |shada-file|).  The string should be a comma-
+        separated list of parameters, each consisting of a single character
+        identifying the particular parameter, followed by a number or string
+        which specifies the value of that parameter.  If a particular
+        character is left out, then the default value is used for that
+        parameter.  The following is a list of the identifying characters and
+        the effect of their value.
+        CHAR    VALUE   ~
+                                                        *shada-!*
+        !       When included, save and restore global variables that start
+                with an uppercase letter, and don't contain a lowercase
+                letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
+                and "_K_L_M" are not.  Nested List and Dict items may not be
+                read back correctly, you end up with an empty item.
+                                                        *shada-quote*
+        "       Maximum number of lines saved for each register.  Old name of
+                the '<' item, with the disadvantage that you need to put a
+                backslash before the ", otherwise it will be recognized as the
+                start of a comment!
+                                                        *shada-%*
+        %       When included, save and restore the buffer list.  If Vim is
+                started with a file name argument, the buffer list is not
+                restored.  If Vim is started without a file name argument, the
+                buffer list is restored from the shada file.  Quickfix
+                ('buftype'), unlisted ('buflisted'), unnamed and buffers on
+                removable media (|shada-r|) are not saved.
+                When followed by a number, the number specifies the maximum
+                number of buffers that are stored.  Without a number all
+                buffers are stored.
+                                                        *shada-'*
+        '       Maximum number of previously edited files for which the marks
+                are remembered.  This parameter must always be included when
+                'shada' is non-empty.
+                Including this item also means that the |jumplist| and the
+                |changelist| are stored in the shada file.
+                                                        *shada-/*
+        /       Maximum number of items in the search pattern history to be
+                saved.  If non-zero, then the previous search and substitute
+                patterns are also saved.  When not included, the value of
+                'history' is used.
+                                                        *shada-:*
+        :       Maximum number of items in the command-line history to be
+                saved.  When not included, the value of 'history' is used.
+                                                        *shada-<*
+        <      Maximum number of lines saved for each register.  If zero then
+                registers are not saved.  When not included, all lines are
+                saved.  '"' is the old name for this item.
+                Also see the 's' item below: limit specified in KiB.
+                                                        *shada-@*
+        @       Maximum number of items in the input-line history to be
+                saved.  When not included, the value of 'history' is used.
+                                                        *shada-c*
+        c       Dummy option, kept for compatibility reasons.  Has no actual
+                effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
+                to UTF-8 as well.
+                                                        *shada-f*
+        f       Whether file marks need to be stored.  If zero, file marks ('0
+                to '9, 'A to 'Z) are not stored.  When not present or when
+                non-zero, they are all stored.  '0 is used for the current
+                cursor position (when exiting or when doing |:wshada|).
+                                                        *shada-h*
+        h       Disable the effect of 'hlsearch' when loading the shada
+                file.  When not included, it depends on whether ":nohlsearch"
+                has been used since the last search command.
+                                                        *shada-n*
+        n       Name of the shada file.  The name must immediately follow
+                the 'n'.  Must be at the end of the option!  If the
+                'shadafile' option is set, that file name overrides the one
+                given here with 'shada'.  Environment variables are
+                expanded when opening the file, not when setting the option.
+                                                        *shada-r*
+        r       Removable media.  The argument is a string (up to the next
+                ',').  This parameter can be given several times.  Each
+                specifies the start of a path for which no marks will be
+                stored.  This is to avoid removable media.  For Windows you
+                could use "ra:,rb:".  You can also use it for temp files,
+                e.g., for Unix: "r/tmp".  Case is ignored.
+                                                        *shada-s*
+        s       Maximum size of an item contents in KiB.  If zero then nothing
+                is saved.  Unlike Vim this applies to all items, except for
+                the buffer list and header.  Full item size is off by three
+                unsigned integers: with `s10` maximum item size may be 1 byte
+                (type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+                integer) + 3 bytes (item size: up to 16-bit integer because
+                2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
+                contents size) = 10253 bytes.
+
+        Example: >vim
+            set shada='50,<1000,s100,:0,n~/nvim/shada
+<
+        '50             Marks will be remembered for the last 50 files you
+                        edited.
+        <1000           Contents of registers (up to 1000 lines each) will be
+                        remembered.
+        s100            Items with contents occupying more then 100 KiB are
+                        skipped.
+        :0              Command-line history will not be saved.
+        n~/nvim/shada   The name of the file to use is "~/nvim/shada".
+        no /            Since '/' is not specified, the default will be used,
+                        that is, save all of the search history, and also the
+                        previous search and substitute patterns.
+        no %            The buffer list will not be saved nor read back.
+        no h            'hlsearch' highlighting will be restored.
+
+        When setting 'shada' from an empty value you can use |:rshada| to
+        load the contents of the file, this is not done automatically.
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                             *'shadafile'* *'sdf'*
+'shadafile' 'sdf'       string (default "")
+                        global
+        When non-empty, overrides the file name used for |shada| (viminfo).
+        When equal to "NONE" no shada file will be read or written.
+        This option can be set with the |-i| command line flag.  The |--clean|
+        command line flag sets it to "NONE".
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                              *'shell'* *'sh'* *E91*
+'shell' 'sh'            string (default $SHELL or "sh", Win32: "cmd.exe")
+                        global
+        Name of the shell to use for ! and :! commands.  When changing the
+        value also check these options: 'shellpipe', 'shellslash'
+        'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
+        It is allowed to give an argument to the command, e.g.  "csh -f".
+        See |option-backslash| about including spaces and backslashes.
+        Environment variables are expanded |:set_env|.
+
+        If the name of the shell contains a space, you need to enclose it in
+        quotes.  Example with quotes: >vim
+                set shell=\"c:\program\ files\unix\sh.exe\"\ -f
+<       Note the backslash before each quote (to avoid starting a comment) and
+        each space (to avoid ending the option value), so better use |:let-&|
+        like this: >vim
+                let &shell='"C:\Program Files\unix\sh.exe" -f'
+<       Also note that the "-f" is not inside the quotes, because it is not
+        part of the command name.
+                                                        *shell-unquoting*
+        Rules regarding quotes:
+        1. Option is split on space and tab characters that are not inside
+           quotes: "abc def" runs shell named "abc" with additional argument
+           "def", '"abc def"' runs shell named "abc def" with no additional
+           arguments (here and below: additional means “additional to
+           'shellcmdflag'”).
+        2. Quotes in option may be present in any position and any number:
+           '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
+           to just "abc".
+        3. Inside quotes backslash preceding backslash means one backslash.
+           Backslash preceding quote means one quote. Backslash preceding
+           anything else means backslash and next character literally:
+           '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
+           'a"b', '"a\b"' is the same as "a\b" again.
+        4. Outside of quotes backslash always means itself, it cannot be used
+           to escape quote: 'a\"b"' is the same as "a\b".
+        Note that such processing is done after |:set| did its own round of
+        unescaping, so to keep yourself sane use |:let-&| like shown above.
+                                                        *shell-powershell*
+        To use PowerShell: >vim
+                let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
+                let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
+                let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+                let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
+                set shellquote= shellxquote=
+
+<       This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                         *'shellcmdflag'* *'shcf'*
+'shellcmdflag' 'shcf'   string (default "-c"; Windows: "/s /c")
+                        global
+        Flag passed to the shell to execute "!" and ":!" commands; e.g.,
+        `bash.exe -c ls` or `cmd.exe /s /c "dir"`.  For MS-Windows, the
+        default is set according to the value of 'shell', to reduce the need
+        to set this option by the user.
+        On Unix it can have more than one flag.  Each white space separated
+        part is passed as an argument to the shell command.
+        See |option-backslash| about including spaces and backslashes.
+        See |shell-unquoting| which talks about separating this option into
+        multiple arguments.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                              *'shellpipe'* *'sp'*
+'shellpipe' 'sp'        string (default ">", "| tee", "|& tee" or "2>&1| tee")
+                        global
+        String to be used to put the output of the ":make" command in the
+        error file.  See also |:make_makeprg|.  See |option-backslash| about
+        including spaces and backslashes.
+        The name of the temporary file can be represented by "%s" if necessary
+        (the file name is appended automatically if no %s appears in the value
+        of this option).
+        For MS-Windows the default is "2>&1| tee".  The stdout and stderr are
+        saved in a file and echoed to the screen.
+        For Unix the default is "| tee".  The stdout of the compiler is saved
+        in a file and echoed to the screen.  If the 'shell' option is "csh" or
+        "tcsh" after initializations, the default becomes "|& tee".  If the
+        'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
+        "bash", "fish", "ash" or "dash" the default becomes "2>&1| tee".  This
+        means that stderr is also included.  Before using the 'shell' option a
+        path is removed, thus "/bin/sh" uses "sh".
+        The initialization of this option is done after reading the vimrc
+        and the other initializations, so that when the 'shell' option is set
+        there, the 'shellpipe' option changes automatically, unless it was
+        explicitly set before.
+        When 'shellpipe' is set to an empty string, no redirection of the
+        ":make" output will be done.  This is useful if you use a 'makeprg'
+        that writes to 'makeef' by itself.  If you want no piping, but do
+        want to include the 'makeef', set 'shellpipe' to a single space.
+        Don't forget to precede the space with a backslash: ":set sp=\ ".
+        In the future pipes may be used for filtering and this option will
+        become obsolete (at least for Unix).
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                            *'shellquote'* *'shq'*
+'shellquote' 'shq'      string (default ""; Windows, when 'shell'
                                         contains "sh" somewhere: "\"")
-			global
-	Quoting character(s), put around the command passed to the shell, for
-	the "!" and ":!" commands.  The redirection is kept outside of the
-	quoting.  See 'shellxquote' to include the redirection.  It's
-	probably not useful to set both options.
-	This is an empty string by default.  Only known to be useful for
-	third-party shells on Windows systems, such as the MKS Korn Shell
-	or bash, where it should be "\"".  The default is adjusted according
-	the value of 'shell', to reduce the need to set this option by the
-	user.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                        global
+        Quoting character(s), put around the command passed to the shell, for
+        the "!" and ":!" commands.  The redirection is kept outside of the
+        quoting.  See 'shellxquote' to include the redirection.  It's
+        probably not useful to set both options.
+        This is an empty string by default.  Only known to be useful for
+        third-party shells on Windows systems, such as the MKS Korn Shell
+        or bash, where it should be "\"".  The default is adjusted according
+        the value of 'shell', to reduce the need to set this option by the
+        user.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'shellredir'* *'srr'*
-'shellredir' 'srr'	string	(default ">", ">&" or ">%s 2>&1")
-			global
-	String to be used to put the output of a filter command in a temporary
-	file.  See also |:!|.  See |option-backslash| about including spaces
-	and backslashes.
-	The name of the temporary file can be represented by "%s" if necessary
-	(the file name is appended automatically if no %s appears in the value
-	of this option).
-	The default is ">".  For Unix, if the 'shell' option is "csh" or
-	"tcsh" during initializations, the default becomes ">&".  If the
-	'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
-	"bash" or "fish", the default becomes ">%s 2>&1".  This means that
-	stderr is also included.  For Win32, the Unix checks are done and
-	additionally "cmd" is checked for, which makes the default ">%s 2>&1".
-	Also, the same names with ".exe" appended are checked for.
-	The initialization of this option is done after reading the vimrc
-	and the other initializations, so that when the 'shell' option is set
-	there, the 'shellredir' option changes automatically unless it was
-	explicitly set before.
-	In the future pipes may be used for filtering and this option will
-	become obsolete (at least for Unix).
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                            *'shellredir'* *'srr'*
+'shellredir' 'srr'      string (default ">", ">&" or ">%s 2>&1")
+                        global
+        String to be used to put the output of a filter command in a temporary
+        file.  See also |:!|.  See |option-backslash| about including spaces
+        and backslashes.
+        The name of the temporary file can be represented by "%s" if necessary
+        (the file name is appended automatically if no %s appears in the value
+        of this option).
+        The default is ">".  For Unix, if the 'shell' option is "csh" or
+        "tcsh" during initializations, the default becomes ">&".  If the
+        'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
+        "bash" or "fish", the default becomes ">%s 2>&1".  This means that
+        stderr is also included.  For Win32, the Unix checks are done and
+        additionally "cmd" is checked for, which makes the default ">%s 2>&1".
+        Also, the same names with ".exe" appended are checked for.
+        The initialization of this option is done after reading the vimrc
+        and the other initializations, so that when the 'shell' option is set
+        there, the 'shellredir' option changes automatically unless it was
+        explicitly set before.
+        In the future pipes may be used for filtering and this option will
+        become obsolete (at least for Unix).
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
-'shellslash' 'ssl'	boolean	(default off)
-			global
-			only for MS-Windows
-	When set, a forward slash is used when expanding file names.  This is
-	useful when a Unix-like shell is used instead of cmd.exe.  Backward
-	slashes can still be typed, but they are changed to forward slashes by
-	Vim.
-	Note that setting or resetting this option has no effect for some
-	existing file names, thus this option needs to be set before opening
-	any file for best results.  This might change in the future.
-	'shellslash' only works when a backslash can be used as a path
-	separator.  To test if this is so use: >vim
-		if exists('+shellslash')
-<	Also see 'completeslash'.
+                                     *'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
+'shellslash' 'ssl'      boolean (default off)
+                        global
+        only for MS-Windows
+        When set, a forward slash is used when expanding file names.  This is
+        useful when a Unix-like shell is used instead of cmd.exe.  Backward
+        slashes can still be typed, but they are changed to forward slashes by
+        Vim.
+        Note that setting or resetting this option has no effect for some
+        existing file names, thus this option needs to be set before opening
+        any file for best results.  This might change in the future.
+        'shellslash' only works when a backslash can be used as a path
+        separator.  To test if this is so use: >vim
+        if exists('+shellslash')
+<       Also see 'completeslash'.
 
-			*'shelltemp'* *'stmp'* *'noshelltemp'* *'nostmp'*
-'shelltemp' 'stmp'	boolean	(default on)
-			global
-	When on, use temp files for shell commands.  When off use a pipe.
-	When using a pipe is not possible temp files are used anyway.
-	The advantage of using a pipe is that nobody can read the temp file
-	and the 'shell' command does not need to support redirection.
-	The advantage of using a temp file is that the file type and encoding
-	can be detected.
-	The |FilterReadPre|, |FilterReadPost| and |FilterWritePre|,
-	|FilterWritePost| autocommands event are not triggered when
-	'shelltemp' is off.
-	|system()| does not respect this option, it always uses pipes.
+                                     *'shelltemp'* *'stmp'* *'noshelltemp'* *'nostmp'*
+'shelltemp' 'stmp'      boolean (default on)
+                        global
+        When on, use temp files for shell commands.  When off use a pipe.
+        When using a pipe is not possible temp files are used anyway.
+        The advantage of using a pipe is that nobody can read the temp file
+        and the 'shell' command does not need to support redirection.
+        The advantage of using a temp file is that the file type and encoding
+        can be detected.
+        The |FilterReadPre|, |FilterReadPost| and |FilterWritePre|,
+        |FilterWritePost| autocommands event are not triggered when
+        'shelltemp' is off.
+        |system()| does not respect this option, it always uses pipes.
 
-						*'shellxescape'* *'sxe'*
-'shellxescape' 'sxe'	string	(default "")
-			global
-	When 'shellxquote' is set to "(" then the characters listed in this
-	option will be escaped with a '^' character.  This makes it possible
-	to execute most external commands with cmd.exe.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                          *'shellxescape'* *'sxe'*
+'shellxescape' 'sxe'    string (default "")
+                        global
+        When 'shellxquote' is set to "(" then the characters listed in this
+        option will be escaped with a '^' character.  This makes it possible
+        to execute most external commands with cmd.exe.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-						*'shellxquote'* *'sxq'*
-'shellxquote' 'sxq'	string	(default "", Windows: "\"")
-			global
-	Quoting character(s), put around the command passed to the shell, for
-	the "!" and ":!" commands.  Includes the redirection.  See
-	'shellquote' to exclude the redirection.  It's probably not useful
-	to set both options.
-	When the value is '(' then ')' is appended. When the value is '"('
-	then ')"' is appended.
-	When the value is '(' then also see 'shellxescape'.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
+                                                           *'shellxquote'* *'sxq'*
+'shellxquote' 'sxq'     string (default "", Windows: "\"")
+                        global
+        Quoting character(s), put around the command passed to the shell, for
+        the "!" and ":!" commands.  Includes the redirection.  See
+        'shellquote' to exclude the redirection.  It's probably not useful
+        to set both options.
+        When the value is '(' then ')' is appended. When the value is '"('
+        then ')"' is appended.
+        When the value is '(' then also see 'shellxescape'.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
 
-			*'shiftround'* *'sr'* *'noshiftround'* *'nosr'*
-'shiftround' 'sr'	boolean	(default off)
-			global
-	Round indent to multiple of 'shiftwidth'.  Applies to > and <
-	commands.  CTRL-T and CTRL-D in Insert mode always round the indent to
-	a multiple of 'shiftwidth' (this is Vi compatible).
+                                       *'shiftround'* *'sr'* *'noshiftround'* *'nosr'*
+'shiftround' 'sr'       boolean (default off)
+                        global
+        Round indent to multiple of 'shiftwidth'.  Applies to > and <
+        commands.  CTRL-T and CTRL-D in Insert mode always round the indent to
+        a multiple of 'shiftwidth' (this is Vi compatible).
 
-						*'shiftwidth'* *'sw'*
-'shiftwidth' 'sw'	number	(default 8)
-			local to buffer
-	Number of spaces to use for each step of (auto)indent.  Used for
-	|'cindent'|, |>>|, |<<|, etc.
-	When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
-	function to get the effective shiftwidth value.
+                                                             *'shiftwidth'* *'sw'*
+'shiftwidth' 'sw'       number (default 8)
+                        local to buffer
+        Number of spaces to use for each step of (auto)indent.  Used for
+        |'cindent'|, |>>|, |<<|, etc.
+        When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
+        function to get the effective shiftwidth value.
 
-					*'shortmess'* *'shm'* *E1336*
-'shortmess' 'shm'	string	(default "ltToOCF")
-			global
-	This option helps to avoid all the |hit-enter| prompts caused by file
-	messages, for example  with CTRL-G, and to avoid some other messages.
-	It is a list of flags:
-	 flag	meaning when present	~
-	  l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
-	  m	use "[+]" instead of "[Modified]"			*shm-m*
-	  r	use "[RO]" instead of "[readonly]"			*shm-r*
-	  w	use "[w]" instead of "written" for file write message	*shm-w*
-		and "[a]" instead of "appended" for ':w >> file' command
-	  a	all of the above abbreviations				*shm-a*
+                                                       *'shortmess'* *'shm'* *E1336*
+'shortmess' 'shm'       string (default "ltToOCF")
+                        global
+        This option helps to avoid all the |hit-enter| prompts caused by file
+        messages, for example  with CTRL-G, and to avoid some other messages.
+        It is a list of flags:
+         flag   meaning when present    ~
+          l     use "999L, 888B" instead of "999 lines, 888 bytes"      *shm-l*
+          m     use "[+]" instead of "[Modified]"                       *shm-m*
+          r     use "[RO]" instead of "[readonly]"                      *shm-r*
+          w     use "[w]" instead of "written" for file write message   *shm-w*
+                and "[a]" instead of "appended" for ':w >> file' command
+          a     all of the above abbreviations                          *shm-a*
 
-	  o	overwrite message for writing a file with subsequent	*shm-o*
-		message for reading a file (useful for ":wn" or when
-		'autowrite' on)
-	  O	message for reading a file overwrites any previous	*shm-O*
-		message;  also for quickfix message (e.g., ":cn")
-	  s	don't give "search hit BOTTOM, continuing at TOP" or	*shm-s*
-		"search hit TOP, continuing at BOTTOM" messages; when using
-		the search count do not show "W" after the count message (see
-		S below)
-	  t	truncate file message at the start if it is too long	*shm-t*
-		to fit on the command-line, "<" will appear in the left most
-		column; ignored in Ex mode
-	  T	truncate other messages in the middle if they are too	*shm-T*
-		long to fit on the command line; "..." will appear in the
-		middle; ignored in Ex mode
-	  W	don't give "written" or "[w]" when writing a file	*shm-W*
-	  A	don't give the "ATTENTION" message when an existing	*shm-A*
-		swap file is found
-	  I	don't give the intro message when starting Vim,		*shm-I*
-		see |:intro|
-	  c	don't give |ins-completion-menu| messages; for		*shm-c*
-		example, "-- XXX completion (YYY)", "match 1 of 2", "The only
-		match", "Pattern not found", "Back at original", etc.
-	  C	don't give messages while scanning for ins-completion	*shm-C*
-		items, for instance "scanning tags"
-	  q	use "recording" instead of "recording @a"		*shm-q*
-	  F	don't give the file info when editing a file, like	*shm-F*
-		`:silent` was used for the command
-	  S	do not show search count message when searching, e.g.	*shm-S*
-		"[1/5]"
+          o     overwrite message for writing a file with subsequent    *shm-o*
+                message for reading a file (useful for ":wn" or when
+                'autowrite' on)
+          O     message for reading a file overwrites any previous      *shm-O*
+                message;  also for quickfix message (e.g., ":cn")
+          s     don't give "search hit BOTTOM, continuing at TOP" or    *shm-s*
+                "search hit TOP, continuing at BOTTOM" messages; when using
+                the search count do not show "W" after the count message (see
+                S below)
+          t     truncate file message at the start if it is too long    *shm-t*
+                to fit on the command-line, "<" will appear in the left most
+                column; ignored in Ex mode
+          T     truncate other messages in the middle if they are too   *shm-T*
+                long to fit on the command line; "..." will appear in the
+                middle; ignored in Ex mode
+          W     don't give "written" or "[w]" when writing a file       *shm-W*
+          A     don't give the "ATTENTION" message when an existing     *shm-A*
+                swap file is found
+          I     don't give the intro message when starting Vim,         *shm-I*
+                see |:intro|
+          c     don't give |ins-completion-menu| messages; for          *shm-c*
+                example, "-- XXX completion (YYY)", "match 1 of 2", "The only
+                match", "Pattern not found", "Back at original", etc.
+          C     don't give messages while scanning for ins-completion   *shm-C*
+                items, for instance "scanning tags"
+          q     use "recording" instead of "recording @a"               *shm-q*
+          F     don't give the file info when editing a file, like      *shm-F*
+                `:silent` was used for the command
+          S     do not show search count message when searching, e.g.   *shm-S*
+                "[1/5]"
 
-	This gives you the opportunity to avoid that a change between buffers
-	requires you to hit <Enter>, but still gives as useful a message as
-	possible for the space available.  To get the whole message that you
-	would have got with 'shm' empty, use ":file!"
-	Useful values:
-	    shm=	No abbreviation of message.
-	    shm=a	Abbreviation, but no loss of information.
-	    shm=at	Abbreviation, and truncate message when necessary.
+        This gives you the opportunity to avoid that a change between buffers
+        requires you to hit <Enter>, but still gives as useful a message as
+        possible for the space available.  To get the whole message that you
+        would have got with 'shm' empty, use ":file!"
+        Useful values:
+            shm=        No abbreviation of message.
+            shm=a       Abbreviation, but no loss of information.
+            shm=at      Abbreviation, and truncate message when necessary.
 
-					*'showbreak'* *'sbr'* *E595*
-'showbreak' 'sbr'	string	(default "")
-			global or local to window |global-local|
-	String to put at the start of lines that have been wrapped.  Useful
-	values are "> " or "+++ ": >vim
-		let &showbreak = "> "
-		let &showbreak = '+++ '
-<	Only printable single-cell characters are allowed, excluding <Tab> and
-	comma (in a future version the comma might be used to separate the
-	part that is shown at the end and at the start of a line).
-	The |hl-NonText| highlight group determines the highlighting.
-	Note that tabs after the showbreak will be displayed differently.
-	If you want the 'showbreak' to appear in between line numbers, add the
-	"n" flag to 'cpoptions'.
-	A window-local value overrules a global value.  If the global value is
-	set and you want no value in the current window use NONE: >vim
-		setlocal showbreak=NONE
+                                                        *'showbreak'* *'sbr'* *E595*
+'showbreak' 'sbr'       string (default "")
+                        global or local to window |global-local|
+        String to put at the start of lines that have been wrapped.  Useful
+        values are "> " or "+++ ": >vim
+                let &showbreak = "> "
+                let &showbreak = '+++ '
+<       Only printable single-cell characters are allowed, excluding <Tab> and
+        comma (in a future version the comma might be used to separate the
+        part that is shown at the end and at the start of a line).
+        The |hl-NonText| highlight group determines the highlighting.
+        Note that tabs after the showbreak will be displayed differently.
+        If you want the 'showbreak' to appear in between line numbers, add the
+        "n" flag to 'cpoptions'.
+        A window-local value overrules a global value.  If the global value is
+        set and you want no value in the current window use NONE: >vim
+                setlocal showbreak=NONE
 <
 
-				*'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
-'showcmd' 'sc'		boolean	(default on)
-			global
-	Show (partial) command in the last line of the screen.  Set this
-	option off if your terminal is slow.
-	In Visual mode the size of the selected area is shown:
-	- When selecting characters within a line, the number of characters.
-	  If the number of bytes is different it is also displayed: "2-6"
-	  means two characters and six bytes.
-	- When selecting more than one line, the number of lines.
-	- When selecting a block, the size in screen characters:
-	  {lines}x{columns}.
-	This information can be displayed in an alternative location using the
-	'showcmdloc' option, useful when 'cmdheight' is 0.
+                                             *'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
+'showcmd' 'sc'          boolean (default on)
+                        global
+        Show (partial) command in the last line of the screen.  Set this
+        option off if your terminal is slow.
+        In Visual mode the size of the selected area is shown:
+        - When selecting characters within a line, the number of characters.
+          If the number of bytes is different it is also displayed: "2-6"
+          means two characters and six bytes.
+        - When selecting more than one line, the number of lines.
+        - When selecting a block, the size in screen characters:
+          {lines}x{columns}.
+        This information can be displayed in an alternative location using the
+        'showcmdloc' option, useful when 'cmdheight' is 0.
 
-						*'showcmdloc'* *'sloc'*
-'showcmdloc' 'sloc'	string	(default "last")
-			global
-	This option can be used to display the (partially) entered command in
-	another location.  Possible values are:
-	  last		Last line of the screen (default).
-	  statusline	Status line of the current window.
-	  tabline	First line of the screen if 'showtabline' is enabled.
-	Setting this option to "statusline" or "tabline" means that these will
-	be redrawn whenever the command changes, which can be on every key
-	pressed.
-	The %S 'statusline' item can be used in 'statusline' or 'tabline' to
-	place the text.  Without a custom 'statusline' or 'tabline' it will be
-	displayed in a convenient location.
+                                                           *'showcmdloc'* *'sloc'*
+'showcmdloc' 'sloc'     string (default "last")
+                        global
+        This option can be used to display the (partially) entered command in
+        another location.  Possible values are:
+          last          Last line of the screen (default).
+          statusline    Status line of the current window.
+          tabline       First line of the screen if 'showtabline' is enabled.
+        Setting this option to "statusline" or "tabline" means that these will
+        be redrawn whenever the command changes, which can be on every key
+        pressed.
+        The %S 'statusline' item can be used in 'statusline' or 'tabline' to
+        place the text.  Without a custom 'statusline' or 'tabline' it will be
+        displayed in a convenient location.
 
-			*'showfulltag'* *'sft'* *'noshowfulltag'* *'nosft'*
-'showfulltag' 'sft'	boolean	(default off)
-			global
-	When completing a word in insert mode (see |ins-completion|) from the
-	tags file, show both the tag name and a tidied-up form of the search
-	pattern (if there is one) as possible matches.  Thus, if you have
-	matched a C function, you can see a template for what arguments are
-	required (coding style permitting).
-	Note that this doesn't work well together with having "longest" in
-	'completeopt', because the completion from the search pattern may not
-	match the typed text.
+                                   *'showfulltag'* *'sft'* *'noshowfulltag'* *'nosft'*
+'showfulltag' 'sft'     boolean (default off)
+                        global
+        When completing a word in insert mode (see |ins-completion|) from the
+        tags file, show both the tag name and a tidied-up form of the search
+        pattern (if there is one) as possible matches.  Thus, if you have
+        matched a C function, you can see a template for what arguments are
+        required (coding style permitting).
+        Note that this doesn't work well together with having "longest" in
+        'completeopt', because the completion from the search pattern may not
+        match the typed text.
 
-				*'showmatch'* *'sm'* *'noshowmatch'* *'nosm'*
-'showmatch' 'sm'	boolean	(default off)
-			global
-	When a bracket is inserted, briefly jump to the matching one.  The
-	jump is only done if the match can be seen on the screen.  The time to
-	show the match can be set with 'matchtime'.
-	A Beep is given if there is no match (no matter if the match can be
-	seen or not).
-	When the 'm' flag is not included in 'cpoptions', typing a character
-	will immediately move the cursor back to where it belongs.
-	See the "sm" field in 'guicursor' for setting the cursor shape and
-	blinking when showing the match.
-	The 'matchpairs' option can be used to specify the characters to show
-	matches for.  'rightleft' and 'revins' are used to look for opposite
-	matches.
-	Also see the matchparen plugin for highlighting the match when moving
-	around |pi_paren.txt|.
-	Note: Use of the short form is rated PG.
+                                         *'showmatch'* *'sm'* *'noshowmatch'* *'nosm'*
+'showmatch' 'sm'        boolean (default off)
+                        global
+        When a bracket is inserted, briefly jump to the matching one.  The
+        jump is only done if the match can be seen on the screen.  The time to
+        show the match can be set with 'matchtime'.
+        A Beep is given if there is no match (no matter if the match can be
+        seen or not).
+        When the 'm' flag is not included in 'cpoptions', typing a character
+        will immediately move the cursor back to where it belongs.
+        See the "sm" field in 'guicursor' for setting the cursor shape and
+        blinking when showing the match.
+        The 'matchpairs' option can be used to specify the characters to show
+        matches for.  'rightleft' and 'revins' are used to look for opposite
+        matches.
+        Also see the matchparen plugin for highlighting the match when moving
+        around |pi_paren.txt|.
+        Note: Use of the short form is rated PG.
 
-				*'showmode'* *'smd'* *'noshowmode'* *'nosmd'*
-'showmode' 'smd'	boolean	(default on)
-			global
-	If in Insert, Replace or Visual mode put a message on the last line.
-	The |hl-ModeMsg| highlight group determines the highlighting.
-	The option has no effect when 'cmdheight' is zero.
+                                         *'showmode'* *'smd'* *'noshowmode'* *'nosmd'*
+'showmode' 'smd'        boolean (default on)
+                        global
+        If in Insert, Replace or Visual mode put a message on the last line.
+        The |hl-ModeMsg| highlight group determines the highlighting.
+        The option has no effect when 'cmdheight' is zero.
 
-						*'showtabline'* *'stal'*
-'showtabline' 'stal'	number	(default 1)
-			global
-	The value of this option specifies when the line with tab page labels
-	will be displayed:
-		0: never
-		1: only if there are at least two tab pages
-		2: always
-	This is both for the GUI and non-GUI implementation of the tab pages
-	line.
-	See |tab-page| for more information about tab pages.
+                                                          *'showtabline'* *'stal'*
+'showtabline' 'stal'    number (default 1)
+                        global
+        The value of this option specifies when the line with tab page labels
+        will be displayed:
+                0: never
+                1: only if there are at least two tab pages
+                2: always
+        This is both for the GUI and non-GUI implementation of the tab pages
+        line.
+        See |tab-page| for more information about tab pages.
 
-						*'sidescroll'* *'ss'*
-'sidescroll' 'ss'	number	(default 1)
-			global
-	The minimal number of columns to scroll horizontally.  Used only when
-	the 'wrap' option is off and the cursor is moved off of the screen.
-	When it is zero the cursor will be put in the middle of the screen.
-	When using a slow terminal set it to a large number or 0.  Not used
-	for "zh" and "zl" commands.
+                                                             *'sidescroll'* *'ss'*
+'sidescroll' 'ss'       number (default 1)
+                        global
+        The minimal number of columns to scroll horizontally.  Used only when
+        the 'wrap' option is off and the cursor is moved off of the screen.
+        When it is zero the cursor will be put in the middle of the screen.
+        When using a slow terminal set it to a large number or 0.  Not used
+        for "zh" and "zl" commands.
 
-					*'sidescrolloff'* *'siso'*
-'sidescrolloff' 'siso'	number	(default 0)
-			global or local to window |global-local|
-	The minimal number of screen columns to keep to the left and to the
-	right of the cursor if 'nowrap' is set.  Setting this option to a
-	value greater than 0 while having |'sidescroll'| also at a non-zero
-	value makes some context visible in the line you are scrolling in
-	horizontally (except at beginning of the line).  Setting this option
-	to a large value (like 999) has the effect of keeping the cursor
-	horizontally centered in the window, as long as one does not come too
-	close to the beginning of the line.
-	After using the local value, go back the global value with one of
-	these two: >vim
-		setlocal sidescrolloff<
-		setlocal sidescrolloff=-1
+                                                        *'sidescrolloff'* *'siso'*
+'sidescrolloff' 'siso'  number (default 0)
+                        global or local to window |global-local|
+        The minimal number of screen columns to keep to the left and to the
+        right of the cursor if 'nowrap' is set.  Setting this option to a
+        value greater than 0 while having |'sidescroll'| also at a non-zero
+        value makes some context visible in the line you are scrolling in
+        horizontally (except at beginning of the line).  Setting this option
+        to a large value (like 999) has the effect of keeping the cursor
+        horizontally centered in the window, as long as one does not come too
+        close to the beginning of the line.
+        After using the local value, go back the global value with one of
+        these two: >vim
+                setlocal sidescrolloff<
+                setlocal sidescrolloff=-1
 <
-	Example: Try this together with 'sidescroll' and 'listchars' as
-		 in the following example to never allow the cursor to move
-		 onto the "extends" character: >vim
+        Example: Try this together with 'sidescroll' and 'listchars' as
+                 in the following example to never allow the cursor to move
+                 onto the "extends" character: >vim
 
-		 set nowrap sidescroll=1 listchars=extends:>,precedes:<
-		 set sidescrolloff=1
-<
-
-						*'signcolumn'* *'scl'*
-'signcolumn' 'scl'	string	(default "auto")
-			local to window
-	When and how to draw the signcolumn. Valid values are:
-	   "auto"	only when there is a sign to display
-	   "auto:[1-9]" resize to accommodate multiple signs up to the
-	                given number (maximum 9), e.g. "auto:4"
-	   "auto:[1-8]-[2-9]"
-	                resize to accommodate multiple signs up to the
-			given maximum number (maximum 9) while keeping
-			at least the given minimum (maximum 8) fixed
-			space. The minimum number should always be less
-			than the maximum number, e.g. "auto:2-5"
-	   "no"		never
-	   "yes"	always
-	   "yes:[1-9]"  always, with fixed space for signs up to the given
-	                number (maximum 9), e.g. "yes:3"
-	   "number"	display signs in the 'number' column. If the number
-			column is not present, then behaves like "auto".
-
-			*'smartcase'* *'scs'* *'nosmartcase'* *'noscs'*
-'smartcase' 'scs'	boolean	(default off)
-			global
-	Override the 'ignorecase' option if the search pattern contains upper
-	case characters.  Only used when the search pattern is typed and
-	'ignorecase' option is on.  Used for the commands "/", "?", "n", "N",
-	":g" and ":s".  Not used for "*", "#", "gd", tag search, etc.  After
-	"*" and "#" you can make 'smartcase' used by doing a "/" command,
-	recalling the search pattern from history and hitting <Enter>.
-
-			*'smartindent'* *'si'* *'nosmartindent'* *'nosi'*
-'smartindent' 'si'	boolean	(default off)
-			local to buffer
-	Do smart autoindenting when starting a new line.  Works for C-like
-	programs, but can also be used for other languages.  'cindent' does
-	something like this, works better in most cases, but is more strict,
-	see |C-indenting|.  When 'cindent' is on or 'indentexpr' is set,
-	setting 'si' has no effect.  'indentexpr' is a more advanced
-	alternative.
-	Normally 'autoindent' should also be on when using 'smartindent'.
-	An indent is automatically inserted:
-	- After a line ending in "{".
-	- After a line starting with a keyword from 'cinwords'.
-	- Before a line starting with "}" (only with the "O" command).
-	When typing '}' as the first character in a new line, that line is
-	given the same indent as the matching "{".
-	When typing '#' as the first character in a new line, the indent for
-	that line is removed, the '#' is put in the first column.  The indent
-	is restored for the next line.  If you don't want this, use this
-	mapping: ":inoremap # X^H#", where ^H is entered with CTRL-V CTRL-H.
-	When using the ">>" command, lines starting with '#' are not shifted
-	right.
-
-				*'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
-'smarttab' 'sta'	boolean	(default on)
-			global
-	When on, a <Tab> in front of a line inserts blanks according to
-	'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
-	<BS> will delete a 'shiftwidth' worth of space at the start of the
-	line.
-	When off, a <Tab> always inserts blanks according to 'tabstop' or
-	'softtabstop'.  'shiftwidth' is only used for shifting text left or
-	right |shift-left-right|.
-	What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
-	option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
-	number of spaces is minimized by using <Tab>s.
-
-			*'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
-'smoothscroll' 'sms'	boolean	(default off)
-			local to window
-	Scrolling works with screen lines.  When 'wrap' is set and the first
-	line in the window wraps part of it may not be visible, as if it is
-	above the window. "<<<" is displayed at the start of the first line,
-	highlighted with |hl-NonText|.
-	You may also want to add "lastline" to the 'display' option to show as
-	much of the last line as possible.
-	NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
-	and scrolling with the mouse.
-
-						*'softtabstop'* *'sts'*
-'softtabstop' 'sts'	number	(default 0)
-			local to buffer
-	Number of spaces that a <Tab> counts for while performing editing
-	operations, like inserting a <Tab> or using <BS>.  It "feels" like
-	<Tab>s are being inserted, while in fact a mix of spaces and <Tab>s is
-	used.  This is useful to keep the 'ts' setting at its standard value
-	of 8, while being able to edit like it is set to 'sts'.  However,
-	commands like "x" still work on the actual characters.
-	When 'sts' is zero, this feature is off.
-	When 'sts' is negative, the value of 'shiftwidth' is used.
-	See also |ins-expandtab|.  When 'expandtab' is not set, the number of
-	spaces is minimized by using <Tab>s.
-	The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
-	set.
-
-	The value of 'softtabstop' will be ignored if |'varsofttabstop'| is set
-	to anything other than an empty string.
-
-						*'spell'* *'nospell'*
-'spell'			boolean	(default off)
-			local to window
-	When on spell checking will be done.  See |spell|.
-	The languages are specified with 'spelllang'.
-
-						*'spellcapcheck'* *'spc'*
-'spellcapcheck' 'spc'	string	(default "[.?!]\_[\])'"\t ]\+")
-			local to buffer
-	Pattern to locate the end of a sentence.  The following word will be
-	checked to start with a capital letter.  If not then it is highlighted
-	with SpellCap |hl-SpellCap| (unless the word is also badly spelled).
-	When this check is not wanted make this option empty.
-	Only used when 'spell' is set.
-	Be careful with special characters, see |option-backslash| about
-	including spaces and backslashes.
-	To set this option automatically depending on the language, see
-	|set-spc-auto|.
-
-						*'spellfile'* *'spf'*
-'spellfile' 'spf'	string	(default "")
-			local to buffer
-	Name of the word list file where words are added for the |zg| and |zw|
-	commands.  It must end in ".{encoding}.add".  You need to include the
-	path, otherwise the file is placed in the current directory.
-	The path may include characters from 'isfname', space, comma and '@'.
-								*E765*
-	It may also be a comma-separated list of names.  A count before the
-	|zg| and |zw| commands can be used to access each.  This allows using
-	a personal word list file and a project word list file.
-	When a word is added while this option is empty Vim will set it for
-	you: Using the first directory in 'runtimepath' that is writable.  If
-	there is no "spell" directory yet it will be created.  For the file
-	name the first language name that appears in 'spelllang' is used,
-	ignoring the region.
-	The resulting ".spl" file will be used for spell checking, it does not
-	have to appear in 'spelllang'.
-	Normally one file is used for all regions, but you can add the region
-	name if you want to.  However, it will then only be used when
-	'spellfile' is set to it, for entries in 'spelllang' only files
-	without region name will be found.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'spelllang'* *'spl'*
-'spelllang' 'spl'	string	(default "en")
-			local to buffer
-	A comma-separated list of word list names.  When the 'spell' option is
-	on spellchecking will be done for these languages.  Example: >vim
-		set spelllang=en_us,nl,medical
-<	This means US English, Dutch and medical words are recognized.  Words
-	that are not recognized will be highlighted.
-	The word list name must consist of alphanumeric characters, a dash or
-	an underscore.  It should not include a comma or dot.  Using a dash is
-	recommended to separate the two letter language name from a
-	specification.  Thus "en-rare" is used for rare English words.
-	A region name must come last and have the form "_xx", where "xx" is
-	the two-letter, lower case region name.  You can use more than one
-	region by listing them: "en_us,en_ca" supports both US and Canadian
-	English, but not words specific for Australia, New Zealand or Great
-	Britain. (Note: currently en_au and en_nz dictionaries are older than
-	en_ca, en_gb and en_us).
-	If the name "cjk" is included East Asian characters are excluded from
-	spell checking.  This is useful when editing text that also has Asian
-	words.
-	Note that the "medical" dictionary does not exist, it is just an
-	example of a longer name.
-							*E757*
-	As a special case the name of a .spl file can be given as-is.  The
-	first "_xx" in the name is removed and used as the region name
-	(_xx is an underscore, two letters and followed by a non-letter).
-	This is mainly for testing purposes.  You must make sure the correct
-	encoding is used, Vim doesn't check it.
-	How the related spell files are found is explained here: |spell-load|.
-
-	If the |spellfile.vim| plugin is active and you use a language name
-	for which Vim cannot find the .spl file in 'runtimepath' the plugin
-	will ask you if you want to download the file.
-
-	After this option has been set successfully, Vim will source the files
-	"spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
-	up to the first character that is not an ASCII letter or number and
-	not a dash.  Also see |set-spc-auto|.
-
-						*'spelloptions'* *'spo'*
-'spelloptions' 'spo'	string	(default "")
-			local to buffer
-	A comma-separated list of options for spell checking:
-	camel		When a word is CamelCased, assume "Cased" is a
-			separate word: every upper-case character in a word
-			that comes after a lower case character indicates the
-			start of a new word.
-	noplainbuffer	Only spellcheck a buffer when 'syntax' is enabled,
-			or when extmarks are set within the buffer. Only
-			designated regions of the buffer are spellchecked in
-			this case.
-
-						*'spellsuggest'* *'sps'*
-'spellsuggest' 'sps'	string	(default "best")
-			global
-	Methods used for spelling suggestions.  Both for the |z=| command and
-	the |spellsuggest()| function.  This is a comma-separated list of
-	items:
-
-	best		Internal method that works best for English.  Finds
-			changes like "fast" and uses a bit of sound-a-like
-			scoring to improve the ordering.
-
-	double		Internal method that uses two methods and mixes the
-			results.  The first method is "fast", the other method
-			computes how much the suggestion sounds like the bad
-			word.  That only works when the language specifies
-			sound folding.  Can be slow and doesn't always give
-			better results.
-
-	fast		Internal method that only checks for simple changes:
-			character inserts/deletes/swaps.  Works well for
-			simple typing mistakes.
-
-	{number}	The maximum number of suggestions listed for |z=|.
-			Not used for |spellsuggest()|.  The number of
-			suggestions is never more than the value of 'lines'
-			minus two.
-
-	timeout:{millisec}   Limit the time searching for suggestions to
-			{millisec} milli seconds.  Applies to the following
-			methods.  When omitted the limit is 5000. When
-			negative there is no limit.
-
-	file:{filename} Read file {filename}, which must have two columns,
-			separated by a slash.  The first column contains the
-			bad word, the second column the suggested good word.
-			Example:
-				theribal/terrible ~
-			Use this for common mistakes that do not appear at the
-			top of the suggestion list with the internal methods.
-			Lines without a slash are ignored, use this for
-			comments.
-			The word in the second column must be correct,
-			otherwise it will not be used.  Add the word to an
-			".add" file if it is currently flagged as a spelling
-			mistake.
-			The file is used for all languages.
-
-	expr:{expr}	Evaluate expression {expr}.  Use a function to avoid
-			trouble with spaces.  |v:val| holds the badly spelled
-			word.  The expression must evaluate to a List of
-			Lists, each with a suggestion and a score.
-			Example:
-				[['the', 33], ['that', 44]] ~
-			Set 'verbose' and use |z=| to see the scores that the
-			internal methods use.  A lower score is better.
-			This may invoke |spellsuggest()| if you temporarily
-			set 'spellsuggest' to exclude the "expr:" part.
-			Errors are silently ignored, unless you set the
-			'verbose' option to a non-zero value.
-
-	Only one of "best", "double" or "fast" may be used.  The others may
-	appear several times in any order.  Example: >vim
-		set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
-<
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-			*'splitbelow'* *'sb'* *'nosplitbelow'* *'nosb'*
-'splitbelow' 'sb'	boolean	(default off)
-			global
-	When on, splitting a window will put the new window below the current
-	one. |:split|
-
-						*'splitkeep'* *'spk'*
-'splitkeep' 'spk'	string	(default "cursor")
-			global
-	The value of this option determines the scroll behavior when opening,
-	closing or resizing horizontal splits.
-
-	Possible values are:
-	  cursor	Keep the same relative cursor position.
-	  screen	Keep the text on the same screen line.
-	  topline	Keep the topline the same.
-
-	For the "screen" and "topline" values, the cursor position will be
-	changed when necessary. In this case, the jumplist will be populated
-	with the previous cursor position. For "screen", the text cannot always
-	be kept on the same screen line when 'wrap' is enabled.
-
-			*'splitright'* *'spr'* *'nosplitright'* *'nospr'*
-'splitright' 'spr'	boolean	(default off)
-			global
-	When on, splitting a window will put the new window right of the
-	current one. |:vsplit|
-
-			*'startofline'* *'sol'* *'nostartofline'* *'nosol'*
-'startofline' 'sol'	boolean	(default off)
-			global
-	When "on" the commands listed below move the cursor to the first
-	non-blank of the line.  When off the cursor is kept in the same column
-	(if possible).  This applies to the commands:
-	- CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
-	- "d", "<<" and ">>" with a linewise operator
-	- "%" with a count
-	- buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
-	- Ex commands that only have a line number, e.g., ":25" or ":+".
-	In case of buffer changing commands the cursor is placed at the column
-	where it was the last time the buffer was edited.
-
-						*'statuscolumn'* *'stc'*
-'statuscolumn' 'stc'	string	(default "")
-			local to window
-	EXPERIMENTAL
-	When non-empty, this option determines the content of the area to the
-	side of a window, normally containing the fold, sign and number columns.
-	The format of this option is like that of 'statusline'.
-
-	Some of the items from the 'statusline' format are different for
-	'statuscolumn':
-
-	%l	line number of currently drawn line
-	%r	relative line number of currently drawn line
-	%s	sign column for currently drawn line
-	%C	fold column for currently drawn line
-
-	NOTE: To draw the sign and fold columns, their items must be included in
-	'statuscolumn'. Even when they are not included, the status column width
-	will adapt to the 'signcolumn' and 'foldcolumn' width.
-
-	The |v:lnum|    variable holds the line number to be drawn.
-	The |v:relnum|  variable holds the relative line number to be drawn.
-	The |v:virtnum| variable is negative when drawing virtual lines, zero
-		      when drawing the actual buffer line, and positive when
-		      drawing the wrapped part of a buffer line.
-
-	NOTE: The %@ click execute function item is supported as well but the
-	specified function will be the same for each row in the same column.
-	It cannot be switched out through a dynamic 'statuscolumn' format, the
-	handler should be written with this in mind.
-
-	Examples: >vim
-		" Relative number with bar separator and click handlers:
-		set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
-
-		" Right aligned relative cursor line number:
-		let &stc='%=%{v:relnum?v:relnum:v:lnum} '
-
-		" Line numbers in hexadecimal for non wrapped part of lines:
-		let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
-
-		" Human readable line numbers with thousands separator:
-		let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
-			   . '%(\\d\\d\\d\\)\\+$",",","g")}'
-
-		" Both relative and absolute line numbers with different
-		" highlighting for odd and even relative numbers:
-		let &stc='%#NonText#%{&nu?v:lnum:""}' .
-		 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
-		 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
-
-<	WARNING: this expression is evaluated for each screen line so defining
-	an expensive expression can negatively affect render performance.
-
-					*'statusline'* *'stl'* *E540* *E542*
-'statusline' 'stl'	string	(default "")
-			global or local to window |global-local|
-	When non-empty, this option determines the content of the status line.
-	Also see |status-line|.
-
-	The option consists of printf style '%' items interspersed with
-	normal text.  Each status line item is of the form:
-	  %-0{minwid}.{maxwid}{item}
-	All fields except the {item} are optional.  A single percent sign can
-	be given as "%%".
-
-	When the option starts with "%!" then it is used as an expression,
-	evaluated and the result is used as the option value.  Example: >vim
-		set statusline=%!MyStatusLine()
-<	The *g:statusline_winid* variable will be set to the |window-ID| of the
-	window that the status line belongs to.
-	The result can contain %{} items that will be evaluated too.
-	Note that the "%!" expression is evaluated in the context of the
-	current window and buffer, while %{} items are evaluated in the
-	context of the window that the statusline belongs to.
-
-	When there is error while evaluating the option then it will be made
-	empty to avoid further errors.  Otherwise screen updating would loop.
-	When the result contains unprintable characters the result is
-	unpredictable.
-
-	Note that the only effect of 'ruler' when this option is set (and
-	'laststatus' is 2 or 3) is controlling the output of |CTRL-G|.
-
-	field	    meaning ~
-	-	    Left justify the item.  The default is right justified
-		    when minwid is larger than the length of the item.
-	0	    Leading zeroes in numeric items.  Overridden by "-".
-	minwid	    Minimum width of the item, padding as set by "-" & "0".
-		    Value must be 50 or less.
-	maxwid	    Maximum width of the item.  Truncation occurs with a "<"
-		    on the left for text items.  Numeric items will be
-		    shifted down to maxwid-2 digits followed by ">"number
-		    where number is the amount of missing digits, much like
-		    an exponential notation.
-	item	    A one letter code as described below.
-
-	Following is a description of the possible statusline items.  The
-	second character in "item" is the type:
-		N for number
-		S for string
-		F for flags as described below
-		- not applicable
-
-	item  meaning ~
-	f S   Path to the file in the buffer, as typed or relative to current
-	      directory.
-	F S   Full path to the file in the buffer.
-	t S   File name (tail) of file in the buffer.
-	m F   Modified flag, text is "[+]"; "[-]" if 'modifiable' is off.
-	M F   Modified flag, text is ",+" or ",-".
-	r F   Readonly flag, text is "[RO]".
-	R F   Readonly flag, text is ",RO".
-	h F   Help buffer flag, text is "[help]".
-	H F   Help buffer flag, text is ",HLP".
-	w F   Preview window flag, text is "[Preview]".
-	W F   Preview window flag, text is ",PRV".
-	y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
-	Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
-	q S   "[Quickfix List]", "[Location List]" or empty.
-	k S   Value of "b:keymap_name" or 'keymap' when |:lmap| mappings are
-	      being used: "<keymap>"
-	n N   Buffer number.
-	b N   Value of character under cursor.
-	B N   As above, in hexadecimal.
-	o N   Byte number in file of byte under cursor, first byte is 1.
-	      Mnemonic: Offset from start of file (with one added)
-	O N   As above, in hexadecimal.
-	l N   Line number.
-	L N   Number of lines in buffer.
-	c N   Column number (byte index).
-	v N   Virtual column number (screen column).
-	V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
-	p N   Percentage through file in lines as in |CTRL-G|.
-	P S   Percentage through file of displayed window.  This is like the
-	      percentage described for 'ruler'.  Always 3 in length, unless
-	      translated.
-	S S   'showcmd' content, see 'showcmdloc'.
-	a S   Argument list status as in default title.  ({current} of {max})
-	      Empty if the argument file count is zero or one.
-	{ NF  Evaluate expression between "%{" and "}" and substitute result.
-	      Note that there is no "%" before the closing "}".  The
-	      expression cannot contain a "}" character, call a function to
-	      work around that.  See |stl-%{| below.
-	`{%` -  This is almost same as "{" except the result of the expression is
-	      re-evaluated as a statusline format string.  Thus if the
-	      return value of expr contains "%" items they will get expanded.
-	      The expression can contain the "}" character, the end of
-	      expression is denoted by "%}".
-	      For example: >vim
-		func! Stl_filename() abort
-		    return "%t"
-		endfunc
-<	        `stl=%{Stl_filename()}`   results in `"%t"`
-	        `stl=%{%Stl_filename()%}` results in `"Name of current file"`
-	%} -  End of "{%" expression
-	( -   Start of item group.  Can be used for setting the width and
-	      alignment of a section.  Must be followed by %) somewhere.
-	) -   End of item group.  No width fields allowed.
-	T N   For 'tabline': start of tab page N label.  Use %T or %X to end
-	      the label.  Clicking this label with left mouse button switches
-	      to the specified tab page.
-	X N   For 'tabline': start of close tab N label.  Use %X or %T to end
-	      the label, e.g.: %3Xclose%X.  Use %999X for a "close current
-	      tab" label.    Clicking this label with left mouse button closes
-	      specified tab page.
-	@ N   Start of execute function label. Use %X or %T to
-	      end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
-	      label runs specified function: in the example when clicking once
-	      using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
-	      '    ')" expression will be run.  Function receives the
-	      following arguments in order:
-	      1. minwid field value or zero if no N was specified
-	      2. number of mouse clicks to detect multiple clicks
-	      3. mouse button used: "l", "r" or "m" for left, right or middle
-	         button respectively; one should not rely on third argument
-	         being only "l", "r" or "m": any other non-empty string value
-	         that contains only ASCII lower case letters may be expected
-	         for other mouse buttons
-	      4. modifiers pressed: string which contains "s" if shift
-	         modifier was pressed, "c" for control, "a" for alt and "m"
-	         for meta; currently if modifier is not pressed string
-	         contains space instead, but one should not rely on presence
-	         of spaces or specific order of modifiers: use |stridx()| to
-	         test whether some modifier is present; string is guaranteed
-	         to contain only ASCII letters and spaces, one letter per
-	         modifier; "?" modifier may also be present, but its presence
-	         is a bug that denotes that new mouse button recognition was
-	         added without modifying code that reacts on mouse clicks on
-	         this label.
-	      Use |getmousepos()|.winid in the specified function to get the
-	      corresponding window id of the clicked item.
-	< -   Where to truncate line if too long.  Default is at the start.
-	      No width fields allowed.
-	= -   Separation point between alignment sections.  Each section will
-	      be separated by an equal number of spaces.  With one %= what
-	      comes after it will be right-aligned.  With two %= there is a
-	      middle part, with white space left and right of it.
-	      No width fields allowed.
-	# -   Set highlight group.  The name must follow and then a # again.
-	      Thus use %#HLname# for highlight group HLname.  The same
-	      highlighting is used, also for the statusline of non-current
-	      windows.
-	* -   Set highlight group to User{N}, where {N} is taken from the
-	      minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
-	      The difference between User{N} and StatusLine will be applied to
-	      StatusLineNC for the statusline of non-current windows.
-	      The number N must be between 1 and 9.  See |hl-User1..9|
-
-	When displaying a flag, Vim removes the leading comma, if any, when
-	that flag comes right after plaintext.  This will make a nice display
-	when flags are used like in the examples below.
-
-	When all items in a group becomes an empty string (i.e. flags that are
-	not set) and a minwid is not set for the group, the whole group will
-	become empty.  This will make a group like the following disappear
-	completely from the statusline when none of the flags are set. >vim
-		set statusline=...%(\ [%M%R%H]%)...
-<	Beware that an expression is evaluated each and every time the status
-	line is displayed.
-				*stl-%{* *g:actual_curbuf* *g:actual_curwin*
-	While evaluating %{} the current buffer and current window will be set
-	temporarily to that of the window (and buffer) whose statusline is
-	currently being drawn.  The expression will evaluate in this context.
-	The variable "g:actual_curbuf" is set to the `bufnr()` number of the
-	real current buffer and "g:actual_curwin" to the |window-ID| of the
-	real current window.  These values are strings.
-
-	The 'statusline' option will be evaluated in the |sandbox| if set from
-	a modeline, see |sandbox-option|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	It is not allowed to change text or jump to another window while
-	evaluating 'statusline' |textlock|.
-
-	If the statusline is not updated when you want it (e.g., after setting
-	a variable that's used in an expression), you can force an update by
-	using `:redrawstatus`.
-
-	A result of all digits is regarded a number for display purposes.
-	Otherwise the result is taken as flag text and applied to the rules
-	described above.
-
-	Watch out for errors in expressions.  They may render Vim unusable!
-	If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and
-	edit your vimrc or whatever with "vim --clean" to get it right.
-
-	Examples:
-	Emulate standard status line with 'ruler' set >vim
-	  set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
-<	Similar, but add ASCII value of char under the cursor (like "ga") >vim
-	  set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
-<	Display byte count and byte value, modified flag in red. >vim
-	  set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
-	  hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
-<	Display a ,GZ flag if a compressed file is loaded >vim
-	  set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
-<	In the |:autocmd|'s: >vim
-	  let b:gzflag = 1
-<	And: >vim
-	  unlet b:gzflag
-<	And define this function: >vim
-	  function VarExists(var, val)
-	      if exists(a:var) | return a:val | else | return '' | endif
-	  endfunction
+                 set nowrap sidescroll=1 listchars=extends:>,precedes:<
+                 set sidescrolloff=1
 <
 
-						*'suffixes'* *'su'*
-'suffixes' 'su'		string	(default ".bak,~,.o,.h,.info,.swp,.obj")
-			global
-	Files with these suffixes get a lower priority when multiple files
-	match a wildcard.  See |suffixes|.  Commas can be used to separate the
-	suffixes.  Spaces after the comma are ignored.  A dot is also seen as
-	the start of a suffix.  To avoid a dot or comma being recognized as a
-	separator, precede it with a backslash (see |option-backslash| about
-	including spaces and backslashes).
-	See 'wildignore' for completely ignoring files.
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	suffixes from the list.  This avoids problems when a future version
-	uses another default.
+                                                            *'signcolumn'* *'scl'*
+'signcolumn' 'scl'      string (default "auto")
+                        local to window
+        When and how to draw the signcolumn. Valid values are:
+           "auto"       only when there is a sign to display
+           "auto:[1-9]" resize to accommodate multiple signs up to the
+                        given number (maximum 9), e.g. "auto:4"
+           "auto:[1-8]-[2-9]"
+                        resize to accommodate multiple signs up to the
+                        given maximum number (maximum 9) while keeping
+                        at least the given minimum (maximum 8) fixed
+                        space. The minimum number should always be less
+                        than the maximum number, e.g. "auto:2-5"
+           "no"         never
+           "yes"        always
+           "yes:[1-9]"  always, with fixed space for signs up to the given
+                        number (maximum 9), e.g. "yes:3"
+           "number"     display signs in the 'number' column. If the number
+                        column is not present, then behaves like "auto".
 
-						*'suffixesadd'* *'sua'*
-'suffixesadd' 'sua'	string	(default "")
-			local to buffer
-	Comma-separated list of suffixes, which are used when searching for a
-	file for the "gf", "[I", etc. commands.  Example: >vim
-		set suffixesadd=.java
+                                       *'smartcase'* *'scs'* *'nosmartcase'* *'noscs'*
+'smartcase' 'scs'       boolean (default off)
+                        global
+        Override the 'ignorecase' option if the search pattern contains upper
+        case characters.  Only used when the search pattern is typed and
+        'ignorecase' option is on.  Used for the commands "/", "?", "n", "N",
+        ":g" and ":s".  Not used for "*", "#", "gd", tag search, etc.  After
+        "*" and "#" you can make 'smartcase' used by doing a "/" command,
+        recalling the search pattern from history and hitting <Enter>.
+
+                                     *'smartindent'* *'si'* *'nosmartindent'* *'nosi'*
+'smartindent' 'si'      boolean (default off)
+                        local to buffer
+        Do smart autoindenting when starting a new line.  Works for C-like
+        programs, but can also be used for other languages.  'cindent' does
+        something like this, works better in most cases, but is more strict,
+        see |C-indenting|.  When 'cindent' is on or 'indentexpr' is set,
+        setting 'si' has no effect.  'indentexpr' is a more advanced
+        alternative.
+        Normally 'autoindent' should also be on when using 'smartindent'.
+        An indent is automatically inserted:
+        - After a line ending in "{".
+        - After a line starting with a keyword from 'cinwords'.
+        - Before a line starting with "}" (only with the "O" command).
+        When typing '}' as the first character in a new line, that line is
+        given the same indent as the matching "{".
+        When typing '#' as the first character in a new line, the indent for
+        that line is removed, the '#' is put in the first column.  The indent
+        is restored for the next line.  If you don't want this, use this
+        mapping: ":inoremap # X^H#", where ^H is entered with CTRL-V CTRL-H.
+        When using the ">>" command, lines starting with '#' are not shifted
+        right.
+
+                                         *'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
+'smarttab' 'sta'        boolean (default on)
+                        global
+        When on, a <Tab> in front of a line inserts blanks according to
+        'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
+        <BS> will delete a 'shiftwidth' worth of space at the start of the
+        line.
+        When off, a <Tab> always inserts blanks according to 'tabstop' or
+        'softtabstop'.  'shiftwidth' is only used for shifting text left or
+        right |shift-left-right|.
+        What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
+        option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
+        number of spaces is minimized by using <Tab>s.
+
+                                 *'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
+'smoothscroll' 'sms'    boolean (default off)
+                        local to window
+        Scrolling works with screen lines.  When 'wrap' is set and the first
+        line in the window wraps part of it may not be visible, as if it is
+        above the window. "<<<" is displayed at the start of the first line,
+        highlighted with |hl-NonText|.
+        You may also want to add "lastline" to the 'display' option to show as
+        much of the last line as possible.
+        NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
+        and scrolling with the mouse.
+
+                                                           *'softtabstop'* *'sts'*
+'softtabstop' 'sts'     number (default 0)
+                        local to buffer
+        Number of spaces that a <Tab> counts for while performing editing
+        operations, like inserting a <Tab> or using <BS>.  It "feels" like
+        <Tab>s are being inserted, while in fact a mix of spaces and <Tab>s is
+        used.  This is useful to keep the 'ts' setting at its standard value
+        of 8, while being able to edit like it is set to 'sts'.  However,
+        commands like "x" still work on the actual characters.
+        When 'sts' is zero, this feature is off.
+        When 'sts' is negative, the value of 'shiftwidth' is used.
+        See also |ins-expandtab|.  When 'expandtab' is not set, the number of
+        spaces is minimized by using <Tab>s.
+        The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
+        set.
+
+        The value of 'softtabstop' will be ignored if |'varsofttabstop'| is set
+        to anything other than an empty string.
+
+                                                             *'spell'* *'nospell'*
+'spell'                 boolean (default off)
+                        local to window
+        When on spell checking will be done.  See |spell|.
+        The languages are specified with 'spelllang'.
+
+                                                         *'spellcapcheck'* *'spc'*
+'spellcapcheck' 'spc'   string (default "[.?!]\_[\])'"\t ]\+")
+                        local to buffer
+        Pattern to locate the end of a sentence.  The following word will be
+        checked to start with a capital letter.  If not then it is highlighted
+        with SpellCap |hl-SpellCap| (unless the word is also badly spelled).
+        When this check is not wanted make this option empty.
+        Only used when 'spell' is set.
+        Be careful with special characters, see |option-backslash| about
+        including spaces and backslashes.
+        To set this option automatically depending on the language, see
+        |set-spc-auto|.
+
+                                                             *'spellfile'* *'spf'*
+'spellfile' 'spf'       string (default "")
+                        local to buffer
+        Name of the word list file where words are added for the |zg| and |zw|
+        commands.  It must end in ".{encoding}.add".  You need to include the
+        path, otherwise the file is placed in the current directory.
+        The path may include characters from 'isfname', space, comma and '@'.
+                                                                *E765*
+        It may also be a comma-separated list of names.  A count before the
+        |zg| and |zw| commands can be used to access each.  This allows using
+        a personal word list file and a project word list file.
+        When a word is added while this option is empty Vim will set it for
+        you: Using the first directory in 'runtimepath' that is writable.  If
+        there is no "spell" directory yet it will be created.  For the file
+        name the first language name that appears in 'spelllang' is used,
+        ignoring the region.
+        The resulting ".spl" file will be used for spell checking, it does not
+        have to appear in 'spelllang'.
+        Normally one file is used for all regions, but you can add the region
+        name if you want to.  However, it will then only be used when
+        'spellfile' is set to it, for entries in 'spelllang' only files
+        without region name will be found.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                             *'spelllang'* *'spl'*
+'spelllang' 'spl'       string (default "en")
+                        local to buffer
+        A comma-separated list of word list names.  When the 'spell' option is
+        on spellchecking will be done for these languages.  Example: >vim
+                set spelllang=en_us,nl,medical
+<       This means US English, Dutch and medical words are recognized.  Words
+        that are not recognized will be highlighted.
+        The word list name must consist of alphanumeric characters, a dash or
+        an underscore.  It should not include a comma or dot.  Using a dash is
+        recommended to separate the two letter language name from a
+        specification.  Thus "en-rare" is used for rare English words.
+        A region name must come last and have the form "_xx", where "xx" is
+        the two-letter, lower case region name.  You can use more than one
+        region by listing them: "en_us,en_ca" supports both US and Canadian
+        English, but not words specific for Australia, New Zealand or Great
+        Britain. (Note: currently en_au and en_nz dictionaries are older than
+        en_ca, en_gb and en_us).
+        If the name "cjk" is included East Asian characters are excluded from
+        spell checking.  This is useful when editing text that also has Asian
+        words.
+        Note that the "medical" dictionary does not exist, it is just an
+        example of a longer name.
+                                                        *E757*
+        As a special case the name of a .spl file can be given as-is.  The
+        first "_xx" in the name is removed and used as the region name
+        (_xx is an underscore, two letters and followed by a non-letter).
+        This is mainly for testing purposes.  You must make sure the correct
+        encoding is used, Vim doesn't check it.
+        How the related spell files are found is explained here: |spell-load|.
+
+        If the |spellfile.vim| plugin is active and you use a language name
+        for which Vim cannot find the .spl file in 'runtimepath' the plugin
+        will ask you if you want to download the file.
+
+        After this option has been set successfully, Vim will source the files
+        "spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
+        up to the first character that is not an ASCII letter or number and
+        not a dash.  Also see |set-spc-auto|.
+
+                                                          *'spelloptions'* *'spo'*
+'spelloptions' 'spo'    string (default "")
+                        local to buffer
+        A comma-separated list of options for spell checking:
+        camel           When a word is CamelCased, assume "Cased" is a
+                        separate word: every upper-case character in a word
+                        that comes after a lower case character indicates the
+                        start of a new word.
+        noplainbuffer   Only spellcheck a buffer when 'syntax' is enabled,
+                        or when extmarks are set within the buffer. Only
+                        designated regions of the buffer are spellchecked in
+                        this case.
+
+                                                          *'spellsuggest'* *'sps'*
+'spellsuggest' 'sps'    string (default "best")
+                        global
+        Methods used for spelling suggestions.  Both for the |z=| command and
+        the |spellsuggest()| function.  This is a comma-separated list of
+        items:
+
+        best            Internal method that works best for English.  Finds
+                        changes like "fast" and uses a bit of sound-a-like
+                        scoring to improve the ordering.
+
+        double          Internal method that uses two methods and mixes the
+                        results.  The first method is "fast", the other method
+                        computes how much the suggestion sounds like the bad
+                        word.  That only works when the language specifies
+                        sound folding.  Can be slow and doesn't always give
+                        better results.
+
+        fast            Internal method that only checks for simple changes:
+                        character inserts/deletes/swaps.  Works well for
+                        simple typing mistakes.
+
+        {number}        The maximum number of suggestions listed for |z=|.
+                        Not used for |spellsuggest()|.  The number of
+                        suggestions is never more than the value of 'lines'
+                        minus two.
+
+        timeout:{millisec}   Limit the time searching for suggestions to
+                        {millisec} milli seconds.  Applies to the following
+                        methods.  When omitted the limit is 5000. When
+                        negative there is no limit.
+
+        file:{filename} Read file {filename}, which must have two columns,
+                        separated by a slash.  The first column contains the
+                        bad word, the second column the suggested good word.
+                        Example:
+                                theribal/terrible ~
+                        Use this for common mistakes that do not appear at the
+                        top of the suggestion list with the internal methods.
+                        Lines without a slash are ignored, use this for
+                        comments.
+                        The word in the second column must be correct,
+                        otherwise it will not be used.  Add the word to an
+                        ".add" file if it is currently flagged as a spelling
+                        mistake.
+                        The file is used for all languages.
+
+        expr:{expr}     Evaluate expression {expr}.  Use a function to avoid
+                        trouble with spaces.  |v:val| holds the badly spelled
+                        word.  The expression must evaluate to a List of
+                        Lists, each with a suggestion and a score.
+                        Example:
+                                [['the', 33], ['that', 44]] ~
+                        Set 'verbose' and use |z=| to see the scores that the
+                        internal methods use.  A lower score is better.
+                        This may invoke |spellsuggest()| if you temporarily
+                        set 'spellsuggest' to exclude the "expr:" part.
+                        Errors are silently ignored, unless you set the
+                        'verbose' option to a non-zero value.
+
+        Only one of "best", "double" or "fast" may be used.  The others may
+        appear several times in any order.  Example: >vim
+                set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+<
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                       *'splitbelow'* *'sb'* *'nosplitbelow'* *'nosb'*
+'splitbelow' 'sb'       boolean (default off)
+                        global
+        When on, splitting a window will put the new window below the current
+        one. |:split|
+
+                                                             *'splitkeep'* *'spk'*
+'splitkeep' 'spk'       string (default "cursor")
+                        global
+        The value of this option determines the scroll behavior when opening,
+        closing or resizing horizontal splits.
+
+        Possible values are:
+          cursor        Keep the same relative cursor position.
+          screen        Keep the text on the same screen line.
+          topline       Keep the topline the same.
+
+        For the "screen" and "topline" values, the cursor position will be
+        changed when necessary. In this case, the jumplist will be populated
+        with the previous cursor position. For "screen", the text cannot always
+        be kept on the same screen line when 'wrap' is enabled.
+
+                                     *'splitright'* *'spr'* *'nosplitright'* *'nospr'*
+'splitright' 'spr'      boolean (default off)
+                        global
+        When on, splitting a window will put the new window right of the
+        current one. |:vsplit|
+
+                                   *'startofline'* *'sol'* *'nostartofline'* *'nosol'*
+'startofline' 'sol'     boolean (default off)
+                        global
+        When "on" the commands listed below move the cursor to the first
+        non-blank of the line.  When off the cursor is kept in the same column
+        (if possible).  This applies to the commands:
+        - CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
+        - "d", "<<" and ">>" with a linewise operator
+        - "%" with a count
+        - buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
+        - Ex commands that only have a line number, e.g., ":25" or ":+".
+        In case of buffer changing commands the cursor is placed at the column
+        where it was the last time the buffer was edited.
+
+                                                          *'statuscolumn'* *'stc'*
+'statuscolumn' 'stc'    string (default "")
+                        local to window
+        EXPERIMENTAL
+        When non-empty, this option determines the content of the area to the
+        side of a window, normally containing the fold, sign and number columns.
+        The format of this option is like that of 'statusline'.
+
+        Some of the items from the 'statusline' format are different for
+        'statuscolumn':
+
+        %l      line number of currently drawn line
+        %r      relative line number of currently drawn line
+        %s      sign column for currently drawn line
+        %C      fold column for currently drawn line
+
+        NOTE: To draw the sign and fold columns, their items must be included in
+        'statuscolumn'. Even when they are not included, the status column width
+        will adapt to the 'signcolumn' and 'foldcolumn' width.
+
+        The |v:lnum|    variable holds the line number to be drawn.
+        The |v:relnum|  variable holds the relative line number to be drawn.
+        The |v:virtnum| variable is negative when drawing virtual lines, zero
+                      when drawing the actual buffer line, and positive when
+                      drawing the wrapped part of a buffer line.
+
+        NOTE: The %@ click execute function item is supported as well but the
+        specified function will be the same for each row in the same column.
+        It cannot be switched out through a dynamic 'statuscolumn' format, the
+        handler should be written with this in mind.
+
+        Examples: >vim
+                " Relative number with bar separator and click handlers:
+                set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
+
+                " Right aligned relative cursor line number:
+                let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+
+                " Line numbers in hexadecimal for non wrapped part of lines:
+                let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
+
+                " Human readable line numbers with thousands separator:
+                let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
+                           . '%(\\d\\d\\d\\)\\+$",",","g")}'
+
+                " Both relative and absolute line numbers with different
+                " highlighting for odd and even relative numbers:
+                let &stc='%#NonText#%{&nu?v:lnum:""}' .
+                 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
+                 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
+
+<       WARNING: this expression is evaluated for each screen line so defining
+        an expensive expression can negatively affect render performance.
+
+                                                  *'statusline'* *'stl'* *E540* *E542*
+'statusline' 'stl'      string (default "")
+                        global or local to window |global-local|
+        When non-empty, this option determines the content of the status line.
+        Also see |status-line|.
+
+        The option consists of printf style '%' items interspersed with
+        normal text.  Each status line item is of the form:
+          %-0{minwid}.{maxwid}{item}
+        All fields except the {item} are optional.  A single percent sign can
+        be given as "%%".
+
+        When the option starts with "%!" then it is used as an expression,
+        evaluated and the result is used as the option value.  Example: >vim
+                set statusline=%!MyStatusLine()
+<       The *g:statusline_winid* variable will be set to the |window-ID| of the
+        window that the status line belongs to.
+        The result can contain %{} items that will be evaluated too.
+        Note that the "%!" expression is evaluated in the context of the
+        current window and buffer, while %{} items are evaluated in the
+        context of the window that the statusline belongs to.
+
+        When there is error while evaluating the option then it will be made
+        empty to avoid further errors.  Otherwise screen updating would loop.
+        When the result contains unprintable characters the result is
+        unpredictable.
+
+        Note that the only effect of 'ruler' when this option is set (and
+        'laststatus' is 2 or 3) is controlling the output of |CTRL-G|.
+
+        field       meaning ~
+        -           Left justify the item.  The default is right justified
+                    when minwid is larger than the length of the item.
+        0           Leading zeroes in numeric items.  Overridden by "-".
+        minwid      Minimum width of the item, padding as set by "-" & "0".
+                    Value must be 50 or less.
+        maxwid      Maximum width of the item.  Truncation occurs with a "<"
+                    on the left for text items.  Numeric items will be
+                    shifted down to maxwid-2 digits followed by ">"number
+                    where number is the amount of missing digits, much like
+                    an exponential notation.
+        item        A one letter code as described below.
+
+        Following is a description of the possible statusline items.  The
+        second character in "item" is the type:
+                N for number
+                S for string
+                F for flags as described below
+                - not applicable
+
+        item  meaning ~
+        f S   Path to the file in the buffer, as typed or relative to current
+              directory.
+        F S   Full path to the file in the buffer.
+        t S   File name (tail) of file in the buffer.
+        m F   Modified flag, text is "[+]"; "[-]" if 'modifiable' is off.
+        M F   Modified flag, text is ",+" or ",-".
+        r F   Readonly flag, text is "[RO]".
+        R F   Readonly flag, text is ",RO".
+        h F   Help buffer flag, text is "[help]".
+        H F   Help buffer flag, text is ",HLP".
+        w F   Preview window flag, text is "[Preview]".
+        W F   Preview window flag, text is ",PRV".
+        y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
+        Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
+        q S   "[Quickfix List]", "[Location List]" or empty.
+        k S   Value of "b:keymap_name" or 'keymap' when |:lmap| mappings are
+              being used: "<keymap>"
+        n N   Buffer number.
+        b N   Value of character under cursor.
+        B N   As above, in hexadecimal.
+        o N   Byte number in file of byte under cursor, first byte is 1.
+              Mnemonic: Offset from start of file (with one added)
+        O N   As above, in hexadecimal.
+        l N   Line number.
+        L N   Number of lines in buffer.
+        c N   Column number (byte index).
+        v N   Virtual column number (screen column).
+        V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
+        p N   Percentage through file in lines as in |CTRL-G|.
+        P S   Percentage through file of displayed window.  This is like the
+              percentage described for 'ruler'.  Always 3 in length, unless
+              translated.
+        S S   'showcmd' content, see 'showcmdloc'.
+        a S   Argument list status as in default title.  ({current} of {max})
+              Empty if the argument file count is zero or one.
+        { NF  Evaluate expression between "%{" and "}" and substitute result.
+              Note that there is no "%" before the closing "}".  The
+              expression cannot contain a "}" character, call a function to
+              work around that.  See |stl-%{| below.
+        `{%` -  This is almost same as "{" except the result of the expression is
+              re-evaluated as a statusline format string.  Thus if the
+              return value of expr contains "%" items they will get expanded.
+              The expression can contain the "}" character, the end of
+              expression is denoted by "%}".
+              For example: >vim
+                func! Stl_filename() abort
+                    return "%t"
+                endfunc
+<               `stl=%{Stl_filename()}`   results in `"%t"`
+                `stl=%{%Stl_filename()%}` results in `"Name of current file"`
+        %} -  End of "{%" expression
+        ( -   Start of item group.  Can be used for setting the width and
+              alignment of a section.  Must be followed by %) somewhere.
+        ) -   End of item group.  No width fields allowed.
+        T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+              the label.  Clicking this label with left mouse button switches
+              to the specified tab page.
+        X N   For 'tabline': start of close tab N label.  Use %X or %T to end
+              the label, e.g.: %3Xclose%X.  Use %999X for a "close current
+              tab" label.    Clicking this label with left mouse button closes
+              specified tab page.
+        @ N   Start of execute function label. Use %X or %T to
+              end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
+              label runs specified function: in the example when clicking once
+              using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
+              '    ')" expression will be run.  Function receives the
+              following arguments in order:
+              1. minwid field value or zero if no N was specified
+              2. number of mouse clicks to detect multiple clicks
+              3. mouse button used: "l", "r" or "m" for left, right or middle
+                 button respectively; one should not rely on third argument
+                 being only "l", "r" or "m": any other non-empty string value
+                 that contains only ASCII lower case letters may be expected
+                 for other mouse buttons
+              4. modifiers pressed: string which contains "s" if shift
+                 modifier was pressed, "c" for control, "a" for alt and "m"
+                 for meta; currently if modifier is not pressed string
+                 contains space instead, but one should not rely on presence
+                 of spaces or specific order of modifiers: use |stridx()| to
+                 test whether some modifier is present; string is guaranteed
+                 to contain only ASCII letters and spaces, one letter per
+                 modifier; "?" modifier may also be present, but its presence
+                 is a bug that denotes that new mouse button recognition was
+                 added without modifying code that reacts on mouse clicks on
+                 this label.
+              Use |getmousepos()|.winid in the specified function to get the
+              corresponding window id of the clicked item.
+        < -   Where to truncate line if too long.  Default is at the start.
+              No width fields allowed.
+        = -   Separation point between alignment sections.  Each section will
+              be separated by an equal number of spaces.  With one %= what
+              comes after it will be right-aligned.  With two %= there is a
+              middle part, with white space left and right of it.
+              No width fields allowed.
+        # -   Set highlight group.  The name must follow and then a # again.
+              Thus use %#HLname# for highlight group HLname.  The same
+              highlighting is used, also for the statusline of non-current
+              windows.
+        * -   Set highlight group to User{N}, where {N} is taken from the
+              minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
+              The difference between User{N} and StatusLine will be applied to
+              StatusLineNC for the statusline of non-current windows.
+              The number N must be between 1 and 9.  See |hl-User1..9|
+
+        When displaying a flag, Vim removes the leading comma, if any, when
+        that flag comes right after plaintext.  This will make a nice display
+        when flags are used like in the examples below.
+
+        When all items in a group becomes an empty string (i.e. flags that are
+        not set) and a minwid is not set for the group, the whole group will
+        become empty.  This will make a group like the following disappear
+        completely from the statusline when none of the flags are set. >vim
+                set statusline=...%(\ [%M%R%H]%)...
+<       Beware that an expression is evaluated each and every time the status
+        line is displayed.
+                                *stl-%{* *g:actual_curbuf* *g:actual_curwin*
+        While evaluating %{} the current buffer and current window will be set
+        temporarily to that of the window (and buffer) whose statusline is
+        currently being drawn.  The expression will evaluate in this context.
+        The variable "g:actual_curbuf" is set to the `bufnr()` number of the
+        real current buffer and "g:actual_curwin" to the |window-ID| of the
+        real current window.  These values are strings.
+
+        The 'statusline' option will be evaluated in the |sandbox| if set from
+        a modeline, see |sandbox-option|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        It is not allowed to change text or jump to another window while
+        evaluating 'statusline' |textlock|.
+
+        If the statusline is not updated when you want it (e.g., after setting
+        a variable that's used in an expression), you can force an update by
+        using `:redrawstatus`.
+
+        A result of all digits is regarded a number for display purposes.
+        Otherwise the result is taken as flag text and applied to the rules
+        described above.
+
+        Watch out for errors in expressions.  They may render Vim unusable!
+        If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and
+        edit your vimrc or whatever with "vim --clean" to get it right.
+
+        Examples:
+        Emulate standard status line with 'ruler' set >vim
+          set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
+<       Similar, but add ASCII value of char under the cursor (like "ga") >vim
+          set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
+<       Display byte count and byte value, modified flag in red. >vim
+          set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
+          hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
+<       Display a ,GZ flag if a compressed file is loaded >vim
+          set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
+<       In the |:autocmd|'s: >vim
+          let b:gzflag = 1
+<       And: >vim
+          unlet b:gzflag
+<       And define this function: >vim
+          function VarExists(var, val)
+              if exists(a:var) | return a:val | else | return '' | endif
+          endfunction
 <
 
-				*'swapfile'* *'swf'* *'noswapfile'* *'noswf'*
-'swapfile' 'swf'	boolean	(default on)
-			local to buffer
-	Use a swapfile for the buffer.  This option can be reset when a
-	swapfile is not wanted for a specific buffer.  For example, with
-	confidential information that even root must not be able to access.
-	Careful: All text will be in memory:
-		- Don't use this for big files.
-		- Recovery will be impossible!
-	A swapfile will only be present when |'updatecount'| is non-zero and
-	'swapfile' is set.
-	When 'swapfile' is reset, the swap file for the current buffer is
-	immediately deleted.  When 'swapfile' is set, and 'updatecount' is
-	non-zero, a swap file is immediately created.
-	Also see |swap-file|.
-	If you want to open a new buffer without creating a swap file for it,
-	use the |:noswapfile| modifier.
-	See 'directory' for where the swap file is created.
-
-	This option is used together with 'bufhidden' and 'buftype' to
-	specify special kinds of buffers.   See |special-buffers|.
-
-						*'switchbuf'* *'swb'*
-'switchbuf' 'swb'	string	(default "uselast")
-			global
-	This option controls the behavior when switching between buffers.
-	This option is checked, when
-	- jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
-	  etc.).
-	- jumping to a tag using the |:stag| command.
-	- opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
-	- jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
-	  |:sbnext|, or |:sbrewind|).
-	Possible values (comma-separated list):
-	   useopen	If included, jump to the first open window in the
-			current tab page that contains the specified buffer
-			(if there is one).  Otherwise: Do not examine other
-			windows.
-	   usetab	Like "useopen", but also consider windows in other tab
-			pages.
-	   split	If included, split the current window before loading
-			a buffer for a |quickfix| command that display errors.
-			Otherwise: do not split, use current window (when used
-			in the quickfix window: the previously used window or
-			split if there is no other window).
-	   vsplit	Just like "split" but split vertically.
-	   newtab	Like "split", but open a new tab page.  Overrules
-			"split" when both are present.
-	   uselast	If included, jump to the previously used window when
-			jumping to errors with |quickfix| commands.
-
-						*'synmaxcol'* *'smc'*
-'synmaxcol' 'smc'	number	(default 3000)
-			local to buffer
-	Maximum column in which to search for syntax items.  In long lines the
-	text after this column is not highlighted and following lines may not
-	be highlighted correctly, because the syntax state is cleared.
-	This helps to avoid very slow redrawing for an XML file that is one
-	long line.
-	Set to zero to remove the limit.
-
-						*'syntax'* *'syn'*
-'syntax' 'syn'		string	(default "")
-			local to buffer  |local-noglobal|
-	When this option is set, the syntax with this name is loaded, unless
-	syntax highlighting has been switched off with ":syntax off".
-	Otherwise this option does not always reflect the current syntax (the
-	b:current_syntax variable does).
-	This option is most useful in a modeline, for a file which syntax is
-	not automatically recognized.  Example, in an IDL file: >c
-		/* vim: set syntax=idl : */
-<	When a dot appears in the value then this separates two filetype
-	names.  Example: >c
-		/* vim: set syntax=c.doxygen : */
-<	This will use the "c" syntax first, then the "doxygen" syntax.
-	Note that the second one must be prepared to be loaded as an addition,
-	otherwise it will be skipped.  More than one dot may appear.
-	To switch off syntax highlighting for the current file, use: >vim
-		set syntax=OFF
-<	To switch syntax highlighting on according to the current value of the
-	'filetype' option: >vim
-		set syntax=ON
-<	What actually happens when setting the 'syntax' option is that the
-	Syntax autocommand event is triggered with the value as argument.
-	This option is not copied to another buffer, independent of the 's' or
-	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, `/\*?[|<>` are illegal.
-
-						*'tabline'* *'tal'*
-'tabline' 'tal'		string	(default "")
-			global
-	When non-empty, this option determines the content of the tab pages
-	line at the top of the Vim window.  When empty Vim will use a default
-	tab pages line.  See |setting-tabline| for more info.
-
-	The tab pages line only appears as specified with the 'showtabline'
-	option and only when there is no GUI tab line.  When 'e' is in
-	'guioptions' and the GUI supports a tab line 'guitablabel' is used
-	instead.  Note that the two tab pages lines are very different.
-
-	The value is evaluated like with 'statusline'.  You can use
-	|tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
-	the text to be displayed.  Use "%1T" for the first label, "%2T" for
-	the second one, etc.  Use "%X" items for closing labels.
-
-	When changing something that is used in 'tabline' that does not
-	trigger it to be updated, use |:redrawtabline|.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	Keep in mind that only one of the tab pages is the current one, others
-	are invisible and you can't jump to their windows.
-
-						*'tabpagemax'* *'tpm'*
-'tabpagemax' 'tpm'	number	(default 50)
-			global
-	Maximum number of tab pages to be opened by the |-p| command line
-	argument or the ":tab all" command. |tabpage|
-
-						*'tabstop'* *'ts'*
-'tabstop' 'ts'		number	(default 8)
-			local to buffer
-	Number of spaces that a <Tab> in the file counts for.  Also see
-	the |:retab| command, and the 'softtabstop' option.
-
-	Note: Setting 'tabstop' to any other value than 8 can make your file
-	appear wrong in many places.
-	The value must be more than 0 and less than 10000.
-
-	There are four main ways to use tabs in Vim:
-	1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
-	   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
-	   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
-	   behave like a tab appears every 4 (or 3) characters.
-	   This is the recommended way, the file will look the same with other
-	   tools and when listing it in a terminal.
-	2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
-	   'expandtab'.  This way you will always insert spaces.  The
-	   formatting will never be messed up when 'tabstop' is changed (leave
-	   it at 8 just in case).  The file will be a bit larger.
-	   You do need to check if no Tabs exist in the file.  You can get rid
-	   of them by first setting 'expandtab' and using `%retab!`, making
-	   sure the value of 'tabstop' is set correctly.
-	3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
-	   'expandtab'.  This way you will always insert spaces.  The
-	   formatting will never be messed up when 'tabstop' is changed.
-	   You do need to check if no Tabs exist in the file, just like in the
-	   item just above.
-	4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
-	   |modeline| to set these values when editing the file again.  Only
-	   works when using Vim to edit the file, other tools assume a tabstop
-	   is worth 8 spaces.
-	5. Always set 'tabstop' and 'shiftwidth' to the same value, and
-	   'noexpandtab'.  This should then work (for initial indents only)
-	   for any tabstop setting that people use.  It might be nice to have
-	   tabs after the first non-blank inserted as spaces if you do this
-	   though.  Otherwise aligned comments will be wrong when 'tabstop' is
-	   changed.
-
-	The value of 'tabstop' will be ignored if |'vartabstop'| is set to
-	anything other than an empty string.
-
-			*'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
-'tagbsearch' 'tbs'	boolean	(default on)
-			global
-	When searching for a tag (e.g., for the |:ta| command), Vim can either
-	use a binary search or a linear search in a tags file.  Binary
-	searching makes searching for a tag a LOT faster, but a linear search
-	will find more tags if the tags file wasn't properly sorted.
-	Vim normally assumes that your tags files are sorted, or indicate that
-	they are not sorted.  Only when this is not the case does the
-	'tagbsearch' option need to be switched off.
-
-	When 'tagbsearch' is on, binary searching is first used in the tags
-	files.  In certain situations, Vim will do a linear search instead for
-	certain files, or retry all files with a linear search.  When
-	'tagbsearch' is off, only a linear search is done.
-
-	Linear searching is done anyway, for one file, when Vim finds a line
-	at the start of the file indicating that it's not sorted: >
-	   !_TAG_FILE_SORTED	0	/some comment/
-<	[The whitespace before and after the '0' must be a single <Tab>]
-
-	When a binary search was done and no match was found in any of the
-	files listed in 'tags', and case is ignored or a pattern is used
-	instead of a normal tag name, a retry is done with a linear search.
-	Tags in unsorted tags files, and matches with different case will only
-	be found in the retry.
-
-	If a tag file indicates that it is case-fold sorted, the second,
-	linear search can be avoided when case is ignored.  Use a value of '2'
-	in the "!_TAG_FILE_SORTED" line for this.  A tag file can be case-fold
-	sorted with the -f switch to "sort" in most unices, as in the command:
-	"sort -f -o tags tags".  For Universal ctags and Exuberant ctags
-	version 5.x or higher (at least 5.5) the --sort=foldcase switch can be
-	used for this as well.  Note that case must be folded to uppercase for
-	this to work.
-
-	By default, tag searches are case-sensitive.  Case is ignored when
-	'ignorecase' is set and 'tagcase' is "followic", or when 'tagcase' is
-	"ignore".
-	Also when 'tagcase' is "followscs" and 'smartcase' is set, or
-	'tagcase' is "smart", and the pattern contains only lowercase
-	characters.
-
-	When 'tagbsearch' is off, tags searching is slower when a full match
-	exists, but faster when no full match exists.  Tags in unsorted tags
-	files may only be found with 'tagbsearch' off.
-	When the tags file is not sorted, or sorted in a wrong way (not on
-	ASCII byte value), 'tagbsearch' should be off, or the line given above
-	must be included in the tags file.
-	This option doesn't affect commands that find all matching tags (e.g.,
-	command-line completion and ":help").
-
-						*'tagcase'* *'tc'*
-'tagcase' 'tc'		string	(default "followic")
-			global or local to buffer |global-local|
-	This option specifies how case is handled when searching the tags
-	file:
-	   followic	Follow the 'ignorecase' option
-	   followscs    Follow the 'smartcase' and 'ignorecase' options
-	   ignore	Ignore case
-	   match	Match case
-	   smart	Ignore case unless an upper case letter is used
-
-						*'tagfunc'* *'tfu'*
-'tagfunc' 'tfu'		string	(default "")
-			local to buffer
-	This option specifies a function to be used to perform tag searches.
-	The function gets the tag pattern and should return a List of matching
-	tags.  See |tag-function| for an explanation of how to write the
-	function and an example.  The value can be the name of a function, a
-	|lambda| or a |Funcref|. See |option-value-function| for more
-	information.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'taglength'* *'tl'*
-'taglength' 'tl'	number	(default 0)
-			global
-	If non-zero, tags are significant up to this number of characters.
-
-			*'tagrelative'* *'tr'* *'notagrelative'* *'notr'*
-'tagrelative' 'tr'	boolean	(default on)
-			global
-	If on and using a tags file in another directory, file names in that
-	tags file are relative to the directory where the tags file is.
-
-						*'tags'* *'tag'* *E433*
-'tags' 'tag'		string	(default "./tags;,tags")
-			global or local to buffer |global-local|
-	Filenames for the tag command, separated by spaces or commas.  To
-	include a space or comma in a file name, precede it with backslashes
-	(see |option-backslash| about including spaces/commas and backslashes).
-	When a file name starts with "./", the '.' is replaced with the path
-	of the current file.  But only when the 'd' flag is not included in
-	'cpoptions'.  Environment variables are expanded |:set_env|.  Also see
-	|tags-option|.
-	"*", "**" and other wildcards can be used to search for tags files in
-	a directory tree.  See |file-searching|.  E.g., "/lib/**/tags" will
-	find all files named "tags" below "/lib".  The filename itself cannot
-	contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
-	files called "tags?".
-	The |tagfiles()| function can be used to get a list of the file names
-	actually used.
-	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	file names from the list.  This avoids problems when a future version
-	uses another default.
-
-			*'tagstack'* *'tgst'* *'notagstack'* *'notgst'*
-'tagstack' 'tgst'	boolean	(default on)
-			global
-	When on, the |tagstack| is used normally.  When off, a ":tag" or
-	":tselect" command with an argument will not push the tag onto the
-	tagstack.  A following ":tag" without an argument, a ":pop" command or
-	any other command that uses the tagstack will use the unmodified
-	tagstack, but does change the pointer to the active entry.
-	Resetting this option is useful when using a ":tag" command in a
-	mapping which should not change the tagstack.
-
-			*'termbidi'* *'tbidi'* *'notermbidi'* *'notbidi'*
-'termbidi' 'tbidi'	boolean	(default off)
-			global
-	The terminal is in charge of Bi-directionality of text (as specified
-	by Unicode).  The terminal is also expected to do the required shaping
-	that some languages (such as Arabic) require.
-	Setting this option implies that 'rightleft' will not be set when
-	'arabic' is set and the value of 'arabicshape' will be ignored.
-	Note that setting 'termbidi' has the immediate effect that
-	'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
-	For further details see |arabic.txt|.
-
-		*'termguicolors'* *'tgc'* *'notermguicolors'* *'notgc'*
-'termguicolors' 'tgc'	boolean	(default off)
-			global
-	Enables 24-bit RGB color in the |TUI|.  Uses "gui" |:highlight|
-	attributes instead of "cterm" attributes. |guifg|
-	Requires an ISO-8613-3 compatible terminal.
-
-	Nvim will automatically attempt to determine if the host terminal
-	supports 24-bit color and will enable this option if it does
-	(unless explicitly disabled by the user).
-
-					*'termpastefilter'* *'tpf'*
-'termpastefilter' 'tpf'	string	(default "BS,HT,ESC,DEL")
-			global
-	A comma-separated list of options for specifying control characters
-	to be removed from the text pasted into the terminal window. The
-	supported values are:
-
-	   BS	    Backspace
-
-	   HT	    TAB
-
-	   FF	    Form feed
-
-	   ESC	    Escape
-
-	   DEL	    DEL
-
-	   C0	    Other control characters, excluding Line feed and
-		    Carriage return < ' '
-
-	   C1	    Control characters 0x80...0x9F
-
-					*'termsync'* *'notermsync'*
-'termsync'		boolean	(default on)
-			global
-	If the host terminal supports it, buffer all screen updates
-	made during a redraw cycle so that each screen is displayed in
-	the terminal all at once. This can prevent tearing or flickering
-	when the terminal updates faster than Nvim can redraw.
-
-						*'textwidth'* *'tw'*
-'textwidth' 'tw'	number	(default 0)
-			local to buffer
-	Maximum width of text that is being inserted.  A longer line will be
-	broken after white space to get this width.  A zero value disables
-	this.
-	When 'textwidth' is zero, 'wrapmargin' may be used.  See also
-	'formatoptions' and |ins-textwidth|.
-	When 'formatexpr' is set it will be used to break the line.
-
-						*'thesaurus'* *'tsr'*
-'thesaurus' 'tsr'	string	(default "")
-			global or local to buffer |global-local|
-	List of file names, separated by commas, that are used to lookup words
-	for thesaurus completion commands |i_CTRL-X_CTRL-T|.  See
-	|compl-thesaurus|.
-
-	This option is not used if 'thesaurusfunc' is set, either for the
-	buffer or globally.
-
-	To include a comma in a file name precede it with a backslash.  Spaces
-	after a comma are ignored, otherwise spaces are included in the file
-	name.  See |option-backslash| about using backslashes.  The use of
-	|:set+=| and |:set-=| is preferred when adding or removing directories
-	from the list.  This avoids problems when a future version uses
-	another default.  Backticks cannot be used in this option for security
-	reasons.
-
-					*'thesaurusfunc'* *'tsrfu'*
-'thesaurusfunc' 'tsrfu'	string	(default "")
-			global or local to buffer |global-local|
-	This option specifies a function to be used for thesaurus completion
-	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
-	The value can be the name of a function, a |lambda| or a |Funcref|.
-	See |option-value-function| for more information.
-
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-				*'tildeop'* *'top'* *'notildeop'* *'notop'*
-'tildeop' 'top'		boolean	(default off)
-			global
-	When on: The tilde command "~" behaves like an operator.
-
-				*'timeout'* *'to'* *'notimeout'* *'noto'*
-'timeout' 'to'		boolean	(default on)
-			global
-	This option and 'timeoutlen' determine the behavior when part of a
-	mapped key sequence has been received. For example, if <c-f> is
-	pressed and 'timeout' is set, Nvim will wait 'timeoutlen' milliseconds
-	for any key that can follow <c-f> in a mapping.
-
-						*'timeoutlen'* *'tm'*
-'timeoutlen' 'tm'	number	(default 1000)
-			global
-	Time in milliseconds to wait for a mapped sequence to complete.
-
-						*'title'* *'notitle'*
-'title'			boolean	(default off)
-			global
-	When on, the title of the window will be set to the value of
-	'titlestring' (if it is not empty), or to:
-		filename [+=-] (path) - NVIM
-	Where:
-		filename	the name of the file being edited
-		-		indicates the file cannot be modified, 'ma' off
-		+		indicates the file was modified
-		=		indicates the file is read-only
-		=+		indicates the file is read-only and modified
-		(path)		is the path of the file being edited
-		- NVIM		the server name |v:servername| or "NVIM"
-
-							*'titlelen'*
-'titlelen'		number	(default 85)
-			global
-	Gives the percentage of 'columns' to use for the length of the window
-	title.  When the title is longer, only the end of the path name is
-	shown.  A '<' character before the path name is used to indicate this.
-	Using a percentage makes this adapt to the width of the window.  But
-	it won't work perfectly, because the actual number of characters
-	available also depends on the font used and other things in the title
-	bar.  When 'titlelen' is zero the full path is used.  Otherwise,
-	values from 1 to 30000 percent can be used.
-	'titlelen' is also used for the 'titlestring' option.
-
-							*'titleold'*
-'titleold'		string	(default "")
-			global
-	If not empty, this option will be used to set the window title when
-	exiting.  Only if 'title' is enabled.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-							*'titlestring'*
-'titlestring'		string	(default "")
-			global
-	When this option is not empty, it will be used for the title of the
-	window.  This happens only when the 'title' option is on.
-
-	When this option contains printf-style '%' items, they will be
-	expanded according to the rules used for 'statusline'.
-	This option cannot be set in a modeline when 'modelineexpr' is off.
-
-	Example: >vim
-	    auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
-	    set title titlestring=%<%F%=%l/%L-%P titlelen=70
-<	The value of 'titlelen' is used to align items in the middle or right
-	of the available space.
-	Some people prefer to have the file name first: >vim
-	    set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
-<	Note the use of "%{ }" and an expression to get the path of the file,
-	without the file name.  The "%( %)" constructs are used to add a
-	separating space only when needed.
-	NOTE: Use of special characters in 'titlestring' may cause the display
-	to be garbled (e.g., when it contains a CR or NL character).
-
-					*'ttimeout'* *'nottimeout'*
-'ttimeout'		boolean	(default on)
-			global
-	This option and 'ttimeoutlen' determine the behavior when part of a
-	key code sequence has been received by the |TUI|.
-
-	For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
-	set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
-	complete a key code sequence. If no input arrives before the timeout,
-	a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
-
-	On very slow systems this may fail, causing cursor keys not to work
-	sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
-	Nvim will wait for the next character to arrive after an <Esc>.
-
-						*'ttimeoutlen'* *'ttm'*
-'ttimeoutlen' 'ttm'	number	(default 50)
-			global
-	Time in milliseconds to wait for a key code sequence to complete. Also
-	used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
-	been typed.
-
-					*'undodir'* *'udir'* *E5003*
-'undodir' 'udir'	string	(default "$XDG_STATE_HOME/nvim/undo//")
-			global
-	List of directory names for undo files, separated with commas.
-	See 'backupdir' for details of the format.
-	"." means using the directory of the file.  The undo file name for
-	"file.txt" is ".file.txt.un~".
-	For other directories the file name is the full path of the edited
-	file, with path separators replaced with "%".
-	When writing: The first directory that exists is used.  "." always
-	works, no directories after "." will be used for writing.  If none of
-	the directories exist Nvim will attempt to create the last directory in
-	the list.
-	When reading all entries are tried to find an undo file.  The first
-	undo file that exists is used.  When it cannot be read an error is
-	given, no further entry is used.
-	See |undo-persistence|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-	Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
-	though the trailing slashes are present (see 'backupdir' for what this
-	means).
-
-				*'undofile'* *'udf'* *'noundofile'* *'noudf'*
-'undofile' 'udf'	boolean	(default off)
-			local to buffer
-	When on, Vim automatically saves undo history to an undo file when
-	writing a buffer to a file, and restores undo history from the same
-	file on buffer read.
-	The directory where the undo file is stored is specified by 'undodir'.
-	For more information about this feature see |undo-persistence|.
-	The undo file is not read when 'undoreload' causes the buffer from
-	before a reload to be saved for undo.
-	When 'undofile' is turned off the undo file is NOT deleted.
-
-						*'undolevels'* *'ul'*
-'undolevels' 'ul'	number	(default 1000)
-			global or local to buffer |global-local|
-	Maximum number of changes that can be undone.  Since undo information
-	is kept in memory, higher numbers will cause more memory to be used.
-	Nevertheless, a single change can already use a large amount of memory.
-	Set to 0 for Vi compatibility: One level of undo and "u" undoes
-	itself: >vim
-		set ul=0
-<	But you can also get Vi compatibility by including the 'u' flag in
-	'cpoptions', and still be able to use CTRL-R to repeat undo.
-	Also see |undo-two-ways|.
-	Set to -1 for no undo at all.  You might want to do this only for the
-	current buffer: >vim
-		setlocal ul=-1
-<	This helps when you run out of memory for a single change.
-
-	The local value is set to -123456 when the global value is to be used.
-
-	Also see |clear-undo|.
-
-						*'undoreload'* *'ur'*
-'undoreload' 'ur'	number	(default 10000)
-			global
-	Save the whole buffer for undo when reloading it.  This applies to the
-	":e!" command and reloading for when the buffer changed outside of
-	Vim. |FileChangedShell|
-	The save only happens when this option is negative or when the number
-	of lines is smaller than the value of this option.
-	Set this option to zero to disable undo for a reload.
-
-	When saving undo for a reload, any undo file is not read.
-
-	Note that this causes the whole buffer to be stored in memory.  Set
-	this option to a lower value if you run out of memory.
-
-						*'updatecount'* *'uc'*
-'updatecount' 'uc'	number	(default 200)
-			global
-	After typing this many characters the swap file will be written to
-	disk.  When zero, no swap file will be created at all (see chapter on
-	recovery |crash-recovery|).  'updatecount' is set to zero by starting
-	Vim with the "-n" option, see |startup|.  When editing in readonly
-	mode this option will be initialized to 10000.
-	The swapfile can be disabled per buffer with |'swapfile'|.
-	When 'updatecount' is set from zero to non-zero, swap files are
-	created for all buffers that have 'swapfile' set.  When 'updatecount'
-	is set to zero, existing swap files are not deleted.
-	This option has no meaning in buffers where |'buftype'| is "nofile"
-	or "nowrite".
-
-						*'updatetime'* *'ut'*
-'updatetime' 'ut'	number	(default 4000)
-			global
-	If this many milliseconds nothing is typed the swap file will be
-	written to disk (see |crash-recovery|).  Also used for the
-	|CursorHold| autocommand event.
-
-					*'varsofttabstop'* *'vsts'*
-'varsofttabstop' 'vsts'	string	(default "")
-			local to buffer
-	A list of the number of spaces that a <Tab> counts for while editing,
-	such as inserting a <Tab> or using <BS>.  It "feels" like variable-
-	width <Tab>s are being inserted, while in fact a mixture of spaces
-	and <Tab>s is used.  Tab widths are separated with commas, with the
-	final value applying to all subsequent tabs.
-
-	For example, when editing assembly language files where statements
-	start in the 9th column and comments in the 41st, it may be useful
-	to use the following: >vim
-		set varsofttabstop=8,32,8
-<	This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
-	for every column thereafter.
-
-	Note that the value of |'softtabstop'| will be ignored while
-	'varsofttabstop' is set.
-
-						*'vartabstop'* *'vts'*
-'vartabstop' 'vts'	string	(default "")
-			local to buffer
-	A list of the number of spaces that a <Tab> in the file counts for,
-	separated by commas.  Each value corresponds to one tab, with the
-	final value applying to all subsequent tabs. For example: >vim
-		set vartabstop=4,20,10,8
-<	This will make the first tab 4 spaces wide, the second 20 spaces,
-	the third 10 spaces, and all following tabs 8 spaces.
-
-	Note that the value of |'tabstop'| will be ignored while 'vartabstop'
-	is set.
-
-						*'verbose'* *'vbs'*
-'verbose' 'vbs'		number	(default 0)
-			global
-	Sets the verbosity level.  Also set by |-V| and |:verbose|.
-
-	Tracing of options in Lua scripts is activated at level 1; Lua scripts
-	are not traced with verbose=0, for performance.
-
-	If greater than or equal to a given level, Nvim produces the following
-	messages:
-
-	Level   Messages ~
-	----------------------------------------------------------------------
-	1	Lua assignments to options, mappings, etc.
-	2	When a file is ":source"'ed, or |shada| file is read or written.
-	3	UI info, terminal capabilities.
-	4	Shell commands.
-	5	Every searched tags file and include file.
-	8	Files for which a group of autocommands is executed.
-	9	Executed autocommands.
-	11	Finding items in a path.
-	12	Vimscript function calls.
-	13	When an exception is thrown, caught, finished, or discarded.
-	14	Anything pending in a ":finally" clause.
-	15	Ex commands from a script (truncated at 200 characters).
-	16	Ex commands.
-
-	If 'verbosefile' is set then the verbose messages are not displayed.
-
-						*'verbosefile'* *'vfile'*
-'verbosefile' 'vfile'	string	(default "")
-			global
-	When not empty all messages are written in a file with this name.
-	When the file exists messages are appended.
-	Writing to the file ends when Vim exits or when 'verbosefile' is made
-	empty.  Writes are buffered, thus may not show up for some time.
-	Setting 'verbosefile' to a new value is like making it empty first.
-	The difference with |:redir| is that verbose messages are not
-	displayed when 'verbosefile' is set.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'viewdir'* *'vdir'*
-'viewdir' 'vdir'	string	(default "$XDG_STATE_HOME/nvim/view//")
-			global
-	Name of the directory where to store files for |:mkview|.
-	This option cannot be set from a |modeline| or in the |sandbox|, for
-	security reasons.
-
-						*'viewoptions'* *'vop'*
-'viewoptions' 'vop'	string	(default "folds,cursor,curdir")
-			global
-	Changes the effect of the |:mkview| command.  It is a comma-separated
-	list of words.  Each word enables saving and restoring something:
-	   word		save and restore ~
-	   cursor	cursor position in file and in window
-	   curdir	local current directory, if set with |:lcd|
-	   folds	manually created folds, opened/closed folds and local
-			fold options
-	   options	options and mappings local to a window or buffer (not
-			global values for local options)
-	   localoptions same as "options"
-	   slash	|deprecated| Always enabled. Uses "/" in filenames.
-	   unix		|deprecated| Always enabled. Uses "\n" line endings.
-
-						*'virtualedit'* *'ve'*
-'virtualedit' 've'	string	(default "")
-			global or local to window |global-local|
-	A comma-separated list of these words:
-	    block	Allow virtual editing in Visual block mode.
-	    insert	Allow virtual editing in Insert mode.
-	    all		Allow virtual editing in all modes.
-	    onemore	Allow the cursor to move just past the end of the line
-	    none	When used as the local value, do not allow virtual
-			editing even when the global value is set.  When used
-			as the global value, "none" is the same as "".
-	    NONE	Alternative spelling of "none".
-
-	Virtual editing means that the cursor can be positioned where there is
-	no actual character.  This can be halfway into a tab or beyond the end
-	of the line.  Useful for selecting a rectangle in Visual mode and
-	editing a table.
-	"onemore" is not the same, it will only allow moving the cursor just
-	after the last character of the line.  This makes some commands more
-	consistent.  Previously the cursor was always past the end of the line
-	if the line was empty.  But it is far from Vi compatible.  It may also
-	break some plugins or Vim scripts.  For example because |l| can move
-	the cursor after the last character.  Use with care!
-	Using the `$` command will move to the last character in the line, not
-	past it.  This may actually move the cursor to the left!
-	The `g$` command will move to the end of the screen line.
-	It doesn't make sense to combine "all" with "onemore", but you will
-	not get a warning for it.
-	When combined with other words, "none" is ignored.
-
-			*'visualbell'* *'vb'* *'novisualbell'* *'novb'*
-'visualbell' 'vb'	boolean	(default off)
-			global
-	Use visual bell instead of beeping.  Also see 'errorbells'.
-
-						*'warn'* *'nowarn'*
-'warn'			boolean	(default on)
-			global
-	Give a warning message when a shell command is used while the buffer
-	has been changed.
-
-						*'whichwrap'* *'ww'*
-'whichwrap' 'ww'	string	(default "b,s")
-			global
-	Allow specified keys that move the cursor left/right to move to the
-	previous/next line when the cursor is on the first/last character in
-	the line.  Concatenate characters to allow this for these keys:
-		char   key	  mode	~
-		 b    <BS>	 Normal and Visual
-		 s    <Space>	 Normal and Visual
-		 h    "h"	 Normal and Visual (not recommended)
-		 l    "l"	 Normal and Visual (not recommended)
-		 <    <Left>	 Normal and Visual
-		 >    <Right>	 Normal and Visual
-		 ~    "~"	 Normal
-		 [    <Left>	 Insert and Replace
-		 ]    <Right>	 Insert and Replace
-	For example: >vim
-		set ww=<,>,[,]
-<	allows wrap only when cursor keys are used.
-	When the movement keys are used in combination with a delete or change
-	operator, the <EOL> also counts for a character.  This makes "3h"
-	different from "3dh" when the cursor crosses the end of a line.  This
-	is also true for "x" and "X", because they do the same as "dl" and
-	"dh".  If you use this, you may also want to use the mapping
-	":map <BS> X" to make backspace delete the character in front of the
-	cursor.
-	When 'l' is included and it is used after an operator at the end of a
-	line (not an empty line) then it will not move to the next line.  This
-	makes "dl", "cl", "yl" etc. work normally.
-
-						*'wildchar'* *'wc'*
-'wildchar' 'wc'		number	(default <Tab>)
-			global
-	Character you have to type to start wildcard expansion in the
-	command-line, as specified with 'wildmode'.
-	More info here: |cmdline-completion|.
-	The character is not recognized when used inside a macro.  See
-	'wildcharm' for that.
-	Some keys will not work, such as CTRL-C, <CR> and Enter.
-	<Esc> can be used, but hitting it twice in a row will still exit
-	command-line as a failsafe measure.
-	Although 'wc' is a number option, you can set it to a special key: >vim
-		set wc=<Tab>
+                                                               *'suffixes'* *'su'*
+'suffixes' 'su'         string (default ".bak,~,.o,.h,.info,.swp,.obj")
+                        global
+        Files with these suffixes get a lower priority when multiple files
+        match a wildcard.  See |suffixes|.  Commas can be used to separate the
+        suffixes.  Spaces after the comma are ignored.  A dot is also seen as
+        the start of a suffix.  To avoid a dot or comma being recognized as a
+        separator, precede it with a backslash (see |option-backslash| about
+        including spaces and backslashes).
+        See 'wildignore' for completely ignoring files.
+        The use of |:set+=| and |:set-=| is preferred when adding or removing
+        suffixes from the list.  This avoids problems when a future version
+        uses another default.
+
+                                                           *'suffixesadd'* *'sua'*
+'suffixesadd' 'sua'     string (default "")
+                        local to buffer
+        Comma-separated list of suffixes, which are used when searching for a
+        file for the "gf", "[I", etc. commands.  Example: >vim
+                set suffixesadd=.java
 <
 
-						*'wildcharm'* *'wcm'*
-'wildcharm' 'wcm'	number	(default 0)
-			global
-	'wildcharm' works exactly like 'wildchar', except that it is
-	recognized when used inside a macro.  You can find "spare" command-line
-	keys suitable for this option by looking at |ex-edit-index|.  Normally
-	you'll never actually type 'wildcharm', just use it in mappings that
-	automatically invoke completion mode, e.g.: >vim
-		set wcm=<C-Z>
-		cnoremap ss so $vim/sessions/*.vim<C-Z>
-<	Then after typing :ss you can use CTRL-P & CTRL-N.
+                                         *'swapfile'* *'swf'* *'noswapfile'* *'noswf'*
+'swapfile' 'swf'        boolean (default on)
+                        local to buffer
+        Use a swapfile for the buffer.  This option can be reset when a
+        swapfile is not wanted for a specific buffer.  For example, with
+        confidential information that even root must not be able to access.
+        Careful: All text will be in memory:
+                - Don't use this for big files.
+                - Recovery will be impossible!
+        A swapfile will only be present when |'updatecount'| is non-zero and
+        'swapfile' is set.
+        When 'swapfile' is reset, the swap file for the current buffer is
+        immediately deleted.  When 'swapfile' is set, and 'updatecount' is
+        non-zero, a swap file is immediately created.
+        Also see |swap-file|.
+        If you want to open a new buffer without creating a swap file for it,
+        use the |:noswapfile| modifier.
+        See 'directory' for where the swap file is created.
 
-						*'wildignore'* *'wig'*
-'wildignore' 'wig'	string	(default "")
-			global
-	A list of file patterns.  A file that matches with one of these
-	patterns is ignored when expanding |wildcards|, completing file or
-	directory names, and influences the result of |expand()|, |glob()| and
-	|globpath()| unless a flag is passed to disable this.
-	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
-	Also see 'suffixes'.
-	Example: >vim
-		set wildignore=*.o,*.obj
-<	The use of |:set+=| and |:set-=| is preferred when adding or removing
-	a pattern from the list.  This avoids problems when a future version
-	uses another default.
+        This option is used together with 'bufhidden' and 'buftype' to
+        specify special kinds of buffers.   See |special-buffers|.
 
-		*'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
-'wildignorecase' 'wic'	boolean	(default off)
-			global
-	When set case is ignored when completing file names and directories.
-	Has no effect when 'fileignorecase' is set.
-	Does not apply when the shell is used to expand wildcards, which
-	happens when there are special characters.
+                                                             *'switchbuf'* *'swb'*
+'switchbuf' 'swb'       string (default "uselast")
+                        global
+        This option controls the behavior when switching between buffers.
+        This option is checked, when
+        - jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
+          etc.).
+        - jumping to a tag using the |:stag| command.
+        - opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
+        - jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
+          |:sbnext|, or |:sbrewind|).
+        Possible values (comma-separated list):
+           useopen      If included, jump to the first open window in the
+                        current tab page that contains the specified buffer
+                        (if there is one).  Otherwise: Do not examine other
+                        windows.
+           usetab       Like "useopen", but also consider windows in other tab
+                        pages.
+           split        If included, split the current window before loading
+                        a buffer for a |quickfix| command that display errors.
+                        Otherwise: do not split, use current window (when used
+                        in the quickfix window: the previously used window or
+                        split if there is no other window).
+           vsplit       Just like "split" but split vertically.
+           newtab       Like "split", but open a new tab page.  Overrules
+                        "split" when both are present.
+           uselast      If included, jump to the previously used window when
+                        jumping to errors with |quickfix| commands.
 
-			*'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
-'wildmenu' 'wmnu'	boolean	(default on)
-			global
-	When 'wildmenu' is on, command-line completion operates in an enhanced
-	mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
-	the possible matches are shown.
-	When 'wildoptions' contains "pum", then the completion matches are
-	shown in a popup menu.  Otherwise they are displayed just above the
-	command line, with the first match highlighted (overwriting the status
-	line, if there is one).
-	Keys that show the previous/next match, such as <Tab> or
-	CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
-	'wildmode' must specify "full": "longest" and "list" do not start
-	'wildmenu' mode. You can check the current mode with |wildmenumode()|.
-	The menu is cancelled when a key is hit that is not used for selecting
-	a completion.
+                                                             *'synmaxcol'* *'smc'*
+'synmaxcol' 'smc'       number (default 3000)
+                        local to buffer
+        Maximum column in which to search for syntax items.  In long lines the
+        text after this column is not highlighted and following lines may not
+        be highlighted correctly, because the syntax state is cleared.
+        This helps to avoid very slow redrawing for an XML file that is one
+        long line.
+        Set to zero to remove the limit.
 
-	While the menu is active these keys have special meanings:
-	CTRL-P		- go to the previous entry
-	CTRL-N		- go to the next entry
-	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
-	<PageUp>	- select a match several entries back
-	<PageDown>	- select a match several entries further
-	<Up>		- in filename/menu name completion: move up into
-			  parent directory or parent menu.
-	<Down>		- in filename/menu name completion: move into a
-			  subdirectory or submenu.
-	<CR>		- in menu completion, when the cursor is just after a
-			  dot: move into a submenu.
-	CTRL-E		- end completion, go back to what was there before
-			  selecting a match.
-	CTRL-Y		- accept the currently selected match and stop
-			  completion.
+                                                                *'syntax'* *'syn'*
+'syntax' 'syn'          string (default "")
+                        local to buffer  |local-noglobal|
+        When this option is set, the syntax with this name is loaded, unless
+        syntax highlighting has been switched off with ":syntax off".
+        Otherwise this option does not always reflect the current syntax (the
+        b:current_syntax variable does).
+        This option is most useful in a modeline, for a file which syntax is
+        not automatically recognized.  Example, in an IDL file: >c
+                /* vim: set syntax=idl : */
+<       When a dot appears in the value then this separates two filetype
+        names.  Example: >c
+                /* vim: set syntax=c.doxygen : */
+<       This will use the "c" syntax first, then the "doxygen" syntax.
+        Note that the second one must be prepared to be loaded as an addition,
+        otherwise it will be skipped.  More than one dot may appear.
+        To switch off syntax highlighting for the current file, use: >vim
+                set syntax=OFF
+<       To switch syntax highlighting on according to the current value of the
+        'filetype' option: >vim
+                set syntax=ON
+<       What actually happens when setting the 'syntax' option is that the
+        Syntax autocommand event is triggered with the value as argument.
+        This option is not copied to another buffer, independent of the 's' or
+        'S' flag in 'cpoptions'.
+        Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
-	If you want <Left> and <Right> to move the cursor instead of selecting
-	a different match, use this: >vim
-		cnoremap <Left> <Space><BS><Left>
-		cnoremap <Right> <Space><BS><Right>
+                                                               *'tabline'* *'tal'*
+'tabline' 'tal'         string (default "")
+                        global
+        When non-empty, this option determines the content of the tab pages
+        line at the top of the Vim window.  When empty Vim will use a default
+        tab pages line.  See |setting-tabline| for more info.
+
+        The tab pages line only appears as specified with the 'showtabline'
+        option and only when there is no GUI tab line.  When 'e' is in
+        'guioptions' and the GUI supports a tab line 'guitablabel' is used
+        instead.  Note that the two tab pages lines are very different.
+
+        The value is evaluated like with 'statusline'.  You can use
+        |tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
+        the text to be displayed.  Use "%1T" for the first label, "%2T" for
+        the second one, etc.  Use "%X" items for closing labels.
+
+        When changing something that is used in 'tabline' that does not
+        trigger it to be updated, use |:redrawtabline|.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        Keep in mind that only one of the tab pages is the current one, others
+        are invisible and you can't jump to their windows.
+
+                                                            *'tabpagemax'* *'tpm'*
+'tabpagemax' 'tpm'      number (default 50)
+                        global
+        Maximum number of tab pages to be opened by the |-p| command line
+        argument or the ":tab all" command. |tabpage|
+
+                                                                *'tabstop'* *'ts'*
+'tabstop' 'ts'          number (default 8)
+                        local to buffer
+        Number of spaces that a <Tab> in the file counts for.  Also see
+        the |:retab| command, and the 'softtabstop' option.
+
+        Note: Setting 'tabstop' to any other value than 8 can make your file
+        appear wrong in many places.
+        The value must be more than 0 and less than 10000.
+
+        There are four main ways to use tabs in Vim:
+        1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
+           (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
+           will use a mix of tabs and spaces, but typing <Tab> and <BS> will
+           behave like a tab appears every 4 (or 3) characters.
+           This is the recommended way, the file will look the same with other
+           tools and when listing it in a terminal.
+        2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
+           'expandtab'.  This way you will always insert spaces.  The
+           formatting will never be messed up when 'tabstop' is changed (leave
+           it at 8 just in case).  The file will be a bit larger.
+           You do need to check if no Tabs exist in the file.  You can get rid
+           of them by first setting 'expandtab' and using `%retab!`, making
+           sure the value of 'tabstop' is set correctly.
+        3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
+           'expandtab'.  This way you will always insert spaces.  The
+           formatting will never be messed up when 'tabstop' is changed.
+           You do need to check if no Tabs exist in the file, just like in the
+           item just above.
+        4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
+           |modeline| to set these values when editing the file again.  Only
+           works when using Vim to edit the file, other tools assume a tabstop
+           is worth 8 spaces.
+        5. Always set 'tabstop' and 'shiftwidth' to the same value, and
+           'noexpandtab'.  This should then work (for initial indents only)
+           for any tabstop setting that people use.  It might be nice to have
+           tabs after the first non-blank inserted as spaces if you do this
+           though.  Otherwise aligned comments will be wrong when 'tabstop' is
+           changed.
+
+        The value of 'tabstop' will be ignored if |'vartabstop'| is set to
+        anything other than an empty string.
+
+                                     *'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
+'tagbsearch' 'tbs'      boolean (default on)
+                        global
+        When searching for a tag (e.g., for the |:ta| command), Vim can either
+        use a binary search or a linear search in a tags file.  Binary
+        searching makes searching for a tag a LOT faster, but a linear search
+        will find more tags if the tags file wasn't properly sorted.
+        Vim normally assumes that your tags files are sorted, or indicate that
+        they are not sorted.  Only when this is not the case does the
+        'tagbsearch' option need to be switched off.
+
+        When 'tagbsearch' is on, binary searching is first used in the tags
+        files.  In certain situations, Vim will do a linear search instead for
+        certain files, or retry all files with a linear search.  When
+        'tagbsearch' is off, only a linear search is done.
+
+        Linear searching is done anyway, for one file, when Vim finds a line
+        at the start of the file indicating that it's not sorted: >
+           !_TAG_FILE_SORTED    0       /some comment/
+<       [The whitespace before and after the '0' must be a single <Tab>]
+
+        When a binary search was done and no match was found in any of the
+        files listed in 'tags', and case is ignored or a pattern is used
+        instead of a normal tag name, a retry is done with a linear search.
+        Tags in unsorted tags files, and matches with different case will only
+        be found in the retry.
+
+        If a tag file indicates that it is case-fold sorted, the second,
+        linear search can be avoided when case is ignored.  Use a value of '2'
+        in the "!_TAG_FILE_SORTED" line for this.  A tag file can be case-fold
+        sorted with the -f switch to "sort" in most unices, as in the command:
+        "sort -f -o tags tags".  For Universal ctags and Exuberant ctags
+        version 5.x or higher (at least 5.5) the --sort=foldcase switch can be
+        used for this as well.  Note that case must be folded to uppercase for
+        this to work.
+
+        By default, tag searches are case-sensitive.  Case is ignored when
+        'ignorecase' is set and 'tagcase' is "followic", or when 'tagcase' is
+        "ignore".
+        Also when 'tagcase' is "followscs" and 'smartcase' is set, or
+        'tagcase' is "smart", and the pattern contains only lowercase
+        characters.
+
+        When 'tagbsearch' is off, tags searching is slower when a full match
+        exists, but faster when no full match exists.  Tags in unsorted tags
+        files may only be found with 'tagbsearch' off.
+        When the tags file is not sorted, or sorted in a wrong way (not on
+        ASCII byte value), 'tagbsearch' should be off, or the line given above
+        must be included in the tags file.
+        This option doesn't affect commands that find all matching tags (e.g.,
+        command-line completion and ":help").
+
+                                                                *'tagcase'* *'tc'*
+'tagcase' 'tc'          string (default "followic")
+                        global or local to buffer |global-local|
+        This option specifies how case is handled when searching the tags
+        file:
+           followic     Follow the 'ignorecase' option
+           followscs    Follow the 'smartcase' and 'ignorecase' options
+           ignore       Ignore case
+           match        Match case
+           smart        Ignore case unless an upper case letter is used
+
+                                                               *'tagfunc'* *'tfu'*
+'tagfunc' 'tfu'         string (default "")
+                        local to buffer
+        This option specifies a function to be used to perform tag searches.
+        The function gets the tag pattern and should return a List of matching
+        tags.  See |tag-function| for an explanation of how to write the
+        function and an example.  The value can be the name of a function, a
+        |lambda| or a |Funcref|. See |option-value-function| for more
+        information.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                              *'taglength'* *'tl'*
+'taglength' 'tl'        number (default 0)
+                        global
+        If non-zero, tags are significant up to this number of characters.
+
+                                     *'tagrelative'* *'tr'* *'notagrelative'* *'notr'*
+'tagrelative' 'tr'      boolean (default on)
+                        global
+        If on and using a tags file in another directory, file names in that
+        tags file are relative to the directory where the tags file is.
+
+                                                             *'tags'* *'tag'* *E433*
+'tags' 'tag'            string (default "./tags;,tags")
+                        global or local to buffer |global-local|
+        Filenames for the tag command, separated by spaces or commas.  To
+        include a space or comma in a file name, precede it with backslashes
+        (see |option-backslash| about including spaces/commas and backslashes).
+        When a file name starts with "./", the '.' is replaced with the path
+        of the current file.  But only when the 'd' flag is not included in
+        'cpoptions'.  Environment variables are expanded |:set_env|.  Also see
+        |tags-option|.
+        "*", "**" and other wildcards can be used to search for tags files in
+        a directory tree.  See |file-searching|.  E.g., "/lib/**/tags" will
+        find all files named "tags" below "/lib".  The filename itself cannot
+        contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
+        files called "tags?".
+        The |tagfiles()| function can be used to get a list of the file names
+        actually used.
+        The use of |:set+=| and |:set-=| is preferred when adding or removing
+        file names from the list.  This avoids problems when a future version
+        uses another default.
+
+                                       *'tagstack'* *'tgst'* *'notagstack'* *'notgst'*
+'tagstack' 'tgst'       boolean (default on)
+                        global
+        When on, the |tagstack| is used normally.  When off, a ":tag" or
+        ":tselect" command with an argument will not push the tag onto the
+        tagstack.  A following ":tag" without an argument, a ":pop" command or
+        any other command that uses the tagstack will use the unmodified
+        tagstack, but does change the pointer to the active entry.
+        Resetting this option is useful when using a ":tag" command in a
+        mapping which should not change the tagstack.
+
+                                     *'termbidi'* *'tbidi'* *'notermbidi'* *'notbidi'*
+'termbidi' 'tbidi'      boolean (default off)
+                        global
+        The terminal is in charge of Bi-directionality of text (as specified
+        by Unicode).  The terminal is also expected to do the required shaping
+        that some languages (such as Arabic) require.
+        Setting this option implies that 'rightleft' will not be set when
+        'arabic' is set and the value of 'arabicshape' will be ignored.
+        Note that setting 'termbidi' has the immediate effect that
+        'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
+        For further details see |arabic.txt|.
+
+                               *'termguicolors'* *'tgc'* *'notermguicolors'* *'notgc'*
+'termguicolors' 'tgc'   boolean (default off)
+                        global
+        Enables 24-bit RGB color in the |TUI|.  Uses "gui" |:highlight|
+        attributes instead of "cterm" attributes. |guifg|
+        Requires an ISO-8613-3 compatible terminal.
+
+        Nvim will automatically attempt to determine if the host terminal
+        supports 24-bit color and will enable this option if it does
+        (unless explicitly disabled by the user).
+
+                                                       *'termpastefilter'* *'tpf'*
+'termpastefilter' 'tpf' string (default "BS,HT,ESC,DEL")
+                        global
+        A comma-separated list of options for specifying control characters
+        to be removed from the text pasted into the terminal window. The
+        supported values are:
+
+           BS       Backspace
+
+           HT       TAB
+
+           FF       Form feed
+
+           ESC      Escape
+
+           DEL      DEL
+
+           C0       Other control characters, excluding Line feed and
+                    Carriage return < ' '
+
+           C1       Control characters 0x80...0x9F
+
+                                                       *'termsync'* *'notermsync'*
+'termsync'              boolean (default on)
+                        global
+        If the host terminal supports it, buffer all screen updates
+        made during a redraw cycle so that each screen is displayed in
+        the terminal all at once. This can prevent tearing or flickering
+        when the terminal updates faster than Nvim can redraw.
+
+                                                              *'textwidth'* *'tw'*
+'textwidth' 'tw'        number (default 0)
+                        local to buffer
+        Maximum width of text that is being inserted.  A longer line will be
+        broken after white space to get this width.  A zero value disables
+        this.
+        When 'textwidth' is zero, 'wrapmargin' may be used.  See also
+        'formatoptions' and |ins-textwidth|.
+        When 'formatexpr' is set it will be used to break the line.
+
+                                                             *'thesaurus'* *'tsr'*
+'thesaurus' 'tsr'       string (default "")
+                        global or local to buffer |global-local|
+        List of file names, separated by commas, that are used to lookup words
+        for thesaurus completion commands |i_CTRL-X_CTRL-T|.  See
+        |compl-thesaurus|.
+
+        This option is not used if 'thesaurusfunc' is set, either for the
+        buffer or globally.
+
+        To include a comma in a file name precede it with a backslash.  Spaces
+        after a comma are ignored, otherwise spaces are included in the file
+        name.  See |option-backslash| about using backslashes.  The use of
+        |:set+=| and |:set-=| is preferred when adding or removing directories
+        from the list.  This avoids problems when a future version uses
+        another default.  Backticks cannot be used in this option for security
+        reasons.
+
+                                                       *'thesaurusfunc'* *'tsrfu'*
+'thesaurusfunc' 'tsrfu' string (default "")
+                        global or local to buffer |global-local|
+        This option specifies a function to be used for thesaurus completion
+        with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
+        The value can be the name of a function, a |lambda| or a |Funcref|.
+        See |option-value-function| for more information.
+
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                           *'tildeop'* *'top'* *'notildeop'* *'notop'*
+'tildeop' 'top'         boolean (default off)
+                        global
+        When on: The tilde command "~" behaves like an operator.
+
+                                             *'timeout'* *'to'* *'notimeout'* *'noto'*
+'timeout' 'to'          boolean (default on)
+                        global
+        This option and 'timeoutlen' determine the behavior when part of a
+        mapped key sequence has been received. For example, if <c-f> is
+        pressed and 'timeout' is set, Nvim will wait 'timeoutlen' milliseconds
+        for any key that can follow <c-f> in a mapping.
+
+                                                             *'timeoutlen'* *'tm'*
+'timeoutlen' 'tm'       number (default 1000)
+                        global
+        Time in milliseconds to wait for a mapped sequence to complete.
+
+                                                             *'title'* *'notitle'*
+'title'                 boolean (default off)
+                        global
+        When on, the title of the window will be set to the value of
+        'titlestring' (if it is not empty), or to:
+                filename [+=-] (path) - NVIM
+        Where:
+                filename        the name of the file being edited
+                -               indicates the file cannot be modified, 'ma' off
+                +               indicates the file was modified
+                =               indicates the file is read-only
+                =+              indicates the file is read-only and modified
+                (path)          is the path of the file being edited
+                - NVIM          the server name |v:servername| or "NVIM"
+
+                                                                    *'titlelen'*
+'titlelen'              number (default 85)
+                        global
+        Gives the percentage of 'columns' to use for the length of the window
+        title.  When the title is longer, only the end of the path name is
+        shown.  A '<' character before the path name is used to indicate this.
+        Using a percentage makes this adapt to the width of the window.  But
+        it won't work perfectly, because the actual number of characters
+        available also depends on the font used and other things in the title
+        bar.  When 'titlelen' is zero the full path is used.  Otherwise,
+        values from 1 to 30000 percent can be used.
+        'titlelen' is also used for the 'titlestring' option.
+
+                                                                    *'titleold'*
+'titleold'              string (default "")
+                        global
+        If not empty, this option will be used to set the window title when
+        exiting.  Only if 'title' is enabled.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                                 *'titlestring'*
+'titlestring'           string (default "")
+                        global
+        When this option is not empty, it will be used for the title of the
+        window.  This happens only when the 'title' option is on.
+
+        When this option contains printf-style '%' items, they will be
+        expanded according to the rules used for 'statusline'.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
+
+        Example: >vim
+            auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
+            set title titlestring=%<%F%=%l/%L-%P titlelen=70
+<       The value of 'titlelen' is used to align items in the middle or right
+        of the available space.
+        Some people prefer to have the file name first: >vim
+            set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
+<       Note the use of "%{ }" and an expression to get the path of the file,
+        without the file name.  The "%( %)" constructs are used to add a
+        separating space only when needed.
+        NOTE: Use of special characters in 'titlestring' may cause the display
+        to be garbled (e.g., when it contains a CR or NL character).
+
+                                                       *'ttimeout'* *'nottimeout'*
+'ttimeout'              boolean (default on)
+                        global
+        This option and 'ttimeoutlen' determine the behavior when part of a
+        key code sequence has been received by the |TUI|.
+
+        For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
+        set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
+        complete a key code sequence. If no input arrives before the timeout,
+        a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
+
+        On very slow systems this may fail, causing cursor keys not to work
+        sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
+        Nvim will wait for the next character to arrive after an <Esc>.
+
+                                                           *'ttimeoutlen'* *'ttm'*
+'ttimeoutlen' 'ttm'     number (default 50)
+                        global
+        Time in milliseconds to wait for a key code sequence to complete. Also
+        used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
+        been typed.
+
+                                                        *'undodir'* *'udir'* *E5003*
+'undodir' 'udir'        string (default "$XDG_STATE_HOME/nvim/undo//")
+                        global
+        List of directory names for undo files, separated with commas.
+        See 'backupdir' for details of the format.
+        "." means using the directory of the file.  The undo file name for
+        "file.txt" is ".file.txt.un~".
+        For other directories the file name is the full path of the edited
+        file, with path separators replaced with "%".
+        When writing: The first directory that exists is used.  "." always
+        works, no directories after "." will be used for writing.  If none of
+        the directories exist Nvim will attempt to create the last directory in
+        the list.
+        When reading all entries are tried to find an undo file.  The first
+        undo file that exists is used.  When it cannot be read an error is
+        given, no further entry is used.
+        See |undo-persistence|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+        Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
+        though the trailing slashes are present (see 'backupdir' for what this
+        means).
+
+                                         *'undofile'* *'udf'* *'noundofile'* *'noudf'*
+'undofile' 'udf'        boolean (default off)
+                        local to buffer
+        When on, Vim automatically saves undo history to an undo file when
+        writing a buffer to a file, and restores undo history from the same
+        file on buffer read.
+        The directory where the undo file is stored is specified by 'undodir'.
+        For more information about this feature see |undo-persistence|.
+        The undo file is not read when 'undoreload' causes the buffer from
+        before a reload to be saved for undo.
+        When 'undofile' is turned off the undo file is NOT deleted.
+
+                                                             *'undolevels'* *'ul'*
+'undolevels' 'ul'       number (default 1000)
+                        global or local to buffer |global-local|
+        Maximum number of changes that can be undone.  Since undo information
+        is kept in memory, higher numbers will cause more memory to be used.
+        Nevertheless, a single change can already use a large amount of memory.
+        Set to 0 for Vi compatibility: One level of undo and "u" undoes
+        itself: >vim
+                set ul=0
+<       But you can also get Vi compatibility by including the 'u' flag in
+        'cpoptions', and still be able to use CTRL-R to repeat undo.
+        Also see |undo-two-ways|.
+        Set to -1 for no undo at all.  You might want to do this only for the
+        current buffer: >vim
+                setlocal ul=-1
+<       This helps when you run out of memory for a single change.
+
+        The local value is set to -123456 when the global value is to be used.
+
+        Also see |clear-undo|.
+
+                                                             *'undoreload'* *'ur'*
+'undoreload' 'ur'       number (default 10000)
+                        global
+        Save the whole buffer for undo when reloading it.  This applies to the
+        ":e!" command and reloading for when the buffer changed outside of
+        Vim. |FileChangedShell|
+        The save only happens when this option is negative or when the number
+        of lines is smaller than the value of this option.
+        Set this option to zero to disable undo for a reload.
+
+        When saving undo for a reload, any undo file is not read.
+
+        Note that this causes the whole buffer to be stored in memory.  Set
+        this option to a lower value if you run out of memory.
+
+                                                            *'updatecount'* *'uc'*
+'updatecount' 'uc'      number (default 200)
+                        global
+        After typing this many characters the swap file will be written to
+        disk.  When zero, no swap file will be created at all (see chapter on
+        recovery |crash-recovery|).  'updatecount' is set to zero by starting
+        Vim with the "-n" option, see |startup|.  When editing in readonly
+        mode this option will be initialized to 10000.
+        The swapfile can be disabled per buffer with |'swapfile'|.
+        When 'updatecount' is set from zero to non-zero, swap files are
+        created for all buffers that have 'swapfile' set.  When 'updatecount'
+        is set to zero, existing swap files are not deleted.
+        This option has no meaning in buffers where |'buftype'| is "nofile"
+        or "nowrite".
+
+                                                             *'updatetime'* *'ut'*
+'updatetime' 'ut'       number (default 4000)
+                        global
+        If this many milliseconds nothing is typed the swap file will be
+        written to disk (see |crash-recovery|).  Also used for the
+        |CursorHold| autocommand event.
+
+                                                       *'varsofttabstop'* *'vsts'*
+'varsofttabstop' 'vsts' string (default "")
+                        local to buffer
+        A list of the number of spaces that a <Tab> counts for while editing,
+        such as inserting a <Tab> or using <BS>.  It "feels" like variable-
+        width <Tab>s are being inserted, while in fact a mixture of spaces
+        and <Tab>s is used.  Tab widths are separated with commas, with the
+        final value applying to all subsequent tabs.
+
+        For example, when editing assembly language files where statements
+        start in the 9th column and comments in the 41st, it may be useful
+        to use the following: >vim
+                set varsofttabstop=8,32,8
+<       This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
+        for every column thereafter.
+
+        Note that the value of |'softtabstop'| will be ignored while
+        'varsofttabstop' is set.
+
+                                                            *'vartabstop'* *'vts'*
+'vartabstop' 'vts'      string (default "")
+                        local to buffer
+        A list of the number of spaces that a <Tab> in the file counts for,
+        separated by commas.  Each value corresponds to one tab, with the
+        final value applying to all subsequent tabs. For example: >vim
+                set vartabstop=4,20,10,8
+<       This will make the first tab 4 spaces wide, the second 20 spaces,
+        the third 10 spaces, and all following tabs 8 spaces.
+
+        Note that the value of |'tabstop'| will be ignored while 'vartabstop'
+        is set.
+
+                                                               *'verbose'* *'vbs'*
+'verbose' 'vbs'         number (default 0)
+                        global
+        Sets the verbosity level.  Also set by |-V| and |:verbose|.
+
+        Tracing of options in Lua scripts is activated at level 1; Lua scripts
+        are not traced with verbose=0, for performance.
+
+        If greater than or equal to a given level, Nvim produces the following
+        messages:
+
+        Level   Messages ~
+        ----------------------------------------------------------------------
+        1       Lua assignments to options, mappings, etc.
+        2       When a file is ":source"'ed, or |shada| file is read or written.
+        3       UI info, terminal capabilities.
+        4       Shell commands.
+        5       Every searched tags file and include file.
+        8       Files for which a group of autocommands is executed.
+        9       Executed autocommands.
+        11      Finding items in a path.
+        12      Vimscript function calls.
+        13      When an exception is thrown, caught, finished, or discarded.
+        14      Anything pending in a ":finally" clause.
+        15      Ex commands from a script (truncated at 200 characters).
+        16      Ex commands.
+
+        If 'verbosefile' is set then the verbose messages are not displayed.
+
+                                                         *'verbosefile'* *'vfile'*
+'verbosefile' 'vfile'   string (default "")
+                        global
+        When not empty all messages are written in a file with this name.
+        When the file exists messages are appended.
+        Writing to the file ends when Vim exits or when 'verbosefile' is made
+        empty.  Writes are buffered, thus may not show up for some time.
+        Setting 'verbosefile' to a new value is like making it empty first.
+        The difference with |:redir| is that verbose messages are not
+        displayed when 'verbosefile' is set.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                              *'viewdir'* *'vdir'*
+'viewdir' 'vdir'        string (default "$XDG_STATE_HOME/nvim/view//")
+                        global
+        Name of the directory where to store files for |:mkview|.
+        This option cannot be set from a |modeline| or in the |sandbox|, for
+        security reasons.
+
+                                                           *'viewoptions'* *'vop'*
+'viewoptions' 'vop'     string (default "folds,cursor,curdir")
+                        global
+        Changes the effect of the |:mkview| command.  It is a comma-separated
+        list of words.  Each word enables saving and restoring something:
+           word         save and restore ~
+           cursor       cursor position in file and in window
+           curdir       local current directory, if set with |:lcd|
+           folds        manually created folds, opened/closed folds and local
+                        fold options
+           options      options and mappings local to a window or buffer (not
+                        global values for local options)
+           localoptions same as "options"
+           slash        |deprecated| Always enabled. Uses "/" in filenames.
+           unix         |deprecated| Always enabled. Uses "\n" line endings.
+
+                                                            *'virtualedit'* *'ve'*
+'virtualedit' 've'      string (default "")
+                        global or local to window |global-local|
+        A comma-separated list of these words:
+            block       Allow virtual editing in Visual block mode.
+            insert      Allow virtual editing in Insert mode.
+            all         Allow virtual editing in all modes.
+            onemore     Allow the cursor to move just past the end of the line
+            none        When used as the local value, do not allow virtual
+                        editing even when the global value is set.  When used
+                        as the global value, "none" is the same as "".
+            NONE        Alternative spelling of "none".
+
+        Virtual editing means that the cursor can be positioned where there is
+        no actual character.  This can be halfway into a tab or beyond the end
+        of the line.  Useful for selecting a rectangle in Visual mode and
+        editing a table.
+        "onemore" is not the same, it will only allow moving the cursor just
+        after the last character of the line.  This makes some commands more
+        consistent.  Previously the cursor was always past the end of the line
+        if the line was empty.  But it is far from Vi compatible.  It may also
+        break some plugins or Vim scripts.  For example because |l| can move
+        the cursor after the last character.  Use with care!
+        Using the `$` command will move to the last character in the line, not
+        past it.  This may actually move the cursor to the left!
+        The `g$` command will move to the end of the screen line.
+        It doesn't make sense to combine "all" with "onemore", but you will
+        not get a warning for it.
+        When combined with other words, "none" is ignored.
+
+                                       *'visualbell'* *'vb'* *'novisualbell'* *'novb'*
+'visualbell' 'vb'       boolean (default off)
+                        global
+        Use visual bell instead of beeping.  Also see 'errorbells'.
+
+                                                               *'warn'* *'nowarn'*
+'warn'                  boolean (default on)
+                        global
+        Give a warning message when a shell command is used while the buffer
+        has been changed.
+
+                                                              *'whichwrap'* *'ww'*
+'whichwrap' 'ww'        string (default "b,s")
+                        global
+        Allow specified keys that move the cursor left/right to move to the
+        previous/next line when the cursor is on the first/last character in
+        the line.  Concatenate characters to allow this for these keys:
+                char   key        mode  ~
+                 b    <BS>       Normal and Visual
+                 s    <Space>    Normal and Visual
+                 h    "h"        Normal and Visual (not recommended)
+                 l    "l"        Normal and Visual (not recommended)
+                 <    <Left>     Normal and Visual
+                 >    <Right>    Normal and Visual
+                 ~    "~"        Normal
+                 [    <Left>     Insert and Replace
+                 ]    <Right>    Insert and Replace
+        For example: >vim
+                set ww=<,>,[,]
+<       allows wrap only when cursor keys are used.
+        When the movement keys are used in combination with a delete or change
+        operator, the <EOL> also counts for a character.  This makes "3h"
+        different from "3dh" when the cursor crosses the end of a line.  This
+        is also true for "x" and "X", because they do the same as "dl" and
+        "dh".  If you use this, you may also want to use the mapping
+        ":map <BS> X" to make backspace delete the character in front of the
+        cursor.
+        When 'l' is included and it is used after an operator at the end of a
+        line (not an empty line) then it will not move to the next line.  This
+        makes "dl", "cl", "yl" etc. work normally.
+
+                                                               *'wildchar'* *'wc'*
+'wildchar' 'wc'         number (default <Tab>)
+                        global
+        Character you have to type to start wildcard expansion in the
+        command-line, as specified with 'wildmode'.
+        More info here: |cmdline-completion|.
+        The character is not recognized when used inside a macro.  See
+        'wildcharm' for that.
+        Some keys will not work, such as CTRL-C, <CR> and Enter.
+        <Esc> can be used, but hitting it twice in a row will still exit
+        command-line as a failsafe measure.
+        Although 'wc' is a number option, you can set it to a special key: >vim
+                set wc=<Tab>
 <
-	|hl-WildMenu| highlights the current match.
 
-						*'wildmode'* *'wim'*
-'wildmode' 'wim'	string	(default "full")
-			global
-	Completion mode that is used for the character specified with
-	'wildchar'.  It is a comma-separated list of up to four parts.  Each
-	part specifies what to do for each consecutive use of 'wildchar'.  The
-	first part specifies the behavior for the first use of 'wildchar',
-	The second part for the second use, etc.
+                                                             *'wildcharm'* *'wcm'*
+'wildcharm' 'wcm'       number (default 0)
+                        global
+        'wildcharm' works exactly like 'wildchar', except that it is
+        recognized when used inside a macro.  You can find "spare" command-line
+        keys suitable for this option by looking at |ex-edit-index|.  Normally
+        you'll never actually type 'wildcharm', just use it in mappings that
+        automatically invoke completion mode, e.g.: >vim
+                set wcm=<C-Z>
+                cnoremap ss so $vim/sessions/*.vim<C-Z>
+<       Then after typing :ss you can use CTRL-P & CTRL-N.
 
-	Each part consists of a colon separated list consisting of the
-	following possible values:
-	""		Complete only the first match.
-	"full"		Complete the next full match.  After the last match,
-			the original string is used and then the first match
-			again.  Will also start 'wildmenu' if it is enabled.
-	"longest"	Complete till longest common string.  If this doesn't
-			result in a longer string, use the next part.
-	"list"		When more than one match, list all matches.
-	"lastused"	When completing buffer names and more than one buffer
-			matches, sort buffers by time last used (other than
-			the current buffer).
-	When there is only a single match, it is fully completed in all cases.
+                                                            *'wildignore'* *'wig'*
+'wildignore' 'wig'      string (default "")
+                        global
+        A list of file patterns.  A file that matches with one of these
+        patterns is ignored when expanding |wildcards|, completing file or
+        directory names, and influences the result of |expand()|, |glob()| and
+        |globpath()| unless a flag is passed to disable this.
+        The pattern is used like with |:autocmd|, see |autocmd-pattern|.
+        Also see 'suffixes'.
+        Example: >vim
+                set wildignore=*.o,*.obj
+<       The use of |:set+=| and |:set-=| is preferred when adding or removing
+        a pattern from the list.  This avoids problems when a future version
+        uses another default.
 
-	Examples of useful colon-separated values:
-	"longest:full"	Like "longest", but also start 'wildmenu' if it is
-			enabled.  Will not complete to the next full match.
-	"list:full"	When more than one match, list all matches and
-			complete first match.
-	"list:longest"	When more than one match, list all matches and
-			complete till longest common string.
-	"list:lastused" When more than one buffer matches, list all matches
-			and sort buffers by time last used (other than the
-			current buffer).
+                             *'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
+'wildignorecase' 'wic'  boolean (default off)
+                        global
+        When set case is ignored when completing file names and directories.
+        Has no effect when 'fileignorecase' is set.
+        Does not apply when the shell is used to expand wildcards, which
+        happens when there are special characters.
 
-	Examples: >vim
-		set wildmode=full
-<	Complete first full match, next match, etc.  (the default) >vim
-		set wildmode=longest,full
-<	Complete longest common string, then each full match >vim
-		set wildmode=list:full
-<	List all matches and complete each full match >vim
-		set wildmode=list,full
-<	List all matches without completing, then each full match >vim
-		set wildmode=longest,list
-<	Complete longest common string, then list alternatives.
-	More info here: |cmdline-completion|.
+                                       *'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
+'wildmenu' 'wmnu'       boolean (default on)
+                        global
+        When 'wildmenu' is on, command-line completion operates in an enhanced
+        mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
+        the possible matches are shown.
+        When 'wildoptions' contains "pum", then the completion matches are
+        shown in a popup menu.  Otherwise they are displayed just above the
+        command line, with the first match highlighted (overwriting the status
+        line, if there is one).
+        Keys that show the previous/next match, such as <Tab> or
+        CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
+        'wildmode' must specify "full": "longest" and "list" do not start
+        'wildmenu' mode. You can check the current mode with |wildmenumode()|.
+        The menu is cancelled when a key is hit that is not used for selecting
+        a completion.
 
-						*'wildoptions'* *'wop'*
-'wildoptions' 'wop'	string	(default "pum,tagfile")
-			global
-	A list of words that change how |cmdline-completion| is done.
-	The following values are supported:
-	  fuzzy		Use |fuzzy-matching| to find completion matches. When
-			this value is specified, wildcard expansion will not
-			be used for completion.  The matches will be sorted by
-			the "best match" rather than alphabetically sorted.
-			This will find more matches than the wildcard
-			expansion. Currently fuzzy matching based completion
-			is not supported for file and directory names and
-			instead wildcard expansion is used.
-	  pum		Display the completion matches using the popup menu
-			in the same style as the |ins-completion-menu|.
-	  tagfile	When using CTRL-D to list matching tags, the kind of
-			tag and the file of the tag is listed.	Only one match
-			is displayed per line.  Often used tag kinds are:
-				d	#define
-				f	function
+        While the menu is active these keys have special meanings:
+        CTRL-P          - go to the previous entry
+        CTRL-N          - go to the next entry
+        <Left> <Right>  - select previous/next match (like CTRL-P/CTRL-N)
+        <PageUp>        - select a match several entries back
+        <PageDown>      - select a match several entries further
+        <Up>            - in filename/menu name completion: move up into
+                          parent directory or parent menu.
+        <Down>          - in filename/menu name completion: move into a
+                          subdirectory or submenu.
+        <CR>            - in menu completion, when the cursor is just after a
+                          dot: move into a submenu.
+        CTRL-E          - end completion, go back to what was there before
+                          selecting a match.
+        CTRL-Y          - accept the currently selected match and stop
+                          completion.
 
-						*'winaltkeys'* *'wak'*
-'winaltkeys' 'wak'	string	(default "menu")
-			global
-			only used in Win32
-	Some GUI versions allow the access to menu entries by using the ALT
-	key in combination with a character that appears underlined in the
-	menu.  This conflicts with the use of the ALT key for mappings and
-	entering special characters.  This option tells what to do:
-	  no	Don't use ALT keys for menus.  ALT key combinations can be
-		mapped, but there is no automatic handling.
-	  yes	ALT key handling is done by the windowing system.  ALT key
-		combinations cannot be mapped.
-	  menu	Using ALT in combination with a character that is a menu
-		shortcut key, will be handled by the windowing system.  Other
-		keys can be mapped.
-	If the menu is disabled by excluding 'm' from 'guioptions', the ALT
-	key is never used for the menu.
-	This option is not used for <F10>; on Win32.
+        If you want <Left> and <Right> to move the cursor instead of selecting
+        a different match, use this: >vim
+                cnoremap <Left> <Space><BS><Left>
+                cnoremap <Right> <Space><BS><Right>
+<
+        |hl-WildMenu| highlights the current match.
 
-						*'winbar'* *'wbr'*
-'winbar' 'wbr'		string	(default "")
-			global or local to window |global-local|
-	When non-empty, this option enables the window bar and determines its
-	contents. The window bar is a bar that's shown at the top of every
-	window with it enabled. The value of 'winbar' is evaluated like with
-	'statusline'.
+                                                              *'wildmode'* *'wim'*
+'wildmode' 'wim'        string (default "full")
+                        global
+        Completion mode that is used for the character specified with
+        'wildchar'.  It is a comma-separated list of up to four parts.  Each
+        part specifies what to do for each consecutive use of 'wildchar'.  The
+        first part specifies the behavior for the first use of 'wildchar',
+        The second part for the second use, etc.
 
-	When changing something that is used in 'winbar' that does not trigger
-	it to be updated, use |:redrawstatus|.
+        Each part consists of a colon separated list consisting of the
+        following possible values:
+        ""              Complete only the first match.
+        "full"          Complete the next full match.  After the last match,
+                        the original string is used and then the first match
+                        again.  Will also start 'wildmenu' if it is enabled.
+        "longest"       Complete till longest common string.  If this doesn't
+                        result in a longer string, use the next part.
+        "list"          When more than one match, list all matches.
+        "lastused"      When completing buffer names and more than one buffer
+                        matches, sort buffers by time last used (other than
+                        the current buffer).
+        When there is only a single match, it is fully completed in all cases.
 
-	Floating windows do not use the global value of 'winbar'. The
-	window-local value of 'winbar' must be set for a floating window to
-	have a window bar.
+        Examples of useful colon-separated values:
+        "longest:full"  Like "longest", but also start 'wildmenu' if it is
+                        enabled.  Will not complete to the next full match.
+        "list:full"     When more than one match, list all matches and
+                        complete first match.
+        "list:longest"  When more than one match, list all matches and
+                        complete till longest common string.
+        "list:lastused" When more than one buffer matches, list all matches
+                        and sort buffers by time last used (other than the
+                        current buffer).
 
-	This option cannot be set in a modeline when 'modelineexpr' is off.
+        Examples: >vim
+                set wildmode=full
+<       Complete first full match, next match, etc.  (the default) >vim
+                set wildmode=longest,full
+<       Complete longest common string, then each full match >vim
+                set wildmode=list:full
+<       List all matches and complete each full match >vim
+                set wildmode=list,full
+<       List all matches without completing, then each full match >vim
+                set wildmode=longest,list
+<       Complete longest common string, then list alternatives.
+        More info here: |cmdline-completion|.
 
-						*'winblend'* *'winbl'*
-'winblend' 'winbl'	number	(default 0)
-			local to window
-	Enables pseudo-transparency for a floating window. Valid values are in
-	the range of 0 for fully opaque window (disabled) to 100 for fully
-	transparent background. Values between 0-30 are typically most useful.
+                                                           *'wildoptions'* *'wop'*
+'wildoptions' 'wop'     string (default "pum,tagfile")
+                        global
+        A list of words that change how |cmdline-completion| is done.
+        The following values are supported:
+          fuzzy         Use |fuzzy-matching| to find completion matches. When
+                        this value is specified, wildcard expansion will not
+                        be used for completion.  The matches will be sorted by
+                        the "best match" rather than alphabetically sorted.
+                        This will find more matches than the wildcard
+                        expansion. Currently fuzzy matching based completion
+                        is not supported for file and directory names and
+                        instead wildcard expansion is used.
+          pum           Display the completion matches using the popup menu
+                        in the same style as the |ins-completion-menu|.
+          tagfile       When using CTRL-D to list matching tags, the kind of
+                        tag and the file of the tag is listed.  Only one match
+                        is displayed per line.  Often used tag kinds are:
+                                d       #define
+                                f       function
 
-	UI-dependent. Works best with RGB colors. 'termguicolors'
+                                                            *'winaltkeys'* *'wak'*
+'winaltkeys' 'wak'      string (default "menu")
+                        global
+        only used in Win32
+        Some GUI versions allow the access to menu entries by using the ALT
+        key in combination with a character that appears underlined in the
+        menu.  This conflicts with the use of the ALT key for mappings and
+        entering special characters.  This option tells what to do:
+        no    Don't use ALT keys for menus.  ALT key combinations can be
+        mapped, but there is no automatic handling.
+        yes   ALT key handling is done by the windowing system.  ALT key
+        combinations cannot be mapped.
+        menu  Using ALT in combination with a character that is a menu
+        shortcut key, will be handled by the windowing system.  Other
+        keys can be mapped.
+        If the menu is disabled by excluding 'm' from 'guioptions', the ALT
+        key is never used for the menu.
+        This option is not used for <F10>; on Win32.
 
-							*'window'* *'wi'*
-'window' 'wi'		number	(default screen height - 1)
-			global
-	Window height used for |CTRL-F| and |CTRL-B| when there is only one
-	window and the value is smaller than 'lines' minus one.  The screen
-	will scroll 'window' minus two lines, with a minimum of one.
-	When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
-	in a much smarter way, taking care of wrapping lines.
-	When resizing the Vim window, the value is smaller than 1 or more than
-	or equal to 'lines' it will be set to 'lines' minus 1.
-	Note: Do not confuse this with the height of the Vim window, use
-	'lines' for that.
+                                                                *'winbar'* *'wbr'*
+'winbar' 'wbr'          string (default "")
+                        global or local to window |global-local|
+        When non-empty, this option enables the window bar and determines its
+        contents. The window bar is a bar that's shown at the top of every
+        window with it enabled. The value of 'winbar' is evaluated like with
+        'statusline'.
 
-			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
-'winfixheight' 'wfh'	boolean	(default off)
-			local to window  |local-noglobal|
-	Keep the window height when windows are opened or closed and
-	'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
-	|preview-window| and |quickfix-window|.
-	The height may be changed anyway when running out of room.
+        When changing something that is used in 'winbar' that does not trigger
+        it to be updated, use |:redrawstatus|.
 
-			*'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
-'winfixwidth' 'wfw'	boolean	(default off)
-			local to window  |local-noglobal|
-	Keep the window width when windows are opened or closed and
-	'equalalways' is set.  Also for |CTRL-W_=|.
-	The width may be changed anyway when running out of room.
+        Floating windows do not use the global value of 'winbar'. The
+        window-local value of 'winbar' must be set for a floating window to
+        have a window bar.
 
-						*'winheight'* *'wh'* *E591*
-'winheight' 'wh'	number	(default 1)
-			global
-	Minimal number of lines for the current window.  This is not a hard
-	minimum, Vim will use fewer lines if there is not enough room.  If the
-	focus goes to a window that is smaller, its size is increased, at the
-	cost of the height of other windows.
-	Set 'winheight' to a small number for normal editing.
-	Set it to 999 to make the current window fill most of the screen.
-	Other windows will be only 'winminheight' high.  This has the drawback
-	that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
-	to create only two windows, set the option after startup is done,
-	using the |VimEnter| event: >vim
-		au VimEnter * set winheight=999
-<	Minimum value is 1.
-	The height is not adjusted after one of the commands that change the
-	height of the current window.
-	'winheight' applies to the current window.  Use 'winminheight' to set
-	the minimal height for other windows.
+        This option cannot be set in a modeline when 'modelineexpr' is off.
 
-					*'winhighlight'* *'winhl'*
-'winhighlight' 'winhl'	string	(default "")
-			local to window
-	Window-local highlights.  Comma-delimited list of highlight
-	|group-name| pairs "{hl-from}:{hl-to},..." where each {hl-from} is
-	a |highlight-groups| item to be overridden by {hl-to} group in
-	the window.
+                                                            *'winblend'* *'winbl'*
+'winblend' 'winbl'      number (default 0)
+                        local to window
+        Enables pseudo-transparency for a floating window. Valid values are in
+        the range of 0 for fully opaque window (disabled) to 100 for fully
+        transparent background. Values between 0-30 are typically most useful.
 
-	Note: highlight namespaces take precedence over 'winhighlight'.
-	See |nvim_win_set_hl_ns()| and |nvim_set_hl()|.
+        UI-dependent. Works best with RGB colors. 'termguicolors'
 
-	Highlights of vertical separators are determined by the window to the
-	left of the separator.  The 'tabline' highlight of a tabpage is
-	decided by the last-focused window of the tabpage.  Highlights of
-	the popupmenu are determined by the current window.  Highlights in the
-	message area cannot be overridden.
+                                                                 *'window'* *'wi'*
+'window' 'wi'           number (default screen height - 1)
+                        global
+        Window height used for |CTRL-F| and |CTRL-B| when there is only one
+        window and the value is smaller than 'lines' minus one.  The screen
+        will scroll 'window' minus two lines, with a minimum of one.
+        When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
+        in a much smarter way, taking care of wrapping lines.
+        When resizing the Vim window, the value is smaller than 1 or more than
+        or equal to 'lines' it will be set to 'lines' minus 1.
+        Note: Do not confuse this with the height of the Vim window, use
+        'lines' for that.
 
-	Example: show a different color for non-current windows: >vim
-		set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
+                                 *'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
+'winfixheight' 'wfh'    boolean (default off)
+                        local to window  |local-noglobal|
+        Keep the window height when windows are opened or closed and
+        'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
+        |preview-window| and |quickfix-window|.
+        The height may be changed anyway when running out of room.
+
+                                   *'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
+'winfixwidth' 'wfw'     boolean (default off)
+                        local to window  |local-noglobal|
+        Keep the window width when windows are opened or closed and
+        'equalalways' is set.  Also for |CTRL-W_=|.
+        The width may be changed anyway when running out of room.
+
+                                                         *'winheight'* *'wh'* *E591*
+'winheight' 'wh'        number (default 1)
+                        global
+        Minimal number of lines for the current window.  This is not a hard
+        minimum, Vim will use fewer lines if there is not enough room.  If the
+        focus goes to a window that is smaller, its size is increased, at the
+        cost of the height of other windows.
+        Set 'winheight' to a small number for normal editing.
+        Set it to 999 to make the current window fill most of the screen.
+        Other windows will be only 'winminheight' high.  This has the drawback
+        that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
+        to create only two windows, set the option after startup is done,
+        using the |VimEnter| event: >vim
+                au VimEnter * set winheight=999
+<       Minimum value is 1.
+        The height is not adjusted after one of the commands that change the
+        height of the current window.
+        'winheight' applies to the current window.  Use 'winminheight' to set
+        the minimal height for other windows.
+
+                                                        *'winhighlight'* *'winhl'*
+'winhighlight' 'winhl'  string (default "")
+                        local to window
+        Window-local highlights.  Comma-delimited list of highlight
+        |group-name| pairs "{hl-from}:{hl-to},..." where each {hl-from} is
+        a |highlight-groups| item to be overridden by {hl-to} group in
+        the window.
+
+        Note: highlight namespaces take precedence over 'winhighlight'.
+        See |nvim_win_set_hl_ns()| and |nvim_set_hl()|.
+
+        Highlights of vertical separators are determined by the window to the
+        left of the separator.  The 'tabline' highlight of a tabpage is
+        decided by the last-focused window of the tabpage.  Highlights of
+        the popupmenu are determined by the current window.  Highlights in the
+        message area cannot be overridden.
+
+        Example: show a different color for non-current windows: >vim
+                set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
 <
 
-						*'winminheight'* *'wmh'*
-'winminheight' 'wmh'	number	(default 1)
-			global
-	The minimal height of a window, when it's not the current window.
-	This is a hard minimum, windows will never become smaller.
-	When set to zero, windows may be "squashed" to zero lines (i.e. just a
-	status bar) if necessary.  They will return to at least one line when
-	they become active (since the cursor has to have somewhere to go.)
-	Use 'winheight' to set the minimal height of the current window.
-	This option is only checked when making a window smaller.  Don't use a
-	large number, it will cause errors when opening more than a few
-	windows.  A value of 0 to 3 is reasonable.
+                                                          *'winminheight'* *'wmh'*
+'winminheight' 'wmh'    number (default 1)
+                        global
+        The minimal height of a window, when it's not the current window.
+        This is a hard minimum, windows will never become smaller.
+        When set to zero, windows may be "squashed" to zero lines (i.e. just a
+        status bar) if necessary.  They will return to at least one line when
+        they become active (since the cursor has to have somewhere to go.)
+        Use 'winheight' to set the minimal height of the current window.
+        This option is only checked when making a window smaller.  Don't use a
+        large number, it will cause errors when opening more than a few
+        windows.  A value of 0 to 3 is reasonable.
 
-						*'winminwidth'* *'wmw'*
-'winminwidth' 'wmw'	number	(default 1)
-			global
-	The minimal width of a window, when it's not the current window.
-	This is a hard minimum, windows will never become smaller.
-	When set to zero, windows may be "squashed" to zero columns (i.e. just
-	a vertical separator) if necessary.  They will return to at least one
-	line when they become active (since the cursor has to have somewhere
-	to go.)
-	Use 'winwidth' to set the minimal width of the current window.
-	This option is only checked when making a window smaller.  Don't use a
-	large number, it will cause errors when opening more than a few
-	windows.  A value of 0 to 12 is reasonable.
+                                                           *'winminwidth'* *'wmw'*
+'winminwidth' 'wmw'     number (default 1)
+                        global
+        The minimal width of a window, when it's not the current window.
+        This is a hard minimum, windows will never become smaller.
+        When set to zero, windows may be "squashed" to zero columns (i.e. just
+        a vertical separator) if necessary.  They will return to at least one
+        line when they become active (since the cursor has to have somewhere
+        to go.)
+        Use 'winwidth' to set the minimal width of the current window.
+        This option is only checked when making a window smaller.  Don't use a
+        large number, it will cause errors when opening more than a few
+        windows.  A value of 0 to 12 is reasonable.
 
-						*'winwidth'* *'wiw'* *E592*
-'winwidth' 'wiw'	number	(default 20)
-			global
-	Minimal number of columns for the current window.  This is not a hard
-	minimum, Vim will use fewer columns if there is not enough room.  If
-	the current window is smaller, its size is increased, at the cost of
-	the width of other windows.  Set it to 999 to make the current window
-	always fill the screen.  Set it to a small number for normal editing.
-	The width is not adjusted after one of the commands to change the
-	width of the current window.
-	'winwidth' applies to the current window.  Use 'winminwidth' to set
-	the minimal width for other windows.
+                                                         *'winwidth'* *'wiw'* *E592*
+'winwidth' 'wiw'        number (default 20)
+                        global
+        Minimal number of columns for the current window.  This is not a hard
+        minimum, Vim will use fewer columns if there is not enough room.  If
+        the current window is smaller, its size is increased, at the cost of
+        the width of other windows.  Set it to 999 to make the current window
+        always fill the screen.  Set it to a small number for normal editing.
+        The width is not adjusted after one of the commands to change the
+        width of the current window.
+        'winwidth' applies to the current window.  Use 'winminwidth' to set
+        the minimal width for other windows.
 
-						*'wrap'* *'nowrap'*
-'wrap'			boolean	(default on)
-			local to window
-	This option changes how text is displayed.  It doesn't change the text
-	in the buffer, see 'textwidth' for that.
-	When on, lines longer than the width of the window will wrap and
-	displaying continues on the next line.  When off lines will not wrap
-	and only part of long lines will be displayed.  When the cursor is
-	moved to a part that is not shown, the screen will scroll
-	horizontally.
-	The line will be broken in the middle of a word if necessary.  See
-	'linebreak' to get the break at a word boundary.
-	To make scrolling horizontally a bit more useful, try this: >vim
-		set sidescroll=5
-		set listchars+=precedes:<,extends:>
-<	See 'sidescroll', 'listchars' and |wrap-off|.
-	This option can't be set from a |modeline| when the 'diff' option is
-	on.
+                                                               *'wrap'* *'nowrap'*
+'wrap'                  boolean (default on)
+                        local to window
+        This option changes how text is displayed.  It doesn't change the text
+        in the buffer, see 'textwidth' for that.
+        When on, lines longer than the width of the window will wrap and
+        displaying continues on the next line.  When off lines will not wrap
+        and only part of long lines will be displayed.  When the cursor is
+        moved to a part that is not shown, the screen will scroll
+        horizontally.
+        The line will be broken in the middle of a word if necessary.  See
+        'linebreak' to get the break at a word boundary.
+        To make scrolling horizontally a bit more useful, try this: >vim
+                set sidescroll=5
+                set listchars+=precedes:<,extends:>
+<       See 'sidescroll', 'listchars' and |wrap-off|.
+        This option can't be set from a |modeline| when the 'diff' option is
+        on.
 
-						*'wrapmargin'* *'wm'*
-'wrapmargin' 'wm'	number	(default 0)
-			local to buffer
-	Number of characters from the right window border where wrapping
-	starts.  When typing text beyond this limit, an <EOL> will be inserted
-	and inserting continues on the next line.
-	Options that add a margin, such as 'number' and 'foldcolumn', cause
-	the text width to be further reduced.
-	When 'textwidth' is non-zero, this option is not used.
-	See also 'formatoptions' and |ins-textwidth|.
+                                                             *'wrapmargin'* *'wm'*
+'wrapmargin' 'wm'       number (default 0)
+                        local to buffer
+        Number of characters from the right window border where wrapping
+        starts.  When typing text beyond this limit, an <EOL> will be inserted
+        and inserting continues on the next line.
+        Options that add a margin, such as 'number' and 'foldcolumn', cause
+        the text width to be further reduced.
+        When 'textwidth' is non-zero, this option is not used.
+        See also 'formatoptions' and |ins-textwidth|.
 
-			*'wrapscan'* *'ws'* *'nowrapscan'* *'nows'* *E384* *E385*
-'wrapscan' 'ws'		boolean	(default on)
-			global
-	Searches wrap around the end of the file.  Also applies to |]s| and
-	|[s|, searching for spelling mistakes.
+                                 *'wrapscan'* *'ws'* *'nowrapscan'* *'nows'* *E384* *E385*
+'wrapscan' 'ws'         boolean (default on)
+                        global
+        Searches wrap around the end of the file.  Also applies to |]s| and
+        |[s|, searching for spelling mistakes.
 
-						*'write'* *'nowrite'*
-'write'			boolean	(default on)
-			global
-	Allows writing files.  When not set, writing a file is not allowed.
-	Can be used for a view-only mode, where modifications to the text are
-	still allowed.  Can be reset with the |-m| or |-M| command line
-	argument.  Filtering text is still possible, even though this requires
-	writing a temporary file.
+                                                             *'write'* *'nowrite'*
+'write'                 boolean (default on)
+                        global
+        Allows writing files.  When not set, writing a file is not allowed.
+        Can be used for a view-only mode, where modifications to the text are
+        still allowed.  Can be reset with the |-m| or |-M| command line
+        argument.  Filtering text is still possible, even though this requires
+        writing a temporary file.
 
-				*'writeany'* *'wa'* *'nowriteany'* *'nowa'*
-'writeany' 'wa'		boolean	(default off)
-			global
-	Allows writing to any file with no need for "!" override.
+                                           *'writeany'* *'wa'* *'nowriteany'* *'nowa'*
+'writeany' 'wa'         boolean (default off)
+                        global
+        Allows writing to any file with no need for "!" override.
 
-			*'writebackup'* *'wb'* *'nowritebackup'* *'nowb'*
-'writebackup' 'wb'	boolean	(default on)
-			global
-	Make a backup before overwriting a file.  The backup is removed after
-	the file was successfully written, unless the 'backup' option is
-	also on.
-	WARNING: Switching this option off means that when Vim fails to write
-	your buffer correctly and then, for whatever reason, Vim exits, you
-	lose both the original file and what you were writing.  Only reset
-	this option if your file system is almost full and it makes the write
-	fail (and make sure not to exit Vim until the write was successful).
-	See |backup-table| for another explanation.
-	When the 'backupskip' pattern matches, a backup is not made anyway.
-	Depending on 'backupcopy' the backup is a new file or the original
-	file renamed (and a new file is written).
+                                     *'writebackup'* *'wb'* *'nowritebackup'* *'nowb'*
+'writebackup' 'wb'      boolean (default on)
+                        global
+        Make a backup before overwriting a file.  The backup is removed after
+        the file was successfully written, unless the 'backup' option is
+        also on.
+        WARNING: Switching this option off means that when Vim fails to write
+        your buffer correctly and then, for whatever reason, Vim exits, you
+        lose both the original file and what you were writing.  Only reset
+        this option if your file system is almost full and it makes the write
+        fail (and make sure not to exit Vim until the write was successful).
+        See |backup-table| for another explanation.
+        When the 'backupskip' pattern matches, a backup is not made anyway.
+        Depending on 'backupcopy' the backup is a new file or the original
+        file renamed (and a new file is written).
 
-						*'writedelay'* *'wd'*
-'writedelay' 'wd'	number	(default 0)
-			global
-	Only takes effect together with 'redrawdebug'.
-	The number of milliseconds to wait after each line or each flush
+                                                             *'writedelay'* *'wd'*
+'writedelay' 'wd'       number (default 0)
+                        global
+        Only takes effect together with 'redrawdebug'.
+        The number of milliseconds to wait after each line or each flush
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -622,6695 +622,6695 @@ supported use something like this: >
 							*E355*
 A jump table for the options with a short description can be found at |Q_op|.
 
-                                   *'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
-'allowrevins' 'ari'     boolean (default off)
-                        global
-        Allow CTRL-_ in Insert and Command-line mode.  This is default off, to
-        avoid that users that accidentally type CTRL-_ instead of SHIFT-_ get
-        into reverse Insert mode, and don't know how to get out.  See
-        'revins'.
+				   *'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
+'allowrevins' 'ari'	boolean (default off)
+			global
+	Allow CTRL-_ in Insert and Command-line mode.  This is default off, to
+	avoid that users that accidentally type CTRL-_ instead of SHIFT-_ get
+	into reverse Insert mode, and don't know how to get out.  See
+	'revins'.
 
-                                                            *'ambiwidth'* *'ambw'*
-'ambiwidth' 'ambw'      string (default "single")
-                        global
-        Tells Vim what to do with characters with East Asian Width Class
-        Ambiguous (such as Euro, Registered Sign, Copyright Sign, Greek
-        letters, Cyrillic letters).
+							    *'ambiwidth'* *'ambw'*
+'ambiwidth' 'ambw'	string (default "single")
+			global
+	Tells Vim what to do with characters with East Asian Width Class
+	Ambiguous (such as Euro, Registered Sign, Copyright Sign, Greek
+	letters, Cyrillic letters).
 
-        There are currently two possible values:
-        "single":       Use the same width as characters in US-ASCII.  This is
-                        expected by most users.
-        "double":       Use twice the width of ASCII characters.
-                                                        *E834* *E835*
-        The value "double" cannot be used if 'listchars' or 'fillchars'
-        contains a character that would be double width.  These errors may
-        also be given when calling setcellwidths().
+	There are currently two possible values:
+	"single":	Use the same width as characters in US-ASCII.  This is
+			expected by most users.
+	"double":	Use twice the width of ASCII characters.
+							*E834* *E835*
+	The value "double" cannot be used if 'listchars' or 'fillchars'
+	contains a character that would be double width.  These errors may
+	also be given when calling setcellwidths().
 
-        The values are overruled for characters specified with
-        |setcellwidths()|.
+	The values are overruled for characters specified with
+	|setcellwidths()|.
 
-        There are a number of CJK fonts for which the width of glyphs for
-        those characters are solely based on how many octets they take in
-        legacy/traditional CJK encodings.  In those encodings, Euro,
-        Registered sign, Greek/Cyrillic letters are represented by two octets,
-        therefore those fonts have "wide" glyphs for them.  This is also
-        true of some line drawing characters used to make tables in text
-        file.  Therefore, when a CJK font is used for GUI Vim or
-        Vim is running inside a terminal (emulators) that uses a CJK font
-        (or Vim is run inside an xterm invoked with "-cjkwidth" option.),
-        this option should be set to "double" to match the width perceived
-        by Vim with the width of glyphs in the font.  Perhaps it also has
-        to be set to "double" under CJK MS-Windows when the system locale is
-        set to one of CJK locales.  See Unicode Standard Annex #11
-        (https://www.unicode.org/reports/tr11).
+	There are a number of CJK fonts for which the width of glyphs for
+	those characters are solely based on how many octets they take in
+	legacy/traditional CJK encodings.  In those encodings, Euro,
+	Registered sign, Greek/Cyrillic letters are represented by two octets,
+	therefore those fonts have "wide" glyphs for them.  This is also
+	true of some line drawing characters used to make tables in text
+	file.  Therefore, when a CJK font is used for GUI Vim or
+	Vim is running inside a terminal (emulators) that uses a CJK font
+	(or Vim is run inside an xterm invoked with "-cjkwidth" option.),
+	this option should be set to "double" to match the width perceived
+	by Vim with the width of glyphs in the font.  Perhaps it also has
+	to be set to "double" under CJK MS-Windows when the system locale is
+	set to one of CJK locales.  See Unicode Standard Annex #11
+	(https://www.unicode.org/reports/tr11).
 
-                                           *'arabic'* *'arab'* *'noarabic'* *'noarab'*
-'arabic' 'arab'         boolean (default off)
-                        local to window
-        This option can be set to start editing Arabic text.
-        Setting this option will:
-        - Set the 'rightleft' option, unless 'termbidi' is set.
-        - Set the 'arabicshape' option, unless 'termbidi' is set.
-        - Set the 'keymap' option to "arabic"; in Insert mode CTRL-^ toggles
-          between typing English and Arabic key mapping.
-        - Set the 'delcombine' option
+					   *'arabic'* *'arab'* *'noarabic'* *'noarab'*
+'arabic' 'arab'		boolean (default off)
+			local to window
+	This option can be set to start editing Arabic text.
+	Setting this option will:
+	- Set the 'rightleft' option, unless 'termbidi' is set.
+	- Set the 'arabicshape' option, unless 'termbidi' is set.
+	- Set the 'keymap' option to "arabic"; in Insert mode CTRL-^ toggles
+	  between typing English and Arabic key mapping.
+	- Set the 'delcombine' option
 
-        Resetting this option will:
-        - Reset the 'rightleft' option.
-        - Disable the use of 'keymap' (without changing its value).
-        Note that 'arabicshape' and 'delcombine' are not reset (it is a global
-        option).
-        Also see |arabic.txt|.
+	Resetting this option will:
+	- Reset the 'rightleft' option.
+	- Disable the use of 'keymap' (without changing its value).
+	Note that 'arabicshape' and 'delcombine' are not reset (it is a global
+	option).
+	Also see |arabic.txt|.
 
-                           *'arabicshape'* *'arshape'* *'noarabicshape'* *'noarshape'*
+			   *'arabicshape'* *'arshape'* *'noarabicshape'* *'noarshape'*
 'arabicshape' 'arshape' boolean (default on)
-                        global
-        When on and 'termbidi' is off, the required visual character
-        corrections that need to take place for displaying the Arabic language
-        take effect.  Shaping, in essence, gets enabled; the term is a broad
-        one which encompasses:
-          a) the changing/morphing of characters based on their location
-             within a word (initial, medial, final and stand-alone).
-          b) the enabling of the ability to compose characters
-          c) the enabling of the required combining of some characters
-        When disabled the display shows each character's true stand-alone
-        form.
-        Arabic is a complex language which requires other settings, for
-        further details see |arabic.txt|.
+			global
+	When on and 'termbidi' is off, the required visual character
+	corrections that need to take place for displaying the Arabic language
+	take effect.  Shaping, in essence, gets enabled; the term is a broad
+	one which encompasses:
+	  a) the changing/morphing of characters based on their location
+	     within a word (initial, medial, final and stand-alone).
+	  b) the enabling of the ability to compose characters
+	  c) the enabling of the required combining of some characters
+	When disabled the display shows each character's true stand-alone
+	form.
+	Arabic is a complex language which requires other settings, for
+	further details see |arabic.txt|.
 
-                                       *'autochdir'* *'acd'* *'noautochdir'* *'noacd'*
-'autochdir' 'acd'       boolean (default off)
-                        global
-        When on, Vim will change the current working directory whenever you
-        open a file, switch buffers, delete a buffer or open/close a window.
-        It will change to the directory containing the file which was opened
-        or selected.  When a buffer has no name it also has no directory, thus
-        the current directory won't change when navigating to it.
-        Note: When this option is on some plugins may not work.
+				       *'autochdir'* *'acd'* *'noautochdir'* *'noacd'*
+'autochdir' 'acd'	boolean (default off)
+			global
+	When on, Vim will change the current working directory whenever you
+	open a file, switch buffers, delete a buffer or open/close a window.
+	It will change to the directory containing the file which was opened
+	or selected.  When a buffer has no name it also has no directory, thus
+	the current directory won't change when navigating to it.
+	Note: When this option is on some plugins may not work.
 
-                                       *'autoindent'* *'ai'* *'noautoindent'* *'noai'*
-'autoindent' 'ai'       boolean (default on)
-                        local to buffer
-        Copy indent from current line when starting a new line (typing <CR>
-        in Insert mode or when using the "o" or "O" command).  If you do not
-        type anything on the new line except <BS> or CTRL-D and then type
-        <Esc>, CTRL-O or <CR>, the indent is deleted again.  Moving the cursor
-        to another line has the same effect, unless the 'I' flag is included
-        in 'cpoptions'.
-        When autoindent is on, formatting (with the "gq" command or when you
-        reach 'textwidth' in Insert mode) uses the indentation of the first
-        line.
-        When 'smartindent' or 'cindent' is on the indent is changed in
-        a different way.
+				       *'autoindent'* *'ai'* *'noautoindent'* *'noai'*
+'autoindent' 'ai'	boolean (default on)
+			local to buffer
+	Copy indent from current line when starting a new line (typing <CR>
+	in Insert mode or when using the "o" or "O" command).  If you do not
+	type anything on the new line except <BS> or CTRL-D and then type
+	<Esc>, CTRL-O or <CR>, the indent is deleted again.  Moving the cursor
+	to another line has the same effect, unless the 'I' flag is included
+	in 'cpoptions'.
+	When autoindent is on, formatting (with the "gq" command or when you
+	reach 'textwidth' in Insert mode) uses the indentation of the first
+	line.
+	When 'smartindent' or 'cindent' is on the indent is changed in
+	a different way.
 
-                                           *'autoread'* *'ar'* *'noautoread'* *'noar'*
-'autoread' 'ar'         boolean (default on)
-                        global or local to buffer |global-local|
-        When a file has been detected to have been changed outside of Vim and
-        it has not been changed inside of Vim, automatically read it again.
-        When the file has been deleted this is not done, so you have the text
-        from before it was deleted.  When it appears again then it is read.
-        |timestamp|
-        If this option has a local value, use this command to switch back to
-        using the global value: >vim
-                set autoread<
+					   *'autoread'* *'ar'* *'noautoread'* *'noar'*
+'autoread' 'ar'		boolean (default on)
+			global or local to buffer |global-local|
+	When a file has been detected to have been changed outside of Vim and
+	it has not been changed inside of Vim, automatically read it again.
+	When the file has been deleted this is not done, so you have the text
+	from before it was deleted.  When it appears again then it is read.
+	|timestamp|
+	If this option has a local value, use this command to switch back to
+	using the global value: >vim
+		set autoread<
 <
 
-                                         *'autowrite'* *'aw'* *'noautowrite'* *'noaw'*
-'autowrite' 'aw'        boolean (default off)
-                        global
-        Write the contents of the file, if it has been modified, on each
-        `:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
-        `:suspend`, `:tag`, `:!`, `:make`, CTRL-] and CTRL-^ command; and when
-        a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
-        to another file.
-        A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is
-        set to "hide" and `:next` is used.
-        Note that for some commands the 'autowrite' option is not used, see
-        'autowriteall' for that.
-        Some buffers will not be written, specifically when 'buftype' is
-        "nowrite", "nofile", "terminal" or "prompt".
-        USE WITH CARE: If you make temporary changes to a buffer that you
-        don't want to be saved this option may cause it to be saved anyway.
-        Renaming the buffer with ":file {name}" may help avoid this.
+					 *'autowrite'* *'aw'* *'noautowrite'* *'noaw'*
+'autowrite' 'aw'	boolean (default off)
+			global
+	Write the contents of the file, if it has been modified, on each
+	`:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
+	`:suspend`, `:tag`, `:!`, `:make`, CTRL-] and CTRL-^ command; and when
+	a `:buffer`, CTRL-O, CTRL-I, '{A-Z0-9}, or `{A-Z0-9} command takes one
+	to another file.
+	A buffer is not written if it becomes hidden, e.g. when 'bufhidden' is
+	set to "hide" and `:next` is used.
+	Note that for some commands the 'autowrite' option is not used, see
+	'autowriteall' for that.
+	Some buffers will not be written, specifically when 'buftype' is
+	"nowrite", "nofile", "terminal" or "prompt".
+	USE WITH CARE: If you make temporary changes to a buffer that you
+	don't want to be saved this option may cause it to be saved anyway.
+	Renaming the buffer with ":file {name}" may help avoid this.
 
-                                 *'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
-'autowriteall' 'awa'    boolean (default off)
-                        global
-        Like 'autowrite', but also used for commands ":edit", ":enew", ":quit",
-        ":qall", ":exit", ":xit", ":recover" and closing the Vim window.
-        Setting this option also implies that Vim behaves like 'autowrite' has
-        been set.
+				 *'autowriteall'* *'awa'* *'noautowriteall'* *'noawa'*
+'autowriteall' 'awa'	boolean (default off)
+			global
+	Like 'autowrite', but also used for commands ":edit", ":enew", ":quit",
+	":qall", ":exit", ":xit", ":recover" and closing the Vim window.
+	Setting this option also implies that Vim behaves like 'autowrite' has
+	been set.
 
-                                                             *'background'* *'bg'*
-'background' 'bg'       string (default "dark")
-                        global
-        When set to "dark" or "light", adjusts the default color groups for
-        that background type.  The |TUI| or other UI sets this on startup
-        (triggering |OptionSet|) if it can detect the background color.
+							     *'background'* *'bg'*
+'background' 'bg'	string (default "dark")
+			global
+	When set to "dark" or "light", adjusts the default color groups for
+	that background type.  The |TUI| or other UI sets this on startup
+	(triggering |OptionSet|) if it can detect the background color.
 
-        This option does NOT change the background color, it tells Nvim what
-        the "inherited" (terminal/GUI) background looks like.
-        See |:hi-normal| if you want to set the background color explicitly.
-                                                *g:colors_name*
-        When a color scheme is loaded (the "g:colors_name" variable is set)
-        changing 'background' will cause the color scheme to be reloaded.  If
-        the color scheme adjusts to the value of 'background' this will work.
-        However, if the color scheme sets 'background' itself the effect may
-        be undone.  First delete the "g:colors_name" variable when needed.
+	This option does NOT change the background color, it tells Nvim what
+	the "inherited" (terminal/GUI) background looks like.
+	See |:hi-normal| if you want to set the background color explicitly.
+						*g:colors_name*
+	When a color scheme is loaded (the "g:colors_name" variable is set)
+	changing 'background' will cause the color scheme to be reloaded.  If
+	the color scheme adjusts to the value of 'background' this will work.
+	However, if the color scheme sets 'background' itself the effect may
+	be undone.  First delete the "g:colors_name" variable when needed.
 
-        Normally this option would be set in the vimrc file.  Possibly
-        depending on the terminal name.  Example: >vim
-                if $TERM ==# "xterm"
-                  set background=dark
-                endif
-<       When this option is changed, the default settings for the highlight groups
-        will change.  To use other settings, place ":highlight" commands AFTER
-        the setting of the 'background' option.
+	Normally this option would be set in the vimrc file.  Possibly
+	depending on the terminal name.  Example: >vim
+		if $TERM ==# "xterm"
+		  set background=dark
+		endif
+<	When this option is changed, the default settings for the highlight groups
+	will change.  To use other settings, place ":highlight" commands AFTER
+	the setting of the 'background' option.
 
-                                                              *'backspace'* *'bs'*
-'backspace' 'bs'        string (default "indent,eol,start")
-                        global
-        Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
-        mode.  This is a list of items, separated by commas.  Each item allows
-        a way to backspace over something:
-        value   effect  ~
-        indent  allow backspacing over autoindent
-        eol     allow backspacing over line breaks (join lines)
-        start   allow backspacing over the start of insert; CTRL-W and CTRL-U
-                stop once at the start of insert.
-        nostop  like start, except CTRL-W and CTRL-U do not stop at the start of
-                insert.
+							      *'backspace'* *'bs'*
+'backspace' 'bs'	string (default "indent,eol,start")
+			global
+	Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
+	mode.  This is a list of items, separated by commas.  Each item allows
+	a way to backspace over something:
+	value	effect	~
+	indent	allow backspacing over autoindent
+	eol	allow backspacing over line breaks (join lines)
+	start	allow backspacing over the start of insert; CTRL-W and CTRL-U
+		stop once at the start of insert.
+	nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
+		insert.
 
-        When the value is empty, Vi compatible backspacing is used, none of
-        the ways mentioned for the items above are possible.
+	When the value is empty, Vi compatible backspacing is used, none of
+	the ways mentioned for the items above are possible.
 
-                                               *'backup'* *'bk'* *'nobackup'* *'nobk'*
-'backup' 'bk'           boolean (default off)
-                        global
-        Make a backup before overwriting a file.  Leave it around after the
-        file has been successfully written.  If you do not want to keep the
-        backup file, but you do want a backup while the file is being
-        written, reset this option and set the 'writebackup' option (this is
-        the default).  If you do not want a backup file at all reset both
-        options (use this if your file system is almost full).  See the
-        |backup-table| for more explanations.
-        When the 'backupskip' pattern matches, a backup is not made anyway.
-        When 'patchmode' is set, the backup may be renamed to become the
-        oldest version of a file.
+					       *'backup'* *'bk'* *'nobackup'* *'nobk'*
+'backup' 'bk'		boolean (default off)
+			global
+	Make a backup before overwriting a file.  Leave it around after the
+	file has been successfully written.  If you do not want to keep the
+	backup file, but you do want a backup while the file is being
+	written, reset this option and set the 'writebackup' option (this is
+	the default).  If you do not want a backup file at all reset both
+	options (use this if your file system is almost full).	See the
+	|backup-table| for more explanations.
+	When the 'backupskip' pattern matches, a backup is not made anyway.
+	When 'patchmode' is set, the backup may be renamed to become the
+	oldest version of a file.
 
-                                                            *'backupcopy'* *'bkc'*
-'backupcopy' 'bkc'      string (default "auto")
-                        global or local to buffer |global-local|
-        When writing a file and a backup is made, this option tells how it's
-        done.  This is a comma-separated list of words.
+							    *'backupcopy'* *'bkc'*
+'backupcopy' 'bkc'	string (default "auto")
+			global or local to buffer |global-local|
+	When writing a file and a backup is made, this option tells how it's
+	done.  This is a comma-separated list of words.
 
-        The main values are:
-        "yes"   make a copy of the file and overwrite the original one
-        "no"    rename the file and write a new one
-        "auto"  one of the previous, what works best
+	The main values are:
+	"yes"	make a copy of the file and overwrite the original one
+	"no"	rename the file and write a new one
+	"auto"	one of the previous, what works best
 
-        Extra values that can be combined with the ones above are:
-        "breaksymlink"  always break symlinks when writing
-        "breakhardlink" always break hardlinks when writing
+	Extra values that can be combined with the ones above are:
+	"breaksymlink"	always break symlinks when writing
+	"breakhardlink" always break hardlinks when writing
 
-        Making a copy and overwriting the original file:
-        - Takes extra time to copy the file.
-        + When the file has special attributes, is a (hard/symbolic) link or
-          has a resource fork, all this is preserved.
-        - When the file is a link the backup will have the name of the link,
-          not of the real file.
+	Making a copy and overwriting the original file:
+	- Takes extra time to copy the file.
+	+ When the file has special attributes, is a (hard/symbolic) link or
+	  has a resource fork, all this is preserved.
+	- When the file is a link the backup will have the name of the link,
+	  not of the real file.
 
-        Renaming the file and writing a new one:
-        + It's fast.
-        - Sometimes not all attributes of the file can be copied to the new
-          file.
-        - When the file is a link the new file will not be a link.
+	Renaming the file and writing a new one:
+	+ It's fast.
+	- Sometimes not all attributes of the file can be copied to the new
+	  file.
+	- When the file is a link the new file will not be a link.
 
-        The "auto" value is the middle way: When Vim sees that renaming the
-        file is possible without side effects (the attributes can be passed on
-        and the file is not a link) that is used.  When problems are expected,
-        a copy will be made.
+	The "auto" value is the middle way: When Vim sees that renaming the
+	file is possible without side effects (the attributes can be passed on
+	and the file is not a link) that is used.  When problems are expected,
+	a copy will be made.
 
-        The "breaksymlink" and "breakhardlink" values can be used in
-        combination with any of "yes", "no" and "auto".  When included, they
-        force Vim to always break either symbolic or hard links by doing
-        exactly what the "no" option does, renaming the original file to
-        become the backup and writing a new file in its place.  This can be
-        useful for example in source trees where all the files are symbolic or
-        hard links and any changes should stay in the local source tree, not
-        be propagated back to the original source.
-                                                        *crontab*
-        One situation where "no" and "auto" will cause problems: A program
-        that opens a file, invokes Vim to edit that file, and then tests if
-        the open file was changed (through the file descriptor) will check the
-        backup file instead of the newly created file.  "crontab -e" is an
-        example.
+	The "breaksymlink" and "breakhardlink" values can be used in
+	combination with any of "yes", "no" and "auto".  When included, they
+	force Vim to always break either symbolic or hard links by doing
+	exactly what the "no" option does, renaming the original file to
+	become the backup and writing a new file in its place.	This can be
+	useful for example in source trees where all the files are symbolic or
+	hard links and any changes should stay in the local source tree, not
+	be propagated back to the original source.
+							*crontab*
+	One situation where "no" and "auto" will cause problems: A program
+	that opens a file, invokes Vim to edit that file, and then tests if
+	the open file was changed (through the file descriptor) will check the
+	backup file instead of the newly created file.	"crontab -e" is an
+	example.
 
-        When a copy is made, the original file is truncated and then filled
-        with the new text.  This means that protection bits, owner and
-        symbolic links of the original file are unmodified.  The backup file,
-        however, is a new file, owned by the user who edited the file.  The
-        group of the backup is set to the group of the original file.  If this
-        fails, the protection bits for the group are made the same as for
-        others.
+	When a copy is made, the original file is truncated and then filled
+	with the new text.  This means that protection bits, owner and
+	symbolic links of the original file are unmodified.  The backup file,
+	however, is a new file, owned by the user who edited the file.	The
+	group of the backup is set to the group of the original file.  If this
+	fails, the protection bits for the group are made the same as for
+	others.
 
-        When the file is renamed, this is the other way around: The backup has
-        the same attributes of the original file, and the newly written file
-        is owned by the current user.  When the file was a (hard/symbolic)
-        link, the new file will not!  That's why the "auto" value doesn't
-        rename when the file is a link.  The owner and group of the newly
-        written file will be set to the same ones as the original file, but
-        the system may refuse to do this.  In that case the "auto" value will
-        again not rename the file.
+	When the file is renamed, this is the other way around: The backup has
+	the same attributes of the original file, and the newly written file
+	is owned by the current user.  When the file was a (hard/symbolic)
+	link, the new file will not!  That's why the "auto" value doesn't
+	rename when the file is a link.  The owner and group of the newly
+	written file will be set to the same ones as the original file, but
+	the system may refuse to do this.  In that case the "auto" value will
+	again not rename the file.
 
-                                                            *'backupdir'* *'bdir'*
-'backupdir' 'bdir'      string (default ".,$XDG_STATE_HOME/nvim/backup//")
-                        global
-        List of directories for the backup file, separated with commas.
-        - The backup file will be created in the first directory in the list
-          where this is possible.  If none of the directories exist Nvim will
-          attempt to create the last directory in the list.
-        - Empty means that no backup file will be created ('patchmode' is
-          impossible!).  Writing may fail because of this.
-        - A directory "." means to put the backup file in the same directory
-          as the edited file.
-        - A directory starting with "./" (or ".\" for MS-Windows) means to put
-          the backup file relative to where the edited file is.  The leading
-          "." is replaced with the path name of the edited file.
-          ("." inside a directory name has no special meaning).
-        - Spaces after the comma are ignored, other spaces are considered part
-          of the directory name.  To have a space at the start of a directory
-          name, precede it with a backslash.
-        - To include a comma in a directory name precede it with a backslash.
-        - A directory name may end in an '/'.
-        - For Unix and Win32, if a directory ends in two path separators "//",
-          the swap file name will be built from the complete path to the file
-          with all path separators changed to percent '%' signs. This will
-          ensure file name uniqueness in the backup directory.
-          On Win32, it is also possible to end with "\\".  However, When a
-          separating comma is following, you must use "//", since "\\" will
-          include the comma in the file name. Therefore it is recommended to
-          use '//', instead of '\\'.
-        - Environment variables are expanded |:set_env|.
-        - Careful with '\' characters, type one before a space, type two to
-          get one in the option (see |option-backslash|), for example: >vim
-            set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
+							    *'backupdir'* *'bdir'*
+'backupdir' 'bdir'	string (default ".,$XDG_STATE_HOME/nvim/backup//")
+			global
+	List of directories for the backup file, separated with commas.
+	- The backup file will be created in the first directory in the list
+	  where this is possible.  If none of the directories exist Nvim will
+	  attempt to create the last directory in the list.
+	- Empty means that no backup file will be created ('patchmode' is
+	  impossible!).  Writing may fail because of this.
+	- A directory "." means to put the backup file in the same directory
+	  as the edited file.
+	- A directory starting with "./" (or ".\" for MS-Windows) means to put
+	  the backup file relative to where the edited file is.  The leading
+	  "." is replaced with the path name of the edited file.
+	  ("." inside a directory name has no special meaning).
+	- Spaces after the comma are ignored, other spaces are considered part
+	  of the directory name.  To have a space at the start of a directory
+	  name, precede it with a backslash.
+	- To include a comma in a directory name precede it with a backslash.
+	- A directory name may end in an '/'.
+	- For Unix and Win32, if a directory ends in two path separators "//",
+	  the swap file name will be built from the complete path to the file
+	  with all path separators changed to percent '%' signs. This will
+	  ensure file name uniqueness in the backup directory.
+	  On Win32, it is also possible to end with "\\".  However, When a
+	  separating comma is following, you must use "//", since "\\" will
+	  include the comma in the file name. Therefore it is recommended to
+	  use '//', instead of '\\'.
+	- Environment variables are expanded |:set_env|.
+	- Careful with '\' characters, type one before a space, type two to
+	  get one in the option (see |option-backslash|), for example: >vim
+	    set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 <
-        See also 'backup' and 'writebackup' options.
-        If you want to hide your backup files on Unix, consider this value: >vim
-                set backupdir=./.backup,~/.backup,.,/tmp
-<       You must create a ".backup" directory in each directory and in your
-        home directory for this to work properly.
-        The use of |:set+=| and |:set-=| is preferred when adding or removing
-        directories from the list.  This avoids problems when a future version
-        uses another default.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	See also 'backup' and 'writebackup' options.
+	If you want to hide your backup files on Unix, consider this value: >vim
+		set backupdir=./.backup,~/.backup,.,/tmp
+<	You must create a ".backup" directory in each directory and in your
+	home directory for this to work properly.
+	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	directories from the list.  This avoids problems when a future version
+	uses another default.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                        *'backupext'* *'bex'* *E589*
-'backupext' 'bex'       string (default "~")
-                        global
-        String which is appended to a file name to make the name of the
-        backup file.  The default is quite unusual, because this avoids
-        accidentally overwriting existing files with a backup file.  You might
-        prefer using ".bak", but make sure that you don't have files with
-        ".bak" that you want to keep.
-        Only normal file name characters can be used; `/\*?[|<>` are illegal.
+							*'backupext'* *'bex'* *E589*
+'backupext' 'bex'	string (default "~")
+			global
+	String which is appended to a file name to make the name of the
+	backup file.  The default is quite unusual, because this avoids
+	accidentally overwriting existing files with a backup file.  You might
+	prefer using ".bak", but make sure that you don't have files with
+	".bak" that you want to keep.
+	Only normal file name characters can be used; `/\*?[|<>` are illegal.
 
-        If you like to keep a lot of backups, you could use a BufWritePre
-        autocommand to change 'backupext' just before writing the file to
-        include a timestamp. >vim
-                au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
-<       Use 'backupdir' to put the backup in a different directory.
+	If you like to keep a lot of backups, you could use a BufWritePre
+	autocommand to change 'backupext' just before writing the file to
+	include a timestamp. >vim
+		au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
+<	Use 'backupdir' to put the backup in a different directory.
 
-                                                            *'backupskip'* *'bsk'*
-'backupskip' 'bsk'      string (default "$TMPDIR/*,$TMP/*,$TEMP/*"
-                                        Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
-                                        Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
-                        global
-        A list of file patterns.  When one of the patterns matches with the
-        name of the file which is written, no backup file is created.  Both
-        the specified file name and the full path name of the file are used.
-        The pattern is used like with |:autocmd|, see |autocmd-pattern|.
-        Watch out for special characters, see |option-backslash|.
-        When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
-        default value.  "/tmp/*" is only used for Unix.
+							    *'backupskip'* *'bsk'*
+'backupskip' 'bsk'	string (default "$TMPDIR/*,$TMP/*,$TEMP/*"
+					Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
+					Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*")
+			global
+	A list of file patterns.  When one of the patterns matches with the
+	name of the file which is written, no backup file is created.  Both
+	the specified file name and the full path name of the file are used.
+	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
+	Watch out for special characters, see |option-backslash|.
+	When $TMPDIR, $TMP or $TEMP is not defined, it is not used for the
+	default value.	"/tmp/*" is only used for Unix.
 
-        WARNING: Not having a backup file means that when Vim fails to write
-        your buffer correctly and then, for whatever reason, Vim exits, you
-        lose both the original file and what you were writing.  Only disable
-        backups if you don't care about losing the file.
+	WARNING: Not having a backup file means that when Vim fails to write
+	your buffer correctly and then, for whatever reason, Vim exits, you
+	lose both the original file and what you were writing.	Only disable
+	backups if you don't care about losing the file.
 
-        Note that environment variables are not expanded.  If you want to use
-        $HOME you must expand it explicitly, e.g.: >vim
-                let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+	Note that environment variables are not expanded.  If you want to use
+	$HOME you must expand it explicitly, e.g.: >vim
+		let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 
-<       Note that the default also makes sure that "crontab -e" works (when a
-        backup would be made by renaming the original file crontab won't see
-        the newly created file).  Also see 'backupcopy' and |crontab|.
+<	Note that the default also makes sure that "crontab -e" works (when a
+	backup would be made by renaming the original file crontab won't see
+	the newly created file).  Also see 'backupcopy' and |crontab|.
 
-                                                                *'belloff'* *'bo'*
-'belloff' 'bo'          string (default "all")
-                        global
-        Specifies for which events the bell will not be rung. It is a comma-
-        separated list of items. For each item that is present, the bell
-        will be silenced. This is most useful to specify specific events in
-        insert mode to be silenced.
+								*'belloff'* *'bo'*
+'belloff' 'bo'		string (default "all")
+			global
+	Specifies for which events the bell will not be rung. It is a comma-
+	separated list of items. For each item that is present, the bell
+	will be silenced. This is most useful to specify specific events in
+	insert mode to be silenced.
 
-        item        meaning when present        ~
-        all         All events.
-        backspace   When hitting <BS> or <Del> and deleting results in an
-                    error.
-        cursor      Fail to move around using the cursor keys or
-                    <PageUp>/<PageDown> in |Insert-mode|.
-        complete    Error occurred when using |i_CTRL-X_CTRL-K| or
-                    |i_CTRL-X_CTRL-T|.
-        copy        Cannot copy char from insert mode using |i_CTRL-Y| or
-                    |i_CTRL-E|.
-        ctrlg       Unknown Char after <C-G> in Insert mode.
-        error       Other Error occurred (e.g. try to join last line)
-                    (mostly used in |Normal-mode| or |Cmdline-mode|).
-        esc         hitting <Esc> in |Normal-mode|.
-        hangul      Ignored.
-        lang        Calling the beep module for Lua/Mzscheme/TCL.
-        mess        No output available for |g<|.
-        showmatch   Error occurred for 'showmatch' function.
-        operator    Empty region error |cpo-E|.
-        register    Unknown register after <C-R> in |Insert-mode|.
-        shell       Bell from shell output |:!|.
-        spell       Error happened on spell suggest.
-        wildmode    More matches in |cmdline-completion| available
-                    (depends on the 'wildmode' setting).
+	item	    meaning when present	~
+	all	    All events.
+	backspace   When hitting <BS> or <Del> and deleting results in an
+		    error.
+	cursor	    Fail to move around using the cursor keys or
+		    <PageUp>/<PageDown> in |Insert-mode|.
+	complete    Error occurred when using |i_CTRL-X_CTRL-K| or
+		    |i_CTRL-X_CTRL-T|.
+	copy	    Cannot copy char from insert mode using |i_CTRL-Y| or
+		    |i_CTRL-E|.
+	ctrlg	    Unknown Char after <C-G> in Insert mode.
+	error	    Other Error occurred (e.g. try to join last line)
+		    (mostly used in |Normal-mode| or |Cmdline-mode|).
+	esc	    hitting <Esc> in |Normal-mode|.
+	hangul	    Ignored.
+	lang	    Calling the beep module for Lua/Mzscheme/TCL.
+	mess	    No output available for |g<|.
+	showmatch   Error occurred for 'showmatch' function.
+	operator    Empty region error |cpo-E|.
+	register    Unknown register after <C-R> in |Insert-mode|.
+	shell	    Bell from shell output |:!|.
+	spell	    Error happened on spell suggest.
+	wildmode    More matches in |cmdline-completion| available
+		    (depends on the 'wildmode' setting).
 
-        This is most useful to fine tune when in Insert mode the bell should
-        be rung. For Normal mode and Ex commands, the bell is often rung to
-        indicate that an error occurred. It can be silenced by adding the
-        "error" keyword.
+	This is most useful to fine tune when in Insert mode the bell should
+	be rung. For Normal mode and Ex commands, the bell is often rung to
+	indicate that an error occurred. It can be silenced by adding the
+	"error" keyword.
 
-                                             *'binary'* *'bin'* *'nobinary'* *'nobin'*
-'binary' 'bin'          boolean (default off)
-                        local to buffer
-        This option should be set before editing a binary file.  You can also
-        use the |-b| Vim argument.  When this option is switched on a few
-        options will be changed (also when it already was on):
-                'textwidth'  will be set to 0
-                'wrapmargin' will be set to 0
-                'modeline'   will be off
-                'expandtab'  will be off
-        Also, 'fileformat' and 'fileformats' options will not be used, the
-        file is read and written like 'fileformat' was "unix" (a single <NL>
-        separates lines).
-        The 'fileencoding' and 'fileencodings' options will not be used, the
-        file is read without conversion.
-        NOTE: When you start editing a(nother) file while the 'bin' option is
-        on, settings from autocommands may change the settings again (e.g.,
-        'textwidth'), causing trouble when editing.  You might want to set
-        'bin' again when the file has been loaded.
-        The previous values of these options are remembered and restored when
-        'bin' is switched from on to off.  Each buffer has its own set of
-        saved option values.
-        To edit a file with 'binary' set you can use the |++bin| argument.
-        This avoids you have to do ":set bin", which would have effect for all
-        files you edit.
-        When writing a file the <EOL> for the last line is only written if
-        there was one in the original file (normally Vim appends an <EOL> to
-        the last line if there is none; this would make the file longer).  See
-        the 'endofline' option.
+					     *'binary'* *'bin'* *'nobinary'* *'nobin'*
+'binary' 'bin'		boolean (default off)
+			local to buffer
+	This option should be set before editing a binary file.  You can also
+	use the |-b| Vim argument.  When this option is switched on a few
+	options will be changed (also when it already was on):
+		'textwidth'  will be set to 0
+		'wrapmargin' will be set to 0
+		'modeline'   will be off
+		'expandtab'  will be off
+	Also, 'fileformat' and 'fileformats' options will not be used, the
+	file is read and written like 'fileformat' was "unix" (a single <NL>
+	separates lines).
+	The 'fileencoding' and 'fileencodings' options will not be used, the
+	file is read without conversion.
+	NOTE: When you start editing a(nother) file while the 'bin' option is
+	on, settings from autocommands may change the settings again (e.g.,
+	'textwidth'), causing trouble when editing.  You might want to set
+	'bin' again when the file has been loaded.
+	The previous values of these options are remembered and restored when
+	'bin' is switched from on to off.  Each buffer has its own set of
+	saved option values.
+	To edit a file with 'binary' set you can use the |++bin| argument.
+	This avoids you have to do ":set bin", which would have effect for all
+	files you edit.
+	When writing a file the <EOL> for the last line is only written if
+	there was one in the original file (normally Vim appends an <EOL> to
+	the last line if there is none; this would make the file longer).  See
+	the 'endofline' option.
 
-                                                               *'bomb'* *'nobomb'*
-'bomb'                  boolean (default off)
-                        local to buffer
-        When writing a file and the following conditions are met, a BOM (Byte
-        Order Mark) is prepended to the file:
-        - this option is on
-        - the 'binary' option is off
-        - 'fileencoding' is "utf-8", "ucs-2", "ucs-4" or one of the little/big
-          endian variants.
-        Some applications use the BOM to recognize the encoding of the file.
-        Often used for UCS-2 files on MS-Windows.  For other applications it
-        causes trouble, for example: "cat file1 file2" makes the BOM of file2
-        appear halfway through the resulting file.  Gcc doesn't accept a BOM.
-        When Vim reads a file and 'fileencodings' starts with "ucs-bom", a
-        check for the presence of the BOM is done and 'bomb' set accordingly.
-        Unless 'binary' is set, it is removed from the first line, so that you
-        don't see it when editing.  When you don't change the options, the BOM
-        will be restored when writing the file.
+							       *'bomb'* *'nobomb'*
+'bomb'			boolean (default off)
+			local to buffer
+	When writing a file and the following conditions are met, a BOM (Byte
+	Order Mark) is prepended to the file:
+	- this option is on
+	- the 'binary' option is off
+	- 'fileencoding' is "utf-8", "ucs-2", "ucs-4" or one of the little/big
+	  endian variants.
+	Some applications use the BOM to recognize the encoding of the file.
+	Often used for UCS-2 files on MS-Windows.  For other applications it
+	causes trouble, for example: "cat file1 file2" makes the BOM of file2
+	appear halfway through the resulting file.  Gcc doesn't accept a BOM.
+	When Vim reads a file and 'fileencodings' starts with "ucs-bom", a
+	check for the presence of the BOM is done and 'bomb' set accordingly.
+	Unless 'binary' is set, it is removed from the first line, so that you
+	don't see it when editing.  When you don't change the options, the BOM
+	will be restored when writing the file.
 
-                                                               *'breakat'* *'brk'*
-'breakat' 'brk'         string (default " ^I!@*-+;:,./?")
-                        global
-        This option lets you choose which characters might cause a line
-        break if 'linebreak' is on.  Only works for ASCII characters.
+							       *'breakat'* *'brk'*
+'breakat' 'brk'		string (default " ^I!@*-+;:,./?")
+			global
+	This option lets you choose which characters might cause a line
+	break if 'linebreak' is on.  Only works for ASCII characters.
 
-                                   *'breakindent'* *'bri'* *'nobreakindent'* *'nobri'*
-'breakindent' 'bri'     boolean (default off)
-                        local to window
-        Every wrapped line will continue visually indented (same amount of
-        space as the beginning of that line), thus preserving horizontal blocks
-        of text.
+				   *'breakindent'* *'bri'* *'nobreakindent'* *'nobri'*
+'breakindent' 'bri'	boolean (default off)
+			local to window
+	Every wrapped line will continue visually indented (same amount of
+	space as the beginning of that line), thus preserving horizontal blocks
+	of text.
 
-                                                     *'breakindentopt'* *'briopt'*
+						     *'breakindentopt'* *'briopt'*
 'breakindentopt' 'briopt' string (default "")
-                        local to window
-        Settings for 'breakindent'. It can consist of the following optional
-        items and must be separated by a comma:
-                min:{n}     Minimum text width that will be kept after
-                            applying 'breakindent', even if the resulting
-                            text should normally be narrower. This prevents
-                            text indented almost to the right window border
-                            occupying lot of vertical space when broken.
-                            (default: 20)
-                shift:{n}   After applying 'breakindent', the wrapped line's
-                            beginning will be shifted by the given number of
-                            characters.  It permits dynamic French paragraph
-                            indentation (negative) or emphasizing the line
-                            continuation (positive).
-                            (default: 0)
-                sbr         Display the 'showbreak' value before applying the
-                            additional indent.
-                            (default: off)
-                list:{n}    Adds an additional indent for lines that match a
-                            numbered or bulleted list (using the
-                            'formatlistpat' setting).
-                list:-1     Uses the length of a match with 'formatlistpat'
-                            for indentation.
-                            (default: 0)
-                column:{n}  Indent at column {n}. Will overrule the other
-                            sub-options. Note: an additional indent may be
-                            added for the 'showbreak' setting.
-                            (default: off)
+			local to window
+	Settings for 'breakindent'. It can consist of the following optional
+	items and must be separated by a comma:
+		min:{n}     Minimum text width that will be kept after
+			    applying 'breakindent', even if the resulting
+			    text should normally be narrower. This prevents
+			    text indented almost to the right window border
+			    occupying lot of vertical space when broken.
+			    (default: 20)
+		shift:{n}   After applying 'breakindent', the wrapped line's
+			    beginning will be shifted by the given number of
+			    characters.  It permits dynamic French paragraph
+			    indentation (negative) or emphasizing the line
+			    continuation (positive).
+			    (default: 0)
+		sbr	    Display the 'showbreak' value before applying the
+			    additional indent.
+			    (default: off)
+		list:{n}    Adds an additional indent for lines that match a
+			    numbered or bulleted list (using the
+			    'formatlistpat' setting).
+		list:-1     Uses the length of a match with 'formatlistpat'
+			    for indentation.
+			    (default: 0)
+		column:{n}  Indent at column {n}. Will overrule the other
+			    sub-options. Note: an additional indent may be
+			    added for the 'showbreak' setting.
+			    (default: off)
 
-                                                           *'browsedir'* *'bsdir'*
-'browsedir' 'bsdir'     string (default "last")
-                        global
-        Which directory to use for the file browser:
-           last         Use same directory as with last file browser, where a
-                        file was opened or saved.
-           buffer       Use the directory of the related buffer.
-           current      Use the current directory.
-           {path}       Use the specified directory
+							   *'browsedir'* *'bsdir'*
+'browsedir' 'bsdir'	string (default "last")
+			global
+	Which directory to use for the file browser:
+	   last		Use same directory as with last file browser, where a
+			file was opened or saved.
+	   buffer	Use the directory of the related buffer.
+	   current	Use the current directory.
+	   {path}	Use the specified directory
 
-                                                              *'bufhidden'* *'bh'*
-'bufhidden' 'bh'        string (default "")
-                        local to buffer  |local-noglobal|
-        This option specifies what happens when a buffer is no longer
-        displayed in a window:
-          <empty>       follow the global 'hidden' option
-          hide          hide the buffer (don't unload it), even if 'hidden' is
-                        not set
-          unload        unload the buffer, even if 'hidden' is set; the
-                        |:hide| command will also unload the buffer
-          delete        delete the buffer from the buffer list, even if
-                        'hidden' is set; the |:hide| command will also delete
-                        the buffer, making it behave like |:bdelete|
-          wipe          wipe the buffer from the buffer list, even if
-                        'hidden' is set; the |:hide| command will also wipe
-                        out the buffer, making it behave like |:bwipeout|
+							      *'bufhidden'* *'bh'*
+'bufhidden' 'bh'	string (default "")
+			local to buffer  |local-noglobal|
+	This option specifies what happens when a buffer is no longer
+	displayed in a window:
+	  <empty>	follow the global 'hidden' option
+	  hide		hide the buffer (don't unload it), even if 'hidden' is
+			not set
+	  unload	unload the buffer, even if 'hidden' is set; the
+			|:hide| command will also unload the buffer
+	  delete	delete the buffer from the buffer list, even if
+			'hidden' is set; the |:hide| command will also delete
+			the buffer, making it behave like |:bdelete|
+	  wipe		wipe the buffer from the buffer list, even if
+			'hidden' is set; the |:hide| command will also wipe
+			out the buffer, making it behave like |:bwipeout|
 
-        CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
-        are lost without a warning.  Also, these values may break autocommands
-        that switch between buffers temporarily.
-        This option is used together with 'buftype' and 'swapfile' to specify
-        special kinds of buffers.   See |special-buffers|.
+	CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
+	are lost without a warning.  Also, these values may break autocommands
+	that switch between buffers temporarily.
+	This option is used together with 'buftype' and 'swapfile' to specify
+	special kinds of buffers.   See |special-buffers|.
 
-                                     *'buflisted'* *'bl'* *'nobuflisted'* *'nobl'* *E85*
-'buflisted' 'bl'        boolean (default on)
-                        local to buffer
-        When this option is set, the buffer shows up in the buffer list.  If
-        it is reset it is not used for ":bnext", "ls", the Buffers menu, etc.
-        This option is reset by Vim for buffers that are only used to remember
-        a file name or marks.  Vim sets it when starting to edit a buffer.
-        But not when moving to a buffer with ":buffer".
+				     *'buflisted'* *'bl'* *'nobuflisted'* *'nobl'* *E85*
+'buflisted' 'bl'	boolean (default on)
+			local to buffer
+	When this option is set, the buffer shows up in the buffer list.  If
+	it is reset it is not used for ":bnext", "ls", the Buffers menu, etc.
+	This option is reset by Vim for buffers that are only used to remember
+	a file name or marks.  Vim sets it when starting to edit a buffer.
+	But not when moving to a buffer with ":buffer".
 
-                                                           *'buftype'* *'bt'* *E382*
-'buftype' 'bt'          string (default "")
-                        local to buffer  |local-noglobal|
-        The value of this option specifies the type of a buffer:
-          <empty>       normal buffer
-          acwrite       buffer will always be written with |BufWriteCmd|s
-          help          help buffer (do not set this manually)
-          nofile        buffer is not related to a file, will not be written
-          nowrite       buffer will not be written
-          quickfix      list of errors |:cwindow| or locations |:lwindow|
-          terminal      |terminal-emulator| buffer
-          prompt        buffer where only the last line can be edited, meant
-                        to be used by a plugin, see |prompt-buffer|
+							   *'buftype'* *'bt'* *E382*
+'buftype' 'bt'		string (default "")
+			local to buffer  |local-noglobal|
+	The value of this option specifies the type of a buffer:
+	  <empty>	normal buffer
+	  acwrite	buffer will always be written with |BufWriteCmd|s
+	  help		help buffer (do not set this manually)
+	  nofile	buffer is not related to a file, will not be written
+	  nowrite	buffer will not be written
+	  quickfix	list of errors |:cwindow| or locations |:lwindow|
+	  terminal	|terminal-emulator| buffer
+	  prompt	buffer where only the last line can be edited, meant
+			to be used by a plugin, see |prompt-buffer|
 
-        This option is used together with 'bufhidden' and 'swapfile' to
-        specify special kinds of buffers.   See |special-buffers|.
-        Also see |win_gettype()|, which returns the type of the window.
+	This option is used together with 'bufhidden' and 'swapfile' to
+	specify special kinds of buffers.   See |special-buffers|.
+	Also see |win_gettype()|, which returns the type of the window.
 
-        Be careful with changing this option, it can have many side effects!
-        One such effect is that Vim will not check the timestamp of the file,
-        if the file is changed by another program this will not be noticed.
+	Be careful with changing this option, it can have many side effects!
+	One such effect is that Vim will not check the timestamp of the file,
+	if the file is changed by another program this will not be noticed.
 
-        A "quickfix" buffer is only used for the error list and the location
-        list.  This value is set by the |:cwindow| and |:lwindow| commands and
-        you are not supposed to change it.
+	A "quickfix" buffer is only used for the error list and the location
+	list.  This value is set by the |:cwindow| and |:lwindow| commands and
+	you are not supposed to change it.
 
-        "nofile" and "nowrite" buffers are similar:
-        both:           The buffer is not to be written to disk, ":w" doesn't
-                        work (":w filename" does work though).
-        both:           The buffer is never considered to be |'modified'|.
-                        There is no warning when the changes will be lost, for
-                        example when you quit Vim.
-        both:           A swap file is only created when using too much memory
-                        (when 'swapfile' has been reset there is never a swap
-                        file).
-        nofile only:    The buffer name is fixed, it is not handled like a
-                        file name.  It is not modified in response to a |:cd|
-                        command.
-        both:           When using ":e bufname" and already editing "bufname"
-                        the buffer is made empty and autocommands are
-                        triggered as usual for |:edit|.
-                                                        *E676*
-        "acwrite" implies that the buffer name is not related to a file, like
-        "nofile", but it will be written.  Thus, in contrast to "nofile" and
-        "nowrite", ":w" does work and a modified buffer can't be abandoned
-        without saving.  For writing there must be matching |BufWriteCmd|,
-        |FileWriteCmd| or |FileAppendCmd| autocommands.
+	"nofile" and "nowrite" buffers are similar:
+	both:		The buffer is not to be written to disk, ":w" doesn't
+			work (":w filename" does work though).
+	both:		The buffer is never considered to be |'modified'|.
+			There is no warning when the changes will be lost, for
+			example when you quit Vim.
+	both:		A swap file is only created when using too much memory
+			(when 'swapfile' has been reset there is never a swap
+			file).
+	nofile only:	The buffer name is fixed, it is not handled like a
+			file name.  It is not modified in response to a |:cd|
+			command.
+	both:		When using ":e bufname" and already editing "bufname"
+			the buffer is made empty and autocommands are
+			triggered as usual for |:edit|.
+							*E676*
+	"acwrite" implies that the buffer name is not related to a file, like
+	"nofile", but it will be written.  Thus, in contrast to "nofile" and
+	"nowrite", ":w" does work and a modified buffer can't be abandoned
+	without saving.  For writing there must be matching |BufWriteCmd|,
+	|FileWriteCmd| or |FileAppendCmd| autocommands.
 
-                                                               *'casemap'* *'cmp'*
-'casemap' 'cmp'         string (default "internal,keepascii")
-                        global
-        Specifies details about changing the case of letters.  It may contain
-        these words, separated by a comma:
-        internal        Use internal case mapping functions, the current
-                        locale does not change the case mapping. When
-                        "internal" is omitted, the towupper() and towlower()
-                        system library functions are used when available.
-        keepascii       For the ASCII characters (0x00 to 0x7f) use the US
-                        case mapping, the current locale is not effective.
-                        This probably only matters for Turkish.
+							       *'casemap'* *'cmp'*
+'casemap' 'cmp'		string (default "internal,keepascii")
+			global
+	Specifies details about changing the case of letters.  It may contain
+	these words, separated by a comma:
+	internal	Use internal case mapping functions, the current
+			locale does not change the case mapping. When
+			"internal" is omitted, the towupper() and towlower()
+			system library functions are used when available.
+	keepascii	For the ASCII characters (0x00 to 0x7f) use the US
+			case mapping, the current locale is not effective.
+			This probably only matters for Turkish.
 
-                                             *'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
-'cdhome' 'cdh'          boolean (default off)
-                        global
-        When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
-        current working directory to the |$HOME| directory like in Unix.
-        When off, those commands just print the current directory name.
-        On Unix this option has no effect.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+					     *'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
+'cdhome' 'cdh'		boolean (default off)
+			global
+	When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
+	current working directory to the |$HOME| directory like in Unix.
+	When off, those commands just print the current directory name.
+	On Unix this option has no effect.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                       *'cdpath'* *'cd'* *E344* *E346*
-'cdpath' 'cd'           string (default equivalent to $CDPATH or ",,")
-                        global
-        This is a list of directories which will be searched when using the
-        |:cd|, |:tcd| and |:lcd| commands, provided that the directory being
-        searched for has a relative path, not an absolute part starting with
-        "/", "./" or "../", the 'cdpath' option is not used then.
-        The 'cdpath' option's value has the same form and semantics as
-        |'path'|.  Also see |file-searching|.
-        The default value is taken from $CDPATH, with a "," prepended to look
-        in the current directory first.
-        If the default value taken from $CDPATH is not what you want, include
-        a modified version of the following command in your vimrc file to
-        override it: >vim
-          let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
-<       This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
-        (parts of 'cdpath' can be passed to the shell to expand file names).
+						       *'cdpath'* *'cd'* *E344* *E346*
+'cdpath' 'cd'		string (default equivalent to $CDPATH or ",,")
+			global
+	This is a list of directories which will be searched when using the
+	|:cd|, |:tcd| and |:lcd| commands, provided that the directory being
+	searched for has a relative path, not an absolute part starting with
+	"/", "./" or "../", the 'cdpath' option is not used then.
+	The 'cdpath' option's value has the same form and semantics as
+	|'path'|.  Also see |file-searching|.
+	The default value is taken from $CDPATH, with a "," prepended to look
+	in the current directory first.
+	If the default value taken from $CDPATH is not what you want, include
+	a modified version of the following command in your vimrc file to
+	override it: >vim
+	  let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
+<	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+	(parts of 'cdpath' can be passed to the shell to expand file names).
 
-                                                                       *'cedit'*
-'cedit'                 string (default CTRL-F)
-                        global
-        The key used in Command-line Mode to open the command-line window.
-        Only non-printable keys are allowed.
-        The key can be specified as a single character, but it is difficult to
-        type.  The preferred way is to use the <> notation.  Examples: >vim
-                exe "set cedit=\<C-Y>"
-                exe "set cedit=\<Esc>"
-<       |Nvi| also has this option, but it only uses the first character.
-        See |cmdwin|.
+								       *'cedit'*
+'cedit'			string (default CTRL-F)
+			global
+	The key used in Command-line Mode to open the command-line window.
+	Only non-printable keys are allowed.
+	The key can be specified as a single character, but it is difficult to
+	type.  The preferred way is to use the <> notation.  Examples: >vim
+		exe "set cedit=\<C-Y>"
+		exe "set cedit=\<Esc>"
+<	|Nvi| also has this option, but it only uses the first character.
+	See |cmdwin|.
 
-                                                                     *'channel'*
-'channel'               number (default 0)
-                        local to buffer
-        |channel| connected to the buffer, or 0 if no channel is connected.
-        In a |:terminal| buffer this is the terminal channel.
-        Read-only.
+								     *'channel'*
+'channel'		number (default 0)
+			local to buffer
+	|channel| connected to the buffer, or 0 if no channel is connected.
+	In a |:terminal| buffer this is the terminal channel.
+	Read-only.
 
-                                            *'charconvert'* *'ccv'* *E202* *E214* *E513*
-'charconvert' 'ccv'     string (default "")
-                        global
-        An expression that is used for character encoding conversion.  It is
-        evaluated when a file that is to be read or has been written has a
-        different encoding from what is desired.
-        'charconvert' is not used when the internal iconv() function is
-        supported and is able to do the conversion.  Using iconv() is
-        preferred, because it is much faster.
-        'charconvert' is not used when reading stdin |--|, because there is no
-        file to convert from.  You will have to save the text in a file first.
-        The expression must return zero, false or an empty string for success,
-        non-zero or true for failure.
-        See |encoding-names| for possible encoding names.
-        Additionally, names given in 'fileencodings' and 'fileencoding' are
-        used.
-        Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
-        is done internally by Vim, 'charconvert' is not used for this.
-        Also used for Unicode conversion.
-        Example: >vim
-                set charconvert=CharConvert()
-                fun CharConvert()
-                  system("recode "
-                        \ .. v:charconvert_from .. ".." .. v:charconvert_to
-                        \ .. " <" .. v:fname_in .. " >" .. v:fname_out)
-                  return v:shell_error
-                endfun
-<       The related Vim variables are:
-                v:charconvert_from      name of the current encoding
-                v:charconvert_to        name of the desired encoding
-                v:fname_in              name of the input file
-                v:fname_out             name of the output file
-        Note that v:fname_in and v:fname_out will never be the same.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+					    *'charconvert'* *'ccv'* *E202* *E214* *E513*
+'charconvert' 'ccv'	string (default "")
+			global
+	An expression that is used for character encoding conversion.  It is
+	evaluated when a file that is to be read or has been written has a
+	different encoding from what is desired.
+	'charconvert' is not used when the internal iconv() function is
+	supported and is able to do the conversion.  Using iconv() is
+	preferred, because it is much faster.
+	'charconvert' is not used when reading stdin |--|, because there is no
+	file to convert from.  You will have to save the text in a file first.
+	The expression must return zero, false or an empty string for success,
+	non-zero or true for failure.
+	See |encoding-names| for possible encoding names.
+	Additionally, names given in 'fileencodings' and 'fileencoding' are
+	used.
+	Conversion between "latin1", "unicode", "ucs-2", "ucs-4" and "utf-8"
+	is done internally by Vim, 'charconvert' is not used for this.
+	Also used for Unicode conversion.
+	Example: >vim
+		set charconvert=CharConvert()
+		fun CharConvert()
+		  system("recode "
+			\ .. v:charconvert_from .. ".." .. v:charconvert_to
+			\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
+		  return v:shell_error
+		endfun
+<	The related Vim variables are:
+		v:charconvert_from	name of the current encoding
+		v:charconvert_to	name of the desired encoding
+		v:fname_in		name of the input file
+		v:fname_out		name of the output file
+	Note that v:fname_in and v:fname_out will never be the same.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                           *'cindent'* *'cin'* *'nocindent'* *'nocin'*
-'cindent' 'cin'         boolean (default off)
-                        local to buffer
-        Enables automatic C program indenting.  See 'cinkeys' to set the keys
-        that trigger reindenting in insert mode and 'cinoptions' to set your
-        preferred indent style.
-        If 'indentexpr' is not empty, it overrules 'cindent'.
-        If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
-        the "=" operator indents using this algorithm rather than calling an
-        external program.
-        See |C-indenting|.
-        When you don't like the way 'cindent' works, try the 'smartindent'
-        option or 'indentexpr'.
+					   *'cindent'* *'cin'* *'nocindent'* *'nocin'*
+'cindent' 'cin'		boolean (default off)
+			local to buffer
+	Enables automatic C program indenting.	See 'cinkeys' to set the keys
+	that trigger reindenting in insert mode and 'cinoptions' to set your
+	preferred indent style.
+	If 'indentexpr' is not empty, it overrules 'cindent'.
+	If 'lisp' is not on and both 'indentexpr' and 'equalprg' are empty,
+	the "=" operator indents using this algorithm rather than calling an
+	external program.
+	See |C-indenting|.
+	When you don't like the way 'cindent' works, try the 'smartindent'
+	option or 'indentexpr'.
 
-                                                              *'cinkeys'* *'cink'*
-'cinkeys' 'cink'        string (default "0{,0},0),0],:,0#,!^F,o,O,e")
-                        local to buffer
-        A list of keys that, when typed in Insert mode, cause reindenting of
-        the current line.  Only used if 'cindent' is on and 'indentexpr' is
-        empty.
-        For the format of this option see |cinkeys-format|.
-        See |C-indenting|.
+							      *'cinkeys'* *'cink'*
+'cinkeys' 'cink'	string (default "0{,0},0),0],:,0#,!^F,o,O,e")
+			local to buffer
+	A list of keys that, when typed in Insert mode, cause reindenting of
+	the current line.  Only used if 'cindent' is on and 'indentexpr' is
+	empty.
+	For the format of this option see |cinkeys-format|.
+	See |C-indenting|.
 
-                                                           *'cinoptions'* *'cino'*
-'cinoptions' 'cino'     string (default "")
-                        local to buffer
-        The 'cinoptions' affect the way 'cindent' reindents lines in a C
-        program.  See |cinoptions-values| for the values of this option, and
-        |C-indenting| for info on C indenting in general.
+							   *'cinoptions'* *'cino'*
+'cinoptions' 'cino'	string (default "")
+			local to buffer
+	The 'cinoptions' affect the way 'cindent' reindents lines in a C
+	program.  See |cinoptions-values| for the values of this option, and
+	|C-indenting| for info on C indenting in general.
 
-                                                       *'cinscopedecls'* *'cinsd'*
+						       *'cinscopedecls'* *'cinsd'*
 'cinscopedecls' 'cinsd' string (default "public,protected,private")
-                        local to buffer
-        Keywords that are interpreted as a C++ scope declaration by |cino-g|.
-        Useful e.g. for working with the Qt framework that defines additional
-        scope declarations "signals", "public slots" and "private slots": >vim
-                set cinscopedecls+=signals,public\ slots,private\ slots
+			local to buffer
+	Keywords that are interpreted as a C++ scope declaration by |cino-g|.
+	Useful e.g. for working with the Qt framework that defines additional
+	scope declarations "signals", "public slots" and "private slots": >vim
+		set cinscopedecls+=signals,public\ slots,private\ slots
 <
 
-                                                             *'cinwords'* *'cinw'*
-'cinwords' 'cinw'       string (default "if,else,while,do,for,switch")
-                        local to buffer
-        These keywords start an extra indent in the next line when
-        'smartindent' or 'cindent' is set.  For 'cindent' this is only done at
-        an appropriate place (inside {}).
-        Note that 'ignorecase' isn't used for 'cinwords'.  If case doesn't
-        matter, include the keyword both the uppercase and lowercase:
-        "if,If,IF".
+							     *'cinwords'* *'cinw'*
+'cinwords' 'cinw'	string (default "if,else,while,do,for,switch")
+			local to buffer
+	These keywords start an extra indent in the next line when
+	'smartindent' or 'cindent' is set.  For 'cindent' this is only done at
+	an appropriate place (inside {}).
+	Note that 'ignorecase' isn't used for 'cinwords'.  If case doesn't
+	matter, include the keyword both the uppercase and lowercase:
+	"if,If,IF".
 
-                                                              *'clipboard'* *'cb'*
-'clipboard' 'cb'        string (default "")
-                        global
-        This option is a list of comma-separated names.
-        These names are recognized:
+							      *'clipboard'* *'cb'*
+'clipboard' 'cb'	string (default "")
+			global
+	This option is a list of comma-separated names.
+	These names are recognized:
 
-                                                *clipboard-unnamed*
-        unnamed         When included, Vim will use the clipboard register "*"
-                        for all yank, delete, change and put operations which
-                        would normally go to the unnamed register.  When a
-                        register is explicitly specified, it will always be
-                        used regardless of whether "unnamed" is in 'clipboard'
-                        or not.  The clipboard register can always be
-                        explicitly accessed using the "* notation.  Also see
-                        |clipboard|.
+						*clipboard-unnamed*
+	unnamed		When included, Vim will use the clipboard register "*"
+			for all yank, delete, change and put operations which
+			would normally go to the unnamed register.  When a
+			register is explicitly specified, it will always be
+			used regardless of whether "unnamed" is in 'clipboard'
+			or not.  The clipboard register can always be
+			explicitly accessed using the "* notation.  Also see
+			|clipboard|.
 
-                                                *clipboard-unnamedplus*
-        unnamedplus     A variant of the "unnamed" flag which uses the
-                        clipboard register "+" (|quoteplus|) instead of
-                        register "*" for all yank, delete, change and put
-                        operations which would normally go to the unnamed
-                        register.  When "unnamed" is also included to the
-                        option, yank and delete operations (but not put)
-                        will additionally copy the text into register
-                        "*". See |clipboard|.
+						*clipboard-unnamedplus*
+	unnamedplus	A variant of the "unnamed" flag which uses the
+			clipboard register "+" (|quoteplus|) instead of
+			register "*" for all yank, delete, change and put
+			operations which would normally go to the unnamed
+			register.  When "unnamed" is also included to the
+			option, yank and delete operations (but not put)
+			will additionally copy the text into register
+			"*". See |clipboard|.
 
-                                                              *'cmdheight'* *'ch'*
-'cmdheight' 'ch'        number (default 1)
-                        global or local to tab page |global-local|
-        Number of screen lines to use for the command-line.  Helps avoiding
-        |hit-enter| prompts.
-        The value of this option is stored with the tab page, so that each tab
-        page can have a different value.
+							      *'cmdheight'* *'ch'*
+'cmdheight' 'ch'	number (default 1)
+			global or local to tab page |global-local|
+	Number of screen lines to use for the command-line.  Helps avoiding
+	|hit-enter| prompts.
+	The value of this option is stored with the tab page, so that each tab
+	page can have a different value.
 
-        When 'cmdheight' is zero, there is no command-line unless it is being
-        used.  The command-line will cover the last line of the screen when
-        shown.
+	When 'cmdheight' is zero, there is no command-line unless it is being
+	used.  The command-line will cover the last line of the screen when
+	shown.
 
-        WARNING: `cmdheight=0` is considered experimental. Expect some
-        unwanted behaviour. Some 'shortmess' flags and similar
-        mechanism might fail to take effect, causing unwanted hit-enter
-        prompts.  Some informative messages, both from Nvim itself and
-        plugins, will not be displayed.
+	WARNING: `cmdheight=0` is considered experimental. Expect some
+	unwanted behaviour. Some 'shortmess' flags and similar
+	mechanism might fail to take effect, causing unwanted hit-enter
+	prompts.  Some informative messages, both from Nvim itself and
+	plugins, will not be displayed.
 
-                                                          *'cmdwinheight'* *'cwh'*
-'cmdwinheight' 'cwh'    number (default 7)
-                        global
-        Number of screen lines to use for the command-line window. |cmdwin|
+							  *'cmdwinheight'* *'cwh'*
+'cmdwinheight' 'cwh'	number (default 7)
+			global
+	Number of screen lines to use for the command-line window. |cmdwin|
 
-                                                            *'colorcolumn'* *'cc'*
-'colorcolumn' 'cc'      string (default "")
-                        local to window
-        'colorcolumn' is a comma-separated list of screen columns that are
-        highlighted with ColorColumn |hl-ColorColumn|.  Useful to align
-        text.  Will make screen redrawing slower.
-        The screen column can be an absolute number, or a number preceded with
-        '+' or '-', which is added to or subtracted from 'textwidth'. >vim
+							    *'colorcolumn'* *'cc'*
+'colorcolumn' 'cc'	string (default "")
+			local to window
+	'colorcolumn' is a comma-separated list of screen columns that are
+	highlighted with ColorColumn |hl-ColorColumn|.	Useful to align
+	text.  Will make screen redrawing slower.
+	The screen column can be an absolute number, or a number preceded with
+	'+' or '-', which is added to or subtracted from 'textwidth'. >vim
 
-                set cc=+1         " highlight column after 'textwidth'
-                set cc=+1,+2,+3  " highlight three columns after 'textwidth'
-                hi ColorColumn ctermbg=lightgrey guibg=lightgrey
+		set cc=+1	  " highlight column after 'textwidth'
+		set cc=+1,+2,+3  " highlight three columns after 'textwidth'
+		hi ColorColumn ctermbg=lightgrey guibg=lightgrey
 <
-        When 'textwidth' is zero then the items with '-' and '+' are not used.
-        A maximum of 256 columns are highlighted.
+	When 'textwidth' is zero then the items with '-' and '+' are not used.
+	A maximum of 256 columns are highlighted.
 
-                                                           *'columns'* *'co'* *E594*
-'columns' 'co'          number (default 80 or terminal width)
-                        global
-        Number of columns of the screen.  Normally this is set by the terminal
-        initialization and does not have to be set by hand.
-        When Vim is running in the GUI or in a resizable window, setting this
-        option will cause the window size to be changed.  When you only want
-        to use the size for the GUI, put the command in your |ginit.vim| file.
-        When you set this option and Vim is unable to change the physical
-        number of columns of the display, the display may be messed up.  For
-        the GUI it is always possible and Vim limits the number of columns to
-        what fits on the screen.  You can use this command to get the widest
-        window possible: >vim
-                set columns=9999
-<       Minimum value is 12, maximum value is 10000.
+							   *'columns'* *'co'* *E594*
+'columns' 'co'		number (default 80 or terminal width)
+			global
+	Number of columns of the screen.  Normally this is set by the terminal
+	initialization and does not have to be set by hand.
+	When Vim is running in the GUI or in a resizable window, setting this
+	option will cause the window size to be changed.  When you only want
+	to use the size for the GUI, put the command in your |ginit.vim| file.
+	When you set this option and Vim is unable to change the physical
+	number of columns of the display, the display may be messed up.  For
+	the GUI it is always possible and Vim limits the number of columns to
+	what fits on the screen.  You can use this command to get the widest
+	window possible: >vim
+		set columns=9999
+<	Minimum value is 12, maximum value is 10000.
 
-                                                    *'comments'* *'com'* *E524* *E525*
-'comments' 'com'        string (default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
-                        local to buffer
-        A comma-separated list of strings that can start a comment line.  See
-        |format-comments|.  See |option-backslash| about using backslashes to
-        insert a space.
+						    *'comments'* *'com'* *E524* *E525*
+'comments' 'com'	string (default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
+			local to buffer
+	A comma-separated list of strings that can start a comment line.  See
+	|format-comments|.  See |option-backslash| about using backslashes to
+	insert a space.
 
-                                                    *'commentstring'* *'cms'* *E537*
-'commentstring' 'cms'   string (default "")
-                        local to buffer
-        A template for a comment.  The "%s" in the value is replaced with the
-        comment text.  For example, C uses "/*%s*/". Currently only used to
-        add markers for folding, see |fold-marker|.
+						    *'commentstring'* *'cms'* *E537*
+'commentstring' 'cms'	string (default "")
+			local to buffer
+	A template for a comment.  The "%s" in the value is replaced with the
+	comment text.  For example, C uses "/*%s*/". Currently only used to
+	add markers for folding, see |fold-marker|.
 
-                                                         *'complete'* *'cpt'* *E535*
-'complete' 'cpt'        string (default ".,w,b,u,t")
-                        local to buffer
-        This option specifies how keyword completion |ins-completion| works
-        when CTRL-P or CTRL-N are used.  It is also used for whole-line
-        completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
-        and the places to scan.  It is a comma-separated list of flags:
-        .       scan the current buffer ('wrapscan' is ignored)
-        w       scan buffers from other windows
-        b       scan other loaded buffers that are in the buffer list
-        u       scan the unloaded buffers that are in the buffer list
-        U       scan the buffers that are not in the buffer list
-        k       scan the files given with the 'dictionary' option
-        kspell  use the currently active spell checking |spell|
-        k{dict} scan the file {dict}.  Several "k" flags can be given,
-                patterns are valid too.  For example: >vim
-                        set cpt=k/usr/dict/*,k~/spanish
-<       s       scan the files given with the 'thesaurus' option
-        s{tsr}  scan the file {tsr}.  Several "s" flags can be given, patterns
-                are valid too.
-        i       scan current and included files
-        d       scan current and included files for defined name or macro
-                |i_CTRL-X_CTRL-D|
-        ]       tag completion
-        t       same as "]"
-        f       scan the buffer names (as opposed to buffer contents)
+							 *'complete'* *'cpt'* *E535*
+'complete' 'cpt'	string (default ".,w,b,u,t")
+			local to buffer
+	This option specifies how keyword completion |ins-completion| works
+	when CTRL-P or CTRL-N are used.  It is also used for whole-line
+	completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
+	and the places to scan.  It is a comma-separated list of flags:
+	.	scan the current buffer ('wrapscan' is ignored)
+	w	scan buffers from other windows
+	b	scan other loaded buffers that are in the buffer list
+	u	scan the unloaded buffers that are in the buffer list
+	U	scan the buffers that are not in the buffer list
+	k	scan the files given with the 'dictionary' option
+	kspell	use the currently active spell checking |spell|
+	k{dict} scan the file {dict}.  Several "k" flags can be given,
+		patterns are valid too.  For example: >vim
+			set cpt=k/usr/dict/*,k~/spanish
+<	s	scan the files given with the 'thesaurus' option
+	s{tsr}	scan the file {tsr}.  Several "s" flags can be given, patterns
+		are valid too.
+	i	scan current and included files
+	d	scan current and included files for defined name or macro
+		|i_CTRL-X_CTRL-D|
+	]	tag completion
+	t	same as "]"
+	f	scan the buffer names (as opposed to buffer contents)
 
-        Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
-        not executed, this may lead to unexpected completions from some files
-        (gzipped files for example).  Unloaded buffers are not scanned for
-        whole-line completion.
+	Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
+	not executed, this may lead to unexpected completions from some files
+	(gzipped files for example).  Unloaded buffers are not scanned for
+	whole-line completion.
 
-        As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
-        based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
-        |i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
+	As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
+	based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
+	|i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
 
-                                                          *'completefunc'* *'cfu'*
-'completefunc' 'cfu'    string (default "")
-                        local to buffer
-        This option specifies a function to be used for Insert mode completion
-        with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
-        See |complete-functions| for an explanation of how the function is
-        invoked and what it should return.  The value can be the name of a
-        function, a |lambda| or a |Funcref|. See |option-value-function| for
-        more information.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							  *'completefunc'* *'cfu'*
+'completefunc' 'cfu'	string (default "")
+			local to buffer
+	This option specifies a function to be used for Insert mode completion
+	with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
+	See |complete-functions| for an explanation of how the function is
+	invoked and what it should return.  The value can be the name of a
+	function, a |lambda| or a |Funcref|. See |option-value-function| for
+	more information.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                           *'completeopt'* *'cot'*
-'completeopt' 'cot'     string (default "menu,preview")
-                        global
-        A comma-separated list of options for Insert mode completion
-        |ins-completion|.  The supported values are:
+							   *'completeopt'* *'cot'*
+'completeopt' 'cot'	string (default "menu,preview")
+			global
+	A comma-separated list of options for Insert mode completion
+	|ins-completion|.  The supported values are:
 
-           menu     Use a popup menu to show the possible completions.  The
-                    menu is only shown when there is more than one match and
-                    sufficient colors are available.  |ins-completion-menu|
+	   menu     Use a popup menu to show the possible completions.	The
+		    menu is only shown when there is more than one match and
+		    sufficient colors are available.  |ins-completion-menu|
 
-           menuone  Use the popup menu also when there is only one match.
-                    Useful when there is additional information about the
-                    match, e.g., what file it comes from.
+	   menuone  Use the popup menu also when there is only one match.
+		    Useful when there is additional information about the
+		    match, e.g., what file it comes from.
 
-           longest  Only insert the longest common text of the matches.  If
-                    the menu is displayed you can use CTRL-L to add more
-                    characters.  Whether case is ignored depends on the kind
-                    of completion.  For buffer text the 'ignorecase' option is
-                    used.
+	   longest  Only insert the longest common text of the matches.  If
+		    the menu is displayed you can use CTRL-L to add more
+		    characters.  Whether case is ignored depends on the kind
+		    of completion.  For buffer text the 'ignorecase' option is
+		    used.
 
-           preview  Show extra information about the currently selected
-                    completion in the preview window.  Only works in
-                    combination with "menu" or "menuone".
+	   preview  Show extra information about the currently selected
+		    completion in the preview window.  Only works in
+		    combination with "menu" or "menuone".
 
-           noinsert Do not insert any text for a match until the user selects
-                    a match from the menu. Only works in combination with
-                    "menu" or "menuone". No effect if "longest" is present.
+	   noinsert Do not insert any text for a match until the user selects
+		    a match from the menu. Only works in combination with
+		    "menu" or "menuone". No effect if "longest" is present.
 
-           noselect Do not select a match in the menu, force the user to
-                    select one from the menu. Only works in combination with
-                    "menu" or "menuone".
+	   noselect Do not select a match in the menu, force the user to
+		    select one from the menu. Only works in combination with
+		    "menu" or "menuone".
 
-           popup    Show extra information about the currently selected
-                    completion in a popup window.  Only works in combination
-                    with "menu" or "menuone".  Overrides "preview".
+	   popup    Show extra information about the currently selected
+		    completion in a popup window.  Only works in combination
+		    with "menu" or "menuone".  Overrides "preview".
 
-                                                         *'completeslash'* *'csl'*
-'completeslash' 'csl'   string (default "")
-                        local to buffer
-        only for MS-Windows
-        When this option is set it overrules 'shellslash' for completion:
-        - When this option is set to "slash", a forward slash is used for path
-        completion in insert mode. This is useful when editing HTML tag, or
-        Makefile with 'noshellslash' on MS-Windows.
-        - When this option is set to "backslash", backslash is used. This is
-        useful when editing a batch file with 'shellslash' set on MS-Windows.
-        - When this option is empty, same character is used as for
-        'shellslash'.
-        For Insert mode completion the buffer-local value is used.  For
-        command line completion the global value is used.
+							 *'completeslash'* *'csl'*
+'completeslash' 'csl'	string (default "")
+			local to buffer
+	only for MS-Windows
+	When this option is set it overrules 'shellslash' for completion:
+	- When this option is set to "slash", a forward slash is used for path
+	completion in insert mode. This is useful when editing HTML tag, or
+	Makefile with 'noshellslash' on MS-Windows.
+	- When this option is set to "backslash", backslash is used. This is
+	useful when editing a batch file with 'shellslash' set on MS-Windows.
+	- When this option is empty, same character is used as for
+	'shellslash'.
+	For Insert mode completion the buffer-local value is used.  For
+	command line completion the global value is used.
 
-                                                        *'concealcursor'* *'cocu'*
-'concealcursor' 'cocu'  string (default "")
-                        local to window
-        Sets the modes in which text in the cursor line can also be concealed.
-        When the current mode is listed then concealing happens just like in
-        other lines.
-          n             Normal mode
-          v             Visual mode
-          i             Insert mode
-          c             Command line editing, for 'incsearch'
+							*'concealcursor'* *'cocu'*
+'concealcursor' 'cocu'	string (default "")
+			local to window
+	Sets the modes in which text in the cursor line can also be concealed.
+	When the current mode is listed then concealing happens just like in
+	other lines.
+	  n		Normal mode
+	  v		Visual mode
+	  i		Insert mode
+	  c		Command line editing, for 'incsearch'
 
-        'v' applies to all lines in the Visual area, not only the cursor.
-        A useful value is "nc".  This is used in help files.  So long as you
-        are moving around text is concealed, but when starting to insert text
-        or selecting a Visual area the concealed text is displayed, so that
-        you can see what you are doing.
-        Keep in mind that the cursor position is not always where it's
-        displayed.  E.g., when moving vertically it may change column.
+	'v' applies to all lines in the Visual area, not only the cursor.
+	A useful value is "nc".  This is used in help files.  So long as you
+	are moving around text is concealed, but when starting to insert text
+	or selecting a Visual area the concealed text is displayed, so that
+	you can see what you are doing.
+	Keep in mind that the cursor position is not always where it's
+	displayed.  E.g., when moving vertically it may change column.
 
-                                                         *'conceallevel'* *'cole'*
-'conceallevel' 'cole'   number (default 0)
-                        local to window
-        Determine how text with the "conceal" syntax attribute |:syn-conceal|
-        is shown:
+							 *'conceallevel'* *'cole'*
+'conceallevel' 'cole'	number (default 0)
+			local to window
+	Determine how text with the "conceal" syntax attribute |:syn-conceal|
+	is shown:
 
-        Value           Effect ~
-        0               Text is shown normally
-        1               Each block of concealed text is replaced with one
-                        character.  If the syntax item does not have a custom
-                        replacement character defined (see |:syn-cchar|) the
-                        character defined in 'listchars' is used.
-                        It is highlighted with the "Conceal" highlight group.
-        2               Concealed text is completely hidden unless it has a
-                        custom replacement character defined (see
-                        |:syn-cchar|).
-        3               Concealed text is completely hidden.
+	Value		Effect ~
+	0		Text is shown normally
+	1		Each block of concealed text is replaced with one
+			character.  If the syntax item does not have a custom
+			replacement character defined (see |:syn-cchar|) the
+			character defined in 'listchars' is used.
+			It is highlighted with the "Conceal" highlight group.
+	2		Concealed text is completely hidden unless it has a
+			custom replacement character defined (see
+			|:syn-cchar|).
+	3		Concealed text is completely hidden.
 
-        Note: in the cursor line concealed text is not hidden, so that you can
-        edit and copy the text.  This can be changed with the 'concealcursor'
-        option.
+	Note: in the cursor line concealed text is not hidden, so that you can
+	edit and copy the text.  This can be changed with the 'concealcursor'
+	option.
 
-                                             *'confirm'* *'cf'* *'noconfirm'* *'nocf'*
-'confirm' 'cf'          boolean (default off)
-                        global
-        When 'confirm' is on, certain operations that would normally
-        fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
-        instead raise a dialog asking if you wish to save the current
-        file(s).  You can still use a ! to unconditionally |abandon| a buffer.
-        If 'confirm' is off you can still activate confirmation for one
-        command only (this is most useful in mappings) with the |:confirm|
-        command.
-        Also see the |confirm()| function and the 'v' flag in 'guioptions'.
+					     *'confirm'* *'cf'* *'noconfirm'* *'nocf'*
+'confirm' 'cf'		boolean (default off)
+			global
+	When 'confirm' is on, certain operations that would normally
+	fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
+	instead raise a dialog asking if you wish to save the current
+	file(s).  You can still use a ! to unconditionally |abandon| a buffer.
+	If 'confirm' is off you can still activate confirmation for one
+	command only (this is most useful in mappings) with the |:confirm|
+	command.
+	Also see the |confirm()| function and the 'v' flag in 'guioptions'.
 
-                                       *'copyindent'* *'ci'* *'nocopyindent'* *'noci'*
-'copyindent' 'ci'       boolean (default off)
-                        local to buffer
-        Copy the structure of the existing lines indent when autoindenting a
-        new line.  Normally the new indent is reconstructed by a series of
-        tabs followed by spaces as required (unless |'expandtab'| is enabled,
-        in which case only spaces are used).  Enabling this option makes the
-        new line copy whatever characters were used for indenting on the
-        existing line.  'expandtab' has no effect on these characters, a Tab
-        remains a Tab.  If the new indent is greater than on the existing
-        line, the remaining space is filled in the normal manner.
-        See 'preserveindent'.
+				       *'copyindent'* *'ci'* *'nocopyindent'* *'noci'*
+'copyindent' 'ci'	boolean (default off)
+			local to buffer
+	Copy the structure of the existing lines indent when autoindenting a
+	new line.  Normally the new indent is reconstructed by a series of
+	tabs followed by spaces as required (unless |'expandtab'| is enabled,
+	in which case only spaces are used).  Enabling this option makes the
+	new line copy whatever characters were used for indenting on the
+	existing line.	'expandtab' has no effect on these characters, a Tab
+	remains a Tab.	If the new indent is greater than on the existing
+	line, the remaining space is filled in the normal manner.
+	See 'preserveindent'.
 
-                                                         *'cpoptions'* *'cpo'* *cpo*
-'cpoptions' 'cpo'       string (default "aABceFs_")
-                        global
-        A sequence of single character flags.  When a character is present
-        this indicates Vi-compatible behavior.  This is used for things where
-        not being Vi-compatible is mostly or sometimes preferred.
-        'cpoptions' stands for "compatible-options".
-        Commas can be added for readability.
-        To avoid problems with flags that are added in the future, use the
-        "+=" and "-=" feature of ":set" |add-option-flags|.
+							 *'cpoptions'* *'cpo'* *cpo*
+'cpoptions' 'cpo'	string (default "aABceFs_")
+			global
+	A sequence of single character flags.  When a character is present
+	this indicates Vi-compatible behavior.	This is used for things where
+	not being Vi-compatible is mostly or sometimes preferred.
+	'cpoptions' stands for "compatible-options".
+	Commas can be added for readability.
+	To avoid problems with flags that are added in the future, use the
+	"+=" and "-=" feature of ":set" |add-option-flags|.
 
-            contains    behavior        ~
-                                                                *cpo-a*
-                a       When included, a ":read" command with a file name
-                        argument will set the alternate file name for the
-                        current window.
-                                                                *cpo-A*
-                A       When included, a ":write" command with a file name
-                        argument will set the alternate file name for the
-                        current window.
-                                                                *cpo-b*
-                b       "\|" in a ":map" command is recognized as the end of
-                        the map command.  The '\' is included in the mapping,
-                        the text after the '|' is interpreted as the next
-                        command.  Use a CTRL-V instead of a backslash to
-                        include the '|' in the mapping.  Applies to all
-                        mapping, abbreviation, menu and autocmd commands.
-                        See also |map_bar|.
-                                                                *cpo-B*
-                B       A backslash has no special meaning in mappings,
-                        abbreviations, user commands and the "to" part of the
-                        menu commands.  Remove this flag to be able to use a
-                        backslash like a CTRL-V.  For example, the command
-                        ":map X \<Esc>" results in X being mapped to:
-                                'B' included:   "\^["    (^[ is a real <Esc>)
-                                'B' excluded:   "<Esc>"  (5 characters)
-                                                                *cpo-c*
-                c       Searching continues at the end of any match at the
-                        cursor position, but not further than the start of the
-                        next line.  When not present searching continues
-                        one character from the cursor position.  With 'c'
-                        "abababababab" only gets three matches when repeating
-                        "/abab", without 'c' there are five matches.
-                                                                *cpo-C*
-                C       Do not concatenate sourced lines that start with a
-                        backslash.  See |line-continuation|.
-                                                                *cpo-d*
-                d       Using "./" in the 'tags' option doesn't mean to use
-                        the tags file relative to the current file, but the
-                        tags file in the current directory.
-                                                                *cpo-D*
-                D       Can't use CTRL-K to enter a digraph after Normal mode
-                        commands with a character argument, like |r|, |f| and
-                        |t|.
-                                                                *cpo-e*
-                e       When executing a register with ":@r", always add a
-                        <CR> to the last line, also when the register is not
-                        linewise.  If this flag is not present, the register
-                        is not linewise and the last line does not end in a
-                        <CR>, then the last line is put on the command-line
-                        and can be edited before hitting <CR>.
-                                                                *cpo-E*
-                E       It is an error when using "y", "d", "c", "g~", "gu" or
-                        "gU" on an Empty region.  The operators only work when
-                        at least one character is to be operated on.  Example:
-                        This makes "y0" fail in the first column.
-                                                                *cpo-f*
-                f       When included, a ":read" command with a file name
-                        argument will set the file name for the current buffer,
-                        if the current buffer doesn't have a file name yet.
-                                                                *cpo-F*
-                F       When included, a ":write" command with a file name
-                        argument will set the file name for the current
-                        buffer, if the current buffer doesn't have a file name
-                        yet.  Also see |cpo-P|.
-                                                                *cpo-i*
-                i       When included, interrupting the reading of a file will
-                        leave it modified.
-                                                                *cpo-I*
-                I       When moving the cursor up or down just after inserting
-                        indent for 'autoindent', do not delete the indent.
-                                                                *cpo-J*
-                J       A |sentence| has to be followed by two spaces after
-                        the '.', '!' or '?'.  A <Tab> is not recognized as
-                        white space.
-                                                                *cpo-K*
-                K       Don't wait for a key code to complete when it is
-                        halfway through a mapping.  This breaks mapping
-                        <F1><F1> when only part of the second <F1> has been
-                        read.  It enables cancelling the mapping by typing
-                        <F1><Esc>.
-                                                                *cpo-l*
-                l       Backslash in a [] range in a search pattern is taken
-                        literally, only "\]", "\^", "\-" and "\\" are special.
-                        See |/[]|
-                           'l' included: "/[ \t]"  finds <Space>, '\' and 't'
-                           'l' excluded: "/[ \t]"  finds <Space> and <Tab>
-                                                                *cpo-L*
-                L       When the 'list' option is set, 'wrapmargin',
-                        'textwidth', 'softtabstop' and Virtual Replace mode
-                        (see |gR|) count a <Tab> as two characters, instead of
-                        the normal behavior of a <Tab>.
-                                                                *cpo-m*
-                m       When included, a showmatch will always wait half a
-                        second.  When not included, a showmatch will wait half
-                        a second or until a character is typed.  |'showmatch'|
-                                                                *cpo-M*
-                M       When excluded, "%" matching will take backslashes into
-                        account.  Thus in "( \( )" and "\( ( \)" the outer
-                        parenthesis match.  When included "%" ignores
-                        backslashes, which is Vi compatible.
-                                                                *cpo-n*
-                n       When included, the column used for 'number' and
-                        'relativenumber' will also be used for text of wrapped
-                        lines.
-                                                                *cpo-o*
-                o       Line offset to search command is not remembered for
-                        next search.
-                                                                *cpo-O*
-                O       Don't complain if a file is being overwritten, even
-                        when it didn't exist when editing it.  This is a
-                        protection against a file unexpectedly created by
-                        someone else.  Vi didn't complain about this.
-                                                                *cpo-p*
-                p       Vi compatible Lisp indenting.  When not present, a
-                        slightly better algorithm is used.
-                                                                *cpo-P*
-                P       When included, a ":write" command that appends to a
-                        file will set the file name for the current buffer, if
-                        the current buffer doesn't have a file name yet and
-                        the 'F' flag is also included |cpo-F|.
-                                                                *cpo-q*
-                q       When joining multiple lines leave the cursor at the
-                        position where it would be when joining two lines.
-                                                                *cpo-r*
-                r       Redo ("." command) uses "/" to repeat a search
-                        command, instead of the actually used search string.
-                                                                *cpo-R*
-                R       Remove marks from filtered lines.  Without this flag
-                        marks are kept like |:keepmarks| was used.
-                                                                *cpo-s*
-                s       Set buffer options when entering the buffer for the
-                        first time.  This is like it is in Vim version 3.0.
-                        And it is the default.  If not present the options are
-                        set when the buffer is created.
-                                                                *cpo-S*
-                S       Set buffer options always when entering a buffer
-                        (except 'readonly', 'fileformat', 'filetype' and
-                        'syntax').  This is the (most) Vi compatible setting.
-                        The options are set to the values in the current
-                        buffer.  When you change an option and go to another
-                        buffer, the value is copied.  Effectively makes the
-                        buffer options global to all buffers.
+	    contains	behavior	~
+								*cpo-a*
+		a	When included, a ":read" command with a file name
+			argument will set the alternate file name for the
+			current window.
+								*cpo-A*
+		A	When included, a ":write" command with a file name
+			argument will set the alternate file name for the
+			current window.
+								*cpo-b*
+		b	"\|" in a ":map" command is recognized as the end of
+			the map command.  The '\' is included in the mapping,
+			the text after the '|' is interpreted as the next
+			command.  Use a CTRL-V instead of a backslash to
+			include the '|' in the mapping.  Applies to all
+			mapping, abbreviation, menu and autocmd commands.
+			See also |map_bar|.
+								*cpo-B*
+		B	A backslash has no special meaning in mappings,
+			abbreviations, user commands and the "to" part of the
+			menu commands.	Remove this flag to be able to use a
+			backslash like a CTRL-V.  For example, the command
+			":map X \<Esc>" results in X being mapped to:
+				'B' included:	"\^["	 (^[ is a real <Esc>)
+				'B' excluded:	"<Esc>"  (5 characters)
+								*cpo-c*
+		c	Searching continues at the end of any match at the
+			cursor position, but not further than the start of the
+			next line.  When not present searching continues
+			one character from the cursor position.  With 'c'
+			"abababababab" only gets three matches when repeating
+			"/abab", without 'c' there are five matches.
+								*cpo-C*
+		C	Do not concatenate sourced lines that start with a
+			backslash.  See |line-continuation|.
+								*cpo-d*
+		d	Using "./" in the 'tags' option doesn't mean to use
+			the tags file relative to the current file, but the
+			tags file in the current directory.
+								*cpo-D*
+		D	Can't use CTRL-K to enter a digraph after Normal mode
+			commands with a character argument, like |r|, |f| and
+			|t|.
+								*cpo-e*
+		e	When executing a register with ":@r", always add a
+			<CR> to the last line, also when the register is not
+			linewise.  If this flag is not present, the register
+			is not linewise and the last line does not end in a
+			<CR>, then the last line is put on the command-line
+			and can be edited before hitting <CR>.
+								*cpo-E*
+		E	It is an error when using "y", "d", "c", "g~", "gu" or
+			"gU" on an Empty region.  The operators only work when
+			at least one character is to be operated on.  Example:
+			This makes "y0" fail in the first column.
+								*cpo-f*
+		f	When included, a ":read" command with a file name
+			argument will set the file name for the current buffer,
+			if the current buffer doesn't have a file name yet.
+								*cpo-F*
+		F	When included, a ":write" command with a file name
+			argument will set the file name for the current
+			buffer, if the current buffer doesn't have a file name
+			yet.  Also see |cpo-P|.
+								*cpo-i*
+		i	When included, interrupting the reading of a file will
+			leave it modified.
+								*cpo-I*
+		I	When moving the cursor up or down just after inserting
+			indent for 'autoindent', do not delete the indent.
+								*cpo-J*
+		J	A |sentence| has to be followed by two spaces after
+			the '.', '!' or '?'.  A <Tab> is not recognized as
+			white space.
+								*cpo-K*
+		K	Don't wait for a key code to complete when it is
+			halfway through a mapping.  This breaks mapping
+			<F1><F1> when only part of the second <F1> has been
+			read.  It enables cancelling the mapping by typing
+			<F1><Esc>.
+								*cpo-l*
+		l	Backslash in a [] range in a search pattern is taken
+			literally, only "\]", "\^", "\-" and "\\" are special.
+			See |/[]|
+			   'l' included: "/[ \t]"  finds <Space>, '\' and 't'
+			   'l' excluded: "/[ \t]"  finds <Space> and <Tab>
+								*cpo-L*
+		L	When the 'list' option is set, 'wrapmargin',
+			'textwidth', 'softtabstop' and Virtual Replace mode
+			(see |gR|) count a <Tab> as two characters, instead of
+			the normal behavior of a <Tab>.
+								*cpo-m*
+		m	When included, a showmatch will always wait half a
+			second.  When not included, a showmatch will wait half
+			a second or until a character is typed.  |'showmatch'|
+								*cpo-M*
+		M	When excluded, "%" matching will take backslashes into
+			account.  Thus in "( \( )" and "\( ( \)" the outer
+			parenthesis match.  When included "%" ignores
+			backslashes, which is Vi compatible.
+								*cpo-n*
+		n	When included, the column used for 'number' and
+			'relativenumber' will also be used for text of wrapped
+			lines.
+								*cpo-o*
+		o	Line offset to search command is not remembered for
+			next search.
+								*cpo-O*
+		O	Don't complain if a file is being overwritten, even
+			when it didn't exist when editing it.  This is a
+			protection against a file unexpectedly created by
+			someone else.  Vi didn't complain about this.
+								*cpo-p*
+		p	Vi compatible Lisp indenting.  When not present, a
+			slightly better algorithm is used.
+								*cpo-P*
+		P	When included, a ":write" command that appends to a
+			file will set the file name for the current buffer, if
+			the current buffer doesn't have a file name yet and
+			the 'F' flag is also included |cpo-F|.
+								*cpo-q*
+		q	When joining multiple lines leave the cursor at the
+			position where it would be when joining two lines.
+								*cpo-r*
+		r	Redo ("." command) uses "/" to repeat a search
+			command, instead of the actually used search string.
+								*cpo-R*
+		R	Remove marks from filtered lines.  Without this flag
+			marks are kept like |:keepmarks| was used.
+								*cpo-s*
+		s	Set buffer options when entering the buffer for the
+			first time.  This is like it is in Vim version 3.0.
+			And it is the default.	If not present the options are
+			set when the buffer is created.
+								*cpo-S*
+		S	Set buffer options always when entering a buffer
+			(except 'readonly', 'fileformat', 'filetype' and
+			'syntax').  This is the (most) Vi compatible setting.
+			The options are set to the values in the current
+			buffer.  When you change an option and go to another
+			buffer, the value is copied.  Effectively makes the
+			buffer options global to all buffers.
 
-                        's'    'S'     copy buffer options
-                        no     no      when buffer created
-                        yes    no      when buffer first entered (default)
-                         X     yes     each time when buffer entered (vi comp.)
-                                                                *cpo-t*
-                t       Search pattern for the tag command is remembered for
-                        "n" command.  Otherwise Vim only puts the pattern in
-                        the history for search pattern, but doesn't change the
-                        last used search pattern.
-                                                                *cpo-u*
-                u       Undo is Vi compatible.  See |undo-two-ways|.
-                                                                *cpo-v*
-                v       Backspaced characters remain visible on the screen in
-                        Insert mode.  Without this flag the characters are
-                        erased from the screen right away.  With this flag the
-                        screen newly typed text overwrites backspaced
-                        characters.
-                                                                *cpo-W*
-                W       Don't overwrite a readonly file.  When omitted, ":w!"
-                        overwrites a readonly file, if possible.
-                                                                *cpo-x*
-                x       <Esc> on the command-line executes the command-line.
-                        The default in Vim is to abandon the command-line,
-                        because <Esc> normally aborts a command.  |c_<Esc>|
-                                                                *cpo-X*
-                X       When using a count with "R" the replaced text is
-                        deleted only once.  Also when repeating "R" with "."
-                        and a count.
-                                                                *cpo-y*
-                y       A yank command can be redone with ".".  Think twice if
-                        you really want to use this, it may break some
-                        plugins, since most people expect "." to only repeat a
-                        change.
-                                                                *cpo-Z*
-                Z       When using "w!" while the 'readonly' option is set,
-                        don't reset 'readonly'.
-                                                                *cpo-!*
-                !       When redoing a filter command, use the last used
-                        external command, whatever it was.  Otherwise the last
-                        used -filter- command is used.
-                                                                *cpo-$*
-                $       When making a change to one line, don't redisplay the
-                        line, but put a '$' at the end of the changed text.
-                        The changed text will be overwritten when you type the
-                        new text.  The line is redisplayed if you type any
-                        command that moves the cursor from the insertion
-                        point.
-                                                                *cpo-%*
-                %       Vi-compatible matching is done for the "%" command.
-                        Does not recognize "#if", "#endif", etc.
-                        Does not recognize "/*" and "*/".
-                        Parens inside single and double quotes are also
-                        counted, causing a string that contains a paren to
-                        disturb the matching.  For example, in a line like
-                        "if (strcmp("foo(", s))" the first paren does not
-                        match the last one.  When this flag is not included,
-                        parens inside single and double quotes are treated
-                        specially.  When matching a paren outside of quotes,
-                        everything inside quotes is ignored.  When matching a
-                        paren inside quotes, it will find the matching one (if
-                        there is one).  This works very well for C programs.
-                        This flag is also used for other features, such as
-                        C-indenting.
-                                                                *cpo-+*
-                +       When included, a ":write file" command will reset the
-                        'modified' flag of the buffer, even though the buffer
-                        itself may still be different from its file.
-                                                                *cpo->*
-                >       When appending to a register, put a line break before
-                        the appended text.
-                                                                *cpo-;*
-                ;       When using |,| or |;| to repeat the last |t| search
-                        and the cursor is right in front of the searched
-                        character, the cursor won't move. When not included,
-                        the cursor would skip over it and jump to the
-                        following occurrence.
-                                                                *cpo-_*
-                _       When using |cw| on a word, do not include the
-                        whitespace following the word in the motion.
+			's'    'S'     copy buffer options
+			no     no      when buffer created
+			yes    no      when buffer first entered (default)
+			 X     yes     each time when buffer entered (vi comp.)
+								*cpo-t*
+		t	Search pattern for the tag command is remembered for
+			"n" command.  Otherwise Vim only puts the pattern in
+			the history for search pattern, but doesn't change the
+			last used search pattern.
+								*cpo-u*
+		u	Undo is Vi compatible.	See |undo-two-ways|.
+								*cpo-v*
+		v	Backspaced characters remain visible on the screen in
+			Insert mode.  Without this flag the characters are
+			erased from the screen right away.  With this flag the
+			screen newly typed text overwrites backspaced
+			characters.
+								*cpo-W*
+		W	Don't overwrite a readonly file.  When omitted, ":w!"
+			overwrites a readonly file, if possible.
+								*cpo-x*
+		x	<Esc> on the command-line executes the command-line.
+			The default in Vim is to abandon the command-line,
+			because <Esc> normally aborts a command.  |c_<Esc>|
+								*cpo-X*
+		X	When using a count with "R" the replaced text is
+			deleted only once.  Also when repeating "R" with "."
+			and a count.
+								*cpo-y*
+		y	A yank command can be redone with ".".	Think twice if
+			you really want to use this, it may break some
+			plugins, since most people expect "." to only repeat a
+			change.
+								*cpo-Z*
+		Z	When using "w!" while the 'readonly' option is set,
+			don't reset 'readonly'.
+								*cpo-!*
+		!	When redoing a filter command, use the last used
+			external command, whatever it was.  Otherwise the last
+			used -filter- command is used.
+								*cpo-$*
+		$	When making a change to one line, don't redisplay the
+			line, but put a '$' at the end of the changed text.
+			The changed text will be overwritten when you type the
+			new text.  The line is redisplayed if you type any
+			command that moves the cursor from the insertion
+			point.
+								*cpo-%*
+		%	Vi-compatible matching is done for the "%" command.
+			Does not recognize "#if", "#endif", etc.
+			Does not recognize "/*" and "*/".
+			Parens inside single and double quotes are also
+			counted, causing a string that contains a paren to
+			disturb the matching.  For example, in a line like
+			"if (strcmp("foo(", s))" the first paren does not
+			match the last one.  When this flag is not included,
+			parens inside single and double quotes are treated
+			specially.  When matching a paren outside of quotes,
+			everything inside quotes is ignored.  When matching a
+			paren inside quotes, it will find the matching one (if
+			there is one).	This works very well for C programs.
+			This flag is also used for other features, such as
+			C-indenting.
+								*cpo-+*
+		+	When included, a ":write file" command will reset the
+			'modified' flag of the buffer, even though the buffer
+			itself may still be different from its file.
+								*cpo->*
+		>	When appending to a register, put a line break before
+			the appended text.
+								*cpo-;*
+		;	When using |,| or |;| to repeat the last |t| search
+			and the cursor is right in front of the searched
+			character, the cursor won't move. When not included,
+			the cursor would skip over it and jump to the
+			following occurrence.
+								*cpo-_*
+		_	When using |cw| on a word, do not include the
+			whitespace following the word in the motion.
 
-                                     *'cursorbind'* *'crb'* *'nocursorbind'* *'nocrb'*
-'cursorbind' 'crb'      boolean (default off)
-                        local to window
-        When this option is set, as the cursor in the current
-        window moves other cursorbound windows (windows that also have
-        this option set) move their cursors to the corresponding line and
-        column.  This option is useful for viewing the
-        differences between two versions of a file (see 'diff'); in diff mode,
-        inserted and deleted lines (though not characters within a line) are
-        taken into account.
+				     *'cursorbind'* *'crb'* *'nocursorbind'* *'nocrb'*
+'cursorbind' 'crb'	boolean (default off)
+			local to window
+	When this option is set, as the cursor in the current
+	window moves other cursorbound windows (windows that also have
+	this option set) move their cursors to the corresponding line and
+	column.  This option is useful for viewing the
+	differences between two versions of a file (see 'diff'); in diff mode,
+	inserted and deleted lines (though not characters within a line) are
+	taken into account.
 
-                                 *'cursorcolumn'* *'cuc'* *'nocursorcolumn'* *'nocuc'*
-'cursorcolumn' 'cuc'    boolean (default off)
-                        local to window
-        Highlight the screen column of the cursor with CursorColumn
-        |hl-CursorColumn|.  Useful to align text.  Will make screen redrawing
-        slower.
-        If you only want the highlighting in the current window you can use
-        these autocommands: >vim
-                au WinLeave * set nocursorline nocursorcolumn
-                au WinEnter * set cursorline cursorcolumn
+				 *'cursorcolumn'* *'cuc'* *'nocursorcolumn'* *'nocuc'*
+'cursorcolumn' 'cuc'	boolean (default off)
+			local to window
+	Highlight the screen column of the cursor with CursorColumn
+	|hl-CursorColumn|.  Useful to align text.  Will make screen redrawing
+	slower.
+	If you only want the highlighting in the current window you can use
+	these autocommands: >vim
+		au WinLeave * set nocursorline nocursorcolumn
+		au WinEnter * set cursorline cursorcolumn
 <
 
-                                     *'cursorline'* *'cul'* *'nocursorline'* *'nocul'*
-'cursorline' 'cul'      boolean (default off)
-                        local to window
-        Highlight the text line of the cursor with CursorLine |hl-CursorLine|.
-        Useful to easily spot the cursor.  Will make screen redrawing slower.
-        When Visual mode is active the highlighting isn't used to make it
-        easier to see the selected text.
+				     *'cursorline'* *'cul'* *'nocursorline'* *'nocul'*
+'cursorline' 'cul'	boolean (default off)
+			local to window
+	Highlight the text line of the cursor with CursorLine |hl-CursorLine|.
+	Useful to easily spot the cursor.  Will make screen redrawing slower.
+	When Visual mode is active the highlighting isn't used to make it
+	easier to see the selected text.
 
-                                                      *'cursorlineopt'* *'culopt'*
+						      *'cursorlineopt'* *'culopt'*
 'cursorlineopt' 'culopt' string (default "both")
-                        local to window
-        Comma-separated list of settings for how 'cursorline' is displayed.
-        Valid values:
-        "line"          Highlight the text line of the cursor with
-                        CursorLine |hl-CursorLine|.
-        "screenline"    Highlight only the screen line of the cursor with
-                        CursorLine |hl-CursorLine|.
-        "number"        Highlight the line number of the cursor with
-                        CursorLineNr |hl-CursorLineNr|.
+			local to window
+	Comma-separated list of settings for how 'cursorline' is displayed.
+	Valid values:
+	"line"		Highlight the text line of the cursor with
+			CursorLine |hl-CursorLine|.
+	"screenline"	Highlight only the screen line of the cursor with
+			CursorLine |hl-CursorLine|.
+	"number"	Highlight the line number of the cursor with
+			CursorLineNr |hl-CursorLineNr|.
 
-        Special value:
-        "both"          Alias for the values "line,number".
+	Special value:
+	"both"		Alias for the values "line,number".
 
-        "line" and "screenline" cannot be used together.
+	"line" and "screenline" cannot be used together.
 
-                                                                       *'debug'*
-'debug'                 string (default "")
-                        global
-        These values can be used:
-        msg     Error messages that would otherwise be omitted will be given
-                anyway.
-        throw   Error messages that would otherwise be omitted will be given
-                anyway and also throw an exception and set |v:errmsg|.
-        beep    A message will be given when otherwise only a beep would be
-                produced.
-        The values can be combined, separated by a comma.
-        "msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
-        'indentexpr'.
+								       *'debug'*
+'debug'			string (default "")
+			global
+	These values can be used:
+	msg	Error messages that would otherwise be omitted will be given
+		anyway.
+	throw	Error messages that would otherwise be omitted will be given
+		anyway and also throw an exception and set |v:errmsg|.
+	beep	A message will be given when otherwise only a beep would be
+		produced.
+	The values can be combined, separated by a comma.
+	"msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
+	'indentexpr'.
 
-                                                                *'define'* *'def'*
-'define' 'def'          string (default "")
-                        global or local to buffer |global-local|
-        Pattern to be used to find a macro definition.  It is a search
-        pattern, just like for the "/" command.  This option is used for the
-        commands like "[i" and "[d" |include-search|.  The 'isident' option is
-        used to recognize the defined name after the match: >
-                {match with 'define'}{non-ID chars}{defined name}{non-ID char}
-<       See |option-backslash| about inserting backslashes to include a space
-        or backslash.
-        For C++ this value would be useful, to include const type declarations: >
-                ^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
-<       You can also use "\ze" just before the name and continue the pattern
-        to check what is following.  E.g. for Javascript, if a function is
-        defined with `func_name = function(args)`: >
-                ^\s*\ze\i\+\s*=\s*function(
-<       If the function is defined with `func_name : function() {...`: >
-                ^\s*\ze\i\+\s*[:]\s*(*function\s*(
-<       When using the ":set" command, you need to double the backslashes!
-        To avoid that use `:let` with a single quote string: >vim
-                let &l:define = '^\s*\ze\k\+\s*=\s*function('
+								*'define'* *'def'*
+'define' 'def'		string (default "")
+			global or local to buffer |global-local|
+	Pattern to be used to find a macro definition.	It is a search
+	pattern, just like for the "/" command.  This option is used for the
+	commands like "[i" and "[d" |include-search|.  The 'isident' option is
+	used to recognize the defined name after the match: >
+		{match with 'define'}{non-ID chars}{defined name}{non-ID char}
+<	See |option-backslash| about inserting backslashes to include a space
+	or backslash.
+	For C++ this value would be useful, to include const type declarations: >
+		^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
+<	You can also use "\ze" just before the name and continue the pattern
+	to check what is following.  E.g. for Javascript, if a function is
+	defined with `func_name = function(args)`: >
+		^\s*\ze\i\+\s*=\s*function(
+<	If the function is defined with `func_name : function() {...`: >
+		^\s*\ze\i\+\s*[:]\s*(*function\s*(
+<	When using the ":set" command, you need to double the backslashes!
+	To avoid that use `:let` with a single quote string: >vim
+		let &l:define = '^\s*\ze\k\+\s*=\s*function('
 <
 
-                                   *'delcombine'* *'deco'* *'nodelcombine'* *'nodeco'*
-'delcombine' 'deco'     boolean (default off)
-                        global
-        If editing Unicode and this option is set, backspace and Normal mode
-        "x" delete each combining character on its own.  When it is off (the
-        default) the character along with its combining characters are
-        deleted.
-        Note: When 'delcombine' is set "xx" may work differently from "2x"!
+				   *'delcombine'* *'deco'* *'nodelcombine'* *'nodeco'*
+'delcombine' 'deco'	boolean (default off)
+			global
+	If editing Unicode and this option is set, backspace and Normal mode
+	"x" delete each combining character on its own.  When it is off (the
+	default) the character along with its combining characters are
+	deleted.
+	Note: When 'delcombine' is set "xx" may work differently from "2x"!
 
-        This is useful for Arabic, Hebrew and many other languages where one
-        may have combining characters overtop of base characters, and want
-        to remove only the combining ones.
+	This is useful for Arabic, Hebrew and many other languages where one
+	may have combining characters overtop of base characters, and want
+	to remove only the combining ones.
 
-                                                           *'dictionary'* *'dict'*
-'dictionary' 'dict'     string (default "")
-                        global or local to buffer |global-local|
-        List of file names, separated by commas, that are used to lookup words
-        for keyword completion commands |i_CTRL-X_CTRL-K|.  Each file should
-        contain a list of words.  This can be one word per line, or several
-        words per line, separated by non-keyword characters (white space is
-        preferred).  Maximum line length is 510 bytes.
+							   *'dictionary'* *'dict'*
+'dictionary' 'dict'	string (default "")
+			global or local to buffer |global-local|
+	List of file names, separated by commas, that are used to lookup words
+	for keyword completion commands |i_CTRL-X_CTRL-K|.  Each file should
+	contain a list of words.  This can be one word per line, or several
+	words per line, separated by non-keyword characters (white space is
+	preferred).  Maximum line length is 510 bytes.
 
-        When this option is empty or an entry "spell" is present, and spell
-        checking is enabled, words in the word lists for the currently active
-        'spelllang' are used. See |spell|.
+	When this option is empty or an entry "spell" is present, and spell
+	checking is enabled, words in the word lists for the currently active
+	'spelllang' are used. See |spell|.
 
-        To include a comma in a file name precede it with a backslash.  Spaces
-        after a comma are ignored, otherwise spaces are included in the file
-        name.  See |option-backslash| about using backslashes.
-        This has nothing to do with the |Dictionary| variable type.
-        Where to find a list of words?
-        - BSD/macOS include the "/usr/share/dict/words" file.
-        - Try "apt install spell" to get the "/usr/share/dict/words" file on
-          apt-managed systems (Debian/Ubuntu).
-        The use of |:set+=| and |:set-=| is preferred when adding or removing
-        directories from the list.  This avoids problems when a future version
-        uses another default.
-        Backticks cannot be used in this option for security reasons.
+	To include a comma in a file name precede it with a backslash.	Spaces
+	after a comma are ignored, otherwise spaces are included in the file
+	name.  See |option-backslash| about using backslashes.
+	This has nothing to do with the |Dictionary| variable type.
+	Where to find a list of words?
+	- BSD/macOS include the "/usr/share/dict/words" file.
+	- Try "apt install spell" to get the "/usr/share/dict/words" file on
+	  apt-managed systems (Debian/Ubuntu).
+	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	directories from the list.  This avoids problems when a future version
+	uses another default.
+	Backticks cannot be used in this option for security reasons.
 
-                                                               *'diff'* *'nodiff'*
-'diff'                  boolean (default off)
-                        local to window
-        Join the current window in the group of windows that shows differences
-        between files.  See |diff-mode|.
+							       *'diff'* *'nodiff'*
+'diff'			boolean (default off)
+			local to window
+	Join the current window in the group of windows that shows differences
+	between files.	See |diff-mode|.
 
-                                                              *'diffexpr'* *'dex'*
-'diffexpr' 'dex'        string (default "")
-                        global
-        Expression which is evaluated to obtain a diff file (either ed-style
-        or unified-style) from two versions of a file.  See |diff-diffexpr|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'diffexpr'* *'dex'*
+'diffexpr' 'dex'	string (default "")
+			global
+	Expression which is evaluated to obtain a diff file (either ed-style
+	or unified-style) from two versions of a file.	See |diff-diffexpr|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                               *'diffopt'* *'dip'*
-'diffopt' 'dip'         string (default "internal,filler,closeoff")
-                        global
-        Option settings for diff mode.  It can consist of the following items.
-        All are optional.  Items must be separated by a comma.
+							       *'diffopt'* *'dip'*
+'diffopt' 'dip'		string (default "internal,filler,closeoff")
+			global
+	Option settings for diff mode.	It can consist of the following items.
+	All are optional.  Items must be separated by a comma.
 
-                filler          Show filler lines, to keep the text
-                                synchronized with a window that has inserted
-                                lines at the same position.  Mostly useful
-                                when windows are side-by-side and 'scrollbind'
-                                is set.
+		filler		Show filler lines, to keep the text
+				synchronized with a window that has inserted
+				lines at the same position.  Mostly useful
+				when windows are side-by-side and 'scrollbind'
+				is set.
 
-                context:{n}     Use a context of {n} lines between a change
-                                and a fold that contains unchanged lines.
-                                When omitted a context of six lines is used.
-                                When using zero the context is actually one,
-                                since folds require a line in between, also
-                                for a deleted line. Set it to a very large
-                                value (999999) to disable folding completely.
-                                See |fold-diff|.
+		context:{n}	Use a context of {n} lines between a change
+				and a fold that contains unchanged lines.
+				When omitted a context of six lines is used.
+				When using zero the context is actually one,
+				since folds require a line in between, also
+				for a deleted line. Set it to a very large
+				value (999999) to disable folding completely.
+				See |fold-diff|.
 
-                iblank          Ignore changes where lines are all blank.  Adds
-                                the "-B" flag to the "diff" command if
-                                'diffexpr' is empty.  Check the documentation
-                                of the "diff" command for what this does
-                                exactly.
-                                NOTE: the diff windows will get out of sync,
-                                because no differences between blank lines are
-                                taken into account.
+		iblank		Ignore changes where lines are all blank.  Adds
+				the "-B" flag to the "diff" command if
+				'diffexpr' is empty.  Check the documentation
+				of the "diff" command for what this does
+				exactly.
+				NOTE: the diff windows will get out of sync,
+				because no differences between blank lines are
+				taken into account.
 
-                icase           Ignore changes in case of text.  "a" and "A"
-                                are considered the same.  Adds the "-i" flag
-                                to the "diff" command if 'diffexpr' is empty.
+		icase		Ignore changes in case of text.  "a" and "A"
+				are considered the same.  Adds the "-i" flag
+				to the "diff" command if 'diffexpr' is empty.
 
-                iwhite          Ignore changes in amount of white space.  Adds
-                                the "-b" flag to the "diff" command if
-                                'diffexpr' is empty.  Check the documentation
-                                of the "diff" command for what this does
-                                exactly.  It should ignore adding trailing
-                                white space, but not leading white space.
+		iwhite		Ignore changes in amount of white space.  Adds
+				the "-b" flag to the "diff" command if
+				'diffexpr' is empty.  Check the documentation
+				of the "diff" command for what this does
+				exactly.  It should ignore adding trailing
+				white space, but not leading white space.
 
-                iwhiteall       Ignore all white space changes.  Adds
-                                the "-w" flag to the "diff" command if
-                                'diffexpr' is empty.  Check the documentation
-                                of the "diff" command for what this does
-                                exactly.
+		iwhiteall	Ignore all white space changes.  Adds
+				the "-w" flag to the "diff" command if
+				'diffexpr' is empty.  Check the documentation
+				of the "diff" command for what this does
+				exactly.
 
-                iwhiteeol       Ignore white space changes at end of line.
-                                Adds the "-Z" flag to the "diff" command if
-                                'diffexpr' is empty.  Check the documentation
-                                of the "diff" command for what this does
-                                exactly.
+		iwhiteeol	Ignore white space changes at end of line.
+				Adds the "-Z" flag to the "diff" command if
+				'diffexpr' is empty.  Check the documentation
+				of the "diff" command for what this does
+				exactly.
 
-                horizontal      Start diff mode with horizontal splits (unless
-                                explicitly specified otherwise).
+		horizontal	Start diff mode with horizontal splits (unless
+				explicitly specified otherwise).
 
-                vertical        Start diff mode with vertical splits (unless
-                                explicitly specified otherwise).
+		vertical	Start diff mode with vertical splits (unless
+				explicitly specified otherwise).
 
-                closeoff        When a window is closed where 'diff' is set
-                                and there is only one window remaining in the
-                                same tab page with 'diff' set, execute
-                                `:diffoff` in that window.  This undoes a
-                                `:diffsplit` command.
+		closeoff	When a window is closed where 'diff' is set
+				and there is only one window remaining in the
+				same tab page with 'diff' set, execute
+				`:diffoff` in that window.  This undoes a
+				`:diffsplit` command.
 
-                hiddenoff       Do not use diff mode for a buffer when it
-                                becomes hidden.
+		hiddenoff	Do not use diff mode for a buffer when it
+				becomes hidden.
 
-                foldcolumn:{n}  Set the 'foldcolumn' option to {n} when
-                                starting diff mode.  Without this 2 is used.
+		foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
+				starting diff mode.  Without this 2 is used.
 
-                followwrap      Follow the 'wrap' option and leave as it is.
+		followwrap	Follow the 'wrap' option and leave as it is.
 
-                internal        Use the internal diff library.  This is
-                                ignored when 'diffexpr' is set.  *E960*
-                                When running out of memory when writing a
-                                buffer this item will be ignored for diffs
-                                involving that buffer.  Set the 'verbose'
-                                option to see when this happens.
+		internal	Use the internal diff library.	This is
+				ignored when 'diffexpr' is set.  *E960*
+				When running out of memory when writing a
+				buffer this item will be ignored for diffs
+				involving that buffer.	Set the 'verbose'
+				option to see when this happens.
 
-                indent-heuristic
-                                Use the indent heuristic for the internal
-                                diff library.
+		indent-heuristic
+				Use the indent heuristic for the internal
+				diff library.
 
-                linematch:{n}   Enable a second stage diff on each generated
-                                hunk in order to align lines. When the total
-                                number of lines in a hunk exceeds {n}, the
-                                second stage diff will not be performed as
-                                very large hunks can cause noticeable lag. A
-                                recommended setting is "linematch:60", as this
-                                will enable alignment for a 2 buffer diff with
-                                hunks of up to 30 lines each, or a 3 buffer
-                                diff with hunks of up to 20 lines each.
+		linematch:{n}	Enable a second stage diff on each generated
+				hunk in order to align lines. When the total
+				number of lines in a hunk exceeds {n}, the
+				second stage diff will not be performed as
+				very large hunks can cause noticeable lag. A
+				recommended setting is "linematch:60", as this
+				will enable alignment for a 2 buffer diff with
+				hunks of up to 30 lines each, or a 3 buffer
+				diff with hunks of up to 20 lines each.
 
-                algorithm:{text} Use the specified diff algorithm with the
-                                internal diff engine. Currently supported
-                                algorithms are:
-                                myers      the default algorithm
-                                minimal    spend extra time to generate the
-                                           smallest possible diff
-                                patience   patience diff algorithm
-                                histogram  histogram diff algorithm
+		algorithm:{text} Use the specified diff algorithm with the
+				internal diff engine. Currently supported
+				algorithms are:
+				myers	   the default algorithm
+				minimal    spend extra time to generate the
+					   smallest possible diff
+				patience   patience diff algorithm
+				histogram  histogram diff algorithm
 
-        Examples: >vim
-                set diffopt=internal,filler,context:4
-                set diffopt=
-                set diffopt=internal,filler,foldcolumn:3
-                set diffopt-=internal  " do NOT use the internal diff parser
+	Examples: >vim
+		set diffopt=internal,filler,context:4
+		set diffopt=
+		set diffopt=internal,filler,foldcolumn:3
+		set diffopt-=internal  " do NOT use the internal diff parser
 <
 
-                                             *'digraph'* *'dg'* *'nodigraph'* *'nodg'*
-'digraph' 'dg'          boolean (default off)
-                        global
-        Enable the entering of digraphs in Insert mode with {char1} <BS>
-        {char2}.  See |digraphs|.
+					     *'digraph'* *'dg'* *'nodigraph'* *'nodg'*
+'digraph' 'dg'		boolean (default off)
+			global
+	Enable the entering of digraphs in Insert mode with {char1} <BS>
+	{char2}.  See |digraphs|.
 
-                                                             *'directory'* *'dir'*
-'directory' 'dir'       string (default "$XDG_STATE_HOME/nvim/swap//")
-                        global
-        List of directory names for the swap file, separated with commas.
+							     *'directory'* *'dir'*
+'directory' 'dir'	string (default "$XDG_STATE_HOME/nvim/swap//")
+			global
+	List of directory names for the swap file, separated with commas.
 
-        Possible items:
-        - The swap file will be created in the first directory where this is
-          possible.  If it is not possible in any directory, but last
-          directory listed in the option does not exist, it is created.
-        - Empty means that no swap file will be used (recovery is
-          impossible!) and no |E303| error will be given.
-        - A directory "." means to put the swap file in the same directory as
-          the edited file.  On Unix, a dot is prepended to the file name, so
-          it doesn't show in a directory listing.  On MS-Windows the "hidden"
-          attribute is set and a dot prepended if possible.
-        - A directory starting with "./" (or ".\" for MS-Windows) means to put
-          the swap file relative to where the edited file is.  The leading "."
-          is replaced with the path name of the edited file.
-        - For Unix and Win32, if a directory ends in two path separators "//",
-          the swap file name will be built from the complete path to the file
-          with all path separators replaced by percent '%' signs (including
-          the colon following the drive letter on Win32). This will ensure
-          file name uniqueness in the preserve directory.
-          On Win32, it is also possible to end with "\\".  However, When a
-          separating comma is following, you must use "//", since "\\" will
-          include the comma in the file name. Therefore it is recommended to
-          use '//', instead of '\\'.
-        - Spaces after the comma are ignored, other spaces are considered part
-          of the directory name.  To have a space at the start of a directory
-          name, precede it with a backslash.
-        - To include a comma in a directory name precede it with a backslash.
-        - A directory name may end in an ':' or '/'.
-        - Environment variables are expanded |:set_env|.
-        - Careful with '\' characters, type one before a space, type two to
-          get one in the option (see |option-backslash|), for example: >vim
-            set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
+	Possible items:
+	- The swap file will be created in the first directory where this is
+	  possible.  If it is not possible in any directory, but last
+	  directory listed in the option does not exist, it is created.
+	- Empty means that no swap file will be used (recovery is
+	  impossible!) and no |E303| error will be given.
+	- A directory "." means to put the swap file in the same directory as
+	  the edited file.  On Unix, a dot is prepended to the file name, so
+	  it doesn't show in a directory listing.  On MS-Windows the "hidden"
+	  attribute is set and a dot prepended if possible.
+	- A directory starting with "./" (or ".\" for MS-Windows) means to put
+	  the swap file relative to where the edited file is.  The leading "."
+	  is replaced with the path name of the edited file.
+	- For Unix and Win32, if a directory ends in two path separators "//",
+	  the swap file name will be built from the complete path to the file
+	  with all path separators replaced by percent '%' signs (including
+	  the colon following the drive letter on Win32). This will ensure
+	  file name uniqueness in the preserve directory.
+	  On Win32, it is also possible to end with "\\".  However, When a
+	  separating comma is following, you must use "//", since "\\" will
+	  include the comma in the file name. Therefore it is recommended to
+	  use '//', instead of '\\'.
+	- Spaces after the comma are ignored, other spaces are considered part
+	  of the directory name.  To have a space at the start of a directory
+	  name, precede it with a backslash.
+	- To include a comma in a directory name precede it with a backslash.
+	- A directory name may end in an ':' or '/'.
+	- Environment variables are expanded |:set_env|.
+	- Careful with '\' characters, type one before a space, type two to
+	  get one in the option (see |option-backslash|), for example: >vim
+	    set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
 <
-        Editing the same file twice will result in a warning.  Using "/tmp" on
-        is discouraged: if the system crashes you lose the swap file. And
-        others on the computer may be able to see the files.
-        Use |:set+=| and |:set-=| when adding or removing directories from the
-        list, this avoids problems if the Nvim default is changed.
+	Editing the same file twice will result in a warning.  Using "/tmp" on
+	is discouraged: if the system crashes you lose the swap file. And
+	others on the computer may be able to see the files.
+	Use |:set+=| and |:set-=| when adding or removing directories from the
+	list, this avoids problems if the Nvim default is changed.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                                *'display'* *'dy'*
-'display' 'dy'          string (default "lastline")
-                        global
-        Change the way text is displayed.  This is a comma-separated list of
-        flags:
-        lastline        When included, as much as possible of the last line
-                        in a window will be displayed.  "@@@" is put in the
-                        last columns of the last screen line to indicate the
-                        rest of the line is not displayed.
-        truncate        Like "lastline", but "@@@" is displayed in the first
-                        column of the last screen line.  Overrules "lastline".
-        uhex            Show unprintable characters hexadecimal as <xx>
-                        instead of using ^C and ~C.
-        msgsep          Obsolete flag. Allowed but takes no effect. |msgsep|
+								*'display'* *'dy'*
+'display' 'dy'		string (default "lastline")
+			global
+	Change the way text is displayed.  This is a comma-separated list of
+	flags:
+	lastline	When included, as much as possible of the last line
+			in a window will be displayed.	"@@@" is put in the
+			last columns of the last screen line to indicate the
+			rest of the line is not displayed.
+	truncate	Like "lastline", but "@@@" is displayed in the first
+			column of the last screen line.  Overrules "lastline".
+	uhex		Show unprintable characters hexadecimal as <xx>
+			instead of using ^C and ~C.
+	msgsep		Obsolete flag. Allowed but takes no effect. |msgsep|
 
-        When neither "lastline" nor "truncate" is included, a last line that
-        doesn't fit is replaced with "@" lines.
+	When neither "lastline" nor "truncate" is included, a last line that
+	doesn't fit is replaced with "@" lines.
 
-        The "@" character can be changed by setting the "lastline" item in
-        'fillchars'.  The character is highlighted with |hl-NonText|.
+	The "@" character can be changed by setting the "lastline" item in
+	'fillchars'.  The character is highlighted with |hl-NonText|.
 
-                                                           *'eadirection'* *'ead'*
-'eadirection' 'ead'     string (default "both")
-                        global
-        Tells when the 'equalalways' option applies:
-                ver     vertically, width of windows is not affected
-                hor     horizontally, height of windows is not affected
-                both    width and height of windows is affected
+							   *'eadirection'* *'ead'*
+'eadirection' 'ead'	string (default "both")
+			global
+	Tells when the 'equalalways' option applies:
+		ver	vertically, width of windows is not affected
+		hor	horizontally, height of windows is not affected
+		both	width and height of windows is affected
 
-                                               *'emoji'* *'emo'* *'noemoji'* *'noemo'*
-'emoji' 'emo'           boolean (default on)
-                        global
-        When on all Unicode emoji characters are considered to be full width.
-        This excludes "text emoji" characters, which are normally displayed as
-        single width.  Unfortunately there is no good specification for this
-        and it has been determined on trial-and-error basis.  Use the
-        |setcellwidths()| function to change the behavior.
+					       *'emoji'* *'emo'* *'noemoji'* *'noemo'*
+'emoji' 'emo'		boolean (default on)
+			global
+	When on all Unicode emoji characters are considered to be full width.
+	This excludes "text emoji" characters, which are normally displayed as
+	single width.  Unfortunately there is no good specification for this
+	and it has been determined on trial-and-error basis.  Use the
+	|setcellwidths()| function to change the behavior.
 
-                                                              *'encoding'* *'enc'*
-'encoding' 'enc'        string (default "utf-8")
-                        global
-        String-encoding used internally and for |RPC| communication.
-        Always UTF-8.
+							      *'encoding'* *'enc'*
+'encoding' 'enc'	string (default "utf-8")
+			global
+	String-encoding used internally and for |RPC| communication.
+	Always UTF-8.
 
-        See 'fileencoding' to control file-content encoding.
+	See 'fileencoding' to control file-content encoding.
 
-                                       *'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
-'endoffile' 'eof'       boolean (default off)
-                        local to buffer
-        Indicates that a CTRL-Z character was found at the end of the file
-        when reading it.  Normally only happens when 'fileformat' is "dos".
-        When writing a file and this option is off and the 'binary' option
-        is on, or 'fixeol' option is off, no CTRL-Z will be written at the
-        end of the file.
-        See |eol-and-eof| for example settings.
+				       *'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
+'endoffile' 'eof'	boolean (default off)
+			local to buffer
+	Indicates that a CTRL-Z character was found at the end of the file
+	when reading it.  Normally only happens when 'fileformat' is "dos".
+	When writing a file and this option is off and the 'binary' option
+	is on, or 'fixeol' option is off, no CTRL-Z will be written at the
+	end of the file.
+	See |eol-and-eof| for example settings.
 
-                                       *'endofline'* *'eol'* *'noendofline'* *'noeol'*
-'endofline' 'eol'       boolean (default on)
-                        local to buffer
-        When writing a file and this option is off and the 'binary' option
-        is on, or 'fixeol' option is off, no <EOL> will be written for the
-        last line in the file.  This option is automatically set or reset when
-        starting to edit a new file, depending on whether file has an <EOL>
-        for the last line in the file.  Normally you don't have to set or
-        reset this option.
-        When 'binary' is off and 'fixeol' is on the value is not used when
-        writing the file.  When 'binary' is on or 'fixeol' is off it is used
-        to remember the presence of a <EOL> for the last line in the file, so
-        that when you write the file the situation from the original file can
-        be kept.  But you can change it if you want to.
-        See |eol-and-eof| for example settings.
+				       *'endofline'* *'eol'* *'noendofline'* *'noeol'*
+'endofline' 'eol'	boolean (default on)
+			local to buffer
+	When writing a file and this option is off and the 'binary' option
+	is on, or 'fixeol' option is off, no <EOL> will be written for the
+	last line in the file.	This option is automatically set or reset when
+	starting to edit a new file, depending on whether file has an <EOL>
+	for the last line in the file.	Normally you don't have to set or
+	reset this option.
+	When 'binary' is off and 'fixeol' is on the value is not used when
+	writing the file.  When 'binary' is on or 'fixeol' is off it is used
+	to remember the presence of a <EOL> for the last line in the file, so
+	that when you write the file the situation from the original file can
+	be kept.  But you can change it if you want to.
+	See |eol-and-eof| for example settings.
 
-                                     *'equalalways'* *'ea'* *'noequalalways'* *'noea'*
-'equalalways' 'ea'      boolean (default on)
-                        global
-        When on, all the windows are automatically made the same size after
-        splitting or closing a window.  This also happens the moment the
-        option is switched on.  When off, splitting a window will reduce the
-        size of the current window and leave the other windows the same.  When
-        closing a window the extra lines are given to the window next to it
-        (depending on 'splitbelow' and 'splitright').
-        When mixing vertically and horizontally split windows, a minimal size
-        is computed and some windows may be larger if there is room.  The
-        'eadirection' option tells in which direction the size is affected.
-        Changing the height and width of a window can be avoided by setting
-        'winfixheight' and 'winfixwidth', respectively.
-        If a window size is specified when creating a new window sizes are
-        currently not equalized (it's complicated, but may be implemented in
-        the future).
+				     *'equalalways'* *'ea'* *'noequalalways'* *'noea'*
+'equalalways' 'ea'	boolean (default on)
+			global
+	When on, all the windows are automatically made the same size after
+	splitting or closing a window.	This also happens the moment the
+	option is switched on.	When off, splitting a window will reduce the
+	size of the current window and leave the other windows the same.  When
+	closing a window the extra lines are given to the window next to it
+	(depending on 'splitbelow' and 'splitright').
+	When mixing vertically and horizontally split windows, a minimal size
+	is computed and some windows may be larger if there is room.  The
+	'eadirection' option tells in which direction the size is affected.
+	Changing the height and width of a window can be avoided by setting
+	'winfixheight' and 'winfixwidth', respectively.
+	If a window size is specified when creating a new window sizes are
+	currently not equalized (it's complicated, but may be implemented in
+	the future).
 
-                                                               *'equalprg'* *'ep'*
-'equalprg' 'ep'         string (default "")
-                        global or local to buffer |global-local|
-        External program to use for "=" command.  When this option is empty
-        the internal formatting functions are used; either 'lisp', 'cindent'
-        or 'indentexpr'.
-        Environment variables are expanded |:set_env|.  See |option-backslash|
-        about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							       *'equalprg'* *'ep'*
+'equalprg' 'ep'		string (default "")
+			global or local to buffer |global-local|
+	External program to use for "=" command.  When this option is empty
+	the internal formatting functions are used; either 'lisp', 'cindent'
+	or 'indentexpr'.
+	Environment variables are expanded |:set_env|.	See |option-backslash|
+	about including spaces and backslashes.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                       *'errorbells'* *'eb'* *'noerrorbells'* *'noeb'*
-'errorbells' 'eb'       boolean (default off)
-                        global
-        Ring the bell (beep or screen flash) for error messages.  This only
-        makes a difference for error messages, the bell will be used always
-        for a lot of errors without a message (e.g., hitting <Esc> in Normal
-        mode).  See 'visualbell' to make the bell behave like a screen flash
-        or do nothing. See 'belloff' to finetune when to ring the bell.
+				       *'errorbells'* *'eb'* *'noerrorbells'* *'noeb'*
+'errorbells' 'eb'	boolean (default off)
+			global
+	Ring the bell (beep or screen flash) for error messages.  This only
+	makes a difference for error messages, the bell will be used always
+	for a lot of errors without a message (e.g., hitting <Esc> in Normal
+	mode).	See 'visualbell' to make the bell behave like a screen flash
+	or do nothing. See 'belloff' to finetune when to ring the bell.
 
-                                                              *'errorfile'* *'ef'*
-'errorfile' 'ef'        string (default "errors.err")
-                        global
-        Name of the errorfile for the QuickFix mode (see |:cf|).
-        When the "-q" command-line argument is used, 'errorfile' is set to the
-        following argument.  See |-q|.
-        NOT used for the ":make" command.  See 'makeef' for that.
-        Environment variables are expanded |:set_env|.
-        See |option-backslash| about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'errorfile'* *'ef'*
+'errorfile' 'ef'	string (default "errors.err")
+			global
+	Name of the errorfile for the QuickFix mode (see |:cf|).
+	When the "-q" command-line argument is used, 'errorfile' is set to the
+	following argument.  See |-q|.
+	NOT used for the ":make" command.  See 'makeef' for that.
+	Environment variables are expanded |:set_env|.
+	See |option-backslash| about including spaces and backslashes.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                           *'errorformat'* *'efm'*
-'errorformat' 'efm'     string (default is very long)
-                        global or local to buffer |global-local|
-        Scanf-like description of the format for the lines in the error file
-        (see |errorformat|).
+							   *'errorformat'* *'efm'*
+'errorformat' 'efm'	string (default is very long)
+			global or local to buffer |global-local|
+	Scanf-like description of the format for the lines in the error file
+	(see |errorformat|).
 
-                                                            *'eventignore'* *'ei'*
-'eventignore' 'ei'      string (default "")
-                        global
-        A list of autocommand event names, which are to be ignored.
-        When set to "all" or when "all" is one of the items, all autocommand
-        events are ignored, autocommands will not be executed.
-        Otherwise this is a comma-separated list of event names.  Example: >vim
-            set ei=WinEnter,WinLeave
+							    *'eventignore'* *'ei'*
+'eventignore' 'ei'	string (default "")
+			global
+	A list of autocommand event names, which are to be ignored.
+	When set to "all" or when "all" is one of the items, all autocommand
+	events are ignored, autocommands will not be executed.
+	Otherwise this is a comma-separated list of event names.  Example: >vim
+	    set ei=WinEnter,WinLeave
 <
 
-                                         *'expandtab'* *'et'* *'noexpandtab'* *'noet'*
-'expandtab' 'et'        boolean (default off)
-                        local to buffer
-        In Insert mode: Use the appropriate number of spaces to insert a
-        <Tab>.  Spaces are used in indents with the '>' and '<' commands and
-        when 'autoindent' is on.  To insert a real tab when 'expandtab' is
-        on, use CTRL-V<Tab>.  See also |:retab| and |ins-expandtab|.
+					 *'expandtab'* *'et'* *'noexpandtab'* *'noet'*
+'expandtab' 'et'	boolean (default off)
+			local to buffer
+	In Insert mode: Use the appropriate number of spaces to insert a
+	<Tab>.	Spaces are used in indents with the '>' and '<' commands and
+	when 'autoindent' is on.  To insert a real tab when 'expandtab' is
+	on, use CTRL-V<Tab>.  See also |:retab| and |ins-expandtab|.
 
-                                                   *'exrc'* *'ex'* *'noexrc'* *'noex'*
-'exrc' 'ex'             boolean (default off)
-                        global
-        Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
-        current directory, if the file is in the |trust| list. Use |:trust| to
-        manage trusted files. See also |vim.secure.read()|.
+						   *'exrc'* *'ex'* *'noexrc'* *'noex'*
+'exrc' 'ex'		boolean (default off)
+			global
+	Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
+	current directory, if the file is in the |trust| list. Use |:trust| to
+	manage trusted files. See also |vim.secure.read()|.
 
-        Compare 'exrc' to |editorconfig|:
-        - 'exrc' can execute any code; editorconfig only specifies settings.
-        - 'exrc' is Nvim-specific; editorconfig works in other editors.
+	Compare 'exrc' to |editorconfig|:
+	- 'exrc' can execute any code; editorconfig only specifies settings.
+	- 'exrc' is Nvim-specific; editorconfig works in other editors.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                    *'fileencoding'* *'fenc'* *E213*
-'fileencoding' 'fenc'   string (default "")
-                        local to buffer
-        File-content encoding for the current buffer. Conversion is done with
-        iconv() or as specified with 'charconvert'.
+						    *'fileencoding'* *'fenc'* *E213*
+'fileencoding' 'fenc'	string (default "")
+			local to buffer
+	File-content encoding for the current buffer. Conversion is done with
+	iconv() or as specified with 'charconvert'.
 
-        When 'fileencoding' is not UTF-8, conversion will be done when
-        writing the file.  For reading see below.
-        When 'fileencoding' is empty, the file will be saved with UTF-8
-        encoding (no conversion when reading or writing a file).
+	When 'fileencoding' is not UTF-8, conversion will be done when
+	writing the file.  For reading see below.
+	When 'fileencoding' is empty, the file will be saved with UTF-8
+	encoding (no conversion when reading or writing a file).
 
-        WARNING: Conversion to a non-Unicode encoding can cause loss of
-        information!
+	WARNING: Conversion to a non-Unicode encoding can cause loss of
+	information!
 
-        See |encoding-names| for the possible values.  Additionally, values may be
-        specified that can be handled by the converter, see
-        |mbyte-conversion|.
+	See |encoding-names| for the possible values.  Additionally, values may be
+	specified that can be handled by the converter, see
+	|mbyte-conversion|.
 
-        When reading a file 'fileencoding' will be set from 'fileencodings'.
-        To read a file in a certain encoding it won't work by setting
-        'fileencoding', use the |++enc| argument.  One exception: when
-        'fileencodings' is empty the value of 'fileencoding' is used.
-        For a new file the global value of 'fileencoding' is used.
+	When reading a file 'fileencoding' will be set from 'fileencodings'.
+	To read a file in a certain encoding it won't work by setting
+	'fileencoding', use the |++enc| argument.  One exception: when
+	'fileencodings' is empty the value of 'fileencoding' is used.
+	For a new file the global value of 'fileencoding' is used.
 
-        Prepending "8bit-" and "2byte-" has no meaning here, they are ignored.
-        When the option is set, the value is converted to lowercase.  Thus
-        you can set it with uppercase values too.  '_' characters are
-        replaced with '-'.  If a name is recognized from the list at
-        |encoding-names|, it is replaced by the standard name.  For example
-        "ISO8859-2" becomes "iso-8859-2".
+	Prepending "8bit-" and "2byte-" has no meaning here, they are ignored.
+	When the option is set, the value is converted to lowercase.  Thus
+	you can set it with uppercase values too.  '_' characters are
+	replaced with '-'.  If a name is recognized from the list at
+	|encoding-names|, it is replaced by the standard name.	For example
+	"ISO8859-2" becomes "iso-8859-2".
 
-        When this option is set, after starting to edit a file, the 'modified'
-        option is set, because the file would be different when written.
+	When this option is set, after starting to edit a file, the 'modified'
+	option is set, because the file would be different when written.
 
-        Keep in mind that changing 'fenc' from a modeline happens
-        AFTER the text has been read, thus it applies to when the file will be
-        written.  If you do set 'fenc' in a modeline, you might want to set
-        'nomodified' to avoid not being able to ":q".
+	Keep in mind that changing 'fenc' from a modeline happens
+	AFTER the text has been read, thus it applies to when the file will be
+	written.  If you do set 'fenc' in a modeline, you might want to set
+	'nomodified' to avoid not being able to ":q".
 
-        This option cannot be changed when 'modifiable' is off.
+	This option cannot be changed when 'modifiable' is off.
 
-                                                       *'fileencodings'* *'fencs'*
+						       *'fileencodings'* *'fencs'*
 'fileencodings' 'fencs' string (default "ucs-bom,utf-8,default,latin1")
-                        global
-        This is a list of character encodings considered when starting to edit
-        an existing file.  When a file is read, Vim tries to use the first
-        mentioned character encoding.  If an error is detected, the next one
-        in the list is tried.  When an encoding is found that works,
-        'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
-        an empty string, which means that UTF-8 is used.
-                WARNING: Conversion can cause loss of information! You can use
-                the |++bad| argument to specify what is done with characters
-                that can't be converted.
-        For an empty file or a file with only ASCII characters most encodings
-        will work and the first entry of 'fileencodings' will be used (except
-        "ucs-bom", which requires the BOM to be present).  If you prefer
-        another encoding use an BufReadPost autocommand event to test if your
-        preferred encoding is to be used.  Example: >vim
-                au BufReadPost * if search('\S', 'w') == 0 |
-                        \ set fenc=iso-2022-jp | endif
-<       This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
-        non-blank characters.
-        When the |++enc| argument is used then the value of 'fileencodings' is
-        not used.
-        Note that 'fileencodings' is not used for a new file, the global value
-        of 'fileencoding' is used instead.  You can set it with: >vim
-                setglobal fenc=iso-8859-2
-<       This means that a non-existing file may get a different encoding than
-        an empty file.
-        The special value "ucs-bom" can be used to check for a Unicode BOM
-        (Byte Order Mark) at the start of the file.  It must not be preceded
-        by "utf-8" or another Unicode encoding for this to work properly.
-        An entry for an 8-bit encoding (e.g., "latin1") should be the last,
-        because Vim cannot detect an error, thus the encoding is always
-        accepted.
-        The special value "default" can be used for the encoding from the
-        environment.  It is useful when your environment uses a non-latin1
-        encoding, such as Russian.
-        When a file contains an illegal UTF-8 byte sequence it won't be
-        recognized as "utf-8".  You can use the |8g8| command to find the
-        illegal byte sequence.
-        WRONG VALUES:                   WHAT'S WRONG:
-                latin1,utf-8            "latin1" will always be used
-                utf-8,ucs-bom,latin1    BOM won't be recognized in an utf-8
-                                        file
-                cp1250,latin1           "cp1250" will always be used
-        If 'fileencodings' is empty, 'fileencoding' is not modified.
-        See 'fileencoding' for the possible values.
-        Setting this option does not have an effect until the next time a file
-        is read.
+			global
+	This is a list of character encodings considered when starting to edit
+	an existing file.  When a file is read, Vim tries to use the first
+	mentioned character encoding.  If an error is detected, the next one
+	in the list is tried.  When an encoding is found that works,
+	'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
+	an empty string, which means that UTF-8 is used.
+		WARNING: Conversion can cause loss of information! You can use
+		the |++bad| argument to specify what is done with characters
+		that can't be converted.
+	For an empty file or a file with only ASCII characters most encodings
+	will work and the first entry of 'fileencodings' will be used (except
+	"ucs-bom", which requires the BOM to be present).  If you prefer
+	another encoding use an BufReadPost autocommand event to test if your
+	preferred encoding is to be used.  Example: >vim
+		au BufReadPost * if search('\S', 'w') == 0 |
+			\ set fenc=iso-2022-jp | endif
+<	This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
+	non-blank characters.
+	When the |++enc| argument is used then the value of 'fileencodings' is
+	not used.
+	Note that 'fileencodings' is not used for a new file, the global value
+	of 'fileencoding' is used instead.  You can set it with: >vim
+		setglobal fenc=iso-8859-2
+<	This means that a non-existing file may get a different encoding than
+	an empty file.
+	The special value "ucs-bom" can be used to check for a Unicode BOM
+	(Byte Order Mark) at the start of the file.  It must not be preceded
+	by "utf-8" or another Unicode encoding for this to work properly.
+	An entry for an 8-bit encoding (e.g., "latin1") should be the last,
+	because Vim cannot detect an error, thus the encoding is always
+	accepted.
+	The special value "default" can be used for the encoding from the
+	environment.  It is useful when your environment uses a non-latin1
+	encoding, such as Russian.
+	When a file contains an illegal UTF-8 byte sequence it won't be
+	recognized as "utf-8".	You can use the |8g8| command to find the
+	illegal byte sequence.
+	WRONG VALUES:			WHAT'S WRONG:
+		latin1,utf-8		"latin1" will always be used
+		utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
+					file
+		cp1250,latin1		"cp1250" will always be used
+	If 'fileencodings' is empty, 'fileencoding' is not modified.
+	See 'fileencoding' for the possible values.
+	Setting this option does not have an effect until the next time a file
+	is read.
 
-                                                             *'fileformat'* *'ff'*
-'fileformat' 'ff'       string (default Windows: "dos", Unix: "unix")
-                        local to buffer
-        This gives the <EOL> of the current buffer, which is used for
-        reading/writing the buffer from/to a file:
-            dos     <CR><NL>
-            unix    <NL>
-            mac     <CR>
-        When "dos" is used, CTRL-Z at the end of a file is ignored.
-        See |file-formats| and |file-read|.
-        For the character encoding of the file see 'fileencoding'.
-        When 'binary' is set, the value of 'fileformat' is ignored, file I/O
-        works like it was set to "unix".
-        This option is set automatically when starting to edit a file and
-        'fileformats' is not empty and 'binary' is off.
-        When this option is set, after starting to edit a file, the 'modified'
-        option is set, because the file would be different when written.
-        This option cannot be changed when 'modifiable' is off.
+							     *'fileformat'* *'ff'*
+'fileformat' 'ff'	string (default Windows: "dos", Unix: "unix")
+			local to buffer
+	This gives the <EOL> of the current buffer, which is used for
+	reading/writing the buffer from/to a file:
+	    dos     <CR><NL>
+	    unix    <NL>
+	    mac     <CR>
+	When "dos" is used, CTRL-Z at the end of a file is ignored.
+	See |file-formats| and |file-read|.
+	For the character encoding of the file see 'fileencoding'.
+	When 'binary' is set, the value of 'fileformat' is ignored, file I/O
+	works like it was set to "unix".
+	This option is set automatically when starting to edit a file and
+	'fileformats' is not empty and 'binary' is off.
+	When this option is set, after starting to edit a file, the 'modified'
+	option is set, because the file would be different when written.
+	This option cannot be changed when 'modifiable' is off.
 
-                                                           *'fileformats'* *'ffs'*
-'fileformats' 'ffs'     string (default Windows: "dos,unix", Unix: "unix,dos")
-                        global
-        This gives the end-of-line (<EOL>) formats that will be tried when
-        starting to edit a new buffer and when reading a file into an existing
-        buffer:
-        - When empty, the format defined with 'fileformat' will be used
-          always.  It is not set automatically.
-        - When set to one name, that format will be used whenever a new buffer
-          is opened.  'fileformat' is set accordingly for that buffer.  The
-          'fileformats' name will be used when a file is read into an existing
-          buffer, no matter what 'fileformat' for that buffer is set to.
-        - When more than one name is present, separated by commas, automatic
-          <EOL> detection will be done when reading a file.  When starting to
-          edit a file, a check is done for the <EOL>:
-          1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
-             'fileformat' is set to "dos".
-          2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
-             is set to "unix".  Note that when a <NL> is found without a
-             preceding <CR>, "unix" is preferred over "dos".
-          3. If 'fileformat' has not yet been set, and if a <CR> is found, and
-             if 'fileformats' includes "mac", 'fileformat' is set to "mac".
-             This means that "mac" is only chosen when:
-              "unix" is not present or no <NL> is found in the file, and
-              "dos" is not present or no <CR><NL> is found in the file.
-             Except: if "unix" was chosen, but there is a <CR> before
-             the first <NL>, and there appear to be more <CR>s than <NL>s in
-             the first few lines, "mac" is used.
-          4. If 'fileformat' is still not set, the first name from
-             'fileformats' is used.
-          When reading a file into an existing buffer, the same is done, but
-          this happens like 'fileformat' has been set appropriately for that
-          file only, the option is not changed.
-        When 'binary' is set, the value of 'fileformats' is not used.
+							   *'fileformats'* *'ffs'*
+'fileformats' 'ffs'	string (default Windows: "dos,unix", Unix: "unix,dos")
+			global
+	This gives the end-of-line (<EOL>) formats that will be tried when
+	starting to edit a new buffer and when reading a file into an existing
+	buffer:
+	- When empty, the format defined with 'fileformat' will be used
+	  always.  It is not set automatically.
+	- When set to one name, that format will be used whenever a new buffer
+	  is opened.  'fileformat' is set accordingly for that buffer.	The
+	  'fileformats' name will be used when a file is read into an existing
+	  buffer, no matter what 'fileformat' for that buffer is set to.
+	- When more than one name is present, separated by commas, automatic
+	  <EOL> detection will be done when reading a file.  When starting to
+	  edit a file, a check is done for the <EOL>:
+	  1. If all lines end in <CR><NL>, and 'fileformats' includes "dos",
+	     'fileformat' is set to "dos".
+	  2. If a <NL> is found and 'fileformats' includes "unix", 'fileformat'
+	     is set to "unix".	Note that when a <NL> is found without a
+	     preceding <CR>, "unix" is preferred over "dos".
+	  3. If 'fileformat' has not yet been set, and if a <CR> is found, and
+	     if 'fileformats' includes "mac", 'fileformat' is set to "mac".
+	     This means that "mac" is only chosen when:
+	      "unix" is not present or no <NL> is found in the file, and
+	      "dos" is not present or no <CR><NL> is found in the file.
+	     Except: if "unix" was chosen, but there is a <CR> before
+	     the first <NL>, and there appear to be more <CR>s than <NL>s in
+	     the first few lines, "mac" is used.
+	  4. If 'fileformat' is still not set, the first name from
+	     'fileformats' is used.
+	  When reading a file into an existing buffer, the same is done, but
+	  this happens like 'fileformat' has been set appropriately for that
+	  file only, the option is not changed.
+	When 'binary' is set, the value of 'fileformats' is not used.
 
-        When Vim starts up with an empty buffer the first item is used.  You
-        can overrule this by setting 'fileformat' in your .vimrc.
+	When Vim starts up with an empty buffer the first item is used.  You
+	can overrule this by setting 'fileformat' in your .vimrc.
 
-        For systems with a Dos-like <EOL> (<CR><NL>), when reading files that
-        are ":source"ed and for vimrc files, automatic <EOL> detection may be
-        done:
-        - When 'fileformats' is empty, there is no automatic detection.  Dos
-          format will be used.
-        - When 'fileformats' is set to one or more names, automatic detection
-          is done.  This is based on the first <NL> in the file: If there is a
-          <CR> in front of it, Dos format is used, otherwise Unix format is
-          used.
-        Also see |file-formats|.
+	For systems with a Dos-like <EOL> (<CR><NL>), when reading files that
+	are ":source"ed and for vimrc files, automatic <EOL> detection may be
+	done:
+	- When 'fileformats' is empty, there is no automatic detection.  Dos
+	  format will be used.
+	- When 'fileformats' is set to one or more names, automatic detection
+	  is done.  This is based on the first <NL> in the file: If there is a
+	  <CR> in front of it, Dos format is used, otherwise Unix format is
+	  used.
+	Also see |file-formats|.
 
-                             *'fileignorecase'* *'fic'* *'nofileignorecase'* *'nofic'*
-'fileignorecase' 'fic'  boolean (default on for systems where case in file
-                                         names is normally ignored)
-                        global
-        When set case is ignored when using file names and directories.
-        See 'wildignorecase' for only ignoring case when doing completion.
+			     *'fileignorecase'* *'fic'* *'nofileignorecase'* *'nofic'*
+'fileignorecase' 'fic'	boolean (default on for systems where case in file
+					 names is normally ignored)
+			global
+	When set case is ignored when using file names and directories.
+	See 'wildignorecase' for only ignoring case when doing completion.
 
-                                                               *'filetype'* *'ft'*
-'filetype' 'ft'         string (default "")
-                        local to buffer  |local-noglobal|
-        When this option is set, the FileType autocommand event is triggered.
-        All autocommands that match with the value of this option will be
-        executed.  Thus the value of 'filetype' is used in place of the file
-        name.
-        Otherwise this option does not always reflect the current file type.
-        This option is normally set when the file type is detected.  To enable
-        this use the ":filetype on" command. |:filetype|
-        Setting this option to a different value is most useful in a modeline,
-        for a file for which the file type is not automatically recognized.
-        Example, for in an IDL file: >c
-                /* vim: set filetype=idl : */
-<       |FileType| |filetypes|
-        When a dot appears in the value then this separates two filetype
-        names.  Example: >c
-                /* vim: set filetype=c.doxygen : */
-<       This will use the "c" filetype first, then the "doxygen" filetype.
-        This works both for filetype plugins and for syntax files.  More than
-        one dot may appear.
-        This option is not copied to another buffer, independent of the 's' or
-        'S' flag in 'cpoptions'.
-        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+							       *'filetype'* *'ft'*
+'filetype' 'ft'		string (default "")
+			local to buffer  |local-noglobal|
+	When this option is set, the FileType autocommand event is triggered.
+	All autocommands that match with the value of this option will be
+	executed.  Thus the value of 'filetype' is used in place of the file
+	name.
+	Otherwise this option does not always reflect the current file type.
+	This option is normally set when the file type is detected.  To enable
+	this use the ":filetype on" command. |:filetype|
+	Setting this option to a different value is most useful in a modeline,
+	for a file for which the file type is not automatically recognized.
+	Example, for in an IDL file: >c
+		/* vim: set filetype=idl : */
+<	|FileType| |filetypes|
+	When a dot appears in the value then this separates two filetype
+	names.	Example: >c
+		/* vim: set filetype=c.doxygen : */
+<	This will use the "c" filetype first, then the "doxygen" filetype.
+	This works both for filetype plugins and for syntax files.  More than
+	one dot may appear.
+	This option is not copied to another buffer, independent of the 's' or
+	'S' flag in 'cpoptions'.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
-                                                             *'fillchars'* *'fcs'*
-'fillchars' 'fcs'       string (default "")
-                        global or local to window |global-local|
-        Characters to fill the statuslines, vertical separators and special
-        lines in the window.
-        It is a comma-separated list of items.  Each item has a name, a colon
-        and the value of that item:
+							     *'fillchars'* *'fcs'*
+'fillchars' 'fcs'	string (default "")
+			global or local to window |global-local|
+	Characters to fill the statuslines, vertical separators and special
+	lines in the window.
+	It is a comma-separated list of items.	Each item has a name, a colon
+	and the value of that item:
 
-          item          default         Used for ~
-          stl           ' '             statusline of the current window
-          stlnc         ' '             statusline of the non-current windows
-          wbr           ' '             window bar
-          horiz         '─' or '-'      horizontal separators |:split|
-          horizup       '┴' or '-'      upwards facing horizontal separator
-          horizdown     '┬' or '-'      downwards facing horizontal separator
-          vert          '│' or '|'      vertical separators |:vsplit|
-          vertleft      '┤' or '|'      left facing vertical separator
-          vertright     '├' or '|'      right facing vertical separator
-          verthoriz     '┼' or '+'      overlapping vertical and horizontal
-                                        separator
-          fold          '·' or '-'      filling 'foldtext'
-          foldopen      '-'             mark the beginning of a fold
-          foldclose     '+'             show a closed fold
-          foldsep       '│' or '|'      open fold middle marker
-          diff          '-'             deleted lines of the 'diff' option
-          msgsep        ' '             message separator 'display'
-          eob           '~'             empty lines at the end of a buffer
-          lastline      '@'             'display' contains lastline/truncate
+	  item		default		Used for ~
+	  stl		' '		statusline of the current window
+	  stlnc		' '		statusline of the non-current windows
+	  wbr		' '		window bar
+	  horiz		'─' or '-'	horizontal separators |:split|
+	  horizup	'┴' or '-'	upwards facing horizontal separator
+	  horizdown	'┬' or '-'	downwards facing horizontal separator
+	  vert		'│' or '|'	vertical separators |:vsplit|
+	  vertleft	'┤' or '|'	left facing vertical separator
+	  vertright	'├' or '|'	right facing vertical separator
+	  verthoriz	'┼' or '+'	overlapping vertical and horizontal
+					separator
+	  fold		'·' or '-'	filling 'foldtext'
+	  foldopen	'-'		mark the beginning of a fold
+	  foldclose	'+'		show a closed fold
+	  foldsep	'│' or '|'	open fold middle marker
+	  diff		'-'		deleted lines of the 'diff' option
+	  msgsep	' '		message separator 'display'
+	  eob		'~'		empty lines at the end of a buffer
+	  lastline	'@'		'display' contains lastline/truncate
 
-        Any one that is omitted will fall back to the default.
+	Any one that is omitted will fall back to the default.
 
-        Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
-        "verthoriz" are only used when 'laststatus' is 3, since only vertical
-        window separators are used otherwise.
+	Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
+	"verthoriz" are only used when 'laststatus' is 3, since only vertical
+	window separators are used otherwise.
 
-        If 'ambiwidth' is "double" then "horiz", "horizup", "horizdown",
-        "vert", "vertleft", "vertright", "verthoriz", "foldsep" and "fold"
-        default to single-byte alternatives.
+	If 'ambiwidth' is "double" then "horiz", "horizup", "horizdown",
+	"vert", "vertleft", "vertright", "verthoriz", "foldsep" and "fold"
+	default to single-byte alternatives.
 
-        Example: >vim
-            set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
+	Example: >vim
+	    set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
 <
-        For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
-        single-byte and multibyte characters are supported.  But double-width
-        characters are not supported.
+	For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
+	single-byte and multibyte characters are supported.  But double-width
+	characters are not supported.
 
-        The highlighting used for these items:
-          item          highlight group ~
-          stl           StatusLine              |hl-StatusLine|
-          stlnc         StatusLineNC            |hl-StatusLineNC|
-          wbr           WinBar                  |hl-WinBar| or |hl-WinBarNC|
-          horiz         WinSeparator            |hl-WinSeparator|
-          horizup       WinSeparator            |hl-WinSeparator|
-          horizdown     WinSeparator            |hl-WinSeparator|
-          vert          WinSeparator            |hl-WinSeparator|
-          vertleft      WinSeparator            |hl-WinSeparator|
-          vertright     WinSeparator            |hl-WinSeparator|
-          verthoriz     WinSeparator            |hl-WinSeparator|
-          fold          Folded                  |hl-Folded|
-          diff          DiffDelete              |hl-DiffDelete|
-          eob           EndOfBuffer             |hl-EndOfBuffer|
-          lastline      NonText                 |hl-NonText|
+	The highlighting used for these items:
+	  item		highlight group ~
+	  stl		StatusLine		|hl-StatusLine|
+	  stlnc		StatusLineNC		|hl-StatusLineNC|
+	  wbr		WinBar			|hl-WinBar| or |hl-WinBarNC|
+	  horiz		WinSeparator		|hl-WinSeparator|
+	  horizup	WinSeparator		|hl-WinSeparator|
+	  horizdown	WinSeparator		|hl-WinSeparator|
+	  vert		WinSeparator		|hl-WinSeparator|
+	  vertleft	WinSeparator		|hl-WinSeparator|
+	  vertright	WinSeparator		|hl-WinSeparator|
+	  verthoriz	WinSeparator		|hl-WinSeparator|
+	  fold		Folded			|hl-Folded|
+	  diff		DiffDelete		|hl-DiffDelete|
+	  eob		EndOfBuffer		|hl-EndOfBuffer|
+	  lastline	NonText			|hl-NonText|
 
-                           *'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
+			   *'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol' boolean (default on)
-                        local to buffer
-        When writing a file and this option is on, <EOL> at the end of file
-        will be restored if missing.  Turn this option off if you want to
-        preserve the situation from the original file.
-        When the 'binary' option is set the value of this option doesn't
-        matter.
-        See the 'endofline' option.
-        See |eol-and-eof| for example settings.
+			local to buffer
+	When writing a file and this option is on, <EOL> at the end of file
+	will be restored if missing.  Turn this option off if you want to
+	preserve the situation from the original file.
+	When the 'binary' option is set the value of this option doesn't
+	matter.
+	See the 'endofline' option.
+	See |eol-and-eof| for example settings.
 
-                                                             *'foldclose'* *'fcl'*
-'foldclose' 'fcl'       string (default "")
-                        global
-        When set to "all", a fold is closed when the cursor isn't in it and
-        its level is higher than 'foldlevel'.  Useful if you want folds to
-        automatically close when moving out of them.
+							     *'foldclose'* *'fcl'*
+'foldclose' 'fcl'	string (default "")
+			global
+	When set to "all", a fold is closed when the cursor isn't in it and
+	its level is higher than 'foldlevel'.  Useful if you want folds to
+	automatically close when moving out of them.
 
-                                                            *'foldcolumn'* *'fdc'*
-'foldcolumn' 'fdc'      string (default "0")
-                        local to window
-        When and how to draw the foldcolumn. Valid values are:
-            "auto":       resize to the minimum amount of folds to display.
-            "auto:[1-9]": resize to accommodate multiple folds up to the
-                          selected level
-            "0":          to disable foldcolumn
-            "[1-9]":      to display a fixed number of columns
-        See |folding|.
+							    *'foldcolumn'* *'fdc'*
+'foldcolumn' 'fdc'	string (default "0")
+			local to window
+	When and how to draw the foldcolumn. Valid values are:
+	    "auto":	  resize to the minimum amount of folds to display.
+	    "auto:[1-9]": resize to accommodate multiple folds up to the
+			  selected level
+	    "0":	  to disable foldcolumn
+	    "[1-9]":	  to display a fixed number of columns
+	See |folding|.
 
-                                     *'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*
-'foldenable' 'fen'      boolean (default on)
-                        local to window
-        When off, all folds are open.  This option can be used to quickly
-        switch between showing all text unfolded and viewing the text with
-        folds (including manually opened or closed folds).  It can be toggled
-        with the |zi| command.  The 'foldcolumn' will remain blank when
-        'foldenable' is off.
-        This option is set by commands that create a new fold or close a fold.
-        See |folding|.
+				     *'foldenable'* *'fen'* *'nofoldenable'* *'nofen'*
+'foldenable' 'fen'	boolean (default on)
+			local to window
+	When off, all folds are open.  This option can be used to quickly
+	switch between showing all text unfolded and viewing the text with
+	folds (including manually opened or closed folds).  It can be toggled
+	with the |zi| command.	The 'foldcolumn' will remain blank when
+	'foldenable' is off.
+	This option is set by commands that create a new fold or close a fold.
+	See |folding|.
 
-                                                              *'foldexpr'* *'fde'*
-'foldexpr' 'fde'        string (default "0")
-                        local to window
-        The expression used for when 'foldmethod' is "expr".  It is evaluated
-        for each line to obtain its fold level.  The context is set to the
-        script where 'foldexpr' was set, script-local items can be accessed.
-        See |fold-expr| for the usage.
+							      *'foldexpr'* *'fde'*
+'foldexpr' 'fde'	string (default "0")
+			local to window
+	The expression used for when 'foldmethod' is "expr".  It is evaluated
+	for each line to obtain its fold level.  The context is set to the
+	script where 'foldexpr' was set, script-local items can be accessed.
+	See |fold-expr| for the usage.
 
-        The expression will be evaluated in the |sandbox| if set from a
-        modeline, see |sandbox-option|.
-        This option can't be set from a |modeline| when the 'diff' option is
-        on or the 'modelineexpr' option is off.
+	The expression will be evaluated in the |sandbox| if set from a
+	modeline, see |sandbox-option|.
+	This option can't be set from a |modeline| when the 'diff' option is
+	on or the 'modelineexpr' option is off.
 
-        It is not allowed to change text or jump to another window while
-        evaluating 'foldexpr' |textlock|.
+	It is not allowed to change text or jump to another window while
+	evaluating 'foldexpr' |textlock|.
 
-                                                            *'foldignore'* *'fdi'*
-'foldignore' 'fdi'      string (default "#")
-                        local to window
-        Used only when 'foldmethod' is "indent".  Lines starting with
-        characters in 'foldignore' will get their fold level from surrounding
-        lines.  White space is skipped before checking for this character.
-        The default "#" works well for C programs.  See |fold-indent|.
+							    *'foldignore'* *'fdi'*
+'foldignore' 'fdi'	string (default "#")
+			local to window
+	Used only when 'foldmethod' is "indent".  Lines starting with
+	characters in 'foldignore' will get their fold level from surrounding
+	lines.	White space is skipped before checking for this character.
+	The default "#" works well for C programs.  See |fold-indent|.
 
-                                                             *'foldlevel'* *'fdl'*
-'foldlevel' 'fdl'       number (default 0)
-                        local to window
-        Sets the fold level: Folds with a higher level will be closed.
-        Setting this option to zero will close all folds.  Higher numbers will
-        close fewer folds.
-        This option is set by commands like |zm|, |zM| and |zR|.
-        See |fold-foldlevel|.
+							     *'foldlevel'* *'fdl'*
+'foldlevel' 'fdl'	number (default 0)
+			local to window
+	Sets the fold level: Folds with a higher level will be closed.
+	Setting this option to zero will close all folds.  Higher numbers will
+	close fewer folds.
+	This option is set by commands like |zm|, |zM| and |zR|.
+	See |fold-foldlevel|.
 
-                                                       *'foldlevelstart'* *'fdls'*
+						       *'foldlevelstart'* *'fdls'*
 'foldlevelstart' 'fdls' number (default -1)
-                        global
-        Sets 'foldlevel' when starting to edit another buffer in a window.
-        Useful to always start editing with all folds closed (value zero),
-        some folds closed (one) or no folds closed (99).
-        This is done before reading any modeline, thus a setting in a modeline
-        overrules this option.  Starting to edit a file for |diff-mode| also
-        ignores this option and closes all folds.
-        It is also done before BufReadPre autocommands, to allow an autocmd to
-        overrule the 'foldlevel' value for specific files.
-        When the value is negative, it is not used.
+			global
+	Sets 'foldlevel' when starting to edit another buffer in a window.
+	Useful to always start editing with all folds closed (value zero),
+	some folds closed (one) or no folds closed (99).
+	This is done before reading any modeline, thus a setting in a modeline
+	overrules this option.	Starting to edit a file for |diff-mode| also
+	ignores this option and closes all folds.
+	It is also done before BufReadPre autocommands, to allow an autocmd to
+	overrule the 'foldlevel' value for specific files.
+	When the value is negative, it is not used.
 
-                                                       *'foldmarker'* *'fmr'* *E536*
-'foldmarker' 'fmr'      string (default "{{{,}}}")
-                        local to window
-        The start and end marker used when 'foldmethod' is "marker".  There
-        must be one comma, which separates the start and end marker.  The
-        marker is a literal string (a regular expression would be too slow).
-        See |fold-marker|.
+						       *'foldmarker'* *'fmr'* *E536*
+'foldmarker' 'fmr'	string (default "{{{,}}}")
+			local to window
+	The start and end marker used when 'foldmethod' is "marker".  There
+	must be one comma, which separates the start and end marker.  The
+	marker is a literal string (a regular expression would be too slow).
+	See |fold-marker|.
 
-                                                            *'foldmethod'* *'fdm'*
-'foldmethod' 'fdm'      string (default "manual")
-                        local to window
-        The kind of folding used for the current window.  Possible values:
-        |fold-manual|   manual      Folds are created manually.
-        |fold-indent|   indent      Lines with equal indent form a fold.
-        |fold-expr|     expr        'foldexpr' gives the fold level of a line.
-        |fold-marker|   marker      Markers are used to specify folds.
-        |fold-syntax|   syntax      Syntax highlighting items specify folds.
-        |fold-diff|     diff        Fold text that is not changed.
+							    *'foldmethod'* *'fdm'*
+'foldmethod' 'fdm'	string (default "manual")
+			local to window
+	The kind of folding used for the current window.  Possible values:
+	|fold-manual|	manual	    Folds are created manually.
+	|fold-indent|	indent	    Lines with equal indent form a fold.
+	|fold-expr|	expr	    'foldexpr' gives the fold level of a line.
+	|fold-marker|	marker	    Markers are used to specify folds.
+	|fold-syntax|	syntax	    Syntax highlighting items specify folds.
+	|fold-diff|	diff	    Fold text that is not changed.
 
-                                                          *'foldminlines'* *'fml'*
-'foldminlines' 'fml'    number (default 1)
-                        local to window
-        Sets the number of screen lines above which a fold can be displayed
-        closed.  Also for manually closed folds.  With the default value of
-        one a fold can only be closed if it takes up two or more screen lines.
-        Set to zero to be able to close folds of just one screen line.
-        Note that this only has an effect on what is displayed.  After using
-        "zc" to close a fold, which is displayed open because it's smaller
-        than 'foldminlines', a following "zc" may close a containing fold.
+							  *'foldminlines'* *'fml'*
+'foldminlines' 'fml'	number (default 1)
+			local to window
+	Sets the number of screen lines above which a fold can be displayed
+	closed.  Also for manually closed folds.  With the default value of
+	one a fold can only be closed if it takes up two or more screen lines.
+	Set to zero to be able to close folds of just one screen line.
+	Note that this only has an effect on what is displayed.  After using
+	"zc" to close a fold, which is displayed open because it's smaller
+	than 'foldminlines', a following "zc" may close a containing fold.
 
-                                                           *'foldnestmax'* *'fdn'*
-'foldnestmax' 'fdn'     number (default 20)
-                        local to window
-        Sets the maximum nesting of folds for the "indent" and "syntax"
-        methods.  This avoids that too many folds will be created.  Using more
-        than 20 doesn't work, because the internal limit is 20.
+							   *'foldnestmax'* *'fdn'*
+'foldnestmax' 'fdn'	number (default 20)
+			local to window
+	Sets the maximum nesting of folds for the "indent" and "syntax"
+	methods.  This avoids that too many folds will be created.  Using more
+	than 20 doesn't work, because the internal limit is 20.
 
-                                                              *'foldopen'* *'fdo'*
-'foldopen' 'fdo'        string (default "block,hor,mark,percent,quickfix,search,tag,undo")
-                        global
-        Specifies for which type of commands folds will be opened, if the
-        command moves the cursor into a closed fold.  It is a comma-separated
-        list of items.
-        NOTE: When the command is part of a mapping this option is not used.
-        Add the |zv| command to the mapping to get the same effect.
-        (rationale: the mapping may want to control opening folds itself)
+							      *'foldopen'* *'fdo'*
+'foldopen' 'fdo'	string (default "block,hor,mark,percent,quickfix,search,tag,undo")
+			global
+	Specifies for which type of commands folds will be opened, if the
+	command moves the cursor into a closed fold.  It is a comma-separated
+	list of items.
+	NOTE: When the command is part of a mapping this option is not used.
+	Add the |zv| command to the mapping to get the same effect.
+	(rationale: the mapping may want to control opening folds itself)
 
-                item            commands ~
-                all             any
-                block           (, {, [[, [{, etc.
-                hor             horizontal movements: "l", "w", "fx", etc.
-                insert          any command in Insert mode
-                jump            far jumps: "G", "gg", etc.
-                mark            jumping to a mark: "'m", CTRL-O, etc.
-                percent         "%"
-                quickfix        ":cn", ":crew", ":make", etc.
-                search          search for a pattern: "/", "n", "*", "gd", etc.
-                                (not for a search pattern in a ":" command)
-                                Also for |[s| and |]s|.
-                tag             jumping to a tag: ":ta", CTRL-T, etc.
-                undo            undo or redo: "u" and CTRL-R
-        When a movement command is used for an operator (e.g., "dl" or "y%")
-        this option is not used.  This means the operator will include the
-        whole closed fold.
-        Note that vertical movements are not here, because it would make it
-        very difficult to move onto a closed fold.
-        In insert mode the folds containing the cursor will always be open
-        when text is inserted.
-        To close folds you can re-apply 'foldlevel' with the |zx| command or
-        set the 'foldclose' option to "all".
+		item		commands ~
+		all		any
+		block		(, {, [[, [{, etc.
+		hor		horizontal movements: "l", "w", "fx", etc.
+		insert		any command in Insert mode
+		jump		far jumps: "G", "gg", etc.
+		mark		jumping to a mark: "'m", CTRL-O, etc.
+		percent		"%"
+		quickfix	":cn", ":crew", ":make", etc.
+		search		search for a pattern: "/", "n", "*", "gd", etc.
+				(not for a search pattern in a ":" command)
+				Also for |[s| and |]s|.
+		tag		jumping to a tag: ":ta", CTRL-T, etc.
+		undo		undo or redo: "u" and CTRL-R
+	When a movement command is used for an operator (e.g., "dl" or "y%")
+	this option is not used.  This means the operator will include the
+	whole closed fold.
+	Note that vertical movements are not here, because it would make it
+	very difficult to move onto a closed fold.
+	In insert mode the folds containing the cursor will always be open
+	when text is inserted.
+	To close folds you can re-apply 'foldlevel' with the |zx| command or
+	set the 'foldclose' option to "all".
 
-                                                              *'foldtext'* *'fdt'*
-'foldtext' 'fdt'        string (default "foldtext()")
-                        local to window
-        An expression which is used to specify the text displayed for a closed
-        fold.  The context is set to the script where 'foldexpr' was set,
-        script-local items can be accessed.  See |fold-foldtext| for the
-        usage.
+							      *'foldtext'* *'fdt'*
+'foldtext' 'fdt'	string (default "foldtext()")
+			local to window
+	An expression which is used to specify the text displayed for a closed
+	fold.  The context is set to the script where 'foldexpr' was set,
+	script-local items can be accessed.  See |fold-foldtext| for the
+	usage.
 
-        The expression will be evaluated in the |sandbox| if set from a
-        modeline, see |sandbox-option|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	The expression will be evaluated in the |sandbox| if set from a
+	modeline, see |sandbox-option|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        It is not allowed to change text or jump to another window while
-        evaluating 'foldtext' |textlock|.
+	It is not allowed to change text or jump to another window while
+	evaluating 'foldtext' |textlock|.
 
-                                                            *'formatexpr'* *'fex'*
-'formatexpr' 'fex'      string (default "")
-                        local to buffer
-        Expression which is evaluated to format a range of lines for the |gq|
-        operator or automatic formatting (see 'formatoptions').  When this
-        option is empty 'formatprg' is used.
+							    *'formatexpr'* *'fex'*
+'formatexpr' 'fex'	string (default "")
+			local to buffer
+	Expression which is evaluated to format a range of lines for the |gq|
+	operator or automatic formatting (see 'formatoptions').  When this
+	option is empty 'formatprg' is used.
 
-        The |v:lnum|  variable holds the first line to be formatted.
-        The |v:count| variable holds the number of lines to be formatted.
-        The |v:char|  variable holds the character that is going to be
-                      inserted if the expression is being evaluated due to
-                      automatic formatting.  This can be empty.  Don't insert
-                      it yet!
+	The |v:lnum|  variable holds the first line to be formatted.
+	The |v:count| variable holds the number of lines to be formatted.
+	The |v:char|  variable holds the character that is going to be
+		      inserted if the expression is being evaluated due to
+		      automatic formatting.  This can be empty.  Don't insert
+		      it yet!
 
-        Example: >vim
-                set formatexpr=mylang#Format()
-<       This will invoke the mylang#Format() function in the
-        autoload/mylang.vim file in 'runtimepath'. |autoload|
+	Example: >vim
+		set formatexpr=mylang#Format()
+<	This will invoke the mylang#Format() function in the
+	autoload/mylang.vim file in 'runtimepath'. |autoload|
 
-        The expression is also evaluated when 'textwidth' is set and adding
-        text beyond that limit.  This happens under the same conditions as
-        when internal formatting is used.  Make sure the cursor is kept in the
-        same spot relative to the text then!  The |mode()| function will
-        return "i" or "R" in this situation.
+	The expression is also evaluated when 'textwidth' is set and adding
+	text beyond that limit.  This happens under the same conditions as
+	when internal formatting is used.  Make sure the cursor is kept in the
+	same spot relative to the text then!  The |mode()| function will
+	return "i" or "R" in this situation.
 
-        When the expression evaluates to non-zero Vim will fall back to using
-        the internal format mechanism.
+	When the expression evaluates to non-zero Vim will fall back to using
+	the internal format mechanism.
 
-        If the expression starts with s: or |<SID>|, then it is replaced with
-        the script ID (|local-function|). Example: >vim
-                set formatexpr=s:MyFormatExpr()
-                set formatexpr=<SID>SomeFormatExpr()
-<       Otherwise, the expression is evaluated in the context of the script
-        where the option was set, thus script-local items are available.
+	If the expression starts with s: or |<SID>|, then it is replaced with
+	the script ID (|local-function|). Example: >vim
+		set formatexpr=s:MyFormatExpr()
+		set formatexpr=<SID>SomeFormatExpr()
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
 
-        The expression will be evaluated in the |sandbox| when set from a
-        modeline, see |sandbox-option|.  That stops the option from working,
-        since changing the buffer text is not allowed.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
-        NOTE: This option is set to "" when 'compatible' is set.
+	The expression will be evaluated in the |sandbox| when set from a
+	modeline, see |sandbox-option|.  That stops the option from working,
+	since changing the buffer text is not allowed.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
+	NOTE: This option is set to "" when 'compatible' is set.
 
-                                                         *'formatlistpat'* *'flp'*
-'formatlistpat' 'flp'   string (default "^\s*\d\+[\]:.)}\t ]\s*")
-                        local to buffer
-        A pattern that is used to recognize a list header.  This is used for
-        the "n" flag in 'formatoptions'.
-        The pattern must match exactly the text that will be the indent for
-        the line below it.  You can use |/\ze| to mark the end of the match
-        while still checking more characters.  There must be a character
-        following the pattern, when it matches the whole line it is handled
-        like there is no match.
-        The default recognizes a number, followed by an optional punctuation
-        character and white space.
+							 *'formatlistpat'* *'flp'*
+'formatlistpat' 'flp'	string (default "^\s*\d\+[\]:.)}\t ]\s*")
+			local to buffer
+	A pattern that is used to recognize a list header.  This is used for
+	the "n" flag in 'formatoptions'.
+	The pattern must match exactly the text that will be the indent for
+	the line below it.  You can use |/\ze| to mark the end of the match
+	while still checking more characters.  There must be a character
+	following the pattern, when it matches the whole line it is handled
+	like there is no match.
+	The default recognizes a number, followed by an optional punctuation
+	character and white space.
 
-                                                          *'formatoptions'* *'fo'*
-'formatoptions' 'fo'    string (default "tcqj")
-                        local to buffer
-        This is a sequence of letters which describes how automatic
-        formatting is to be done.
-        See |fo-table| for possible values and |gq| for how to format text.
-        Commas can be inserted for readability.
-        To avoid problems with flags that are added in the future, use the
-        "+=" and "-=" feature of ":set" |add-option-flags|.
+							  *'formatoptions'* *'fo'*
+'formatoptions' 'fo'	string (default "tcqj")
+			local to buffer
+	This is a sequence of letters which describes how automatic
+	formatting is to be done.
+	See |fo-table| for possible values and |gq| for how to format text.
+	Commas can be inserted for readability.
+	To avoid problems with flags that are added in the future, use the
+	"+=" and "-=" feature of ":set" |add-option-flags|.
 
-                                                              *'formatprg'* *'fp'*
-'formatprg' 'fp'        string (default "")
-                        global or local to buffer |global-local|
-        The name of an external program that will be used to format the lines
-        selected with the |gq| operator.  The program must take the input on
-        stdin and produce the output on stdout.  The Unix program "fmt" is
-        such a program.
-        If the 'formatexpr' option is not empty it will be used instead.
-        Otherwise, if 'formatprg' option is an empty string, the internal
-        format function will be used |C-indenting|.
-        Environment variables are expanded |:set_env|.  See |option-backslash|
-        about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'formatprg'* *'fp'*
+'formatprg' 'fp'	string (default "")
+			global or local to buffer |global-local|
+	The name of an external program that will be used to format the lines
+	selected with the |gq| operator.  The program must take the input on
+	stdin and produce the output on stdout.  The Unix program "fmt" is
+	such a program.
+	If the 'formatexpr' option is not empty it will be used instead.
+	Otherwise, if 'formatprg' option is an empty string, the internal
+	format function will be used |C-indenting|.
+	Environment variables are expanded |:set_env|.	See |option-backslash|
+	about including spaces and backslashes.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                 *'fsync'* *'fs'* *'nofsync'* *'nofs'*
-'fsync' 'fs'            boolean (default on)
-                        global
-        When on, the OS function fsync() will be called after saving a file
-        (|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
-        This flushes the file to disk, ensuring that it is safely written.
-        Slow on some systems: writing buffers, quitting Nvim, and other
-        operations may sometimes take a few seconds.
+						 *'fsync'* *'fs'* *'nofsync'* *'nofs'*
+'fsync' 'fs'		boolean (default on)
+			global
+	When on, the OS function fsync() will be called after saving a file
+	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
+	This flushes the file to disk, ensuring that it is safely written.
+	Slow on some systems: writing buffers, quitting Nvim, and other
+	operations may sometimes take a few seconds.
 
-        Files are ALWAYS flushed ('fsync' is ignored) when:
-        - |CursorHold| event is triggered
-        - |:preserve| is called
-        - system signals low battery life
-        - Nvim exits abnormally
+	Files are ALWAYS flushed ('fsync' is ignored) when:
+	- |CursorHold| event is triggered
+	- |:preserve| is called
+	- system signals low battery life
+	- Nvim exits abnormally
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                           *'gdefault'* *'gd'* *'nogdefault'* *'nogd'*
-'gdefault' 'gd'         boolean (default off)
-                        global
-        When on, the ":substitute" flag 'g' is default on.  This means that
-        all matches in a line are substituted instead of one.  When a 'g' flag
-        is given to a ":substitute" command, this will toggle the substitution
-        of all or one match.  See |complex-change|.
+					   *'gdefault'* *'gd'* *'nogdefault'* *'nogd'*
+'gdefault' 'gd'		boolean (default off)
+			global
+	When on, the ":substitute" flag 'g' is default on.  This means that
+	all matches in a line are substituted instead of one.  When a 'g' flag
+	is given to a ":substitute" command, this will toggle the substitution
+	of all or one match.  See |complex-change|.
 
-                command         'gdefault' on   'gdefault' off  ~
-                :s///             subst. all      subst. one
-                :s///g            subst. one      subst. all
-                :s///gg           subst. all      subst. one
+		command		'gdefault' on	'gdefault' off	~
+		:s///		  subst. all	  subst. one
+		:s///g		  subst. one	  subst. all
+		:s///gg		  subst. all	  subst. one
 
-        NOTE: Setting this option may break plugins that rely on the default
-        behavior of the 'g' flag. This will also make the 'g' flag have the
-        opposite effect of that documented in |:s_g|.
+	NOTE: Setting this option may break plugins that rely on the default
+	behavior of the 'g' flag. This will also make the 'g' flag have the
+	opposite effect of that documented in |:s_g|.
 
-                                                            *'grepformat'* *'gfm'*
-'grepformat' 'gfm'      string (default "%f:%l:%m,%f:%l%m,%f  %l%m")
-                        global
-        Format to recognize for the ":grep" command output.
-        This is a scanf-like string that uses the same format as the
-        'errorformat' option: see |errorformat|.
+							    *'grepformat'* *'gfm'*
+'grepformat' 'gfm'	string (default "%f:%l:%m,%f:%l%m,%f  %l%m")
+			global
+	Format to recognize for the ":grep" command output.
+	This is a scanf-like string that uses the same format as the
+	'errorformat' option: see |errorformat|.
 
-                                                                *'grepprg'* *'gp'*
-'grepprg' 'gp'          string (default "grep -n ",
-                                         Unix: "grep -n $* /dev/null")
-                        global or local to buffer |global-local|
-        Program to use for the |:grep| command.  This option may contain '%'
-        and '#' characters, which are expanded like when used in a command-
-        line.  The placeholder "$*" is allowed to specify where the arguments
-        will be included.  Environment variables are expanded |:set_env|.  See
-        |option-backslash| about including spaces and backslashes.
-        When your "grep" accepts the "-H" argument, use this to make ":grep"
-        also work well with a single file: >vim
-                set grepprg=grep\ -nH
-<       Special value: When 'grepprg' is set to "internal" the |:grep| command
-        works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
-        |:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
-        See also the section |:make_makeprg|, since most of the comments there
-        apply equally to 'grepprg'.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+								*'grepprg'* *'gp'*
+'grepprg' 'gp'		string (default "grep -n ",
+					 Unix: "grep -n $* /dev/null")
+			global or local to buffer |global-local|
+	Program to use for the |:grep| command.  This option may contain '%'
+	and '#' characters, which are expanded like when used in a command-
+	line.  The placeholder "$*" is allowed to specify where the arguments
+	will be included.  Environment variables are expanded |:set_env|.  See
+	|option-backslash| about including spaces and backslashes.
+	When your "grep" accepts the "-H" argument, use this to make ":grep"
+	also work well with a single file: >vim
+		set grepprg=grep\ -nH
+<	Special value: When 'grepprg' is set to "internal" the |:grep| command
+	works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
+	|:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
+	See also the section |:make_makeprg|, since most of the comments there
+	apply equally to 'grepprg'.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                         *'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
-'guicursor' 'gcr'       string (default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")
-                        global
-        Configures the cursor style for each mode. Works in the GUI and many
-        terminals.  See |tui-cursor-shape|.
+					 *'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
+'guicursor' 'gcr'	string (default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")
+			global
+	Configures the cursor style for each mode. Works in the GUI and many
+	terminals.  See |tui-cursor-shape|.
 
-        To disable cursor-styling, reset the option: >vim
-                set guicursor=
+	To disable cursor-styling, reset the option: >vim
+		set guicursor=
 
-<       To enable mode shapes, "Cursor" highlight, and blinking: >vim
-                set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
-                  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
-                  \,sm:block-blinkwait175-blinkoff150-blinkon175
+<	To enable mode shapes, "Cursor" highlight, and blinking: >vim
+		set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
+		  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
+		  \,sm:block-blinkwait175-blinkoff150-blinkon175
 
-<       The option is a comma-separated list of parts.  Each part consists of a
-        mode-list and an argument-list:
-                mode-list:argument-list,mode-list:argument-list,..
-        The mode-list is a dash separated list of these modes:
-                n       Normal mode
-                v       Visual mode
-                ve      Visual mode with 'selection' "exclusive" (same as 'v',
-                        if not specified)
-                o       Operator-pending mode
-                i       Insert mode
-                r       Replace mode
-                c       Command-line Normal (append) mode
-                ci      Command-line Insert mode
-                cr      Command-line Replace mode
-                sm      showmatch in Insert mode
-                a       all modes
-        The argument-list is a dash separated list of these arguments:
-                hor{N}  horizontal bar, {N} percent of the character height
-                ver{N}  vertical bar, {N} percent of the character width
-                block   block cursor, fills the whole character
-                        - Only one of the above three should be present.
-                        - Default is "block" for each mode.
-                blinkwait{N}                            *cursor-blinking*
-                blinkon{N}
-                blinkoff{N}
-                        blink times for cursor: blinkwait is the delay before
-                        the cursor starts blinking, blinkon is the time that
-                        the cursor is shown and blinkoff is the time that the
-                        cursor is not shown.  Times are in msec.  When one of
-                        the numbers is zero, there is no blinking. E.g.: >vim
-                                set guicursor=n:blinkon0
-<                       - Default is "blinkon0" for each mode.
-                {group-name}
-                        Highlight group that decides the color and font of the
-                        cursor.
-                        In the |TUI|:
-                        - |inverse|/reverse and no group-name are interpreted
-                          as "host-terminal default cursor colors" which
-                          typically means "inverted bg and fg colors".
-                        - |ctermfg| and |guifg| are ignored.
-                {group-name}/{group-name}
-                        Two highlight group names, the first is used when
-                        no language mappings are used, the other when they
-                        are. |language-mapping|
+<	The option is a comma-separated list of parts.	Each part consists of a
+	mode-list and an argument-list:
+		mode-list:argument-list,mode-list:argument-list,..
+	The mode-list is a dash separated list of these modes:
+		n	Normal mode
+		v	Visual mode
+		ve	Visual mode with 'selection' "exclusive" (same as 'v',
+			if not specified)
+		o	Operator-pending mode
+		i	Insert mode
+		r	Replace mode
+		c	Command-line Normal (append) mode
+		ci	Command-line Insert mode
+		cr	Command-line Replace mode
+		sm	showmatch in Insert mode
+		a	all modes
+	The argument-list is a dash separated list of these arguments:
+		hor{N}	horizontal bar, {N} percent of the character height
+		ver{N}	vertical bar, {N} percent of the character width
+		block	block cursor, fills the whole character
+			- Only one of the above three should be present.
+			- Default is "block" for each mode.
+		blinkwait{N}				*cursor-blinking*
+		blinkon{N}
+		blinkoff{N}
+			blink times for cursor: blinkwait is the delay before
+			the cursor starts blinking, blinkon is the time that
+			the cursor is shown and blinkoff is the time that the
+			cursor is not shown.  Times are in msec.  When one of
+			the numbers is zero, there is no blinking. E.g.: >vim
+				set guicursor=n:blinkon0
+<			- Default is "blinkon0" for each mode.
+		{group-name}
+			Highlight group that decides the color and font of the
+			cursor.
+			In the |TUI|:
+			- |inverse|/reverse and no group-name are interpreted
+			  as "host-terminal default cursor colors" which
+			  typically means "inverted bg and fg colors".
+			- |ctermfg| and |guifg| are ignored.
+		{group-name}/{group-name}
+			Two highlight group names, the first is used when
+			no language mappings are used, the other when they
+			are. |language-mapping|
 
-        Examples of parts:
-           n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
-                                block cursor with colors from the "nCursor"
-                                highlight group
-           n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
-                                In Normal et al. modes, use a block cursor
-                                with the default colors defined by the host
-                                terminal.  In Insert-like modes, use
-                                a vertical bar cursor with colors from
-                                "Cursor" highlight group.  In Replace-like
-                                modes, use an underline cursor with
-                                default colors.
-           i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
-                                In Insert and Command-line Insert mode, use a
-                                30% vertical bar cursor with colors from the
-                                "iCursor" highlight group.  Blink a bit
-                                faster.
+	Examples of parts:
+	   n-c-v:block-nCursor	In Normal, Command-line and Visual mode, use a
+				block cursor with colors from the "nCursor"
+				highlight group
+	   n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
+				In Normal et al. modes, use a block cursor
+				with the default colors defined by the host
+				terminal.  In Insert-like modes, use
+				a vertical bar cursor with colors from
+				"Cursor" highlight group.  In Replace-like
+				modes, use an underline cursor with
+				default colors.
+	   i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
+				In Insert and Command-line Insert mode, use a
+				30% vertical bar cursor with colors from the
+				"iCursor" highlight group.  Blink a bit
+				faster.
 
-        The 'a' mode is different.  It will set the given argument-list for
-        all modes.  It does not reset anything to defaults.  This can be used
-        to do a common setting for all modes.  For example, to switch off
-        blinking: "a:blinkon0"
+	The 'a' mode is different.  It will set the given argument-list for
+	all modes.  It does not reset anything to defaults.  This can be used
+	to do a common setting for all modes.  For example, to switch off
+	blinking: "a:blinkon0"
 
-        Examples of cursor highlighting: >vim
-            highlight Cursor gui=reverse guifg=NONE guibg=NONE
-            highlight Cursor gui=NONE guifg=bg guibg=fg
+	Examples of cursor highlighting: >vim
+	    highlight Cursor gui=reverse guifg=NONE guibg=NONE
+	    highlight Cursor gui=NONE guifg=bg guibg=fg
 <
 
-                                                     *'guifont'* *'gfn'* *E235* *E596*
-'guifont' 'gfn'         string (default "")
-                        global
-        This is a list of fonts which will be used for the GUI version of Vim.
-        In its simplest form the value is just one font name.  When
-        the font cannot be found you will get an error message.  To try other
-        font names a list can be specified, font names separated with commas.
-        The first valid font is used.
+						     *'guifont'* *'gfn'* *E235* *E596*
+'guifont' 'gfn'		string (default "")
+			global
+	This is a list of fonts which will be used for the GUI version of Vim.
+	In its simplest form the value is just one font name.  When
+	the font cannot be found you will get an error message.  To try other
+	font names a list can be specified, font names separated with commas.
+	The first valid font is used.
 
-        Spaces after a comma are ignored.  To include a comma in a font name
-        precede it with a backslash.  Setting an option requires an extra
-        backslash before a space and a backslash.  See also
-        |option-backslash|.  For example: >vim
-            set guifont=Screen15,\ 7x13,font\\,with\\,commas
-<       will make Vim try to use the font "Screen15" first, and if it fails it
-        will try to use "7x13" and then "font,with,commas" instead.
+	Spaces after a comma are ignored.  To include a comma in a font name
+	precede it with a backslash.  Setting an option requires an extra
+	backslash before a space and a backslash.  See also
+	|option-backslash|.  For example: >vim
+	    set guifont=Screen15,\ 7x13,font\\,with\\,commas
+<	will make Vim try to use the font "Screen15" first, and if it fails it
+	will try to use "7x13" and then "font,with,commas" instead.
 
-        If none of the fonts can be loaded, Vim will keep the current setting.
-        If an empty font list is given, Vim will try using other resource
-        settings (for X, it will use the Vim.font resource), and finally it
-        will try some builtin default which should always be there ("7x13" in
-        the case of X).  The font names given should be "normal" fonts.  Vim
-        will try to find the related bold and italic fonts.
+	If none of the fonts can be loaded, Vim will keep the current setting.
+	If an empty font list is given, Vim will try using other resource
+	settings (for X, it will use the Vim.font resource), and finally it
+	will try some builtin default which should always be there ("7x13" in
+	the case of X).  The font names given should be "normal" fonts.  Vim
+	will try to find the related bold and italic fonts.
 
-        For Win32 and Mac OS: >vim
-            set guifont=*
-<       will bring up a font requester, where you can pick the font you want.
+	For Win32 and Mac OS: >vim
+	    set guifont=*
+<	will bring up a font requester, where you can pick the font you want.
 
-        The font name depends on the GUI used.
+	The font name depends on the GUI used.
 
-        For Mac OSX you can use something like this: >vim
-            set guifont=Monaco:h10
-<                                                               *E236*
-        Note that the fonts must be mono-spaced (all characters have the same
-        width).
+	For Mac OSX you can use something like this: >vim
+	    set guifont=Monaco:h10
+<								*E236*
+	Note that the fonts must be mono-spaced (all characters have the same
+	width).
 
-        To preview a font on X11, you might be able to use the "xfontsel"
-        program.  The "xlsfonts" program gives a list of all available fonts.
+	To preview a font on X11, you might be able to use the "xfontsel"
+	program.  The "xlsfonts" program gives a list of all available fonts.
 
-        For the Win32 GUI                                       *E244* *E245*
-        - takes these options in the font name:
-                hXX - height is XX (points, can be floating-point)
-                wXX - width is XX (points, can be floating-point)
-                b   - bold
-                i   - italic
-                u   - underline
-                s   - strikeout
-                cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
-                      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
-                      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
-                      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
-                      Normally you would use "cDEFAULT".
+	For the Win32 GUI					*E244* *E245*
+	- takes these options in the font name:
+		hXX - height is XX (points, can be floating-point)
+		wXX - width is XX (points, can be floating-point)
+		b   - bold
+		i   - italic
+		u   - underline
+		s   - strikeout
+		cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
+		      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
+		      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
+		      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
+		      Normally you would use "cDEFAULT".
 
-          Use a ':' to separate the options.
-        - A '_' can be used in the place of a space, so you don't need to use
-          backslashes to escape the spaces.
-        - Examples: >vim
-            set guifont=courier_new:h12:w5:b:cRUSSIAN
-            set guifont=Andale_Mono:h7.5:w4.5
+	  Use a ':' to separate the options.
+	- A '_' can be used in the place of a space, so you don't need to use
+	  backslashes to escape the spaces.
+	- Examples: >vim
+	    set guifont=courier_new:h12:w5:b:cRUSSIAN
+	    set guifont=Andale_Mono:h7.5:w4.5
 <
 
-                                            *'guifontwide'* *'gfw'* *E231* *E533* *E534*
-'guifontwide' 'gfw'     string (default "")
-                        global
-        Comma-separated list of fonts to be used for double-width characters.
-        The first font that can be loaded is used.
-        Note: The size of these fonts must be exactly twice as wide as the one
-        specified with 'guifont' and the same height.
+					    *'guifontwide'* *'gfw'* *E231* *E533* *E534*
+'guifontwide' 'gfw'	string (default "")
+			global
+	Comma-separated list of fonts to be used for double-width characters.
+	The first font that can be loaded is used.
+	Note: The size of these fonts must be exactly twice as wide as the one
+	specified with 'guifont' and the same height.
 
-        When 'guifont' has a valid font and 'guifontwide' is empty Vim will
-        attempt to set 'guifontwide' to a matching double-width font.
+	When 'guifont' has a valid font and 'guifontwide' is empty Vim will
+	attempt to set 'guifontwide' to a matching double-width font.
 
-                                                             *'guioptions'* *'go'*
-'guioptions' 'go'       string (default "egmrLT"   (MS-Windows))
-                        global
-        This option only has an effect in the GUI version of Vim.  It is a
-        sequence of letters which describes what components and options of the
-        GUI should be used.
-        To avoid problems with flags that are added in the future, use the
-        "+=" and "-=" feature of ":set" |add-option-flags|.
+							     *'guioptions'* *'go'*
+'guioptions' 'go'	string (default "egmrLT"   (MS-Windows))
+			global
+	This option only has an effect in the GUI version of Vim.  It is a
+	sequence of letters which describes what components and options of the
+	GUI should be used.
+	To avoid problems with flags that are added in the future, use the
+	"+=" and "-=" feature of ":set" |add-option-flags|.
 
-        Valid letters are as follows:
-                                                        *guioptions_a* *'go-a'*
-          'a'   Autoselect:  If present, then whenever VISUAL mode is started,
-                or the Visual area extended, Vim tries to become the owner of
-                the windowing system's global selection.  This means that the
-                Visually highlighted text is available for pasting into other
-                applications as well as into Vim itself.  When the Visual mode
-                ends, possibly due to an operation on the text, or when an
-                application wants to paste the selection, the highlighted text
-                is automatically yanked into the "* selection register.
-                Thus the selection is still available for pasting into other
-                applications after the VISUAL mode has ended.
-                    If not present, then Vim won't become the owner of the
-                windowing system's global selection unless explicitly told to
-                by a yank or delete operation for the "* register.
-                The same applies to the modeless selection.
-                                                                *'go-P'*
-          'P'   Like autoselect but using the "+ register instead of the "*
-                register.
-                                                                *'go-A'*
-          'A'   Autoselect for the modeless selection.  Like 'a', but only
-                applies to the modeless selection.
+	Valid letters are as follows:
+							*guioptions_a* *'go-a'*
+	  'a'	Autoselect:  If present, then whenever VISUAL mode is started,
+		or the Visual area extended, Vim tries to become the owner of
+		the windowing system's global selection.  This means that the
+		Visually highlighted text is available for pasting into other
+		applications as well as into Vim itself.  When the Visual mode
+		ends, possibly due to an operation on the text, or when an
+		application wants to paste the selection, the highlighted text
+		is automatically yanked into the "* selection register.
+		Thus the selection is still available for pasting into other
+		applications after the VISUAL mode has ended.
+		    If not present, then Vim won't become the owner of the
+		windowing system's global selection unless explicitly told to
+		by a yank or delete operation for the "* register.
+		The same applies to the modeless selection.
+								*'go-P'*
+	  'P'	Like autoselect but using the "+ register instead of the "*
+		register.
+								*'go-A'*
+	  'A'	Autoselect for the modeless selection.	Like 'a', but only
+		applies to the modeless selection.
 
-                    'guioptions'   autoselect Visual  autoselect modeless ~
-                         ""              -                       -
-                         "a"            yes                     yes
-                         "A"             -                      yes
-                         "aA"           yes                     yes
+		    'guioptions'   autoselect Visual  autoselect modeless ~
+			 ""		 -			 -
+			 "a"		yes			yes
+			 "A"		 -			yes
+			 "aA"		yes			yes
 
-                                                                *'go-c'*
-          'c'   Use console dialogs instead of popup dialogs for simple
-                choices.
-                                                                *'go-d'*
-          'd'   Use dark theme variant if available.
-                                                                *'go-e'*
-          'e'   Add tab pages when indicated with 'showtabline'.
-                'guitablabel' can be used to change the text in the labels.
-                When 'e' is missing a non-GUI tab pages line may be used.
-                The GUI tabs are only supported on some systems, currently
-                Mac OS/X and MS-Windows.
-                                                                *'go-i'*
-          'i'   Use a Vim icon.
-                                                                *'go-m'*
-          'm'   Menu bar is present.
-                                                                *'go-M'*
-          'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
-                that this flag must be added in the vimrc file, before
-                switching on syntax or filetype recognition (when the |gvimrc|
-                file is sourced the system menu has already been loaded; the
-                `:syntax on` and `:filetype on` commands load the menu too).
-                                                                *'go-g'*
-          'g'   Grey menu items: Make menu items that are not active grey.  If
-                'g' is not included inactive menu items are not shown at all.
-                                                                *'go-T'*
-          'T'   Include Toolbar.  Currently only in Win32 GUI.
-                                                                *'go-r'*
-          'r'   Right-hand scrollbar is always present.
-                                                                *'go-R'*
-          'R'   Right-hand scrollbar is present when there is a vertically
-                split window.
-                                                                *'go-l'*
-          'l'   Left-hand scrollbar is always present.
-                                                                *'go-L'*
-          'L'   Left-hand scrollbar is present when there is a vertically
-                split window.
-                                                                *'go-b'*
-          'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
-                the longest visible line, or on the cursor line if the 'h'
-                flag is included. |gui-horiz-scroll|
-                                                                *'go-h'*
-          'h'   Limit horizontal scrollbar size to the length of the cursor
-                line.  Reduces computations. |gui-horiz-scroll|
+								*'go-c'*
+	  'c'	Use console dialogs instead of popup dialogs for simple
+		choices.
+								*'go-d'*
+	  'd'	Use dark theme variant if available.
+								*'go-e'*
+	  'e'	Add tab pages when indicated with 'showtabline'.
+		'guitablabel' can be used to change the text in the labels.
+		When 'e' is missing a non-GUI tab pages line may be used.
+		The GUI tabs are only supported on some systems, currently
+		Mac OS/X and MS-Windows.
+								*'go-i'*
+	  'i'	Use a Vim icon.
+								*'go-m'*
+	  'm'	Menu bar is present.
+								*'go-M'*
+	  'M'	The system menu "$VIMRUNTIME/menu.vim" is not sourced.	Note
+		that this flag must be added in the vimrc file, before
+		switching on syntax or filetype recognition (when the |gvimrc|
+		file is sourced the system menu has already been loaded; the
+		`:syntax on` and `:filetype on` commands load the menu too).
+								*'go-g'*
+	  'g'	Grey menu items: Make menu items that are not active grey.  If
+		'g' is not included inactive menu items are not shown at all.
+								*'go-T'*
+	  'T'	Include Toolbar.  Currently only in Win32 GUI.
+								*'go-r'*
+	  'r'	Right-hand scrollbar is always present.
+								*'go-R'*
+	  'R'	Right-hand scrollbar is present when there is a vertically
+		split window.
+								*'go-l'*
+	  'l'	Left-hand scrollbar is always present.
+								*'go-L'*
+	  'L'	Left-hand scrollbar is present when there is a vertically
+		split window.
+								*'go-b'*
+	  'b'	Bottom (horizontal) scrollbar is present.  Its size depends on
+		the longest visible line, or on the cursor line if the 'h'
+		flag is included. |gui-horiz-scroll|
+								*'go-h'*
+	  'h'	Limit horizontal scrollbar size to the length of the cursor
+		line.  Reduces computations. |gui-horiz-scroll|
 
-        And yes, you may even have scrollbars on the left AND the right if
-        you really want to :-).  See |gui-scrollbars| for more information.
+	And yes, you may even have scrollbars on the left AND the right if
+	you really want to :-).  See |gui-scrollbars| for more information.
 
-                                                                *'go-v'*
-          'v'   Use a vertical button layout for dialogs.  When not included,
-                a horizontal layout is preferred, but when it doesn't fit a
-                vertical layout is used anyway.  Not supported in GTK 3.
-                                                                *'go-p'*
-          'p'   Use Pointer callbacks for X11 GUI.  This is required for some
-                window managers.  If the cursor is not blinking or hollow at
-                the right moment, try adding this flag.  This must be done
-                before starting the GUI.  Set it in your |gvimrc|.  Adding or
-                removing it after the GUI has started has no effect.
-                                                                *'go-k'*
-          'k'   Keep the GUI window size when adding/removing a scrollbar, or
-                toolbar, tabline, etc.  Instead, the behavior is similar to
-                when the window is maximized and will adjust 'lines' and
-                'columns' to fit to the window.  Without the 'k' flag Vim will
-                try to keep 'lines' and 'columns' the same when adding and
-                removing GUI components.
+								*'go-v'*
+	  'v'	Use a vertical button layout for dialogs.  When not included,
+		a horizontal layout is preferred, but when it doesn't fit a
+		vertical layout is used anyway.  Not supported in GTK 3.
+								*'go-p'*
+	  'p'	Use Pointer callbacks for X11 GUI.  This is required for some
+		window managers.  If the cursor is not blinking or hollow at
+		the right moment, try adding this flag.  This must be done
+		before starting the GUI.  Set it in your |gvimrc|.  Adding or
+		removing it after the GUI has started has no effect.
+								*'go-k'*
+	  'k'	Keep the GUI window size when adding/removing a scrollbar, or
+		toolbar, tabline, etc.	Instead, the behavior is similar to
+		when the window is maximized and will adjust 'lines' and
+		'columns' to fit to the window.  Without the 'k' flag Vim will
+		try to keep 'lines' and 'columns' the same when adding and
+		removing GUI components.
 
-                                                           *'guitablabel'* *'gtl'*
-'guitablabel' 'gtl'     string (default "")
-                        global
-        When non-empty describes the text to use in a label of the GUI tab
-        pages line.  When empty and when the result is empty Vim will use a
-        default label.  See |setting-guitablabel| for more info.
+							   *'guitablabel'* *'gtl'*
+'guitablabel' 'gtl'	string (default "")
+			global
+	When non-empty describes the text to use in a label of the GUI tab
+	pages line.  When empty and when the result is empty Vim will use a
+	default label.	See |setting-guitablabel| for more info.
 
-        The format of this option is like that of 'statusline'.
-        'guitabtooltip' is used for the tooltip, see below.
-        The expression will be evaluated in the |sandbox| when set from a
-        modeline, see |sandbox-option|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	The format of this option is like that of 'statusline'.
+	'guitabtooltip' is used for the tooltip, see below.
+	The expression will be evaluated in the |sandbox| when set from a
+	modeline, see |sandbox-option|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        Only used when the GUI tab pages line is displayed.  'e' must be
-        present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
-        used.
+	Only used when the GUI tab pages line is displayed.  'e' must be
+	present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
+	used.
 
-                                                         *'guitabtooltip'* *'gtt'*
-'guitabtooltip' 'gtt'   string (default "")
-                        global
-        When non-empty describes the text to use in a tooltip for the GUI tab
-        pages line.  When empty Vim will use a default tooltip.
-        This option is otherwise just like 'guitablabel' above.
-        You can include a line break.  Simplest method is to use |:let|: >vim
-                let &guitabtooltip = "line one\nline two"
+							 *'guitabtooltip'* *'gtt'*
+'guitabtooltip' 'gtt'	string (default "")
+			global
+	When non-empty describes the text to use in a tooltip for the GUI tab
+	pages line.  When empty Vim will use a default tooltip.
+	This option is otherwise just like 'guitablabel' above.
+	You can include a line break.  Simplest method is to use |:let|: >vim
+		let &guitabtooltip = "line one\nline two"
 <
 
-                                                               *'helpfile'* *'hf'*
-'helpfile' 'hf'         string (default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
-                                        (others) "$VIMRUNTIME/doc/help.txt")
-                        global
-        Name of the main help file.  All distributed help files should be
-        placed together in one directory.  Additionally, all "doc" directories
-        in 'runtimepath' will be used.
-        Environment variables are expanded |:set_env|.  For example:
-        "$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
-        tried.  Also see |$VIMRUNTIME| and |option-backslash| about including
-        spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							       *'helpfile'* *'hf'*
+'helpfile' 'hf'		string (default (MS-Windows) "$VIMRUNTIME\doc\help.txt"
+					(others) "$VIMRUNTIME/doc/help.txt")
+			global
+	Name of the main help file.  All distributed help files should be
+	placed together in one directory.  Additionally, all "doc" directories
+	in 'runtimepath' will be used.
+	Environment variables are expanded |:set_env|.	For example:
+	"$VIMRUNTIME/doc/help.txt".  If $VIMRUNTIME is not set, $VIM is also
+	tried.	Also see |$VIMRUNTIME| and |option-backslash| about including
+	spaces and backslashes.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                             *'helpheight'* *'hh'*
-'helpheight' 'hh'       number (default 20)
-                        global
-        Minimal initial height of the help window when it is opened with the
-        ":help" command.  The initial height of the help window is half of the
-        current window, or (when the 'ea' option is on) the same as other
-        windows.  When the height is less than 'helpheight', the height is
-        set to 'helpheight'.  Set to zero to disable.
+							     *'helpheight'* *'hh'*
+'helpheight' 'hh'	number (default 20)
+			global
+	Minimal initial height of the help window when it is opened with the
+	":help" command.  The initial height of the help window is half of the
+	current window, or (when the 'ea' option is on) the same as other
+	windows.  When the height is less than 'helpheight', the height is
+	set to 'helpheight'.  Set to zero to disable.
 
-                                                              *'helplang'* *'hlg'*
-'helplang' 'hlg'        string (default messages language or empty)
-                        global
-        Comma-separated list of languages.  Vim will use the first language
-        for which the desired help can be found.  The English help will always
-        be used as a last resort.  You can add "en" to prefer English over
-        another language, but that will only find tags that exist in that
-        language and not in the English help.
-        Example: >vim
-                set helplang=de,it
-<       This will first search German, then Italian and finally English help
-        files.
-        When using |CTRL-]| and ":help!" in a non-English help file Vim will
-        try to find the tag in the current language before using this option.
-        See |help-translated|.
+							      *'helplang'* *'hlg'*
+'helplang' 'hlg'	string (default messages language or empty)
+			global
+	Comma-separated list of languages.  Vim will use the first language
+	for which the desired help can be found.  The English help will always
+	be used as a last resort.  You can add "en" to prefer English over
+	another language, but that will only find tags that exist in that
+	language and not in the English help.
+	Example: >vim
+		set helplang=de,it
+<	This will first search German, then Italian and finally English help
+	files.
+	When using |CTRL-]| and ":help!" in a non-English help file Vim will
+	try to find the tag in the current language before using this option.
+	See |help-translated|.
 
-                                             *'hidden'* *'hid'* *'nohidden'* *'nohid'*
-'hidden' 'hid'          boolean (default on)
-                        global
-        When off a buffer is unloaded (including loss of undo information)
-        when it is |abandon|ed.  When on a buffer becomes hidden when it is
-        |abandon|ed.  A buffer displayed in another window does not become
-        hidden, of course.
+					     *'hidden'* *'hid'* *'nohidden'* *'nohid'*
+'hidden' 'hid'		boolean (default on)
+			global
+	When off a buffer is unloaded (including loss of undo information)
+	when it is |abandon|ed.  When on a buffer becomes hidden when it is
+	|abandon|ed.  A buffer displayed in another window does not become
+	hidden, of course.
 
-        Commands that move through the buffer list sometimes hide a buffer
-        although the 'hidden' option is off when these three are true:
-        - the buffer is modified
-        - 'autowrite' is off or writing is not possible
-        - the '!' flag was used
-        Also see |windows|.
+	Commands that move through the buffer list sometimes hide a buffer
+	although the 'hidden' option is off when these three are true:
+	- the buffer is modified
+	- 'autowrite' is off or writing is not possible
+	- the '!' flag was used
+	Also see |windows|.
 
-        To hide a specific buffer use the 'bufhidden' option.
-        'hidden' is set for one command with ":hide {command}" |:hide|.
+	To hide a specific buffer use the 'bufhidden' option.
+	'hidden' is set for one command with ":hide {command}" |:hide|.
 
-                                                                *'history'* *'hi'*
-'history' 'hi'          number (default 10000)
-                        global
-        A history of ":" commands, and a history of previous search patterns
-        is remembered.  This option decides how many entries may be stored in
-        each of these histories (see |cmdline-editing|).
-        The maximum value is 10000.
+								*'history'* *'hi'*
+'history' 'hi'		number (default 10000)
+			global
+	A history of ":" commands, and a history of previous search patterns
+	is remembered.	This option decides how many entries may be stored in
+	each of these histories (see |cmdline-editing|).
+	The maximum value is 10000.
 
-                                         *'hlsearch'* *'hls'* *'nohlsearch'* *'nohls'*
-'hlsearch' 'hls'        boolean (default on)
-                        global
-        When there is a previous search pattern, highlight all its matches.
-        The |hl-Search| highlight group determines the highlighting for all
-        matches not under the cursor while the |hl-CurSearch| highlight group
-        (if defined) determines the highlighting for the match under the
-        cursor. If |hl-CurSearch| is not defined, then |hl-Search| is used for
-        both. Note that only the matching text is highlighted, any offsets
-        are not applied.
-        See also: 'incsearch' and |:match|.
-        When you get bored looking at the highlighted matches, you can turn it
-        off with |:nohlsearch|.  This does not change the option value, as
-        soon as you use a search command, the highlighting comes back.
-        'redrawtime' specifies the maximum time spent on finding matches.
-        When the search pattern can match an end-of-line, Vim will try to
-        highlight all of the matched text.  However, this depends on where the
-        search starts.  This will be the first line in the window or the first
-        line below a closed fold.  A match in a previous line which is not
-        drawn may not continue in a newly drawn line.
-        You can specify whether the highlight status is restored on startup
-        with the 'h' flag in 'shada' |shada-h|.
+					 *'hlsearch'* *'hls'* *'nohlsearch'* *'nohls'*
+'hlsearch' 'hls'	boolean (default on)
+			global
+	When there is a previous search pattern, highlight all its matches.
+	The |hl-Search| highlight group determines the highlighting for all
+	matches not under the cursor while the |hl-CurSearch| highlight group
+	(if defined) determines the highlighting for the match under the
+	cursor. If |hl-CurSearch| is not defined, then |hl-Search| is used for
+	both. Note that only the matching text is highlighted, any offsets
+	are not applied.
+	See also: 'incsearch' and |:match|.
+	When you get bored looking at the highlighted matches, you can turn it
+	off with |:nohlsearch|.  This does not change the option value, as
+	soon as you use a search command, the highlighting comes back.
+	'redrawtime' specifies the maximum time spent on finding matches.
+	When the search pattern can match an end-of-line, Vim will try to
+	highlight all of the matched text.  However, this depends on where the
+	search starts.	This will be the first line in the window or the first
+	line below a closed fold.  A match in a previous line which is not
+	drawn may not continue in a newly drawn line.
+	You can specify whether the highlight status is restored on startup
+	with the 'h' flag in 'shada' |shada-h|.
 
-                                                               *'icon'* *'noicon'*
-'icon'                  boolean (default off, on when title can be restored)
-                        global
-        When on, the icon text of the window will be set to the value of
-        'iconstring' (if it is not empty), or to the name of the file
-        currently being edited.  Only the last part of the name is used.
-        Overridden by the 'iconstring' option.
-        Only works if the terminal supports setting window icons.
+							       *'icon'* *'noicon'*
+'icon'			boolean (default off, on when title can be restored)
+			global
+	When on, the icon text of the window will be set to the value of
+	'iconstring' (if it is not empty), or to the name of the file
+	currently being edited.  Only the last part of the name is used.
+	Overridden by the 'iconstring' option.
+	Only works if the terminal supports setting window icons.
 
-                                                                  *'iconstring'*
-'iconstring'            string (default "")
-                        global
-        When this option is not empty, it will be used for the icon text of
-        the window.  This happens only when the 'icon' option is on.
-        Only works if the terminal supports setting window icon text
-        When this option contains printf-style '%' items, they will be
-        expanded according to the rules used for 'statusline'.  See
-        'titlestring' for example settings.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+								  *'iconstring'*
+'iconstring'		string (default "")
+			global
+	When this option is not empty, it will be used for the icon text of
+	the window.  This happens only when the 'icon' option is on.
+	Only works if the terminal supports setting window icon text
+	When this option contains printf-style '%' items, they will be
+	expanded according to the rules used for 'statusline'.	See
+	'titlestring' for example settings.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-                                       *'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
-'ignorecase' 'ic'       boolean (default off)
-                        global
-        Ignore case in search patterns, |cmdline-completion|, when
-        searching in the tags file, and |expr-==|.
-        Also see 'smartcase' and 'tagcase'.
-        Can be overruled by using "\c" or "\C" in the pattern, see
-        |/ignorecase|.
+				       *'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
+'ignorecase' 'ic'	boolean (default off)
+			global
+	Ignore case in search patterns, |cmdline-completion|, when
+	searching in the tags file, and |expr-==|.
+	Also see 'smartcase' and 'tagcase'.
+	Can be overruled by using "\c" or "\C" in the pattern, see
+	|/ignorecase|.
 
-                                       *'imcmdline'* *'imc'* *'noimcmdline'* *'noimc'*
-'imcmdline' 'imc'       boolean (default off)
-                        global
-        When set the Input Method is always on when starting to edit a command
-        line, unless entering a search pattern (see 'imsearch' for that).
-        Setting this option is useful when your input method allows entering
-        English characters directly, e.g., when it's used to type accented
-        characters with dead keys.
+				       *'imcmdline'* *'imc'* *'noimcmdline'* *'noimc'*
+'imcmdline' 'imc'	boolean (default off)
+			global
+	When set the Input Method is always on when starting to edit a command
+	line, unless entering a search pattern (see 'imsearch' for that).
+	Setting this option is useful when your input method allows entering
+	English characters directly, e.g., when it's used to type accented
+	characters with dead keys.
 
-                                       *'imdisable'* *'imd'* *'noimdisable'* *'noimd'*
-'imdisable' 'imd'       boolean (default off, on for some systems (SGI))
-                        global
-        When set the Input Method is never used.  This is useful to disable
-        the IM when it doesn't work properly.
-        Currently this option is on by default for SGI/IRIX machines.  This
-        may change in later releases.
+				       *'imdisable'* *'imd'* *'noimdisable'* *'noimd'*
+'imdisable' 'imd'	boolean (default off, on for some systems (SGI))
+			global
+	When set the Input Method is never used.  This is useful to disable
+	the IM when it doesn't work properly.
+	Currently this option is on by default for SGI/IRIX machines.  This
+	may change in later releases.
 
-                                                              *'iminsert'* *'imi'*
-'iminsert' 'imi'        number (default 0)
-                        local to buffer
-        Specifies whether :lmap or an Input Method (IM) is to be used in
-        Insert mode.  Valid values:
-                0       :lmap is off and IM is off
-                1       :lmap is ON and IM is off
-                2       :lmap is off and IM is ON
-        To always reset the option to zero when leaving Insert mode with <Esc>
-        this can be used: >vim
-                inoremap <ESC> <ESC>:set iminsert=0<CR>
-<       This makes :lmap and IM turn off automatically when leaving Insert
-        mode.
-        Note that this option changes when using CTRL-^ in Insert mode
-        |i_CTRL-^|.
-        The value is set to 1 when setting 'keymap' to a valid keymap name.
-        It is also used for the argument of commands like "r" and "f".
+							      *'iminsert'* *'imi'*
+'iminsert' 'imi'	number (default 0)
+			local to buffer
+	Specifies whether :lmap or an Input Method (IM) is to be used in
+	Insert mode.  Valid values:
+		0	:lmap is off and IM is off
+		1	:lmap is ON and IM is off
+		2	:lmap is off and IM is ON
+	To always reset the option to zero when leaving Insert mode with <Esc>
+	this can be used: >vim
+		inoremap <ESC> <ESC>:set iminsert=0<CR>
+<	This makes :lmap and IM turn off automatically when leaving Insert
+	mode.
+	Note that this option changes when using CTRL-^ in Insert mode
+	|i_CTRL-^|.
+	The value is set to 1 when setting 'keymap' to a valid keymap name.
+	It is also used for the argument of commands like "r" and "f".
 
-                                                              *'imsearch'* *'ims'*
-'imsearch' 'ims'        number (default -1)
-                        local to buffer
-        Specifies whether :lmap or an Input Method (IM) is to be used when
-        entering a search pattern.  Valid values:
-                -1      the value of 'iminsert' is used, makes it look like
-                        'iminsert' is also used when typing a search pattern
-                0       :lmap is off and IM is off
-                1       :lmap is ON and IM is off
-                2       :lmap is off and IM is ON
-        Note that this option changes when using CTRL-^ in Command-line mode
-        |c_CTRL-^|.
-        The value is set to 1 when it is not -1 and setting the 'keymap'
-        option to a valid keymap name.
+							      *'imsearch'* *'ims'*
+'imsearch' 'ims'	number (default -1)
+			local to buffer
+	Specifies whether :lmap or an Input Method (IM) is to be used when
+	entering a search pattern.  Valid values:
+		-1	the value of 'iminsert' is used, makes it look like
+			'iminsert' is also used when typing a search pattern
+		0	:lmap is off and IM is off
+		1	:lmap is ON and IM is off
+		2	:lmap is off and IM is ON
+	Note that this option changes when using CTRL-^ in Command-line mode
+	|c_CTRL-^|.
+	The value is set to 1 when it is not -1 and setting the 'keymap'
+	option to a valid keymap name.
 
-                                                            *'inccommand'* *'icm'*
-'inccommand' 'icm'      string (default "nosplit")
-                        global
-        When nonempty, shows the effects of |:substitute|, |:smagic|,
-        |:snomagic| and user commands with the |:command-preview| flag as you
-        type.
+							    *'inccommand'* *'icm'*
+'inccommand' 'icm'	string (default "nosplit")
+			global
+	When nonempty, shows the effects of |:substitute|, |:smagic|,
+	|:snomagic| and user commands with the |:command-preview| flag as you
+	type.
 
-        Possible values:
-                nosplit Shows the effects of a command incrementally in the
-                        buffer.
-                split   Like "nosplit", but also shows partial off-screen
-                        results in a preview window.
+	Possible values:
+		nosplit Shows the effects of a command incrementally in the
+			buffer.
+		split	Like "nosplit", but also shows partial off-screen
+			results in a preview window.
 
-        If the preview for built-in commands is too slow (exceeds
-        'redrawtime') then 'inccommand' is automatically disabled until
-        |Command-line-mode| is done.
+	If the preview for built-in commands is too slow (exceeds
+	'redrawtime') then 'inccommand' is automatically disabled until
+	|Command-line-mode| is done.
 
-                                                               *'include'* *'inc'*
-'include' 'inc'         string (default "")
-                        global or local to buffer |global-local|
-        Pattern to be used to find an include command.  It is a search
-        pattern, just like for the "/" command (See |pattern|).  This option
-        is used for the commands "[i", "]I", "[d", etc.
-        Normally the 'isfname' option is used to recognize the file name that
-        comes after the matched pattern.  But if "\zs" appears in the pattern
-        then the text matched from "\zs" to the end, or until "\ze" if it
-        appears, is used as the file name.  Use this to include characters
-        that are not in 'isfname', such as a space.  You can then use
-        'includeexpr' to process the matched text.
-        See |option-backslash| about including spaces and backslashes.
+							       *'include'* *'inc'*
+'include' 'inc'		string (default "")
+			global or local to buffer |global-local|
+	Pattern to be used to find an include command.	It is a search
+	pattern, just like for the "/" command (See |pattern|).  This option
+	is used for the commands "[i", "]I", "[d", etc.
+	Normally the 'isfname' option is used to recognize the file name that
+	comes after the matched pattern.  But if "\zs" appears in the pattern
+	then the text matched from "\zs" to the end, or until "\ze" if it
+	appears, is used as the file name.  Use this to include characters
+	that are not in 'isfname', such as a space.  You can then use
+	'includeexpr' to process the matched text.
+	See |option-backslash| about including spaces and backslashes.
 
-                                                          *'includeexpr'* *'inex'*
-'includeexpr' 'inex'    string (default "")
-                        local to buffer
-        Expression to be used to transform the string found with the 'include'
-        option to a file name.  Mostly useful to change "." to "/" for Java: >vim
-                setlocal includeexpr=substitute(v:fname,'\\.','/','g')
-<       The "v:fname" variable will be set to the file name that was detected.
-        Note the double backslash: the `:set` command first halves them, then
-        one remains in the value, where "\." matches a dot literally.  For
-        simple character replacements `tr()` avoids the need for escaping: >vim
-                setlocal includeexpr=tr(v:fname,'.','/')
+							  *'includeexpr'* *'inex'*
+'includeexpr' 'inex'	string (default "")
+			local to buffer
+	Expression to be used to transform the string found with the 'include'
+	option to a file name.	Mostly useful to change "." to "/" for Java: >vim
+		setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+<	The "v:fname" variable will be set to the file name that was detected.
+	Note the double backslash: the `:set` command first halves them, then
+	one remains in the value, where "\." matches a dot literally.  For
+	simple character replacements `tr()` avoids the need for escaping: >vim
+		setlocal includeexpr=tr(v:fname,'.','/')
 <
-        Also used for the |gf| command if an unmodified file name can't be
-        found.  Allows doing "gf" on the name after an 'include' statement.
-        Also used for |<cfile>|.
+	Also used for the |gf| command if an unmodified file name can't be
+	found.	Allows doing "gf" on the name after an 'include' statement.
+	Also used for |<cfile>|.
 
-        If the expression starts with s: or |<SID>|, then it is replaced with
-        the script ID (|local-function|). Example: >vim
-                setlocal includeexpr=s:MyIncludeExpr(v:fname)
-                setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
-<       Otherwise, the expression is evaluated in the context of the script
-        where the option was set, thus script-local items are available.
+	If the expression starts with s: or |<SID>|, then it is replaced with
+	the script ID (|local-function|). Example: >vim
+		setlocal includeexpr=s:MyIncludeExpr(v:fname)
+		setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
 
-        The expression will be evaluated in the |sandbox| when set from a
-        modeline, see |sandbox-option|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	The expression will be evaluated in the |sandbox| when set from a
+	modeline, see |sandbox-option|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        It is not allowed to change text or jump to another window while
-        evaluating 'includeexpr' |textlock|.
+	It is not allowed to change text or jump to another window while
+	evaluating 'includeexpr' |textlock|.
 
-                                         *'incsearch'* *'is'* *'noincsearch'* *'nois'*
-'incsearch' 'is'        boolean (default on)
-                        global
-        While typing a search command, show where the pattern, as it was typed
-        so far, matches.  The matched string is highlighted.  If the pattern
-        is invalid or not found, nothing is shown.  The screen will be updated
-        often, this is only useful on fast terminals.
-        Note that the match will be shown, but the cursor will return to its
-        original position when no match is found and when pressing <Esc>.  You
-        still need to finish the search command with <Enter> to move the
-        cursor to the match.
-        You can use the CTRL-G and CTRL-T keys to move to the next and
-        previous match. |c_CTRL-G| |c_CTRL-T|
-        Vim only searches for about half a second.  With a complicated
-        pattern and/or a lot of text the match may not be found.  This is to
-        avoid that Vim hangs while you are typing the pattern.
-        The |hl-IncSearch| highlight group determines the highlighting.
-        When 'hlsearch' is on, all matched strings are highlighted too while
-        typing a search command. See also: 'hlsearch'.
-        If you don't want to turn 'hlsearch' on, but want to highlight all
-        matches while searching, you can turn on and off 'hlsearch' with
-        autocmd.  Example: >vim
-                augroup vimrc-incsearch-highlight
-                  autocmd!
-                  autocmd CmdlineEnter /,\? :set hlsearch
-                  autocmd CmdlineLeave /,\? :set nohlsearch
-                augroup END
+					 *'incsearch'* *'is'* *'noincsearch'* *'nois'*
+'incsearch' 'is'	boolean (default on)
+			global
+	While typing a search command, show where the pattern, as it was typed
+	so far, matches.  The matched string is highlighted.  If the pattern
+	is invalid or not found, nothing is shown.  The screen will be updated
+	often, this is only useful on fast terminals.
+	Note that the match will be shown, but the cursor will return to its
+	original position when no match is found and when pressing <Esc>.  You
+	still need to finish the search command with <Enter> to move the
+	cursor to the match.
+	You can use the CTRL-G and CTRL-T keys to move to the next and
+	previous match. |c_CTRL-G| |c_CTRL-T|
+	Vim only searches for about half a second.  With a complicated
+	pattern and/or a lot of text the match may not be found.  This is to
+	avoid that Vim hangs while you are typing the pattern.
+	The |hl-IncSearch| highlight group determines the highlighting.
+	When 'hlsearch' is on, all matched strings are highlighted too while
+	typing a search command. See also: 'hlsearch'.
+	If you don't want to turn 'hlsearch' on, but want to highlight all
+	matches while searching, you can turn on and off 'hlsearch' with
+	autocmd.  Example: >vim
+		augroup vimrc-incsearch-highlight
+		  autocmd!
+		  autocmd CmdlineEnter /,\? :set hlsearch
+		  autocmd CmdlineLeave /,\? :set nohlsearch
+		augroup END
 <
-        CTRL-L can be used to add one character from after the current match
-        to the command line.  If 'ignorecase' and 'smartcase' are set and the
-        command line has no uppercase characters, the added character is
-        converted to lowercase.
-        CTRL-R CTRL-W can be used to add the word at the end of the current
-        match, excluding the characters that were already typed.
+	CTRL-L can be used to add one character from after the current match
+	to the command line.  If 'ignorecase' and 'smartcase' are set and the
+	command line has no uppercase characters, the added character is
+	converted to lowercase.
+	CTRL-R CTRL-W can be used to add the word at the end of the current
+	match, excluding the characters that were already typed.
 
-                                                           *'indentexpr'* *'inde'*
-'indentexpr' 'inde'     string (default "")
-                        local to buffer
-        Expression which is evaluated to obtain the proper indent for a line.
-        It is used when a new line is created, for the |=| operator and
-        in Insert mode as specified with the 'indentkeys' option.
-        When this option is not empty, it overrules the 'cindent' and
-        'smartindent' indenting.  When 'lisp' is set, this option is
-        is only used when 'lispoptions' contains "expr:1".
-        The expression is evaluated with |v:lnum| set to the line number for
-        which the indent is to be computed.  The cursor is also in this line
-        when the expression is evaluated (but it may be moved around).
+							   *'indentexpr'* *'inde'*
+'indentexpr' 'inde'	string (default "")
+			local to buffer
+	Expression which is evaluated to obtain the proper indent for a line.
+	It is used when a new line is created, for the |=| operator and
+	in Insert mode as specified with the 'indentkeys' option.
+	When this option is not empty, it overrules the 'cindent' and
+	'smartindent' indenting.  When 'lisp' is set, this option is
+	is only used when 'lispoptions' contains "expr:1".
+	The expression is evaluated with |v:lnum| set to the line number for
+	which the indent is to be computed.  The cursor is also in this line
+	when the expression is evaluated (but it may be moved around).
 
-        If the expression starts with s: or |<SID>|, then it is replaced with
-        the script ID (|local-function|). Example: >vim
-                set indentexpr=s:MyIndentExpr()
-                set indentexpr=<SID>SomeIndentExpr()
-<       Otherwise, the expression is evaluated in the context of the script
-        where the option was set, thus script-local items are available.
+	If the expression starts with s: or |<SID>|, then it is replaced with
+	the script ID (|local-function|). Example: >vim
+		set indentexpr=s:MyIndentExpr()
+		set indentexpr=<SID>SomeIndentExpr()
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
 
-        The expression must return the number of spaces worth of indent.  It
-        can return "-1" to keep the current indent (this means 'autoindent' is
-        used for the indent).
-        Functions useful for computing the indent are |indent()|, |cindent()|
-        and |lispindent()|.
-        The evaluation of the expression must not have side effects!  It must
-        not change the text, jump to another window, etc.  Afterwards the
-        cursor position is always restored, thus the cursor may be moved.
-        Normally this option would be set to call a function: >vim
-                set indentexpr=GetMyIndent()
-<       Error messages will be suppressed, unless the 'debug' option contains
-        "msg".
-        See |indent-expression|.
+	The expression must return the number of spaces worth of indent.  It
+	can return "-1" to keep the current indent (this means 'autoindent' is
+	used for the indent).
+	Functions useful for computing the indent are |indent()|, |cindent()|
+	and |lispindent()|.
+	The evaluation of the expression must not have side effects!  It must
+	not change the text, jump to another window, etc.  Afterwards the
+	cursor position is always restored, thus the cursor may be moved.
+	Normally this option would be set to call a function: >vim
+		set indentexpr=GetMyIndent()
+<	Error messages will be suppressed, unless the 'debug' option contains
+	"msg".
+	See |indent-expression|.
 
-        The expression will be evaluated in the |sandbox| when set from a
-        modeline, see |sandbox-option|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	The expression will be evaluated in the |sandbox| when set from a
+	modeline, see |sandbox-option|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        It is not allowed to change text or jump to another window while
-        evaluating 'indentexpr' |textlock|.
+	It is not allowed to change text or jump to another window while
+	evaluating 'indentexpr' |textlock|.
 
-                                                           *'indentkeys'* *'indk'*
-'indentkeys' 'indk'     string (default "0{,0},0),0],:,0#,!^F,o,O,e")
-                        local to buffer
-        A list of keys that, when typed in Insert mode, cause reindenting of
-        the current line.  Only happens if 'indentexpr' isn't empty.
-        The format is identical to 'cinkeys', see |indentkeys-format|.
-        See |C-indenting| and |indent-expression|.
+							   *'indentkeys'* *'indk'*
+'indentkeys' 'indk'	string (default "0{,0},0),0],:,0#,!^F,o,O,e")
+			local to buffer
+	A list of keys that, when typed in Insert mode, cause reindenting of
+	the current line.  Only happens if 'indentexpr' isn't empty.
+	The format is identical to 'cinkeys', see |indentkeys-format|.
+	See |C-indenting| and |indent-expression|.
 
-                                       *'infercase'* *'inf'* *'noinfercase'* *'noinf'*
-'infercase' 'inf'       boolean (default off)
-                        local to buffer
-        When doing keyword completion in insert mode |ins-completion|, and
-        'ignorecase' is also on, the case of the match is adjusted depending
-        on the typed text.  If the typed text contains a lowercase letter
-        where the match has an upper case letter, the completed part is made
-        lowercase.  If the typed text has no lowercase letters and the match
-        has a lowercase letter where the typed text has an uppercase letter,
-        and there is a letter before it, the completed part is made uppercase.
-        With 'noinfercase' the match is used as-is.
+				       *'infercase'* *'inf'* *'noinfercase'* *'noinf'*
+'infercase' 'inf'	boolean (default off)
+			local to buffer
+	When doing keyword completion in insert mode |ins-completion|, and
+	'ignorecase' is also on, the case of the match is adjusted depending
+	on the typed text.  If the typed text contains a lowercase letter
+	where the match has an upper case letter, the completed part is made
+	lowercase.  If the typed text has no lowercase letters and the match
+	has a lowercase letter where the typed text has an uppercase letter,
+	and there is a letter before it, the completed part is made uppercase.
+	With 'noinfercase' the match is used as-is.
 
-                                                               *'isfname'* *'isf'*
-'isfname' 'isf'         string (default for Windows: "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
-                                        otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,=")
-                        global
-        The characters specified by this option are included in file names and
-        path names.  Filenames are used for commands like "gf", "[i" and in
-        the tags file.  It is also used for "\f" in a |pattern|.
-        Multi-byte characters 256 and above are always included, only the
-        characters up to 255 are specified with this option.
-        For UTF-8 the characters 0xa0 to 0xff are included as well.
-        Think twice before adding white space to this option.  Although a
-        space may appear inside a file name, the effect will be that Vim
-        doesn't know where a file name starts or ends when doing completion.
-        It most likely works better without a space in 'isfname'.
+							       *'isfname'* *'isf'*
+'isfname' 'isf'		string (default for Windows: "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
+					otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,=")
+			global
+	The characters specified by this option are included in file names and
+	path names.  Filenames are used for commands like "gf", "[i" and in
+	the tags file.	It is also used for "\f" in a |pattern|.
+	Multi-byte characters 256 and above are always included, only the
+	characters up to 255 are specified with this option.
+	For UTF-8 the characters 0xa0 to 0xff are included as well.
+	Think twice before adding white space to this option.  Although a
+	space may appear inside a file name, the effect will be that Vim
+	doesn't know where a file name starts or ends when doing completion.
+	It most likely works better without a space in 'isfname'.
 
-        Note that on systems using a backslash as path separator, Vim tries to
-        do its best to make it work as you would expect.  That is a bit
-        tricky, since Vi originally used the backslash to escape special
-        characters.  Vim will not remove a backslash in front of a normal file
-        name character on these systems, but it will on Unix and alikes.  The
-        '&' and '^' are not included by default, because these are special for
-        cmd.exe.
+	Note that on systems using a backslash as path separator, Vim tries to
+	do its best to make it work as you would expect.  That is a bit
+	tricky, since Vi originally used the backslash to escape special
+	characters.  Vim will not remove a backslash in front of a normal file
+	name character on these systems, but it will on Unix and alikes.  The
+	'&' and '^' are not included by default, because these are special for
+	cmd.exe.
 
-        The format of this option is a list of parts, separated with commas.
-        Each part can be a single character number or a range.  A range is two
-        character numbers with '-' in between.  A character number can be a
-        decimal number between 0 and 255 or the ASCII character itself (does
-        not work for digits).  Example:
-                "_,-,128-140,#-43"      (include '_' and '-' and the range
-                                        128 to 140 and '#' to 43)
-        If a part starts with '^', the following character number or range
-        will be excluded from the option.  The option is interpreted from left
-        to right.  Put the excluded character after the range where it is
-        included.  To include '^' itself use it as the last character of the
-        option or the end of a range.  Example:
-                "^a-z,#,^"      (exclude 'a' to 'z', include '#' and '^')
-        If the character is '@', all characters where isalpha() returns TRUE
-        are included.  Normally these are the characters a to z and A to Z,
-        plus accented characters.  To include '@' itself use "@-@".  Examples:
-                "@,^a-z"        All alphabetic characters, excluding lower
-                                case ASCII letters.
-                "a-z,A-Z,@-@"   All letters plus the '@' character.
-        A comma can be included by using it where a character number is
-        expected.  Example:
-                "48-57,,,_"     Digits, comma and underscore.
-        A comma can be excluded by prepending a '^'.  Example:
-                " -~,^,,9"      All characters from space to '~', excluding
-                                comma, plus <Tab>.
-        See |option-backslash| about including spaces and backslashes.
+	The format of this option is a list of parts, separated with commas.
+	Each part can be a single character number or a range.	A range is two
+	character numbers with '-' in between.	A character number can be a
+	decimal number between 0 and 255 or the ASCII character itself (does
+	not work for digits).  Example:
+		"_,-,128-140,#-43"	(include '_' and '-' and the range
+					128 to 140 and '#' to 43)
+	If a part starts with '^', the following character number or range
+	will be excluded from the option.  The option is interpreted from left
+	to right.  Put the excluded character after the range where it is
+	included.  To include '^' itself use it as the last character of the
+	option or the end of a range.  Example:
+		"^a-z,#,^"	(exclude 'a' to 'z', include '#' and '^')
+	If the character is '@', all characters where isalpha() returns TRUE
+	are included.  Normally these are the characters a to z and A to Z,
+	plus accented characters.  To include '@' itself use "@-@".  Examples:
+		"@,^a-z"	All alphabetic characters, excluding lower
+				case ASCII letters.
+		"a-z,A-Z,@-@"	All letters plus the '@' character.
+	A comma can be included by using it where a character number is
+	expected.  Example:
+		"48-57,,,_"	Digits, comma and underscore.
+	A comma can be excluded by prepending a '^'.  Example:
+		" -~,^,,9"	All characters from space to '~', excluding
+				comma, plus <Tab>.
+	See |option-backslash| about including spaces and backslashes.
 
-                                                               *'isident'* *'isi'*
-'isident' 'isi'         string (default for Windows: "@,48-57,_,128-167,224-235"
-                                        otherwise: "@,48-57,_,192-255")
-                        global
-        The characters given by this option are included in identifiers.
-        Identifiers are used in recognizing environment variables and after a
-        match of the 'define' option.  It is also used for "\i" in a
-        |pattern|.  See 'isfname' for a description of the format of this
-        option.  For '@' only characters up to 255 are used.
-        Careful: If you change this option, it might break expanding
-        environment variables.  E.g., when '/' is included and Vim tries to
-        expand "$HOME/.local/state/nvim/shada/main.shada".  Maybe you should
-        change 'iskeyword' instead.
+							       *'isident'* *'isi'*
+'isident' 'isi'		string (default for Windows: "@,48-57,_,128-167,224-235"
+					otherwise: "@,48-57,_,192-255")
+			global
+	The characters given by this option are included in identifiers.
+	Identifiers are used in recognizing environment variables and after a
+	match of the 'define' option.  It is also used for "\i" in a
+	|pattern|.  See 'isfname' for a description of the format of this
+	option.  For '@' only characters up to 255 are used.
+	Careful: If you change this option, it might break expanding
+	environment variables.	E.g., when '/' is included and Vim tries to
+	expand "$HOME/.local/state/nvim/shada/main.shada".  Maybe you should
+	change 'iskeyword' instead.
 
-                                                             *'iskeyword'* *'isk'*
-'iskeyword' 'isk'       string (default "@,48-57,_,192-255")
-                        local to buffer
-        Keywords are used in searching and recognizing with many commands:
-        "w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.  See
-        'isfname' for a description of the format of this option.  For '@'
-        characters above 255 check the "word" character class (any character
-        that is not white space or punctuation).
-        For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
-        For a help file it is set to all non-blank printable characters except
-        "*", '"' and '|' (so that CTRL-] on a command finds the help for that
-        command).
-        When the 'lisp' option is on the '-' character is always included.
-        This option also influences syntax highlighting, unless the syntax
-        uses |:syn-iskeyword|.
+							     *'iskeyword'* *'isk'*
+'iskeyword' 'isk'	string (default "@,48-57,_,192-255")
+			local to buffer
+	Keywords are used in searching and recognizing with many commands:
+	"w", "*", "[i", etc.  It is also used for "\k" in a |pattern|.	See
+	'isfname' for a description of the format of this option.  For '@'
+	characters above 255 check the "word" character class (any character
+	that is not white space or punctuation).
+	For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
+	For a help file it is set to all non-blank printable characters except
+	"*", '"' and '|' (so that CTRL-] on a command finds the help for that
+	command).
+	When the 'lisp' option is on the '-' character is always included.
+	This option also influences syntax highlighting, unless the syntax
+	uses |:syn-iskeyword|.
 
-                                                               *'isprint'* *'isp'*
-'isprint' 'isp'         string (default "@,161-255")
-                        global
-        The characters given by this option are displayed directly on the
-        screen.  It is also used for "\p" in a |pattern|.  The characters from
-        space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
-        even when they are not included in 'isprint' or excluded.  See
-        'isfname' for a description of the format of this option.
+							       *'isprint'* *'isp'*
+'isprint' 'isp'		string (default "@,161-255")
+			global
+	The characters given by this option are displayed directly on the
+	screen.  It is also used for "\p" in a |pattern|.  The characters from
+	space (ASCII 32) to '~' (ASCII 126) are always displayed directly,
+	even when they are not included in 'isprint' or excluded.  See
+	'isfname' for a description of the format of this option.
 
-        Non-printable characters are displayed with two characters:
-                  0 -  31       "^@" - "^_"
-                 32 - 126       always single characters
-                   127          "^?"
-                128 - 159       "~@" - "~_"
-                160 - 254       "| " - "|~"
-                   255          "~?"
-        Illegal bytes from 128 to 255 (invalid UTF-8) are
-        displayed as <xx>, with the hexadecimal value of the byte.
-        When 'display' contains "uhex" all unprintable characters are
-        displayed as <xx>.
-        The SpecialKey highlighting will be used for unprintable characters.
-        |hl-SpecialKey|
+	Non-printable characters are displayed with two characters:
+		  0 -  31	"^@" - "^_"
+		 32 - 126	always single characters
+		   127		"^?"
+		128 - 159	"~@" - "~_"
+		160 - 254	"| " - "|~"
+		   255		"~?"
+	Illegal bytes from 128 to 255 (invalid UTF-8) are
+	displayed as <xx>, with the hexadecimal value of the byte.
+	When 'display' contains "uhex" all unprintable characters are
+	displayed as <xx>.
+	The SpecialKey highlighting will be used for unprintable characters.
+	|hl-SpecialKey|
 
-        Multi-byte characters 256 and above are always included, only the
-        characters up to 255 are specified with this option.  When a character
-        is printable but it is not available in the current font, a
-        replacement character will be shown.
-        Unprintable and zero-width Unicode characters are displayed as <xxxx>.
-        There is no option to specify these characters.
+	Multi-byte characters 256 and above are always included, only the
+	characters up to 255 are specified with this option.  When a character
+	is printable but it is not available in the current font, a
+	replacement character will be shown.
+	Unprintable and zero-width Unicode characters are displayed as <xxxx>.
+	There is no option to specify these characters.
 
-                                       *'joinspaces'* *'js'* *'nojoinspaces'* *'nojs'*
-'joinspaces' 'js'       boolean (default off)
-                        global
-        Insert two spaces after a '.', '?' and '!' with a join command.
-        Otherwise only one space is inserted.
+				       *'joinspaces'* *'js'* *'nojoinspaces'* *'nojs'*
+'joinspaces' 'js'	boolean (default off)
+			global
+	Insert two spaces after a '.', '?' and '!' with a join command.
+	Otherwise only one space is inserted.
 
-                                                           *'jumpoptions'* *'jop'*
-'jumpoptions' 'jop'     string (default "")
-                        global
-        List of words that change the behavior of the |jumplist|.
-          stack         Make the jumplist behave like the tagstack.
-                        Relative location of entries in the jumplist is
-                        preserved at the cost of discarding subsequent entries
-                        when navigating backwards in the jumplist and then
-                        jumping to a location.  |jumplist-stack|
+							   *'jumpoptions'* *'jop'*
+'jumpoptions' 'jop'	string (default "")
+			global
+	List of words that change the behavior of the |jumplist|.
+	  stack		Make the jumplist behave like the tagstack.
+			Relative location of entries in the jumplist is
+			preserved at the cost of discarding subsequent entries
+			when navigating backwards in the jumplist and then
+			jumping to a location.	|jumplist-stack|
 
-          view          When moving through the jumplist, |changelist|,
-                        |alternate-file| or using |mark-motions| try to
-                        restore the |mark-view| in which the action occurred.
+	  view		When moving through the jumplist, |changelist|,
+			|alternate-file| or using |mark-motions| try to
+			restore the |mark-view| in which the action occurred.
 
-                                                                *'keymap'* *'kmp'*
-'keymap' 'kmp'          string (default "")
-                        local to buffer
-        Name of a keyboard mapping.  See |mbyte-keymap|.
-        Setting this option to a valid keymap name has the side effect of
-        setting 'iminsert' to one, so that the keymap becomes effective.
-        'imsearch' is also set to one, unless it was -1
-        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+								*'keymap'* *'kmp'*
+'keymap' 'kmp'		string (default "")
+			local to buffer
+	Name of a keyboard mapping.  See |mbyte-keymap|.
+	Setting this option to a valid keymap name has the side effect of
+	setting 'iminsert' to one, so that the keymap becomes effective.
+	'imsearch' is also set to one, unless it was -1
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
-                                                               *'keymodel'* *'km'*
-'keymodel' 'km'         string (default "")
-                        global
-        List of comma-separated words, which enable special things that keys
-        can do.  These values can be used:
-           startsel     Using a shifted special key starts selection (either
-                        Select mode or Visual mode, depending on "key" being
-                        present in 'selectmode').
-           stopsel      Using a not-shifted special key stops selection.
-        Special keys in this context are the cursor keys, <End>, <Home>,
-        <PageUp> and <PageDown>.
+							       *'keymodel'* *'km'*
+'keymodel' 'km'		string (default "")
+			global
+	List of comma-separated words, which enable special things that keys
+	can do.  These values can be used:
+	   startsel	Using a shifted special key starts selection (either
+			Select mode or Visual mode, depending on "key" being
+			present in 'selectmode').
+	   stopsel	Using a not-shifted special key stops selection.
+	Special keys in this context are the cursor keys, <End>, <Home>,
+	<PageUp> and <PageDown>.
 
-                                                             *'keywordprg'* *'kp'*
-'keywordprg' 'kp'       string (default ":Man", Windows: ":help")
-                        global or local to buffer |global-local|
-        Program to use for the |K| command.  Environment variables are
-        expanded |:set_env|.  ":help" may be used to access the Vim internal
-        help.  (Note that previously setting the global option to the empty
-        value did this, which is now deprecated.)
-        When the first character is ":", the command is invoked as a Vim
-        Ex command prefixed with [count].
-        When "man" or "man -s" is used, Vim will automatically translate
-        a [count] for the "K" command to a section number.
-        See |option-backslash| about including spaces and backslashes.
-        Example: >vim
-                set keywordprg=man\ -s
-                set keywordprg=:Man
-<       This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							     *'keywordprg'* *'kp'*
+'keywordprg' 'kp'	string (default ":Man", Windows: ":help")
+			global or local to buffer |global-local|
+	Program to use for the |K| command.  Environment variables are
+	expanded |:set_env|.  ":help" may be used to access the Vim internal
+	help.  (Note that previously setting the global option to the empty
+	value did this, which is now deprecated.)
+	When the first character is ":", the command is invoked as a Vim
+	Ex command prefixed with [count].
+	When "man" or "man -s" is used, Vim will automatically translate
+	a [count] for the "K" command to a section number.
+	See |option-backslash| about including spaces and backslashes.
+	Example: >vim
+		set keywordprg=man\ -s
+		set keywordprg=:Man
+<	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                    *'langmap'* *'lmap'* *E357* *E358*
-'langmap' 'lmap'        string (default "")
-                        global
-        This option allows switching your keyboard into a special language
-        mode.  When you are typing text in Insert mode the characters are
-        inserted directly.  When in Normal mode the 'langmap' option takes
-        care of translating these special characters to the original meaning
-        of the key.  This means you don't have to change the keyboard mode to
-        be able to execute Normal mode commands.
-        This is the opposite of the 'keymap' option, where characters are
-        mapped in Insert mode.
-        Also consider setting 'langremap' to off, to prevent 'langmap' from
-        applying to characters resulting from a mapping.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+						    *'langmap'* *'lmap'* *E357* *E358*
+'langmap' 'lmap'	string (default "")
+			global
+	This option allows switching your keyboard into a special language
+	mode.  When you are typing text in Insert mode the characters are
+	inserted directly.  When in Normal mode the 'langmap' option takes
+	care of translating these special characters to the original meaning
+	of the key.  This means you don't have to change the keyboard mode to
+	be able to execute Normal mode commands.
+	This is the opposite of the 'keymap' option, where characters are
+	mapped in Insert mode.
+	Also consider setting 'langremap' to off, to prevent 'langmap' from
+	applying to characters resulting from a mapping.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-        Example (for Greek, in UTF-8):                          *greek*  >vim
-            set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
-<       Example (exchanges meaning of z and y for commands): >vim
-            set langmap=zy,yz,ZY,YZ
+	Example (for Greek, in UTF-8):				*greek*  >vim
+	    set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
+<	Example (exchanges meaning of z and y for commands): >vim
+	    set langmap=zy,yz,ZY,YZ
 <
-        The 'langmap' option is a list of parts, separated with commas.  Each
-        part can be in one of two forms:
-        1.  A list of pairs.  Each pair is a "from" character immediately
-            followed by the "to" character.  Examples: "aA", "aAbBcC".
-        2.  A list of "from" characters, a semi-colon and a list of "to"
-            characters.  Example: "abc;ABC"
-        Example: "aA,fgh;FGH,cCdDeE"
-        Special characters need to be preceded with a backslash.  These are
-        ";", ',', '"', '|' and backslash itself.
+	The 'langmap' option is a list of parts, separated with commas.  Each
+	part can be in one of two forms:
+	1.  A list of pairs.  Each pair is a "from" character immediately
+	    followed by the "to" character.  Examples: "aA", "aAbBcC".
+	2.  A list of "from" characters, a semi-colon and a list of "to"
+	    characters.  Example: "abc;ABC"
+	Example: "aA,fgh;FGH,cCdDeE"
+	Special characters need to be preceded with a backslash.  These are
+	";", ',', '"', '|' and backslash itself.
 
-        This will allow you to activate vim actions without having to switch
-        back and forth between the languages.  Your language characters will
-        be understood as normal vim English characters (according to the
-        langmap mappings) in the following cases:
-         o Normal/Visual mode (commands, buffer/register names, user mappings)
-         o Insert/Replace Mode: Register names after CTRL-R
-         o Insert/Replace Mode: Mappings
-        Characters entered in Command-line mode will NOT be affected by
-        this option.   Note that this option can be changed at any time
-        allowing to switch between mappings for different languages/encodings.
-        Use a mapping to avoid having to type it each time!
+	This will allow you to activate vim actions without having to switch
+	back and forth between the languages.  Your language characters will
+	be understood as normal vim English characters (according to the
+	langmap mappings) in the following cases:
+	 o Normal/Visual mode (commands, buffer/register names, user mappings)
+	 o Insert/Replace Mode: Register names after CTRL-R
+	 o Insert/Replace Mode: Mappings
+	Characters entered in Command-line mode will NOT be affected by
+	this option.   Note that this option can be changed at any time
+	allowing to switch between mappings for different languages/encodings.
+	Use a mapping to avoid having to type it each time!
 
-                                                               *'langmenu'* *'lm'*
-'langmenu' 'lm'         string (default "")
-                        global
-        Language to use for menu translation.  Tells which file is loaded
-        from the "lang" directory in 'runtimepath': >vim
-                "lang/menu_" .. &langmenu .. ".vim"
-<       (without the spaces).  For example, to always use the Dutch menus, no
-        matter what $LANG is set to: >vim
-                set langmenu=nl_NL.ISO_8859-1
-<       When 'langmenu' is empty, |v:lang| is used.
-        Only normal file name characters can be used, `/\*?[|<>` are illegal.
-        If your $LANG is set to a non-English language but you do want to use
-        the English menus: >vim
-                set langmenu=none
-<       This option must be set before loading menus, switching on filetype
-        detection or syntax highlighting.  Once the menus are defined setting
-        this option has no effect.  But you could do this: >vim
-                source $VIMRUNTIME/delmenu.vim
-                set langmenu=de_DE.ISO_8859-1
-                source $VIMRUNTIME/menu.vim
-<       Warning: This deletes all menus that you defined yourself!
+							       *'langmenu'* *'lm'*
+'langmenu' 'lm'		string (default "")
+			global
+	Language to use for menu translation.  Tells which file is loaded
+	from the "lang" directory in 'runtimepath': >vim
+		"lang/menu_" .. &langmenu .. ".vim"
+<	(without the spaces).  For example, to always use the Dutch menus, no
+	matter what $LANG is set to: >vim
+		set langmenu=nl_NL.ISO_8859-1
+<	When 'langmenu' is empty, |v:lang| is used.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
+	If your $LANG is set to a non-English language but you do want to use
+	the English menus: >vim
+		set langmenu=none
+<	This option must be set before loading menus, switching on filetype
+	detection or syntax highlighting.  Once the menus are defined setting
+	this option has no effect.  But you could do this: >vim
+		source $VIMRUNTIME/delmenu.vim
+		set langmenu=de_DE.ISO_8859-1
+		source $VIMRUNTIME/menu.vim
+<	Warning: This deletes all menus that you defined yourself!
 
-                                       *'langremap'* *'lrm'* *'nolangremap'* *'nolrm'*
-'langremap' 'lrm'       boolean (default off)
-                        global
-        When off, setting 'langmap' does not apply to characters resulting from
-        a mapping.  If setting 'langmap' disables some of your mappings, make
-        sure this option is off.
+				       *'langremap'* *'lrm'* *'nolangremap'* *'nolrm'*
+'langremap' 'lrm'	boolean (default off)
+			global
+	When off, setting 'langmap' does not apply to characters resulting from
+	a mapping.  If setting 'langmap' disables some of your mappings, make
+	sure this option is off.
 
-                                                             *'laststatus'* *'ls'*
-'laststatus' 'ls'       number (default 2)
-                        global
-        The value of this option influences when the last window will have a
-        status line:
-                0: never
-                1: only if there are at least two windows
-                2: always
-                3: always and ONLY the last window
-        The screen looks nicer with a status line if you have several
-        windows, but it takes another screen line. |status-line|
+							     *'laststatus'* *'ls'*
+'laststatus' 'ls'	number (default 2)
+			global
+	The value of this option influences when the last window will have a
+	status line:
+		0: never
+		1: only if there are at least two windows
+		2: always
+		3: always and ONLY the last window
+	The screen looks nicer with a status line if you have several
+	windows, but it takes another screen line. |status-line|
 
-                                       *'lazyredraw'* *'lz'* *'nolazyredraw'* *'nolz'*
-'lazyredraw' 'lz'       boolean (default off)
-                        global
-        When this option is set, the screen will not be redrawn while
-        executing macros, registers and other commands that have not been
-        typed.  Also, updating the window title is postponed.  To force an
-        update use |:redraw|.
-        This may occasionally cause display errors.  It is only meant to be set
-        temporarily when performing an operation where redrawing may cause
-        flickering or cause a slow down.
+				       *'lazyredraw'* *'lz'* *'nolazyredraw'* *'nolz'*
+'lazyredraw' 'lz'	boolean (default off)
+			global
+	When this option is set, the screen will not be redrawn while
+	executing macros, registers and other commands that have not been
+	typed.	Also, updating the window title is postponed.  To force an
+	update use |:redraw|.
+	This may occasionally cause display errors.  It is only meant to be set
+	temporarily when performing an operation where redrawing may cause
+	flickering or cause a slow down.
 
-                                       *'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
-'linebreak' 'lbr'       boolean (default off)
-                        local to window
-        If on, Vim will wrap long lines at a character in 'breakat' rather
-        than at the last character that fits on the screen.  Unlike
-        'wrapmargin' and 'textwidth', this does not insert <EOL>s in the file,
-        it only affects the way the file is displayed, not its contents.
-        If 'breakindent' is set, line is visually indented. Then, the value
-        of 'showbreak' is used to put in front of wrapped lines. This option
-        is not used when the 'wrap' option is off.
-        Note that <Tab> characters after an <EOL> are mostly not displayed
-        with the right amount of white space.
+				       *'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
+'linebreak' 'lbr'	boolean (default off)
+			local to window
+	If on, Vim will wrap long lines at a character in 'breakat' rather
+	than at the last character that fits on the screen.  Unlike
+	'wrapmargin' and 'textwidth', this does not insert <EOL>s in the file,
+	it only affects the way the file is displayed, not its contents.
+	If 'breakindent' is set, line is visually indented. Then, the value
+	of 'showbreak' is used to put in front of wrapped lines. This option
+	is not used when the 'wrap' option is off.
+	Note that <Tab> characters after an <EOL> are mostly not displayed
+	with the right amount of white space.
 
-                                                                  *'lines'* *E593*
-'lines'                 number (default 24 or terminal height)
-                        global
-        Number of lines of the Vim window.
-        Normally you don't need to set this.  It is done automatically by the
-        terminal initialization code.
-        When Vim is running in the GUI or in a resizable window, setting this
-        option will cause the window size to be changed.  When you only want
-        to use the size for the GUI, put the command in your |gvimrc| file.
-        Vim limits the number of lines to what fits on the screen.  You can
-        use this command to get the tallest window possible: >vim
-                set lines=999
-<       Minimum value is 2, maximum value is 1000.
+								  *'lines'* *E593*
+'lines'			number (default 24 or terminal height)
+			global
+	Number of lines of the Vim window.
+	Normally you don't need to set this.  It is done automatically by the
+	terminal initialization code.
+	When Vim is running in the GUI or in a resizable window, setting this
+	option will cause the window size to be changed.  When you only want
+	to use the size for the GUI, put the command in your |gvimrc| file.
+	Vim limits the number of lines to what fits on the screen.  You can
+	use this command to get the tallest window possible: >vim
+		set lines=999
+<	Minimum value is 2, maximum value is 1000.
 
-                                                             *'linespace'* *'lsp'*
-'linespace' 'lsp'       number (default 0)
-                        global
-        only in the GUI
-        Number of pixel lines inserted between characters.  Useful if the font
-        uses the full character cell height, making lines touch each other.
-        When non-zero there is room for underlining.
-        With some fonts there can be too much room between lines (to have
-        space for ascents and descents).  Then it makes sense to set
-        'linespace' to a negative value.  This may cause display problems
-        though!
+							     *'linespace'* *'lsp'*
+'linespace' 'lsp'	number (default 0)
+			global
+	only in the GUI
+	Number of pixel lines inserted between characters.  Useful if the font
+	uses the full character cell height, making lines touch each other.
+	When non-zero there is room for underlining.
+	With some fonts there can be too much room between lines (to have
+	space for ascents and descents).  Then it makes sense to set
+	'linespace' to a negative value.  This may cause display problems
+	though!
 
-                                                               *'lisp'* *'nolisp'*
-'lisp'                  boolean (default off)
-                        local to buffer
-        Lisp mode: When <Enter> is typed in insert mode set the indent for
-        the next line to Lisp standards (well, sort of).  Also happens with
-        "cc" or "S".  'autoindent' must also be on for this to work.  The 'p'
-        flag in 'cpoptions' changes the method of indenting: Vi compatible or
-        better.  Also see 'lispwords'.
-        The '-' character is included in keyword characters.  Redefines the
-        "=" operator to use this same indentation algorithm rather than
-        calling an external program if 'equalprg' is empty.
+							       *'lisp'* *'nolisp'*
+'lisp'			boolean (default off)
+			local to buffer
+	Lisp mode: When <Enter> is typed in insert mode set the indent for
+	the next line to Lisp standards (well, sort of).  Also happens with
+	"cc" or "S".  'autoindent' must also be on for this to work.  The 'p'
+	flag in 'cpoptions' changes the method of indenting: Vi compatible or
+	better.  Also see 'lispwords'.
+	The '-' character is included in keyword characters.  Redefines the
+	"=" operator to use this same indentation algorithm rather than
+	calling an external program if 'equalprg' is empty.
 
-                                                           *'lispoptions'* *'lop'*
-'lispoptions' 'lop'     string (default "")
-                        local to buffer
-        Comma-separated list of items that influence the Lisp indenting when
-        enabled with the |'lisp'| option.  Currently only one item is
-        supported:
-                expr:1  use 'indentexpr' for Lisp indenting when it is set
-                expr:0  do not use 'indentexpr' for Lisp indenting (default)
-        Note that when using 'indentexpr' the `=` operator indents all the
-        lines, otherwise the first line is not indented (Vi-compatible).
+							   *'lispoptions'* *'lop'*
+'lispoptions' 'lop'	string (default "")
+			local to buffer
+	Comma-separated list of items that influence the Lisp indenting when
+	enabled with the |'lisp'| option.  Currently only one item is
+	supported:
+		expr:1	use 'indentexpr' for Lisp indenting when it is set
+		expr:0	do not use 'indentexpr' for Lisp indenting (default)
+	Note that when using 'indentexpr' the `=` operator indents all the
+	lines, otherwise the first line is not indented (Vi-compatible).
 
-                                                              *'lispwords'* *'lw'*
-'lispwords' 'lw'        string (default is very long)
-                        global or local to buffer |global-local|
-        Comma-separated list of words that influence the Lisp indenting when
-        enabled with the |'lisp'| option.
+							      *'lispwords'* *'lw'*
+'lispwords' 'lw'	string (default is very long)
+			global or local to buffer |global-local|
+	Comma-separated list of words that influence the Lisp indenting when
+	enabled with the |'lisp'| option.
 
-                                                               *'list'* *'nolist'*
-'list'                  boolean (default off)
-                        local to window
-        List mode: By default, show tabs as ">", trailing spaces as "-", and
-        non-breakable space characters as "+". Useful to see the difference
-        between tabs and spaces and for trailing blanks. Further changed by
-        the 'listchars' option.
+							       *'list'* *'nolist'*
+'list'			boolean (default off)
+			local to window
+	List mode: By default, show tabs as ">", trailing spaces as "-", and
+	non-breakable space characters as "+". Useful to see the difference
+	between tabs and spaces and for trailing blanks. Further changed by
+	the 'listchars' option.
 
-        The cursor is displayed at the start of the space a Tab character
-        occupies, not at the end as usual in Normal mode.  To get this cursor
-        position while displaying Tabs with spaces, use: >vim
-                set list lcs=tab:\ \
+	The cursor is displayed at the start of the space a Tab character
+	occupies, not at the end as usual in Normal mode.  To get this cursor
+	position while displaying Tabs with spaces, use: >vim
+		set list lcs=tab:\ \
 <
-        Note that list mode will also affect formatting (set with 'textwidth'
-        or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
-        changing the way tabs are displayed.
+	Note that list mode will also affect formatting (set with 'textwidth'
+	or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
+	changing the way tabs are displayed.
 
-                                                             *'listchars'* *'lcs'*
-'listchars' 'lcs'       string (default "tab:> ,trail:-,nbsp:+")
-                        global or local to window |global-local|
-        Strings to use in 'list' mode and for the |:list| command.  It is a
-        comma-separated list of string settings.
+							     *'listchars'* *'lcs'*
+'listchars' 'lcs'	string (default "tab:> ,trail:-,nbsp:+")
+			global or local to window |global-local|
+	Strings to use in 'list' mode and for the |:list| command.  It is a
+	comma-separated list of string settings.
 
-                                                        *lcs-eol*
-          eol:c         Character to show at the end of each line.  When
-                        omitted, there is no extra character at the end of the
-                        line.
-                                                        *lcs-tab*
-          tab:xy[z]     Two or three characters to be used to show a tab.
-                        The third character is optional.
+							*lcs-eol*
+	  eol:c		Character to show at the end of each line.  When
+			omitted, there is no extra character at the end of the
+			line.
+							*lcs-tab*
+	  tab:xy[z]	Two or three characters to be used to show a tab.
+			The third character is optional.
 
-          tab:xy        The 'x' is always used, then 'y' as many times as will
-                        fit.  Thus "tab:>-" displays: >
-                                >
-                                >-
-                                >--
-                                etc.
+	  tab:xy	The 'x' is always used, then 'y' as many times as will
+			fit.  Thus "tab:>-" displays: >
+				>
+				>-
+				>--
+				etc.
 <
-          tab:xyz       The 'z' is always used, then 'x' is prepended, and
-                        then 'y' is used as many times as will fit.  Thus
-                        "tab:<->" displays: >
-                                >
-                                <>
-                                <->
-                                <-->
-                                etc.
+	  tab:xyz	The 'z' is always used, then 'x' is prepended, and
+			then 'y' is used as many times as will fit.  Thus
+			"tab:<->" displays: >
+				>
+				<>
+				<->
+				<-->
+				etc.
 <
-                        When "tab:" is omitted, a tab is shown as ^I.
-                                                        *lcs-space*
-          space:c       Character to show for a space.  When omitted, spaces
-                        are left blank.
-                                                        *lcs-multispace*
-          multispace:c...
-                        One or more characters to use cyclically to show for
-                        multiple consecutive spaces.  Overrides the "space"
-                        setting, except for single spaces.  When omitted, the
-                        "space" setting is used.  For example,
-                        `:set listchars=multispace:---+` shows ten consecutive
-                        spaces as: >
-                                ---+---+--
+			When "tab:" is omitted, a tab is shown as ^I.
+							*lcs-space*
+	  space:c	Character to show for a space.	When omitted, spaces
+			are left blank.
+							*lcs-multispace*
+	  multispace:c...
+			One or more characters to use cyclically to show for
+			multiple consecutive spaces.  Overrides the "space"
+			setting, except for single spaces.  When omitted, the
+			"space" setting is used.  For example,
+			`:set listchars=multispace:---+` shows ten consecutive
+			spaces as: >
+				---+---+--
 <
-                                                        *lcs-lead*
-          lead:c        Character to show for leading spaces.  When omitted,
-                        leading spaces are blank.  Overrides the "space" and
-                        "multispace" settings for leading spaces.  You can
-                        combine it with "tab:", for example: >vim
-                                set listchars+=tab:>-,lead:.
+							*lcs-lead*
+	  lead:c	Character to show for leading spaces.  When omitted,
+			leading spaces are blank.  Overrides the "space" and
+			"multispace" settings for leading spaces.  You can
+			combine it with "tab:", for example: >vim
+				set listchars+=tab:>-,lead:.
 <
-                                                        *lcs-leadmultispace*
-          leadmultispace:c...
-                        Like the |lcs-multispace| value, but for leading
-                        spaces only.  Also overrides |lcs-lead| for leading
-                        multiple spaces.
-                        `:set listchars=leadmultispace:---+` shows ten
-                        consecutive leading spaces as: >
-                                ---+---+--XXX
+							*lcs-leadmultispace*
+	  leadmultispace:c...
+			Like the |lcs-multispace| value, but for leading
+			spaces only.  Also overrides |lcs-lead| for leading
+			multiple spaces.
+			`:set listchars=leadmultispace:---+` shows ten
+			consecutive leading spaces as: >
+				---+---+--XXX
 <
-                        Where "XXX" denotes the first non-blank characters in
-                        the line.
-                                                        *lcs-trail*
-          trail:c       Character to show for trailing spaces.  When omitted,
-                        trailing spaces are blank.  Overrides the "space" and
-                        "multispace" settings for trailing spaces.
-                                                        *lcs-extends*
-          extends:c     Character to show in the last column, when 'wrap' is
-                        off and the line continues beyond the right of the
-                        screen.
-                                                        *lcs-precedes*
-          precedes:c    Character to show in the first visible column of the
-                        physical line, when there is text preceding the
-                        character visible in the first column.
-                                                        *lcs-conceal*
-          conceal:c     Character to show in place of concealed text, when
-                        'conceallevel' is set to 1.  A space when omitted.
-                                                        *lcs-nbsp*
-          nbsp:c        Character to show for a non-breakable space character
-                        (0xA0 (160 decimal) and U+202F).  Left blank when
-                        omitted.
+			Where "XXX" denotes the first non-blank characters in
+			the line.
+							*lcs-trail*
+	  trail:c	Character to show for trailing spaces.	When omitted,
+			trailing spaces are blank.  Overrides the "space" and
+			"multispace" settings for trailing spaces.
+							*lcs-extends*
+	  extends:c	Character to show in the last column, when 'wrap' is
+			off and the line continues beyond the right of the
+			screen.
+							*lcs-precedes*
+	  precedes:c	Character to show in the first visible column of the
+			physical line, when there is text preceding the
+			character visible in the first column.
+							*lcs-conceal*
+	  conceal:c	Character to show in place of concealed text, when
+			'conceallevel' is set to 1.  A space when omitted.
+							*lcs-nbsp*
+	  nbsp:c	Character to show for a non-breakable space character
+			(0xA0 (160 decimal) and U+202F).  Left blank when
+			omitted.
 
-        The characters ':' and ',' should not be used.  UTF-8 characters can
-        be used.  All characters must be single width.
+	The characters ':' and ',' should not be used.	UTF-8 characters can
+	be used.  All characters must be single width.
 
-        Each character can be specified as hex: >vim
-                set listchars=eol:\\x24
-                set listchars=eol:\\u21b5
-                set listchars=eol:\\U000021b5
-<       Note that a double backslash is used.  The number of hex characters
-        must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
+	Each character can be specified as hex: >vim
+		set listchars=eol:\\x24
+		set listchars=eol:\\u21b5
+		set listchars=eol:\\U000021b5
+<	Note that a double backslash is used.  The number of hex characters
+	must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
 
-        Examples: >vim
-            set lcs=tab:>-,trail:-
-            set lcs=tab:>-,eol:<,nbsp:%
-            set lcs=extends:>,precedes:<
-<       |hl-NonText| highlighting will be used for "eol", "extends" and
-        "precedes". |hl-Whitespace| for "nbsp", "space", "tab", "multispace",
-        "lead" and "trail".
+	Examples: >vim
+	    set lcs=tab:>-,trail:-
+	    set lcs=tab:>-,eol:<,nbsp:%
+	    set lcs=extends:>,precedes:<
+<	|hl-NonText| highlighting will be used for "eol", "extends" and
+	"precedes". |hl-Whitespace| for "nbsp", "space", "tab", "multispace",
+	"lead" and "trail".
 
-                                   *'loadplugins'* *'lpl'* *'noloadplugins'* *'nolpl'*
-'loadplugins' 'lpl'     boolean (default on)
-                        global
-        When on the plugin scripts are loaded when starting up |load-plugins|.
-        This option can be reset in your |vimrc| file to disable the loading
-        of plugins.
-        Note that using the "-u NONE" and "--noplugin" command line arguments
-        reset this option. |-u| |--noplugin|
+				   *'loadplugins'* *'lpl'* *'noloadplugins'* *'nolpl'*
+'loadplugins' 'lpl'	boolean (default on)
+			global
+	When on the plugin scripts are loaded when starting up |load-plugins|.
+	This option can be reset in your |vimrc| file to disable the loading
+	of plugins.
+	Note that using the "-u NONE" and "--noplugin" command line arguments
+	reset this option. |-u| |--noplugin|
 
-                                                             *'magic'* *'nomagic'*
-'magic'                 boolean (default on)
-                        global
-        Changes the special characters that can be used in search patterns.
-        See |pattern|.
-        WARNING: Switching this option off most likely breaks plugins!  That
-        is because many patterns assume it's on and will fail when it's off.
-        Only switch it off when working with old Vi scripts.  In any other
-        situation write patterns that work when 'magic' is on.  Include "\M"
-        when you want to |/\M|.
+							     *'magic'* *'nomagic'*
+'magic'			boolean (default on)
+			global
+	Changes the special characters that can be used in search patterns.
+	See |pattern|.
+	WARNING: Switching this option off most likely breaks plugins!	That
+	is because many patterns assume it's on and will fail when it's off.
+	Only switch it off when working with old Vi scripts.  In any other
+	situation write patterns that work when 'magic' is on.	Include "\M"
+	when you want to |/\M|.
 
-                                                                *'makeef'* *'mef'*
-'makeef' 'mef'          string (default "")
-                        global
-        Name of the errorfile for the |:make| command (see |:make_makeprg|)
-        and the |:grep| command.
-        When it is empty, an internally generated temp file will be used.
-        When "##" is included, it is replaced by a number to make the name
-        unique.  This makes sure that the ":make" command doesn't overwrite an
-        existing file.
-        NOT used for the ":cf" command.  See 'errorfile' for that.
-        Environment variables are expanded |:set_env|.
-        See |option-backslash| about including spaces and backslashes.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+								*'makeef'* *'mef'*
+'makeef' 'mef'		string (default "")
+			global
+	Name of the errorfile for the |:make| command (see |:make_makeprg|)
+	and the |:grep| command.
+	When it is empty, an internally generated temp file will be used.
+	When "##" is included, it is replaced by a number to make the name
+	unique.  This makes sure that the ":make" command doesn't overwrite an
+	existing file.
+	NOT used for the ":cf" command.  See 'errorfile' for that.
+	Environment variables are expanded |:set_env|.
+	See |option-backslash| about including spaces and backslashes.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                         *'makeencoding'* *'menc'*
-'makeencoding' 'menc'   string (default "")
-                        global or local to buffer |global-local|
-        Encoding used for reading the output of external commands.  When empty,
-        encoding is not converted.
-        This is used for `:make`, `:lmake`, `:grep`, `:lgrep`, `:grepadd`,
-        `:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
-        and `:laddfile`.
+							 *'makeencoding'* *'menc'*
+'makeencoding' 'menc'	string (default "")
+			global or local to buffer |global-local|
+	Encoding used for reading the output of external commands.  When empty,
+	encoding is not converted.
+	This is used for `:make`, `:lmake`, `:grep`, `:lgrep`, `:grepadd`,
+	`:lgrepadd`, `:cfile`, `:cgetfile`, `:caddfile`, `:lfile`, `:lgetfile`,
+	and `:laddfile`.
 
-        This would be mostly useful when you use MS-Windows.  If iconv is
-        enabled, setting 'makeencoding' to "char" has the same effect as
-        setting to the system locale encoding.  Example: >vim
-                set makeencoding=char   " system locale is used
+	This would be mostly useful when you use MS-Windows.  If iconv is
+	enabled, setting 'makeencoding' to "char" has the same effect as
+	setting to the system locale encoding.	Example: >vim
+		set makeencoding=char	" system locale is used
 <
 
-                                                                *'makeprg'* *'mp'*
-'makeprg' 'mp'          string (default "make")
-                        global or local to buffer |global-local|
-        Program to use for the ":make" command.  See |:make_makeprg|.
-        This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
-        which are expanded to the current and alternate file name.  Use |::S|
-        to escape file names in case they contain special characters.
-        Environment variables are expanded |:set_env|.  See |option-backslash|
-        about including spaces and backslashes.
-        Note that a '|' must be escaped twice: once for ":set" and once for
-        the interpretation of a command.  When you use a filter called
-        "myfilter" do it like this: >vim
-            set makeprg=gmake\ \\\|\ myfilter
-<       The placeholder "$*" can be given (even multiple times) to specify
-        where the arguments will be included, for example: >vim
-            set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
-<       This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+								*'makeprg'* *'mp'*
+'makeprg' 'mp'		string (default "make")
+			global or local to buffer |global-local|
+	Program to use for the ":make" command.  See |:make_makeprg|.
+	This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
+	which are expanded to the current and alternate file name.  Use |::S|
+	to escape file names in case they contain special characters.
+	Environment variables are expanded |:set_env|.	See |option-backslash|
+	about including spaces and backslashes.
+	Note that a '|' must be escaped twice: once for ":set" and once for
+	the interpretation of a command.  When you use a filter called
+	"myfilter" do it like this: >vim
+	    set makeprg=gmake\ \\\|\ myfilter
+<	The placeholder "$*" can be given (even multiple times) to specify
+	where the arguments will be included, for example: >vim
+	    set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
+<	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                            *'matchpairs'* *'mps'*
-'matchpairs' 'mps'      string (default "(:),{:},[:]")
-                        local to buffer
-        Characters that form pairs.  The |%| command jumps from one to the
-        other.
-        Only character pairs are allowed that are different, thus you cannot
-        jump between two double quotes.
-        The characters must be separated by a colon.
-        The pairs must be separated by a comma.  Example for including '<' and
-        '>' (for HTML): >vim
-                set mps+=<:>
+							    *'matchpairs'* *'mps'*
+'matchpairs' 'mps'	string (default "(:),{:},[:]")
+			local to buffer
+	Characters that form pairs.  The |%| command jumps from one to the
+	other.
+	Only character pairs are allowed that are different, thus you cannot
+	jump between two double quotes.
+	The characters must be separated by a colon.
+	The pairs must be separated by a comma.  Example for including '<' and
+	'>' (for HTML): >vim
+		set mps+=<:>
 
-<       A more exotic example, to jump between the '=' and ';' in an
-        assignment, useful for languages like C and Java: >vim
-                au FileType c,cpp,java set mps+==:;
+<	A more exotic example, to jump between the '=' and ';' in an
+	assignment, useful for languages like C and Java: >vim
+		au FileType c,cpp,java set mps+==:;
 
-<       For a more advanced way of using "%", see the matchit.vim plugin in
-        the $VIMRUNTIME/plugin directory. |add-local-help|
+<	For a more advanced way of using "%", see the matchit.vim plugin in
+	the $VIMRUNTIME/plugin directory. |add-local-help|
 
-                                                             *'matchtime'* *'mat'*
-'matchtime' 'mat'       number (default 5)
-                        global
-        Tenths of a second to show the matching paren, when 'showmatch' is
-        set.  Note that this is not in milliseconds, like other options that
-        set a time.  This is to be compatible with Nvi.
+							     *'matchtime'* *'mat'*
+'matchtime' 'mat'	number (default 5)
+			global
+	Tenths of a second to show the matching paren, when 'showmatch' is
+	set.  Note that this is not in milliseconds, like other options that
+	set a time.  This is to be compatible with Nvi.
 
-                                                          *'maxfuncdepth'* *'mfd'*
-'maxfuncdepth' 'mfd'    number (default 100)
-                        global
-        Maximum depth of function calls for user functions.  This normally
-        catches endless recursion.  When using a recursive function with
-        more depth, set 'maxfuncdepth' to a bigger number.  But this will use
-        more memory, there is the danger of failing when memory is exhausted.
-        Increasing this limit above 200 also changes the maximum for Ex
-        command recursion, see |E169|.
-        See also |:function|.
-        Also used for maximum depth of callback functions.
+							  *'maxfuncdepth'* *'mfd'*
+'maxfuncdepth' 'mfd'	number (default 100)
+			global
+	Maximum depth of function calls for user functions.  This normally
+	catches endless recursion.  When using a recursive function with
+	more depth, set 'maxfuncdepth' to a bigger number.  But this will use
+	more memory, there is the danger of failing when memory is exhausted.
+	Increasing this limit above 200 also changes the maximum for Ex
+	command recursion, see |E169|.
+	See also |:function|.
+	Also used for maximum depth of callback functions.
 
-                                                      *'maxmapdepth'* *'mmd'* *E223*
-'maxmapdepth' 'mmd'     number (default 1000)
-                        global
-        Maximum number of times a mapping is done without resulting in a
-        character to be used.  This normally catches endless mappings, like
-        ":map x y" with ":map y x".  It still does not catch ":map g wg",
-        because the 'w' is used before the next mapping is done.  See also
-        |key-mapping|.
+						      *'maxmapdepth'* *'mmd'* *E223*
+'maxmapdepth' 'mmd'	number (default 1000)
+			global
+	Maximum number of times a mapping is done without resulting in a
+	character to be used.  This normally catches endless mappings, like
+	":map x y" with ":map y x".  It still does not catch ":map g wg",
+	because the 'w' is used before the next mapping is done.  See also
+	|key-mapping|.
 
-                                                         *'maxmempattern'* *'mmp'*
-'maxmempattern' 'mmp'   number (default 1000)
-                        global
-        Maximum amount of memory (in Kbyte) to use for pattern matching.
-        The maximum value is about 2000000.  Use this to work without a limit.
-                                                        *E363*
-        When Vim runs into the limit it gives an error message and mostly
-        behaves like CTRL-C was typed.
-        Running into the limit often means that the pattern is very
-        inefficient or too complex.  This may already happen with the pattern
-        "\(.\)*" on a very long line.  ".*" works much better.
-        Might also happen on redraw, when syntax rules try to match a complex
-        text structure.
-        Vim may run out of memory before hitting the 'maxmempattern' limit, in
-        which case you get an "Out of memory" error instead.
+							 *'maxmempattern'* *'mmp'*
+'maxmempattern' 'mmp'	number (default 1000)
+			global
+	Maximum amount of memory (in Kbyte) to use for pattern matching.
+	The maximum value is about 2000000.  Use this to work without a limit.
+							*E363*
+	When Vim runs into the limit it gives an error message and mostly
+	behaves like CTRL-C was typed.
+	Running into the limit often means that the pattern is very
+	inefficient or too complex.  This may already happen with the pattern
+	"\(.\)*" on a very long line.  ".*" works much better.
+	Might also happen on redraw, when syntax rules try to match a complex
+	text structure.
+	Vim may run out of memory before hitting the 'maxmempattern' limit, in
+	which case you get an "Out of memory" error instead.
 
-                                                             *'menuitems'* *'mis'*
-'menuitems' 'mis'       number (default 25)
-                        global
-        Maximum number of items to use in a menu.  Used for menus that are
-        generated from a list of items, e.g., the Buffers menu.  Changing this
-        option has no direct effect, the menu must be refreshed first.
+							     *'menuitems'* *'mis'*
+'menuitems' 'mis'	number (default 25)
+			global
+	Maximum number of items to use in a menu.  Used for menus that are
+	generated from a list of items, e.g., the Buffers menu.  Changing this
+	option has no direct effect, the menu must be refreshed first.
 
-                                                            *'mkspellmem'* *'msm'*
-'mkspellmem' 'msm'      string (default "460000,2000,500")
-                        global
-        Parameters for |:mkspell|.  This tunes when to start compressing the
-        word tree.  Compression can be slow when there are many words, but
-        it's needed to avoid running out of memory.  The amount of memory used
-        per word depends very much on how similar the words are, that's why
-        this tuning is complicated.
+							    *'mkspellmem'* *'msm'*
+'mkspellmem' 'msm'	string (default "460000,2000,500")
+			global
+	Parameters for |:mkspell|.  This tunes when to start compressing the
+	word tree.  Compression can be slow when there are many words, but
+	it's needed to avoid running out of memory.  The amount of memory used
+	per word depends very much on how similar the words are, that's why
+	this tuning is complicated.
 
-        There are three numbers, separated by commas: >
-                {start},{inc},{added}
+	There are three numbers, separated by commas: >
+		{start},{inc},{added}
 <
-        For most languages the uncompressed word tree fits in memory.  {start}
-        gives the amount of memory in Kbyte that can be used before any
-        compression is done.  It should be a bit smaller than the amount of
-        memory that is available to Vim.
+	For most languages the uncompressed word tree fits in memory.  {start}
+	gives the amount of memory in Kbyte that can be used before any
+	compression is done.  It should be a bit smaller than the amount of
+	memory that is available to Vim.
 
-        When going over the {start} limit the {inc} number specifies the
-        amount of memory in Kbyte that can be allocated before another
-        compression is done.  A low number means compression is done after
-        less words are added, which is slow.  A high number means more memory
-        will be allocated.
+	When going over the {start} limit the {inc} number specifies the
+	amount of memory in Kbyte that can be allocated before another
+	compression is done.  A low number means compression is done after
+	less words are added, which is slow.  A high number means more memory
+	will be allocated.
 
-        After doing compression, {added} times 1024 words can be added before
-        the {inc} limit is ignored and compression is done when any extra
-        amount of memory is needed.  A low number means there is a smaller
-        chance of hitting the {inc} limit, less memory is used but it's
-        slower.
+	After doing compression, {added} times 1024 words can be added before
+	the {inc} limit is ignored and compression is done when any extra
+	amount of memory is needed.  A low number means there is a smaller
+	chance of hitting the {inc} limit, less memory is used but it's
+	slower.
 
-        The languages for which these numbers are important are Italian and
-        Hungarian.  The default works for when you have about 512 Mbyte.  If
-        you have 1 Gbyte you could use: >vim
-                set mkspellmem=900000,3000,800
-<       If you have less than 512 Mbyte |:mkspell| may fail for some
-        languages, no matter what you set 'mkspellmem' to.
+	The languages for which these numbers are important are Italian and
+	Hungarian.  The default works for when you have about 512 Mbyte.  If
+	you have 1 Gbyte you could use: >vim
+		set mkspellmem=900000,3000,800
+<	If you have less than 512 Mbyte |:mkspell| may fail for some
+	languages, no matter what you set 'mkspellmem' to.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                           *'modeline'* *'ml'* *'nomodeline'* *'noml'*
-'modeline' 'ml'         boolean (default on (off for root))
-                        local to buffer
-        If 'modeline' is on 'modelines' gives the number of lines that is
-        checked for set commands.  If 'modeline' is off or 'modelines' is zero
-        no lines are checked.  See |modeline|.
+					   *'modeline'* *'ml'* *'nomodeline'* *'noml'*
+'modeline' 'ml'		boolean (default on (off for root))
+			local to buffer
+	If 'modeline' is on 'modelines' gives the number of lines that is
+	checked for set commands.  If 'modeline' is off or 'modelines' is zero
+	no lines are checked.  See |modeline|.
 
-                                 *'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
-'modelineexpr' 'mle'    boolean (default off)
-                        global
-        When on allow some options that are an expression to be set in the
-        modeline.  Check the option for whether it is affected by
-        'modelineexpr'.  Also see |modeline|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+				 *'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
+'modelineexpr' 'mle'	boolean (default off)
+			global
+	When on allow some options that are an expression to be set in the
+	modeline.  Check the option for whether it is affected by
+	'modelineexpr'.  Also see |modeline|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                             *'modelines'* *'mls'*
-'modelines' 'mls'       number (default 5)
-                        global
-        If 'modeline' is on 'modelines' gives the number of lines that is
-        checked for set commands.  If 'modeline' is off or 'modelines' is zero
-        no lines are checked.  See |modeline|.
+							     *'modelines'* *'mls'*
+'modelines' 'mls'	number (default 5)
+			global
+	If 'modeline' is on 'modelines' gives the number of lines that is
+	checked for set commands.  If 'modeline' is off or 'modelines' is zero
+	no lines are checked.  See |modeline|.
 
 
-                                   *'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
-'modifiable' 'ma'       boolean (default on)
-                        local to buffer
-        When off the buffer contents cannot be changed.  The 'fileformat' and
-        'fileencoding' options also can't be changed.
-        Can be reset on startup with the |-M| command line argument.
+				   *'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
+'modifiable' 'ma'	boolean (default on)
+			local to buffer
+	When off the buffer contents cannot be changed.  The 'fileformat' and
+	'fileencoding' options also can't be changed.
+	Can be reset on startup with the |-M| command line argument.
 
-                                         *'modified'* *'mod'* *'nomodified'* *'nomod'*
-'modified' 'mod'        boolean (default off)
-                        local to buffer  |local-noglobal|
-        When on, the buffer is considered to be modified.  This option is set
-        when:
-        1. A change was made to the text since it was last written.  Using the
-           |undo| command to go back to the original text will reset the
-           option.  But undoing changes that were made before writing the
-           buffer will set the option again, since the text is different from
-           when it was written.
-        2. 'fileformat' or 'fileencoding' is different from its original
-           value.  The original value is set when the buffer is read or
-           written.  A ":set nomodified" command also resets the original
-           values to the current values and the 'modified' option will be
-           reset.
-           Similarly for 'eol' and 'bomb'.
-        This option is not set when a change is made to the buffer as the
-        result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
-        FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
-        an explanation.
-        When 'buftype' is "nowrite" or "nofile" this option may be set, but
-        will be ignored.
-        Note that the text may actually be the same, e.g. 'modified' is set
-        when using "rA" on an "A".
+					 *'modified'* *'mod'* *'nomodified'* *'nomod'*
+'modified' 'mod'	boolean (default off)
+			local to buffer  |local-noglobal|
+	When on, the buffer is considered to be modified.  This option is set
+	when:
+	1. A change was made to the text since it was last written.  Using the
+	   |undo| command to go back to the original text will reset the
+	   option.  But undoing changes that were made before writing the
+	   buffer will set the option again, since the text is different from
+	   when it was written.
+	2. 'fileformat' or 'fileencoding' is different from its original
+	   value.  The original value is set when the buffer is read or
+	   written.  A ":set nomodified" command also resets the original
+	   values to the current values and the 'modified' option will be
+	   reset.
+	   Similarly for 'eol' and 'bomb'.
+	This option is not set when a change is made to the buffer as the
+	result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
+	FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
+	an explanation.
+	When 'buftype' is "nowrite" or "nofile" this option may be set, but
+	will be ignored.
+	Note that the text may actually be the same, e.g. 'modified' is set
+	when using "rA" on an "A".
 
-                                                               *'more'* *'nomore'*
-'more'                  boolean (default on)
-                        global
-        When on, listings pause when the whole screen is filled.  You will get
-        the |more-prompt|.  When this option is off there are no pauses, the
-        listing continues until finished.
+							       *'more'* *'nomore'*
+'more'			boolean (default on)
+			global
+	When on, listings pause when the whole screen is filled.  You will get
+	the |more-prompt|.  When this option is off there are no pauses, the
+	listing continues until finished.
 
-                                                                       *'mouse'*
-'mouse'                 string (default "nvi")
-                        global
-        Enables mouse support. For example, to enable the mouse in Normal mode
-        and Visual mode: >vim
-                set mouse=nv
+								       *'mouse'*
+'mouse'			string (default "nvi")
+			global
+	Enables mouse support. For example, to enable the mouse in Normal mode
+	and Visual mode: >vim
+		set mouse=nv
 <
-        To temporarily disable mouse support, hold the shift key while using
-        the mouse.
+	To temporarily disable mouse support, hold the shift key while using
+	the mouse.
 
-        Mouse support can be enabled for different modes:
-                n       Normal mode
-                v       Visual mode
-                i       Insert mode
-                c       Command-line mode
-                h       all previous modes when editing a help file
-                a       all previous modes
-                r       for |hit-enter| and |more-prompt| prompt
+	Mouse support can be enabled for different modes:
+		n	Normal mode
+		v	Visual mode
+		i	Insert mode
+		c	Command-line mode
+		h	all previous modes when editing a help file
+		a	all previous modes
+		r	for |hit-enter| and |more-prompt| prompt
 
-        Left-click anywhere in a text buffer to place the cursor there.  This
-        works with operators too, e.g. type |d| then left-click to delete text
-        from the current cursor position to the position where you clicked.
+	Left-click anywhere in a text buffer to place the cursor there.  This
+	works with operators too, e.g. type |d| then left-click to delete text
+	from the current cursor position to the position where you clicked.
 
-        Drag the |status-line| or vertical separator of a window to resize it.
+	Drag the |status-line| or vertical separator of a window to resize it.
 
-        If enabled for "v" (Visual mode) then double-click selects word-wise,
-        triple-click makes it line-wise, and quadruple-click makes it
-        rectangular block-wise.
+	If enabled for "v" (Visual mode) then double-click selects word-wise,
+	triple-click makes it line-wise, and quadruple-click makes it
+	rectangular block-wise.
 
-        For scrolling with a mouse wheel see |scroll-mouse-wheel|.
+	For scrolling with a mouse wheel see |scroll-mouse-wheel|.
 
-        Note: When enabling the mouse in a terminal, copy/paste will use the
-        "* register if possible. See also 'clipboard'.
+	Note: When enabling the mouse in a terminal, copy/paste will use the
+	"* register if possible. See also 'clipboard'.
 
-        Related options:
-        'mousefocus'    window focus follows mouse pointer
-        'mousemodel'    what mouse button does which action
-        'mousehide'     hide mouse pointer while typing text
-        'selectmode'    whether to start Select mode or Visual mode
+	Related options:
+	'mousefocus'	window focus follows mouse pointer
+	'mousemodel'	what mouse button does which action
+	'mousehide'	hide mouse pointer while typing text
+	'selectmode'	whether to start Select mode or Visual mode
 
-                               *'mousefocus'* *'mousef'* *'nomousefocus'* *'nomousef'*
-'mousefocus' 'mousef'   boolean (default off)
-                        global
-        The window that the mouse pointer is on is automatically activated.
-        When changing the window layout or window focus in another way, the
-        mouse pointer is moved to the window with keyboard focus.  Off is the
-        default because it makes using the pull down menus a little goofy, as
-        a pointer transit may activate a window unintentionally.
+			       *'mousefocus'* *'mousef'* *'nomousefocus'* *'nomousef'*
+'mousefocus' 'mousef'	boolean (default off)
+			global
+	The window that the mouse pointer is on is automatically activated.
+	When changing the window layout or window focus in another way, the
+	mouse pointer is moved to the window with keyboard focus.  Off is the
+	default because it makes using the pull down menus a little goofy, as
+	a pointer transit may activate a window unintentionally.
 
-                                         *'mousehide'* *'mh'* *'nomousehide'* *'nomh'*
-'mousehide' 'mh'        boolean (default on)
-                        global
-        only in the GUI
-        When on, the mouse pointer is hidden when characters are typed.
-        The mouse pointer is restored when the mouse is moved.
+					 *'mousehide'* *'mh'* *'nomousehide'* *'nomh'*
+'mousehide' 'mh'	boolean (default on)
+			global
+	only in the GUI
+	When on, the mouse pointer is hidden when characters are typed.
+	The mouse pointer is restored when the mouse is moved.
 
-                                                         *'mousemodel'* *'mousem'*
-'mousemodel' 'mousem'   string (default "popup_setpos")
-                        global
-        Sets the model to use for the mouse.  The name mostly specifies what
-        the right mouse button is used for:
-           extend       Right mouse button extends a selection.  This works
-                        like in an xterm.
-           popup        Right mouse button pops up a menu.  The shifted left
-                        mouse button extends a selection.  This works like
-                        with Microsoft Windows.
-           popup_setpos Like "popup", but the cursor will be moved to the
-                        position where the mouse was clicked, and thus the
-                        selected operation will act upon the clicked object.
-                        If clicking inside a selection, that selection will
-                        be acted upon, i.e. no cursor move.  This implies of
-                        course, that right clicking outside a selection will
-                        end Visual mode.
-        Overview of what button does what for each model:
-        mouse               extend              popup(_setpos) ~
-        left click          place cursor        place cursor
-        left drag           start selection     start selection
-        shift-left          search word         extend selection
-        right click         extend selection    popup menu (place cursor)
-        right drag          extend selection    -
-        middle click        paste               paste
+							 *'mousemodel'* *'mousem'*
+'mousemodel' 'mousem'	string (default "popup_setpos")
+			global
+	Sets the model to use for the mouse.  The name mostly specifies what
+	the right mouse button is used for:
+	   extend	Right mouse button extends a selection.  This works
+			like in an xterm.
+	   popup	Right mouse button pops up a menu.  The shifted left
+			mouse button extends a selection.  This works like
+			with Microsoft Windows.
+	   popup_setpos Like "popup", but the cursor will be moved to the
+			position where the mouse was clicked, and thus the
+			selected operation will act upon the clicked object.
+			If clicking inside a selection, that selection will
+			be acted upon, i.e. no cursor move.  This implies of
+			course, that right clicking outside a selection will
+			end Visual mode.
+	Overview of what button does what for each model:
+	mouse		    extend		popup(_setpos) ~
+	left click	    place cursor	place cursor
+	left drag	    start selection	start selection
+	shift-left	    search word		extend selection
+	right click	    extend selection	popup menu (place cursor)
+	right drag	    extend selection	-
+	middle click	    paste		paste
 
-        In the "popup" model the right mouse button produces a pop-up menu.
-        Nvim creates a default |popup-menu| but you can redefine it.
+	In the "popup" model the right mouse button produces a pop-up menu.
+	Nvim creates a default |popup-menu| but you can redefine it.
 
-        Note that you can further refine the meaning of buttons with mappings.
-        See |mouse-overview|.  But mappings are NOT used for modeless selection.
+	Note that you can further refine the meaning of buttons with mappings.
+	See |mouse-overview|.  But mappings are NOT used for modeless selection.
 
-        Example: >vim
-            map <S-LeftMouse>     <RightMouse>
-            map <S-LeftDrag>      <RightDrag>
-            map <S-LeftRelease>   <RightRelease>
-            map <2-S-LeftMouse>   <2-RightMouse>
-            map <2-S-LeftDrag>    <2-RightDrag>
-            map <2-S-LeftRelease> <2-RightRelease>
-            map <3-S-LeftMouse>   <3-RightMouse>
-            map <3-S-LeftDrag>    <3-RightDrag>
-            map <3-S-LeftRelease> <3-RightRelease>
-            map <4-S-LeftMouse>   <4-RightMouse>
-            map <4-S-LeftDrag>    <4-RightDrag>
-            map <4-S-LeftRelease> <4-RightRelease>
+	Example: >vim
+	    map <S-LeftMouse>	  <RightMouse>
+	    map <S-LeftDrag>	  <RightDrag>
+	    map <S-LeftRelease>   <RightRelease>
+	    map <2-S-LeftMouse>   <2-RightMouse>
+	    map <2-S-LeftDrag>	  <2-RightDrag>
+	    map <2-S-LeftRelease> <2-RightRelease>
+	    map <3-S-LeftMouse>   <3-RightMouse>
+	    map <3-S-LeftDrag>	  <3-RightDrag>
+	    map <3-S-LeftRelease> <3-RightRelease>
+	    map <4-S-LeftMouse>   <4-RightMouse>
+	    map <4-S-LeftDrag>	  <4-RightDrag>
+	    map <4-S-LeftRelease> <4-RightRelease>
 <
-        Mouse commands requiring the CTRL modifier can be simulated by typing
-        the "g" key before using the mouse:
-            "g<LeftMouse>"  is "<C-LeftMouse>   (jump to tag under mouse click)
-            "g<RightMouse>" is "<C-RightMouse>  ("CTRL-T")
+	Mouse commands requiring the CTRL modifier can be simulated by typing
+	the "g" key before using the mouse:
+	    "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
+	    "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
 
-                   *'mousemoveevent'* *'mousemev'* *'nomousemoveevent'* *'nomousemev'*
+		   *'mousemoveevent'* *'mousemev'* *'nomousemoveevent'* *'nomousemev'*
 'mousemoveevent' 'mousemev' boolean (default off)
-                        global
-        When on, mouse move events are delivered to the input queue and are
-        available for mapping. The default, off, avoids the mouse movement
-        overhead except when needed.
-        Warning: Setting this option can make pending mappings to be aborted
-        when the mouse is moved.
+			global
+	When on, mouse move events are delivered to the input queue and are
+	available for mapping. The default, off, avoids the mouse movement
+	overhead except when needed.
+	Warning: Setting this option can make pending mappings to be aborted
+	when the mouse is moved.
 
-                                                           *'mousescroll'* *E5080*
-'mousescroll'           string (default "ver:3,hor:6")
-                        global
-        This option controls the number of lines / columns to scroll by when
-        scrolling with a mouse wheel (|scroll-mouse-wheel|). The option is
-        a comma-separated list. Each part consists of a direction and a count
-        as follows:
-                direction:count,direction:count
-        Direction is one of either "hor" or "ver". "hor" controls horizontal
-        scrolling and "ver" controls vertical scrolling. Count sets the amount
-        to scroll by for the given direction, it should be a non negative
-        integer. Each direction should be set at most once. If a direction
-        is omitted, a default value is used (6 for horizontal scrolling and 3
-        for vertical scrolling). You can disable mouse scrolling by using
-        a count of 0.
+							   *'mousescroll'* *E5080*
+'mousescroll'		string (default "ver:3,hor:6")
+			global
+	This option controls the number of lines / columns to scroll by when
+	scrolling with a mouse wheel (|scroll-mouse-wheel|). The option is
+	a comma-separated list. Each part consists of a direction and a count
+	as follows:
+		direction:count,direction:count
+	Direction is one of either "hor" or "ver". "hor" controls horizontal
+	scrolling and "ver" controls vertical scrolling. Count sets the amount
+	to scroll by for the given direction, it should be a non negative
+	integer. Each direction should be set at most once. If a direction
+	is omitted, a default value is used (6 for horizontal scrolling and 3
+	for vertical scrolling). You can disable mouse scrolling by using
+	a count of 0.
 
-        Example: >vim
-                set mousescroll=ver:5,hor:2
-<       Will make Nvim scroll 5 lines at a time when scrolling vertically, and
-        scroll 2 columns at a time when scrolling horizontally.
+	Example: >vim
+		set mousescroll=ver:5,hor:2
+<	Will make Nvim scroll 5 lines at a time when scrolling vertically, and
+	scroll 2 columns at a time when scrolling horizontally.
 
-                                                    *'mouseshape'* *'mouses'* *E547*
-'mouseshape' 'mouses'   string (default "i:beam,r:beam,s:updown,sd:cross,
-                                         m:no,ml:up-arrow,v:rightup-arrow")
-                        global
-        This option tells Vim what the mouse pointer should look like in
-        different modes.  The option is a comma-separated list of parts, much
-        like used for 'guicursor'.  Each part consist of a mode/location-list
-        and an argument-list:
-                mode-list:shape,mode-list:shape,..
-        The mode-list is a dash separated list of these modes/locations:
-                        In a normal window: ~
-                n       Normal mode
-                v       Visual mode
-                ve      Visual mode with 'selection' "exclusive" (same as 'v',
-                        if not specified)
-                o       Operator-pending mode
-                i       Insert mode
-                r       Replace mode
+						    *'mouseshape'* *'mouses'* *E547*
+'mouseshape' 'mouses'	string (default "i:beam,r:beam,s:updown,sd:cross,
+					 m:no,ml:up-arrow,v:rightup-arrow")
+			global
+	This option tells Vim what the mouse pointer should look like in
+	different modes.  The option is a comma-separated list of parts, much
+	like used for 'guicursor'.  Each part consist of a mode/location-list
+	and an argument-list:
+		mode-list:shape,mode-list:shape,..
+	The mode-list is a dash separated list of these modes/locations:
+			In a normal window: ~
+		n	Normal mode
+		v	Visual mode
+		ve	Visual mode with 'selection' "exclusive" (same as 'v',
+			if not specified)
+		o	Operator-pending mode
+		i	Insert mode
+		r	Replace mode
 
-                        Others: ~
-                c       appending to the command-line
-                ci      inserting in the command-line
-                cr      replacing in the command-line
-                m       at the 'Hit ENTER' or 'More' prompts
-                ml      idem, but cursor in the last line
-                e       any mode, pointer below last window
-                s       any mode, pointer on a status line
-                sd      any mode, while dragging a status line
-                vs      any mode, pointer on a vertical separator line
-                vd      any mode, while dragging a vertical separator line
-                a       everywhere
+			Others: ~
+		c	appending to the command-line
+		ci	inserting in the command-line
+		cr	replacing in the command-line
+		m	at the 'Hit ENTER' or 'More' prompts
+		ml	idem, but cursor in the last line
+		e	any mode, pointer below last window
+		s	any mode, pointer on a status line
+		sd	any mode, while dragging a status line
+		vs	any mode, pointer on a vertical separator line
+		vd	any mode, while dragging a vertical separator line
+		a	everywhere
 
-        The shape is one of the following:
-        avail   name            looks like ~
-        w x     arrow           Normal mouse pointer
-        w x     blank           no pointer at all (use with care!)
-        w x     beam            I-beam
-        w x     updown          up-down sizing arrows
-        w x     leftright       left-right sizing arrows
-        w x     busy            The system's usual busy pointer
-        w x     no              The system's usual "no input" pointer
-          x     udsizing        indicates up-down resizing
-          x     lrsizing        indicates left-right resizing
-          x     crosshair       like a big thin +
-          x     hand1           black hand
-          x     hand2           white hand
-          x     pencil          what you write with
-          x     question        big ?
-          x     rightup-arrow   arrow pointing right-up
-        w x     up-arrow        arrow pointing up
-          x     <number>        any X11 pointer number (see X11/cursorfont.h)
+	The shape is one of the following:
+	avail	name		looks like ~
+	w x	arrow		Normal mouse pointer
+	w x	blank		no pointer at all (use with care!)
+	w x	beam		I-beam
+	w x	updown		up-down sizing arrows
+	w x	leftright	left-right sizing arrows
+	w x	busy		The system's usual busy pointer
+	w x	no		The system's usual "no input" pointer
+	  x	udsizing	indicates up-down resizing
+	  x	lrsizing	indicates left-right resizing
+	  x	crosshair	like a big thin +
+	  x	hand1		black hand
+	  x	hand2		white hand
+	  x	pencil		what you write with
+	  x	question	big ?
+	  x	rightup-arrow	arrow pointing right-up
+	w x	up-arrow	arrow pointing up
+	  x	<number>	any X11 pointer number (see X11/cursorfont.h)
 
-        The "avail" column contains a 'w' if the shape is available for Win32,
-        x for X11.
-        Any modes not specified or shapes not available use the normal mouse
-        pointer.
+	The "avail" column contains a 'w' if the shape is available for Win32,
+	x for X11.
+	Any modes not specified or shapes not available use the normal mouse
+	pointer.
 
-        Example: >vim
-                set mouseshape=s:udsizing,m:no
-<       will make the mouse turn to a sizing arrow over the status lines and
-        indicate no input when the hit-enter prompt is displayed (since
-        clicking the mouse has no effect in this state.)
+	Example: >vim
+		set mouseshape=s:udsizing,m:no
+<	will make the mouse turn to a sizing arrow over the status lines and
+	indicate no input when the hit-enter prompt is displayed (since
+	clicking the mouse has no effect in this state.)
 
-                                                          *'mousetime'* *'mouset'*
-'mousetime' 'mouset'    number (default 500)
-                        global
-        Defines the maximum time in msec between two mouse clicks for the
-        second click to be recognized as a multi click.
+							  *'mousetime'* *'mouset'*
+'mousetime' 'mouset'	number (default 500)
+			global
+	Defines the maximum time in msec between two mouse clicks for the
+	second click to be recognized as a multi click.
 
-                                                              *'nrformats'* *'nf'*
-'nrformats' 'nf'        string (default "bin,hex")
-                        local to buffer
-        This defines what bases Vim will consider for numbers when using the
-        CTRL-A and CTRL-X commands for adding to and subtracting from a number
-        respectively; see |CTRL-A| for more info on these commands.
-        alpha   If included, single alphabetical characters will be
-                incremented or decremented.  This is useful for a list with a
-                letter index a), b), etc.               *octal-nrformats*
-        octal   If included, numbers that start with a zero will be considered
-                to be octal.  Example: Using CTRL-A on "007" results in "010".
-        hex     If included, numbers starting with "0x" or "0X" will be
-                considered to be hexadecimal.  Example: Using CTRL-X on
-                "0x100" results in "0x0ff".
-        bin     If included, numbers starting with "0b" or "0B" will be
-                considered to be binary.  Example: Using CTRL-X on
-                "0b1000" subtracts one, resulting in "0b0111".
-        unsigned    If included, numbers are recognized as unsigned. Thus a
-                leading dash or negative sign won't be considered as part of
-                the number.  Examples:
-                    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
-                    (without "unsigned" it would become "9-2021").
-                    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
-                    (without "unsigned" it would become "9-2019").
-                    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
-                    (2^64 - 1) has no effect, overflow is prevented.
-        Numbers which simply begin with a digit in the range 1-9 are always
-        considered decimal.  This also happens for numbers that are not
-        recognized as octal or hex.
+							      *'nrformats'* *'nf'*
+'nrformats' 'nf'	string (default "bin,hex")
+			local to buffer
+	This defines what bases Vim will consider for numbers when using the
+	CTRL-A and CTRL-X commands for adding to and subtracting from a number
+	respectively; see |CTRL-A| for more info on these commands.
+	alpha	If included, single alphabetical characters will be
+		incremented or decremented.  This is useful for a list with a
+		letter index a), b), etc.		*octal-nrformats*
+	octal	If included, numbers that start with a zero will be considered
+		to be octal.  Example: Using CTRL-A on "007" results in "010".
+	hex	If included, numbers starting with "0x" or "0X" will be
+		considered to be hexadecimal.  Example: Using CTRL-X on
+		"0x100" results in "0x0ff".
+	bin	If included, numbers starting with "0b" or "0B" will be
+		considered to be binary.  Example: Using CTRL-X on
+		"0b1000" subtracts one, resulting in "0b0111".
+	unsigned    If included, numbers are recognized as unsigned. Thus a
+		leading dash or negative sign won't be considered as part of
+		the number.  Examples:
+		    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
+		    (without "unsigned" it would become "9-2021").
+		    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
+		    (without "unsigned" it would become "9-2019").
+		    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
+		    (2^64 - 1) has no effect, overflow is prevented.
+	Numbers which simply begin with a digit in the range 1-9 are always
+	considered decimal.  This also happens for numbers that are not
+	recognized as octal or hex.
 
-                                               *'number'* *'nu'* *'nonumber'* *'nonu'*
-'number' 'nu'           boolean (default off)
-                        local to window
-        Print the line number in front of each line.  When the 'n' option is
-        excluded from 'cpoptions' a wrapped line will not use the column of
-        line numbers.
-        Use the 'numberwidth' option to adjust the room for the line number.
-        When a long, wrapped line doesn't start with the first character, '-'
-        characters are put before the number.
-        For highlighting see |hl-LineNr|, |hl-CursorLineNr|, and the
-        |:sign-define| "numhl" argument.
-                                                *number_relativenumber*
-        The 'relativenumber' option changes the displayed number to be
-        relative to the cursor.  Together with 'number' there are these
-        four combinations (cursor in line 3):
+					       *'number'* *'nu'* *'nonumber'* *'nonu'*
+'number' 'nu'		boolean (default off)
+			local to window
+	Print the line number in front of each line.  When the 'n' option is
+	excluded from 'cpoptions' a wrapped line will not use the column of
+	line numbers.
+	Use the 'numberwidth' option to adjust the room for the line number.
+	When a long, wrapped line doesn't start with the first character, '-'
+	characters are put before the number.
+	For highlighting see |hl-LineNr|, |hl-CursorLineNr|, and the
+	|:sign-define| "numhl" argument.
+						*number_relativenumber*
+	The 'relativenumber' option changes the displayed number to be
+	relative to the cursor.  Together with 'number' there are these
+	four combinations (cursor in line 3):
 
-                'nonu'          'nu'            'nonu'          'nu'
-                'nornu'         'nornu'         'rnu'           'rnu'
-        >
-            |apple          |  1 apple      |  2 apple      |  2 apple
-            |pear           |  2 pear       |  1 pear       |  1 pear
-            |nobody         |  3 nobody     |  0 nobody     |3   nobody
-            |there          |  4 there      |  1 there      |  1 there
+		'nonu'		'nu'		'nonu'		'nu'
+		'nornu'		'nornu'		'rnu'		'rnu'
+	>
+	    |apple	    |  1 apple	    |  2 apple	    |  2 apple
+	    |pear	    |  2 pear	    |  1 pear	    |  1 pear
+	    |nobody	    |  3 nobody     |  0 nobody     |3	 nobody
+	    |there	    |  4 there	    |  1 there	    |  1 there
 <
 
-                                                           *'numberwidth'* *'nuw'*
-'numberwidth' 'nuw'     number (default 4)
-                        local to window
-        Minimal number of columns to use for the line number.  Only relevant
-        when the 'number' or 'relativenumber' option is set or printing lines
-        with a line number. Since one space is always between the number and
-        the text, there is one less character for the number itself.
-        The value is the minimum width.  A bigger width is used when needed to
-        fit the highest line number in the buffer respectively the number of
-        rows in the window, depending on whether 'number' or 'relativenumber'
-        is set. Thus with the Vim default of 4 there is room for a line number
-        up to 999. When the buffer has 1000 lines five columns will be used.
-        The minimum value is 1, the maximum value is 20.
+							   *'numberwidth'* *'nuw'*
+'numberwidth' 'nuw'	number (default 4)
+			local to window
+	Minimal number of columns to use for the line number.  Only relevant
+	when the 'number' or 'relativenumber' option is set or printing lines
+	with a line number. Since one space is always between the number and
+	the text, there is one less character for the number itself.
+	The value is the minimum width.  A bigger width is used when needed to
+	fit the highest line number in the buffer respectively the number of
+	rows in the window, depending on whether 'number' or 'relativenumber'
+	is set. Thus with the Vim default of 4 there is room for a line number
+	up to 999. When the buffer has 1000 lines five columns will be used.
+	The minimum value is 1, the maximum value is 20.
 
-                                                              *'omnifunc'* *'ofu'*
-'omnifunc' 'ofu'        string (default "")
-                        local to buffer
-        This option specifies a function to be used for Insert mode omni
-        completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
-        See |complete-functions| for an explanation of how the function is
-        invoked and what it should return.  The value can be the name of a
-        function, a |lambda| or a |Funcref|. See |option-value-function| for
-        more information.
-        This option is usually set by a filetype plugin:
-        |:filetype-plugin-on|
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'omnifunc'* *'ofu'*
+'omnifunc' 'ofu'	string (default "")
+			local to buffer
+	This option specifies a function to be used for Insert mode omni
+	completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
+	See |complete-functions| for an explanation of how the function is
+	invoked and what it should return.  The value can be the name of a
+	function, a |lambda| or a |Funcref|. See |option-value-function| for
+	more information.
+	This option is usually set by a filetype plugin:
+	|:filetype-plugin-on|
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                   *'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
-'opendevice' 'odev'     boolean (default off)
-                        global
-        only for Windows
-        Enable reading and writing from devices.  This may get Vim stuck on a
-        device that can be opened but doesn't actually do the I/O.  Therefore
-        it is off by default.
-        Note that on Windows editing "aux.h", "lpt1.txt" and the like also
-        result in editing a device.
+				   *'opendevice'* *'odev'* *'noopendevice'* *'noodev'*
+'opendevice' 'odev'	boolean (default off)
+			global
+	only for Windows
+	Enable reading and writing from devices.  This may get Vim stuck on a
+	device that can be opened but doesn't actually do the I/O.  Therefore
+	it is off by default.
+	Note that on Windows editing "aux.h", "lpt1.txt" and the like also
+	result in editing a device.
 
-                                                       *'operatorfunc'* *'opfunc'*
+						       *'operatorfunc'* *'opfunc'*
 'operatorfunc' 'opfunc' string (default "")
-                        global
-        This option specifies a function to be called by the |g@| operator.
-        See |:map-operator| for more info and an example.  The value can be
-        the name of a function, a |lambda| or a |Funcref|. See
-        |option-value-function| for more information.
+			global
+	This option specifies a function to be called by the |g@| operator.
+	See |:map-operator| for more info and an example.  The value can be
+	the name of a function, a |lambda| or a |Funcref|. See
+	|option-value-function| for more information.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                               *'packpath'* *'pp'*
-'packpath' 'pp'         string (default see 'runtimepath')
-                        global
-        Directories used to find packages.
-        See |packages| and |packages-runtimepath|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							       *'packpath'* *'pp'*
+'packpath' 'pp'		string (default see 'runtimepath')
+			global
+	Directories used to find packages.
+	See |packages| and |packages-runtimepath|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                           *'paragraphs'* *'para'*
-'paragraphs' 'para'     string (default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
-                        global
-        Specifies the nroff macros that separate paragraphs.  These are pairs
-        of two letters (see |object-motions|).
+							   *'paragraphs'* *'para'*
+'paragraphs' 'para'	string (default "IPLPPPQPP TPHPLIPpLpItpplpipbp")
+			global
+	Specifies the nroff macros that separate paragraphs.  These are pairs
+	of two letters (see |object-motions|).
 
-                                                             *'patchexpr'* *'pex'*
-'patchexpr' 'pex'       string (default "")
-                        global
-        Expression which is evaluated to apply a patch to a file and generate
-        the resulting new version of the file.  See |diff-patchexpr|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							     *'patchexpr'* *'pex'*
+'patchexpr' 'pex'	string (default "")
+			global
+	Expression which is evaluated to apply a patch to a file and generate
+	the resulting new version of the file.	See |diff-patchexpr|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                    *'patchmode'* *'pm'* *E205* *E206*
-'patchmode' 'pm'        string (default "")
-                        global
-        When non-empty the oldest version of a file is kept.  This can be used
-        to keep the original version of a file if you are changing files in a
-        source distribution.  Only the first time that a file is written a
-        copy of the original file will be kept.  The name of the copy is the
-        name of the original file with the string in the 'patchmode' option
-        appended.  This option should start with a dot.  Use a string like
-        ".orig" or ".org".  'backupdir' must not be empty for this to work
-        (Detail: The backup file is renamed to the patchmode file after the
-        new file has been successfully written, that's why it must be possible
-        to write a backup file).  If there was no file to be backed up, an
-        empty file is created.
-        When the 'backupskip' pattern matches, a patchmode file is not made.
-        Using 'patchmode' for compressed files appends the extension at the
-        end (e.g., "file.gz.orig"), thus the resulting name isn't always
-        recognized as a compressed file.
-        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+						    *'patchmode'* *'pm'* *E205* *E206*
+'patchmode' 'pm'	string (default "")
+			global
+	When non-empty the oldest version of a file is kept.  This can be used
+	to keep the original version of a file if you are changing files in a
+	source distribution.  Only the first time that a file is written a
+	copy of the original file will be kept.  The name of the copy is the
+	name of the original file with the string in the 'patchmode' option
+	appended.  This option should start with a dot.  Use a string like
+	".orig" or ".org".  'backupdir' must not be empty for this to work
+	(Detail: The backup file is renamed to the patchmode file after the
+	new file has been successfully written, that's why it must be possible
+	to write a backup file).  If there was no file to be backed up, an
+	empty file is created.
+	When the 'backupskip' pattern matches, a patchmode file is not made.
+	Using 'patchmode' for compressed files appends the extension at the
+	end (e.g., "file.gz.orig"), thus the resulting name isn't always
+	recognized as a compressed file.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
-                                               *'path'* *'pa'* *E343* *E345* *E347* *E854*
-'path' 'pa'             string (default ".,,")
-                        global or local to buffer |global-local|
-        This is a list of directories which will be searched when using the
-        |gf|, [f, ]f, ^Wf, |:find|, |:sfind|, |:tabfind| and other commands,
-        provided that the file being searched for has a relative path (not
-        starting with "/", "./" or "../").  The directories in the 'path'
-        option may be relative or absolute.
-        - Use commas to separate directory names: >vim
-                set path=.,/usr/local/include,/usr/include
-<       - Spaces can also be used to separate directory names.  To have a
-          space in a directory name, precede it with an extra backslash, and
-          escape the space: >vim
-                set path=.,/dir/with\\\ space
-<       - To include a comma in a directory name precede it with an extra
-          backslash: >vim
-                set path=.,/dir/with\\,comma
-<       - To search relative to the directory of the current file, use: >vim
-                set path=.
-<       - To search in the current directory use an empty string between two
-          commas: >vim
-                set path=,,
-<       - A directory name may end in a ':' or '/'.
-        - Environment variables are expanded |:set_env|.
-        - When using |netrw.vim| URLs can be used.  For example, adding
-          "https://www.vim.org" will make ":find index.html" work.
-        - Search upwards and downwards in a directory tree using "*", "**" and
-          ";".  See |file-searching| for info and syntax.
-        - Careful with '\' characters, type two to get one in the option: >vim
-                set path=.,c:\\include
-<         Or just use '/' instead: >vim
-                set path=.,c:/include
-<       Don't forget "." or files won't even be found in the same directory as
-        the file!
-        The maximum length is limited.  How much depends on the system, mostly
-        it is something like 256 or 1024 characters.
-        You can check if all the include files are found, using the value of
-        'path', see |:checkpath|.
-        The use of |:set+=| and |:set-=| is preferred when adding or removing
-        directories from the list.  This avoids problems when a future version
-        uses another default.  To remove the current directory use: >vim
-                set path-=
-<       To add the current directory use: >vim
-                set path+=
-<       To use an environment variable, you probably need to replace the
-        separator.  Here is an example to append $INCL, in which directory
-        names are separated with a semi-colon: >vim
-                let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
-<       Replace the ';' with a ':' or whatever separator is used.  Note that
-        this doesn't work when $INCL contains a comma or white space.
+					       *'path'* *'pa'* *E343* *E345* *E347* *E854*
+'path' 'pa'		string (default ".,,")
+			global or local to buffer |global-local|
+	This is a list of directories which will be searched when using the
+	|gf|, [f, ]f, ^Wf, |:find|, |:sfind|, |:tabfind| and other commands,
+	provided that the file being searched for has a relative path (not
+	starting with "/", "./" or "../").  The directories in the 'path'
+	option may be relative or absolute.
+	- Use commas to separate directory names: >vim
+		set path=.,/usr/local/include,/usr/include
+<	- Spaces can also be used to separate directory names.	To have a
+	  space in a directory name, precede it with an extra backslash, and
+	  escape the space: >vim
+		set path=.,/dir/with\\\ space
+<	- To include a comma in a directory name precede it with an extra
+	  backslash: >vim
+		set path=.,/dir/with\\,comma
+<	- To search relative to the directory of the current file, use: >vim
+		set path=.
+<	- To search in the current directory use an empty string between two
+	  commas: >vim
+		set path=,,
+<	- A directory name may end in a ':' or '/'.
+	- Environment variables are expanded |:set_env|.
+	- When using |netrw.vim| URLs can be used.  For example, adding
+	  "https://www.vim.org" will make ":find index.html" work.
+	- Search upwards and downwards in a directory tree using "*", "**" and
+	  ";".	See |file-searching| for info and syntax.
+	- Careful with '\' characters, type two to get one in the option: >vim
+		set path=.,c:\\include
+<	  Or just use '/' instead: >vim
+		set path=.,c:/include
+<	Don't forget "." or files won't even be found in the same directory as
+	the file!
+	The maximum length is limited.	How much depends on the system, mostly
+	it is something like 256 or 1024 characters.
+	You can check if all the include files are found, using the value of
+	'path', see |:checkpath|.
+	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	directories from the list.  This avoids problems when a future version
+	uses another default.  To remove the current directory use: >vim
+		set path-=
+<	To add the current directory use: >vim
+		set path+=
+<	To use an environment variable, you probably need to replace the
+	separator.  Here is an example to append $INCL, in which directory
+	names are separated with a semi-colon: >vim
+		let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
+<	Replace the ';' with a ':' or whatever separator is used.  Note that
+	this doesn't work when $INCL contains a comma or white space.
 
-                               *'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
-'preserveindent' 'pi'   boolean (default off)
-                        local to buffer
-        When changing the indent of the current line, preserve as much of the
-        indent structure as possible.  Normally the indent is replaced by a
-        series of tabs followed by spaces as required (unless |'expandtab'| is
-        enabled, in which case only spaces are used).  Enabling this option
-        means the indent will preserve as many existing characters as possible
-        for indenting, and only add additional tabs or spaces as required.
-        'expandtab' does not apply to the preserved white space, a Tab remains
-        a Tab.
-        NOTE: When using ">>" multiple times the resulting indent is a mix of
-        tabs and spaces.  You might not like this.
-        Also see 'copyindent'.
-        Use |:retab| to clean up white space.
+			       *'preserveindent'* *'pi'* *'nopreserveindent'* *'nopi'*
+'preserveindent' 'pi'	boolean (default off)
+			local to buffer
+	When changing the indent of the current line, preserve as much of the
+	indent structure as possible.  Normally the indent is replaced by a
+	series of tabs followed by spaces as required (unless |'expandtab'| is
+	enabled, in which case only spaces are used).  Enabling this option
+	means the indent will preserve as many existing characters as possible
+	for indenting, and only add additional tabs or spaces as required.
+	'expandtab' does not apply to the preserved white space, a Tab remains
+	a Tab.
+	NOTE: When using ">>" multiple times the resulting indent is a mix of
+	tabs and spaces.  You might not like this.
+	Also see 'copyindent'.
+	Use |:retab| to clean up white space.
 
-                                                         *'previewheight'* *'pvh'*
-'previewheight' 'pvh'   number (default 12)
-                        global
-        Default height for a preview window.  Used for |:ptag| and associated
-        commands.  Used for |CTRL-W_}| when no count is given.
+							 *'previewheight'* *'pvh'*
+'previewheight' 'pvh'	number (default 12)
+			global
+	Default height for a preview window.  Used for |:ptag| and associated
+	commands.  Used for |CTRL-W_}| when no count is given.
 
-                          *'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
-'previewwindow' 'pvw'   boolean (default off)
-                        local to window  |local-noglobal|
-        Identifies the preview window.  Only one window can have this option
-        set.  It's normally not set directly, but by using one of the commands
-        |:ptag|, |:pedit|, etc.
+			  *'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
+'previewwindow' 'pvw'	boolean (default off)
+			local to window  |local-noglobal|
+	Identifies the preview window.	Only one window can have this option
+	set.  It's normally not set directly, but by using one of the commands
+	|:ptag|, |:pedit|, etc.
 
-                                                               *'pumblend'* *'pb'*
-'pumblend' 'pb'         number (default 0)
-                        global
-        Enables pseudo-transparency for the |popup-menu|. Valid values are in
-        the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
-        transparent background. Values between 0-30 are typically most useful.
+							       *'pumblend'* *'pb'*
+'pumblend' 'pb'		number (default 0)
+			global
+	Enables pseudo-transparency for the |popup-menu|. Valid values are in
+	the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
+	transparent background. Values between 0-30 are typically most useful.
 
-        It is possible to override the level for individual highlights within
-        the popupmenu using |highlight-blend|. For instance, to enable
-        transparency but force the current selected element to be fully opaque: >vim
+	It is possible to override the level for individual highlights within
+	the popupmenu using |highlight-blend|. For instance, to enable
+	transparency but force the current selected element to be fully opaque: >vim
 
-                set pumblend=15
-                hi PmenuSel blend=0
+		set pumblend=15
+		hi PmenuSel blend=0
 <
-        UI-dependent. Works best with RGB colors. 'termguicolors'
+	UI-dependent. Works best with RGB colors. 'termguicolors'
 
-                                                              *'pumheight'* *'ph'*
-'pumheight' 'ph'        number (default 0)
-                        global
-        Maximum number of items to show in the popup menu
-        (|ins-completion-menu|). Zero means "use available screen space".
+							      *'pumheight'* *'ph'*
+'pumheight' 'ph'	number (default 0)
+			global
+	Maximum number of items to show in the popup menu
+	(|ins-completion-menu|). Zero means "use available screen space".
 
-                                                               *'pumwidth'* *'pw'*
-'pumwidth' 'pw'         number (default 15)
-                        global
-        Minimum width for the popup menu (|ins-completion-menu|).  If the
-        cursor column + 'pumwidth' exceeds screen width, the popup menu is
-        nudged to fit on the screen.
+							       *'pumwidth'* *'pw'*
+'pumwidth' 'pw'		number (default 15)
+			global
+	Minimum width for the popup menu (|ins-completion-menu|).  If the
+	cursor column + 'pumwidth' exceeds screen width, the popup menu is
+	nudged to fit on the screen.
 
-                                                            *'pyxversion'* *'pyx'*
-'pyxversion' 'pyx'      number (default 3)
-                        global
-        Specifies the python version used for pyx* functions and commands
-        |python_x|.  As only Python 3 is supported, this always has the value
-        `3`. Setting any other value is an error.
+							    *'pyxversion'* *'pyx'*
+'pyxversion' 'pyx'	number (default 3)
+			global
+	Specifies the python version used for pyx* functions and commands
+	|python_x|.  As only Python 3 is supported, this always has the value
+	`3`. Setting any other value is an error.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                     *'quickfixtextfunc'* *'qftf'*
+						     *'quickfixtextfunc'* *'qftf'*
 'quickfixtextfunc' 'qftf' string (default "")
-                        global
-        This option specifies a function to be used to get the text to display
-        in the quickfix and location list windows.  This can be used to
-        customize the information displayed in the quickfix or location window
-        for each entry in the corresponding quickfix or location list.  See
-        |quickfix-window-function| for an explanation of how to write the
-        function and an example.  The value can be the name of a function, a
-        |lambda| or a |Funcref|. See |option-value-function| for more
-        information.
+			global
+	This option specifies a function to be used to get the text to display
+	in the quickfix and location list windows.  This can be used to
+	customize the information displayed in the quickfix or location window
+	for each entry in the corresponding quickfix or location list.	See
+	|quickfix-window-function| for an explanation of how to write the
+	function and an example.  The value can be the name of a function, a
+	|lambda| or a |Funcref|. See |option-value-function| for more
+	information.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                            *'quoteescape'* *'qe'*
-'quoteescape' 'qe'      string (default "\")
-                        local to buffer
-        The characters that are used to escape quotes in a string.  Used for
-        objects like a', a" and a` |a'|.
-        When one of the characters in this option is found inside a string,
-        the following character will be skipped.  The default value makes the
-        text "foo\"bar\\" considered to be one string.
+							    *'quoteescape'* *'qe'*
+'quoteescape' 'qe'	string (default "\")
+			local to buffer
+	The characters that are used to escape quotes in a string.  Used for
+	objects like a', a" and a` |a'|.
+	When one of the characters in this option is found inside a string,
+	the following character will be skipped.  The default value makes the
+	text "foo\"bar\\" considered to be one string.
 
-                                           *'readonly'* *'ro'* *'noreadonly'* *'noro'*
-'readonly' 'ro'         boolean (default off)
-                        local to buffer  |local-noglobal|
-        If on, writes fail unless you use a '!'.  Protects you from
-        accidentally overwriting a file.  Default on when Vim is started
-        in read-only mode ("vim -R") or when the executable is called "view".
-        When using ":w!" the 'readonly' option is reset for the current
-        buffer, unless the 'Z' flag is in 'cpoptions'.
-        When using the ":view" command the 'readonly' option is set for the
-        newly edited buffer.
-        See 'modifiable' for disallowing changes to the buffer.
+					   *'readonly'* *'ro'* *'noreadonly'* *'noro'*
+'readonly' 'ro'		boolean (default off)
+			local to buffer  |local-noglobal|
+	If on, writes fail unless you use a '!'.  Protects you from
+	accidentally overwriting a file.  Default on when Vim is started
+	in read-only mode ("vim -R") or when the executable is called "view".
+	When using ":w!" the 'readonly' option is reset for the current
+	buffer, unless the 'Z' flag is in 'cpoptions'.
+	When using the ":view" command the 'readonly' option is set for the
+	newly edited buffer.
+	See 'modifiable' for disallowing changes to the buffer.
 
-                                                           *'redrawdebug'* *'rdb'*
-'redrawdebug' 'rdb'     string (default "")
-                        global
-        Flags to change the way redrawing works, for debugging purposes.
-        Most useful with 'writedelay' set to some reasonable value.
-        Supports the following flags:
-            compositor  Indicate each redraw event handled by the compositor
-                        by briefly flashing the redrawn regions in colors
-                        indicating the redraw type. These are the highlight
-                        groups used (and their default colors):
-                RedrawDebugNormal   gui=reverse   normal redraw passed through
-                RedrawDebugClear    guibg=Yellow  clear event passed through
-                RedrawDebugComposed guibg=Green   redraw event modified by the
-                                                  compositor (due to
-                                                  overlapping grids, etc)
-                RedrawDebugRecompose guibg=Red    redraw generated by the
-                                                  compositor itself, due to a
-                                                  grid being moved or deleted.
-            line        introduce a delay after each line drawn on the screen.
-                        When using the TUI or another single-grid UI, "compositor"
-                        gives more information and should be preferred (every
-                        line is processed as a separate event by the compositor)
-            flush       introduce a delay after each "flush" event.
-            nothrottle  Turn off throttling of the message grid. This is an
-                        optimization that joins many small scrolls to one
-                        larger scroll when drawing the message area (with
-                        'display' msgsep flag active).
-            invalid     Enable stricter checking (abort) of inconsistencies
-                        of the internal screen state. This is mostly
-                        useful when running nvim inside a debugger (and
-                        the test suite).
-            nodelta     Send all internally redrawn cells to the UI, even if
-                        they are unchanged from the already displayed state.
+							   *'redrawdebug'* *'rdb'*
+'redrawdebug' 'rdb'	string (default "")
+			global
+	Flags to change the way redrawing works, for debugging purposes.
+	Most useful with 'writedelay' set to some reasonable value.
+	Supports the following flags:
+	    compositor	Indicate each redraw event handled by the compositor
+			by briefly flashing the redrawn regions in colors
+			indicating the redraw type. These are the highlight
+			groups used (and their default colors):
+		RedrawDebugNormal   gui=reverse   normal redraw passed through
+		RedrawDebugClear    guibg=Yellow  clear event passed through
+		RedrawDebugComposed guibg=Green   redraw event modified by the
+						  compositor (due to
+						  overlapping grids, etc)
+		RedrawDebugRecompose guibg=Red	  redraw generated by the
+						  compositor itself, due to a
+						  grid being moved or deleted.
+	    line	introduce a delay after each line drawn on the screen.
+			When using the TUI or another single-grid UI, "compositor"
+			gives more information and should be preferred (every
+			line is processed as a separate event by the compositor)
+	    flush	introduce a delay after each "flush" event.
+	    nothrottle	Turn off throttling of the message grid. This is an
+			optimization that joins many small scrolls to one
+			larger scroll when drawing the message area (with
+			'display' msgsep flag active).
+	    invalid	Enable stricter checking (abort) of inconsistencies
+			of the internal screen state. This is mostly
+			useful when running nvim inside a debugger (and
+			the test suite).
+	    nodelta	Send all internally redrawn cells to the UI, even if
+			they are unchanged from the already displayed state.
 
-                                                            *'redrawtime'* *'rdt'*
-'redrawtime' 'rdt'      number (default 2000)
-                        global
-        Time in milliseconds for redrawing the display.  Applies to
-        'hlsearch', 'inccommand', |:match| highlighting and syntax
-        highlighting.
-        When redrawing takes more than this many milliseconds no further
-        matches will be highlighted.
-        For syntax highlighting the time applies per window.  When over the
-        limit syntax highlighting is disabled until |CTRL-L| is used.
-        This is used to avoid that Vim hangs when using a very complicated
-        pattern.
+							    *'redrawtime'* *'rdt'*
+'redrawtime' 'rdt'	number (default 2000)
+			global
+	Time in milliseconds for redrawing the display.  Applies to
+	'hlsearch', 'inccommand', |:match| highlighting and syntax
+	highlighting.
+	When redrawing takes more than this many milliseconds no further
+	matches will be highlighted.
+	For syntax highlighting the time applies per window.  When over the
+	limit syntax highlighting is disabled until |CTRL-L| is used.
+	This is used to avoid that Vim hangs when using a very complicated
+	pattern.
 
-                                                           *'regexpengine'* *'re'*
-'regexpengine' 're'     number (default 0)
-                        global
-        This selects the default regexp engine. |two-engines|
-        The possible values are:
-                0       automatic selection
-                1       old engine
-                2       NFA engine
-        Note that when using the NFA engine and the pattern contains something
-        that is not supported the pattern will not match.  This is only useful
-        for debugging the regexp engine.
-        Using automatic selection enables Vim to switch the engine, if the
-        default engine becomes too costly.  E.g., when the NFA engine uses too
-        many states.  This should prevent Vim from hanging on a combination of
-        a complex pattern with long text.
+							   *'regexpengine'* *'re'*
+'regexpengine' 're'	number (default 0)
+			global
+	This selects the default regexp engine. |two-engines|
+	The possible values are:
+		0	automatic selection
+		1	old engine
+		2	NFA engine
+	Note that when using the NFA engine and the pattern contains something
+	that is not supported the pattern will not match.  This is only useful
+	for debugging the regexp engine.
+	Using automatic selection enables Vim to switch the engine, if the
+	default engine becomes too costly.  E.g., when the NFA engine uses too
+	many states.  This should prevent Vim from hanging on a combination of
+	a complex pattern with long text.
 
-                             *'relativenumber'* *'rnu'* *'norelativenumber'* *'nornu'*
-'relativenumber' 'rnu'  boolean (default off)
-                        local to window
-        Show the line number relative to the line with the cursor in front of
-        each line. Relative line numbers help you use the |count| you can
-        precede some vertical motion commands (e.g. j k + -) with, without
-        having to calculate it yourself. Especially useful in combination with
-        other commands (e.g. y d c < > gq gw =).
-        When the 'n' option is excluded from 'cpoptions' a wrapped
-        line will not use the column of line numbers.
-        The 'numberwidth' option can be used to set the room used for the line
-        number.
-        When a long, wrapped line doesn't start with the first character, '-'
-        characters are put before the number.
-        See |hl-LineNr|  and |hl-CursorLineNr| for the highlighting used for
-        the number.
+			     *'relativenumber'* *'rnu'* *'norelativenumber'* *'nornu'*
+'relativenumber' 'rnu'	boolean (default off)
+			local to window
+	Show the line number relative to the line with the cursor in front of
+	each line. Relative line numbers help you use the |count| you can
+	precede some vertical motion commands (e.g. j k + -) with, without
+	having to calculate it yourself. Especially useful in combination with
+	other commands (e.g. y d c < > gq gw =).
+	When the 'n' option is excluded from 'cpoptions' a wrapped
+	line will not use the column of line numbers.
+	The 'numberwidth' option can be used to set the room used for the line
+	number.
+	When a long, wrapped line doesn't start with the first character, '-'
+	characters are put before the number.
+	See |hl-LineNr|  and |hl-CursorLineNr| for the highlighting used for
+	the number.
 
-        The number in front of the cursor line also depends on the value of
-        'number', see |number_relativenumber| for all combinations of the two
-        options.
+	The number in front of the cursor line also depends on the value of
+	'number', see |number_relativenumber| for all combinations of the two
+	options.
 
-                                                                      *'report'*
-'report'                number (default 2)
-                        global
-        Threshold for reporting number of lines changed.  When the number of
-        changed lines is more than 'report' a message will be given for most
-        ":" commands.  If you want it always, set 'report' to 0.
-        For the ":substitute" command the number of substitutions is used
-        instead of the number of lines.
+								      *'report'*
+'report'		number (default 2)
+			global
+	Threshold for reporting number of lines changed.  When the number of
+	changed lines is more than 'report' a message will be given for most
+	":" commands.  If you want it always, set 'report' to 0.
+	For the ":substitute" command the number of substitutions is used
+	instead of the number of lines.
 
-                                               *'revins'* *'ri'* *'norevins'* *'nori'*
-'revins' 'ri'           boolean (default off)
-                        global
-        Inserting characters in Insert mode will work backwards.  See "typing
-        backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
-        command in Insert mode, when 'allowrevins' is set.
+					       *'revins'* *'ri'* *'norevins'* *'nori'*
+'revins' 'ri'		boolean (default off)
+			global
+	Inserting characters in Insert mode will work backwards.  See "typing
+	backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
+	command in Insert mode, when 'allowrevins' is set.
 
-                                         *'rightleft'* *'rl'* *'norightleft'* *'norl'*
-'rightleft' 'rl'        boolean (default off)
-                        local to window
-        When on, display orientation becomes right-to-left, i.e., characters
-        that are stored in the file appear from the right to the left.
-        Using this option, it is possible to edit files for languages that
-        are written from the right to the left such as Hebrew and Arabic.
-        This option is per window, so it is possible to edit mixed files
-        simultaneously, or to view the same file in both ways (this is
-        useful whenever you have a mixed text file with both right-to-left
-        and left-to-right strings so that both sets are displayed properly
-        in different windows).  Also see |rileft.txt|.
+					 *'rightleft'* *'rl'* *'norightleft'* *'norl'*
+'rightleft' 'rl'	boolean (default off)
+			local to window
+	When on, display orientation becomes right-to-left, i.e., characters
+	that are stored in the file appear from the right to the left.
+	Using this option, it is possible to edit files for languages that
+	are written from the right to the left such as Hebrew and Arabic.
+	This option is per window, so it is possible to edit mixed files
+	simultaneously, or to view the same file in both ways (this is
+	useful whenever you have a mixed text file with both right-to-left
+	and left-to-right strings so that both sets are displayed properly
+	in different windows).	Also see |rileft.txt|.
 
-                                                          *'rightleftcmd'* *'rlc'*
-'rightleftcmd' 'rlc'    string (default "search")
-                        local to window
-        Each word in this option enables the command line editing to work in
-        right-to-left mode for a group of commands:
+							  *'rightleftcmd'* *'rlc'*
+'rightleftcmd' 'rlc'	string (default "search")
+			local to window
+	Each word in this option enables the command line editing to work in
+	right-to-left mode for a group of commands:
 
-                search          "/" and "?" commands
+		search		"/" and "?" commands
 
-        This is useful for languages such as Hebrew, Arabic and Farsi.
-        The 'rightleft' option must be set for 'rightleftcmd' to take effect.
+	This is useful for languages such as Hebrew, Arabic and Farsi.
+	The 'rightleft' option must be set for 'rightleftcmd' to take effect.
 
-                                                 *'ruler'* *'ru'* *'noruler'* *'noru'*
-'ruler' 'ru'            boolean (default on)
-                        global
-        Show the line and column number of the cursor position, separated by a
-        comma.  When there is room, the relative position of the displayed
-        text in the file is shown on the far right:
-                Top     first line is visible
-                Bot     last line is visible
-                All     first and last line are visible
-                45%     relative position in the file
-        If 'rulerformat' is set, it will determine the contents of the ruler.
-        Each window has its own ruler.  If a window has a status line, the
-        ruler is shown there.  If a window doesn't have a status line and
-        'cmdheight' is zero, the ruler is not shown.  Otherwise it is shown in
-        the last line of the screen.  If the statusline is given by
-        'statusline' (i.e. not empty), this option takes precedence over
-        'ruler' and 'rulerformat'.
-        If the number of characters displayed is different from the number of
-        bytes in the text (e.g., for a TAB or a multibyte character), both
-        the text column (byte number) and the screen column are shown,
-        separated with a dash.
-        For an empty line "0-1" is shown.
-        For an empty buffer the line number will also be zero: "0,0-1".
-        If you don't want to see the ruler all the time but want to know where
-        you are, use "g CTRL-G" |g_CTRL-G|.
+						 *'ruler'* *'ru'* *'noruler'* *'noru'*
+'ruler' 'ru'		boolean (default on)
+			global
+	Show the line and column number of the cursor position, separated by a
+	comma.	When there is room, the relative position of the displayed
+	text in the file is shown on the far right:
+		Top	first line is visible
+		Bot	last line is visible
+		All	first and last line are visible
+		45%	relative position in the file
+	If 'rulerformat' is set, it will determine the contents of the ruler.
+	Each window has its own ruler.	If a window has a status line, the
+	ruler is shown there.  If a window doesn't have a status line and
+	'cmdheight' is zero, the ruler is not shown.  Otherwise it is shown in
+	the last line of the screen.  If the statusline is given by
+	'statusline' (i.e. not empty), this option takes precedence over
+	'ruler' and 'rulerformat'.
+	If the number of characters displayed is different from the number of
+	bytes in the text (e.g., for a TAB or a multibyte character), both
+	the text column (byte number) and the screen column are shown,
+	separated with a dash.
+	For an empty line "0-1" is shown.
+	For an empty buffer the line number will also be zero: "0,0-1".
+	If you don't want to see the ruler all the time but want to know where
+	you are, use "g CTRL-G" |g_CTRL-G|.
 
-                                                           *'rulerformat'* *'ruf'*
-'rulerformat' 'ruf'     string (default "")
-                        global
-        When this option is not empty, it determines the content of the ruler
-        string, as displayed for the 'ruler' option.
-        The format of this option is like that of 'statusline'.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+							   *'rulerformat'* *'ruf'*
+'rulerformat' 'ruf'	string (default "")
+			global
+	When this option is not empty, it determines the content of the ruler
+	string, as displayed for the 'ruler' option.
+	The format of this option is like that of 'statusline'.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        The default ruler width is 17 characters.  To make the ruler 15
-        characters wide, put "%15(" at the start and "%)" at the end.
-        Example: >vim
-                set rulerformat=%15(%c%V\ %p%%%)
+	The default ruler width is 17 characters.  To make the ruler 15
+	characters wide, put "%15(" at the start and "%)" at the end.
+	Example: >vim
+		set rulerformat=%15(%c%V\ %p%%%)
 <
 
-                                                  *'runtimepath'* *'rtp'* *vimfiles*
-'runtimepath' 'rtp'     string (default "$XDG_CONFIG_HOME/nvim,
-                                         $XDG_CONFIG_DIRS[1]/nvim,
-                                         $XDG_CONFIG_DIRS[2]/nvim,
-                                         …
-                                         $XDG_DATA_HOME/nvim[-data]/site,
-                                         $XDG_DATA_DIRS[1]/nvim/site,
-                                         $XDG_DATA_DIRS[2]/nvim/site,
-                                         …
-                                         $VIMRUNTIME,
-                                         …
-                                         $XDG_DATA_DIRS[2]/nvim/site/after,
-                                         $XDG_DATA_DIRS[1]/nvim/site/after,
-                                         $XDG_DATA_HOME/nvim[-data]/site/after,
-                                         …
-                                         $XDG_CONFIG_DIRS[2]/nvim/after,
-                                         $XDG_CONFIG_DIRS[1]/nvim/after,
-                                         $XDG_CONFIG_HOME/nvim/after")
-                        global
-        List of directories to be searched for these runtime files:
-          filetype.lua  filetypes |new-filetype|
-          autoload/     automatically loaded scripts |autoload-functions|
-          colors/       color scheme files |:colorscheme|
-          compiler/     compiler files |:compiler|
-          doc/          documentation |write-local-help|
-          ftplugin/     filetype plugins |write-filetype-plugin|
-          indent/       indent scripts |indent-expression|
-          keymap/       key mapping files |mbyte-keymap|
-          lang/         menu translations |:menutrans|
-          lua/          |Lua| plugins
-          menu.vim      GUI menus |menu.vim|
-          pack/         packages |:packadd|
-          parser/       |treesitter| syntax parsers
-          plugin/       plugin scripts |write-plugin|
-          queries/      |treesitter| queries
-          rplugin/      |remote-plugin| scripts
-          spell/        spell checking files |spell|
-          syntax/       syntax files |mysyntaxfile|
-          tutor/        tutorial files |:Tutor|
+						  *'runtimepath'* *'rtp'* *vimfiles*
+'runtimepath' 'rtp'	string (default "$XDG_CONFIG_HOME/nvim,
+					 $XDG_CONFIG_DIRS[1]/nvim,
+					 $XDG_CONFIG_DIRS[2]/nvim,
+					 …
+					 $XDG_DATA_HOME/nvim[-data]/site,
+					 $XDG_DATA_DIRS[1]/nvim/site,
+					 $XDG_DATA_DIRS[2]/nvim/site,
+					 …
+					 $VIMRUNTIME,
+					 …
+					 $XDG_DATA_DIRS[2]/nvim/site/after,
+					 $XDG_DATA_DIRS[1]/nvim/site/after,
+					 $XDG_DATA_HOME/nvim[-data]/site/after,
+					 …
+					 $XDG_CONFIG_DIRS[2]/nvim/after,
+					 $XDG_CONFIG_DIRS[1]/nvim/after,
+					 $XDG_CONFIG_HOME/nvim/after")
+			global
+	List of directories to be searched for these runtime files:
+	  filetype.lua	filetypes |new-filetype|
+	  autoload/	automatically loaded scripts |autoload-functions|
+	  colors/	color scheme files |:colorscheme|
+	  compiler/	compiler files |:compiler|
+	  doc/		documentation |write-local-help|
+	  ftplugin/	filetype plugins |write-filetype-plugin|
+	  indent/	indent scripts |indent-expression|
+	  keymap/	key mapping files |mbyte-keymap|
+	  lang/		menu translations |:menutrans|
+	  lua/		|Lua| plugins
+	  menu.vim	GUI menus |menu.vim|
+	  pack/		packages |:packadd|
+	  parser/	|treesitter| syntax parsers
+	  plugin/	plugin scripts |write-plugin|
+	  queries/	|treesitter| queries
+	  rplugin/	|remote-plugin| scripts
+	  spell/	spell checking files |spell|
+	  syntax/	syntax files |mysyntaxfile|
+	  tutor/	tutorial files |:Tutor|
 
-        And any other file searched for with the |:runtime| command.
+	And any other file searched for with the |:runtime| command.
 
-        Defaults are setup to search these locations:
-        1. Your home directory, for personal preferences.
-           Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
-        2. Directories which must contain configuration files according to
-           |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
-           preferences from system administrator.
-        3. Data home directory, for plugins installed by user.
-           Given by `stdpath("data")/site`.  |$XDG_DATA_HOME|
-        4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
-           This is for plugins which were installed by system administrator,
-           but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
-           to /usr/local/share/:/usr/share/, so system administrators are
-           expected to install site plugins to /usr/share/nvim/site.
-        5. Session state directory, for state data such as swap, backupdir,
-           viewdir, undodir, etc.
-           Given by `stdpath("state")`.  |$XDG_STATE_HOME|
-        6. $VIMRUNTIME, for files distributed with Nvim.
-                                                        *after-directory*
-        7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
-           ordering.  This is for preferences to overrule or add to the
-           distributed defaults or system-wide settings (rarely needed).
+	Defaults are setup to search these locations:
+	1. Your home directory, for personal preferences.
+	   Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
+	2. Directories which must contain configuration files according to
+	   |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
+	   preferences from system administrator.
+	3. Data home directory, for plugins installed by user.
+	   Given by `stdpath("data")/site`.  |$XDG_DATA_HOME|
+	4. nvim/site subdirectories for each directory in $XDG_DATA_DIRS.
+	   This is for plugins which were installed by system administrator,
+	   but are not part of the Nvim distribution. XDG_DATA_DIRS defaults
+	   to /usr/local/share/:/usr/share/, so system administrators are
+	   expected to install site plugins to /usr/share/nvim/site.
+	5. Session state directory, for state data such as swap, backupdir,
+	   viewdir, undodir, etc.
+	   Given by `stdpath("state")`.  |$XDG_STATE_HOME|
+	6. $VIMRUNTIME, for files distributed with Nvim.
+							*after-directory*
+	7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
+	   ordering.  This is for preferences to overrule or add to the
+	   distributed defaults or system-wide settings (rarely needed).
 
-                                                        *packages-runtimepath*
-        "start" packages will also be searched (|runtime-search-path|) for
-        runtime files after these, though such packages are not explicitly
-        reported in &runtimepath. But "opt" packages are explicitly added to
-        &runtimepath by |:packadd|.
+							*packages-runtimepath*
+	"start" packages will also be searched (|runtime-search-path|) for
+	runtime files after these, though such packages are not explicitly
+	reported in &runtimepath. But "opt" packages are explicitly added to
+	&runtimepath by |:packadd|.
 
-        Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
-        wildcards are allowed, but can significantly slow down searching for
-        runtime files.  For speed, use as few items as possible and avoid
-        wildcards.
-        See |:runtime|.
-        Example: >vim
-                set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
-<       This will use the directory "~/vimruntime" first (containing your
-        personal Nvim runtime files), then "/mygroup/vim", and finally
-        "$VIMRUNTIME" (the default runtime files).
-        You can put a directory before $VIMRUNTIME to find files which replace
-        distributed runtime files.  You can put a directory after $VIMRUNTIME
-        to find files which add to distributed runtime files.
+	Note that, unlike 'path', no wildcards like "**" are allowed.  Normal
+	wildcards are allowed, but can significantly slow down searching for
+	runtime files.	For speed, use as few items as possible and avoid
+	wildcards.
+	See |:runtime|.
+	Example: >vim
+		set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
+<	This will use the directory "~/vimruntime" first (containing your
+	personal Nvim runtime files), then "/mygroup/vim", and finally
+	"$VIMRUNTIME" (the default runtime files).
+	You can put a directory before $VIMRUNTIME to find files which replace
+	distributed runtime files.  You can put a directory after $VIMRUNTIME
+	to find files which add to distributed runtime files.
 
-        With |--clean| the home directory entries are not included.
+	With |--clean| the home directory entries are not included.
 
-                                                                *'scroll'* *'scr'*
-'scroll' 'scr'          number (default half the window height)
-                        local to window  |local-noglobal|
-        Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
-        set to half the number of lines in the window when the window size
-        changes.  This may happen when enabling the |status-line| or
-        'tabline' option after setting the 'scroll' option.
-        If you give a count to the CTRL-U or CTRL-D command it will
-        be used as the new value for 'scroll'.  Reset to half the window
-        height with ":set scroll=0".
+								*'scroll'* *'scr'*
+'scroll' 'scr'		number (default half the window height)
+			local to window  |local-noglobal|
+	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
+	set to half the number of lines in the window when the window size
+	changes.  This may happen when enabling the |status-line| or
+	'tabline' option after setting the 'scroll' option.
+	If you give a count to the CTRL-U or CTRL-D command it will
+	be used as the new value for 'scroll'.	Reset to half the window
+	height with ":set scroll=0".
 
-                                                           *'scrollback'* *'scbk'*
-'scrollback' 'scbk'     number (default 10000)
-                        local to buffer
-        Maximum number of lines kept beyond the visible screen. Lines at the
-        top are deleted if new lines exceed this limit.
-        Minimum is 1, maximum is 100000.
-        Only in |terminal| buffers.
+							   *'scrollback'* *'scbk'*
+'scrollback' 'scbk'	number (default 10000)
+			local to buffer
+	Maximum number of lines kept beyond the visible screen. Lines at the
+	top are deleted if new lines exceed this limit.
+	Minimum is 1, maximum is 100000.
+	Only in |terminal| buffers.
 
-        Note: Lines that are not visible and kept in scrollback are not
-        reflown when the terminal buffer is resized horizontally.
+	Note: Lines that are not visible and kept in scrollback are not
+	reflown when the terminal buffer is resized horizontally.
 
-                                     *'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
-'scrollbind' 'scb'      boolean (default off)
-                        local to window
-        See also |scroll-binding|.  When this option is set, scrolling the
-        current window also scrolls other scrollbind windows (windows that
-        also have this option set).  This option is useful for viewing the
-        differences between two versions of a file, see 'diff'.
-        See |'scrollopt'| for options that determine how this option should be
-        interpreted.
-        This option is mostly reset when splitting a window to edit another
-        file.  This means that ":split | edit file" results in two windows
-        with scroll-binding, but ":split file" does not.
+				     *'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
+'scrollbind' 'scb'	boolean (default off)
+			local to window
+	See also |scroll-binding|.  When this option is set, scrolling the
+	current window also scrolls other scrollbind windows (windows that
+	also have this option set).  This option is useful for viewing the
+	differences between two versions of a file, see 'diff'.
+	See |'scrollopt'| for options that determine how this option should be
+	interpreted.
+	This option is mostly reset when splitting a window to edit another
+	file.  This means that ":split | edit file" results in two windows
+	with scroll-binding, but ":split file" does not.
 
-                                                             *'scrolljump'* *'sj'*
-'scrolljump' 'sj'       number (default 1)
-                        global
-        Minimal number of lines to scroll when the cursor gets off the
-        screen (e.g., with "j").  Not used for scroll commands (e.g., CTRL-E,
-        CTRL-D).  Useful if your terminal scrolls very slowly.
-        When set to a negative number from -1 to -100 this is used as the
-        percentage of the window height.  Thus -50 scrolls half the window
-        height.
+							     *'scrolljump'* *'sj'*
+'scrolljump' 'sj'	number (default 1)
+			global
+	Minimal number of lines to scroll when the cursor gets off the
+	screen (e.g., with "j").  Not used for scroll commands (e.g., CTRL-E,
+	CTRL-D).  Useful if your terminal scrolls very slowly.
+	When set to a negative number from -1 to -100 this is used as the
+	percentage of the window height.  Thus -50 scrolls half the window
+	height.
 
-                                                              *'scrolloff'* *'so'*
-'scrolloff' 'so'        number (default 0)
-                        global or local to window |global-local|
-        Minimal number of screen lines to keep above and below the cursor.
-        This will make some context visible around where you are working.  If
-        you set it to a very large value (999) the cursor line will always be
-        in the middle of the window (except at the start or end of the file or
-        when long lines wrap).
-        After using the local value, go back the global value with one of
-        these two: >vim
-                setlocal scrolloff<
-                setlocal scrolloff=-1
-<       For scrolling horizontally see 'sidescrolloff'.
+							      *'scrolloff'* *'so'*
+'scrolloff' 'so'	number (default 0)
+			global or local to window |global-local|
+	Minimal number of screen lines to keep above and below the cursor.
+	This will make some context visible around where you are working.  If
+	you set it to a very large value (999) the cursor line will always be
+	in the middle of the window (except at the start or end of the file or
+	when long lines wrap).
+	After using the local value, go back the global value with one of
+	these two: >vim
+		setlocal scrolloff<
+		setlocal scrolloff=-1
+<	For scrolling horizontally see 'sidescrolloff'.
 
-                                                             *'scrollopt'* *'sbo'*
-'scrollopt' 'sbo'       string (default "ver,jump")
-                        global
-        This is a comma-separated list of words that specifies how
-        'scrollbind' windows should behave.  'sbo' stands for ScrollBind
-        Options.
-        The following words are available:
-            ver         Bind vertical scrolling for 'scrollbind' windows
-            hor         Bind horizontal scrolling for 'scrollbind' windows
-            jump        Applies to the offset between two windows for vertical
-                        scrolling.  This offset is the difference in the first
-                        displayed line of the bound windows.  When moving
-                        around in a window, another 'scrollbind' window may
-                        reach a position before the start or after the end of
-                        the buffer.  The offset is not changed though, when
-                        moving back the 'scrollbind' window will try to scroll
-                        to the desired position when possible.
-                        When now making that window the current one, two
-                        things can be done with the relative offset:
-                        1. When "jump" is not included, the relative offset is
-                           adjusted for the scroll position in the new current
-                           window.  When going back to the other window, the
-                           new relative offset will be used.
-                        2. When "jump" is included, the other windows are
-                           scrolled to keep the same relative offset.  When
-                           going back to the other window, it still uses the
-                           same relative offset.
-        Also see |scroll-binding|.
-        When 'diff' mode is active there always is vertical scroll binding,
-        even when "ver" isn't there.
+							     *'scrollopt'* *'sbo'*
+'scrollopt' 'sbo'	string (default "ver,jump")
+			global
+	This is a comma-separated list of words that specifies how
+	'scrollbind' windows should behave.  'sbo' stands for ScrollBind
+	Options.
+	The following words are available:
+	    ver		Bind vertical scrolling for 'scrollbind' windows
+	    hor		Bind horizontal scrolling for 'scrollbind' windows
+	    jump	Applies to the offset between two windows for vertical
+			scrolling.  This offset is the difference in the first
+			displayed line of the bound windows.  When moving
+			around in a window, another 'scrollbind' window may
+			reach a position before the start or after the end of
+			the buffer.  The offset is not changed though, when
+			moving back the 'scrollbind' window will try to scroll
+			to the desired position when possible.
+			When now making that window the current one, two
+			things can be done with the relative offset:
+			1. When "jump" is not included, the relative offset is
+			   adjusted for the scroll position in the new current
+			   window.  When going back to the other window, the
+			   new relative offset will be used.
+			2. When "jump" is included, the other windows are
+			   scrolled to keep the same relative offset.  When
+			   going back to the other window, it still uses the
+			   same relative offset.
+	Also see |scroll-binding|.
+	When 'diff' mode is active there always is vertical scroll binding,
+	even when "ver" isn't there.
 
-                                                             *'sections'* *'sect'*
-'sections' 'sect'       string (default "SHNHH HUnhsh")
-                        global
-        Specifies the nroff macros that separate sections.  These are pairs of
-        two letters (See |object-motions|).  The default makes a section start
-        at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
+							     *'sections'* *'sect'*
+'sections' 'sect'	string (default "SHNHH HUnhsh")
+			global
+	Specifies the nroff macros that separate sections.  These are pairs of
+	two letters (See |object-motions|).  The default makes a section start
+	at the nroff macros ".SH", ".NH", ".H", ".HU", ".nh" and ".sh".
 
-                                                             *'selection'* *'sel'*
-'selection' 'sel'       string (default "inclusive")
-                        global
-        This option defines the behavior of the selection.  It is only used
-        in Visual and Select mode.
-        Possible values:
-           value        past line     inclusive ~
-           old             no           yes
-           inclusive       yes          yes
-           exclusive       yes          no
-        "past line" means that the cursor is allowed to be positioned one
-        character past the line.
-        "inclusive" means that the last character of the selection is included
-        in an operation.  For example, when "x" is used to delete the
-        selection.
-        When "old" is used and 'virtualedit' allows the cursor to move past
-        the end of line the line break still isn't included.
-        Note that when "exclusive" is used and selecting from the end
-        backwards, you cannot include the last character of a line, when
-        starting in Normal mode and 'virtualedit' empty.
+							     *'selection'* *'sel'*
+'selection' 'sel'	string (default "inclusive")
+			global
+	This option defines the behavior of the selection.  It is only used
+	in Visual and Select mode.
+	Possible values:
+	   value	past line     inclusive ~
+	   old		   no		yes
+	   inclusive	   yes		yes
+	   exclusive	   yes		no
+	"past line" means that the cursor is allowed to be positioned one
+	character past the line.
+	"inclusive" means that the last character of the selection is included
+	in an operation.  For example, when "x" is used to delete the
+	selection.
+	When "old" is used and 'virtualedit' allows the cursor to move past
+	the end of line the line break still isn't included.
+	Note that when "exclusive" is used and selecting from the end
+	backwards, you cannot include the last character of a line, when
+	starting in Normal mode and 'virtualedit' empty.
 
-                                                            *'selectmode'* *'slm'*
-'selectmode' 'slm'      string (default "")
-                        global
-        This is a comma-separated list of words, which specifies when to start
-        Select mode instead of Visual mode, when a selection is started.
-        Possible values:
-           mouse        when using the mouse
-           key          when using shifted special keys
-           cmd          when using "v", "V" or CTRL-V
-        See |Select-mode|.
+							    *'selectmode'* *'slm'*
+'selectmode' 'slm'	string (default "")
+			global
+	This is a comma-separated list of words, which specifies when to start
+	Select mode instead of Visual mode, when a selection is started.
+	Possible values:
+	   mouse	when using the mouse
+	   key		when using shifted special keys
+	   cmd		when using "v", "V" or CTRL-V
+	See |Select-mode|.
 
-                                                       *'sessionoptions'* *'ssop'*
+						       *'sessionoptions'* *'ssop'*
 'sessionoptions' 'ssop' string (default "blank,buffers,curdir,folds,help,tabpages,winsize,terminal")
-                        global
-        Changes the effect of the |:mksession| command.  It is a comma-
-        separated list of words.  Each word enables saving and restoring
-        something:
-           word         save and restore ~
-           blank        empty windows
-           buffers      hidden and unloaded buffers, not just those in windows
-           curdir       the current directory
-           folds        manually created folds, opened/closed folds and local
-                        fold options
-           globals      global variables that start with an uppercase letter
-                        and contain at least one lowercase letter.  Only
-                        String and Number types are stored.
-           help         the help window
-           localoptions options and mappings local to a window or buffer (not
-                        global values for local options)
-           options      all options and mappings (also global values for local
-                        options)
-           skiprtp      exclude 'runtimepath' and 'packpath' from the options
-           resize       size of the Vim window: 'lines' and 'columns'
-           sesdir       the directory in which the session file is located
-                        will become the current directory (useful with
-                        projects accessed over a network from different
-                        systems)
-           tabpages     all tab pages; without this only the current tab page
-                        is restored, so that you can make a session for each
-                        tab page separately
-           terminal     include terminal windows where the command can be
-                        restored
-           winpos       position of the whole Vim window
-           winsize      window sizes
-           slash        |deprecated| Always enabled. Uses "/" in filenames.
-           unix         |deprecated| Always enabled. Uses "\n" line endings.
+			global
+	Changes the effect of the |:mksession| command.  It is a comma-
+	separated list of words.  Each word enables saving and restoring
+	something:
+	   word		save and restore ~
+	   blank	empty windows
+	   buffers	hidden and unloaded buffers, not just those in windows
+	   curdir	the current directory
+	   folds	manually created folds, opened/closed folds and local
+			fold options
+	   globals	global variables that start with an uppercase letter
+			and contain at least one lowercase letter.  Only
+			String and Number types are stored.
+	   help		the help window
+	   localoptions options and mappings local to a window or buffer (not
+			global values for local options)
+	   options	all options and mappings (also global values for local
+			options)
+	   skiprtp	exclude 'runtimepath' and 'packpath' from the options
+	   resize	size of the Vim window: 'lines' and 'columns'
+	   sesdir	the directory in which the session file is located
+			will become the current directory (useful with
+			projects accessed over a network from different
+			systems)
+	   tabpages	all tab pages; without this only the current tab page
+			is restored, so that you can make a session for each
+			tab page separately
+	   terminal	include terminal windows where the command can be
+			restored
+	   winpos	position of the whole Vim window
+	   winsize	window sizes
+	   slash	|deprecated| Always enabled. Uses "/" in filenames.
+	   unix		|deprecated| Always enabled. Uses "\n" line endings.
 
-        Don't include both "curdir" and "sesdir". When neither is included
-        filenames are stored as absolute paths.
-        If you leave out "options" many things won't work well after restoring
-        the session.
+	Don't include both "curdir" and "sesdir". When neither is included
+	filenames are stored as absolute paths.
+	If you leave out "options" many things won't work well after restoring
+	the session.
 
-                                                   *'shada'* *'sd'* *E526* *E527* *E528*
-'shada' 'sd'            string (default for Win32:  !,'100,<50,s10,h,rA:,rB:
-                                            others: !,'100,<50,s10,h)
-                        global
-        When non-empty, the shada file is read upon startup and written
-        when exiting Vim (see |shada-file|).  The string should be a comma-
-        separated list of parameters, each consisting of a single character
-        identifying the particular parameter, followed by a number or string
-        which specifies the value of that parameter.  If a particular
-        character is left out, then the default value is used for that
-        parameter.  The following is a list of the identifying characters and
-        the effect of their value.
-        CHAR    VALUE   ~
-                                                        *shada-!*
-        !       When included, save and restore global variables that start
-                with an uppercase letter, and don't contain a lowercase
-                letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
-                and "_K_L_M" are not.  Nested List and Dict items may not be
-                read back correctly, you end up with an empty item.
-                                                        *shada-quote*
-        "       Maximum number of lines saved for each register.  Old name of
-                the '<' item, with the disadvantage that you need to put a
-                backslash before the ", otherwise it will be recognized as the
-                start of a comment!
-                                                        *shada-%*
-        %       When included, save and restore the buffer list.  If Vim is
-                started with a file name argument, the buffer list is not
-                restored.  If Vim is started without a file name argument, the
-                buffer list is restored from the shada file.  Quickfix
-                ('buftype'), unlisted ('buflisted'), unnamed and buffers on
-                removable media (|shada-r|) are not saved.
-                When followed by a number, the number specifies the maximum
-                number of buffers that are stored.  Without a number all
-                buffers are stored.
-                                                        *shada-'*
-        '       Maximum number of previously edited files for which the marks
-                are remembered.  This parameter must always be included when
-                'shada' is non-empty.
-                Including this item also means that the |jumplist| and the
-                |changelist| are stored in the shada file.
-                                                        *shada-/*
-        /       Maximum number of items in the search pattern history to be
-                saved.  If non-zero, then the previous search and substitute
-                patterns are also saved.  When not included, the value of
-                'history' is used.
-                                                        *shada-:*
-        :       Maximum number of items in the command-line history to be
-                saved.  When not included, the value of 'history' is used.
-                                                        *shada-<*
-        <      Maximum number of lines saved for each register.  If zero then
-                registers are not saved.  When not included, all lines are
-                saved.  '"' is the old name for this item.
-                Also see the 's' item below: limit specified in KiB.
-                                                        *shada-@*
-        @       Maximum number of items in the input-line history to be
-                saved.  When not included, the value of 'history' is used.
-                                                        *shada-c*
-        c       Dummy option, kept for compatibility reasons.  Has no actual
-                effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
-                to UTF-8 as well.
-                                                        *shada-f*
-        f       Whether file marks need to be stored.  If zero, file marks ('0
-                to '9, 'A to 'Z) are not stored.  When not present or when
-                non-zero, they are all stored.  '0 is used for the current
-                cursor position (when exiting or when doing |:wshada|).
-                                                        *shada-h*
-        h       Disable the effect of 'hlsearch' when loading the shada
-                file.  When not included, it depends on whether ":nohlsearch"
-                has been used since the last search command.
-                                                        *shada-n*
-        n       Name of the shada file.  The name must immediately follow
-                the 'n'.  Must be at the end of the option!  If the
-                'shadafile' option is set, that file name overrides the one
-                given here with 'shada'.  Environment variables are
-                expanded when opening the file, not when setting the option.
-                                                        *shada-r*
-        r       Removable media.  The argument is a string (up to the next
-                ',').  This parameter can be given several times.  Each
-                specifies the start of a path for which no marks will be
-                stored.  This is to avoid removable media.  For Windows you
-                could use "ra:,rb:".  You can also use it for temp files,
-                e.g., for Unix: "r/tmp".  Case is ignored.
-                                                        *shada-s*
-        s       Maximum size of an item contents in KiB.  If zero then nothing
-                is saved.  Unlike Vim this applies to all items, except for
-                the buffer list and header.  Full item size is off by three
-                unsigned integers: with `s10` maximum item size may be 1 byte
-                (type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
-                integer) + 3 bytes (item size: up to 16-bit integer because
-                2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
-                contents size) = 10253 bytes.
+						   *'shada'* *'sd'* *E526* *E527* *E528*
+'shada' 'sd'		string (default for Win32:  !,'100,<50,s10,h,rA:,rB:
+					    others: !,'100,<50,s10,h)
+			global
+	When non-empty, the shada file is read upon startup and written
+	when exiting Vim (see |shada-file|).  The string should be a comma-
+	separated list of parameters, each consisting of a single character
+	identifying the particular parameter, followed by a number or string
+	which specifies the value of that parameter.  If a particular
+	character is left out, then the default value is used for that
+	parameter.  The following is a list of the identifying characters and
+	the effect of their value.
+	CHAR	VALUE	~
+							*shada-!*
+	!	When included, save and restore global variables that start
+		with an uppercase letter, and don't contain a lowercase
+		letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
+		and "_K_L_M" are not.  Nested List and Dict items may not be
+		read back correctly, you end up with an empty item.
+							*shada-quote*
+	"	Maximum number of lines saved for each register.  Old name of
+		the '<' item, with the disadvantage that you need to put a
+		backslash before the ", otherwise it will be recognized as the
+		start of a comment!
+							*shada-%*
+	%	When included, save and restore the buffer list.  If Vim is
+		started with a file name argument, the buffer list is not
+		restored.  If Vim is started without a file name argument, the
+		buffer list is restored from the shada file.  Quickfix
+		('buftype'), unlisted ('buflisted'), unnamed and buffers on
+		removable media (|shada-r|) are not saved.
+		When followed by a number, the number specifies the maximum
+		number of buffers that are stored.  Without a number all
+		buffers are stored.
+							*shada-'*
+	'	Maximum number of previously edited files for which the marks
+		are remembered.  This parameter must always be included when
+		'shada' is non-empty.
+		Including this item also means that the |jumplist| and the
+		|changelist| are stored in the shada file.
+							*shada-/*
+	/	Maximum number of items in the search pattern history to be
+		saved.	If non-zero, then the previous search and substitute
+		patterns are also saved.  When not included, the value of
+		'history' is used.
+							*shada-:*
+	:	Maximum number of items in the command-line history to be
+		saved.	When not included, the value of 'history' is used.
+							*shada-<*
+	<      Maximum number of lines saved for each register.  If zero then
+		registers are not saved.  When not included, all lines are
+		saved.	'"' is the old name for this item.
+		Also see the 's' item below: limit specified in KiB.
+							*shada-@*
+	@	Maximum number of items in the input-line history to be
+		saved.	When not included, the value of 'history' is used.
+							*shada-c*
+	c	Dummy option, kept for compatibility reasons.  Has no actual
+		effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
+		to UTF-8 as well.
+							*shada-f*
+	f	Whether file marks need to be stored.  If zero, file marks ('0
+		to '9, 'A to 'Z) are not stored.  When not present or when
+		non-zero, they are all stored.	'0 is used for the current
+		cursor position (when exiting or when doing |:wshada|).
+							*shada-h*
+	h	Disable the effect of 'hlsearch' when loading the shada
+		file.  When not included, it depends on whether ":nohlsearch"
+		has been used since the last search command.
+							*shada-n*
+	n	Name of the shada file.  The name must immediately follow
+		the 'n'.  Must be at the end of the option!  If the
+		'shadafile' option is set, that file name overrides the one
+		given here with 'shada'.  Environment variables are
+		expanded when opening the file, not when setting the option.
+							*shada-r*
+	r	Removable media.  The argument is a string (up to the next
+		',').  This parameter can be given several times.  Each
+		specifies the start of a path for which no marks will be
+		stored.  This is to avoid removable media.  For Windows you
+		could use "ra:,rb:".  You can also use it for temp files,
+		e.g., for Unix: "r/tmp".  Case is ignored.
+							*shada-s*
+	s	Maximum size of an item contents in KiB.  If zero then nothing
+		is saved.  Unlike Vim this applies to all items, except for
+		the buffer list and header.  Full item size is off by three
+		unsigned integers: with `s10` maximum item size may be 1 byte
+		(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+		integer) + 3 bytes (item size: up to 16-bit integer because
+		2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
+		contents size) = 10253 bytes.
 
-        Example: >vim
-            set shada='50,<1000,s100,:0,n~/nvim/shada
+	Example: >vim
+	    set shada='50,<1000,s100,:0,n~/nvim/shada
 <
-        '50             Marks will be remembered for the last 50 files you
-                        edited.
-        <1000           Contents of registers (up to 1000 lines each) will be
-                        remembered.
-        s100            Items with contents occupying more then 100 KiB are
-                        skipped.
-        :0              Command-line history will not be saved.
-        n~/nvim/shada   The name of the file to use is "~/nvim/shada".
-        no /            Since '/' is not specified, the default will be used,
-                        that is, save all of the search history, and also the
-                        previous search and substitute patterns.
-        no %            The buffer list will not be saved nor read back.
-        no h            'hlsearch' highlighting will be restored.
+	'50		Marks will be remembered for the last 50 files you
+			edited.
+	<1000		Contents of registers (up to 1000 lines each) will be
+			remembered.
+	s100		Items with contents occupying more then 100 KiB are
+			skipped.
+	:0		Command-line history will not be saved.
+	n~/nvim/shada	The name of the file to use is "~/nvim/shada".
+	no /		Since '/' is not specified, the default will be used,
+			that is, save all of the search history, and also the
+			previous search and substitute patterns.
+	no %		The buffer list will not be saved nor read back.
+	no h		'hlsearch' highlighting will be restored.
 
-        When setting 'shada' from an empty value you can use |:rshada| to
-        load the contents of the file, this is not done automatically.
+	When setting 'shada' from an empty value you can use |:rshada| to
+	load the contents of the file, this is not done automatically.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                             *'shadafile'* *'sdf'*
-'shadafile' 'sdf'       string (default "")
-                        global
-        When non-empty, overrides the file name used for |shada| (viminfo).
-        When equal to "NONE" no shada file will be read or written.
-        This option can be set with the |-i| command line flag.  The |--clean|
-        command line flag sets it to "NONE".
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							     *'shadafile'* *'sdf'*
+'shadafile' 'sdf'	string (default "")
+			global
+	When non-empty, overrides the file name used for |shada| (viminfo).
+	When equal to "NONE" no shada file will be read or written.
+	This option can be set with the |-i| command line flag.  The |--clean|
+	command line flag sets it to "NONE".
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                              *'shell'* *'sh'* *E91*
-'shell' 'sh'            string (default $SHELL or "sh", Win32: "cmd.exe")
-                        global
-        Name of the shell to use for ! and :! commands.  When changing the
-        value also check these options: 'shellpipe', 'shellslash'
-        'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
-        It is allowed to give an argument to the command, e.g.  "csh -f".
-        See |option-backslash| about including spaces and backslashes.
-        Environment variables are expanded |:set_env|.
+							      *'shell'* *'sh'* *E91*
+'shell' 'sh'		string (default $SHELL or "sh", Win32: "cmd.exe")
+			global
+	Name of the shell to use for ! and :! commands.  When changing the
+	value also check these options: 'shellpipe', 'shellslash'
+	'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
+	It is allowed to give an argument to the command, e.g.	"csh -f".
+	See |option-backslash| about including spaces and backslashes.
+	Environment variables are expanded |:set_env|.
 
-        If the name of the shell contains a space, you need to enclose it in
-        quotes.  Example with quotes: >vim
-                set shell=\"c:\program\ files\unix\sh.exe\"\ -f
-<       Note the backslash before each quote (to avoid starting a comment) and
-        each space (to avoid ending the option value), so better use |:let-&|
-        like this: >vim
-                let &shell='"C:\Program Files\unix\sh.exe" -f'
-<       Also note that the "-f" is not inside the quotes, because it is not
-        part of the command name.
-                                                        *shell-unquoting*
-        Rules regarding quotes:
-        1. Option is split on space and tab characters that are not inside
-           quotes: "abc def" runs shell named "abc" with additional argument
-           "def", '"abc def"' runs shell named "abc def" with no additional
-           arguments (here and below: additional means “additional to
-           'shellcmdflag'”).
-        2. Quotes in option may be present in any position and any number:
-           '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
-           to just "abc".
-        3. Inside quotes backslash preceding backslash means one backslash.
-           Backslash preceding quote means one quote. Backslash preceding
-           anything else means backslash and next character literally:
-           '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
-           'a"b', '"a\b"' is the same as "a\b" again.
-        4. Outside of quotes backslash always means itself, it cannot be used
-           to escape quote: 'a\"b"' is the same as "a\b".
-        Note that such processing is done after |:set| did its own round of
-        unescaping, so to keep yourself sane use |:let-&| like shown above.
-                                                        *shell-powershell*
-        To use PowerShell: >vim
-                let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-                let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
-                let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-                let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
-                set shellquote= shellxquote=
+	If the name of the shell contains a space, you need to enclose it in
+	quotes.  Example with quotes: >vim
+		set shell=\"c:\program\ files\unix\sh.exe\"\ -f
+<	Note the backslash before each quote (to avoid starting a comment) and
+	each space (to avoid ending the option value), so better use |:let-&|
+	like this: >vim
+		let &shell='"C:\Program Files\unix\sh.exe" -f'
+<	Also note that the "-f" is not inside the quotes, because it is not
+	part of the command name.
+							*shell-unquoting*
+	Rules regarding quotes:
+	1. Option is split on space and tab characters that are not inside
+	   quotes: "abc def" runs shell named "abc" with additional argument
+	   "def", '"abc def"' runs shell named "abc def" with no additional
+	   arguments (here and below: additional means “additional to
+	   'shellcmdflag'”).
+	2. Quotes in option may be present in any position and any number:
+	   '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
+	   to just "abc".
+	3. Inside quotes backslash preceding backslash means one backslash.
+	   Backslash preceding quote means one quote. Backslash preceding
+	   anything else means backslash and next character literally:
+	   '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
+	   'a"b', '"a\b"' is the same as "a\b" again.
+	4. Outside of quotes backslash always means itself, it cannot be used
+	   to escape quote: 'a\"b"' is the same as "a\b".
+	Note that such processing is done after |:set| did its own round of
+	unescaping, so to keep yourself sane use |:let-&| like shown above.
+							*shell-powershell*
+	To use PowerShell: >vim
+		let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
+		let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
+		let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+		let &shellpipe	= '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
+		set shellquote= shellxquote=
 
-<       This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+<	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                         *'shellcmdflag'* *'shcf'*
-'shellcmdflag' 'shcf'   string (default "-c"; Windows: "/s /c")
-                        global
-        Flag passed to the shell to execute "!" and ":!" commands; e.g.,
-        `bash.exe -c ls` or `cmd.exe /s /c "dir"`.  For MS-Windows, the
-        default is set according to the value of 'shell', to reduce the need
-        to set this option by the user.
-        On Unix it can have more than one flag.  Each white space separated
-        part is passed as an argument to the shell command.
-        See |option-backslash| about including spaces and backslashes.
-        See |shell-unquoting| which talks about separating this option into
-        multiple arguments.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							 *'shellcmdflag'* *'shcf'*
+'shellcmdflag' 'shcf'	string (default "-c"; Windows: "/s /c")
+			global
+	Flag passed to the shell to execute "!" and ":!" commands; e.g.,
+	`bash.exe -c ls` or `cmd.exe /s /c "dir"`.  For MS-Windows, the
+	default is set according to the value of 'shell', to reduce the need
+	to set this option by the user.
+	On Unix it can have more than one flag.  Each white space separated
+	part is passed as an argument to the shell command.
+	See |option-backslash| about including spaces and backslashes.
+	See |shell-unquoting| which talks about separating this option into
+	multiple arguments.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                              *'shellpipe'* *'sp'*
-'shellpipe' 'sp'        string (default ">", "| tee", "|& tee" or "2>&1| tee")
-                        global
-        String to be used to put the output of the ":make" command in the
-        error file.  See also |:make_makeprg|.  See |option-backslash| about
-        including spaces and backslashes.
-        The name of the temporary file can be represented by "%s" if necessary
-        (the file name is appended automatically if no %s appears in the value
-        of this option).
-        For MS-Windows the default is "2>&1| tee".  The stdout and stderr are
-        saved in a file and echoed to the screen.
-        For Unix the default is "| tee".  The stdout of the compiler is saved
-        in a file and echoed to the screen.  If the 'shell' option is "csh" or
-        "tcsh" after initializations, the default becomes "|& tee".  If the
-        'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
-        "bash", "fish", "ash" or "dash" the default becomes "2>&1| tee".  This
-        means that stderr is also included.  Before using the 'shell' option a
-        path is removed, thus "/bin/sh" uses "sh".
-        The initialization of this option is done after reading the vimrc
-        and the other initializations, so that when the 'shell' option is set
-        there, the 'shellpipe' option changes automatically, unless it was
-        explicitly set before.
-        When 'shellpipe' is set to an empty string, no redirection of the
-        ":make" output will be done.  This is useful if you use a 'makeprg'
-        that writes to 'makeef' by itself.  If you want no piping, but do
-        want to include the 'makeef', set 'shellpipe' to a single space.
-        Don't forget to precede the space with a backslash: ":set sp=\ ".
-        In the future pipes may be used for filtering and this option will
-        become obsolete (at least for Unix).
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'shellpipe'* *'sp'*
+'shellpipe' 'sp'	string (default ">", "| tee", "|& tee" or "2>&1| tee")
+			global
+	String to be used to put the output of the ":make" command in the
+	error file.  See also |:make_makeprg|.	See |option-backslash| about
+	including spaces and backslashes.
+	The name of the temporary file can be represented by "%s" if necessary
+	(the file name is appended automatically if no %s appears in the value
+	of this option).
+	For MS-Windows the default is "2>&1| tee".  The stdout and stderr are
+	saved in a file and echoed to the screen.
+	For Unix the default is "| tee".  The stdout of the compiler is saved
+	in a file and echoed to the screen.  If the 'shell' option is "csh" or
+	"tcsh" after initializations, the default becomes "|& tee".  If the
+	'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
+	"bash", "fish", "ash" or "dash" the default becomes "2>&1| tee".  This
+	means that stderr is also included.  Before using the 'shell' option a
+	path is removed, thus "/bin/sh" uses "sh".
+	The initialization of this option is done after reading the vimrc
+	and the other initializations, so that when the 'shell' option is set
+	there, the 'shellpipe' option changes automatically, unless it was
+	explicitly set before.
+	When 'shellpipe' is set to an empty string, no redirection of the
+	":make" output will be done.  This is useful if you use a 'makeprg'
+	that writes to 'makeef' by itself.  If you want no piping, but do
+	want to include the 'makeef', set 'shellpipe' to a single space.
+	Don't forget to precede the space with a backslash: ":set sp=\ ".
+	In the future pipes may be used for filtering and this option will
+	become obsolete (at least for Unix).
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                            *'shellquote'* *'shq'*
-'shellquote' 'shq'      string (default ""; Windows, when 'shell'
-                                        contains "sh" somewhere: "\"")
-                        global
-        Quoting character(s), put around the command passed to the shell, for
-        the "!" and ":!" commands.  The redirection is kept outside of the
-        quoting.  See 'shellxquote' to include the redirection.  It's
-        probably not useful to set both options.
-        This is an empty string by default.  Only known to be useful for
-        third-party shells on Windows systems, such as the MKS Korn Shell
-        or bash, where it should be "\"".  The default is adjusted according
-        the value of 'shell', to reduce the need to set this option by the
-        user.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							    *'shellquote'* *'shq'*
+'shellquote' 'shq'	string (default ""; Windows, when 'shell'
+					contains "sh" somewhere: "\"")
+			global
+	Quoting character(s), put around the command passed to the shell, for
+	the "!" and ":!" commands.  The redirection is kept outside of the
+	quoting.  See 'shellxquote' to include the redirection.  It's
+	probably not useful to set both options.
+	This is an empty string by default.  Only known to be useful for
+	third-party shells on Windows systems, such as the MKS Korn Shell
+	or bash, where it should be "\"".  The default is adjusted according
+	the value of 'shell', to reduce the need to set this option by the
+	user.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                            *'shellredir'* *'srr'*
-'shellredir' 'srr'      string (default ">", ">&" or ">%s 2>&1")
-                        global
-        String to be used to put the output of a filter command in a temporary
-        file.  See also |:!|.  See |option-backslash| about including spaces
-        and backslashes.
-        The name of the temporary file can be represented by "%s" if necessary
-        (the file name is appended automatically if no %s appears in the value
-        of this option).
-        The default is ">".  For Unix, if the 'shell' option is "csh" or
-        "tcsh" during initializations, the default becomes ">&".  If the
-        'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
-        "bash" or "fish", the default becomes ">%s 2>&1".  This means that
-        stderr is also included.  For Win32, the Unix checks are done and
-        additionally "cmd" is checked for, which makes the default ">%s 2>&1".
-        Also, the same names with ".exe" appended are checked for.
-        The initialization of this option is done after reading the vimrc
-        and the other initializations, so that when the 'shell' option is set
-        there, the 'shellredir' option changes automatically unless it was
-        explicitly set before.
-        In the future pipes may be used for filtering and this option will
-        become obsolete (at least for Unix).
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							    *'shellredir'* *'srr'*
+'shellredir' 'srr'	string (default ">", ">&" or ">%s 2>&1")
+			global
+	String to be used to put the output of a filter command in a temporary
+	file.  See also |:!|.  See |option-backslash| about including spaces
+	and backslashes.
+	The name of the temporary file can be represented by "%s" if necessary
+	(the file name is appended automatically if no %s appears in the value
+	of this option).
+	The default is ">".  For Unix, if the 'shell' option is "csh" or
+	"tcsh" during initializations, the default becomes ">&".  If the
+	'shell' option is "sh", "ksh", "mksh", "pdksh", "zsh", "zsh-beta",
+	"bash" or "fish", the default becomes ">%s 2>&1".  This means that
+	stderr is also included.  For Win32, the Unix checks are done and
+	additionally "cmd" is checked for, which makes the default ">%s 2>&1".
+	Also, the same names with ".exe" appended are checked for.
+	The initialization of this option is done after reading the vimrc
+	and the other initializations, so that when the 'shell' option is set
+	there, the 'shellredir' option changes automatically unless it was
+	explicitly set before.
+	In the future pipes may be used for filtering and this option will
+	become obsolete (at least for Unix).
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                     *'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
-'shellslash' 'ssl'      boolean (default off)
-                        global
-        only for MS-Windows
-        When set, a forward slash is used when expanding file names.  This is
-        useful when a Unix-like shell is used instead of cmd.exe.  Backward
-        slashes can still be typed, but they are changed to forward slashes by
-        Vim.
-        Note that setting or resetting this option has no effect for some
-        existing file names, thus this option needs to be set before opening
-        any file for best results.  This might change in the future.
-        'shellslash' only works when a backslash can be used as a path
-        separator.  To test if this is so use: >vim
-        if exists('+shellslash')
-<       Also see 'completeslash'.
+				     *'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
+'shellslash' 'ssl'	boolean (default off)
+			global
+	only for MS-Windows
+	When set, a forward slash is used when expanding file names.  This is
+	useful when a Unix-like shell is used instead of cmd.exe.  Backward
+	slashes can still be typed, but they are changed to forward slashes by
+	Vim.
+	Note that setting or resetting this option has no effect for some
+	existing file names, thus this option needs to be set before opening
+	any file for best results.  This might change in the future.
+	'shellslash' only works when a backslash can be used as a path
+	separator.  To test if this is so use: >vim
+	if exists('+shellslash')
+<	Also see 'completeslash'.
 
-                                     *'shelltemp'* *'stmp'* *'noshelltemp'* *'nostmp'*
-'shelltemp' 'stmp'      boolean (default on)
-                        global
-        When on, use temp files for shell commands.  When off use a pipe.
-        When using a pipe is not possible temp files are used anyway.
-        The advantage of using a pipe is that nobody can read the temp file
-        and the 'shell' command does not need to support redirection.
-        The advantage of using a temp file is that the file type and encoding
-        can be detected.
-        The |FilterReadPre|, |FilterReadPost| and |FilterWritePre|,
-        |FilterWritePost| autocommands event are not triggered when
-        'shelltemp' is off.
-        |system()| does not respect this option, it always uses pipes.
+				     *'shelltemp'* *'stmp'* *'noshelltemp'* *'nostmp'*
+'shelltemp' 'stmp'	boolean (default on)
+			global
+	When on, use temp files for shell commands.  When off use a pipe.
+	When using a pipe is not possible temp files are used anyway.
+	The advantage of using a pipe is that nobody can read the temp file
+	and the 'shell' command does not need to support redirection.
+	The advantage of using a temp file is that the file type and encoding
+	can be detected.
+	The |FilterReadPre|, |FilterReadPost| and |FilterWritePre|,
+	|FilterWritePost| autocommands event are not triggered when
+	'shelltemp' is off.
+	|system()| does not respect this option, it always uses pipes.
 
-                                                          *'shellxescape'* *'sxe'*
-'shellxescape' 'sxe'    string (default "")
-                        global
-        When 'shellxquote' is set to "(" then the characters listed in this
-        option will be escaped with a '^' character.  This makes it possible
-        to execute most external commands with cmd.exe.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							  *'shellxescape'* *'sxe'*
+'shellxescape' 'sxe'	string (default "")
+			global
+	When 'shellxquote' is set to "(" then the characters listed in this
+	option will be escaped with a '^' character.  This makes it possible
+	to execute most external commands with cmd.exe.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                           *'shellxquote'* *'sxq'*
-'shellxquote' 'sxq'     string (default "", Windows: "\"")
-                        global
-        Quoting character(s), put around the command passed to the shell, for
-        the "!" and ":!" commands.  Includes the redirection.  See
-        'shellquote' to exclude the redirection.  It's probably not useful
-        to set both options.
-        When the value is '(' then ')' is appended. When the value is '"('
-        then ')"' is appended.
-        When the value is '(' then also see 'shellxescape'.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							   *'shellxquote'* *'sxq'*
+'shellxquote' 'sxq'	string (default "", Windows: "\"")
+			global
+	Quoting character(s), put around the command passed to the shell, for
+	the "!" and ":!" commands.  Includes the redirection.  See
+	'shellquote' to exclude the redirection.  It's probably not useful
+	to set both options.
+	When the value is '(' then ')' is appended. When the value is '"('
+	then ')"' is appended.
+	When the value is '(' then also see 'shellxescape'.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                       *'shiftround'* *'sr'* *'noshiftround'* *'nosr'*
-'shiftround' 'sr'       boolean (default off)
-                        global
-        Round indent to multiple of 'shiftwidth'.  Applies to > and <
-        commands.  CTRL-T and CTRL-D in Insert mode always round the indent to
-        a multiple of 'shiftwidth' (this is Vi compatible).
+				       *'shiftround'* *'sr'* *'noshiftround'* *'nosr'*
+'shiftround' 'sr'	boolean (default off)
+			global
+	Round indent to multiple of 'shiftwidth'.  Applies to > and <
+	commands.  CTRL-T and CTRL-D in Insert mode always round the indent to
+	a multiple of 'shiftwidth' (this is Vi compatible).
 
-                                                             *'shiftwidth'* *'sw'*
-'shiftwidth' 'sw'       number (default 8)
-                        local to buffer
-        Number of spaces to use for each step of (auto)indent.  Used for
-        |'cindent'|, |>>|, |<<|, etc.
-        When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
-        function to get the effective shiftwidth value.
+							     *'shiftwidth'* *'sw'*
+'shiftwidth' 'sw'	number (default 8)
+			local to buffer
+	Number of spaces to use for each step of (auto)indent.	Used for
+	|'cindent'|, |>>|, |<<|, etc.
+	When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
+	function to get the effective shiftwidth value.
 
-                                                       *'shortmess'* *'shm'* *E1336*
-'shortmess' 'shm'       string (default "ltToOCF")
-                        global
-        This option helps to avoid all the |hit-enter| prompts caused by file
-        messages, for example  with CTRL-G, and to avoid some other messages.
-        It is a list of flags:
-         flag   meaning when present    ~
-          l     use "999L, 888B" instead of "999 lines, 888 bytes"      *shm-l*
-          m     use "[+]" instead of "[Modified]"                       *shm-m*
-          r     use "[RO]" instead of "[readonly]"                      *shm-r*
-          w     use "[w]" instead of "written" for file write message   *shm-w*
-                and "[a]" instead of "appended" for ':w >> file' command
-          a     all of the above abbreviations                          *shm-a*
+						       *'shortmess'* *'shm'* *E1336*
+'shortmess' 'shm'	string (default "ltToOCF")
+			global
+	This option helps to avoid all the |hit-enter| prompts caused by file
+	messages, for example  with CTRL-G, and to avoid some other messages.
+	It is a list of flags:
+	 flag	meaning when present	~
+	  l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
+	  m	use "[+]" instead of "[Modified]"			*shm-m*
+	  r	use "[RO]" instead of "[readonly]"			*shm-r*
+	  w	use "[w]" instead of "written" for file write message	*shm-w*
+		and "[a]" instead of "appended" for ':w >> file' command
+	  a	all of the above abbreviations				*shm-a*
 
-          o     overwrite message for writing a file with subsequent    *shm-o*
-                message for reading a file (useful for ":wn" or when
-                'autowrite' on)
-          O     message for reading a file overwrites any previous      *shm-O*
-                message;  also for quickfix message (e.g., ":cn")
-          s     don't give "search hit BOTTOM, continuing at TOP" or    *shm-s*
-                "search hit TOP, continuing at BOTTOM" messages; when using
-                the search count do not show "W" after the count message (see
-                S below)
-          t     truncate file message at the start if it is too long    *shm-t*
-                to fit on the command-line, "<" will appear in the left most
-                column; ignored in Ex mode
-          T     truncate other messages in the middle if they are too   *shm-T*
-                long to fit on the command line; "..." will appear in the
-                middle; ignored in Ex mode
-          W     don't give "written" or "[w]" when writing a file       *shm-W*
-          A     don't give the "ATTENTION" message when an existing     *shm-A*
-                swap file is found
-          I     don't give the intro message when starting Vim,         *shm-I*
-                see |:intro|
-          c     don't give |ins-completion-menu| messages; for          *shm-c*
-                example, "-- XXX completion (YYY)", "match 1 of 2", "The only
-                match", "Pattern not found", "Back at original", etc.
-          C     don't give messages while scanning for ins-completion   *shm-C*
-                items, for instance "scanning tags"
-          q     use "recording" instead of "recording @a"               *shm-q*
-          F     don't give the file info when editing a file, like      *shm-F*
-                `:silent` was used for the command
-          S     do not show search count message when searching, e.g.   *shm-S*
-                "[1/5]"
+	  o	overwrite message for writing a file with subsequent	*shm-o*
+		message for reading a file (useful for ":wn" or when
+		'autowrite' on)
+	  O	message for reading a file overwrites any previous	*shm-O*
+		message;  also for quickfix message (e.g., ":cn")
+	  s	don't give "search hit BOTTOM, continuing at TOP" or	*shm-s*
+		"search hit TOP, continuing at BOTTOM" messages; when using
+		the search count do not show "W" after the count message (see
+		S below)
+	  t	truncate file message at the start if it is too long	*shm-t*
+		to fit on the command-line, "<" will appear in the left most
+		column; ignored in Ex mode
+	  T	truncate other messages in the middle if they are too	*shm-T*
+		long to fit on the command line; "..." will appear in the
+		middle; ignored in Ex mode
+	  W	don't give "written" or "[w]" when writing a file	*shm-W*
+	  A	don't give the "ATTENTION" message when an existing	*shm-A*
+		swap file is found
+	  I	don't give the intro message when starting Vim,		*shm-I*
+		see |:intro|
+	  c	don't give |ins-completion-menu| messages; for		*shm-c*
+		example, "-- XXX completion (YYY)", "match 1 of 2", "The only
+		match", "Pattern not found", "Back at original", etc.
+	  C	don't give messages while scanning for ins-completion	*shm-C*
+		items, for instance "scanning tags"
+	  q	use "recording" instead of "recording @a"		*shm-q*
+	  F	don't give the file info when editing a file, like	*shm-F*
+		`:silent` was used for the command
+	  S	do not show search count message when searching, e.g.	*shm-S*
+		"[1/5]"
 
-        This gives you the opportunity to avoid that a change between buffers
-        requires you to hit <Enter>, but still gives as useful a message as
-        possible for the space available.  To get the whole message that you
-        would have got with 'shm' empty, use ":file!"
-        Useful values:
-            shm=        No abbreviation of message.
-            shm=a       Abbreviation, but no loss of information.
-            shm=at      Abbreviation, and truncate message when necessary.
+	This gives you the opportunity to avoid that a change between buffers
+	requires you to hit <Enter>, but still gives as useful a message as
+	possible for the space available.  To get the whole message that you
+	would have got with 'shm' empty, use ":file!"
+	Useful values:
+	    shm=	No abbreviation of message.
+	    shm=a	Abbreviation, but no loss of information.
+	    shm=at	Abbreviation, and truncate message when necessary.
 
-                                                        *'showbreak'* *'sbr'* *E595*
-'showbreak' 'sbr'       string (default "")
-                        global or local to window |global-local|
-        String to put at the start of lines that have been wrapped.  Useful
-        values are "> " or "+++ ": >vim
-                let &showbreak = "> "
-                let &showbreak = '+++ '
-<       Only printable single-cell characters are allowed, excluding <Tab> and
-        comma (in a future version the comma might be used to separate the
-        part that is shown at the end and at the start of a line).
-        The |hl-NonText| highlight group determines the highlighting.
-        Note that tabs after the showbreak will be displayed differently.
-        If you want the 'showbreak' to appear in between line numbers, add the
-        "n" flag to 'cpoptions'.
-        A window-local value overrules a global value.  If the global value is
-        set and you want no value in the current window use NONE: >vim
-                setlocal showbreak=NONE
-<
-
-                                             *'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
-'showcmd' 'sc'          boolean (default on)
-                        global
-        Show (partial) command in the last line of the screen.  Set this
-        option off if your terminal is slow.
-        In Visual mode the size of the selected area is shown:
-        - When selecting characters within a line, the number of characters.
-          If the number of bytes is different it is also displayed: "2-6"
-          means two characters and six bytes.
-        - When selecting more than one line, the number of lines.
-        - When selecting a block, the size in screen characters:
-          {lines}x{columns}.
-        This information can be displayed in an alternative location using the
-        'showcmdloc' option, useful when 'cmdheight' is 0.
-
-                                                           *'showcmdloc'* *'sloc'*
-'showcmdloc' 'sloc'     string (default "last")
-                        global
-        This option can be used to display the (partially) entered command in
-        another location.  Possible values are:
-          last          Last line of the screen (default).
-          statusline    Status line of the current window.
-          tabline       First line of the screen if 'showtabline' is enabled.
-        Setting this option to "statusline" or "tabline" means that these will
-        be redrawn whenever the command changes, which can be on every key
-        pressed.
-        The %S 'statusline' item can be used in 'statusline' or 'tabline' to
-        place the text.  Without a custom 'statusline' or 'tabline' it will be
-        displayed in a convenient location.
-
-                                   *'showfulltag'* *'sft'* *'noshowfulltag'* *'nosft'*
-'showfulltag' 'sft'     boolean (default off)
-                        global
-        When completing a word in insert mode (see |ins-completion|) from the
-        tags file, show both the tag name and a tidied-up form of the search
-        pattern (if there is one) as possible matches.  Thus, if you have
-        matched a C function, you can see a template for what arguments are
-        required (coding style permitting).
-        Note that this doesn't work well together with having "longest" in
-        'completeopt', because the completion from the search pattern may not
-        match the typed text.
-
-                                         *'showmatch'* *'sm'* *'noshowmatch'* *'nosm'*
-'showmatch' 'sm'        boolean (default off)
-                        global
-        When a bracket is inserted, briefly jump to the matching one.  The
-        jump is only done if the match can be seen on the screen.  The time to
-        show the match can be set with 'matchtime'.
-        A Beep is given if there is no match (no matter if the match can be
-        seen or not).
-        When the 'm' flag is not included in 'cpoptions', typing a character
-        will immediately move the cursor back to where it belongs.
-        See the "sm" field in 'guicursor' for setting the cursor shape and
-        blinking when showing the match.
-        The 'matchpairs' option can be used to specify the characters to show
-        matches for.  'rightleft' and 'revins' are used to look for opposite
-        matches.
-        Also see the matchparen plugin for highlighting the match when moving
-        around |pi_paren.txt|.
-        Note: Use of the short form is rated PG.
-
-                                         *'showmode'* *'smd'* *'noshowmode'* *'nosmd'*
-'showmode' 'smd'        boolean (default on)
-                        global
-        If in Insert, Replace or Visual mode put a message on the last line.
-        The |hl-ModeMsg| highlight group determines the highlighting.
-        The option has no effect when 'cmdheight' is zero.
-
-                                                          *'showtabline'* *'stal'*
-'showtabline' 'stal'    number (default 1)
-                        global
-        The value of this option specifies when the line with tab page labels
-        will be displayed:
-                0: never
-                1: only if there are at least two tab pages
-                2: always
-        This is both for the GUI and non-GUI implementation of the tab pages
-        line.
-        See |tab-page| for more information about tab pages.
-
-                                                             *'sidescroll'* *'ss'*
-'sidescroll' 'ss'       number (default 1)
-                        global
-        The minimal number of columns to scroll horizontally.  Used only when
-        the 'wrap' option is off and the cursor is moved off of the screen.
-        When it is zero the cursor will be put in the middle of the screen.
-        When using a slow terminal set it to a large number or 0.  Not used
-        for "zh" and "zl" commands.
-
-                                                        *'sidescrolloff'* *'siso'*
-'sidescrolloff' 'siso'  number (default 0)
-                        global or local to window |global-local|
-        The minimal number of screen columns to keep to the left and to the
-        right of the cursor if 'nowrap' is set.  Setting this option to a
-        value greater than 0 while having |'sidescroll'| also at a non-zero
-        value makes some context visible in the line you are scrolling in
-        horizontally (except at beginning of the line).  Setting this option
-        to a large value (like 999) has the effect of keeping the cursor
-        horizontally centered in the window, as long as one does not come too
-        close to the beginning of the line.
-        After using the local value, go back the global value with one of
-        these two: >vim
-                setlocal sidescrolloff<
-                setlocal sidescrolloff=-1
-<
-        Example: Try this together with 'sidescroll' and 'listchars' as
-                 in the following example to never allow the cursor to move
-                 onto the "extends" character: >vim
-
-                 set nowrap sidescroll=1 listchars=extends:>,precedes:<
-                 set sidescrolloff=1
+							*'showbreak'* *'sbr'* *E595*
+'showbreak' 'sbr'	string (default "")
+			global or local to window |global-local|
+	String to put at the start of lines that have been wrapped.  Useful
+	values are "> " or "+++ ": >vim
+		let &showbreak = "> "
+		let &showbreak = '+++ '
+<	Only printable single-cell characters are allowed, excluding <Tab> and
+	comma (in a future version the comma might be used to separate the
+	part that is shown at the end and at the start of a line).
+	The |hl-NonText| highlight group determines the highlighting.
+	Note that tabs after the showbreak will be displayed differently.
+	If you want the 'showbreak' to appear in between line numbers, add the
+	"n" flag to 'cpoptions'.
+	A window-local value overrules a global value.	If the global value is
+	set and you want no value in the current window use NONE: >vim
+		setlocal showbreak=NONE
 <
 
-                                                            *'signcolumn'* *'scl'*
-'signcolumn' 'scl'      string (default "auto")
-                        local to window
-        When and how to draw the signcolumn. Valid values are:
-           "auto"       only when there is a sign to display
-           "auto:[1-9]" resize to accommodate multiple signs up to the
-                        given number (maximum 9), e.g. "auto:4"
-           "auto:[1-8]-[2-9]"
-                        resize to accommodate multiple signs up to the
-                        given maximum number (maximum 9) while keeping
-                        at least the given minimum (maximum 8) fixed
-                        space. The minimum number should always be less
-                        than the maximum number, e.g. "auto:2-5"
-           "no"         never
-           "yes"        always
-           "yes:[1-9]"  always, with fixed space for signs up to the given
-                        number (maximum 9), e.g. "yes:3"
-           "number"     display signs in the 'number' column. If the number
-                        column is not present, then behaves like "auto".
+					     *'showcmd'* *'sc'* *'noshowcmd'* *'nosc'*
+'showcmd' 'sc'		boolean (default on)
+			global
+	Show (partial) command in the last line of the screen.	Set this
+	option off if your terminal is slow.
+	In Visual mode the size of the selected area is shown:
+	- When selecting characters within a line, the number of characters.
+	  If the number of bytes is different it is also displayed: "2-6"
+	  means two characters and six bytes.
+	- When selecting more than one line, the number of lines.
+	- When selecting a block, the size in screen characters:
+	  {lines}x{columns}.
+	This information can be displayed in an alternative location using the
+	'showcmdloc' option, useful when 'cmdheight' is 0.
 
-                                       *'smartcase'* *'scs'* *'nosmartcase'* *'noscs'*
-'smartcase' 'scs'       boolean (default off)
-                        global
-        Override the 'ignorecase' option if the search pattern contains upper
-        case characters.  Only used when the search pattern is typed and
-        'ignorecase' option is on.  Used for the commands "/", "?", "n", "N",
-        ":g" and ":s".  Not used for "*", "#", "gd", tag search, etc.  After
-        "*" and "#" you can make 'smartcase' used by doing a "/" command,
-        recalling the search pattern from history and hitting <Enter>.
+							   *'showcmdloc'* *'sloc'*
+'showcmdloc' 'sloc'	string (default "last")
+			global
+	This option can be used to display the (partially) entered command in
+	another location.  Possible values are:
+	  last		Last line of the screen (default).
+	  statusline	Status line of the current window.
+	  tabline	First line of the screen if 'showtabline' is enabled.
+	Setting this option to "statusline" or "tabline" means that these will
+	be redrawn whenever the command changes, which can be on every key
+	pressed.
+	The %S 'statusline' item can be used in 'statusline' or 'tabline' to
+	place the text.  Without a custom 'statusline' or 'tabline' it will be
+	displayed in a convenient location.
 
-                                     *'smartindent'* *'si'* *'nosmartindent'* *'nosi'*
-'smartindent' 'si'      boolean (default off)
-                        local to buffer
-        Do smart autoindenting when starting a new line.  Works for C-like
-        programs, but can also be used for other languages.  'cindent' does
-        something like this, works better in most cases, but is more strict,
-        see |C-indenting|.  When 'cindent' is on or 'indentexpr' is set,
-        setting 'si' has no effect.  'indentexpr' is a more advanced
-        alternative.
-        Normally 'autoindent' should also be on when using 'smartindent'.
-        An indent is automatically inserted:
-        - After a line ending in "{".
-        - After a line starting with a keyword from 'cinwords'.
-        - Before a line starting with "}" (only with the "O" command).
-        When typing '}' as the first character in a new line, that line is
-        given the same indent as the matching "{".
-        When typing '#' as the first character in a new line, the indent for
-        that line is removed, the '#' is put in the first column.  The indent
-        is restored for the next line.  If you don't want this, use this
-        mapping: ":inoremap # X^H#", where ^H is entered with CTRL-V CTRL-H.
-        When using the ">>" command, lines starting with '#' are not shifted
-        right.
+				   *'showfulltag'* *'sft'* *'noshowfulltag'* *'nosft'*
+'showfulltag' 'sft'	boolean (default off)
+			global
+	When completing a word in insert mode (see |ins-completion|) from the
+	tags file, show both the tag name and a tidied-up form of the search
+	pattern (if there is one) as possible matches.	Thus, if you have
+	matched a C function, you can see a template for what arguments are
+	required (coding style permitting).
+	Note that this doesn't work well together with having "longest" in
+	'completeopt', because the completion from the search pattern may not
+	match the typed text.
 
-                                         *'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
-'smarttab' 'sta'        boolean (default on)
-                        global
-        When on, a <Tab> in front of a line inserts blanks according to
-        'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
-        <BS> will delete a 'shiftwidth' worth of space at the start of the
-        line.
-        When off, a <Tab> always inserts blanks according to 'tabstop' or
-        'softtabstop'.  'shiftwidth' is only used for shifting text left or
-        right |shift-left-right|.
-        What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
-        option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
-        number of spaces is minimized by using <Tab>s.
+					 *'showmatch'* *'sm'* *'noshowmatch'* *'nosm'*
+'showmatch' 'sm'	boolean (default off)
+			global
+	When a bracket is inserted, briefly jump to the matching one.  The
+	jump is only done if the match can be seen on the screen.  The time to
+	show the match can be set with 'matchtime'.
+	A Beep is given if there is no match (no matter if the match can be
+	seen or not).
+	When the 'm' flag is not included in 'cpoptions', typing a character
+	will immediately move the cursor back to where it belongs.
+	See the "sm" field in 'guicursor' for setting the cursor shape and
+	blinking when showing the match.
+	The 'matchpairs' option can be used to specify the characters to show
+	matches for.  'rightleft' and 'revins' are used to look for opposite
+	matches.
+	Also see the matchparen plugin for highlighting the match when moving
+	around |pi_paren.txt|.
+	Note: Use of the short form is rated PG.
 
-                                 *'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
-'smoothscroll' 'sms'    boolean (default off)
-                        local to window
-        Scrolling works with screen lines.  When 'wrap' is set and the first
-        line in the window wraps part of it may not be visible, as if it is
-        above the window. "<<<" is displayed at the start of the first line,
-        highlighted with |hl-NonText|.
-        You may also want to add "lastline" to the 'display' option to show as
-        much of the last line as possible.
-        NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
-        and scrolling with the mouse.
+					 *'showmode'* *'smd'* *'noshowmode'* *'nosmd'*
+'showmode' 'smd'	boolean (default on)
+			global
+	If in Insert, Replace or Visual mode put a message on the last line.
+	The |hl-ModeMsg| highlight group determines the highlighting.
+	The option has no effect when 'cmdheight' is zero.
 
-                                                           *'softtabstop'* *'sts'*
-'softtabstop' 'sts'     number (default 0)
-                        local to buffer
-        Number of spaces that a <Tab> counts for while performing editing
-        operations, like inserting a <Tab> or using <BS>.  It "feels" like
-        <Tab>s are being inserted, while in fact a mix of spaces and <Tab>s is
-        used.  This is useful to keep the 'ts' setting at its standard value
-        of 8, while being able to edit like it is set to 'sts'.  However,
-        commands like "x" still work on the actual characters.
-        When 'sts' is zero, this feature is off.
-        When 'sts' is negative, the value of 'shiftwidth' is used.
-        See also |ins-expandtab|.  When 'expandtab' is not set, the number of
-        spaces is minimized by using <Tab>s.
-        The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
-        set.
+							  *'showtabline'* *'stal'*
+'showtabline' 'stal'	number (default 1)
+			global
+	The value of this option specifies when the line with tab page labels
+	will be displayed:
+		0: never
+		1: only if there are at least two tab pages
+		2: always
+	This is both for the GUI and non-GUI implementation of the tab pages
+	line.
+	See |tab-page| for more information about tab pages.
 
-        The value of 'softtabstop' will be ignored if |'varsofttabstop'| is set
-        to anything other than an empty string.
+							     *'sidescroll'* *'ss'*
+'sidescroll' 'ss'	number (default 1)
+			global
+	The minimal number of columns to scroll horizontally.  Used only when
+	the 'wrap' option is off and the cursor is moved off of the screen.
+	When it is zero the cursor will be put in the middle of the screen.
+	When using a slow terminal set it to a large number or 0.  Not used
+	for "zh" and "zl" commands.
 
-                                                             *'spell'* *'nospell'*
-'spell'                 boolean (default off)
-                        local to window
-        When on spell checking will be done.  See |spell|.
-        The languages are specified with 'spelllang'.
-
-                                                         *'spellcapcheck'* *'spc'*
-'spellcapcheck' 'spc'   string (default "[.?!]\_[\])'"\t ]\+")
-                        local to buffer
-        Pattern to locate the end of a sentence.  The following word will be
-        checked to start with a capital letter.  If not then it is highlighted
-        with SpellCap |hl-SpellCap| (unless the word is also badly spelled).
-        When this check is not wanted make this option empty.
-        Only used when 'spell' is set.
-        Be careful with special characters, see |option-backslash| about
-        including spaces and backslashes.
-        To set this option automatically depending on the language, see
-        |set-spc-auto|.
-
-                                                             *'spellfile'* *'spf'*
-'spellfile' 'spf'       string (default "")
-                        local to buffer
-        Name of the word list file where words are added for the |zg| and |zw|
-        commands.  It must end in ".{encoding}.add".  You need to include the
-        path, otherwise the file is placed in the current directory.
-        The path may include characters from 'isfname', space, comma and '@'.
-                                                                *E765*
-        It may also be a comma-separated list of names.  A count before the
-        |zg| and |zw| commands can be used to access each.  This allows using
-        a personal word list file and a project word list file.
-        When a word is added while this option is empty Vim will set it for
-        you: Using the first directory in 'runtimepath' that is writable.  If
-        there is no "spell" directory yet it will be created.  For the file
-        name the first language name that appears in 'spelllang' is used,
-        ignoring the region.
-        The resulting ".spl" file will be used for spell checking, it does not
-        have to appear in 'spelllang'.
-        Normally one file is used for all regions, but you can add the region
-        name if you want to.  However, it will then only be used when
-        'spellfile' is set to it, for entries in 'spelllang' only files
-        without region name will be found.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
-
-                                                             *'spelllang'* *'spl'*
-'spelllang' 'spl'       string (default "en")
-                        local to buffer
-        A comma-separated list of word list names.  When the 'spell' option is
-        on spellchecking will be done for these languages.  Example: >vim
-                set spelllang=en_us,nl,medical
-<       This means US English, Dutch and medical words are recognized.  Words
-        that are not recognized will be highlighted.
-        The word list name must consist of alphanumeric characters, a dash or
-        an underscore.  It should not include a comma or dot.  Using a dash is
-        recommended to separate the two letter language name from a
-        specification.  Thus "en-rare" is used for rare English words.
-        A region name must come last and have the form "_xx", where "xx" is
-        the two-letter, lower case region name.  You can use more than one
-        region by listing them: "en_us,en_ca" supports both US and Canadian
-        English, but not words specific for Australia, New Zealand or Great
-        Britain. (Note: currently en_au and en_nz dictionaries are older than
-        en_ca, en_gb and en_us).
-        If the name "cjk" is included East Asian characters are excluded from
-        spell checking.  This is useful when editing text that also has Asian
-        words.
-        Note that the "medical" dictionary does not exist, it is just an
-        example of a longer name.
-                                                        *E757*
-        As a special case the name of a .spl file can be given as-is.  The
-        first "_xx" in the name is removed and used as the region name
-        (_xx is an underscore, two letters and followed by a non-letter).
-        This is mainly for testing purposes.  You must make sure the correct
-        encoding is used, Vim doesn't check it.
-        How the related spell files are found is explained here: |spell-load|.
-
-        If the |spellfile.vim| plugin is active and you use a language name
-        for which Vim cannot find the .spl file in 'runtimepath' the plugin
-        will ask you if you want to download the file.
-
-        After this option has been set successfully, Vim will source the files
-        "spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
-        up to the first character that is not an ASCII letter or number and
-        not a dash.  Also see |set-spc-auto|.
-
-                                                          *'spelloptions'* *'spo'*
-'spelloptions' 'spo'    string (default "")
-                        local to buffer
-        A comma-separated list of options for spell checking:
-        camel           When a word is CamelCased, assume "Cased" is a
-                        separate word: every upper-case character in a word
-                        that comes after a lower case character indicates the
-                        start of a new word.
-        noplainbuffer   Only spellcheck a buffer when 'syntax' is enabled,
-                        or when extmarks are set within the buffer. Only
-                        designated regions of the buffer are spellchecked in
-                        this case.
-
-                                                          *'spellsuggest'* *'sps'*
-'spellsuggest' 'sps'    string (default "best")
-                        global
-        Methods used for spelling suggestions.  Both for the |z=| command and
-        the |spellsuggest()| function.  This is a comma-separated list of
-        items:
-
-        best            Internal method that works best for English.  Finds
-                        changes like "fast" and uses a bit of sound-a-like
-                        scoring to improve the ordering.
-
-        double          Internal method that uses two methods and mixes the
-                        results.  The first method is "fast", the other method
-                        computes how much the suggestion sounds like the bad
-                        word.  That only works when the language specifies
-                        sound folding.  Can be slow and doesn't always give
-                        better results.
-
-        fast            Internal method that only checks for simple changes:
-                        character inserts/deletes/swaps.  Works well for
-                        simple typing mistakes.
-
-        {number}        The maximum number of suggestions listed for |z=|.
-                        Not used for |spellsuggest()|.  The number of
-                        suggestions is never more than the value of 'lines'
-                        minus two.
-
-        timeout:{millisec}   Limit the time searching for suggestions to
-                        {millisec} milli seconds.  Applies to the following
-                        methods.  When omitted the limit is 5000. When
-                        negative there is no limit.
-
-        file:{filename} Read file {filename}, which must have two columns,
-                        separated by a slash.  The first column contains the
-                        bad word, the second column the suggested good word.
-                        Example:
-                                theribal/terrible ~
-                        Use this for common mistakes that do not appear at the
-                        top of the suggestion list with the internal methods.
-                        Lines without a slash are ignored, use this for
-                        comments.
-                        The word in the second column must be correct,
-                        otherwise it will not be used.  Add the word to an
-                        ".add" file if it is currently flagged as a spelling
-                        mistake.
-                        The file is used for all languages.
-
-        expr:{expr}     Evaluate expression {expr}.  Use a function to avoid
-                        trouble with spaces.  |v:val| holds the badly spelled
-                        word.  The expression must evaluate to a List of
-                        Lists, each with a suggestion and a score.
-                        Example:
-                                [['the', 33], ['that', 44]] ~
-                        Set 'verbose' and use |z=| to see the scores that the
-                        internal methods use.  A lower score is better.
-                        This may invoke |spellsuggest()| if you temporarily
-                        set 'spellsuggest' to exclude the "expr:" part.
-                        Errors are silently ignored, unless you set the
-                        'verbose' option to a non-zero value.
-
-        Only one of "best", "double" or "fast" may be used.  The others may
-        appear several times in any order.  Example: >vim
-                set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+							*'sidescrolloff'* *'siso'*
+'sidescrolloff' 'siso'	number (default 0)
+			global or local to window |global-local|
+	The minimal number of screen columns to keep to the left and to the
+	right of the cursor if 'nowrap' is set.  Setting this option to a
+	value greater than 0 while having |'sidescroll'| also at a non-zero
+	value makes some context visible in the line you are scrolling in
+	horizontally (except at beginning of the line).  Setting this option
+	to a large value (like 999) has the effect of keeping the cursor
+	horizontally centered in the window, as long as one does not come too
+	close to the beginning of the line.
+	After using the local value, go back the global value with one of
+	these two: >vim
+		setlocal sidescrolloff<
+		setlocal sidescrolloff=-1
 <
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	Example: Try this together with 'sidescroll' and 'listchars' as
+		 in the following example to never allow the cursor to move
+		 onto the "extends" character: >vim
 
-                                       *'splitbelow'* *'sb'* *'nosplitbelow'* *'nosb'*
-'splitbelow' 'sb'       boolean (default off)
-                        global
-        When on, splitting a window will put the new window below the current
-        one. |:split|
-
-                                                             *'splitkeep'* *'spk'*
-'splitkeep' 'spk'       string (default "cursor")
-                        global
-        The value of this option determines the scroll behavior when opening,
-        closing or resizing horizontal splits.
-
-        Possible values are:
-          cursor        Keep the same relative cursor position.
-          screen        Keep the text on the same screen line.
-          topline       Keep the topline the same.
-
-        For the "screen" and "topline" values, the cursor position will be
-        changed when necessary. In this case, the jumplist will be populated
-        with the previous cursor position. For "screen", the text cannot always
-        be kept on the same screen line when 'wrap' is enabled.
-
-                                     *'splitright'* *'spr'* *'nosplitright'* *'nospr'*
-'splitright' 'spr'      boolean (default off)
-                        global
-        When on, splitting a window will put the new window right of the
-        current one. |:vsplit|
-
-                                   *'startofline'* *'sol'* *'nostartofline'* *'nosol'*
-'startofline' 'sol'     boolean (default off)
-                        global
-        When "on" the commands listed below move the cursor to the first
-        non-blank of the line.  When off the cursor is kept in the same column
-        (if possible).  This applies to the commands:
-        - CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
-        - "d", "<<" and ">>" with a linewise operator
-        - "%" with a count
-        - buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
-        - Ex commands that only have a line number, e.g., ":25" or ":+".
-        In case of buffer changing commands the cursor is placed at the column
-        where it was the last time the buffer was edited.
-
-                                                          *'statuscolumn'* *'stc'*
-'statuscolumn' 'stc'    string (default "")
-                        local to window
-        EXPERIMENTAL
-        When non-empty, this option determines the content of the area to the
-        side of a window, normally containing the fold, sign and number columns.
-        The format of this option is like that of 'statusline'.
-
-        Some of the items from the 'statusline' format are different for
-        'statuscolumn':
-
-        %l      line number of currently drawn line
-        %r      relative line number of currently drawn line
-        %s      sign column for currently drawn line
-        %C      fold column for currently drawn line
-
-        NOTE: To draw the sign and fold columns, their items must be included in
-        'statuscolumn'. Even when they are not included, the status column width
-        will adapt to the 'signcolumn' and 'foldcolumn' width.
-
-        The |v:lnum|    variable holds the line number to be drawn.
-        The |v:relnum|  variable holds the relative line number to be drawn.
-        The |v:virtnum| variable is negative when drawing virtual lines, zero
-                      when drawing the actual buffer line, and positive when
-                      drawing the wrapped part of a buffer line.
-
-        NOTE: The %@ click execute function item is supported as well but the
-        specified function will be the same for each row in the same column.
-        It cannot be switched out through a dynamic 'statuscolumn' format, the
-        handler should be written with this in mind.
-
-        Examples: >vim
-                " Relative number with bar separator and click handlers:
-                set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
-
-                " Right aligned relative cursor line number:
-                let &stc='%=%{v:relnum?v:relnum:v:lnum} '
-
-                " Line numbers in hexadecimal for non wrapped part of lines:
-                let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
-
-                " Human readable line numbers with thousands separator:
-                let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
-                           . '%(\\d\\d\\d\\)\\+$",",","g")}'
-
-                " Both relative and absolute line numbers with different
-                " highlighting for odd and even relative numbers:
-                let &stc='%#NonText#%{&nu?v:lnum:""}' .
-                 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
-                 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
-
-<       WARNING: this expression is evaluated for each screen line so defining
-        an expensive expression can negatively affect render performance.
-
-                                                  *'statusline'* *'stl'* *E540* *E542*
-'statusline' 'stl'      string (default "")
-                        global or local to window |global-local|
-        When non-empty, this option determines the content of the status line.
-        Also see |status-line|.
-
-        The option consists of printf style '%' items interspersed with
-        normal text.  Each status line item is of the form:
-          %-0{minwid}.{maxwid}{item}
-        All fields except the {item} are optional.  A single percent sign can
-        be given as "%%".
-
-        When the option starts with "%!" then it is used as an expression,
-        evaluated and the result is used as the option value.  Example: >vim
-                set statusline=%!MyStatusLine()
-<       The *g:statusline_winid* variable will be set to the |window-ID| of the
-        window that the status line belongs to.
-        The result can contain %{} items that will be evaluated too.
-        Note that the "%!" expression is evaluated in the context of the
-        current window and buffer, while %{} items are evaluated in the
-        context of the window that the statusline belongs to.
-
-        When there is error while evaluating the option then it will be made
-        empty to avoid further errors.  Otherwise screen updating would loop.
-        When the result contains unprintable characters the result is
-        unpredictable.
-
-        Note that the only effect of 'ruler' when this option is set (and
-        'laststatus' is 2 or 3) is controlling the output of |CTRL-G|.
-
-        field       meaning ~
-        -           Left justify the item.  The default is right justified
-                    when minwid is larger than the length of the item.
-        0           Leading zeroes in numeric items.  Overridden by "-".
-        minwid      Minimum width of the item, padding as set by "-" & "0".
-                    Value must be 50 or less.
-        maxwid      Maximum width of the item.  Truncation occurs with a "<"
-                    on the left for text items.  Numeric items will be
-                    shifted down to maxwid-2 digits followed by ">"number
-                    where number is the amount of missing digits, much like
-                    an exponential notation.
-        item        A one letter code as described below.
-
-        Following is a description of the possible statusline items.  The
-        second character in "item" is the type:
-                N for number
-                S for string
-                F for flags as described below
-                - not applicable
-
-        item  meaning ~
-        f S   Path to the file in the buffer, as typed or relative to current
-              directory.
-        F S   Full path to the file in the buffer.
-        t S   File name (tail) of file in the buffer.
-        m F   Modified flag, text is "[+]"; "[-]" if 'modifiable' is off.
-        M F   Modified flag, text is ",+" or ",-".
-        r F   Readonly flag, text is "[RO]".
-        R F   Readonly flag, text is ",RO".
-        h F   Help buffer flag, text is "[help]".
-        H F   Help buffer flag, text is ",HLP".
-        w F   Preview window flag, text is "[Preview]".
-        W F   Preview window flag, text is ",PRV".
-        y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
-        Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
-        q S   "[Quickfix List]", "[Location List]" or empty.
-        k S   Value of "b:keymap_name" or 'keymap' when |:lmap| mappings are
-              being used: "<keymap>"
-        n N   Buffer number.
-        b N   Value of character under cursor.
-        B N   As above, in hexadecimal.
-        o N   Byte number in file of byte under cursor, first byte is 1.
-              Mnemonic: Offset from start of file (with one added)
-        O N   As above, in hexadecimal.
-        l N   Line number.
-        L N   Number of lines in buffer.
-        c N   Column number (byte index).
-        v N   Virtual column number (screen column).
-        V N   Virtual column number as -{num}.  Not displayed if equal to 'c'.
-        p N   Percentage through file in lines as in |CTRL-G|.
-        P S   Percentage through file of displayed window.  This is like the
-              percentage described for 'ruler'.  Always 3 in length, unless
-              translated.
-        S S   'showcmd' content, see 'showcmdloc'.
-        a S   Argument list status as in default title.  ({current} of {max})
-              Empty if the argument file count is zero or one.
-        { NF  Evaluate expression between "%{" and "}" and substitute result.
-              Note that there is no "%" before the closing "}".  The
-              expression cannot contain a "}" character, call a function to
-              work around that.  See |stl-%{| below.
-        `{%` -  This is almost same as "{" except the result of the expression is
-              re-evaluated as a statusline format string.  Thus if the
-              return value of expr contains "%" items they will get expanded.
-              The expression can contain the "}" character, the end of
-              expression is denoted by "%}".
-              For example: >vim
-                func! Stl_filename() abort
-                    return "%t"
-                endfunc
-<               `stl=%{Stl_filename()}`   results in `"%t"`
-                `stl=%{%Stl_filename()%}` results in `"Name of current file"`
-        %} -  End of "{%" expression
-        ( -   Start of item group.  Can be used for setting the width and
-              alignment of a section.  Must be followed by %) somewhere.
-        ) -   End of item group.  No width fields allowed.
-        T N   For 'tabline': start of tab page N label.  Use %T or %X to end
-              the label.  Clicking this label with left mouse button switches
-              to the specified tab page.
-        X N   For 'tabline': start of close tab N label.  Use %X or %T to end
-              the label, e.g.: %3Xclose%X.  Use %999X for a "close current
-              tab" label.    Clicking this label with left mouse button closes
-              specified tab page.
-        @ N   Start of execute function label. Use %X or %T to
-              end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
-              label runs specified function: in the example when clicking once
-              using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
-              '    ')" expression will be run.  Function receives the
-              following arguments in order:
-              1. minwid field value or zero if no N was specified
-              2. number of mouse clicks to detect multiple clicks
-              3. mouse button used: "l", "r" or "m" for left, right or middle
-                 button respectively; one should not rely on third argument
-                 being only "l", "r" or "m": any other non-empty string value
-                 that contains only ASCII lower case letters may be expected
-                 for other mouse buttons
-              4. modifiers pressed: string which contains "s" if shift
-                 modifier was pressed, "c" for control, "a" for alt and "m"
-                 for meta; currently if modifier is not pressed string
-                 contains space instead, but one should not rely on presence
-                 of spaces or specific order of modifiers: use |stridx()| to
-                 test whether some modifier is present; string is guaranteed
-                 to contain only ASCII letters and spaces, one letter per
-                 modifier; "?" modifier may also be present, but its presence
-                 is a bug that denotes that new mouse button recognition was
-                 added without modifying code that reacts on mouse clicks on
-                 this label.
-              Use |getmousepos()|.winid in the specified function to get the
-              corresponding window id of the clicked item.
-        < -   Where to truncate line if too long.  Default is at the start.
-              No width fields allowed.
-        = -   Separation point between alignment sections.  Each section will
-              be separated by an equal number of spaces.  With one %= what
-              comes after it will be right-aligned.  With two %= there is a
-              middle part, with white space left and right of it.
-              No width fields allowed.
-        # -   Set highlight group.  The name must follow and then a # again.
-              Thus use %#HLname# for highlight group HLname.  The same
-              highlighting is used, also for the statusline of non-current
-              windows.
-        * -   Set highlight group to User{N}, where {N} is taken from the
-              minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
-              The difference between User{N} and StatusLine will be applied to
-              StatusLineNC for the statusline of non-current windows.
-              The number N must be between 1 and 9.  See |hl-User1..9|
-
-        When displaying a flag, Vim removes the leading comma, if any, when
-        that flag comes right after plaintext.  This will make a nice display
-        when flags are used like in the examples below.
-
-        When all items in a group becomes an empty string (i.e. flags that are
-        not set) and a minwid is not set for the group, the whole group will
-        become empty.  This will make a group like the following disappear
-        completely from the statusline when none of the flags are set. >vim
-                set statusline=...%(\ [%M%R%H]%)...
-<       Beware that an expression is evaluated each and every time the status
-        line is displayed.
-                                *stl-%{* *g:actual_curbuf* *g:actual_curwin*
-        While evaluating %{} the current buffer and current window will be set
-        temporarily to that of the window (and buffer) whose statusline is
-        currently being drawn.  The expression will evaluate in this context.
-        The variable "g:actual_curbuf" is set to the `bufnr()` number of the
-        real current buffer and "g:actual_curwin" to the |window-ID| of the
-        real current window.  These values are strings.
-
-        The 'statusline' option will be evaluated in the |sandbox| if set from
-        a modeline, see |sandbox-option|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
-
-        It is not allowed to change text or jump to another window while
-        evaluating 'statusline' |textlock|.
-
-        If the statusline is not updated when you want it (e.g., after setting
-        a variable that's used in an expression), you can force an update by
-        using `:redrawstatus`.
-
-        A result of all digits is regarded a number for display purposes.
-        Otherwise the result is taken as flag text and applied to the rules
-        described above.
-
-        Watch out for errors in expressions.  They may render Vim unusable!
-        If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and
-        edit your vimrc or whatever with "vim --clean" to get it right.
-
-        Examples:
-        Emulate standard status line with 'ruler' set >vim
-          set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
-<       Similar, but add ASCII value of char under the cursor (like "ga") >vim
-          set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
-<       Display byte count and byte value, modified flag in red. >vim
-          set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
-          hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
-<       Display a ,GZ flag if a compressed file is loaded >vim
-          set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
-<       In the |:autocmd|'s: >vim
-          let b:gzflag = 1
-<       And: >vim
-          unlet b:gzflag
-<       And define this function: >vim
-          function VarExists(var, val)
-              if exists(a:var) | return a:val | else | return '' | endif
-          endfunction
+		 set nowrap sidescroll=1 listchars=extends:>,precedes:<
+		 set sidescrolloff=1
 <
 
-                                                               *'suffixes'* *'su'*
-'suffixes' 'su'         string (default ".bak,~,.o,.h,.info,.swp,.obj")
-                        global
-        Files with these suffixes get a lower priority when multiple files
-        match a wildcard.  See |suffixes|.  Commas can be used to separate the
-        suffixes.  Spaces after the comma are ignored.  A dot is also seen as
-        the start of a suffix.  To avoid a dot or comma being recognized as a
-        separator, precede it with a backslash (see |option-backslash| about
-        including spaces and backslashes).
-        See 'wildignore' for completely ignoring files.
-        The use of |:set+=| and |:set-=| is preferred when adding or removing
-        suffixes from the list.  This avoids problems when a future version
-        uses another default.
+							    *'signcolumn'* *'scl'*
+'signcolumn' 'scl'	string (default "auto")
+			local to window
+	When and how to draw the signcolumn. Valid values are:
+	   "auto"	only when there is a sign to display
+	   "auto:[1-9]" resize to accommodate multiple signs up to the
+			given number (maximum 9), e.g. "auto:4"
+	   "auto:[1-8]-[2-9]"
+			resize to accommodate multiple signs up to the
+			given maximum number (maximum 9) while keeping
+			at least the given minimum (maximum 8) fixed
+			space. The minimum number should always be less
+			than the maximum number, e.g. "auto:2-5"
+	   "no"		never
+	   "yes"	always
+	   "yes:[1-9]"	always, with fixed space for signs up to the given
+			number (maximum 9), e.g. "yes:3"
+	   "number"	display signs in the 'number' column. If the number
+			column is not present, then behaves like "auto".
 
-                                                           *'suffixesadd'* *'sua'*
-'suffixesadd' 'sua'     string (default "")
-                        local to buffer
-        Comma-separated list of suffixes, which are used when searching for a
-        file for the "gf", "[I", etc. commands.  Example: >vim
-                set suffixesadd=.java
+				       *'smartcase'* *'scs'* *'nosmartcase'* *'noscs'*
+'smartcase' 'scs'	boolean (default off)
+			global
+	Override the 'ignorecase' option if the search pattern contains upper
+	case characters.  Only used when the search pattern is typed and
+	'ignorecase' option is on.  Used for the commands "/", "?", "n", "N",
+	":g" and ":s".	Not used for "*", "#", "gd", tag search, etc.  After
+	"*" and "#" you can make 'smartcase' used by doing a "/" command,
+	recalling the search pattern from history and hitting <Enter>.
+
+				     *'smartindent'* *'si'* *'nosmartindent'* *'nosi'*
+'smartindent' 'si'	boolean (default off)
+			local to buffer
+	Do smart autoindenting when starting a new line.  Works for C-like
+	programs, but can also be used for other languages.  'cindent' does
+	something like this, works better in most cases, but is more strict,
+	see |C-indenting|.  When 'cindent' is on or 'indentexpr' is set,
+	setting 'si' has no effect.  'indentexpr' is a more advanced
+	alternative.
+	Normally 'autoindent' should also be on when using 'smartindent'.
+	An indent is automatically inserted:
+	- After a line ending in "{".
+	- After a line starting with a keyword from 'cinwords'.
+	- Before a line starting with "}" (only with the "O" command).
+	When typing '}' as the first character in a new line, that line is
+	given the same indent as the matching "{".
+	When typing '#' as the first character in a new line, the indent for
+	that line is removed, the '#' is put in the first column.  The indent
+	is restored for the next line.	If you don't want this, use this
+	mapping: ":inoremap # X^H#", where ^H is entered with CTRL-V CTRL-H.
+	When using the ">>" command, lines starting with '#' are not shifted
+	right.
+
+					 *'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
+'smarttab' 'sta'	boolean (default on)
+			global
+	When on, a <Tab> in front of a line inserts blanks according to
+	'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
+	<BS> will delete a 'shiftwidth' worth of space at the start of the
+	line.
+	When off, a <Tab> always inserts blanks according to 'tabstop' or
+	'softtabstop'.	'shiftwidth' is only used for shifting text left or
+	right |shift-left-right|.
+	What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
+	option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
+	number of spaces is minimized by using <Tab>s.
+
+				 *'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
+'smoothscroll' 'sms'	boolean (default off)
+			local to window
+	Scrolling works with screen lines.  When 'wrap' is set and the first
+	line in the window wraps part of it may not be visible, as if it is
+	above the window. "<<<" is displayed at the start of the first line,
+	highlighted with |hl-NonText|.
+	You may also want to add "lastline" to the 'display' option to show as
+	much of the last line as possible.
+	NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
+	and scrolling with the mouse.
+
+							   *'softtabstop'* *'sts'*
+'softtabstop' 'sts'	number (default 0)
+			local to buffer
+	Number of spaces that a <Tab> counts for while performing editing
+	operations, like inserting a <Tab> or using <BS>.  It "feels" like
+	<Tab>s are being inserted, while in fact a mix of spaces and <Tab>s is
+	used.  This is useful to keep the 'ts' setting at its standard value
+	of 8, while being able to edit like it is set to 'sts'.  However,
+	commands like "x" still work on the actual characters.
+	When 'sts' is zero, this feature is off.
+	When 'sts' is negative, the value of 'shiftwidth' is used.
+	See also |ins-expandtab|.  When 'expandtab' is not set, the number of
+	spaces is minimized by using <Tab>s.
+	The 'L' flag in 'cpoptions' changes how tabs are used when 'list' is
+	set.
+
+	The value of 'softtabstop' will be ignored if |'varsofttabstop'| is set
+	to anything other than an empty string.
+
+							     *'spell'* *'nospell'*
+'spell'			boolean (default off)
+			local to window
+	When on spell checking will be done.  See |spell|.
+	The languages are specified with 'spelllang'.
+
+							 *'spellcapcheck'* *'spc'*
+'spellcapcheck' 'spc'	string (default "[.?!]\_[\])'"\t ]\+")
+			local to buffer
+	Pattern to locate the end of a sentence.  The following word will be
+	checked to start with a capital letter.  If not then it is highlighted
+	with SpellCap |hl-SpellCap| (unless the word is also badly spelled).
+	When this check is not wanted make this option empty.
+	Only used when 'spell' is set.
+	Be careful with special characters, see |option-backslash| about
+	including spaces and backslashes.
+	To set this option automatically depending on the language, see
+	|set-spc-auto|.
+
+							     *'spellfile'* *'spf'*
+'spellfile' 'spf'	string (default "")
+			local to buffer
+	Name of the word list file where words are added for the |zg| and |zw|
+	commands.  It must end in ".{encoding}.add".  You need to include the
+	path, otherwise the file is placed in the current directory.
+	The path may include characters from 'isfname', space, comma and '@'.
+								*E765*
+	It may also be a comma-separated list of names.  A count before the
+	|zg| and |zw| commands can be used to access each.  This allows using
+	a personal word list file and a project word list file.
+	When a word is added while this option is empty Vim will set it for
+	you: Using the first directory in 'runtimepath' that is writable.  If
+	there is no "spell" directory yet it will be created.  For the file
+	name the first language name that appears in 'spelllang' is used,
+	ignoring the region.
+	The resulting ".spl" file will be used for spell checking, it does not
+	have to appear in 'spelllang'.
+	Normally one file is used for all regions, but you can add the region
+	name if you want to.  However, it will then only be used when
+	'spellfile' is set to it, for entries in 'spelllang' only files
+	without region name will be found.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
+							     *'spelllang'* *'spl'*
+'spelllang' 'spl'	string (default "en")
+			local to buffer
+	A comma-separated list of word list names.  When the 'spell' option is
+	on spellchecking will be done for these languages.  Example: >vim
+		set spelllang=en_us,nl,medical
+<	This means US English, Dutch and medical words are recognized.	Words
+	that are not recognized will be highlighted.
+	The word list name must consist of alphanumeric characters, a dash or
+	an underscore.	It should not include a comma or dot.  Using a dash is
+	recommended to separate the two letter language name from a
+	specification.	Thus "en-rare" is used for rare English words.
+	A region name must come last and have the form "_xx", where "xx" is
+	the two-letter, lower case region name.  You can use more than one
+	region by listing them: "en_us,en_ca" supports both US and Canadian
+	English, but not words specific for Australia, New Zealand or Great
+	Britain. (Note: currently en_au and en_nz dictionaries are older than
+	en_ca, en_gb and en_us).
+	If the name "cjk" is included East Asian characters are excluded from
+	spell checking.  This is useful when editing text that also has Asian
+	words.
+	Note that the "medical" dictionary does not exist, it is just an
+	example of a longer name.
+							*E757*
+	As a special case the name of a .spl file can be given as-is.  The
+	first "_xx" in the name is removed and used as the region name
+	(_xx is an underscore, two letters and followed by a non-letter).
+	This is mainly for testing purposes.  You must make sure the correct
+	encoding is used, Vim doesn't check it.
+	How the related spell files are found is explained here: |spell-load|.
+
+	If the |spellfile.vim| plugin is active and you use a language name
+	for which Vim cannot find the .spl file in 'runtimepath' the plugin
+	will ask you if you want to download the file.
+
+	After this option has been set successfully, Vim will source the files
+	"spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
+	up to the first character that is not an ASCII letter or number and
+	not a dash.  Also see |set-spc-auto|.
+
+							  *'spelloptions'* *'spo'*
+'spelloptions' 'spo'	string (default "")
+			local to buffer
+	A comma-separated list of options for spell checking:
+	camel		When a word is CamelCased, assume "Cased" is a
+			separate word: every upper-case character in a word
+			that comes after a lower case character indicates the
+			start of a new word.
+	noplainbuffer	Only spellcheck a buffer when 'syntax' is enabled,
+			or when extmarks are set within the buffer. Only
+			designated regions of the buffer are spellchecked in
+			this case.
+
+							  *'spellsuggest'* *'sps'*
+'spellsuggest' 'sps'	string (default "best")
+			global
+	Methods used for spelling suggestions.	Both for the |z=| command and
+	the |spellsuggest()| function.	This is a comma-separated list of
+	items:
+
+	best		Internal method that works best for English.  Finds
+			changes like "fast" and uses a bit of sound-a-like
+			scoring to improve the ordering.
+
+	double		Internal method that uses two methods and mixes the
+			results.  The first method is "fast", the other method
+			computes how much the suggestion sounds like the bad
+			word.  That only works when the language specifies
+			sound folding.	Can be slow and doesn't always give
+			better results.
+
+	fast		Internal method that only checks for simple changes:
+			character inserts/deletes/swaps.  Works well for
+			simple typing mistakes.
+
+	{number}	The maximum number of suggestions listed for |z=|.
+			Not used for |spellsuggest()|.	The number of
+			suggestions is never more than the value of 'lines'
+			minus two.
+
+	timeout:{millisec}   Limit the time searching for suggestions to
+			{millisec} milli seconds.  Applies to the following
+			methods.  When omitted the limit is 5000. When
+			negative there is no limit.
+
+	file:{filename} Read file {filename}, which must have two columns,
+			separated by a slash.  The first column contains the
+			bad word, the second column the suggested good word.
+			Example:
+				theribal/terrible ~
+			Use this for common mistakes that do not appear at the
+			top of the suggestion list with the internal methods.
+			Lines without a slash are ignored, use this for
+			comments.
+			The word in the second column must be correct,
+			otherwise it will not be used.	Add the word to an
+			".add" file if it is currently flagged as a spelling
+			mistake.
+			The file is used for all languages.
+
+	expr:{expr}	Evaluate expression {expr}.  Use a function to avoid
+			trouble with spaces.  |v:val| holds the badly spelled
+			word.  The expression must evaluate to a List of
+			Lists, each with a suggestion and a score.
+			Example:
+				[['the', 33], ['that', 44]] ~
+			Set 'verbose' and use |z=| to see the scores that the
+			internal methods use.  A lower score is better.
+			This may invoke |spellsuggest()| if you temporarily
+			set 'spellsuggest' to exclude the "expr:" part.
+			Errors are silently ignored, unless you set the
+			'verbose' option to a non-zero value.
+
+	Only one of "best", "double" or "fast" may be used.  The others may
+	appear several times in any order.  Example: >vim
+		set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+<
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
+				       *'splitbelow'* *'sb'* *'nosplitbelow'* *'nosb'*
+'splitbelow' 'sb'	boolean (default off)
+			global
+	When on, splitting a window will put the new window below the current
+	one. |:split|
+
+							     *'splitkeep'* *'spk'*
+'splitkeep' 'spk'	string (default "cursor")
+			global
+	The value of this option determines the scroll behavior when opening,
+	closing or resizing horizontal splits.
+
+	Possible values are:
+	  cursor	Keep the same relative cursor position.
+	  screen	Keep the text on the same screen line.
+	  topline	Keep the topline the same.
+
+	For the "screen" and "topline" values, the cursor position will be
+	changed when necessary. In this case, the jumplist will be populated
+	with the previous cursor position. For "screen", the text cannot always
+	be kept on the same screen line when 'wrap' is enabled.
+
+				     *'splitright'* *'spr'* *'nosplitright'* *'nospr'*
+'splitright' 'spr'	boolean (default off)
+			global
+	When on, splitting a window will put the new window right of the
+	current one. |:vsplit|
+
+				   *'startofline'* *'sol'* *'nostartofline'* *'nosol'*
+'startofline' 'sol'	boolean (default off)
+			global
+	When "on" the commands listed below move the cursor to the first
+	non-blank of the line.	When off the cursor is kept in the same column
+	(if possible).	This applies to the commands:
+	- CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
+	- "d", "<<" and ">>" with a linewise operator
+	- "%" with a count
+	- buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
+	- Ex commands that only have a line number, e.g., ":25" or ":+".
+	In case of buffer changing commands the cursor is placed at the column
+	where it was the last time the buffer was edited.
+
+							  *'statuscolumn'* *'stc'*
+'statuscolumn' 'stc'	string (default "")
+			local to window
+	EXPERIMENTAL
+	When non-empty, this option determines the content of the area to the
+	side of a window, normally containing the fold, sign and number columns.
+	The format of this option is like that of 'statusline'.
+
+	Some of the items from the 'statusline' format are different for
+	'statuscolumn':
+
+	%l	line number of currently drawn line
+	%r	relative line number of currently drawn line
+	%s	sign column for currently drawn line
+	%C	fold column for currently drawn line
+
+	NOTE: To draw the sign and fold columns, their items must be included in
+	'statuscolumn'. Even when they are not included, the status column width
+	will adapt to the 'signcolumn' and 'foldcolumn' width.
+
+	The |v:lnum|	variable holds the line number to be drawn.
+	The |v:relnum|	variable holds the relative line number to be drawn.
+	The |v:virtnum| variable is negative when drawing virtual lines, zero
+		      when drawing the actual buffer line, and positive when
+		      drawing the wrapped part of a buffer line.
+
+	NOTE: The %@ click execute function item is supported as well but the
+	specified function will be the same for each row in the same column.
+	It cannot be switched out through a dynamic 'statuscolumn' format, the
+	handler should be written with this in mind.
+
+	Examples: >vim
+		" Relative number with bar separator and click handlers:
+		set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
+
+		" Right aligned relative cursor line number:
+		let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+
+		" Line numbers in hexadecimal for non wrapped part of lines:
+		let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
+
+		" Human readable line numbers with thousands separator:
+		let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
+			   . '%(\\d\\d\\d\\)\\+$",",","g")}'
+
+		" Both relative and absolute line numbers with different
+		" highlighting for odd and even relative numbers:
+		let &stc='%#NonText#%{&nu?v:lnum:""}' .
+		 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
+		 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
+
+<	WARNING: this expression is evaluated for each screen line so defining
+	an expensive expression can negatively affect render performance.
+
+						  *'statusline'* *'stl'* *E540* *E542*
+'statusline' 'stl'	string (default "")
+			global or local to window |global-local|
+	When non-empty, this option determines the content of the status line.
+	Also see |status-line|.
+
+	The option consists of printf style '%' items interspersed with
+	normal text.  Each status line item is of the form:
+	  %-0{minwid}.{maxwid}{item}
+	All fields except the {item} are optional.  A single percent sign can
+	be given as "%%".
+
+	When the option starts with "%!" then it is used as an expression,
+	evaluated and the result is used as the option value.  Example: >vim
+		set statusline=%!MyStatusLine()
+<	The *g:statusline_winid* variable will be set to the |window-ID| of the
+	window that the status line belongs to.
+	The result can contain %{} items that will be evaluated too.
+	Note that the "%!" expression is evaluated in the context of the
+	current window and buffer, while %{} items are evaluated in the
+	context of the window that the statusline belongs to.
+
+	When there is error while evaluating the option then it will be made
+	empty to avoid further errors.	Otherwise screen updating would loop.
+	When the result contains unprintable characters the result is
+	unpredictable.
+
+	Note that the only effect of 'ruler' when this option is set (and
+	'laststatus' is 2 or 3) is controlling the output of |CTRL-G|.
+
+	field	    meaning ~
+	-	    Left justify the item.  The default is right justified
+		    when minwid is larger than the length of the item.
+	0	    Leading zeroes in numeric items.  Overridden by "-".
+	minwid	    Minimum width of the item, padding as set by "-" & "0".
+		    Value must be 50 or less.
+	maxwid	    Maximum width of the item.	Truncation occurs with a "<"
+		    on the left for text items.  Numeric items will be
+		    shifted down to maxwid-2 digits followed by ">"number
+		    where number is the amount of missing digits, much like
+		    an exponential notation.
+	item	    A one letter code as described below.
+
+	Following is a description of the possible statusline items.  The
+	second character in "item" is the type:
+		N for number
+		S for string
+		F for flags as described below
+		- not applicable
+
+	item  meaning ~
+	f S   Path to the file in the buffer, as typed or relative to current
+	      directory.
+	F S   Full path to the file in the buffer.
+	t S   File name (tail) of file in the buffer.
+	m F   Modified flag, text is "[+]"; "[-]" if 'modifiable' is off.
+	M F   Modified flag, text is ",+" or ",-".
+	r F   Readonly flag, text is "[RO]".
+	R F   Readonly flag, text is ",RO".
+	h F   Help buffer flag, text is "[help]".
+	H F   Help buffer flag, text is ",HLP".
+	w F   Preview window flag, text is "[Preview]".
+	W F   Preview window flag, text is ",PRV".
+	y F   Type of file in the buffer, e.g., "[vim]".  See 'filetype'.
+	Y F   Type of file in the buffer, e.g., ",VIM".  See 'filetype'.
+	q S   "[Quickfix List]", "[Location List]" or empty.
+	k S   Value of "b:keymap_name" or 'keymap' when |:lmap| mappings are
+	      being used: "<keymap>"
+	n N   Buffer number.
+	b N   Value of character under cursor.
+	B N   As above, in hexadecimal.
+	o N   Byte number in file of byte under cursor, first byte is 1.
+	      Mnemonic: Offset from start of file (with one added)
+	O N   As above, in hexadecimal.
+	l N   Line number.
+	L N   Number of lines in buffer.
+	c N   Column number (byte index).
+	v N   Virtual column number (screen column).
+	V N   Virtual column number as -{num}.	Not displayed if equal to 'c'.
+	p N   Percentage through file in lines as in |CTRL-G|.
+	P S   Percentage through file of displayed window.  This is like the
+	      percentage described for 'ruler'.  Always 3 in length, unless
+	      translated.
+	S S   'showcmd' content, see 'showcmdloc'.
+	a S   Argument list status as in default title.  ({current} of {max})
+	      Empty if the argument file count is zero or one.
+	{ NF  Evaluate expression between "%{" and "}" and substitute result.
+	      Note that there is no "%" before the closing "}".  The
+	      expression cannot contain a "}" character, call a function to
+	      work around that.  See |stl-%{| below.
+	`{%` -	This is almost same as "{" except the result of the expression is
+	      re-evaluated as a statusline format string.  Thus if the
+	      return value of expr contains "%" items they will get expanded.
+	      The expression can contain the "}" character, the end of
+	      expression is denoted by "%}".
+	      For example: >vim
+		func! Stl_filename() abort
+		    return "%t"
+		endfunc
+<		`stl=%{Stl_filename()}`   results in `"%t"`
+		`stl=%{%Stl_filename()%}` results in `"Name of current file"`
+	%} -  End of "{%" expression
+	( -   Start of item group.  Can be used for setting the width and
+	      alignment of a section.  Must be followed by %) somewhere.
+	) -   End of item group.  No width fields allowed.
+	T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+	      the label.  Clicking this label with left mouse button switches
+	      to the specified tab page.
+	X N   For 'tabline': start of close tab N label.  Use %X or %T to end
+	      the label, e.g.: %3Xclose%X.  Use %999X for a "close current
+	      tab" label.    Clicking this label with left mouse button closes
+	      specified tab page.
+	@ N   Start of execute function label. Use %X or %T to
+	      end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
+	      label runs specified function: in the example when clicking once
+	      using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
+	      '    ')" expression will be run.	Function receives the
+	      following arguments in order:
+	      1. minwid field value or zero if no N was specified
+	      2. number of mouse clicks to detect multiple clicks
+	      3. mouse button used: "l", "r" or "m" for left, right or middle
+		 button respectively; one should not rely on third argument
+		 being only "l", "r" or "m": any other non-empty string value
+		 that contains only ASCII lower case letters may be expected
+		 for other mouse buttons
+	      4. modifiers pressed: string which contains "s" if shift
+		 modifier was pressed, "c" for control, "a" for alt and "m"
+		 for meta; currently if modifier is not pressed string
+		 contains space instead, but one should not rely on presence
+		 of spaces or specific order of modifiers: use |stridx()| to
+		 test whether some modifier is present; string is guaranteed
+		 to contain only ASCII letters and spaces, one letter per
+		 modifier; "?" modifier may also be present, but its presence
+		 is a bug that denotes that new mouse button recognition was
+		 added without modifying code that reacts on mouse clicks on
+		 this label.
+	      Use |getmousepos()|.winid in the specified function to get the
+	      corresponding window id of the clicked item.
+	< -   Where to truncate line if too long.  Default is at the start.
+	      No width fields allowed.
+	= -   Separation point between alignment sections.  Each section will
+	      be separated by an equal number of spaces.  With one %= what
+	      comes after it will be right-aligned.  With two %= there is a
+	      middle part, with white space left and right of it.
+	      No width fields allowed.
+	# -   Set highlight group.  The name must follow and then a # again.
+	      Thus use %#HLname# for highlight group HLname.  The same
+	      highlighting is used, also for the statusline of non-current
+	      windows.
+	* -   Set highlight group to User{N}, where {N} is taken from the
+	      minwid field, e.g. %1*.  Restore normal highlight with %* or %0*.
+	      The difference between User{N} and StatusLine will be applied to
+	      StatusLineNC for the statusline of non-current windows.
+	      The number N must be between 1 and 9.  See |hl-User1..9|
+
+	When displaying a flag, Vim removes the leading comma, if any, when
+	that flag comes right after plaintext.	This will make a nice display
+	when flags are used like in the examples below.
+
+	When all items in a group becomes an empty string (i.e. flags that are
+	not set) and a minwid is not set for the group, the whole group will
+	become empty.  This will make a group like the following disappear
+	completely from the statusline when none of the flags are set. >vim
+		set statusline=...%(\ [%M%R%H]%)...
+<	Beware that an expression is evaluated each and every time the status
+	line is displayed.
+				*stl-%{* *g:actual_curbuf* *g:actual_curwin*
+	While evaluating %{} the current buffer and current window will be set
+	temporarily to that of the window (and buffer) whose statusline is
+	currently being drawn.	The expression will evaluate in this context.
+	The variable "g:actual_curbuf" is set to the `bufnr()` number of the
+	real current buffer and "g:actual_curwin" to the |window-ID| of the
+	real current window.  These values are strings.
+
+	The 'statusline' option will be evaluated in the |sandbox| if set from
+	a modeline, see |sandbox-option|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
+
+	It is not allowed to change text or jump to another window while
+	evaluating 'statusline' |textlock|.
+
+	If the statusline is not updated when you want it (e.g., after setting
+	a variable that's used in an expression), you can force an update by
+	using `:redrawstatus`.
+
+	A result of all digits is regarded a number for display purposes.
+	Otherwise the result is taken as flag text and applied to the rules
+	described above.
+
+	Watch out for errors in expressions.  They may render Vim unusable!
+	If you are stuck, hold down ':' or 'Q' to get a prompt, then quit and
+	edit your vimrc or whatever with "vim --clean" to get it right.
+
+	Examples:
+	Emulate standard status line with 'ruler' set >vim
+	  set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
+<	Similar, but add ASCII value of char under the cursor (like "ga") >vim
+	  set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
+<	Display byte count and byte value, modified flag in red. >vim
+	  set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
+	  hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
+<	Display a ,GZ flag if a compressed file is loaded >vim
+	  set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
+<	In the |:autocmd|'s: >vim
+	  let b:gzflag = 1
+<	And: >vim
+	  unlet b:gzflag
+<	And define this function: >vim
+	  function VarExists(var, val)
+	      if exists(a:var) | return a:val | else | return '' | endif
+	  endfunction
 <
 
-                                         *'swapfile'* *'swf'* *'noswapfile'* *'noswf'*
-'swapfile' 'swf'        boolean (default on)
-                        local to buffer
-        Use a swapfile for the buffer.  This option can be reset when a
-        swapfile is not wanted for a specific buffer.  For example, with
-        confidential information that even root must not be able to access.
-        Careful: All text will be in memory:
-                - Don't use this for big files.
-                - Recovery will be impossible!
-        A swapfile will only be present when |'updatecount'| is non-zero and
-        'swapfile' is set.
-        When 'swapfile' is reset, the swap file for the current buffer is
-        immediately deleted.  When 'swapfile' is set, and 'updatecount' is
-        non-zero, a swap file is immediately created.
-        Also see |swap-file|.
-        If you want to open a new buffer without creating a swap file for it,
-        use the |:noswapfile| modifier.
-        See 'directory' for where the swap file is created.
+							       *'suffixes'* *'su'*
+'suffixes' 'su'		string (default ".bak,~,.o,.h,.info,.swp,.obj")
+			global
+	Files with these suffixes get a lower priority when multiple files
+	match a wildcard.  See |suffixes|.  Commas can be used to separate the
+	suffixes.  Spaces after the comma are ignored.	A dot is also seen as
+	the start of a suffix.	To avoid a dot or comma being recognized as a
+	separator, precede it with a backslash (see |option-backslash| about
+	including spaces and backslashes).
+	See 'wildignore' for completely ignoring files.
+	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	suffixes from the list.  This avoids problems when a future version
+	uses another default.
 
-        This option is used together with 'bufhidden' and 'buftype' to
-        specify special kinds of buffers.   See |special-buffers|.
+							   *'suffixesadd'* *'sua'*
+'suffixesadd' 'sua'	string (default "")
+			local to buffer
+	Comma-separated list of suffixes, which are used when searching for a
+	file for the "gf", "[I", etc. commands.  Example: >vim
+		set suffixesadd=.java
+<
 
-                                                             *'switchbuf'* *'swb'*
-'switchbuf' 'swb'       string (default "uselast")
-                        global
-        This option controls the behavior when switching between buffers.
-        This option is checked, when
-        - jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
-          etc.).
-        - jumping to a tag using the |:stag| command.
-        - opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
-        - jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
-          |:sbnext|, or |:sbrewind|).
-        Possible values (comma-separated list):
-           useopen      If included, jump to the first open window in the
-                        current tab page that contains the specified buffer
-                        (if there is one).  Otherwise: Do not examine other
-                        windows.
-           usetab       Like "useopen", but also consider windows in other tab
-                        pages.
-           split        If included, split the current window before loading
-                        a buffer for a |quickfix| command that display errors.
-                        Otherwise: do not split, use current window (when used
-                        in the quickfix window: the previously used window or
-                        split if there is no other window).
-           vsplit       Just like "split" but split vertically.
-           newtab       Like "split", but open a new tab page.  Overrules
-                        "split" when both are present.
-           uselast      If included, jump to the previously used window when
-                        jumping to errors with |quickfix| commands.
+					 *'swapfile'* *'swf'* *'noswapfile'* *'noswf'*
+'swapfile' 'swf'	boolean (default on)
+			local to buffer
+	Use a swapfile for the buffer.	This option can be reset when a
+	swapfile is not wanted for a specific buffer.  For example, with
+	confidential information that even root must not be able to access.
+	Careful: All text will be in memory:
+		- Don't use this for big files.
+		- Recovery will be impossible!
+	A swapfile will only be present when |'updatecount'| is non-zero and
+	'swapfile' is set.
+	When 'swapfile' is reset, the swap file for the current buffer is
+	immediately deleted.  When 'swapfile' is set, and 'updatecount' is
+	non-zero, a swap file is immediately created.
+	Also see |swap-file|.
+	If you want to open a new buffer without creating a swap file for it,
+	use the |:noswapfile| modifier.
+	See 'directory' for where the swap file is created.
 
-                                                             *'synmaxcol'* *'smc'*
-'synmaxcol' 'smc'       number (default 3000)
-                        local to buffer
-        Maximum column in which to search for syntax items.  In long lines the
-        text after this column is not highlighted and following lines may not
-        be highlighted correctly, because the syntax state is cleared.
-        This helps to avoid very slow redrawing for an XML file that is one
-        long line.
-        Set to zero to remove the limit.
+	This option is used together with 'bufhidden' and 'buftype' to
+	specify special kinds of buffers.   See |special-buffers|.
 
-                                                                *'syntax'* *'syn'*
-'syntax' 'syn'          string (default "")
-                        local to buffer  |local-noglobal|
-        When this option is set, the syntax with this name is loaded, unless
-        syntax highlighting has been switched off with ":syntax off".
-        Otherwise this option does not always reflect the current syntax (the
-        b:current_syntax variable does).
-        This option is most useful in a modeline, for a file which syntax is
-        not automatically recognized.  Example, in an IDL file: >c
-                /* vim: set syntax=idl : */
-<       When a dot appears in the value then this separates two filetype
-        names.  Example: >c
-                /* vim: set syntax=c.doxygen : */
-<       This will use the "c" syntax first, then the "doxygen" syntax.
-        Note that the second one must be prepared to be loaded as an addition,
-        otherwise it will be skipped.  More than one dot may appear.
-        To switch off syntax highlighting for the current file, use: >vim
-                set syntax=OFF
-<       To switch syntax highlighting on according to the current value of the
-        'filetype' option: >vim
-                set syntax=ON
-<       What actually happens when setting the 'syntax' option is that the
-        Syntax autocommand event is triggered with the value as argument.
-        This option is not copied to another buffer, independent of the 's' or
-        'S' flag in 'cpoptions'.
-        Only normal file name characters can be used, `/\*?[|<>` are illegal.
+							     *'switchbuf'* *'swb'*
+'switchbuf' 'swb'	string (default "uselast")
+			global
+	This option controls the behavior when switching between buffers.
+	This option is checked, when
+	- jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
+	  etc.).
+	- jumping to a tag using the |:stag| command.
+	- opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
+	- jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
+	  |:sbnext|, or |:sbrewind|).
+	Possible values (comma-separated list):
+	   useopen	If included, jump to the first open window in the
+			current tab page that contains the specified buffer
+			(if there is one).  Otherwise: Do not examine other
+			windows.
+	   usetab	Like "useopen", but also consider windows in other tab
+			pages.
+	   split	If included, split the current window before loading
+			a buffer for a |quickfix| command that display errors.
+			Otherwise: do not split, use current window (when used
+			in the quickfix window: the previously used window or
+			split if there is no other window).
+	   vsplit	Just like "split" but split vertically.
+	   newtab	Like "split", but open a new tab page.	Overrules
+			"split" when both are present.
+	   uselast	If included, jump to the previously used window when
+			jumping to errors with |quickfix| commands.
 
-                                                               *'tabline'* *'tal'*
-'tabline' 'tal'         string (default "")
-                        global
-        When non-empty, this option determines the content of the tab pages
-        line at the top of the Vim window.  When empty Vim will use a default
-        tab pages line.  See |setting-tabline| for more info.
+							     *'synmaxcol'* *'smc'*
+'synmaxcol' 'smc'	number (default 3000)
+			local to buffer
+	Maximum column in which to search for syntax items.  In long lines the
+	text after this column is not highlighted and following lines may not
+	be highlighted correctly, because the syntax state is cleared.
+	This helps to avoid very slow redrawing for an XML file that is one
+	long line.
+	Set to zero to remove the limit.
 
-        The tab pages line only appears as specified with the 'showtabline'
-        option and only when there is no GUI tab line.  When 'e' is in
-        'guioptions' and the GUI supports a tab line 'guitablabel' is used
-        instead.  Note that the two tab pages lines are very different.
+								*'syntax'* *'syn'*
+'syntax' 'syn'		string (default "")
+			local to buffer  |local-noglobal|
+	When this option is set, the syntax with this name is loaded, unless
+	syntax highlighting has been switched off with ":syntax off".
+	Otherwise this option does not always reflect the current syntax (the
+	b:current_syntax variable does).
+	This option is most useful in a modeline, for a file which syntax is
+	not automatically recognized.  Example, in an IDL file: >c
+		/* vim: set syntax=idl : */
+<	When a dot appears in the value then this separates two filetype
+	names.	Example: >c
+		/* vim: set syntax=c.doxygen : */
+<	This will use the "c" syntax first, then the "doxygen" syntax.
+	Note that the second one must be prepared to be loaded as an addition,
+	otherwise it will be skipped.  More than one dot may appear.
+	To switch off syntax highlighting for the current file, use: >vim
+		set syntax=OFF
+<	To switch syntax highlighting on according to the current value of the
+	'filetype' option: >vim
+		set syntax=ON
+<	What actually happens when setting the 'syntax' option is that the
+	Syntax autocommand event is triggered with the value as argument.
+	This option is not copied to another buffer, independent of the 's' or
+	'S' flag in 'cpoptions'.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
-        The value is evaluated like with 'statusline'.  You can use
-        |tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
-        the text to be displayed.  Use "%1T" for the first label, "%2T" for
-        the second one, etc.  Use "%X" items for closing labels.
+							       *'tabline'* *'tal'*
+'tabline' 'tal'		string (default "")
+			global
+	When non-empty, this option determines the content of the tab pages
+	line at the top of the Vim window.  When empty Vim will use a default
+	tab pages line.  See |setting-tabline| for more info.
 
-        When changing something that is used in 'tabline' that does not
-        trigger it to be updated, use |:redrawtabline|.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	The tab pages line only appears as specified with the 'showtabline'
+	option and only when there is no GUI tab line.	When 'e' is in
+	'guioptions' and the GUI supports a tab line 'guitablabel' is used
+	instead.  Note that the two tab pages lines are very different.
 
-        Keep in mind that only one of the tab pages is the current one, others
-        are invisible and you can't jump to their windows.
+	The value is evaluated like with 'statusline'.	You can use
+	|tabpagenr()|, |tabpagewinnr()| and |tabpagebuflist()| to figure out
+	the text to be displayed.  Use "%1T" for the first label, "%2T" for
+	the second one, etc.  Use "%X" items for closing labels.
 
-                                                            *'tabpagemax'* *'tpm'*
-'tabpagemax' 'tpm'      number (default 50)
-                        global
-        Maximum number of tab pages to be opened by the |-p| command line
-        argument or the ":tab all" command. |tabpage|
+	When changing something that is used in 'tabline' that does not
+	trigger it to be updated, use |:redrawtabline|.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-                                                                *'tabstop'* *'ts'*
-'tabstop' 'ts'          number (default 8)
-                        local to buffer
-        Number of spaces that a <Tab> in the file counts for.  Also see
-        the |:retab| command, and the 'softtabstop' option.
+	Keep in mind that only one of the tab pages is the current one, others
+	are invisible and you can't jump to their windows.
 
-        Note: Setting 'tabstop' to any other value than 8 can make your file
-        appear wrong in many places.
-        The value must be more than 0 and less than 10000.
+							    *'tabpagemax'* *'tpm'*
+'tabpagemax' 'tpm'	number (default 50)
+			global
+	Maximum number of tab pages to be opened by the |-p| command line
+	argument or the ":tab all" command. |tabpage|
 
-        There are four main ways to use tabs in Vim:
-        1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
-           (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
-           will use a mix of tabs and spaces, but typing <Tab> and <BS> will
-           behave like a tab appears every 4 (or 3) characters.
-           This is the recommended way, the file will look the same with other
-           tools and when listing it in a terminal.
-        2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
-           'expandtab'.  This way you will always insert spaces.  The
-           formatting will never be messed up when 'tabstop' is changed (leave
-           it at 8 just in case).  The file will be a bit larger.
-           You do need to check if no Tabs exist in the file.  You can get rid
-           of them by first setting 'expandtab' and using `%retab!`, making
-           sure the value of 'tabstop' is set correctly.
-        3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
-           'expandtab'.  This way you will always insert spaces.  The
-           formatting will never be messed up when 'tabstop' is changed.
-           You do need to check if no Tabs exist in the file, just like in the
-           item just above.
-        4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
-           |modeline| to set these values when editing the file again.  Only
-           works when using Vim to edit the file, other tools assume a tabstop
-           is worth 8 spaces.
-        5. Always set 'tabstop' and 'shiftwidth' to the same value, and
-           'noexpandtab'.  This should then work (for initial indents only)
-           for any tabstop setting that people use.  It might be nice to have
-           tabs after the first non-blank inserted as spaces if you do this
-           though.  Otherwise aligned comments will be wrong when 'tabstop' is
-           changed.
+								*'tabstop'* *'ts'*
+'tabstop' 'ts'		number (default 8)
+			local to buffer
+	Number of spaces that a <Tab> in the file counts for.  Also see
+	the |:retab| command, and the 'softtabstop' option.
 
-        The value of 'tabstop' will be ignored if |'vartabstop'| is set to
-        anything other than an empty string.
+	Note: Setting 'tabstop' to any other value than 8 can make your file
+	appear wrong in many places.
+	The value must be more than 0 and less than 10000.
 
-                                     *'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
-'tagbsearch' 'tbs'      boolean (default on)
-                        global
-        When searching for a tag (e.g., for the |:ta| command), Vim can either
-        use a binary search or a linear search in a tags file.  Binary
-        searching makes searching for a tag a LOT faster, but a linear search
-        will find more tags if the tags file wasn't properly sorted.
-        Vim normally assumes that your tags files are sorted, or indicate that
-        they are not sorted.  Only when this is not the case does the
-        'tagbsearch' option need to be switched off.
+	There are four main ways to use tabs in Vim:
+	1. Always keep 'tabstop' at 8, set 'softtabstop' and 'shiftwidth' to 4
+	   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
+	   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
+	   behave like a tab appears every 4 (or 3) characters.
+	   This is the recommended way, the file will look the same with other
+	   tools and when listing it in a terminal.
+	2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
+	   'expandtab'.  This way you will always insert spaces.  The
+	   formatting will never be messed up when 'tabstop' is changed (leave
+	   it at 8 just in case).  The file will be a bit larger.
+	   You do need to check if no Tabs exist in the file.  You can get rid
+	   of them by first setting 'expandtab' and using `%retab!`, making
+	   sure the value of 'tabstop' is set correctly.
+	3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
+	   'expandtab'.  This way you will always insert spaces.  The
+	   formatting will never be messed up when 'tabstop' is changed.
+	   You do need to check if no Tabs exist in the file, just like in the
+	   item just above.
+	4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
+	   |modeline| to set these values when editing the file again.	Only
+	   works when using Vim to edit the file, other tools assume a tabstop
+	   is worth 8 spaces.
+	5. Always set 'tabstop' and 'shiftwidth' to the same value, and
+	   'noexpandtab'.  This should then work (for initial indents only)
+	   for any tabstop setting that people use.  It might be nice to have
+	   tabs after the first non-blank inserted as spaces if you do this
+	   though.  Otherwise aligned comments will be wrong when 'tabstop' is
+	   changed.
 
-        When 'tagbsearch' is on, binary searching is first used in the tags
-        files.  In certain situations, Vim will do a linear search instead for
-        certain files, or retry all files with a linear search.  When
-        'tagbsearch' is off, only a linear search is done.
+	The value of 'tabstop' will be ignored if |'vartabstop'| is set to
+	anything other than an empty string.
 
-        Linear searching is done anyway, for one file, when Vim finds a line
-        at the start of the file indicating that it's not sorted: >
-           !_TAG_FILE_SORTED    0       /some comment/
-<       [The whitespace before and after the '0' must be a single <Tab>]
+				     *'tagbsearch'* *'tbs'* *'notagbsearch'* *'notbs'*
+'tagbsearch' 'tbs'	boolean (default on)
+			global
+	When searching for a tag (e.g., for the |:ta| command), Vim can either
+	use a binary search or a linear search in a tags file.	Binary
+	searching makes searching for a tag a LOT faster, but a linear search
+	will find more tags if the tags file wasn't properly sorted.
+	Vim normally assumes that your tags files are sorted, or indicate that
+	they are not sorted.  Only when this is not the case does the
+	'tagbsearch' option need to be switched off.
 
-        When a binary search was done and no match was found in any of the
-        files listed in 'tags', and case is ignored or a pattern is used
-        instead of a normal tag name, a retry is done with a linear search.
-        Tags in unsorted tags files, and matches with different case will only
-        be found in the retry.
+	When 'tagbsearch' is on, binary searching is first used in the tags
+	files.	In certain situations, Vim will do a linear search instead for
+	certain files, or retry all files with a linear search.  When
+	'tagbsearch' is off, only a linear search is done.
 
-        If a tag file indicates that it is case-fold sorted, the second,
-        linear search can be avoided when case is ignored.  Use a value of '2'
-        in the "!_TAG_FILE_SORTED" line for this.  A tag file can be case-fold
-        sorted with the -f switch to "sort" in most unices, as in the command:
-        "sort -f -o tags tags".  For Universal ctags and Exuberant ctags
-        version 5.x or higher (at least 5.5) the --sort=foldcase switch can be
-        used for this as well.  Note that case must be folded to uppercase for
-        this to work.
+	Linear searching is done anyway, for one file, when Vim finds a line
+	at the start of the file indicating that it's not sorted: >
+	   !_TAG_FILE_SORTED	0	/some comment/
+<	[The whitespace before and after the '0' must be a single <Tab>]
 
-        By default, tag searches are case-sensitive.  Case is ignored when
-        'ignorecase' is set and 'tagcase' is "followic", or when 'tagcase' is
-        "ignore".
-        Also when 'tagcase' is "followscs" and 'smartcase' is set, or
-        'tagcase' is "smart", and the pattern contains only lowercase
-        characters.
+	When a binary search was done and no match was found in any of the
+	files listed in 'tags', and case is ignored or a pattern is used
+	instead of a normal tag name, a retry is done with a linear search.
+	Tags in unsorted tags files, and matches with different case will only
+	be found in the retry.
 
-        When 'tagbsearch' is off, tags searching is slower when a full match
-        exists, but faster when no full match exists.  Tags in unsorted tags
-        files may only be found with 'tagbsearch' off.
-        When the tags file is not sorted, or sorted in a wrong way (not on
-        ASCII byte value), 'tagbsearch' should be off, or the line given above
-        must be included in the tags file.
-        This option doesn't affect commands that find all matching tags (e.g.,
-        command-line completion and ":help").
+	If a tag file indicates that it is case-fold sorted, the second,
+	linear search can be avoided when case is ignored.  Use a value of '2'
+	in the "!_TAG_FILE_SORTED" line for this.  A tag file can be case-fold
+	sorted with the -f switch to "sort" in most unices, as in the command:
+	"sort -f -o tags tags".  For Universal ctags and Exuberant ctags
+	version 5.x or higher (at least 5.5) the --sort=foldcase switch can be
+	used for this as well.	Note that case must be folded to uppercase for
+	this to work.
 
-                                                                *'tagcase'* *'tc'*
-'tagcase' 'tc'          string (default "followic")
-                        global or local to buffer |global-local|
-        This option specifies how case is handled when searching the tags
-        file:
-           followic     Follow the 'ignorecase' option
-           followscs    Follow the 'smartcase' and 'ignorecase' options
-           ignore       Ignore case
-           match        Match case
-           smart        Ignore case unless an upper case letter is used
+	By default, tag searches are case-sensitive.  Case is ignored when
+	'ignorecase' is set and 'tagcase' is "followic", or when 'tagcase' is
+	"ignore".
+	Also when 'tagcase' is "followscs" and 'smartcase' is set, or
+	'tagcase' is "smart", and the pattern contains only lowercase
+	characters.
 
-                                                               *'tagfunc'* *'tfu'*
-'tagfunc' 'tfu'         string (default "")
-                        local to buffer
-        This option specifies a function to be used to perform tag searches.
-        The function gets the tag pattern and should return a List of matching
-        tags.  See |tag-function| for an explanation of how to write the
-        function and an example.  The value can be the name of a function, a
-        |lambda| or a |Funcref|. See |option-value-function| for more
-        information.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	When 'tagbsearch' is off, tags searching is slower when a full match
+	exists, but faster when no full match exists.  Tags in unsorted tags
+	files may only be found with 'tagbsearch' off.
+	When the tags file is not sorted, or sorted in a wrong way (not on
+	ASCII byte value), 'tagbsearch' should be off, or the line given above
+	must be included in the tags file.
+	This option doesn't affect commands that find all matching tags (e.g.,
+	command-line completion and ":help").
 
-                                                              *'taglength'* *'tl'*
-'taglength' 'tl'        number (default 0)
-                        global
-        If non-zero, tags are significant up to this number of characters.
+								*'tagcase'* *'tc'*
+'tagcase' 'tc'		string (default "followic")
+			global or local to buffer |global-local|
+	This option specifies how case is handled when searching the tags
+	file:
+	   followic	Follow the 'ignorecase' option
+	   followscs	Follow the 'smartcase' and 'ignorecase' options
+	   ignore	Ignore case
+	   match	Match case
+	   smart	Ignore case unless an upper case letter is used
 
-                                     *'tagrelative'* *'tr'* *'notagrelative'* *'notr'*
-'tagrelative' 'tr'      boolean (default on)
-                        global
-        If on and using a tags file in another directory, file names in that
-        tags file are relative to the directory where the tags file is.
+							       *'tagfunc'* *'tfu'*
+'tagfunc' 'tfu'		string (default "")
+			local to buffer
+	This option specifies a function to be used to perform tag searches.
+	The function gets the tag pattern and should return a List of matching
+	tags.  See |tag-function| for an explanation of how to write the
+	function and an example.  The value can be the name of a function, a
+	|lambda| or a |Funcref|. See |option-value-function| for more
+	information.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                             *'tags'* *'tag'* *E433*
-'tags' 'tag'            string (default "./tags;,tags")
-                        global or local to buffer |global-local|
-        Filenames for the tag command, separated by spaces or commas.  To
-        include a space or comma in a file name, precede it with backslashes
-        (see |option-backslash| about including spaces/commas and backslashes).
-        When a file name starts with "./", the '.' is replaced with the path
-        of the current file.  But only when the 'd' flag is not included in
-        'cpoptions'.  Environment variables are expanded |:set_env|.  Also see
-        |tags-option|.
-        "*", "**" and other wildcards can be used to search for tags files in
-        a directory tree.  See |file-searching|.  E.g., "/lib/**/tags" will
-        find all files named "tags" below "/lib".  The filename itself cannot
-        contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
-        files called "tags?".
-        The |tagfiles()| function can be used to get a list of the file names
-        actually used.
-        The use of |:set+=| and |:set-=| is preferred when adding or removing
-        file names from the list.  This avoids problems when a future version
-        uses another default.
+							      *'taglength'* *'tl'*
+'taglength' 'tl'	number (default 0)
+			global
+	If non-zero, tags are significant up to this number of characters.
 
-                                       *'tagstack'* *'tgst'* *'notagstack'* *'notgst'*
-'tagstack' 'tgst'       boolean (default on)
-                        global
-        When on, the |tagstack| is used normally.  When off, a ":tag" or
-        ":tselect" command with an argument will not push the tag onto the
-        tagstack.  A following ":tag" without an argument, a ":pop" command or
-        any other command that uses the tagstack will use the unmodified
-        tagstack, but does change the pointer to the active entry.
-        Resetting this option is useful when using a ":tag" command in a
-        mapping which should not change the tagstack.
+				     *'tagrelative'* *'tr'* *'notagrelative'* *'notr'*
+'tagrelative' 'tr'	boolean (default on)
+			global
+	If on and using a tags file in another directory, file names in that
+	tags file are relative to the directory where the tags file is.
 
-                                     *'termbidi'* *'tbidi'* *'notermbidi'* *'notbidi'*
-'termbidi' 'tbidi'      boolean (default off)
-                        global
-        The terminal is in charge of Bi-directionality of text (as specified
-        by Unicode).  The terminal is also expected to do the required shaping
-        that some languages (such as Arabic) require.
-        Setting this option implies that 'rightleft' will not be set when
-        'arabic' is set and the value of 'arabicshape' will be ignored.
-        Note that setting 'termbidi' has the immediate effect that
-        'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
-        For further details see |arabic.txt|.
+							     *'tags'* *'tag'* *E433*
+'tags' 'tag'		string (default "./tags;,tags")
+			global or local to buffer |global-local|
+	Filenames for the tag command, separated by spaces or commas.  To
+	include a space or comma in a file name, precede it with backslashes
+	(see |option-backslash| about including spaces/commas and backslashes).
+	When a file name starts with "./", the '.' is replaced with the path
+	of the current file.  But only when the 'd' flag is not included in
+	'cpoptions'.  Environment variables are expanded |:set_env|.  Also see
+	|tags-option|.
+	"*", "**" and other wildcards can be used to search for tags files in
+	a directory tree.  See |file-searching|.  E.g., "/lib/**/tags" will
+	find all files named "tags" below "/lib".  The filename itself cannot
+	contain wildcards, it is used as-is.  E.g., "/lib/**/tags?" will find
+	files called "tags?".
+	The |tagfiles()| function can be used to get a list of the file names
+	actually used.
+	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	file names from the list.  This avoids problems when a future version
+	uses another default.
 
-                               *'termguicolors'* *'tgc'* *'notermguicolors'* *'notgc'*
-'termguicolors' 'tgc'   boolean (default off)
-                        global
-        Enables 24-bit RGB color in the |TUI|.  Uses "gui" |:highlight|
-        attributes instead of "cterm" attributes. |guifg|
-        Requires an ISO-8613-3 compatible terminal.
+				       *'tagstack'* *'tgst'* *'notagstack'* *'notgst'*
+'tagstack' 'tgst'	boolean (default on)
+			global
+	When on, the |tagstack| is used normally.  When off, a ":tag" or
+	":tselect" command with an argument will not push the tag onto the
+	tagstack.  A following ":tag" without an argument, a ":pop" command or
+	any other command that uses the tagstack will use the unmodified
+	tagstack, but does change the pointer to the active entry.
+	Resetting this option is useful when using a ":tag" command in a
+	mapping which should not change the tagstack.
 
-        Nvim will automatically attempt to determine if the host terminal
-        supports 24-bit color and will enable this option if it does
-        (unless explicitly disabled by the user).
+				     *'termbidi'* *'tbidi'* *'notermbidi'* *'notbidi'*
+'termbidi' 'tbidi'	boolean (default off)
+			global
+	The terminal is in charge of Bi-directionality of text (as specified
+	by Unicode).  The terminal is also expected to do the required shaping
+	that some languages (such as Arabic) require.
+	Setting this option implies that 'rightleft' will not be set when
+	'arabic' is set and the value of 'arabicshape' will be ignored.
+	Note that setting 'termbidi' has the immediate effect that
+	'arabicshape' is ignored, but 'rightleft' isn't changed automatically.
+	For further details see |arabic.txt|.
 
-                                                       *'termpastefilter'* *'tpf'*
+			       *'termguicolors'* *'tgc'* *'notermguicolors'* *'notgc'*
+'termguicolors' 'tgc'	boolean (default off)
+			global
+	Enables 24-bit RGB color in the |TUI|.	Uses "gui" |:highlight|
+	attributes instead of "cterm" attributes. |guifg|
+	Requires an ISO-8613-3 compatible terminal.
+
+	Nvim will automatically attempt to determine if the host terminal
+	supports 24-bit color and will enable this option if it does
+	(unless explicitly disabled by the user).
+
+						       *'termpastefilter'* *'tpf'*
 'termpastefilter' 'tpf' string (default "BS,HT,ESC,DEL")
-                        global
-        A comma-separated list of options for specifying control characters
-        to be removed from the text pasted into the terminal window. The
-        supported values are:
+			global
+	A comma-separated list of options for specifying control characters
+	to be removed from the text pasted into the terminal window. The
+	supported values are:
 
-           BS       Backspace
+	   BS	    Backspace
 
-           HT       TAB
+	   HT	    TAB
 
-           FF       Form feed
+	   FF	    Form feed
 
-           ESC      Escape
+	   ESC	    Escape
 
-           DEL      DEL
+	   DEL	    DEL
 
-           C0       Other control characters, excluding Line feed and
-                    Carriage return < ' '
+	   C0	    Other control characters, excluding Line feed and
+		    Carriage return < ' '
 
-           C1       Control characters 0x80...0x9F
+	   C1	    Control characters 0x80...0x9F
 
-                                                       *'termsync'* *'notermsync'*
-'termsync'              boolean (default on)
-                        global
-        If the host terminal supports it, buffer all screen updates
-        made during a redraw cycle so that each screen is displayed in
-        the terminal all at once. This can prevent tearing or flickering
-        when the terminal updates faster than Nvim can redraw.
+						       *'termsync'* *'notermsync'*
+'termsync'		boolean (default on)
+			global
+	If the host terminal supports it, buffer all screen updates
+	made during a redraw cycle so that each screen is displayed in
+	the terminal all at once. This can prevent tearing or flickering
+	when the terminal updates faster than Nvim can redraw.
 
-                                                              *'textwidth'* *'tw'*
-'textwidth' 'tw'        number (default 0)
-                        local to buffer
-        Maximum width of text that is being inserted.  A longer line will be
-        broken after white space to get this width.  A zero value disables
-        this.
-        When 'textwidth' is zero, 'wrapmargin' may be used.  See also
-        'formatoptions' and |ins-textwidth|.
-        When 'formatexpr' is set it will be used to break the line.
+							      *'textwidth'* *'tw'*
+'textwidth' 'tw'	number (default 0)
+			local to buffer
+	Maximum width of text that is being inserted.  A longer line will be
+	broken after white space to get this width.  A zero value disables
+	this.
+	When 'textwidth' is zero, 'wrapmargin' may be used.  See also
+	'formatoptions' and |ins-textwidth|.
+	When 'formatexpr' is set it will be used to break the line.
 
-                                                             *'thesaurus'* *'tsr'*
-'thesaurus' 'tsr'       string (default "")
-                        global or local to buffer |global-local|
-        List of file names, separated by commas, that are used to lookup words
-        for thesaurus completion commands |i_CTRL-X_CTRL-T|.  See
-        |compl-thesaurus|.
+							     *'thesaurus'* *'tsr'*
+'thesaurus' 'tsr'	string (default "")
+			global or local to buffer |global-local|
+	List of file names, separated by commas, that are used to lookup words
+	for thesaurus completion commands |i_CTRL-X_CTRL-T|.  See
+	|compl-thesaurus|.
 
-        This option is not used if 'thesaurusfunc' is set, either for the
-        buffer or globally.
+	This option is not used if 'thesaurusfunc' is set, either for the
+	buffer or globally.
 
-        To include a comma in a file name precede it with a backslash.  Spaces
-        after a comma are ignored, otherwise spaces are included in the file
-        name.  See |option-backslash| about using backslashes.  The use of
-        |:set+=| and |:set-=| is preferred when adding or removing directories
-        from the list.  This avoids problems when a future version uses
-        another default.  Backticks cannot be used in this option for security
-        reasons.
+	To include a comma in a file name precede it with a backslash.	Spaces
+	after a comma are ignored, otherwise spaces are included in the file
+	name.  See |option-backslash| about using backslashes.	The use of
+	|:set+=| and |:set-=| is preferred when adding or removing directories
+	from the list.	This avoids problems when a future version uses
+	another default.  Backticks cannot be used in this option for security
+	reasons.
 
-                                                       *'thesaurusfunc'* *'tsrfu'*
+						       *'thesaurusfunc'* *'tsrfu'*
 'thesaurusfunc' 'tsrfu' string (default "")
-                        global or local to buffer |global-local|
-        This option specifies a function to be used for thesaurus completion
-        with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
-        The value can be the name of a function, a |lambda| or a |Funcref|.
-        See |option-value-function| for more information.
+			global or local to buffer |global-local|
+	This option specifies a function to be used for thesaurus completion
+	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
+	The value can be the name of a function, a |lambda| or a |Funcref|.
+	See |option-value-function| for more information.
 
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                           *'tildeop'* *'top'* *'notildeop'* *'notop'*
-'tildeop' 'top'         boolean (default off)
-                        global
-        When on: The tilde command "~" behaves like an operator.
+					   *'tildeop'* *'top'* *'notildeop'* *'notop'*
+'tildeop' 'top'		boolean (default off)
+			global
+	When on: The tilde command "~" behaves like an operator.
 
-                                             *'timeout'* *'to'* *'notimeout'* *'noto'*
-'timeout' 'to'          boolean (default on)
-                        global
-        This option and 'timeoutlen' determine the behavior when part of a
-        mapped key sequence has been received. For example, if <c-f> is
-        pressed and 'timeout' is set, Nvim will wait 'timeoutlen' milliseconds
-        for any key that can follow <c-f> in a mapping.
+					     *'timeout'* *'to'* *'notimeout'* *'noto'*
+'timeout' 'to'		boolean (default on)
+			global
+	This option and 'timeoutlen' determine the behavior when part of a
+	mapped key sequence has been received. For example, if <c-f> is
+	pressed and 'timeout' is set, Nvim will wait 'timeoutlen' milliseconds
+	for any key that can follow <c-f> in a mapping.
 
-                                                             *'timeoutlen'* *'tm'*
-'timeoutlen' 'tm'       number (default 1000)
-                        global
-        Time in milliseconds to wait for a mapped sequence to complete.
+							     *'timeoutlen'* *'tm'*
+'timeoutlen' 'tm'	number (default 1000)
+			global
+	Time in milliseconds to wait for a mapped sequence to complete.
 
-                                                             *'title'* *'notitle'*
-'title'                 boolean (default off)
-                        global
-        When on, the title of the window will be set to the value of
-        'titlestring' (if it is not empty), or to:
-                filename [+=-] (path) - NVIM
-        Where:
-                filename        the name of the file being edited
-                -               indicates the file cannot be modified, 'ma' off
-                +               indicates the file was modified
-                =               indicates the file is read-only
-                =+              indicates the file is read-only and modified
-                (path)          is the path of the file being edited
-                - NVIM          the server name |v:servername| or "NVIM"
+							     *'title'* *'notitle'*
+'title'			boolean (default off)
+			global
+	When on, the title of the window will be set to the value of
+	'titlestring' (if it is not empty), or to:
+		filename [+=-] (path) - NVIM
+	Where:
+		filename	the name of the file being edited
+		-		indicates the file cannot be modified, 'ma' off
+		+		indicates the file was modified
+		=		indicates the file is read-only
+		=+		indicates the file is read-only and modified
+		(path)		is the path of the file being edited
+		- NVIM		the server name |v:servername| or "NVIM"
 
-                                                                    *'titlelen'*
-'titlelen'              number (default 85)
-                        global
-        Gives the percentage of 'columns' to use for the length of the window
-        title.  When the title is longer, only the end of the path name is
-        shown.  A '<' character before the path name is used to indicate this.
-        Using a percentage makes this adapt to the width of the window.  But
-        it won't work perfectly, because the actual number of characters
-        available also depends on the font used and other things in the title
-        bar.  When 'titlelen' is zero the full path is used.  Otherwise,
-        values from 1 to 30000 percent can be used.
-        'titlelen' is also used for the 'titlestring' option.
+								    *'titlelen'*
+'titlelen'		number (default 85)
+			global
+	Gives the percentage of 'columns' to use for the length of the window
+	title.	When the title is longer, only the end of the path name is
+	shown.	A '<' character before the path name is used to indicate this.
+	Using a percentage makes this adapt to the width of the window.  But
+	it won't work perfectly, because the actual number of characters
+	available also depends on the font used and other things in the title
+	bar.  When 'titlelen' is zero the full path is used.  Otherwise,
+	values from 1 to 30000 percent can be used.
+	'titlelen' is also used for the 'titlestring' option.
 
-                                                                    *'titleold'*
-'titleold'              string (default "")
-                        global
-        If not empty, this option will be used to set the window title when
-        exiting.  Only if 'title' is enabled.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+								    *'titleold'*
+'titleold'		string (default "")
+			global
+	If not empty, this option will be used to set the window title when
+	exiting.  Only if 'title' is enabled.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                                 *'titlestring'*
-'titlestring'           string (default "")
-                        global
-        When this option is not empty, it will be used for the title of the
-        window.  This happens only when the 'title' option is on.
+								 *'titlestring'*
+'titlestring'		string (default "")
+			global
+	When this option is not empty, it will be used for the title of the
+	window.  This happens only when the 'title' option is on.
 
-        When this option contains printf-style '%' items, they will be
-        expanded according to the rules used for 'statusline'.
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	When this option contains printf-style '%' items, they will be
+	expanded according to the rules used for 'statusline'.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-        Example: >vim
-            auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
-            set title titlestring=%<%F%=%l/%L-%P titlelen=70
-<       The value of 'titlelen' is used to align items in the middle or right
-        of the available space.
-        Some people prefer to have the file name first: >vim
-            set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
-<       Note the use of "%{ }" and an expression to get the path of the file,
-        without the file name.  The "%( %)" constructs are used to add a
-        separating space only when needed.
-        NOTE: Use of special characters in 'titlestring' may cause the display
-        to be garbled (e.g., when it contains a CR or NL character).
+	Example: >vim
+	    auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
+	    set title titlestring=%<%F%=%l/%L-%P titlelen=70
+<	The value of 'titlelen' is used to align items in the middle or right
+	of the available space.
+	Some people prefer to have the file name first: >vim
+	    set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
+<	Note the use of "%{ }" and an expression to get the path of the file,
+	without the file name.	The "%( %)" constructs are used to add a
+	separating space only when needed.
+	NOTE: Use of special characters in 'titlestring' may cause the display
+	to be garbled (e.g., when it contains a CR or NL character).
 
-                                                       *'ttimeout'* *'nottimeout'*
-'ttimeout'              boolean (default on)
-                        global
-        This option and 'ttimeoutlen' determine the behavior when part of a
-        key code sequence has been received by the |TUI|.
+						       *'ttimeout'* *'nottimeout'*
+'ttimeout'		boolean (default on)
+			global
+	This option and 'ttimeoutlen' determine the behavior when part of a
+	key code sequence has been received by the |TUI|.
 
-        For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
-        set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
-        complete a key code sequence. If no input arrives before the timeout,
-        a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
+	For example if <Esc> (the \x1b byte) is received and 'ttimeout' is
+	set, Nvim waits 'ttimeoutlen' milliseconds for the terminal to
+	complete a key code sequence. If no input arrives before the timeout,
+	a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
 
-        On very slow systems this may fail, causing cursor keys not to work
-        sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
-        Nvim will wait for the next character to arrive after an <Esc>.
+	On very slow systems this may fail, causing cursor keys not to work
+	sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
+	Nvim will wait for the next character to arrive after an <Esc>.
 
-                                                           *'ttimeoutlen'* *'ttm'*
-'ttimeoutlen' 'ttm'     number (default 50)
-                        global
-        Time in milliseconds to wait for a key code sequence to complete. Also
-        used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
-        been typed.
+							   *'ttimeoutlen'* *'ttm'*
+'ttimeoutlen' 'ttm'	number (default 50)
+			global
+	Time in milliseconds to wait for a key code sequence to complete. Also
+	used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
+	been typed.
 
-                                                        *'undodir'* *'udir'* *E5003*
-'undodir' 'udir'        string (default "$XDG_STATE_HOME/nvim/undo//")
-                        global
-        List of directory names for undo files, separated with commas.
-        See 'backupdir' for details of the format.
-        "." means using the directory of the file.  The undo file name for
-        "file.txt" is ".file.txt.un~".
-        For other directories the file name is the full path of the edited
-        file, with path separators replaced with "%".
-        When writing: The first directory that exists is used.  "." always
-        works, no directories after "." will be used for writing.  If none of
-        the directories exist Nvim will attempt to create the last directory in
-        the list.
-        When reading all entries are tried to find an undo file.  The first
-        undo file that exists is used.  When it cannot be read an error is
-        given, no further entry is used.
-        See |undo-persistence|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							*'undodir'* *'udir'* *E5003*
+'undodir' 'udir'	string (default "$XDG_STATE_HOME/nvim/undo//")
+			global
+	List of directory names for undo files, separated with commas.
+	See 'backupdir' for details of the format.
+	"." means using the directory of the file.  The undo file name for
+	"file.txt" is ".file.txt.un~".
+	For other directories the file name is the full path of the edited
+	file, with path separators replaced with "%".
+	When writing: The first directory that exists is used.	"." always
+	works, no directories after "." will be used for writing.  If none of
+	the directories exist Nvim will attempt to create the last directory in
+	the list.
+	When reading all entries are tried to find an undo file.  The first
+	undo file that exists is used.	When it cannot be read an error is
+	given, no further entry is used.
+	See |undo-persistence|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-        Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
-        though the trailing slashes are present (see 'backupdir' for what this
-        means).
+	Note that unlike 'directory' and 'backupdir', 'undodir' always acts as
+	though the trailing slashes are present (see 'backupdir' for what this
+	means).
 
-                                         *'undofile'* *'udf'* *'noundofile'* *'noudf'*
-'undofile' 'udf'        boolean (default off)
-                        local to buffer
-        When on, Vim automatically saves undo history to an undo file when
-        writing a buffer to a file, and restores undo history from the same
-        file on buffer read.
-        The directory where the undo file is stored is specified by 'undodir'.
-        For more information about this feature see |undo-persistence|.
-        The undo file is not read when 'undoreload' causes the buffer from
-        before a reload to be saved for undo.
-        When 'undofile' is turned off the undo file is NOT deleted.
+					 *'undofile'* *'udf'* *'noundofile'* *'noudf'*
+'undofile' 'udf'	boolean (default off)
+			local to buffer
+	When on, Vim automatically saves undo history to an undo file when
+	writing a buffer to a file, and restores undo history from the same
+	file on buffer read.
+	The directory where the undo file is stored is specified by 'undodir'.
+	For more information about this feature see |undo-persistence|.
+	The undo file is not read when 'undoreload' causes the buffer from
+	before a reload to be saved for undo.
+	When 'undofile' is turned off the undo file is NOT deleted.
 
-                                                             *'undolevels'* *'ul'*
-'undolevels' 'ul'       number (default 1000)
-                        global or local to buffer |global-local|
-        Maximum number of changes that can be undone.  Since undo information
-        is kept in memory, higher numbers will cause more memory to be used.
-        Nevertheless, a single change can already use a large amount of memory.
-        Set to 0 for Vi compatibility: One level of undo and "u" undoes
-        itself: >vim
-                set ul=0
-<       But you can also get Vi compatibility by including the 'u' flag in
-        'cpoptions', and still be able to use CTRL-R to repeat undo.
-        Also see |undo-two-ways|.
-        Set to -1 for no undo at all.  You might want to do this only for the
-        current buffer: >vim
-                setlocal ul=-1
-<       This helps when you run out of memory for a single change.
+							     *'undolevels'* *'ul'*
+'undolevels' 'ul'	number (default 1000)
+			global or local to buffer |global-local|
+	Maximum number of changes that can be undone.  Since undo information
+	is kept in memory, higher numbers will cause more memory to be used.
+	Nevertheless, a single change can already use a large amount of memory.
+	Set to 0 for Vi compatibility: One level of undo and "u" undoes
+	itself: >vim
+		set ul=0
+<	But you can also get Vi compatibility by including the 'u' flag in
+	'cpoptions', and still be able to use CTRL-R to repeat undo.
+	Also see |undo-two-ways|.
+	Set to -1 for no undo at all.  You might want to do this only for the
+	current buffer: >vim
+		setlocal ul=-1
+<	This helps when you run out of memory for a single change.
 
-        The local value is set to -123456 when the global value is to be used.
+	The local value is set to -123456 when the global value is to be used.
 
-        Also see |clear-undo|.
+	Also see |clear-undo|.
 
-                                                             *'undoreload'* *'ur'*
-'undoreload' 'ur'       number (default 10000)
-                        global
-        Save the whole buffer for undo when reloading it.  This applies to the
-        ":e!" command and reloading for when the buffer changed outside of
-        Vim. |FileChangedShell|
-        The save only happens when this option is negative or when the number
-        of lines is smaller than the value of this option.
-        Set this option to zero to disable undo for a reload.
+							     *'undoreload'* *'ur'*
+'undoreload' 'ur'	number (default 10000)
+			global
+	Save the whole buffer for undo when reloading it.  This applies to the
+	":e!" command and reloading for when the buffer changed outside of
+	Vim. |FileChangedShell|
+	The save only happens when this option is negative or when the number
+	of lines is smaller than the value of this option.
+	Set this option to zero to disable undo for a reload.
 
-        When saving undo for a reload, any undo file is not read.
+	When saving undo for a reload, any undo file is not read.
 
-        Note that this causes the whole buffer to be stored in memory.  Set
-        this option to a lower value if you run out of memory.
+	Note that this causes the whole buffer to be stored in memory.	Set
+	this option to a lower value if you run out of memory.
 
-                                                            *'updatecount'* *'uc'*
-'updatecount' 'uc'      number (default 200)
-                        global
-        After typing this many characters the swap file will be written to
-        disk.  When zero, no swap file will be created at all (see chapter on
-        recovery |crash-recovery|).  'updatecount' is set to zero by starting
-        Vim with the "-n" option, see |startup|.  When editing in readonly
-        mode this option will be initialized to 10000.
-        The swapfile can be disabled per buffer with |'swapfile'|.
-        When 'updatecount' is set from zero to non-zero, swap files are
-        created for all buffers that have 'swapfile' set.  When 'updatecount'
-        is set to zero, existing swap files are not deleted.
-        This option has no meaning in buffers where |'buftype'| is "nofile"
-        or "nowrite".
+							    *'updatecount'* *'uc'*
+'updatecount' 'uc'	number (default 200)
+			global
+	After typing this many characters the swap file will be written to
+	disk.  When zero, no swap file will be created at all (see chapter on
+	recovery |crash-recovery|).  'updatecount' is set to zero by starting
+	Vim with the "-n" option, see |startup|.  When editing in readonly
+	mode this option will be initialized to 10000.
+	The swapfile can be disabled per buffer with |'swapfile'|.
+	When 'updatecount' is set from zero to non-zero, swap files are
+	created for all buffers that have 'swapfile' set.  When 'updatecount'
+	is set to zero, existing swap files are not deleted.
+	This option has no meaning in buffers where |'buftype'| is "nofile"
+	or "nowrite".
 
-                                                             *'updatetime'* *'ut'*
-'updatetime' 'ut'       number (default 4000)
-                        global
-        If this many milliseconds nothing is typed the swap file will be
-        written to disk (see |crash-recovery|).  Also used for the
-        |CursorHold| autocommand event.
+							     *'updatetime'* *'ut'*
+'updatetime' 'ut'	number (default 4000)
+			global
+	If this many milliseconds nothing is typed the swap file will be
+	written to disk (see |crash-recovery|).  Also used for the
+	|CursorHold| autocommand event.
 
-                                                       *'varsofttabstop'* *'vsts'*
+						       *'varsofttabstop'* *'vsts'*
 'varsofttabstop' 'vsts' string (default "")
-                        local to buffer
-        A list of the number of spaces that a <Tab> counts for while editing,
-        such as inserting a <Tab> or using <BS>.  It "feels" like variable-
-        width <Tab>s are being inserted, while in fact a mixture of spaces
-        and <Tab>s is used.  Tab widths are separated with commas, with the
-        final value applying to all subsequent tabs.
+			local to buffer
+	A list of the number of spaces that a <Tab> counts for while editing,
+	such as inserting a <Tab> or using <BS>.  It "feels" like variable-
+	width <Tab>s are being inserted, while in fact a mixture of spaces
+	and <Tab>s is used.  Tab widths are separated with commas, with the
+	final value applying to all subsequent tabs.
 
-        For example, when editing assembly language files where statements
-        start in the 9th column and comments in the 41st, it may be useful
-        to use the following: >vim
-                set varsofttabstop=8,32,8
-<       This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
-        for every column thereafter.
+	For example, when editing assembly language files where statements
+	start in the 9th column and comments in the 41st, it may be useful
+	to use the following: >vim
+		set varsofttabstop=8,32,8
+<	This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
+	for every column thereafter.
 
-        Note that the value of |'softtabstop'| will be ignored while
-        'varsofttabstop' is set.
+	Note that the value of |'softtabstop'| will be ignored while
+	'varsofttabstop' is set.
 
-                                                            *'vartabstop'* *'vts'*
-'vartabstop' 'vts'      string (default "")
-                        local to buffer
-        A list of the number of spaces that a <Tab> in the file counts for,
-        separated by commas.  Each value corresponds to one tab, with the
-        final value applying to all subsequent tabs. For example: >vim
-                set vartabstop=4,20,10,8
-<       This will make the first tab 4 spaces wide, the second 20 spaces,
-        the third 10 spaces, and all following tabs 8 spaces.
+							    *'vartabstop'* *'vts'*
+'vartabstop' 'vts'	string (default "")
+			local to buffer
+	A list of the number of spaces that a <Tab> in the file counts for,
+	separated by commas.  Each value corresponds to one tab, with the
+	final value applying to all subsequent tabs. For example: >vim
+		set vartabstop=4,20,10,8
+<	This will make the first tab 4 spaces wide, the second 20 spaces,
+	the third 10 spaces, and all following tabs 8 spaces.
 
-        Note that the value of |'tabstop'| will be ignored while 'vartabstop'
-        is set.
+	Note that the value of |'tabstop'| will be ignored while 'vartabstop'
+	is set.
 
-                                                               *'verbose'* *'vbs'*
-'verbose' 'vbs'         number (default 0)
-                        global
-        Sets the verbosity level.  Also set by |-V| and |:verbose|.
+							       *'verbose'* *'vbs'*
+'verbose' 'vbs'		number (default 0)
+			global
+	Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
-        Tracing of options in Lua scripts is activated at level 1; Lua scripts
-        are not traced with verbose=0, for performance.
+	Tracing of options in Lua scripts is activated at level 1; Lua scripts
+	are not traced with verbose=0, for performance.
 
-        If greater than or equal to a given level, Nvim produces the following
-        messages:
+	If greater than or equal to a given level, Nvim produces the following
+	messages:
 
-        Level   Messages ~
-        ----------------------------------------------------------------------
-        1       Lua assignments to options, mappings, etc.
-        2       When a file is ":source"'ed, or |shada| file is read or written.
-        3       UI info, terminal capabilities.
-        4       Shell commands.
-        5       Every searched tags file and include file.
-        8       Files for which a group of autocommands is executed.
-        9       Executed autocommands.
-        11      Finding items in a path.
-        12      Vimscript function calls.
-        13      When an exception is thrown, caught, finished, or discarded.
-        14      Anything pending in a ":finally" clause.
-        15      Ex commands from a script (truncated at 200 characters).
-        16      Ex commands.
+	Level	Messages ~
+	----------------------------------------------------------------------
+	1	Lua assignments to options, mappings, etc.
+	2	When a file is ":source"'ed, or |shada| file is read or written.
+	3	UI info, terminal capabilities.
+	4	Shell commands.
+	5	Every searched tags file and include file.
+	8	Files for which a group of autocommands is executed.
+	9	Executed autocommands.
+	11	Finding items in a path.
+	12	Vimscript function calls.
+	13	When an exception is thrown, caught, finished, or discarded.
+	14	Anything pending in a ":finally" clause.
+	15	Ex commands from a script (truncated at 200 characters).
+	16	Ex commands.
 
-        If 'verbosefile' is set then the verbose messages are not displayed.
+	If 'verbosefile' is set then the verbose messages are not displayed.
 
-                                                         *'verbosefile'* *'vfile'*
-'verbosefile' 'vfile'   string (default "")
-                        global
-        When not empty all messages are written in a file with this name.
-        When the file exists messages are appended.
-        Writing to the file ends when Vim exits or when 'verbosefile' is made
-        empty.  Writes are buffered, thus may not show up for some time.
-        Setting 'verbosefile' to a new value is like making it empty first.
-        The difference with |:redir| is that verbose messages are not
-        displayed when 'verbosefile' is set.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							 *'verbosefile'* *'vfile'*
+'verbosefile' 'vfile'	string (default "")
+			global
+	When not empty all messages are written in a file with this name.
+	When the file exists messages are appended.
+	Writing to the file ends when Vim exits or when 'verbosefile' is made
+	empty.	Writes are buffered, thus may not show up for some time.
+	Setting 'verbosefile' to a new value is like making it empty first.
+	The difference with |:redir| is that verbose messages are not
+	displayed when 'verbosefile' is set.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                              *'viewdir'* *'vdir'*
-'viewdir' 'vdir'        string (default "$XDG_STATE_HOME/nvim/view//")
-                        global
-        Name of the directory where to store files for |:mkview|.
-        This option cannot be set from a |modeline| or in the |sandbox|, for
-        security reasons.
+							      *'viewdir'* *'vdir'*
+'viewdir' 'vdir'	string (default "$XDG_STATE_HOME/nvim/view//")
+			global
+	Name of the directory where to store files for |:mkview|.
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
 
-                                                           *'viewoptions'* *'vop'*
-'viewoptions' 'vop'     string (default "folds,cursor,curdir")
-                        global
-        Changes the effect of the |:mkview| command.  It is a comma-separated
-        list of words.  Each word enables saving and restoring something:
-           word         save and restore ~
-           cursor       cursor position in file and in window
-           curdir       local current directory, if set with |:lcd|
-           folds        manually created folds, opened/closed folds and local
-                        fold options
-           options      options and mappings local to a window or buffer (not
-                        global values for local options)
-           localoptions same as "options"
-           slash        |deprecated| Always enabled. Uses "/" in filenames.
-           unix         |deprecated| Always enabled. Uses "\n" line endings.
+							   *'viewoptions'* *'vop'*
+'viewoptions' 'vop'	string (default "folds,cursor,curdir")
+			global
+	Changes the effect of the |:mkview| command.  It is a comma-separated
+	list of words.	Each word enables saving and restoring something:
+	   word		save and restore ~
+	   cursor	cursor position in file and in window
+	   curdir	local current directory, if set with |:lcd|
+	   folds	manually created folds, opened/closed folds and local
+			fold options
+	   options	options and mappings local to a window or buffer (not
+			global values for local options)
+	   localoptions same as "options"
+	   slash	|deprecated| Always enabled. Uses "/" in filenames.
+	   unix		|deprecated| Always enabled. Uses "\n" line endings.
 
-                                                            *'virtualedit'* *'ve'*
-'virtualedit' 've'      string (default "")
-                        global or local to window |global-local|
-        A comma-separated list of these words:
-            block       Allow virtual editing in Visual block mode.
-            insert      Allow virtual editing in Insert mode.
-            all         Allow virtual editing in all modes.
-            onemore     Allow the cursor to move just past the end of the line
-            none        When used as the local value, do not allow virtual
-                        editing even when the global value is set.  When used
-                        as the global value, "none" is the same as "".
-            NONE        Alternative spelling of "none".
+							    *'virtualedit'* *'ve'*
+'virtualedit' 've'	string (default "")
+			global or local to window |global-local|
+	A comma-separated list of these words:
+	    block	Allow virtual editing in Visual block mode.
+	    insert	Allow virtual editing in Insert mode.
+	    all		Allow virtual editing in all modes.
+	    onemore	Allow the cursor to move just past the end of the line
+	    none	When used as the local value, do not allow virtual
+			editing even when the global value is set.  When used
+			as the global value, "none" is the same as "".
+	    NONE	Alternative spelling of "none".
 
-        Virtual editing means that the cursor can be positioned where there is
-        no actual character.  This can be halfway into a tab or beyond the end
-        of the line.  Useful for selecting a rectangle in Visual mode and
-        editing a table.
-        "onemore" is not the same, it will only allow moving the cursor just
-        after the last character of the line.  This makes some commands more
-        consistent.  Previously the cursor was always past the end of the line
-        if the line was empty.  But it is far from Vi compatible.  It may also
-        break some plugins or Vim scripts.  For example because |l| can move
-        the cursor after the last character.  Use with care!
-        Using the `$` command will move to the last character in the line, not
-        past it.  This may actually move the cursor to the left!
-        The `g$` command will move to the end of the screen line.
-        It doesn't make sense to combine "all" with "onemore", but you will
-        not get a warning for it.
-        When combined with other words, "none" is ignored.
+	Virtual editing means that the cursor can be positioned where there is
+	no actual character.  This can be halfway into a tab or beyond the end
+	of the line.  Useful for selecting a rectangle in Visual mode and
+	editing a table.
+	"onemore" is not the same, it will only allow moving the cursor just
+	after the last character of the line.  This makes some commands more
+	consistent.  Previously the cursor was always past the end of the line
+	if the line was empty.	But it is far from Vi compatible.  It may also
+	break some plugins or Vim scripts.  For example because |l| can move
+	the cursor after the last character.  Use with care!
+	Using the `$` command will move to the last character in the line, not
+	past it.  This may actually move the cursor to the left!
+	The `g$` command will move to the end of the screen line.
+	It doesn't make sense to combine "all" with "onemore", but you will
+	not get a warning for it.
+	When combined with other words, "none" is ignored.
 
-                                       *'visualbell'* *'vb'* *'novisualbell'* *'novb'*
-'visualbell' 'vb'       boolean (default off)
-                        global
-        Use visual bell instead of beeping.  Also see 'errorbells'.
+				       *'visualbell'* *'vb'* *'novisualbell'* *'novb'*
+'visualbell' 'vb'	boolean (default off)
+			global
+	Use visual bell instead of beeping.  Also see 'errorbells'.
 
-                                                               *'warn'* *'nowarn'*
-'warn'                  boolean (default on)
-                        global
-        Give a warning message when a shell command is used while the buffer
-        has been changed.
+							       *'warn'* *'nowarn'*
+'warn'			boolean (default on)
+			global
+	Give a warning message when a shell command is used while the buffer
+	has been changed.
 
-                                                              *'whichwrap'* *'ww'*
-'whichwrap' 'ww'        string (default "b,s")
-                        global
-        Allow specified keys that move the cursor left/right to move to the
-        previous/next line when the cursor is on the first/last character in
-        the line.  Concatenate characters to allow this for these keys:
-                char   key        mode  ~
-                 b    <BS>       Normal and Visual
-                 s    <Space>    Normal and Visual
-                 h    "h"        Normal and Visual (not recommended)
-                 l    "l"        Normal and Visual (not recommended)
-                 <    <Left>     Normal and Visual
-                 >    <Right>    Normal and Visual
-                 ~    "~"        Normal
-                 [    <Left>     Insert and Replace
-                 ]    <Right>    Insert and Replace
-        For example: >vim
-                set ww=<,>,[,]
-<       allows wrap only when cursor keys are used.
-        When the movement keys are used in combination with a delete or change
-        operator, the <EOL> also counts for a character.  This makes "3h"
-        different from "3dh" when the cursor crosses the end of a line.  This
-        is also true for "x" and "X", because they do the same as "dl" and
-        "dh".  If you use this, you may also want to use the mapping
-        ":map <BS> X" to make backspace delete the character in front of the
-        cursor.
-        When 'l' is included and it is used after an operator at the end of a
-        line (not an empty line) then it will not move to the next line.  This
-        makes "dl", "cl", "yl" etc. work normally.
+							      *'whichwrap'* *'ww'*
+'whichwrap' 'ww'	string (default "b,s")
+			global
+	Allow specified keys that move the cursor left/right to move to the
+	previous/next line when the cursor is on the first/last character in
+	the line.  Concatenate characters to allow this for these keys:
+		char   key	  mode	~
+		 b    <BS>	 Normal and Visual
+		 s    <Space>	 Normal and Visual
+		 h    "h"	 Normal and Visual (not recommended)
+		 l    "l"	 Normal and Visual (not recommended)
+		 <    <Left>	 Normal and Visual
+		 >    <Right>	 Normal and Visual
+		 ~    "~"	 Normal
+		 [    <Left>	 Insert and Replace
+		 ]    <Right>	 Insert and Replace
+	For example: >vim
+		set ww=<,>,[,]
+<	allows wrap only when cursor keys are used.
+	When the movement keys are used in combination with a delete or change
+	operator, the <EOL> also counts for a character.  This makes "3h"
+	different from "3dh" when the cursor crosses the end of a line.  This
+	is also true for "x" and "X", because they do the same as "dl" and
+	"dh".  If you use this, you may also want to use the mapping
+	":map <BS> X" to make backspace delete the character in front of the
+	cursor.
+	When 'l' is included and it is used after an operator at the end of a
+	line (not an empty line) then it will not move to the next line.  This
+	makes "dl", "cl", "yl" etc. work normally.
 
-                                                               *'wildchar'* *'wc'*
-'wildchar' 'wc'         number (default <Tab>)
-                        global
-        Character you have to type to start wildcard expansion in the
-        command-line, as specified with 'wildmode'.
-        More info here: |cmdline-completion|.
-        The character is not recognized when used inside a macro.  See
-        'wildcharm' for that.
-        Some keys will not work, such as CTRL-C, <CR> and Enter.
-        <Esc> can be used, but hitting it twice in a row will still exit
-        command-line as a failsafe measure.
-        Although 'wc' is a number option, you can set it to a special key: >vim
-                set wc=<Tab>
+							       *'wildchar'* *'wc'*
+'wildchar' 'wc'		number (default <Tab>)
+			global
+	Character you have to type to start wildcard expansion in the
+	command-line, as specified with 'wildmode'.
+	More info here: |cmdline-completion|.
+	The character is not recognized when used inside a macro.  See
+	'wildcharm' for that.
+	Some keys will not work, such as CTRL-C, <CR> and Enter.
+	<Esc> can be used, but hitting it twice in a row will still exit
+	command-line as a failsafe measure.
+	Although 'wc' is a number option, you can set it to a special key: >vim
+		set wc=<Tab>
 <
 
-                                                             *'wildcharm'* *'wcm'*
-'wildcharm' 'wcm'       number (default 0)
-                        global
-        'wildcharm' works exactly like 'wildchar', except that it is
-        recognized when used inside a macro.  You can find "spare" command-line
-        keys suitable for this option by looking at |ex-edit-index|.  Normally
-        you'll never actually type 'wildcharm', just use it in mappings that
-        automatically invoke completion mode, e.g.: >vim
-                set wcm=<C-Z>
-                cnoremap ss so $vim/sessions/*.vim<C-Z>
-<       Then after typing :ss you can use CTRL-P & CTRL-N.
+							     *'wildcharm'* *'wcm'*
+'wildcharm' 'wcm'	number (default 0)
+			global
+	'wildcharm' works exactly like 'wildchar', except that it is
+	recognized when used inside a macro.  You can find "spare" command-line
+	keys suitable for this option by looking at |ex-edit-index|.  Normally
+	you'll never actually type 'wildcharm', just use it in mappings that
+	automatically invoke completion mode, e.g.: >vim
+		set wcm=<C-Z>
+		cnoremap ss so $vim/sessions/*.vim<C-Z>
+<	Then after typing :ss you can use CTRL-P & CTRL-N.
 
-                                                            *'wildignore'* *'wig'*
-'wildignore' 'wig'      string (default "")
-                        global
-        A list of file patterns.  A file that matches with one of these
-        patterns is ignored when expanding |wildcards|, completing file or
-        directory names, and influences the result of |expand()|, |glob()| and
-        |globpath()| unless a flag is passed to disable this.
-        The pattern is used like with |:autocmd|, see |autocmd-pattern|.
-        Also see 'suffixes'.
-        Example: >vim
-                set wildignore=*.o,*.obj
-<       The use of |:set+=| and |:set-=| is preferred when adding or removing
-        a pattern from the list.  This avoids problems when a future version
-        uses another default.
+							    *'wildignore'* *'wig'*
+'wildignore' 'wig'	string (default "")
+			global
+	A list of file patterns.  A file that matches with one of these
+	patterns is ignored when expanding |wildcards|, completing file or
+	directory names, and influences the result of |expand()|, |glob()| and
+	|globpath()| unless a flag is passed to disable this.
+	The pattern is used like with |:autocmd|, see |autocmd-pattern|.
+	Also see 'suffixes'.
+	Example: >vim
+		set wildignore=*.o,*.obj
+<	The use of |:set+=| and |:set-=| is preferred when adding or removing
+	a pattern from the list.  This avoids problems when a future version
+	uses another default.
 
-                             *'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
-'wildignorecase' 'wic'  boolean (default off)
-                        global
-        When set case is ignored when completing file names and directories.
-        Has no effect when 'fileignorecase' is set.
-        Does not apply when the shell is used to expand wildcards, which
-        happens when there are special characters.
+			     *'wildignorecase'* *'wic'* *'nowildignorecase'* *'nowic'*
+'wildignorecase' 'wic'	boolean (default off)
+			global
+	When set case is ignored when completing file names and directories.
+	Has no effect when 'fileignorecase' is set.
+	Does not apply when the shell is used to expand wildcards, which
+	happens when there are special characters.
 
-                                       *'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
-'wildmenu' 'wmnu'       boolean (default on)
-                        global
-        When 'wildmenu' is on, command-line completion operates in an enhanced
-        mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
-        the possible matches are shown.
-        When 'wildoptions' contains "pum", then the completion matches are
-        shown in a popup menu.  Otherwise they are displayed just above the
-        command line, with the first match highlighted (overwriting the status
-        line, if there is one).
-        Keys that show the previous/next match, such as <Tab> or
-        CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
-        'wildmode' must specify "full": "longest" and "list" do not start
-        'wildmenu' mode. You can check the current mode with |wildmenumode()|.
-        The menu is cancelled when a key is hit that is not used for selecting
-        a completion.
+				       *'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
+'wildmenu' 'wmnu'	boolean (default on)
+			global
+	When 'wildmenu' is on, command-line completion operates in an enhanced
+	mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
+	the possible matches are shown.
+	When 'wildoptions' contains "pum", then the completion matches are
+	shown in a popup menu.	Otherwise they are displayed just above the
+	command line, with the first match highlighted (overwriting the status
+	line, if there is one).
+	Keys that show the previous/next match, such as <Tab> or
+	CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
+	'wildmode' must specify "full": "longest" and "list" do not start
+	'wildmenu' mode. You can check the current mode with |wildmenumode()|.
+	The menu is cancelled when a key is hit that is not used for selecting
+	a completion.
 
-        While the menu is active these keys have special meanings:
-        CTRL-P          - go to the previous entry
-        CTRL-N          - go to the next entry
-        <Left> <Right>  - select previous/next match (like CTRL-P/CTRL-N)
-        <PageUp>        - select a match several entries back
-        <PageDown>      - select a match several entries further
-        <Up>            - in filename/menu name completion: move up into
-                          parent directory or parent menu.
-        <Down>          - in filename/menu name completion: move into a
-                          subdirectory or submenu.
-        <CR>            - in menu completion, when the cursor is just after a
-                          dot: move into a submenu.
-        CTRL-E          - end completion, go back to what was there before
-                          selecting a match.
-        CTRL-Y          - accept the currently selected match and stop
-                          completion.
+	While the menu is active these keys have special meanings:
+	CTRL-P		- go to the previous entry
+	CTRL-N		- go to the next entry
+	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
+	<PageUp>	- select a match several entries back
+	<PageDown>	- select a match several entries further
+	<Up>		- in filename/menu name completion: move up into
+			  parent directory or parent menu.
+	<Down>		- in filename/menu name completion: move into a
+			  subdirectory or submenu.
+	<CR>		- in menu completion, when the cursor is just after a
+			  dot: move into a submenu.
+	CTRL-E		- end completion, go back to what was there before
+			  selecting a match.
+	CTRL-Y		- accept the currently selected match and stop
+			  completion.
 
-        If you want <Left> and <Right> to move the cursor instead of selecting
-        a different match, use this: >vim
-                cnoremap <Left> <Space><BS><Left>
-                cnoremap <Right> <Space><BS><Right>
+	If you want <Left> and <Right> to move the cursor instead of selecting
+	a different match, use this: >vim
+		cnoremap <Left> <Space><BS><Left>
+		cnoremap <Right> <Space><BS><Right>
 <
-        |hl-WildMenu| highlights the current match.
+	|hl-WildMenu| highlights the current match.
 
-                                                              *'wildmode'* *'wim'*
-'wildmode' 'wim'        string (default "full")
-                        global
-        Completion mode that is used for the character specified with
-        'wildchar'.  It is a comma-separated list of up to four parts.  Each
-        part specifies what to do for each consecutive use of 'wildchar'.  The
-        first part specifies the behavior for the first use of 'wildchar',
-        The second part for the second use, etc.
+							      *'wildmode'* *'wim'*
+'wildmode' 'wim'	string (default "full")
+			global
+	Completion mode that is used for the character specified with
+	'wildchar'.  It is a comma-separated list of up to four parts.	Each
+	part specifies what to do for each consecutive use of 'wildchar'.  The
+	first part specifies the behavior for the first use of 'wildchar',
+	The second part for the second use, etc.
 
-        Each part consists of a colon separated list consisting of the
-        following possible values:
-        ""              Complete only the first match.
-        "full"          Complete the next full match.  After the last match,
-                        the original string is used and then the first match
-                        again.  Will also start 'wildmenu' if it is enabled.
-        "longest"       Complete till longest common string.  If this doesn't
-                        result in a longer string, use the next part.
-        "list"          When more than one match, list all matches.
-        "lastused"      When completing buffer names and more than one buffer
-                        matches, sort buffers by time last used (other than
-                        the current buffer).
-        When there is only a single match, it is fully completed in all cases.
+	Each part consists of a colon separated list consisting of the
+	following possible values:
+	""		Complete only the first match.
+	"full"		Complete the next full match.  After the last match,
+			the original string is used and then the first match
+			again.	Will also start 'wildmenu' if it is enabled.
+	"longest"	Complete till longest common string.  If this doesn't
+			result in a longer string, use the next part.
+	"list"		When more than one match, list all matches.
+	"lastused"	When completing buffer names and more than one buffer
+			matches, sort buffers by time last used (other than
+			the current buffer).
+	When there is only a single match, it is fully completed in all cases.
 
-        Examples of useful colon-separated values:
-        "longest:full"  Like "longest", but also start 'wildmenu' if it is
-                        enabled.  Will not complete to the next full match.
-        "list:full"     When more than one match, list all matches and
-                        complete first match.
-        "list:longest"  When more than one match, list all matches and
-                        complete till longest common string.
-        "list:lastused" When more than one buffer matches, list all matches
-                        and sort buffers by time last used (other than the
-                        current buffer).
+	Examples of useful colon-separated values:
+	"longest:full"	Like "longest", but also start 'wildmenu' if it is
+			enabled.  Will not complete to the next full match.
+	"list:full"	When more than one match, list all matches and
+			complete first match.
+	"list:longest"	When more than one match, list all matches and
+			complete till longest common string.
+	"list:lastused" When more than one buffer matches, list all matches
+			and sort buffers by time last used (other than the
+			current buffer).
 
-        Examples: >vim
-                set wildmode=full
-<       Complete first full match, next match, etc.  (the default) >vim
-                set wildmode=longest,full
-<       Complete longest common string, then each full match >vim
-                set wildmode=list:full
-<       List all matches and complete each full match >vim
-                set wildmode=list,full
-<       List all matches without completing, then each full match >vim
-                set wildmode=longest,list
-<       Complete longest common string, then list alternatives.
-        More info here: |cmdline-completion|.
+	Examples: >vim
+		set wildmode=full
+<	Complete first full match, next match, etc.  (the default) >vim
+		set wildmode=longest,full
+<	Complete longest common string, then each full match >vim
+		set wildmode=list:full
+<	List all matches and complete each full match >vim
+		set wildmode=list,full
+<	List all matches without completing, then each full match >vim
+		set wildmode=longest,list
+<	Complete longest common string, then list alternatives.
+	More info here: |cmdline-completion|.
 
-                                                           *'wildoptions'* *'wop'*
-'wildoptions' 'wop'     string (default "pum,tagfile")
-                        global
-        A list of words that change how |cmdline-completion| is done.
-        The following values are supported:
-          fuzzy         Use |fuzzy-matching| to find completion matches. When
-                        this value is specified, wildcard expansion will not
-                        be used for completion.  The matches will be sorted by
-                        the "best match" rather than alphabetically sorted.
-                        This will find more matches than the wildcard
-                        expansion. Currently fuzzy matching based completion
-                        is not supported for file and directory names and
-                        instead wildcard expansion is used.
-          pum           Display the completion matches using the popup menu
-                        in the same style as the |ins-completion-menu|.
-          tagfile       When using CTRL-D to list matching tags, the kind of
-                        tag and the file of the tag is listed.  Only one match
-                        is displayed per line.  Often used tag kinds are:
-                                d       #define
-                                f       function
+							   *'wildoptions'* *'wop'*
+'wildoptions' 'wop'	string (default "pum,tagfile")
+			global
+	A list of words that change how |cmdline-completion| is done.
+	The following values are supported:
+	  fuzzy		Use |fuzzy-matching| to find completion matches. When
+			this value is specified, wildcard expansion will not
+			be used for completion.  The matches will be sorted by
+			the "best match" rather than alphabetically sorted.
+			This will find more matches than the wildcard
+			expansion. Currently fuzzy matching based completion
+			is not supported for file and directory names and
+			instead wildcard expansion is used.
+	  pum		Display the completion matches using the popup menu
+			in the same style as the |ins-completion-menu|.
+	  tagfile	When using CTRL-D to list matching tags, the kind of
+			tag and the file of the tag is listed.	Only one match
+			is displayed per line.	Often used tag kinds are:
+				d	#define
+				f	function
 
-                                                            *'winaltkeys'* *'wak'*
-'winaltkeys' 'wak'      string (default "menu")
-                        global
-        only used in Win32
-        Some GUI versions allow the access to menu entries by using the ALT
-        key in combination with a character that appears underlined in the
-        menu.  This conflicts with the use of the ALT key for mappings and
-        entering special characters.  This option tells what to do:
-        no    Don't use ALT keys for menus.  ALT key combinations can be
-        mapped, but there is no automatic handling.
-        yes   ALT key handling is done by the windowing system.  ALT key
-        combinations cannot be mapped.
-        menu  Using ALT in combination with a character that is a menu
-        shortcut key, will be handled by the windowing system.  Other
-        keys can be mapped.
-        If the menu is disabled by excluding 'm' from 'guioptions', the ALT
-        key is never used for the menu.
-        This option is not used for <F10>; on Win32.
+							    *'winaltkeys'* *'wak'*
+'winaltkeys' 'wak'	string (default "menu")
+			global
+	only used in Win32
+	Some GUI versions allow the access to menu entries by using the ALT
+	key in combination with a character that appears underlined in the
+	menu.  This conflicts with the use of the ALT key for mappings and
+	entering special characters.  This option tells what to do:
+	no    Don't use ALT keys for menus.  ALT key combinations can be
+	mapped, but there is no automatic handling.
+	yes   ALT key handling is done by the windowing system.  ALT key
+	combinations cannot be mapped.
+	menu  Using ALT in combination with a character that is a menu
+	shortcut key, will be handled by the windowing system.	Other
+	keys can be mapped.
+	If the menu is disabled by excluding 'm' from 'guioptions', the ALT
+	key is never used for the menu.
+	This option is not used for <F10>; on Win32.
 
-                                                                *'winbar'* *'wbr'*
-'winbar' 'wbr'          string (default "")
-                        global or local to window |global-local|
-        When non-empty, this option enables the window bar and determines its
-        contents. The window bar is a bar that's shown at the top of every
-        window with it enabled. The value of 'winbar' is evaluated like with
-        'statusline'.
+								*'winbar'* *'wbr'*
+'winbar' 'wbr'		string (default "")
+			global or local to window |global-local|
+	When non-empty, this option enables the window bar and determines its
+	contents. The window bar is a bar that's shown at the top of every
+	window with it enabled. The value of 'winbar' is evaluated like with
+	'statusline'.
 
-        When changing something that is used in 'winbar' that does not trigger
-        it to be updated, use |:redrawstatus|.
+	When changing something that is used in 'winbar' that does not trigger
+	it to be updated, use |:redrawstatus|.
 
-        Floating windows do not use the global value of 'winbar'. The
-        window-local value of 'winbar' must be set for a floating window to
-        have a window bar.
+	Floating windows do not use the global value of 'winbar'. The
+	window-local value of 'winbar' must be set for a floating window to
+	have a window bar.
 
-        This option cannot be set in a modeline when 'modelineexpr' is off.
+	This option cannot be set in a modeline when 'modelineexpr' is off.
 
-                                                            *'winblend'* *'winbl'*
-'winblend' 'winbl'      number (default 0)
-                        local to window
-        Enables pseudo-transparency for a floating window. Valid values are in
-        the range of 0 for fully opaque window (disabled) to 100 for fully
-        transparent background. Values between 0-30 are typically most useful.
+							    *'winblend'* *'winbl'*
+'winblend' 'winbl'	number (default 0)
+			local to window
+	Enables pseudo-transparency for a floating window. Valid values are in
+	the range of 0 for fully opaque window (disabled) to 100 for fully
+	transparent background. Values between 0-30 are typically most useful.
 
-        UI-dependent. Works best with RGB colors. 'termguicolors'
+	UI-dependent. Works best with RGB colors. 'termguicolors'
 
-                                                                 *'window'* *'wi'*
-'window' 'wi'           number (default screen height - 1)
-                        global
-        Window height used for |CTRL-F| and |CTRL-B| when there is only one
-        window and the value is smaller than 'lines' minus one.  The screen
-        will scroll 'window' minus two lines, with a minimum of one.
-        When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
-        in a much smarter way, taking care of wrapping lines.
-        When resizing the Vim window, the value is smaller than 1 or more than
-        or equal to 'lines' it will be set to 'lines' minus 1.
-        Note: Do not confuse this with the height of the Vim window, use
-        'lines' for that.
+								 *'window'* *'wi'*
+'window' 'wi'		number (default screen height - 1)
+			global
+	Window height used for |CTRL-F| and |CTRL-B| when there is only one
+	window and the value is smaller than 'lines' minus one.  The screen
+	will scroll 'window' minus two lines, with a minimum of one.
+	When 'window' is equal to 'lines' minus one CTRL-F and CTRL-B scroll
+	in a much smarter way, taking care of wrapping lines.
+	When resizing the Vim window, the value is smaller than 1 or more than
+	or equal to 'lines' it will be set to 'lines' minus 1.
+	Note: Do not confuse this with the height of the Vim window, use
+	'lines' for that.
 
-                                 *'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
-'winfixheight' 'wfh'    boolean (default off)
-                        local to window  |local-noglobal|
-        Keep the window height when windows are opened or closed and
-        'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
-        |preview-window| and |quickfix-window|.
-        The height may be changed anyway when running out of room.
+				 *'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
+'winfixheight' 'wfh'	boolean (default off)
+			local to window  |local-noglobal|
+	Keep the window height when windows are opened or closed and
+	'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
+	|preview-window| and |quickfix-window|.
+	The height may be changed anyway when running out of room.
 
-                                   *'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
-'winfixwidth' 'wfw'     boolean (default off)
-                        local to window  |local-noglobal|
-        Keep the window width when windows are opened or closed and
-        'equalalways' is set.  Also for |CTRL-W_=|.
-        The width may be changed anyway when running out of room.
+				   *'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
+'winfixwidth' 'wfw'	boolean (default off)
+			local to window  |local-noglobal|
+	Keep the window width when windows are opened or closed and
+	'equalalways' is set.  Also for |CTRL-W_=|.
+	The width may be changed anyway when running out of room.
 
-                                                         *'winheight'* *'wh'* *E591*
-'winheight' 'wh'        number (default 1)
-                        global
-        Minimal number of lines for the current window.  This is not a hard
-        minimum, Vim will use fewer lines if there is not enough room.  If the
-        focus goes to a window that is smaller, its size is increased, at the
-        cost of the height of other windows.
-        Set 'winheight' to a small number for normal editing.
-        Set it to 999 to make the current window fill most of the screen.
-        Other windows will be only 'winminheight' high.  This has the drawback
-        that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
-        to create only two windows, set the option after startup is done,
-        using the |VimEnter| event: >vim
-                au VimEnter * set winheight=999
-<       Minimum value is 1.
-        The height is not adjusted after one of the commands that change the
-        height of the current window.
-        'winheight' applies to the current window.  Use 'winminheight' to set
-        the minimal height for other windows.
+							 *'winheight'* *'wh'* *E591*
+'winheight' 'wh'	number (default 1)
+			global
+	Minimal number of lines for the current window.  This is not a hard
+	minimum, Vim will use fewer lines if there is not enough room.	If the
+	focus goes to a window that is smaller, its size is increased, at the
+	cost of the height of other windows.
+	Set 'winheight' to a small number for normal editing.
+	Set it to 999 to make the current window fill most of the screen.
+	Other windows will be only 'winminheight' high.  This has the drawback
+	that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
+	to create only two windows, set the option after startup is done,
+	using the |VimEnter| event: >vim
+		au VimEnter * set winheight=999
+<	Minimum value is 1.
+	The height is not adjusted after one of the commands that change the
+	height of the current window.
+	'winheight' applies to the current window.  Use 'winminheight' to set
+	the minimal height for other windows.
 
-                                                        *'winhighlight'* *'winhl'*
-'winhighlight' 'winhl'  string (default "")
-                        local to window
-        Window-local highlights.  Comma-delimited list of highlight
-        |group-name| pairs "{hl-from}:{hl-to},..." where each {hl-from} is
-        a |highlight-groups| item to be overridden by {hl-to} group in
-        the window.
+							*'winhighlight'* *'winhl'*
+'winhighlight' 'winhl'	string (default "")
+			local to window
+	Window-local highlights.  Comma-delimited list of highlight
+	|group-name| pairs "{hl-from}:{hl-to},..." where each {hl-from} is
+	a |highlight-groups| item to be overridden by {hl-to} group in
+	the window.
 
-        Note: highlight namespaces take precedence over 'winhighlight'.
-        See |nvim_win_set_hl_ns()| and |nvim_set_hl()|.
+	Note: highlight namespaces take precedence over 'winhighlight'.
+	See |nvim_win_set_hl_ns()| and |nvim_set_hl()|.
 
-        Highlights of vertical separators are determined by the window to the
-        left of the separator.  The 'tabline' highlight of a tabpage is
-        decided by the last-focused window of the tabpage.  Highlights of
-        the popupmenu are determined by the current window.  Highlights in the
-        message area cannot be overridden.
+	Highlights of vertical separators are determined by the window to the
+	left of the separator.	The 'tabline' highlight of a tabpage is
+	decided by the last-focused window of the tabpage.  Highlights of
+	the popupmenu are determined by the current window.  Highlights in the
+	message area cannot be overridden.
 
-        Example: show a different color for non-current windows: >vim
-                set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
+	Example: show a different color for non-current windows: >vim
+		set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
 <
 
-                                                          *'winminheight'* *'wmh'*
-'winminheight' 'wmh'    number (default 1)
-                        global
-        The minimal height of a window, when it's not the current window.
-        This is a hard minimum, windows will never become smaller.
-        When set to zero, windows may be "squashed" to zero lines (i.e. just a
-        status bar) if necessary.  They will return to at least one line when
-        they become active (since the cursor has to have somewhere to go.)
-        Use 'winheight' to set the minimal height of the current window.
-        This option is only checked when making a window smaller.  Don't use a
-        large number, it will cause errors when opening more than a few
-        windows.  A value of 0 to 3 is reasonable.
+							  *'winminheight'* *'wmh'*
+'winminheight' 'wmh'	number (default 1)
+			global
+	The minimal height of a window, when it's not the current window.
+	This is a hard minimum, windows will never become smaller.
+	When set to zero, windows may be "squashed" to zero lines (i.e. just a
+	status bar) if necessary.  They will return to at least one line when
+	they become active (since the cursor has to have somewhere to go.)
+	Use 'winheight' to set the minimal height of the current window.
+	This option is only checked when making a window smaller.  Don't use a
+	large number, it will cause errors when opening more than a few
+	windows.  A value of 0 to 3 is reasonable.
 
-                                                           *'winminwidth'* *'wmw'*
-'winminwidth' 'wmw'     number (default 1)
-                        global
-        The minimal width of a window, when it's not the current window.
-        This is a hard minimum, windows will never become smaller.
-        When set to zero, windows may be "squashed" to zero columns (i.e. just
-        a vertical separator) if necessary.  They will return to at least one
-        line when they become active (since the cursor has to have somewhere
-        to go.)
-        Use 'winwidth' to set the minimal width of the current window.
-        This option is only checked when making a window smaller.  Don't use a
-        large number, it will cause errors when opening more than a few
-        windows.  A value of 0 to 12 is reasonable.
+							   *'winminwidth'* *'wmw'*
+'winminwidth' 'wmw'	number (default 1)
+			global
+	The minimal width of a window, when it's not the current window.
+	This is a hard minimum, windows will never become smaller.
+	When set to zero, windows may be "squashed" to zero columns (i.e. just
+	a vertical separator) if necessary.  They will return to at least one
+	line when they become active (since the cursor has to have somewhere
+	to go.)
+	Use 'winwidth' to set the minimal width of the current window.
+	This option is only checked when making a window smaller.  Don't use a
+	large number, it will cause errors when opening more than a few
+	windows.  A value of 0 to 12 is reasonable.
 
-                                                         *'winwidth'* *'wiw'* *E592*
-'winwidth' 'wiw'        number (default 20)
-                        global
-        Minimal number of columns for the current window.  This is not a hard
-        minimum, Vim will use fewer columns if there is not enough room.  If
-        the current window is smaller, its size is increased, at the cost of
-        the width of other windows.  Set it to 999 to make the current window
-        always fill the screen.  Set it to a small number for normal editing.
-        The width is not adjusted after one of the commands to change the
-        width of the current window.
-        'winwidth' applies to the current window.  Use 'winminwidth' to set
-        the minimal width for other windows.
+							 *'winwidth'* *'wiw'* *E592*
+'winwidth' 'wiw'	number (default 20)
+			global
+	Minimal number of columns for the current window.  This is not a hard
+	minimum, Vim will use fewer columns if there is not enough room.  If
+	the current window is smaller, its size is increased, at the cost of
+	the width of other windows.  Set it to 999 to make the current window
+	always fill the screen.  Set it to a small number for normal editing.
+	The width is not adjusted after one of the commands to change the
+	width of the current window.
+	'winwidth' applies to the current window.  Use 'winminwidth' to set
+	the minimal width for other windows.
 
-                                                               *'wrap'* *'nowrap'*
-'wrap'                  boolean (default on)
-                        local to window
-        This option changes how text is displayed.  It doesn't change the text
-        in the buffer, see 'textwidth' for that.
-        When on, lines longer than the width of the window will wrap and
-        displaying continues on the next line.  When off lines will not wrap
-        and only part of long lines will be displayed.  When the cursor is
-        moved to a part that is not shown, the screen will scroll
-        horizontally.
-        The line will be broken in the middle of a word if necessary.  See
-        'linebreak' to get the break at a word boundary.
-        To make scrolling horizontally a bit more useful, try this: >vim
-                set sidescroll=5
-                set listchars+=precedes:<,extends:>
-<       See 'sidescroll', 'listchars' and |wrap-off|.
-        This option can't be set from a |modeline| when the 'diff' option is
-        on.
+							       *'wrap'* *'nowrap'*
+'wrap'			boolean (default on)
+			local to window
+	This option changes how text is displayed.  It doesn't change the text
+	in the buffer, see 'textwidth' for that.
+	When on, lines longer than the width of the window will wrap and
+	displaying continues on the next line.	When off lines will not wrap
+	and only part of long lines will be displayed.	When the cursor is
+	moved to a part that is not shown, the screen will scroll
+	horizontally.
+	The line will be broken in the middle of a word if necessary.  See
+	'linebreak' to get the break at a word boundary.
+	To make scrolling horizontally a bit more useful, try this: >vim
+		set sidescroll=5
+		set listchars+=precedes:<,extends:>
+<	See 'sidescroll', 'listchars' and |wrap-off|.
+	This option can't be set from a |modeline| when the 'diff' option is
+	on.
 
-                                                             *'wrapmargin'* *'wm'*
-'wrapmargin' 'wm'       number (default 0)
-                        local to buffer
-        Number of characters from the right window border where wrapping
-        starts.  When typing text beyond this limit, an <EOL> will be inserted
-        and inserting continues on the next line.
-        Options that add a margin, such as 'number' and 'foldcolumn', cause
-        the text width to be further reduced.
-        When 'textwidth' is non-zero, this option is not used.
-        See also 'formatoptions' and |ins-textwidth|.
+							     *'wrapmargin'* *'wm'*
+'wrapmargin' 'wm'	number (default 0)
+			local to buffer
+	Number of characters from the right window border where wrapping
+	starts.  When typing text beyond this limit, an <EOL> will be inserted
+	and inserting continues on the next line.
+	Options that add a margin, such as 'number' and 'foldcolumn', cause
+	the text width to be further reduced.
+	When 'textwidth' is non-zero, this option is not used.
+	See also 'formatoptions' and |ins-textwidth|.
 
-                                 *'wrapscan'* *'ws'* *'nowrapscan'* *'nows'* *E384* *E385*
-'wrapscan' 'ws'         boolean (default on)
-                        global
-        Searches wrap around the end of the file.  Also applies to |]s| and
-        |[s|, searching for spelling mistakes.
+				 *'wrapscan'* *'ws'* *'nowrapscan'* *'nows'* *E384* *E385*
+'wrapscan' 'ws'		boolean (default on)
+			global
+	Searches wrap around the end of the file.  Also applies to |]s| and
+	|[s|, searching for spelling mistakes.
 
-                                                             *'write'* *'nowrite'*
-'write'                 boolean (default on)
-                        global
-        Allows writing files.  When not set, writing a file is not allowed.
-        Can be used for a view-only mode, where modifications to the text are
-        still allowed.  Can be reset with the |-m| or |-M| command line
-        argument.  Filtering text is still possible, even though this requires
-        writing a temporary file.
+							     *'write'* *'nowrite'*
+'write'			boolean (default on)
+			global
+	Allows writing files.  When not set, writing a file is not allowed.
+	Can be used for a view-only mode, where modifications to the text are
+	still allowed.	Can be reset with the |-m| or |-M| command line
+	argument.  Filtering text is still possible, even though this requires
+	writing a temporary file.
 
-                                           *'writeany'* *'wa'* *'nowriteany'* *'nowa'*
-'writeany' 'wa'         boolean (default off)
-                        global
-        Allows writing to any file with no need for "!" override.
+					   *'writeany'* *'wa'* *'nowriteany'* *'nowa'*
+'writeany' 'wa'		boolean (default off)
+			global
+	Allows writing to any file with no need for "!" override.
 
-                                     *'writebackup'* *'wb'* *'nowritebackup'* *'nowb'*
-'writebackup' 'wb'      boolean (default on)
-                        global
-        Make a backup before overwriting a file.  The backup is removed after
-        the file was successfully written, unless the 'backup' option is
-        also on.
-        WARNING: Switching this option off means that when Vim fails to write
-        your buffer correctly and then, for whatever reason, Vim exits, you
-        lose both the original file and what you were writing.  Only reset
-        this option if your file system is almost full and it makes the write
-        fail (and make sure not to exit Vim until the write was successful).
-        See |backup-table| for another explanation.
-        When the 'backupskip' pattern matches, a backup is not made anyway.
-        Depending on 'backupcopy' the backup is a new file or the original
-        file renamed (and a new file is written).
+				     *'writebackup'* *'wb'* *'nowritebackup'* *'nowb'*
+'writebackup' 'wb'	boolean (default on)
+			global
+	Make a backup before overwriting a file.  The backup is removed after
+	the file was successfully written, unless the 'backup' option is
+	also on.
+	WARNING: Switching this option off means that when Vim fails to write
+	your buffer correctly and then, for whatever reason, Vim exits, you
+	lose both the original file and what you were writing.	Only reset
+	this option if your file system is almost full and it makes the write
+	fail (and make sure not to exit Vim until the write was successful).
+	See |backup-table| for another explanation.
+	When the 'backupskip' pattern matches, a backup is not made anyway.
+	Depending on 'backupcopy' the backup is a new file or the original
+	file renamed (and a new file is written).
 
-                                                             *'writedelay'* *'wd'*
-'writedelay' 'wd'       number (default 0)
-                        global
-        Only takes effect together with 'redrawdebug'.
-        The number of milliseconds to wait after each line or each flush
+							     *'writedelay'* *'wd'*
+'writedelay' 'wd'	number (default 0)
+			global
+	Only takes effect together with 'redrawdebug'.
+	The number of milliseconds to wait after each line or each flush
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -1,728 +1,728 @@
 *vvars.txt*	Nvim
 
 
-                NVIM REFERENCE MANUAL
+		NVIM REFERENCE MANUAL
 
 
-Predefined variables                                             *vvars*
+Predefined variables						 *vvars*
 
 Some variables can be set by the user, but the type cannot be changed.
 
-                                       Type |gO| to see the table of contents.
+				       Type |gO| to see the table of contents.
 
-                                                          *v:argv* *argv-variable*
+							  *v:argv* *argv-variable*
 v:argv
-                The command line arguments Vim was invoked with.  This is a
-                list of strings.  The first item is the Vim command.
-                See |v:progpath| for the command with full path.
+		The command line arguments Vim was invoked with.  This is a
+		list of strings.  The first item is the Vim command.
+		See |v:progpath| for the command with full path.
 
-                                                          *v:char* *char-variable*
+							  *v:char* *char-variable*
 v:char
-                Argument for evaluating 'formatexpr' and used for the typed
-                character when using <expr> in an abbreviation |:map-<expr>|.
-                It is also used by the |InsertCharPre| and |InsertEnter| events.
+		Argument for evaluating 'formatexpr' and used for the typed
+		character when using <expr> in an abbreviation |:map-<expr>|.
+		It is also used by the |InsertCharPre| and |InsertEnter| events.
 
-                                  *v:charconvert_from* *charconvert_from-variable*
+				  *v:charconvert_from* *charconvert_from-variable*
 v:charconvert_from
-                The name of the character encoding of a file to be converted.
-                Only valid while evaluating the 'charconvert' option.
+		The name of the character encoding of a file to be converted.
+		Only valid while evaluating the 'charconvert' option.
 
-                                      *v:charconvert_to* *charconvert_to-variable*
+				      *v:charconvert_to* *charconvert_to-variable*
 v:charconvert_to
-                The name of the character encoding of a file after conversion.
-                Only valid while evaluating the 'charconvert' option.
+		The name of the character encoding of a file after conversion.
+		Only valid while evaluating the 'charconvert' option.
 
-                                                      *v:cmdarg* *cmdarg-variable*
+						      *v:cmdarg* *cmdarg-variable*
 v:cmdarg
-                The extra arguments ("++p", "++enc=", "++ff=") given to a file
-                read/write command.  This is set before an autocommand event
-                for a file read/write command is triggered.  There is a
-                leading space to make it possible to append this variable
-                directly after the read/write command. Note: "+cmd" isn't
-                included here, because it will be executed anyway.
+		The extra arguments ("++p", "++enc=", "++ff=") given to a file
+		read/write command.  This is set before an autocommand event
+		for a file read/write command is triggered.  There is a
+		leading space to make it possible to append this variable
+		directly after the read/write command. Note: "+cmd" isn't
+		included here, because it will be executed anyway.
 
-                                                    *v:cmdbang* *cmdbang-variable*
+						    *v:cmdbang* *cmdbang-variable*
 v:cmdbang
-                Set like v:cmdarg for a file read/write command.  When a "!"
-                was used the value is 1, otherwise it is 0.  Note that this
-                can only be used in autocommands.  For user commands |<bang>|
-                can be used.
+		Set like v:cmdarg for a file read/write command.  When a "!"
+		was used the value is 1, otherwise it is 0.  Note that this
+		can only be used in autocommands.  For user commands |<bang>|
+		can be used.
 
-                                                    *v:collate* *collate-variable*
+						    *v:collate* *collate-variable*
 v:collate
-                The current locale setting for collation order of the runtime
-                environment.  This allows Vim scripts to be aware of the
-                current locale encoding.  Technical: it's the value of
-                LC_COLLATE.  When not using a locale the value is "C".
-                This variable can not be set directly, use the |:language|
-                command.
-                See |multi-lang|.
+		The current locale setting for collation order of the runtime
+		environment.  This allows Vim scripts to be aware of the
+		current locale encoding.  Technical: it's the value of
+		LC_COLLATE.  When not using a locale the value is "C".
+		This variable can not be set directly, use the |:language|
+		command.
+		See |multi-lang|.
 
-                                      *v:completed_item* *completed_item-variable*
+				      *v:completed_item* *completed_item-variable*
 v:completed_item
-                Dictionary containing the most recent |complete-items| after
-                |CompleteDone|.  Empty if the completion failed, or after
-                leaving and re-entering insert mode.
-                Note: Plugins can modify the value to emulate the builtin
-                |CompleteDone| event behavior.
+		Dictionary containing the most recent |complete-items| after
+		|CompleteDone|.  Empty if the completion failed, or after
+		leaving and re-entering insert mode.
+		Note: Plugins can modify the value to emulate the builtin
+		|CompleteDone| event behavior.
 
-                                                        *v:count* *count-variable*
+							*v:count* *count-variable*
 v:count
-                The count given for the last Normal mode command.  Can be used
-                to get the count before a mapping.  Read-only.  Example: >vim
-                  :map _x :<C-U>echo "the count is " .. v:count<CR>
+		The count given for the last Normal mode command.  Can be used
+		to get the count before a mapping.  Read-only.	Example: >vim
+		  :map _x :<C-U>echo "the count is " .. v:count<CR>
 <
-                Note: The <C-U> is required to remove the line range that you
-                get when typing ':' after a count.
-                When there are two counts, as in "3d2w", they are multiplied,
-                just like what happens in the command, "d6w" for the example.
-                Also used for evaluating the 'formatexpr' option.
+		Note: The <C-U> is required to remove the line range that you
+		get when typing ':' after a count.
+		When there are two counts, as in "3d2w", they are multiplied,
+		just like what happens in the command, "d6w" for the example.
+		Also used for evaluating the 'formatexpr' option.
 
-                                                      *v:count1* *count1-variable*
+						      *v:count1* *count1-variable*
 v:count1
-                Just like "v:count", but defaults to one when no count is
-                used.
+		Just like "v:count", but defaults to one when no count is
+		used.
 
-                                                        *v:ctype* *ctype-variable*
+							*v:ctype* *ctype-variable*
 v:ctype
-                The current locale setting for characters of the runtime
-                environment.  This allows Vim scripts to be aware of the
-                current locale encoding.  Technical: it's the value of
-                LC_CTYPE.  When not using a locale the value is "C".
-                This variable can not be set directly, use the |:language|
-                command.
-                See |multi-lang|.
+		The current locale setting for characters of the runtime
+		environment.  This allows Vim scripts to be aware of the
+		current locale encoding.  Technical: it's the value of
+		LC_CTYPE.  When not using a locale the value is "C".
+		This variable can not be set directly, use the |:language|
+		command.
+		See |multi-lang|.
 
-                                                        *v:dying* *dying-variable*
+							*v:dying* *dying-variable*
 v:dying
-                Normally zero.  When a deadly signal is caught it's set to
-                one.  When multiple signals are caught the number increases.
-                Can be used in an autocommand to check if Vim didn't
-                terminate normally.
-                Example: >vim
-                  :au VimLeave * if v:dying | echo "\nAAAAaaaarrrggghhhh!!!\n" | endif
+		Normally zero.	When a deadly signal is caught it's set to
+		one.  When multiple signals are caught the number increases.
+		Can be used in an autocommand to check if Vim didn't
+		terminate normally.
+		Example: >vim
+		  :au VimLeave * if v:dying | echo "\nAAAAaaaarrrggghhhh!!!\n" | endif
 <
-                Note: if another deadly signal is caught when v:dying is one,
-                VimLeave autocommands will not be executed.
+		Note: if another deadly signal is caught when v:dying is one,
+		VimLeave autocommands will not be executed.
 
-                                                *v:echospace* *echospace-variable*
+						*v:echospace* *echospace-variable*
 v:echospace
-                Number of screen cells that can be used for an `:echo` message
-                in the last screen line before causing the |hit-enter-prompt|.
-                Depends on 'showcmd', 'ruler' and 'columns'.  You need to
-                check 'cmdheight' for whether there are full-width lines
-                available above the last line.
+		Number of screen cells that can be used for an `:echo` message
+		in the last screen line before causing the |hit-enter-prompt|.
+		Depends on 'showcmd', 'ruler' and 'columns'.  You need to
+		check 'cmdheight' for whether there are full-width lines
+		available above the last line.
 
-                                                      *v:errmsg* *errmsg-variable*
+						      *v:errmsg* *errmsg-variable*
 v:errmsg
-                Last given error message.
-                Modifiable (can be set).
-                Example: >vim
-                  let v:errmsg = ""
-                  silent! next
-                  if v:errmsg != ""
-                    " ... handle error
+		Last given error message.
+		Modifiable (can be set).
+		Example: >vim
+		  let v:errmsg = ""
+		  silent! next
+		  if v:errmsg != ""
+		    " ... handle error
 <
 
-                                        *v:errors* *errors-variable* *assert-return*
+					*v:errors* *errors-variable* *assert-return*
 v:errors
-                Errors found by assert functions, such as |assert_true()|.
-                This is a list of strings.
-                The assert functions append an item when an assert fails.
-                The return value indicates this: a one is returned if an item
-                was added to v:errors, otherwise zero is returned.
-                To remove old results make it empty: >vim
-                  let v:errors = []
+		Errors found by assert functions, such as |assert_true()|.
+		This is a list of strings.
+		The assert functions append an item when an assert fails.
+		The return value indicates this: a one is returned if an item
+		was added to v:errors, otherwise zero is returned.
+		To remove old results make it empty: >vim
+		  let v:errors = []
 <
-                If v:errors is set to anything but a list it is made an empty
-                list by the assert function.
+		If v:errors is set to anything but a list it is made an empty
+		list by the assert function.
 
-                                                        *v:event* *event-variable*
+							*v:event* *event-variable*
 v:event
-                Dictionary of event data for the current |autocommand|.  Valid
-                only during the event lifetime; storing or passing v:event is
-                invalid!  Copy it instead: >vim
-                  au TextYankPost * let g:foo = deepcopy(v:event)
+		Dictionary of event data for the current |autocommand|.  Valid
+		only during the event lifetime; storing or passing v:event is
+		invalid!  Copy it instead: >vim
+		  au TextYankPost * let g:foo = deepcopy(v:event)
 <
-                Keys vary by event; see the documentation for the specific
-                event, e.g. |DirChanged| or |TextYankPost|.
-                  KEY              DESCRIPTION ~
-                  abort            Whether the event triggered during
-                                   an aborting condition (e.g. |c_Esc| or
-                                   |c_CTRL-C| for |CmdlineLeave|).
-                  chan             |channel-id|
-                  cmdlevel         Level of cmdline.
-                  cmdtype          Type of cmdline, |cmdline-char|.
-                  cwd              Current working directory.
-                  inclusive        Motion is |inclusive|, else exclusive.
-                  scope            Event-specific scope name.
-                  operator         Current |operator|.  Also set for Ex
-                  commands         (unlike |v:operator|). For
-                                   example if |TextYankPost| is triggered
-                                   by the |:yank| Ex command then
-                                   `v:event.operator` is "y".
-                  regcontents      Text stored in the register as a
-                                   |readfile()|-style list of lines.
-                  regname          Requested register (e.g "x" for "xyy)
-                                   or the empty string for an unnamed
-                                   operation.
-                  regtype          Type of register as returned by
-                                   |getregtype()|.
-                  visual           Selection is visual (as opposed to,
-                                   e.g., via motion).
-                  completed_item   Current selected complete item on
-                                   |CompleteChanged|, Is `{}` when no complete
-                                   item selected.
-                  height           Height of popup menu on |CompleteChanged|
-                  width            Width of popup menu on |CompleteChanged|
-                  row              Row count of popup menu on |CompleteChanged|,
-                                   relative to screen.
-                  col              Col count of popup menu on |CompleteChanged|,
-                                   relative to screen.
-                  size             Total number of completion items on
-                                   |CompleteChanged|.
-                  scrollbar        Is |v:true| if popup menu have scrollbar, or
-                                   |v:false| if not.
-                  changed_window   Is |v:true| if the event fired while
-                                   changing window  (or tab) on |DirChanged|.
-                  status           Job status or exit code, -1 means "unknown". |TermClose|
+		Keys vary by event; see the documentation for the specific
+		event, e.g. |DirChanged| or |TextYankPost|.
+		  KEY		   DESCRIPTION ~
+		  abort		   Whether the event triggered during
+				   an aborting condition (e.g. |c_Esc| or
+				   |c_CTRL-C| for |CmdlineLeave|).
+		  chan		   |channel-id|
+		  cmdlevel	   Level of cmdline.
+		  cmdtype	   Type of cmdline, |cmdline-char|.
+		  cwd		   Current working directory.
+		  inclusive	   Motion is |inclusive|, else exclusive.
+		  scope		   Event-specific scope name.
+		  operator	   Current |operator|.	Also set for Ex
+		  commands	   (unlike |v:operator|). For
+				   example if |TextYankPost| is triggered
+				   by the |:yank| Ex command then
+				   `v:event.operator` is "y".
+		  regcontents	   Text stored in the register as a
+				   |readfile()|-style list of lines.
+		  regname	   Requested register (e.g "x" for "xyy)
+				   or the empty string for an unnamed
+				   operation.
+		  regtype	   Type of register as returned by
+				   |getregtype()|.
+		  visual	   Selection is visual (as opposed to,
+				   e.g., via motion).
+		  completed_item   Current selected complete item on
+				   |CompleteChanged|, Is `{}` when no complete
+				   item selected.
+		  height	   Height of popup menu on |CompleteChanged|
+		  width		   Width of popup menu on |CompleteChanged|
+		  row		   Row count of popup menu on |CompleteChanged|,
+				   relative to screen.
+		  col		   Col count of popup menu on |CompleteChanged|,
+				   relative to screen.
+		  size		   Total number of completion items on
+				   |CompleteChanged|.
+		  scrollbar	   Is |v:true| if popup menu have scrollbar, or
+				   |v:false| if not.
+		  changed_window   Is |v:true| if the event fired while
+				   changing window  (or tab) on |DirChanged|.
+		  status	   Job status or exit code, -1 means "unknown". |TermClose|
 
-                                                *v:exception* *exception-variable*
+						*v:exception* *exception-variable*
 v:exception
-                The value of the exception most recently caught and not
-                finished.  See also |v:throwpoint| and |throw-variables|.
-                Example: >vim
-                  try
-                    throw "oops"
-                  catch /.*/
-                    echo "caught " .. v:exception
-                  endtry
+		The value of the exception most recently caught and not
+		finished.  See also |v:throwpoint| and |throw-variables|.
+		Example: >vim
+		  try
+		    throw "oops"
+		  catch /.*/
+		    echo "caught " .. v:exception
+		  endtry
 <
-                Output: "caught oops".
+		Output: "caught oops".
 
-                                                    *v:exiting* *exiting-variable*
+						    *v:exiting* *exiting-variable*
 v:exiting
-                Exit code, or |v:null| before invoking the |VimLeavePre|
-                and |VimLeave| autocmds.  See |:q|, |:x| and |:cquit|.
-                Example: >vim
-                  :au VimLeave * echo "Exit value is " .. v:exiting
+		Exit code, or |v:null| before invoking the |VimLeavePre|
+		and |VimLeave| autocmds.  See |:q|, |:x| and |:cquit|.
+		Example: >vim
+		  :au VimLeave * echo "Exit value is " .. v:exiting
 <
 
-                                                        *v:false* *false-variable*
+							*v:false* *false-variable*
 v:false
-                Special value used to put "false" in JSON and msgpack.  See
-                |json_encode()|.  This value is converted to "v:false" when used
-                as a String (e.g. in |expr5| with string concatenation
-                operator) and to zero when used as a Number (e.g. in |expr5|
-                or |expr7| when used with numeric operators). Read-only.
+		Special value used to put "false" in JSON and msgpack.	See
+		|json_encode()|.  This value is converted to "v:false" when used
+		as a String (e.g. in |expr5| with string concatenation
+		operator) and to zero when used as a Number (e.g. in |expr5|
+		or |expr7| when used with numeric operators). Read-only.
 
-                                              *v:fcs_choice* *fcs_choice-variable*
+					      *v:fcs_choice* *fcs_choice-variable*
 v:fcs_choice
-                What should happen after a |FileChangedShell| event was
-                triggered.  Can be used in an autocommand to tell Vim what to
-                do with the affected buffer:
-                  reload  Reload the buffer (does not work if
-                          the file was deleted).
-                  edit    Reload the buffer and detect the
-                          values for options such as
-                          'fileformat', 'fileencoding', 'binary'
-                          (does not work if the file was
-                          deleted).
-                  ask     Ask the user what to do, as if there
-                          was no autocommand.  Except that when
-                          only the timestamp changed nothing
-                          will happen.
-                  <empty> Nothing, the autocommand should do
-                          everything that needs to be done.
-                The default is empty.  If another (invalid) value is used then
-                Vim behaves like it is empty, there is no warning message.
+		What should happen after a |FileChangedShell| event was
+		triggered.  Can be used in an autocommand to tell Vim what to
+		do with the affected buffer:
+		  reload  Reload the buffer (does not work if
+			  the file was deleted).
+		  edit	  Reload the buffer and detect the
+			  values for options such as
+			  'fileformat', 'fileencoding', 'binary'
+			  (does not work if the file was
+			  deleted).
+		  ask	  Ask the user what to do, as if there
+			  was no autocommand.  Except that when
+			  only the timestamp changed nothing
+			  will happen.
+		  <empty> Nothing, the autocommand should do
+			  everything that needs to be done.
+		The default is empty.  If another (invalid) value is used then
+		Vim behaves like it is empty, there is no warning message.
 
-                                              *v:fcs_reason* *fcs_reason-variable*
+					      *v:fcs_reason* *fcs_reason-variable*
 v:fcs_reason
-                The reason why the |FileChangedShell| event was triggered.
-                Can be used in an autocommand to decide what to do and/or what
-                to set v:fcs_choice to.  Possible values:
-                  deleted   file no longer exists
-                  conflict  file contents, mode or timestamp was
-                            changed and buffer is modified
-                  changed   file contents has changed
-                  mode      mode of file changed
-                  time      only file timestamp changed
+		The reason why the |FileChangedShell| event was triggered.
+		Can be used in an autocommand to decide what to do and/or what
+		to set v:fcs_choice to.  Possible values:
+		  deleted   file no longer exists
+		  conflict  file contents, mode or timestamp was
+			    changed and buffer is modified
+		  changed   file contents has changed
+		  mode	    mode of file changed
+		  time	    only file timestamp changed
 
-                                                        *v:fname* *fname-variable*
+							*v:fname* *fname-variable*
 v:fname
-                When evaluating 'includeexpr': the file name that was
-                detected.  Empty otherwise.
+		When evaluating 'includeexpr': the file name that was
+		detected.  Empty otherwise.
 
-                                              *v:fname_diff* *fname_diff-variable*
+					      *v:fname_diff* *fname_diff-variable*
 v:fname_diff
-                The name of the diff (patch) file.  Only valid while
-                evaluating 'patchexpr'.
+		The name of the diff (patch) file.  Only valid while
+		evaluating 'patchexpr'.
 
-                                                  *v:fname_in* *fname_in-variable*
+						  *v:fname_in* *fname_in-variable*
 v:fname_in
-                The name of the input file.  Valid while evaluating:
-                  option         used for ~
-                  'charconvert'  file to be converted
-                  'diffexpr'     original file
-                  'patchexpr'    original file
-                And set to the swap file name for |SwapExists|.
+		The name of the input file.  Valid while evaluating:
+		  option	 used for ~
+		  'charconvert'  file to be converted
+		  'diffexpr'	 original file
+		  'patchexpr'	 original file
+		And set to the swap file name for |SwapExists|.
 
-                                                *v:fname_new* *fname_new-variable*
+						*v:fname_new* *fname_new-variable*
 v:fname_new
-                The name of the new version of the file.  Only valid while
-                evaluating 'diffexpr'.
+		The name of the new version of the file.  Only valid while
+		evaluating 'diffexpr'.
 
-                                                *v:fname_out* *fname_out-variable*
+						*v:fname_out* *fname_out-variable*
 v:fname_out
-                The name of the output file.  Only valid while
-                evaluating:
-                  option           used for ~
-                  'charconvert'    resulting converted file [1]
-                  'diffexpr'       output of diff
-                  'patchexpr'      resulting patched file
-                [1] When doing conversion for a write command (e.g., ":w
-                file") it will be equal to v:fname_in.  When doing conversion
-                for a read command (e.g., ":e file") it will be a temporary
-                file and different from v:fname_in.
+		The name of the output file.  Only valid while
+		evaluating:
+		  option	   used for ~
+		  'charconvert'    resulting converted file [1]
+		  'diffexpr'	   output of diff
+		  'patchexpr'	   resulting patched file
+		[1] When doing conversion for a write command (e.g., ":w
+		file") it will be equal to v:fname_in.	When doing conversion
+		for a read command (e.g., ":e file") it will be a temporary
+		file and different from v:fname_in.
 
-                                              *v:folddashes* *folddashes-variable*
+					      *v:folddashes* *folddashes-variable*
 v:folddashes
-                Used for 'foldtext': dashes representing foldlevel of a closed
-                fold.
-                Read-only in the |sandbox|. |fold-foldtext|
+		Used for 'foldtext': dashes representing foldlevel of a closed
+		fold.
+		Read-only in the |sandbox|. |fold-foldtext|
 
-                                                    *v:foldend* *foldend-variable*
+						    *v:foldend* *foldend-variable*
 v:foldend
-                Used for 'foldtext': last line of closed fold.
-                Read-only in the |sandbox|. |fold-foldtext|
+		Used for 'foldtext': last line of closed fold.
+		Read-only in the |sandbox|. |fold-foldtext|
 
-                                                *v:foldlevel* *foldlevel-variable*
+						*v:foldlevel* *foldlevel-variable*
 v:foldlevel
-                Used for 'foldtext': foldlevel of closed fold.
-                Read-only in the |sandbox|. |fold-foldtext|
+		Used for 'foldtext': foldlevel of closed fold.
+		Read-only in the |sandbox|. |fold-foldtext|
 
-                                                *v:foldstart* *foldstart-variable*
+						*v:foldstart* *foldstart-variable*
 v:foldstart
-                Used for 'foldtext': first line of closed fold.
-                Read-only in the |sandbox|. |fold-foldtext|
+		Used for 'foldtext': first line of closed fold.
+		Read-only in the |sandbox|. |fold-foldtext|
 
-                                                  *v:hlsearch* *hlsearch-variable*
+						  *v:hlsearch* *hlsearch-variable*
 v:hlsearch
-                Variable that indicates whether search highlighting is on.
-                Setting it makes sense only if 'hlsearch' is enabled. Setting
-                this variable to zero acts like the |:nohlsearch| command,
-                setting it to one acts like >vim
-                  let &hlsearch = &hlsearch
+		Variable that indicates whether search highlighting is on.
+		Setting it makes sense only if 'hlsearch' is enabled. Setting
+		this variable to zero acts like the |:nohlsearch| command,
+		setting it to one acts like >vim
+		  let &hlsearch = &hlsearch
 <
-                Note that the value is restored when returning from a
-                function. |function-search-undo|.
+		Note that the value is restored when returning from a
+		function. |function-search-undo|.
 
-                                              *v:insertmode* *insertmode-variable*
+					      *v:insertmode* *insertmode-variable*
 v:insertmode
-                Used for the |InsertEnter| and |InsertChange| autocommand
-                events.  Values:
-                  i    Insert mode
-                  r    Replace mode
-                  v    Virtual Replace mode
+		Used for the |InsertEnter| and |InsertChange| autocommand
+		events.  Values:
+		  i    Insert mode
+		  r    Replace mode
+		  v    Virtual Replace mode
 
-                                                            *v:key* *key-variable*
+							    *v:key* *key-variable*
 v:key
-                Key of the current item of a |Dictionary|.  Only valid while
-                evaluating the expression used with |map()| and |filter()|.
-                Read-only.
+		Key of the current item of a |Dictionary|.  Only valid while
+		evaluating the expression used with |map()| and |filter()|.
+		Read-only.
 
-                                                          *v:lang* *lang-variable*
+							  *v:lang* *lang-variable*
 v:lang
-                The current locale setting for messages of the runtime
-                environment.  This allows Vim scripts to be aware of the
-                current language.  Technical: it's the value of LC_MESSAGES.
-                The value is system dependent.
-                This variable can not be set directly, use the |:language|
-                command.
-                It can be different from |v:ctype| when messages are desired
-                in a different language than what is used for character
-                encoding.  See |multi-lang|.
+		The current locale setting for messages of the runtime
+		environment.  This allows Vim scripts to be aware of the
+		current language.  Technical: it's the value of LC_MESSAGES.
+		The value is system dependent.
+		This variable can not be set directly, use the |:language|
+		command.
+		It can be different from |v:ctype| when messages are desired
+		in a different language than what is used for character
+		encoding.  See |multi-lang|.
 
-                                                    *v:lc_time* *lc_time-variable*
+						    *v:lc_time* *lc_time-variable*
 v:lc_time
-                The current locale setting for time messages of the runtime
-                environment.  This allows Vim scripts to be aware of the
-                current language.  Technical: it's the value of LC_TIME.
-                This variable can not be set directly, use the |:language|
-                command.  See |multi-lang|.
+		The current locale setting for time messages of the runtime
+		environment.  This allows Vim scripts to be aware of the
+		current language.  Technical: it's the value of LC_TIME.
+		This variable can not be set directly, use the |:language|
+		command.  See |multi-lang|.
 
-                                                          *v:lnum* *lnum-variable*
+							  *v:lnum* *lnum-variable*
 v:lnum
-                Line number for the 'foldexpr' |fold-expr|, 'formatexpr',
-                'indentexpr' and 'statuscolumn' expressions, tab page number
-                for 'guitablabel' and 'guitabtooltip'.  Only valid while one of
-                these expressions is being evaluated.  Read-only when in the
-                |sandbox|.
+		Line number for the 'foldexpr' |fold-expr|, 'formatexpr',
+		'indentexpr' and 'statuscolumn' expressions, tab page number
+		for 'guitablabel' and 'guitabtooltip'.	Only valid while one of
+		these expressions is being evaluated.  Read-only when in the
+		|sandbox|.
 
-                                                            *v:lua* *lua-variable*
+							    *v:lua* *lua-variable*
 v:lua
-                Prefix for calling Lua functions from expressions.
-                See |v:lua-call| for more information.
+		Prefix for calling Lua functions from expressions.
+		See |v:lua-call| for more information.
 
-                                                      *v:maxcol* *maxcol-variable*
+						      *v:maxcol* *maxcol-variable*
 v:maxcol
-                Maximum line length.  Depending on where it is used it can be
-                screen columns, characters or bytes.  The value currently is
-                2147483647 on all systems.
+		Maximum line length.  Depending on where it is used it can be
+		screen columns, characters or bytes.  The value currently is
+		2147483647 on all systems.
 
-                                                *v:mouse_col* *mouse_col-variable*
+						*v:mouse_col* *mouse_col-variable*
 v:mouse_col
-                Column number for a mouse click obtained with |getchar()|.
-                This is the screen column number, like with |virtcol()|.  The
-                value is zero when there was no mouse button click.
+		Column number for a mouse click obtained with |getchar()|.
+		This is the screen column number, like with |virtcol()|.  The
+		value is zero when there was no mouse button click.
 
-                                              *v:mouse_lnum* *mouse_lnum-variable*
+					      *v:mouse_lnum* *mouse_lnum-variable*
 v:mouse_lnum
-                Line number for a mouse click obtained with |getchar()|.
-                This is the text line number, not the screen line number.  The
-                value is zero when there was no mouse button click.
+		Line number for a mouse click obtained with |getchar()|.
+		This is the text line number, not the screen line number.  The
+		value is zero when there was no mouse button click.
 
-                                                *v:mouse_win* *mouse_win-variable*
+						*v:mouse_win* *mouse_win-variable*
 v:mouse_win
-                Window number for a mouse click obtained with |getchar()|.
-                First window has number 1, like with |winnr()|.  The value is
-                zero when there was no mouse button click.
+		Window number for a mouse click obtained with |getchar()|.
+		First window has number 1, like with |winnr()|.  The value is
+		zero when there was no mouse button click.
 
-                                            *v:mouse_winid* *mouse_winid-variable*
+					    *v:mouse_winid* *mouse_winid-variable*
 v:mouse_winid
-                |window-ID| for a mouse click obtained with |getchar()|.
-                The value is zero when there was no mouse button click.
+		|window-ID| for a mouse click obtained with |getchar()|.
+		The value is zero when there was no mouse button click.
 
-                                        *v:msgpack_types* *msgpack_types-variable*
+					*v:msgpack_types* *msgpack_types-variable*
 v:msgpack_types
-                Dictionary containing msgpack types used by |msgpackparse()|
-                and |msgpackdump()|. All types inside dictionary are fixed
-                (not editable) empty lists. To check whether some list is one
-                of msgpack types, use |is| operator.
+		Dictionary containing msgpack types used by |msgpackparse()|
+		and |msgpackdump()|. All types inside dictionary are fixed
+		(not editable) empty lists. To check whether some list is one
+		of msgpack types, use |is| operator.
 
-                                                          *v:null* *null-variable*
+							  *v:null* *null-variable*
 v:null
-                Special value used to put "null" in JSON and NIL in msgpack.
-                See |json_encode()|.  This value is converted to "v:null" when
-                used as a String (e.g. in |expr5| with string concatenation
-                operator) and to zero when used as a Number (e.g. in |expr5|
-                or |expr7| when used with numeric operators). Read-only.
-                In some places `v:null` can be used for a List, Dict, etc.
-                that is not set.  That is slightly different than an empty
-                List, Dict, etc.
+		Special value used to put "null" in JSON and NIL in msgpack.
+		See |json_encode()|.  This value is converted to "v:null" when
+		used as a String (e.g. in |expr5| with string concatenation
+		operator) and to zero when used as a Number (e.g. in |expr5|
+		or |expr7| when used with numeric operators). Read-only.
+		In some places `v:null` can be used for a List, Dict, etc.
+		that is not set.  That is slightly different than an empty
+		List, Dict, etc.
 
-                                                *v:numbermax* *numbermax-variable*
-v:numbermax     Maximum value of a number.
+						*v:numbermax* *numbermax-variable*
+v:numbermax	Maximum value of a number.
 
-                                                *v:numbermin* *numbermin-variable*
-v:numbermin     Minimum value of a number (negative).
+						*v:numbermin* *numbermin-variable*
+v:numbermin	Minimum value of a number (negative).
 
-                                              *v:numbersize* *numbersize-variable*
+					      *v:numbersize* *numbersize-variable*
 v:numbersize
-                Number of bits in a Number.  This is normally 64, but on some
-                systems it may be 32.
+		Number of bits in a Number.  This is normally 64, but on some
+		systems it may be 32.
 
-                                                  *v:oldfiles* *oldfiles-variable*
+						  *v:oldfiles* *oldfiles-variable*
 v:oldfiles
-                List of file names that is loaded from the |shada| file on
-                startup.  These are the files that Vim remembers marks for.
-                The length of the List is limited by the ' argument of the
-                'shada' option (default is 100).
-                When the |shada| file is not used the List is empty.
-                Also see |:oldfiles| and |c_#<|.
-                The List can be modified, but this has no effect on what is
-                stored in the |shada| file later.  If you use values other
-                than String this will cause trouble.
+		List of file names that is loaded from the |shada| file on
+		startup.  These are the files that Vim remembers marks for.
+		The length of the List is limited by the ' argument of the
+		'shada' option (default is 100).
+		When the |shada| file is not used the List is empty.
+		Also see |:oldfiles| and |c_#<|.
+		The List can be modified, but this has no effect on what is
+		stored in the |shada| file later.  If you use values other
+		than String this will cause trouble.
 
-                                                  *v:operator* *operator-variable*
+						  *v:operator* *operator-variable*
 v:operator
-                The last operator given in Normal mode.  This is a single
-                character except for commands starting with <g> or <z>,
-                in which case it is two characters.  Best used alongside
-                |v:prevcount| and |v:register|.  Useful if you want to cancel
-                Operator-pending mode and then use the operator, e.g.: >vim
-                  :omap O <Esc>:call MyMotion(v:operator)<CR>
+		The last operator given in Normal mode.  This is a single
+		character except for commands starting with <g> or <z>,
+		in which case it is two characters.  Best used alongside
+		|v:prevcount| and |v:register|.  Useful if you want to cancel
+		Operator-pending mode and then use the operator, e.g.: >vim
+		  :omap O <Esc>:call MyMotion(v:operator)<CR>
 <
-                The value remains set until another operator is entered, thus
-                don't expect it to be empty.
-                v:operator is not set for |:delete|, |:yank| or other Ex
-                commands.
-                Read-only.
+		The value remains set until another operator is entered, thus
+		don't expect it to be empty.
+		v:operator is not set for |:delete|, |:yank| or other Ex
+		commands.
+		Read-only.
 
-                                      *v:option_command* *option_command-variable*
+				      *v:option_command* *option_command-variable*
 v:option_command
-                Command used to set the option. Valid while executing an
-                |OptionSet| autocommand.
-                  value        option was set via ~
-                  "setlocal"   |:setlocal| or `:let l:xxx`
-                  "setglobal"  |:setglobal| or `:let g:xxx`
-                  "set"        |:set| or |:let|
-                  "modeline"   |modeline|
+		Command used to set the option. Valid while executing an
+		|OptionSet| autocommand.
+		  value        option was set via ~
+		  "setlocal"   |:setlocal| or `:let l:xxx`
+		  "setglobal"  |:setglobal| or `:let g:xxx`
+		  "set"        |:set| or |:let|
+		  "modeline"   |modeline|
 
-                                              *v:option_new* *option_new-variable*
+					      *v:option_new* *option_new-variable*
 v:option_new
-                New value of the option. Valid while executing an |OptionSet|
-                autocommand.
+		New value of the option. Valid while executing an |OptionSet|
+		autocommand.
 
-                                              *v:option_old* *option_old-variable*
+					      *v:option_old* *option_old-variable*
 v:option_old
-                Old value of the option. Valid while executing an |OptionSet|
-                autocommand. Depending on the command used for setting and the
-                kind of option this is either the local old value or the
-                global old value.
+		Old value of the option. Valid while executing an |OptionSet|
+		autocommand. Depending on the command used for setting and the
+		kind of option this is either the local old value or the
+		global old value.
 
-                                  *v:option_oldglobal* *option_oldglobal-variable*
+				  *v:option_oldglobal* *option_oldglobal-variable*
 v:option_oldglobal
-                Old global value of the option. Valid while executing an
-                |OptionSet| autocommand.
+		Old global value of the option. Valid while executing an
+		|OptionSet| autocommand.
 
-                                    *v:option_oldlocal* *option_oldlocal-variable*
+				    *v:option_oldlocal* *option_oldlocal-variable*
 v:option_oldlocal
-                Old local value of the option. Valid while executing an
-                |OptionSet| autocommand.
+		Old local value of the option. Valid while executing an
+		|OptionSet| autocommand.
 
-                                            *v:option_type* *option_type-variable*
+					    *v:option_type* *option_type-variable*
 v:option_type
-                Scope of the set command. Valid while executing an
-                |OptionSet| autocommand. Can be either "global" or "local"
+		Scope of the set command. Valid while executing an
+		|OptionSet| autocommand. Can be either "global" or "local"
 
-                                                *v:prevcount* *prevcount-variable*
+						*v:prevcount* *prevcount-variable*
 v:prevcount
-                The count given for the last but one Normal mode command.
-                This is the v:count value of the previous command.  Useful if
-                you want to cancel Visual or Operator-pending mode and then
-                use the count, e.g.: >vim
-                  :vmap % <Esc>:call MyFilter(v:prevcount)<CR>
+		The count given for the last but one Normal mode command.
+		This is the v:count value of the previous command.  Useful if
+		you want to cancel Visual or Operator-pending mode and then
+		use the count, e.g.: >vim
+		  :vmap % <Esc>:call MyFilter(v:prevcount)<CR>
 <
-                Read-only.
+		Read-only.
 
-                                                *v:profiling* *profiling-variable*
+						*v:profiling* *profiling-variable*
 v:profiling
-                Normally zero.  Set to one after using ":profile start".
-                See |profiling|.
+		Normally zero.	Set to one after using ":profile start".
+		See |profiling|.
 
-                                                  *v:progname* *progname-variable*
+						  *v:progname* *progname-variable*
 v:progname
-                The name by which Nvim was invoked (with path removed).
-                Read-only.
+		The name by which Nvim was invoked (with path removed).
+		Read-only.
 
-                                                  *v:progpath* *progpath-variable*
+						  *v:progpath* *progpath-variable*
 v:progpath
-                Absolute path to the current running Nvim.
-                Read-only.
+		Absolute path to the current running Nvim.
+		Read-only.
 
-                                                  *v:register* *register-variable*
+						  *v:register* *register-variable*
 v:register
-                The name of the register in effect for the current normal mode
-                command (regardless of whether that command actually used a
-                register).  Or for the currently executing normal mode mapping
-                (use this in custom commands that take a register).
-                If none is supplied it is the default register '"', unless
-                'clipboard' contains "unnamed" or "unnamedplus", then it is
-                "*" or '+'.
-                Also see |getreg()| and |setreg()|
+		The name of the register in effect for the current normal mode
+		command (regardless of whether that command actually used a
+		register).  Or for the currently executing normal mode mapping
+		(use this in custom commands that take a register).
+		If none is supplied it is the default register '"', unless
+		'clipboard' contains "unnamed" or "unnamedplus", then it is
+		"*" or '+'.
+		Also see |getreg()| and |setreg()|
 
-                                                      *v:relnum* *relnum-variable*
+						      *v:relnum* *relnum-variable*
 v:relnum
-                Relative line number for the 'statuscolumn' expression.
-                Read-only.
+		Relative line number for the 'statuscolumn' expression.
+		Read-only.
 
-                                            *v:scrollstart* *scrollstart-variable*
+					    *v:scrollstart* *scrollstart-variable*
 v:scrollstart
-                String describing the script or function that caused the
-                screen to scroll up.  It's only set when it is empty, thus the
-                first reason is remembered.  It is set to "Unknown" for a
-                typed command.
-                This can be used to find out why your script causes the
-                hit-enter prompt.
+		String describing the script or function that caused the
+		screen to scroll up.  It's only set when it is empty, thus the
+		first reason is remembered.  It is set to "Unknown" for a
+		typed command.
+		This can be used to find out why your script causes the
+		hit-enter prompt.
 
-                                        *v:searchforward* *searchforward-variable*
+					*v:searchforward* *searchforward-variable*
 v:searchforward
-                Search direction:  1 after a forward search, 0 after a
-                backward search.  It is reset to forward when directly setting
-                the last search pattern, see |quote/|.
-                Note that the value is restored when returning from a
-                function. |function-search-undo|.
-                Read-write.
+		Search direction:  1 after a forward search, 0 after a
+		backward search.  It is reset to forward when directly setting
+		the last search pattern, see |quote/|.
+		Note that the value is restored when returning from a
+		function. |function-search-undo|.
+		Read-write.
 
-                                              *v:servername* *servername-variable*
+					      *v:servername* *servername-variable*
 v:servername
-                Primary listen-address of Nvim, the first item returned by
-                |serverlist()|. Usually this is the named pipe created by Nvim
-                at |startup| or given by |--listen| (or the deprecated
-                |$NVIM_LISTEN_ADDRESS| env var).
+		Primary listen-address of Nvim, the first item returned by
+		|serverlist()|. Usually this is the named pipe created by Nvim
+		at |startup| or given by |--listen| (or the deprecated
+		|$NVIM_LISTEN_ADDRESS| env var).
 
-                See also |serverstart()| |serverstop()|.
-                Read-only.
+		See also |serverstart()| |serverstop()|.
+		Read-only.
 
-                                                                     *$NVIM*
-                $NVIM is set by |terminal| and |jobstart()|, and is thus
-                a hint that the current environment is a subprocess of Nvim.
-                Example: >vim
-                  if $NVIM
-                    echo nvim_get_chan_info(v:parent)
-                  endif
+								     *$NVIM*
+		$NVIM is set by |terminal| and |jobstart()|, and is thus
+		a hint that the current environment is a subprocess of Nvim.
+		Example: >vim
+		  if $NVIM
+		    echo nvim_get_chan_info(v:parent)
+		  endif
 <
 
-                Note the contents of $NVIM may change in the future.
+		Note the contents of $NVIM may change in the future.
 
-                                            *v:shell_error* *shell_error-variable*
+					    *v:shell_error* *shell_error-variable*
 v:shell_error
-                Result of the last shell command.  When non-zero, the last
-                shell command had an error.  When zero, there was no problem.
-                This only works when the shell returns the error code to Vim.
-                The value -1 is often used when the command could not be
-                executed.  Read-only.
-                Example: >vim
-                  !mv foo bar
-                  if v:shell_error
-                    echo 'could not rename "foo" to "bar"!'
-                  endif
+		Result of the last shell command.  When non-zero, the last
+		shell command had an error.  When zero, there was no problem.
+		This only works when the shell returns the error code to Vim.
+		The value -1 is often used when the command could not be
+		executed.  Read-only.
+		Example: >vim
+		  !mv foo bar
+		  if v:shell_error
+		    echo 'could not rename "foo" to "bar"!'
+		  endif
 <
 
-                                                *v:statusmsg* *statusmsg-variable*
+						*v:statusmsg* *statusmsg-variable*
 v:statusmsg
-                Last given status message.
-                Modifiable (can be set).
+		Last given status message.
+		Modifiable (can be set).
 
-                                                      *v:stderr* *stderr-variable*
+						      *v:stderr* *stderr-variable*
 v:stderr
-                |channel-id| corresponding to stderr. The value is always 2;
-                use this variable to make your code more descriptive.
-                Unlike stdin and stdout (see |stdioopen()|), stderr is always
-                open for writing. Example: >vim
-                :call chansend(v:stderr, "error: toaster empty\n")
+		|channel-id| corresponding to stderr. The value is always 2;
+		use this variable to make your code more descriptive.
+		Unlike stdin and stdout (see |stdioopen()|), stderr is always
+		open for writing. Example: >vim
+		:call chansend(v:stderr, "error: toaster empty\n")
 <
 
-                                              *v:swapchoice* *swapchoice-variable*
+					      *v:swapchoice* *swapchoice-variable*
 v:swapchoice
-                |SwapExists| autocommands can set this to the selected choice
-                for handling an existing swapfile:
-                  'o'    Open read-only
-                  'e'    Edit anyway
-                  'r'    Recover
-                  'd'    Delete swapfile
-                  'q'    Quit
-                  'a'    Abort
-                The value should be a single-character string.  An empty value
-                results in the user being asked, as would happen when there is
-                no SwapExists autocommand.  The default is empty.
+		|SwapExists| autocommands can set this to the selected choice
+		for handling an existing swapfile:
+		  'o'	 Open read-only
+		  'e'	 Edit anyway
+		  'r'	 Recover
+		  'd'	 Delete swapfile
+		  'q'	 Quit
+		  'a'	 Abort
+		The value should be a single-character string.	An empty value
+		results in the user being asked, as would happen when there is
+		no SwapExists autocommand.  The default is empty.
 
-                                            *v:swapcommand* *swapcommand-variable*
+					    *v:swapcommand* *swapcommand-variable*
 v:swapcommand
-                Normal mode command to be executed after a file has been
-                opened.  Can be used for a |SwapExists| autocommand to have
-                another Vim open the file and jump to the right place.  For
-                example, when jumping to a tag the value is ":tag tagname\r".
-                For ":edit +cmd file" the value is ":cmd\r".
+		Normal mode command to be executed after a file has been
+		opened.  Can be used for a |SwapExists| autocommand to have
+		another Vim open the file and jump to the right place.	For
+		example, when jumping to a tag the value is ":tag tagname\r".
+		For ":edit +cmd file" the value is ":cmd\r".
 
-                                                  *v:swapname* *swapname-variable*
+						  *v:swapname* *swapname-variable*
 v:swapname
-                Name of the swapfile found.
-                Only valid during |SwapExists| event.
-                Read-only.
+		Name of the swapfile found.
+		Only valid during |SwapExists| event.
+		Read-only.
 
-                                             *v:t_blob* *t_blob-variable* *v:t_TYPE*
-v:t_blob        Value of |Blob| type.  Read-only.  See: |type()|
+					     *v:t_blob* *t_blob-variable* *v:t_TYPE*
+v:t_blob	Value of |Blob| type.  Read-only.  See: |type()|
 
-                                                      *v:t_bool* *t_bool-variable*
-v:t_bool        Value of |Boolean| type.  Read-only.  See: |type()|
+						      *v:t_bool* *t_bool-variable*
+v:t_bool	Value of |Boolean| type.  Read-only.  See: |type()|
 
-                                                      *v:t_dict* *t_dict-variable*
-v:t_dict        Value of |Dictionary| type.  Read-only.  See: |type()|
+						      *v:t_dict* *t_dict-variable*
+v:t_dict	Value of |Dictionary| type.  Read-only.  See: |type()|
 
-                                                    *v:t_float* *t_float-variable*
-v:t_float       Value of |Float| type.  Read-only.  See: |type()|
+						    *v:t_float* *t_float-variable*
+v:t_float	Value of |Float| type.	Read-only.  See: |type()|
 
-                                                      *v:t_func* *t_func-variable*
-v:t_func        Value of |Funcref| type.  Read-only.  See: |type()|
+						      *v:t_func* *t_func-variable*
+v:t_func	Value of |Funcref| type.  Read-only.  See: |type()|
 
-                                                      *v:t_list* *t_list-variable*
-v:t_list        Value of |List| type.  Read-only.  See: |type()|
+						      *v:t_list* *t_list-variable*
+v:t_list	Value of |List| type.  Read-only.  See: |type()|
 
-                                                  *v:t_number* *t_number-variable*
-v:t_number      Value of |Number| type.  Read-only.  See: |type()|
+						  *v:t_number* *t_number-variable*
+v:t_number	Value of |Number| type.  Read-only.  See: |type()|
 
-                                                  *v:t_string* *t_string-variable*
-v:t_string      Value of |String| type.  Read-only.  See: |type()|
+						  *v:t_string* *t_string-variable*
+v:t_string	Value of |String| type.  Read-only.  See: |type()|
 
-                                          *v:termresponse* *termresponse-variable*
+					  *v:termresponse* *termresponse-variable*
 v:termresponse
-                The value of the most recent OSC or DCS escape sequence
-                received by Nvim from the terminal. This can be read in a
-                |TermResponse| event handler after querying the terminal using
-                another escape sequence.
+		The value of the most recent OSC or DCS escape sequence
+		received by Nvim from the terminal. This can be read in a
+		|TermResponse| event handler after querying the terminal using
+		another escape sequence.
 
-                                                    *v:testing* *testing-variable*
-v:testing       Must be set before using `test_garbagecollect_now()`.
+						    *v:testing* *testing-variable*
+v:testing	Must be set before using `test_garbagecollect_now()`.
 
-                                          *v:this_session* *this_session-variable*
+					  *v:this_session* *this_session-variable*
 v:this_session
-                Full filename of the last loaded or saved session file.
-                Empty when no session file has been saved.  See |:mksession|.
-                Modifiable (can be set).
+		Full filename of the last loaded or saved session file.
+		Empty when no session file has been saved.  See |:mksession|.
+		Modifiable (can be set).
 
-                                              *v:throwpoint* *throwpoint-variable*
+					      *v:throwpoint* *throwpoint-variable*
 v:throwpoint
-                The point where the exception most recently caught and not
-                finished was thrown.  Not set when commands are typed.  See
-                also |v:exception| and |throw-variables|.
-                Example: >vim
-                  try
-                    throw "oops"
-                  catch /.*/
-                    echo "Exception from" v:throwpoint
-                  endtry
+		The point where the exception most recently caught and not
+		finished was thrown.  Not set when commands are typed.	See
+		also |v:exception| and |throw-variables|.
+		Example: >vim
+		  try
+		    throw "oops"
+		  catch /.*/
+		    echo "Exception from" v:throwpoint
+		  endtry
 <
-                Output: "Exception from test.vim, line 2"
+		Output: "Exception from test.vim, line 2"
 
-                                                          *v:true* *true-variable*
+							  *v:true* *true-variable*
 v:true
-                Special value used to put "true" in JSON and msgpack.  See
-                |json_encode()|.  This value is converted to "v:true" when used
-                as a String (e.g. in |expr5| with string concatenation
-                operator) and to one when used as a Number (e.g. in |expr5| or
-                |expr7| when used with numeric operators). Read-only.
+		Special value used to put "true" in JSON and msgpack.  See
+		|json_encode()|.  This value is converted to "v:true" when used
+		as a String (e.g. in |expr5| with string concatenation
+		operator) and to one when used as a Number (e.g. in |expr5| or
+		|expr7| when used with numeric operators). Read-only.
 
-                                                            *v:val* *val-variable*
+							    *v:val* *val-variable*
 v:val
-                Value of the current item of a |List| or |Dictionary|.  Only
-                valid while evaluating the expression used with |map()| and
-                |filter()|.  Read-only.
+		Value of the current item of a |List| or |Dictionary|.	Only
+		valid while evaluating the expression used with |map()| and
+		|filter()|.  Read-only.
 
-                                                    *v:version* *version-variable*
+						    *v:version* *version-variable*
 v:version
-                Vim version number: major version times 100 plus minor
-                version.  Vim 5.0 is 500, Vim 5.1 is 501.
-                Read-only.
-                Use |has()| to check the Nvim (not Vim) version: >vim
-                  :if has("nvim-0.2.1")
+		Vim version number: major version times 100 plus minor
+		version.  Vim 5.0 is 500, Vim 5.1 is 501.
+		Read-only.
+		Use |has()| to check the Nvim (not Vim) version: >vim
+		  :if has("nvim-0.2.1")
 <
 
-                                        *v:vim_did_enter* *vim_did_enter-variable*
+					*v:vim_did_enter* *vim_did_enter-variable*
 v:vim_did_enter
-                0 during startup, 1 just before |VimEnter|.
-                Read-only.
+		0 during startup, 1 just before |VimEnter|.
+		Read-only.
 
-                                                    *v:virtnum* *virtnum-variable*
+						    *v:virtnum* *virtnum-variable*
 v:virtnum
-                Virtual line number for the 'statuscolumn' expression.
-                Negative when drawing the status column for virtual lines, zero
-                when drawing an actual buffer line, and positive when drawing
-                the wrapped part of a buffer line.
-                Read-only.
+		Virtual line number for the 'statuscolumn' expression.
+		Negative when drawing the status column for virtual lines, zero
+		when drawing an actual buffer line, and positive when drawing
+		the wrapped part of a buffer line.
+		Read-only.
 
-                                              *v:warningmsg* *warningmsg-variable*
+					      *v:warningmsg* *warningmsg-variable*
 v:warningmsg
-                Last given warning message.
-                Modifiable (can be set).
+		Last given warning message.
+		Modifiable (can be set).
 
-                                                  *v:windowid* *windowid-variable*
+						  *v:windowid* *windowid-variable*
 v:windowid
-                Application-specific window "handle" which may be set by any
-                attached UI. Defaults to zero.
-                Note: For Nvim |windows| use |winnr()| or |win_getid()|, see
-                |window-ID|.
+		Application-specific window "handle" which may be set by any
+		attached UI. Defaults to zero.
+		Note: For Nvim |windows| use |winnr()| or |win_getid()|, see
+		|window-ID|.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -10,719 +10,719 @@ Some variables can be set by the user, but the type cannot be changed.
 
                                        Type |gO| to see the table of contents.
 
-						*v:argv* *argv-variable*
+                                                          *v:argv* *argv-variable*
 v:argv
-		The command line arguments Vim was invoked with.  This is a
-		list of strings.  The first item is the Vim command.
-		See |v:progpath| for the command with full path.
+                The command line arguments Vim was invoked with.  This is a
+                list of strings.  The first item is the Vim command.
+                See |v:progpath| for the command with full path.
 
-						*v:char* *char-variable*
+                                                          *v:char* *char-variable*
 v:char
-		Argument for evaluating 'formatexpr' and used for the typed
-		character when using <expr> in an abbreviation |:map-<expr>|.
-		It is also used by the |InsertCharPre| and |InsertEnter| events.
+                Argument for evaluating 'formatexpr' and used for the typed
+                character when using <expr> in an abbreviation |:map-<expr>|.
+                It is also used by the |InsertCharPre| and |InsertEnter| events.
 
-			*v:charconvert_from* *charconvert_from-variable*
+                                  *v:charconvert_from* *charconvert_from-variable*
 v:charconvert_from
-		The name of the character encoding of a file to be converted.
-		Only valid while evaluating the 'charconvert' option.
+                The name of the character encoding of a file to be converted.
+                Only valid while evaluating the 'charconvert' option.
 
-			*v:charconvert_to* *charconvert_to-variable*
+                                      *v:charconvert_to* *charconvert_to-variable*
 v:charconvert_to
-		The name of the character encoding of a file after conversion.
-		Only valid while evaluating the 'charconvert' option.
+                The name of the character encoding of a file after conversion.
+                Only valid while evaluating the 'charconvert' option.
 
-					*v:cmdarg* *cmdarg-variable*
+                                                      *v:cmdarg* *cmdarg-variable*
 v:cmdarg
-		The extra arguments ("++p", "++enc=", "++ff=") given to a file
-		read/write command.  This is set before an autocommand event
-		for a file read/write command is triggered.  There is a
-		leading space to make it possible to append this variable
-		directly after the read/write command. Note: "+cmd" isn't
-		included here, because it will be executed anyway.
+                The extra arguments ("++p", "++enc=", "++ff=") given to a file
+                read/write command.  This is set before an autocommand event
+                for a file read/write command is triggered.  There is a
+                leading space to make it possible to append this variable
+                directly after the read/write command. Note: "+cmd" isn't
+                included here, because it will be executed anyway.
 
-					*v:cmdbang* *cmdbang-variable*
+                                                    *v:cmdbang* *cmdbang-variable*
 v:cmdbang
-		Set like v:cmdarg for a file read/write command.  When a "!"
-		was used the value is 1, otherwise it is 0.  Note that this
-		can only be used in autocommands.  For user commands |<bang>|
-		can be used.
+                Set like v:cmdarg for a file read/write command.  When a "!"
+                was used the value is 1, otherwise it is 0.  Note that this
+                can only be used in autocommands.  For user commands |<bang>|
+                can be used.
 
-					*v:collate* *collate-variable*
+                                                    *v:collate* *collate-variable*
 v:collate
-		The current locale setting for collation order of the runtime
-		environment.  This allows Vim scripts to be aware of the
-		current locale encoding.  Technical: it's the value of
-		LC_COLLATE.  When not using a locale the value is "C".
-		This variable can not be set directly, use the |:language|
-		command.
-		See |multi-lang|.
+                The current locale setting for collation order of the runtime
+                environment.  This allows Vim scripts to be aware of the
+                current locale encoding.  Technical: it's the value of
+                LC_COLLATE.  When not using a locale the value is "C".
+                This variable can not be set directly, use the |:language|
+                command.
+                See |multi-lang|.
 
-			*v:completed_item* *completed_item-variable*
+                                      *v:completed_item* *completed_item-variable*
 v:completed_item
-		Dictionary containing the most recent |complete-items| after
-		|CompleteDone|.  Empty if the completion failed, or after
-		leaving and re-entering insert mode.
-		Note: Plugins can modify the value to emulate the builtin
-		|CompleteDone| event behavior.
+                Dictionary containing the most recent |complete-items| after
+                |CompleteDone|.  Empty if the completion failed, or after
+                leaving and re-entering insert mode.
+                Note: Plugins can modify the value to emulate the builtin
+                |CompleteDone| event behavior.
 
-					*v:count* *count-variable*
+                                                        *v:count* *count-variable*
 v:count
-		The count given for the last Normal mode command.  Can be used
-		to get the count before a mapping.  Read-only.  Example: >vim
-		  :map _x :<C-U>echo "the count is " .. v:count<CR>
+                The count given for the last Normal mode command.  Can be used
+                to get the count before a mapping.  Read-only.  Example: >vim
+                  :map _x :<C-U>echo "the count is " .. v:count<CR>
 <
-		Note: The <C-U> is required to remove the line range that you
-		get when typing ':' after a count.
-		When there are two counts, as in "3d2w", they are multiplied,
-		just like what happens in the command, "d6w" for the example.
-		Also used for evaluating the 'formatexpr' option.
+                Note: The <C-U> is required to remove the line range that you
+                get when typing ':' after a count.
+                When there are two counts, as in "3d2w", they are multiplied,
+                just like what happens in the command, "d6w" for the example.
+                Also used for evaluating the 'formatexpr' option.
 
-					*v:count1* *count1-variable*
+                                                      *v:count1* *count1-variable*
 v:count1
-		Just like "v:count", but defaults to one when no count is
-		used.
+                Just like "v:count", but defaults to one when no count is
+                used.
 
-					*v:ctype* *ctype-variable*
+                                                        *v:ctype* *ctype-variable*
 v:ctype
-		The current locale setting for characters of the runtime
-		environment.  This allows Vim scripts to be aware of the
-		current locale encoding.  Technical: it's the value of
-		LC_CTYPE.  When not using a locale the value is "C".
-		This variable can not be set directly, use the |:language|
-		command.
-		See |multi-lang|.
+                The current locale setting for characters of the runtime
+                environment.  This allows Vim scripts to be aware of the
+                current locale encoding.  Technical: it's the value of
+                LC_CTYPE.  When not using a locale the value is "C".
+                This variable can not be set directly, use the |:language|
+                command.
+                See |multi-lang|.
 
-					*v:dying* *dying-variable*
+                                                        *v:dying* *dying-variable*
 v:dying
-		Normally zero.  When a deadly signal is caught it's set to
-		one.  When multiple signals are caught the number increases.
-		Can be used in an autocommand to check if Vim didn't
-		terminate normally.
-		Example: >vim
-		  :au VimLeave * if v:dying | echo "\nAAAAaaaarrrggghhhh!!!\n" | endif
+                Normally zero.  When a deadly signal is caught it's set to
+                one.  When multiple signals are caught the number increases.
+                Can be used in an autocommand to check if Vim didn't
+                terminate normally.
+                Example: >vim
+                  :au VimLeave * if v:dying | echo "\nAAAAaaaarrrggghhhh!!!\n" | endif
 <
-		Note: if another deadly signal is caught when v:dying is one,
-		VimLeave autocommands will not be executed.
+                Note: if another deadly signal is caught when v:dying is one,
+                VimLeave autocommands will not be executed.
 
-				*v:echospace* *echospace-variable*
+                                                *v:echospace* *echospace-variable*
 v:echospace
-		Number of screen cells that can be used for an `:echo` message
-		in the last screen line before causing the |hit-enter-prompt|.
-		Depends on 'showcmd', 'ruler' and 'columns'.  You need to
-		check 'cmdheight' for whether there are full-width lines
-		available above the last line.
+                Number of screen cells that can be used for an `:echo` message
+                in the last screen line before causing the |hit-enter-prompt|.
+                Depends on 'showcmd', 'ruler' and 'columns'.  You need to
+                check 'cmdheight' for whether there are full-width lines
+                available above the last line.
 
-					*v:errmsg* *errmsg-variable*
+                                                      *v:errmsg* *errmsg-variable*
 v:errmsg
-		Last given error message.
-		Modifiable (can be set).
-		Example: >vim
-		  let v:errmsg = ""
-		  silent! next
-		  if v:errmsg != ""
-		    " ... handle error
+                Last given error message.
+                Modifiable (can be set).
+                Example: >vim
+                  let v:errmsg = ""
+                  silent! next
+                  if v:errmsg != ""
+                    " ... handle error
 <
 
-			*v:errors* *errors-variable* *assert-return*
+                                        *v:errors* *errors-variable* *assert-return*
 v:errors
-		Errors found by assert functions, such as |assert_true()|.
-		This is a list of strings.
-		The assert functions append an item when an assert fails.
-		The return value indicates this: a one is returned if an item
-		was added to v:errors, otherwise zero is returned.
-		To remove old results make it empty: >vim
-		  let v:errors = []
+                Errors found by assert functions, such as |assert_true()|.
+                This is a list of strings.
+                The assert functions append an item when an assert fails.
+                The return value indicates this: a one is returned if an item
+                was added to v:errors, otherwise zero is returned.
+                To remove old results make it empty: >vim
+                  let v:errors = []
 <
-		If v:errors is set to anything but a list it is made an empty
-		list by the assert function.
+                If v:errors is set to anything but a list it is made an empty
+                list by the assert function.
 
-					*v:event* *event-variable*
+                                                        *v:event* *event-variable*
 v:event
-		Dictionary of event data for the current |autocommand|.  Valid
-		only during the event lifetime; storing or passing v:event is
-		invalid!  Copy it instead: >vim
-		  au TextYankPost * let g:foo = deepcopy(v:event)
+                Dictionary of event data for the current |autocommand|.  Valid
+                only during the event lifetime; storing or passing v:event is
+                invalid!  Copy it instead: >vim
+                  au TextYankPost * let g:foo = deepcopy(v:event)
 <
-		Keys vary by event; see the documentation for the specific
-		event, e.g. |DirChanged| or |TextYankPost|.
-		  KEY              DESCRIPTION ~
-		  abort            Whether the event triggered during
-		                   an aborting condition (e.g. |c_Esc| or
-		                   |c_CTRL-C| for |CmdlineLeave|).
-		  chan             |channel-id|
-		  cmdlevel         Level of cmdline.
-		  cmdtype          Type of cmdline, |cmdline-char|.
-		  cwd              Current working directory.
-		  inclusive        Motion is |inclusive|, else exclusive.
-		  scope            Event-specific scope name.
-		  operator         Current |operator|.  Also set for Ex
-		  commands         (unlike |v:operator|). For
-		                   example if |TextYankPost| is triggered
-		                   by the |:yank| Ex command then
-		                   `v:event.operator` is "y".
-		  regcontents      Text stored in the register as a
-		                   |readfile()|-style list of lines.
-		  regname          Requested register (e.g "x" for "xyy)
-		                   or the empty string for an unnamed
-		                   operation.
-		  regtype          Type of register as returned by
-		                   |getregtype()|.
-		  visual           Selection is visual (as opposed to,
-		                   e.g., via motion).
-		  completed_item   Current selected complete item on
-		                   |CompleteChanged|, Is `{}` when no complete
-		                   item selected.
-		  height           Height of popup menu on |CompleteChanged|
-		  width            Width of popup menu on |CompleteChanged|
-		  row              Row count of popup menu on |CompleteChanged|,
-		                   relative to screen.
-		  col              Col count of popup menu on |CompleteChanged|,
-		                   relative to screen.
-		  size             Total number of completion items on
-		                   |CompleteChanged|.
-		  scrollbar        Is |v:true| if popup menu have scrollbar, or
-		                   |v:false| if not.
-		  changed_window   Is |v:true| if the event fired while
-		                   changing window  (or tab) on |DirChanged|.
-		  status           Job status or exit code, -1 means "unknown". |TermClose|
+                Keys vary by event; see the documentation for the specific
+                event, e.g. |DirChanged| or |TextYankPost|.
+                  KEY              DESCRIPTION ~
+                  abort            Whether the event triggered during
+                                   an aborting condition (e.g. |c_Esc| or
+                                   |c_CTRL-C| for |CmdlineLeave|).
+                  chan             |channel-id|
+                  cmdlevel         Level of cmdline.
+                  cmdtype          Type of cmdline, |cmdline-char|.
+                  cwd              Current working directory.
+                  inclusive        Motion is |inclusive|, else exclusive.
+                  scope            Event-specific scope name.
+                  operator         Current |operator|.  Also set for Ex
+                  commands         (unlike |v:operator|). For
+                                   example if |TextYankPost| is triggered
+                                   by the |:yank| Ex command then
+                                   `v:event.operator` is "y".
+                  regcontents      Text stored in the register as a
+                                   |readfile()|-style list of lines.
+                  regname          Requested register (e.g "x" for "xyy)
+                                   or the empty string for an unnamed
+                                   operation.
+                  regtype          Type of register as returned by
+                                   |getregtype()|.
+                  visual           Selection is visual (as opposed to,
+                                   e.g., via motion).
+                  completed_item   Current selected complete item on
+                                   |CompleteChanged|, Is `{}` when no complete
+                                   item selected.
+                  height           Height of popup menu on |CompleteChanged|
+                  width            Width of popup menu on |CompleteChanged|
+                  row              Row count of popup menu on |CompleteChanged|,
+                                   relative to screen.
+                  col              Col count of popup menu on |CompleteChanged|,
+                                   relative to screen.
+                  size             Total number of completion items on
+                                   |CompleteChanged|.
+                  scrollbar        Is |v:true| if popup menu have scrollbar, or
+                                   |v:false| if not.
+                  changed_window   Is |v:true| if the event fired while
+                                   changing window  (or tab) on |DirChanged|.
+                  status           Job status or exit code, -1 means "unknown". |TermClose|
 
-				*v:exception* *exception-variable*
+                                                *v:exception* *exception-variable*
 v:exception
-		The value of the exception most recently caught and not
-		finished.  See also |v:throwpoint| and |throw-variables|.
-		Example: >vim
-		  try
-		    throw "oops"
-		  catch /.*/
-		    echo "caught " .. v:exception
-		  endtry
+                The value of the exception most recently caught and not
+                finished.  See also |v:throwpoint| and |throw-variables|.
+                Example: >vim
+                  try
+                    throw "oops"
+                  catch /.*/
+                    echo "caught " .. v:exception
+                  endtry
 <
-		Output: "caught oops".
+                Output: "caught oops".
 
-					*v:exiting* *exiting-variable*
+                                                    *v:exiting* *exiting-variable*
 v:exiting
-		Exit code, or |v:null| before invoking the |VimLeavePre|
-		and |VimLeave| autocmds.  See |:q|, |:x| and |:cquit|.
-		Example: >vim
-		  :au VimLeave * echo "Exit value is " .. v:exiting
+                Exit code, or |v:null| before invoking the |VimLeavePre|
+                and |VimLeave| autocmds.  See |:q|, |:x| and |:cquit|.
+                Example: >vim
+                  :au VimLeave * echo "Exit value is " .. v:exiting
 <
 
-					*v:false* *false-variable*
+                                                        *v:false* *false-variable*
 v:false
-		Special value used to put "false" in JSON and msgpack.  See
-		|json_encode()|.  This value is converted to "v:false" when used
-		as a String (e.g. in |expr5| with string concatenation
-		operator) and to zero when used as a Number (e.g. in |expr5|
-		or |expr7| when used with numeric operators). Read-only.
+                Special value used to put "false" in JSON and msgpack.  See
+                |json_encode()|.  This value is converted to "v:false" when used
+                as a String (e.g. in |expr5| with string concatenation
+                operator) and to zero when used as a Number (e.g. in |expr5|
+                or |expr7| when used with numeric operators). Read-only.
 
-				*v:fcs_choice* *fcs_choice-variable*
+                                              *v:fcs_choice* *fcs_choice-variable*
 v:fcs_choice
-		What should happen after a |FileChangedShell| event was
-		triggered.  Can be used in an autocommand to tell Vim what to
-		do with the affected buffer:
-		  reload  Reload the buffer (does not work if
-		          the file was deleted).
-		  edit    Reload the buffer and detect the
-		          values for options such as
-		          'fileformat', 'fileencoding', 'binary'
-		          (does not work if the file was
-		          deleted).
-		  ask     Ask the user what to do, as if there
-		          was no autocommand.  Except that when
-		          only the timestamp changed nothing
-		          will happen.
-		  <empty> Nothing, the autocommand should do
-		          everything that needs to be done.
-		The default is empty.  If another (invalid) value is used then
-		Vim behaves like it is empty, there is no warning message.
+                What should happen after a |FileChangedShell| event was
+                triggered.  Can be used in an autocommand to tell Vim what to
+                do with the affected buffer:
+                  reload  Reload the buffer (does not work if
+                          the file was deleted).
+                  edit    Reload the buffer and detect the
+                          values for options such as
+                          'fileformat', 'fileencoding', 'binary'
+                          (does not work if the file was
+                          deleted).
+                  ask     Ask the user what to do, as if there
+                          was no autocommand.  Except that when
+                          only the timestamp changed nothing
+                          will happen.
+                  <empty> Nothing, the autocommand should do
+                          everything that needs to be done.
+                The default is empty.  If another (invalid) value is used then
+                Vim behaves like it is empty, there is no warning message.
 
-				*v:fcs_reason* *fcs_reason-variable*
+                                              *v:fcs_reason* *fcs_reason-variable*
 v:fcs_reason
-		The reason why the |FileChangedShell| event was triggered.
-		Can be used in an autocommand to decide what to do and/or what
-		to set v:fcs_choice to.  Possible values:
-		  deleted   file no longer exists
-		  conflict  file contents, mode or timestamp was
-		            changed and buffer is modified
-		  changed   file contents has changed
-		  mode      mode of file changed
-		  time      only file timestamp changed
+                The reason why the |FileChangedShell| event was triggered.
+                Can be used in an autocommand to decide what to do and/or what
+                to set v:fcs_choice to.  Possible values:
+                  deleted   file no longer exists
+                  conflict  file contents, mode or timestamp was
+                            changed and buffer is modified
+                  changed   file contents has changed
+                  mode      mode of file changed
+                  time      only file timestamp changed
 
-					*v:fname* *fname-variable*
+                                                        *v:fname* *fname-variable*
 v:fname
-		When evaluating 'includeexpr': the file name that was
-		detected.  Empty otherwise.
+                When evaluating 'includeexpr': the file name that was
+                detected.  Empty otherwise.
 
-				*v:fname_diff* *fname_diff-variable*
+                                              *v:fname_diff* *fname_diff-variable*
 v:fname_diff
-		The name of the diff (patch) file.  Only valid while
-		evaluating 'patchexpr'.
+                The name of the diff (patch) file.  Only valid while
+                evaluating 'patchexpr'.
 
-					*v:fname_in* *fname_in-variable*
+                                                  *v:fname_in* *fname_in-variable*
 v:fname_in
-		The name of the input file.  Valid while evaluating:
-		  option         used for ~
-		  'charconvert'  file to be converted
-		  'diffexpr'     original file
-		  'patchexpr'    original file
-		And set to the swap file name for |SwapExists|.
+                The name of the input file.  Valid while evaluating:
+                  option         used for ~
+                  'charconvert'  file to be converted
+                  'diffexpr'     original file
+                  'patchexpr'    original file
+                And set to the swap file name for |SwapExists|.
 
-				*v:fname_new* *fname_new-variable*
+                                                *v:fname_new* *fname_new-variable*
 v:fname_new
-		The name of the new version of the file.  Only valid while
-		evaluating 'diffexpr'.
+                The name of the new version of the file.  Only valid while
+                evaluating 'diffexpr'.
 
-				*v:fname_out* *fname_out-variable*
+                                                *v:fname_out* *fname_out-variable*
 v:fname_out
-		The name of the output file.  Only valid while
-		evaluating:
-		  option           used for ~
-		  'charconvert'    resulting converted file [1]
-		  'diffexpr'       output of diff
-		  'patchexpr'      resulting patched file
-		[1] When doing conversion for a write command (e.g., ":w
-		file") it will be equal to v:fname_in.  When doing conversion
-		for a read command (e.g., ":e file") it will be a temporary
-		file and different from v:fname_in.
+                The name of the output file.  Only valid while
+                evaluating:
+                  option           used for ~
+                  'charconvert'    resulting converted file [1]
+                  'diffexpr'       output of diff
+                  'patchexpr'      resulting patched file
+                [1] When doing conversion for a write command (e.g., ":w
+                file") it will be equal to v:fname_in.  When doing conversion
+                for a read command (e.g., ":e file") it will be a temporary
+                file and different from v:fname_in.
 
-				*v:folddashes* *folddashes-variable*
+                                              *v:folddashes* *folddashes-variable*
 v:folddashes
-		Used for 'foldtext': dashes representing foldlevel of a closed
-		fold.
-		Read-only in the |sandbox|. |fold-foldtext|
+                Used for 'foldtext': dashes representing foldlevel of a closed
+                fold.
+                Read-only in the |sandbox|. |fold-foldtext|
 
-					*v:foldend* *foldend-variable*
+                                                    *v:foldend* *foldend-variable*
 v:foldend
-		Used for 'foldtext': last line of closed fold.
-		Read-only in the |sandbox|. |fold-foldtext|
+                Used for 'foldtext': last line of closed fold.
+                Read-only in the |sandbox|. |fold-foldtext|
 
-				*v:foldlevel* *foldlevel-variable*
+                                                *v:foldlevel* *foldlevel-variable*
 v:foldlevel
-		Used for 'foldtext': foldlevel of closed fold.
-		Read-only in the |sandbox|. |fold-foldtext|
+                Used for 'foldtext': foldlevel of closed fold.
+                Read-only in the |sandbox|. |fold-foldtext|
 
-				*v:foldstart* *foldstart-variable*
+                                                *v:foldstart* *foldstart-variable*
 v:foldstart
-		Used for 'foldtext': first line of closed fold.
-		Read-only in the |sandbox|. |fold-foldtext|
+                Used for 'foldtext': first line of closed fold.
+                Read-only in the |sandbox|. |fold-foldtext|
 
-					*v:hlsearch* *hlsearch-variable*
+                                                  *v:hlsearch* *hlsearch-variable*
 v:hlsearch
-		Variable that indicates whether search highlighting is on.
-		Setting it makes sense only if 'hlsearch' is enabled. Setting
-		this variable to zero acts like the |:nohlsearch| command,
-		setting it to one acts like >vim
-		  let &hlsearch = &hlsearch
+                Variable that indicates whether search highlighting is on.
+                Setting it makes sense only if 'hlsearch' is enabled. Setting
+                this variable to zero acts like the |:nohlsearch| command,
+                setting it to one acts like >vim
+                  let &hlsearch = &hlsearch
 <
-		Note that the value is restored when returning from a
-		function. |function-search-undo|.
+                Note that the value is restored when returning from a
+                function. |function-search-undo|.
 
-				*v:insertmode* *insertmode-variable*
+                                              *v:insertmode* *insertmode-variable*
 v:insertmode
-		Used for the |InsertEnter| and |InsertChange| autocommand
-		events.  Values:
-		  i    Insert mode
-		  r    Replace mode
-		  v    Virtual Replace mode
+                Used for the |InsertEnter| and |InsertChange| autocommand
+                events.  Values:
+                  i    Insert mode
+                  r    Replace mode
+                  v    Virtual Replace mode
 
-						*v:key* *key-variable*
+                                                            *v:key* *key-variable*
 v:key
-		Key of the current item of a |Dictionary|.  Only valid while
-		evaluating the expression used with |map()| and |filter()|.
-		Read-only.
+                Key of the current item of a |Dictionary|.  Only valid while
+                evaluating the expression used with |map()| and |filter()|.
+                Read-only.
 
-						*v:lang* *lang-variable*
+                                                          *v:lang* *lang-variable*
 v:lang
-		The current locale setting for messages of the runtime
-		environment.  This allows Vim scripts to be aware of the
-		current language.  Technical: it's the value of LC_MESSAGES.
-		The value is system dependent.
-		This variable can not be set directly, use the |:language|
-		command.
-		It can be different from |v:ctype| when messages are desired
-		in a different language than what is used for character
-		encoding.  See |multi-lang|.
+                The current locale setting for messages of the runtime
+                environment.  This allows Vim scripts to be aware of the
+                current language.  Technical: it's the value of LC_MESSAGES.
+                The value is system dependent.
+                This variable can not be set directly, use the |:language|
+                command.
+                It can be different from |v:ctype| when messages are desired
+                in a different language than what is used for character
+                encoding.  See |multi-lang|.
 
-					*v:lc_time* *lc_time-variable*
+                                                    *v:lc_time* *lc_time-variable*
 v:lc_time
-		The current locale setting for time messages of the runtime
-		environment.  This allows Vim scripts to be aware of the
-		current language.  Technical: it's the value of LC_TIME.
-		This variable can not be set directly, use the |:language|
-		command.  See |multi-lang|.
+                The current locale setting for time messages of the runtime
+                environment.  This allows Vim scripts to be aware of the
+                current language.  Technical: it's the value of LC_TIME.
+                This variable can not be set directly, use the |:language|
+                command.  See |multi-lang|.
 
-						*v:lnum* *lnum-variable*
+                                                          *v:lnum* *lnum-variable*
 v:lnum
-		Line number for the 'foldexpr' |fold-expr|, 'formatexpr',
-		'indentexpr' and 'statuscolumn' expressions, tab page number
-		for 'guitablabel' and 'guitabtooltip'.  Only valid while one of
-		these expressions is being evaluated.  Read-only when in the
-		|sandbox|.
+                Line number for the 'foldexpr' |fold-expr|, 'formatexpr',
+                'indentexpr' and 'statuscolumn' expressions, tab page number
+                for 'guitablabel' and 'guitabtooltip'.  Only valid while one of
+                these expressions is being evaluated.  Read-only when in the
+                |sandbox|.
 
-						*v:lua* *lua-variable*
+                                                            *v:lua* *lua-variable*
 v:lua
-		Prefix for calling Lua functions from expressions.
-		See |v:lua-call| for more information.
+                Prefix for calling Lua functions from expressions.
+                See |v:lua-call| for more information.
 
-					*v:maxcol* *maxcol-variable*
+                                                      *v:maxcol* *maxcol-variable*
 v:maxcol
-		Maximum line length.  Depending on where it is used it can be
-		screen columns, characters or bytes.  The value currently is
-		2147483647 on all systems.
+                Maximum line length.  Depending on where it is used it can be
+                screen columns, characters or bytes.  The value currently is
+                2147483647 on all systems.
 
-				*v:mouse_col* *mouse_col-variable*
+                                                *v:mouse_col* *mouse_col-variable*
 v:mouse_col
-		Column number for a mouse click obtained with |getchar()|.
-		This is the screen column number, like with |virtcol()|.  The
-		value is zero when there was no mouse button click.
+                Column number for a mouse click obtained with |getchar()|.
+                This is the screen column number, like with |virtcol()|.  The
+                value is zero when there was no mouse button click.
 
-				*v:mouse_lnum* *mouse_lnum-variable*
+                                              *v:mouse_lnum* *mouse_lnum-variable*
 v:mouse_lnum
-		Line number for a mouse click obtained with |getchar()|.
-		This is the text line number, not the screen line number.  The
-		value is zero when there was no mouse button click.
+                Line number for a mouse click obtained with |getchar()|.
+                This is the text line number, not the screen line number.  The
+                value is zero when there was no mouse button click.
 
-				*v:mouse_win* *mouse_win-variable*
+                                                *v:mouse_win* *mouse_win-variable*
 v:mouse_win
-		Window number for a mouse click obtained with |getchar()|.
-		First window has number 1, like with |winnr()|.  The value is
-		zero when there was no mouse button click.
+                Window number for a mouse click obtained with |getchar()|.
+                First window has number 1, like with |winnr()|.  The value is
+                zero when there was no mouse button click.
 
-				*v:mouse_winid* *mouse_winid-variable*
+                                            *v:mouse_winid* *mouse_winid-variable*
 v:mouse_winid
-		|window-ID| for a mouse click obtained with |getchar()|.
-		The value is zero when there was no mouse button click.
+                |window-ID| for a mouse click obtained with |getchar()|.
+                The value is zero when there was no mouse button click.
 
-			*v:msgpack_types* *msgpack_types-variable*
+                                        *v:msgpack_types* *msgpack_types-variable*
 v:msgpack_types
-		Dictionary containing msgpack types used by |msgpackparse()|
-		and |msgpackdump()|. All types inside dictionary are fixed
-		(not editable) empty lists. To check whether some list is one
-		of msgpack types, use |is| operator.
+                Dictionary containing msgpack types used by |msgpackparse()|
+                and |msgpackdump()|. All types inside dictionary are fixed
+                (not editable) empty lists. To check whether some list is one
+                of msgpack types, use |is| operator.
 
-						*v:null* *null-variable*
+                                                          *v:null* *null-variable*
 v:null
-		Special value used to put "null" in JSON and NIL in msgpack.
-		See |json_encode()|.  This value is converted to "v:null" when
-		used as a String (e.g. in |expr5| with string concatenation
-		operator) and to zero when used as a Number (e.g. in |expr5|
-		or |expr7| when used with numeric operators). Read-only.
-		In some places `v:null` can be used for a List, Dict, etc.
-		that is not set.  That is slightly different than an empty
-		List, Dict, etc.
+                Special value used to put "null" in JSON and NIL in msgpack.
+                See |json_encode()|.  This value is converted to "v:null" when
+                used as a String (e.g. in |expr5| with string concatenation
+                operator) and to zero when used as a Number (e.g. in |expr5|
+                or |expr7| when used with numeric operators). Read-only.
+                In some places `v:null` can be used for a List, Dict, etc.
+                that is not set.  That is slightly different than an empty
+                List, Dict, etc.
 
-				*v:numbermax* *numbermax-variable*
-v:numbermax	Maximum value of a number.
+                                                *v:numbermax* *numbermax-variable*
+v:numbermax     Maximum value of a number.
 
-				*v:numbermin* *numbermin-variable*
-v:numbermin	Minimum value of a number (negative).
+                                                *v:numbermin* *numbermin-variable*
+v:numbermin     Minimum value of a number (negative).
 
-				*v:numbersize* *numbersize-variable*
+                                              *v:numbersize* *numbersize-variable*
 v:numbersize
-		Number of bits in a Number.  This is normally 64, but on some
-		systems it may be 32.
+                Number of bits in a Number.  This is normally 64, but on some
+                systems it may be 32.
 
-					*v:oldfiles* *oldfiles-variable*
+                                                  *v:oldfiles* *oldfiles-variable*
 v:oldfiles
-		List of file names that is loaded from the |shada| file on
-		startup.  These are the files that Vim remembers marks for.
-		The length of the List is limited by the ' argument of the
-		'shada' option (default is 100).
-		When the |shada| file is not used the List is empty.
-		Also see |:oldfiles| and |c_#<|.
-		The List can be modified, but this has no effect on what is
-		stored in the |shada| file later.  If you use values other
-		than String this will cause trouble.
+                List of file names that is loaded from the |shada| file on
+                startup.  These are the files that Vim remembers marks for.
+                The length of the List is limited by the ' argument of the
+                'shada' option (default is 100).
+                When the |shada| file is not used the List is empty.
+                Also see |:oldfiles| and |c_#<|.
+                The List can be modified, but this has no effect on what is
+                stored in the |shada| file later.  If you use values other
+                than String this will cause trouble.
 
-					*v:operator* *operator-variable*
+                                                  *v:operator* *operator-variable*
 v:operator
-		The last operator given in Normal mode.  This is a single
-		character except for commands starting with <g> or <z>,
-		in which case it is two characters.  Best used alongside
-		|v:prevcount| and |v:register|.  Useful if you want to cancel
-		Operator-pending mode and then use the operator, e.g.: >vim
-		  :omap O <Esc>:call MyMotion(v:operator)<CR>
+                The last operator given in Normal mode.  This is a single
+                character except for commands starting with <g> or <z>,
+                in which case it is two characters.  Best used alongside
+                |v:prevcount| and |v:register|.  Useful if you want to cancel
+                Operator-pending mode and then use the operator, e.g.: >vim
+                  :omap O <Esc>:call MyMotion(v:operator)<CR>
 <
-		The value remains set until another operator is entered, thus
-		don't expect it to be empty.
-		v:operator is not set for |:delete|, |:yank| or other Ex
-		commands.
-		Read-only.
+                The value remains set until another operator is entered, thus
+                don't expect it to be empty.
+                v:operator is not set for |:delete|, |:yank| or other Ex
+                commands.
+                Read-only.
 
-			*v:option_command* *option_command-variable*
+                                      *v:option_command* *option_command-variable*
 v:option_command
-		Command used to set the option. Valid while executing an
-		|OptionSet| autocommand.
-		  value        option was set via ~
-		  "setlocal"   |:setlocal| or `:let l:xxx`
-		  "setglobal"  |:setglobal| or `:let g:xxx`
-		  "set"        |:set| or |:let|
-		  "modeline"   |modeline|
+                Command used to set the option. Valid while executing an
+                |OptionSet| autocommand.
+                  value        option was set via ~
+                  "setlocal"   |:setlocal| or `:let l:xxx`
+                  "setglobal"  |:setglobal| or `:let g:xxx`
+                  "set"        |:set| or |:let|
+                  "modeline"   |modeline|
 
-				*v:option_new* *option_new-variable*
+                                              *v:option_new* *option_new-variable*
 v:option_new
-		New value of the option. Valid while executing an |OptionSet|
-		autocommand.
+                New value of the option. Valid while executing an |OptionSet|
+                autocommand.
 
-				*v:option_old* *option_old-variable*
+                                              *v:option_old* *option_old-variable*
 v:option_old
-		Old value of the option. Valid while executing an |OptionSet|
-		autocommand. Depending on the command used for setting and the
-		kind of option this is either the local old value or the
-		global old value.
+                Old value of the option. Valid while executing an |OptionSet|
+                autocommand. Depending on the command used for setting and the
+                kind of option this is either the local old value or the
+                global old value.
 
-			*v:option_oldglobal* *option_oldglobal-variable*
+                                  *v:option_oldglobal* *option_oldglobal-variable*
 v:option_oldglobal
-		Old global value of the option. Valid while executing an
-		|OptionSet| autocommand.
+                Old global value of the option. Valid while executing an
+                |OptionSet| autocommand.
 
-			*v:option_oldlocal* *option_oldlocal-variable*
+                                    *v:option_oldlocal* *option_oldlocal-variable*
 v:option_oldlocal
-		Old local value of the option. Valid while executing an
-		|OptionSet| autocommand.
+                Old local value of the option. Valid while executing an
+                |OptionSet| autocommand.
 
-				*v:option_type* *option_type-variable*
+                                            *v:option_type* *option_type-variable*
 v:option_type
-		Scope of the set command. Valid while executing an
-		|OptionSet| autocommand. Can be either "global" or "local"
+                Scope of the set command. Valid while executing an
+                |OptionSet| autocommand. Can be either "global" or "local"
 
-				*v:prevcount* *prevcount-variable*
+                                                *v:prevcount* *prevcount-variable*
 v:prevcount
-		The count given for the last but one Normal mode command.
-		This is the v:count value of the previous command.  Useful if
-		you want to cancel Visual or Operator-pending mode and then
-		use the count, e.g.: >vim
-		  :vmap % <Esc>:call MyFilter(v:prevcount)<CR>
+                The count given for the last but one Normal mode command.
+                This is the v:count value of the previous command.  Useful if
+                you want to cancel Visual or Operator-pending mode and then
+                use the count, e.g.: >vim
+                  :vmap % <Esc>:call MyFilter(v:prevcount)<CR>
 <
-		Read-only.
+                Read-only.
 
-				*v:profiling* *profiling-variable*
+                                                *v:profiling* *profiling-variable*
 v:profiling
-		Normally zero.  Set to one after using ":profile start".
-		See |profiling|.
+                Normally zero.  Set to one after using ":profile start".
+                See |profiling|.
 
-					*v:progname* *progname-variable*
+                                                  *v:progname* *progname-variable*
 v:progname
-		The name by which Nvim was invoked (with path removed).
-		Read-only.
+                The name by which Nvim was invoked (with path removed).
+                Read-only.
 
-					*v:progpath* *progpath-variable*
+                                                  *v:progpath* *progpath-variable*
 v:progpath
-		Absolute path to the current running Nvim.
-		Read-only.
+                Absolute path to the current running Nvim.
+                Read-only.
 
-					*v:register* *register-variable*
+                                                  *v:register* *register-variable*
 v:register
-		The name of the register in effect for the current normal mode
-		command (regardless of whether that command actually used a
-		register).  Or for the currently executing normal mode mapping
-		(use this in custom commands that take a register).
-		If none is supplied it is the default register '"', unless
-		'clipboard' contains "unnamed" or "unnamedplus", then it is
-		"*" or '+'.
-		Also see |getreg()| and |setreg()|
+                The name of the register in effect for the current normal mode
+                command (regardless of whether that command actually used a
+                register).  Or for the currently executing normal mode mapping
+                (use this in custom commands that take a register).
+                If none is supplied it is the default register '"', unless
+                'clipboard' contains "unnamed" or "unnamedplus", then it is
+                "*" or '+'.
+                Also see |getreg()| and |setreg()|
 
-					*v:relnum* *relnum-variable*
+                                                      *v:relnum* *relnum-variable*
 v:relnum
-		Relative line number for the 'statuscolumn' expression.
-		Read-only.
+                Relative line number for the 'statuscolumn' expression.
+                Read-only.
 
-				*v:scrollstart* *scrollstart-variable*
+                                            *v:scrollstart* *scrollstart-variable*
 v:scrollstart
-		String describing the script or function that caused the
-		screen to scroll up.  It's only set when it is empty, thus the
-		first reason is remembered.  It is set to "Unknown" for a
-		typed command.
-		This can be used to find out why your script causes the
-		hit-enter prompt.
+                String describing the script or function that caused the
+                screen to scroll up.  It's only set when it is empty, thus the
+                first reason is remembered.  It is set to "Unknown" for a
+                typed command.
+                This can be used to find out why your script causes the
+                hit-enter prompt.
 
-			*v:searchforward* *searchforward-variable*
+                                        *v:searchforward* *searchforward-variable*
 v:searchforward
-		Search direction:  1 after a forward search, 0 after a
-		backward search.  It is reset to forward when directly setting
-		the last search pattern, see |quote/|.
-		Note that the value is restored when returning from a
-		function. |function-search-undo|.
-		Read-write.
+                Search direction:  1 after a forward search, 0 after a
+                backward search.  It is reset to forward when directly setting
+                the last search pattern, see |quote/|.
+                Note that the value is restored when returning from a
+                function. |function-search-undo|.
+                Read-write.
 
-				*v:servername* *servername-variable*
+                                              *v:servername* *servername-variable*
 v:servername
-		Primary listen-address of Nvim, the first item returned by
-		|serverlist()|. Usually this is the named pipe created by Nvim
-		at |startup| or given by |--listen| (or the deprecated
-		|$NVIM_LISTEN_ADDRESS| env var).
+                Primary listen-address of Nvim, the first item returned by
+                |serverlist()|. Usually this is the named pipe created by Nvim
+                at |startup| or given by |--listen| (or the deprecated
+                |$NVIM_LISTEN_ADDRESS| env var).
 
-		See also |serverstart()| |serverstop()|.
-		Read-only.
+                See also |serverstart()| |serverstop()|.
+                Read-only.
 
-		                                                     *$NVIM*
-		$NVIM is set by |terminal| and |jobstart()|, and is thus
-		a hint that the current environment is a subprocess of Nvim.
-		Example: >vim
-		  if $NVIM
-		    echo nvim_get_chan_info(v:parent)
-		  endif
+                                                                     *$NVIM*
+                $NVIM is set by |terminal| and |jobstart()|, and is thus
+                a hint that the current environment is a subprocess of Nvim.
+                Example: >vim
+                  if $NVIM
+                    echo nvim_get_chan_info(v:parent)
+                  endif
 <
 
-		Note the contents of $NVIM may change in the future.
+                Note the contents of $NVIM may change in the future.
 
-				*v:shell_error* *shell_error-variable*
+                                            *v:shell_error* *shell_error-variable*
 v:shell_error
-		Result of the last shell command.  When non-zero, the last
-		shell command had an error.  When zero, there was no problem.
-		This only works when the shell returns the error code to Vim.
-		The value -1 is often used when the command could not be
-		executed.  Read-only.
-		Example: >vim
-		  !mv foo bar
-		  if v:shell_error
-		    echo 'could not rename "foo" to "bar"!'
-		  endif
+                Result of the last shell command.  When non-zero, the last
+                shell command had an error.  When zero, there was no problem.
+                This only works when the shell returns the error code to Vim.
+                The value -1 is often used when the command could not be
+                executed.  Read-only.
+                Example: >vim
+                  !mv foo bar
+                  if v:shell_error
+                    echo 'could not rename "foo" to "bar"!'
+                  endif
 <
 
-				*v:statusmsg* *statusmsg-variable*
+                                                *v:statusmsg* *statusmsg-variable*
 v:statusmsg
-		Last given status message.
-		Modifiable (can be set).
+                Last given status message.
+                Modifiable (can be set).
 
-					*v:stderr* *stderr-variable*
+                                                      *v:stderr* *stderr-variable*
 v:stderr
-		|channel-id| corresponding to stderr. The value is always 2;
-		use this variable to make your code more descriptive.
-		Unlike stdin and stdout (see |stdioopen()|), stderr is always
-		open for writing. Example: >vim
-		:call chansend(v:stderr, "error: toaster empty\n")
+                |channel-id| corresponding to stderr. The value is always 2;
+                use this variable to make your code more descriptive.
+                Unlike stdin and stdout (see |stdioopen()|), stderr is always
+                open for writing. Example: >vim
+                :call chansend(v:stderr, "error: toaster empty\n")
 <
 
-				*v:swapchoice* *swapchoice-variable*
+                                              *v:swapchoice* *swapchoice-variable*
 v:swapchoice
-		|SwapExists| autocommands can set this to the selected choice
-		for handling an existing swapfile:
-		  'o'    Open read-only
-		  'e'    Edit anyway
-		  'r'    Recover
-		  'd'    Delete swapfile
-		  'q'    Quit
-		  'a'    Abort
-		The value should be a single-character string.  An empty value
-		results in the user being asked, as would happen when there is
-		no SwapExists autocommand.  The default is empty.
+                |SwapExists| autocommands can set this to the selected choice
+                for handling an existing swapfile:
+                  'o'    Open read-only
+                  'e'    Edit anyway
+                  'r'    Recover
+                  'd'    Delete swapfile
+                  'q'    Quit
+                  'a'    Abort
+                The value should be a single-character string.  An empty value
+                results in the user being asked, as would happen when there is
+                no SwapExists autocommand.  The default is empty.
 
-				*v:swapcommand* *swapcommand-variable*
+                                            *v:swapcommand* *swapcommand-variable*
 v:swapcommand
-		Normal mode command to be executed after a file has been
-		opened.  Can be used for a |SwapExists| autocommand to have
-		another Vim open the file and jump to the right place.  For
-		example, when jumping to a tag the value is ":tag tagname\r".
-		For ":edit +cmd file" the value is ":cmd\r".
+                Normal mode command to be executed after a file has been
+                opened.  Can be used for a |SwapExists| autocommand to have
+                another Vim open the file and jump to the right place.  For
+                example, when jumping to a tag the value is ":tag tagname\r".
+                For ":edit +cmd file" the value is ":cmd\r".
 
-					*v:swapname* *swapname-variable*
+                                                  *v:swapname* *swapname-variable*
 v:swapname
-		Name of the swapfile found.
-		Only valid during |SwapExists| event.
-		Read-only.
+                Name of the swapfile found.
+                Only valid during |SwapExists| event.
+                Read-only.
 
-				*v:t_blob* *t_blob-variable* *v:t_TYPE*
-v:t_blob	Value of |Blob| type.  Read-only.  See: |type()|
+                                             *v:t_blob* *t_blob-variable* *v:t_TYPE*
+v:t_blob        Value of |Blob| type.  Read-only.  See: |type()|
 
-					*v:t_bool* *t_bool-variable*
-v:t_bool	Value of |Boolean| type.  Read-only.  See: |type()|
+                                                      *v:t_bool* *t_bool-variable*
+v:t_bool        Value of |Boolean| type.  Read-only.  See: |type()|
 
-					*v:t_dict* *t_dict-variable*
-v:t_dict	Value of |Dictionary| type.  Read-only.  See: |type()|
+                                                      *v:t_dict* *t_dict-variable*
+v:t_dict        Value of |Dictionary| type.  Read-only.  See: |type()|
 
-					*v:t_float* *t_float-variable*
-v:t_float	Value of |Float| type.  Read-only.  See: |type()|
+                                                    *v:t_float* *t_float-variable*
+v:t_float       Value of |Float| type.  Read-only.  See: |type()|
 
-					*v:t_func* *t_func-variable*
-v:t_func	Value of |Funcref| type.  Read-only.  See: |type()|
+                                                      *v:t_func* *t_func-variable*
+v:t_func        Value of |Funcref| type.  Read-only.  See: |type()|
 
-					*v:t_list* *t_list-variable*
-v:t_list	Value of |List| type.  Read-only.  See: |type()|
+                                                      *v:t_list* *t_list-variable*
+v:t_list        Value of |List| type.  Read-only.  See: |type()|
 
-					*v:t_number* *t_number-variable*
-v:t_number	Value of |Number| type.  Read-only.  See: |type()|
+                                                  *v:t_number* *t_number-variable*
+v:t_number      Value of |Number| type.  Read-only.  See: |type()|
 
-					*v:t_string* *t_string-variable*
-v:t_string	Value of |String| type.  Read-only.  See: |type()|
+                                                  *v:t_string* *t_string-variable*
+v:t_string      Value of |String| type.  Read-only.  See: |type()|
 
-				*v:termresponse* *termresponse-variable*
+                                          *v:termresponse* *termresponse-variable*
 v:termresponse
-		The value of the most recent OSC or DCS escape sequence
-		received by Nvim from the terminal. This can be read in a
-		|TermResponse| event handler after querying the terminal using
-		another escape sequence.
+                The value of the most recent OSC or DCS escape sequence
+                received by Nvim from the terminal. This can be read in a
+                |TermResponse| event handler after querying the terminal using
+                another escape sequence.
 
-					*v:testing* *testing-variable*
-v:testing	Must be set before using `test_garbagecollect_now()`.
+                                                    *v:testing* *testing-variable*
+v:testing       Must be set before using `test_garbagecollect_now()`.
 
-				*v:this_session* *this_session-variable*
+                                          *v:this_session* *this_session-variable*
 v:this_session
-		Full filename of the last loaded or saved session file.
-		Empty when no session file has been saved.  See |:mksession|.
-		Modifiable (can be set).
+                Full filename of the last loaded or saved session file.
+                Empty when no session file has been saved.  See |:mksession|.
+                Modifiable (can be set).
 
-				*v:throwpoint* *throwpoint-variable*
+                                              *v:throwpoint* *throwpoint-variable*
 v:throwpoint
-		The point where the exception most recently caught and not
-		finished was thrown.  Not set when commands are typed.  See
-		also |v:exception| and |throw-variables|.
-		Example: >vim
-		  try
-		    throw "oops"
-		  catch /.*/
-		    echo "Exception from" v:throwpoint
-		  endtry
+                The point where the exception most recently caught and not
+                finished was thrown.  Not set when commands are typed.  See
+                also |v:exception| and |throw-variables|.
+                Example: >vim
+                  try
+                    throw "oops"
+                  catch /.*/
+                    echo "Exception from" v:throwpoint
+                  endtry
 <
-		Output: "Exception from test.vim, line 2"
+                Output: "Exception from test.vim, line 2"
 
-						*v:true* *true-variable*
+                                                          *v:true* *true-variable*
 v:true
-		Special value used to put "true" in JSON and msgpack.  See
-		|json_encode()|.  This value is converted to "v:true" when used
-		as a String (e.g. in |expr5| with string concatenation
-		operator) and to one when used as a Number (e.g. in |expr5| or
-		|expr7| when used with numeric operators). Read-only.
+                Special value used to put "true" in JSON and msgpack.  See
+                |json_encode()|.  This value is converted to "v:true" when used
+                as a String (e.g. in |expr5| with string concatenation
+                operator) and to one when used as a Number (e.g. in |expr5| or
+                |expr7| when used with numeric operators). Read-only.
 
-						*v:val* *val-variable*
+                                                            *v:val* *val-variable*
 v:val
-		Value of the current item of a |List| or |Dictionary|.  Only
-		valid while evaluating the expression used with |map()| and
-		|filter()|.  Read-only.
+                Value of the current item of a |List| or |Dictionary|.  Only
+                valid while evaluating the expression used with |map()| and
+                |filter()|.  Read-only.
 
-					*v:version* *version-variable*
+                                                    *v:version* *version-variable*
 v:version
-		Vim version number: major version times 100 plus minor
-		version.  Vim 5.0 is 500, Vim 5.1 is 501.
-		Read-only.
-		Use |has()| to check the Nvim (not Vim) version: >vim
-		  :if has("nvim-0.2.1")
+                Vim version number: major version times 100 plus minor
+                version.  Vim 5.0 is 500, Vim 5.1 is 501.
+                Read-only.
+                Use |has()| to check the Nvim (not Vim) version: >vim
+                  :if has("nvim-0.2.1")
 <
 
-			*v:vim_did_enter* *vim_did_enter-variable*
+                                        *v:vim_did_enter* *vim_did_enter-variable*
 v:vim_did_enter
-		0 during startup, 1 just before |VimEnter|.
-		Read-only.
+                0 during startup, 1 just before |VimEnter|.
+                Read-only.
 
-					*v:virtnum* *virtnum-variable*
+                                                    *v:virtnum* *virtnum-variable*
 v:virtnum
-		Virtual line number for the 'statuscolumn' expression.
-		Negative when drawing the status column for virtual lines, zero
-		when drawing an actual buffer line, and positive when drawing
-		the wrapped part of a buffer line.
-		Read-only.
+                Virtual line number for the 'statuscolumn' expression.
+                Negative when drawing the status column for virtual lines, zero
+                when drawing an actual buffer line, and positive when drawing
+                the wrapped part of a buffer line.
+                Read-only.
 
-				*v:warningmsg* *warningmsg-variable*
+                                              *v:warningmsg* *warningmsg-variable*
 v:warningmsg
-		Last given warning message.
-		Modifiable (can be set).
+                Last given warning message.
+                Modifiable (can be set).
 
-					*v:windowid* *windowid-variable*
+                                                  *v:windowid* *windowid-variable*
 v:windowid
-		Application-specific window "handle" which may be set by any
-		attached UI. Defaults to zero.
-		Note: For Nvim |windows| use |winnr()| or |win_getid()|, see
-		|window-ID|.
+                Application-specific window "handle" which may be set by any
+                attached UI. Defaults to zero.
+                Note: For Nvim |windows| use |winnr()| or |win_getid()|, see
+                |window-ID|.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -27,10 +27,10 @@ vim.go.ari = vim.go.allowrevins
 --- letters, Cyrillic letters).
 ---
 --- There are currently two possible values:
---- "single":	Use the same width as characters in US-ASCII.  This is
---- 		expected by most users.
---- "double":	Use twice the width of ASCII characters.
---- 						*E834* *E835*
+--- "single":       Use the same width as characters in US-ASCII.  This is
+---                 expected by most users.
+--- "double":       Use twice the width of ASCII characters.
+---                                                 *E834* *E835*
 --- The value "double" cannot be used if 'listchars' or 'fillchars'
 --- contains a character that would be double width.  These errors may
 --- also be given when calling setcellwidths().
@@ -139,7 +139,7 @@ vim.bo.ai = vim.bo.autoindent
 --- using the global value:
 ---
 --- ```vim
---- 	set autoread<
+---         set autoread<
 --- ```
 ---
 ---
@@ -190,7 +190,7 @@ vim.go.awa = vim.go.autowriteall
 --- This option does NOT change the background color, it tells Nvim what
 --- the "inherited" (terminal/GUI) background looks like.
 --- See `:hi-normal` if you want to set the background color explicitly.
---- 					*g:colors_name*
+---                                         *g:colors_name*
 --- When a color scheme is loaded (the "g:colors_name" variable is set)
 --- changing 'background' will cause the color scheme to be reloaded.  If
 --- the color scheme adjusts to the value of 'background' this will work.
@@ -201,9 +201,9 @@ vim.go.awa = vim.go.autowriteall
 --- depending on the terminal name.  Example:
 ---
 --- ```vim
---- 	if $TERM ==# "xterm"
---- 	  set background=dark
---- 	endif
+---         if $TERM ==# "xterm"
+---           set background=dark
+---         endif
 --- ```
 --- When this option is changed, the default settings for the highlight groups
 --- will change.  To use other settings, place ":highlight" commands AFTER
@@ -218,13 +218,13 @@ vim.go.bg = vim.go.background
 --- Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
 --- mode.  This is a list of items, separated by commas.  Each item allows
 --- a way to backspace over something:
---- value	effect	~
---- indent	allow backspacing over autoindent
---- eol	allow backspacing over line breaks (join lines)
---- start	allow backspacing over the start of insert; CTRL-W and CTRL-U
---- 	stop once at the start of insert.
---- nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
---- 	insert.
+--- value   effect  ~
+--- indent  allow backspacing over autoindent
+--- eol     allow backspacing over line breaks (join lines)
+--- start   allow backspacing over the start of insert; CTRL-W and CTRL-U
+---         stop once at the start of insert.
+--- nostop  like start, except CTRL-W and CTRL-U do not stop at the start of
+---         insert.
 ---
 --- When the value is empty, Vi compatible backspacing is used, none of
 --- the ways mentioned for the items above are possible.
@@ -256,13 +256,13 @@ vim.go.bk = vim.go.backup
 --- done.  This is a comma-separated list of words.
 ---
 --- The main values are:
---- "yes"	make a copy of the file and overwrite the original one
---- "no"	rename the file and write a new one
---- "auto"	one of the previous, what works best
+--- "yes"   make a copy of the file and overwrite the original one
+--- "no"    rename the file and write a new one
+--- "auto"  one of the previous, what works best
 ---
 --- Extra values that can be combined with the ones above are:
---- "breaksymlink"	always break symlinks when writing
---- "breakhardlink"	always break hardlinks when writing
+--- "breaksymlink"  always break symlinks when writing
+--- "breakhardlink" always break hardlinks when writing
 ---
 --- Making a copy and overwriting the original file:
 --- - Takes extra time to copy the file.
@@ -290,7 +290,7 @@ vim.go.bk = vim.go.backup
 --- useful for example in source trees where all the files are symbolic or
 --- hard links and any changes should stay in the local source tree, not
 --- be propagated back to the original source.
---- 						*crontab*
+---                                                 *crontab*
 --- One situation where "no" and "auto" will cause problems: A program
 --- that opens a file, invokes Vim to edit that file, and then tests if
 --- the open file was changed (through the file descriptor) will check the
@@ -359,7 +359,7 @@ vim.go.bkc = vim.go.backupcopy
 --- If you want to hide your backup files on Unix, consider this value:
 ---
 --- ```vim
---- 	set backupdir=./.backup,~/.backup,.,/tmp
+---         set backupdir=./.backup,~/.backup,.,/tmp
 --- ```
 --- You must create a ".backup" directory in each directory and in your
 --- home directory for this to work properly.
@@ -387,7 +387,7 @@ vim.go.bdir = vim.go.backupdir
 --- include a timestamp.
 ---
 --- ```vim
---- 	au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
+---         au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
 --- ```
 --- Use 'backupdir' to put the backup in a different directory.
 ---
@@ -414,7 +414,7 @@ vim.go.bex = vim.go.backupext
 --- $HOME you must expand it explicitly, e.g.:
 ---
 --- ```vim
---- 	let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+---         let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 --- ```
 --- Note that the default also makes sure that "crontab -e" works (when a
 --- backup would be made by renaming the original file crontab won't see
@@ -431,30 +431,30 @@ vim.go.bsk = vim.go.backupskip
 --- will be silenced. This is most useful to specify specific events in
 --- insert mode to be silenced.
 ---
---- item	    meaning when present	~
---- all	    All events.
+--- item        meaning when present        ~
+--- all         All events.
 --- backspace   When hitting <BS> or <Del> and deleting results in an
---- 	    error.
---- cursor	    Fail to move around using the cursor keys or
---- 	    <PageUp>/<PageDown> in `Insert-mode`.
+---             error.
+--- cursor      Fail to move around using the cursor keys or
+---             <PageUp>/<PageDown> in `Insert-mode`.
 --- complete    Error occurred when using `i_CTRL-X_CTRL-K` or
---- 	    `i_CTRL-X_CTRL-T`.
---- copy	    Cannot copy char from insert mode using `i_CTRL-Y` or
---- 	    `i_CTRL-E`.
---- ctrlg	    Unknown Char after <C-G> in Insert mode.
---- error	    Other Error occurred (e.g. try to join last line)
---- 	    (mostly used in `Normal-mode` or `Cmdline-mode`).
---- esc	    hitting <Esc> in `Normal-mode`.
---- hangul	    Ignored.
---- lang	    Calling the beep module for Lua/Mzscheme/TCL.
---- mess	    No output available for `g<`.
+---             `i_CTRL-X_CTRL-T`.
+--- copy        Cannot copy char from insert mode using `i_CTRL-Y` or
+---             `i_CTRL-E`.
+--- ctrlg       Unknown Char after <C-G> in Insert mode.
+--- error       Other Error occurred (e.g. try to join last line)
+---             (mostly used in `Normal-mode` or `Cmdline-mode`).
+--- esc         hitting <Esc> in `Normal-mode`.
+--- hangul      Ignored.
+--- lang        Calling the beep module for Lua/Mzscheme/TCL.
+--- mess        No output available for `g<`.
 --- showmatch   Error occurred for 'showmatch' function.
 --- operator    Empty region error `cpo-E`.
 --- register    Unknown register after <C-R> in `Insert-mode`.
---- shell	    Bell from shell output `:!`.
---- spell	    Error happened on spell suggest.
+--- shell       Bell from shell output `:!`.
+--- spell       Error happened on spell suggest.
 --- wildmode    More matches in `cmdline-completion` available
---- 	    (depends on the 'wildmode' setting).
+---             (depends on the 'wildmode' setting).
 ---
 --- This is most useful to fine tune when in Insert mode the bell should
 --- be rung. For Normal mode and Ex commands, the bell is often rung to
@@ -470,10 +470,10 @@ vim.go.bo = vim.go.belloff
 --- This option should be set before editing a binary file.  You can also
 --- use the `-b` Vim argument.  When this option is switched on a few
 --- options will be changed (also when it already was on):
---- 	'textwidth'  will be set to 0
---- 	'wrapmargin' will be set to 0
---- 	'modeline'   will be off
---- 	'expandtab'  will be off
+---         'textwidth'  will be set to 0
+---         'wrapmargin' will be set to 0
+---         'modeline'   will be off
+---         'expandtab'  will be off
 --- Also, 'fileformat' and 'fileformats' options will not be used, the
 --- file is read and written like 'fileformat' was "unix" (a single <NL>
 --- separates lines).
@@ -541,31 +541,31 @@ vim.wo.bri = vim.wo.breakindent
 
 --- Settings for 'breakindent'. It can consist of the following optional
 --- items and must be separated by a comma:
---- 	min:{n}	    Minimum text width that will be kept after
---- 		    applying 'breakindent', even if the resulting
---- 		    text should normally be narrower. This prevents
---- 		    text indented almost to the right window border
---- 		    occupying lot of vertical space when broken.
---- 		    (default: 20)
---- 	shift:{n}   After applying 'breakindent', the wrapped line's
---- 		    beginning will be shifted by the given number of
---- 		    characters.  It permits dynamic French paragraph
---- 		    indentation (negative) or emphasizing the line
---- 		    continuation (positive).
---- 		    (default: 0)
---- 	sbr	    Display the 'showbreak' value before applying the
---- 		    additional indent.
---- 		    (default: off)
---- 	list:{n}    Adds an additional indent for lines that match a
---- 		    numbered or bulleted list (using the
---- 		    'formatlistpat' setting).
---- 	list:-1	    Uses the length of a match with 'formatlistpat'
---- 		    for indentation.
---- 		    (default: 0)
---- 	column:{n}  Indent at column {n}. Will overrule the other
---- 		    sub-options. Note: an additional indent may be
---- 		    added for the 'showbreak' setting.
---- 		    (default: off)
+---         min:{n}     Minimum text width that will be kept after
+---                     applying 'breakindent', even if the resulting
+---                     text should normally be narrower. This prevents
+---                     text indented almost to the right window border
+---                     occupying lot of vertical space when broken.
+---                     (default: 20)
+---         shift:{n}   After applying 'breakindent', the wrapped line's
+---                     beginning will be shifted by the given number of
+---                     characters.  It permits dynamic French paragraph
+---                     indentation (negative) or emphasizing the line
+---                     continuation (positive).
+---                     (default: 0)
+---         sbr         Display the 'showbreak' value before applying the
+---                     additional indent.
+---                     (default: off)
+---         list:{n}    Adds an additional indent for lines that match a
+---                     numbered or bulleted list (using the
+---                     'formatlistpat' setting).
+---         list:-1     Uses the length of a match with 'formatlistpat'
+---                     for indentation.
+---                     (default: 0)
+---         column:{n}  Indent at column {n}. Will overrule the other
+---                     sub-options. Note: an additional indent may be
+---                     added for the 'showbreak' setting.
+---                     (default: off)
 ---
 --- @type string
 vim.o.breakindentopt = ""
@@ -574,11 +574,11 @@ vim.wo.breakindentopt = vim.o.breakindentopt
 vim.wo.briopt = vim.wo.breakindentopt
 
 --- Which directory to use for the file browser:
----    last		Use same directory as with last file browser, where a
---- 		file was opened or saved.
----    buffer	Use the directory of the related buffer.
----    current	Use the current directory.
----    {path}	Use the specified directory
+---    last         Use same directory as with last file browser, where a
+---                 file was opened or saved.
+---    buffer       Use the directory of the related buffer.
+---    current      Use the current directory.
+---    {path}       Use the specified directory
 ---
 --- @type string
 vim.o.browsedir = ""
@@ -588,17 +588,17 @@ vim.go.bsdir = vim.go.browsedir
 
 --- This option specifies what happens when a buffer is no longer
 --- displayed in a window:
----   <empty>	follow the global 'hidden' option
----   hide		hide the buffer (don't unload it), even if 'hidden' is
---- 		not set
----   unload	unload the buffer, even if 'hidden' is set; the
---- 		`:hide` command will also unload the buffer
----   delete	delete the buffer from the buffer list, even if
---- 		'hidden' is set; the `:hide` command will also delete
---- 		the buffer, making it behave like `:bdelete`
----   wipe		wipe the buffer from the buffer list, even if
---- 		'hidden' is set; the `:hide` command will also wipe
---- 		out the buffer, making it behave like `:bwipeout`
+---   <empty>       follow the global 'hidden' option
+---   hide          hide the buffer (don't unload it), even if 'hidden' is
+---                 not set
+---   unload        unload the buffer, even if 'hidden' is set; the
+---                 `:hide` command will also unload the buffer
+---   delete        delete the buffer from the buffer list, even if
+---                 'hidden' is set; the `:hide` command will also delete
+---                 the buffer, making it behave like `:bdelete`
+---   wipe          wipe the buffer from the buffer list, even if
+---                 'hidden' is set; the `:hide` command will also wipe
+---                 out the buffer, making it behave like `:bwipeout`
 ---
 --- CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
 --- are lost without a warning.  Also, these values may break autocommands
@@ -625,15 +625,15 @@ vim.bo.buflisted = vim.o.buflisted
 vim.bo.bl = vim.bo.buflisted
 
 --- The value of this option specifies the type of a buffer:
----   <empty>	normal buffer
----   acwrite	buffer will always be written with `BufWriteCmd`s
----   help		help buffer (do not set this manually)
----   nofile	buffer is not related to a file, will not be written
----   nowrite	buffer will not be written
----   quickfix	list of errors `:cwindow` or locations `:lwindow`
----   terminal	`terminal-emulator` buffer
----   prompt	buffer where only the last line can be edited, meant
---- 		to be used by a plugin, see `prompt-buffer`
+---   <empty>       normal buffer
+---   acwrite       buffer will always be written with `BufWriteCmd`s
+---   help          help buffer (do not set this manually)
+---   nofile        buffer is not related to a file, will not be written
+---   nowrite       buffer will not be written
+---   quickfix      list of errors `:cwindow` or locations `:lwindow`
+---   terminal      `terminal-emulator` buffer
+---   prompt        buffer where only the last line can be edited, meant
+---                 to be used by a plugin, see `prompt-buffer`
 ---
 --- This option is used together with 'bufhidden' and 'swapfile' to
 --- specify special kinds of buffers.   See `special-buffers`.
@@ -648,21 +648,21 @@ vim.bo.bl = vim.bo.buflisted
 --- you are not supposed to change it.
 ---
 --- "nofile" and "nowrite" buffers are similar:
---- both:		The buffer is not to be written to disk, ":w" doesn't
---- 		work (":w filename" does work though).
---- both:		The buffer is never considered to be `'modified'`.
---- 		There is no warning when the changes will be lost, for
---- 		example when you quit Vim.
---- both:		A swap file is only created when using too much memory
---- 		(when 'swapfile' has been reset there is never a swap
---- 		file).
---- nofile only:	The buffer name is fixed, it is not handled like a
---- 		file name.  It is not modified in response to a `:cd`
---- 		command.
---- both:		When using ":e bufname" and already editing "bufname"
---- 		the buffer is made empty and autocommands are
---- 		triggered as usual for `:edit`.
---- 						*E676*
+--- both:           The buffer is not to be written to disk, ":w" doesn't
+---                 work (":w filename" does work though).
+--- both:           The buffer is never considered to be `'modified'`.
+---                 There is no warning when the changes will be lost, for
+---                 example when you quit Vim.
+--- both:           A swap file is only created when using too much memory
+---                 (when 'swapfile' has been reset there is never a swap
+---                 file).
+--- nofile only:    The buffer name is fixed, it is not handled like a
+---                 file name.  It is not modified in response to a `:cd`
+---                 command.
+--- both:           When using ":e bufname" and already editing "bufname"
+---                 the buffer is made empty and autocommands are
+---                 triggered as usual for `:edit`.
+---                                                 *E676*
 --- "acwrite" implies that the buffer name is not related to a file, like
 --- "nofile", but it will be written.  Thus, in contrast to "nofile" and
 --- "nowrite", ":w" does work and a modified buffer can't be abandoned
@@ -677,13 +677,13 @@ vim.bo.bt = vim.bo.buftype
 
 --- Specifies details about changing the case of letters.  It may contain
 --- these words, separated by a comma:
---- internal	Use internal case mapping functions, the current
---- 		locale does not change the case mapping. When
---- 		"internal" is omitted, the towupper() and towlower()
---- 		system library functions are used when available.
---- keepascii	For the ASCII characters (0x00 to 0x7f) use the US
---- 		case mapping, the current locale is not effective.
---- 		This probably only matters for Turkish.
+--- internal        Use internal case mapping functions, the current
+---                 locale does not change the case mapping. When
+---                 "internal" is omitted, the towupper() and towlower()
+---                 system library functions are used when available.
+--- keepascii       For the ASCII characters (0x00 to 0x7f) use the US
+---                 case mapping, the current locale is not effective.
+---                 This probably only matters for Turkish.
 ---
 --- @type string
 vim.o.casemap = "internal,keepascii"
@@ -735,8 +735,8 @@ vim.go.cd = vim.go.cdpath
 --- type.  The preferred way is to use the <> notation.  Examples:
 ---
 --- ```vim
---- 	exe "set cedit=\\<C-Y>"
---- 	exe "set cedit=\\<Esc>"
+---         exe "set cedit=\\<C-Y>"
+---         exe "set cedit=\\<Esc>"
 --- ```
 --- `Nvi` also has this option, but it only uses the first character.
 --- See `cmdwin`.
@@ -772,19 +772,19 @@ vim.bo.channel = vim.o.channel
 --- Example:
 ---
 --- ```vim
---- 	set charconvert=CharConvert()
---- 	fun CharConvert()
---- 	  system("recode "
---- 		\ .. v:charconvert_from .. ".." .. v:charconvert_to
---- 		\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
---- 	  return v:shell_error
---- 	endfun
+---         set charconvert=CharConvert()
+---         fun CharConvert()
+---           system("recode "
+---                 \ .. v:charconvert_from .. ".." .. v:charconvert_to
+---                 \ .. " <" .. v:fname_in .. " >" .. v:fname_out)
+---           return v:shell_error
+---         endfun
 --- ```
 --- The related Vim variables are:
---- 	v:charconvert_from	name of the current encoding
---- 	v:charconvert_to	name of the desired encoding
---- 	v:fname_in		name of the input file
---- 	v:fname_out		name of the output file
+---         v:charconvert_from      name of the current encoding
+---         v:charconvert_to        name of the desired encoding
+---         v:fname_in              name of the input file
+---         v:fname_out             name of the output file
 --- Note that v:fname_in and v:fname_out will never be the same.
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
@@ -839,7 +839,7 @@ vim.bo.cino = vim.bo.cinoptions
 --- scope declarations "signals", "public slots" and "private slots":
 ---
 --- ```vim
---- 	set cinscopedecls+=signals,public\ slots,private\ slots
+---         set cinscopedecls+=signals,public\ slots,private\ slots
 --- ```
 ---
 ---
@@ -865,25 +865,25 @@ vim.bo.cinw = vim.bo.cinwords
 --- This option is a list of comma-separated names.
 --- These names are recognized:
 ---
---- 					*clipboard-unnamed*
---- unnamed		When included, Vim will use the clipboard register "*"
---- 		for all yank, delete, change and put operations which
---- 		would normally go to the unnamed register.  When a
---- 		register is explicitly specified, it will always be
---- 		used regardless of whether "unnamed" is in 'clipboard'
---- 		or not.  The clipboard register can always be
---- 		explicitly accessed using the "* notation.  Also see
---- 		`clipboard`.
+---                                         *clipboard-unnamed*
+--- unnamed         When included, Vim will use the clipboard register "*"
+---                 for all yank, delete, change and put operations which
+---                 would normally go to the unnamed register.  When a
+---                 register is explicitly specified, it will always be
+---                 used regardless of whether "unnamed" is in 'clipboard'
+---                 or not.  The clipboard register can always be
+---                 explicitly accessed using the "* notation.  Also see
+---                 `clipboard`.
 ---
---- 					*clipboard-unnamedplus*
---- unnamedplus	A variant of the "unnamed" flag which uses the
---- 		clipboard register "+" (`quoteplus`) instead of
---- 		register "*" for all yank, delete, change and put
---- 		operations which would normally go to the unnamed
---- 		register.  When "unnamed" is also included to the
---- 		option, yank and delete operations (but not put)
---- 		will additionally copy the text into register
---- 		"*". See `clipboard`.
+---                                         *clipboard-unnamedplus*
+--- unnamedplus     A variant of the "unnamed" flag which uses the
+---                 clipboard register "+" (`quoteplus`) instead of
+---                 register "*" for all yank, delete, change and put
+---                 operations which would normally go to the unnamed
+---                 register.  When "unnamed" is also included to the
+---                 option, yank and delete operations (but not put)
+---                 will additionally copy the text into register
+---                 "*". See `clipboard`.
 ---
 --- @type string
 vim.o.clipboard = ""
@@ -928,9 +928,9 @@ vim.go.cwh = vim.go.cmdwinheight
 ---
 --- ```vim
 ---
---- 	set cc=+1	  " highlight column after 'textwidth'
---- 	set cc=+1,+2,+3  " highlight three columns after 'textwidth'
---- 	hi ColorColumn ctermbg=lightgrey guibg=lightgrey
+---         set cc=+1         " highlight column after 'textwidth'
+---         set cc=+1,+2,+3  " highlight three columns after 'textwidth'
+---         hi ColorColumn ctermbg=lightgrey guibg=lightgrey
 --- ```
 ---
 --- When 'textwidth' is zero then the items with '-' and '+' are not used.
@@ -954,7 +954,7 @@ vim.wo.cc = vim.wo.colorcolumn
 --- window possible:
 ---
 --- ```vim
---- 	set columns=9999
+---         set columns=9999
 --- ```
 --- Minimum value is 12, maximum value is 10000.
 ---
@@ -988,28 +988,28 @@ vim.bo.cms = vim.bo.commentstring
 --- when CTRL-P or CTRL-N are used.  It is also used for whole-line
 --- completion `i_CTRL-X_CTRL-L`.  It indicates the type of completion
 --- and the places to scan.  It is a comma-separated list of flags:
---- .	scan the current buffer ('wrapscan' is ignored)
---- w	scan buffers from other windows
---- b	scan other loaded buffers that are in the buffer list
---- u	scan the unloaded buffers that are in the buffer list
---- U	scan the buffers that are not in the buffer list
---- k	scan the files given with the 'dictionary' option
+--- .       scan the current buffer ('wrapscan' is ignored)
+--- w       scan buffers from other windows
+--- b       scan other loaded buffers that are in the buffer list
+--- u       scan the unloaded buffers that are in the buffer list
+--- U       scan the buffers that are not in the buffer list
+--- k       scan the files given with the 'dictionary' option
 --- kspell  use the currently active spell checking `spell`
---- k{dict}	scan the file {dict}.  Several "k" flags can be given,
---- 	patterns are valid too.  For example:
+--- k{dict} scan the file {dict}.  Several "k" flags can be given,
+---         patterns are valid too.  For example:
 ---
 --- ```vim
---- 		set cpt=k/usr/dict/*,k~/spanish
+---                 set cpt=k/usr/dict/*,k~/spanish
 --- ```
---- s	scan the files given with the 'thesaurus' option
---- s{tsr}	scan the file {tsr}.  Several "s" flags can be given, patterns
---- 	are valid too.
---- i	scan current and included files
---- d	scan current and included files for defined name or macro
---- 	`i_CTRL-X_CTRL-D`
---- ]	tag completion
---- t	same as "]"
---- f	scan the buffer names (as opposed to buffer contents)
+--- s       scan the files given with the 'thesaurus' option
+--- s{tsr}  scan the file {tsr}.  Several "s" flags can be given, patterns
+---         are valid too.
+--- i       scan current and included files
+--- d       scan current and included files for defined name or macro
+---         `i_CTRL-X_CTRL-D`
+--- ]       tag completion
+--- t       same as "]"
+--- f       scan the buffer names (as opposed to buffer contents)
 ---
 --- Unloaded buffers are not loaded, thus their autocmds `:autocmd` are
 --- not executed, this may lead to unexpected completions from some files
@@ -1044,35 +1044,35 @@ vim.bo.cfu = vim.bo.completefunc
 --- A comma-separated list of options for Insert mode completion
 --- `ins-completion`.  The supported values are:
 ---
----    menu	    Use a popup menu to show the possible completions.  The
---- 	    menu is only shown when there is more than one match and
---- 	    sufficient colors are available.  `ins-completion-menu`
+---    menu     Use a popup menu to show the possible completions.  The
+---             menu is only shown when there is more than one match and
+---             sufficient colors are available.  `ins-completion-menu`
 ---
 ---    menuone  Use the popup menu also when there is only one match.
---- 	    Useful when there is additional information about the
---- 	    match, e.g., what file it comes from.
+---             Useful when there is additional information about the
+---             match, e.g., what file it comes from.
 ---
 ---    longest  Only insert the longest common text of the matches.  If
---- 	    the menu is displayed you can use CTRL-L to add more
---- 	    characters.  Whether case is ignored depends on the kind
---- 	    of completion.  For buffer text the 'ignorecase' option is
---- 	    used.
+---             the menu is displayed you can use CTRL-L to add more
+---             characters.  Whether case is ignored depends on the kind
+---             of completion.  For buffer text the 'ignorecase' option is
+---             used.
 ---
 ---    preview  Show extra information about the currently selected
---- 	    completion in the preview window.  Only works in
---- 	    combination with "menu" or "menuone".
+---             completion in the preview window.  Only works in
+---             combination with "menu" or "menuone".
 ---
 ---    noinsert Do not insert any text for a match until the user selects
---- 	    a match from the menu. Only works in combination with
---- 	    "menu" or "menuone". No effect if "longest" is present.
+---             a match from the menu. Only works in combination with
+---             "menu" or "menuone". No effect if "longest" is present.
 ---
 ---    noselect Do not select a match in the menu, force the user to
---- 	    select one from the menu. Only works in combination with
---- 	    "menu" or "menuone".
+---             select one from the menu. Only works in combination with
+---             "menu" or "menuone".
 ---
 ---    popup    Show extra information about the currently selected
---- 	    completion in a popup window.  Only works in combination
---- 	    with "menu" or "menuone".  Overrides "preview".
+---             completion in a popup window.  Only works in combination
+---             with "menu" or "menuone".  Overrides "preview".
 ---
 --- @type string
 vim.o.completeopt = "menu,preview"
@@ -1080,15 +1080,15 @@ vim.o.cot = vim.o.completeopt
 vim.go.completeopt = vim.o.completeopt
 vim.go.cot = vim.go.completeopt
 
---- 		only for MS-Windows
+--- only for MS-Windows
 --- When this option is set it overrules 'shellslash' for completion:
 --- - When this option is set to "slash", a forward slash is used for path
----   completion in insert mode. This is useful when editing HTML tag, or
----   Makefile with 'noshellslash' on MS-Windows.
+--- completion in insert mode. This is useful when editing HTML tag, or
+--- Makefile with 'noshellslash' on MS-Windows.
 --- - When this option is set to "backslash", backslash is used. This is
----   useful when editing a batch file with 'shellslash' set on MS-Windows.
+--- useful when editing a batch file with 'shellslash' set on MS-Windows.
 --- - When this option is empty, same character is used as for
----   'shellslash'.
+--- 'shellslash'.
 --- For Insert mode completion the buffer-local value is used.  For
 --- command line completion the global value is used.
 ---
@@ -1101,10 +1101,10 @@ vim.bo.csl = vim.bo.completeslash
 --- Sets the modes in which text in the cursor line can also be concealed.
 --- When the current mode is listed then concealing happens just like in
 --- other lines.
----   n		Normal mode
----   v		Visual mode
----   i		Insert mode
----   c		Command line editing, for 'incsearch'
+---   n             Normal mode
+---   v             Visual mode
+---   i             Insert mode
+---   c             Command line editing, for 'incsearch'
 ---
 --- 'v' applies to all lines in the Visual area, not only the cursor.
 --- A useful value is "nc".  This is used in help files.  So long as you
@@ -1123,17 +1123,17 @@ vim.wo.cocu = vim.wo.concealcursor
 --- Determine how text with the "conceal" syntax attribute `:syn-conceal`
 --- is shown:
 ---
---- Value		Effect ~
---- 0		Text is shown normally
---- 1		Each block of concealed text is replaced with one
---- 		character.  If the syntax item does not have a custom
---- 		replacement character defined (see `:syn-cchar`) the
---- 		character defined in 'listchars' is used.
---- 		It is highlighted with the "Conceal" highlight group.
---- 2		Concealed text is completely hidden unless it has a
---- 		custom replacement character defined (see
---- 		`:syn-cchar`).
---- 3		Concealed text is completely hidden.
+--- Value           Effect ~
+--- 0               Text is shown normally
+--- 1               Each block of concealed text is replaced with one
+---                 character.  If the syntax item does not have a custom
+---                 replacement character defined (see `:syn-cchar`) the
+---                 character defined in 'listchars' is used.
+---                 It is highlighted with the "Conceal" highlight group.
+--- 2               Concealed text is completely hidden unless it has a
+---                 custom replacement character defined (see
+---                 `:syn-cchar`).
+--- 3               Concealed text is completely hidden.
 ---
 --- Note: in the cursor line concealed text is not hidden, so that you can
 --- edit and copy the text.  This can be changed with the 'concealcursor'
@@ -1184,228 +1184,228 @@ vim.bo.ci = vim.bo.copyindent
 --- To avoid problems with flags that are added in the future, use the
 --- "+=" and "-=" feature of ":set" `add-option-flags`.
 ---
----     contains	behavior	~
---- 							*cpo-a*
---- 	a	When included, a ":read" command with a file name
---- 		argument will set the alternate file name for the
---- 		current window.
---- 							*cpo-A*
---- 	A	When included, a ":write" command with a file name
---- 		argument will set the alternate file name for the
---- 		current window.
---- 							*cpo-b*
---- 	b	"\|" in a ":map" command is recognized as the end of
---- 		the map command.  The '\' is included in the mapping,
---- 		the text after the '|' is interpreted as the next
---- 		command.  Use a CTRL-V instead of a backslash to
---- 		include the '|' in the mapping.  Applies to all
---- 		mapping, abbreviation, menu and autocmd commands.
---- 		See also `map_bar`.
---- 							*cpo-B*
---- 	B	A backslash has no special meaning in mappings,
---- 		abbreviations, user commands and the "to" part of the
---- 		menu commands.  Remove this flag to be able to use a
---- 		backslash like a CTRL-V.  For example, the command
---- 		":map X \\<Esc>" results in X being mapped to:
---- 			'B' included:	"\^["	 (^[ is a real <Esc>)
---- 			'B' excluded:	"<Esc>"  (5 characters)
---- 							*cpo-c*
---- 	c	Searching continues at the end of any match at the
---- 		cursor position, but not further than the start of the
---- 		next line.  When not present searching continues
---- 		one character from the cursor position.  With 'c'
---- 		"abababababab" only gets three matches when repeating
---- 		"/abab", without 'c' there are five matches.
---- 							*cpo-C*
---- 	C	Do not concatenate sourced lines that start with a
---- 		backslash.  See `line-continuation`.
---- 							*cpo-d*
---- 	d	Using "./" in the 'tags' option doesn't mean to use
---- 		the tags file relative to the current file, but the
---- 		tags file in the current directory.
---- 							*cpo-D*
---- 	D	Can't use CTRL-K to enter a digraph after Normal mode
---- 		commands with a character argument, like `r`, `f` and
---- 		`t`.
---- 							*cpo-e*
---- 	e	When executing a register with ":@r", always add a
---- 		<CR> to the last line, also when the register is not
---- 		linewise.  If this flag is not present, the register
---- 		is not linewise and the last line does not end in a
---- 		<CR>, then the last line is put on the command-line
---- 		and can be edited before hitting <CR>.
---- 							*cpo-E*
---- 	E	It is an error when using "y", "d", "c", "g~", "gu" or
---- 		"gU" on an Empty region.  The operators only work when
---- 		at least one character is to be operated on.  Example:
---- 		This makes "y0" fail in the first column.
---- 							*cpo-f*
---- 	f	When included, a ":read" command with a file name
---- 		argument will set the file name for the current buffer,
---- 		if the current buffer doesn't have a file name yet.
---- 							*cpo-F*
---- 	F	When included, a ":write" command with a file name
---- 		argument will set the file name for the current
---- 		buffer, if the current buffer doesn't have a file name
---- 		yet.  Also see `cpo-P`.
---- 							*cpo-i*
---- 	i	When included, interrupting the reading of a file will
---- 		leave it modified.
---- 							*cpo-I*
---- 	I	When moving the cursor up or down just after inserting
---- 		indent for 'autoindent', do not delete the indent.
---- 							*cpo-J*
---- 	J	A `sentence` has to be followed by two spaces after
---- 		the '.', '!' or '?'.  A <Tab> is not recognized as
---- 		white space.
---- 							*cpo-K*
---- 	K	Don't wait for a key code to complete when it is
---- 		halfway through a mapping.  This breaks mapping
---- 		<F1><F1> when only part of the second <F1> has been
---- 		read.  It enables cancelling the mapping by typing
---- 		<F1><Esc>.
---- 							*cpo-l*
---- 	l	Backslash in a [] range in a search pattern is taken
---- 		literally, only "\]", "\^", "\-" and "\\" are special.
---- 		See `/[]`
---- 		   'l' included: "/[ \t]"  finds <Space>, '\' and 't'
---- 		   'l' excluded: "/[ \t]"  finds <Space> and <Tab>
---- 							*cpo-L*
---- 	L	When the 'list' option is set, 'wrapmargin',
---- 		'textwidth', 'softtabstop' and Virtual Replace mode
---- 		(see `gR`) count a <Tab> as two characters, instead of
---- 		the normal behavior of a <Tab>.
---- 							*cpo-m*
---- 	m	When included, a showmatch will always wait half a
---- 		second.  When not included, a showmatch will wait half
---- 		a second or until a character is typed.  `'showmatch'`
---- 							*cpo-M*
---- 	M	When excluded, "%" matching will take backslashes into
---- 		account.  Thus in "( \( )" and "\( ( \)" the outer
---- 		parenthesis match.  When included "%" ignores
---- 		backslashes, which is Vi compatible.
---- 							*cpo-n*
---- 	n	When included, the column used for 'number' and
---- 		'relativenumber' will also be used for text of wrapped
---- 		lines.
---- 							*cpo-o*
---- 	o	Line offset to search command is not remembered for
---- 		next search.
---- 							*cpo-O*
---- 	O	Don't complain if a file is being overwritten, even
---- 		when it didn't exist when editing it.  This is a
---- 		protection against a file unexpectedly created by
---- 		someone else.  Vi didn't complain about this.
---- 							*cpo-p*
---- 	p	Vi compatible Lisp indenting.  When not present, a
---- 		slightly better algorithm is used.
---- 							*cpo-P*
---- 	P	When included, a ":write" command that appends to a
---- 		file will set the file name for the current buffer, if
---- 		the current buffer doesn't have a file name yet and
---- 		the 'F' flag is also included `cpo-F`.
---- 							*cpo-q*
---- 	q	When joining multiple lines leave the cursor at the
---- 		position where it would be when joining two lines.
---- 							*cpo-r*
---- 	r	Redo ("." command) uses "/" to repeat a search
---- 		command, instead of the actually used search string.
---- 							*cpo-R*
---- 	R	Remove marks from filtered lines.  Without this flag
---- 		marks are kept like `:keepmarks` was used.
---- 							*cpo-s*
---- 	s	Set buffer options when entering the buffer for the
---- 		first time.  This is like it is in Vim version 3.0.
---- 		And it is the default.  If not present the options are
---- 		set when the buffer is created.
---- 							*cpo-S*
---- 	S	Set buffer options always when entering a buffer
---- 		(except 'readonly', 'fileformat', 'filetype' and
---- 		'syntax').  This is the (most) Vi compatible setting.
---- 		The options are set to the values in the current
---- 		buffer.  When you change an option and go to another
---- 		buffer, the value is copied.  Effectively makes the
---- 		buffer options global to all buffers.
+---     contains    behavior        ~
+---                                                         *cpo-a*
+---         a       When included, a ":read" command with a file name
+---                 argument will set the alternate file name for the
+---                 current window.
+---                                                         *cpo-A*
+---         A       When included, a ":write" command with a file name
+---                 argument will set the alternate file name for the
+---                 current window.
+---                                                         *cpo-b*
+---         b       "\|" in a ":map" command is recognized as the end of
+---                 the map command.  The '\' is included in the mapping,
+---                 the text after the '|' is interpreted as the next
+---                 command.  Use a CTRL-V instead of a backslash to
+---                 include the '|' in the mapping.  Applies to all
+---                 mapping, abbreviation, menu and autocmd commands.
+---                 See also `map_bar`.
+---                                                         *cpo-B*
+---         B       A backslash has no special meaning in mappings,
+---                 abbreviations, user commands and the "to" part of the
+---                 menu commands.  Remove this flag to be able to use a
+---                 backslash like a CTRL-V.  For example, the command
+---                 ":map X \\<Esc>" results in X being mapped to:
+---                         'B' included:   "\^["    (^[ is a real <Esc>)
+---                         'B' excluded:   "<Esc>"  (5 characters)
+---                                                         *cpo-c*
+---         c       Searching continues at the end of any match at the
+---                 cursor position, but not further than the start of the
+---                 next line.  When not present searching continues
+---                 one character from the cursor position.  With 'c'
+---                 "abababababab" only gets three matches when repeating
+---                 "/abab", without 'c' there are five matches.
+---                                                         *cpo-C*
+---         C       Do not concatenate sourced lines that start with a
+---                 backslash.  See `line-continuation`.
+---                                                         *cpo-d*
+---         d       Using "./" in the 'tags' option doesn't mean to use
+---                 the tags file relative to the current file, but the
+---                 tags file in the current directory.
+---                                                         *cpo-D*
+---         D       Can't use CTRL-K to enter a digraph after Normal mode
+---                 commands with a character argument, like `r`, `f` and
+---                 `t`.
+---                                                         *cpo-e*
+---         e       When executing a register with ":@r", always add a
+---                 <CR> to the last line, also when the register is not
+---                 linewise.  If this flag is not present, the register
+---                 is not linewise and the last line does not end in a
+---                 <CR>, then the last line is put on the command-line
+---                 and can be edited before hitting <CR>.
+---                                                         *cpo-E*
+---         E       It is an error when using "y", "d", "c", "g~", "gu" or
+---                 "gU" on an Empty region.  The operators only work when
+---                 at least one character is to be operated on.  Example:
+---                 This makes "y0" fail in the first column.
+---                                                         *cpo-f*
+---         f       When included, a ":read" command with a file name
+---                 argument will set the file name for the current buffer,
+---                 if the current buffer doesn't have a file name yet.
+---                                                         *cpo-F*
+---         F       When included, a ":write" command with a file name
+---                 argument will set the file name for the current
+---                 buffer, if the current buffer doesn't have a file name
+---                 yet.  Also see `cpo-P`.
+---                                                         *cpo-i*
+---         i       When included, interrupting the reading of a file will
+---                 leave it modified.
+---                                                         *cpo-I*
+---         I       When moving the cursor up or down just after inserting
+---                 indent for 'autoindent', do not delete the indent.
+---                                                         *cpo-J*
+---         J       A `sentence` has to be followed by two spaces after
+---                 the '.', '!' or '?'.  A <Tab> is not recognized as
+---                 white space.
+---                                                         *cpo-K*
+---         K       Don't wait for a key code to complete when it is
+---                 halfway through a mapping.  This breaks mapping
+---                 <F1><F1> when only part of the second <F1> has been
+---                 read.  It enables cancelling the mapping by typing
+---                 <F1><Esc>.
+---                                                         *cpo-l*
+---         l       Backslash in a [] range in a search pattern is taken
+---                 literally, only "\]", "\^", "\-" and "\\" are special.
+---                 See `/[]`
+---                    'l' included: "/[ \t]"  finds <Space>, '\' and 't'
+---                    'l' excluded: "/[ \t]"  finds <Space> and <Tab>
+---                                                         *cpo-L*
+---         L       When the 'list' option is set, 'wrapmargin',
+---                 'textwidth', 'softtabstop' and Virtual Replace mode
+---                 (see `gR`) count a <Tab> as two characters, instead of
+---                 the normal behavior of a <Tab>.
+---                                                         *cpo-m*
+---         m       When included, a showmatch will always wait half a
+---                 second.  When not included, a showmatch will wait half
+---                 a second or until a character is typed.  `'showmatch'`
+---                                                         *cpo-M*
+---         M       When excluded, "%" matching will take backslashes into
+---                 account.  Thus in "( \( )" and "\( ( \)" the outer
+---                 parenthesis match.  When included "%" ignores
+---                 backslashes, which is Vi compatible.
+---                                                         *cpo-n*
+---         n       When included, the column used for 'number' and
+---                 'relativenumber' will also be used for text of wrapped
+---                 lines.
+---                                                         *cpo-o*
+---         o       Line offset to search command is not remembered for
+---                 next search.
+---                                                         *cpo-O*
+---         O       Don't complain if a file is being overwritten, even
+---                 when it didn't exist when editing it.  This is a
+---                 protection against a file unexpectedly created by
+---                 someone else.  Vi didn't complain about this.
+---                                                         *cpo-p*
+---         p       Vi compatible Lisp indenting.  When not present, a
+---                 slightly better algorithm is used.
+---                                                         *cpo-P*
+---         P       When included, a ":write" command that appends to a
+---                 file will set the file name for the current buffer, if
+---                 the current buffer doesn't have a file name yet and
+---                 the 'F' flag is also included `cpo-F`.
+---                                                         *cpo-q*
+---         q       When joining multiple lines leave the cursor at the
+---                 position where it would be when joining two lines.
+---                                                         *cpo-r*
+---         r       Redo ("." command) uses "/" to repeat a search
+---                 command, instead of the actually used search string.
+---                                                         *cpo-R*
+---         R       Remove marks from filtered lines.  Without this flag
+---                 marks are kept like `:keepmarks` was used.
+---                                                         *cpo-s*
+---         s       Set buffer options when entering the buffer for the
+---                 first time.  This is like it is in Vim version 3.0.
+---                 And it is the default.  If not present the options are
+---                 set when the buffer is created.
+---                                                         *cpo-S*
+---         S       Set buffer options always when entering a buffer
+---                 (except 'readonly', 'fileformat', 'filetype' and
+---                 'syntax').  This is the (most) Vi compatible setting.
+---                 The options are set to the values in the current
+---                 buffer.  When you change an option and go to another
+---                 buffer, the value is copied.  Effectively makes the
+---                 buffer options global to all buffers.
 ---
---- 		's'    'S'     copy buffer options
---- 		no     no      when buffer created
---- 		yes    no      when buffer first entered (default)
---- 		 X     yes     each time when buffer entered (vi comp.)
---- 							*cpo-t*
---- 	t	Search pattern for the tag command is remembered for
---- 		"n" command.  Otherwise Vim only puts the pattern in
---- 		the history for search pattern, but doesn't change the
---- 		last used search pattern.
---- 							*cpo-u*
---- 	u	Undo is Vi compatible.  See `undo-two-ways`.
---- 							*cpo-v*
---- 	v	Backspaced characters remain visible on the screen in
---- 		Insert mode.  Without this flag the characters are
---- 		erased from the screen right away.  With this flag the
---- 		screen newly typed text overwrites backspaced
---- 		characters.
---- 							*cpo-W*
---- 	W	Don't overwrite a readonly file.  When omitted, ":w!"
---- 		overwrites a readonly file, if possible.
---- 							*cpo-x*
---- 	x	<Esc> on the command-line executes the command-line.
---- 		The default in Vim is to abandon the command-line,
---- 		because <Esc> normally aborts a command.  `c_<Esc>`
---- 							*cpo-X*
---- 	X	When using a count with "R" the replaced text is
---- 		deleted only once.  Also when repeating "R" with "."
---- 		and a count.
---- 							*cpo-y*
---- 	y	A yank command can be redone with ".".  Think twice if
---- 		you really want to use this, it may break some
---- 		plugins, since most people expect "." to only repeat a
---- 		change.
---- 							*cpo-Z*
---- 	Z	When using "w!" while the 'readonly' option is set,
---- 		don't reset 'readonly'.
---- 							*cpo-!*
---- 	!	When redoing a filter command, use the last used
---- 		external command, whatever it was.  Otherwise the last
---- 		used -filter- command is used.
---- 							*cpo-$*
---- 	$	When making a change to one line, don't redisplay the
---- 		line, but put a '$' at the end of the changed text.
---- 		The changed text will be overwritten when you type the
---- 		new text.  The line is redisplayed if you type any
---- 		command that moves the cursor from the insertion
---- 		point.
---- 							*cpo-%*
---- 	%	Vi-compatible matching is done for the "%" command.
---- 		Does not recognize "#if", "#endif", etc.
---- 		Does not recognize "/*" and "*/".
---- 		Parens inside single and double quotes are also
---- 		counted, causing a string that contains a paren to
---- 		disturb the matching.  For example, in a line like
---- 		"if (strcmp("foo(", s))" the first paren does not
---- 		match the last one.  When this flag is not included,
---- 		parens inside single and double quotes are treated
---- 		specially.  When matching a paren outside of quotes,
---- 		everything inside quotes is ignored.  When matching a
---- 		paren inside quotes, it will find the matching one (if
---- 		there is one).  This works very well for C programs.
---- 		This flag is also used for other features, such as
---- 		C-indenting.
---- 							*cpo-+*
---- 	+	When included, a ":write file" command will reset the
---- 		'modified' flag of the buffer, even though the buffer
---- 		itself may still be different from its file.
---- 							*cpo->*
---- 	>	When appending to a register, put a line break before
---- 		the appended text.
---- 							*cpo-;*
---- 	;	When using `,` or `;` to repeat the last `t` search
---- 		and the cursor is right in front of the searched
---- 		character, the cursor won't move. When not included,
---- 		the cursor would skip over it and jump to the
---- 		following occurrence.
---- 							*cpo-_*
---- 	_	When using `cw` on a word, do not include the
---- 		whitespace following the word in the motion.
+---                 's'    'S'     copy buffer options
+---                 no     no      when buffer created
+---                 yes    no      when buffer first entered (default)
+---                  X     yes     each time when buffer entered (vi comp.)
+---                                                         *cpo-t*
+---         t       Search pattern for the tag command is remembered for
+---                 "n" command.  Otherwise Vim only puts the pattern in
+---                 the history for search pattern, but doesn't change the
+---                 last used search pattern.
+---                                                         *cpo-u*
+---         u       Undo is Vi compatible.  See `undo-two-ways`.
+---                                                         *cpo-v*
+---         v       Backspaced characters remain visible on the screen in
+---                 Insert mode.  Without this flag the characters are
+---                 erased from the screen right away.  With this flag the
+---                 screen newly typed text overwrites backspaced
+---                 characters.
+---                                                         *cpo-W*
+---         W       Don't overwrite a readonly file.  When omitted, ":w!"
+---                 overwrites a readonly file, if possible.
+---                                                         *cpo-x*
+---         x       <Esc> on the command-line executes the command-line.
+---                 The default in Vim is to abandon the command-line,
+---                 because <Esc> normally aborts a command.  `c_<Esc>`
+---                                                         *cpo-X*
+---         X       When using a count with "R" the replaced text is
+---                 deleted only once.  Also when repeating "R" with "."
+---                 and a count.
+---                                                         *cpo-y*
+---         y       A yank command can be redone with ".".  Think twice if
+---                 you really want to use this, it may break some
+---                 plugins, since most people expect "." to only repeat a
+---                 change.
+---                                                         *cpo-Z*
+---         Z       When using "w!" while the 'readonly' option is set,
+---                 don't reset 'readonly'.
+---                                                         *cpo-!*
+---         !       When redoing a filter command, use the last used
+---                 external command, whatever it was.  Otherwise the last
+---                 used -filter- command is used.
+---                                                         *cpo-$*
+---         $       When making a change to one line, don't redisplay the
+---                 line, but put a '$' at the end of the changed text.
+---                 The changed text will be overwritten when you type the
+---                 new text.  The line is redisplayed if you type any
+---                 command that moves the cursor from the insertion
+---                 point.
+---                                                         *cpo-%*
+---         %       Vi-compatible matching is done for the "%" command.
+---                 Does not recognize "#if", "#endif", etc.
+---                 Does not recognize "/*" and "*/".
+---                 Parens inside single and double quotes are also
+---                 counted, causing a string that contains a paren to
+---                 disturb the matching.  For example, in a line like
+---                 "if (strcmp("foo(", s))" the first paren does not
+---                 match the last one.  When this flag is not included,
+---                 parens inside single and double quotes are treated
+---                 specially.  When matching a paren outside of quotes,
+---                 everything inside quotes is ignored.  When matching a
+---                 paren inside quotes, it will find the matching one (if
+---                 there is one).  This works very well for C programs.
+---                 This flag is also used for other features, such as
+---                 C-indenting.
+---                                                         *cpo-+*
+---         +       When included, a ":write file" command will reset the
+---                 'modified' flag of the buffer, even though the buffer
+---                 itself may still be different from its file.
+---                                                         *cpo->*
+---         >       When appending to a register, put a line break before
+---                 the appended text.
+---                                                         *cpo-;*
+---         ;       When using `,` or `;` to repeat the last `t` search
+---                 and the cursor is right in front of the searched
+---                 character, the cursor won't move. When not included,
+---                 the cursor would skip over it and jump to the
+---                 following occurrence.
+---                                                         *cpo-_*
+---         _       When using `cw` on a word, do not include the
+---                 whitespace following the word in the motion.
 ---
 --- @type string
 vim.o.cpoptions = "aABceFs_"
@@ -1434,8 +1434,8 @@ vim.wo.crb = vim.wo.cursorbind
 --- these autocommands:
 ---
 --- ```vim
---- 	au WinLeave * set nocursorline nocursorcolumn
---- 	au WinEnter * set cursorline cursorcolumn
+---         au WinLeave * set nocursorline nocursorcolumn
+---         au WinEnter * set cursorline cursorcolumn
 --- ```
 ---
 ---
@@ -1458,15 +1458,15 @@ vim.wo.cul = vim.wo.cursorline
 
 --- Comma-separated list of settings for how 'cursorline' is displayed.
 --- Valid values:
---- "line"		Highlight the text line of the cursor with
---- 		CursorLine `hl-CursorLine`.
---- "screenline"	Highlight only the screen line of the cursor with
---- 		CursorLine `hl-CursorLine`.
---- "number"	Highlight the line number of the cursor with
---- 		CursorLineNr `hl-CursorLineNr`.
+--- "line"          Highlight the text line of the cursor with
+---                 CursorLine `hl-CursorLine`.
+--- "screenline"    Highlight only the screen line of the cursor with
+---                 CursorLine `hl-CursorLine`.
+--- "number"        Highlight the line number of the cursor with
+---                 CursorLineNr `hl-CursorLineNr`.
 ---
 --- Special value:
---- "both"		Alias for the values "line,number".
+--- "both"          Alias for the values "line,number".
 ---
 --- "line" and "screenline" cannot be used together.
 ---
@@ -1477,12 +1477,12 @@ vim.wo.cursorlineopt = vim.o.cursorlineopt
 vim.wo.culopt = vim.wo.cursorlineopt
 
 --- These values can be used:
---- msg	Error messages that would otherwise be omitted will be given
---- 	anyway.
---- throw	Error messages that would otherwise be omitted will be given
---- 	anyway and also throw an exception and set `v:errmsg`.
---- beep	A message will be given when otherwise only a beep would be
---- 	produced.
+--- msg     Error messages that would otherwise be omitted will be given
+---         anyway.
+--- throw   Error messages that would otherwise be omitted will be given
+---         anyway and also throw an exception and set `v:errmsg`.
+--- beep    A message will be given when otherwise only a beep would be
+---         produced.
 --- The values can be combined, separated by a comma.
 --- "msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
 --- 'indentexpr'.
@@ -1496,19 +1496,19 @@ vim.go.debug = vim.o.debug
 --- commands like "[i" and "[d" `include-search`.  The 'isident' option is
 --- used to recognize the defined name after the match:
 --- ```
---- 	{match with 'define'}{non-ID chars}{defined name}{non-ID char}
+---         {match with 'define'}{non-ID chars}{defined name}{non-ID char}
 --- ```
 --- See `option-backslash` about inserting backslashes to include a space
 --- or backslash.
 --- For C++ this value would be useful, to include const type declarations:
 --- ```
---- 	^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
+---         ^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
 --- ```
 --- You can also use "\ze" just before the name and continue the pattern
 --- to check what is following.  E.g. for Javascript, if a function is
 --- defined with `func_name = function(args)`:
 --- ```
---- 	^\s*\ze\i\+\s*=\s*function(
+---         ^\s*\ze\i\+\s*=\s*function(
 --- ```
 --- If the function is defined with `func_name : function() {...`:
 --- ```
@@ -1518,7 +1518,7 @@ vim.go.debug = vim.o.debug
 --- To avoid that use `:let` with a single quote string:
 ---
 --- ```vim
---- 	let &l:define = '^\s*\ze\k\+\s*=\s*function('
+---         let &l:define = '^\s*\ze\k\+\s*=\s*function('
 --- ```
 ---
 ---
@@ -1598,110 +1598,110 @@ vim.go.dex = vim.go.diffexpr
 --- Option settings for diff mode.  It can consist of the following items.
 --- All are optional.  Items must be separated by a comma.
 ---
---- 	filler		Show filler lines, to keep the text
---- 			synchronized with a window that has inserted
---- 			lines at the same position.  Mostly useful
---- 			when windows are side-by-side and 'scrollbind'
---- 			is set.
+---         filler          Show filler lines, to keep the text
+---                         synchronized with a window that has inserted
+---                         lines at the same position.  Mostly useful
+---                         when windows are side-by-side and 'scrollbind'
+---                         is set.
 ---
---- 	context:{n}	Use a context of {n} lines between a change
---- 			and a fold that contains unchanged lines.
---- 			When omitted a context of six lines is used.
---- 			When using zero the context is actually one,
---- 			since folds require a line in between, also
---- 			for a deleted line. Set it to a very large
---- 			value (999999) to disable folding completely.
---- 			See `fold-diff`.
+---         context:{n}     Use a context of {n} lines between a change
+---                         and a fold that contains unchanged lines.
+---                         When omitted a context of six lines is used.
+---                         When using zero the context is actually one,
+---                         since folds require a line in between, also
+---                         for a deleted line. Set it to a very large
+---                         value (999999) to disable folding completely.
+---                         See `fold-diff`.
 ---
---- 	iblank		Ignore changes where lines are all blank.  Adds
---- 			the "-B" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
---- 			NOTE: the diff windows will get out of sync,
---- 			because no differences between blank lines are
---- 			taken into account.
+---         iblank          Ignore changes where lines are all blank.  Adds
+---                         the "-B" flag to the "diff" command if
+---                         'diffexpr' is empty.  Check the documentation
+---                         of the "diff" command for what this does
+---                         exactly.
+---                         NOTE: the diff windows will get out of sync,
+---                         because no differences between blank lines are
+---                         taken into account.
 ---
---- 	icase		Ignore changes in case of text.  "a" and "A"
---- 			are considered the same.  Adds the "-i" flag
---- 			to the "diff" command if 'diffexpr' is empty.
+---         icase           Ignore changes in case of text.  "a" and "A"
+---                         are considered the same.  Adds the "-i" flag
+---                         to the "diff" command if 'diffexpr' is empty.
 ---
---- 	iwhite		Ignore changes in amount of white space.  Adds
---- 			the "-b" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.  It should ignore adding trailing
---- 			white space, but not leading white space.
+---         iwhite          Ignore changes in amount of white space.  Adds
+---                         the "-b" flag to the "diff" command if
+---                         'diffexpr' is empty.  Check the documentation
+---                         of the "diff" command for what this does
+---                         exactly.  It should ignore adding trailing
+---                         white space, but not leading white space.
 ---
---- 	iwhiteall	Ignore all white space changes.  Adds
---- 			the "-w" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
+---         iwhiteall       Ignore all white space changes.  Adds
+---                         the "-w" flag to the "diff" command if
+---                         'diffexpr' is empty.  Check the documentation
+---                         of the "diff" command for what this does
+---                         exactly.
 ---
---- 	iwhiteeol	Ignore white space changes at end of line.
---- 			Adds the "-Z" flag to the "diff" command if
---- 			'diffexpr' is empty.  Check the documentation
---- 			of the "diff" command for what this does
---- 			exactly.
+---         iwhiteeol       Ignore white space changes at end of line.
+---                         Adds the "-Z" flag to the "diff" command if
+---                         'diffexpr' is empty.  Check the documentation
+---                         of the "diff" command for what this does
+---                         exactly.
 ---
---- 	horizontal	Start diff mode with horizontal splits (unless
---- 			explicitly specified otherwise).
+---         horizontal      Start diff mode with horizontal splits (unless
+---                         explicitly specified otherwise).
 ---
---- 	vertical	Start diff mode with vertical splits (unless
---- 			explicitly specified otherwise).
+---         vertical        Start diff mode with vertical splits (unless
+---                         explicitly specified otherwise).
 ---
---- 	closeoff	When a window is closed where 'diff' is set
---- 			and there is only one window remaining in the
---- 			same tab page with 'diff' set, execute
---- 			`:diffoff` in that window.  This undoes a
---- 			`:diffsplit` command.
+---         closeoff        When a window is closed where 'diff' is set
+---                         and there is only one window remaining in the
+---                         same tab page with 'diff' set, execute
+---                         `:diffoff` in that window.  This undoes a
+---                         `:diffsplit` command.
 ---
---- 	hiddenoff	Do not use diff mode for a buffer when it
---- 			becomes hidden.
+---         hiddenoff       Do not use diff mode for a buffer when it
+---                         becomes hidden.
 ---
---- 	foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
---- 			starting diff mode.  Without this 2 is used.
+---         foldcolumn:{n}  Set the 'foldcolumn' option to {n} when
+---                         starting diff mode.  Without this 2 is used.
 ---
---- 	followwrap	Follow the 'wrap' option and leave as it is.
+---         followwrap      Follow the 'wrap' option and leave as it is.
 ---
---- 	internal	Use the internal diff library.  This is
---- 			ignored when 'diffexpr' is set.  *E960*
---- 			When running out of memory when writing a
---- 			buffer this item will be ignored for diffs
---- 			involving that buffer.  Set the 'verbose'
---- 			option to see when this happens.
+---         internal        Use the internal diff library.  This is
+---                         ignored when 'diffexpr' is set.  *E960*
+---                         When running out of memory when writing a
+---                         buffer this item will be ignored for diffs
+---                         involving that buffer.  Set the 'verbose'
+---                         option to see when this happens.
 ---
---- 	indent-heuristic
---- 			Use the indent heuristic for the internal
---- 			diff library.
+---         indent-heuristic
+---                         Use the indent heuristic for the internal
+---                         diff library.
 ---
---- 	linematch:{n}   Enable a second stage diff on each generated
---- 			hunk in order to align lines. When the total
---- 			number of lines in a hunk exceeds {n}, the
---- 			second stage diff will not be performed as
---- 			very large hunks can cause noticeable lag. A
---- 			recommended setting is "linematch:60", as this
---- 			will enable alignment for a 2 buffer diff with
---- 			hunks of up to 30 lines each, or a 3 buffer
---- 			diff with hunks of up to 20 lines each.
+---         linematch:{n}   Enable a second stage diff on each generated
+---                         hunk in order to align lines. When the total
+---                         number of lines in a hunk exceeds {n}, the
+---                         second stage diff will not be performed as
+---                         very large hunks can cause noticeable lag. A
+---                         recommended setting is "linematch:60", as this
+---                         will enable alignment for a 2 buffer diff with
+---                         hunks of up to 30 lines each, or a 3 buffer
+---                         diff with hunks of up to 20 lines each.
 ---
---- 	algorithm:{text} Use the specified diff algorithm with the
---- 			internal diff engine. Currently supported
---- 			algorithms are:
---- 			myers      the default algorithm
---- 			minimal    spend extra time to generate the
---- 				   smallest possible diff
---- 			patience   patience diff algorithm
---- 			histogram  histogram diff algorithm
+---         algorithm:{text} Use the specified diff algorithm with the
+---                         internal diff engine. Currently supported
+---                         algorithms are:
+---                         myers      the default algorithm
+---                         minimal    spend extra time to generate the
+---                                    smallest possible diff
+---                         patience   patience diff algorithm
+---                         histogram  histogram diff algorithm
 ---
 --- Examples:
 ---
 --- ```vim
---- 	set diffopt=internal,filler,context:4
---- 	set diffopt=
---- 	set diffopt=internal,filler,foldcolumn:3
---- 	set diffopt-=internal  " do NOT use the internal diff parser
+---         set diffopt=internal,filler,context:4
+---         set diffopt=
+---         set diffopt=internal,filler,foldcolumn:3
+---         set diffopt-=internal  " do NOT use the internal diff parser
 --- ```
 ---
 ---
@@ -1774,15 +1774,15 @@ vim.go.dir = vim.go.directory
 
 --- Change the way text is displayed.  This is a comma-separated list of
 --- flags:
---- lastline	When included, as much as possible of the last line
---- 		in a window will be displayed.  "@@@" is put in the
---- 		last columns of the last screen line to indicate the
---- 		rest of the line is not displayed.
---- truncate	Like "lastline", but "@@@" is displayed in the first
---- 		column of the last screen line.  Overrules "lastline".
---- uhex		Show unprintable characters hexadecimal as <xx>
---- 		instead of using ^C and ~C.
---- msgsep		Obsolete flag. Allowed but takes no effect. `msgsep`
+--- lastline        When included, as much as possible of the last line
+---                 in a window will be displayed.  "@@@" is put in the
+---                 last columns of the last screen line to indicate the
+---                 rest of the line is not displayed.
+--- truncate        Like "lastline", but "@@@" is displayed in the first
+---                 column of the last screen line.  Overrules "lastline".
+--- uhex            Show unprintable characters hexadecimal as <xx>
+---                 instead of using ^C and ~C.
+--- msgsep          Obsolete flag. Allowed but takes no effect. `msgsep`
 ---
 --- When neither "lastline" nor "truncate" is included, a last line that
 --- doesn't fit is replaced with "@" lines.
@@ -1797,9 +1797,9 @@ vim.go.display = vim.o.display
 vim.go.dy = vim.go.display
 
 --- Tells when the 'equalalways' option applies:
---- 	ver	vertically, width of windows is not affected
---- 	hor	horizontally, height of windows is not affected
---- 	both	width and height of windows is affected
+---         ver     vertically, width of windows is not affected
+---         hor     horizontally, height of windows is not affected
+---         both    width and height of windows is affected
 ---
 --- @type string
 vim.o.eadirection = "both"
@@ -2031,9 +2031,9 @@ vim.bo.fenc = vim.bo.fileencoding
 --- in the list is tried.  When an encoding is found that works,
 --- 'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
 --- an empty string, which means that UTF-8 is used.
---- 	WARNING: Conversion can cause loss of information! You can use
---- 	the `++bad` argument to specify what is done with characters
---- 	that can't be converted.
+---         WARNING: Conversion can cause loss of information! You can use
+---         the `++bad` argument to specify what is done with characters
+---         that can't be converted.
 --- For an empty file or a file with only ASCII characters most encodings
 --- will work and the first entry of 'fileencodings' will be used (except
 --- "ucs-bom", which requires the BOM to be present).  If you prefer
@@ -2041,8 +2041,8 @@ vim.bo.fenc = vim.bo.fileencoding
 --- preferred encoding is to be used.  Example:
 ---
 --- ```vim
---- 	au BufReadPost * if search('\S', 'w') == 0 |
---- 		\ set fenc=iso-2022-jp | endif
+---         au BufReadPost * if search('\S', 'w') == 0 |
+---                 \ set fenc=iso-2022-jp | endif
 --- ```
 --- This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
 --- non-blank characters.
@@ -2052,7 +2052,7 @@ vim.bo.fenc = vim.bo.fileencoding
 --- of 'fileencoding' is used instead.  You can set it with:
 ---
 --- ```vim
---- 	setglobal fenc=iso-8859-2
+---         setglobal fenc=iso-8859-2
 --- ```
 --- This means that a non-existing file may get a different encoding than
 --- an empty file.
@@ -2068,11 +2068,11 @@ vim.bo.fenc = vim.bo.fileencoding
 --- When a file contains an illegal UTF-8 byte sequence it won't be
 --- recognized as "utf-8".  You can use the `8g8` command to find the
 --- illegal byte sequence.
---- WRONG VALUES:			WHAT'S WRONG:
---- 	latin1,utf-8		"latin1" will always be used
---- 	utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
---- 				file
---- 	cp1250,latin1		"cp1250" will always be used
+--- WRONG VALUES:                   WHAT'S WRONG:
+---         latin1,utf-8            "latin1" will always be used
+---         utf-8,ucs-bom,latin1    BOM won't be recognized in an utf-8
+---                                 file
+---         cp1250,latin1           "cp1250" will always be used
 --- If 'fileencodings' is empty, 'fileencoding' is not modified.
 --- See 'fileencoding' for the possible values.
 --- Setting this option does not have an effect until the next time a file
@@ -2086,9 +2086,9 @@ vim.go.fencs = vim.go.fileencodings
 
 --- This gives the <EOL> of the current buffer, which is used for
 --- reading/writing the buffer from/to a file:
----     dos	    <CR><NL>
+---     dos     <CR><NL>
 ---     unix    <NL>
----     mac	    <CR>
+---     mac     <CR>
 --- When "dos" is used, CTRL-Z at the end of a file is ignored.
 --- See `file-formats` and `file-read`.
 --- For the character encoding of the file see 'fileencoding'.
@@ -2177,12 +2177,12 @@ vim.go.fic = vim.go.fileignorecase
 --- Setting this option to a different value is most useful in a modeline,
 --- for a file for which the file type is not automatically recognized.
 --- Example, for in an IDL file: >c
---- 	/* vim: set filetype=idl : */
+---         /* vim: set filetype=idl : */
 --- ```
 --- `FileType` `filetypes`
 --- When a dot appears in the value then this separates two filetype
 --- names.  Example: >c
---- 	/* vim: set filetype=c.doxygen : */
+---         /* vim: set filetype=c.doxygen : */
 --- ```
 --- This will use the "c" filetype first, then the "doxygen" filetype.
 --- This works both for filetype plugins and for syntax files.  More than
@@ -2202,26 +2202,26 @@ vim.bo.ft = vim.bo.filetype
 --- It is a comma-separated list of items.  Each item has a name, a colon
 --- and the value of that item:
 ---
----   item		default		Used for ~
----   stl		' '		statusline of the current window
----   stlnc		' '		statusline of the non-current windows
----   wbr		' '		window bar
----   horiz		'─' or '-'	horizontal separators `:split`
----   horizup	'┴' or '-'	upwards facing horizontal separator
----   horizdown	'┬' or '-'	downwards facing horizontal separator
----   vert		'│' or '|'	vertical separators `:vsplit`
----   vertleft	'┤' or '|'	left facing vertical separator
----   vertright	'├' or '|'	right facing vertical separator
----   verthoriz	'┼' or '+'	overlapping vertical and horizontal
---- 				separator
----   fold		'·' or '-'	filling 'foldtext'
----   foldopen	'-'		mark the beginning of a fold
----   foldclose	'+'		show a closed fold
----   foldsep	'│' or '|'      open fold middle marker
----   diff		'-'		deleted lines of the 'diff' option
----   msgsep	' '		message separator 'display'
----   eob		'~'		empty lines at the end of a buffer
----   lastline	'@'		'display' contains lastline/truncate
+---   item          default         Used for ~
+---   stl           ' '             statusline of the current window
+---   stlnc         ' '             statusline of the non-current windows
+---   wbr           ' '             window bar
+---   horiz         '─' or '-'      horizontal separators `:split`
+---   horizup       '┴' or '-'      upwards facing horizontal separator
+---   horizdown     '┬' or '-'      downwards facing horizontal separator
+---   vert          '│' or '|'      vertical separators `:vsplit`
+---   vertleft      '┤' or '|'      left facing vertical separator
+---   vertright     '├' or '|'      right facing vertical separator
+---   verthoriz     '┼' or '+'      overlapping vertical and horizontal
+---                                 separator
+---   fold          '·' or '-'      filling 'foldtext'
+---   foldopen      '-'             mark the beginning of a fold
+---   foldclose     '+'             show a closed fold
+---   foldsep       '│' or '|'      open fold middle marker
+---   diff          '-'             deleted lines of the 'diff' option
+---   msgsep        ' '             message separator 'display'
+---   eob           '~'             empty lines at the end of a buffer
+---   lastline      '@'             'display' contains lastline/truncate
 ---
 --- Any one that is omitted will fall back to the default.
 ---
@@ -2244,21 +2244,21 @@ vim.bo.ft = vim.bo.filetype
 --- characters are not supported.
 ---
 --- The highlighting used for these items:
----   item		highlight group ~
----   stl		StatusLine		`hl-StatusLine`
----   stlnc		StatusLineNC		`hl-StatusLineNC`
----   wbr		WinBar			`hl-WinBar` or `hl-WinBarNC`
----   horiz		WinSeparator		`hl-WinSeparator`
----   horizup	WinSeparator		`hl-WinSeparator`
----   horizdown	WinSeparator		`hl-WinSeparator`
----   vert		WinSeparator		`hl-WinSeparator`
----   vertleft	WinSeparator		`hl-WinSeparator`
----   vertright	WinSeparator		`hl-WinSeparator`
----   verthoriz	WinSeparator		`hl-WinSeparator`
----   fold		Folded			`hl-Folded`
----   diff		DiffDelete		`hl-DiffDelete`
----   eob		EndOfBuffer		`hl-EndOfBuffer`
----   lastline	NonText			`hl-NonText`
+---   item          highlight group ~
+---   stl           StatusLine              `hl-StatusLine`
+---   stlnc         StatusLineNC            `hl-StatusLineNC`
+---   wbr           WinBar                  `hl-WinBar` or `hl-WinBarNC`
+---   horiz         WinSeparator            `hl-WinSeparator`
+---   horizup       WinSeparator            `hl-WinSeparator`
+---   horizdown     WinSeparator            `hl-WinSeparator`
+---   vert          WinSeparator            `hl-WinSeparator`
+---   vertleft      WinSeparator            `hl-WinSeparator`
+---   vertright     WinSeparator            `hl-WinSeparator`
+---   verthoriz     WinSeparator            `hl-WinSeparator`
+---   fold          Folded                  `hl-Folded`
+---   diff          DiffDelete              `hl-DiffDelete`
+---   eob           EndOfBuffer             `hl-EndOfBuffer`
+---   lastline      NonText                 `hl-NonText`
 ---
 --- @type string
 vim.o.fillchars = ""
@@ -2295,7 +2295,7 @@ vim.go.fcl = vim.go.foldclose
 --- When and how to draw the foldcolumn. Valid values are:
 ---     "auto":       resize to the minimum amount of folds to display.
 ---     "auto:[1-9]": resize to accommodate multiple folds up to the
---- 		  selected level
+---                   selected level
 ---     "0":          to disable foldcolumn
 ---     "[1-9]":      to display a fixed number of columns
 --- See `folding`.
@@ -2390,12 +2390,12 @@ vim.wo.foldmarker = vim.o.foldmarker
 vim.wo.fmr = vim.wo.foldmarker
 
 --- The kind of folding used for the current window.  Possible values:
---- `fold-manual`	manual	    Folds are created manually.
---- `fold-indent`	indent	    Lines with equal indent form a fold.
---- `fold-expr`	expr	    'foldexpr' gives the fold level of a line.
---- `fold-marker`	marker	    Markers are used to specify folds.
---- `fold-syntax`	syntax	    Syntax highlighting items specify folds.
---- `fold-diff`	diff	    Fold text that is not changed.
+--- `fold-manual`   manual      Folds are created manually.
+--- `fold-indent`   indent      Lines with equal indent form a fold.
+--- `fold-expr`     expr        'foldexpr' gives the fold level of a line.
+--- `fold-marker`   marker      Markers are used to specify folds.
+--- `fold-syntax`   syntax      Syntax highlighting items specify folds.
+--- `fold-diff`     diff        Fold text that is not changed.
 ---
 --- @type string
 vim.o.foldmethod = "manual"
@@ -2434,20 +2434,20 @@ vim.wo.fdn = vim.wo.foldnestmax
 --- Add the `zv` command to the mapping to get the same effect.
 --- (rationale: the mapping may want to control opening folds itself)
 ---
---- 	item		commands ~
---- 	all		any
---- 	block		(, {, [[, [{, etc.
---- 	hor		horizontal movements: "l", "w", "fx", etc.
---- 	insert		any command in Insert mode
---- 	jump		far jumps: "G", "gg", etc.
---- 	mark		jumping to a mark: "'m", CTRL-O, etc.
---- 	percent		"%"
---- 	quickfix	":cn", ":crew", ":make", etc.
---- 	search		search for a pattern: "/", "n", "*", "gd", etc.
---- 			(not for a search pattern in a ":" command)
---- 			Also for `[s` and `]s`.
---- 	tag		jumping to a tag: ":ta", CTRL-T, etc.
---- 	undo		undo or redo: "u" and CTRL-R
+---         item            commands ~
+---         all             any
+---         block           (, {, [[, [{, etc.
+---         hor             horizontal movements: "l", "w", "fx", etc.
+---         insert          any command in Insert mode
+---         jump            far jumps: "G", "gg", etc.
+---         mark            jumping to a mark: "'m", CTRL-O, etc.
+---         percent         "%"
+---         quickfix        ":cn", ":crew", ":make", etc.
+---         search          search for a pattern: "/", "n", "*", "gd", etc.
+---                         (not for a search pattern in a ":" command)
+---                         Also for `[s` and `]s`.
+---         tag             jumping to a tag: ":ta", CTRL-T, etc.
+---         undo            undo or redo: "u" and CTRL-R
 --- When a movement command is used for an operator (e.g., "dl" or "y%")
 --- this option is not used.  This means the operator will include the
 --- whole closed fold.
@@ -2489,14 +2489,14 @@ vim.wo.fdt = vim.wo.foldtext
 --- The `v:lnum`  variable holds the first line to be formatted.
 --- The `v:count` variable holds the number of lines to be formatted.
 --- The `v:char`  variable holds the character that is going to be
---- 	      inserted if the expression is being evaluated due to
---- 	      automatic formatting.  This can be empty.  Don't insert
---- 	      it yet!
+---               inserted if the expression is being evaluated due to
+---               automatic formatting.  This can be empty.  Don't insert
+---               it yet!
 ---
 --- Example:
 ---
 --- ```vim
---- 	set formatexpr=mylang#Format()
+---         set formatexpr=mylang#Format()
 --- ```
 --- This will invoke the mylang#Format() function in the
 --- autoload/mylang.vim file in 'runtimepath'. `autoload`
@@ -2514,8 +2514,8 @@ vim.wo.fdt = vim.wo.foldtext
 --- the script ID (`local-function`). Example:
 ---
 --- ```vim
---- 	set formatexpr=s:MyFormatExpr()
---- 	set formatexpr=<SID>SomeFormatExpr()
+---         set formatexpr=s:MyFormatExpr()
+---         set formatexpr=<SID>SomeFormatExpr()
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
@@ -2607,10 +2607,10 @@ vim.go.fs = vim.go.fsync
 --- is given to a ":substitute" command, this will toggle the substitution
 --- of all or one match.  See `complex-change`.
 ---
---- 	command		'gdefault' on	'gdefault' off	~
---- 	:s///		  subst. all	  subst. one
---- 	:s///g		  subst. one	  subst. all
---- 	:s///gg		  subst. all	  subst. one
+---         command         'gdefault' on   'gdefault' off  ~
+---         :s///             subst. all      subst. one
+---         :s///g            subst. one      subst. all
+---         :s///gg           subst. all      subst. one
 ---
 --- NOTE: Setting this option may break plugins that rely on the default
 --- behavior of the 'g' flag. This will also make the 'g' flag have the
@@ -2641,7 +2641,7 @@ vim.go.gfm = vim.go.grepformat
 --- also work well with a single file:
 ---
 --- ```vim
---- 	set grepprg=grep\ -nH
+---         set grepprg=grep\ -nH
 --- ```
 --- Special value: When 'grepprg' is set to "internal" the `:grep` command
 --- works like `:vimgrep`, `:lgrep` like `:lvimgrep`, `:grepadd` like
@@ -2665,80 +2665,80 @@ vim.go.gp = vim.go.grepprg
 --- To disable cursor-styling, reset the option:
 ---
 --- ```vim
---- 	set guicursor=
+---         set guicursor=
 --- ```
 --- To enable mode shapes, "Cursor" highlight, and blinking:
 ---
 --- ```vim
---- 	set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
---- 	  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
---- 	  \,sm:block-blinkwait175-blinkoff150-blinkon175
+---         set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
+---           \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
+---           \,sm:block-blinkwait175-blinkoff150-blinkon175
 --- ```
 --- The option is a comma-separated list of parts.  Each part consists of a
 --- mode-list and an argument-list:
---- 	mode-list:argument-list,mode-list:argument-list,..
+---         mode-list:argument-list,mode-list:argument-list,..
 --- The mode-list is a dash separated list of these modes:
---- 	n	Normal mode
---- 	v	Visual mode
---- 	ve	Visual mode with 'selection' "exclusive" (same as 'v',
---- 		if not specified)
---- 	o	Operator-pending mode
---- 	i	Insert mode
---- 	r	Replace mode
---- 	c	Command-line Normal (append) mode
---- 	ci	Command-line Insert mode
---- 	cr	Command-line Replace mode
---- 	sm	showmatch in Insert mode
---- 	a	all modes
+---         n       Normal mode
+---         v       Visual mode
+---         ve      Visual mode with 'selection' "exclusive" (same as 'v',
+---                 if not specified)
+---         o       Operator-pending mode
+---         i       Insert mode
+---         r       Replace mode
+---         c       Command-line Normal (append) mode
+---         ci      Command-line Insert mode
+---         cr      Command-line Replace mode
+---         sm      showmatch in Insert mode
+---         a       all modes
 --- The argument-list is a dash separated list of these arguments:
---- 	hor{N}	horizontal bar, {N} percent of the character height
---- 	ver{N}	vertical bar, {N} percent of the character width
---- 	block	block cursor, fills the whole character
---- 		- Only one of the above three should be present.
---- 		- Default is "block" for each mode.
---- 	blinkwait{N}				*cursor-blinking*
---- 	blinkon{N}
---- 	blinkoff{N}
---- 		blink times for cursor: blinkwait is the delay before
---- 		the cursor starts blinking, blinkon is the time that
---- 		the cursor is shown and blinkoff is the time that the
---- 		cursor is not shown.  Times are in msec.  When one of
---- 		the numbers is zero, there is no blinking. E.g.:
+---         hor{N}  horizontal bar, {N} percent of the character height
+---         ver{N}  vertical bar, {N} percent of the character width
+---         block   block cursor, fills the whole character
+---                 - Only one of the above three should be present.
+---                 - Default is "block" for each mode.
+---         blinkwait{N}                            *cursor-blinking*
+---         blinkon{N}
+---         blinkoff{N}
+---                 blink times for cursor: blinkwait is the delay before
+---                 the cursor starts blinking, blinkon is the time that
+---                 the cursor is shown and blinkoff is the time that the
+---                 cursor is not shown.  Times are in msec.  When one of
+---                 the numbers is zero, there is no blinking. E.g.:
 ---
 --- ```vim
---- 			set guicursor=n:blinkon0
+---                         set guicursor=n:blinkon0
 --- ```
 --- - Default is "blinkon0" for each mode.
---- 	{group-name}
---- 		Highlight group that decides the color and font of the
---- 		cursor.
---- 		In the `TUI`:
---- 		- `inverse`/reverse and no group-name are interpreted
---- 		  as "host-terminal default cursor colors" which
---- 		  typically means "inverted bg and fg colors".
---- 		- `ctermfg` and `guifg` are ignored.
---- 	{group-name}/{group-name}
---- 		Two highlight group names, the first is used when
---- 		no language mappings are used, the other when they
---- 		are. `language-mapping`
+---         {group-name}
+---                 Highlight group that decides the color and font of the
+---                 cursor.
+---                 In the `TUI`:
+---                 - `inverse`/reverse and no group-name are interpreted
+---                   as "host-terminal default cursor colors" which
+---                   typically means "inverted bg and fg colors".
+---                 - `ctermfg` and `guifg` are ignored.
+---         {group-name}/{group-name}
+---                 Two highlight group names, the first is used when
+---                 no language mappings are used, the other when they
+---                 are. `language-mapping`
 ---
 --- Examples of parts:
----    n-c-v:block-nCursor	In Normal, Command-line and Visual mode, use a
---- 			block cursor with colors from the "nCursor"
---- 			highlight group
+---    n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
+---                         block cursor with colors from the "nCursor"
+---                         highlight group
 ---    n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
---- 			In Normal et al. modes, use a block cursor
---- 			with the default colors defined by the host
---- 			terminal.  In Insert-like modes, use
---- 			a vertical bar cursor with colors from
---- 			"Cursor" highlight group.  In Replace-like
---- 			modes, use an underline cursor with
---- 			default colors.
+---                         In Normal et al. modes, use a block cursor
+---                         with the default colors defined by the host
+---                         terminal.  In Insert-like modes, use
+---                         a vertical bar cursor with colors from
+---                         "Cursor" highlight group.  In Replace-like
+---                         modes, use an underline cursor with
+---                         default colors.
 ---    i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
---- 			In Insert and Command-line Insert mode, use a
---- 			30% vertical bar cursor with colors from the
---- 			"iCursor" highlight group.  Blink a bit
---- 			faster.
+---                         In Insert and Command-line Insert mode, use a
+---                         30% vertical bar cursor with colors from the
+---                         "iCursor" highlight group.  Blink a bit
+---                         faster.
 ---
 --- The 'a' mode is different.  It will set the given argument-list for
 --- all modes.  It does not reset anything to defaults.  This can be used
@@ -2804,19 +2804,19 @@ vim.go.gcr = vim.go.guicursor
 --- To preview a font on X11, you might be able to use the "xfontsel"
 --- program.  The "xlsfonts" program gives a list of all available fonts.
 ---
---- For the Win32 GUI					*E244* *E245*
+--- For the Win32 GUI                                       *E244* *E245*
 --- - takes these options in the font name:
---- 	hXX - height is XX (points, can be floating-point)
---- 	wXX - width is XX (points, can be floating-point)
---- 	b   - bold
---- 	i   - italic
---- 	u   - underline
---- 	s   - strikeout
---- 	cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
---- 	      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
---- 	      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
---- 	      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
---- 	      Normally you would use "cDEFAULT".
+---         hXX - height is XX (points, can be floating-point)
+---         wXX - width is XX (points, can be floating-point)
+---         b   - bold
+---         i   - italic
+---         u   - underline
+---         s   - strikeout
+---         cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
+---               BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
+---               HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
+---               SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
+---               Normally you would use "cDEFAULT".
 ---
 ---   Use a ':' to separate the options.
 --- - A '_' can be used in the place of a space, so you don't need to use
@@ -2856,98 +2856,98 @@ vim.go.gfw = vim.go.guifontwide
 --- "+=" and "-=" feature of ":set" `add-option-flags`.
 ---
 --- Valid letters are as follows:
---- 						*guioptions_a* *'go-a'*
----   'a'	Autoselect:  If present, then whenever VISUAL mode is started,
---- 	or the Visual area extended, Vim tries to become the owner of
---- 	the windowing system's global selection.  This means that the
---- 	Visually highlighted text is available for pasting into other
---- 	applications as well as into Vim itself.  When the Visual mode
---- 	ends, possibly due to an operation on the text, or when an
---- 	application wants to paste the selection, the highlighted text
---- 	is automatically yanked into the "* selection register.
---- 	Thus the selection is still available for pasting into other
---- 	applications after the VISUAL mode has ended.
---- 	    If not present, then Vim won't become the owner of the
---- 	windowing system's global selection unless explicitly told to
---- 	by a yank or delete operation for the "* register.
---- 	The same applies to the modeless selection.
---- 							*'go-P'*
----   'P'	Like autoselect but using the "+ register instead of the "*
---- 	register.
---- 							*'go-A'*
----   'A'	Autoselect for the modeless selection.  Like 'a', but only
---- 	applies to the modeless selection.
+---                                                 *guioptions_a* *'go-a'*
+---   'a'   Autoselect:  If present, then whenever VISUAL mode is started,
+---         or the Visual area extended, Vim tries to become the owner of
+---         the windowing system's global selection.  This means that the
+---         Visually highlighted text is available for pasting into other
+---         applications as well as into Vim itself.  When the Visual mode
+---         ends, possibly due to an operation on the text, or when an
+---         application wants to paste the selection, the highlighted text
+---         is automatically yanked into the "* selection register.
+---         Thus the selection is still available for pasting into other
+---         applications after the VISUAL mode has ended.
+---             If not present, then Vim won't become the owner of the
+---         windowing system's global selection unless explicitly told to
+---         by a yank or delete operation for the "* register.
+---         The same applies to the modeless selection.
+---                                                         *'go-P'*
+---   'P'   Like autoselect but using the "+ register instead of the "*
+---         register.
+---                                                         *'go-A'*
+---   'A'   Autoselect for the modeless selection.  Like 'a', but only
+---         applies to the modeless selection.
 ---
---- 	    'guioptions'   autoselect Visual  autoselect modeless ~
---- 		 ""		 -			 -
---- 		 "a"		yes			yes
---- 		 "A"		 -			yes
---- 		 "aA"		yes			yes
+---             'guioptions'   autoselect Visual  autoselect modeless ~
+---                  ""              -                       -
+---                  "a"            yes                     yes
+---                  "A"             -                      yes
+---                  "aA"           yes                     yes
 ---
---- 							*'go-c'*
----   'c'	Use console dialogs instead of popup dialogs for simple
---- 	choices.
---- 							*'go-d'*
----   'd'	Use dark theme variant if available.
---- 							*'go-e'*
----   'e'	Add tab pages when indicated with 'showtabline'.
---- 	'guitablabel' can be used to change the text in the labels.
---- 	When 'e' is missing a non-GUI tab pages line may be used.
---- 	The GUI tabs are only supported on some systems, currently
---- 	Mac OS/X and MS-Windows.
---- 							*'go-i'*
----   'i'	Use a Vim icon.
---- 							*'go-m'*
----   'm'	Menu bar is present.
---- 							*'go-M'*
----   'M'	The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
---- 	that this flag must be added in the vimrc file, before
---- 	switching on syntax or filetype recognition (when the `gvimrc`
---- 	file is sourced the system menu has already been loaded; the
---- 	`:syntax on` and `:filetype on` commands load the menu too).
---- 							*'go-g'*
----   'g'	Grey menu items: Make menu items that are not active grey.  If
---- 	'g' is not included inactive menu items are not shown at all.
---- 							*'go-T'*
----   'T'	Include Toolbar.  Currently only in Win32 GUI.
---- 							*'go-r'*
----   'r'	Right-hand scrollbar is always present.
---- 							*'go-R'*
----   'R'	Right-hand scrollbar is present when there is a vertically
---- 	split window.
---- 							*'go-l'*
----   'l'	Left-hand scrollbar is always present.
---- 							*'go-L'*
----   'L'	Left-hand scrollbar is present when there is a vertically
---- 	split window.
---- 							*'go-b'*
----   'b'	Bottom (horizontal) scrollbar is present.  Its size depends on
---- 	the longest visible line, or on the cursor line if the 'h'
---- 	flag is included. `gui-horiz-scroll`
---- 							*'go-h'*
----   'h'	Limit horizontal scrollbar size to the length of the cursor
---- 	line.  Reduces computations. `gui-horiz-scroll`
+---                                                         *'go-c'*
+---   'c'   Use console dialogs instead of popup dialogs for simple
+---         choices.
+---                                                         *'go-d'*
+---   'd'   Use dark theme variant if available.
+---                                                         *'go-e'*
+---   'e'   Add tab pages when indicated with 'showtabline'.
+---         'guitablabel' can be used to change the text in the labels.
+---         When 'e' is missing a non-GUI tab pages line may be used.
+---         The GUI tabs are only supported on some systems, currently
+---         Mac OS/X and MS-Windows.
+---                                                         *'go-i'*
+---   'i'   Use a Vim icon.
+---                                                         *'go-m'*
+---   'm'   Menu bar is present.
+---                                                         *'go-M'*
+---   'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
+---         that this flag must be added in the vimrc file, before
+---         switching on syntax or filetype recognition (when the `gvimrc`
+---         file is sourced the system menu has already been loaded; the
+---         `:syntax on` and `:filetype on` commands load the menu too).
+---                                                         *'go-g'*
+---   'g'   Grey menu items: Make menu items that are not active grey.  If
+---         'g' is not included inactive menu items are not shown at all.
+---                                                         *'go-T'*
+---   'T'   Include Toolbar.  Currently only in Win32 GUI.
+---                                                         *'go-r'*
+---   'r'   Right-hand scrollbar is always present.
+---                                                         *'go-R'*
+---   'R'   Right-hand scrollbar is present when there is a vertically
+---         split window.
+---                                                         *'go-l'*
+---   'l'   Left-hand scrollbar is always present.
+---                                                         *'go-L'*
+---   'L'   Left-hand scrollbar is present when there is a vertically
+---         split window.
+---                                                         *'go-b'*
+---   'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
+---         the longest visible line, or on the cursor line if the 'h'
+---         flag is included. `gui-horiz-scroll`
+---                                                         *'go-h'*
+---   'h'   Limit horizontal scrollbar size to the length of the cursor
+---         line.  Reduces computations. `gui-horiz-scroll`
 ---
 --- And yes, you may even have scrollbars on the left AND the right if
 --- you really want to :-).  See `gui-scrollbars` for more information.
 ---
---- 							*'go-v'*
----   'v'	Use a vertical button layout for dialogs.  When not included,
---- 	a horizontal layout is preferred, but when it doesn't fit a
---- 	vertical layout is used anyway.  Not supported in GTK 3.
---- 							*'go-p'*
----   'p'	Use Pointer callbacks for X11 GUI.  This is required for some
---- 	window managers.  If the cursor is not blinking or hollow at
---- 	the right moment, try adding this flag.  This must be done
---- 	before starting the GUI.  Set it in your `gvimrc`.  Adding or
---- 	removing it after the GUI has started has no effect.
---- 							*'go-k'*
----   'k'	Keep the GUI window size when adding/removing a scrollbar, or
---- 	toolbar, tabline, etc.  Instead, the behavior is similar to
---- 	when the window is maximized and will adjust 'lines' and
---- 	'columns' to fit to the window.  Without the 'k' flag Vim will
---- 	try to keep 'lines' and 'columns' the same when adding and
---- 	removing GUI components.
+---                                                         *'go-v'*
+---   'v'   Use a vertical button layout for dialogs.  When not included,
+---         a horizontal layout is preferred, but when it doesn't fit a
+---         vertical layout is used anyway.  Not supported in GTK 3.
+---                                                         *'go-p'*
+---   'p'   Use Pointer callbacks for X11 GUI.  This is required for some
+---         window managers.  If the cursor is not blinking or hollow at
+---         the right moment, try adding this flag.  This must be done
+---         before starting the GUI.  Set it in your `gvimrc`.  Adding or
+---         removing it after the GUI has started has no effect.
+---                                                         *'go-k'*
+---   'k'   Keep the GUI window size when adding/removing a scrollbar, or
+---         toolbar, tabline, etc.  Instead, the behavior is similar to
+---         when the window is maximized and will adjust 'lines' and
+---         'columns' to fit to the window.  Without the 'k' flag Vim will
+---         try to keep 'lines' and 'columns' the same when adding and
+---         removing GUI components.
 ---
 --- @type string
 vim.o.guioptions = ""
@@ -2981,7 +2981,7 @@ vim.go.gtl = vim.go.guitablabel
 --- You can include a line break.  Simplest method is to use `:let`:
 ---
 --- ```vim
---- 	let &guitabtooltip = "line one\nline two"
+---         let &guitabtooltip = "line one\nline two"
 --- ```
 ---
 ---
@@ -3027,7 +3027,7 @@ vim.go.hh = vim.go.helpheight
 --- Example:
 ---
 --- ```vim
---- 	set helplang=de,it
+---         set helplang=de,it
 --- ```
 --- This will first search German, then Italian and finally English help
 --- files.
@@ -3158,14 +3158,14 @@ vim.go.imd = vim.go.imdisable
 
 --- Specifies whether :lmap or an Input Method (IM) is to be used in
 --- Insert mode.  Valid values:
---- 	0	:lmap is off and IM is off
---- 	1	:lmap is ON and IM is off
---- 	2	:lmap is off and IM is ON
+---         0       :lmap is off and IM is off
+---         1       :lmap is ON and IM is off
+---         2       :lmap is off and IM is ON
 --- To always reset the option to zero when leaving Insert mode with <Esc>
 --- this can be used:
 ---
 --- ```vim
---- 	inoremap <ESC> <ESC>:set iminsert=0<CR>
+---         inoremap <ESC> <ESC>:set iminsert=0<CR>
 --- ```
 --- This makes :lmap and IM turn off automatically when leaving Insert
 --- mode.
@@ -3182,11 +3182,11 @@ vim.bo.imi = vim.bo.iminsert
 
 --- Specifies whether :lmap or an Input Method (IM) is to be used when
 --- entering a search pattern.  Valid values:
---- 	-1	the value of 'iminsert' is used, makes it look like
---- 		'iminsert' is also used when typing a search pattern
---- 	0	:lmap is off and IM is off
---- 	1	:lmap is ON and IM is off
---- 	2	:lmap is off and IM is ON
+---         -1      the value of 'iminsert' is used, makes it look like
+---                 'iminsert' is also used when typing a search pattern
+---         0       :lmap is off and IM is off
+---         1       :lmap is ON and IM is off
+---         2       :lmap is off and IM is ON
 --- Note that this option changes when using CTRL-^ in Command-line mode
 --- `c_CTRL-^`.
 --- The value is set to 1 when it is not -1 and setting the 'keymap'
@@ -3203,10 +3203,10 @@ vim.bo.ims = vim.bo.imsearch
 --- type.
 ---
 --- Possible values:
---- 	nosplit	Shows the effects of a command incrementally in the
---- 		buffer.
---- 	split	Like "nosplit", but also shows partial off-screen
---- 		results in a preview window.
+---         nosplit Shows the effects of a command incrementally in the
+---                 buffer.
+---         split   Like "nosplit", but also shows partial off-screen
+---                 results in a preview window.
 ---
 --- If the preview for built-in commands is too slow (exceeds
 --- 'redrawtime') then 'inccommand' is automatically disabled until
@@ -3241,7 +3241,7 @@ vim.go.inc = vim.go.include
 --- option to a file name.  Mostly useful to change "." to "/" for Java:
 ---
 --- ```vim
---- 	setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+---         setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 --- ```
 --- The "v:fname" variable will be set to the file name that was detected.
 --- Note the double backslash: the `:set` command first halves them, then
@@ -3249,7 +3249,7 @@ vim.go.inc = vim.go.include
 --- simple character replacements `tr()` avoids the need for escaping:
 ---
 --- ```vim
---- 	setlocal includeexpr=tr(v:fname,'.','/')
+---         setlocal includeexpr=tr(v:fname,'.','/')
 --- ```
 ---
 --- Also used for the `gf` command if an unmodified file name can't be
@@ -3260,8 +3260,8 @@ vim.go.inc = vim.go.include
 --- the script ID (`local-function`). Example:
 ---
 --- ```vim
---- 	setlocal includeexpr=s:MyIncludeExpr(v:fname)
---- 	setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
+---         setlocal includeexpr=s:MyIncludeExpr(v:fname)
+---         setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
@@ -3300,11 +3300,11 @@ vim.bo.inex = vim.bo.includeexpr
 --- autocmd.  Example:
 ---
 --- ```vim
---- 	augroup vimrc-incsearch-highlight
---- 	  autocmd!
---- 	  autocmd CmdlineEnter /,\? :set hlsearch
---- 	  autocmd CmdlineLeave /,\? :set nohlsearch
---- 	augroup END
+---         augroup vimrc-incsearch-highlight
+---           autocmd!
+---           autocmd CmdlineEnter /,\? :set hlsearch
+---           autocmd CmdlineLeave /,\? :set nohlsearch
+---         augroup END
 --- ```
 ---
 --- CTRL-L can be used to add one character from after the current match
@@ -3334,8 +3334,8 @@ vim.go.is = vim.go.incsearch
 --- the script ID (`local-function`). Example:
 ---
 --- ```vim
---- 	set indentexpr=s:MyIndentExpr()
---- 	set indentexpr=<SID>SomeIndentExpr()
+---         set indentexpr=s:MyIndentExpr()
+---         set indentexpr=<SID>SomeIndentExpr()
 --- ```
 --- Otherwise, the expression is evaluated in the context of the script
 --- where the option was set, thus script-local items are available.
@@ -3351,7 +3351,7 @@ vim.go.is = vim.go.incsearch
 --- Normally this option would be set to call a function:
 ---
 --- ```vim
---- 	set indentexpr=GetMyIndent()
+---         set indentexpr=GetMyIndent()
 --- ```
 --- Error messages will be suppressed, unless the 'debug' option contains
 --- "msg".
@@ -3420,26 +3420,26 @@ vim.bo.inf = vim.bo.infercase
 --- character numbers with '-' in between.  A character number can be a
 --- decimal number between 0 and 255 or the ASCII character itself (does
 --- not work for digits).  Example:
---- 	"_,-,128-140,#-43"	(include '_' and '-' and the range
---- 				128 to 140 and '#' to 43)
+---         "_,-,128-140,#-43"      (include '_' and '-' and the range
+---                                 128 to 140 and '#' to 43)
 --- If a part starts with '^', the following character number or range
 --- will be excluded from the option.  The option is interpreted from left
 --- to right.  Put the excluded character after the range where it is
 --- included.  To include '^' itself use it as the last character of the
 --- option or the end of a range.  Example:
---- 	"^a-z,#,^"	(exclude 'a' to 'z', include '#' and '^')
+---         "^a-z,#,^"      (exclude 'a' to 'z', include '#' and '^')
 --- If the character is '@', all characters where isalpha() returns TRUE
 --- are included.  Normally these are the characters a to z and A to Z,
 --- plus accented characters.  To include '@' itself use "@-@".  Examples:
---- 	"@,^a-z"	All alphabetic characters, excluding lower
---- 			case ASCII letters.
---- 	"a-z,A-Z,@-@"	All letters plus the '@' character.
+---         "@,^a-z"        All alphabetic characters, excluding lower
+---                         case ASCII letters.
+---         "a-z,A-Z,@-@"   All letters plus the '@' character.
 --- A comma can be included by using it where a character number is
 --- expected.  Example:
---- 	"48-57,,,_"	Digits, comma and underscore.
+---         "48-57,,,_"     Digits, comma and underscore.
 --- A comma can be excluded by prepending a '^'.  Example:
---- 	" -~,^,,9"	All characters from space to '~', excluding
---- 			comma, plus <Tab>.
+---         " -~,^,,9"      All characters from space to '~', excluding
+---                         comma, plus <Tab>.
 --- See `option-backslash` about including spaces and backslashes.
 ---
 --- @type string
@@ -3490,12 +3490,12 @@ vim.bo.isk = vim.bo.iskeyword
 --- 'isfname' for a description of the format of this option.
 ---
 --- Non-printable characters are displayed with two characters:
---- 	  0 -  31	"^@" - "^_"
---- 	 32 - 126	always single characters
---- 	   127		"^?"
---- 	128 - 159	"~@" - "~_"
---- 	160 - 254	"| " - "|~"
---- 	   255		"~?"
+---           0 -  31       "^@" - "^_"
+---          32 - 126       always single characters
+---            127          "^?"
+---         128 - 159       "~@" - "~_"
+---         160 - 254       "| " - "|~"
+---            255          "~?"
 --- Illegal bytes from 128 to 255 (invalid UTF-8) are
 --- displayed as <xx>, with the hexadecimal value of the byte.
 --- When 'display' contains "uhex" all unprintable characters are
@@ -3527,14 +3527,14 @@ vim.go.js = vim.go.joinspaces
 
 --- List of words that change the behavior of the `jumplist`.
 ---   stack         Make the jumplist behave like the tagstack.
---- 		Relative location of entries in the jumplist is
---- 		preserved at the cost of discarding subsequent entries
---- 		when navigating backwards in the jumplist and then
---- 		jumping to a location.  `jumplist-stack`
+---                 Relative location of entries in the jumplist is
+---                 preserved at the cost of discarding subsequent entries
+---                 when navigating backwards in the jumplist and then
+---                 jumping to a location.  `jumplist-stack`
 ---
----   view          When moving through the jumplist, `changelist|,
---- 		|alternate-file` or using `mark-motions` try to
---- 		restore the `mark-view` in which the action occurred.
+---   view          When moving through the jumplist, `changelist`,
+---                 `alternate-file` or using `mark-motions` try to
+---                 restore the `mark-view` in which the action occurred.
 ---
 --- @type string
 vim.o.jumpoptions = ""
@@ -3556,10 +3556,10 @@ vim.bo.kmp = vim.bo.keymap
 
 --- List of comma-separated words, which enable special things that keys
 --- can do.  These values can be used:
----    startsel	Using a shifted special key starts selection (either
---- 		Select mode or Visual mode, depending on "key" being
---- 		present in 'selectmode').
----    stopsel	Using a not-shifted special key stops selection.
+---    startsel     Using a shifted special key starts selection (either
+---                 Select mode or Visual mode, depending on "key" being
+---                 present in 'selectmode').
+---    stopsel      Using a not-shifted special key stops selection.
 --- Special keys in this context are the cursor keys, <End>, <Home>,
 --- <PageUp> and <PageDown>.
 ---
@@ -3581,8 +3581,8 @@ vim.go.km = vim.go.keymodel
 --- Example:
 ---
 --- ```vim
---- 	set keywordprg=man\ -s
---- 	set keywordprg=:Man
+---         set keywordprg=man\ -s
+---         set keywordprg=:Man
 --- ```
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
@@ -3608,7 +3608,7 @@ vim.go.kp = vim.go.keywordprg
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
 ---
---- Example (for Greek, in UTF-8):				*greek*
+--- Example (for Greek, in UTF-8):                          *greek*
 ---
 --- ```vim
 ---     set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
@@ -3651,13 +3651,13 @@ vim.go.lmap = vim.go.langmap
 --- from the "lang" directory in 'runtimepath':
 ---
 --- ```vim
---- 	"lang/menu_" .. &langmenu .. ".vim"
+---         "lang/menu_" .. &langmenu .. ".vim"
 --- ```
 --- (without the spaces).  For example, to always use the Dutch menus, no
 --- matter what $LANG is set to:
 ---
 --- ```vim
---- 	set langmenu=nl_NL.ISO_8859-1
+---         set langmenu=nl_NL.ISO_8859-1
 --- ```
 --- When 'langmenu' is empty, `v:lang` is used.
 --- Only normal file name characters can be used, `/\*?[|<>` are illegal.
@@ -3665,16 +3665,16 @@ vim.go.lmap = vim.go.langmap
 --- the English menus:
 ---
 --- ```vim
---- 	set langmenu=none
+---         set langmenu=none
 --- ```
 --- This option must be set before loading menus, switching on filetype
 --- detection or syntax highlighting.  Once the menus are defined setting
 --- this option has no effect.  But you could do this:
 ---
 --- ```vim
---- 	source $VIMRUNTIME/delmenu.vim
---- 	set langmenu=de_DE.ISO_8859-1
---- 	source $VIMRUNTIME/menu.vim
+---         source $VIMRUNTIME/delmenu.vim
+---         set langmenu=de_DE.ISO_8859-1
+---         source $VIMRUNTIME/menu.vim
 --- ```
 --- Warning: This deletes all menus that you defined yourself!
 ---
@@ -3696,10 +3696,10 @@ vim.go.lrm = vim.go.langremap
 
 --- The value of this option influences when the last window will have a
 --- status line:
---- 	0: never
---- 	1: only if there are at least two windows
---- 	2: always
---- 	3: always and ONLY the last window
+---         0: never
+---         1: only if there are at least two windows
+---         2: always
+---         3: always and ONLY the last window
 --- The screen looks nicer with a status line if you have several
 --- windows, but it takes another screen line. `status-line`
 ---
@@ -3749,7 +3749,7 @@ vim.wo.lbr = vim.wo.linebreak
 --- use this command to get the tallest window possible:
 ---
 --- ```vim
---- 	set lines=999
+---         set lines=999
 --- ```
 --- Minimum value is 2, maximum value is 1000.
 ---
@@ -3757,7 +3757,7 @@ vim.wo.lbr = vim.wo.linebreak
 vim.o.lines = 24
 vim.go.lines = vim.o.lines
 
---- 		only in the GUI
+--- only in the GUI
 --- Number of pixel lines inserted between characters.  Useful if the font
 --- uses the full character cell height, making lines touch each other.
 --- When non-zero there is room for underlining.
@@ -3788,8 +3788,8 @@ vim.bo.lisp = vim.o.lisp
 --- Comma-separated list of items that influence the Lisp indenting when
 --- enabled with the `'lisp'` option.  Currently only one item is
 --- supported:
---- 	expr:1	use 'indentexpr' for Lisp indenting when it is set
---- 	expr:0	do not use 'indentexpr' for Lisp indenting (default)
+---         expr:1  use 'indentexpr' for Lisp indenting when it is set
+---         expr:0  do not use 'indentexpr' for Lisp indenting (default)
 --- Note that when using 'indentexpr' the `=` operator indents all the
 --- lines, otherwise the first line is not indented (Vi-compatible).
 ---
@@ -3820,7 +3820,7 @@ vim.go.lw = vim.go.lispwords
 --- position while displaying Tabs with spaces, use:
 ---
 --- ```vim
---- 	set list lcs=tab:\ \
+---         set list lcs=tab:\ \
 --- ```
 ---
 --- Note that list mode will also affect formatting (set with 'textwidth'
@@ -3834,94 +3834,94 @@ vim.wo.list = vim.o.list
 --- Strings to use in 'list' mode and for the `:list` command.  It is a
 --- comma-separated list of string settings.
 ---
---- 						*lcs-eol*
----   eol:c		Character to show at the end of each line.  When
---- 		omitted, there is no extra character at the end of the
---- 		line.
---- 						*lcs-tab*
----   tab:xy[z]	Two or three characters to be used to show a tab.
---- 		The third character is optional.
+---                                                 *lcs-eol*
+---   eol:c         Character to show at the end of each line.  When
+---                 omitted, there is no extra character at the end of the
+---                 line.
+---                                                 *lcs-tab*
+---   tab:xy[z]     Two or three characters to be used to show a tab.
+---                 The third character is optional.
 ---
----   tab:xy	The 'x' is always used, then 'y' as many times as will
---- 		fit.  Thus "tab:>-" displays:
---- ```
----
---- ```
---- 			>-
---- 			>--
---- 			etc.
---- ```
----
----   tab:xyz	The 'z' is always used, then 'x' is prepended, and
---- 		then 'y' is used as many times as will fit.  Thus
---- 		"tab:<->" displays:
+---   tab:xy        The 'x' is always used, then 'y' as many times as will
+---                 fit.  Thus "tab:>-" displays:
 --- ```
 ---
 --- ```
---- 			<>
---- 			<->
---- 			<-->
---- 			etc.
+---                         >-
+---                         >--
+---                         etc.
 --- ```
 ---
---- 		When "tab:" is omitted, a tab is shown as ^I.
---- 						*lcs-space*
----   space:c	Character to show for a space.  When omitted, spaces
---- 		are left blank.
---- 						*lcs-multispace*
+---   tab:xyz       The 'z' is always used, then 'x' is prepended, and
+---                 then 'y' is used as many times as will fit.  Thus
+---                 "tab:<->" displays:
+--- ```
+---
+--- ```
+---                         <>
+---                         <->
+---                         <-->
+---                         etc.
+--- ```
+---
+---                 When "tab:" is omitted, a tab is shown as ^I.
+---                                                 *lcs-space*
+---   space:c       Character to show for a space.  When omitted, spaces
+---                 are left blank.
+---                                                 *lcs-multispace*
 ---   multispace:c...
---- 		One or more characters to use cyclically to show for
---- 		multiple consecutive spaces.  Overrides the "space"
---- 		setting, except for single spaces.  When omitted, the
---- 		"space" setting is used.  For example,
---- 		`:set listchars=multispace:---+` shows ten consecutive
---- 		spaces as:
+---                 One or more characters to use cyclically to show for
+---                 multiple consecutive spaces.  Overrides the "space"
+---                 setting, except for single spaces.  When omitted, the
+---                 "space" setting is used.  For example,
+---                 `:set listchars=multispace:---+` shows ten consecutive
+---                 spaces as:
 --- ```
---- 			---+---+--
+---                         ---+---+--
 --- ```
 ---
---- 						*lcs-lead*
----   lead:c	Character to show for leading spaces.  When omitted,
---- 		leading spaces are blank.  Overrides the "space" and
---- 		"multispace" settings for leading spaces.  You can
---- 		combine it with "tab:", for example:
+---                                                 *lcs-lead*
+---   lead:c        Character to show for leading spaces.  When omitted,
+---                 leading spaces are blank.  Overrides the "space" and
+---                 "multispace" settings for leading spaces.  You can
+---                 combine it with "tab:", for example:
 ---
 --- ```vim
---- 			set listchars+=tab:>-,lead:.
+---                         set listchars+=tab:>-,lead:.
 --- ```
 ---
---- 						*lcs-leadmultispace*
+---                                                 *lcs-leadmultispace*
 ---   leadmultispace:c...
---- 		Like the `lcs-multispace` value, but for leading
---- 		spaces only.  Also overrides `lcs-lead` for leading
---- 		multiple spaces.
---- 		`:set listchars=leadmultispace:---+` shows ten
---- 		consecutive leading spaces as:
+---                 Like the `lcs-multispace` value, but for leading
+---                 spaces only.  Also overrides `lcs-lead` for leading
+---                 multiple spaces.
+---                 `:set listchars=leadmultispace:---+` shows ten
+---                 consecutive leading spaces as:
 --- ```
---- 			---+---+--XXX
+---                         ---+---+--XXX
 --- ```
 ---
---- 		Where "XXX" denotes the first non-blank characters in
---- 		the line.
---- 						*lcs-trail*
----   trail:c	Character to show for trailing spaces.  When omitted,
---- 		trailing spaces are blank.  Overrides the "space" and
---- 		"multispace" settings for trailing spaces.
---- 						*lcs-extends*
----   extends:c	Character to show in the last column, when 'wrap' is
---- 		off and the line continues beyond the right of the
---- 		screen.
---- 						*lcs-precedes*
----   precedes:c	Character to show in the first visible column of the
---- 		physical line, when there is text preceding the
---- 		character visible in the first column.
---- 						*lcs-conceal*
----   conceal:c	Character to show in place of concealed text, when
---- 		'conceallevel' is set to 1.  A space when omitted.
---- 						*lcs-nbsp*
----   nbsp:c	Character to show for a non-breakable space character
---- 		(0xA0 (160 decimal) and U+202F).  Left blank when
---- 		omitted.
+---                 Where "XXX" denotes the first non-blank characters in
+---                 the line.
+---                                                 *lcs-trail*
+---   trail:c       Character to show for trailing spaces.  When omitted,
+---                 trailing spaces are blank.  Overrides the "space" and
+---                 "multispace" settings for trailing spaces.
+---                                                 *lcs-extends*
+---   extends:c     Character to show in the last column, when 'wrap' is
+---                 off and the line continues beyond the right of the
+---                 screen.
+---                                                 *lcs-precedes*
+---   precedes:c    Character to show in the first visible column of the
+---                 physical line, when there is text preceding the
+---                 character visible in the first column.
+---                                                 *lcs-conceal*
+---   conceal:c     Character to show in place of concealed text, when
+---                 'conceallevel' is set to 1.  A space when omitted.
+---                                                 *lcs-nbsp*
+---   nbsp:c        Character to show for a non-breakable space character
+---                 (0xA0 (160 decimal) and U+202F).  Left blank when
+---                 omitted.
 ---
 --- The characters ':' and ',' should not be used.  UTF-8 characters can
 --- be used.  All characters must be single width.
@@ -3929,9 +3929,9 @@ vim.wo.list = vim.o.list
 --- Each character can be specified as hex:
 ---
 --- ```vim
---- 	set listchars=eol:\\x24
---- 	set listchars=eol:\\u21b5
---- 	set listchars=eol:\\U000021b5
+---         set listchars=eol:\\x24
+---         set listchars=eol:\\u21b5
+---         set listchars=eol:\\U000021b5
 --- ```
 --- Note that a double backslash is used.  The number of hex characters
 --- must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
@@ -4008,7 +4008,7 @@ vim.go.mef = vim.go.makeef
 --- setting to the system locale encoding.  Example:
 ---
 --- ```vim
---- 	set makeencoding=char	" system locale is used
+---         set makeencoding=char   " system locale is used
 --- ```
 ---
 ---
@@ -4059,13 +4059,13 @@ vim.go.mp = vim.go.makeprg
 --- '>' (for HTML):
 ---
 --- ```vim
---- 	set mps+=<:>
+---         set mps+=<:>
 --- ```
 --- A more exotic example, to jump between the '=' and ';' in an
 --- assignment, useful for languages like C and Java:
 ---
 --- ```vim
---- 	au FileType c,cpp,java set mps+==:;
+---         au FileType c,cpp,java set mps+==:;
 --- ```
 --- For a more advanced way of using "%", see the matchit.vim plugin in
 --- the $VIMRUNTIME/plugin directory. `add-local-help`
@@ -4115,7 +4115,7 @@ vim.go.mmd = vim.go.maxmapdepth
 
 --- Maximum amount of memory (in Kbyte) to use for pattern matching.
 --- The maximum value is about 2000000.  Use this to work without a limit.
---- 						*E363*
+---                                                 *E363*
 --- When Vim runs into the limit it gives an error message and mostly
 --- behaves like CTRL-C was typed.
 --- Running into the limit often means that the pattern is very
@@ -4150,7 +4150,7 @@ vim.go.mis = vim.go.menuitems
 ---
 --- There are three numbers, separated by commas:
 --- ```
---- 	{start},{inc},{added}
+---         {start},{inc},{added}
 --- ```
 ---
 --- For most languages the uncompressed word tree fits in memory.  {start}
@@ -4175,7 +4175,7 @@ vim.go.mis = vim.go.menuitems
 --- you have 1 Gbyte you could use:
 ---
 --- ```vim
---- 	set mkspellmem=900000,3000,800
+---         set mkspellmem=900000,3000,800
 --- ```
 --- If you have less than 512 Mbyte `:mkspell` may fail for some
 --- languages, no matter what you set 'mkspellmem' to.
@@ -4272,20 +4272,20 @@ vim.go.more = vim.o.more
 --- and Visual mode:
 ---
 --- ```vim
---- 	set mouse=nv
+---         set mouse=nv
 --- ```
 ---
 --- To temporarily disable mouse support, hold the shift key while using
 --- the mouse.
 ---
 --- Mouse support can be enabled for different modes:
---- 	n	Normal mode
---- 	v	Visual mode
---- 	i	Insert mode
---- 	c	Command-line mode
---- 	h	all previous modes when editing a help file
---- 	a	all previous modes
---- 	r	for `hit-enter` and `more-prompt` prompt
+---         n       Normal mode
+---         v       Visual mode
+---         i       Insert mode
+---         c       Command-line mode
+---         h       all previous modes when editing a help file
+---         a       all previous modes
+---         r       for `hit-enter` and `more-prompt` prompt
 ---
 --- Left-click anywhere in a text buffer to place the cursor there.  This
 --- works with operators too, e.g. type `d` then left-click to delete text
@@ -4303,10 +4303,10 @@ vim.go.more = vim.o.more
 --- "* register if possible. See also 'clipboard'.
 ---
 --- Related options:
---- 'mousefocus'	window focus follows mouse pointer
---- 'mousemodel'	what mouse button does which action
---- 'mousehide'	hide mouse pointer while typing text
---- 'selectmode'	whether to start Select mode or Visual mode
+--- 'mousefocus'    window focus follows mouse pointer
+--- 'mousemodel'    what mouse button does which action
+--- 'mousehide'     hide mouse pointer while typing text
+--- 'selectmode'    whether to start Select mode or Visual mode
 ---
 --- @type string
 vim.o.mouse = "nvi"
@@ -4324,7 +4324,7 @@ vim.o.mousef = vim.o.mousefocus
 vim.go.mousefocus = vim.o.mousefocus
 vim.go.mousef = vim.go.mousefocus
 
---- 		only in the GUI
+--- only in the GUI
 --- When on, the mouse pointer is hidden when characters are typed.
 --- The mouse pointer is restored when the mouse is moved.
 ---
@@ -4336,26 +4336,26 @@ vim.go.mh = vim.go.mousehide
 
 --- Sets the model to use for the mouse.  The name mostly specifies what
 --- the right mouse button is used for:
----    extend	Right mouse button extends a selection.  This works
---- 		like in an xterm.
----    popup	Right mouse button pops up a menu.  The shifted left
---- 		mouse button extends a selection.  This works like
---- 		with Microsoft Windows.
+---    extend       Right mouse button extends a selection.  This works
+---                 like in an xterm.
+---    popup        Right mouse button pops up a menu.  The shifted left
+---                 mouse button extends a selection.  This works like
+---                 with Microsoft Windows.
 ---    popup_setpos Like "popup", but the cursor will be moved to the
---- 		position where the mouse was clicked, and thus the
---- 		selected operation will act upon the clicked object.
---- 		If clicking inside a selection, that selection will
---- 		be acted upon, i.e. no cursor move.  This implies of
---- 		course, that right clicking outside a selection will
---- 		end Visual mode.
+---                 position where the mouse was clicked, and thus the
+---                 selected operation will act upon the clicked object.
+---                 If clicking inside a selection, that selection will
+---                 be acted upon, i.e. no cursor move.  This implies of
+---                 course, that right clicking outside a selection will
+---                 end Visual mode.
 --- Overview of what button does what for each model:
---- mouse		    extend		popup(_setpos) ~
---- left click	    place cursor	place cursor
---- left drag	    start selection	start selection
---- shift-left	    search word		extend selection
---- right click	    extend selection	popup menu (place cursor)
---- right drag	    extend selection	-
---- middle click	    paste		paste
+--- mouse               extend              popup(_setpos) ~
+--- left click          place cursor        place cursor
+--- left drag           start selection     start selection
+--- shift-left          search word         extend selection
+--- right click         extend selection    popup menu (place cursor)
+--- right drag          extend selection    -
+--- middle click        paste               paste
 ---
 --- In the "popup" model the right mouse button produces a pop-up menu.
 --- Nvim creates a default `popup-menu` but you can redefine it.
@@ -4382,8 +4382,8 @@ vim.go.mh = vim.go.mousehide
 ---
 --- Mouse commands requiring the CTRL modifier can be simulated by typing
 --- the "g" key before using the mouse:
----     "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
----     "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
+---     "g<LeftMouse>"  is "<C-LeftMouse>   (jump to tag under mouse click)
+---     "g<RightMouse>" is "<C-RightMouse>  ("CTRL-T")
 ---
 --- @type string
 vim.o.mousemodel = "popup_setpos"
@@ -4407,7 +4407,7 @@ vim.go.mousemev = vim.go.mousemoveevent
 --- scrolling with a mouse wheel (`scroll-mouse-wheel`). The option is
 --- a comma-separated list. Each part consists of a direction and a count
 --- as follows:
---- 	direction:count,direction:count
+---         direction:count,direction:count
 --- Direction is one of either "hor" or "ver". "hor" controls horizontal
 --- scrolling and "ver" controls vertical scrolling. Count sets the amount
 --- to scroll by for the given direction, it should be a non negative
@@ -4419,7 +4419,7 @@ vim.go.mousemev = vim.go.mousemoveevent
 --- Example:
 ---
 --- ```vim
---- 	set mousescroll=ver:5,hor:2
+---         set mousescroll=ver:5,hor:2
 --- ```
 --- Will make Nvim scroll 5 lines at a time when scrolling vertically, and
 --- scroll 2 columns at a time when scrolling horizontally.
@@ -4432,49 +4432,49 @@ vim.go.mousescroll = vim.o.mousescroll
 --- different modes.  The option is a comma-separated list of parts, much
 --- like used for 'guicursor'.  Each part consist of a mode/location-list
 --- and an argument-list:
---- 	mode-list:shape,mode-list:shape,..
+---         mode-list:shape,mode-list:shape,..
 --- The mode-list is a dash separated list of these modes/locations:
---- 		In a normal window: ~
---- 	n	Normal mode
---- 	v	Visual mode
---- 	ve	Visual mode with 'selection' "exclusive" (same as 'v',
---- 		if not specified)
---- 	o	Operator-pending mode
---- 	i	Insert mode
---- 	r	Replace mode
+---                 In a normal window: ~
+---         n       Normal mode
+---         v       Visual mode
+---         ve      Visual mode with 'selection' "exclusive" (same as 'v',
+---                 if not specified)
+---         o       Operator-pending mode
+---         i       Insert mode
+---         r       Replace mode
 ---
---- 		Others: ~
---- 	c	appending to the command-line
---- 	ci	inserting in the command-line
---- 	cr	replacing in the command-line
---- 	m	at the 'Hit ENTER' or 'More' prompts
---- 	ml	idem, but cursor in the last line
---- 	e	any mode, pointer below last window
---- 	s	any mode, pointer on a status line
---- 	sd	any mode, while dragging a status line
---- 	vs	any mode, pointer on a vertical separator line
---- 	vd	any mode, while dragging a vertical separator line
---- 	a	everywhere
+---                 Others: ~
+---         c       appending to the command-line
+---         ci      inserting in the command-line
+---         cr      replacing in the command-line
+---         m       at the 'Hit ENTER' or 'More' prompts
+---         ml      idem, but cursor in the last line
+---         e       any mode, pointer below last window
+---         s       any mode, pointer on a status line
+---         sd      any mode, while dragging a status line
+---         vs      any mode, pointer on a vertical separator line
+---         vd      any mode, while dragging a vertical separator line
+---         a       everywhere
 ---
 --- The shape is one of the following:
---- avail	name		looks like ~
---- w x	arrow		Normal mouse pointer
---- w x	blank		no pointer at all (use with care!)
---- w x	beam		I-beam
---- w x	updown		up-down sizing arrows
---- w x	leftright	left-right sizing arrows
---- w x	busy		The system's usual busy pointer
---- w x	no		The system's usual "no input" pointer
----   x	udsizing	indicates up-down resizing
----   x	lrsizing	indicates left-right resizing
----   x	crosshair	like a big thin +
----   x	hand1		black hand
----   x	hand2		white hand
----   x	pencil		what you write with
----   x	question	big ?
----   x	rightup-arrow	arrow pointing right-up
---- w x	up-arrow	arrow pointing up
----   x	<number>	any X11 pointer number (see X11/cursorfont.h)
+--- avail   name            looks like ~
+--- w x     arrow           Normal mouse pointer
+--- w x     blank           no pointer at all (use with care!)
+--- w x     beam            I-beam
+--- w x     updown          up-down sizing arrows
+--- w x     leftright       left-right sizing arrows
+--- w x     busy            The system's usual busy pointer
+--- w x     no              The system's usual "no input" pointer
+---   x     udsizing        indicates up-down resizing
+---   x     lrsizing        indicates left-right resizing
+---   x     crosshair       like a big thin +
+---   x     hand1           black hand
+---   x     hand2           white hand
+---   x     pencil          what you write with
+---   x     question        big ?
+---   x     rightup-arrow   arrow pointing right-up
+--- w x     up-arrow        arrow pointing up
+---   x     <number>        any X11 pointer number (see X11/cursorfont.h)
 ---
 --- The "avail" column contains a 'w' if the shape is available for Win32,
 --- x for X11.
@@ -4484,7 +4484,7 @@ vim.go.mousescroll = vim.o.mousescroll
 --- Example:
 ---
 --- ```vim
---- 	set mouseshape=s:udsizing,m:no
+---         set mouseshape=s:udsizing,m:no
 --- ```
 --- will make the mouse turn to a sizing arrow over the status lines and
 --- indicate no input when the hit-enter prompt is displayed (since
@@ -4508,26 +4508,26 @@ vim.go.mouset = vim.go.mousetime
 --- This defines what bases Vim will consider for numbers when using the
 --- CTRL-A and CTRL-X commands for adding to and subtracting from a number
 --- respectively; see `CTRL-A` for more info on these commands.
---- alpha	If included, single alphabetical characters will be
---- 	incremented or decremented.  This is useful for a list with a
---- 	letter index a), b), etc.		*octal-nrformats*
---- octal	If included, numbers that start with a zero will be considered
---- 	to be octal.  Example: Using CTRL-A on "007" results in "010".
---- hex	If included, numbers starting with "0x" or "0X" will be
---- 	considered to be hexadecimal.  Example: Using CTRL-X on
---- 	"0x100" results in "0x0ff".
---- bin	If included, numbers starting with "0b" or "0B" will be
---- 	considered to be binary.  Example: Using CTRL-X on
---- 	"0b1000" subtracts one, resulting in "0b0111".
+--- alpha   If included, single alphabetical characters will be
+---         incremented or decremented.  This is useful for a list with a
+---         letter index a), b), etc.               *octal-nrformats*
+--- octal   If included, numbers that start with a zero will be considered
+---         to be octal.  Example: Using CTRL-A on "007" results in "010".
+--- hex     If included, numbers starting with "0x" or "0X" will be
+---         considered to be hexadecimal.  Example: Using CTRL-X on
+---         "0x100" results in "0x0ff".
+--- bin     If included, numbers starting with "0b" or "0B" will be
+---         considered to be binary.  Example: Using CTRL-X on
+---         "0b1000" subtracts one, resulting in "0b0111".
 --- unsigned    If included, numbers are recognized as unsigned. Thus a
---- 	leading dash or negative sign won't be considered as part of
---- 	the number.  Examples:
---- 	    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
---- 	    (without "unsigned" it would become "9-2021").
---- 	    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
---- 	    (without "unsigned" it would become "9-2019").
---- 	    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
---- 	    (2^64 - 1) has no effect, overflow is prevented.
+---         leading dash or negative sign won't be considered as part of
+---         the number.  Examples:
+---             Using CTRL-X on "2020" in "9-2020" results in "9-2019"
+---             (without "unsigned" it would become "9-2021").
+---             Using CTRL-A on "2020" in "9-2020" results in "9-2021"
+---             (without "unsigned" it would become "9-2019").
+---             Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
+---             (2^64 - 1) has no effect, overflow is prevented.
 --- Numbers which simply begin with a digit in the range 1-9 are always
 --- considered decimal.  This also happens for numbers that are not
 --- recognized as octal or hex.
@@ -4546,13 +4546,13 @@ vim.bo.nf = vim.bo.nrformats
 --- characters are put before the number.
 --- For highlighting see `hl-LineNr`, `hl-CursorLineNr`, and the
 --- `:sign-define` "numhl" argument.
---- 					*number_relativenumber*
+---                                         *number_relativenumber*
 --- The 'relativenumber' option changes the displayed number to be
 --- relative to the cursor.  Together with 'number' there are these
 --- four combinations (cursor in line 3):
 ---
---- 	'nonu'          'nu'            'nonu'          'nu'
---- 	'nornu'         'nornu'         'rnu'           'rnu'
+---         'nonu'          'nu'            'nonu'          'nu'
+---         'nornu'         'nornu'         'rnu'           'rnu'
 --- ```
 ---     |apple          |  1 apple      |  2 apple      |  2 apple
 ---     |pear           |  2 pear       |  1 pear       |  1 pear
@@ -4601,7 +4601,7 @@ vim.o.ofu = vim.o.omnifunc
 vim.bo.omnifunc = vim.o.omnifunc
 vim.bo.ofu = vim.bo.omnifunc
 
---- 		only for Windows
+--- only for Windows
 --- Enable reading and writing from devices.  This may get Vim stuck on a
 --- device that can be opened but doesn't actually do the I/O.  Therefore
 --- it is off by default.
@@ -4690,31 +4690,31 @@ vim.go.pm = vim.go.patchmode
 --- - Use commas to separate directory names:
 ---
 --- ```vim
---- 	set path=.,/usr/local/include,/usr/include
+---         set path=.,/usr/local/include,/usr/include
 --- ```
 --- - Spaces can also be used to separate directory names.  To have a
 ---   space in a directory name, precede it with an extra backslash, and
 ---   escape the space:
 ---
 --- ```vim
---- 	set path=.,/dir/with\\\ space
+---         set path=.,/dir/with\\\ space
 --- ```
 --- - To include a comma in a directory name precede it with an extra
 ---   backslash:
 ---
 --- ```vim
---- 	set path=.,/dir/with\\,comma
+---         set path=.,/dir/with\\,comma
 --- ```
 --- - To search relative to the directory of the current file, use:
 ---
 --- ```vim
---- 	set path=.
+---         set path=.
 --- ```
 --- - To search in the current directory use an empty string between two
 ---   commas:
 ---
 --- ```vim
---- 	set path=,,
+---         set path=,,
 --- ```
 --- - A directory name may end in a ':' or '/'.
 --- - Environment variables are expanded `:set_env`.
@@ -4725,12 +4725,12 @@ vim.go.pm = vim.go.patchmode
 --- - Careful with '\' characters, type two to get one in the option:
 ---
 --- ```vim
---- 	set path=.,c:\\include
+---         set path=.,c:\\include
 --- ```
 --- Or just use '/' instead:
 ---
 --- ```vim
---- 	set path=.,c:/include
+---         set path=.,c:/include
 --- ```
 --- Don't forget "." or files won't even be found in the same directory as
 --- the file!
@@ -4743,19 +4743,19 @@ vim.go.pm = vim.go.patchmode
 --- uses another default.  To remove the current directory use:
 ---
 --- ```vim
---- 	set path-=
+---         set path-=
 --- ```
 --- To add the current directory use:
 ---
 --- ```vim
---- 	set path+=
+---         set path+=
 --- ```
 --- To use an environment variable, you probably need to replace the
 --- separator.  Here is an example to append $INCL, in which directory
 --- names are separated with a semi-colon:
 ---
 --- ```vim
---- 	let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
+---         let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
 --- ```
 --- Replace the ';' with a ':' or whatever separator is used.  Note that
 --- this doesn't work when $INCL contains a comma or white space.
@@ -4816,8 +4816,8 @@ vim.wo.pvw = vim.wo.previewwindow
 ---
 --- ```vim
 ---
---- 	set pumblend=15
---- 	hi PmenuSel blend=0
+---         set pumblend=15
+---         hi PmenuSel blend=0
 --- ```
 ---
 --- UI-dependent. Works best with RGB colors. 'termguicolors'
@@ -4908,33 +4908,33 @@ vim.bo.ro = vim.bo.readonly
 --- Flags to change the way redrawing works, for debugging purposes.
 --- Most useful with 'writedelay' set to some reasonable value.
 --- Supports the following flags:
----     compositor	Indicate each redraw event handled by the compositor
---- 		by briefly flashing the redrawn regions in colors
---- 		indicating the redraw type. These are the highlight
---- 		groups used (and their default colors):
---- 	RedrawDebugNormal   gui=reverse   normal redraw passed through
---- 	RedrawDebugClear    guibg=Yellow  clear event passed through
---- 	RedrawDebugComposed guibg=Green   redraw event modified by the
---- 					  compositor (due to
---- 					  overlapping grids, etc)
---- 	RedrawDebugRecompose guibg=Red    redraw generated by the
---- 					  compositor itself, due to a
---- 					  grid being moved or deleted.
----     line	introduce a delay after each line drawn on the screen.
---- 		When using the TUI or another single-grid UI, "compositor"
---- 		gives more information and should be preferred (every
---- 		line is processed as a separate event by the compositor)
----     flush	introduce a delay after each "flush" event.
----     nothrottle	Turn off throttling of the message grid. This is an
---- 		optimization that joins many small scrolls to one
---- 		larger scroll when drawing the message area (with
---- 		'display' msgsep flag active).
----     invalid	Enable stricter checking (abort) of inconsistencies
---- 		of the internal screen state. This is mostly
---- 		useful when running nvim inside a debugger (and
---- 		the test suite).
----     nodelta	Send all internally redrawn cells to the UI, even if
---- 		they are unchanged from the already displayed state.
+---     compositor  Indicate each redraw event handled by the compositor
+---                 by briefly flashing the redrawn regions in colors
+---                 indicating the redraw type. These are the highlight
+---                 groups used (and their default colors):
+---         RedrawDebugNormal   gui=reverse   normal redraw passed through
+---         RedrawDebugClear    guibg=Yellow  clear event passed through
+---         RedrawDebugComposed guibg=Green   redraw event modified by the
+---                                           compositor (due to
+---                                           overlapping grids, etc)
+---         RedrawDebugRecompose guibg=Red    redraw generated by the
+---                                           compositor itself, due to a
+---                                           grid being moved or deleted.
+---     line        introduce a delay after each line drawn on the screen.
+---                 When using the TUI or another single-grid UI, "compositor"
+---                 gives more information and should be preferred (every
+---                 line is processed as a separate event by the compositor)
+---     flush       introduce a delay after each "flush" event.
+---     nothrottle  Turn off throttling of the message grid. This is an
+---                 optimization that joins many small scrolls to one
+---                 larger scroll when drawing the message area (with
+---                 'display' msgsep flag active).
+---     invalid     Enable stricter checking (abort) of inconsistencies
+---                 of the internal screen state. This is mostly
+---                 useful when running nvim inside a debugger (and
+---                 the test suite).
+---     nodelta     Send all internally redrawn cells to the UI, even if
+---                 they are unchanged from the already displayed state.
 ---
 --- @type string
 vim.o.redrawdebug = ""
@@ -4960,9 +4960,9 @@ vim.go.rdt = vim.go.redrawtime
 
 --- This selects the default regexp engine. `two-engines`
 --- The possible values are:
---- 	0	automatic selection
---- 	1	old engine
---- 	2	NFA engine
+---         0       automatic selection
+---         1       old engine
+---         2       NFA engine
 --- Note that when using the NFA engine and the pattern contains something
 --- that is not supported the pattern will not match.  This is only useful
 --- for debugging the regexp engine.
@@ -5040,7 +5040,7 @@ vim.wo.rl = vim.wo.rightleft
 --- Each word in this option enables the command line editing to work in
 --- right-to-left mode for a group of commands:
 ---
---- 	search		"/" and "?" commands
+---         search          "/" and "?" commands
 ---
 --- This is useful for languages such as Hebrew, Arabic and Farsi.
 --- The 'rightleft' option must be set for 'rightleftcmd' to take effect.
@@ -5054,10 +5054,10 @@ vim.wo.rlc = vim.wo.rightleftcmd
 --- Show the line and column number of the cursor position, separated by a
 --- comma.  When there is room, the relative position of the displayed
 --- text in the file is shown on the far right:
---- 	Top	first line is visible
---- 	Bot	last line is visible
---- 	All	first and last line are visible
---- 	45%	relative position in the file
+---         Top     first line is visible
+---         Bot     last line is visible
+---         All     first and last line are visible
+---         45%     relative position in the file
 --- If 'rulerformat' is set, it will determine the contents of the ruler.
 --- Each window has its own ruler.  If a window has a status line, the
 --- ruler is shown there.  If a window doesn't have a status line and
@@ -5090,7 +5090,7 @@ vim.go.ru = vim.go.ruler
 --- Example:
 ---
 --- ```vim
---- 	set rulerformat=%15(%c%V\ %p%%%)
+---         set rulerformat=%15(%c%V\ %p%%%)
 --- ```
 ---
 ---
@@ -5101,25 +5101,25 @@ vim.go.rulerformat = vim.o.rulerformat
 vim.go.ruf = vim.go.rulerformat
 
 --- List of directories to be searched for these runtime files:
----   filetype.lua	filetypes `new-filetype`
----   autoload/	automatically loaded scripts `autoload-functions`
----   colors/	color scheme files `:colorscheme`
----   compiler/	compiler files `:compiler`
----   doc/		documentation `write-local-help`
----   ftplugin/	filetype plugins `write-filetype-plugin`
----   indent/	indent scripts `indent-expression`
----   keymap/	key mapping files `mbyte-keymap`
----   lang/		menu translations `:menutrans`
----   lua/		`Lua` plugins
----   menu.vim	GUI menus `menu.vim`
----   pack/		packages `:packadd`
----   parser/	`treesitter` syntax parsers
----   plugin/	plugin scripts `write-plugin`
----   queries/	`treesitter` queries
----   rplugin/	`remote-plugin` scripts
----   spell/	spell checking files `spell`
----   syntax/	syntax files `mysyntaxfile`
----   tutor/	tutorial files `:Tutor`
+---   filetype.lua  filetypes `new-filetype`
+---   autoload/     automatically loaded scripts `autoload-functions`
+---   colors/       color scheme files `:colorscheme`
+---   compiler/     compiler files `:compiler`
+---   doc/          documentation `write-local-help`
+---   ftplugin/     filetype plugins `write-filetype-plugin`
+---   indent/       indent scripts `indent-expression`
+---   keymap/       key mapping files `mbyte-keymap`
+---   lang/         menu translations `:menutrans`
+---   lua/          `Lua` plugins
+---   menu.vim      GUI menus `menu.vim`
+---   pack/         packages `:packadd`
+---   parser/       `treesitter` syntax parsers
+---   plugin/       plugin scripts `write-plugin`
+---   queries/      `treesitter` queries
+---   rplugin/      `remote-plugin` scripts
+---   spell/        spell checking files `spell`
+---   syntax/       syntax files `mysyntaxfile`
+---   tutor/        tutorial files `:Tutor`
 ---
 --- And any other file searched for with the `:runtime` command.
 ---
@@ -5140,12 +5140,12 @@ vim.go.ruf = vim.go.rulerformat
 ---    viewdir, undodir, etc.
 ---    Given by `stdpath("state")`.  `$XDG_STATE_HOME`
 --- 6. $VIMRUNTIME, for files distributed with Nvim.
---- 						*after-directory*
+---                                                 *after-directory*
 --- 7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
 ---    ordering.  This is for preferences to overrule or add to the
 ---    distributed defaults or system-wide settings (rarely needed).
 ---
---- 						*packages-runtimepath*
+---                                                 *packages-runtimepath*
 --- "start" packages will also be searched (`runtime-search-path`) for
 --- runtime files after these, though such packages are not explicitly
 --- reported in &runtimepath. But "opt" packages are explicitly added to
@@ -5159,7 +5159,7 @@ vim.go.ruf = vim.go.rulerformat
 --- Example:
 ---
 --- ```vim
---- 	set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
+---         set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
 --- ```
 --- This will use the directory "~/vimruntime" first (containing your
 --- personal Nvim runtime files), then "/mygroup/vim", and finally
@@ -5242,8 +5242,8 @@ vim.go.sj = vim.go.scrolljump
 --- these two:
 ---
 --- ```vim
---- 	setlocal scrolloff<
---- 	setlocal scrolloff=-1
+---         setlocal scrolloff<
+---         setlocal scrolloff=-1
 --- ```
 --- For scrolling horizontally see 'sidescrolloff'.
 ---
@@ -5259,26 +5259,26 @@ vim.go.so = vim.go.scrolloff
 --- 'scrollbind' windows should behave.  'sbo' stands for ScrollBind
 --- Options.
 --- The following words are available:
----     ver		Bind vertical scrolling for 'scrollbind' windows
----     hor		Bind horizontal scrolling for 'scrollbind' windows
----     jump	Applies to the offset between two windows for vertical
---- 		scrolling.  This offset is the difference in the first
---- 		displayed line of the bound windows.  When moving
---- 		around in a window, another 'scrollbind' window may
---- 		reach a position before the start or after the end of
---- 		the buffer.  The offset is not changed though, when
---- 		moving back the 'scrollbind' window will try to scroll
---- 		to the desired position when possible.
---- 		When now making that window the current one, two
---- 		things can be done with the relative offset:
---- 		1. When "jump" is not included, the relative offset is
---- 		   adjusted for the scroll position in the new current
---- 		   window.  When going back to the other window, the
---- 		   new relative offset will be used.
---- 		2. When "jump" is included, the other windows are
---- 		   scrolled to keep the same relative offset.  When
---- 		   going back to the other window, it still uses the
---- 		   same relative offset.
+---     ver         Bind vertical scrolling for 'scrollbind' windows
+---     hor         Bind horizontal scrolling for 'scrollbind' windows
+---     jump        Applies to the offset between two windows for vertical
+---                 scrolling.  This offset is the difference in the first
+---                 displayed line of the bound windows.  When moving
+---                 around in a window, another 'scrollbind' window may
+---                 reach a position before the start or after the end of
+---                 the buffer.  The offset is not changed though, when
+---                 moving back the 'scrollbind' window will try to scroll
+---                 to the desired position when possible.
+---                 When now making that window the current one, two
+---                 things can be done with the relative offset:
+---                 1. When "jump" is not included, the relative offset is
+---                    adjusted for the scroll position in the new current
+---                    window.  When going back to the other window, the
+---                    new relative offset will be used.
+---                 2. When "jump" is included, the other windows are
+---                    scrolled to keep the same relative offset.  When
+---                    going back to the other window, it still uses the
+---                    same relative offset.
 --- Also see `scroll-binding`.
 --- When 'diff' mode is active there always is vertical scroll binding,
 --- even when "ver" isn't there.
@@ -5302,10 +5302,10 @@ vim.go.sect = vim.go.sections
 --- This option defines the behavior of the selection.  It is only used
 --- in Visual and Select mode.
 --- Possible values:
----    value	past line     inclusive ~
----    old		   no		yes
----    inclusive	   yes		yes
----    exclusive	   yes		no
+---    value        past line     inclusive ~
+---    old             no           yes
+---    inclusive       yes          yes
+---    exclusive       yes          no
 --- "past line" means that the cursor is allowed to be positioned one
 --- character past the line.
 --- "inclusive" means that the last character of the selection is included
@@ -5326,9 +5326,9 @@ vim.go.sel = vim.go.selection
 --- This is a comma-separated list of words, which specifies when to start
 --- Select mode instead of Visual mode, when a selection is started.
 --- Possible values:
----    mouse	when using the mouse
----    key		when using shifted special keys
----    cmd		when using "v", "V" or CTRL-V
+---    mouse        when using the mouse
+---    key          when using shifted special keys
+---    cmd          when using "v", "V" or CTRL-V
 --- See `Select-mode`.
 ---
 --- @type string
@@ -5340,35 +5340,35 @@ vim.go.slm = vim.go.selectmode
 --- Changes the effect of the `:mksession` command.  It is a comma-
 --- separated list of words.  Each word enables saving and restoring
 --- something:
----    word		save and restore ~
----    blank	empty windows
----    buffers	hidden and unloaded buffers, not just those in windows
----    curdir	the current directory
----    folds	manually created folds, opened/closed folds and local
---- 		fold options
----    globals	global variables that start with an uppercase letter
---- 		and contain at least one lowercase letter.  Only
---- 		String and Number types are stored.
----    help		the help window
----    localoptions	options and mappings local to a window or buffer (not
---- 		global values for local options)
----    options	all options and mappings (also global values for local
---- 		options)
----    skiprtp	exclude 'runtimepath' and 'packpath' from the options
----    resize	size of the Vim window: 'lines' and 'columns'
----    sesdir	the directory in which the session file is located
---- 		will become the current directory (useful with
---- 		projects accessed over a network from different
---- 		systems)
----    tabpages	all tab pages; without this only the current tab page
---- 		is restored, so that you can make a session for each
---- 		tab page separately
----    terminal	include terminal windows where the command can be
---- 		restored
----    winpos	position of the whole Vim window
----    winsize	window sizes
----    slash	`deprecated` Always enabled. Uses "/" in filenames.
----    unix		`deprecated` Always enabled. Uses "\n" line endings.
+---    word         save and restore ~
+---    blank        empty windows
+---    buffers      hidden and unloaded buffers, not just those in windows
+---    curdir       the current directory
+---    folds        manually created folds, opened/closed folds and local
+---                 fold options
+---    globals      global variables that start with an uppercase letter
+---                 and contain at least one lowercase letter.  Only
+---                 String and Number types are stored.
+---    help         the help window
+---    localoptions options and mappings local to a window or buffer (not
+---                 global values for local options)
+---    options      all options and mappings (also global values for local
+---                 options)
+---    skiprtp      exclude 'runtimepath' and 'packpath' from the options
+---    resize       size of the Vim window: 'lines' and 'columns'
+---    sesdir       the directory in which the session file is located
+---                 will become the current directory (useful with
+---                 projects accessed over a network from different
+---                 systems)
+---    tabpages     all tab pages; without this only the current tab page
+---                 is restored, so that you can make a session for each
+---                 tab page separately
+---    terminal     include terminal windows where the command can be
+---                 restored
+---    winpos       position of the whole Vim window
+---    winsize      window sizes
+---    slash        `deprecated` Always enabled. Uses "/" in filenames.
+---    unix         `deprecated` Always enabled. Uses "\n" line endings.
 ---
 --- Don't include both "curdir" and "sesdir". When neither is included
 --- filenames are stored as absolute paths.
@@ -5389,85 +5389,85 @@ vim.go.ssop = vim.go.sessionoptions
 --- character is left out, then the default value is used for that
 --- parameter.  The following is a list of the identifying characters and
 --- the effect of their value.
---- CHAR	VALUE	~
---- 						*shada-!*
---- !	When included, save and restore global variables that start
---- 	with an uppercase letter, and don't contain a lowercase
---- 	letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
---- 	and "_K_L_M" are not.  Nested List and Dict items may not be
---- 	read back correctly, you end up with an empty item.
---- 						*shada-quote*
---- "	Maximum number of lines saved for each register.  Old name of
---- 	the '<' item, with the disadvantage that you need to put a
---- 	backslash before the ", otherwise it will be recognized as the
---- 	start of a comment!
---- 						*shada-%*
---- %	When included, save and restore the buffer list.  If Vim is
---- 	started with a file name argument, the buffer list is not
---- 	restored.  If Vim is started without a file name argument, the
---- 	buffer list is restored from the shada file.  Quickfix
---- 	('buftype'), unlisted ('buflisted'), unnamed and buffers on
---- 	removable media (`shada-r`) are not saved.
---- 	When followed by a number, the number specifies the maximum
---- 	number of buffers that are stored.  Without a number all
---- 	buffers are stored.
---- 						*shada-'*
---- '	Maximum number of previously edited files for which the marks
---- 	are remembered.  This parameter must always be included when
---- 	'shada' is non-empty.
---- 	Including this item also means that the `jumplist` and the
---- 	`changelist` are stored in the shada file.
---- 						*shada-/*
---- /	Maximum number of items in the search pattern history to be
---- 	saved.  If non-zero, then the previous search and substitute
---- 	patterns are also saved.  When not included, the value of
---- 	'history' is used.
---- 						*shada-:*
---- :	Maximum number of items in the command-line history to be
---- 	saved.  When not included, the value of 'history' is used.
---- 						*shada-<*
---- \<	Maximum number of lines saved for each register.  If zero then
---- 	registers are not saved.  When not included, all lines are
---- 	saved.  '"' is the old name for this item.
---- 	Also see the 's' item below: limit specified in KiB.
---- 						*shada-@*
---- @	Maximum number of items in the input-line history to be
---- 	saved.  When not included, the value of 'history' is used.
---- 						*shada-c*
---- c	Dummy option, kept for compatibility reasons.  Has no actual
---- 	effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
---- 	to UTF-8 as well.
---- 						*shada-f*
---- f	Whether file marks need to be stored.  If zero, file marks ('0
---- 	to '9, 'A to 'Z) are not stored.  When not present or when
---- 	non-zero, they are all stored.  '0 is used for the current
---- 	cursor position (when exiting or when doing `:wshada`).
---- 						*shada-h*
---- h	Disable the effect of 'hlsearch' when loading the shada
---- 	file.  When not included, it depends on whether ":nohlsearch"
---- 	has been used since the last search command.
---- 						*shada-n*
---- n	Name of the shada file.  The name must immediately follow
---- 	the 'n'.  Must be at the end of the option!  If the
---- 	'shadafile' option is set, that file name overrides the one
---- 	given here with 'shada'.  Environment variables are
---- 	expanded when opening the file, not when setting the option.
---- 						*shada-r*
---- r	Removable media.  The argument is a string (up to the next
---- 	',').  This parameter can be given several times.  Each
---- 	specifies the start of a path for which no marks will be
---- 	stored.  This is to avoid removable media.  For Windows you
---- 	could use "ra:,rb:".  You can also use it for temp files,
---- 	e.g., for Unix: "r/tmp".  Case is ignored.
---- 						*shada-s*
---- s	Maximum size of an item contents in KiB.  If zero then nothing
---- 	is saved.  Unlike Vim this applies to all items, except for
---- 	the buffer list and header.  Full item size is off by three
---- 	unsigned integers: with `s10` maximum item size may be 1 byte
---- 	(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
---- 	integer) + 3 bytes (item size: up to 16-bit integer because
---- 	2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
---- 	contents size) = 10253 bytes.
+--- CHAR    VALUE   ~
+---                                                 *shada-!*
+--- !       When included, save and restore global variables that start
+---         with an uppercase letter, and don't contain a lowercase
+---         letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
+---         and "_K_L_M" are not.  Nested List and Dict items may not be
+---         read back correctly, you end up with an empty item.
+---                                                 *shada-quote*
+--- "       Maximum number of lines saved for each register.  Old name of
+---         the '<' item, with the disadvantage that you need to put a
+---         backslash before the ", otherwise it will be recognized as the
+---         start of a comment!
+---                                                 *shada-%*
+--- %       When included, save and restore the buffer list.  If Vim is
+---         started with a file name argument, the buffer list is not
+---         restored.  If Vim is started without a file name argument, the
+---         buffer list is restored from the shada file.  Quickfix
+---         ('buftype'), unlisted ('buflisted'), unnamed and buffers on
+---         removable media (`shada-r`) are not saved.
+---         When followed by a number, the number specifies the maximum
+---         number of buffers that are stored.  Without a number all
+---         buffers are stored.
+---                                                 *shada-'*
+--- '       Maximum number of previously edited files for which the marks
+---         are remembered.  This parameter must always be included when
+---         'shada' is non-empty.
+---         Including this item also means that the `jumplist` and the
+---         `changelist` are stored in the shada file.
+---                                                 *shada-/*
+--- /       Maximum number of items in the search pattern history to be
+---         saved.  If non-zero, then the previous search and substitute
+---         patterns are also saved.  When not included, the value of
+---         'history' is used.
+---                                                 *shada-:*
+--- :       Maximum number of items in the command-line history to be
+---         saved.  When not included, the value of 'history' is used.
+---                                                 *shada-<*
+--- \<      Maximum number of lines saved for each register.  If zero then
+---         registers are not saved.  When not included, all lines are
+---         saved.  '"' is the old name for this item.
+---         Also see the 's' item below: limit specified in KiB.
+---                                                 *shada-@*
+--- @       Maximum number of items in the input-line history to be
+---         saved.  When not included, the value of 'history' is used.
+---                                                 *shada-c*
+--- c       Dummy option, kept for compatibility reasons.  Has no actual
+---         effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
+---         to UTF-8 as well.
+---                                                 *shada-f*
+--- f       Whether file marks need to be stored.  If zero, file marks ('0
+---         to '9, 'A to 'Z) are not stored.  When not present or when
+---         non-zero, they are all stored.  '0 is used for the current
+---         cursor position (when exiting or when doing `:wshada`).
+---                                                 *shada-h*
+--- h       Disable the effect of 'hlsearch' when loading the shada
+---         file.  When not included, it depends on whether ":nohlsearch"
+---         has been used since the last search command.
+---                                                 *shada-n*
+--- n       Name of the shada file.  The name must immediately follow
+---         the 'n'.  Must be at the end of the option!  If the
+---         'shadafile' option is set, that file name overrides the one
+---         given here with 'shada'.  Environment variables are
+---         expanded when opening the file, not when setting the option.
+---                                                 *shada-r*
+--- r       Removable media.  The argument is a string (up to the next
+---         ',').  This parameter can be given several times.  Each
+---         specifies the start of a path for which no marks will be
+---         stored.  This is to avoid removable media.  For Windows you
+---         could use "ra:,rb:".  You can also use it for temp files,
+---         e.g., for Unix: "r/tmp".  Case is ignored.
+---                                                 *shada-s*
+--- s       Maximum size of an item contents in KiB.  If zero then nothing
+---         is saved.  Unlike Vim this applies to all items, except for
+---         the buffer list and header.  Full item size is off by three
+---         unsigned integers: with `s10` maximum item size may be 1 byte
+---         (type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+---         integer) + 3 bytes (item size: up to 16-bit integer because
+---         2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
+---         contents size) = 10253 bytes.
 ---
 --- Example:
 ---
@@ -5475,19 +5475,19 @@ vim.go.ssop = vim.go.sessionoptions
 ---     set shada='50,<1000,s100,:0,n~/nvim/shada
 --- ```
 ---
---- '50		Marks will be remembered for the last 50 files you
---- 		edited.
---- <1000		Contents of registers (up to 1000 lines each) will be
---- 		remembered.
---- s100		Items with contents occupying more then 100 KiB are
---- 		skipped.
---- :0		Command-line history will not be saved.
---- n~/nvim/shada	The name of the file to use is "~/nvim/shada".
---- no /		Since '/' is not specified, the default will be used,
---- 		that is, save all of the search history, and also the
---- 		previous search and substitute patterns.
---- no %		The buffer list will not be saved nor read back.
---- no h		'hlsearch' highlighting will be restored.
+--- '50             Marks will be remembered for the last 50 files you
+---                 edited.
+--- <1000           Contents of registers (up to 1000 lines each) will be
+---                 remembered.
+--- s100            Items with contents occupying more then 100 KiB are
+---                 skipped.
+--- :0              Command-line history will not be saved.
+--- n~/nvim/shada   The name of the file to use is "~/nvim/shada".
+--- no /            Since '/' is not specified, the default will be used,
+---                 that is, save all of the search history, and also the
+---                 previous search and substitute patterns.
+--- no %            The buffer list will not be saved nor read back.
+--- no h            'hlsearch' highlighting will be restored.
 ---
 --- When setting 'shada' from an empty value you can use `:rshada` to
 --- load the contents of the file, this is not done automatically.
@@ -5525,18 +5525,18 @@ vim.go.sdf = vim.go.shadafile
 --- quotes.  Example with quotes:
 ---
 --- ```vim
---- 	set shell=\"c:\program\ files\unix\sh.exe\"\ -f
+---         set shell=\"c:\program\ files\unix\sh.exe\"\ -f
 --- ```
 --- Note the backslash before each quote (to avoid starting a comment) and
 --- each space (to avoid ending the option value), so better use `:let-&`
 --- like this:
 ---
 --- ```vim
---- 	let &shell='"C:\Program Files\unix\sh.exe" -f'
+---         let &shell='"C:\Program Files\unix\sh.exe" -f'
 --- ```
 --- Also note that the "-f" is not inside the quotes, because it is not
 --- part of the command name.
---- 						*shell-unquoting*
+---                                                 *shell-unquoting*
 --- Rules regarding quotes:
 --- 1. Option is split on space and tab characters that are not inside
 ---    quotes: "abc def" runs shell named "abc" with additional argument
@@ -5555,15 +5555,15 @@ vim.go.sdf = vim.go.shadafile
 ---    to escape quote: 'a\"b"' is the same as "a\b".
 --- Note that such processing is done after `:set` did its own round of
 --- unescaping, so to keep yourself sane use `:let-&` like shown above.
---- 						*shell-powershell*
+---                                                 *shell-powershell*
 --- To use PowerShell:
 ---
 --- ```vim
---- 	let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
---- 	let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
---- 	let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
---- 	let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
---- 	set shellquote= shellxquote=
+---         let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
+---         let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
+---         let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+---         let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
+---         set shellquote= shellxquote=
 --- ```
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
@@ -5673,7 +5673,7 @@ vim.o.srr = vim.o.shellredir
 vim.go.shellredir = vim.o.shellredir
 vim.go.srr = vim.go.shellredir
 
---- 		only for MS-Windows
+--- only for MS-Windows
 --- When set, a forward slash is used when expanding file names.  This is
 --- useful when a Unix-like shell is used instead of cmd.exe.  Backward
 --- slashes can still be typed, but they are changed to forward slashes by
@@ -5685,7 +5685,7 @@ vim.go.srr = vim.go.shellredir
 --- separator.  To test if this is so use:
 ---
 --- ```vim
---- 	if exists('+shellslash')
+--- if exists('+shellslash')
 --- ```
 --- Also see 'completeslash'.
 ---
@@ -5764,53 +5764,53 @@ vim.bo.sw = vim.bo.shiftwidth
 --- This option helps to avoid all the `hit-enter` prompts caused by file
 --- messages, for example  with CTRL-G, and to avoid some other messages.
 --- It is a list of flags:
----  flag	meaning when present	~
----   l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
----   m	use "[+]" instead of "[Modified]"			*shm-m*
----   r	use "[RO]" instead of "[readonly]"			*shm-r*
----   w	use "[w]" instead of "written" for file write message	*shm-w*
---- 	and "[a]" instead of "appended" for ':w >> file' command
----   a	all of the above abbreviations				*shm-a*
+---  flag   meaning when present    ~
+---   l     use "999L, 888B" instead of "999 lines, 888 bytes"      *shm-l*
+---   m     use "[+]" instead of "[Modified]"                       *shm-m*
+---   r     use "[RO]" instead of "[readonly]"                      *shm-r*
+---   w     use "[w]" instead of "written" for file write message   *shm-w*
+---         and "[a]" instead of "appended" for ':w >> file' command
+---   a     all of the above abbreviations                          *shm-a*
 ---
----   o	overwrite message for writing a file with subsequent	*shm-o*
---- 	message for reading a file (useful for ":wn" or when
---- 	'autowrite' on)
----   O	message for reading a file overwrites any previous	*shm-O*
---- 	message;  also for quickfix message (e.g., ":cn")
----   s	don't give "search hit BOTTOM, continuing at TOP" or	*shm-s*
---- 	"search hit TOP, continuing at BOTTOM" messages; when using
---- 	the search count do not show "W" after the count message (see
---- 	S below)
----   t	truncate file message at the start if it is too long	*shm-t*
---- 	to fit on the command-line, "<" will appear in the left most
---- 	column; ignored in Ex mode
----   T	truncate other messages in the middle if they are too	*shm-T*
---- 	long to fit on the command line; "..." will appear in the
---- 	middle; ignored in Ex mode
----   W	don't give "written" or "[w]" when writing a file	*shm-W*
----   A	don't give the "ATTENTION" message when an existing	*shm-A*
---- 	swap file is found
----   I	don't give the intro message when starting Vim,		*shm-I*
---- 	see `:intro`
----   c	don't give `ins-completion-menu` messages; for		*shm-c*
---- 	example, "-- XXX completion (YYY)", "match 1 of 2", "The only
---- 	match", "Pattern not found", "Back at original", etc.
----   C	don't give messages while scanning for ins-completion	*shm-C*
---- 	items, for instance "scanning tags"
----   q	use "recording" instead of "recording @a"		*shm-q*
----   F	don't give the file info when editing a file, like	*shm-F*
---- 	`:silent` was used for the command
----   S	do not show search count message when searching, e.g.	*shm-S*
---- 	"[1/5]"
+---   o     overwrite message for writing a file with subsequent    *shm-o*
+---         message for reading a file (useful for ":wn" or when
+---         'autowrite' on)
+---   O     message for reading a file overwrites any previous      *shm-O*
+---         message;  also for quickfix message (e.g., ":cn")
+---   s     don't give "search hit BOTTOM, continuing at TOP" or    *shm-s*
+---         "search hit TOP, continuing at BOTTOM" messages; when using
+---         the search count do not show "W" after the count message (see
+---         S below)
+---   t     truncate file message at the start if it is too long    *shm-t*
+---         to fit on the command-line, "<" will appear in the left most
+---         column; ignored in Ex mode
+---   T     truncate other messages in the middle if they are too   *shm-T*
+---         long to fit on the command line; "..." will appear in the
+---         middle; ignored in Ex mode
+---   W     don't give "written" or "[w]" when writing a file       *shm-W*
+---   A     don't give the "ATTENTION" message when an existing     *shm-A*
+---         swap file is found
+---   I     don't give the intro message when starting Vim,         *shm-I*
+---         see `:intro`
+---   c     don't give `ins-completion-menu` messages; for          *shm-c*
+---         example, "-- XXX completion (YYY)", "match 1 of 2", "The only
+---         match", "Pattern not found", "Back at original", etc.
+---   C     don't give messages while scanning for ins-completion   *shm-C*
+---         items, for instance "scanning tags"
+---   q     use "recording" instead of "recording @a"               *shm-q*
+---   F     don't give the file info when editing a file, like      *shm-F*
+---         `:silent` was used for the command
+---   S     do not show search count message when searching, e.g.   *shm-S*
+---         "[1/5]"
 ---
 --- This gives you the opportunity to avoid that a change between buffers
 --- requires you to hit <Enter>, but still gives as useful a message as
 --- possible for the space available.  To get the whole message that you
 --- would have got with 'shm' empty, use ":file!"
 --- Useful values:
----     shm=	No abbreviation of message.
----     shm=a	Abbreviation, but no loss of information.
----     shm=at	Abbreviation, and truncate message when necessary.
+---     shm=        No abbreviation of message.
+---     shm=a       Abbreviation, but no loss of information.
+---     shm=at      Abbreviation, and truncate message when necessary.
 ---
 --- @type string
 vim.o.shortmess = "ltToOCF"
@@ -5822,8 +5822,8 @@ vim.go.shm = vim.go.shortmess
 --- values are "> " or "+++ ":
 ---
 --- ```vim
---- 	let &showbreak = "> "
---- 	let &showbreak = '+++ '
+---         let &showbreak = "> "
+---         let &showbreak = '+++ '
 --- ```
 --- Only printable single-cell characters are allowed, excluding <Tab> and
 --- comma (in a future version the comma might be used to separate the
@@ -5836,7 +5836,7 @@ vim.go.shm = vim.go.shortmess
 --- set and you want no value in the current window use NONE:
 ---
 --- ```vim
---- 	setlocal showbreak=NONE
+---         setlocal showbreak=NONE
 --- ```
 ---
 ---
@@ -5868,9 +5868,9 @@ vim.go.sc = vim.go.showcmd
 
 --- This option can be used to display the (partially) entered command in
 --- another location.  Possible values are:
----   last		Last line of the screen (default).
----   statusline	Status line of the current window.
----   tabline	First line of the screen if 'showtabline' is enabled.
+---   last          Last line of the screen (default).
+---   statusline    Status line of the current window.
+---   tabline       First line of the screen if 'showtabline' is enabled.
 --- Setting this option to "statusline" or "tabline" means that these will
 --- be redrawn whenever the command changes, which can be on every key
 --- pressed.
@@ -5933,9 +5933,9 @@ vim.go.smd = vim.go.showmode
 
 --- The value of this option specifies when the line with tab page labels
 --- will be displayed:
---- 	0: never
---- 	1: only if there are at least two tab pages
---- 	2: always
+---         0: never
+---         1: only if there are at least two tab pages
+---         2: always
 --- This is both for the GUI and non-GUI implementation of the tab pages
 --- line.
 --- See `tab-page` for more information about tab pages.
@@ -5970,18 +5970,18 @@ vim.go.ss = vim.go.sidescroll
 --- these two:
 ---
 --- ```vim
---- 	setlocal sidescrolloff<
---- 	setlocal sidescrolloff=-1
+---         setlocal sidescrolloff<
+---         setlocal sidescrolloff=-1
 --- ```
 ---
 --- Example: Try this together with 'sidescroll' and 'listchars' as
---- 	 in the following example to never allow the cursor to move
---- 	 onto the "extends" character:
+---          in the following example to never allow the cursor to move
+---          onto the "extends" character:
 ---
 --- ```vim
 ---
---- 	 set nowrap sidescroll=1 listchars=extends:>,precedes:<
---- 	 set sidescrolloff=1
+---          set nowrap sidescroll=1 listchars=extends:>,precedes:<
+---          set sidescrolloff=1
 --- ```
 ---
 ---
@@ -5994,21 +5994,21 @@ vim.go.sidescrolloff = vim.o.sidescrolloff
 vim.go.siso = vim.go.sidescrolloff
 
 --- When and how to draw the signcolumn. Valid values are:
----    "auto"	only when there is a sign to display
+---    "auto"       only when there is a sign to display
 ---    "auto:[1-9]" resize to accommodate multiple signs up to the
 ---                 given number (maximum 9), e.g. "auto:4"
 ---    "auto:[1-8]-[2-9]"
 ---                 resize to accommodate multiple signs up to the
---- 		given maximum number (maximum 9) while keeping
---- 		at least the given minimum (maximum 8) fixed
---- 		space. The minimum number should always be less
---- 		than the maximum number, e.g. "auto:2-5"
----    "no"		never
----    "yes"	always
+---                 given maximum number (maximum 9) while keeping
+---                 at least the given minimum (maximum 8) fixed
+---                 space. The minimum number should always be less
+---                 than the maximum number, e.g. "auto:2-5"
+---    "no"         never
+---    "yes"        always
 ---    "yes:[1-9]"  always, with fixed space for signs up to the given
 ---                 number (maximum 9), e.g. "yes:3"
----    "number"	display signs in the 'number' column. If the number
---- 		column is not present, then behaves like "auto".
+---    "number"     display signs in the 'number' column. If the number
+---                 column is not present, then behaves like "auto".
 ---
 --- @type string
 vim.o.signcolumn = "auto"
@@ -6136,7 +6136,7 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- commands.  It must end in ".{encoding}.add".  You need to include the
 --- path, otherwise the file is placed in the current directory.
 --- The path may include characters from 'isfname', space, comma and '@'.
---- 							*E765*
+---                                                         *E765*
 --- It may also be a comma-separated list of names.  A count before the
 --- `zg` and `zw` commands can be used to access each.  This allows using
 --- a personal word list file and a project word list file.
@@ -6164,7 +6164,7 @@ vim.bo.spf = vim.bo.spellfile
 --- on spellchecking will be done for these languages.  Example:
 ---
 --- ```vim
---- 	set spelllang=en_us,nl,medical
+---         set spelllang=en_us,nl,medical
 --- ```
 --- This means US English, Dutch and medical words are recognized.  Words
 --- that are not recognized will be highlighted.
@@ -6183,7 +6183,7 @@ vim.bo.spf = vim.bo.spellfile
 --- words.
 --- Note that the "medical" dictionary does not exist, it is just an
 --- example of a longer name.
---- 						*E757*
+---                                                 *E757*
 --- As a special case the name of a .spl file can be given as-is.  The
 --- first "_xx" in the name is removed and used as the region name
 --- (_xx is an underscore, two letters and followed by a non-letter).
@@ -6207,14 +6207,14 @@ vim.bo.spelllang = vim.o.spelllang
 vim.bo.spl = vim.bo.spelllang
 
 --- A comma-separated list of options for spell checking:
---- camel		When a word is CamelCased, assume "Cased" is a
---- 		separate word: every upper-case character in a word
---- 		that comes after a lower case character indicates the
---- 		start of a new word.
---- noplainbuffer	Only spellcheck a buffer when 'syntax' is enabled,
---- 		or when extmarks are set within the buffer. Only
---- 		designated regions of the buffer are spellchecked in
---- 		this case.
+--- camel           When a word is CamelCased, assume "Cased" is a
+---                 separate word: every upper-case character in a word
+---                 that comes after a lower case character indicates the
+---                 start of a new word.
+--- noplainbuffer   Only spellcheck a buffer when 'syntax' is enabled,
+---                 or when extmarks are set within the buffer. Only
+---                 designated regions of the buffer are spellchecked in
+---                 this case.
 ---
 --- @type string
 vim.o.spelloptions = ""
@@ -6226,64 +6226,64 @@ vim.bo.spo = vim.bo.spelloptions
 --- the `spellsuggest()` function.  This is a comma-separated list of
 --- items:
 ---
---- best		Internal method that works best for English.  Finds
---- 		changes like "fast" and uses a bit of sound-a-like
---- 		scoring to improve the ordering.
+--- best            Internal method that works best for English.  Finds
+---                 changes like "fast" and uses a bit of sound-a-like
+---                 scoring to improve the ordering.
 ---
---- double		Internal method that uses two methods and mixes the
---- 		results.  The first method is "fast", the other method
---- 		computes how much the suggestion sounds like the bad
---- 		word.  That only works when the language specifies
---- 		sound folding.  Can be slow and doesn't always give
---- 		better results.
+--- double          Internal method that uses two methods and mixes the
+---                 results.  The first method is "fast", the other method
+---                 computes how much the suggestion sounds like the bad
+---                 word.  That only works when the language specifies
+---                 sound folding.  Can be slow and doesn't always give
+---                 better results.
 ---
---- fast		Internal method that only checks for simple changes:
---- 		character inserts/deletes/swaps.  Works well for
---- 		simple typing mistakes.
+--- fast            Internal method that only checks for simple changes:
+---                 character inserts/deletes/swaps.  Works well for
+---                 simple typing mistakes.
 ---
---- {number}	The maximum number of suggestions listed for `z=`.
---- 		Not used for `spellsuggest()`.  The number of
---- 		suggestions is never more than the value of 'lines'
---- 		minus two.
+--- {number}        The maximum number of suggestions listed for `z=`.
+---                 Not used for `spellsuggest()`.  The number of
+---                 suggestions is never more than the value of 'lines'
+---                 minus two.
 ---
 --- timeout:{millisec}   Limit the time searching for suggestions to
---- 		{millisec} milli seconds.  Applies to the following
---- 		methods.  When omitted the limit is 5000. When
---- 		negative there is no limit.
+---                 {millisec} milli seconds.  Applies to the following
+---                 methods.  When omitted the limit is 5000. When
+---                 negative there is no limit.
 ---
 --- file:{filename} Read file {filename}, which must have two columns,
---- 		separated by a slash.  The first column contains the
---- 		bad word, the second column the suggested good word.
---- 		Example:
---- 			theribal/terrible ~
---- 		Use this for common mistakes that do not appear at the
---- 		top of the suggestion list with the internal methods.
---- 		Lines without a slash are ignored, use this for
---- 		comments.
---- 		The word in the second column must be correct,
---- 		otherwise it will not be used.  Add the word to an
---- 		".add" file if it is currently flagged as a spelling
---- 		mistake.
---- 		The file is used for all languages.
+---                 separated by a slash.  The first column contains the
+---                 bad word, the second column the suggested good word.
+---                 Example:
+---                         theribal/terrible ~
+---                 Use this for common mistakes that do not appear at the
+---                 top of the suggestion list with the internal methods.
+---                 Lines without a slash are ignored, use this for
+---                 comments.
+---                 The word in the second column must be correct,
+---                 otherwise it will not be used.  Add the word to an
+---                 ".add" file if it is currently flagged as a spelling
+---                 mistake.
+---                 The file is used for all languages.
 ---
---- expr:{expr}	Evaluate expression {expr}.  Use a function to avoid
---- 		trouble with spaces.  `v:val` holds the badly spelled
---- 		word.  The expression must evaluate to a List of
---- 		Lists, each with a suggestion and a score.
---- 		Example:
---- 			[['the', 33], ['that', 44]] ~
---- 		Set 'verbose' and use `z=` to see the scores that the
---- 		internal methods use.  A lower score is better.
---- 		This may invoke `spellsuggest()` if you temporarily
---- 		set 'spellsuggest' to exclude the "expr:" part.
---- 		Errors are silently ignored, unless you set the
---- 		'verbose' option to a non-zero value.
+--- expr:{expr}     Evaluate expression {expr}.  Use a function to avoid
+---                 trouble with spaces.  `v:val` holds the badly spelled
+---                 word.  The expression must evaluate to a List of
+---                 Lists, each with a suggestion and a score.
+---                 Example:
+---                         [['the', 33], ['that', 44]] ~
+---                 Set 'verbose' and use `z=` to see the scores that the
+---                 internal methods use.  A lower score is better.
+---                 This may invoke `spellsuggest()` if you temporarily
+---                 set 'spellsuggest' to exclude the "expr:" part.
+---                 Errors are silently ignored, unless you set the
+---                 'verbose' option to a non-zero value.
 ---
 --- Only one of "best", "double" or "fast" may be used.  The others may
 --- appear several times in any order.  Example:
 ---
 --- ```vim
---- 	set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+---         set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
 --- ```
 ---
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
@@ -6308,9 +6308,9 @@ vim.go.sb = vim.go.splitbelow
 --- closing or resizing horizontal splits.
 ---
 --- Possible values are:
----   cursor	Keep the same relative cursor position.
----   screen	Keep the text on the same screen line.
----   topline	Keep the topline the same.
+---   cursor        Keep the same relative cursor position.
+---   screen        Keep the text on the same screen line.
+---   topline       Keep the topline the same.
 ---
 --- For the "screen" and "topline" values, the cursor position will be
 --- changed when necessary. In this case, the jumplist will be populated
@@ -6357,10 +6357,10 @@ vim.go.sol = vim.go.startofline
 --- Some of the items from the 'statusline' format are different for
 --- 'statuscolumn':
 ---
---- %l	line number of currently drawn line
---- %r	relative line number of currently drawn line
---- %s	sign column for currently drawn line
---- %C	fold column for currently drawn line
+--- %l      line number of currently drawn line
+--- %r      relative line number of currently drawn line
+--- %s      sign column for currently drawn line
+--- %C      fold column for currently drawn line
 ---
 --- NOTE: To draw the sign and fold columns, their items must be included in
 --- 'statuscolumn'. Even when they are not included, the status column width
@@ -6369,8 +6369,8 @@ vim.go.sol = vim.go.startofline
 --- The `v:lnum`    variable holds the line number to be drawn.
 --- The `v:relnum`  variable holds the relative line number to be drawn.
 --- The `v:virtnum` variable is negative when drawing virtual lines, zero
---- 	      when drawing the actual buffer line, and positive when
---- 	      drawing the wrapped part of a buffer line.
+---               when drawing the actual buffer line, and positive when
+---               drawing the wrapped part of a buffer line.
 ---
 --- NOTE: The %@ click execute function item is supported as well but the
 --- specified function will be the same for each row in the same column.
@@ -6380,24 +6380,24 @@ vim.go.sol = vim.go.startofline
 --- Examples:
 ---
 --- ```vim
---- 	" Relative number with bar separator and click handlers:
---- 	set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
+---         " Relative number with bar separator and click handlers:
+---         set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
 ---
---- 	" Right aligned relative cursor line number:
---- 	let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+---         " Right aligned relative cursor line number:
+---         let &stc='%=%{v:relnum?v:relnum:v:lnum} '
 ---
---- 	" Line numbers in hexadecimal for non wrapped part of lines:
---- 	let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
+---         " Line numbers in hexadecimal for non wrapped part of lines:
+---         let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
 ---
---- 	" Human readable line numbers with thousands separator:
---- 	let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
---- 		   . '%(\\d\\d\\d\\)\\+$",",","g")}'
+---         " Human readable line numbers with thousands separator:
+---         let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
+---                    . '%(\\d\\d\\d\\)\\+$",",","g")}'
 ---
---- 	" Both relative and absolute line numbers with different
---- 	" highlighting for odd and even relative numbers:
---- 	let &stc='%#NonText#%{&nu?v:lnum:""}' .
---- 	 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
---- 	 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
+---         " Both relative and absolute line numbers with different
+---         " highlighting for odd and even relative numbers:
+---         let &stc='%#NonText#%{&nu?v:lnum:""}' .
+---          '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
+---          '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
 --- ```
 --- WARNING: this expression is evaluated for each screen line so defining
 --- an expensive expression can negatively affect render performance.
@@ -6421,7 +6421,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- evaluated and the result is used as the option value.  Example:
 ---
 --- ```vim
---- 	set statusline=%!MyStatusLine()
+---         set statusline=%!MyStatusLine()
 --- ```
 --- The *g:statusline_winid* variable will be set to the `window-ID` of the
 --- window that the status line belongs to.
@@ -6438,25 +6438,25 @@ vim.wo.stc = vim.wo.statuscolumn
 --- Note that the only effect of 'ruler' when this option is set (and
 --- 'laststatus' is 2 or 3) is controlling the output of `CTRL-G`.
 ---
---- field	    meaning ~
---- -	    Left justify the item.  The default is right justified
---- 	    when minwid is larger than the length of the item.
---- 0	    Leading zeroes in numeric items.  Overridden by "-".
---- minwid	    Minimum width of the item, padding as set by "-" & "0".
---- 	    Value must be 50 or less.
---- maxwid	    Maximum width of the item.  Truncation occurs with a "<"
---- 	    on the left for text items.  Numeric items will be
---- 	    shifted down to maxwid-2 digits followed by ">"number
---- 	    where number is the amount of missing digits, much like
---- 	    an exponential notation.
---- item	    A one letter code as described below.
+--- field       meaning ~
+--- -           Left justify the item.  The default is right justified
+---             when minwid is larger than the length of the item.
+--- 0           Leading zeroes in numeric items.  Overridden by "-".
+--- minwid      Minimum width of the item, padding as set by "-" & "0".
+---             Value must be 50 or less.
+--- maxwid      Maximum width of the item.  Truncation occurs with a "<"
+---             on the left for text items.  Numeric items will be
+---             shifted down to maxwid-2 digits followed by ">"number
+---             where number is the amount of missing digits, much like
+---             an exponential notation.
+--- item        A one letter code as described below.
 ---
 --- Following is a description of the possible statusline items.  The
 --- second character in "item" is the type:
---- 	N for number
---- 	S for string
---- 	F for flags as described below
---- 	- not applicable
+---         N for number
+---         S for string
+---         F for flags as described below
+---         - not applicable
 ---
 --- item  meaning ~
 --- f S   Path to the file in the buffer, as typed or relative to current
@@ -6506,9 +6506,9 @@ vim.wo.stc = vim.wo.statuscolumn
 ---       For example:
 ---
 --- ```vim
---- 	func! Stl_filename() abort
---- 	    return "%t"
---- 	endfunc
+---         func! Stl_filename() abort
+---             return "%t"
+---         endfunc
 --- ```
 --- `stl=%{Stl_filename()}`   results in `"%t"`
 ---         `stl=%{%Stl_filename()%}` results in `"Name of current file"`
@@ -6576,11 +6576,11 @@ vim.wo.stc = vim.wo.statuscolumn
 --- completely from the statusline when none of the flags are set.
 ---
 --- ```vim
---- 	set statusline=...%(\ [%M%R%H]%)...
+---         set statusline=...%(\ [%M%R%H]%)...
 --- ```
 --- Beware that an expression is evaluated each and every time the status
 --- line is displayed.
---- 			*stl-%{* *g:actual_curbuf* *g:actual_curwin*
+---                         *stl-%{* *g:actual_curbuf* *g:actual_curwin*
 --- While evaluating %{} the current buffer and current window will be set
 --- temporarily to that of the window (and buffer) whose statusline is
 --- currently being drawn.  The expression will evaluate in this context.
@@ -6677,7 +6677,7 @@ vim.go.su = vim.go.suffixes
 --- file for the "gf", "[I", etc. commands.  Example:
 ---
 --- ```vim
---- 	set suffixesadd=.java
+---         set suffixesadd=.java
 --- ```
 ---
 ---
@@ -6691,8 +6691,8 @@ vim.bo.sua = vim.bo.suffixesadd
 --- swapfile is not wanted for a specific buffer.  For example, with
 --- confidential information that even root must not be able to access.
 --- Careful: All text will be in memory:
---- 	- Don't use this for big files.
---- 	- Recovery will be impossible!
+---         - Don't use this for big files.
+---         - Recovery will be impossible!
 --- A swapfile will only be present when `'updatecount'` is non-zero and
 --- 'swapfile' is set.
 --- When 'swapfile' is reset, the swap file for the current buffer is
@@ -6721,22 +6721,22 @@ vim.bo.swf = vim.bo.swapfile
 --- - jumping to a buffer using a buffer split command (e.g.  `:sbuffer`,
 ---   `:sbnext`, or `:sbrewind`).
 --- Possible values (comma-separated list):
----    useopen	If included, jump to the first open window in the
---- 		current tab page that contains the specified buffer
---- 		(if there is one).  Otherwise: Do not examine other
---- 		windows.
----    usetab	Like "useopen", but also consider windows in other tab
---- 		pages.
----    split	If included, split the current window before loading
---- 		a buffer for a `quickfix` command that display errors.
---- 		Otherwise: do not split, use current window (when used
---- 		in the quickfix window: the previously used window or
---- 		split if there is no other window).
----    vsplit	Just like "split" but split vertically.
----    newtab	Like "split", but open a new tab page.  Overrules
---- 		"split" when both are present.
----    uselast	If included, jump to the previously used window when
---- 		jumping to errors with `quickfix` commands.
+---    useopen      If included, jump to the first open window in the
+---                 current tab page that contains the specified buffer
+---                 (if there is one).  Otherwise: Do not examine other
+---                 windows.
+---    usetab       Like "useopen", but also consider windows in other tab
+---                 pages.
+---    split        If included, split the current window before loading
+---                 a buffer for a `quickfix` command that display errors.
+---                 Otherwise: do not split, use current window (when used
+---                 in the quickfix window: the previously used window or
+---                 split if there is no other window).
+---    vsplit       Just like "split" but split vertically.
+---    newtab       Like "split", but open a new tab page.  Overrules
+---                 "split" when both are present.
+---    uselast      If included, jump to the previously used window when
+---                 jumping to errors with `quickfix` commands.
 ---
 --- @type string
 vim.o.switchbuf = "uselast"
@@ -6763,11 +6763,11 @@ vim.bo.smc = vim.bo.synmaxcol
 --- b:current_syntax variable does).
 --- This option is most useful in a modeline, for a file which syntax is
 --- not automatically recognized.  Example, in an IDL file: >c
---- 	/* vim: set syntax=idl : */
+---         /* vim: set syntax=idl : */
 --- ```
 --- When a dot appears in the value then this separates two filetype
 --- names.  Example: >c
---- 	/* vim: set syntax=c.doxygen : */
+---         /* vim: set syntax=c.doxygen : */
 --- ```
 --- This will use the "c" syntax first, then the "doxygen" syntax.
 --- Note that the second one must be prepared to be loaded as an addition,
@@ -6775,13 +6775,13 @@ vim.bo.smc = vim.bo.synmaxcol
 --- To switch off syntax highlighting for the current file, use:
 ---
 --- ```vim
---- 	set syntax=OFF
+---         set syntax=OFF
 --- ```
 --- To switch syntax highlighting on according to the current value of the
 --- 'filetype' option:
 ---
 --- ```vim
---- 	set syntax=ON
+---         set syntax=ON
 --- ```
 --- What actually happens when setting the 'syntax' option is that the
 --- Syntax autocommand event is triggered with the value as argument.
@@ -6893,7 +6893,7 @@ vim.bo.ts = vim.bo.tabstop
 --- Linear searching is done anyway, for one file, when Vim finds a line
 --- at the start of the file indicating that it's not sorted:
 --- ```
----    !_TAG_FILE_SORTED	0	/some comment/
+---    !_TAG_FILE_SORTED    0       /some comment/
 --- ```
 --- [The whitespace before and after the '0' must be a single <Tab>]
 ---
@@ -6936,11 +6936,11 @@ vim.go.tbs = vim.go.tagbsearch
 
 --- This option specifies how case is handled when searching the tags
 --- file:
----    followic	Follow the 'ignorecase' option
+---    followic     Follow the 'ignorecase' option
 ---    followscs    Follow the 'smartcase' and 'ignorecase' options
----    ignore	Ignore case
----    match	Match case
----    smart	Ignore case unless an upper case letter is used
+---    ignore       Ignore case
+---    match        Match case
+---    smart        Ignore case unless an upper case letter is used
 ---
 --- @type string
 vim.o.tagcase = "followic"
@@ -7055,20 +7055,20 @@ vim.go.tgc = vim.go.termguicolors
 --- to be removed from the text pasted into the terminal window. The
 --- supported values are:
 ---
----    BS	    Backspace
+---    BS       Backspace
 ---
----    HT	    TAB
+---    HT       TAB
 ---
----    FF	    Form feed
+---    FF       Form feed
 ---
----    ESC	    Escape
+---    ESC      Escape
 ---
----    DEL	    DEL
+---    DEL      DEL
 ---
----    C0	    Other control characters, excluding Line feed and
---- 	    Carriage return < ' '
+---    C0       Other control characters, excluding Line feed and
+---             Carriage return < ' '
 ---
----    C1	    Control characters 0x80...0x9F
+---    C1       Control characters 0x80...0x9F
 ---
 --- @type string
 vim.o.termpastefilter = "BS,HT,ESC,DEL"
@@ -7166,15 +7166,15 @@ vim.go.tm = vim.go.timeoutlen
 
 --- When on, the title of the window will be set to the value of
 --- 'titlestring' (if it is not empty), or to:
---- 	filename [+=-] (path) - NVIM
+---         filename [+=-] (path) - NVIM
 --- Where:
---- 	filename	the name of the file being edited
---- 	-		indicates the file cannot be modified, 'ma' off
---- 	+		indicates the file was modified
---- 	=		indicates the file is read-only
---- 	=+		indicates the file is read-only and modified
---- 	(path)		is the path of the file being edited
---- 	- NVIM		the server name `v:servername` or "NVIM"
+---         filename        the name of the file being edited
+---         -               indicates the file cannot be modified, 'ma' off
+---         +               indicates the file was modified
+---         =               indicates the file is read-only
+---         =+              indicates the file is read-only and modified
+---         (path)          is the path of the file being edited
+---         - NVIM          the server name `v:servername` or "NVIM"
 ---
 --- @type boolean
 vim.o.title = false
@@ -7308,7 +7308,7 @@ vim.bo.udf = vim.bo.undofile
 --- itself:
 ---
 --- ```vim
---- 	set ul=0
+---         set ul=0
 --- ```
 --- But you can also get Vi compatibility by including the 'u' flag in
 --- 'cpoptions', and still be able to use CTRL-R to repeat undo.
@@ -7317,7 +7317,7 @@ vim.bo.udf = vim.bo.undofile
 --- current buffer:
 ---
 --- ```vim
---- 	setlocal ul=-1
+---         setlocal ul=-1
 --- ```
 --- This helps when you run out of memory for a single change.
 ---
@@ -7390,7 +7390,7 @@ vim.go.ut = vim.go.updatetime
 --- to use the following:
 ---
 --- ```vim
---- 	set varsofttabstop=8,32,8
+---         set varsofttabstop=8,32,8
 --- ```
 --- This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
 --- for every column thereafter.
@@ -7409,7 +7409,7 @@ vim.bo.vsts = vim.bo.varsofttabstop
 --- final value applying to all subsequent tabs. For example:
 ---
 --- ```vim
---- 	set vartabstop=4,20,10,8
+---         set vartabstop=4,20,10,8
 --- ```
 --- This will make the first tab 4 spaces wide, the second 20 spaces,
 --- the third 10 spaces, and all following tabs 8 spaces.
@@ -7433,19 +7433,19 @@ vim.bo.vts = vim.bo.vartabstop
 ---
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
---- 1	Lua assignments to options, mappings, etc.
---- 2	When a file is ":source"'ed, or `shada` file is read or written.
---- 3	UI info, terminal capabilities.
---- 4	Shell commands.
---- 5	Every searched tags file and include file.
---- 8	Files for which a group of autocommands is executed.
---- 9	Executed autocommands.
---- 11	Finding items in a path.
---- 12	Vimscript function calls.
---- 13	When an exception is thrown, caught, finished, or discarded.
---- 14	Anything pending in a ":finally" clause.
---- 15	Ex commands from a script (truncated at 200 characters).
---- 16	Ex commands.
+--- 1       Lua assignments to options, mappings, etc.
+--- 2       When a file is ":source"'ed, or `shada` file is read or written.
+--- 3       UI info, terminal capabilities.
+--- 4       Shell commands.
+--- 5       Every searched tags file and include file.
+--- 8       Files for which a group of autocommands is executed.
+--- 9       Executed autocommands.
+--- 11      Finding items in a path.
+--- 12      Vimscript function calls.
+--- 13      When an exception is thrown, caught, finished, or discarded.
+--- 14      Anything pending in a ":finally" clause.
+--- 15      Ex commands from a script (truncated at 200 characters).
+--- 16      Ex commands.
 ---
 --- If 'verbosefile' is set then the verbose messages are not displayed.
 ---
@@ -7483,16 +7483,16 @@ vim.go.vdir = vim.go.viewdir
 
 --- Changes the effect of the `:mkview` command.  It is a comma-separated
 --- list of words.  Each word enables saving and restoring something:
----    word		save and restore ~
----    cursor	cursor position in file and in window
----    curdir	local current directory, if set with `:lcd`
----    folds	manually created folds, opened/closed folds and local
---- 		fold options
----    options	options and mappings local to a window or buffer (not
---- 		global values for local options)
+---    word         save and restore ~
+---    cursor       cursor position in file and in window
+---    curdir       local current directory, if set with `:lcd`
+---    folds        manually created folds, opened/closed folds and local
+---                 fold options
+---    options      options and mappings local to a window or buffer (not
+---                 global values for local options)
 ---    localoptions same as "options"
----    slash	`deprecated` Always enabled. Uses "/" in filenames.
----    unix		`deprecated` Always enabled. Uses "\n" line endings.
+---    slash        `deprecated` Always enabled. Uses "/" in filenames.
+---    unix         `deprecated` Always enabled. Uses "\n" line endings.
 ---
 --- @type string
 vim.o.viewoptions = "folds,cursor,curdir"
@@ -7501,14 +7501,14 @@ vim.go.viewoptions = vim.o.viewoptions
 vim.go.vop = vim.go.viewoptions
 
 --- A comma-separated list of these words:
----     block	Allow virtual editing in Visual block mode.
----     insert	Allow virtual editing in Insert mode.
----     all		Allow virtual editing in all modes.
----     onemore	Allow the cursor to move just past the end of the line
----     none	When used as the local value, do not allow virtual
---- 		editing even when the global value is set.  When used
---- 		as the global value, "none" is the same as "".
----     NONE	Alternative spelling of "none".
+---     block       Allow virtual editing in Visual block mode.
+---     insert      Allow virtual editing in Insert mode.
+---     all         Allow virtual editing in all modes.
+---     onemore     Allow the cursor to move just past the end of the line
+---     none        When used as the local value, do not allow virtual
+---                 editing even when the global value is set.  When used
+---                 as the global value, "none" is the same as "".
+---     NONE        Alternative spelling of "none".
 ---
 --- Virtual editing means that the cursor can be positioned where there is
 --- no actual character.  This can be halfway into a tab or beyond the end
@@ -7553,20 +7553,20 @@ vim.go.warn = vim.o.warn
 --- Allow specified keys that move the cursor left/right to move to the
 --- previous/next line when the cursor is on the first/last character in
 --- the line.  Concatenate characters to allow this for these keys:
---- 	char   key	  mode	~
---- 	 b    <BS>	 Normal and Visual
---- 	 s    <Space>	 Normal and Visual
---- 	 h    "h"	 Normal and Visual (not recommended)
---- 	 l    "l"	 Normal and Visual (not recommended)
---- 	 <    <Left>	 Normal and Visual
---- 	 >    <Right>	 Normal and Visual
---- 	 ~    "~"	 Normal
---- 	 [    <Left>	 Insert and Replace
---- 	 ]    <Right>	 Insert and Replace
+---         char   key        mode  ~
+---          b    <BS>       Normal and Visual
+---          s    <Space>    Normal and Visual
+---          h    "h"        Normal and Visual (not recommended)
+---          l    "l"        Normal and Visual (not recommended)
+---          <    <Left>     Normal and Visual
+---          >    <Right>    Normal and Visual
+---          ~    "~"        Normal
+---          [    <Left>     Insert and Replace
+---          ]    <Right>    Insert and Replace
 --- For example:
 ---
 --- ```vim
---- 	set ww=<,>,[,]
+---         set ww=<,>,[,]
 --- ```
 --- allows wrap only when cursor keys are used.
 --- When the movement keys are used in combination with a delete or change
@@ -7597,7 +7597,7 @@ vim.go.ww = vim.go.whichwrap
 --- Although 'wc' is a number option, you can set it to a special key:
 ---
 --- ```vim
---- 	set wc=<Tab>
+---         set wc=<Tab>
 --- ```
 ---
 ---
@@ -7614,8 +7614,8 @@ vim.go.wc = vim.go.wildchar
 --- automatically invoke completion mode, e.g.:
 ---
 --- ```vim
---- 	set wcm=<C-Z>
---- 	cnoremap ss so $vim/sessions/*.vim<C-Z>
+---         set wcm=<C-Z>
+---         cnoremap ss so $vim/sessions/*.vim<C-Z>
 --- ```
 --- Then after typing :ss you can use CTRL-P & CTRL-N.
 ---
@@ -7634,7 +7634,7 @@ vim.go.wcm = vim.go.wildcharm
 --- Example:
 ---
 --- ```vim
---- 	set wildignore=*.o,*.obj
+---         set wildignore=*.o,*.obj
 --- ```
 --- The use of `:set+=` and `:set-=` is preferred when adding or removing
 --- a pattern from the list.  This avoids problems when a future version
@@ -7672,28 +7672,28 @@ vim.go.wic = vim.go.wildignorecase
 --- a completion.
 ---
 --- While the menu is active these keys have special meanings:
---- CTRL-P		- go to the previous entry
---- CTRL-N		- go to the next entry
---- <Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
---- <PageUp>	- select a match several entries back
---- <PageDown>	- select a match several entries further
---- <Up>		- in filename/menu name completion: move up into
---- 		  parent directory or parent menu.
---- <Down>		- in filename/menu name completion: move into a
---- 		  subdirectory or submenu.
---- <CR>		- in menu completion, when the cursor is just after a
---- 		  dot: move into a submenu.
---- CTRL-E		- end completion, go back to what was there before
---- 		  selecting a match.
---- CTRL-Y		- accept the currently selected match and stop
---- 		  completion.
+--- CTRL-P          - go to the previous entry
+--- CTRL-N          - go to the next entry
+--- <Left> <Right>  - select previous/next match (like CTRL-P/CTRL-N)
+--- <PageUp>        - select a match several entries back
+--- <PageDown>      - select a match several entries further
+--- <Up>            - in filename/menu name completion: move up into
+---                   parent directory or parent menu.
+--- <Down>          - in filename/menu name completion: move into a
+---                   subdirectory or submenu.
+--- <CR>            - in menu completion, when the cursor is just after a
+---                   dot: move into a submenu.
+--- CTRL-E          - end completion, go back to what was there before
+---                   selecting a match.
+--- CTRL-Y          - accept the currently selected match and stop
+---                   completion.
 ---
 --- If you want <Left> and <Right> to move the cursor instead of selecting
 --- a different match, use this:
 ---
 --- ```vim
---- 	cnoremap <Left> <Space><BS><Left>
---- 	cnoremap <Right> <Space><BS><Right>
+---         cnoremap <Left> <Space><BS><Left>
+---         cnoremap <Right> <Space><BS><Right>
 --- ```
 ---
 --- `hl-WildMenu` highlights the current match.
@@ -7712,53 +7712,53 @@ vim.go.wmnu = vim.go.wildmenu
 ---
 --- Each part consists of a colon separated list consisting of the
 --- following possible values:
---- ""		Complete only the first match.
---- "full"		Complete the next full match.  After the last match,
---- 		the original string is used and then the first match
---- 		again.  Will also start 'wildmenu' if it is enabled.
---- "longest"	Complete till longest common string.  If this doesn't
---- 		result in a longer string, use the next part.
---- "list"		When more than one match, list all matches.
---- "lastused"	When completing buffer names and more than one buffer
---- 		matches, sort buffers by time last used (other than
---- 		the current buffer).
+--- ""              Complete only the first match.
+--- "full"          Complete the next full match.  After the last match,
+---                 the original string is used and then the first match
+---                 again.  Will also start 'wildmenu' if it is enabled.
+--- "longest"       Complete till longest common string.  If this doesn't
+---                 result in a longer string, use the next part.
+--- "list"          When more than one match, list all matches.
+--- "lastused"      When completing buffer names and more than one buffer
+---                 matches, sort buffers by time last used (other than
+---                 the current buffer).
 --- When there is only a single match, it is fully completed in all cases.
 ---
 --- Examples of useful colon-separated values:
---- "longest:full"	Like "longest", but also start 'wildmenu' if it is
---- 		enabled.  Will not complete to the next full match.
---- "list:full"	When more than one match, list all matches and
---- 		complete first match.
---- "list:longest"	When more than one match, list all matches and
---- 		complete till longest common string.
+--- "longest:full"  Like "longest", but also start 'wildmenu' if it is
+---                 enabled.  Will not complete to the next full match.
+--- "list:full"     When more than one match, list all matches and
+---                 complete first match.
+--- "list:longest"  When more than one match, list all matches and
+---                 complete till longest common string.
 --- "list:lastused" When more than one buffer matches, list all matches
---- 		and sort buffers by time last used (other than the
---- 		current buffer).
+---                 and sort buffers by time last used (other than the
+---                 current buffer).
 ---
 --- Examples:
 ---
 --- ```vim
---- 	set wildmode=full
+---         set wildmode=full
 --- ```
 --- Complete first full match, next match, etc.  (the default)
 ---
 --- ```vim
---- 	set wildmode=longest,full
+---         set wildmode=longest,full
 --- ```
 --- Complete longest common string, then each full match
 ---
 --- ```vim
---- 	set wildmode=list:full
+---         set wildmode=list:full
 --- ```
 --- List all matches and complete each full match
 ---
 --- ```vim
---- 	set wildmode=list,full
+---         set wildmode=list,full
 --- ```
 --- List all matches without completing, then each full match
 ---
 --- ```vim
---- 	set wildmode=longest,list
+---         set wildmode=longest,list
 --- ```
 --- Complete longest common string, then list alternatives.
 --- More info here: `cmdline-completion`.
@@ -7771,21 +7771,21 @@ vim.go.wim = vim.go.wildmode
 
 --- A list of words that change how `cmdline-completion` is done.
 --- The following values are supported:
----   fuzzy		Use `fuzzy-matching` to find completion matches. When
---- 		this value is specified, wildcard expansion will not
---- 		be used for completion.  The matches will be sorted by
---- 		the "best match" rather than alphabetically sorted.
---- 		This will find more matches than the wildcard
---- 		expansion. Currently fuzzy matching based completion
---- 		is not supported for file and directory names and
---- 		instead wildcard expansion is used.
----   pum		Display the completion matches using the popup menu
---- 		in the same style as the `ins-completion-menu`.
----   tagfile	When using CTRL-D to list matching tags, the kind of
---- 		tag and the file of the tag is listed.	Only one match
---- 		is displayed per line.  Often used tag kinds are:
---- 			d	#define
---- 			f	function
+---   fuzzy         Use `fuzzy-matching` to find completion matches. When
+---                 this value is specified, wildcard expansion will not
+---                 be used for completion.  The matches will be sorted by
+---                 the "best match" rather than alphabetically sorted.
+---                 This will find more matches than the wildcard
+---                 expansion. Currently fuzzy matching based completion
+---                 is not supported for file and directory names and
+---                 instead wildcard expansion is used.
+---   pum           Display the completion matches using the popup menu
+---                 in the same style as the `ins-completion-menu`.
+---   tagfile       When using CTRL-D to list matching tags, the kind of
+---                 tag and the file of the tag is listed.  Only one match
+---                 is displayed per line.  Often used tag kinds are:
+---                         d       #define
+---                         f       function
 ---
 --- @type string
 vim.o.wildoptions = "pum,tagfile"
@@ -7793,18 +7793,18 @@ vim.o.wop = vim.o.wildoptions
 vim.go.wildoptions = vim.o.wildoptions
 vim.go.wop = vim.go.wildoptions
 
---- 		only used in Win32
+--- only used in Win32
 --- Some GUI versions allow the access to menu entries by using the ALT
 --- key in combination with a character that appears underlined in the
 --- menu.  This conflicts with the use of the ALT key for mappings and
 --- entering special characters.  This option tells what to do:
----   no	Don't use ALT keys for menus.  ALT key combinations can be
---- 	mapped, but there is no automatic handling.
----   yes	ALT key handling is done by the windowing system.  ALT key
---- 	combinations cannot be mapped.
----   menu	Using ALT in combination with a character that is a menu
---- 	shortcut key, will be handled by the windowing system.  Other
---- 	keys can be mapped.
+--- no    Don't use ALT keys for menus.  ALT key combinations can be
+--- mapped, but there is no automatic handling.
+--- yes   ALT key handling is done by the windowing system.  ALT key
+--- combinations cannot be mapped.
+--- menu  Using ALT in combination with a character that is a menu
+--- shortcut key, will be handled by the windowing system.  Other
+--- keys can be mapped.
 --- If the menu is disabled by excluding 'm' from 'guioptions', the ALT
 --- key is never used for the menu.
 --- This option is not used for <F10>; on Win32.
@@ -7898,7 +7898,7 @@ vim.wo.wfw = vim.wo.winfixwidth
 --- using the `VimEnter` event:
 ---
 --- ```vim
---- 	au VimEnter * set winheight=999
+---         au VimEnter * set winheight=999
 --- ```
 --- Minimum value is 1.
 --- The height is not adjusted after one of the commands that change the
@@ -7929,7 +7929,7 @@ vim.go.wh = vim.go.winheight
 --- Example: show a different color for non-current windows:
 ---
 --- ```vim
---- 	set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
+---         set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
 --- ```
 ---
 ---
@@ -8000,8 +8000,8 @@ vim.go.wiw = vim.go.winwidth
 --- To make scrolling horizontally a bit more useful, try this:
 ---
 --- ```vim
---- 	set sidescroll=5
---- 	set listchars+=precedes:<,extends:>
+---         set sidescroll=5
+---         set listchars+=precedes:<,extends:>
 --- ```
 --- See 'sidescroll', 'listchars' and `wrap-off`.
 --- This option can't be set from a `modeline` when the 'diff' option is

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8,12 +8,12 @@ error('Cannot require a meta file')
 --- converted to a |Number| abs() returns a |Number|.  Otherwise
 --- abs() gives an error message and returns -1.
 --- Examples: >vim
----   echo abs(1.456)
---- <  1.456  >vim
----   echo abs(-5.456)
---- <  5.456  >vim
----   echo abs(-4)
---- <  4
+---         echo abs(1.456)
+--- <        1.456  >vim
+---         echo abs(-5.456)
+--- <        5.456  >vim
+---         echo abs(-4)
+--- <        4
 ---
 --- @param expr any
 --- @return number
@@ -26,10 +26,10 @@ function vim.fn.abs(expr) end
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
 --- 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo acos(0)
---- <  1.570796 >vim
----   echo acos(-0.5)
---- <  2.094395
+---         echo acos(0)
+--- <        1.570796 >vim
+---         echo acos(-0.5)
+--- <        2.094395
 ---
 --- @param expr any
 --- @return number
@@ -37,8 +37,8 @@ function vim.fn.acos(expr) end
 
 --- Append the item {expr} to |List| or |Blob| {object}.  Returns
 --- the resulting |List| or |Blob|.  Examples: >vim
----   let alist = add([1, 2, 3], item)
----   call add(mylist, "woodstock")
+---         let alist = add([1, 2, 3], item)
+---         call add(mylist, "woodstock")
 --- <Note that when {expr} is a |List| it is appended as a single
 --- item.  Use |extend()| to concatenate |Lists|.
 --- When {object} is a |Blob| then {expr} must be a number.
@@ -54,7 +54,7 @@ function vim.fn.add(object, expr) end
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `or()` and `xor()`.
 --- Example: >vim
----   let flag = and(bits, 0x80)
+---         let flag = and(bits, 0x80)
 --- <
 ---
 --- @param expr any
@@ -81,8 +81,8 @@ function vim.fn.api_info() end
 --- Returns 1 for failure ({lnum} out of range or out of memory),
 --- 0 for success.  When {text} is an empty list zero is returned,
 --- no matter the value of {lnum}.  Example: >vim
----   let failed = append(line('$'), "# THE END")
----   let failed = append(0, ["Chapter 1", "the beginning"])
+---         let failed = append(line('$'), "# THE END")
+---         let failed = append(0, ["Chapter 1", "the beginning"])
 --- <
 ---
 --- @param lnum integer
@@ -106,7 +106,7 @@ function vim.fn.append(lnum, text) end
 ---
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given. Example: >vim
----   let failed = appendbufline(13, 0, "# THE START")
+---         let failed = appendbufline(13, 0, "# THE START")
 --- <However, when {text} is an empty list then no error is given
 --- for an invalid {lnum}, since {lnum} isn't actually used.
 ---
@@ -153,12 +153,12 @@ function vim.fn.arglistid(winnr, tabnr) end
 
 --- The result is the {nr}th file in the argument list.  See
 --- |arglist|.  "argv(0)" is the first one.  Example: >vim
----   let i = 0
----   while i < argc()
----     let f = escape(fnameescape(argv(i)), '.')
----     exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
----     let i = i + 1
----   endwhile
+---         let i = 0
+---         while i < argc()
+---           let f = escape(fnameescape(argv(i)), '.')
+---           exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
+---           let i = i + 1
+---         endwhile
 --- <Without the {nr} argument, or when {nr} is -1, a |List| with
 --- the whole |arglist| is returned.
 ---
@@ -181,10 +181,10 @@ function vim.fn.argv(nr, winid) end
 --- Returns NaN if {expr} is outside the range [-1, 1].  Returns
 --- 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo asin(0.8)
---- <  0.927295 >vim
----   echo asin(-0.5)
---- <  -0.523599
+---         echo asin(0.8)
+--- <        0.927295 >vim
+---         echo asin(-0.5)
+--- <        -0.523599
 ---
 --- @param expr any
 --- @return number
@@ -210,9 +210,9 @@ function vim.fn.assert_beeps(cmd) end
 --- Float 4.0.  The value of 'ignorecase' is not used here, case
 --- always matters.
 --- Example: >vim
----   assert_equal('foo', 'bar')
+---         assert_equal('foo', 'bar')
 --- <Will result in a string to be added to |v:errors|:
----   test.vim line 12: Expected 'foo' but got 'bar' ~
+---         test.vim line 12: Expected 'foo' but got 'bar' ~
 ---
 --- @param expected any
 --- @param actual any
@@ -234,12 +234,12 @@ function vim.fn.assert_equalfile() end
 --- This can be used to assert that a command throws an exception.
 --- Using the error number, followed by a colon, avoids problems
 --- with translations: >vim
----   try
----     commandthatfails
----     call assert_false(1, 'command should have failed')
----   catch
----     call assert_exception('E492:')
----   endtry
+---         try
+---           commandthatfails
+---           call assert_false(1, 'command should have failed')
+---         catch
+---           call assert_exception('E492:')
+---         endtry
 --- <
 ---
 --- @param error any
@@ -254,16 +254,16 @@ function vim.fn.assert_exception(error, msg) end
 --- When {error} is a string it must be found literally in the
 --- first reported error. Most often this will be the error code,
 --- including the colon, e.g. "E123:". >vim
----   assert_fails('bad cmd', 'E987:')
+---         assert_fails('bad cmd', 'E987:')
 --- <
 --- When {error} is a |List| with one or two strings, these are
 --- used as patterns.  The first pattern is matched against the
 --- first reported error: >vim
----   assert_fails('cmd', ['E987:.*expected bool'])
+---         assert_fails('cmd', ['E987:.*expected bool'])
 --- <The second pattern, if present, is matched against the last
 --- reported error.  To only match the last error use an empty
 --- string for the first error: >vim
----   assert_fails('cmd', ['', 'E987:'])
+---         assert_fails('cmd', ['', 'E987:'])
 --- <
 --- If {msg} is empty then it is not used.  Do this to get the
 --- default message when passing the {lnum} argument.
@@ -330,9 +330,9 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- Use both to match the whole text.
 ---
 --- Example: >vim
----   assert_match('^f.*o$', 'foobar')
+---         assert_match('^f.*o$', 'foobar')
 --- <Will result in a string to be added to |v:errors|:
----   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+---         test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 ---
 --- @param pattern any
 --- @param actual any
@@ -392,10 +392,10 @@ function vim.fn.assert_true(actual, msg) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo atan(100)
---- <  1.560797 >vim
----   echo atan(-4.01)
---- <  -1.326405
+---         echo atan(100)
+--- <        1.560797 >vim
+---         echo atan(-4.01)
+--- <        -1.326405
 ---
 --- @param expr any
 --- @return number
@@ -407,10 +407,10 @@ function vim.fn.atan(expr) end
 --- Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
 --- |Number|.
 --- Examples: >vim
----   echo atan2(-1, 1)
---- <  -0.785398 >vim
----   echo atan2(1, -1)
---- <  2.356194
+---         echo atan2(-1, 1)
+--- <        -0.785398 >vim
+---         echo atan2(1, -1)
+--- <        2.356194
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -419,8 +419,8 @@ function vim.fn.atan2(expr1, expr2) end
 
 --- Return a List containing the number value of each byte in Blob
 --- {blob}.  Examples: >vim
----   blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
----   blob2list(0z)    " returns []
+---         blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
+---         blob2list(0z)           " returns []
 --- <Returns an empty List on error.  |list2blob()| does the
 --- opposite.
 ---
@@ -431,10 +431,10 @@ function vim.fn.blob2list(blob) end
 --- Put up a file requester.  This only works when "has("browse")"
 --- returns |TRUE| (only in some GUI versions).
 --- The input fields are:
----     {save}  when |TRUE|, select file to write
----     {title}  title for the requester
----     {initdir}  directory to start browsing in
----     {default}  default file name
+---     {save}      when |TRUE|, select file to write
+---     {title}     title for the requester
+---     {initdir}   directory to start browsing in
+---     {default}   default file name
 --- An empty string is returned when the "Cancel" button is hit,
 --- something went wrong, or browsing is not possible.
 ---
@@ -451,8 +451,8 @@ function vim.fn.browse(save, title, initdir, default) end
 --- browser is used.  In that case: select a file in the directory
 --- to be used.
 --- The input fields are:
----     {title}  title for the requester
----     {initdir}  directory to start browsing in
+---     {title}     title for the requester
+---     {initdir}   directory to start browsing in
 --- When the "Cancel" button is hit, something went wrong, or
 --- browsing is not possible, an empty string is returned.
 ---
@@ -469,9 +469,9 @@ function vim.fn.browsedir(title, initdir) end
 --- buffer is always created.
 --- The buffer will not have 'buflisted' set and not be loaded
 --- yet.  To add some text to the buffer use this: >vim
----   let bufnr = bufadd('someName')
----   call bufload(bufnr)
----   call setbufline(bufnr, 1, ['some', 'text'])
+---         let bufnr = bufadd('someName')
+---         call bufload(bufnr)
+---         call setbufline(bufnr, 1, ['some', 'text'])
 --- <Returns 0 on error.
 ---
 --- @param name string
@@ -573,13 +573,13 @@ function vim.fn.bufloaded(buf) end
 --- buffers are searched for.
 --- If the {buf} is a String, but you want to use it as a buffer
 --- number, force it to be a Number by adding zero to it: >vim
----   echo bufname("3" + 0)
+---         echo bufname("3" + 0)
 --- <If the buffer doesn't exist, or doesn't have a name, an empty
 --- string is returned. >vim
----   echo bufname("#")  " alternate buffer name
----   echo bufname(3)    " name of buffer 3
----   echo bufname("%")  " name of current buffer
----   echo bufname("file2")  " name of buffer where "file2" matches.
+---         echo bufname("#")       " alternate buffer name
+---         echo bufname(3)         " name of buffer 3
+---         echo bufname("%")       " name of current buffer
+---         echo bufname("file2")   " name of buffer where "file2" matches.
 --- <
 ---
 --- @param buf? any
@@ -593,7 +593,7 @@ function vim.fn.bufname(buf) end
 --- {create} argument is present and TRUE, a new, unlisted,
 --- buffer is created and its number is returned.
 --- bufnr("$") is the last buffer: >vim
----   let last_buffer = bufnr("$")
+---         let last_buffer = bufnr("$")
 --- <The result is a Number, which is the highest buffer number
 --- of existing buffers.  Note that not all buffers with a smaller
 --- number necessarily exist, because ":bwipeout" may have removed
@@ -609,7 +609,7 @@ function vim.fn.bufnr(buf, create) end
 --- see |bufname()| above.  If buffer {buf} doesn't exist or
 --- there is no such window, -1 is returned.  Example: >vim
 ---
----   echo "A window containing buffer 1 is " .. (bufwinid(1))
+---         echo "A window containing buffer 1 is " .. (bufwinid(1))
 --- <
 --- Only deals with the current tab page.  See |win_findbuf()| for
 --- finding more.
@@ -623,7 +623,7 @@ function vim.fn.bufwinid(buf) end
 --- If buffer {buf} doesn't exist or there is no such window, -1
 --- is returned.  Example: >vim
 ---
----   echo "A window containing buffer 1 is " .. (bufwinnr(1))
+---         echo "A window containing buffer 1 is " .. (bufwinnr(1))
 ---
 --- <The number can be used with |CTRL-W_w| and ":wincmd w"
 --- |:wincmd|.
@@ -662,11 +662,11 @@ function vim.fn.byte2line(byte) end
 --- byte index of the first byte in the character is returned.
 --- Refer to |string-offset-encoding| for more information.
 --- Example : >vim
----   echo matchstr(str, ".", byteidx(str, 3))
+---         echo matchstr(str, ".", byteidx(str, 3))
 --- <will display the fourth character.  Another way to do the
 --- same: >vim
----   let s = strpart(str, byteidx(str, 3))
----   echo strpart(s, 0, byteidx(s, 1))
+---         let s = strpart(str, byteidx(str, 3))
+---         echo strpart(s, 0, byteidx(s, 1))
 --- <Also see |strgetchar()| and |strcharpart()|.
 ---
 --- If there are less than {nr} characters -1 is returned.
@@ -675,9 +675,9 @@ function vim.fn.byte2line(byte) end
 --- See |charidx()| and |utf16idx()| for getting the character and
 --- UTF-16 index respectively from the byte index.
 --- Examples: >vim
----   echo byteidx('a😊😊', 2)  " returns 5
----   echo byteidx('a😊😊', 2, 1)  " returns 1
----   echo byteidx('a😊😊', 3, 1)  " returns 5
+---         echo byteidx('a😊😊', 2)        " returns 5
+---         echo byteidx('a😊😊', 2, 1)     " returns 1
+---         echo byteidx('a😊😊', 3, 1)     " returns 5
 --- <
 ---
 --- @param expr any
@@ -688,10 +688,10 @@ function vim.fn.byteidx(expr, nr, utf16) end
 
 --- Like byteidx(), except that a composing character is counted
 --- as a separate character.  Example: >vim
----   let s = 'e' .. nr2char(0x301)
----   echo byteidx(s, 1)
----   echo byteidxcomp(s, 1)
----   echo byteidxcomp(s, 2)
+---         let s = 'e' .. nr2char(0x301)
+---         echo byteidx(s, 1)
+---         echo byteidxcomp(s, 1)
+---         echo byteidxcomp(s, 2)
 --- <The first and third echo result in 3 ('e' plus composing
 --- character is 3 bytes), the second echo results in 1 ('e' is
 --- one byte).
@@ -720,12 +720,12 @@ function vim.fn.call(func, arglist, dict) end
 --- {expr} as a |Float| (round up).
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Examples: >vim
----   echo ceil(1.456)
---- <  2.0  >vim
----   echo ceil(-5.456)
---- <  -5.0  >vim
----   echo ceil(4.0)
---- <  4.0
+---         echo ceil(1.456)
+--- <        2.0  >vim
+---         echo ceil(-5.456)
+--- <        -5.0  >vim
+---         echo ceil(4.0)
+--- <        4.0
 ---
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 ---
@@ -768,7 +768,7 @@ function vim.fn.changenr() end
 --- If {data} is a list, the items will be joined by newlines; any
 --- newlines in an item will be sent as NUL. To send a final
 --- newline, include a final empty string. Example: >vim
----   call chansend(id, ["abc", "123\n456", ""])
+---         call chansend(id, ["abc", "123\n456", ""])
 --- <will send "abc<NL>123<NUL>456<NL>".
 ---
 --- chansend() writes raw data, not RPC messages.  If the channel
@@ -782,11 +782,11 @@ function vim.fn.chansend(id, data) end
 
 --- Return Number value of the first char in {string}.
 --- Examples: >vim
----   echo char2nr(" ")  " returns 32
----   echo char2nr("ABC")  " returns 65
----   echo char2nr("á")  " returns 225
----   echo char2nr("á"[0])  " returns 195
----   echo char2nr("\<M-x>")  " returns 128
+---         echo char2nr(" ")       " returns 32
+---         echo char2nr("ABC")     " returns 65
+---         echo char2nr("á")       " returns 225
+---         echo char2nr("á"[0])    " returns 195
+---         echo char2nr("\<M-x>")  " returns 128
 --- <Non-ASCII characters are always treated as UTF-8 characters.
 --- {utf8} is ignored, it exists only for backwards-compatibility.
 --- A combining character is a separate character.
@@ -801,11 +801,11 @@ function vim.fn.char2nr(string, utf8) end
 
 --- Return the character class of the first character in {string}.
 --- The character class is one of:
----   0  blank
----   1  punctuation
----   2  word character
----   3  emoji
----   other  specific Unicode class
+---         0       blank
+---         1       punctuation
+---         2       word character
+---         3       emoji
+---         other   specific Unicode class
 --- The class is used in patterns and word motions.
 --- Returns 0 if {string} is not a |String|.
 ---
@@ -818,8 +818,8 @@ function vim.fn.charclass(string) end
 ---
 --- Example:
 --- With the cursor on '세' in line 5 with text "여보세요": >vim
----   echo charcol('.')  " returns 3
----   echo col('.')    " returns 7
+---         echo charcol('.')       " returns 3
+---         echo col('.')           " returns 7
 ---
 --- @param expr any
 --- @param winid? integer
@@ -853,10 +853,10 @@ function vim.fn.charcol(expr, winid) end
 --- UTF-16 index from the character index.
 --- Refer to |string-offset-encoding| for more information.
 --- Examples: >vim
----   echo charidx('áb́ć', 3)    " returns 1
----   echo charidx('áb́ć', 6, 1)  " returns 4
----   echo charidx('áb́ć', 16)    " returns -1
----   echo charidx('a😊😊', 4, 0, 1)  " returns 2
+---         echo charidx('áb́ć', 3)          " returns 1
+---         echo charidx('áb́ć', 6, 1)       " returns 4
+---         echo charidx('áb́ć', 16)         " returns -1
+---         echo charidx('a😊😊', 4, 0, 1)  " returns 2
 --- <
 ---
 --- @param string string
@@ -869,23 +869,23 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 --- Change the current working directory to {dir}.  The scope of
 --- the directory change depends on the directory of the current
 --- window:
----   - If the current window has a window-local directory
----     (|:lcd|), then changes the window local directory.
----   - Otherwise, if the current tabpage has a local
----     directory (|:tcd|) then changes the tabpage local
----     directory.
----   - Otherwise, changes the global directory.
+---         - If the current window has a window-local directory
+---           (|:lcd|), then changes the window local directory.
+---         - Otherwise, if the current tabpage has a local
+---           directory (|:tcd|) then changes the tabpage local
+---           directory.
+---         - Otherwise, changes the global directory.
 --- {dir} must be a String.
 --- If successful, returns the previous working directory.  Pass
 --- this to another chdir() to restore the directory.
 --- On failure, returns an empty string.
 ---
 --- Example: >vim
----   let save_dir = chdir(newdir)
----   if save_dir != ""
----      " ... do some work
----      call chdir(save_dir)
----   endif
+---         let save_dir = chdir(newdir)
+---         if save_dir != ""
+---            " ... do some work
+---            call chdir(save_dir)
+---         endif
 ---
 --- @param dir string
 --- @return string
@@ -912,15 +912,15 @@ function vim.fn.clearmatches(win) end
 
 --- The result is a Number, which is the byte index of the column
 --- position given with {expr}.  The accepted positions are:
----     .      the cursor position
----     $      the end of the cursor line (the result is the
----       number of bytes in the cursor line plus one)
+---     .       the cursor position
+---     $       the end of the cursor line (the result is the
+---             number of bytes in the cursor line plus one)
 ---     'x      position of mark x (if the mark is not set, 0 is
----       returned)
+---             returned)
 ---     v       In Visual mode: the start of the Visual area (the
----       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
----       that it's updated right away.
+---             cursor is the end).  When not in Visual mode
+---             returns the cursor position.  Differs from |'<| in
+---             that it's updated right away.
 --- Additionally {expr} can be [lnum, col]: a |List| with the line
 --- and column number. Most useful when the column is "$", to get
 --- the last column of a specific line.  When "lnum" or "col" is
@@ -933,10 +933,10 @@ function vim.fn.clearmatches(win) end
 --- character position use |charcol()|.
 --- Note that only marks in the current file can be used.
 --- Examples: >vim
----   echo col(".")      " column of cursor
----   echo col("$")      " length of cursor line plus one
----   echo col("'t")      " column of mark t
----   echo col("'" .. markname)  " column of mark markname
+---         echo col(".")                   " column of cursor
+---         echo col("$")                   " length of cursor line plus one
+---         echo col("'t")                  " column of mark t
+---         echo col("'" .. markname)       " column of mark markname
 --- <The first column is 1.  Returns 0 if {expr} is invalid or when
 --- the window with ID {winid} is not found.
 --- For an uppercase mark the column may actually be in another
@@ -945,7 +945,7 @@ function vim.fn.clearmatches(win) end
 --- column is one higher if the cursor is after the end of the
 --- line.  Also, when using a <Cmd> mapping the cursor isn't
 --- moved, this can be used to obtain the column in Insert mode: >vim
----   imap <F2> <Cmd>echo col(".").."\n"<CR>
+---         imap <F2> <Cmd>echo col(".").."\n"<CR>
 ---
 --- @param expr any
 --- @param winid? integer
@@ -970,14 +970,14 @@ function vim.fn.col(expr, winid) end
 --- Insert mode completion.  The popup menu will appear if
 --- specified, see |ins-completion-menu|.
 --- Example: >vim
----   inoremap <F5> <C-R>=ListMonths()<CR>
+---         inoremap <F5> <C-R>=ListMonths()<CR>
 ---
----   func ListMonths()
----     call complete(col('.'), ['January', 'February', 'March',
----       \ 'April', 'May', 'June', 'July', 'August', 'September',
----       \ 'October', 'November', 'December'])
----     return ''
----   endfunc
+---         func ListMonths()
+---           call complete(col('.'), ['January', 'February', 'March',
+---             \ 'April', 'May', 'June', 'July', 'August', 'September',
+---             \ 'October', 'November', 'December'])
+---           return ''
+---         endfunc
 --- <This isn't very useful, but it shows how it works.  Note that
 --- an empty string is returned to avoid a zero being inserted.
 ---
@@ -1010,43 +1010,43 @@ function vim.fn.complete_check() end
 --- Returns a |Dictionary| with information about Insert mode
 --- completion.  See |ins-completion|.
 --- The items are:
----    mode    Current completion mode name string.
----     See |complete_info_mode| for the values.
+---    mode         Current completion mode name string.
+---                 See |complete_info_mode| for the values.
 ---    pum_visible  |TRUE| if popup menu is visible.
----     See |pumvisible()|.
----    items  List of completion matches.  Each item is a
----     dictionary containing the entries "word",
----     "abbr", "menu", "kind", "info" and "user_data".
----     See |complete-items|.
----    selected  Selected item index.  First index is zero.
----     Index is -1 if no item is selected (showing
----     typed text only, or the last completion after
----     no item is selected when using the <Up> or
----     <Down> keys)
----    inserted  Inserted string. [NOT IMPLEMENTED YET]
+---                 See |pumvisible()|.
+---    items        List of completion matches.  Each item is a
+---                 dictionary containing the entries "word",
+---                 "abbr", "menu", "kind", "info" and "user_data".
+---                 See |complete-items|.
+---    selected     Selected item index.  First index is zero.
+---                 Index is -1 if no item is selected (showing
+---                 typed text only, or the last completion after
+---                 no item is selected when using the <Up> or
+---                 <Down> keys)
+---    inserted     Inserted string. [NOT IMPLEMENTED YET]
 ---    preview_winid     Info floating preview window id.
 ---    preview_bufnr     Info floating preview buffer id.
 ---
----           *complete_info_mode*
+---                                         *complete_info_mode*
 --- mode values are:
----    ""         Not in completion mode
----    "keyword"       Keyword completion |i_CTRL-X_CTRL-N|
----    "ctrl_x"       Just pressed CTRL-X |i_CTRL-X|
----    "scroll"       Scrolling with |i_CTRL-X_CTRL-E| or
----          |i_CTRL-X_CTRL-Y|
----    "whole_line"       Whole lines |i_CTRL-X_CTRL-L|
----    "files"       File names |i_CTRL-X_CTRL-F|
----    "tags"       Tags |i_CTRL-X_CTRL-]|
+---    ""                Not in completion mode
+---    "keyword"         Keyword completion |i_CTRL-X_CTRL-N|
+---    "ctrl_x"          Just pressed CTRL-X |i_CTRL-X|
+---    "scroll"          Scrolling with |i_CTRL-X_CTRL-E| or
+---                      |i_CTRL-X_CTRL-Y|
+---    "whole_line"      Whole lines |i_CTRL-X_CTRL-L|
+---    "files"           File names |i_CTRL-X_CTRL-F|
+---    "tags"            Tags |i_CTRL-X_CTRL-]|
 ---    "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
 ---    "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
----    "dictionary"       Dictionary |i_CTRL-X_CTRL-K|
+---    "dictionary"      Dictionary |i_CTRL-X_CTRL-K|
 ---    "thesaurus"       Thesaurus |i_CTRL-X_CTRL-T|
----    "cmdline"       Vim Command line |i_CTRL-X_CTRL-V|
----    "function"       User defined completion |i_CTRL-X_CTRL-U|
----    "omni"       Omni completion |i_CTRL-X_CTRL-O|
----    "spell"       Spelling suggestions |i_CTRL-X_s|
----    "eval"       |complete()| completion
----    "unknown"       Other internal modes
+---    "cmdline"         Vim Command line |i_CTRL-X_CTRL-V|
+---    "function"        User defined completion |i_CTRL-X_CTRL-U|
+---    "omni"            Omni completion |i_CTRL-X_CTRL-O|
+---    "spell"           Spelling suggestions |i_CTRL-X_s|
+---    "eval"            |complete()| completion
+---    "unknown"         Other internal modes
 ---
 --- If the optional {what} list argument is supplied, then only
 --- the items listed in {what} are returned.  Unsupported items in
@@ -1059,12 +1059,12 @@ function vim.fn.complete_check() end
 --- Returns an empty |Dictionary| on error.
 ---
 --- Examples: >vim
----   " Get all items
----   call complete_info()
----   " Get only 'mode'
----   call complete_info(['mode'])
----   " Get only 'mode' and 'pum_visible'
----   call complete_info(['mode', 'pum_visible'])
+---         " Get all items
+---         call complete_info()
+---         " Get only 'mode'
+---         call complete_info(['mode'])
+---         " Get only 'mode' and 'pum_visible'
+---         call complete_info(['mode', 'pum_visible'])
 ---
 --- @param what? any
 --- @return table
@@ -1082,11 +1082,11 @@ function vim.fn.complete_info(what) end
 ---
 --- {choices} is a String, with the individual choices separated
 --- by '\n', e.g. >vim
----   confirm("Save changes?", "&Yes\n&No\n&Cancel")
+---         confirm("Save changes?", "&Yes\n&No\n&Cancel")
 --- <The letter after the '&' is the shortcut key for that choice.
 --- Thus you can type 'c' to select "Cancel".  The shortcut does
 --- not need to be the first letter: >vim
----   confirm("file has been modified", "&Save\nSave &All")
+---         confirm("file has been modified", "&Save\nSave &All")
 --- <For the console, the first letter of each choice is used as
 --- the default shortcut key.  Case is ignored.
 ---
@@ -1106,13 +1106,13 @@ function vim.fn.complete_info(what) end
 ---
 --- An example: >vim
 ---    let choice = confirm("What do you want?",
----       \ "&Apples\n&Oranges\n&Bananas", 2)
+---                         \ "&Apples\n&Oranges\n&Bananas", 2)
 ---    if choice == 0
----   echo "make up your mind!"
+---         echo "make up your mind!"
 ---    elseif choice == 3
----   echo "tasteful"
+---         echo "tasteful"
 ---    else
----   echo "I prefer bananas myself."
+---         echo "I prefer bananas myself."
 ---    endif
 --- <In a GUI dialog, buttons are used.  The layout of the buttons
 --- depends on the 'v' flag in 'guioptions'.  If it is included,
@@ -1145,10 +1145,10 @@ function vim.fn.copy(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo cos(100)
---- <  0.862319 >vim
----   echo cos(-4.01)
---- <  -0.646043
+---         echo cos(100)
+--- <        0.862319 >vim
+---         echo cos(-4.01)
+--- <        -0.646043
 ---
 --- @param expr any
 --- @return number
@@ -1159,10 +1159,10 @@ function vim.fn.cos(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo cosh(0.5)
---- <  1.127626 >vim
----   echo cosh(-0.5)
---- <  -1.127626
+---         echo cosh(0.5)
+--- <        1.127626 >vim
+---         echo cosh(-0.5)
+--- <        -1.127626
 ---
 --- @param expr any
 --- @return number
@@ -1237,9 +1237,9 @@ function vim.fn.cursor(lnum, col, off) end
 ---
 --- When there is one argument {list} this is used as a |List|
 --- with two, three or four item:
----   [{lnum}, {col}]
----   [{lnum}, {col}, {off}]
----   [{lnum}, {col}, {off}, {curswant}]
+---         [{lnum}, {col}]
+---         [{lnum}, {col}, {off}]
+---         [{lnum}, {col}, {off}, {curswant}]
 --- This is like the return value of |getpos()| or |getcurpos()|,
 --- but without the first item.
 ---
@@ -1292,7 +1292,7 @@ function vim.fn.debugbreak(pid) end
 --- this single copy.  With {noref} set to 1 every occurrence of a
 --- |List| or |Dictionary| results in a new copy.  This also means
 --- that a cyclic reference causes deepcopy() to fail.
----             *E724*
+---                                                 *E724*
 --- Nesting is possible up to 100 levels.  When there is an item
 --- that refers back to a higher level making a deep copy with
 --- {noref} set to 1 will fail.
@@ -1356,11 +1356,11 @@ function vim.fn.deletebufline(buf, first, last) end
 --- matching {pattern} will result in {callback} being invoked.
 ---
 --- For example, to watch all global variables: >vim
----   silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
----   function! OnDictChanged(d,k,z)
----     echomsg string(a:k) string(a:z)
----   endfunction
----   call dictwatcheradd(g:, '*', 'OnDictChanged')
+---         silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
+---         function! OnDictChanged(d,k,z)
+---           echomsg string(a:k) string(a:z)
+---         endfunction
+---         call dictwatcheradd(g:, '*', 'OnDictChanged')
 --- <
 --- For now {pattern} only accepts very simple patterns that can
 --- contain a "*" at the end of the string, in which case it will
@@ -1450,11 +1450,11 @@ function vim.fn.diff_hlID(lnum, col) end
 ---
 --- Examples: >vim
 --- " Get a built-in digraph
---- echo digraph_get('00')    " Returns '∞'
+--- echo digraph_get('00')          " Returns '∞'
 ---
 --- " Get a user-defined digraph
 --- call digraph_set('aa', 'あ')
---- echo digraph_get('aa')    " Returns 'あ'
+--- echo digraph_get('aa')          " Returns 'あ'
 --- <
 ---
 --- @param chars any
@@ -1493,10 +1493,10 @@ function vim.fn.digraph_getlist(listall) end
 --- |digraph_setlist()|.
 ---
 --- Example: >vim
----   call digraph_set('  ', 'あ')
+---         call digraph_set('  ', 'あ')
 --- <
 --- Can be used as a |method|: >vim
----   GetString()->digraph_set('あ')
+---         GetString()->digraph_set('あ')
 --- <
 ---
 --- @param chars any
@@ -1513,7 +1513,7 @@ function vim.fn.digraph_set(chars, digraph) end
 --- <
 --- It is similar to the following: >vim
 ---     for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
----     call digraph_set(chars, digraph)
+---           call digraph_set(chars, digraph)
 ---     endfor
 --- <Except that the function returns after the first error,
 --- following digraphs will not be added.
@@ -1540,10 +1540,10 @@ function vim.fn.empty(expr) end
 
 --- Return all of environment variables as dictionary. You can
 --- check if an environment variable exists like this: >vim
----   echo has_key(environ(), 'HOME')
+---         echo has_key(environ(), 'HOME')
 --- <Note that the variable name may be CamelCase; to ignore case
 --- use this: >vim
----   echo index(keys(environ()), 'HOME', 0, 1) != -1
+---         echo index(keys(environ()), 'HOME', 0, 1) != -1
 --- <
 ---
 --- @return any
@@ -1551,9 +1551,9 @@ function vim.fn.environ() end
 
 --- Escape the characters in {chars} that occur in {string} with a
 --- backslash.  Example: >vim
----   echo escape('c:\program files\vim', ' \')
+---         echo escape('c:\program files\vim', ' \')
 --- <results in: >
----   c:\\program\ files\\vim
+---         c:\\program\ files\\vim
 --- <Also see |shellescape()| and |fnameescape()|.
 ---
 --- @param string string
@@ -1583,7 +1583,7 @@ function vim.fn.eventhandler() end
 --- exists.  {expr} must be the name of the program without any
 --- arguments.
 --- executable() uses the value of $PATH and/or the normal
---- searchpath for programs.    *PATHEXT*
+--- searchpath for programs.                *PATHEXT*
 --- On MS-Windows the ".exe", ".bat", etc. can optionally be
 --- included.  Then the extensions in $PATHEXT are tried.  Thus if
 --- "foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -1596,9 +1596,9 @@ function vim.fn.eventhandler() end
 --- On Windows an executable in the same directory as Vim is
 --- always found (it is added to $PATH at |startup|).
 --- The result is a Number:
----   1  exists
----   0  does not exist
----   -1  not implemented on this system
+---         1       exists
+---         0       does not exist
+---         -1      not implemented on this system
 --- |exepath()| can be used to get the full path of an executable.
 ---
 --- @param expr any
@@ -1610,20 +1610,20 @@ function vim.fn.executable(expr) end
 --- If {command} is a |List|, returns concatenated outputs.
 --- Line continuations in {command} are not recognized.
 --- Examples: >vim
----   echo execute('echon "foo"')
---- <  foo >vim
----   echo execute(['echon "foo"', 'echon "bar"'])
---- <  foobar
+---         echo execute('echon "foo"')
+--- <       foo >vim
+---         echo execute(['echon "foo"', 'echon "bar"'])
+--- <       foobar
 ---
 --- The optional {silent} argument can have these values:
----   ""    no `:silent` used
----   "silent"  `:silent` used
----   "silent!"  `:silent!` used
+---         ""              no `:silent` used
+---         "silent"        `:silent` used
+---         "silent!"       `:silent!` used
 --- The default is "silent".  Note that with "silent!", unlike
 --- `:redir`, error messages are dropped.
 ---
 --- To get a list of lines use `split()` on the result: >vim
----   execute('args')->split("\n")
+---         execute('args')->split("\n")
 ---
 --- <This function is not available in the |sandbox|.
 --- Note: If nested, an outer execute() will not observe output of
@@ -1653,83 +1653,83 @@ function vim.fn.exepath(expr) end
 --- For checking if a file exists use |filereadable()|.
 ---
 --- The {expr} argument is a string, which contains one of these:
----   varname    internal variable (see
----   dict.key  |internal-variables|).  Also works
----   list[i]    for |curly-braces-names|, |Dictionary|
----       entries, |List| items, etc.
----       Beware that evaluating an index may
----       cause an error message for an invalid
----       expression.  E.g.: >vim
----          let l = [1, 2, 3]
----          echo exists("l[5]")
---- <         0 >vim
----          echo exists("l[xx]")
---- <         E121: Undefined variable: xx
----          0
----   &option-name  Vim option (only checks if it exists,
----       not if it really works)
----   +option-name  Vim option that works.
----   $ENVNAME  environment variable (could also be
----       done by comparing with an empty
----       string)
----   `*funcname`  built-in function (see |functions|)
----       or user defined function (see
----       |user-function|). Also works for a
----       variable that is a Funcref.
----   :cmdname  Ex command: built-in command, user
----       command or command modifier |:command|.
----       Returns:
----       1  for match with start of a command
----       2  full match with a command
----       3  matches several user commands
----       To check for a supported command
----       always check the return value to be 2.
----   :2match    The |:2match| command.
----   :3match    The |:3match| command (but you
----       probably should not use it, it is
----       reserved for internal usage)
----   #event    autocommand defined for this event
----   #event#pattern  autocommand defined for this event and
----       pattern (the pattern is taken
----       literally and compared to the
----       autocommand patterns character by
----       character)
----   #group    autocommand group exists
----   #group#event  autocommand defined for this group and
----       event.
----   #group#event#pattern
----       autocommand defined for this group,
----       event and pattern.
----   ##event    autocommand for this event is
----       supported.
+---         varname         internal variable (see
+---         dict.key        |internal-variables|).  Also works
+---         list[i]         for |curly-braces-names|, |Dictionary|
+---                         entries, |List| items, etc.
+---                         Beware that evaluating an index may
+---                         cause an error message for an invalid
+---                         expression.  E.g.: >vim
+---                            let l = [1, 2, 3]
+---                            echo exists("l[5]")
+--- <                          0 >vim
+---                            echo exists("l[xx]")
+--- <                          E121: Undefined variable: xx
+---                            0
+---         &option-name    Vim option (only checks if it exists,
+---                         not if it really works)
+---         +option-name    Vim option that works.
+---         $ENVNAME        environment variable (could also be
+---                         done by comparing with an empty
+---                         string)
+---         `*funcname`     built-in function (see |functions|)
+---                         or user defined function (see
+---                         |user-function|). Also works for a
+---                         variable that is a Funcref.
+---         :cmdname        Ex command: built-in command, user
+---                         command or command modifier |:command|.
+---                         Returns:
+---                         1  for match with start of a command
+---                         2  full match with a command
+---                         3  matches several user commands
+---                         To check for a supported command
+---                         always check the return value to be 2.
+---         :2match         The |:2match| command.
+---         :3match         The |:3match| command (but you
+---                         probably should not use it, it is
+---                         reserved for internal usage)
+---         #event          autocommand defined for this event
+---         #event#pattern  autocommand defined for this event and
+---                         pattern (the pattern is taken
+---                         literally and compared to the
+---                         autocommand patterns character by
+---                         character)
+---         #group          autocommand group exists
+---         #group#event    autocommand defined for this group and
+---                         event.
+---         #group#event#pattern
+---                         autocommand defined for this group,
+---                         event and pattern.
+---         ##event         autocommand for this event is
+---                         supported.
 ---
 --- Examples: >vim
----   echo exists("&mouse")
----   echo exists("$HOSTNAME")
----   echo exists("*strftime")
----   echo exists("*s:MyFunc")
----   echo exists("*MyFunc")
----   echo exists("bufcount")
----   echo exists(":Make")
----   echo exists("#CursorHold")
----   echo exists("#BufReadPre#*.gz")
----   echo exists("#filetypeindent")
----   echo exists("#filetypeindent#FileType")
----   echo exists("#filetypeindent#FileType#*")
----   echo exists("##ColorScheme")
+---         echo exists("&mouse")
+---         echo exists("$HOSTNAME")
+---         echo exists("*strftime")
+---         echo exists("*s:MyFunc")
+---         echo exists("*MyFunc")
+---         echo exists("bufcount")
+---         echo exists(":Make")
+---         echo exists("#CursorHold")
+---         echo exists("#BufReadPre#*.gz")
+---         echo exists("#filetypeindent")
+---         echo exists("#filetypeindent#FileType")
+---         echo exists("#filetypeindent#FileType#*")
+---         echo exists("##ColorScheme")
 --- <There must be no space between the symbol (&/$/*/#) and the
 --- name.
 --- There must be no extra characters after the name, although in
 --- a few cases this is ignored.  That may become stricter in the
 --- future, thus don't count on it!
 --- Working example: >vim
----   echo exists(":make")
+---         echo exists(":make")
 --- <NOT working example: >vim
----   echo exists(":make install")
+---         echo exists(":make install")
 ---
 --- <Note that the argument must be a string, not the name of the
 --- variable itself.  For example: >vim
----   echo exists(bufcount)
+---         echo exists(bufcount)
 --- <This doesn't check for existence of the "bufcount" variable,
 --- but gets the value of "bufcount", and checks if that exists.
 ---
@@ -1742,10 +1742,10 @@ function vim.fn.exists(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo exp(2)
---- <  7.389056 >vim
----   echo exp(-1)
---- <  0.367879
+---         echo exp(2)
+--- <        7.389056 >vim
+---         echo exp(-1)
+--- <        0.367879
 ---
 --- @param expr any
 --- @return any
@@ -1766,47 +1766,47 @@ function vim.fn.exp(expr) end
 --- done like for the |cmdline-special| variables with their
 --- associated modifiers.  Here is a short overview:
 ---
----   %    current file name
----   #    alternate file name
----   #n    alternate file name n
----   <cfile>    file name under the cursor
----   <afile>    autocmd file name
----   <abuf>    autocmd buffer number (as a String!)
----   <amatch>  autocmd matched name
----   <cexpr>    C expression under the cursor
----   <sfile>    sourced script file or function name
----   <slnum>    sourced script line number or function
----       line number
----   <sflnum>  script file line number, also when in
----       a function
----   <SID>    "<SNR>123_"  where "123" is the
----       current script ID  |<SID>|
----   <script>  sourced script file, or script file
----       where the current function was defined
----   <stack>    call stack
----   <cword>    word under the cursor
----   <cWORD>    WORD under the cursor
----   <client>  the {clientid} of the last received
----       message
+---         %               current file name
+---         #               alternate file name
+---         #n              alternate file name n
+---         <cfile>         file name under the cursor
+---         <afile>         autocmd file name
+---         <abuf>          autocmd buffer number (as a String!)
+---         <amatch>        autocmd matched name
+---         <cexpr>         C expression under the cursor
+---         <sfile>         sourced script file or function name
+---         <slnum>         sourced script line number or function
+---                         line number
+---         <sflnum>        script file line number, also when in
+---                         a function
+---         <SID>           "<SNR>123_"  where "123" is the
+---                         current script ID  |<SID>|
+---         <script>        sourced script file, or script file
+---                         where the current function was defined
+---         <stack>         call stack
+---         <cword>         word under the cursor
+---         <cWORD>         WORD under the cursor
+---         <client>        the {clientid} of the last received
+---                         message
 --- Modifiers:
----   :p    expand to full path
----   :h    head (last path component removed)
----   :t    tail (last path component only)
----   :r    root (one extension removed)
----   :e    extension only
+---         :p              expand to full path
+---         :h              head (last path component removed)
+---         :t              tail (last path component only)
+---         :r              root (one extension removed)
+---         :e              extension only
 ---
 --- Example: >vim
----   let &tags = expand("%:p:h") .. "/tags"
+---         let &tags = expand("%:p:h") .. "/tags"
 --- <Note that when expanding a string that starts with '%', '#' or
 --- '<', any following text is ignored.  This does NOT work: >vim
----   let doesntwork = expand("%:h.bak")
+---         let doesntwork = expand("%:h.bak")
 --- <Use this: >vim
----   let doeswork = expand("%:h") .. ".bak"
+---         let doeswork = expand("%:h") .. ".bak"
 --- <Also note that expanding "<cfile>" and others only returns the
 --- referenced file name without further expansion.  If "<cfile>"
 --- is "~/.cshrc", you need to do another expand() to have the
 --- "~/" expanded into the path of the home directory: >vim
----   echo expand(expand("<cfile>"))
+---         echo expand(expand("<cfile>"))
 --- <
 --- There cannot be white space between the variables and the
 --- following modifier.  The |fnamemodify()| function can be used
@@ -1827,7 +1827,7 @@ function vim.fn.exp(expr) end
 --- Names for non-existing files are included.  The "**" item can
 --- be used to search in a directory tree.  For example, to find
 --- all "README" files in the current directory and below: >vim
----   echo expand("**/README")
+---         echo expand("**/README")
 --- <
 --- expand() can also be used to expand variables and environment
 --- variables that are only known in a shell.  But this can be
@@ -1855,19 +1855,19 @@ function vim.fn.expand(string, nosuf, list) end
 ---
 --- The following items are supported in the {options} Dict
 --- argument:
----     errmsg  If set to TRUE, error messages are displayed
----     if an error is encountered during expansion.
----     By default, error messages are not displayed.
+---     errmsg      If set to TRUE, error messages are displayed
+---                 if an error is encountered during expansion.
+---                 By default, error messages are not displayed.
 ---
 --- Returns the expanded string.  If an error is encountered
 --- during expansion, the unmodified {string} is returned.
 ---
 --- Example: >vim
----   echo expandcmd('make %<.o')
+---         echo expandcmd('make %<.o')
 --- < >
----   make /path/runtime/doc/builtin.o
+---         make /path/runtime/doc/builtin.o
 --- < >vim
----   echo expandcmd('make %<.o', {'errmsg': v:true})
+---         echo expandcmd('make %<.o', {'errmsg': v:true})
 --- <
 ---
 --- @param string string
@@ -1884,15 +1884,15 @@ function vim.fn.expandcmd(string, options) end
 --- insert before the first item.  When {expr3} is equal to
 --- len({expr1}) then {expr2} is appended.
 --- Examples: >vim
----   echo sort(extend(mylist, [7, 5]))
----   call extend(mylist, [2, 3], 1)
+---         echo sort(extend(mylist, [7, 5]))
+---         call extend(mylist, [2, 3], 1)
 --- <When {expr1} is the same List as {expr2} then the number of
 --- items copied is equal to the original length of the List.
 --- E.g., when {expr3} is 1 you get N new copies of the first item
 --- (where N is the original length of the List).
 --- Use |add()| to concatenate one item to a list.  To concatenate
 --- two lists into a new list use the + operator: >vim
----   let newlist = [1, 2, 3] + [4, 5]
+---         let newlist = [1, 2, 3] + [4, 5]
 --- <
 --- If they are |Dictionaries|:
 --- Add all entries from {expr2} to {expr1}.
@@ -1900,7 +1900,7 @@ function vim.fn.expandcmd(string, options) end
 --- used to decide what to do:
 --- {expr3} = "keep": keep the value of {expr1}
 --- {expr3} = "force": use the value of {expr2}
---- {expr3} = "error": give an error message    *E737*
+--- {expr3} = "error": give an error message                *E737*
 --- When {expr3} is omitted then "force" is assumed.
 ---
 --- {expr1} is changed when {expr2} is not empty.  If necessary
@@ -1946,27 +1946,27 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 --- wait-for-character without doing anything.
 ---
 --- {mode} is a String, which can contain these character flags:
---- 'm'  Remap keys. This is default.  If {mode} is absent,
----   keys are remapped.
---- 'n'  Do not remap keys.
---- 't'  Handle keys as if typed; otherwise they are handled as
----   if coming from a mapping.  This matters for undo,
----   opening folds, etc.
---- 'i'  Insert the string instead of appending (see above).
---- 'x'  Execute commands until typeahead is empty.  This is
----   similar to using ":normal!".  You can call feedkeys()
----   several times without 'x' and then one time with 'x'
----   (possibly with an empty {string}) to execute all the
----   typeahead.  Note that when Vim ends in Insert mode it
----   will behave as if <Esc> is typed, to avoid getting
----   stuck, waiting for a character to be typed before the
----   script continues.
----   Note that if you manage to call feedkeys() while
----   executing commands, thus calling it recursively, then
----   all typeahead will be consumed by the last call.
---- '!'  When used with 'x' will not end Insert mode. Can be
----   used in a test when a timer is set to exit Insert mode
----   a little later.  Useful for testing CursorHoldI.
+--- 'm'     Remap keys. This is default.  If {mode} is absent,
+---         keys are remapped.
+--- 'n'     Do not remap keys.
+--- 't'     Handle keys as if typed; otherwise they are handled as
+---         if coming from a mapping.  This matters for undo,
+---         opening folds, etc.
+--- 'i'     Insert the string instead of appending (see above).
+--- 'x'     Execute commands until typeahead is empty.  This is
+---         similar to using ":normal!".  You can call feedkeys()
+---         several times without 'x' and then one time with 'x'
+---         (possibly with an empty {string}) to execute all the
+---         typeahead.  Note that when Vim ends in Insert mode it
+---         will behave as if <Esc> is typed, to avoid getting
+---         stuck, waiting for a character to be typed before the
+---         script continues.
+---         Note that if you manage to call feedkeys() while
+---         executing commands, thus calling it recursively, then
+---         all typeahead will be consumed by the last call.
+--- '!'     When used with 'x' will not end Insert mode. Can be
+---         used in a test when a timer is set to exit Insert mode
+---         a little later.  Useful for testing CursorHoldI.
 ---
 --- Return value is always 0.
 ---
@@ -1989,13 +1989,13 @@ function vim.fn.file_readable(file) end
 --- If you don't care about the file being readable you can use
 --- |glob()|.
 --- {file} is used as-is, you may want to expand wildcards first: >vim
----   echo filereadable('~/.vimrc')
+---         echo filereadable('~/.vimrc')
 --- < >
----   0
+---         0
 --- < >vim
----   echo filereadable(expand('~/.vimrc'))
+---         echo filereadable(expand('~/.vimrc'))
 --- < >
----   1
+---         1
 --- <
 ---
 --- @param file string
@@ -2026,11 +2026,11 @@ function vim.fn.filewritable(file) end
 --- current byte. For a |String| |v:key| has the index of the
 --- current character.
 --- Examples: >vim
----   call filter(mylist, 'v:val !~ "OLD"')
+---         call filter(mylist, 'v:val !~ "OLD"')
 --- <Removes the items where "OLD" appears. >vim
----   call filter(mydict, 'v:key >= 8')
+---         call filter(mydict, 'v:key >= 8')
 --- <Removes the items with a key below 8. >vim
----   call filter(var, 0)
+---         call filter(var, 0)
 --- <Removes all the items, thus clears the |List| or |Dictionary|.
 ---
 --- Note that {expr2} is the result of expression and is then
@@ -2038,23 +2038,23 @@ function vim.fn.filewritable(file) end
 --- |literal-string| to avoid having to double backslashes.
 ---
 --- If {expr2} is a |Funcref| it must take two arguments:
----   1. the key or the index of the current item.
----   2. the value of the current item.
+---         1. the key or the index of the current item.
+---         2. the value of the current item.
 --- The function must return |TRUE| if the item should be kept.
 --- Example that keeps the odd items of a list: >vim
----   func Odd(idx, val)
----     return a:idx % 2 == 1
----   endfunc
----   call filter(mylist, function('Odd'))
+---         func Odd(idx, val)
+---           return a:idx % 2 == 1
+---         endfunc
+---         call filter(mylist, function('Odd'))
 --- <It is shorter when using a |lambda|: >vim
----   call filter(myList, {idx, val -> idx * val <= 42})
+---         call filter(myList, {idx, val -> idx * val <= 42})
 --- <If you do not use "val" you can leave it out: >vim
----   call filter(myList, {idx -> idx % 2 == 1})
+---         call filter(myList, {idx -> idx % 2 == 1})
 --- <
 --- For a |List| and a |Dictionary| the operation is done
 --- in-place.  If you want it to remain unmodified make a copy
 --- first: >vim
----   let l = filter(copy(mylist), 'v:val =~ "KEEP"')
+---         let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 ---
 --- <Returns {expr1}, the |List| or |Dictionary| that was filtered,
 --- or a new |Blob| or |String|.
@@ -2094,7 +2094,7 @@ function vim.fn.finddir(name, path, count) end
 --- Just like |finddir()|, but find a file instead of a directory.
 --- Uses 'suffixesadd'.
 --- Example: >vim
----   echo findfile("tags.vim", ".;")
+---         echo findfile("tags.vim", ".;")
 --- <Searches from the directory of the current file upwards until
 --- it finds the file "tags.vim".
 ---
@@ -2109,7 +2109,7 @@ function vim.fn.findfile(name, path, count) end
 --- a very large number.
 --- The {list} is changed in place, use |flattennew()| if you do
 --- not want that.
----             *E900*
+---                                                 *E900*
 --- {maxdepth} means how deep in nested lists changes are made.
 --- {list} is not modified when {maxdepth} is 0.
 --- {maxdepth} must be positive number.
@@ -2117,10 +2117,10 @@ function vim.fn.findfile(name, path, count) end
 --- If there is an error the number zero is returned.
 ---
 --- Example: >vim
----   echo flatten([1, [2, [3, 4]], 5])
---- <  [1, 2, 3, 4, 5] >vim
----   echo flatten([1, [2, [3, 4]], 5], 1)
---- <  [1, 2, [3, 4], 5]
+---         echo flatten([1, [2, [3, 4]], 5])
+--- <        [1, 2, 3, 4, 5] >vim
+---         echo flatten([1, [2, [3, 4]], 5], 1)
+--- <        [1, 2, [3, 4], 5]
 ---
 --- @param list any
 --- @param maxdepth? any
@@ -2144,16 +2144,16 @@ function vim.fn.flattennew(list, maxdepth) end
 --- -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
 --- 64-bit Number support is enabled, -0x8000000000000000).
 --- Examples: >vim
----   echo float2nr(3.95)
---- <  3  >vim
----   echo float2nr(-23.45)
---- <  -23  >vim
----   echo float2nr(1.0e100)
---- <  2147483647  (or 9223372036854775807) >vim
----   echo float2nr(-1.0e150)
---- <  -2147483647 (or -9223372036854775807) >vim
----   echo float2nr(1.0e-100)
---- <  0
+---         echo float2nr(3.95)
+--- <        3  >vim
+---         echo float2nr(-23.45)
+--- <        -23  >vim
+---         echo float2nr(1.0e100)
+--- <        2147483647  (or 9223372036854775807) >vim
+---         echo float2nr(-1.0e150)
+--- <        -2147483647 (or -9223372036854775807) >vim
+---         echo float2nr(1.0e-100)
+--- <        0
 ---
 --- @param expr any
 --- @return any
@@ -2164,12 +2164,12 @@ function vim.fn.float2nr(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo floor(1.856)
---- <  1.0  >vim
----   echo floor(-5.456)
---- <  -6.0  >vim
----   echo floor(4.0)
---- <  4.0
+---         echo floor(1.856)
+--- <        1.0  >vim
+---         echo floor(-5.456)
+--- <        -6.0  >vim
+---         echo floor(4.0)
+--- <        4.0
 ---
 --- @param expr any
 --- @return any
@@ -2185,10 +2185,10 @@ function vim.fn.floor(expr) end
 --- Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
 --- |Number|.
 --- Examples: >vim
----   echo fmod(12.33, 1.22)
---- <  0.13 >vim
----   echo fmod(-12.33, 1.22)
---- <  -0.13
+---         echo fmod(12.33, 1.22)
+--- <        0.13 >vim
+---         echo fmod(-12.33, 1.22)
+--- <        -0.13
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -2205,10 +2205,10 @@ function vim.fn.fmod(expr1, expr2) end
 --- and |:write|).  And a "-" by itself (special after |:cd|).
 --- Returns an empty string on error.
 --- Example: >vim
----   let fname = '+some str%nge|name'
----   exe "edit " .. fnameescape(fname)
+---         let fname = '+some str%nge|name'
+---         exe "edit " .. fnameescape(fname)
 --- <results in executing: >vim
----   edit \+some\ str\%nge\|name
+---         edit \+some\ str\%nge\|name
 --- <
 ---
 --- @param string string
@@ -2219,9 +2219,9 @@ function vim.fn.fnameescape(string) end
 --- string of characters like it is used for file names on the
 --- command line.  See |filename-modifiers|.
 --- Example: >vim
----   echo fnamemodify("main.c", ":p:h")
+---         echo fnamemodify("main.c", ":p:h")
 --- <results in: >
----   /home/user/vim/vim/src
+---         /home/user/vim/vim/src
 --- <If {mods} is empty or an unsupported modifier is used then
 --- {fname} is returned.
 --- When {fname} is empty then with {mods} ":h" returns ".", so
@@ -2276,7 +2276,7 @@ function vim.fn.foldlevel(lnum) end
 --- only be called from evaluating 'foldtext'.  It uses the
 --- |v:foldstart|, |v:foldend| and |v:folddashes| variables.
 --- The returned string looks like this: >
----   +-- 45 lines: abcdef
+---         +-- 45 lines: abcdef
 --- <The number of leading dashes depends on the foldlevel.  The
 --- "45" is the number of lines in the fold.  "abcdef" is the text
 --- in the first non-blank line of the fold.  Leading white space,
@@ -2341,8 +2341,8 @@ function vim.fn.funcref(name, arglist, dict) end
 --- {name} can also be a Funcref or a partial. When it is a
 --- partial the dict stored in it will be used and the {dict}
 --- argument is not allowed. E.g.: >vim
----   let FuncWithArg = function(dict.Func, [arg])
----   let Broken = function(dict.Func, [arg], dict)
+---         let FuncWithArg = function(dict.Func, [arg])
+---         let Broken = function(dict.Func, [arg], dict)
 --- <
 --- When using the Funcref the function will be found by {name},
 --- also when it was redefined later. Use |funcref()| to keep the
@@ -2354,64 +2354,64 @@ function vim.fn.funcref(name, arglist, dict) end
 ---
 --- The arguments are passed to the function in front of other
 --- arguments, but after any argument from |method|.  Example: >vim
----   func Callback(arg1, arg2, name)
----   "...
----   endfunc
----   let Partial = function('Callback', ['one', 'two'])
----   "...
----   call Partial('name')
+---         func Callback(arg1, arg2, name)
+---         "...
+---         endfunc
+---         let Partial = function('Callback', ['one', 'two'])
+---         "...
+---         call Partial('name')
 --- <Invokes the function as with: >vim
----   call Callback('one', 'two', 'name')
+---         call Callback('one', 'two', 'name')
 ---
 --- <With a |method|: >vim
----   func Callback(one, two, three)
----   "...
----   endfunc
----   let Partial = function('Callback', ['two'])
----   "...
----   eval 'one'->Partial('three')
+---         func Callback(one, two, three)
+---         "...
+---         endfunc
+---         let Partial = function('Callback', ['two'])
+---         "...
+---         eval 'one'->Partial('three')
 --- <Invokes the function as with: >vim
----   call Callback('one', 'two', 'three')
+---         call Callback('one', 'two', 'three')
 ---
 --- <The function() call can be nested to add more arguments to the
 --- Funcref.  The extra arguments are appended to the list of
 --- arguments.  Example: >vim
----   func Callback(arg1, arg2, name)
----   "...
----   endfunc
----   let Func = function('Callback', ['one'])
----   let Func2 = function(Func, ['two'])
----   "...
----   call Func2('name')
+---         func Callback(arg1, arg2, name)
+---         "...
+---         endfunc
+---         let Func = function('Callback', ['one'])
+---         let Func2 = function(Func, ['two'])
+---         "...
+---         call Func2('name')
 --- <Invokes the function as with: >vim
----   call Callback('one', 'two', 'name')
+---         call Callback('one', 'two', 'name')
 ---
 --- <The Dictionary is only useful when calling a "dict" function.
 --- In that case the {dict} is passed in as "self". Example: >vim
----   function Callback() dict
----      echo "called for " .. self.name
----   endfunction
----   "...
----   let context = {"name": "example"}
----   let Func = function('Callback', context)
----   "...
----   call Func()  " will echo: called for example
+---         function Callback() dict
+---            echo "called for " .. self.name
+---         endfunction
+---         "...
+---         let context = {"name": "example"}
+---         let Func = function('Callback', context)
+---         "...
+---         call Func()     " will echo: called for example
 --- <The use of function() is not needed when there are no extra
 --- arguments, these two are equivalent, if Callback() is defined
 --- as context.Callback(): >vim
----   let Func = function('Callback', context)
----   let Func = context.Callback
+---         let Func = function('Callback', context)
+---         let Func = context.Callback
 ---
 --- <The argument list and the Dictionary can be combined: >vim
----   function Callback(arg1, count) dict
----   "...
----   endfunction
----   let context = {"name": "example"}
----   let Func = function('Callback', ['one'], context)
----   "...
----   call Func(500)
+---         function Callback(arg1, count) dict
+---         "...
+---         endfunction
+---         let context = {"name": "example"}
+---         let Func = function('Callback', ['one'], context)
+---         "...
+---         call Func(500)
 --- <Invokes the function as with: >vim
----   call context.Callback('one', 500)
+---         call context.Callback('one', 500)
 --- <
 --- Returns 0 on error.
 ---
@@ -2467,7 +2467,7 @@ function vim.fn.get(blob, idx, default) end
 --- Get item with key {key} from |Dictionary| {dict}.  When this
 --- item is not available return {default}.  Return zero when
 --- {default} is omitted.  Useful example: >vim
----   let val = get(g:, 'var_name', 'default')
+---         let val = get(g:, 'var_name', 'default')
 --- <This gets the value of g:var_name if it exists, and uses
 --- "default" when it does not exist.
 ---
@@ -2479,10 +2479,10 @@ function vim.fn.get(dict, key, default) end
 
 --- Get item {what} from Funcref {func}.  Possible values for
 --- {what} are:
----   "name"  The function name
----   "func"  The function
----   "dict"  The dictionary
----   "args"  The list with arguments
+---         "name"  The function name
+---         "func"  The function
+---         "dict"  The dictionary
+---         "args"  The list with arguments
 --- Returns zero on error.
 ---
 --- @param func function
@@ -2502,9 +2502,9 @@ function vim.fn.getbufinfo(buf) end
 --- When the argument is a |Dictionary| only the buffers matching
 --- the specified criteria are returned.  The following keys can
 --- be specified in {dict}:
----   buflisted  include only listed buffers.
----   bufloaded  include only loaded buffers.
----   bufmodified  include only modified buffers.
+---         buflisted       include only listed buffers.
+---         bufloaded       include only loaded buffers.
+---         bufmodified     include only modified buffers.
 ---
 --- Otherwise, {buf} specifies a particular buffer to return
 --- information for.  For the use of {buf}, see |bufname()|
@@ -2513,50 +2513,50 @@ function vim.fn.getbufinfo(buf) end
 ---
 --- Each returned List item is a dictionary with the following
 --- entries:
----   bufnr    Buffer number.
----   changed    TRUE if the buffer is modified.
----   changedtick  Number of changes made to the buffer.
----   hidden    TRUE if the buffer is hidden.
----   lastused  Timestamp in seconds, like
----       |localtime()|, when the buffer was
----       last used.
----   listed    TRUE if the buffer is listed.
----   lnum    Line number used for the buffer when
----       opened in the current window.
----       Only valid if the buffer has been
----       displayed in the window in the past.
----       If you want the line number of the
----       last known cursor position in a given
----       window, use |line()|: >vim
----         echo line('.', {winid})
+---         bufnr           Buffer number.
+---         changed         TRUE if the buffer is modified.
+---         changedtick     Number of changes made to the buffer.
+---         hidden          TRUE if the buffer is hidden.
+---         lastused        Timestamp in seconds, like
+---                         |localtime()|, when the buffer was
+---                         last used.
+---         listed          TRUE if the buffer is listed.
+---         lnum            Line number used for the buffer when
+---                         opened in the current window.
+---                         Only valid if the buffer has been
+---                         displayed in the window in the past.
+---                         If you want the line number of the
+---                         last known cursor position in a given
+---                         window, use |line()|: >vim
+---                                 echo line('.', {winid})
 --- <
----   linecount  Number of lines in the buffer (only
----       valid when loaded)
----   loaded    TRUE if the buffer is loaded.
----   name    Full path to the file in the buffer.
----   signs    List of signs placed in the buffer.
----       Each list item is a dictionary with
----       the following fields:
----           id    sign identifier
----           lnum  line number
----           name  sign name
----   variables  A reference to the dictionary with
----       buffer-local variables.
----   windows    List of |window-ID|s that display this
----       buffer
+---         linecount       Number of lines in the buffer (only
+---                         valid when loaded)
+---         loaded          TRUE if the buffer is loaded.
+---         name            Full path to the file in the buffer.
+---         signs           List of signs placed in the buffer.
+---                         Each list item is a dictionary with
+---                         the following fields:
+---                             id    sign identifier
+---                             lnum  line number
+---                             name  sign name
+---         variables       A reference to the dictionary with
+---                         buffer-local variables.
+---         windows         List of |window-ID|s that display this
+---                         buffer
 ---
 --- Examples: >vim
----   for buf in getbufinfo()
----       echo buf.name
----   endfor
----   for buf in getbufinfo({'buflisted':1})
----       if buf.changed
----     " ....
----       endif
----   endfor
+---         for buf in getbufinfo()
+---             echo buf.name
+---         endfor
+---         for buf in getbufinfo({'buflisted':1})
+---             if buf.changed
+---                 " ....
+---             endif
+---         endfor
 --- <
 --- To get buffer-local options use: >vim
----   getbufvar({bufnr}, '&option_name')
+---         getbufvar({bufnr}, '&option_name')
 --- <
 ---
 --- @param dict? vim.fn.getbufinfo.dict
@@ -2585,7 +2585,7 @@ function vim.fn.getbufinfo(dict) end
 --- non-existing buffers, an empty |List| is returned.
 ---
 --- Example: >vim
----   let lines = getbufline(bufnr("myfile"), 1, "$")
+---         let lines = getbufline(bufnr("myfile"), 1, "$")
 ---
 --- @param buf any
 --- @param lnum integer
@@ -2618,8 +2618,8 @@ function vim.fn.getbufoneline(buf, lnum) end
 --- When the buffer or variable doesn't exist {def} or an empty
 --- string is returned, there is no error message.
 --- Examples: >vim
----   let bufmodified = getbufvar(1, "&mod")
----   echo "todo myvar = " .. getbufvar("todo", "myvar")
+---         let bufmodified = getbufvar(1, "&mod")
+---         echo "todo myvar = " .. getbufvar("todo", "myvar")
 ---
 --- @param buf any
 --- @param varname string
@@ -2643,9 +2643,9 @@ function vim.fn.getcellwidths() end
 --- locations and the current position in the list.  Each
 --- entry in the change list is a dictionary with the following
 --- entries:
----   col    column number
----   coladd    column offset for 'virtualedit'
----   lnum    line number
+---         col             column number
+---         coladd          column offset for 'virtualedit'
+---         lnum            line number
 --- If buffer {buf} is the current buffer, then the current
 --- position refers to the position in the list. For other
 --- buffers, it is set to the length of the list.
@@ -2657,9 +2657,9 @@ function vim.fn.getchangelist(buf) end
 --- Get a single character from the user or input stream.
 --- If [expr] is omitted, wait until a character is available.
 --- If [expr] is 0, only get a character when one is available.
----   Return zero otherwise.
+---         Return zero otherwise.
 --- If [expr] is 1, only check if a character is available, it is
----   not consumed.  Return zero if no character available.
+---         not consumed.  Return zero if no character available.
 --- If you prefer always getting a string use |getcharstr()|.
 ---
 --- Without [expr] and when [expr] is 0 a whole character or
@@ -2688,12 +2688,12 @@ function vim.fn.getchangelist(buf) end
 --- |getmousepos()| can also be used.  Mouse move events will be
 --- ignored.
 --- This example positions the mouse as it would normally happen: >vim
----   let c = getchar()
----   if c == "\<LeftMouse>" && v:mouse_win > 0
----     exe v:mouse_win .. "wincmd w"
----     exe v:mouse_lnum
----     exe "normal " .. v:mouse_col .. "|"
----   endif
+---         let c = getchar()
+---         if c == "\<LeftMouse>" && v:mouse_win > 0
+---           exe v:mouse_win .. "wincmd w"
+---           exe v:mouse_lnum
+---           exe "normal " .. v:mouse_col .. "|"
+---         endif
 --- <
 --- There is no prompt, you will somehow have to make clear to the
 --- user that a character has to be typed.  The screen is not
@@ -2703,19 +2703,19 @@ function vim.fn.getchangelist(buf) end
 --- Key codes are replaced, thus when the user presses the <Del>
 --- key you get the code for the <Del> key, not the raw character
 --- sequence.  Examples: >vim
----   getchar() == "\<Del>"
----   getchar() == "\<S-Left>"
+---         getchar() == "\<Del>"
+---         getchar() == "\<S-Left>"
 --- <This example redefines "f" to ignore case: >vim
----   nmap f :call FindChar()<CR>
----   function FindChar()
----     let c = nr2char(getchar())
----     while col('.') < col('$') - 1
----       normal l
----       if getline('.')[col('.') - 1] ==? c
----         break
----       endif
----     endwhile
----   endfunction
+---         nmap f :call FindChar()<CR>
+---         function FindChar()
+---           let c = nr2char(getchar())
+---           while col('.') < col('$') - 1
+---             normal l
+---             if getline('.')[col('.') - 1] ==? c
+---               break
+---             endif
+---           endwhile
+---         endfunction
 --- <
 ---
 --- @return integer
@@ -2724,14 +2724,14 @@ function vim.fn.getchar() end
 --- The result is a Number which is the state of the modifiers for
 --- the last obtained character with getchar() or in another way.
 --- These values are added together:
----   2  shift
----   4  control
----   8  alt (meta)
----   16  meta (when it's different from ALT)
----   32  mouse double click
----   64  mouse triple click
----   96  mouse quadruple click (== 32 + 64)
----   128  command (Macintosh only)
+---         2       shift
+---         4       control
+---         8       alt (meta)
+---         16      meta (when it's different from ALT)
+---         32      mouse double click
+---         64      mouse triple click
+---         96      mouse quadruple click (== 32 + 64)
+---         128     command (Macintosh only)
 --- Only the modifiers that have not been included in the
 --- character itself are obtained.  Thus Shift-a results in "A"
 --- without a modifier.  Returns 0 if no modifiers are used.
@@ -2748,8 +2748,8 @@ function vim.fn.getcharmod() end
 ---
 --- Example:
 --- With the cursor on '세' in line 5 with text "여보세요": >vim
----   getcharpos('.')    returns [0, 5, 3, 0]
----   getpos('.')    returns [0, 5, 7, 0]
+---         getcharpos('.')         returns [0, 5, 3, 0]
+---         getpos('.')             returns [0, 5, 7, 0]
 --- <
 ---
 --- @param expr any
@@ -2759,20 +2759,20 @@ function vim.fn.getcharpos(expr) end
 --- Return the current character search information as a {dict}
 --- with the following entries:
 ---
----     char  character previously used for a character
----     search (|t|, |f|, |T|, or |F|); empty string
----     if no character search has been performed
----     forward  direction of character search; 1 for forward,
----     0 for backward
----     until  type of character search; 1 for a |t| or |T|
----     character search, 0 for an |f| or |F|
----     character search
+---     char        character previously used for a character
+---                 search (|t|, |f|, |T|, or |F|); empty string
+---                 if no character search has been performed
+---     forward     direction of character search; 1 for forward,
+---                 0 for backward
+---     until       type of character search; 1 for a |t| or |T|
+---                 character search, 0 for an |f| or |F|
+---                 character search
 ---
 --- This can be useful to always have |;| and |,| search
 --- forward/backward regardless of the direction of the previous
 --- character search: >vim
----   nnoremap <expr> ; getcharsearch().forward ? ';' : ','
----   nnoremap <expr> , getcharsearch().forward ? ',' : ';'
+---         nnoremap <expr> ; getcharsearch().forward ? ';' : ','
+---         nnoremap <expr> , getcharsearch().forward ? ',' : ';'
 --- <Also see |setcharsearch()|.
 ---
 --- @return table[]
@@ -2782,10 +2782,10 @@ function vim.fn.getcharsearch() end
 --- string.
 --- If [expr] is omitted, wait until a character is available.
 --- If [expr] is 0 or false, only get a character when one is
----   available.  Return an empty string otherwise.
+---         available.  Return an empty string otherwise.
 --- If [expr] is 1 or true, only check if a character is
----   available, it is not consumed.  Return an empty string
----   if no character is available.
+---         available, it is not consumed.  Return an empty string
+---         if no character is available.
 --- Otherwise this works like |getchar()|, except that a number
 --- result is converted to a string.
 ---
@@ -2807,7 +2807,7 @@ function vim.fn.getcmdcompltype() end
 --- line is being edited, thus requires use of |c_CTRL-\_e| or
 --- |c_CTRL-R_=|.
 --- Example: >vim
----   cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
+---         cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
 --- <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
 --- |setcmdline()|.
 --- Returns an empty string when entering a password or using
@@ -2841,13 +2841,13 @@ function vim.fn.getcmdscreenpos() end
 
 --- Return the current command-line type. Possible return values
 --- are:
----     :  normal Ex command
----     >  debug mode command |debug-mode|
----     /  forward search command
----     ?  backward search command
----     \@  |input()| command
----     `-`  |:insert| or |:append| command
----     =  |i_CTRL-R_=|
+---     :   normal Ex command
+---     >   debug mode command |debug-mode|
+---     /   forward search command
+---     ?   backward search command
+---     @   |input()| command
+---     `-` |:insert| or |:append| command
+---     =   |i_CTRL-R_=|
 --- Only works when editing the command line, thus requires use of
 --- |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
 --- Returns an empty string otherwise.
@@ -2867,45 +2867,45 @@ function vim.fn.getcmdwintype() end
 --- {type} argument specifies what for.  The following completion
 --- types are supported:
 ---
---- arglist    file names in argument list
---- augroup    autocmd groups
---- buffer    buffer names
---- breakpoint  |:breakadd| and |:breakdel| suboptions
---- cmdline    |cmdline-completion| result
---- color    color schemes
---- command    Ex command
---- compiler  compilers
---- custom,{func}  custom completion, defined via {func}
+--- arglist         file names in argument list
+--- augroup         autocmd groups
+--- buffer          buffer names
+--- breakpoint      |:breakadd| and |:breakdel| suboptions
+--- cmdline         |cmdline-completion| result
+--- color           color schemes
+--- command         Ex command
+--- compiler        compilers
+--- custom,{func}   custom completion, defined via {func}
 --- customlist,{func} custom completion, defined via {func}
---- diff_buffer  |:diffget| and |:diffput| completion
---- dir    directory names
---- environment  environment variable names
---- event    autocommand events
---- expression  Vim expression
---- file    file and directory names
---- file_in_path  file and directory names in |'path'|
---- filetype  filetype names |'filetype'|
---- function  function name
---- help    help subjects
---- highlight  highlight groups
---- history    |:history| suboptions
---- locale    locale names (as output of locale -a)
---- mapclear  buffer argument
---- mapping    mapping name
---- menu    menus
---- messages  |:messages| suboptions
---- option    options
---- packadd    optional package |pack-add| names
---- runtime    |:runtime| completion
---- scriptnames  sourced script names |:scriptnames|
---- shellcmd  Shell command
---- sign    |:sign| suboptions
---- syntax    syntax file names |'syntax'|
---- syntime    |:syntime| suboptions
---- tag    tags
---- tag_listfiles  tags, file names
---- user    user names
---- var    user variables
+--- diff_buffer     |:diffget| and |:diffput| completion
+--- dir             directory names
+--- environment     environment variable names
+--- event           autocommand events
+--- expression      Vim expression
+--- file            file and directory names
+--- file_in_path    file and directory names in |'path'|
+--- filetype        filetype names |'filetype'|
+--- function        function name
+--- help            help subjects
+--- highlight       highlight groups
+--- history         |:history| suboptions
+--- locale          locale names (as output of locale -a)
+--- mapclear        buffer argument
+--- mapping         mapping name
+--- menu            menus
+--- messages        |:messages| suboptions
+--- option          options
+--- packadd         optional package |pack-add| names
+--- runtime         |:runtime| completion
+--- scriptnames     sourced script names |:scriptnames|
+--- shellcmd        Shell command
+--- sign            |:sign| suboptions
+--- syntax          syntax file names |'syntax'|
+--- syntime         |:syntime| suboptions
+--- tag             tags
+--- tag_listfiles   tags, file names
+--- user            user names
+--- var             user variables
 ---
 --- If {pat} is an empty string, then all the matches are
 --- returned.  Otherwise only items matching {pat} are returned.
@@ -2925,7 +2925,7 @@ function vim.fn.getcmdwintype() end
 --- If {type} is "cmdline", then the |cmdline-completion| result is
 --- returned.  For example, to complete the possible values after
 --- a ":call" command: >vim
----   echo getcompletion('call ', 'cmdline')
+---         echo getcompletion('call ', 'cmdline')
 --- <
 --- If there are no matches, an empty list is returned.  An
 --- invalid value for {type} produces an error.
@@ -2954,9 +2954,9 @@ function vim.fn.getcompletion(pat, type, filtered) end
 --- If {winid} is invalid a list with zeroes is returned.
 ---
 --- This can be used to save and restore the cursor position: >vim
----   let save_cursor = getcurpos()
----   MoveTheCursorAround
----   call setpos('.', save_cursor)
+---         let save_cursor = getcurpos()
+---         MoveTheCursorAround
+---         call setpos('.', save_cursor)
 --- <Note that this only works within the window.  See
 --- |winrestview()| for restoring more state.
 ---
@@ -2969,8 +2969,8 @@ function vim.fn.getcurpos(winid) end
 ---
 --- Example:
 --- With the cursor on '보' in line 3 with text "여보세요": >vim
----   getcursorcharpos()  " returns [0, 3, 2, 0, 3]
----   getcurpos()    " returns [0, 3, 4, 0, 3]
+---         getcursorcharpos()      " returns [0, 3, 2, 0, 3]
+---         getcurpos()             " returns [0, 3, 4, 0, 3]
 --- <
 ---
 --- @param winid? integer
@@ -2984,8 +2984,8 @@ function vim.fn.getcursorcharpos(winid) end
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing tab number implies 0.
 --- Thus the following are equivalent: >vim
----   getcwd(0)
----   getcwd(0, 0)
+---         getcwd(0)
+---         getcwd(0, 0)
 --- <If {winnr} is -1 it is ignored, only the tab is resolved.
 --- {winnr} can be the window number or the |window-ID|.
 --- If both {winnr} and {tabnr} are -1 the global working
@@ -2999,7 +2999,7 @@ function vim.fn.getcwd(winnr, tabnr) end
 
 --- Return the value of environment variable {name}.  The {name}
 --- argument is a string, without a leading '$'.  Example: >vim
----   myHome = getenv('HOME')
+---         myHome = getenv('HOME')
 ---
 --- <When the variable does not exist |v:null| is returned.  That
 --- is different from a variable set to an empty string.
@@ -3033,8 +3033,8 @@ function vim.fn.getfontname(name) end
 --- of the file, the group the file belongs to, and other users.
 --- If a user does not have a given permission the flag for this
 --- is replaced with the string "-".  Examples: >vim
----   echo getfperm("/etc/passwd")
----   echo getfperm(expand("~/.config/nvim/init.vim"))
+---         echo getfperm("/etc/passwd")
+---         echo getfperm(expand("~/.config/nvim/init.vim"))
 --- <This will hopefully (from a security point of view) display
 --- the string "rw-r--r--" or even "rw-------".
 ---
@@ -3070,16 +3070,16 @@ function vim.fn.getftime(fname) end
 --- If {fname} does not exist an empty string is returned.
 --- Here is a table over different kinds of files and their
 --- results:
----   Normal file    "file"
----   Directory    "dir"
----   Symbolic link    "link"
----   Block device    "bdev"
----   Character device  "cdev"
----   Socket      "socket"
----   FIFO      "fifo"
----   All other    "other"
+---         Normal file             "file"
+---         Directory               "dir"
+---         Symbolic link           "link"
+---         Block device            "bdev"
+---         Character device        "cdev"
+---         Socket                  "socket"
+---         FIFO                    "fifo"
+---         All other               "other"
 --- Example: >vim
----   getftype("/home")
+---         getftype("/home")
 --- <Note that a type such as "link" will only be returned on
 --- systems that support it.  On some systems only "dir" and
 --- "file" are returned.
@@ -3101,11 +3101,11 @@ function vim.fn.getftype(fname) end
 --- locations and the last used jump position number in the list.
 --- Each entry in the jump location list is a dictionary with
 --- the following entries:
----   bufnr    buffer number
----   col    column number
----   coladd    column offset for 'virtualedit'
----   filename  filename if available
----   lnum    line number
+---         bufnr           buffer number
+---         col             column number
+---         coladd          column offset for 'virtualedit'
+---         filename        filename if available
+---         lnum            line number
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -3114,11 +3114,11 @@ function vim.fn.getjumplist(winnr, tabnr) end
 
 --- Without {end} the result is a String, which is line {lnum}
 --- from the current buffer.  Example: >vim
----   getline(1)
+---         getline(1)
 --- <When {lnum} is a String that doesn't start with a
 --- digit, |line()| is called to translate the String into a Number.
 --- To get the line under the cursor: >vim
----   getline(".")
+---         getline(".")
 --- <When {lnum} is a number smaller than 1 or bigger than the
 --- number of lines in the buffer, an empty string is returned.
 ---
@@ -3129,9 +3129,9 @@ function vim.fn.getjumplist(winnr, tabnr) end
 --- Non-existing lines are silently omitted.
 --- When {end} is before {lnum} an empty |List| is returned.
 --- Example: >vim
----   let start = line('.')
----   let end = search("^$") - 1
----   let lines = getline(start, end)
+---         let start = line('.')
+---         let end = search("^$") - 1
+---         let lines = getline(start, end)
 ---
 --- <To get lines from another buffer see |getbufline()| and
 --- |getbufoneline()|
@@ -3156,20 +3156,20 @@ function vim.fn.getline(lnum, end_) end
 --- In addition to the items supported by |getqflist()| in {what},
 --- the following item is supported by |getloclist()|:
 ---
----   filewinid  id of the window used to display files
----       from the location list. This field is
----       applicable only when called from a
----       location list window. See
----       |location-list-file-window| for more
----       details.
+---         filewinid       id of the window used to display files
+---                         from the location list. This field is
+---                         applicable only when called from a
+---                         location list window. See
+---                         |location-list-file-window| for more
+---                         details.
 ---
 --- Returns a |Dictionary| with default values if there is no
 --- location list for the window {nr}.
 --- Returns an empty Dictionary if window {nr} does not exist.
 ---
 --- Examples (See also |getqflist-examples|): >vim
----   echo getloclist(3, {'all': 0})
----   echo getloclist(5, {'filewinid': 0})
+---         echo getloclist(3, {'all': 0})
+---         echo getloclist(5, {'filewinid': 0})
 --- <
 ---
 --- @param nr integer
@@ -3187,9 +3187,9 @@ function vim.fn.getloclist(nr, what) end
 ---
 --- Each item in the returned List is a |Dict| with the following:
 ---     mark   name of the mark prefixed by "'"
----     pos     a |List| with the position of the mark:
----     [bufnum, lnum, col, off]
----      Refer to |getpos()| for more information.
+---     pos    a |List| with the position of the mark:
+---                 [bufnum, lnum, col, off]
+---            Refer to |getpos()| for more information.
 ---     file   file name
 ---
 --- Refer to |getpos()| for getting information about a specific
@@ -3208,26 +3208,26 @@ function vim.fn.getmarklist(buf) end
 --- window ID instead of the current window.  If {win} is invalid,
 --- an empty list is returned.
 --- Example: >vim
----   echo getmatches()
+---         echo getmatches()
 --- < >
----   [{"group": "MyGroup1", "pattern": "TODO",
----   "priority": 10, "id": 1}, {"group": "MyGroup2",
----   "pattern": "FIXME", "priority": 10, "id": 2}]
+---         [{"group": "MyGroup1", "pattern": "TODO",
+---         "priority": 10, "id": 1}, {"group": "MyGroup2",
+---         "pattern": "FIXME", "priority": 10, "id": 2}]
 --- < >vim
----   let m = getmatches()
----   call clearmatches()
----   echo getmatches()
+---         let m = getmatches()
+---         call clearmatches()
+---         echo getmatches()
 --- < >
----   []
+---         []
 --- < >vim
----   call setmatches(m)
----   echo getmatches()
+---         call setmatches(m)
+---         echo getmatches()
 --- < >
----   [{"group": "MyGroup1", "pattern": "TODO",
----   "priority": 10, "id": 1}, {"group": "MyGroup2",
----   "pattern": "FIXME", "priority": 10, "id": 2}]
+---         [{"group": "MyGroup1", "pattern": "TODO",
+---         "priority": 10, "id": 1}, {"group": "MyGroup2",
+---         "pattern": "FIXME", "priority": 10, "id": 2}]
 --- < >vim
----   unlet m
+---         unlet m
 --- <
 ---
 --- @param win? any
@@ -3237,15 +3237,15 @@ function vim.fn.getmatches(win) end
 --- Returns a |Dictionary| with the last known position of the
 --- mouse.  This can be used in a mapping for a mouse click.  The
 --- items are:
----   screenrow  screen row
----   screencol  screen column
----   winid    Window ID of the click
----   winrow    row inside "winid"
----   wincol    column inside "winid"
----   line    text line inside "winid"
----   column    text column inside "winid"
----   coladd    offset (in screen columns) from the
----       start of the clicked char
+---         screenrow       screen row
+---         screencol       screen column
+---         winid           Window ID of the click
+---         winrow          row inside "winid"
+---         wincol          column inside "winid"
+---         line            text line inside "winid"
+---         column          text column inside "winid"
+---         coladd          offset (in screen columns) from the
+---                         start of the clicked char
 --- All numbers are 1-based.
 ---
 --- If not over a window, e.g. when in the command line, then only
@@ -3296,9 +3296,9 @@ function vim.fn.getpid() end
 --- in which case it means "after the end of the line".
 --- If {expr} is invalid, returns a list with all zeros.
 --- This can be used to save and restore the position of a mark: >vim
----   let save_a_mark = getpos("'a")
----   " ...
----   call setpos("'a", save_a_mark)
+---         let save_a_mark = getpos("'a")
+---         " ...
+---         call setpos("'a", save_a_mark)
 --- <Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 ---
 --- @param expr string
@@ -3307,24 +3307,24 @@ function vim.fn.getpos(expr) end
 
 --- Returns a |List| with all the current quickfix errors.  Each
 --- list item is a dictionary with these entries:
----   bufnr  number of buffer that has the file name, use
----     bufname() to get the name
----   module  module name
----   lnum  line number in the buffer (first line is 1)
----   end_lnum
----     end of line number if the item is multiline
----   col  column number (first column is 1)
----   end_col  end of column number if the item has range
----   vcol  |TRUE|: "col" is visual column
----     |FALSE|: "col" is byte index
----   nr  error number
----   pattern  search pattern used to locate the error
----   text  description of the error
----   type  type of the error, 'E', '1', etc.
----   valid  |TRUE|: recognized error message
----   user_data
----     custom data associated with the item, can be
----     any type.
+---         bufnr   number of buffer that has the file name, use
+---                 bufname() to get the name
+---         module  module name
+---         lnum    line number in the buffer (first line is 1)
+---         end_lnum
+---                 end of line number if the item is multiline
+---         col     column number (first column is 1)
+---         end_col end of column number if the item has range
+---         vcol    |TRUE|: "col" is visual column
+---                 |FALSE|: "col" is byte index
+---         nr      error number
+---         pattern search pattern used to locate the error
+---         text    description of the error
+---         type    type of the error, 'E', '1', etc.
+---         valid   |TRUE|: recognized error message
+---         user_data
+---                 custom data associated with the item, can be
+---                 any type.
 ---
 --- When there is no error list or it's empty, an empty list is
 --- returned. Quickfix list entries with a non-existing buffer
@@ -3334,42 +3334,42 @@ function vim.fn.getpos(expr) end
 ---
 --- Useful application: Find pattern matches in multiple files and
 --- do something with them: >vim
----   vimgrep /theword/jg *.c
----   for d in getqflist()
----      echo bufname(d.bufnr) ':' d.lnum '=' d.text
----   endfor
+---         vimgrep /theword/jg *.c
+---         for d in getqflist()
+---            echo bufname(d.bufnr) ':' d.lnum '=' d.text
+---         endfor
 --- <
 --- If the optional {what} dictionary argument is supplied, then
 --- returns only the items listed in {what} as a dictionary. The
 --- following string items are supported in {what}:
----   changedtick  get the total number of changes made
----       to the list |quickfix-changedtick|
----   context  get the |quickfix-context|
----   efm  errorformat to use when parsing "lines". If
----     not present, then the 'errorformat' option
----     value is used.
----   id  get information for the quickfix list with
----     |quickfix-ID|; zero means the id for the
----     current list or the list specified by "nr"
----   idx  get information for the quickfix entry at this
----     index in the list specified by "id" or "nr".
----     If set to zero, then uses the current entry.
----     See |quickfix-index|
----   items  quickfix list entries
----   lines  parse a list of lines using 'efm' and return
----     the resulting entries.  Only a |List| type is
----     accepted.  The current quickfix list is not
----     modified. See |quickfix-parse|.
----   nr  get information for this quickfix list; zero
----     means the current quickfix list and "$" means
----     the last quickfix list
----   qfbufnr number of the buffer displayed in the quickfix
----     window. Returns 0 if the quickfix buffer is
----     not present. See |quickfix-buffer|.
----   size  number of entries in the quickfix list
----   title  get the list title |quickfix-title|
----   winid  get the quickfix |window-ID|
----   all  all of the above quickfix properties
+---         changedtick     get the total number of changes made
+---                         to the list |quickfix-changedtick|
+---         context get the |quickfix-context|
+---         efm     errorformat to use when parsing "lines". If
+---                 not present, then the 'errorformat' option
+---                 value is used.
+---         id      get information for the quickfix list with
+---                 |quickfix-ID|; zero means the id for the
+---                 current list or the list specified by "nr"
+---         idx     get information for the quickfix entry at this
+---                 index in the list specified by "id" or "nr".
+---                 If set to zero, then uses the current entry.
+---                 See |quickfix-index|
+---         items   quickfix list entries
+---         lines   parse a list of lines using 'efm' and return
+---                 the resulting entries.  Only a |List| type is
+---                 accepted.  The current quickfix list is not
+---                 modified. See |quickfix-parse|.
+---         nr      get information for this quickfix list; zero
+---                 means the current quickfix list and "$" means
+---                 the last quickfix list
+---         qfbufnr number of the buffer displayed in the quickfix
+---                 window. Returns 0 if the quickfix buffer is
+---                 not present. See |quickfix-buffer|.
+---         size    number of entries in the quickfix list
+---         title   get the list title |quickfix-title|
+---         winid   get the quickfix |window-ID|
+---         all     all of the above quickfix properties
 --- Non-string items in {what} are ignored. To get the value of a
 --- particular item, set it to zero.
 --- If "nr" is not present then the current quickfix list is used.
@@ -3383,29 +3383,29 @@ function vim.fn.getpos(expr) end
 --- "items" with the list of entries.
 ---
 --- The returned dictionary contains the following entries:
----   changedtick  total number of changes made to the
----       list |quickfix-changedtick|
----   context  quickfix list context. See |quickfix-context|
----     If not present, set to "".
----   id  quickfix list ID |quickfix-ID|. If not
----     present, set to 0.
----   idx  index of the quickfix entry in the list. If not
----     present, set to 0.
----   items  quickfix list entries. If not present, set to
----     an empty list.
----   nr  quickfix list number. If not present, set to 0
----   qfbufnr  number of the buffer displayed in the quickfix
----     window. If not present, set to 0.
----   size  number of entries in the quickfix list. If not
----     present, set to 0.
----   title  quickfix list title text. If not present, set
----     to "".
----   winid  quickfix |window-ID|. If not present, set to 0
+---         changedtick     total number of changes made to the
+---                         list |quickfix-changedtick|
+---         context quickfix list context. See |quickfix-context|
+---                 If not present, set to "".
+---         id      quickfix list ID |quickfix-ID|. If not
+---                 present, set to 0.
+---         idx     index of the quickfix entry in the list. If not
+---                 present, set to 0.
+---         items   quickfix list entries. If not present, set to
+---                 an empty list.
+---         nr      quickfix list number. If not present, set to 0
+---         qfbufnr number of the buffer displayed in the quickfix
+---                 window. If not present, set to 0.
+---         size    number of entries in the quickfix list. If not
+---                 present, set to 0.
+---         title   quickfix list title text. If not present, set
+---                 to "".
+---         winid   quickfix |window-ID|. If not present, set to 0
 ---
 --- Examples (See also |getqflist-examples|): >vim
----   echo getqflist({'all': 1})
----   echo getqflist({'nr': 2, 'title': 1})
----   echo getqflist({'lines' : ["F1:10:L10"]})
+---         echo getqflist({'all': 1})
+---         echo getqflist({'nr': 2, 'title': 1})
+---         echo getqflist({'lines' : ["F1:10:L10"]})
 --- <
 ---
 --- @param what? any
@@ -3414,7 +3414,7 @@ function vim.fn.getqflist(what) end
 
 --- The result is a String, which is the contents of register
 --- {regname}.  Example: >vim
----   let cliptext = getreg('*')
+---         let cliptext = getreg('*')
 --- <When register {regname} was not set the result is an empty
 --- string.
 --- The {regname} argument must be a string.
@@ -3441,21 +3441,21 @@ function vim.fn.getreg(regname, list) end
 
 --- Returns detailed information about register {regname} as a
 --- Dictionary with the following entries:
----   regcontents  List of lines contained in register
----       {regname}, like
----       getreg({regname}, 1, 1).
----   regtype    the type of register {regname}, as in
----       |getregtype()|.
----   isunnamed  Boolean flag, v:true if this register
----       is currently pointed to by the unnamed
----       register.
----   points_to  for the unnamed register, gives the
----       single letter name of the register
----       currently pointed to (see |quotequote|).
----       For example, after deleting a line
----       with `dd`, this field will be "1",
----       which is the register that got the
----       deleted text.
+---         regcontents     List of lines contained in register
+---                         {regname}, like
+---                         getreg({regname}, 1, 1).
+---         regtype         the type of register {regname}, as in
+---                         |getregtype()|.
+---         isunnamed       Boolean flag, v:true if this register
+---                         is currently pointed to by the unnamed
+---                         register.
+---         points_to       for the unnamed register, gives the
+---                         single letter name of the register
+---                         currently pointed to (see |quotequote|).
+---                         For example, after deleting a line
+---                         with `dd`, this field will be "1",
+---                         which is the register that got the
+---                         deleted text.
 ---
 --- The {regname} argument is a string.  If {regname} is invalid
 --- or not set, an empty Dictionary will be returned.
@@ -3468,10 +3468,10 @@ function vim.fn.getreginfo(regname) end
 
 --- The result is a String, which is type of register {regname}.
 --- The value will be one of:
----     "v"      for |charwise| text
----     "V"      for |linewise| text
----     "<CTRL-V>{width}"  for |blockwise-visual| text
----     ""      for an empty or unknown register
+---     "v"                 for |charwise| text
+---     "V"                 for |linewise| text
+---     "<CTRL-V>{width}"   for |blockwise-visual| text
+---     ""                  for an empty or unknown register
 --- <CTRL-V> is one character with value 0x16.
 --- The {regname} argument is a string.  If {regname} is not
 --- specified, |v:register| is used.
@@ -3486,34 +3486,34 @@ function vim.fn.getregtype(regname) end
 ---
 --- The optional Dict argument {opts} supports the following
 --- optional items:
----     name  Script name match pattern. If specified,
----     and "sid" is not specified, information about
----     scripts with a name that match the pattern
----     "name" are returned.
----     sid    Script ID |<SID>|.  If specified, only
----     information about the script with ID "sid" is
----     returned and "name" is ignored.
+---     name        Script name match pattern. If specified,
+---                 and "sid" is not specified, information about
+---                 scripts with a name that match the pattern
+---                 "name" are returned.
+---     sid         Script ID |<SID>|.  If specified, only
+---                 information about the script with ID "sid" is
+---                 returned and "name" is ignored.
 ---
 --- Each item in the returned List is a |Dict| with the following
 --- items:
----     autoload  Always set to FALSE.
+---     autoload    Always set to FALSE.
 ---     functions   List of script-local function names defined in
----     the script.  Present only when a particular
----     script is specified using the "sid" item in
----     {opts}.
----     name  Vim script file name.
----     sid    Script ID |<SID>|.
+---                 the script.  Present only when a particular
+---                 script is specified using the "sid" item in
+---                 {opts}.
+---     name        Vim script file name.
+---     sid         Script ID |<SID>|.
 ---     variables   A dictionary with the script-local variables.
----     Present only when a particular script is
----     specified using the "sid" item in {opts}.
----     Note that this is a copy, the value of
----     script-local variables cannot be changed using
----     this dictionary.
----     version  Vim script version, always 1
+---                 Present only when a particular script is
+---                 specified using the "sid" item in {opts}.
+---                 Note that this is a copy, the value of
+---                 script-local variables cannot be changed using
+---                 this dictionary.
+---     version     Vim script version, always 1
 ---
 --- Examples: >vim
----   echo getscriptinfo({'name': 'myscript'})
----   echo getscriptinfo({'sid': 15}).variables
+---         echo getscriptinfo({'name': 'myscript'})
+---         echo getscriptinfo({'sid': 15}).variables
 --- <
 ---
 --- @param opts? table
@@ -3527,10 +3527,10 @@ function vim.fn.getscriptinfo(opts) end
 --- page does not exist an empty List is returned.
 ---
 --- Each List item is a |Dictionary| with the following entries:
----   tabnr    tab page number.
----   variables  a reference to the dictionary with
----       tabpage-local variables
----   windows    List of |window-ID|s in the tab page.
+---         tabnr           tab page number.
+---         variables       a reference to the dictionary with
+---                         tabpage-local variables
+---         windows         List of |window-ID|s in the tab page.
 ---
 --- @param tabnr? integer
 --- @return any
@@ -3570,11 +3570,11 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 --- When the tab, window or variable doesn't exist {def} or an
 --- empty string is returned, there is no error message.
 --- Examples: >vim
----   let list_is_on = gettabwinvar(1, 2, '&list')
----   echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
+---         let list_is_on = gettabwinvar(1, 2, '&list')
+---         echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
 --- <
 --- To obtain all window-local variables use: >vim
----   gettabwinvar({tabnr}, {winnr}, '&')
+---         gettabwinvar({tabnr}, {winnr}, '&')
 --- <
 ---
 --- @param tabnr integer
@@ -3590,24 +3590,24 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 --- When window {winnr} doesn't exist, an empty Dict is returned.
 ---
 --- The returned dictionary contains the following entries:
----   curidx    Current index in the stack. When at
----       top of the stack, set to (length + 1).
----       Index of bottom of the stack is 1.
----   items    List of items in the stack. Each item
----       is a dictionary containing the
----       entries described below.
----   length    Number of entries in the stack.
+---         curidx          Current index in the stack. When at
+---                         top of the stack, set to (length + 1).
+---                         Index of bottom of the stack is 1.
+---         items           List of items in the stack. Each item
+---                         is a dictionary containing the
+---                         entries described below.
+---         length          Number of entries in the stack.
 ---
 --- Each item in the stack is a dictionary with the following
 --- entries:
----   bufnr    buffer number of the current jump
----   from    cursor position before the tag jump.
----       See |getpos()| for the format of the
----       returned list.
----   matchnr    current matching tag number. Used when
----       multiple matching tags are found for a
----       name.
----   tagname    name of the tag
+---         bufnr           buffer number of the current jump
+---         from            cursor position before the tag jump.
+---                         See |getpos()| for the format of the
+---                         returned list.
+---         matchnr         current matching tag number. Used when
+---                         multiple matching tags are found for a
+---                         name.
+---         tagname         name of the tag
 ---
 --- See |tagstack| for more information about the tag stack.
 ---
@@ -3639,28 +3639,28 @@ function vim.fn.gettext(text) end
 --- tab pages is returned.
 ---
 --- Each List item is a |Dictionary| with the following entries:
----   botline    last complete displayed buffer line
----   bufnr    number of buffer in the window
----   height    window height (excluding winbar)
----   loclist    1 if showing a location list
----   quickfix  1 if quickfix or location list window
----   terminal  1 if a terminal window
----   tabnr    tab page number
----   topline    first displayed buffer line
----   variables  a reference to the dictionary with
----       window-local variables
----   width    window width
----   winbar    1 if the window has a toolbar, 0
----       otherwise
----   wincol    leftmost screen column of the window;
----       "col" from |win_screenpos()|
----   textoff    number of columns occupied by any
----       'foldcolumn', 'signcolumn' and line
----       number in front of the text
----   winid    |window-ID|
----   winnr    window number
----   winrow    topmost screen line of the window;
----       "row" from |win_screenpos()|
+---         botline         last complete displayed buffer line
+---         bufnr           number of buffer in the window
+---         height          window height (excluding winbar)
+---         loclist         1 if showing a location list
+---         quickfix        1 if quickfix or location list window
+---         terminal        1 if a terminal window
+---         tabnr           tab page number
+---         topline         first displayed buffer line
+---         variables       a reference to the dictionary with
+---                         window-local variables
+---         width           window width
+---         winbar          1 if the window has a toolbar, 0
+---                         otherwise
+---         wincol          leftmost screen column of the window;
+---                         "col" from |win_screenpos()|
+---         textoff         number of columns occupied by any
+---                         'foldcolumn', 'signcolumn' and line
+---                         number in front of the text
+---         winid           |window-ID|
+---         winnr           window number
+---         winrow          topmost screen line of the window;
+---                         "row" from |win_screenpos()|
 ---
 --- @param winid? integer
 --- @return vim.fn.getwininfo.ret.item[]
@@ -3668,7 +3668,7 @@ function vim.fn.getwininfo(winid) end
 
 --- The result is a |List| with two numbers, the result of
 --- |getwinposx()| and |getwinposy()| combined:
----   [x-pos, y-pos]
+---         [x-pos, y-pos]
 --- {timeout} can be used to specify how long to wait in msec for
 --- a response from the terminal.  When omitted 100 msec is used.
 ---
@@ -3677,13 +3677,13 @@ function vim.fn.getwininfo(winid) end
 --- within that time, a previously reported position is returned,
 --- if available.  This can be used to poll for the position and
 --- do some work in the meantime: >vim
----   while 1
----     let res = getwinpos(1)
----     if res[0] >= 0
----       break
----     endif
----     " Do some work here
----   endwhile
+---         while 1
+---           let res = getwinpos(1)
+---           if res[0] >= 0
+---             break
+---           endif
+---           " Do some work here
+---         endwhile
 --- <
 ---
 --- @param timeout? integer
@@ -3708,8 +3708,8 @@ function vim.fn.getwinposy() end
 
 --- Like |gettabwinvar()| for the current tabpage.
 --- Examples: >vim
----   let list_is_on = getwinvar(2, '&list')
----   echo "myvar = " .. getwinvar(1, 'myvar')
+---         let list_is_on = getwinvar(2, '&list')
+---         echo "myvar = " .. getwinvar(1, 'myvar')
 ---
 --- @param winnr integer
 --- @param varname string
@@ -3744,8 +3744,8 @@ function vim.fn.getwinvar(winnr, varname, def) end
 ---
 --- For most systems backticks can be used to get files names from
 --- any external command.  Example: >vim
----   let tagfiles = glob("`find . -name tags -print`")
----   let &tags = substitute(tagfiles, "\n", ",", "g")
+---         let tagfiles = glob("`find . -name tags -print`")
+---         let &tags = substitute(tagfiles, "\n", ",", "g")
 --- <The result of the program inside the backticks should be one
 --- item per line.  Spaces inside an item are allowed.
 ---
@@ -3762,13 +3762,13 @@ function vim.fn.glob(expr, nosuf, list, alllinks) end
 --- Convert a file pattern, as used by glob(), into a search
 --- pattern.  The result can be used to match with a string that
 --- is a file name.  E.g. >vim
----   if filename =~ glob2regpat('Make*.mak')
----     " ...
----   endif
+---         if filename =~ glob2regpat('Make*.mak')
+---           " ...
+---         endif
 --- <This is equivalent to: >vim
----   if filename =~ '^Make.*\.mak$'
----     " ...
----   endif
+---         if filename =~ '^Make.*\.mak$'
+---           " ...
+---         endif
 --- <When {string} is an empty string the result is "^$", match an
 --- empty string.
 --- Note that the result depends on the system.  On MS-Windows
@@ -3780,7 +3780,7 @@ function vim.fn.glob2regpat(string) end
 
 --- Perform glob() for String {expr} on all directories in {path}
 --- and concatenate the results.  Example: >vim
----   echo globpath(&rtp, "syntax/c.vim")
+---         echo globpath(&rtp, "syntax/c.vim")
 --- <
 --- {path} is a comma-separated list of directory names.  Each
 --- directory name is prepended to {expr} and expanded like with
@@ -3801,14 +3801,14 @@ function vim.fn.glob2regpat(string) end
 --- also get filenames containing newlines correctly. Otherwise
 --- the result is a String and when there are several matches,
 --- they are separated by <NL> characters.  Example: >vim
----   echo globpath(&rtp, "syntax/c.vim", 0, 1)
+---         echo globpath(&rtp, "syntax/c.vim", 0, 1)
 --- <
 --- {allinks} is used as with |glob()|.
 ---
 --- The "**" item can be used to search in a directory tree.
 --- For example, to find all "README.txt" files in the directories
 --- in 'runtimepath' and below: >vim
----   echo globpath(&rtp, "**/README.txt")
+---         echo globpath(&rtp, "**/README.txt")
 --- <Upwards search and limiting the depth of "**" is not
 --- supported, thus using 'path' will not always work properly.
 ---
@@ -3825,14 +3825,14 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- "win32", see below.  See also |exists()|.
 ---
 --- To get the system name use |vim.uv|.os_uname() in Lua: >lua
----   print(vim.uv.os_uname().sysname)
+---         print(vim.uv.os_uname().sysname)
 ---
 --- <If the code has a syntax error then Vimscript may skip the
 --- rest of the line.  Put |:if| and |:endif| on separate lines to
 --- avoid the syntax error: >vim
----   if has('feature')
----     let x = this_breaks_without_the_feature()
----   endif
+---         if has('feature')
+---           let x = this_breaks_without_the_feature()
+---         endif
 --- <
 --- Vim's compile-time feature-names (prefixed with "+") are not
 --- recognized because Nvim is always compiled with all possible
@@ -3841,50 +3841,50 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 --- Feature names can be:
 --- 1.  Nvim version. For example the "nvim-0.2.1" feature means
 ---     that Nvim is version 0.2.1 or later: >vim
----   if has("nvim-0.2.1")
----     " ...
----   endif
+---         if has("nvim-0.2.1")
+---           " ...
+---         endif
 ---
 --- <2.  Runtime condition or other pseudo-feature. For example the
 ---     "win32" feature checks if the current system is Windows: >vim
----   if has("win32")
----     " ...
----   endif
---- <          *feature-list*
+---         if has("win32")
+---           " ...
+---         endif
+--- <                                       *feature-list*
 ---     List of supported pseudo-feature names:
----   acl    |ACL| support.
----   bsd    BSD system (not macOS, use "mac" for that).
----   clipboard  |clipboard| provider is available.
----   fname_case  Case in file names matters (for Darwin and MS-Windows
----       this is not present).
----   gui_running  Nvim has a GUI.
----   iconv    Can use |iconv()| for conversion.
----   linux    Linux system.
----   mac    MacOS system.
----   nvim    This is Nvim.
----   python3    Legacy Vim |python3| interface. |has-python|
----   pythonx    Legacy Vim |python_x| interface. |has-pythonx|
----   sun    SunOS system.
----   ttyin    input is a terminal (tty).
----   ttyout    output is a terminal (tty).
----   unix    Unix system.
----   *vim_starting*  True during |startup|.
----   win32    Windows system (32 or 64 bit).
----   win64    Windows system (64 bit).
----   wsl    WSL (Windows Subsystem for Linux) system.
+---         acl             |ACL| support.
+---         bsd             BSD system (not macOS, use "mac" for that).
+---         clipboard       |clipboard| provider is available.
+---         fname_case      Case in file names matters (for Darwin and MS-Windows
+---                         this is not present).
+---         gui_running     Nvim has a GUI.
+---         iconv           Can use |iconv()| for conversion.
+---         linux           Linux system.
+---         mac             MacOS system.
+---         nvim            This is Nvim.
+---         python3         Legacy Vim |python3| interface. |has-python|
+---         pythonx         Legacy Vim |python_x| interface. |has-pythonx|
+---         sun             SunOS system.
+---         ttyin           input is a terminal (tty).
+---         ttyout          output is a terminal (tty).
+---         unix            Unix system.
+---         *vim_starting*  True during |startup|.
+---         win32           Windows system (32 or 64 bit).
+---         win64           Windows system (64 bit).
+---         wsl             WSL (Windows Subsystem for Linux) system.
 ---
----           *has-patch*
+---                                         *has-patch*
 --- 3.  Vim patch. For example the "patch123" feature means that
 ---     Vim patch 123 at the current |v:version| was included: >vim
----   if v:version > 602 || v:version == 602 && has("patch148")
----     " ...
----   endif
+---         if v:version > 602 || v:version == 602 && has("patch148")
+---           " ...
+---         endif
 ---
 --- <4.  Vim version. For example the "patch-7.4.237" feature means
 ---     that Nvim is Vim-compatible to version 7.4.237 or later. >vim
----   if has("patch-7.4.237")
----     " ...
----   endif
+---         if has("patch-7.4.237")
+---           " ...
+---         endif
 --- <
 ---
 --- @param feature any
@@ -3907,9 +3907,9 @@ function vim.fn.has_key(dict, key) end
 --- Tabs and windows are identified by their respective numbers,
 --- 0 means current tab or window. Missing argument implies 0.
 --- Thus the following are equivalent: >vim
----   echo haslocaldir()
----   echo haslocaldir(0)
----   echo haslocaldir(0, 0)
+---         echo haslocaldir()
+---         echo haslocaldir(0)
+---         echo haslocaldir(0, 0)
 --- <With {winnr} use that window in the current tabpage.
 --- With {winnr} and {tabnr} use the window in that tabpage.
 --- {winnr} can be the window number or the |window-ID|.
@@ -3933,21 +3933,21 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 --- buffer are checked for a match.
 --- If no matching mapping is found FALSE is returned.
 --- The following characters are recognized in {mode}:
----   n  Normal mode
----   v  Visual and Select mode
----   x  Visual mode
----   s  Select mode
----   o  Operator-pending mode
----   i  Insert mode
----   l  Language-Argument ("r", "f", "t", etc.)
----   c  Command-line mode
+---         n       Normal mode
+---         v       Visual and Select mode
+---         x       Visual mode
+---         s       Select mode
+---         o       Operator-pending mode
+---         i       Insert mode
+---         l       Language-Argument ("r", "f", "t", etc.)
+---         c       Command-line mode
 --- When {mode} is omitted, "nvo" is used.
 ---
 --- This function is useful to check if a mapping already exists
 --- to a function in a Vim script.  Example: >vim
----   if !hasmapto('\ABCdoit')
----      map <Leader>d \ABCdoit
----   endif
+---         if !hasmapto('\ABCdoit')
+---            map <Leader>d \ABCdoit
+---         endif
 --- <This installs the mapping to "\ABCdoit" only if there isn't
 --- already a mapping to "\ABCdoit".
 ---
@@ -3972,13 +3972,13 @@ function vim.fn.highlightID(name) end
 function vim.fn.highlight_exists(name) end
 
 --- Add the String {item} to the history {history} which can be
---- one of:          *hist-names*
----   "cmd"   or ":"    command line history
----   "search" or "/"   search pattern history
----   "expr"   or "="   typed expression history
----   "input"  or "\@"    input line history
----   "debug"  or ">"   debug command history
----   empty      the current or last used history
+--- one of:                                 *hist-names*
+---         "cmd"    or ":"   command line history
+---         "search" or "/"   search pattern history
+---         "expr"   or "="   typed expression history
+---         "input"  or "@"   input line history
+---         "debug"  or ">"   debug command history
+---         empty             the current or last used history
 --- The {history} string does not need to be the whole name, one
 --- character is sufficient.
 --- If {item} does already exist in the history, it will be
@@ -3987,8 +3987,8 @@ function vim.fn.highlight_exists(name) end
 --- otherwise FALSE is returned.
 ---
 --- Example: >vim
----   call histadd("input", strftime("%Y %b %d"))
----   let date=input("Enter date: ")
+---         call histadd("input", strftime("%Y %b %d"))
+---         let date=input("Enter date: ")
 --- <This function is not available in the |sandbox|.
 ---
 --- @param history any
@@ -4012,20 +4012,20 @@ function vim.fn.histadd(history, item) end
 ---
 --- Examples:
 --- Clear expression register history: >vim
----   call histdel("expr")
+---         call histdel("expr")
 --- <
 --- Remove all entries starting with "*" from the search history: >vim
----   call histdel("/", '^\*')
+---         call histdel("/", '^\*')
 --- <
 --- The following three are equivalent: >vim
----   call histdel("search", histnr("search"))
----   call histdel("search", -1)
----   call histdel("search", '^' .. histget("search", -1) .. '$')
+---         call histdel("search", histnr("search"))
+---         call histdel("search", -1)
+---         call histdel("search", '^' .. histget("search", -1) .. '$')
 --- <
 --- To delete the last search pattern and use the last-but-one for
 --- the "n" command and 'hlsearch': >vim
----   call histdel("search", -1)
----   let \@/ = histget("search", -1)
+---         call histdel("search", -1)
+---         let @/ = histget("search", -1)
 --- <
 ---
 --- @param history any
@@ -4041,11 +4041,11 @@ function vim.fn.histdel(history, item) end
 ---
 --- Examples:
 --- Redo the second last search from history. >vim
----   execute '/' .. histget("search", -2)
+---         execute '/' .. histget("search", -2)
 ---
 --- <Define an Ex command ":H {num}" that supports re-execution of
 --- the {num}th entry from the output of |:history|. >vim
----   command -nargs=1 H execute histget("cmd", 0+<args>)
+---         command -nargs=1 H execute histget("cmd", 0+<args>)
 --- <
 ---
 --- @param history any
@@ -4058,7 +4058,7 @@ function vim.fn.histget(history, index) end
 --- If an error occurred, -1 is returned.
 ---
 --- Example: >vim
----   let inp_index = histnr("expr")
+---         let inp_index = histnr("expr")
 ---
 --- @param history any
 --- @return integer
@@ -4070,7 +4070,7 @@ function vim.fn.histnr(history) end
 --- This can be used to retrieve information about the highlight
 --- group.  For example, to get the background color of the
 --- "Comment" group: >vim
----   echo synIDattr(synIDtrans(hlID("Comment")), "bg")
+---         echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 --- <
 ---
 --- @param name string
@@ -4162,10 +4162,10 @@ function vim.fn.indent(lnum) end
 ---
 --- -1 is returned when {expr} is not found in {object}.
 --- Example: >vim
----   let idx = index(words, "the")
----   if index(numbers, 123) >= 0
----     " ...
----   endif
+---         let idx = index(words, "the")
+---         if index(numbers, 123) >= 0
+---           " ...
+---         endif
 ---
 --- @param object any
 --- @param expr any
@@ -4194,22 +4194,22 @@ function vim.fn.index(object, expr, start, ic) end
 --- |v:val| has the byte value.
 ---
 --- If {expr} is a |Funcref| it must take two arguments:
----   1. the key or the index of the current item.
----   2. the value of the current item.
+---         1. the key or the index of the current item.
+---         2. the value of the current item.
 --- The function must return |TRUE| if the item is found and the
 --- search should stop.
 ---
 --- The optional argument {opts} is a Dict and supports the
 --- following items:
----     startidx  start evaluating {expr} at the item with this
----     index; may be negative for an item relative to
----     the end
+---     startidx    start evaluating {expr} at the item with this
+---                 index; may be negative for an item relative to
+---                 the end
 --- Returns -1 when {expr} evaluates to v:false for all the items.
 --- Example: >vim
----   let l = [#{n: 10}, #{n: 20}, #{n: 30}]
----   echo indexof(l, "v:val.n == 20")
----   echo indexof(l, {i, v -> v.n == 30})
----   echo indexof(l, "v:val.n == 20", #{startidx: 1})
+---         let l = [#{n: 10}, #{n: 20}, #{n: 30}]
+---         echo indexof(l, "v:val.n == 20")
+---         echo indexof(l, {i, v -> v.n == 30})
+---         echo indexof(l, "v:val.n == 20", #{startidx: 1})
 ---
 --- @param object any
 --- @param expr any
@@ -4245,14 +4245,14 @@ function vim.fn.input(prompt, text, completion) end
 --- editing commands and mappings.  There is a separate history
 --- for lines typed for input().
 --- Example: >vim
----   if input("Coffee or beer? ") == "beer"
----     echo "Cheers!"
----   endif
+---         if input("Coffee or beer? ") == "beer"
+---           echo "Cheers!"
+---         endif
 --- <
 --- If the optional {text} argument is present and not empty, this
 --- is used for the default reply, as if the user typed this.
 --- Example: >vim
----   let color = input("Color? ", "white")
+---         let color = input("Color? ", "white")
 ---
 --- <The optional {completion} argument specifies the type of
 --- completion supported for the input.  Without it completion is
@@ -4260,18 +4260,18 @@ function vim.fn.input(prompt, text, completion) end
 --- that can be supplied to a user-defined command using the
 --- "-complete=" argument.  Refer to |:command-completion| for
 --- more information.  Example: >vim
----   let fname = input("File: ", "", "file")
+---         let fname = input("File: ", "", "file")
 ---
---- <      *input()-highlight* *E5400* *E5402*
+--- <                       *input()-highlight* *E5400* *E5402*
 --- The optional `highlight` key allows specifying function which
 --- will be used for highlighting user input.  This function
 --- receives user input as its only argument and must return
 --- a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
 --- where
----   hl_start_col is the first highlighted column,
----   hl_end_col is the last highlighted column (+ 1!),
----   hl_group is |:hi| group used for highlighting.
----             *E5403* *E5404* *E5405* *E5406*
+---         hl_start_col is the first highlighted column,
+---         hl_end_col is the last highlighted column (+ 1!),
+---         hl_group is |:hi| group used for highlighting.
+---                               *E5403* *E5404* *E5405* *E5406*
 --- Both hl_start_col and hl_end_col + 1 must point to the start
 --- of the multibyte character (highlighting must not break
 --- multibyte characters), hl_end_col + 1 may be equal to the
@@ -4281,28 +4281,28 @@ function vim.fn.input(prompt, text, completion) end
 --- then or equal to previous hl_end_col.
 ---
 --- Example (try some input with parentheses): >vim
----   highlight RBP1 guibg=Red ctermbg=red
----   highlight RBP2 guibg=Yellow ctermbg=yellow
----   highlight RBP3 guibg=Green ctermbg=green
----   highlight RBP4 guibg=Blue ctermbg=blue
----   let g:rainbow_levels = 4
----   function! RainbowParens(cmdline)
----     let ret = []
----     let i = 0
----     let lvl = 0
----     while i < len(a:cmdline)
----       if a:cmdline[i] is# '('
----         call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
----         let lvl += 1
----       elseif a:cmdline[i] is# ')'
----         let lvl -= 1
----         call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
----       endif
----       let i += 1
----     endwhile
----     return ret
----   endfunction
----   call input({'prompt':'>','highlight':'RainbowParens'})
+---         highlight RBP1 guibg=Red ctermbg=red
+---         highlight RBP2 guibg=Yellow ctermbg=yellow
+---         highlight RBP3 guibg=Green ctermbg=green
+---         highlight RBP4 guibg=Blue ctermbg=blue
+---         let g:rainbow_levels = 4
+---         function! RainbowParens(cmdline)
+---           let ret = []
+---           let i = 0
+---           let lvl = 0
+---           while i < len(a:cmdline)
+---             if a:cmdline[i] is# '('
+---               call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+---               let lvl += 1
+---             elseif a:cmdline[i] is# ')'
+---               let lvl -= 1
+---               call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+---             endif
+---             let i += 1
+---           endwhile
+---           return ret
+---         endfunction
+---         call input({'prompt':'>','highlight':'RainbowParens'})
 --- <
 --- Highlight function is called at least once for each new
 --- displayed input string, before command-line is redrawn.  It is
@@ -4326,12 +4326,12 @@ function vim.fn.input(prompt, text, completion) end
 --- |:execute| or |:normal|.
 ---
 --- Example with a mapping: >vim
----   nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
----   function GetFoo()
----     call inputsave()
----     let g:Foo = input("enter search pattern: ")
----     call inputrestore()
----   endfunction
+---         nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
+---         function GetFoo()
+---           call inputsave()
+---           let g:Foo = input("enter search pattern: ")
+---           call inputrestore()
+---         endfunction
 ---
 --- @param opts table
 --- @return any
@@ -4357,8 +4357,8 @@ function vim.fn.inputdialog(...) end
 --- it won't work.  It's a good idea to put the entry number at
 --- the start of the string.  And put a prompt in the first item.
 --- Example: >vim
----   let color = inputlist(['Select color:', '1. red',
----     \ '2. green', '3. blue'])
+---         let color = inputlist(['Select color:', '1. red',
+---                 \ '2. green', '3. blue'])
 ---
 --- @param textlist any
 --- @return any
@@ -4406,9 +4406,9 @@ function vim.fn.inputsecret(prompt, text) end
 --- |list-index|.  -1 inserts just before the last item.
 ---
 --- Returns the resulting |List| or |Blob|.  Examples: >vim
----   let mylist = insert([2, 3, 5], 1)
----   call insert(mylist, 4, -1)
----   call insert(mylist, 6, len(mylist))
+---         let mylist = insert([2, 3, 5], 1)
+---         call insert(mylist, 4, -1)
+---         call insert(mylist, 6, len(mylist))
 --- <The last example can be done simpler with |add()|.
 --- Note that when {item} is a |List| it is inserted as a single
 --- item.  Use |extend()| to concatenate |Lists|.
@@ -4437,7 +4437,7 @@ function vim.fn.interrupt() end
 
 --- Bitwise invert.  The argument is converted to a number.  A
 --- List, Dict or Float argument causes an error.  Example: >vim
----   let bits = invert(bits)
+---         let bits = invert(bits)
 --- <
 ---
 --- @param expr any
@@ -4455,10 +4455,10 @@ function vim.fn.isdirectory(directory) end
 
 --- Return 1 if {expr} is a positive infinity, or -1 a negative
 --- infinity, otherwise 0. >vim
----   echo isinf(1.0 / 0.0)
---- <  1 >vim
----   echo isinf(-1.0 / 0.0)
---- <  -1
+---         echo isinf(1.0 / 0.0)
+--- <        1 >vim
+---         echo isinf(-1.0 / 0.0)
+--- <        -1
 ---
 --- @param expr any
 --- @return 1|0|-1
@@ -4469,10 +4469,10 @@ function vim.fn.isinf(expr) end
 --- The string argument {expr} must be the name of a variable,
 --- |List| item or |Dictionary| entry, not the variable itself!
 --- Example: >vim
----   let alist = [0, ['a', 'b'], 2, 3]
----   lockvar 1 alist
----   echo islocked('alist')    " 1
----   echo islocked('alist[1]')  " 0
+---         let alist = [0, ['a', 'b'], 2, 3]
+---         lockvar 1 alist
+---         echo islocked('alist')          " 1
+---         echo islocked('alist[1]')       " 0
 ---
 --- <When {expr} is a variable that does not exist you get an error
 --- message.  Use |exists()| to check for existence.
@@ -4482,8 +4482,8 @@ function vim.fn.isinf(expr) end
 function vim.fn.islocked(expr) end
 
 --- Return |TRUE| if {expr} is a float with value NaN. >vim
----   echo isnan(0.0 / 0.0)
---- <  1
+---         echo isnan(0.0 / 0.0)
+--- <        1
 ---
 --- @param expr any
 --- @return 0|1
@@ -4494,9 +4494,9 @@ function vim.fn.isnan(expr) end
 --- entry and the value of this entry.  The |List| is in arbitrary
 --- order.  Also see |keys()| and |values()|.
 --- Example: >vim
----   for [key, value] in items(mydict)
----      echo key .. ': ' .. value
----   endfor
+---         for [key, value] in items(mydict)
+---            echo key .. ': ' .. value
+---         endfor
 ---
 --- @param dict any
 --- @return any
@@ -4562,7 +4562,7 @@ function vim.fn.jobsend(...) end
 ---     by CommandLineToArgvW https://msdn.microsoft.com/bb776391
 ---     unless cmd[0] is some form of "cmd.exe".
 ---
----           *jobstart-env*
+---                                         *jobstart-env*
 --- The job environment is initialized as follows:
 ---   $NVIM                is set to |v:servername| of the parent Nvim
 ---   $NVIM_LISTEN_ADDRESS is unset
@@ -4571,41 +4571,41 @@ function vim.fn.jobsend(...) end
 ---   $VIMRUNTIME          is unset
 --- You can set these with the `env` option.
 ---
----           *jobstart-options*
+---                                         *jobstart-options*
 --- {opts} is a dictionary with these keys:
 ---   clear_env:  (boolean) `env` defines the job environment
----         exactly, instead of merging current environment.
+---               exactly, instead of merging current environment.
 ---   cwd:        (string, default=|current-directory|) Working
----         directory of the job.
+---               directory of the job.
 ---   detach:     (boolean) Detach the job process: it will not be
----         killed when Nvim exits. If the process exits
----         before Nvim, `on_exit` will be invoked.
+---               killed when Nvim exits. If the process exits
+---               before Nvim, `on_exit` will be invoked.
 ---   env:        (dict) Map of environment variable name:value
----         pairs extending (or replace with "clear_env")
----         the current environment. |jobstart-env|
+---               pairs extending (or replace with "clear_env")
+---               the current environment. |jobstart-env|
 ---   height:     (number) Height of the `pty` terminal.
 ---   |on_exit|:    (function) Callback invoked when the job exits.
 ---   |on_stdout|:  (function) Callback invoked when the job emits
----         stdout data.
+---               stdout data.
 ---   |on_stderr|:  (function) Callback invoked when the job emits
----         stderr data.
+---               stderr data.
 ---   overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
----         stdio passed to the child process. Only on
----         MS-Windows; ignored on other platforms.
+---               stdio passed to the child process. Only on
+---               MS-Windows; ignored on other platforms.
 ---   pty:        (boolean) Connect the job to a new pseudo
----         terminal, and its streams to the master file
----         descriptor. `on_stdout` receives all output,
----         `on_stderr` is ignored. |terminal-start|
+---               terminal, and its streams to the master file
+---               descriptor. `on_stdout` receives all output,
+---               `on_stderr` is ignored. |terminal-start|
 ---   rpc:        (boolean) Use |msgpack-rpc| to communicate with
----         the job over stdio. Then `on_stdout` is ignored,
----         but `on_stderr` can still be used.
+---               the job over stdio. Then `on_stdout` is ignored,
+---               but `on_stderr` can still be used.
 ---   stderr_buffered: (boolean) Collect data until EOF (stream closed)
----         before invoking `on_stderr`. |channel-buffered|
+---               before invoking `on_stderr`. |channel-buffered|
 ---   stdout_buffered: (boolean) Collect data until EOF (stream
----         closed) before invoking `on_stdout`. |channel-buffered|
+---               closed) before invoking `on_stdout`. |channel-buffered|
 ---   stdin:      (string) Either "pipe" (default) to connect the
----         job's stdin to a channel or "null" to disconnect
----         stdin.
+---               job's stdin to a channel or "null" to disconnect
+---               stdin.
 ---   width:      (number) Width of the `pty` terminal.
 ---
 --- {opts} is passed as |self| dictionary to the callback; the
@@ -4642,7 +4642,7 @@ function vim.fn.jobstop(id) end
 --- omitted or -1, wait forever.
 ---
 --- Timeout of 0 can be used to check the status of a job: >vim
----   let running = jobwait([{job-id}], 0)[0] == -1
+---         let running = jobwait([{job-id}], 0)[0] == -1
 --- <
 --- During jobwait() callbacks for jobs not in the {jobs} list may
 --- be invoked. The screen will not redraw unless |:redraw| is
@@ -4650,10 +4650,10 @@ function vim.fn.jobstop(id) end
 ---
 --- Returns a list of len({jobs}) integers, where each integer is
 --- the status of the corresponding job:
----   Exit-code, if the job exited
----   -1 if the timeout was exceeded
----   -2 if the job was interrupted (by |CTRL-C|)
----   -3 if the job-id is invalid
+---         Exit-code, if the job exited
+---         -1 if the timeout was exceeded
+---         -2 if the job was interrupted (by |CTRL-C|)
+---         -3 if the job-id is invalid
 ---
 --- @param jobs any
 --- @param timeout? integer
@@ -4665,7 +4665,7 @@ function vim.fn.jobwait(jobs, timeout) end
 --- {sep} is omitted a single space is used.
 --- Note that {sep} is not added at the end.  You might want to
 --- add it there too: >vim
----   let lines = join(mylist, "\n") .. "\n"
+---         let lines = join(mylist, "\n") .. "\n"
 --- <String items are used as-is.  |Lists| and |Dictionaries| are
 --- converted into a string like with |string()|.
 --- The opposite function is |split()|.
@@ -4717,9 +4717,9 @@ function vim.fn.keys(dict) end
 
 --- Turn the internal byte representation of keys into a form that
 --- can be used for |:map|.  E.g. >vim
----   let xx = "\<C-Home>"
----   echo keytrans(xx)
---- <  <C-Home>
+---         let xx = "\<C-Home>"
+---         echo keytrans(xx)
+--- <       <C-Home>
 ---
 --- @param string string
 --- @return any
@@ -4784,7 +4784,7 @@ function vim.fn.len(expr) end
 --- For Unix: When compiling your own plugins, remember that the
 --- object code must be compiled as position-independent ('PIC').
 --- Examples: >vim
----   echo libcall("libc.so", "getenv", "HOME")
+---         echo libcall("libc.so", "getenv", "HOME")
 ---
 --- @param libname string
 --- @param funcname string
@@ -4795,9 +4795,9 @@ function vim.fn.libcall(libname, funcname, argument) end
 --- Just like |libcall()|, but used for a function that returns an
 --- int instead of a string.
 --- Examples: >vim
----   echo libcallnr("/usr/lib/libc.so", "getpid", "")
----   call libcallnr("libc.so", "printf", "Hello World!\n")
----   call libcallnr("libc.so", "sleep", 10)
+---         echo libcallnr("/usr/lib/libc.so", "getpid", "")
+---         call libcallnr("libc.so", "printf", "Hello World!\n")
+---         call libcallnr("libc.so", "sleep", 10)
 --- <
 ---
 --- @param libname string
@@ -4809,18 +4809,18 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 --- The result is a Number, which is the line number of the file
 --- position given with {expr}.  The {expr} argument is a string.
 --- The accepted positions are:
----     .      the cursor position
----     $      the last line in the current buffer
+---     .       the cursor position
+---     $       the last line in the current buffer
 ---     'x      position of mark x (if the mark is not set, 0 is
----       returned)
+---             returned)
 ---     w0      first line visible in current window (one if the
----       display isn't updated, e.g. in silent Ex mode)
+---             display isn't updated, e.g. in silent Ex mode)
 ---     w$      last line visible in current window (this is one
----       less than "w0" if no lines are visible)
----     v      In Visual mode: the start of the Visual area (the
----       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
----       that it's updated right away.
+---             less than "w0" if no lines are visible)
+---     v       In Visual mode: the start of the Visual area (the
+---             cursor is the end).  When not in Visual mode
+---             returns the cursor position.  Differs from |'<| in
+---             that it's updated right away.
 --- Note that a mark in another file can be used.  The line number
 --- then applies to another buffer.
 --- To get the column number use |col()|.  To get both use
@@ -4829,10 +4829,10 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 --- that window instead of the current window.
 --- Returns 0 for invalid values of {expr} and {winid}.
 --- Examples: >vim
----   echo line(".")      " line number of the cursor
----   echo line(".", winid)    " idem, in window "winid"
----   echo line("'t")      " line number of mark t
----   echo line("'" .. marker)  " line number of mark marker
+---         echo line(".")                  " line number of the cursor
+---         echo line(".", winid)           " idem, in window "winid"
+---         echo line("'t")                 " line number of mark t
+---         echo line("'" .. marker)        " line number of mark marker
 --- <
 --- To jump to the last known position when opening a file see
 --- |last-position-jump|.
@@ -4848,7 +4848,7 @@ function vim.fn.line(expr, winid) end
 --- line returns 1. UTF-8 encoding is used, 'fileencoding' is
 --- ignored.  This can also be used to get the byte count for the
 --- line just below the last line: >vim
----   echo line2byte(line("$") + 1)
+---         echo line2byte(line("$") + 1)
 --- <This is the buffer size plus one.  If 'fileencoding' is empty
 --- it is the file size plus one.  {lnum} is used like with
 --- |getline()|.  When {lnum} is invalid -1 is returned.
@@ -4870,8 +4870,8 @@ function vim.fn.lispindent(lnum) end
 
 --- Return a Blob concatenating all the number values in {list}.
 --- Examples: >vim
----   echo list2blob([1, 2, 3, 4])  " returns 0z01020304
----   echo list2blob([])    " returns 0z
+---         echo list2blob([1, 2, 3, 4])    " returns 0z01020304
+---         echo list2blob([])              " returns 0z
 --- <Returns an empty Blob on error.  If one of the numbers is
 --- negative or more than 255 error *E1239* is given.
 ---
@@ -4883,16 +4883,16 @@ function vim.fn.list2blob(list) end
 
 --- Convert each number in {list} to a character string can
 --- concatenate them all.  Examples: >vim
----   echo list2str([32])    " returns " "
----   echo list2str([65, 66, 67])  " returns "ABC"
+---         echo list2str([32])             " returns " "
+---         echo list2str([65, 66, 67])     " returns "ABC"
 --- <The same can be done (slowly) with: >vim
----   echo join(map(list, {nr, val -> nr2char(val)}), '')
+---         echo join(map(list, {nr, val -> nr2char(val)}), '')
 --- <|str2list()| does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
 --- With UTF-8 composing characters work as expected: >vim
----   echo list2str([97, 769])  " returns "á"
+---         echo list2str([97, 769])        " returns "á"
 --- <
 --- Returns an empty string on error.
 ---
@@ -4912,10 +4912,10 @@ function vim.fn.localtime() end
 --- (0, inf].
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo log(10)
---- <  2.302585 >vim
----   echo log(exp(5))
---- <  5.0
+---         echo log(10)
+--- <        2.302585 >vim
+---         echo log(exp(5))
+--- <        5.0
 ---
 --- @param expr any
 --- @return any
@@ -4925,10 +4925,10 @@ function vim.fn.log(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo log10(1000)
---- <  3.0 >vim
----   echo log10(0.01)
---- <  -2.0
+---         echo log10(1000)
+--- <        3.0 >vim
+---         echo log10(0.01)
+--- <        -2.0
 ---
 --- @param expr any
 --- @return any
@@ -4952,7 +4952,7 @@ function vim.fn.log10(expr) end
 --- current byte. For a |String| |v:key| has the index of the
 --- current character.
 --- Example: >vim
----   call map(mylist, '"> " .. v:val .. " <"')
+---         call map(mylist, '"> " .. v:val .. " <"')
 --- <This puts "> " before and " <" after each item in "mylist".
 ---
 --- Note that {expr2} is the result of an expression and is then
@@ -4961,24 +4961,24 @@ function vim.fn.log10(expr) end
 --- still have to double ' quotes
 ---
 --- If {expr2} is a |Funcref| it is called with two arguments:
----   1. The key or the index of the current item.
----   2. the value of the current item.
+---         1. The key or the index of the current item.
+---         2. the value of the current item.
 --- The function must return the new value of the item. Example
 --- that changes each value by "key-value": >vim
----   func KeyValue(key, val)
----     return a:key .. '-' .. a:val
----   endfunc
----   call map(myDict, function('KeyValue'))
+---         func KeyValue(key, val)
+---           return a:key .. '-' .. a:val
+---         endfunc
+---         call map(myDict, function('KeyValue'))
 --- <It is shorter when using a |lambda|: >vim
----   call map(myDict, {key, val -> key .. '-' .. val})
+---         call map(myDict, {key, val -> key .. '-' .. val})
 --- <If you do not use "val" you can leave it out: >vim
----   call map(myDict, {key -> 'item: ' .. key})
+---         call map(myDict, {key -> 'item: ' .. key})
 --- <If you do not use "key" you can use a short name: >vim
----   call map(myDict, {_, val -> 'item: ' .. val})
+---         call map(myDict, {_, val -> 'item: ' .. val})
 --- <
 --- The operation is done in-place for a |List| and |Dictionary|.
 --- If you want it to remain unmodified make a copy first: >vim
----   let tlist = map(copy(mylist), ' v:val .. "\t"')
+---         let tlist = map(copy(mylist), ' v:val .. "\t"')
 ---
 --- <Returns {expr1}, the |List| or |Dictionary| that was filtered,
 --- or a new |Blob| or |String|.
@@ -5007,16 +5007,16 @@ function vim.fn.map(expr1, expr2) end
 --- command.
 ---
 --- {mode} can be one of these strings:
----   "n"  Normal
----   "v"  Visual (including Select)
----   "o"  Operator-pending
----   "i"  Insert
----   "c"  Cmd-line
----   "s"  Select
----   "x"  Visual
----   "l"  langmap |language-mapping|
----   "t"  Terminal
----   ""  Normal, Visual and Operator-pending
+---         "n"     Normal
+---         "v"     Visual (including Select)
+---         "o"     Operator-pending
+---         "i"     Insert
+---         "c"     Cmd-line
+---         "s"     Select
+---         "x"     Visual
+---         "l"     langmap |language-mapping|
+---         "t"     Terminal
+---         ""      Normal, Visual and Operator-pending
 --- When {mode} is omitted, the modes for "" are used.
 ---
 --- When {abbr} is there and it is |TRUE| use abbreviations
@@ -5024,35 +5024,35 @@ function vim.fn.map(expr1, expr2) end
 ---
 --- When {dict} is there and it is |TRUE| return a dictionary
 --- containing all the information of the mapping with the
---- following items:      *mapping-dict*
----   "lhs"       The {lhs} of the mapping as it would be typed
+--- following items:                        *mapping-dict*
+---   "lhs"      The {lhs} of the mapping as it would be typed
 ---   "lhsraw"   The {lhs} of the mapping as raw bytes
 ---   "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
----         form, only present when it differs from "lhsraw"
----   "rhs"       The {rhs} of the mapping as typed.
+---               form, only present when it differs from "lhsraw"
+---   "rhs"      The {rhs} of the mapping as typed.
 ---   "silent"   1 for a |:map-silent| mapping, else 0.
 ---   "noremap"  1 if the {rhs} of the mapping is not remappable.
 ---   "script"   1 if mapping was defined with <script>.
 ---   "expr"     1 for an expression mapping (|:map-<expr>|).
 ---   "buffer"   1 for a buffer local mapping (|:map-local|).
 ---   "mode"     Modes for which the mapping is defined. In
----        addition to the modes mentioned above, these
----        characters will be used:
----        " "     Normal, Visual and Operator-pending
----        "!"     Insert and Commandline mode
----          (|mapmode-ic|)
----   "sid"       The script local ID, used for <sid> mappings
----        (|<SID>|).  Negative for special contexts.
+---              addition to the modes mentioned above, these
+---              characters will be used:
+---              " "     Normal, Visual and Operator-pending
+---              "!"     Insert and Commandline mode
+---                      (|mapmode-ic|)
+---   "sid"      The script local ID, used for <sid> mappings
+---              (|<SID>|).  Negative for special contexts.
 ---   "scriptversion"  The version of the script, always 1.
 ---   "lnum"     The line number in "sid", zero if unknown.
 ---   "nowait"   Do not wait for other, longer mappings.
----        (|:map-<nowait>|).
+---              (|:map-<nowait>|).
 ---   "abbr"     True if this is an |abbreviation|.
 ---   "mode_bits" Nvim's internal binary representation of "mode".
----        |mapset()| ignores this; only "mode" is used.
----        See |maplist()| for usage examples. The values
----        are from src/nvim/state_defs.h and may change in
----        the future.
+---              |mapset()| ignores this; only "mode" is used.
+---              See |maplist()| for usage examples. The values
+---              are from src/nvim/state_defs.h and may change in
+---              the future.
 ---
 --- The dictionary can be used to restore a mapping with
 --- |mapset()|.
@@ -5061,7 +5061,7 @@ function vim.fn.map(expr1, expr2) end
 --- then the global mappings.
 --- This function can be used to map a key even when it's already
 --- mapped, and have it do the original mapping too.  Sketch: >vim
----   exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+---         exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 ---
 --- @param name string
 --- @param mode? string
@@ -5078,11 +5078,11 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 --- A match happens with a mapping that starts with {name} and
 --- with a mapping which is equal to the start of {name}.
 ---
----   matches mapping "a"  "ab"  "abc" ~
----    mapcheck("a")  yes  yes   yes
----    mapcheck("abc")  yes  yes   yes
----    mapcheck("ax")  yes  no   no
----    mapcheck("b")  no  no   no
+---         matches mapping "a"     "ab"    "abc" ~
+---    mapcheck("a")        yes     yes      yes
+---    mapcheck("abc")      yes     yes      yes
+---    mapcheck("ax")       yes     no       no
+---    mapcheck("b")        no      no       no
 ---
 --- The difference with maparg() is that mapcheck() finds a
 --- mapping that matches with {name}, while maparg() only finds a
@@ -5096,9 +5096,9 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 --- then the global mappings.
 --- This function can be used to check if a mapping can be added
 --- without being ambiguous.  Example: >vim
----   if mapcheck("_vv") == ""
----      map _vv :set guifont=7x13<CR>
----   endif
+---         if mapcheck("_vv") == ""
+---            map _vv :set guifont=7x13<CR>
+---         endif
 --- <This avoids adding the "_vv" mapping when there already is a
 --- mapping for "_v" or for "_vvv".
 ---
@@ -5114,29 +5114,29 @@ function vim.fn.mapcheck(name, mode, abbr) end
 --- abbreviations instead of mappings.
 ---
 --- Example to show all mappings with "MultiMatch" in rhs: >vim
----   echo maplist()->filter({_, m ->
----     \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
----     \ })
+---         echo maplist()->filter({_, m ->
+---                 \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
+---                 \ })
 --- <It can be tricky to find mappings for particular |:map-modes|.
 --- |mapping-dict|'s "mode_bits" can simplify this. For example,
 --- the mode_bits for Normal, Insert or Command-line modes are
 --- 0x19. To find all the mappings available in those modes you
 --- can do: >vim
----   let saved_maps = []
----   for m in maplist()
----       if and(m.mode_bits, 0x19) != 0
----     eval saved_maps->add(m)
----       endif
----   endfor
----   echo saved_maps->mapnew({_, m -> m.lhs})
+---         let saved_maps = []
+---         for m in maplist()
+---             if and(m.mode_bits, 0x19) != 0
+---                 eval saved_maps->add(m)
+---             endif
+---         endfor
+---         echo saved_maps->mapnew({_, m -> m.lhs})
 --- <The values of the mode_bits are defined in Nvim's
 --- src/nvim/state_defs.h file and they can be discovered at
 --- runtime using |:map-commands| and "maplist()". Example: >vim
----   omap xyzzy <Nop>
----   let op_bit = maplist()->filter(
----       \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
----   ounmap xyzzy
----   echo printf("Operator-pending mode bit: 0x%x", op_bit)
+---         omap xyzzy <Nop>
+---         let op_bit = maplist()->filter(
+---             \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
+---         ounmap xyzzy
+---         echo printf("Operator-pending mode bit: 0x%x", op_bit)
 ---
 --- @return any
 function vim.fn.maplist() end
@@ -5165,10 +5165,10 @@ function vim.fn.mapnew(expr1, expr2) end
 --- {mode} is used to define the mode in which the mapping is set,
 --- not the "mode" entry in {dict}.
 --- Example for saving and restoring a mapping: >vim
----   let save_map = maparg('K', 'n', 0, 1)
----   nnoremap K somethingelse
----   " ...
----   call mapset('n', 0, save_map)
+---         let save_map = maparg('K', 'n', 0, 1)
+---         nnoremap K somethingelse
+---         " ...
+---         call mapset('n', 0, save_map)
 --- <Note that if you are going to replace a map in several modes,
 --- e.g. with `:map!`, you need to save/restore the mapping for
 --- all of them, when they might differ.
@@ -5176,15 +5176,15 @@ function vim.fn.mapnew(expr1, expr2) end
 --- In the second form, with {dict} as the only argument, mode
 --- and abbr are taken from the dict.
 --- Example: >vim
----   let save_maps = maplist()->filter(
----         \ {_, m -> m.lhs == 'K'})
----   nnoremap K somethingelse
----   cnoremap K somethingelse2
----   " ...
----   unmap K
----   for d in save_maps
----       call mapset(d)
----   endfor
+---         let save_maps = maplist()->filter(
+---                                 \ {_, m -> m.lhs == 'K'})
+---         nnoremap K somethingelse
+---         cnoremap K somethingelse2
+---         " ...
+---         unmap K
+---         for d in save_maps
+---             call mapset(d)
+---         endfor
 ---
 --- @param mode string
 --- @param abbr? any
@@ -5205,26 +5205,26 @@ function vim.fn.mapset(mode, abbr, dict) end
 ---
 --- For getting submatches see |matchlist()|.
 --- Example: >vim
----   echo match("testing", "ing")  " results in 4
----   echo match([1, 'x'], '\a')  " results in 1
+---         echo match("testing", "ing")    " results in 4
+---         echo match([1, 'x'], '\a')      " results in 1
 --- <See |string-match| for how {pat} is used.
----             *strpbrk()*
+---                                                 *strpbrk()*
 --- Vim doesn't have a strpbrk() function.  But you can do: >vim
----   let sepidx = match(line, '[.,;: \t]')
---- <            *strcasestr()*
+---         let sepidx = match(line, '[.,;: \t]')
+--- <                                               *strcasestr()*
 --- Vim doesn't have a strcasestr() function.  But you can add
 --- "\c" to the pattern to ignore case: >vim
----   let idx = match(haystack, '\cneedle')
+---         let idx = match(haystack, '\cneedle')
 --- <
 --- If {start} is given, the search starts from byte index
 --- {start} in a String or item {start} in a |List|.
 --- The result, however, is still the index counted from the
 --- first character/item.  Example: >vim
----   echo match("testing", "ing", 2)
+---         echo match("testing", "ing", 2)
 --- <result is again "4". >vim
----   echo match("testing", "ing", 4)
+---         echo match("testing", "ing", 4)
 --- <result is again "4". >vim
----   echo match("testing", "t", 2)
+---         echo match("testing", "t", 2)
 --- <result is "3".
 --- For a String, if {start} > 0 then it is like the string starts
 --- {start} bytes later, thus "^" will match at {start}.  Except
@@ -5239,7 +5239,7 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- When {count} is given use the {count}th match.  When a match
 --- is found in a String the search for the next one starts one
 --- character further.  Thus this example results in 1: >vim
----   echo match("testing", "..", 0, 2)
+---         echo match("testing", "..", 0, 2)
 --- <In a |List| the search continues in the next item.
 --- Note that when {count} is added the way {start} works changes,
 --- see above.
@@ -5296,11 +5296,11 @@ function vim.fn.match(expr, pat, start, count) end
 --- conceal character that will be shown for |hl-Conceal|
 --- highlighted matches. The dict can have the following members:
 ---
----   conceal      Special character to show instead of the
----         match (only for |hl-Conceal| highlighted
----         matches, see |:syn-cchar|)
----   window      Instead of the current window use the
----         window with this number or window ID.
+---         conceal     Special character to show instead of the
+---                     match (only for |hl-Conceal| highlighted
+---                     matches, see |:syn-cchar|)
+---         window      Instead of the current window use the
+---                     window with this number or window ID.
 ---
 --- The number of matches is not limited, as it is the case with
 --- the |:match| commands.
@@ -5308,10 +5308,10 @@ function vim.fn.match(expr, pat, start, count) end
 --- Returns -1 on error.
 ---
 --- Example: >vim
----   highlight MyGroup ctermbg=green guibg=green
----   let m = matchadd("MyGroup", "TODO")
+---         highlight MyGroup ctermbg=green guibg=green
+---         let m = matchadd("MyGroup", "TODO")
 --- <Deletion of the pattern: >vim
----   call matchdelete(m)
+---         call matchdelete(m)
 ---
 --- <A list of matches defined by |matchadd()| and |:match| are
 --- available from |getmatches()|.  All matches can be deleted in
@@ -5331,7 +5331,7 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- sets buffer line boundaries to redraw screen. It is supposed
 --- to be used when fast match additions and deletions are
 --- required, for example to highlight matching parentheses.
----           *E5030* *E5031*
+---                                         *E5030* *E5031*
 --- {pos} is a list of positions.  Each position can be one of
 --- these:
 --- - A number.  This whole line will be highlighted.  The first
@@ -5353,10 +5353,10 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- Returns -1 on error.
 ---
 --- Example: >vim
----   highlight MyGroup ctermbg=green guibg=green
----   let m = matchaddpos("MyGroup", [[23, 24], 34])
+---         highlight MyGroup ctermbg=green guibg=green
+---         let m = matchaddpos("MyGroup", [[23, 24], 34])
 --- <Deletion of the pattern: >vim
----   call matchdelete(m)
+---         call matchdelete(m)
 ---
 --- <Matches added by |matchaddpos()| are returned by
 --- |getmatches()|.
@@ -5372,8 +5372,8 @@ function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 --- Selects the {nr} match item, as set with a |:match|,
 --- |:2match| or |:3match| command.
 --- Return a |List| with two elements:
----   The name of the highlight group used
----   The pattern used.
+---         The name of the highlight group used
+---         The pattern used.
 --- When {nr} is not 1, 2 or 3 returns an empty |List|.
 --- When there is no match item set returns ['', ''].
 --- This is useful to save and restore a |:match|.
@@ -5398,19 +5398,19 @@ function vim.fn.matchdelete(id, win) end
 
 --- Same as |match()|, but return the index of first character
 --- after the match.  Example: >vim
----   echo matchend("testing", "ing")
+---         echo matchend("testing", "ing")
 --- <results in "7".
----           *strspn()* *strcspn()*
+---                                         *strspn()* *strcspn()*
 --- Vim doesn't have a strspn() or strcspn() function, but you can
 --- do it with matchend(): >vim
----   let span = matchend(line, '[a-zA-Z]')
----   let span = matchend(line, '[^a-zA-Z]')
+---         let span = matchend(line, '[a-zA-Z]')
+---         let span = matchend(line, '[^a-zA-Z]')
 --- <Except that -1 is returned when there are no matches.
 ---
 --- The {start}, if given, has the same meaning as for |match()|. >vim
----   echo matchend("testing", "ing", 2)
+---         echo matchend("testing", "ing", 2)
 --- <results in "7". >vim
----   echo matchend("testing", "ing", 5)
+---         echo matchend("testing", "ing", 5)
 --- <result is "-1".
 --- When {expr} is a |List| the result is equal to |match()|.
 ---
@@ -5427,22 +5427,22 @@ function vim.fn.matchend(expr, pat, start, count) end
 ---
 --- The optional {dict} argument always supports the following
 --- items:
----     matchseq  When this item is present return only matches
----     that contain the characters in {str} in the
----     given sequence.
----     limit  Maximum number of matches in {list} to be
----     returned.  Zero means no limit.
+---     matchseq    When this item is present return only matches
+---                 that contain the characters in {str} in the
+---                 given sequence.
+---     limit       Maximum number of matches in {list} to be
+---                 returned.  Zero means no limit.
 ---
 --- If {list} is a list of dictionaries, then the optional {dict}
 --- argument supports the following additional items:
----     key    Key of the item which is fuzzy matched against
----     {str}. The value of this item should be a
----     string.
----     text_cb  |Funcref| that will be called for every item
----     in {list} to get the text for fuzzy matching.
----     This should accept a dictionary item as the
----     argument and return the text for that item to
----     use for fuzzy matching.
+---     key         Key of the item which is fuzzy matched against
+---                 {str}. The value of this item should be a
+---                 string.
+---     text_cb     |Funcref| that will be called for every item
+---                 in {list} to get the text for fuzzy matching.
+---                 This should accept a dictionary item as the
+---                 argument and return the text for that item to
+---                 use for fuzzy matching.
 ---
 --- {str} is treated as a literal string and regular expression
 --- matching is NOT supported.  The maximum supported {str} length
@@ -5470,7 +5470,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 --- <results in a list of buffer information dicts with buffer
 --- names fuzzy matching "ndl". >vim
 ---    echo getbufinfo()->matchfuzzy("spl",
----         \ {'text_cb' : {v -> v.name}})
+---                                 \ {'text_cb' : {v -> v.name}})
 --- <results in a list of buffer information dicts with buffer
 --- names fuzzy matching "spl". >vim
 ---    echo v:oldfiles->matchfuzzy("test")
@@ -5480,7 +5480,7 @@ function vim.fn.matchend(expr, pat, start, count) end
 ---    echo ['one two', 'two one']->matchfuzzy('two one')
 --- <results in `['two one', 'one two']` . >vim
 ---    echo ['one two', 'two one']->matchfuzzy('two one',
----         \ {'matchseq': 1})
+---                                 \ {'matchseq': 1})
 --- <results in `['two one']`.
 ---
 --- @param list any
@@ -5502,12 +5502,12 @@ function vim.fn.matchfuzzy(list, str, dict) end
 --- list with three empty list items is returned.
 ---
 --- Example: >vim
----   echo matchfuzzypos(['testing'], 'tsg')
+---         echo matchfuzzypos(['testing'], 'tsg')
 --- <results in [["testing"], [[0, 2, 6]], [99]] >vim
----   echo matchfuzzypos(['clay', 'lacy'], 'la')
+---         echo matchfuzzypos(['clay', 'lacy'], 'la')
 --- <results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
----   echo [{'text': 'hello', 'id' : 10}]
----     \ ->matchfuzzypos('ll', {'key' : 'text'})
+---         echo [{'text': 'hello', 'id' : 10}]
+---                 \ ->matchfuzzypos('ll', {'key' : 'text'})
 --- <results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 ---
 --- @param list any
@@ -5521,7 +5521,7 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 --- return.  Following items are submatches, like "\1", "\2", etc.
 --- in |:substitute|.  When an optional submatch didn't match an
 --- empty string is used.  Example: >vim
----   echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
+---         echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
 --- <Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
 --- When there is no match an empty list is returned.
 ---
@@ -5535,13 +5535,13 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 function vim.fn.matchlist(expr, pat, start, count) end
 
 --- Same as |match()|, but return the matched string.  Example: >vim
----   echo matchstr("testing", "ing")
+---         echo matchstr("testing", "ing")
 --- <results in "ing".
 --- When there is no match "" is returned.
 --- The {start}, if given, has the same meaning as for |match()|. >vim
----   echo matchstr("testing", "ing", 2)
+---         echo matchstr("testing", "ing", 2)
 --- <results in "ing". >vim
----   echo matchstr("testing", "ing", 5)
+---         echo matchstr("testing", "ing", 5)
 --- <result is "".
 --- When {expr} is a |List| then the matching item is returned.
 --- The type isn't changed, it's not necessarily a String.
@@ -5555,18 +5555,18 @@ function vim.fn.matchstr(expr, pat, start, count) end
 
 --- Same as |matchstr()|, but return the matched string, the start
 --- position and the end position of the match.  Example: >vim
----   echo matchstrpos("testing", "ing")
+---         echo matchstrpos("testing", "ing")
 --- <results in ["ing", 4, 7].
 --- When there is no match ["", -1, -1] is returned.
 --- The {start}, if given, has the same meaning as for |match()|. >vim
----   echo matchstrpos("testing", "ing", 2)
+---         echo matchstrpos("testing", "ing", 2)
 --- <results in ["ing", 4, 7]. >vim
----   echo matchstrpos("testing", "ing", 5)
+---         echo matchstrpos("testing", "ing", 5)
 --- <result is ["", -1, -1].
 --- When {expr} is a |List| then the matching item, the index
 --- of first item where {pat} matches, the start position and the
 --- end position of the match are returned. >vim
----   echo matchstrpos([1, '__x'], '\a')
+---         echo matchstrpos([1, '__x'], '\a')
 --- <result is ["x", 1, 2, 3].
 --- The type isn't changed, it's not necessarily a String.
 ---
@@ -5578,7 +5578,7 @@ function vim.fn.matchstr(expr, pat, start, count) end
 function vim.fn.matchstrpos(expr, pat, start, count) end
 
 --- Return the maximum value of all items in {expr}. Example: >vim
----   echo max([apples, pears, oranges])
+---         echo max([apples, pears, oranges])
 ---
 --- <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
 --- it returns the maximum of all values in the Dictionary.
@@ -5595,44 +5595,44 @@ function vim.fn.max(expr) end
 ---
 --- {path} matches a menu by name, or all menus if {path} is an
 --- empty string.  Example: >vim
----   echo menu_get('File','')
----   echo menu_get('')
+---         echo menu_get('File','')
+---         echo menu_get('')
 --- <
 --- {modes} is a string of zero or more modes (see |maparg()| or
 --- |creating-menus| for the list of modes). "a" means "all".
 ---
 --- Example: >vim
----   nnoremenu &Test.Test inormal
----   inoremenu Test.Test insert
----   vnoremenu Test.Test x
----   echo menu_get("")
+---         nnoremenu &Test.Test inormal
+---         inoremenu Test.Test insert
+---         vnoremenu Test.Test x
+---         echo menu_get("")
 ---
 --- <returns something like this: >
 ---
----   [ {
----     "hidden": 0,
----     "name": "Test",
----     "priority": 500,
----     "shortcut": 84,
----     "submenus": [ {
----       "hidden": 0,
----       "mappings": {
----         i": {
----     "enabled": 1,
----     "noremap": 1,
----     "rhs": "insert",
----     "sid": 1,
----     "silent": 0
----         },
----         n": { ... },
----         s": { ... },
----         v": { ... }
----       },
----       "name": "Test",
----       "priority": 500,
----       "shortcut": 0
----     } ]
----   } ]
+---         [ {
+---           "hidden": 0,
+---           "name": "Test",
+---           "priority": 500,
+---           "shortcut": 84,
+---           "submenus": [ {
+---             "hidden": 0,
+---             "mappings": {
+---               i": {
+---                 "enabled": 1,
+---                 "noremap": 1,
+---                 "rhs": "insert",
+---                 "sid": 1,
+---                 "silent": 0
+---               },
+---               n": { ... },
+---               s": { ... },
+---               v": { ... }
+---             },
+---             "name": "Test",
+---             "priority": 500,
+---             "shortcut": 0
+---           } ]
+---         } ]
 --- <
 ---
 --- @param path string
@@ -5646,68 +5646,68 @@ function vim.fn.menu_get(path, modes) end
 --- menu names are returned.
 ---
 --- {mode} can be one of these strings:
----   "n"  Normal
----   "v"  Visual (including Select)
----   "o"  Operator-pending
----   "i"  Insert
----   "c"  Cmd-line
----   "s"  Select
----   "x"  Visual
----   "t"  Terminal-Job
----   ""  Normal, Visual and Operator-pending
----   "!"  Insert and Cmd-line
+---         "n"     Normal
+---         "v"     Visual (including Select)
+---         "o"     Operator-pending
+---         "i"     Insert
+---         "c"     Cmd-line
+---         "s"     Select
+---         "x"     Visual
+---         "t"     Terminal-Job
+---         ""      Normal, Visual and Operator-pending
+---         "!"     Insert and Cmd-line
 --- When {mode} is omitted, the modes for "" are used.
 ---
 --- Returns a |Dictionary| containing the following items:
----   accel    menu item accelerator text |menu-text|
----   display  display name (name without '&')
----   enabled  v:true if this menu item is enabled
----     Refer to |:menu-enable|
----   icon    name of the icon file (for toolbar)
----     |toolbar-icon|
----   iconidx  index of a built-in icon
----   modes    modes for which the menu is defined. In
----     addition to the modes mentioned above, these
----     characters will be used:
----     " "  Normal, Visual and Operator-pending
----   name    menu item name.
----   noremenu  v:true if the {rhs} of the menu item is not
----     remappable else v:false.
----   priority  menu order priority |menu-priority|
----   rhs    right-hand-side of the menu item. The returned
----     string has special characters translated like
----     in the output of the ":menu" command listing.
----     When the {rhs} of a menu item is empty, then
----     "<Nop>" is returned.
----   script  v:true if script-local remapping of {rhs} is
----     allowed else v:false.  See |:menu-script|.
----   shortcut  shortcut key (character after '&' in
----     the menu name) |menu-shortcut|
----   silent  v:true if the menu item is created
----     with <silent> argument |:menu-silent|
----   submenus  |List| containing the names of
----     all the submenus.  Present only if the menu
----     item has submenus.
+---   accel         menu item accelerator text |menu-text|
+---   display       display name (name without '&')
+---   enabled       v:true if this menu item is enabled
+---                 Refer to |:menu-enable|
+---   icon          name of the icon file (for toolbar)
+---                 |toolbar-icon|
+---   iconidx       index of a built-in icon
+---   modes         modes for which the menu is defined. In
+---                 addition to the modes mentioned above, these
+---                 characters will be used:
+---                 " "     Normal, Visual and Operator-pending
+---   name          menu item name.
+---   noremenu      v:true if the {rhs} of the menu item is not
+---                 remappable else v:false.
+---   priority      menu order priority |menu-priority|
+---   rhs           right-hand-side of the menu item. The returned
+---                 string has special characters translated like
+---                 in the output of the ":menu" command listing.
+---                 When the {rhs} of a menu item is empty, then
+---                 "<Nop>" is returned.
+---   script        v:true if script-local remapping of {rhs} is
+---                 allowed else v:false.  See |:menu-script|.
+---   shortcut      shortcut key (character after '&' in
+---                 the menu name) |menu-shortcut|
+---   silent        v:true if the menu item is created
+---                 with <silent> argument |:menu-silent|
+---   submenus      |List| containing the names of
+---                 all the submenus.  Present only if the menu
+---                 item has submenus.
 ---
 --- Returns an empty dictionary if the menu item is not found.
 ---
 --- Examples: >vim
----   echo menu_info('Edit.Cut')
----   echo menu_info('File.Save', 'n')
+---         echo menu_info('Edit.Cut')
+---         echo menu_info('File.Save', 'n')
 ---
----   " Display the entire menu hierarchy in a buffer
----   func ShowMenu(name, pfx)
----     let m = menu_info(a:name)
----     call append(line('$'), a:pfx .. m.display)
----     for child in m->get('submenus', [])
----       call ShowMenu(a:name .. '.' .. escape(child, '.'),
----           \ a:pfx .. '    ')
----     endfor
----   endfunc
----   new
----   for topmenu in menu_info('').submenus
----     call ShowMenu(topmenu, '')
----   endfor
+---         " Display the entire menu hierarchy in a buffer
+---         func ShowMenu(name, pfx)
+---           let m = menu_info(a:name)
+---           call append(line('$'), a:pfx .. m.display)
+---           for child in m->get('submenus', [])
+---             call ShowMenu(a:name .. '.' .. escape(child, '.'),
+---                                         \ a:pfx .. '    ')
+---           endfor
+---         endfunc
+---         new
+---         for topmenu in menu_info('').submenus
+---           call ShowMenu(topmenu, '')
+---         endfor
 --- <
 ---
 --- @param name string
@@ -5716,7 +5716,7 @@ function vim.fn.menu_get(path, modes) end
 function vim.fn.menu_info(name, mode) end
 
 --- Return the minimum value of all items in {expr}. Example: >vim
----   echo min([apples, pears, oranges])
+---         echo min([apples, pears, oranges])
 ---
 --- <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
 --- it returns the minimum of all values in the Dictionary.
@@ -5738,19 +5738,19 @@ function vim.fn.min(expr) end
 ---
 --- If {flags} contains "D" then {name} is deleted at the end of
 --- the current function, as with: >vim
----   defer delete({name}, 'd')
+---         defer delete({name}, 'd')
 --- <
 --- If {flags} contains "R" then {name} is deleted recursively at
 --- the end of the current function, as with: >vim
----   defer delete({name}, 'rf')
+---         defer delete({name}, 'rf')
 --- <Note that when {name} has more than one part and "p" is used
 --- some directories may already exist.  Only the first one that
 --- is created and what it contains is scheduled to be deleted.
 --- E.g. when using: >vim
----   call mkdir('subdir/tmp/autoload', 'pR')
+---         call mkdir('subdir/tmp/autoload', 'pR')
 --- <and "subdir" already exists then "subdir/tmp" will be
 --- scheduled for deletion, like with: >vim
----   defer delete('subdir/tmp', 'rf')
+---         defer delete('subdir/tmp', 'rf')
 --- <
 --- If {prot} is given it is used to set the protection bits of
 --- the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
@@ -5759,7 +5759,7 @@ function vim.fn.min(expr) end
 ---
 --- {prot} is applied for all parts of {name}.  Thus if you create
 --- /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
----   call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
+---         call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 ---
 --- <This function is not available in the |sandbox|.
 ---
@@ -5782,45 +5782,45 @@ function vim.fn.mkdir(name, flags, prot) end
 --- returned, otherwise only the first letter is returned.
 --- Also see |state()|.
 ---
----    n      Normal
----    no      Operator-pending
+---    n        Normal
+---    no       Operator-pending
 ---    nov      Operator-pending (forced charwise |o_v|)
 ---    noV      Operator-pending (forced linewise |o_V|)
 ---    noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
----     CTRL-V is one character
+---                 CTRL-V is one character
 ---    niI      Normal using |i_CTRL-O| in |Insert-mode|
 ---    niR      Normal using |i_CTRL-O| in |Replace-mode|
 ---    niV      Normal using |i_CTRL-O| in |Virtual-Replace-mode|
----    nt      Normal in |terminal-emulator| (insert goes to
----     Terminal mode)
+---    nt       Normal in |terminal-emulator| (insert goes to
+---                 Terminal mode)
 ---    ntT      Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
----    v      Visual by character
----    vs      Visual by character using |v_CTRL-O| in Select mode
----    V      Visual by line
----    Vs      Visual by line using |v_CTRL-O| in Select mode
+---    v        Visual by character
+---    vs       Visual by character using |v_CTRL-O| in Select mode
+---    V        Visual by line
+---    Vs       Visual by line using |v_CTRL-O| in Select mode
 ---    CTRL-V   Visual blockwise
 ---    CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
----    s      Select by character
----    S      Select by line
+---    s        Select by character
+---    S        Select by line
 ---    CTRL-S   Select blockwise
----    i      Insert
----    ic      Insert mode completion |compl-generic|
----    ix      Insert mode |i_CTRL-X| completion
----    R      Replace |R|
----    Rc      Replace mode completion |compl-generic|
----    Rx      Replace mode |i_CTRL-X| completion
----    Rv      Virtual Replace |gR|
+---    i        Insert
+---    ic       Insert mode completion |compl-generic|
+---    ix       Insert mode |i_CTRL-X| completion
+---    R        Replace |R|
+---    Rc       Replace mode completion |compl-generic|
+---    Rx       Replace mode |i_CTRL-X| completion
+---    Rv       Virtual Replace |gR|
 ---    Rvc      Virtual Replace mode completion |compl-generic|
 ---    Rvx      Virtual Replace mode |i_CTRL-X| completion
----    c      Command-line editing
----    cr      Command-line editing overstrike mode |c_<Insert>|
----    cv      Vim Ex mode |gQ|
+---    c        Command-line editing
+---    cr       Command-line editing overstrike mode |c_<Insert>|
+---    cv       Vim Ex mode |gQ|
 ---    cvr      Vim Ex mode while in overstrike mode |c_<Insert>|
----    r      Hit-enter prompt
----    rm      The -- more -- prompt
----    r?      A |:confirm| query of some sort
----    !      Shell or external command is executing
----    t      Terminal mode: keys go to the job
+---    r        Hit-enter prompt
+---    rm       The -- more -- prompt
+---    r?       A |:confirm| query of some sort
+---    !        Shell or external command is executing
+---    t        Terminal mode: keys go to the job
 ---
 --- This is useful in the 'statusline' option or RPC calls. In
 --- most other places it always returns "c" or "n".
@@ -5835,15 +5835,15 @@ function vim.fn.mode() end
 --- Convert a list of Vimscript objects to msgpack. Returned value is a
 --- |readfile()|-style list. When {type} contains "B", a |Blob| is
 --- returned instead. Example: >vim
----   call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
+---         call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
 --- <or, using a |Blob|: >vim
----   call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
+---         call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
 --- <
 --- This will write the single 0x80 byte to a `fname.mpack` file
 --- (dictionary with zero items is represented by 0x80 byte in
 --- messagepack).
 ---
---- Limitations:        *E5004* *E5005*
+--- Limitations:                            *E5004* *E5005*
 --- 1. |Funcref|s cannot be dumped.
 --- 2. Containers that reference themselves cannot be dumped.
 --- 3. Dictionary keys are always dumped as STR strings.
@@ -5858,9 +5858,9 @@ function vim.fn.msgpackdump(list, type) end
 --- Convert a |readfile()|-style list or a |Blob| to a list of
 --- Vimscript objects.
 --- Example: >vim
----   let fname = expand('~/.config/nvim/shada/main.shada')
----   let mpack = readfile(fname, 'b')
----   let shada_objects = msgpackparse(mpack)
+---         let fname = expand('~/.config/nvim/shada/main.shada')
+---         let mpack = readfile(fname, 'b')
+---         let shada_objects = msgpackparse(mpack)
 --- <This will read ~/.config/nvim/shada/main.shada file to
 --- `shada_objects` list.
 ---
@@ -5872,7 +5872,7 @@ function vim.fn.msgpackdump(list, type) end
 ---    (except for 1.) some strings are parsed to
 ---    |msgpack-special-dict| format which is not convenient to
 ---    use.
----           *msgpack-special-dict*
+---                                         *msgpack-special-dict*
 --- Some messagepack strings may be parsed to special
 --- dictionaries. Special dictionaries are dictionaries which
 ---
@@ -5882,50 +5882,50 @@ function vim.fn.msgpackdump(list, type) end
 --- 3. Value for `_VAL` has the following format (Key column
 ---    contains name of the key from |v:msgpack_types|):
 ---
---- Key  Value ~
---- nil  Zero, ignored when dumping.  Not returned by
----   |msgpackparse()| since |v:null| was introduced.
---- boolean  One or zero.  When dumping it is only checked that
----   value is a |Number|.  Not returned by |msgpackparse()|
----   since |v:true| and |v:false| were introduced.
---- integer  |List| with four numbers: sign (-1 or 1), highest two
----   bits, number with bits from 62nd to 31st, lowest 31
----   bits. I.e. to get actual number one will need to use
----   code like >
----     _VAL[0] * ((_VAL[1] << 62)
----                & (_VAL[2] << 31)
----                & _VAL[3])
---- <  Special dictionary with this type will appear in
----   |msgpackparse()| output under one of the following
----   circumstances:
----   1. |Number| is 32-bit and value is either above
----      INT32_MAX or below INT32_MIN.
----   2. |Number| is 64-bit and value is above INT64_MAX. It
----      cannot possibly be below INT64_MIN because msgpack
----      C parser does not support such values.
---- float  |Float|. This value cannot possibly appear in
----   |msgpackparse()| output.
+--- Key     Value ~
+--- nil     Zero, ignored when dumping.  Not returned by
+---         |msgpackparse()| since |v:null| was introduced.
+--- boolean One or zero.  When dumping it is only checked that
+---         value is a |Number|.  Not returned by |msgpackparse()|
+---         since |v:true| and |v:false| were introduced.
+--- integer |List| with four numbers: sign (-1 or 1), highest two
+---         bits, number with bits from 62nd to 31st, lowest 31
+---         bits. I.e. to get actual number one will need to use
+---         code like >
+---                 _VAL[0] * ((_VAL[1] << 62)
+---                            & (_VAL[2] << 31)
+---                            & _VAL[3])
+--- <       Special dictionary with this type will appear in
+---         |msgpackparse()| output under one of the following
+---         circumstances:
+---         1. |Number| is 32-bit and value is either above
+---            INT32_MAX or below INT32_MIN.
+---         2. |Number| is 64-bit and value is above INT64_MAX. It
+---            cannot possibly be below INT64_MIN because msgpack
+---            C parser does not support such values.
+--- float   |Float|. This value cannot possibly appear in
+---         |msgpackparse()| output.
 --- string  |readfile()|-style list of strings. This value will
----   appear in |msgpackparse()| output if string contains
----   zero byte or if string is a mapping key and mapping is
----   being represented as special dictionary for other
----   reasons.
+---         appear in |msgpackparse()| output if string contains
+---         zero byte or if string is a mapping key and mapping is
+---         being represented as special dictionary for other
+---         reasons.
 --- binary  |String|, or |Blob| if binary string contains zero
----   byte. This value cannot appear in |msgpackparse()|
----   output since blobs were introduced.
---- array  |List|. This value cannot appear in |msgpackparse()|
----   output.
----           *msgpack-special-map*
---- map  |List| of |List|s with two items (key and value) each.
----   This value will appear in |msgpackparse()| output if
----   parsed mapping contains one of the following keys:
----   1. Any key that is not a string (including keys which
----      are binary strings).
----   2. String with NUL byte inside.
----   3. Duplicate key.
---- ext  |List| with two values: first is a signed integer
----   representing extension type. Second is
----   |readfile()|-style list of strings.
+---         byte. This value cannot appear in |msgpackparse()|
+---         output since blobs were introduced.
+--- array   |List|. This value cannot appear in |msgpackparse()|
+---         output.
+---                                         *msgpack-special-map*
+--- map     |List| of |List|s with two items (key and value) each.
+---         This value will appear in |msgpackparse()| output if
+---         parsed mapping contains one of the following keys:
+---         1. Any key that is not a string (including keys which
+---            are binary strings).
+---         2. String with NUL byte inside.
+---         3. Duplicate key.
+--- ext     |List| with two values: first is a signed integer
+---         representing extension type. Second is
+---         |readfile()|-style list of strings.
 ---
 --- @param data any
 --- @return any
@@ -5933,7 +5933,7 @@ function vim.fn.msgpackparse(data) end
 
 --- Return the line number of the first line at or below {lnum}
 --- that is not blank.  Example: >vim
----   if getline(nextnonblank(1)) =~ "Java" | endif
+---         if getline(nextnonblank(1)) =~ "Java" | endif
 --- <When {lnum} is invalid or there is no non-blank line at or
 --- below it, zero is returned.
 --- {lnum} is used like with |getline()|.
@@ -5945,10 +5945,10 @@ function vim.fn.nextnonblank(lnum) end
 
 --- Return a string with a single character, which has the number
 --- value {expr}.  Examples: >vim
----   echo nr2char(64)    " returns '\@'
----   echo nr2char(32)    " returns ' '
+---         echo nr2char(64)                " returns '@'
+---         echo nr2char(32)                " returns ' '
 --- <Example for "utf-8": >vim
----   echo nr2char(300)    " returns I with bow character
+---         echo nr2char(300)               " returns I with bow character
 --- <
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
@@ -5966,7 +5966,7 @@ function vim.fn.nr2char(expr, utf8) end
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `and()` and `xor()`.
 --- Example: >vim
----   let bits = or(bits, 0x80)
+---         let bits = or(bits, 0x80)
 ---
 --- <Rationale: The reason this is a function and not using the "|"
 --- character like many languages, is that Vi has always used "|"
@@ -5983,11 +5983,11 @@ vim.fn['or'] = function(expr, expr1) end
 --- components in the path are reduced to {len} letters in length.
 --- If {len} is omitted or smaller than 1 then 1 is used (single
 --- letters).  Leading '~' and '.' characters are kept.  Examples: >vim
----   echo pathshorten('~/.config/nvim/autoload/file1.vim')
---- <  ~/.c/n/a/file1.vim ~
+---         echo pathshorten('~/.config/nvim/autoload/file1.vim')
+--- <       ~/.c/n/a/file1.vim ~
 --- >vim
----   echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
---- <  ~/.co/nv/au/file2.vim ~
+---         echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
+--- <       ~/.co/nv/au/file2.vim ~
 --- It doesn't matter if the path exists or not.
 --- Returns an empty string on error.
 ---
@@ -6007,8 +6007,8 @@ function vim.fn.pathshorten(path, len) end
 --- Note: If you want an array or hash, {expr} must return a
 --- reference to it.
 --- Example: >vim
----   echo perleval('[1 .. 4]')
---- <  [1, 2, 3, 4]
+---         echo perleval('[1 .. 4]')
+--- <       [1, 2, 3, 4]
 ---
 --- @param expr any
 --- @return any
@@ -6018,12 +6018,12 @@ function vim.fn.perleval(expr) end
 --- {x} and {y} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo pow(3, 3)
---- <  27.0 >vim
----   echo pow(2, 16)
---- <  65536.0 >vim
----   echo pow(32, 0.20)
---- <  2.0
+---         echo pow(3, 3)
+--- <        27.0 >vim
+---         echo pow(2, 16)
+--- <        65536.0 >vim
+---         echo pow(32, 0.20)
+--- <        2.0
 ---
 --- @param x any
 --- @param y any
@@ -6032,7 +6032,7 @@ function vim.fn.pow(x, y) end
 
 --- Return the line number of the first line at or above {lnum}
 --- that is not blank.  Example: >vim
----   let ind = indent(prevnonblank(v:lnum - 1))
+---         let ind = indent(prevnonblank(v:lnum - 1))
 --- <When {lnum} is invalid or there is no non-blank line at or
 --- above it, zero is returned.
 --- {lnum} is used like with |getline()|.
@@ -6044,39 +6044,39 @@ function vim.fn.prevnonblank(lnum) end
 
 --- Return a String with {fmt}, where "%" items are replaced by
 --- the formatted form of their respective arguments.  Example: >vim
----   echo printf("%4d: E%d %.30s", lnum, errno, msg)
+---         echo printf("%4d: E%d %.30s", lnum, errno, msg)
 --- <May result in:
----   "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
+---         "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 ---
 --- When used as a |method| the base is passed as the second
 --- argument: >vim
----   Compute()->printf("result: %d")
+---         Compute()->printf("result: %d")
 --- <
 --- You can use `call()` to pass the items as a list.
 ---
 --- Often used items are:
----   %s  string
----   %6S  string right-aligned in 6 display cells
----   %6s  string right-aligned in 6 bytes
+---   %s    string
+---   %6S   string right-aligned in 6 display cells
+---   %6s   string right-aligned in 6 bytes
 ---   %.9s  string truncated to 9 bytes
----   %c  single byte
----   %d  decimal number
----   %5d  decimal number padded with spaces to 5 characters
----   %b  binary number
+---   %c    single byte
+---   %d    decimal number
+---   %5d   decimal number padded with spaces to 5 characters
+---   %b    binary number
 ---   %08b  binary number padded with zeros to at least 8 characters
----   %B  binary number using upper case letters
----   %x  hex number
+---   %B    binary number using upper case letters
+---   %x    hex number
 ---   %04x  hex number padded with zeros to at least 4 characters
----   %X  hex number using upper case letters
----   %o  octal number
----   %f  floating point number as 12.23, inf, -inf or nan
----   %F  floating point number as 12.23, INF, -INF or NAN
----   %e  floating point number as 1.23e3, inf, -inf or nan
----   %E  floating point number as 1.23E3, INF, -INF or NAN
----   %g  floating point number, as %f or %e depending on value
----   %G  floating point number, as %F or %E depending on value
----   %%  the % character itself
----   %p  representation of the pointer to the container
+---   %X    hex number using upper case letters
+---   %o    octal number
+---   %f    floating point number as 12.23, inf, -inf or nan
+---   %F    floating point number as 12.23, INF, -INF or NAN
+---   %e    floating point number as 1.23e3, inf, -inf or nan
+---   %E    floating point number as 1.23E3, INF, -INF or NAN
+---   %g    floating point number, as %f or %e depending on value
+---   %G    floating point number, as %F or %E depending on value
+---   %%    the % character itself
+---   %p    representation of the pointer to the container
 ---
 --- Conversion specifications start with '%' and end with the
 --- conversion type.  All other characters are copied unchanged to
@@ -6085,68 +6085,68 @@ function vim.fn.prevnonblank(lnum) end
 --- The "%" starts a conversion specification.  The following
 --- arguments appear in sequence:
 ---
----   % [pos-argument] [flags] [field-width] [.precision] type
+---         % [pos-argument] [flags] [field-width] [.precision] type
 ---
 --- pos-argument
----   At most one positional argument specifier. These
----   take the form {n$}, where n is >= 1.
+---         At most one positional argument specifier. These
+---         take the form {n$}, where n is >= 1.
 ---
 --- flags
----   Zero or more of the following flags:
+---         Zero or more of the following flags:
 ---
----     #        The value should be converted to an "alternate
----         form".  For c, d, and s conversions, this option
----         has no effect.  For o conversions, the precision
----         of the number is increased to force the first
----         character of the output string to a zero (except
----         if a zero value is printed with an explicit
----         precision of zero).
----         For x and X conversions, a non-zero result has
----         the string "0x" (or "0X" for X conversions)
----         prepended to it.
+---     #         The value should be converted to an "alternate
+---               form".  For c, d, and s conversions, this option
+---               has no effect.  For o conversions, the precision
+---               of the number is increased to force the first
+---               character of the output string to a zero (except
+---               if a zero value is printed with an explicit
+---               precision of zero).
+---               For x and X conversions, a non-zero result has
+---               the string "0x" (or "0X" for X conversions)
+---               prepended to it.
 ---
 ---     0 (zero)  Zero padding.  For all conversions the converted
----         value is padded on the left with zeros rather
----         than blanks.  If a precision is given with a
----         numeric conversion (d, o, x, and X), the 0 flag
----         is ignored.
+---               value is padded on the left with zeros rather
+---               than blanks.  If a precision is given with a
+---               numeric conversion (d, o, x, and X), the 0 flag
+---               is ignored.
 ---
----     -        A negative field width flag; the converted value
----         is to be left adjusted on the field boundary.
----         The converted value is padded on the right with
----         blanks, rather than on the left with blanks or
----         zeros.  A - overrides a 0 if both are given.
+---     -         A negative field width flag; the converted value
+---               is to be left adjusted on the field boundary.
+---               The converted value is padded on the right with
+---               blanks, rather than on the left with blanks or
+---               zeros.  A - overrides a 0 if both are given.
 ---
 ---     ' ' (space)  A blank should be left before a positive
----         number produced by a signed conversion (d).
+---               number produced by a signed conversion (d).
 ---
----     +        A sign must always be placed before a number
----         produced by a signed conversion.  A + overrides
----         a space if both are used.
+---     +         A sign must always be placed before a number
+---               produced by a signed conversion.  A + overrides
+---               a space if both are used.
 ---
 --- field-width
----   An optional decimal digit string specifying a minimum
----   field width.  If the converted value has fewer bytes
----   than the field width, it will be padded with spaces on
----   the left (or right, if the left-adjustment flag has
----   been given) to fill out the field width.  For the S
----   conversion the count is in cells.
+---         An optional decimal digit string specifying a minimum
+---         field width.  If the converted value has fewer bytes
+---         than the field width, it will be padded with spaces on
+---         the left (or right, if the left-adjustment flag has
+---         been given) to fill out the field width.  For the S
+---         conversion the count is in cells.
 ---
 --- .precision
----   An optional precision, in the form of a period '.'
----   followed by an optional digit string.  If the digit
----   string is omitted, the precision is taken as zero.
----   This gives the minimum number of digits to appear for
----   d, o, x, and X conversions, the maximum number of
----   bytes to be printed from a string for s conversions,
----   or the maximum number of cells to be printed from a
----   string for S conversions.
----   For floating point it is the number of digits after
----   the decimal point.
+---         An optional precision, in the form of a period '.'
+---         followed by an optional digit string.  If the digit
+---         string is omitted, the precision is taken as zero.
+---         This gives the minimum number of digits to appear for
+---         d, o, x, and X conversions, the maximum number of
+---         bytes to be printed from a string for s conversions,
+---         or the maximum number of cells to be printed from a
+---         string for S conversions.
+---         For floating point it is the number of digits after
+---         the decimal point.
 ---
 --- type
----   A character that specifies the type of conversion to
----   be applied, see below.
+---         A character that specifies the type of conversion to
+---         be applied, see below.
 ---
 --- A field width or precision, or both, may be indicated by an
 --- asterisk "*" instead of a digit string.  In this case, a
@@ -6154,7 +6154,7 @@ function vim.fn.prevnonblank(lnum) end
 --- negative field width is treated as a left adjustment flag
 --- followed by a positive field width; a negative precision is
 --- treated as though it were missing.  Example: >vim
----   echo printf("%d: %.*s", nr, width, line)
+---         echo printf("%d: %.*s", nr, width, line)
 --- <This limits the length of the text used from "line" to
 --- "width" bytes.
 ---
@@ -6166,84 +6166,84 @@ function vim.fn.prevnonblank(lnum) end
 ---
 --- The conversion specifiers and their meanings are:
 ---
----     *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
+---                 *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
 --- dbBoxX  The Number argument is converted to signed decimal (d),
----   unsigned binary (b and B), unsigned octal (o), or
----   unsigned hexadecimal (x and X) notation.  The letters
----   "abcdef" are used for x conversions; the letters
----   "ABCDEF" are used for X conversions.  The precision, if
----   any, gives the minimum number of digits that must
----   appear; if the converted value requires fewer digits, it
----   is padded on the left with zeros.  In no case does a
----   non-existent or small field width cause truncation of a
----   numeric field; if the result of a conversion is wider
----   than the field width, the field is expanded to contain
----   the conversion result.
----   The 'h' modifier indicates the argument is 16 bits.
----   The 'l' modifier indicates the argument is a long
----   integer.  The size will be 32 bits or 64 bits
----   depending on your platform.
----   The "ll" modifier indicates the argument is 64 bits.
----   The b and B conversion specifiers never take a width
----   modifier and always assume their argument is a 64 bit
----   integer.
----   Generally, these modifiers are not useful. They are
----   ignored when type is known from the argument.
+---         unsigned binary (b and B), unsigned octal (o), or
+---         unsigned hexadecimal (x and X) notation.  The letters
+---         "abcdef" are used for x conversions; the letters
+---         "ABCDEF" are used for X conversions.  The precision, if
+---         any, gives the minimum number of digits that must
+---         appear; if the converted value requires fewer digits, it
+---         is padded on the left with zeros.  In no case does a
+---         non-existent or small field width cause truncation of a
+---         numeric field; if the result of a conversion is wider
+---         than the field width, the field is expanded to contain
+---         the conversion result.
+---         The 'h' modifier indicates the argument is 16 bits.
+---         The 'l' modifier indicates the argument is a long
+---         integer.  The size will be 32 bits or 64 bits
+---         depending on your platform.
+---         The "ll" modifier indicates the argument is 64 bits.
+---         The b and B conversion specifiers never take a width
+---         modifier and always assume their argument is a 64 bit
+---         integer.
+---         Generally, these modifiers are not useful. They are
+---         ignored when type is known from the argument.
 ---
---- i  alias for d
---- D  alias for ld
---- U  alias for lu
---- O  alias for lo
+--- i       alias for d
+--- D       alias for ld
+--- U       alias for lu
+--- O       alias for lo
 ---
----           *printf-c*
---- c  The Number argument is converted to a byte, and the
----   resulting character is written.
+---                                         *printf-c*
+--- c       The Number argument is converted to a byte, and the
+---         resulting character is written.
 ---
----           *printf-s*
---- s  The text of the String argument is used.  If a
----   precision is specified, no more bytes than the number
----   specified are used.
----   If the argument is not a String type, it is
----   automatically converted to text with the same format
----   as ":echo".
----           *printf-S*
---- S  The text of the String argument is used.  If a
----   precision is specified, no more display cells than the
----   number specified are used.
+---                                         *printf-s*
+--- s       The text of the String argument is used.  If a
+---         precision is specified, no more bytes than the number
+---         specified are used.
+---         If the argument is not a String type, it is
+---         automatically converted to text with the same format
+---         as ":echo".
+---                                         *printf-S*
+--- S       The text of the String argument is used.  If a
+---         precision is specified, no more display cells than the
+---         number specified are used.
 ---
----           *printf-f* *E807*
---- f F  The Float argument is converted into a string of the
----   form 123.456.  The precision specifies the number of
----   digits after the decimal point.  When the precision is
----   zero the decimal point is omitted.  When the precision
----   is not specified 6 is used.  A really big number
----   (out of range or dividing by zero) results in "inf"
----    or "-inf" with %f (INF or -INF with %F).
----    "0.0 / 0.0" results in "nan" with %f (NAN with %F).
----   Example: >vim
----     echo printf("%.2f", 12.115)
---- <    12.12
----   Note that roundoff depends on the system libraries.
----   Use |round()| when in doubt.
+---                                         *printf-f* *E807*
+--- f F     The Float argument is converted into a string of the
+---         form 123.456.  The precision specifies the number of
+---         digits after the decimal point.  When the precision is
+---         zero the decimal point is omitted.  When the precision
+---         is not specified 6 is used.  A really big number
+---         (out of range or dividing by zero) results in "inf"
+---          or "-inf" with %f (INF or -INF with %F).
+---          "0.0 / 0.0" results in "nan" with %f (NAN with %F).
+---         Example: >vim
+---                 echo printf("%.2f", 12.115)
+--- <               12.12
+---         Note that roundoff depends on the system libraries.
+---         Use |round()| when in doubt.
 ---
----           *printf-e* *printf-E*
---- e E  The Float argument is converted into a string of the
----   form 1.234e+03 or 1.234E+03 when using 'E'.  The
----   precision specifies the number of digits after the
----   decimal point, like with 'f'.
+---                                         *printf-e* *printf-E*
+--- e E     The Float argument is converted into a string of the
+---         form 1.234e+03 or 1.234E+03 when using 'E'.  The
+---         precision specifies the number of digits after the
+---         decimal point, like with 'f'.
 ---
----           *printf-g* *printf-G*
---- g G  The Float argument is converted like with 'f' if the
----   value is between 0.001 (inclusive) and 10000000.0
----   (exclusive).  Otherwise 'e' is used for 'g' and 'E'
----   for 'G'.  When no precision is specified superfluous
----   zeroes and '+' signs are removed, except for the zero
----   immediately after the decimal point.  Thus 10000000.0
----   results in 1.0e7.
+---                                         *printf-g* *printf-G*
+--- g G     The Float argument is converted like with 'f' if the
+---         value is between 0.001 (inclusive) and 10000000.0
+---         (exclusive).  Otherwise 'e' is used for 'g' and 'E'
+---         for 'G'.  When no precision is specified superfluous
+---         zeroes and '+' signs are removed, except for the zero
+---         immediately after the decimal point.  Thus 10000000.0
+---         results in 1.0e7.
 ---
----           *printf-%*
---- %  A '%' is written.  No argument is converted.  The
----   complete conversion specification is "%%".
+---                                         *printf-%*
+--- %       A '%' is written.  No argument is converted.  The
+---         complete conversion specification is "%%".
 ---
 --- When a Number argument is expected a String argument is also
 --- accepted and automatically converted.
@@ -6251,12 +6251,12 @@ function vim.fn.prevnonblank(lnum) end
 --- is also accepted and automatically converted.
 --- Any other argument type results in an error message.
 ---
----           *E766* *E767*
+---                                         *E766* *E767*
 --- The number of {exprN} arguments must exactly match the number
 --- of "%" items.  If there are not sufficient or too many
 --- arguments an error is given.  Up to 18 arguments can be used.
 ---
----           *printf-$*
+---                                         *printf-$*
 --- In certain languages, error and informative messages are
 --- more readable when the order of words is different from the
 --- corresponding message in English. To accommodate translations
@@ -6271,13 +6271,13 @@ function vim.fn.prevnonblank(lnum) end
 --- reversed in the output. >vim
 ---
 ---     echo printf(
----   "In The Netherlands, vim's creator's name is: %1$s %2$s",
----   "Bram", "Moolenaar")
+---         "In The Netherlands, vim's creator's name is: %1$s %2$s",
+---         "Bram", "Moolenaar")
 --- <    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 ---
 ---     echo printf(
----   "In Belgium, vim's creator's name is: %2$s %1$s",
----   "Bram", "Moolenaar")
+---         "In Belgium, vim's creator's name is: %2$s %1$s",
+---         "Bram", "Moolenaar")
 --- <    In Belgium, vim's creator's name is: Moolenaar Bram
 ---
 --- Width (and precision) can be specified using the '*' specifier.
@@ -6303,19 +6303,19 @@ function vim.fn.prevnonblank(lnum) end
 ---     echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
 --- <      1.41
 ---
----           *E1500*
+---                                         *E1500*
 --- You cannot mix positional and non-positional arguments: >vim
 ---     echo printf("%s%1$s", "One", "Two")
 --- <    E1500: Cannot mix positional and non-positional arguments:
 ---     %s%1$s
 ---
----           *E1501*
+---                                         *E1501*
 --- You cannot skip a positional argument in a format string: >vim
 ---     echo printf("%3$s%1$s", "One", "Two", "Three")
 --- <    E1501: format argument 2 unused in $-style format:
 ---     %3$s%1$s
 ---
----           *E1502*
+---                                         *E1502*
 --- You can re-use a [field-width] (or [precision]) argument: >vim
 ---     echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
 --- <    1 at width 2 is: 01
@@ -6325,7 +6325,7 @@ function vim.fn.prevnonblank(lnum) end
 --- <    E1502: Positional argument 2 used as field width reused as
 ---     different type: long int/int
 ---
----           *E1503*
+---                                         *E1503*
 --- When a positional argument is used, but not the correct number
 --- or arguments is given, an error is raised: >vim
 ---     echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
@@ -6337,7 +6337,7 @@ function vim.fn.prevnonblank(lnum) end
 --- <    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
 ---     %4$d
 ---
----           *E1504*
+---                                         *E1504*
 --- A positional argument can be used more than once: >vim
 ---     echo printf("%1$s %2$s %1$s", "One", "Two")
 --- <    One Two One
@@ -6347,14 +6347,14 @@ function vim.fn.prevnonblank(lnum) end
 --- <    E1504: Positional argument 1 type used inconsistently:
 ---     int/string
 ---
----           *E1505*
+---                                         *E1505*
 --- Various other errors that lead to a format string being
 --- wrongly formatted lead to: >vim
 ---     echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
 --- <    E1505: Invalid format specifier: %1$d at width %2$d is:
 ---     %01$*2$.3$d
 ---
----           *E1507*
+---                                         *E1507*
 --- This internal error indicates that the logic to parse a
 --- positional format argument ran into a problem that couldn't be
 --- otherwise reported.  Please file a bug against Vim if you run
@@ -6429,7 +6429,7 @@ function vim.fn.prompt_setinterrupt(buf, expr) end
 --- {text} to end in a space.
 --- The result is only visible if {buf} has 'buftype' set to
 --- "prompt".  Example: >vim
----   call prompt_setprompt(bufnr(''), 'command: ')
+---         call prompt_setprompt(bufnr(''), 'command: ')
 --- <
 ---
 --- @param buf any
@@ -6440,12 +6440,12 @@ function vim.fn.prompt_setprompt(buf, text) end
 --- If the popup menu (see |ins-completion-menu|) is not visible,
 --- returns an empty |Dictionary|, otherwise, returns a
 --- |Dictionary| with the following keys:
----   height    nr of items visible
----   width    screen cells
----   row    top screen row (0 first row)
----   col    leftmost screen column (0 first col)
----   size    total nr of items
----   scrollbar  |TRUE| if scrollbar is visible
+---         height          nr of items visible
+---         width           screen cells
+---         row             top screen row (0 first row)
+---         col             leftmost screen column (0 first col)
+---         size            total nr of items
+---         scrollbar       |TRUE| if scrollbar is visible
 ---
 --- The values are the same as in |v:event| during |CompleteChanged|.
 ---
@@ -6503,10 +6503,10 @@ function vim.fn.pyxeval(expr) end
 --- Returns -1 if {expr} is invalid.
 ---
 --- Examples: >vim
----   echo rand()
----   let seed = srand()
----   echo rand(seed)
----   echo rand(seed) % 16  " random number 0 - 15
+---         echo rand()
+---         let seed = srand()
+---         echo rand(seed)
+---         echo rand(seed) % 16  " random number 0 - 15
 --- <
 ---
 --- @param expr? any
@@ -6523,12 +6523,12 @@ function vim.fn.rand(expr) end
 --- empty list.  When the maximum is more than one before the
 --- start this is an error.
 --- Examples: >vim
----   echo range(4)    " [0, 1, 2, 3]
----   echo range(2, 4)  " [2, 3, 4]
----   echo range(2, 9, 3)  " [2, 5, 8]
----   echo range(2, -2, -1)  " [2, 1, 0, -1, -2]
----   echo range(0)    " []
----   echo range(2, 0)  " error!
+---         echo range(4)           " [0, 1, 2, 3]
+---         echo range(2, 4)        " [2, 3, 4]
+---         echo range(2, 9, 3)     " [2, 5, 8]
+---         echo range(2, -2, -1)   " [2, 1, 0, -1, -2]
+---         echo range(0)           " []
+---         echo range(2, 0)        " error!
 --- <
 ---
 --- @param expr any
@@ -6541,17 +6541,17 @@ function vim.fn.range(expr, max, stride) end
 --- If {offset} is specified, read the file from the specified
 --- offset.  If it is a negative value, it is used as an offset
 --- from the end of the file.  E.g., to read the last 12 bytes: >vim
----   echo readblob('file.bin', -12)
+---         echo readblob('file.bin', -12)
 --- <If {size} is specified, only the specified size will be read.
 --- E.g. to read the first 100 bytes of a file: >vim
----   echo readblob('file.bin', 0, 100)
+---         echo readblob('file.bin', 0, 100)
 --- <If {size} is -1 or omitted, the whole data starting from
 --- {offset} will be read.
 --- This can be also used to read the data from a character device
 --- on Unix when {size} is explicitly set.  Only if the device
 --- supports seeking {offset} can be used.  Otherwise it should be
 --- zero.  E.g. to read 10 bytes from a serial console: >vim
----   echo readblob('/dev/ttyS0', 0, 10)
+---         echo readblob('/dev/ttyS0', 0, 10)
 --- <When the file can't be opened an error message is given and
 --- the result is an empty |Blob|.
 --- When the offset is beyond the end of the file the result is an
@@ -6572,12 +6572,12 @@ function vim.fn.readblob(fname, offset, size) end
 ---
 --- When {expr} is omitted all entries are included.
 --- When {expr} is given, it is evaluated to check what to do:
----   If {expr} results in -1 then no further entries will
----   be handled.
----   If {expr} results in 0 then this entry will not be
----   added to the list.
----   If {expr} results in 1 then this entry will be added
----   to the list.
+---         If {expr} results in -1 then no further entries will
+---         be handled.
+---         If {expr} results in 0 then this entry will not be
+---         added to the list.
+---         If {expr} results in 1 then this entry will be added
+---         to the list.
 --- Each time {expr} is evaluated |v:val| is set to the entry name.
 --- When {expr} is a function the name is passed as the argument.
 --- For example, to get a list of files ending in ".txt": >vim
@@ -6616,9 +6616,9 @@ function vim.fn.readdir(directory, expr) end
 --- When {max} is given this specifies the maximum number of lines
 --- to be read.  Useful if you only want to check the first ten
 --- lines of a file: >vim
----   for line in readfile(fname, '', 10)
----     if line =~ 'Date' | echo line | endif
----   endfor
+---         for line in readfile(fname, '', 10)
+---           if line =~ 'Date' | echo line | endif
+---         endfor
 --- <When {max} is negative -{max} lines from the end of the file
 --- are returned, or as many as there are.
 --- When {max} is zero the result is an empty list.
@@ -6649,10 +6649,10 @@ function vim.fn.readfile(fname, type, max) end
 --- result can be computed, an E998 error is given.
 ---
 --- Examples: >vim
----   echo reduce([1, 3, 5], { acc, val -> acc + val })
----   echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
----   echo reduce(0z1122, { acc, val -> 2 * acc + val })
----   echo reduce('xyz', { acc, val -> acc .. ',' .. val })
+---         echo reduce([1, 3, 5], { acc, val -> acc + val })
+---         echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+---         echo reduce(0z1122, { acc, val -> 2 * acc + val })
+---         echo reduce('xyz', { acc, val -> acc .. ',' .. val })
 --- <
 ---
 --- @param object any
@@ -6663,7 +6663,7 @@ function vim.fn.reduce(object, func, initial) end
 
 --- Returns the single letter name of the register being executed.
 --- Returns an empty string when no register is being executed.
---- See |\@|.
+--- See |@|.
 ---
 --- @return any
 function vim.fn.reg_executing() end
@@ -6715,9 +6715,9 @@ function vim.fn.reltime(start, end_) end
 --- Return a Float that represents the time value of {time}.
 --- Unit of time is seconds.
 --- Example:
----   let start = reltime()
----   call MyFunction()
----   let seconds = reltimefloat(reltime(start))
+---         let start = reltime()
+---         call MyFunction()
+---         let seconds = reltimefloat(reltime(start))
 --- See the note of reltimestr() about overhead.
 --- Also see |profiling|.
 --- If there is an error an empty string is returned
@@ -6729,13 +6729,13 @@ function vim.fn.reltimefloat(time) end
 --- Return a String that represents the time value of {time}.
 --- This is the number of seconds, a dot and the number of
 --- microseconds.  Example: >vim
----   let start = reltime()
----   call MyFunction()
----   echo reltimestr(reltime(start))
+---         let start = reltime()
+---         call MyFunction()
+---         echo reltimestr(reltime(start))
 --- <Note that overhead for the commands will be added to the time.
 --- Leading spaces are used to make the string align nicely.  You
 --- can use split() to remove it. >vim
----   echo split(reltimestr(reltime(start)))[0]
+---         echo split(reltimestr(reltime(start)))[0]
 --- <Also see |profiling|.
 --- If there is an error an empty string is returned
 ---
@@ -6757,8 +6757,8 @@ function vim.fn.remove(list, idx) end
 --- See |list-index| for possible values of {idx} and {end}.
 --- Returns zero on error.
 --- Example: >vim
----   echo "last item: " .. remove(mylist, -1)
----   call remove(mylist, 0, 9)
+---         echo "last item: " .. remove(mylist, -1)
+---         call remove(mylist, 0, 9)
 --- <
 --- Use |delete()| to remove a file.
 ---
@@ -6781,8 +6781,8 @@ function vim.fn.remove(blob, idx) end
 --- points to a byte before {idx} this is an error.
 --- Returns zero on error.
 --- Example: >vim
----   echo "last byte: " .. remove(myblob, -1)
----   call remove(mylist, 0, 9)
+---         echo "last byte: " .. remove(myblob, -1)
+---         call remove(mylist, 0, 9)
 --- <
 ---
 --- @param blob any
@@ -6793,7 +6793,7 @@ function vim.fn.remove(blob, idx, end_) end
 
 --- Remove the entry from {dict} with key {key} and return it.
 --- Example: >vim
----   echo "removed " .. remove(dict, "one")
+---         echo "removed " .. remove(dict, "one")
 --- <If there is no {key} in {dict} this is an error.
 --- Returns zero on error.
 ---
@@ -6816,11 +6816,11 @@ function vim.fn.rename(from, to) end
 
 --- Repeat {expr} {count} times and return the concatenated
 --- result.  Example: >vim
----   let separator = repeat('-', 80)
+---         let separator = repeat('-', 80)
 --- <When {count} is zero or negative the result is empty.
 --- When {expr} is a |List| or a |Blob| the result is {expr}
 --- concatenated {count} times.  Example: >vim
----   let longlist = repeat(['a', 'b'], 3)
+---         let longlist = repeat(['a', 'b'], 3)
 --- <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 ---
 --- @param expr any
@@ -6851,7 +6851,7 @@ function vim.fn.resolve(filename) end
 --- Returns zero if {object} is not a List, Blob or a String.
 --- If you want a List or Blob to remain unmodified make a copy
 --- first: >vim
----   let revlist = reverse(copy(mylist))
+---         let revlist = reverse(copy(mylist))
 --- <
 ---
 --- @param object any
@@ -6864,12 +6864,12 @@ function vim.fn.reverse(object) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo round(0.456)
---- <  0.0  >vim
----   echo round(4.5)
---- <  5.0 >vim
----   echo round(-4.5)
---- <  -5.0
+---         echo round(0.456)
+--- <        0.0  >vim
+---         echo round(4.5)
+--- <        5.0 >vim
+---         echo round(-4.5)
+--- <        -5.0
 ---
 --- @param expr any
 --- @return any
@@ -6878,7 +6878,7 @@ function vim.fn.round(expr) end
 --- Sends {event} to {channel} via |RPC| and returns immediately.
 --- If {channel} is 0, the event is broadcast to all channels.
 --- Example: >vim
----   au VimLeave call rpcnotify(0, "leaving")
+---         au VimLeave call rpcnotify(0, "leaving")
 --- <
 ---
 --- @param channel any
@@ -6890,7 +6890,7 @@ function vim.fn.rpcnotify(channel, event, args) end
 --- Sends a request to {channel} to invoke {method} via
 --- |RPC| and blocks until a response is received.
 --- Example: >vim
----   let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+---         let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 --- <
 ---
 --- @param channel any
@@ -6900,9 +6900,9 @@ function vim.fn.rpcnotify(channel, event, args) end
 function vim.fn.rpcrequest(channel, method, args) end
 
 --- Deprecated. Replace  >vim
----   let id = rpcstart('prog', ['arg1', 'arg2'])
+---         let id = rpcstart('prog', ['arg1', 'arg2'])
 --- <with >vim
----   let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+---         let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 --- <
 ---
 --- @param prog any
@@ -6977,9 +6977,9 @@ function vim.fn.screenchars(row, col) end
 --- column inside the command line, which is 1 when the command is
 --- executed. To get the cursor position in the file use one of
 --- the following mappings: >vim
----   nnoremap <expr> GG ":echom " .. screencol() .. "\n"
----   nnoremap <silent> GG :echom screencol()<CR>
----   noremap GG <Cmd>echom screencol()<Cr>
+---         nnoremap <expr> GG ":echom " .. screencol() .. "\n"
+---         nnoremap <silent> GG :echom screencol()<CR>
+---         noremap GG <Cmd>echom screencol()<Cr>
 --- <
 ---
 --- @return any
@@ -6989,10 +6989,10 @@ function vim.fn.screencol() end
 --- character in window {winid} at buffer line {lnum} and column
 --- {col}.  {col} is a one-based byte index.
 --- The Dict has these members:
----   row  screen row
----   col  first screen column
----   endcol  last screen column
----   curscol  cursor screen column
+---         row     screen row
+---         col     first screen column
+---         endcol  last screen column
+---         curscol cursor screen column
 --- If the specified position is not visible, all values are zero.
 --- The "endcol" value differs from "col" when the character
 --- occupies more than one screen cell.  E.g. for a Tab "col" can
@@ -7044,15 +7044,15 @@ function vim.fn.screenstring(row, col) end
 --- move.  No error message is given.
 ---
 --- {flags} is a String, which can contain these character flags:
---- 'b'  search Backward instead of forward
---- 'c'  accept a match at the Cursor position
---- 'e'  move to the End of the match
---- 'n'  do Not move the cursor
---- 'p'  return number of matching sub-Pattern (see below)
---- 's'  Set the ' mark at the previous location of the cursor
---- 'w'  Wrap around the end of the file
---- 'W'  don't Wrap around the end of the file
---- 'z'  start searching at the cursor column instead of Zero
+--- 'b'     search Backward instead of forward
+--- 'c'     accept a match at the Cursor position
+--- 'e'     move to the End of the match
+--- 'n'     do Not move the cursor
+--- 'p'     return number of matching sub-Pattern (see below)
+--- 's'     Set the ' mark at the previous location of the cursor
+--- 'w'     Wrap around the end of the file
+--- 'W'     don't Wrap around the end of the file
+--- 'z'     start searching at the cursor column instead of Zero
 --- If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 ---
 --- If the 's' flag is supplied, the ' mark is set, only if the
@@ -7077,8 +7077,8 @@ function vim.fn.screenstring(row, col) end
 --- When the {stopline} argument is given then the search stops
 --- after searching this line.  This is useful to restrict the
 --- search to a range of lines.  Examples: >vim
----   let match = search('(', 'b', line("w0"))
----   let end = search('END', '', line("w$"))
+---         let match = search('(', 'b', line("w0"))
+---         let end = search('END', '', line("w$"))
 --- <When {stopline} is used and it is not zero this also implies
 --- that the search does not wrap around the end of the file.
 --- A zero value is equal to not giving the argument.
@@ -7098,7 +7098,7 @@ function vim.fn.screenstring(row, col) end
 --- When {skip} is omitted or empty, every match is accepted.
 --- When evaluating {skip} causes an error the search is aborted
 --- and -1 returned.
----           *search()-sub-match*
+---                                         *search()-sub-match*
 --- With the 'p' flag the returned value is one more than the
 --- first sub-match in \(\).  One if none of them matched but the
 --- whole pattern did match.
@@ -7109,7 +7109,7 @@ function vim.fn.screenstring(row, col) end
 ---
 --- Example (goes over all files in the argument list): >vim
 ---     let n = 1
----     while n <= argc()      " loop over all files in arglist
+---     while n <= argc()       " loop over all files in arglist
 ---       exe "argument " .. n
 ---       " start at the last char in the file and wrap for the
 ---       " first search to find match at start of file
@@ -7119,7 +7119,7 @@ function vim.fn.screenstring(row, col) end
 ---         s/foo/bar/g
 ---         let flags = "W"
 ---       endwhile
----       update        " write the file if modified
+---       update                " write the file if modified
 ---       let n = n + 1
 ---     endwhile
 --- <
@@ -7151,16 +7151,16 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- This returns a |Dictionary|. The dictionary is empty if the
 --- previous pattern was not set and "pattern" was not specified.
 ---
----   key    type    meaning ~
----   current  |Number|  current position of match;
----         0 if the cursor position is
----         before the first match
----   exact_match  |Boolean|  1 if "current" is matched on
----         "pos", otherwise 0
----   total    |Number|  total count of matches found
----   incomplete  |Number|  0: search was fully completed
----         1: recomputing was timed out
----         2: max count exceeded
+---   key           type            meaning ~
+---   current       |Number|        current position of match;
+---                                 0 if the cursor position is
+---                                 before the first match
+---   exact_match   |Boolean|       1 if "current" is matched on
+---                                 "pos", otherwise 0
+---   total         |Number|        total count of matches found
+---   incomplete    |Number|        0: search was fully completed
+---                                 1: recomputing was timed out
+---                                 2: max count exceeded
 ---
 --- For {options} see further down.
 ---
@@ -7170,99 +7170,99 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 --- If it exceeded 99 the result must be max count + 1 (100). If
 --- you want to get correct information, specify `recompute: 1`: >vim
 ---
----   " result == maxcount + 1 (100) when many matches
----   let result = searchcount(#{recompute: 0})
+---         " result == maxcount + 1 (100) when many matches
+---         let result = searchcount(#{recompute: 0})
 ---
----   " Below returns correct result (recompute defaults
----   " to 1)
----   let result = searchcount()
+---         " Below returns correct result (recompute defaults
+---         " to 1)
+---         let result = searchcount()
 --- <
 --- The function is useful to add the count to 'statusline': >vim
----   function! LastSearchCount() abort
----     let result = searchcount(#{recompute: 0})
----     if empty(result)
----       return ''
----     endif
----     if result.incomplete ==# 1     " timed out
----       return printf(' /%s [?/??]', \@/)
----     elseif result.incomplete ==# 2 " max count exceeded
----       if result.total > result.maxcount &&
----       \  result.current > result.maxcount
----         return printf(' /%s [>%d/>%d]', \@/,
----         \             result.current, result.total)
----       elseif result.total > result.maxcount
----         return printf(' /%s [%d/>%d]', \@/,
----         \             result.current, result.total)
----       endif
----     endif
----     return printf(' /%s [%d/%d]', \@/,
----     \             result.current, result.total)
----   endfunction
----   let &statusline ..= '%{LastSearchCount()}'
+---         function! LastSearchCount() abort
+---           let result = searchcount(#{recompute: 0})
+---           if empty(result)
+---             return ''
+---           endif
+---           if result.incomplete ==# 1     " timed out
+---             return printf(' /%s [?/??]', @/)
+---           elseif result.incomplete ==# 2 " max count exceeded
+---             if result.total > result.maxcount &&
+---             \  result.current > result.maxcount
+---               return printf(' /%s [>%d/>%d]', @/,
+---               \             result.current, result.total)
+---             elseif result.total > result.maxcount
+---               return printf(' /%s [%d/>%d]', @/,
+---               \             result.current, result.total)
+---             endif
+---           endif
+---           return printf(' /%s [%d/%d]', @/,
+---           \             result.current, result.total)
+---         endfunction
+---         let &statusline ..= '%{LastSearchCount()}'
 ---
----   " Or if you want to show the count only when
----   " 'hlsearch' was on
----   " let &statusline ..=
----   " \   '%{v:hlsearch ? LastSearchCount() : ""}'
+---         " Or if you want to show the count only when
+---         " 'hlsearch' was on
+---         " let &statusline ..=
+---         " \   '%{v:hlsearch ? LastSearchCount() : ""}'
 --- <
 --- You can also update the search count, which can be useful in a
 --- |CursorMoved| or |CursorMovedI| autocommand: >vim
 ---
----   autocmd CursorMoved,CursorMovedI *
----     \ let s:searchcount_timer = timer_start(
----     \   200, function('s:update_searchcount'))
----   function! s:update_searchcount(timer) abort
----     if a:timer ==# s:searchcount_timer
----       call searchcount(#{
----       \ recompute: 1, maxcount: 0, timeout: 100})
----       redrawstatus
----     endif
----   endfunction
+---         autocmd CursorMoved,CursorMovedI *
+---           \ let s:searchcount_timer = timer_start(
+---           \   200, function('s:update_searchcount'))
+---         function! s:update_searchcount(timer) abort
+---           if a:timer ==# s:searchcount_timer
+---             call searchcount(#{
+---             \ recompute: 1, maxcount: 0, timeout: 100})
+---             redrawstatus
+---           endif
+---         endfunction
 --- <
 --- This can also be used to count matched texts with specified
 --- pattern in the current buffer using "pattern":  >vim
 ---
----   " Count '\<foo\>' in this buffer
----   " (Note that it also updates search count)
----   let result = searchcount(#{pattern: '\<foo\>'})
+---         " Count '\<foo\>' in this buffer
+---         " (Note that it also updates search count)
+---         let result = searchcount(#{pattern: '\<foo\>'})
 ---
----   " To restore old search count by old pattern,
----   " search again
----   call searchcount()
+---         " To restore old search count by old pattern,
+---         " search again
+---         call searchcount()
 --- <
 --- {options} must be a |Dictionary|. It can contain:
----   key    type    meaning ~
----   recompute  |Boolean|  if |TRUE|, recompute the count
----         like |n| or |N| was executed.
----         otherwise returns the last
----         computed result (when |n| or
----         |N| was used when "S" is not
----         in 'shortmess', or this
----         function was called).
----         (default: |TRUE|)
----   pattern  |String|  recompute if this was given
----         and different with |\@/|.
----         this works as same as the
----         below command is executed
----         before calling this function >vim
----           let \@/ = pattern
---- <        (default: |\@/|)
----   timeout  |Number|  0 or negative number is no
----         timeout. timeout milliseconds
----         for recomputing the result
----         (default: 0)
----   maxcount  |Number|  0 or negative number is no
----         limit. max count of matched
----         text while recomputing the
----         result.  if search exceeded
----         total count, "total" value
----         becomes `maxcount + 1`
----         (default: 0)
----   pos    |List|    `[lnum, col, off]` value
----         when recomputing the result.
----         this changes "current" result
----         value. see |cursor()|, |getpos()|
----         (default: cursor's position)
+---   key           type            meaning ~
+---   recompute     |Boolean|         if |TRUE|, recompute the count
+---                                 like |n| or |N| was executed.
+---                                 otherwise returns the last
+---                                 computed result (when |n| or
+---                                 |N| was used when "S" is not
+---                                 in 'shortmess', or this
+---                                 function was called).
+---                                 (default: |TRUE|)
+---   pattern       |String|          recompute if this was given
+---                                 and different with |@/|.
+---                                 this works as same as the
+---                                 below command is executed
+---                                 before calling this function >vim
+---                                   let @/ = pattern
+--- <                               (default: |@/|)
+---   timeout       |Number|          0 or negative number is no
+---                                 timeout. timeout milliseconds
+---                                 for recomputing the result
+---                                 (default: 0)
+---   maxcount      |Number|          0 or negative number is no
+---                                 limit. max count of matched
+---                                 text while recomputing the
+---                                 result.  if search exceeded
+---                                 total count, "total" value
+---                                 becomes `maxcount + 1`
+---                                 (default: 0)
+---   pos           |List|            `[lnum, col, off]` value
+---                                 when recomputing the result.
+---                                 this changes "current" result
+---                                 value. see |cursor()|, |getpos()|
+---                                 (default: cursor's position)
 ---
 --- @param options? table
 --- @return any
@@ -7281,9 +7281,9 @@ function vim.fn.searchcount(options) end
 --- Moves the cursor to the found match.
 --- Returns zero for success, non-zero for failure.
 --- Example: >vim
----   if searchdecl('myvar') == 0
----      echo getline('.')
----   endif
+---         if searchdecl('myvar') == 0
+---            echo getline('.')
+---         endif
 --- <
 ---
 --- @param name string
@@ -7307,15 +7307,15 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- {middle} is not empty, it is found when searching from either
 --- direction, but only when not in a nested start-end pair.  A
 --- typical use is: >vim
----   echo searchpair('\<if\>', '\<else\>', '\<endif\>')
+---         echo searchpair('\<if\>', '\<else\>', '\<endif\>')
 --- <By leaving {middle} empty the "else" is skipped.
 ---
 --- {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
 --- |search()|.  Additionally:
---- 'r'  Repeat until no more matches found; will find the
----   outer pair.  Implies the 'W' flag.
---- 'm'  Return number of matches instead of line number with
----   the match; will be > 1 when 'r' is used.
+--- 'r'     Repeat until no more matches found; will find the
+---         outer pair.  Implies the 'W' flag.
+--- 'm'     Return number of matches instead of line number with
+---         the match; will be > 1 when 'r' is used.
 --- Note: it's nearly always a good idea to use the 'W' flag, to
 --- avoid wrapping around the end of the file.
 ---
@@ -7338,10 +7338,10 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- The search starts exactly at the cursor.  A match with
 --- {start}, {middle} or {end} at the next character, in the
 --- direction of searching, is the first one found.  Example: >vim
----   if 1
----     if 2
----     endif 2
----   endif 1
+---         if 1
+---           if 2
+---           endif 2
+---         endif 1
 --- <When starting at the "if 2", with the cursor on the "i", and
 --- searching forwards, the "endif 2" is found.  When starting on
 --- the character just before the "if 2", the "endif 1" will be
@@ -7355,8 +7355,8 @@ function vim.fn.searchdecl(name, global, thisblock) end
 ---
 --- Example, to find the "endif" command in a Vim script: >vim
 ---
----   echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
----   \ 'getline(".") =~ "^\\s*\""')
+---         echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
+---         \ 'getline(".") =~ "^\\s*\""')
 ---
 --- <The cursor must be at or after the "if" for which a match is
 --- to be found.  Note that single-quote strings are used to avoid
@@ -7366,14 +7366,14 @@ function vim.fn.searchdecl(name, global, thisblock) end
 --- a match.
 --- Another example, to search for the matching "{" of a "}": >vim
 ---
----   echo searchpair('{', '', '}', 'bW')
+---         echo searchpair('{', '', '}', 'bW')
 ---
 --- <This works when the cursor is at or before the "}" for which a
 --- match is to be found.  To reject matches that syntax
 --- highlighting recognized as strings: >vim
 ---
----   echo searchpair('{', '', '}', 'bW',
----        \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
+---         echo searchpair('{', '', '}', 'bW',
+---              \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
 --- <
 ---
 --- @return any
@@ -7385,7 +7385,7 @@ function vim.fn.searchpair() end
 --- the column position of the match.  If no match is found,
 --- returns [0, 0]. >vim
 ---
----   let [lnum,col] = searchpairpos('{', '', '}', 'n')
+---         let [lnum,col] = searchpairpos('{', '', '}', 'n')
 --- <
 --- See |match-parens| for a bigger and more useful example.
 ---
@@ -7398,11 +7398,11 @@ function vim.fn.searchpairpos() end
 --- the column position of the match. If no match is found,
 --- returns [0, 0].
 --- Example: >vim
----   let [lnum, col] = searchpos('mypattern', 'n')
+---         let [lnum, col] = searchpos('mypattern', 'n')
 ---
 --- <When the 'p' flag is given then there is an extra item with
 --- the sub-pattern match number |search()-sub-match|.  Example: >vim
----   let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
+---         let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
 --- <In this example "submatch" is 2 when a lowercase letter is
 --- found |/\l|, 3 when an uppercase letter is found |/\u|.
 ---
@@ -7417,7 +7417,7 @@ function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 --- Returns a list of server addresses, or empty if all servers
 --- were stopped. |serverstart()| |serverstop()|
 --- Example: >vim
----   echo serverlist()
+---         echo serverlist()
 --- <
 ---
 --- @return any
@@ -7436,24 +7436,24 @@ function vim.fn.serverlist() end
 --- - Else {address} is the path to a named pipe (except on Windows).
 ---   - If {address} has no slashes ("/") it is treated as the
 ---     "name" part of a generated path in this format: >vim
----   stdpath("run").."/{name}.{pid}.{counter}"
+---         stdpath("run").."/{name}.{pid}.{counter}"
 --- <  - If {address} is omitted the name is "nvim". >vim
----   echo serverstart()
+---         echo serverstart()
 --- < >
----   => /tmp/nvim.bram/oknANW/nvim.15430.5
+---         => /tmp/nvim.bram/oknANW/nvim.15430.5
 --- <
 --- Example bash command to list all Nvim servers: >bash
----   ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
+---         ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
 ---
 --- <Example named pipe: >vim
----   if has('win32')
----     echo serverstart('\\.\pipe\nvim-pipe-1234')
----   else
----     echo serverstart('nvim.sock')
----   endif
+---         if has('win32')
+---           echo serverstart('\\.\pipe\nvim-pipe-1234')
+---         else
+---           echo serverstart('nvim.sock')
+---         endif
 --- <
 --- Example TCP/IP address: >vim
----   echo serverstart('::1:12345')
+---         echo serverstart('::1:12345')
 --- <
 ---
 --- @param address? any
@@ -7508,8 +7508,8 @@ function vim.fn.setbufline(buf, lnum, text) end
 --- The {varname} argument is a string.
 --- Note that the variable name without "b:" must be used.
 --- Examples: >vim
----   call setbufvar(1, "&mod", 1)
----   call setbufvar("todo", "myvar", "foobar")
+---         call setbufvar(1, "&mod", 1)
+---         call setbufvar("todo", "myvar", "foobar")
 --- <This function is not available in the |sandbox|.
 ---
 --- @param buf any
@@ -7523,21 +7523,21 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- terminal, counted in screen cells.  The values override
 --- 'ambiwidth'.  Example: >vim
 ---    call setcellwidths([
----     \ [0x111, 0x111, 1],
----     \ [0x2194, 0x2199, 2],
----     \ ])
+---                 \ [0x111, 0x111, 1],
+---                 \ [0x2194, 0x2199, 2],
+---                 \ ])
 ---
 --- <The {list} argument is a List of Lists with each three
---- numbers: [{low}, {high}, {width}].  *E1109* *E1110*
+--- numbers: [{low}, {high}, {width}].      *E1109* *E1110*
 --- {low} and {high} can be the same, in which case this refers to
 --- one character.  Otherwise it is the range of characters from
---- {low} to {high} (inclusive).    *E1111* *E1114*
+--- {low} to {high} (inclusive).            *E1111* *E1114*
 --- Only characters with value 0x80 and higher can be used.
 ---
 --- {width} must be either 1 or 2, indicating the character width
---- in screen cells.      *E1112*
+--- in screen cells.                        *E1112*
 --- An error is given if the argument is invalid, also when a
---- range overlaps with another.    *E1113*
+--- range overlaps with another.            *E1113*
 ---
 --- If the new value causes 'fillchars' or 'listchars' to become
 --- invalid it is rejected and an error is given.
@@ -7560,9 +7560,9 @@ function vim.fn.setcellwidths(list) end
 ---
 --- Example:
 --- With the text "여보세요" in line 8: >vim
----   call setcharpos('.', [0, 8, 4, 0])
+---         call setcharpos('.', [0, 8, 4, 0])
 --- <positions the cursor on the fourth character '요'. >vim
----   call setpos('.', [0, 8, 4, 0])
+---         call setpos('.', [0, 8, 4, 0])
 --- <positions the cursor on the second character '보'.
 ---
 --- @param expr any
@@ -7573,20 +7573,20 @@ function vim.fn.setcharpos(expr, list) end
 --- Set the current character search information to {dict},
 --- which contains one or more of the following entries:
 ---
----     char  character which will be used for a subsequent
----     |,| or |;| command; an empty string clears the
----     character search
----     forward  direction of character search; 1 for forward,
----     0 for backward
----     until  type of character search; 1 for a |t| or |T|
----     character search, 0 for an |f| or |F|
----     character search
+---     char        character which will be used for a subsequent
+---                 |,| or |;| command; an empty string clears the
+---                 character search
+---     forward     direction of character search; 1 for forward,
+---                 0 for backward
+---     until       type of character search; 1 for a |t| or |T|
+---                 character search, 0 for an |f| or |F|
+---                 character search
 ---
 --- This can be useful to save/restore a user's character search
 --- from a script: >vim
----   let prevsearch = getcharsearch()
----   " Perform a command which clobbers user's search
----   call setcharsearch(prevsearch)
+---         let prevsearch = getcharsearch()
+---         " Perform a command which clobbers user's search
+---         call setcharsearch(prevsearch)
 --- <Also see |getcharsearch()|.
 ---
 --- @param dict any
@@ -7633,9 +7633,9 @@ function vim.fn.setcursorcharpos(lnum, col, off) end
 ---
 --- Example:
 --- With the text "여보세요" in line 4: >vim
----   call setcursorcharpos(4, 3)
+---         call setcursorcharpos(4, 3)
 --- <positions the cursor on the third character '세'. >vim
----   call cursor(4, 3)
+---         call cursor(4, 3)
 --- <positions the cursor on the first character '여'.
 ---
 --- @param list any
@@ -7643,7 +7643,7 @@ function vim.fn.setcursorcharpos(lnum, col, off) end
 function vim.fn.setcursorcharpos(list) end
 
 --- Set environment variable {name} to {val}.  Example: >vim
----   call setenv('HOME', '/home/myhome')
+---         call setenv('HOME', '/home/myhome')
 ---
 --- <When {val} is |v:null| the environment variable is deleted.
 --- See also |expr-env|.
@@ -7689,15 +7689,15 @@ function vim.fn.setfperm(fname, mode) end
 --- because {lnum} is invalid) TRUE is returned.
 ---
 --- Example: >vim
----   call setline(5, strftime("%c"))
+---         call setline(5, strftime("%c"))
 ---
 --- <When {text} is a |List| then line {lnum} and following lines
 --- will be set to the items in the list.  Example: >vim
----   call setline(5, ['aaa', 'bbb', 'ccc'])
+---         call setline(5, ['aaa', 'bbb', 'ccc'])
 --- <This is equivalent to: >vim
----   for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
----     call setline(n, l)
----   endfor
+---         for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
+---           call setline(n, l)
+---         endfor
 ---
 --- <Note: The '[ and '] marks are not set.
 ---
@@ -7741,8 +7741,8 @@ function vim.fn.setloclist(nr, list, action, what) end
 function vim.fn.setmatches(list, win) end
 
 --- Set the position for String {expr}.  Possible values:
----   .  the cursor
----   'x  mark x
+---         .       the cursor
+---         'x      mark x
 ---
 --- {list} must be a |List| with four or five numbers:
 ---     [bufnum, lnum, col, off]
@@ -7799,32 +7799,32 @@ function vim.fn.setpos(expr, list) end
 --- only the items listed in {what} are set. The first {list}
 --- argument is ignored.  See below for the supported items in
 --- {what}.
----           *setqflist-what*
+---                                         *setqflist-what*
 --- When {what} is not present, the items in {list} are used.  Each
 --- item must be a dictionary.  Non-dictionary items in {list} are
 --- ignored.  Each dictionary item can contain the following
 --- entries:
 ---
----     bufnr  buffer number; must be the number of a valid
----     buffer
----     filename  name of a file; only used when "bufnr" is not
----     present or it is invalid.
----     module  name of a module; if given it will be used in
----     quickfix error window instead of the filename.
----     lnum  line number in the file
----     end_lnum  end of lines, if the item spans multiple lines
----     pattern  search pattern used to locate the error
----     col    column number
----     vcol  when non-zero: "col" is visual column
----     when zero: "col" is byte index
----     end_col  end column, if the item spans multiple columns
----     nr    error number
----     text  description of the error
----     type  single-character error type, 'E', 'W', etc.
----     valid  recognized error message
+---     bufnr       buffer number; must be the number of a valid
+---                 buffer
+---     filename    name of a file; only used when "bufnr" is not
+---                 present or it is invalid.
+---     module      name of a module; if given it will be used in
+---                 quickfix error window instead of the filename.
+---     lnum        line number in the file
+---     end_lnum    end of lines, if the item spans multiple lines
+---     pattern     search pattern used to locate the error
+---     col         column number
+---     vcol        when non-zero: "col" is visual column
+---                 when zero: "col" is byte index
+---     end_col     end column, if the item spans multiple columns
+---     nr          error number
+---     text        description of the error
+---     type        single-character error type, 'E', 'W', etc.
+---     valid       recognized error message
 ---     user_data
----     custom data associated with the item, can be
----     any type.
+---                 custom data associated with the item, can be
+---                 any type.
 ---
 --- The "col", "vcol", "nr", "type" and "text" entries are
 --- optional.  Either "lnum" or "pattern" entry can be used to
@@ -7841,18 +7841,18 @@ function vim.fn.setpos(expr, list) end
 --- Note that the list is not exactly the same as what
 --- |getqflist()| returns.
 ---
---- {action} values:    *setqflist-action* *E927*
---- 'a'  The items from {list} are added to the existing
----   quickfix list. If there is no existing list, then a
----   new list is created.
+--- {action} values:                *setqflist-action* *E927*
+--- 'a'     The items from {list} are added to the existing
+---         quickfix list. If there is no existing list, then a
+---         new list is created.
 ---
---- 'r'  The items from the current quickfix list are replaced
----   with the items from {list}.  This can also be used to
----   clear the list: >vim
----     call setqflist([], 'r')
+--- 'r'     The items from the current quickfix list are replaced
+---         with the items from {list}.  This can also be used to
+---         clear the list: >vim
+---                 call setqflist([], 'r')
 --- <
---- 'f'  All the quickfix lists in the quickfix stack are
----   freed.
+--- 'f'     All the quickfix lists in the quickfix stack are
+---         freed.
 ---
 --- If {action} is not present or is set to ' ', then a new list
 --- is created. The new quickfix list is added after the current
@@ -7861,32 +7861,32 @@ function vim.fn.setpos(expr, list) end
 --- set "nr" in {what} to "$".
 ---
 --- The following items can be specified in dictionary {what}:
----     context  quickfix list context. See |quickfix-context|
----     efm    errorformat to use when parsing text from
----     "lines". If this is not present, then the
----     'errorformat' option value is used.
----     See |quickfix-parse|
----     id    quickfix list identifier |quickfix-ID|
----     idx    index of the current entry in the quickfix
----     list specified by "id" or "nr". If set to '$',
----     then the last entry in the list is set as the
----     current entry.  See |quickfix-index|
----     items  list of quickfix entries. Same as the {list}
----     argument.
----     lines  use 'errorformat' to parse a list of lines and
----     add the resulting entries to the quickfix list
----     {nr} or {id}.  Only a |List| value is supported.
----     See |quickfix-parse|
----     nr    list number in the quickfix stack; zero
----     means the current quickfix list and "$" means
----     the last quickfix list.
+---     context     quickfix list context. See |quickfix-context|
+---     efm         errorformat to use when parsing text from
+---                 "lines". If this is not present, then the
+---                 'errorformat' option value is used.
+---                 See |quickfix-parse|
+---     id          quickfix list identifier |quickfix-ID|
+---     idx         index of the current entry in the quickfix
+---                 list specified by "id" or "nr". If set to '$',
+---                 then the last entry in the list is set as the
+---                 current entry.  See |quickfix-index|
+---     items       list of quickfix entries. Same as the {list}
+---                 argument.
+---     lines       use 'errorformat' to parse a list of lines and
+---                 add the resulting entries to the quickfix list
+---                 {nr} or {id}.  Only a |List| value is supported.
+---                 See |quickfix-parse|
+---     nr          list number in the quickfix stack; zero
+---                 means the current quickfix list and "$" means
+---                 the last quickfix list.
 ---     quickfixtextfunc
----     function to get the text to display in the
----     quickfix window.  The value can be the name of
----     a function or a funcref or a lambda.  Refer to
----     |quickfix-window-function| for an explanation
----     of how to write the function and an example.
----     title  quickfix list title text. See |quickfix-title|
+---                 function to get the text to display in the
+---                 quickfix window.  The value can be the name of
+---                 a function or a funcref or a lambda.  Refer to
+---                 |quickfix-window-function| for an explanation
+---                 of how to write the function and an example.
+---     title       quickfix list title text. See |quickfix-title|
 --- Unsupported keys in {what} are ignored.
 --- If the "nr" item is not present, then the current quickfix list
 --- is modified. When creating a new quickfix list, "nr" can be
@@ -7913,7 +7913,7 @@ function vim.fn.setpos(expr, list) end
 function vim.fn.setqflist(list, action, what) end
 
 --- Set the register {regname} to {value}.
---- If {regname} is "" or "\@", the unnamed register '"' is used.
+--- If {regname} is "" or "@", the unnamed register '"' is used.
 --- The {regname} argument is a string.
 ---
 --- {value} may be any value returned by |getreg()| or
@@ -7938,26 +7938,26 @@ function vim.fn.setqflist(list, action, what) end
 --- mode is never selected automatically.
 --- Returns zero for success, non-zero for failure.
 ---
----           *E883*
+---                                         *E883*
 --- Note: you may not use |List| containing more than one item to
 ---       set search and expression registers. Lists containing no
 ---       items act like empty strings.
 ---
 --- Examples: >vim
----   call setreg(v:register, \@*)
----   call setreg('*', \@%, 'ac')
----   call setreg('a', "1\n2\n3", 'b5')
----   call setreg('"', { 'points_to': 'a'})
+---         call setreg(v:register, @*)
+---         call setreg('*', @%, 'ac')
+---         call setreg('a', "1\n2\n3", 'b5')
+---         call setreg('"', { 'points_to': 'a'})
 ---
 --- <This example shows using the functions to save and restore a
 --- register: >vim
----   let var_a = getreginfo()
----   call setreg('a', var_a)
+---         let var_a = getreginfo()
+---         call setreg('a', var_a)
 --- <or: >vim
----   let var_a = getreg('a', 1, 1)
----   let var_amode = getregtype('a')
----   " ....
----   call setreg('a', var_a, var_amode)
+---         let var_a = getreg('a', 1, 1)
+---         let var_amode = getregtype('a')
+---         " ....
+---         call setreg('a', var_a, var_amode)
 --- <Note: you may not reliably restore register value
 --- without using the third argument to |getreg()| as without it
 --- newlines are represented as newlines AND Nul bytes are
@@ -7965,7 +7965,7 @@ function vim.fn.setqflist(list, action, what) end
 ---
 --- You can also change the type of a register by appending
 --- nothing: >vim
----   call setreg('a', '', 'al')
+---         call setreg('a', '', 'al')
 ---
 --- @param regname string
 --- @param value any
@@ -7997,8 +7997,8 @@ function vim.fn.settabvar(tabnr, varname, val) end
 --- For a local buffer option the global value is unchanged.
 --- Note that the variable name without "w:" must be used.
 --- Examples: >vim
----   call settabwinvar(1, 1, "&list", 0)
----   call settabwinvar(3, 2, "myvar", "foobar")
+---         call settabwinvar(1, 1, "&list", 0)
+---         call settabwinvar(3, 2, "myvar", "foobar")
 --- <This function is not available in the |sandbox|.
 ---
 --- @param tabnr integer
@@ -8014,7 +8014,7 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 --- For a list of supported items in {dict}, refer to
 --- |gettagstack()|. "curidx" takes effect before changing the tag
 --- stack.
----           *E962*
+---                                         *E962*
 --- How the tag stack is modified depends on the {action}
 --- argument:
 --- - If {action} is not present or is set to 'r', then the tag
@@ -8032,13 +8032,13 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 ---
 --- Examples (for more examples see |tagstack-examples|):
 ---     Empty the tag stack of window 3: >vim
----   call settagstack(3, {'items' : []})
+---         call settagstack(3, {'items' : []})
 ---
 --- <    Save and restore the tag stack: >vim
----   let stack = gettagstack(1003)
----   " do something else
----   call settagstack(1003, stack)
----   unlet stack
+---         let stack = gettagstack(1003)
+---         " do something else
+---         call settagstack(1003, stack)
+---         unlet stack
 --- <
 ---
 --- @param nr integer
@@ -8049,8 +8049,8 @@ function vim.fn.settagstack(nr, dict, action) end
 
 --- Like |settabwinvar()| for the current tab page.
 --- Examples: >vim
----   call setwinvar(1, "&list", 0)
----   call setwinvar(2, "myvar", "foobar")
+---         call setwinvar(1, "&list", 0)
+---         call setwinvar(2, "myvar", "foobar")
 ---
 --- @param nr integer
 --- @param varname string
@@ -8104,15 +8104,15 @@ function vim.fn.shellescape(string, special) end
 --- 'shiftwidth' value unless it is zero, in which case it is the
 --- 'tabstop' value.  To be backwards compatible in indent
 --- plugins, use this: >vim
----   if exists('*shiftwidth')
----     func s:sw()
----       return shiftwidth()
----     endfunc
----   else
----     func s:sw()
----       return &sw
----     endfunc
----   endif
+---         if exists('*shiftwidth')
+---           func s:sw()
+---             return shiftwidth()
+---           endfunc
+---         else
+---           func s:sw()
+---             return &sw
+---           endfunc
+---         endif
 --- <And then use s:sw() instead of &sw.
 ---
 --- When there is one argument {col} this is used as column number
@@ -8138,17 +8138,17 @@ function vim.fn.sign_define(name, dict) end
 --- The {name} can be a String or a Number.  The optional {dict}
 --- argument specifies the sign attributes.  The following values
 --- are supported:
----    icon    full path to the bitmap file for the sign.
----    linehl  highlight group used for the whole line the
----     sign is placed in.
----    numhl  highlight group used for the line number where
----     the sign is placed.
----    text    text that is displayed when there is no icon
----     or the GUI is not being used.
----    texthl  highlight group used for the text item
----    culhl  highlight group used for the text item when
----     the cursor is on the same line as the sign and
----     'cursorline' is enabled.
+---    icon         full path to the bitmap file for the sign.
+---    linehl       highlight group used for the whole line the
+---                 sign is placed in.
+---    numhl        highlight group used for the line number where
+---                 the sign is placed.
+---    text         text that is displayed when there is no icon
+---                 or the GUI is not being used.
+---    texthl       highlight group used for the text item
+---    culhl        highlight group used for the text item when
+---                 the cursor is on the same line as the sign and
+---                 'cursorline' is enabled.
 ---
 --- If the sign named {name} already exists, then the attributes
 --- of the sign are updated.
@@ -8162,16 +8162,16 @@ function vim.fn.sign_define(name, dict) end
 --- defined sign.
 ---
 --- Examples: >vim
----   call sign_define("mySign", {
----     \ "text" : "=>",
----     \ "texthl" : "Error",
----     \ "linehl" : "Search"})
----   call sign_define([
----     \ {'name' : 'sign1',
----     \  'text' : '=>'},
----     \ {'name' : 'sign2',
----     \  'text' : '!!'}
----     \ ])
+---         call sign_define("mySign", {
+---                 \ "text" : "=>",
+---                 \ "texthl" : "Error",
+---                 \ "linehl" : "Search"})
+---         call sign_define([
+---                 \ {'name' : 'sign1',
+---                 \  'text' : '=>'},
+---                 \ {'name' : 'sign2',
+---                 \  'text' : '!!'}
+---                 \ ])
 --- <
 ---
 --- @param list vim.fn.sign_define.dict[]
@@ -8187,30 +8187,30 @@ function vim.fn.sign_define(list) end
 ---
 --- Each list item in the returned value is a dictionary with the
 --- following entries:
----    icon    full path to the bitmap file of the sign
----    linehl  highlight group used for the whole line the
----     sign is placed in; not present if not set.
----    name    name of the sign
----    numhl  highlight group used for the line number where
----     the sign is placed; not present if not set.
----    text    text that is displayed when there is no icon
----     or the GUI is not being used.
----    texthl  highlight group used for the text item; not
----     present if not set.
----    culhl  highlight group used for the text item when
----     the cursor is on the same line as the sign and
----     'cursorline' is enabled; not present if not
----     set.
+---    icon         full path to the bitmap file of the sign
+---    linehl       highlight group used for the whole line the
+---                 sign is placed in; not present if not set.
+---    name         name of the sign
+---    numhl        highlight group used for the line number where
+---                 the sign is placed; not present if not set.
+---    text         text that is displayed when there is no icon
+---                 or the GUI is not being used.
+---    texthl       highlight group used for the text item; not
+---                 present if not set.
+---    culhl        highlight group used for the text item when
+---                 the cursor is on the same line as the sign and
+---                 'cursorline' is enabled; not present if not
+---                 set.
 ---
 --- Returns an empty List if there are no signs and when {name} is
 --- not found.
 ---
 --- Examples: >vim
----   " Get a list of all the defined signs
----   echo sign_getdefined()
+---         " Get a list of all the defined signs
+---         echo sign_getdefined()
 ---
----   " Get the attribute of the sign named mySign
----   echo sign_getdefined("mySign")
+---         " Get the attribute of the sign named mySign
+---         echo sign_getdefined("mySign")
 --- <
 ---
 --- @param name? string
@@ -8224,10 +8224,10 @@ function vim.fn.sign_getdefined(name) end
 --- list of signs placed in that buffer is returned.  For the use
 --- of {buf}, see |bufname()|. The optional {dict} can contain
 --- the following entries:
----    group  select only signs in this group
----    id    select sign with this identifier
----    lnum    select signs placed in this line. For the use
----     of {lnum}, see |line()|.
+---    group        select only signs in this group
+---    id           select sign with this identifier
+---    lnum         select signs placed in this line. For the use
+---                 of {lnum}, see |line()|.
 --- If {group} is "*", then signs in all the groups including the
 --- global group are returned. If {group} is not supplied or is an
 --- empty string, then only signs in the global group are
@@ -8237,17 +8237,17 @@ function vim.fn.sign_getdefined(name) end
 ---
 --- Each list item in the returned value is a dictionary with the
 --- following entries:
----   bufnr  number of the buffer with the sign
----   signs  list of signs placed in {bufnr}. Each list
----     item is a dictionary with the below listed
----     entries
+---         bufnr   number of the buffer with the sign
+---         signs   list of signs placed in {bufnr}. Each list
+---                 item is a dictionary with the below listed
+---                 entries
 ---
 --- The dictionary for each sign contains the following entries:
----   group   sign group. Set to '' for the global group.
----   id   identifier of the sign
----   lnum   line number where the sign is placed
----   name   name of the defined sign
----   priority sign priority
+---         group    sign group. Set to '' for the global group.
+---         id       identifier of the sign
+---         lnum     line number where the sign is placed
+---         name     name of the defined sign
+---         priority sign priority
 ---
 --- The returned signs in a buffer are ordered by their line
 --- number and priority.
@@ -8256,25 +8256,25 @@ function vim.fn.sign_getdefined(name) end
 --- signs.
 ---
 --- Examples: >vim
----   " Get a List of signs placed in eval.c in the
----   " global group
----   echo sign_getplaced("eval.c")
+---         " Get a List of signs placed in eval.c in the
+---         " global group
+---         echo sign_getplaced("eval.c")
 ---
----   " Get a List of signs in group 'g1' placed in eval.c
----   echo sign_getplaced("eval.c", {'group' : 'g1'})
+---         " Get a List of signs in group 'g1' placed in eval.c
+---         echo sign_getplaced("eval.c", {'group' : 'g1'})
 ---
----   " Get a List of signs placed at line 10 in eval.c
----   echo sign_getplaced("eval.c", {'lnum' : 10})
+---         " Get a List of signs placed at line 10 in eval.c
+---         echo sign_getplaced("eval.c", {'lnum' : 10})
 ---
----   " Get sign with identifier 10 placed in a.py
----   echo sign_getplaced("a.py", {'id' : 10})
+---         " Get sign with identifier 10 placed in a.py
+---         echo sign_getplaced("a.py", {'id' : 10})
 ---
----   " Get sign with id 20 in group 'g1' placed in a.py
----   echo sign_getplaced("a.py", {'group' : 'g1',
----           \  'id' : 20})
+---         " Get sign with id 20 in group 'g1' placed in a.py
+---         echo sign_getplaced("a.py", {'group' : 'g1',
+---                                         \  'id' : 20})
 ---
----   " Get a List of all the placed signs
----   echo sign_getplaced()
+---         " Get a List of all the placed signs
+---         echo sign_getplaced()
 --- <
 ---
 --- @param buf? any
@@ -8293,8 +8293,8 @@ function vim.fn.sign_getplaced(buf, dict) end
 --- arguments are invalid.
 ---
 --- Example: >vim
----   " Jump to sign 10 in the current buffer
----   call sign_jump(10, '', '')
+---         " Jump to sign 10 in the current buffer
+---         call sign_jump(10, '', '')
 --- <
 ---
 --- @param id integer
@@ -8319,11 +8319,11 @@ function vim.fn.sign_jump(id, group, buf) end
 --- values, see |bufname()|.
 ---
 --- The optional {dict} argument supports the following entries:
----   lnum    line number in the file or buffer
----       {buf} where the sign is to be placed.
----       For the accepted values, see |line()|.
----   priority  priority of the sign. See
----       |sign-priority| for more information.
+---         lnum            line number in the file or buffer
+---                         {buf} where the sign is to be placed.
+---                         For the accepted values, see |line()|.
+---         priority        priority of the sign. See
+---                         |sign-priority| for more information.
 ---
 --- If the optional {dict} is not specified, then it modifies the
 --- placed sign {id} in group {group} to use the defined sign
@@ -8332,23 +8332,23 @@ function vim.fn.sign_jump(id, group, buf) end
 --- Returns the sign identifier on success and -1 on failure.
 ---
 --- Examples: >vim
----   " Place a sign named sign1 with id 5 at line 20 in
----   " buffer json.c
----   call sign_place(5, '', 'sign1', 'json.c',
----           \ {'lnum' : 20})
+---         " Place a sign named sign1 with id 5 at line 20 in
+---         " buffer json.c
+---         call sign_place(5, '', 'sign1', 'json.c',
+---                                         \ {'lnum' : 20})
 ---
----   " Updates sign 5 in buffer json.c to use sign2
----   call sign_place(5, '', 'sign2', 'json.c')
+---         " Updates sign 5 in buffer json.c to use sign2
+---         call sign_place(5, '', 'sign2', 'json.c')
 ---
----   " Place a sign named sign3 at line 30 in
----   " buffer json.c with a new identifier
----   let id = sign_place(0, '', 'sign3', 'json.c',
----           \ {'lnum' : 30})
+---         " Place a sign named sign3 at line 30 in
+---         " buffer json.c with a new identifier
+---         let id = sign_place(0, '', 'sign3', 'json.c',
+---                                         \ {'lnum' : 30})
 ---
----   " Place a sign named sign4 with id 10 in group 'g3'
----   " at line 40 in buffer json.c with priority 90
----   call sign_place(10, 'g3', 'sign4', 'json.c',
----       \ {'lnum' : 40, 'priority' : 90})
+---         " Place a sign named sign4 with id 10 in group 'g3'
+---         " at line 40 in buffer json.c with priority 90
+---         call sign_place(10, 'g3', 'sign4', 'json.c',
+---                         \ {'lnum' : 40, 'priority' : 90})
 --- <
 ---
 --- @param id any
@@ -8363,27 +8363,27 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 --- |sign_place()| function.  The {list} argument specifies the
 --- List of signs to place. Each list item is a dict with the
 --- following sign attributes:
----     buffer  Buffer name or number. For the accepted
----     values, see |bufname()|.
----     group  Sign group. {group} functions as a namespace
----     for {id}, thus two groups can use the same
----     IDs. If not specified or set to an empty
----     string, then the global group is used.   See
----     |sign-group| for more information.
----     id    Sign identifier. If not specified or zero,
----     then a new unique identifier is allocated.
----     Otherwise the specified number is used. See
----     |sign-identifier| for more information.
----     lnum  Line number in the buffer where the sign is to
----     be placed. For the accepted values, see
----     |line()|.
----     name  Name of the sign to place. See |sign_define()|
----     for more information.
----     priority  Priority of the sign. When multiple signs are
----     placed on a line, the sign with the highest
----     priority is used. If not specified, the
----     default value of 10 is used. See
----     |sign-priority| for more information.
+---     buffer      Buffer name or number. For the accepted
+---                 values, see |bufname()|.
+---     group       Sign group. {group} functions as a namespace
+---                 for {id}, thus two groups can use the same
+---                 IDs. If not specified or set to an empty
+---                 string, then the global group is used.   See
+---                 |sign-group| for more information.
+---     id          Sign identifier. If not specified or zero,
+---                 then a new unique identifier is allocated.
+---                 Otherwise the specified number is used. See
+---                 |sign-identifier| for more information.
+---     lnum        Line number in the buffer where the sign is to
+---                 be placed. For the accepted values, see
+---                 |line()|.
+---     name        Name of the sign to place. See |sign_define()|
+---                 for more information.
+---     priority    Priority of the sign. When multiple signs are
+---                 placed on a line, the sign with the highest
+---                 priority is used. If not specified, the
+---                 default value of 10 is used. See
+---                 |sign-priority| for more information.
 ---
 --- If {id} refers to an existing sign, then the existing sign is
 --- modified to use the specified {name} and/or {priority}.
@@ -8392,29 +8392,29 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 --- sign, the corresponding list item is set to -1.
 ---
 --- Examples: >vim
----   " Place sign s1 with id 5 at line 20 and id 10 at line
----   " 30 in buffer a.c
----   let [n1, n2] = sign_placelist([
----     \ {'id' : 5,
----     \  'name' : 's1',
----     \  'buffer' : 'a.c',
----     \  'lnum' : 20},
----     \ {'id' : 10,
----     \  'name' : 's1',
----     \  'buffer' : 'a.c',
----     \  'lnum' : 30}
----     \ ])
+---         " Place sign s1 with id 5 at line 20 and id 10 at line
+---         " 30 in buffer a.c
+---         let [n1, n2] = sign_placelist([
+---                 \ {'id' : 5,
+---                 \  'name' : 's1',
+---                 \  'buffer' : 'a.c',
+---                 \  'lnum' : 20},
+---                 \ {'id' : 10,
+---                 \  'name' : 's1',
+---                 \  'buffer' : 'a.c',
+---                 \  'lnum' : 30}
+---                 \ ])
 ---
----   " Place sign s1 in buffer a.c at line 40 and 50
----   " with auto-generated identifiers
----   let [n1, n2] = sign_placelist([
----     \ {'name' : 's1',
----     \  'buffer' : 'a.c',
----     \  'lnum' : 40},
----     \ {'name' : 's1',
----     \  'buffer' : 'a.c',
----     \  'lnum' : 50}
----     \ ])
+---         " Place sign s1 in buffer a.c at line 40 and 50
+---         " with auto-generated identifiers
+---         let [n1, n2] = sign_placelist([
+---                 \ {'name' : 's1',
+---                 \  'buffer' : 'a.c',
+---                 \  'lnum' : 40},
+---                 \ {'name' : 's1',
+---                 \  'buffer' : 'a.c',
+---                 \  'lnum' : 50}
+---                 \ ])
 --- <
 ---
 --- @param list vim.fn.sign_placelist.list.item[]
@@ -8437,14 +8437,14 @@ function vim.fn.sign_undefine(name) end
 --- sign.
 ---
 --- Examples: >vim
----   " Delete a sign named mySign
----   call sign_undefine("mySign")
+---         " Delete a sign named mySign
+---         call sign_undefine("mySign")
 ---
----   " Delete signs 'sign1' and 'sign2'
----   call sign_undefine(["sign1", "sign2"])
+---         " Delete signs 'sign1' and 'sign2'
+---         call sign_undefine(["sign1", "sign2"])
 ---
----   " Delete all the signs
----   call sign_undefine()
+---         " Delete all the signs
+---         call sign_undefine()
 --- <
 ---
 --- @param list? string[]
@@ -8460,37 +8460,37 @@ function vim.fn.sign_undefine(list) end
 --- The signs in {group} are selected based on the entries in
 --- {dict}.  The following optional entries in {dict} are
 --- supported:
----   buffer  buffer name or number. See |bufname()|.
----   id  sign identifier
+---         buffer  buffer name or number. See |bufname()|.
+---         id      sign identifier
 --- If {dict} is not supplied, then all the signs in {group} are
 --- removed.
 ---
 --- Returns 0 on success and -1 on failure.
 ---
 --- Examples: >vim
----   " Remove sign 10 from buffer a.vim
----   call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
+---         " Remove sign 10 from buffer a.vim
+---         call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
 ---
----   " Remove sign 20 in group 'g1' from buffer 3
----   call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
+---         " Remove sign 20 in group 'g1' from buffer 3
+---         call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
 ---
----   " Remove all the signs in group 'g2' from buffer 10
----   call sign_unplace('g2', {'buffer' : 10})
+---         " Remove all the signs in group 'g2' from buffer 10
+---         call sign_unplace('g2', {'buffer' : 10})
 ---
----   " Remove sign 30 in group 'g3' from all the buffers
----   call sign_unplace('g3', {'id' : 30})
+---         " Remove sign 30 in group 'g3' from all the buffers
+---         call sign_unplace('g3', {'id' : 30})
 ---
----   " Remove all the signs placed in buffer 5
----   call sign_unplace('*', {'buffer' : 5})
+---         " Remove all the signs placed in buffer 5
+---         call sign_unplace('*', {'buffer' : 5})
 ---
----   " Remove the signs in group 'g4' from all the buffers
----   call sign_unplace('g4')
+---         " Remove the signs in group 'g4' from all the buffers
+---         call sign_unplace('g4')
 ---
----   " Remove sign 40 from all the buffers
----   call sign_unplace('*', {'id' : 40})
+---         " Remove sign 40 from all the buffers
+---         call sign_unplace('*', {'id' : 40})
 ---
----   " Remove all the placed signs from all the buffers
----   call sign_unplace('*')
+---         " Remove all the placed signs from all the buffers
+---         call sign_unplace('*')
 ---
 --- @param group string
 --- @param dict? vim.fn.sign_unplace.dict
@@ -8502,27 +8502,27 @@ function vim.fn.sign_unplace(group, dict) end
 ---
 --- The {list} argument specifies the List of signs to remove.
 --- Each list item is a dict with the following sign attributes:
----     buffer  buffer name or number. For the accepted
----     values, see |bufname()|. If not specified,
----     then the specified sign is removed from all
----     the buffers.
----     group  sign group name. If not specified or set to an
----     empty string, then the global sign group is
----     used. If set to "*", then all the groups
----     including the global group are used.
----     id    sign identifier. If not specified, then all
----     the signs in the specified group are removed.
+---     buffer      buffer name or number. For the accepted
+---                 values, see |bufname()|. If not specified,
+---                 then the specified sign is removed from all
+---                 the buffers.
+---     group       sign group name. If not specified or set to an
+---                 empty string, then the global sign group is
+---                 used. If set to "*", then all the groups
+---                 including the global group are used.
+---     id          sign identifier. If not specified, then all
+---                 the signs in the specified group are removed.
 ---
 --- Returns a List where an entry is set to 0 if the corresponding
 --- sign was successfully removed or -1 on failure.
 ---
 --- Example: >vim
----   " Remove sign with id 10 from buffer a.vim and sign
----   " with id 20 from buffer b.vim
----   call sign_unplacelist([
----     \ {'id' : 10, 'buffer' : "a.vim"},
----     \ {'id' : 20, 'buffer' : 'b.vim'},
----     \ ])
+---         " Remove sign with id 10 from buffer a.vim and sign
+---         " with id 20 from buffer b.vim
+---         call sign_unplacelist([
+---                 \ {'id' : 10, 'buffer' : "a.vim"},
+---                 \ {'id' : 20, 'buffer' : 'b.vim'},
+---                 \ ])
 --- <
 ---
 --- @param list vim.fn.sign_unplacelist.list.item
@@ -8538,7 +8538,7 @@ function vim.fn.sign_unplacelist(list) end
 --- "///path" is simplified to "/path" (this follows the Posix
 --- standard).
 --- Example: >vim
----   simplify("./dir/.././/file/") == "./file/"
+---         simplify("./dir/.././/file/") == "./file/"
 --- <Note: The combination "dir/.." is only removed if "dir" is
 --- a searchable directory or does not exist.  On Unix, it is also
 --- removed when "dir" is a symbolic link within the same
@@ -8553,10 +8553,10 @@ function vim.fn.simplify(filename) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo sin(100)
---- <  -0.506366 >vim
----   echo sin(-4.01)
---- <  0.763301
+---         echo sin(100)
+--- <        -0.506366 >vim
+---         echo sin(-4.01)
+--- <        0.763301
 ---
 --- @param expr any
 --- @return any
@@ -8567,10 +8567,10 @@ function vim.fn.sin(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo sinh(0.5)
---- <  0.521095 >vim
----   echo sinh(-0.9)
---- <  -1.026517
+---         echo sinh(0.5)
+--- <       0.521095 >vim
+---         echo sinh(-0.9)
+--- <       -1.026517
 ---
 --- @param expr any
 --- @return any
@@ -8609,7 +8609,7 @@ function vim.fn.slice(expr, start, end_) end
 ---   |on_data| : callback invoked when data was read from socket
 ---   data_buffered : read socket data in |channel-buffered| mode.
 ---   rpc     : If set, |msgpack-rpc| will be used to communicate
----       over the socket.
+---             over the socket.
 --- Returns:
 ---   - The channel ID on success (greater than zero)
 ---   - 0 on invalid arguments or connection failure.
@@ -8623,7 +8623,7 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- Sort the items in {list} in-place.  Returns {list}.
 ---
 --- If you want a list to remain unmodified make a copy first: >vim
----   let sortedlist = sort(copy(mylist))
+---         let sortedlist = sort(copy(mylist))
 ---
 --- <When {how} is omitted or is a string, then sort() uses the
 --- string representation of each item to sort on.  Numbers sort
@@ -8640,15 +8640,15 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- collation locale. |v:collate| can also be used to check the
 --- current locale. Sorting using the locale typically ignores
 --- case. Example: >vim
----   " ö is sorted similarly to o with English locale.
----   language collate en_US.UTF8
----   echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
---- <  ['n', 'o', 'O', 'ö', 'p', 'z'] ~
+---         " ö is sorted similarly to o with English locale.
+---         language collate en_US.UTF8
+---         echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+--- <        ['n', 'o', 'O', 'ö', 'p', 'z'] ~
 --- >vim
----   " ö is sorted after z with Swedish locale.
----   language collate sv_SE.UTF8
----   echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
---- <  ['n', 'o', 'O', 'p', 'z', 'ö'] ~
+---         " ö is sorted after z with Swedish locale.
+---         language collate sv_SE.UTF8
+---         echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+--- <        ['n', 'o', 'O', 'p', 'z', 'ö'] ~
 --- This does not work properly on Mac.
 ---
 --- When {how} is given and it is 'n' then all items will be
@@ -8679,17 +8679,17 @@ function vim.fn.sockconnect(mode, address, opts) end
 ---
 ---
 --- Example: >vim
----   func MyCompare(i1, i2)
----      return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
----   endfunc
----   eval mylist->sort("MyCompare")
+---         func MyCompare(i1, i2)
+---            return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
+---         endfunc
+---         eval mylist->sort("MyCompare")
 --- <A shorter compare version for this specific simple case, which
 --- ignores overflow: >vim
----   func MyCompare(i1, i2)
----      return a:i1 - a:i2
----   endfunc
+---         func MyCompare(i1, i2)
+---            return a:i1 - a:i2
+---         endfunc
 --- <For a simple expression you can use a lambda: >vim
----   eval mylist->sort({i1, i2 -> i1 - i2})
+---         eval mylist->sort({i1, i2 -> i1 - i2})
 --- <
 ---
 --- @param list any
@@ -8721,13 +8721,13 @@ function vim.fn.soundfold(word) end
 --- The return value is a list with two items:
 --- - The badly spelled word or an empty string.
 --- - The type of the spelling error:
----   "bad"    spelling mistake
----   "rare"    rare word
----   "local"    word only valid in another region
----   "caps"    word should start with Capital
+---         "bad"           spelling mistake
+---         "rare"          rare word
+---         "local"         word only valid in another region
+---         "caps"          word should start with Capital
 --- Example: >vim
----   echo spellbadword("the quik brown fox")
---- <  ['quik', 'bad'] ~
+---         echo spellbadword("the quik brown fox")
+--- <        ['quik', 'bad'] ~
 ---
 --- The spelling information for the current window and the value
 --- of 'spelllang' are used.
@@ -8773,17 +8773,17 @@ function vim.fn.spellsuggest(word, max, capital) end
 --- Other empty items are kept when {pattern} matches at least one
 --- character or when {keepempty} is non-zero.
 --- Example: >vim
----   let words = split(getline('.'), '\W\+')
+---         let words = split(getline('.'), '\W\+')
 --- <To split a string in individual characters: >vim
----   for c in split(mystring, '\zs') | endfor
+---         for c in split(mystring, '\zs') | endfor
 --- <If you want to keep the separator you can also use '\zs' at
 --- the end of the pattern: >vim
----   echo split('abc:def:ghi', ':\zs')
+---         echo split('abc:def:ghi', ':\zs')
 --- < >
----   ['abc:', 'def:', 'ghi']
+---         ['abc:', 'def:', 'ghi']
 --- <
 --- Splitting a table where the first element can be empty: >vim
----   let items = split(line, ':', 1)
+---         let items = split(line, ':', 1)
 --- <The opposite function is |join()|.
 ---
 --- @param string string
@@ -8798,10 +8798,10 @@ function vim.fn.split(string, pattern, keepempty) end
 --- is negative the result is NaN (Not a Number).  Returns 0.0 if
 --- {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo sqrt(100)
---- <  10.0 >vim
----   echo sqrt(-4.01)
---- <  str2float("nan")
+---         echo sqrt(100)
+--- <        10.0 >vim
+---         echo sqrt(-4.01)
+--- <        str2float("nan")
 --- NaN may be different, it depends on system libraries.
 ---
 --- @param expr any
@@ -8817,9 +8817,9 @@ function vim.fn.sqrt(expr) end
 ---   when a predictable sequence is intended.
 ---
 --- Examples: >vim
----   let seed = srand()
----   let seed = srand(userinput)
----   echo rand(seed)
+---         let seed = srand()
+---         let seed = srand(userinput)
+---         echo rand(seed)
 --- <
 ---
 --- @param expr? any
@@ -8840,20 +8840,20 @@ function vim.fn.srand(expr) end
 ---
 --- When {what} is given only characters in this string will be
 --- added.  E.g, this checks if the screen has scrolled: >vim
----   if state('s') == ''
----      " screen has not scrolled
+---         if state('s') == ''
+---            " screen has not scrolled
 --- <
 --- These characters indicate the state, generally indicating that
 --- something is busy:
----     m  halfway a mapping, :normal command, feedkeys() or
----   stuffed command
----     o  operator pending, e.g. after |d|
----     a  Insert mode autocomplete active
----     x  executing an autocommand
----     S  not triggering SafeState, e.g. after |f| or a count
----     c  callback invoked, including timer (repeats for
----   recursiveness up to "ccc")
----     s  screen has scrolled for messages
+---     m   halfway a mapping, :normal command, feedkeys() or
+---         stuffed command
+---     o   operator pending, e.g. after |d|
+---     a   Insert mode autocomplete active
+---     x   executing an autocommand
+---     S   not triggering SafeState, e.g. after |f| or a count
+---     c   callback invoked, including timer (repeats for
+---         recursiveness up to "ccc")
+---     s   screen has scrolled for messages
 ---
 --- @param what? string
 --- @return any
@@ -8870,11 +8870,11 @@ function vim.fn.state(what) end
 --- {opts} is a dictionary with these keys:
 ---   |on_stdin| : callback invoked when stdin is written to.
 ---   on_print : callback invoked when Nvim needs to print a
----        message, with the message (whose type is string)
----        as sole argument.
+---              message, with the message (whose type is string)
+---              as sole argument.
 ---   stdin_buffered : read stdin in |channel-buffered| mode.
 ---   rpc      : If set, |msgpack-rpc| will be used to communicate
----        over stdio
+---              over stdio
 --- Returns:
 ---   - |channel-id| on success (value is always 1)
 ---   - 0 on invalid arguments
@@ -8896,12 +8896,12 @@ function vim.fn.stdioopen(opts) end
 --- data_dirs    List    Other data directories.
 --- log          String  Logs directory (for use by plugins too).
 --- run          String  Run directory: temporary, local storage
----          for sockets, named pipes, etc.
+---                      for sockets, named pipes, etc.
 --- state        String  Session state directory: storage for file
----          drafts, swap, undo, |shada|.
+---                      drafts, swap, undo, |shada|.
 ---
 --- Example: >vim
----   echo stdpath("config")
+---         echo stdpath("config")
 --- <
 ---
 --- @param what 'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'
@@ -8922,7 +8922,7 @@ function vim.fn.stdpath(what) end
 --- set to.  A comma ends the number: "12,345.67" is converted to
 --- 12.0.  You can strip out thousands separators with
 --- |substitute()|: >vim
----   let f = str2float(substitute(text, ',', '', 'g'))
+---         let f = str2float(substitute(text, ',', '', 'g'))
 --- <
 --- Returns 0.0 if the conversion fails.
 ---
@@ -8933,14 +8933,14 @@ function vim.fn.str2float(string, quoted) end
 
 --- Return a list containing the number values which represent
 --- each character in String {string}.  Examples: >vim
----   echo str2list(" ")    " returns [32]
----   echo str2list("ABC")    " returns [65, 66, 67]
+---         echo str2list(" ")              " returns [32]
+---         echo str2list("ABC")            " returns [65, 66, 67]
 --- <|list2str()| does the opposite.
 ---
 --- UTF-8 encoding is always used, {utf8} option has no effect,
 --- and exists only for backwards-compatibility.
 --- With UTF-8 composing characters are handled properly: >vim
----   echo str2list("á")    " returns [97, 769]
+---         echo str2list("á")              " returns [97, 769]
 ---
 --- @param string string
 --- @param utf8? any
@@ -8955,7 +8955,7 @@ function vim.fn.str2list(string, utf8) end
 --- When {base} is omitted base 10 is used.  This also means that
 --- a leading zero doesn't cause octal conversion to be used, as
 --- with the default String to Number conversion.  Example: >vim
----   let nr = str2nr('0123')
+---         let nr = str2nr('0123')
 --- <
 --- When {base} is 16 a leading "0x" or "0X" is ignored.  With a
 --- different base the result will be zero. Similarly, when
@@ -8992,7 +8992,7 @@ function vim.fn.strcharlen(string) end
 --- When a character index is used where a character does not
 --- exist it is omitted and counted as one character.  For
 --- example: >vim
----   echo strcharpart('abc', -1, 2)
+---         echo strcharpart('abc', -1, 2)
 --- <results in 'a'.
 ---
 --- Returns an empty string on error.
@@ -9019,15 +9019,15 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- compatibility, you can define a wrapper function: >vim
 ---     if has("patch-7.4.755")
 ---       function s:strchars(str, skipcc)
----   return strchars(a:str, a:skipcc)
+---         return strchars(a:str, a:skipcc)
 ---       endfunction
 ---     else
 ---       function s:strchars(str, skipcc)
----   if a:skipcc
----     return strlen(substitute(a:str, ".", "x", "g"))
----   else
----     return strchars(a:str)
----   endif
+---         if a:skipcc
+---           return strlen(substitute(a:str, ".", "x", "g"))
+---         else
+---           return strchars(a:str)
+---         endif
 ---       endfunction
 ---     endif
 --- <
@@ -9064,12 +9064,12 @@ function vim.fn.strdisplaywidth(string, col) end
 --- See also |localtime()|, |getftime()| and |strptime()|.
 --- The language can be changed with the |:language| command.
 --- Examples: >vim
----   echo strftime("%c")       " Sun Apr 27 11:49:23 1997
+---   echo strftime("%c")              " Sun Apr 27 11:49:23 1997
 ---   echo strftime("%Y %b %d %X")     " 1997 Apr 27 11:53:25
----   echo strftime("%y%m%d %T")     " 970427 11:53:55
----   echo strftime("%H:%M")       " 11:55
+---   echo strftime("%y%m%d %T")       " 970427 11:53:55
+---   echo strftime("%H:%M")                   " 11:55
 ---   echo strftime("%c", getftime("file.c"))
----            " Show mod time of file.c.
+---                                    " Show mod time of file.c.
 ---
 --- @param format any
 --- @param time? any
@@ -9093,8 +9093,8 @@ function vim.fn.strgetchar(str, index) end
 --- {haystack} of the first occurrence of the String {needle}.
 --- If {start} is specified, the search starts at index {start}.
 --- This can be used to find a second match: >vim
----   let colon1 = stridx(line, ":")
----   let colon2 = stridx(line, ":", colon1 + 1)
+---         let colon1 = stridx(line, ":")
+---         let colon2 = stridx(line, ":", colon1 + 1)
 --- <The search is done case-sensitive.
 --- For pattern searches use |match()|.
 --- -1 is returned if the {needle} does not occur in {haystack}.
@@ -9103,7 +9103,7 @@ function vim.fn.strgetchar(str, index) end
 ---   echo stridx("An Example", "Example")     " 3
 ---   echo stridx("Starting point", "Start")   " 0
 ---   echo stridx("Starting point", "start")   " -1
---- <        *strstr()* *strchr()*
+--- <                               *strstr()* *strchr()*
 --- stridx() works similar to the C function strstr().  When used
 --- with a single character it works similar to strchr().
 ---
@@ -9116,15 +9116,15 @@ function vim.fn.stridx(haystack, needle, start) end
 --- Return {expr} converted to a String.  If {expr} is a Number,
 --- Float, String, Blob or a composition of them, then the result
 --- can be parsed back with |eval()|.
----   {expr} type  result ~
----   String    'string'
----   Number    123
----   Float    123.123456 or 1.123456e8 or
----       `str2float('inf')`
----   Funcref    `function('name')`
----   Blob    0z00112233.44556677.8899
----   List    [item, item]
----   Dictionary  `{key: value, key: value}`
+---         {expr} type     result ~
+---         String          'string'
+---         Number          123
+---         Float           123.123456 or 1.123456e8 or
+---                         `str2float('inf')`
+---         Funcref         `function('name')`
+---         Blob            0z00112233.44556677.8899
+---         List            [item, item]
+---         Dictionary      `{key: value, key: value}`
 --- Note that in String values the ' character is doubled.
 --- Also see |strtrans()|.
 --- Note 2: Output format is mostly compatible with YAML, except
@@ -9165,14 +9165,14 @@ function vim.fn.strlen(string) end
 --- result in an error, the bytes are simply omitted.
 --- If {len} is missing, the copy continues from {start} till the
 --- end of the {src}. >vim
----   echo strpart("abcdefg", 3, 2)    " returns 'de'
----   echo strpart("abcdefg", -2, 4)   " returns 'ab'
----   echo strpart("abcdefg", 5, 4)    " returns 'fg'
----   echo strpart("abcdefg", 3)   " returns 'defg'
+---         echo strpart("abcdefg", 3, 2)    " returns 'de'
+---         echo strpart("abcdefg", -2, 4)   " returns 'ab'
+---         echo strpart("abcdefg", 5, 4)    " returns 'fg'
+---         echo strpart("abcdefg", 3)       " returns 'defg'
 ---
 --- <Note: To get the first character, {start} must be 0.  For
 --- example, to get the character under the cursor: >vim
----   strpart(getline("."), col(".") - 1, 1, v:true)
+---         strpart(getline("."), col(".") - 1, 1, v:true)
 --- <
 --- Returns an empty string on error.
 ---
@@ -9216,15 +9216,15 @@ function vim.fn.strptime(format, timestring) end
 --- When {start} is specified, matches beyond this index are
 --- ignored.  This can be used to find a match before a previous
 --- match: >vim
----   let lastcomma = strridx(line, ",")
----   let comma2 = strridx(line, ",", lastcomma - 1)
+---         let lastcomma = strridx(line, ",")
+---         let comma2 = strridx(line, ",", lastcomma - 1)
 --- <The search is done case-sensitive.
 --- For pattern searches use |match()|.
 --- -1 is returned if the {needle} does not occur in {haystack}.
 --- If the {needle} is empty the length of {haystack} is returned.
 --- See also |stridx()|.  Examples: >vim
----   echo strridx("an angry armadillo", "an")       3
---- <          *strrchr()*
+---   echo strridx("an angry armadillo", "an")           3
+--- <                                       *strrchr()*
 --- When used with a single character it works similar to the C
 --- function strrchr().
 ---
@@ -9237,8 +9237,8 @@ function vim.fn.strridx(haystack, needle, start) end
 --- The result is a String, which is {string} with all unprintable
 --- characters translated into printable characters |'isprint'|.
 --- Like they are shown in a window.  Example: >vim
----   echo strtrans(\@a)
---- <This displays a newline in register a as "^\@" instead of
+---         echo strtrans(@a)
+--- <This displays a newline in register a as "^@" instead of
 --- starting a new line.
 ---
 --- Returns an empty string on error.
@@ -9259,11 +9259,11 @@ function vim.fn.strtrans(string) end
 ---
 --- Also see |strlen()| and |strcharlen()|.
 --- Examples: >vim
----     echo strutf16len('a')    " returns 1
----     echo strutf16len('©')    " returns 1
----     echo strutf16len('😊')    " returns 2
----     echo strutf16len('ą́')    " returns 1
----     echo strutf16len('ą́', v:true)  " returns 3
+---     echo strutf16len('a')               " returns 1
+---     echo strutf16len('©')               " returns 1
+---     echo strutf16len('😊')              " returns 2
+---     echo strutf16len('ą́')               " returns 1
+---     echo strutf16len('ą́', v:true)       " returns 3
 --- <
 ---
 --- @param string string
@@ -9305,8 +9305,8 @@ function vim.fn.strwidth(string) end
 --- Returns an empty string or list on error.
 ---
 --- Examples: >vim
----   s/\d\+/\=submatch(0) + 1/
----   echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
+---         s/\d\+/\=submatch(0) + 1/
+---         echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 --- <This finds the first number in the line and adds one to it.
 --- A line break is included as a newline character.
 ---
@@ -9337,15 +9337,15 @@ function vim.fn.submatch(nr, list) end
 --- unmodified.
 ---
 --- Example: >vim
----   let &path = substitute(&path, ",\\=[^,]*$", "", "")
+---         let &path = substitute(&path, ",\\=[^,]*$", "", "")
 --- <This removes the last component of the 'path' option. >vim
----   echo substitute("testing", ".*", "\\U\\0", "")
+---         echo substitute("testing", ".*", "\\U\\0", "")
 --- <results in "TESTING".
 ---
 --- When {sub} starts with "\=", the remainder is interpreted as
 --- an expression. See |sub-replace-expression|.  Example: >vim
----   echo substitute(s, '%\(\x\x\)',
----      \ '\=nr2char("0x" .. submatch(1))', 'g')
+---         echo substitute(s, '%\(\x\x\)',
+---            \ '\=nr2char("0x" .. submatch(1))', 'g')
 ---
 --- <When {sub} is a Funcref that function is called, with one
 --- optional argument.  Example: >vim
@@ -9369,30 +9369,30 @@ function vim.fn.substitute(string, pat, sub, flags) end
 --- for the directories to inspect.  If you only want to get a
 --- list of swap files in the current directory then temporarily
 --- set 'directory' to a dot: >vim
----   let save_dir = &directory
----   let &directory = '.'
----   let swapfiles = swapfilelist()
----   let &directory = save_dir
+---         let save_dir = &directory
+---         let &directory = '.'
+---         let swapfiles = swapfilelist()
+---         let &directory = save_dir
 ---
 --- @return string[]
 function vim.fn.swapfilelist() end
 
 --- The result is a dictionary, which holds information about the
 --- swapfile {fname}. The available fields are:
----   version Vim version
----   user  user name
----   host  host name
----   fname  original file name
----   pid  PID of the Nvim process that created the swap
----     file, or zero if not running.
----   mtime  last modification time in seconds
----   inode  Optional: INODE number of the file
----   dirty  1 if file was modified, 0 if not
+---         version Vim version
+---         user    user name
+---         host    host name
+---         fname   original file name
+---         pid     PID of the Nvim process that created the swap
+---                 file, or zero if not running.
+---         mtime   last modification time in seconds
+---         inode   Optional: INODE number of the file
+---         dirty   1 if file was modified, 0 if not
 --- In case of failure an "error" item is added with the reason:
----   Cannot open file: file not found or in accessible
----   Cannot read file: cannot read first block
----   Not a swap file: does not contain correct block ID
----   Magic number mismatch: Info in first block is invalid
+---         Cannot open file: file not found or in accessible
+---         Cannot read file: cannot read first block
+---         Not a swap file: does not contain correct block ID
+---         Magic number mismatch: Info in first block is invalid
 ---
 --- @param fname string
 --- @return any
@@ -9430,7 +9430,7 @@ function vim.fn.swapname(buf) end
 --- Returns zero on error.
 ---
 --- Example (echoes the name of the syntax item under the cursor): >vim
----   echo synIDattr(synID(line("."), col("."), 1), "name")
+---         echo synIDattr(synID(line("."), col("."), 1), "name")
 --- <
 ---
 --- @param lnum integer
@@ -9447,41 +9447,41 @@ function vim.fn.synID(lnum, col, trans) end
 --- used, the attributes for the currently active highlighting are
 --- used (GUI or cterm).
 --- Use synIDtrans() to follow linked highlight groups.
---- {what}    result
---- "name"    the name of the syntax item
---- "fg"    foreground color (GUI: color name used to set
----     the color, cterm: color number as a string,
----     term: empty string)
---- "bg"    background color (as with "fg")
---- "font"    font name (only available in the GUI)
----     |highlight-font|
---- "sp"    special color (as with "fg") |guisp|
---- "fg#"    like "fg", but for the GUI and the GUI is
----     running the name in "#RRGGBB" form
---- "bg#"    like "fg#" for "bg"
---- "sp#"    like "fg#" for "sp"
---- "bold"    "1" if bold
---- "italic"  "1" if italic
---- "reverse"  "1" if reverse
---- "inverse"  "1" if inverse (= reverse)
---- "standout"  "1" if standout
---- "underline"  "1" if underlined
---- "undercurl"  "1" if undercurled
---- "underdouble"  "1" if double underlined
---- "underdotted"  "1" if dotted underlined
---- "underdashed"  "1" if dashed underlined
---- "strikethrough"  "1" if struckthrough
---- "altfont"  "1" if alternative font
---- "nocombine"  "1" if nocombine
+--- {what}          result
+--- "name"          the name of the syntax item
+--- "fg"            foreground color (GUI: color name used to set
+---                 the color, cterm: color number as a string,
+---                 term: empty string)
+--- "bg"            background color (as with "fg")
+--- "font"          font name (only available in the GUI)
+---                 |highlight-font|
+--- "sp"            special color (as with "fg") |guisp|
+--- "fg#"           like "fg", but for the GUI and the GUI is
+---                 running the name in "#RRGGBB" form
+--- "bg#"           like "fg#" for "bg"
+--- "sp#"           like "fg#" for "sp"
+--- "bold"          "1" if bold
+--- "italic"        "1" if italic
+--- "reverse"       "1" if reverse
+--- "inverse"       "1" if inverse (= reverse)
+--- "standout"      "1" if standout
+--- "underline"     "1" if underlined
+--- "undercurl"     "1" if undercurled
+--- "underdouble"   "1" if double underlined
+--- "underdotted"   "1" if dotted underlined
+--- "underdashed"   "1" if dashed underlined
+--- "strikethrough" "1" if struckthrough
+--- "altfont"       "1" if alternative font
+--- "nocombine"     "1" if nocombine
 ---
 --- Returns an empty string on error.
 ---
 --- Example (echoes the color of the syntax item under the
 --- cursor): >vim
----   echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
+---         echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
 --- <
 --- Can also be used as a |method|: >vim
----   echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+---         echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
 --- <
 ---
 --- @param synID integer
@@ -9517,13 +9517,13 @@ function vim.fn.synIDtrans(synID) end
 ---    with the same replacement character.  For an example, if
 ---    the text is "123456" and both "23" and "45" are concealed
 ---    and replaced by the character "X", then:
----   call      returns ~
----   synconcealed(lnum, 1)   [0, '', 0]
----   synconcealed(lnum, 2)   [1, 'X', 1]
----   synconcealed(lnum, 3)   [1, 'X', 1]
----   synconcealed(lnum, 4)   [1, 'X', 2]
----   synconcealed(lnum, 5)   [1, 'X', 2]
----   synconcealed(lnum, 6)   [0, '', 0]
+---         call                    returns ~
+---         synconcealed(lnum, 1)   [0, '', 0]
+---         synconcealed(lnum, 2)   [1, 'X', 1]
+---         synconcealed(lnum, 3)   [1, 'X', 1]
+---         synconcealed(lnum, 4)   [1, 'X', 2]
+---         synconcealed(lnum, 5)   [1, 'X', 2]
+---         synconcealed(lnum, 6)   [0, '', 0]
 ---
 --- @param lnum integer
 --- @param col integer
@@ -9540,9 +9540,9 @@ function vim.fn.synconcealed(lnum, col) end
 --- transparent item.
 --- This function is useful for debugging a syntax file.
 --- Example that shows the syntax stack under the cursor: >vim
----   for id in synstack(line("."), col("."))
----      echo synIDattr(id, "name")
----   endfor
+---         for id in synstack(line("."), col("."))
+---            echo synIDattr(id, "name")
+---         endfor
 --- <When the position specified with {lnum} and {col} is invalid
 --- an empty list is returned.  The position just after the last
 --- character in a line and the first column in an empty line are
@@ -9581,7 +9581,7 @@ function vim.fn.synstack(lnum, col) end
 --- When {input} is given and is a valid buffer id, the content of
 --- the buffer is written to the file line by line, each line
 --- terminated by NL (and NUL where the text has NL).
----             *E5677*
+---                                                 *E5677*
 --- Note: system() cannot write to or read from backgrounded ("&")
 --- shell commands, e.g.: >vim
 ---     echo system("cat - &", "foo")
@@ -9615,7 +9615,7 @@ function vim.fn.system(cmd, input) end
 ---
 --- To see the difference between "echo hello" and "echo -n hello"
 --- use |system()| and |split()|: >vim
----   echo split(system('echo hello'), '\n', 1)
+---         echo split(system('echo hello'), '\n', 1)
 --- <
 --- Returns an empty string on error.
 ---
@@ -9631,10 +9631,10 @@ function vim.fn.systemlist(cmd, input, keepempty) end
 --- omitted the current tab page is used.
 --- When {arg} is invalid the number zero is returned.
 --- To get a list of all buffers in all tabs use this: >vim
----   let buflist = []
----   for i in range(tabpagenr('$'))
----      call extend(buflist, tabpagebuflist(i + 1))
----   endfor
+---         let buflist = []
+---         for i in range(tabpagenr('$'))
+---            call extend(buflist, tabpagebuflist(i + 1))
+---         endfor
 --- <Note that a buffer may appear in more than one window.
 ---
 --- @param arg? any
@@ -9645,11 +9645,11 @@ function vim.fn.tabpagebuflist(arg) end
 --- tab page.  The first tab page has number 1.
 ---
 --- The optional argument {arg} supports the following values:
----   $  the number of the last tab page (the tab page
----     count).
----   #  the number of the last accessed tab page
----     (where |g<Tab>| goes to).  If there is no
----     previous tab page, 0 is returned.
+---         $       the number of the last tab page (the tab page
+---                 count).
+---         #       the number of the last accessed tab page
+---                 (where |g<Tab>| goes to).  If there is no
+---                 previous tab page, 0 is returned.
 --- The number can be used with the |:tab| command.
 ---
 --- Returns zero on error.
@@ -9666,7 +9666,7 @@ function vim.fn.tabpagenr(arg) end
 --- - When "$" the number of windows is returned.
 --- - When "#" the previous window nr is returned.
 --- Useful examples: >vim
----     tabpagewinnr(1)      " current window of tab page 1
+---     tabpagewinnr(1)         " current window of tab page 1
 ---     tabpagewinnr(4, '$')    " number of windows in tab page 4
 --- <When {tabarg} is invalid zero is returned.
 ---
@@ -9689,19 +9689,19 @@ function vim.fn.tagfiles() end
 ---
 --- Each list item is a dictionary with at least the following
 --- entries:
----   name    Name of the tag.
----   filename  Name of the file where the tag is
----       defined.  It is either relative to the
----       current directory or a full path.
----   cmd    Ex command used to locate the tag in
----       the file.
----   kind    Type of the tag.  The value for this
----       entry depends on the language specific
----       kind values.  Only available when
----       using a tags file generated by
----       Universal/Exuberant ctags or hdrtag.
----   static    A file specific tag.  Refer to
----       |static-tag| for more information.
+---         name            Name of the tag.
+---         filename        Name of the file where the tag is
+---                         defined.  It is either relative to the
+---                         current directory or a full path.
+---         cmd             Ex command used to locate the tag in
+---                         the file.
+---         kind            Type of the tag.  The value for this
+---                         entry depends on the language specific
+---                         kind values.  Only available when
+---                         using a tags file generated by
+---                         Universal/Exuberant ctags or hdrtag.
+---         static          A file specific tag.  Refer to
+---                         |static-tag| for more information.
 --- More entries may be present, depending on the content of the
 --- tags file: access, implementation, inherits and signature.
 --- Refer to the ctags documentation for information about these
@@ -9733,10 +9733,10 @@ function vim.fn.taglist(expr, filename) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo tan(10)
---- <  0.648361 >vim
----   echo tan(-4.01)
---- <  -1.181502
+---         echo tan(10)
+--- <        0.648361 >vim
+---         echo tan(-4.01)
+--- <        -1.181502
 ---
 --- @param expr number
 --- @return number
@@ -9747,10 +9747,10 @@ function vim.fn.tan(expr) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo tanh(0.5)
---- <  0.462117 >vim
----   echo tanh(-1)
---- <  -0.761594
+---         echo tanh(0.5)
+--- <        0.462117 >vim
+---         echo tanh(-1)
+--- <        -0.761594
 ---
 --- @param expr number
 --- @return number
@@ -9759,8 +9759,8 @@ function vim.fn.tanh(expr) end
 --- Generates a (non-existent) filename located in the Nvim root
 --- |tempdir|. Scripts can use the filename as a temporary file.
 --- Example: >vim
----   let tmpfile = tempname()
----   exe "redir > " .. tmpfile
+---         let tmpfile = tempname()
+---         exe "redir > " .. tmpfile
 --- <
 ---
 --- @return string
@@ -9793,10 +9793,10 @@ function vim.fn.termopen(cmd, opts) end
 ---
 --- For each timer the information is stored in a |Dictionary| with
 --- these items:
----     "id"      the timer ID
----     "time"      time the timer was started with
----     "repeat"      number of times the timer will still fire;
----         -1 means forever
+---     "id"            the timer ID
+---     "time"          time the timer was started with
+---     "repeat"        number of times the timer will still fire;
+---                     -1 means forever
 ---     "callback"      the callback
 ---
 --- @param id? any
@@ -9834,19 +9834,19 @@ function vim.fn.timer_pause(timer, paused) end
 --- waiting for input.
 ---
 --- {options} is a dictionary.  Supported entries:
----    "repeat"  Number of times to repeat the callback.
----     -1 means forever.  Default is 1.
----     If the timer causes an error three times in a
----     row the repeat is cancelled.
+---    "repeat"     Number of times to repeat the callback.
+---                 -1 means forever.  Default is 1.
+---                 If the timer causes an error three times in a
+---                 row the repeat is cancelled.
 ---
 --- Returns -1 on error.
 ---
 --- Example: >vim
----   func MyHandler(timer)
----     echo 'Handler called'
----   endfunc
----   let timer = timer_start(500, 'MyHandler',
----     \ {'repeat': 3})
+---         func MyHandler(timer)
+---           echo 'Handler called'
+---         endfunc
+---         let timer = timer_start(500, 'MyHandler',
+---                 \ {'repeat': 3})
 --- <This invokes MyHandler() three times at 500 msec intervals.
 ---
 --- @param time any
@@ -9896,9 +9896,9 @@ function vim.fn.toupper(expr) end
 --- Returns an empty string on error.
 ---
 --- Examples: >vim
----   echo tr("hello there", "ht", "HT")
+---         echo tr("hello there", "ht", "HT")
 --- <returns "Hello THere" >vim
----   echo tr("<blob>", "<>", "{}")
+---         echo tr("<blob>", "<>", "{}")
 --- <returns "{blob}"
 ---
 --- @param src string
@@ -9916,22 +9916,22 @@ function vim.fn.tr(src, fromstr, tostr) end
 ---
 --- The optional {dir} argument specifies where to remove the
 --- characters:
----   0  remove from the beginning and end of {text}
----   1  remove only at the beginning of {text}
----   2  remove only at the end of {text}
+---         0       remove from the beginning and end of {text}
+---         1       remove only at the beginning of {text}
+---         2       remove only at the end of {text}
 --- When omitted both ends are trimmed.
 ---
 --- This function deals with multibyte characters properly.
 --- Returns an empty string on error.
 ---
 --- Examples: >vim
----   echo trim("   some text ")
+---         echo trim("   some text ")
 --- <returns "some text" >vim
----   echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
+---         echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
 --- <returns "RESERVE_TAIL" >vim
----   echo trim("rm<Xrm<>X>rrm", "rm<>")
+---         echo trim("rm<Xrm<>X>rrm", "rm<>")
 --- <returns "Xrm<>X" (characters in the middle are not removed) >vim
----   echo trim("  vim  ", " ", 2)
+---         echo trim("  vim  ", " ", 2)
 --- <returns "  vim"
 ---
 --- @param text any
@@ -9945,12 +9945,12 @@ function vim.fn.trim(text, mask, dir) end
 --- {expr} must evaluate to a |Float| or a |Number|.
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 --- Examples: >vim
----   echo trunc(1.456)
---- <  1.0  >vim
----   echo trunc(-5.456)
---- <  -5.0  >vim
----   echo trunc(4.0)
---- <  4.0
+---         echo trunc(1.456)
+--- <        1.0  >vim
+---         echo trunc(-5.456)
+--- <        -5.0  >vim
+---         echo trunc(4.0)
+--- <        4.0
 ---
 --- @param expr any
 --- @return integer
@@ -9959,28 +9959,28 @@ function vim.fn.trunc(expr) end
 --- The result is a Number representing the type of {expr}.
 --- Instead of using the number directly, it is better to use the
 --- v:t_ variable that has the value:
----   Number:      0  |v:t_number|
----   String:      1  |v:t_string|
----   Funcref:    2  |v:t_func|
----   List:      3  |v:t_list|
----   Dictionary: 4  |v:t_dict|
----   Float:      5  |v:t_float|
----   Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
----   Null:      7  (|v:null|)
----   Blob:     10  |v:t_blob|
+---         Number:     0  |v:t_number|
+---         String:     1  |v:t_string|
+---         Funcref:    2  |v:t_func|
+---         List:       3  |v:t_list|
+---         Dictionary: 4  |v:t_dict|
+---         Float:      5  |v:t_float|
+---         Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
+---         Null:       7  (|v:null|)
+---         Blob:      10  |v:t_blob|
 --- For backward compatibility, this method can be used: >vim
----   if type(myvar) == type(0) | endif
----   if type(myvar) == type("") | endif
----   if type(myvar) == type(function("tr")) | endif
----   if type(myvar) == type([]) | endif
----   if type(myvar) == type({}) | endif
----   if type(myvar) == type(0.0) | endif
----   if type(myvar) == type(v:true) | endif
+---         if type(myvar) == type(0) | endif
+---         if type(myvar) == type("") | endif
+---         if type(myvar) == type(function("tr")) | endif
+---         if type(myvar) == type([]) | endif
+---         if type(myvar) == type({}) | endif
+---         if type(myvar) == type(0.0) | endif
+---         if type(myvar) == type(v:true) | endif
 --- <In place of checking for |v:null| type it is better to check
 --- for |v:null| directly as it is the only value of this type: >vim
----   if myvar is v:null | endif
+---         if myvar is v:null | endif
 --- <To check if the v:t_ variables exist use this: >vim
----   if exists('v:t_number') | endif
+---         if exists('v:t_number') | endif
 ---
 --- @param expr any
 --- @return integer
@@ -10003,45 +10003,45 @@ function vim.fn.undofile(name) end
 --- Return the current state of the undo tree for the current
 --- buffer, or for a specific buffer if {buf} is given.  The
 --- result is a dictionary with the following items:
----   "seq_last"  The highest undo sequence number used.
----   "seq_cur"  The sequence number of the current position in
----     the undo tree.  This differs from "seq_last"
----     when some changes were undone.
----   "time_cur"  Time last used for |:earlier| and related
----     commands.  Use |strftime()| to convert to
----     something readable.
----   "save_last"  Number of the last file write.  Zero when no
----     write yet.
----   "save_cur"  Number of the current position in the undo
----     tree.
----   "synced"  Non-zero when the last undo block was synced.
----     This happens when waiting from input from the
----     user.  See |undo-blocks|.
----   "entries"  A list of dictionaries with information about
----     undo blocks.
+---   "seq_last"    The highest undo sequence number used.
+---   "seq_cur"     The sequence number of the current position in
+---                 the undo tree.  This differs from "seq_last"
+---                 when some changes were undone.
+---   "time_cur"    Time last used for |:earlier| and related
+---                 commands.  Use |strftime()| to convert to
+---                 something readable.
+---   "save_last"   Number of the last file write.  Zero when no
+---                 write yet.
+---   "save_cur"    Number of the current position in the undo
+---                 tree.
+---   "synced"      Non-zero when the last undo block was synced.
+---                 This happens when waiting from input from the
+---                 user.  See |undo-blocks|.
+---   "entries"     A list of dictionaries with information about
+---                 undo blocks.
 ---
 --- The first item in the "entries" list is the oldest undo item.
 --- Each List item is a |Dictionary| with these items:
----   "seq"    Undo sequence number.  Same as what appears in
----     |:undolist|.
----   "time"  Timestamp when the change happened.  Use
----     |strftime()| to convert to something readable.
----   "newhead"  Only appears in the item that is the last one
----     that was added.  This marks the last change
----     and where further changes will be added.
----   "curhead"  Only appears in the item that is the last one
----     that was undone.  This marks the current
----     position in the undo tree, the block that will
----     be used by a redo command.  When nothing was
----     undone after the last change this item will
----     not appear anywhere.
----   "save"  Only appears on the last block before a file
----     write.  The number is the write count.  The
----     first write has number 1, the last one the
----     "save_last" mentioned above.
----   "alt"    Alternate entry.  This is again a List of undo
----     blocks.  Each item may again have an "alt"
----     item.
+---   "seq"         Undo sequence number.  Same as what appears in
+---                 |:undolist|.
+---   "time"        Timestamp when the change happened.  Use
+---                 |strftime()| to convert to something readable.
+---   "newhead"     Only appears in the item that is the last one
+---                 that was added.  This marks the last change
+---                 and where further changes will be added.
+---   "curhead"     Only appears in the item that is the last one
+---                 that was undone.  This marks the current
+---                 position in the undo tree, the block that will
+---                 be used by a redo command.  When nothing was
+---                 undone after the last change this item will
+---                 not appear anywhere.
+---   "save"        Only appears on the last block before a file
+---                 write.  The number is the write count.  The
+---                 first write has number 1, the last one the
+---                 "save_last" mentioned above.
+---   "alt"         Alternate entry.  This is again a List of undo
+---                 blocks.  Each item may again have an "alt"
+---                 item.
 ---
 --- @param buf? integer|string
 --- @return any
@@ -10050,7 +10050,7 @@ function vim.fn.undotree(buf) end
 --- Remove second and succeeding copies of repeated adjacent
 --- {list} items in-place.  Returns {list}.  If you want a list
 --- to remain unmodified make a copy first: >vim
----   let newlist = uniq(copy(mylist))
+---         let newlist = uniq(copy(mylist))
 --- <The default compare function uses the string representation of
 --- each item.  For the use of {func} and {dict} see |sort()|.
 ---
@@ -10080,13 +10080,13 @@ function vim.fn.uniq(list, func, dict) end
 --- character index from the UTF-16 index.
 --- Refer to |string-offset-encoding| for more information.
 --- Examples: >vim
----   echo utf16idx('a😊😊', 3)  " returns 2
----   echo utf16idx('a😊😊', 7)  " returns 4
----   echo utf16idx('a😊😊', 1, 0, 1)  " returns 2
----   echo utf16idx('a😊😊', 2, 0, 1)  " returns 4
----   echo utf16idx('aą́c', 6)    " returns 2
----   echo utf16idx('aą́c', 6, 1)  " returns 4
----   echo utf16idx('a😊😊', 9)  " returns -1
+---         echo utf16idx('a😊😊', 3)       " returns 2
+---         echo utf16idx('a😊😊', 7)       " returns 4
+---         echo utf16idx('a😊😊', 1, 0, 1) " returns 2
+---         echo utf16idx('a😊😊', 2, 0, 1) " returns 4
+---         echo utf16idx('aą́c', 6)         " returns 2
+---         echo utf16idx('aą́c', 6, 1)      " returns 4
+---         echo utf16idx('a😊😊', 9)       " returns -1
 --- <
 ---
 --- @param string string
@@ -10124,16 +10124,16 @@ function vim.fn.values(dict) end
 --- |'virtualedit'|
 ---
 --- The accepted positions are:
----     .      the cursor position
----     $      the end of the cursor line (the result is the
----       number of displayed characters in the cursor line
----       plus one)
+---     .       the cursor position
+---     $       the end of the cursor line (the result is the
+---             number of displayed characters in the cursor line
+---             plus one)
 ---     'x      position of mark x (if the mark is not set, 0 is
----       returned)
+---             returned)
 ---     v       In Visual mode: the start of the Visual area (the
----       cursor is the end).  When not in Visual mode
----       returns the cursor position.  Differs from |'<| in
----       that it's updated right away.
+---             cursor is the end).  When not in Visual mode
+---             returns the cursor position.  Differs from |'<| in
+---             that it's updated right away.
 ---
 --- If {list} is present and non-zero then virtcol() returns a
 --- List with the first and last screen position occupied by the
@@ -10144,15 +10144,15 @@ function vim.fn.values(dict) end
 ---
 --- Note that only marks in the current file can be used.
 --- Examples: >vim
----   " With text "foo^Lbar" and cursor on the "^L":
+---         " With text "foo^Lbar" and cursor on the "^L":
 ---
----   echo virtcol(".")  " returns 5
----   echo virtcol(".", 1)  " returns [4, 5]
----   echo virtcol("$")  " returns 9
+---         echo virtcol(".")       " returns 5
+---         echo virtcol(".", 1)    " returns [4, 5]
+---         echo virtcol("$")       " returns 9
 ---
----   " With text "    there", with 't at 'h':
+---         " With text "     there", with 't at 'h':
 ---
----   echo virtcol("'t")  " returns 6
+---         echo virtcol("'t")      " returns 6
 --- <The first column is 1.  0 or [0, 0] is returned for an error.
 --- A more advanced example that echoes the maximum length of
 --- all lines: >vim
@@ -10198,7 +10198,7 @@ function vim.fn.virtcol2col(winid, lnum, col) end
 --- character-wise, line-wise, or block-wise Visual mode
 --- respectively.
 --- Example: >vim
----   exe "normal " .. visualmode()
+---         exe "normal " .. visualmode()
 --- <This enters the same Visual mode as before.  It is also useful
 --- in scripts if you wish to act differently depending on the
 --- Visual mode that was used.
@@ -10222,10 +10222,10 @@ function vim.fn.visualmode(expr) end
 --- every {interval} milliseconds (default: 200).
 ---
 --- Returns a status integer:
----   0 if the condition was satisfied before timeout
----   -1 if the timeout was exceeded
----   -2 if the function was interrupted (by |CTRL-C|)
----   -3 if an error occurred
+---         0 if the condition was satisfied before timeout
+---         -1 if the timeout was exceeded
+---         -2 if the function was interrupted (by |CTRL-C|)
+---         -3 if an error occurred
 ---
 --- @param timeout integer
 --- @param condition any
@@ -10252,7 +10252,7 @@ function vim.fn.wildmenumode() end
 --- executing {command} autocommands will be triggered, this may
 --- have unexpected side effects.  Use `:noautocmd` if needed.
 --- Example: >vim
----   call win_execute(winid, 'syntax enable')
+---         call win_execute(winid, 'syntax enable')
 --- <Doing the same with `setwinvar()` would not trigger
 --- autocommands and not actually show syntax highlighting.
 ---
@@ -10286,15 +10286,15 @@ function vim.fn.win_findbuf(bufnr) end
 function vim.fn.win_getid(win, tab) end
 
 --- Return the type of the window:
----   "autocmd"  autocommand window. Temporary window
----       used to execute autocommands.
----   "command"  command-line window |cmdwin|
----   (empty)    normal window
----   "loclist"  |location-list-window|
----   "popup"    floating window |api-floatwin|
----   "preview"  preview window |preview-window|
----   "quickfix"  |quickfix-window|
----   "unknown"  window {nr} not found
+---         "autocmd"       autocommand window. Temporary window
+---                         used to execute autocommands.
+---         "command"       command-line window |cmdwin|
+---         (empty)         normal window
+---         "loclist"       |location-list-window|
+---         "popup"         floating window |api-floatwin|
+---         "preview"       preview window |preview-window|
+---         "quickfix"      |quickfix-window|
+---         "unknown"       window {nr} not found
 ---
 --- When {nr} is omitted return the type of the current window.
 --- When {nr} is given return the type of this window by number or
@@ -10387,13 +10387,13 @@ function vim.fn.win_screenpos(nr) end
 --- Returns zero for success, non-zero for failure.
 ---
 --- {options} is a |Dictionary| with the following optional entries:
----   "vertical"  When TRUE, the split is created vertically,
----     like with |:vsplit|.
+---   "vertical"    When TRUE, the split is created vertically,
+---                 like with |:vsplit|.
 ---   "rightbelow"  When TRUE, the split is made below or to the
----     right (if vertical).  When FALSE, it is done
----     above or to the left (if vertical).  When not
----     present, the values of 'splitbelow' and
----     'splitright' are used.
+---                 right (if vertical).  When FALSE, it is done
+---                 above or to the left (if vertical).  When not
+---                 present, the values of 'splitbelow' and
+---                 'splitright' are used.
 ---
 --- @param nr integer
 --- @param target any
@@ -10451,32 +10451,32 @@ function vim.fn.winheight(nr) end
 --- returns an empty list.
 ---
 --- For a leaf window, it returns: >
----   ["leaf", {winid}]
+---         ["leaf", {winid}]
 --- <
 --- For horizontally split windows, which form a column, it
 --- returns: >
----   ["col", [{nested list of windows}]]
+---         ["col", [{nested list of windows}]]
 --- <For vertically split windows, which form a row, it returns: >
----   ["row", [{nested list of windows}]]
+---         ["row", [{nested list of windows}]]
 --- <
 --- Example: >vim
----   " Only one window in the tab page
----   echo winlayout()
+---         " Only one window in the tab page
+---         echo winlayout()
 --- < >
----   ['leaf', 1000]
+---         ['leaf', 1000]
 --- < >vim
----   " Two horizontally split windows
----   echo winlayout()
+---         " Two horizontally split windows
+---         echo winlayout()
 --- < >
----   ['col', [['leaf', 1000], ['leaf', 1001]]]
+---         ['col', [['leaf', 1000], ['leaf', 1001]]]
 --- < >vim
----   " The second tab page, with three horizontally split
----   " windows, with two vertically split windows in the
----   " middle window
----   echo winlayout(2)
+---         " The second tab page, with three horizontally split
+---         " windows, with two vertically split windows in the
+---         " middle window
+---         echo winlayout(2)
 --- < >
----   ['col', [['leaf', 1002], ['row', [['leaf', 1003],
----           ['leaf', 1001]]], ['leaf', 1000]]]
+---         ['col', [['leaf', 1002], ['row', [['leaf', 1003],
+---                             ['leaf', 1001]]], ['leaf', 1000]]]
 --- <
 ---
 --- @param tabnr? integer
@@ -10497,28 +10497,28 @@ function vim.fn.winline() end
 --- Returns zero for a popup window.
 ---
 --- The optional argument {arg} supports the following values:
----   $  the number of the last window (the window
----     count).
----   #  the number of the last accessed window (where
----     |CTRL-W_p| goes to).  If there is no previous
----     window or it is in another tab page 0 is
----     returned.
----   {N}j  the number of the Nth window below the
----     current window (where |CTRL-W_j| goes to).
----   {N}k  the number of the Nth window above the current
----     window (where |CTRL-W_k| goes to).
----   {N}h  the number of the Nth window left of the
----     current window (where |CTRL-W_h| goes to).
----   {N}l  the number of the Nth window right of the
----     current window (where |CTRL-W_l| goes to).
+---         $       the number of the last window (the window
+---                 count).
+---         #       the number of the last accessed window (where
+---                 |CTRL-W_p| goes to).  If there is no previous
+---                 window or it is in another tab page 0 is
+---                 returned.
+---         {N}j    the number of the Nth window below the
+---                 current window (where |CTRL-W_j| goes to).
+---         {N}k    the number of the Nth window above the current
+---                 window (where |CTRL-W_k| goes to).
+---         {N}h    the number of the Nth window left of the
+---                 current window (where |CTRL-W_h| goes to).
+---         {N}l    the number of the Nth window right of the
+---                 current window (where |CTRL-W_l| goes to).
 --- The number can be used with |CTRL-W_w| and ":wincmd w"
 --- |:wincmd|.
 --- When {arg} is invalid an error is given and zero is returned.
 --- Also see |tabpagewinnr()| and |win_getid()|.
 --- Examples: >vim
----   let window_count = winnr('$')
----   let prev_window = winnr('#')
----   let wnum = winnr('3k')
+---         let window_count = winnr('$')
+---         let prev_window = winnr('#')
+---         let wnum = winnr('3k')
 ---
 --- @param arg? any
 --- @return any
@@ -10529,9 +10529,9 @@ function vim.fn.winnr(arg) end
 --- are opened or closed and the current window and tab page is
 --- unchanged.
 --- Example: >vim
----   let cmd = winrestcmd()
----   call MessWithWindowSizes()
----   exe cmd
+---         let cmd = winrestcmd()
+---         call MessWithWindowSizes()
+---         exe cmd
 --- <
 ---
 --- @return any
@@ -10565,21 +10565,21 @@ function vim.fn.winrestview(dict) end
 --- option to temporarily switch off folding, so that folds are
 --- not opened when moving around. This may have side effects.
 --- The return value includes:
----   lnum    cursor line number
----   col    cursor column (Note: the first column
----       zero, as opposed to what |getcurpos()|
----       returns)
----   coladd    cursor column offset for 'virtualedit'
----   curswant  column for vertical movement (Note:
----       the first column is zero, as opposed
----       to what |getcurpos()| returns).  After
----       |$| command it will be a very large
----       number equal to |v:maxcol|.
----   topline    first line in the window
----   topfill    filler lines, only in diff mode
----   leftcol    first column displayed; only used when
----       'wrap' is off
----   skipcol    columns skipped
+---         lnum            cursor line number
+---         col             cursor column (Note: the first column
+---                         zero, as opposed to what |getcurpos()|
+---                         returns)
+---         coladd          cursor column offset for 'virtualedit'
+---         curswant        column for vertical movement (Note:
+---                         the first column is zero, as opposed
+---                         to what |getcurpos()| returns).  After
+---                         |$| command it will be a very large
+---                         number equal to |v:maxcol|.
+---         topline         first line in the window
+---         topfill         filler lines, only in diff mode
+---         leftcol         first column displayed; only used when
+---                         'wrap' is off
+---         skipcol         columns skipped
 --- Note that no option values are saved.
 ---
 --- @return vim.fn.winsaveview.ret
@@ -10606,21 +10606,21 @@ function vim.fn.winwidth(nr) end
 --- the current buffer.  This is the same info as provided by
 --- |g_CTRL-G|
 --- The return value includes:
----   bytes    Number of bytes in the buffer
----   chars    Number of chars in the buffer
----   words    Number of words in the buffer
----   cursor_bytes    Number of bytes before cursor position
----       (not in Visual mode)
----   cursor_chars    Number of chars before cursor position
----       (not in Visual mode)
----   cursor_words    Number of words before cursor position
----       (not in Visual mode)
----   visual_bytes    Number of bytes visually selected
----       (only in Visual mode)
----   visual_chars    Number of chars visually selected
----       (only in Visual mode)
----   visual_words    Number of words visually selected
----       (only in Visual mode)
+---         bytes           Number of bytes in the buffer
+---         chars           Number of chars in the buffer
+---         words           Number of words in the buffer
+---         cursor_bytes    Number of bytes before cursor position
+---                         (not in Visual mode)
+---         cursor_chars    Number of chars before cursor position
+---                         (not in Visual mode)
+---         cursor_words    Number of words before cursor position
+---                         (not in Visual mode)
+---         visual_bytes    Number of bytes visually selected
+---                         (only in Visual mode)
+---         visual_chars    Number of chars visually selected
+---                         (only in Visual mode)
+---         visual_words    Number of words visually selected
+---                         (only in Visual mode)
 ---
 --- @return any
 function vim.fn.wordcount() end
@@ -10642,12 +10642,12 @@ function vim.fn.wordcount() end
 ---      last line in the file to end in a NL.
 ---
 --- 'a'  Append mode is used, lines are appended to the file: >vim
----   call writefile(["foo"], "event.log", "a")
----   call writefile(["bar"], "event.log", "a")
+---         call writefile(["foo"], "event.log", "a")
+---         call writefile(["bar"], "event.log", "a")
 --- <
 --- 'D'  Delete the file when the current function ends.  This
 ---      works like: >vim
----   defer delete({fname})
+---         defer delete({fname})
 --- <     Fails when not in a function.  Also see |:defer|.
 ---
 --- 's'  fsync() is called after writing the file.  This flushes
@@ -10667,8 +10667,8 @@ function vim.fn.wordcount() end
 ---
 --- Also see |readfile()|.
 --- To copy a file byte for byte: >vim
----   let fl = readfile("foo", "b")
----   call writefile(fl, "foocopy", "b")
+---         let fl = readfile("foo", "b")
+---         call writefile(fl, "foocopy", "b")
 ---
 --- @param object any
 --- @param fname string
@@ -10680,7 +10680,7 @@ function vim.fn.writefile(object, fname, flags) end
 --- to a number.  A List, Dict or Float argument causes an error.
 --- Also see `and()` and `or()`.
 --- Example: >vim
----   let bits = xor(bits, 0x80)
+---         let bits = xor(bits, 0x80)
 --- <
 ---
 --- @param expr any

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -924,6 +924,22 @@ local function render(elem)
   end
 
   o:close()
+
+  if vim.endswith(elem.path, '.txt') then
+    vim.cmd.edit(elem.path)
+    vim.opt.expandtab = false
+    local range --- @type {[1]:integer,[2]:integer}
+    if elem.from then
+      local start = vim.fn.searchpos('\\V'..elem.from)[1]
+      if start then
+        local eend = vim.api.nvim_buf_line_count(0)
+        range = {start, eend}
+      end
+    else
+    end
+    vim.cmd({cmd = 'retab', bang = true, range = range})
+    vim.cmd.write()
+  end
 end
 
 local function main()

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -470,11 +470,11 @@ local function render_eval_doc(f, fun, write)
   local desc_l = split(vim.trim(desc))
   for _, l in ipairs(desc_l) do
     if vim.startswith(l, '<') and not l:match('^<[^ \t]+>') then
-      write('<                ' .. l:sub(2))
+      write('<' .. string.rep(' ', 15) .. l:sub(2))
     elseif l:match('^>[a-z0-9]*$') then
       write(l)
     else
-      write('                ' .. l)
+      write(string.rep(' ', 16) .. l)
     end
   end
 
@@ -930,14 +930,14 @@ local function render(elem)
     vim.opt.expandtab = false
     local range --- @type {[1]:integer,[2]:integer}
     if elem.from then
-      local start = vim.fn.searchpos('\\V'..elem.from)[1]
+      local start = vim.fn.searchpos('\\V' .. elem.from)[1]
       if start then
         local eend = vim.api.nvim_buf_line_count(0)
-        range = {start, eend}
+        range = { start, eend }
       end
     else
     end
-    vim.cmd({cmd = 'retab', bang = true, range = range})
+    vim.cmd({ cmd = 'retab', bang = true, range = range })
     vim.cmd.write()
   end
 end

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -43,12 +43,12 @@ M.funcs = {
       converted to a |Number| abs() returns a |Number|.  Otherwise
       abs() gives an error message and returns -1.
       Examples: >vim
-      	echo abs(1.456)
-      <	1.456  >vim
-      	echo abs(-5.456)
-      <	5.456  >vim
-      	echo abs(-4)
-      <	4
+              echo abs(1.456)
+      <        1.456  >vim
+              echo abs(-5.456)
+      <        5.456  >vim
+              echo abs(-4)
+      <        4
 
     ]=],
     name = 'abs',
@@ -67,10 +67,10 @@ M.funcs = {
       Returns NaN if {expr} is outside the range [-1, 1].  Returns
       0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo acos(0)
-      <	1.570796 >vim
-      	echo acos(-0.5)
-      <	2.094395
+              echo acos(0)
+      <        1.570796 >vim
+              echo acos(-0.5)
+      <        2.094395
 
     ]=],
     float_func = 'acos',
@@ -85,8 +85,8 @@ M.funcs = {
     desc = [=[
       Append the item {expr} to |List| or |Blob| {object}.  Returns
       the resulting |List| or |Blob|.  Examples: >vim
-      	let alist = add([1, 2, 3], item)
-      	call add(mylist, "woodstock")
+              let alist = add([1, 2, 3], item)
+              call add(mylist, "woodstock")
       <Note that when {expr} is a |List| it is appended as a single
       item.  Use |extend()| to concatenate |Lists|.
       When {object} is a |Blob| then {expr} must be a number.
@@ -107,7 +107,7 @@ M.funcs = {
       to a number.  A List, Dict or Float argument causes an error.
       Also see `or()` and `xor()`.
       Example: >vim
-      	let flag = and(bits, 0x80)
+              let flag = and(bits, 0x80)
       <
     ]=],
     name = 'and',
@@ -143,8 +143,8 @@ M.funcs = {
       Returns 1 for failure ({lnum} out of range or out of memory),
       0 for success.  When {text} is an empty list zero is returned,
       no matter the value of {lnum}.  Example: >vim
-      	let failed = append(line('$'), "# THE END")
-      	let failed = append(0, ["Chapter 1", "the beginning"])
+              let failed = append(line('$'), "# THE END")
+              let failed = append(0, ["Chapter 1", "the beginning"])
       <
 
     ]=],
@@ -173,7 +173,7 @@ M.funcs = {
 
       If {buf} is not a valid buffer or {lnum} is not valid, an
       error message is given. Example: >vim
-      	let failed = appendbufline(13, 0, "# THE START")
+              let failed = appendbufline(13, 0, "# THE START")
       <However, when {text} is an empty list then no error is given
       for an invalid {lnum}, since {lnum} isn't actually used.
 
@@ -234,12 +234,12 @@ M.funcs = {
     desc = [=[
       The result is the {nr}th file in the argument list.  See
       |arglist|.  "argv(0)" is the first one.  Example: >vim
-      	let i = 0
-      	while i < argc()
-      	  let f = escape(fnameescape(argv(i)), '.')
-      	  exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
-      	  let i = i + 1
-      	endwhile
+              let i = 0
+              while i < argc()
+                let f = escape(fnameescape(argv(i)), '.')
+                exe 'amenu Arg.' .. f .. ' :e ' .. f .. '<CR>'
+                let i = i + 1
+              endwhile
       <Without the {nr} argument, or when {nr} is -1, a |List| with
       the whole |arglist| is returned.
 
@@ -266,10 +266,10 @@ M.funcs = {
       Returns NaN if {expr} is outside the range [-1, 1].  Returns
       0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo asin(0.8)
-      <	0.927295 >vim
-      	echo asin(-0.5)
-      <	-0.523599
+              echo asin(0.8)
+      <        0.927295 >vim
+              echo asin(-0.5)
+      <        -0.523599
 
     ]=],
     float_func = 'asin',
@@ -308,9 +308,9 @@ M.funcs = {
       Float 4.0.  The value of 'ignorecase' is not used here, case
       always matters.
       Example: >vim
-      	assert_equal('foo', 'bar')
+              assert_equal('foo', 'bar')
       <Will result in a string to be added to |v:errors|:
-      	test.vim line 12: Expected 'foo' but got 'bar' ~
+              test.vim line 12: Expected 'foo' but got 'bar' ~
 
     ]=],
     name = 'assert_equal',
@@ -342,12 +342,12 @@ M.funcs = {
       This can be used to assert that a command throws an exception.
       Using the error number, followed by a colon, avoids problems
       with translations: >vim
-      	try
-      	  commandthatfails
-      	  call assert_false(1, 'command should have failed')
-      	catch
-      	  call assert_exception('E492:')
-      	endtry
+              try
+                commandthatfails
+                call assert_false(1, 'command should have failed')
+              catch
+                call assert_exception('E492:')
+              endtry
       <
     ]=],
     name = 'assert_exception',
@@ -366,16 +366,16 @@ M.funcs = {
       When {error} is a string it must be found literally in the
       first reported error. Most often this will be the error code,
       including the colon, e.g. "E123:". >vim
-      	assert_fails('bad cmd', 'E987:')
+              assert_fails('bad cmd', 'E987:')
       <
       When {error} is a |List| with one or two strings, these are
       used as patterns.  The first pattern is matched against the
       first reported error: >vim
-      	assert_fails('cmd', ['E987:.*expected bool'])
+              assert_fails('cmd', ['E987:.*expected bool'])
       <The second pattern, if present, is matched against the last
       reported error.  To only match the last error use an empty
       string for the first error: >vim
-      	assert_fails('cmd', ['', 'E987:'])
+              assert_fails('cmd', ['', 'E987:'])
       <
       If {msg} is empty then it is not used.  Do this to get the
       default message when passing the {lnum} argument.
@@ -457,9 +457,9 @@ M.funcs = {
       Use both to match the whole text.
 
       Example: >vim
-      	assert_match('^f.*o$', 'foobar')
+              assert_match('^f.*o$', 'foobar')
       <Will result in a string to be added to |v:errors|:
-      	test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
+              test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
     ]=],
     name = 'assert_match',
@@ -548,10 +548,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo atan(100)
-      <	1.560797 >vim
-      	echo atan(-4.01)
-      <	-1.326405
+              echo atan(100)
+      <        1.560797 >vim
+              echo atan(-4.01)
+      <        -1.326405
 
     ]=],
     float_func = 'atan',
@@ -570,10 +570,10 @@ M.funcs = {
       Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
       |Number|.
       Examples: >vim
-      	echo atan2(-1, 1)
-      <	-0.785398 >vim
-      	echo atan2(1, -1)
-      <	2.356194
+              echo atan2(-1, 1)
+      <        -0.785398 >vim
+              echo atan2(1, -1)
+      <        2.356194
 
     ]=],
     name = 'atan2',
@@ -587,8 +587,8 @@ M.funcs = {
     desc = [=[
       Return a List containing the number value of each byte in Blob
       {blob}.  Examples: >vim
-      	blob2list(0z0102.0304)	" returns [1, 2, 3, 4]
-      	blob2list(0z)		" returns []
+              blob2list(0z0102.0304)  " returns [1, 2, 3, 4]
+              blob2list(0z)           " returns []
       <Returns an empty List on error.  |list2blob()| does the
       opposite.
 
@@ -604,10 +604,10 @@ M.funcs = {
       Put up a file requester.  This only works when "has("browse")"
       returns |TRUE| (only in some GUI versions).
       The input fields are:
-          {save}	when |TRUE|, select file to write
-          {title}	title for the requester
-          {initdir}	directory to start browsing in
-          {default}	default file name
+          {save}      when |TRUE|, select file to write
+          {title}     title for the requester
+          {initdir}   directory to start browsing in
+          {default}   default file name
       An empty string is returned when the "Cancel" button is hit,
       something went wrong, or browsing is not possible.
     ]=],
@@ -625,8 +625,8 @@ M.funcs = {
       browser is used.  In that case: select a file in the directory
       to be used.
       The input fields are:
-          {title}	title for the requester
-          {initdir}	directory to start browsing in
+          {title}     title for the requester
+          {initdir}   directory to start browsing in
       When the "Cancel" button is hit, something went wrong, or
       browsing is not possible, an empty string is returned.
     ]=],
@@ -647,9 +647,9 @@ M.funcs = {
       buffer is always created.
       The buffer will not have 'buflisted' set and not be loaded
       yet.  To add some text to the buffer use this: >vim
-      	let bufnr = bufadd('someName')
-      	call bufload(bufnr)
-      	call setbufline(bufnr, 1, ['some', 'text'])
+              let bufnr = bufadd('someName')
+              call bufload(bufnr)
+              call setbufline(bufnr, 1, ['some', 'text'])
       <Returns 0 on error.
     ]=],
     name = 'bufadd',
@@ -799,13 +799,13 @@ M.funcs = {
       buffers are searched for.
       If the {buf} is a String, but you want to use it as a buffer
       number, force it to be a Number by adding zero to it: >vim
-      	echo bufname("3" + 0)
+              echo bufname("3" + 0)
       <If the buffer doesn't exist, or doesn't have a name, an empty
       string is returned. >vim
-      	echo bufname("#")	" alternate buffer name
-      	echo bufname(3)		" name of buffer 3
-      	echo bufname("%")	" name of current buffer
-      	echo bufname("file2")	" name of buffer where "file2" matches.
+              echo bufname("#")       " alternate buffer name
+              echo bufname(3)         " name of buffer 3
+              echo bufname("%")       " name of current buffer
+              echo bufname("file2")   " name of buffer where "file2" matches.
       <
     ]=],
     name = 'bufname',
@@ -824,7 +824,7 @@ M.funcs = {
       {create} argument is present and TRUE, a new, unlisted,
       buffer is created and its number is returned.
       bufnr("$") is the last buffer: >vim
-      	let last_buffer = bufnr("$")
+              let last_buffer = bufnr("$")
       <The result is a Number, which is the highest buffer number
       of existing buffers.  Note that not all buffers with a smaller
       number necessarily exist, because ":bwipeout" may have removed
@@ -845,7 +845,7 @@ M.funcs = {
       see |bufname()| above.  If buffer {buf} doesn't exist or
       there is no such window, -1 is returned.  Example: >vim
 
-      	echo "A window containing buffer 1 is " .. (bufwinid(1))
+              echo "A window containing buffer 1 is " .. (bufwinid(1))
       <
       Only deals with the current tab page.  See |win_findbuf()| for
       finding more.
@@ -865,7 +865,7 @@ M.funcs = {
       If buffer {buf} doesn't exist or there is no such window, -1
       is returned.  Example: >vim
 
-      	echo "A window containing buffer 1 is " .. (bufwinnr(1))
+              echo "A window containing buffer 1 is " .. (bufwinnr(1))
 
       <The number can be used with |CTRL-W_w| and ":wincmd w"
       |:wincmd|.
@@ -916,11 +916,11 @@ M.funcs = {
       byte index of the first byte in the character is returned.
       Refer to |string-offset-encoding| for more information.
       Example : >vim
-      	echo matchstr(str, ".", byteidx(str, 3))
+              echo matchstr(str, ".", byteidx(str, 3))
       <will display the fourth character.  Another way to do the
       same: >vim
-      	let s = strpart(str, byteidx(str, 3))
-      	echo strpart(s, 0, byteidx(s, 1))
+              let s = strpart(str, byteidx(str, 3))
+              echo strpart(s, 0, byteidx(s, 1))
       <Also see |strgetchar()| and |strcharpart()|.
 
       If there are less than {nr} characters -1 is returned.
@@ -929,9 +929,9 @@ M.funcs = {
       See |charidx()| and |utf16idx()| for getting the character and
       UTF-16 index respectively from the byte index.
       Examples: >vim
-      	echo byteidx('a😊😊', 2)	" returns 5
-      	echo byteidx('a😊😊', 2, 1)	" returns 1
-      	echo byteidx('a😊😊', 3, 1)	" returns 5
+              echo byteidx('a😊😊', 2)        " returns 5
+              echo byteidx('a😊😊', 2, 1)     " returns 1
+              echo byteidx('a😊😊', 3, 1)     " returns 5
       <
     ]=],
     fast = true,
@@ -946,10 +946,10 @@ M.funcs = {
     desc = [=[
       Like byteidx(), except that a composing character is counted
       as a separate character.  Example: >vim
-      	let s = 'e' .. nr2char(0x301)
-      	echo byteidx(s, 1)
-      	echo byteidxcomp(s, 1)
-      	echo byteidxcomp(s, 2)
+              let s = 'e' .. nr2char(0x301)
+              echo byteidx(s, 1)
+              echo byteidxcomp(s, 1)
+              echo byteidxcomp(s, 2)
       <The first and third echo result in 3 ('e' plus composing
       character is 3 bytes), the second echo results in 1 ('e' is
       one byte).
@@ -988,12 +988,12 @@ M.funcs = {
       {expr} as a |Float| (round up).
       {expr} must evaluate to a |Float| or a |Number|.
       Examples: >vim
-      	echo ceil(1.456)
-      <	2.0  >vim
-      	echo ceil(-5.456)
-      <	-5.0  >vim
-      	echo ceil(4.0)
-      <	4.0
+              echo ceil(1.456)
+      <        2.0  >vim
+              echo ceil(-5.456)
+      <        -5.0  >vim
+              echo ceil(4.0)
+      <        4.0
 
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
@@ -1049,7 +1049,7 @@ M.funcs = {
       If {data} is a list, the items will be joined by newlines; any
       newlines in an item will be sent as NUL. To send a final
       newline, include a final empty string. Example: >vim
-      	call chansend(id, ["abc", "123\n456", ""])
+              call chansend(id, ["abc", "123\n456", ""])
       <will send "abc<NL>123<NUL>456<NL>".
 
       chansend() writes raw data, not RPC messages.  If the channel
@@ -1067,11 +1067,11 @@ M.funcs = {
     desc = [=[
       Return Number value of the first char in {string}.
       Examples: >vim
-      	echo char2nr(" ")	" returns 32
-      	echo char2nr("ABC")	" returns 65
-      	echo char2nr("á")	" returns 225
-      	echo char2nr("á"[0])	" returns 195
-      	echo char2nr("\<M-x>")	" returns 128
+              echo char2nr(" ")       " returns 32
+              echo char2nr("ABC")     " returns 65
+              echo char2nr("á")       " returns 225
+              echo char2nr("á"[0])    " returns 195
+              echo char2nr("\<M-x>")  " returns 128
       <Non-ASCII characters are always treated as UTF-8 characters.
       {utf8} is ignored, it exists only for backwards-compatibility.
       A combining character is a separate character.
@@ -1092,11 +1092,11 @@ M.funcs = {
     desc = [=[
       Return the character class of the first character in {string}.
       The character class is one of:
-      	0	blank
-      	1	punctuation
-      	2	word character
-      	3	emoji
-      	other	specific Unicode class
+              0       blank
+              1       punctuation
+              2       word character
+              3       emoji
+              other   specific Unicode class
       The class is used in patterns and word motions.
       Returns 0 if {string} is not a |String|.
     ]=],
@@ -1114,8 +1114,8 @@ M.funcs = {
 
       Example:
       With the cursor on '세' in line 5 with text "여보세요": >vim
-      	echo charcol('.')	" returns 3
-      	echo col('.')		" returns 7
+              echo charcol('.')       " returns 3
+              echo col('.')           " returns 7
 
     ]=],
     name = 'charcol',
@@ -1154,10 +1154,10 @@ M.funcs = {
       UTF-16 index from the character index.
       Refer to |string-offset-encoding| for more information.
       Examples: >vim
-      	echo charidx('áb́ć', 3)		" returns 1
-      	echo charidx('áb́ć', 6, 1)	" returns 4
-      	echo charidx('áb́ć', 16)		" returns -1
-      	echo charidx('a😊😊', 4, 0, 1)	" returns 2
+              echo charidx('áb́ć', 3)          " returns 1
+              echo charidx('áb́ć', 6, 1)       " returns 4
+              echo charidx('áb́ć', 16)         " returns -1
+              echo charidx('a😊😊', 4, 0, 1)  " returns 2
       <
     ]=],
     name = 'charidx',
@@ -1177,23 +1177,23 @@ M.funcs = {
       Change the current working directory to {dir}.  The scope of
       the directory change depends on the directory of the current
       window:
-      	- If the current window has a window-local directory
-      	  (|:lcd|), then changes the window local directory.
-      	- Otherwise, if the current tabpage has a local
-      	  directory (|:tcd|) then changes the tabpage local
-      	  directory.
-      	- Otherwise, changes the global directory.
+              - If the current window has a window-local directory
+                (|:lcd|), then changes the window local directory.
+              - Otherwise, if the current tabpage has a local
+                directory (|:tcd|) then changes the tabpage local
+                directory.
+              - Otherwise, changes the global directory.
       {dir} must be a String.
       If successful, returns the previous working directory.  Pass
       this to another chdir() to restore the directory.
       On failure, returns an empty string.
 
       Example: >vim
-      	let save_dir = chdir(newdir)
-      	if save_dir != ""
-      	   " ... do some work
-      	   call chdir(save_dir)
-      	endif
+              let save_dir = chdir(newdir)
+              if save_dir != ""
+                 " ... do some work
+                 call chdir(save_dir)
+              endif
 
     ]=],
     name = 'chdir',
@@ -1239,15 +1239,15 @@ M.funcs = {
     desc = [=[
       The result is a Number, which is the byte index of the column
       position given with {expr}.  The accepted positions are:
-          .	    the cursor position
-          $	    the end of the cursor line (the result is the
-      	    number of bytes in the cursor line plus one)
-          'x	    position of mark x (if the mark is not set, 0 is
-      	    returned)
+          .       the cursor position
+          $       the end of the cursor line (the result is the
+                  number of bytes in the cursor line plus one)
+          'x      position of mark x (if the mark is not set, 0 is
+                  returned)
           v       In Visual mode: the start of the Visual area (the
-      	    cursor is the end).  When not in Visual mode
-      	    returns the cursor position.  Differs from |'<| in
-      	    that it's updated right away.
+                  cursor is the end).  When not in Visual mode
+                  returns the cursor position.  Differs from |'<| in
+                  that it's updated right away.
       Additionally {expr} can be [lnum, col]: a |List| with the line
       and column number. Most useful when the column is "$", to get
       the last column of a specific line.  When "lnum" or "col" is
@@ -1260,10 +1260,10 @@ M.funcs = {
       character position use |charcol()|.
       Note that only marks in the current file can be used.
       Examples: >vim
-      	echo col(".")			" column of cursor
-      	echo col("$")			" length of cursor line plus one
-      	echo col("'t")			" column of mark t
-      	echo col("'" .. markname)	" column of mark markname
+              echo col(".")                   " column of cursor
+              echo col("$")                   " length of cursor line plus one
+              echo col("'t")                  " column of mark t
+              echo col("'" .. markname)       " column of mark markname
       <The first column is 1.  Returns 0 if {expr} is invalid or when
       the window with ID {winid} is not found.
       For an uppercase mark the column may actually be in another
@@ -1272,7 +1272,7 @@ M.funcs = {
       column is one higher if the cursor is after the end of the
       line.  Also, when using a <Cmd> mapping the cursor isn't
       moved, this can be used to obtain the column in Insert mode: >vim
-      	imap <F2> <Cmd>echo col(".").."\n"<CR>
+              imap <F2> <Cmd>echo col(".").."\n"<CR>
 
     ]=],
     name = 'col',
@@ -1302,14 +1302,14 @@ M.funcs = {
       Insert mode completion.  The popup menu will appear if
       specified, see |ins-completion-menu|.
       Example: >vim
-      	inoremap <F5> <C-R>=ListMonths()<CR>
+              inoremap <F5> <C-R>=ListMonths()<CR>
 
-      	func ListMonths()
-      	  call complete(col('.'), ['January', 'February', 'March',
-      	    \ 'April', 'May', 'June', 'July', 'August', 'September',
-      	    \ 'October', 'November', 'December'])
-      	  return ''
-      	endfunc
+              func ListMonths()
+                call complete(col('.'), ['January', 'February', 'March',
+                  \ 'April', 'May', 'June', 'July', 'August', 'September',
+                  \ 'October', 'November', 'December'])
+                return ''
+              endfunc
       <This isn't very useful, but it shows how it works.  Note that
       an empty string is returned to avoid a zero being inserted.
 
@@ -1359,43 +1359,43 @@ M.funcs = {
       Returns a |Dictionary| with information about Insert mode
       completion.  See |ins-completion|.
       The items are:
-         mode		Current completion mode name string.
-      		See |complete_info_mode| for the values.
-         pum_visible	|TRUE| if popup menu is visible.
-      		See |pumvisible()|.
-         items	List of completion matches.  Each item is a
-      		dictionary containing the entries "word",
-      		"abbr", "menu", "kind", "info" and "user_data".
-      		See |complete-items|.
-         selected	Selected item index.  First index is zero.
-      		Index is -1 if no item is selected (showing
-      		typed text only, or the last completion after
-      		no item is selected when using the <Up> or
-      		<Down> keys)
-         inserted	Inserted string. [NOT IMPLEMENTED YET]
+         mode         Current completion mode name string.
+                      See |complete_info_mode| for the values.
+         pum_visible  |TRUE| if popup menu is visible.
+                      See |pumvisible()|.
+         items        List of completion matches.  Each item is a
+                      dictionary containing the entries "word",
+                      "abbr", "menu", "kind", "info" and "user_data".
+                      See |complete-items|.
+         selected     Selected item index.  First index is zero.
+                      Index is -1 if no item is selected (showing
+                      typed text only, or the last completion after
+                      no item is selected when using the <Up> or
+                      <Down> keys)
+         inserted     Inserted string. [NOT IMPLEMENTED YET]
          preview_winid     Info floating preview window id.
          preview_bufnr     Info floating preview buffer id.
 
-      					*complete_info_mode*
+                                              *complete_info_mode*
       mode values are:
-         ""		     Not in completion mode
-         "keyword"	     Keyword completion |i_CTRL-X_CTRL-N|
-         "ctrl_x"	     Just pressed CTRL-X |i_CTRL-X|
-         "scroll"	     Scrolling with |i_CTRL-X_CTRL-E| or
-      		     |i_CTRL-X_CTRL-Y|
-         "whole_line"	     Whole lines |i_CTRL-X_CTRL-L|
-         "files"	     File names |i_CTRL-X_CTRL-F|
-         "tags"	     Tags |i_CTRL-X_CTRL-]|
+         ""                Not in completion mode
+         "keyword"         Keyword completion |i_CTRL-X_CTRL-N|
+         "ctrl_x"          Just pressed CTRL-X |i_CTRL-X|
+         "scroll"          Scrolling with |i_CTRL-X_CTRL-E| or
+                           |i_CTRL-X_CTRL-Y|
+         "whole_line"      Whole lines |i_CTRL-X_CTRL-L|
+         "files"           File names |i_CTRL-X_CTRL-F|
+         "tags"            Tags |i_CTRL-X_CTRL-]|
          "path_defines"    Definition completion |i_CTRL-X_CTRL-D|
          "path_patterns"   Include completion |i_CTRL-X_CTRL-I|
-         "dictionary"	     Dictionary |i_CTRL-X_CTRL-K|
-         "thesaurus"	     Thesaurus |i_CTRL-X_CTRL-T|
-         "cmdline"	     Vim Command line |i_CTRL-X_CTRL-V|
-         "function"	     User defined completion |i_CTRL-X_CTRL-U|
-         "omni"	     Omni completion |i_CTRL-X_CTRL-O|
-         "spell"	     Spelling suggestions |i_CTRL-X_s|
-         "eval"	     |complete()| completion
-         "unknown"	     Other internal modes
+         "dictionary"      Dictionary |i_CTRL-X_CTRL-K|
+         "thesaurus"       Thesaurus |i_CTRL-X_CTRL-T|
+         "cmdline"         Vim Command line |i_CTRL-X_CTRL-V|
+         "function"        User defined completion |i_CTRL-X_CTRL-U|
+         "omni"            Omni completion |i_CTRL-X_CTRL-O|
+         "spell"           Spelling suggestions |i_CTRL-X_s|
+         "eval"            |complete()| completion
+         "unknown"         Other internal modes
 
       If the optional {what} list argument is supplied, then only
       the items listed in {what} are returned.  Unsupported items in
@@ -1408,12 +1408,12 @@ M.funcs = {
       Returns an empty |Dictionary| on error.
 
       Examples: >vim
-      	" Get all items
-      	call complete_info()
-      	" Get only 'mode'
-      	call complete_info(['mode'])
-      	" Get only 'mode' and 'pum_visible'
-      	call complete_info(['mode', 'pum_visible'])
+              " Get all items
+              call complete_info()
+              " Get only 'mode'
+              call complete_info(['mode'])
+              " Get only 'mode' and 'pum_visible'
+              call complete_info(['mode', 'pum_visible'])
 
     ]=],
     name = 'complete_info',
@@ -1437,11 +1437,11 @@ M.funcs = {
 
       {choices} is a String, with the individual choices separated
       by '\n', e.g. >vim
-      	confirm("Save changes?", "&Yes\n&No\n&Cancel")
+              confirm("Save changes?", "&Yes\n&No\n&Cancel")
       <The letter after the '&' is the shortcut key for that choice.
       Thus you can type 'c' to select "Cancel".  The shortcut does
       not need to be the first letter: >vim
-      	confirm("file has been modified", "&Save\nSave &All")
+              confirm("file has been modified", "&Save\nSave &All")
       <For the console, the first letter of each choice is used as
       the default shortcut key.  Case is ignored.
 
@@ -1461,13 +1461,13 @@ M.funcs = {
 
       An example: >vim
          let choice = confirm("What do you want?",
-      			\ "&Apples\n&Oranges\n&Bananas", 2)
+                              \ "&Apples\n&Oranges\n&Bananas", 2)
          if choice == 0
-      	echo "make up your mind!"
+              echo "make up your mind!"
          elseif choice == 3
-      	echo "tasteful"
+              echo "tasteful"
          else
-      	echo "I prefer bananas myself."
+              echo "I prefer bananas myself."
          endif
       <In a GUI dialog, buttons are used.  The layout of the buttons
       depends on the 'v' flag in 'guioptions'.  If it is included,
@@ -1508,10 +1508,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo cos(100)
-      <	0.862319 >vim
-      	echo cos(-4.01)
-      <	-0.646043
+              echo cos(100)
+      <        0.862319 >vim
+              echo cos(-4.01)
+      <        -0.646043
 
     ]=],
     float_func = 'cos',
@@ -1529,10 +1529,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo cosh(0.5)
-      <	1.127626 >vim
-      	echo cosh(-0.5)
-      <	-1.127626
+              echo cosh(0.5)
+      <        1.127626 >vim
+              echo cosh(-0.5)
+      <        -1.127626
 
     ]=],
     float_func = 'cosh',
@@ -1634,9 +1634,9 @@ M.funcs = {
 
       When there is one argument {list} this is used as a |List|
       with two, three or four item:
-      	[{lnum}, {col}]
-      	[{lnum}, {col}, {off}]
-      	[{lnum}, {col}, {off}, {curswant}]
+              [{lnum}, {col}]
+              [{lnum}, {col}, {off}]
+              [{lnum}, {col}, {off}, {curswant}]
       This is like the return value of |getpos()| or |getcurpos()|,
       but without the first item.
 
@@ -1700,7 +1700,7 @@ M.funcs = {
       this single copy.  With {noref} set to 1 every occurrence of a
       |List| or |Dictionary| results in a new copy.  This also means
       that a cyclic reference causes deepcopy() to fail.
-      						*E724*
+                                                      *E724*
       Nesting is possible up to 100 levels.  When there is an item
       that refers back to a higher level making a deep copy with
       {noref} set to 1 will fail.
@@ -1775,11 +1775,11 @@ M.funcs = {
       matching {pattern} will result in {callback} being invoked.
 
       For example, to watch all global variables: >vim
-      	silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
-      	function! OnDictChanged(d,k,z)
-      	  echomsg string(a:k) string(a:z)
-      	endfunction
-      	call dictwatcheradd(g:, '*', 'OnDictChanged')
+              silent! call dictwatcherdel(g:, '*', 'OnDictChanged')
+              function! OnDictChanged(d,k,z)
+                echomsg string(a:k) string(a:z)
+              endfunction
+              call dictwatcheradd(g:, '*', 'OnDictChanged')
       <
       For now {pattern} only accepts very simple patterns that can
       contain a "*" at the end of the string, in which case it will
@@ -1886,11 +1886,11 @@ M.funcs = {
 
       Examples: >vim
       " Get a built-in digraph
-      echo digraph_get('00')		" Returns '∞'
+      echo digraph_get('00')          " Returns '∞'
 
       " Get a user-defined digraph
       call digraph_set('aa', 'あ')
-      echo digraph_get('aa')		" Returns 'あ'
+      echo digraph_get('aa')          " Returns 'あ'
       <
     ]=],
     name = 'digraph_get',
@@ -1937,10 +1937,10 @@ M.funcs = {
       |digraph_setlist()|.
 
       Example: >vim
-      	call digraph_set('  ', 'あ')
+              call digraph_set('  ', 'あ')
       <
       Can be used as a |method|: >vim
-      	GetString()->digraph_set('あ')
+              GetString()->digraph_set('あ')
       <
     ]=],
     name = 'digraph_set',
@@ -1960,7 +1960,7 @@ M.funcs = {
       <
       It is similar to the following: >vim
           for [chars, digraph] in [['aa', 'あ'], ['ii', 'い']]
-      	  call digraph_set(chars, digraph)
+                call digraph_set(chars, digraph)
           endfor
       <Except that the function returns after the first error,
       following digraphs will not be added.
@@ -1994,10 +1994,10 @@ M.funcs = {
     desc = [=[
       Return all of environment variables as dictionary. You can
       check if an environment variable exists like this: >vim
-      	echo has_key(environ(), 'HOME')
+              echo has_key(environ(), 'HOME')
       <Note that the variable name may be CamelCase; to ignore case
       use this: >vim
-      	echo index(keys(environ()), 'HOME', 0, 1) != -1
+              echo index(keys(environ()), 'HOME', 0, 1) != -1
       <
     ]=],
     fast = true,
@@ -2011,9 +2011,9 @@ M.funcs = {
     desc = [=[
       Escape the characters in {chars} that occur in {string} with a
       backslash.  Example: >vim
-      	echo escape('c:\program files\vim', ' \')
+              echo escape('c:\program files\vim', ' \')
       <results in: >
-      	c:\\program\ files\\vim
+              c:\\program\ files\\vim
       <Also see |shellescape()| and |fnameescape()|.
 
     ]=],
@@ -2056,7 +2056,7 @@ M.funcs = {
       exists.  {expr} must be the name of the program without any
       arguments.
       executable() uses the value of $PATH and/or the normal
-      searchpath for programs.		*PATHEXT*
+      searchpath for programs.                *PATHEXT*
       On MS-Windows the ".exe", ".bat", etc. can optionally be
       included.  Then the extensions in $PATHEXT are tried.  Thus if
       "foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -2069,9 +2069,9 @@ M.funcs = {
       On Windows an executable in the same directory as Vim is
       always found (it is added to $PATH at |startup|).
       The result is a Number:
-      	1	exists
-      	0	does not exist
-      	-1	not implemented on this system
+              1       exists
+              0       does not exist
+              -1      not implemented on this system
       |exepath()| can be used to get the full path of an executable.
 
     ]=],
@@ -2090,20 +2090,20 @@ M.funcs = {
       If {command} is a |List|, returns concatenated outputs.
       Line continuations in {command} are not recognized.
       Examples: >vim
-      	echo execute('echon "foo"')
-      <	foo >vim
-      	echo execute(['echon "foo"', 'echon "bar"'])
-      <	foobar
+              echo execute('echon "foo"')
+      <       foo >vim
+              echo execute(['echon "foo"', 'echon "bar"'])
+      <       foobar
 
       The optional {silent} argument can have these values:
-      	""		no `:silent` used
-      	"silent"	`:silent` used
-      	"silent!"	`:silent!` used
+              ""              no `:silent` used
+              "silent"        `:silent` used
+              "silent!"       `:silent!` used
       The default is "silent".  Note that with "silent!", unlike
       `:redir`, error messages are dropped.
 
       To get a list of lines use `split()` on the result: >vim
-      	execute('args')->split("\n")
+              execute('args')->split("\n")
 
       <This function is not available in the |sandbox|.
       Note: If nested, an outer execute() will not observe output of
@@ -2146,83 +2146,83 @@ M.funcs = {
       For checking if a file exists use |filereadable()|.
 
       The {expr} argument is a string, which contains one of these:
-      	varname		internal variable (see
-      	dict.key	|internal-variables|).  Also works
-      	list[i]		for |curly-braces-names|, |Dictionary|
-      			entries, |List| items, etc.
-      			Beware that evaluating an index may
-      			cause an error message for an invalid
-      			expression.  E.g.: >vim
-      			   let l = [1, 2, 3]
-      			   echo exists("l[5]")
-      <			   0 >vim
-      			   echo exists("l[xx]")
-      <			   E121: Undefined variable: xx
-      			   0
-      	&option-name	Vim option (only checks if it exists,
-      			not if it really works)
-      	+option-name	Vim option that works.
-      	$ENVNAME	environment variable (could also be
-      			done by comparing with an empty
-      			string)
-      	`*funcname`	built-in function (see |functions|)
-      			or user defined function (see
-      			|user-function|). Also works for a
-      			variable that is a Funcref.
-      	:cmdname	Ex command: built-in command, user
-      			command or command modifier |:command|.
-      			Returns:
-      			1  for match with start of a command
-      			2  full match with a command
-      			3  matches several user commands
-      			To check for a supported command
-      			always check the return value to be 2.
-      	:2match		The |:2match| command.
-      	:3match		The |:3match| command (but you
-      			probably should not use it, it is
-      			reserved for internal usage)
-      	#event		autocommand defined for this event
-      	#event#pattern	autocommand defined for this event and
-      			pattern (the pattern is taken
-      			literally and compared to the
-      			autocommand patterns character by
-      			character)
-      	#group		autocommand group exists
-      	#group#event	autocommand defined for this group and
-      			event.
-      	#group#event#pattern
-      			autocommand defined for this group,
-      			event and pattern.
-      	##event		autocommand for this event is
-      			supported.
+              varname         internal variable (see
+              dict.key        |internal-variables|).  Also works
+              list[i]         for |curly-braces-names|, |Dictionary|
+                              entries, |List| items, etc.
+                              Beware that evaluating an index may
+                              cause an error message for an invalid
+                              expression.  E.g.: >vim
+                                 let l = [1, 2, 3]
+                                 echo exists("l[5]")
+      <                          0 >vim
+                                 echo exists("l[xx]")
+      <                          E121: Undefined variable: xx
+                                 0
+              &option-name    Vim option (only checks if it exists,
+                              not if it really works)
+              +option-name    Vim option that works.
+              $ENVNAME        environment variable (could also be
+                              done by comparing with an empty
+                              string)
+              `*funcname`     built-in function (see |functions|)
+                              or user defined function (see
+                              |user-function|). Also works for a
+                              variable that is a Funcref.
+              :cmdname        Ex command: built-in command, user
+                              command or command modifier |:command|.
+                              Returns:
+                              1  for match with start of a command
+                              2  full match with a command
+                              3  matches several user commands
+                              To check for a supported command
+                              always check the return value to be 2.
+              :2match         The |:2match| command.
+              :3match         The |:3match| command (but you
+                              probably should not use it, it is
+                              reserved for internal usage)
+              #event          autocommand defined for this event
+              #event#pattern  autocommand defined for this event and
+                              pattern (the pattern is taken
+                              literally and compared to the
+                              autocommand patterns character by
+                              character)
+              #group          autocommand group exists
+              #group#event    autocommand defined for this group and
+                              event.
+              #group#event#pattern
+                              autocommand defined for this group,
+                              event and pattern.
+              ##event         autocommand for this event is
+                              supported.
 
       Examples: >vim
-      	echo exists("&mouse")
-      	echo exists("$HOSTNAME")
-      	echo exists("*strftime")
-      	echo exists("*s:MyFunc")
-      	echo exists("*MyFunc")
-      	echo exists("bufcount")
-      	echo exists(":Make")
-      	echo exists("#CursorHold")
-      	echo exists("#BufReadPre#*.gz")
-      	echo exists("#filetypeindent")
-      	echo exists("#filetypeindent#FileType")
-      	echo exists("#filetypeindent#FileType#*")
-      	echo exists("##ColorScheme")
+              echo exists("&mouse")
+              echo exists("$HOSTNAME")
+              echo exists("*strftime")
+              echo exists("*s:MyFunc")
+              echo exists("*MyFunc")
+              echo exists("bufcount")
+              echo exists(":Make")
+              echo exists("#CursorHold")
+              echo exists("#BufReadPre#*.gz")
+              echo exists("#filetypeindent")
+              echo exists("#filetypeindent#FileType")
+              echo exists("#filetypeindent#FileType#*")
+              echo exists("##ColorScheme")
       <There must be no space between the symbol (&/$/*/#) and the
       name.
       There must be no extra characters after the name, although in
       a few cases this is ignored.  That may become stricter in the
       future, thus don't count on it!
       Working example: >vim
-      	echo exists(":make")
+              echo exists(":make")
       <NOT working example: >vim
-      	echo exists(":make install")
+              echo exists(":make install")
 
       <Note that the argument must be a string, not the name of the
       variable itself.  For example: >vim
-      	echo exists(bufcount)
+              echo exists(bufcount)
       <This doesn't check for existence of the "bufcount" variable,
       but gets the value of "bufcount", and checks if that exists.
 
@@ -2241,10 +2241,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo exp(2)
-      <	7.389056 >vim
-      	echo exp(-1)
-      <	0.367879
+              echo exp(2)
+      <        7.389056 >vim
+              echo exp(-1)
+      <        0.367879
 
     ]=],
     float_func = 'exp',
@@ -2271,47 +2271,47 @@ M.funcs = {
       done like for the |cmdline-special| variables with their
       associated modifiers.  Here is a short overview:
 
-      	%		current file name
-      	#		alternate file name
-      	#n		alternate file name n
-      	<cfile>		file name under the cursor
-      	<afile>		autocmd file name
-      	<abuf>		autocmd buffer number (as a String!)
-      	<amatch>	autocmd matched name
-      	<cexpr>		C expression under the cursor
-      	<sfile>		sourced script file or function name
-      	<slnum>		sourced script line number or function
-      			line number
-      	<sflnum>	script file line number, also when in
-      			a function
-      	<SID>		"<SNR>123_"  where "123" is the
-      			current script ID  |<SID>|
-      	<script>	sourced script file, or script file
-      			where the current function was defined
-      	<stack>		call stack
-      	<cword>		word under the cursor
-      	<cWORD>		WORD under the cursor
-      	<client>	the {clientid} of the last received
-      			message
+              %               current file name
+              #               alternate file name
+              #n              alternate file name n
+              <cfile>         file name under the cursor
+              <afile>         autocmd file name
+              <abuf>          autocmd buffer number (as a String!)
+              <amatch>        autocmd matched name
+              <cexpr>         C expression under the cursor
+              <sfile>         sourced script file or function name
+              <slnum>         sourced script line number or function
+                              line number
+              <sflnum>        script file line number, also when in
+                              a function
+              <SID>           "<SNR>123_"  where "123" is the
+                              current script ID  |<SID>|
+              <script>        sourced script file, or script file
+                              where the current function was defined
+              <stack>         call stack
+              <cword>         word under the cursor
+              <cWORD>         WORD under the cursor
+              <client>        the {clientid} of the last received
+                              message
       Modifiers:
-      	:p		expand to full path
-      	:h		head (last path component removed)
-      	:t		tail (last path component only)
-      	:r		root (one extension removed)
-      	:e		extension only
+              :p              expand to full path
+              :h              head (last path component removed)
+              :t              tail (last path component only)
+              :r              root (one extension removed)
+              :e              extension only
 
       Example: >vim
-      	let &tags = expand("%:p:h") .. "/tags"
+              let &tags = expand("%:p:h") .. "/tags"
       <Note that when expanding a string that starts with '%', '#' or
       '<', any following text is ignored.  This does NOT work: >vim
-      	let doesntwork = expand("%:h.bak")
+              let doesntwork = expand("%:h.bak")
       <Use this: >vim
-      	let doeswork = expand("%:h") .. ".bak"
+              let doeswork = expand("%:h") .. ".bak"
       <Also note that expanding "<cfile>" and others only returns the
       referenced file name without further expansion.  If "<cfile>"
       is "~/.cshrc", you need to do another expand() to have the
       "~/" expanded into the path of the home directory: >vim
-      	echo expand(expand("<cfile>"))
+              echo expand(expand("<cfile>"))
       <
       There cannot be white space between the variables and the
       following modifier.  The |fnamemodify()| function can be used
@@ -2332,7 +2332,7 @@ M.funcs = {
       Names for non-existing files are included.  The "**" item can
       be used to search in a directory tree.  For example, to find
       all "README" files in the current directory and below: >vim
-      	echo expand("**/README")
+              echo expand("**/README")
       <
       expand() can also be used to expand variables and environment
       variables that are only known in a shell.  But this can be
@@ -2364,19 +2364,19 @@ M.funcs = {
 
       The following items are supported in the {options} Dict
       argument:
-          errmsg	If set to TRUE, error messages are displayed
-      		if an error is encountered during expansion.
-      		By default, error messages are not displayed.
+          errmsg      If set to TRUE, error messages are displayed
+                      if an error is encountered during expansion.
+                      By default, error messages are not displayed.
 
       Returns the expanded string.  If an error is encountered
       during expansion, the unmodified {string} is returned.
 
       Example: >vim
-      	echo expandcmd('make %<.o')
+              echo expandcmd('make %<.o')
       < >
-      	make /path/runtime/doc/builtin.o
+              make /path/runtime/doc/builtin.o
       < >vim
-      	echo expandcmd('make %<.o', {'errmsg': v:true})
+              echo expandcmd('make %<.o', {'errmsg': v:true})
       <
     ]=],
     name = 'expandcmd',
@@ -2396,15 +2396,15 @@ M.funcs = {
       insert before the first item.  When {expr3} is equal to
       len({expr1}) then {expr2} is appended.
       Examples: >vim
-      	echo sort(extend(mylist, [7, 5]))
-      	call extend(mylist, [2, 3], 1)
+              echo sort(extend(mylist, [7, 5]))
+              call extend(mylist, [2, 3], 1)
       <When {expr1} is the same List as {expr2} then the number of
       items copied is equal to the original length of the List.
       E.g., when {expr3} is 1 you get N new copies of the first item
       (where N is the original length of the List).
       Use |add()| to concatenate one item to a list.  To concatenate
       two lists into a new list use the + operator: >vim
-      	let newlist = [1, 2, 3] + [4, 5]
+              let newlist = [1, 2, 3] + [4, 5]
       <
       If they are |Dictionaries|:
       Add all entries from {expr2} to {expr1}.
@@ -2412,7 +2412,7 @@ M.funcs = {
       used to decide what to do:
       {expr3} = "keep": keep the value of {expr1}
       {expr3} = "force": use the value of {expr2}
-      {expr3} = "error": give an error message		*E737*
+      {expr3} = "error": give an error message                *E737*
       When {expr3} is omitted then "force" is assumed.
 
       {expr1} is changed when {expr2} is not empty.  If necessary
@@ -2463,27 +2463,27 @@ M.funcs = {
       wait-for-character without doing anything.
 
       {mode} is a String, which can contain these character flags:
-      'm'	Remap keys. This is default.  If {mode} is absent,
-      	keys are remapped.
-      'n'	Do not remap keys.
-      't'	Handle keys as if typed; otherwise they are handled as
-      	if coming from a mapping.  This matters for undo,
-      	opening folds, etc.
-      'i'	Insert the string instead of appending (see above).
-      'x'	Execute commands until typeahead is empty.  This is
-      	similar to using ":normal!".  You can call feedkeys()
-      	several times without 'x' and then one time with 'x'
-      	(possibly with an empty {string}) to execute all the
-      	typeahead.  Note that when Vim ends in Insert mode it
-      	will behave as if <Esc> is typed, to avoid getting
-      	stuck, waiting for a character to be typed before the
-      	script continues.
-      	Note that if you manage to call feedkeys() while
-      	executing commands, thus calling it recursively, then
-      	all typeahead will be consumed by the last call.
-      '!'	When used with 'x' will not end Insert mode. Can be
-      	used in a test when a timer is set to exit Insert mode
-      	a little later.  Useful for testing CursorHoldI.
+      'm'     Remap keys. This is default.  If {mode} is absent,
+              keys are remapped.
+      'n'     Do not remap keys.
+      't'     Handle keys as if typed; otherwise they are handled as
+              if coming from a mapping.  This matters for undo,
+              opening folds, etc.
+      'i'     Insert the string instead of appending (see above).
+      'x'     Execute commands until typeahead is empty.  This is
+              similar to using ":normal!".  You can call feedkeys()
+              several times without 'x' and then one time with 'x'
+              (possibly with an empty {string}) to execute all the
+              typeahead.  Note that when Vim ends in Insert mode it
+              will behave as if <Esc> is typed, to avoid getting
+              stuck, waiting for a character to be typed before the
+              script continues.
+              Note that if you manage to call feedkeys() while
+              executing commands, thus calling it recursively, then
+              all typeahead will be consumed by the last call.
+      '!'     When used with 'x' will not end Insert mode. Can be
+              used in a test when a timer is set to exit Insert mode
+              a little later.  Useful for testing CursorHoldI.
 
       Return value is always 0.
 
@@ -2515,13 +2515,13 @@ M.funcs = {
       If you don't care about the file being readable you can use
       |glob()|.
       {file} is used as-is, you may want to expand wildcards first: >vim
-      	echo filereadable('~/.vimrc')
+              echo filereadable('~/.vimrc')
       < >
-      	0
+              0
       < >vim
-      	echo filereadable(expand('~/.vimrc'))
+              echo filereadable(expand('~/.vimrc'))
       < >
-      	1
+              1
       <
 
     ]=],
@@ -2566,11 +2566,11 @@ M.funcs = {
       current byte. For a |String| |v:key| has the index of the
       current character.
       Examples: >vim
-      	call filter(mylist, 'v:val !~ "OLD"')
+              call filter(mylist, 'v:val !~ "OLD"')
       <Removes the items where "OLD" appears. >vim
-      	call filter(mydict, 'v:key >= 8')
+              call filter(mydict, 'v:key >= 8')
       <Removes the items with a key below 8. >vim
-      	call filter(var, 0)
+              call filter(var, 0)
       <Removes all the items, thus clears the |List| or |Dictionary|.
 
       Note that {expr2} is the result of expression and is then
@@ -2578,23 +2578,23 @@ M.funcs = {
       |literal-string| to avoid having to double backslashes.
 
       If {expr2} is a |Funcref| it must take two arguments:
-      	1. the key or the index of the current item.
-      	2. the value of the current item.
+              1. the key or the index of the current item.
+              2. the value of the current item.
       The function must return |TRUE| if the item should be kept.
       Example that keeps the odd items of a list: >vim
-      	func Odd(idx, val)
-      	  return a:idx % 2 == 1
-      	endfunc
-      	call filter(mylist, function('Odd'))
+              func Odd(idx, val)
+                return a:idx % 2 == 1
+              endfunc
+              call filter(mylist, function('Odd'))
       <It is shorter when using a |lambda|: >vim
-      	call filter(myList, {idx, val -> idx * val <= 42})
+              call filter(myList, {idx, val -> idx * val <= 42})
       <If you do not use "val" you can leave it out: >vim
-      	call filter(myList, {idx -> idx % 2 == 1})
+              call filter(myList, {idx -> idx % 2 == 1})
       <
       For a |List| and a |Dictionary| the operation is done
       in-place.  If you want it to remain unmodified make a copy
       first: >vim
-      	let l = filter(copy(mylist), 'v:val =~ "KEEP"')
+              let l = filter(copy(mylist), 'v:val =~ "KEEP"')
 
       <Returns {expr1}, the |List| or |Dictionary| that was filtered,
       or a new |Blob| or |String|.
@@ -2641,7 +2641,7 @@ M.funcs = {
       Just like |finddir()|, but find a file instead of a directory.
       Uses 'suffixesadd'.
       Example: >vim
-      	echo findfile("tags.vim", ".;")
+              echo findfile("tags.vim", ".;")
       <Searches from the directory of the current file upwards until
       it finds the file "tags.vim".
 
@@ -2659,7 +2659,7 @@ M.funcs = {
       a very large number.
       The {list} is changed in place, use |flattennew()| if you do
       not want that.
-      						*E900*
+                                                      *E900*
       {maxdepth} means how deep in nested lists changes are made.
       {list} is not modified when {maxdepth} is 0.
       {maxdepth} must be positive number.
@@ -2667,10 +2667,10 @@ M.funcs = {
       If there is an error the number zero is returned.
 
       Example: >vim
-      	echo flatten([1, [2, [3, 4]], 5])
-      <	[1, 2, 3, 4, 5] >vim
-      	echo flatten([1, [2, [3, 4]], 5], 1)
-      <	[1, 2, [3, 4], 5]
+              echo flatten([1, [2, [3, 4]], 5])
+      <        [1, 2, 3, 4, 5] >vim
+              echo flatten([1, [2, [3, 4]], 5], 1)
+      <        [1, 2, [3, 4], 5]
 
     ]=],
     name = 'flatten',
@@ -2703,16 +2703,16 @@ M.funcs = {
       -0x7fffffffffffffff).  NaN results in -0x80000000 (or when
       64-bit Number support is enabled, -0x8000000000000000).
       Examples: >vim
-      	echo float2nr(3.95)
-      <	3  >vim
-      	echo float2nr(-23.45)
-      <	-23  >vim
-      	echo float2nr(1.0e100)
-      <	2147483647  (or 9223372036854775807) >vim
-      	echo float2nr(-1.0e150)
-      <	-2147483647 (or -9223372036854775807) >vim
-      	echo float2nr(1.0e-100)
-      <	0
+              echo float2nr(3.95)
+      <        3  >vim
+              echo float2nr(-23.45)
+      <        -23  >vim
+              echo float2nr(1.0e100)
+      <        2147483647  (or 9223372036854775807) >vim
+              echo float2nr(-1.0e150)
+      <        -2147483647 (or -9223372036854775807) >vim
+              echo float2nr(1.0e-100)
+      <        0
 
     ]=],
     name = 'float2nr',
@@ -2728,12 +2728,12 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo floor(1.856)
-      <	1.0  >vim
-      	echo floor(-5.456)
-      <	-6.0  >vim
-      	echo floor(4.0)
-      <	4.0
+              echo floor(1.856)
+      <        1.0  >vim
+              echo floor(-5.456)
+      <        -6.0  >vim
+              echo floor(4.0)
+      <        4.0
 
     ]=],
     float_func = 'floor',
@@ -2755,10 +2755,10 @@ M.funcs = {
       Returns 0.0 if {expr1} or {expr2} is not a |Float| or a
       |Number|.
       Examples: >vim
-      	echo fmod(12.33, 1.22)
-      <	0.13 >vim
-      	echo fmod(-12.33, 1.22)
-      <	-0.13
+              echo fmod(12.33, 1.22)
+      <        0.13 >vim
+              echo fmod(-12.33, 1.22)
+      <        -0.13
 
     ]=],
     name = 'fmod',
@@ -2779,10 +2779,10 @@ M.funcs = {
       and |:write|).  And a "-" by itself (special after |:cd|).
       Returns an empty string on error.
       Example: >vim
-      	let fname = '+some str%nge|name'
-      	exe "edit " .. fnameescape(fname)
+              let fname = '+some str%nge|name'
+              exe "edit " .. fnameescape(fname)
       <results in executing: >vim
-      	edit \+some\ str\%nge\|name
+              edit \+some\ str\%nge\|name
       <
     ]=],
     fast = true,
@@ -2799,9 +2799,9 @@ M.funcs = {
       string of characters like it is used for file names on the
       command line.  See |filename-modifiers|.
       Example: >vim
-      	echo fnamemodify("main.c", ":p:h")
+              echo fnamemodify("main.c", ":p:h")
       <results in: >
-      	/home/user/vim/vim/src
+              /home/user/vim/vim/src
       <If {mods} is empty or an unsupported modifier is used then
       {fname} is returned.
       When {fname} is empty then with {mods} ":h" returns ".", so
@@ -2878,7 +2878,7 @@ M.funcs = {
       only be called from evaluating 'foldtext'.  It uses the
       |v:foldstart|, |v:foldend| and |v:folddashes| variables.
       The returned string looks like this: >
-      	+-- 45 lines: abcdef
+              +-- 45 lines: abcdef
       <The number of leading dashes depends on the foldlevel.  The
       "45" is the number of lines in the fold.  "abcdef" is the text
       in the first non-blank line of the fold.  Leading white space,
@@ -2970,8 +2970,8 @@ M.funcs = {
       {name} can also be a Funcref or a partial. When it is a
       partial the dict stored in it will be used and the {dict}
       argument is not allowed. E.g.: >vim
-      	let FuncWithArg = function(dict.Func, [arg])
-      	let Broken = function(dict.Func, [arg], dict)
+              let FuncWithArg = function(dict.Func, [arg])
+              let Broken = function(dict.Func, [arg], dict)
       <
       When using the Funcref the function will be found by {name},
       also when it was redefined later. Use |funcref()| to keep the
@@ -2983,64 +2983,64 @@ M.funcs = {
 
       The arguments are passed to the function in front of other
       arguments, but after any argument from |method|.  Example: >vim
-      	func Callback(arg1, arg2, name)
-      	"...
-      	endfunc
-      	let Partial = function('Callback', ['one', 'two'])
-      	"...
-      	call Partial('name')
+              func Callback(arg1, arg2, name)
+              "...
+              endfunc
+              let Partial = function('Callback', ['one', 'two'])
+              "...
+              call Partial('name')
       <Invokes the function as with: >vim
-      	call Callback('one', 'two', 'name')
+              call Callback('one', 'two', 'name')
 
       <With a |method|: >vim
-      	func Callback(one, two, three)
-      	"...
-      	endfunc
-      	let Partial = function('Callback', ['two'])
-      	"...
-      	eval 'one'->Partial('three')
+              func Callback(one, two, three)
+              "...
+              endfunc
+              let Partial = function('Callback', ['two'])
+              "...
+              eval 'one'->Partial('three')
       <Invokes the function as with: >vim
-      	call Callback('one', 'two', 'three')
+              call Callback('one', 'two', 'three')
 
       <The function() call can be nested to add more arguments to the
       Funcref.  The extra arguments are appended to the list of
       arguments.  Example: >vim
-      	func Callback(arg1, arg2, name)
-      	"...
-      	endfunc
-      	let Func = function('Callback', ['one'])
-      	let Func2 = function(Func, ['two'])
-      	"...
-      	call Func2('name')
+              func Callback(arg1, arg2, name)
+              "...
+              endfunc
+              let Func = function('Callback', ['one'])
+              let Func2 = function(Func, ['two'])
+              "...
+              call Func2('name')
       <Invokes the function as with: >vim
-      	call Callback('one', 'two', 'name')
+              call Callback('one', 'two', 'name')
 
       <The Dictionary is only useful when calling a "dict" function.
       In that case the {dict} is passed in as "self". Example: >vim
-      	function Callback() dict
-      	   echo "called for " .. self.name
-      	endfunction
-      	"...
-      	let context = {"name": "example"}
-      	let Func = function('Callback', context)
-      	"...
-      	call Func()	" will echo: called for example
+              function Callback() dict
+                 echo "called for " .. self.name
+              endfunction
+              "...
+              let context = {"name": "example"}
+              let Func = function('Callback', context)
+              "...
+              call Func()     " will echo: called for example
       <The use of function() is not needed when there are no extra
       arguments, these two are equivalent, if Callback() is defined
       as context.Callback(): >vim
-      	let Func = function('Callback', context)
-      	let Func = context.Callback
+              let Func = function('Callback', context)
+              let Func = context.Callback
 
       <The argument list and the Dictionary can be combined: >vim
-      	function Callback(arg1, count) dict
-      	"...
-      	endfunction
-      	let context = {"name": "example"}
-      	let Func = function('Callback', ['one'], context)
-      	"...
-      	call Func(500)
+              function Callback(arg1, count) dict
+              "...
+              endfunction
+              let context = {"name": "example"}
+              let Func = function('Callback', ['one'], context)
+              "...
+              call Func(500)
       <Invokes the function as with: >vim
-      	call context.Callback('one', 500)
+              call context.Callback('one', 500)
       <
       Returns 0 on error.
 
@@ -3107,7 +3107,7 @@ M.funcs = {
       Get item with key {key} from |Dictionary| {dict}.  When this
       item is not available return {default}.  Return zero when
       {default} is omitted.  Useful example: >vim
-      	let val = get(g:, 'var_name', 'default')
+              let val = get(g:, 'var_name', 'default')
       <This gets the value of g:var_name if it exists, and uses
       "default" when it does not exist.
     ]=],
@@ -3121,10 +3121,10 @@ M.funcs = {
     desc = [=[
       Get item {what} from Funcref {func}.  Possible values for
       {what} are:
-      	"name"	The function name
-      	"func"	The function
-      	"dict"	The dictionary
-      	"args"	The list with arguments
+              "name"  The function name
+              "func"  The function
+              "dict"  The dictionary
+              "args"  The list with arguments
       Returns zero on error.
     ]=],
     name = 'get',
@@ -3152,9 +3152,9 @@ M.funcs = {
       When the argument is a |Dictionary| only the buffers matching
       the specified criteria are returned.  The following keys can
       be specified in {dict}:
-      	buflisted	include only listed buffers.
-      	bufloaded	include only loaded buffers.
-      	bufmodified	include only modified buffers.
+              buflisted       include only listed buffers.
+              bufloaded       include only loaded buffers.
+              bufmodified     include only modified buffers.
 
       Otherwise, {buf} specifies a particular buffer to return
       information for.  For the use of {buf}, see |bufname()|
@@ -3163,50 +3163,50 @@ M.funcs = {
 
       Each returned List item is a dictionary with the following
       entries:
-      	bufnr		Buffer number.
-      	changed		TRUE if the buffer is modified.
-      	changedtick	Number of changes made to the buffer.
-      	hidden		TRUE if the buffer is hidden.
-      	lastused	Timestamp in seconds, like
-      			|localtime()|, when the buffer was
-      			last used.
-      	listed		TRUE if the buffer is listed.
-      	lnum		Line number used for the buffer when
-      			opened in the current window.
-      			Only valid if the buffer has been
-      			displayed in the window in the past.
-      			If you want the line number of the
-      			last known cursor position in a given
-      			window, use |line()|: >vim
-      				echo line('.', {winid})
+              bufnr           Buffer number.
+              changed         TRUE if the buffer is modified.
+              changedtick     Number of changes made to the buffer.
+              hidden          TRUE if the buffer is hidden.
+              lastused        Timestamp in seconds, like
+                              |localtime()|, when the buffer was
+                              last used.
+              listed          TRUE if the buffer is listed.
+              lnum            Line number used for the buffer when
+                              opened in the current window.
+                              Only valid if the buffer has been
+                              displayed in the window in the past.
+                              If you want the line number of the
+                              last known cursor position in a given
+                              window, use |line()|: >vim
+                                      echo line('.', {winid})
       <
-      	linecount	Number of lines in the buffer (only
-      			valid when loaded)
-      	loaded		TRUE if the buffer is loaded.
-      	name		Full path to the file in the buffer.
-      	signs		List of signs placed in the buffer.
-      			Each list item is a dictionary with
-      			the following fields:
-      			    id	  sign identifier
-      			    lnum  line number
-      			    name  sign name
-      	variables	A reference to the dictionary with
-      			buffer-local variables.
-      	windows		List of |window-ID|s that display this
-      			buffer
+              linecount       Number of lines in the buffer (only
+                              valid when loaded)
+              loaded          TRUE if the buffer is loaded.
+              name            Full path to the file in the buffer.
+              signs           List of signs placed in the buffer.
+                              Each list item is a dictionary with
+                              the following fields:
+                                  id    sign identifier
+                                  lnum  line number
+                                  name  sign name
+              variables       A reference to the dictionary with
+                              buffer-local variables.
+              windows         List of |window-ID|s that display this
+                              buffer
 
       Examples: >vim
-      	for buf in getbufinfo()
-      	    echo buf.name
-      	endfor
-      	for buf in getbufinfo({'buflisted':1})
-      	    if buf.changed
-      		" ....
-      	    endif
-      	endfor
+              for buf in getbufinfo()
+                  echo buf.name
+              endfor
+              for buf in getbufinfo({'buflisted':1})
+                  if buf.changed
+                      " ....
+                  endif
+              endfor
       <
       To get buffer-local options use: >vim
-      	getbufvar({bufnr}, '&option_name')
+              getbufvar({bufnr}, '&option_name')
       <
     ]=],
     name = 'getbufinfo',
@@ -3240,7 +3240,7 @@ M.funcs = {
       non-existing buffers, an empty |List| is returned.
 
       Example: >vim
-      	let lines = getbufline(bufnr("myfile"), 1, "$")
+              let lines = getbufline(bufnr("myfile"), 1, "$")
 
     ]=],
     name = 'getbufline',
@@ -3280,8 +3280,8 @@ M.funcs = {
       When the buffer or variable doesn't exist {def} or an empty
       string is returned, there is no error message.
       Examples: >vim
-      	let bufmodified = getbufvar(1, "&mod")
-      	echo "todo myvar = " .. getbufvar("todo", "myvar")
+              let bufmodified = getbufvar(1, "&mod")
+              echo "todo myvar = " .. getbufvar("todo", "myvar")
 
     ]=],
     name = 'getbufvar',
@@ -3311,9 +3311,9 @@ M.funcs = {
       locations and the current position in the list.  Each
       entry in the change list is a dictionary with the following
       entries:
-      	col		column number
-      	coladd		column offset for 'virtualedit'
-      	lnum		line number
+              col             column number
+              coladd          column offset for 'virtualedit'
+              lnum            line number
       If buffer {buf} is the current buffer, then the current
       position refers to the position in the list. For other
       buffers, it is set to the length of the list.
@@ -3330,9 +3330,9 @@ M.funcs = {
       Get a single character from the user or input stream.
       If [expr] is omitted, wait until a character is available.
       If [expr] is 0, only get a character when one is available.
-      	Return zero otherwise.
+              Return zero otherwise.
       If [expr] is 1, only check if a character is available, it is
-      	not consumed.  Return zero if no character available.
+              not consumed.  Return zero if no character available.
       If you prefer always getting a string use |getcharstr()|.
 
       Without [expr] and when [expr] is 0 a whole character or
@@ -3361,12 +3361,12 @@ M.funcs = {
       |getmousepos()| can also be used.  Mouse move events will be
       ignored.
       This example positions the mouse as it would normally happen: >vim
-      	let c = getchar()
-      	if c == "\<LeftMouse>" && v:mouse_win > 0
-      	  exe v:mouse_win .. "wincmd w"
-      	  exe v:mouse_lnum
-      	  exe "normal " .. v:mouse_col .. "|"
-      	endif
+              let c = getchar()
+              if c == "\<LeftMouse>" && v:mouse_win > 0
+                exe v:mouse_win .. "wincmd w"
+                exe v:mouse_lnum
+                exe "normal " .. v:mouse_col .. "|"
+              endif
       <
       There is no prompt, you will somehow have to make clear to the
       user that a character has to be typed.  The screen is not
@@ -3376,19 +3376,19 @@ M.funcs = {
       Key codes are replaced, thus when the user presses the <Del>
       key you get the code for the <Del> key, not the raw character
       sequence.  Examples: >vim
-      	getchar() == "\<Del>"
-      	getchar() == "\<S-Left>"
+              getchar() == "\<Del>"
+              getchar() == "\<S-Left>"
       <This example redefines "f" to ignore case: >vim
-      	nmap f :call FindChar()<CR>
-      	function FindChar()
-      	  let c = nr2char(getchar())
-      	  while col('.') < col('$') - 1
-      	    normal l
-      	    if getline('.')[col('.') - 1] ==? c
-      	      break
-      	    endif
-      	  endwhile
-      	endfunction
+              nmap f :call FindChar()<CR>
+              function FindChar()
+                let c = nr2char(getchar())
+                while col('.') < col('$') - 1
+                  normal l
+                  if getline('.')[col('.') - 1] ==? c
+                    break
+                  endif
+                endwhile
+              endfunction
       <
     ]=],
     name = 'getchar',
@@ -3401,14 +3401,14 @@ M.funcs = {
       The result is a Number which is the state of the modifiers for
       the last obtained character with getchar() or in another way.
       These values are added together:
-      	2	shift
-      	4	control
-      	8	alt (meta)
-      	16	meta (when it's different from ALT)
-      	32	mouse double click
-      	64	mouse triple click
-      	96	mouse quadruple click (== 32 + 64)
-      	128	command (Macintosh only)
+              2       shift
+              4       control
+              8       alt (meta)
+              16      meta (when it's different from ALT)
+              32      mouse double click
+              64      mouse triple click
+              96      mouse quadruple click (== 32 + 64)
+              128     command (Macintosh only)
       Only the modifiers that have not been included in the
       character itself are obtained.  Thus Shift-a results in "A"
       without a modifier.  Returns 0 if no modifiers are used.
@@ -3431,8 +3431,8 @@ M.funcs = {
 
       Example:
       With the cursor on '세' in line 5 with text "여보세요": >vim
-      	getcharpos('.')		returns [0, 5, 3, 0]
-      	getpos('.')		returns [0, 5, 7, 0]
+              getcharpos('.')         returns [0, 5, 3, 0]
+              getpos('.')             returns [0, 5, 7, 0]
       <
     ]=],
     name = 'getcharpos',
@@ -3445,20 +3445,20 @@ M.funcs = {
       Return the current character search information as a {dict}
       with the following entries:
 
-          char	character previously used for a character
-      		search (|t|, |f|, |T|, or |F|); empty string
-      		if no character search has been performed
-          forward	direction of character search; 1 for forward,
-      		0 for backward
-          until	type of character search; 1 for a |t| or |T|
-      		character search, 0 for an |f| or |F|
-      		character search
+          char        character previously used for a character
+                      search (|t|, |f|, |T|, or |F|); empty string
+                      if no character search has been performed
+          forward     direction of character search; 1 for forward,
+                      0 for backward
+          until       type of character search; 1 for a |t| or |T|
+                      character search, 0 for an |f| or |F|
+                      character search
 
       This can be useful to always have |;| and |,| search
       forward/backward regardless of the direction of the previous
       character search: >vim
-      	nnoremap <expr> ; getcharsearch().forward ? ';' : ','
-      	nnoremap <expr> , getcharsearch().forward ? ',' : ';'
+              nnoremap <expr> ; getcharsearch().forward ? ';' : ','
+              nnoremap <expr> , getcharsearch().forward ? ',' : ';'
       <Also see |setcharsearch()|.
     ]=],
     name = 'getcharsearch',
@@ -3473,10 +3473,10 @@ M.funcs = {
       string.
       If [expr] is omitted, wait until a character is available.
       If [expr] is 0 or false, only get a character when one is
-      	available.  Return an empty string otherwise.
+              available.  Return an empty string otherwise.
       If [expr] is 1 or true, only check if a character is
-      	available, it is not consumed.  Return an empty string
-      	if no character is available.
+              available, it is not consumed.  Return an empty string
+              if no character is available.
       Otherwise this works like |getchar()|, except that a number
       result is converted to a string.
     ]=],
@@ -3506,7 +3506,7 @@ M.funcs = {
       line is being edited, thus requires use of |c_CTRL-\_e| or
       |c_CTRL-R_=|.
       Example: >vim
-      	cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
+              cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
       <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
       |setcmdline()|.
       Returns an empty string when entering a password or using
@@ -3551,13 +3551,13 @@ M.funcs = {
     desc = [=[
       Return the current command-line type. Possible return values
       are:
-          :	normal Ex command
-          >	debug mode command |debug-mode|
-          /	forward search command
-          ?	backward search command
-          @	|input()| command
-          `-`	|:insert| or |:append| command
-          =	|i_CTRL-R_=|
+          :   normal Ex command
+          >   debug mode command |debug-mode|
+          /   forward search command
+          ?   backward search command
+          @   |input()| command
+          `-` |:insert| or |:append| command
+          =   |i_CTRL-R_=|
       Only works when editing the command line, thus requires use of
       |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
       Returns an empty string otherwise.
@@ -3587,45 +3587,45 @@ M.funcs = {
       {type} argument specifies what for.  The following completion
       types are supported:
 
-      arglist		file names in argument list
-      augroup		autocmd groups
-      buffer		buffer names
-      breakpoint	|:breakadd| and |:breakdel| suboptions
-      cmdline		|cmdline-completion| result
-      color		color schemes
-      command		Ex command
-      compiler	compilers
-      custom,{func}	custom completion, defined via {func}
+      arglist         file names in argument list
+      augroup         autocmd groups
+      buffer          buffer names
+      breakpoint      |:breakadd| and |:breakdel| suboptions
+      cmdline         |cmdline-completion| result
+      color           color schemes
+      command         Ex command
+      compiler        compilers
+      custom,{func}   custom completion, defined via {func}
       customlist,{func} custom completion, defined via {func}
-      diff_buffer	|:diffget| and |:diffput| completion
-      dir		directory names
-      environment	environment variable names
-      event		autocommand events
-      expression	Vim expression
-      file		file and directory names
-      file_in_path	file and directory names in |'path'|
-      filetype	filetype names |'filetype'|
-      function	function name
-      help		help subjects
-      highlight	highlight groups
-      history		|:history| suboptions
-      locale		locale names (as output of locale -a)
-      mapclear	buffer argument
-      mapping		mapping name
-      menu		menus
-      messages	|:messages| suboptions
-      option		options
-      packadd		optional package |pack-add| names
-      runtime		|:runtime| completion
-      scriptnames	sourced script names |:scriptnames|
-      shellcmd	Shell command
-      sign		|:sign| suboptions
-      syntax		syntax file names |'syntax'|
-      syntime		|:syntime| suboptions
-      tag		tags
-      tag_listfiles	tags, file names
-      user		user names
-      var		user variables
+      diff_buffer     |:diffget| and |:diffput| completion
+      dir             directory names
+      environment     environment variable names
+      event           autocommand events
+      expression      Vim expression
+      file            file and directory names
+      file_in_path    file and directory names in |'path'|
+      filetype        filetype names |'filetype'|
+      function        function name
+      help            help subjects
+      highlight       highlight groups
+      history         |:history| suboptions
+      locale          locale names (as output of locale -a)
+      mapclear        buffer argument
+      mapping         mapping name
+      menu            menus
+      messages        |:messages| suboptions
+      option          options
+      packadd         optional package |pack-add| names
+      runtime         |:runtime| completion
+      scriptnames     sourced script names |:scriptnames|
+      shellcmd        Shell command
+      sign            |:sign| suboptions
+      syntax          syntax file names |'syntax'|
+      syntime         |:syntime| suboptions
+      tag             tags
+      tag_listfiles   tags, file names
+      user            user names
+      var             user variables
 
       If {pat} is an empty string, then all the matches are
       returned.  Otherwise only items matching {pat} are returned.
@@ -3645,7 +3645,7 @@ M.funcs = {
       If {type} is "cmdline", then the |cmdline-completion| result is
       returned.  For example, to complete the possible values after
       a ":call" command: >vim
-      	echo getcompletion('call ', 'cmdline')
+              echo getcompletion('call ', 'cmdline')
       <
       If there are no matches, an empty list is returned.  An
       invalid value for {type} produces an error.
@@ -3678,9 +3678,9 @@ M.funcs = {
       If {winid} is invalid a list with zeroes is returned.
 
       This can be used to save and restore the cursor position: >vim
-      	let save_cursor = getcurpos()
-      	MoveTheCursorAround
-      	call setpos('.', save_cursor)
+              let save_cursor = getcurpos()
+              MoveTheCursorAround
+              call setpos('.', save_cursor)
       <Note that this only works within the window.  See
       |winrestview()| for restoring more state.
 
@@ -3698,8 +3698,8 @@ M.funcs = {
 
       Example:
       With the cursor on '보' in line 3 with text "여보세요": >vim
-      	getcursorcharpos()	" returns [0, 3, 2, 0, 3]
-      	getcurpos()		" returns [0, 3, 4, 0, 3]
+              getcursorcharpos()      " returns [0, 3, 2, 0, 3]
+              getcurpos()             " returns [0, 3, 4, 0, 3]
       <
     ]=],
     name = 'getcursorcharpos',
@@ -3717,8 +3717,8 @@ M.funcs = {
       Tabs and windows are identified by their respective numbers,
       0 means current tab or window. Missing tab number implies 0.
       Thus the following are equivalent: >vim
-      	getcwd(0)
-      	getcwd(0, 0)
+              getcwd(0)
+              getcwd(0, 0)
       <If {winnr} is -1 it is ignored, only the tab is resolved.
       {winnr} can be the window number or the |window-ID|.
       If both {winnr} and {tabnr} are -1 the global working
@@ -3737,7 +3737,7 @@ M.funcs = {
     desc = [=[
       Return the value of environment variable {name}.  The {name}
       argument is a string, without a leading '$'.  Example: >vim
-      	myHome = getenv('HOME')
+              myHome = getenv('HOME')
 
       <When the variable does not exist |v:null| is returned.  That
       is different from a variable set to an empty string.
@@ -3781,8 +3781,8 @@ M.funcs = {
       of the file, the group the file belongs to, and other users.
       If a user does not have a given permission the flag for this
       is replaced with the string "-".  Examples: >vim
-      	echo getfperm("/etc/passwd")
-      	echo getfperm(expand("~/.config/nvim/init.vim"))
+              echo getfperm("/etc/passwd")
+              echo getfperm(expand("~/.config/nvim/init.vim"))
       <This will hopefully (from a security point of view) display
       the string "rw-r--r--" or even "rw-------".
 
@@ -3838,16 +3838,16 @@ M.funcs = {
       If {fname} does not exist an empty string is returned.
       Here is a table over different kinds of files and their
       results:
-      	Normal file		"file"
-      	Directory		"dir"
-      	Symbolic link		"link"
-      	Block device		"bdev"
-      	Character device	"cdev"
-      	Socket			"socket"
-      	FIFO			"fifo"
-      	All other		"other"
+              Normal file             "file"
+              Directory               "dir"
+              Symbolic link           "link"
+              Block device            "bdev"
+              Character device        "cdev"
+              Socket                  "socket"
+              FIFO                    "fifo"
+              All other               "other"
       Example: >vim
-      	getftype("/home")
+              getftype("/home")
       <Note that a type such as "link" will only be returned on
       systems that support it.  On some systems only "dir" and
       "file" are returned.
@@ -3876,11 +3876,11 @@ M.funcs = {
       locations and the last used jump position number in the list.
       Each entry in the jump location list is a dictionary with
       the following entries:
-      	bufnr		buffer number
-      	col		column number
-      	coladd		column offset for 'virtualedit'
-      	filename	filename if available
-      	lnum		line number
+              bufnr           buffer number
+              col             column number
+              coladd          column offset for 'virtualedit'
+              filename        filename if available
+              lnum            line number
 
     ]=],
     name = 'getjumplist',
@@ -3894,11 +3894,11 @@ M.funcs = {
     desc = [=[
       Without {end} the result is a String, which is line {lnum}
       from the current buffer.  Example: >vim
-      	getline(1)
+              getline(1)
       <When {lnum} is a String that doesn't start with a
       digit, |line()| is called to translate the String into a Number.
       To get the line under the cursor: >vim
-      	getline(".")
+              getline(".")
       <When {lnum} is a number smaller than 1 or bigger than the
       number of lines in the buffer, an empty string is returned.
 
@@ -3909,9 +3909,9 @@ M.funcs = {
       Non-existing lines are silently omitted.
       When {end} is before {lnum} an empty |List| is returned.
       Example: >vim
-      	let start = line('.')
-      	let end = search("^$") - 1
-      	let lines = getline(start, end)
+              let start = line('.')
+              let end = search("^$") - 1
+              let lines = getline(start, end)
 
       <To get lines from another buffer see |getbufline()| and
       |getbufoneline()|
@@ -3939,20 +3939,20 @@ M.funcs = {
       In addition to the items supported by |getqflist()| in {what},
       the following item is supported by |getloclist()|:
 
-      	filewinid	id of the window used to display files
-      			from the location list. This field is
-      			applicable only when called from a
-      			location list window. See
-      			|location-list-file-window| for more
-      			details.
+              filewinid       id of the window used to display files
+                              from the location list. This field is
+                              applicable only when called from a
+                              location list window. See
+                              |location-list-file-window| for more
+                              details.
 
       Returns a |Dictionary| with default values if there is no
       location list for the window {nr}.
       Returns an empty Dictionary if window {nr} does not exist.
 
       Examples (See also |getqflist-examples|): >vim
-      	echo getloclist(3, {'all': 0})
-      	echo getloclist(5, {'filewinid': 0})
+              echo getloclist(3, {'all': 0})
+              echo getloclist(5, {'filewinid': 0})
       <
     ]=],
     name = 'getloclist',
@@ -3973,9 +3973,9 @@ M.funcs = {
 
       Each item in the returned List is a |Dict| with the following:
           mark   name of the mark prefixed by "'"
-          pos	   a |List| with the position of the mark:
-      		[bufnum, lnum, col, off]
-      	   Refer to |getpos()| for more information.
+          pos    a |List| with the position of the mark:
+                      [bufnum, lnum, col, off]
+                 Refer to |getpos()| for more information.
           file   file name
 
       Refer to |getpos()| for getting information about a specific
@@ -3998,26 +3998,26 @@ M.funcs = {
       window ID instead of the current window.  If {win} is invalid,
       an empty list is returned.
       Example: >vim
-      	echo getmatches()
+              echo getmatches()
       < >
-      	[{"group": "MyGroup1", "pattern": "TODO",
-      	"priority": 10, "id": 1}, {"group": "MyGroup2",
-      	"pattern": "FIXME", "priority": 10, "id": 2}]
+              [{"group": "MyGroup1", "pattern": "TODO",
+              "priority": 10, "id": 1}, {"group": "MyGroup2",
+              "pattern": "FIXME", "priority": 10, "id": 2}]
       < >vim
-      	let m = getmatches()
-      	call clearmatches()
-      	echo getmatches()
+              let m = getmatches()
+              call clearmatches()
+              echo getmatches()
       < >
-      	[]
+              []
       < >vim
-      	call setmatches(m)
-      	echo getmatches()
+              call setmatches(m)
+              echo getmatches()
       < >
-      	[{"group": "MyGroup1", "pattern": "TODO",
-      	"priority": 10, "id": 1}, {"group": "MyGroup2",
-      	"pattern": "FIXME", "priority": 10, "id": 2}]
+              [{"group": "MyGroup1", "pattern": "TODO",
+              "priority": 10, "id": 1}, {"group": "MyGroup2",
+              "pattern": "FIXME", "priority": 10, "id": 2}]
       < >vim
-      	unlet m
+              unlet m
       <
     ]=],
     name = 'getmatches',
@@ -4029,15 +4029,15 @@ M.funcs = {
       Returns a |Dictionary| with the last known position of the
       mouse.  This can be used in a mapping for a mouse click.  The
       items are:
-      	screenrow	screen row
-      	screencol	screen column
-      	winid		Window ID of the click
-      	winrow		row inside "winid"
-      	wincol		column inside "winid"
-      	line		text line inside "winid"
-      	column		text column inside "winid"
-      	coladd		offset (in screen columns) from the
-      			start of the clicked char
+              screenrow       screen row
+              screencol       screen column
+              winid           Window ID of the click
+              winrow          row inside "winid"
+              wincol          column inside "winid"
+              line            text line inside "winid"
+              column          text column inside "winid"
+              coladd          offset (in screen columns) from the
+                              start of the clicked char
       All numbers are 1-based.
 
       If not over a window, e.g. when in the command line, then only
@@ -4099,9 +4099,9 @@ M.funcs = {
       in which case it means "after the end of the line".
       If {expr} is invalid, returns a list with all zeros.
       This can be used to save and restore the position of a mark: >vim
-      	let save_a_mark = getpos("'a")
-      	" ...
-      	call setpos("'a", save_a_mark)
+              let save_a_mark = getpos("'a")
+              " ...
+              call setpos("'a", save_a_mark)
       <Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
     ]=],
@@ -4115,24 +4115,24 @@ M.funcs = {
     desc = [=[
       Returns a |List| with all the current quickfix errors.  Each
       list item is a dictionary with these entries:
-      	bufnr	number of buffer that has the file name, use
-      		bufname() to get the name
-      	module	module name
-      	lnum	line number in the buffer (first line is 1)
-      	end_lnum
-      		end of line number if the item is multiline
-      	col	column number (first column is 1)
-      	end_col	end of column number if the item has range
-      	vcol	|TRUE|: "col" is visual column
-      		|FALSE|: "col" is byte index
-      	nr	error number
-      	pattern	search pattern used to locate the error
-      	text	description of the error
-      	type	type of the error, 'E', '1', etc.
-      	valid	|TRUE|: recognized error message
-      	user_data
-      		custom data associated with the item, can be
-      		any type.
+              bufnr   number of buffer that has the file name, use
+                      bufname() to get the name
+              module  module name
+              lnum    line number in the buffer (first line is 1)
+              end_lnum
+                      end of line number if the item is multiline
+              col     column number (first column is 1)
+              end_col end of column number if the item has range
+              vcol    |TRUE|: "col" is visual column
+                      |FALSE|: "col" is byte index
+              nr      error number
+              pattern search pattern used to locate the error
+              text    description of the error
+              type    type of the error, 'E', '1', etc.
+              valid   |TRUE|: recognized error message
+              user_data
+                      custom data associated with the item, can be
+                      any type.
 
       When there is no error list or it's empty, an empty list is
       returned. Quickfix list entries with a non-existing buffer
@@ -4142,42 +4142,42 @@ M.funcs = {
 
       Useful application: Find pattern matches in multiple files and
       do something with them: >vim
-      	vimgrep /theword/jg *.c
-      	for d in getqflist()
-      	   echo bufname(d.bufnr) ':' d.lnum '=' d.text
-      	endfor
+              vimgrep /theword/jg *.c
+              for d in getqflist()
+                 echo bufname(d.bufnr) ':' d.lnum '=' d.text
+              endfor
       <
       If the optional {what} dictionary argument is supplied, then
       returns only the items listed in {what} as a dictionary. The
       following string items are supported in {what}:
-      	changedtick	get the total number of changes made
-      			to the list |quickfix-changedtick|
-      	context	get the |quickfix-context|
-      	efm	errorformat to use when parsing "lines". If
-      		not present, then the 'errorformat' option
-      		value is used.
-      	id	get information for the quickfix list with
-      		|quickfix-ID|; zero means the id for the
-      		current list or the list specified by "nr"
-      	idx	get information for the quickfix entry at this
-      		index in the list specified by "id" or "nr".
-      		If set to zero, then uses the current entry.
-      		See |quickfix-index|
-      	items	quickfix list entries
-      	lines	parse a list of lines using 'efm' and return
-      		the resulting entries.  Only a |List| type is
-      		accepted.  The current quickfix list is not
-      		modified. See |quickfix-parse|.
-      	nr	get information for this quickfix list; zero
-      		means the current quickfix list and "$" means
-      		the last quickfix list
-      	qfbufnr number of the buffer displayed in the quickfix
-      		window. Returns 0 if the quickfix buffer is
-      		not present. See |quickfix-buffer|.
-      	size	number of entries in the quickfix list
-      	title	get the list title |quickfix-title|
-      	winid	get the quickfix |window-ID|
-      	all	all of the above quickfix properties
+              changedtick     get the total number of changes made
+                              to the list |quickfix-changedtick|
+              context get the |quickfix-context|
+              efm     errorformat to use when parsing "lines". If
+                      not present, then the 'errorformat' option
+                      value is used.
+              id      get information for the quickfix list with
+                      |quickfix-ID|; zero means the id for the
+                      current list or the list specified by "nr"
+              idx     get information for the quickfix entry at this
+                      index in the list specified by "id" or "nr".
+                      If set to zero, then uses the current entry.
+                      See |quickfix-index|
+              items   quickfix list entries
+              lines   parse a list of lines using 'efm' and return
+                      the resulting entries.  Only a |List| type is
+                      accepted.  The current quickfix list is not
+                      modified. See |quickfix-parse|.
+              nr      get information for this quickfix list; zero
+                      means the current quickfix list and "$" means
+                      the last quickfix list
+              qfbufnr number of the buffer displayed in the quickfix
+                      window. Returns 0 if the quickfix buffer is
+                      not present. See |quickfix-buffer|.
+              size    number of entries in the quickfix list
+              title   get the list title |quickfix-title|
+              winid   get the quickfix |window-ID|
+              all     all of the above quickfix properties
       Non-string items in {what} are ignored. To get the value of a
       particular item, set it to zero.
       If "nr" is not present then the current quickfix list is used.
@@ -4191,29 +4191,29 @@ M.funcs = {
       "items" with the list of entries.
 
       The returned dictionary contains the following entries:
-      	changedtick	total number of changes made to the
-      			list |quickfix-changedtick|
-      	context	quickfix list context. See |quickfix-context|
-      		If not present, set to "".
-      	id	quickfix list ID |quickfix-ID|. If not
-      		present, set to 0.
-      	idx	index of the quickfix entry in the list. If not
-      		present, set to 0.
-      	items	quickfix list entries. If not present, set to
-      		an empty list.
-      	nr	quickfix list number. If not present, set to 0
-      	qfbufnr	number of the buffer displayed in the quickfix
-      		window. If not present, set to 0.
-      	size	number of entries in the quickfix list. If not
-      		present, set to 0.
-      	title	quickfix list title text. If not present, set
-      		to "".
-      	winid	quickfix |window-ID|. If not present, set to 0
+              changedtick     total number of changes made to the
+                              list |quickfix-changedtick|
+              context quickfix list context. See |quickfix-context|
+                      If not present, set to "".
+              id      quickfix list ID |quickfix-ID|. If not
+                      present, set to 0.
+              idx     index of the quickfix entry in the list. If not
+                      present, set to 0.
+              items   quickfix list entries. If not present, set to
+                      an empty list.
+              nr      quickfix list number. If not present, set to 0
+              qfbufnr number of the buffer displayed in the quickfix
+                      window. If not present, set to 0.
+              size    number of entries in the quickfix list. If not
+                      present, set to 0.
+              title   quickfix list title text. If not present, set
+                      to "".
+              winid   quickfix |window-ID|. If not present, set to 0
 
       Examples (See also |getqflist-examples|): >vim
-      	echo getqflist({'all': 1})
-      	echo getqflist({'nr': 2, 'title': 1})
-      	echo getqflist({'lines' : ["F1:10:L10"]})
+              echo getqflist({'all': 1})
+              echo getqflist({'nr': 2, 'title': 1})
+              echo getqflist({'lines' : ["F1:10:L10"]})
       <
     ]=],
     name = 'getqflist',
@@ -4226,7 +4226,7 @@ M.funcs = {
     desc = [=[
       The result is a String, which is the contents of register
       {regname}.  Example: >vim
-      	let cliptext = getreg('*')
+              let cliptext = getreg('*')
       <When register {regname} was not set the result is an empty
       string.
       The {regname} argument must be a string.
@@ -4258,21 +4258,21 @@ M.funcs = {
     desc = [=[
       Returns detailed information about register {regname} as a
       Dictionary with the following entries:
-      	regcontents	List of lines contained in register
-      			{regname}, like
-      			getreg({regname}, 1, 1).
-      	regtype		the type of register {regname}, as in
-      			|getregtype()|.
-      	isunnamed	Boolean flag, v:true if this register
-      			is currently pointed to by the unnamed
-      			register.
-      	points_to	for the unnamed register, gives the
-      			single letter name of the register
-      			currently pointed to (see |quotequote|).
-      			For example, after deleting a line
-      			with `dd`, this field will be "1",
-      			which is the register that got the
-      			deleted text.
+              regcontents     List of lines contained in register
+                              {regname}, like
+                              getreg({regname}, 1, 1).
+              regtype         the type of register {regname}, as in
+                              |getregtype()|.
+              isunnamed       Boolean flag, v:true if this register
+                              is currently pointed to by the unnamed
+                              register.
+              points_to       for the unnamed register, gives the
+                              single letter name of the register
+                              currently pointed to (see |quotequote|).
+                              For example, after deleting a line
+                              with `dd`, this field will be "1",
+                              which is the register that got the
+                              deleted text.
 
       The {regname} argument is a string.  If {regname} is invalid
       or not set, an empty Dictionary will be returned.
@@ -4291,10 +4291,10 @@ M.funcs = {
     desc = [=[
       The result is a String, which is type of register {regname}.
       The value will be one of:
-          "v"			for |charwise| text
-          "V"			for |linewise| text
-          "<CTRL-V>{width}"	for |blockwise-visual| text
-          ""			for an empty or unknown register
+          "v"                 for |charwise| text
+          "V"                 for |linewise| text
+          "<CTRL-V>{width}"   for |blockwise-visual| text
+          ""                  for an empty or unknown register
       <CTRL-V> is one character with value 0x16.
       The {regname} argument is a string.  If {regname} is not
       specified, |v:register| is used.
@@ -4314,34 +4314,34 @@ M.funcs = {
 
       The optional Dict argument {opts} supports the following
       optional items:
-          name	Script name match pattern. If specified,
-      		and "sid" is not specified, information about
-      		scripts with a name that match the pattern
-      		"name" are returned.
-          sid		Script ID |<SID>|.  If specified, only
-      		information about the script with ID "sid" is
-      		returned and "name" is ignored.
+          name        Script name match pattern. If specified,
+                      and "sid" is not specified, information about
+                      scripts with a name that match the pattern
+                      "name" are returned.
+          sid         Script ID |<SID>|.  If specified, only
+                      information about the script with ID "sid" is
+                      returned and "name" is ignored.
 
       Each item in the returned List is a |Dict| with the following
       items:
-          autoload	Always set to FALSE.
+          autoload    Always set to FALSE.
           functions   List of script-local function names defined in
-      		the script.  Present only when a particular
-      		script is specified using the "sid" item in
-      		{opts}.
-          name	Vim script file name.
-          sid		Script ID |<SID>|.
+                      the script.  Present only when a particular
+                      script is specified using the "sid" item in
+                      {opts}.
+          name        Vim script file name.
+          sid         Script ID |<SID>|.
           variables   A dictionary with the script-local variables.
-      		Present only when a particular script is
-      		specified using the "sid" item in {opts}.
-      		Note that this is a copy, the value of
-      		script-local variables cannot be changed using
-      		this dictionary.
-          version	Vim script version, always 1
+                      Present only when a particular script is
+                      specified using the "sid" item in {opts}.
+                      Note that this is a copy, the value of
+                      script-local variables cannot be changed using
+                      this dictionary.
+          version     Vim script version, always 1
 
       Examples: >vim
-      	echo getscriptinfo({'name': 'myscript'})
-      	echo getscriptinfo({'sid': 15}).variables
+              echo getscriptinfo({'name': 'myscript'})
+              echo getscriptinfo({'sid': 15}).variables
       <
     ]=],
     name = 'getscriptinfo',
@@ -4359,10 +4359,10 @@ M.funcs = {
       page does not exist an empty List is returned.
 
       Each List item is a |Dictionary| with the following entries:
-      	tabnr		tab page number.
-      	variables	a reference to the dictionary with
-      			tabpage-local variables
-      	windows		List of |window-ID|s in the tab page.
+              tabnr           tab page number.
+              variables       a reference to the dictionary with
+                              tabpage-local variables
+              windows         List of |window-ID|s in the tab page.
 
     ]=],
     name = 'gettabinfo',
@@ -4410,11 +4410,11 @@ M.funcs = {
       When the tab, window or variable doesn't exist {def} or an
       empty string is returned, there is no error message.
       Examples: >vim
-      	let list_is_on = gettabwinvar(1, 2, '&list')
-      	echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
+              let list_is_on = gettabwinvar(1, 2, '&list')
+              echo "myvar = " .. gettabwinvar(3, 1, 'myvar')
       <
       To obtain all window-local variables use: >vim
-      	gettabwinvar({tabnr}, {winnr}, '&')
+              gettabwinvar({tabnr}, {winnr}, '&')
       <
     ]=],
     name = 'gettabwinvar',
@@ -4436,24 +4436,24 @@ M.funcs = {
       When window {winnr} doesn't exist, an empty Dict is returned.
 
       The returned dictionary contains the following entries:
-      	curidx		Current index in the stack. When at
-      			top of the stack, set to (length + 1).
-      			Index of bottom of the stack is 1.
-      	items		List of items in the stack. Each item
-      			is a dictionary containing the
-      			entries described below.
-      	length		Number of entries in the stack.
+              curidx          Current index in the stack. When at
+                              top of the stack, set to (length + 1).
+                              Index of bottom of the stack is 1.
+              items           List of items in the stack. Each item
+                              is a dictionary containing the
+                              entries described below.
+              length          Number of entries in the stack.
 
       Each item in the stack is a dictionary with the following
       entries:
-      	bufnr		buffer number of the current jump
-      	from		cursor position before the tag jump.
-      			See |getpos()| for the format of the
-      			returned list.
-      	matchnr		current matching tag number. Used when
-      			multiple matching tags are found for a
-      			name.
-      	tagname		name of the tag
+              bufnr           buffer number of the current jump
+              from            cursor position before the tag jump.
+                              See |getpos()| for the format of the
+                              returned list.
+              matchnr         current matching tag number. Used when
+                              multiple matching tags are found for a
+                              name.
+              tagname         name of the tag
 
       See |tagstack| for more information about the tag stack.
 
@@ -4494,28 +4494,28 @@ M.funcs = {
       tab pages is returned.
 
       Each List item is a |Dictionary| with the following entries:
-      	botline		last complete displayed buffer line
-      	bufnr		number of buffer in the window
-      	height		window height (excluding winbar)
-      	loclist		1 if showing a location list
-      	quickfix	1 if quickfix or location list window
-      	terminal	1 if a terminal window
-      	tabnr		tab page number
-      	topline		first displayed buffer line
-      	variables	a reference to the dictionary with
-      			window-local variables
-      	width		window width
-      	winbar		1 if the window has a toolbar, 0
-      			otherwise
-      	wincol		leftmost screen column of the window;
-      			"col" from |win_screenpos()|
-      	textoff		number of columns occupied by any
-      			'foldcolumn', 'signcolumn' and line
-      			number in front of the text
-      	winid		|window-ID|
-      	winnr		window number
-      	winrow		topmost screen line of the window;
-      			"row" from |win_screenpos()|
+              botline         last complete displayed buffer line
+              bufnr           number of buffer in the window
+              height          window height (excluding winbar)
+              loclist         1 if showing a location list
+              quickfix        1 if quickfix or location list window
+              terminal        1 if a terminal window
+              tabnr           tab page number
+              topline         first displayed buffer line
+              variables       a reference to the dictionary with
+                              window-local variables
+              width           window width
+              winbar          1 if the window has a toolbar, 0
+                              otherwise
+              wincol          leftmost screen column of the window;
+                              "col" from |win_screenpos()|
+              textoff         number of columns occupied by any
+                              'foldcolumn', 'signcolumn' and line
+                              number in front of the text
+              winid           |window-ID|
+              winnr           window number
+              winrow          topmost screen line of the window;
+                              "row" from |win_screenpos()|
 
     ]=],
     name = 'getwininfo',
@@ -4529,7 +4529,7 @@ M.funcs = {
     desc = [=[
       The result is a |List| with two numbers, the result of
       |getwinposx()| and |getwinposy()| combined:
-      	[x-pos, y-pos]
+              [x-pos, y-pos]
       {timeout} can be used to specify how long to wait in msec for
       a response from the terminal.  When omitted 100 msec is used.
 
@@ -4538,13 +4538,13 @@ M.funcs = {
       within that time, a previously reported position is returned,
       if available.  This can be used to poll for the position and
       do some work in the meantime: >vim
-      	while 1
-      	  let res = getwinpos(1)
-      	  if res[0] >= 0
-      	    break
-      	  endif
-      	  " Do some work here
-      	endwhile
+              while 1
+                let res = getwinpos(1)
+                if res[0] >= 0
+                  break
+                endif
+                " Do some work here
+              endwhile
       <
     ]=],
     name = 'getwinpos',
@@ -4581,8 +4581,8 @@ M.funcs = {
     desc = [=[
       Like |gettabwinvar()| for the current tabpage.
       Examples: >vim
-      	let list_is_on = getwinvar(2, '&list')
-      	echo "myvar = " .. getwinvar(1, 'myvar')
+              let list_is_on = getwinvar(2, '&list')
+              echo "myvar = " .. getwinvar(1, 'myvar')
 
     ]=],
     name = 'getwinvar',
@@ -4620,8 +4620,8 @@ M.funcs = {
 
       For most systems backticks can be used to get files names from
       any external command.  Example: >vim
-      	let tagfiles = glob("`find . -name tags -print`")
-      	let &tags = substitute(tagfiles, "\n", ",", "g")
+              let tagfiles = glob("`find . -name tags -print`")
+              let &tags = substitute(tagfiles, "\n", ",", "g")
       <The result of the program inside the backticks should be one
       item per line.  Spaces inside an item are allowed.
 
@@ -4640,13 +4640,13 @@ M.funcs = {
       Convert a file pattern, as used by glob(), into a search
       pattern.  The result can be used to match with a string that
       is a file name.  E.g. >vim
-      	if filename =~ glob2regpat('Make*.mak')
-	  " ...
-	endif
+              if filename =~ glob2regpat('Make*.mak')
+                " ...
+              endif
       <This is equivalent to: >vim
-      	if filename =~ '^Make.*\.mak$'
-	  " ...
-	endif
+              if filename =~ '^Make.*\.mak$'
+                " ...
+              endif
       <When {string} is an empty string the result is "^$", match an
       empty string.
       Note that the result depends on the system.  On MS-Windows
@@ -4663,7 +4663,7 @@ M.funcs = {
     desc = [=[
       Perform glob() for String {expr} on all directories in {path}
       and concatenate the results.  Example: >vim
-      	echo globpath(&rtp, "syntax/c.vim")
+              echo globpath(&rtp, "syntax/c.vim")
       <
       {path} is a comma-separated list of directory names.  Each
       directory name is prepended to {expr} and expanded like with
@@ -4684,14 +4684,14 @@ M.funcs = {
       also get filenames containing newlines correctly. Otherwise
       the result is a String and when there are several matches,
       they are separated by <NL> characters.  Example: >vim
-      	echo globpath(&rtp, "syntax/c.vim", 0, 1)
+              echo globpath(&rtp, "syntax/c.vim", 0, 1)
       <
       {allinks} is used as with |glob()|.
 
       The "**" item can be used to search in a directory tree.
       For example, to find all "README.txt" files in the directories
       in 'runtimepath' and below: >vim
-      	echo globpath(&rtp, "**/README.txt")
+              echo globpath(&rtp, "**/README.txt")
       <Upwards search and limiting the depth of "**" is not
       supported, thus using 'path' will not always work properly.
 
@@ -4714,14 +4714,14 @@ M.funcs = {
       "win32", see below.  See also |exists()|.
 
       To get the system name use |vim.uv|.os_uname() in Lua: >lua
-      	print(vim.uv.os_uname().sysname)
+              print(vim.uv.os_uname().sysname)
 
       <If the code has a syntax error then Vimscript may skip the
       rest of the line.  Put |:if| and |:endif| on separate lines to
       avoid the syntax error: >vim
-      	if has('feature')
-      	  let x = this_breaks_without_the_feature()
-      	endif
+              if has('feature')
+                let x = this_breaks_without_the_feature()
+              endif
       <
       Vim's compile-time feature-names (prefixed with "+") are not
       recognized because Nvim is always compiled with all possible
@@ -4730,50 +4730,50 @@ M.funcs = {
       Feature names can be:
       1.  Nvim version. For example the "nvim-0.2.1" feature means
           that Nvim is version 0.2.1 or later: >vim
-      	if has("nvim-0.2.1")
-      	  " ...
-      	endif
+              if has("nvim-0.2.1")
+                " ...
+              endif
 
       <2.  Runtime condition or other pseudo-feature. For example the
           "win32" feature checks if the current system is Windows: >vim
-      	if has("win32")
-      	  " ...
-      	endif
-      <					*feature-list*
+              if has("win32")
+                " ...
+              endif
+      <                                       *feature-list*
           List of supported pseudo-feature names:
-      	acl		|ACL| support.
-      	bsd		BSD system (not macOS, use "mac" for that).
-      	clipboard	|clipboard| provider is available.
-      	fname_case	Case in file names matters (for Darwin and MS-Windows
-      			this is not present).
-      	gui_running	Nvim has a GUI.
-      	iconv		Can use |iconv()| for conversion.
-      	linux		Linux system.
-      	mac		MacOS system.
-      	nvim		This is Nvim.
-      	python3		Legacy Vim |python3| interface. |has-python|
-      	pythonx		Legacy Vim |python_x| interface. |has-pythonx|
-      	sun		SunOS system.
-      	ttyin		input is a terminal (tty).
-      	ttyout		output is a terminal (tty).
-      	unix		Unix system.
-      	*vim_starting*	True during |startup|.
-      	win32		Windows system (32 or 64 bit).
-      	win64		Windows system (64 bit).
-      	wsl		WSL (Windows Subsystem for Linux) system.
+              acl             |ACL| support.
+              bsd             BSD system (not macOS, use "mac" for that).
+              clipboard       |clipboard| provider is available.
+              fname_case      Case in file names matters (for Darwin and MS-Windows
+                              this is not present).
+              gui_running     Nvim has a GUI.
+              iconv           Can use |iconv()| for conversion.
+              linux           Linux system.
+              mac             MacOS system.
+              nvim            This is Nvim.
+              python3         Legacy Vim |python3| interface. |has-python|
+              pythonx         Legacy Vim |python_x| interface. |has-pythonx|
+              sun             SunOS system.
+              ttyin           input is a terminal (tty).
+              ttyout          output is a terminal (tty).
+              unix            Unix system.
+              *vim_starting*  True during |startup|.
+              win32           Windows system (32 or 64 bit).
+              win64           Windows system (64 bit).
+              wsl             WSL (Windows Subsystem for Linux) system.
 
-      					*has-patch*
+                                              *has-patch*
       3.  Vim patch. For example the "patch123" feature means that
           Vim patch 123 at the current |v:version| was included: >vim
-      	if v:version > 602 || v:version == 602 && has("patch148")
-      	  " ...
-      	endif
+              if v:version > 602 || v:version == 602 && has("patch148")
+                " ...
+              endif
 
       <4.  Vim version. For example the "patch-7.4.237" feature means
           that Nvim is Vim-compatible to version 7.4.237 or later. >vim
-      	if has("patch-7.4.237")
-      	  " ...
-      	endif
+              if has("patch-7.4.237")
+                " ...
+              endif
       <
     ]=],
     name = 'has',
@@ -4806,9 +4806,9 @@ M.funcs = {
       Tabs and windows are identified by their respective numbers,
       0 means current tab or window. Missing argument implies 0.
       Thus the following are equivalent: >vim
-      	echo haslocaldir()
-      	echo haslocaldir(0)
-      	echo haslocaldir(0, 0)
+              echo haslocaldir()
+              echo haslocaldir(0)
+              echo haslocaldir(0, 0)
       <With {winnr} use that window in the current tabpage.
       With {winnr} and {tabnr} use the window in that tabpage.
       {winnr} can be the window number or the |window-ID|.
@@ -4837,21 +4837,21 @@ M.funcs = {
       buffer are checked for a match.
       If no matching mapping is found FALSE is returned.
       The following characters are recognized in {mode}:
-      	n	Normal mode
-      	v	Visual and Select mode
-      	x	Visual mode
-      	s	Select mode
-      	o	Operator-pending mode
-      	i	Insert mode
-      	l	Language-Argument ("r", "f", "t", etc.)
-      	c	Command-line mode
+              n       Normal mode
+              v       Visual and Select mode
+              x       Visual mode
+              s       Select mode
+              o       Operator-pending mode
+              i       Insert mode
+              l       Language-Argument ("r", "f", "t", etc.)
+              c       Command-line mode
       When {mode} is omitted, "nvo" is used.
 
       This function is useful to check if a mapping already exists
       to a function in a Vim script.  Example: >vim
-      	if !hasmapto('\ABCdoit')
-      	   map <Leader>d \ABCdoit
-      	endif
+              if !hasmapto('\ABCdoit')
+                 map <Leader>d \ABCdoit
+              endif
       <This installs the mapping to "\ABCdoit" only if there isn't
       already a mapping to "\ABCdoit".
 
@@ -4888,13 +4888,13 @@ M.funcs = {
     base = 2,
     desc = [=[
       Add the String {item} to the history {history} which can be
-      one of:					*hist-names*
-      	"cmd"	 or ":"	  command line history
-      	"search" or "/"   search pattern history
-      	"expr"	 or "="   typed expression history
-      	"input"  or "@"	  input line history
-      	"debug"  or ">"   debug command history
-      	empty		  the current or last used history
+      one of:                                 *hist-names*
+              "cmd"    or ":"   command line history
+              "search" or "/"   search pattern history
+              "expr"   or "="   typed expression history
+              "input"  or "@"   input line history
+              "debug"  or ">"   debug command history
+              empty             the current or last used history
       The {history} string does not need to be the whole name, one
       character is sufficient.
       If {item} does already exist in the history, it will be
@@ -4903,8 +4903,8 @@ M.funcs = {
       otherwise FALSE is returned.
 
       Example: >vim
-      	call histadd("input", strftime("%Y %b %d"))
-      	let date=input("Enter date: ")
+              call histadd("input", strftime("%Y %b %d"))
+              let date=input("Enter date: ")
       <This function is not available in the |sandbox|.
 
     ]=],
@@ -4933,20 +4933,20 @@ M.funcs = {
 
       Examples:
       Clear expression register history: >vim
-      	call histdel("expr")
+              call histdel("expr")
       <
       Remove all entries starting with "*" from the search history: >vim
-      	call histdel("/", '^\*')
+              call histdel("/", '^\*')
       <
       The following three are equivalent: >vim
-      	call histdel("search", histnr("search"))
-      	call histdel("search", -1)
-      	call histdel("search", '^' .. histget("search", -1) .. '$')
+              call histdel("search", histnr("search"))
+              call histdel("search", -1)
+              call histdel("search", '^' .. histget("search", -1) .. '$')
       <
       To delete the last search pattern and use the last-but-one for
       the "n" command and 'hlsearch': >vim
-      	call histdel("search", -1)
-      	let @/ = histget("search", -1)
+              call histdel("search", -1)
+              let @/ = histget("search", -1)
       <
     ]=],
     name = 'histdel',
@@ -4966,11 +4966,11 @@ M.funcs = {
 
       Examples:
       Redo the second last search from history. >vim
-      	execute '/' .. histget("search", -2)
+              execute '/' .. histget("search", -2)
 
       <Define an Ex command ":H {num}" that supports re-execution of
       the {num}th entry from the output of |:history|. >vim
-      	command -nargs=1 H execute histget("cmd", 0+<args>)
+              command -nargs=1 H execute histget("cmd", 0+<args>)
       <
     ]=],
     name = 'histget',
@@ -4987,7 +4987,7 @@ M.funcs = {
       If an error occurred, -1 is returned.
 
       Example: >vim
-      	let inp_index = histnr("expr")
+              let inp_index = histnr("expr")
 
     ]=],
     name = 'histnr',
@@ -5005,7 +5005,7 @@ M.funcs = {
       This can be used to retrieve information about the highlight
       group.  For example, to get the background color of the
       "Comment" group: >vim
-      	echo synIDattr(synIDtrans(hlID("Comment")), "bg")
+              echo synIDattr(synIDtrans(hlID("Comment")), "bg")
       <
     ]=],
     name = 'hlID',
@@ -5126,10 +5126,10 @@ M.funcs = {
 
       -1 is returned when {expr} is not found in {object}.
       Example: >vim
-      	let idx = index(words, "the")
-      	if index(numbers, 123) >= 0
-      	  " ...
-      	endif
+              let idx = index(words, "the")
+              if index(numbers, 123) >= 0
+                " ...
+              endif
 
     ]=],
     name = 'index',
@@ -5160,22 +5160,22 @@ M.funcs = {
       |v:val| has the byte value.
 
       If {expr} is a |Funcref| it must take two arguments:
-      	1. the key or the index of the current item.
-      	2. the value of the current item.
+              1. the key or the index of the current item.
+              2. the value of the current item.
       The function must return |TRUE| if the item is found and the
       search should stop.
 
       The optional argument {opts} is a Dict and supports the
       following items:
-          startidx	start evaluating {expr} at the item with this
-      		index; may be negative for an item relative to
-      		the end
+          startidx    start evaluating {expr} at the item with this
+                      index; may be negative for an item relative to
+                      the end
       Returns -1 when {expr} evaluates to v:false for all the items.
       Example: >vim
-      	let l = [#{n: 10}, #{n: 20}, #{n: 30}]
-      	echo indexof(l, "v:val.n == 20")
-      	echo indexof(l, {i, v -> v.n == 30})
-      	echo indexof(l, "v:val.n == 20", #{startidx: 1})
+              let l = [#{n: 10}, #{n: 20}, #{n: 30}]
+              echo indexof(l, "v:val.n == 20")
+              echo indexof(l, {i, v -> v.n == 30})
+              echo indexof(l, "v:val.n == 20", #{startidx: 1})
 
     ]=],
     name = 'indexof',
@@ -5215,14 +5215,14 @@ M.funcs = {
       editing commands and mappings.  There is a separate history
       for lines typed for input().
       Example: >vim
-      	if input("Coffee or beer? ") == "beer"
-      	  echo "Cheers!"
-      	endif
+              if input("Coffee or beer? ") == "beer"
+                echo "Cheers!"
+              endif
       <
       If the optional {text} argument is present and not empty, this
       is used for the default reply, as if the user typed this.
       Example: >vim
-      	let color = input("Color? ", "white")
+              let color = input("Color? ", "white")
 
       <The optional {completion} argument specifies the type of
       completion supported for the input.  Without it completion is
@@ -5230,18 +5230,18 @@ M.funcs = {
       that can be supplied to a user-defined command using the
       "-complete=" argument.  Refer to |:command-completion| for
       more information.  Example: >vim
-      	let fname = input("File: ", "", "file")
+              let fname = input("File: ", "", "file")
 
-      <			*input()-highlight* *E5400* *E5402*
+      <                       *input()-highlight* *E5400* *E5402*
       The optional `highlight` key allows specifying function which
       will be used for highlighting user input.  This function
       receives user input as its only argument and must return
       a list of 3-tuples [hl_start_col, hl_end_col + 1, hl_group]
       where
-      	hl_start_col is the first highlighted column,
-      	hl_end_col is the last highlighted column (+ 1!),
-      	hl_group is |:hi| group used for highlighting.
-      			      *E5403* *E5404* *E5405* *E5406*
+              hl_start_col is the first highlighted column,
+              hl_end_col is the last highlighted column (+ 1!),
+              hl_group is |:hi| group used for highlighting.
+                                    *E5403* *E5404* *E5405* *E5406*
       Both hl_start_col and hl_end_col + 1 must point to the start
       of the multibyte character (highlighting must not break
       multibyte characters), hl_end_col + 1 may be equal to the
@@ -5251,28 +5251,28 @@ M.funcs = {
       then or equal to previous hl_end_col.
 
       Example (try some input with parentheses): >vim
-      	highlight RBP1 guibg=Red ctermbg=red
-      	highlight RBP2 guibg=Yellow ctermbg=yellow
-      	highlight RBP3 guibg=Green ctermbg=green
-      	highlight RBP4 guibg=Blue ctermbg=blue
-      	let g:rainbow_levels = 4
-      	function! RainbowParens(cmdline)
-      	  let ret = []
-      	  let i = 0
-      	  let lvl = 0
-      	  while i < len(a:cmdline)
-      	    if a:cmdline[i] is# '('
-      	      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-      	      let lvl += 1
-      	    elseif a:cmdline[i] is# ')'
-      	      let lvl -= 1
-      	      call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
-      	    endif
-      	    let i += 1
-      	  endwhile
-      	  return ret
-      	endfunction
-      	call input({'prompt':'>','highlight':'RainbowParens'})
+              highlight RBP1 guibg=Red ctermbg=red
+              highlight RBP2 guibg=Yellow ctermbg=yellow
+              highlight RBP3 guibg=Green ctermbg=green
+              highlight RBP4 guibg=Blue ctermbg=blue
+              let g:rainbow_levels = 4
+              function! RainbowParens(cmdline)
+                let ret = []
+                let i = 0
+                let lvl = 0
+                while i < len(a:cmdline)
+                  if a:cmdline[i] is# '('
+                    call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+                    let lvl += 1
+                  elseif a:cmdline[i] is# ')'
+                    let lvl -= 1
+                    call add(ret, [i, i + 1, 'RBP' .. ((lvl % g:rainbow_levels) + 1)])
+                  endif
+                  let i += 1
+                endwhile
+                return ret
+              endfunction
+              call input({'prompt':'>','highlight':'RainbowParens'})
       <
       Highlight function is called at least once for each new
       displayed input string, before command-line is redrawn.  It is
@@ -5296,12 +5296,12 @@ M.funcs = {
       |:execute| or |:normal|.
 
       Example with a mapping: >vim
-      	nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
-      	function GetFoo()
-      	  call inputsave()
-      	  let g:Foo = input("enter search pattern: ")
-      	  call inputrestore()
-      	endfunction
+              nmap \x :call GetFoo()<CR>:exe "/" .. Foo<CR>
+              function GetFoo()
+                call inputsave()
+                let g:Foo = input("enter search pattern: ")
+                call inputrestore()
+              endfunction
 
     ]=],
     name = 'input',
@@ -5335,8 +5335,8 @@ M.funcs = {
       it won't work.  It's a good idea to put the entry number at
       the start of the string.  And put a prompt in the first item.
       Example: >vim
-      	let color = inputlist(['Select color:', '1. red',
-      		\ '2. green', '3. blue'])
+              let color = inputlist(['Select color:', '1. red',
+                      \ '2. green', '3. blue'])
 
     ]=],
     name = 'inputlist',
@@ -5399,9 +5399,9 @@ M.funcs = {
       |list-index|.  -1 inserts just before the last item.
 
       Returns the resulting |List| or |Blob|.  Examples: >vim
-      	let mylist = insert([2, 3, 5], 1)
-      	call insert(mylist, 4, -1)
-      	call insert(mylist, 6, len(mylist))
+              let mylist = insert([2, 3, 5], 1)
+              call insert(mylist, 4, -1)
+              call insert(mylist, 6, len(mylist))
       <The last example can be done simpler with |add()|.
       Note that when {item} is a |List| it is inserted as a single
       item.  Use |extend()| to concatenate |Lists|.
@@ -5437,7 +5437,7 @@ M.funcs = {
     desc = [=[
       Bitwise invert.  The argument is converted to a number.  A
       List, Dict or Float argument causes an error.  Example: >vim
-      	let bits = invert(bits)
+              let bits = invert(bits)
       <
     ]=],
     name = 'invert',
@@ -5466,10 +5466,10 @@ M.funcs = {
     desc = [=[
       Return 1 if {expr} is a positive infinity, or -1 a negative
       infinity, otherwise 0. >vim
-      	echo isinf(1.0 / 0.0)
-      <	1 >vim
-      	echo isinf(-1.0 / 0.0)
-      <	-1
+              echo isinf(1.0 / 0.0)
+      <        1 >vim
+              echo isinf(-1.0 / 0.0)
+      <        -1
 
     ]=],
     name = 'isinf',
@@ -5486,10 +5486,10 @@ M.funcs = {
       The string argument {expr} must be the name of a variable,
       |List| item or |Dictionary| entry, not the variable itself!
       Example: >vim
-      	let alist = [0, ['a', 'b'], 2, 3]
-      	lockvar 1 alist
-      	echo islocked('alist')		" 1
-      	echo islocked('alist[1]')	" 0
+              let alist = [0, ['a', 'b'], 2, 3]
+              lockvar 1 alist
+              echo islocked('alist')          " 1
+              echo islocked('alist[1]')       " 0
 
       <When {expr} is a variable that does not exist you get an error
       message.  Use |exists()| to check for existence.
@@ -5506,8 +5506,8 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return |TRUE| if {expr} is a float with value NaN. >vim
-      	echo isnan(0.0 / 0.0)
-      <	1
+              echo isnan(0.0 / 0.0)
+      <        1
 
     ]=],
     name = 'isnan',
@@ -5524,9 +5524,9 @@ M.funcs = {
       entry and the value of this entry.  The |List| is in arbitrary
       order.  Also see |keys()| and |values()|.
       Example: >vim
-      	for [key, value] in items(mydict)
-      	   echo key .. ': ' .. value
-      	endfor
+              for [key, value] in items(mydict)
+                 echo key .. ': ' .. value
+              endfor
 
     ]=],
     name = 'items',
@@ -5607,7 +5607,7 @@ M.funcs = {
           by CommandLineToArgvW https://msdn.microsoft.com/bb776391
           unless cmd[0] is some form of "cmd.exe".
 
-      					*jobstart-env*
+                                              *jobstart-env*
       The job environment is initialized as follows:
         $NVIM                is set to |v:servername| of the parent Nvim
         $NVIM_LISTEN_ADDRESS is unset
@@ -5616,41 +5616,41 @@ M.funcs = {
         $VIMRUNTIME          is unset
       You can set these with the `env` option.
 
-      					*jobstart-options*
+                                              *jobstart-options*
       {opts} is a dictionary with these keys:
         clear_env:  (boolean) `env` defines the job environment
-      	      exactly, instead of merging current environment.
-        cwd:	      (string, default=|current-directory|) Working
-      	      directory of the job.
+                    exactly, instead of merging current environment.
+        cwd:        (string, default=|current-directory|) Working
+                    directory of the job.
         detach:     (boolean) Detach the job process: it will not be
-      	      killed when Nvim exits. If the process exits
-      	      before Nvim, `on_exit` will be invoked.
-        env:	      (dict) Map of environment variable name:value
-      	      pairs extending (or replace with "clear_env")
-      	      the current environment. |jobstart-env|
+                    killed when Nvim exits. If the process exits
+                    before Nvim, `on_exit` will be invoked.
+        env:        (dict) Map of environment variable name:value
+                    pairs extending (or replace with "clear_env")
+                    the current environment. |jobstart-env|
         height:     (number) Height of the `pty` terminal.
         |on_exit|:    (function) Callback invoked when the job exits.
         |on_stdout|:  (function) Callback invoked when the job emits
-      	      stdout data.
+                    stdout data.
         |on_stderr|:  (function) Callback invoked when the job emits
-      	      stderr data.
+                    stderr data.
         overlapped: (boolean) Sets FILE_FLAG_OVERLAPPED for the
-      	      stdio passed to the child process. Only on
-      	      MS-Windows; ignored on other platforms.
-        pty:	      (boolean) Connect the job to a new pseudo
-      	      terminal, and its streams to the master file
-      	      descriptor. `on_stdout` receives all output,
-      	      `on_stderr` is ignored. |terminal-start|
-        rpc:	      (boolean) Use |msgpack-rpc| to communicate with
-      	      the job over stdio. Then `on_stdout` is ignored,
-      	      but `on_stderr` can still be used.
+                    stdio passed to the child process. Only on
+                    MS-Windows; ignored on other platforms.
+        pty:        (boolean) Connect the job to a new pseudo
+                    terminal, and its streams to the master file
+                    descriptor. `on_stdout` receives all output,
+                    `on_stderr` is ignored. |terminal-start|
+        rpc:        (boolean) Use |msgpack-rpc| to communicate with
+                    the job over stdio. Then `on_stdout` is ignored,
+                    but `on_stderr` can still be used.
         stderr_buffered: (boolean) Collect data until EOF (stream closed)
-      	      before invoking `on_stderr`. |channel-buffered|
+                    before invoking `on_stderr`. |channel-buffered|
         stdout_buffered: (boolean) Collect data until EOF (stream
-      	      closed) before invoking `on_stdout`. |channel-buffered|
+                    closed) before invoking `on_stdout`. |channel-buffered|
         stdin:      (string) Either "pipe" (default) to connect the
-      	      job's stdin to a channel or "null" to disconnect
-      	      stdin.
+                    job's stdin to a channel or "null" to disconnect
+                    stdin.
         width:      (number) Width of the `pty` terminal.
 
       {opts} is passed as |self| dictionary to the callback; the
@@ -5692,7 +5692,7 @@ M.funcs = {
       omitted or -1, wait forever.
 
       Timeout of 0 can be used to check the status of a job: >vim
-      	let running = jobwait([{job-id}], 0)[0] == -1
+              let running = jobwait([{job-id}], 0)[0] == -1
       <
       During jobwait() callbacks for jobs not in the {jobs} list may
       be invoked. The screen will not redraw unless |:redraw| is
@@ -5700,10 +5700,10 @@ M.funcs = {
 
       Returns a list of len({jobs}) integers, where each integer is
       the status of the corresponding job:
-      	Exit-code, if the job exited
-      	-1 if the timeout was exceeded
-      	-2 if the job was interrupted (by |CTRL-C|)
-      	-3 if the job-id is invalid
+              Exit-code, if the job exited
+              -1 if the timeout was exceeded
+              -2 if the job was interrupted (by |CTRL-C|)
+              -3 if the job-id is invalid
     ]=],
     name = 'jobwait',
     params = { { 'jobs', 'any' }, { 'timeout', 'integer' } },
@@ -5718,7 +5718,7 @@ M.funcs = {
       {sep} is omitted a single space is used.
       Note that {sep} is not added at the end.  You might want to
       add it there too: >vim
-      	let lines = join(mylist, "\n") .. "\n"
+              let lines = join(mylist, "\n") .. "\n"
       <String items are used as-is.  |Lists| and |Dictionaries| are
       converted into a string like with |string()|.
       The opposite function is |split()|.
@@ -5789,9 +5789,9 @@ M.funcs = {
     desc = [=[
       Turn the internal byte representation of keys into a form that
       can be used for |:map|.  E.g. >vim
-      	let xx = "\<C-Home>"
-      	echo keytrans(xx)
-      <	<C-Home>
+              let xx = "\<C-Home>"
+              echo keytrans(xx)
+      <       <C-Home>
 
     ]=],
     name = 'keytrans',
@@ -5861,7 +5861,7 @@ M.funcs = {
       it's then freed when the DLL is unloaded.
 
       WARNING: If the function returns a non-valid pointer, Vim may
-      crash!	This also happens if the function returns a number,
+      crash!  This also happens if the function returns a number,
       because Vim thinks it's a pointer.
       For Win32 systems, {libname} should be the filename of the DLL
       without the ".DLL" suffix.  A full path is only required if
@@ -5869,7 +5869,7 @@ M.funcs = {
       For Unix: When compiling your own plugins, remember that the
       object code must be compiled as position-independent ('PIC').
       Examples: >vim
-      	echo libcall("libc.so", "getenv", "HOME")
+              echo libcall("libc.so", "getenv", "HOME")
 
     ]=],
     name = 'libcall',
@@ -5884,9 +5884,9 @@ M.funcs = {
       Just like |libcall()|, but used for a function that returns an
       int instead of a string.
       Examples: >vim
-      	echo libcallnr("/usr/lib/libc.so", "getpid", "")
-      	call libcallnr("libc.so", "printf", "Hello World!\n")
-      	call libcallnr("libc.so", "sleep", 10)
+              echo libcallnr("/usr/lib/libc.so", "getpid", "")
+              call libcallnr("libc.so", "printf", "Hello World!\n")
+              call libcallnr("libc.so", "sleep", 10)
       <
     ]=],
     name = 'libcallnr',
@@ -5900,18 +5900,18 @@ M.funcs = {
       The result is a Number, which is the line number of the file
       position given with {expr}.  The {expr} argument is a string.
       The accepted positions are:
-          .	    the cursor position
-          $	    the last line in the current buffer
-          'x	    position of mark x (if the mark is not set, 0 is
-      	    returned)
-          w0	    first line visible in current window (one if the
-      	    display isn't updated, e.g. in silent Ex mode)
-          w$	    last line visible in current window (this is one
-      	    less than "w0" if no lines are visible)
-          v	    In Visual mode: the start of the Visual area (the
-      	    cursor is the end).  When not in Visual mode
-      	    returns the cursor position.  Differs from |'<| in
-      	    that it's updated right away.
+          .       the cursor position
+          $       the last line in the current buffer
+          'x      position of mark x (if the mark is not set, 0 is
+                  returned)
+          w0      first line visible in current window (one if the
+                  display isn't updated, e.g. in silent Ex mode)
+          w$      last line visible in current window (this is one
+                  less than "w0" if no lines are visible)
+          v       In Visual mode: the start of the Visual area (the
+                  cursor is the end).  When not in Visual mode
+                  returns the cursor position.  Differs from |'<| in
+                  that it's updated right away.
       Note that a mark in another file can be used.  The line number
       then applies to another buffer.
       To get the column number use |col()|.  To get both use
@@ -5920,10 +5920,10 @@ M.funcs = {
       that window instead of the current window.
       Returns 0 for invalid values of {expr} and {winid}.
       Examples: >vim
-      	echo line(".")			" line number of the cursor
-      	echo line(".", winid)		" idem, in window "winid"
-      	echo line("'t")			" line number of mark t
-      	echo line("'" .. marker)	" line number of mark marker
+              echo line(".")                  " line number of the cursor
+              echo line(".", winid)           " idem, in window "winid"
+              echo line("'t")                 " line number of mark t
+              echo line("'" .. marker)        " line number of mark marker
       <
       To jump to the last known position when opening a file see
       |last-position-jump|.
@@ -5944,7 +5944,7 @@ M.funcs = {
       line returns 1. UTF-8 encoding is used, 'fileencoding' is
       ignored.  This can also be used to get the byte count for the
       line just below the last line: >vim
-      	echo line2byte(line("$") + 1)
+              echo line2byte(line("$") + 1)
       <This is the buffer size plus one.  If 'fileencoding' is empty
       it is the file size plus one.  {lnum} is used like with
       |getline()|.  When {lnum} is invalid -1 is returned.
@@ -5977,8 +5977,8 @@ M.funcs = {
     desc = [=[
       Return a Blob concatenating all the number values in {list}.
       Examples: >vim
-      	echo list2blob([1, 2, 3, 4])	" returns 0z01020304
-      	echo list2blob([])		" returns 0z
+              echo list2blob([1, 2, 3, 4])    " returns 0z01020304
+              echo list2blob([])              " returns 0z
       <Returns an empty Blob on error.  If one of the numbers is
       negative or more than 255 error *E1239* is given.
 
@@ -5995,16 +5995,16 @@ M.funcs = {
     desc = [=[
       Convert each number in {list} to a character string can
       concatenate them all.  Examples: >vim
-      	echo list2str([32])		" returns " "
-      	echo list2str([65, 66, 67])	" returns "ABC"
+              echo list2str([32])             " returns " "
+              echo list2str([65, 66, 67])     " returns "ABC"
       <The same can be done (slowly) with: >vim
-      	echo join(map(list, {nr, val -> nr2char(val)}), '')
+              echo join(map(list, {nr, val -> nr2char(val)}), '')
       <|str2list()| does the opposite.
 
       UTF-8 encoding is always used, {utf8} option has no effect,
       and exists only for backwards-compatibility.
       With UTF-8 composing characters work as expected: >vim
-      	echo list2str([97, 769])	" returns "á"
+              echo list2str([97, 769])        " returns "á"
       <
       Returns an empty string on error.
 
@@ -6031,10 +6031,10 @@ M.funcs = {
       (0, inf].
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo log(10)
-      <	2.302585 >vim
-      	echo log(exp(5))
-      <	5.0
+              echo log(10)
+      <        2.302585 >vim
+              echo log(exp(5))
+      <        5.0
 
     ]=],
     float_func = 'log',
@@ -6050,10 +6050,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo log10(1000)
-      <	3.0 >vim
-      	echo log10(0.01)
-      <	-2.0
+              echo log10(1000)
+      <        3.0 >vim
+              echo log10(0.01)
+      <        -2.0
 
     ]=],
     float_func = 'log10',
@@ -6096,7 +6096,7 @@ M.funcs = {
       current byte. For a |String| |v:key| has the index of the
       current character.
       Example: >vim
-      	call map(mylist, '"> " .. v:val .. " <"')
+              call map(mylist, '"> " .. v:val .. " <"')
       <This puts "> " before and " <" after each item in "mylist".
 
       Note that {expr2} is the result of an expression and is then
@@ -6105,24 +6105,24 @@ M.funcs = {
       still have to double ' quotes
 
       If {expr2} is a |Funcref| it is called with two arguments:
-      	1. The key or the index of the current item.
-      	2. the value of the current item.
+              1. The key or the index of the current item.
+              2. the value of the current item.
       The function must return the new value of the item. Example
       that changes each value by "key-value": >vim
-      	func KeyValue(key, val)
-      	  return a:key .. '-' .. a:val
-      	endfunc
-      	call map(myDict, function('KeyValue'))
+              func KeyValue(key, val)
+                return a:key .. '-' .. a:val
+              endfunc
+              call map(myDict, function('KeyValue'))
       <It is shorter when using a |lambda|: >vim
-      	call map(myDict, {key, val -> key .. '-' .. val})
+              call map(myDict, {key, val -> key .. '-' .. val})
       <If you do not use "val" you can leave it out: >vim
-      	call map(myDict, {key -> 'item: ' .. key})
+              call map(myDict, {key -> 'item: ' .. key})
       <If you do not use "key" you can use a short name: >vim
-      	call map(myDict, {_, val -> 'item: ' .. val})
+              call map(myDict, {_, val -> 'item: ' .. val})
       <
       The operation is done in-place for a |List| and |Dictionary|.
       If you want it to remain unmodified make a copy first: >vim
-      	let tlist = map(copy(mylist), ' v:val .. "\t"')
+              let tlist = map(copy(mylist), ' v:val .. "\t"')
 
       <Returns {expr1}, the |List| or |Dictionary| that was filtered,
       or a new |Blob| or |String|.
@@ -6155,16 +6155,16 @@ M.funcs = {
       command.
 
       {mode} can be one of these strings:
-      	"n"	Normal
-      	"v"	Visual (including Select)
-      	"o"	Operator-pending
-      	"i"	Insert
-      	"c"	Cmd-line
-      	"s"	Select
-      	"x"	Visual
-      	"l"	langmap |language-mapping|
-      	"t"	Terminal
-      	""	Normal, Visual and Operator-pending
+              "n"     Normal
+              "v"     Visual (including Select)
+              "o"     Operator-pending
+              "i"     Insert
+              "c"     Cmd-line
+              "s"     Select
+              "x"     Visual
+              "l"     langmap |language-mapping|
+              "t"     Terminal
+              ""      Normal, Visual and Operator-pending
       When {mode} is omitted, the modes for "" are used.
 
       When {abbr} is there and it is |TRUE| use abbreviations
@@ -6172,35 +6172,35 @@ M.funcs = {
 
       When {dict} is there and it is |TRUE| return a dictionary
       containing all the information of the mapping with the
-      following items:			*mapping-dict*
-        "lhs"	     The {lhs} of the mapping as it would be typed
+      following items:                        *mapping-dict*
+        "lhs"      The {lhs} of the mapping as it would be typed
         "lhsraw"   The {lhs} of the mapping as raw bytes
         "lhsrawalt" The {lhs} of the mapping as raw bytes, alternate
-      	      form, only present when it differs from "lhsraw"
-        "rhs"	     The {rhs} of the mapping as typed.
+                    form, only present when it differs from "lhsraw"
+        "rhs"      The {rhs} of the mapping as typed.
         "silent"   1 for a |:map-silent| mapping, else 0.
         "noremap"  1 if the {rhs} of the mapping is not remappable.
         "script"   1 if mapping was defined with <script>.
         "expr"     1 for an expression mapping (|:map-<expr>|).
         "buffer"   1 for a buffer local mapping (|:map-local|).
         "mode"     Modes for which the mapping is defined. In
-      	     addition to the modes mentioned above, these
-      	     characters will be used:
-      	     " "     Normal, Visual and Operator-pending
-      	     "!"     Insert and Commandline mode
-      		     (|mapmode-ic|)
-        "sid"	     The script local ID, used for <sid> mappings
-      	     (|<SID>|).  Negative for special contexts.
+                   addition to the modes mentioned above, these
+                   characters will be used:
+                   " "     Normal, Visual and Operator-pending
+                   "!"     Insert and Commandline mode
+                           (|mapmode-ic|)
+        "sid"      The script local ID, used for <sid> mappings
+                   (|<SID>|).  Negative for special contexts.
         "scriptversion"  The version of the script, always 1.
         "lnum"     The line number in "sid", zero if unknown.
         "nowait"   Do not wait for other, longer mappings.
-      	     (|:map-<nowait>|).
+                   (|:map-<nowait>|).
         "abbr"     True if this is an |abbreviation|.
         "mode_bits" Nvim's internal binary representation of "mode".
-      	     |mapset()| ignores this; only "mode" is used.
-      	     See |maplist()| for usage examples. The values
-      	     are from src/nvim/state_defs.h and may change in
-      	     the future.
+                   |mapset()| ignores this; only "mode" is used.
+                   See |maplist()| for usage examples. The values
+                   are from src/nvim/state_defs.h and may change in
+                   the future.
 
       The dictionary can be used to restore a mapping with
       |mapset()|.
@@ -6209,7 +6209,7 @@ M.funcs = {
       then the global mappings.
       This function can be used to map a key even when it's already
       mapped, and have it do the original mapping too.  Sketch: >vim
-      	exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+              exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
     ]=],
     name = 'maparg',
@@ -6234,11 +6234,11 @@ M.funcs = {
       A match happens with a mapping that starts with {name} and
       with a mapping which is equal to the start of {name}.
 
-      	matches mapping "a"	"ab"	"abc" ~
-         mapcheck("a")	yes	yes	 yes
-         mapcheck("abc")	yes	yes	 yes
-         mapcheck("ax")	yes	no	 no
-         mapcheck("b")	no	no	 no
+              matches mapping "a"     "ab"    "abc" ~
+         mapcheck("a")        yes     yes      yes
+         mapcheck("abc")      yes     yes      yes
+         mapcheck("ax")       yes     no       no
+         mapcheck("b")        no      no       no
 
       The difference with maparg() is that mapcheck() finds a
       mapping that matches with {name}, while maparg() only finds a
@@ -6252,9 +6252,9 @@ M.funcs = {
       then the global mappings.
       This function can be used to check if a mapping can be added
       without being ambiguous.  Example: >vim
-      	if mapcheck("_vv") == ""
-      	   map _vv :set guifont=7x13<CR>
-      	endif
+              if mapcheck("_vv") == ""
+                 map _vv :set guifont=7x13<CR>
+              endif
       <This avoids adding the "_vv" mapping when there already is a
       mapping for "_v" or for "_vvv".
 
@@ -6272,29 +6272,29 @@ M.funcs = {
       abbreviations instead of mappings.
 
       Example to show all mappings with "MultiMatch" in rhs: >vim
-      	echo maplist()->filter({_, m ->
-      		\ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
-      		\ })
+              echo maplist()->filter({_, m ->
+                      \ match(get(m, 'rhs', ''), 'MultiMatch') >= 0
+                      \ })
       <It can be tricky to find mappings for particular |:map-modes|.
       |mapping-dict|'s "mode_bits" can simplify this. For example,
       the mode_bits for Normal, Insert or Command-line modes are
       0x19. To find all the mappings available in those modes you
       can do: >vim
-      	let saved_maps = []
-      	for m in maplist()
-      	    if and(m.mode_bits, 0x19) != 0
-      		eval saved_maps->add(m)
-      	    endif
-      	endfor
-      	echo saved_maps->mapnew({_, m -> m.lhs})
+              let saved_maps = []
+              for m in maplist()
+                  if and(m.mode_bits, 0x19) != 0
+                      eval saved_maps->add(m)
+                  endif
+              endfor
+              echo saved_maps->mapnew({_, m -> m.lhs})
       <The values of the mode_bits are defined in Nvim's
       src/nvim/state_defs.h file and they can be discovered at
       runtime using |:map-commands| and "maplist()". Example: >vim
-      	omap xyzzy <Nop>
-      	let op_bit = maplist()->filter(
-      	    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
-      	ounmap xyzzy
-      	echo printf("Operator-pending mode bit: 0x%x", op_bit)
+              omap xyzzy <Nop>
+              let op_bit = maplist()->filter(
+                  \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
+              ounmap xyzzy
+              echo printf("Operator-pending mode bit: 0x%x", op_bit)
     ]],
     name = 'maplist',
     params = {},
@@ -6331,10 +6331,10 @@ M.funcs = {
       {mode} is used to define the mode in which the mapping is set,
       not the "mode" entry in {dict}.
       Example for saving and restoring a mapping: >vim
-      	let save_map = maparg('K', 'n', 0, 1)
-      	nnoremap K somethingelse
-      	" ...
-      	call mapset('n', 0, save_map)
+              let save_map = maparg('K', 'n', 0, 1)
+              nnoremap K somethingelse
+              " ...
+              call mapset('n', 0, save_map)
       <Note that if you are going to replace a map in several modes,
       e.g. with `:map!`, you need to save/restore the mapping for
       all of them, when they might differ.
@@ -6342,15 +6342,15 @@ M.funcs = {
       In the second form, with {dict} as the only argument, mode
       and abbr are taken from the dict.
       Example: >vim
-      	let save_maps = maplist()->filter(
-      				\ {_, m -> m.lhs == 'K'})
-      	nnoremap K somethingelse
-      	cnoremap K somethingelse2
-      	" ...
-      	unmap K
-      	for d in save_maps
-      	    call mapset(d)
-      	endfor
+              let save_maps = maplist()->filter(
+                                      \ {_, m -> m.lhs == 'K'})
+              nnoremap K somethingelse
+              cnoremap K somethingelse2
+              " ...
+              unmap K
+              for d in save_maps
+                  call mapset(d)
+              endfor
     ]=],
     name = 'mapset',
     params = { { 'mode', 'string' }, { 'abbr', 'any' }, { 'dict', 'any' } },
@@ -6373,26 +6373,26 @@ M.funcs = {
 
       For getting submatches see |matchlist()|.
       Example: >vim
-      	echo match("testing", "ing")	" results in 4
-      	echo match([1, 'x'], '\a')	" results in 1
+              echo match("testing", "ing")    " results in 4
+              echo match([1, 'x'], '\a')      " results in 1
       <See |string-match| for how {pat} is used.
-      						*strpbrk()*
+                                                      *strpbrk()*
       Vim doesn't have a strpbrk() function.  But you can do: >vim
-      	let sepidx = match(line, '[.,;: \t]')
-      <						*strcasestr()*
+              let sepidx = match(line, '[.,;: \t]')
+      <                                               *strcasestr()*
       Vim doesn't have a strcasestr() function.  But you can add
       "\c" to the pattern to ignore case: >vim
-      	let idx = match(haystack, '\cneedle')
+              let idx = match(haystack, '\cneedle')
       <
       If {start} is given, the search starts from byte index
       {start} in a String or item {start} in a |List|.
       The result, however, is still the index counted from the
       first character/item.  Example: >vim
-      	echo match("testing", "ing", 2)
+              echo match("testing", "ing", 2)
       <result is again "4". >vim
-      	echo match("testing", "ing", 4)
+              echo match("testing", "ing", 4)
       <result is again "4". >vim
-      	echo match("testing", "t", 2)
+              echo match("testing", "t", 2)
       <result is "3".
       For a String, if {start} > 0 then it is like the string starts
       {start} bytes later, thus "^" will match at {start}.  Except
@@ -6407,7 +6407,7 @@ M.funcs = {
       When {count} is given use the {count}th match.  When a match
       is found in a String the search for the next one starts one
       character further.  Thus this example results in 1: >vim
-      	echo match("testing", "..", 0, 2)
+              echo match("testing", "..", 0, 2)
       <In a |List| the search continues in the next item.
       Note that when {count} is added the way {start} works changes,
       see above.
@@ -6466,11 +6466,11 @@ M.funcs = {
       conceal character that will be shown for |hl-Conceal|
       highlighted matches. The dict can have the following members:
 
-      	conceal	    Special character to show instead of the
-      		    match (only for |hl-Conceal| highlighted
-      		    matches, see |:syn-cchar|)
-      	window	    Instead of the current window use the
-      		    window with this number or window ID.
+              conceal     Special character to show instead of the
+                          match (only for |hl-Conceal| highlighted
+                          matches, see |:syn-cchar|)
+              window      Instead of the current window use the
+                          window with this number or window ID.
 
       The number of matches is not limited, as it is the case with
       the |:match| commands.
@@ -6478,10 +6478,10 @@ M.funcs = {
       Returns -1 on error.
 
       Example: >vim
-      	highlight MyGroup ctermbg=green guibg=green
-      	let m = matchadd("MyGroup", "TODO")
+              highlight MyGroup ctermbg=green guibg=green
+              let m = matchadd("MyGroup", "TODO")
       <Deletion of the pattern: >vim
-      	call matchdelete(m)
+              call matchdelete(m)
 
       <A list of matches defined by |matchadd()| and |:match| are
       available from |getmatches()|.  All matches can be deleted in
@@ -6509,7 +6509,7 @@ M.funcs = {
       sets buffer line boundaries to redraw screen. It is supposed
       to be used when fast match additions and deletions are
       required, for example to highlight matching parentheses.
-      					*E5030* *E5031*
+                                              *E5030* *E5031*
       {pos} is a list of positions.  Each position can be one of
       these:
       - A number.  This whole line will be highlighted.  The first
@@ -6531,10 +6531,10 @@ M.funcs = {
       Returns -1 on error.
 
       Example: >vim
-      	highlight MyGroup ctermbg=green guibg=green
-      	let m = matchaddpos("MyGroup", [[23, 24], 34])
+              highlight MyGroup ctermbg=green guibg=green
+              let m = matchaddpos("MyGroup", [[23, 24], 34])
       <Deletion of the pattern: >vim
-      	call matchdelete(m)
+              call matchdelete(m)
 
       <Matches added by |matchaddpos()| are returned by
       |getmatches()|.
@@ -6557,8 +6557,8 @@ M.funcs = {
       Selects the {nr} match item, as set with a |:match|,
       |:2match| or |:3match| command.
       Return a |List| with two elements:
-      	The name of the highlight group used
-      	The pattern used.
+              The name of the highlight group used
+              The pattern used.
       When {nr} is not 1, 2 or 3 returns an empty |List|.
       When there is no match item set returns ['', ''].
       This is useful to save and restore a |:match|.
@@ -6593,19 +6593,19 @@ M.funcs = {
     desc = [=[
       Same as |match()|, but return the index of first character
       after the match.  Example: >vim
-      	echo matchend("testing", "ing")
+              echo matchend("testing", "ing")
       <results in "7".
-      					*strspn()* *strcspn()*
+                                              *strspn()* *strcspn()*
       Vim doesn't have a strspn() or strcspn() function, but you can
       do it with matchend(): >vim
-      	let span = matchend(line, '[a-zA-Z]')
-      	let span = matchend(line, '[^a-zA-Z]')
+              let span = matchend(line, '[a-zA-Z]')
+              let span = matchend(line, '[^a-zA-Z]')
       <Except that -1 is returned when there are no matches.
 
       The {start}, if given, has the same meaning as for |match()|. >vim
-      	echo matchend("testing", "ing", 2)
+              echo matchend("testing", "ing", 2)
       <results in "7". >vim
-      	echo matchend("testing", "ing", 5)
+              echo matchend("testing", "ing", 5)
       <result is "-1".
       When {expr} is a |List| the result is equal to |match()|.
 
@@ -6624,22 +6624,22 @@ M.funcs = {
 
       The optional {dict} argument always supports the following
       items:
-          matchseq	When this item is present return only matches
-      		that contain the characters in {str} in the
-      		given sequence.
-          limit	Maximum number of matches in {list} to be
-      		returned.  Zero means no limit.
+          matchseq    When this item is present return only matches
+                      that contain the characters in {str} in the
+                      given sequence.
+          limit       Maximum number of matches in {list} to be
+                      returned.  Zero means no limit.
 
       If {list} is a list of dictionaries, then the optional {dict}
       argument supports the following additional items:
-          key		Key of the item which is fuzzy matched against
-      		{str}. The value of this item should be a
-      		string.
-          text_cb	|Funcref| that will be called for every item
-      		in {list} to get the text for fuzzy matching.
-      		This should accept a dictionary item as the
-      		argument and return the text for that item to
-      		use for fuzzy matching.
+          key         Key of the item which is fuzzy matched against
+                      {str}. The value of this item should be a
+                      string.
+          text_cb     |Funcref| that will be called for every item
+                      in {list} to get the text for fuzzy matching.
+                      This should accept a dictionary item as the
+                      argument and return the text for that item to
+                      use for fuzzy matching.
 
       {str} is treated as a literal string and regular expression
       matching is NOT supported.  The maximum supported {str} length
@@ -6667,7 +6667,7 @@ M.funcs = {
       <results in a list of buffer information dicts with buffer
       names fuzzy matching "ndl". >vim
          echo getbufinfo()->matchfuzzy("spl",
-      				\ {'text_cb' : {v -> v.name}})
+                                      \ {'text_cb' : {v -> v.name}})
       <results in a list of buffer information dicts with buffer
       names fuzzy matching "spl". >vim
          echo v:oldfiles->matchfuzzy("test")
@@ -6677,7 +6677,7 @@ M.funcs = {
          echo ['one two', 'two one']->matchfuzzy('two one')
       <results in `['two one', 'one two']` . >vim
          echo ['one two', 'two one']->matchfuzzy('two one',
-      				\ {'matchseq': 1})
+                                      \ {'matchseq': 1})
       <results in `['two one']`.
     ]=],
     name = 'matchfuzzy',
@@ -6701,12 +6701,12 @@ M.funcs = {
       list with three empty list items is returned.
 
       Example: >vim
-      	echo matchfuzzypos(['testing'], 'tsg')
+              echo matchfuzzypos(['testing'], 'tsg')
       <results in [["testing"], [[0, 2, 6]], [99]] >vim
-      	echo matchfuzzypos(['clay', 'lacy'], 'la')
+              echo matchfuzzypos(['clay', 'lacy'], 'la')
       <results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >vim
-      	echo [{'text': 'hello', 'id' : 10}]
-      		\ ->matchfuzzypos('ll', {'key' : 'text'})
+              echo [{'text': 'hello', 'id' : 10}]
+                      \ ->matchfuzzypos('ll', {'key' : 'text'})
       <results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
     ]=],
     name = 'matchfuzzypos',
@@ -6722,7 +6722,7 @@ M.funcs = {
       return.  Following items are submatches, like "\1", "\2", etc.
       in |:substitute|.  When an optional submatch didn't match an
       empty string is used.  Example: >vim
-      	echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
+              echo matchlist('acd', '\(a\)\?\(b\)\?\(c\)\?\(.*\)')
       <Results in: ['acd', 'a', '', 'c', 'd', '', '', '', '', '']
       When there is no match an empty list is returned.
 
@@ -6738,13 +6738,13 @@ M.funcs = {
     base = 1,
     desc = [=[
       Same as |match()|, but return the matched string.  Example: >vim
-      	echo matchstr("testing", "ing")
+              echo matchstr("testing", "ing")
       <results in "ing".
       When there is no match "" is returned.
       The {start}, if given, has the same meaning as for |match()|. >vim
-      	echo matchstr("testing", "ing", 2)
+              echo matchstr("testing", "ing", 2)
       <results in "ing". >vim
-      	echo matchstr("testing", "ing", 5)
+              echo matchstr("testing", "ing", 5)
       <result is "".
       When {expr} is a |List| then the matching item is returned.
       The type isn't changed, it's not necessarily a String.
@@ -6760,18 +6760,18 @@ M.funcs = {
     desc = [=[
       Same as |matchstr()|, but return the matched string, the start
       position and the end position of the match.  Example: >vim
-      	echo matchstrpos("testing", "ing")
+              echo matchstrpos("testing", "ing")
       <results in ["ing", 4, 7].
       When there is no match ["", -1, -1] is returned.
       The {start}, if given, has the same meaning as for |match()|. >vim
-      	echo matchstrpos("testing", "ing", 2)
+              echo matchstrpos("testing", "ing", 2)
       <results in ["ing", 4, 7]. >vim
-      	echo matchstrpos("testing", "ing", 5)
+              echo matchstrpos("testing", "ing", 5)
       <result is ["", -1, -1].
       When {expr} is a |List| then the matching item, the index
       of first item where {pat} matches, the start position and the
       end position of the match are returned. >vim
-      	echo matchstrpos([1, '__x'], '\a')
+              echo matchstrpos([1, '__x'], '\a')
       <result is ["x", 1, 2, 3].
       The type isn't changed, it's not necessarily a String.
 
@@ -6785,7 +6785,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return the maximum value of all items in {expr}. Example: >vim
-      	echo max([apples, pears, oranges])
+              echo max([apples, pears, oranges])
 
       <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
       it returns the maximum of all values in the Dictionary.
@@ -6806,44 +6806,44 @@ M.funcs = {
 
       {path} matches a menu by name, or all menus if {path} is an
       empty string.  Example: >vim
-      	echo menu_get('File','')
-      	echo menu_get('')
+              echo menu_get('File','')
+              echo menu_get('')
       <
       {modes} is a string of zero or more modes (see |maparg()| or
       |creating-menus| for the list of modes). "a" means "all".
 
       Example: >vim
-      	nnoremenu &Test.Test inormal
-      	inoremenu Test.Test insert
-      	vnoremenu Test.Test x
-      	echo menu_get("")
+              nnoremenu &Test.Test inormal
+              inoremenu Test.Test insert
+              vnoremenu Test.Test x
+              echo menu_get("")
 
       <returns something like this: >
 
-      	[ {
-      	  "hidden": 0,
-      	  "name": "Test",
-      	  "priority": 500,
-      	  "shortcut": 84,
-      	  "submenus": [ {
-      	    "hidden": 0,
-      	    "mappings": {
-      	      i": {
-      		"enabled": 1,
-      		"noremap": 1,
-      		"rhs": "insert",
-      		"sid": 1,
-      		"silent": 0
-      	      },
-      	      n": { ... },
-      	      s": { ... },
-      	      v": { ... }
-      	    },
-      	    "name": "Test",
-      	    "priority": 500,
-      	    "shortcut": 0
-      	  } ]
-      	} ]
+              [ {
+                "hidden": 0,
+                "name": "Test",
+                "priority": 500,
+                "shortcut": 84,
+                "submenus": [ {
+                  "hidden": 0,
+                  "mappings": {
+                    i": {
+                      "enabled": 1,
+                      "noremap": 1,
+                      "rhs": "insert",
+                      "sid": 1,
+                      "silent": 0
+                    },
+                    n": { ... },
+                    s": { ... },
+                    v": { ... }
+                  },
+                  "name": "Test",
+                  "priority": 500,
+                  "shortcut": 0
+                } ]
+              } ]
       <
     ]=],
     name = 'menu_get',
@@ -6860,68 +6860,68 @@ M.funcs = {
       menu names are returned.
 
       {mode} can be one of these strings:
-      	"n"	Normal
-      	"v"	Visual (including Select)
-      	"o"	Operator-pending
-      	"i"	Insert
-      	"c"	Cmd-line
-      	"s"	Select
-      	"x"	Visual
-      	"t"	Terminal-Job
-      	""	Normal, Visual and Operator-pending
-      	"!"	Insert and Cmd-line
+              "n"     Normal
+              "v"     Visual (including Select)
+              "o"     Operator-pending
+              "i"     Insert
+              "c"     Cmd-line
+              "s"     Select
+              "x"     Visual
+              "t"     Terminal-Job
+              ""      Normal, Visual and Operator-pending
+              "!"     Insert and Cmd-line
       When {mode} is omitted, the modes for "" are used.
 
       Returns a |Dictionary| containing the following items:
-        accel		menu item accelerator text |menu-text|
-        display	display name (name without '&')
-        enabled	v:true if this menu item is enabled
-      		Refer to |:menu-enable|
-        icon		name of the icon file (for toolbar)
-      		|toolbar-icon|
-        iconidx	index of a built-in icon
-        modes		modes for which the menu is defined. In
-      		addition to the modes mentioned above, these
-      		characters will be used:
-      		" "	Normal, Visual and Operator-pending
-        name		menu item name.
-        noremenu	v:true if the {rhs} of the menu item is not
-      		remappable else v:false.
-        priority	menu order priority |menu-priority|
-        rhs		right-hand-side of the menu item. The returned
-      		string has special characters translated like
-      		in the output of the ":menu" command listing.
-      		When the {rhs} of a menu item is empty, then
-      		"<Nop>" is returned.
-        script	v:true if script-local remapping of {rhs} is
-      		allowed else v:false.  See |:menu-script|.
-        shortcut	shortcut key (character after '&' in
-      		the menu name) |menu-shortcut|
-        silent	v:true if the menu item is created
-      		with <silent> argument |:menu-silent|
-        submenus	|List| containing the names of
-      		all the submenus.  Present only if the menu
-      		item has submenus.
+        accel         menu item accelerator text |menu-text|
+        display       display name (name without '&')
+        enabled       v:true if this menu item is enabled
+                      Refer to |:menu-enable|
+        icon          name of the icon file (for toolbar)
+                      |toolbar-icon|
+        iconidx       index of a built-in icon
+        modes         modes for which the menu is defined. In
+                      addition to the modes mentioned above, these
+                      characters will be used:
+                      " "     Normal, Visual and Operator-pending
+        name          menu item name.
+        noremenu      v:true if the {rhs} of the menu item is not
+                      remappable else v:false.
+        priority      menu order priority |menu-priority|
+        rhs           right-hand-side of the menu item. The returned
+                      string has special characters translated like
+                      in the output of the ":menu" command listing.
+                      When the {rhs} of a menu item is empty, then
+                      "<Nop>" is returned.
+        script        v:true if script-local remapping of {rhs} is
+                      allowed else v:false.  See |:menu-script|.
+        shortcut      shortcut key (character after '&' in
+                      the menu name) |menu-shortcut|
+        silent        v:true if the menu item is created
+                      with <silent> argument |:menu-silent|
+        submenus      |List| containing the names of
+                      all the submenus.  Present only if the menu
+                      item has submenus.
 
       Returns an empty dictionary if the menu item is not found.
 
       Examples: >vim
-      	echo menu_info('Edit.Cut')
-      	echo menu_info('File.Save', 'n')
+              echo menu_info('Edit.Cut')
+              echo menu_info('File.Save', 'n')
 
-      	" Display the entire menu hierarchy in a buffer
-      	func ShowMenu(name, pfx)
-      	  let m = menu_info(a:name)
-      	  call append(line('$'), a:pfx .. m.display)
-      	  for child in m->get('submenus', [])
-      	    call ShowMenu(a:name .. '.' .. escape(child, '.'),
-      					\ a:pfx .. '    ')
-      	  endfor
-      	endfunc
-      	new
-      	for topmenu in menu_info('').submenus
-      	  call ShowMenu(topmenu, '')
-      	endfor
+              " Display the entire menu hierarchy in a buffer
+              func ShowMenu(name, pfx)
+                let m = menu_info(a:name)
+                call append(line('$'), a:pfx .. m.display)
+                for child in m->get('submenus', [])
+                  call ShowMenu(a:name .. '.' .. escape(child, '.'),
+                                              \ a:pfx .. '    ')
+                endfor
+              endfunc
+              new
+              for topmenu in menu_info('').submenus
+                call ShowMenu(topmenu, '')
+              endfor
       <
     ]=],
     name = 'menu_info',
@@ -6933,7 +6933,7 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return the minimum value of all items in {expr}. Example: >vim
-      	echo min([apples, pears, oranges])
+              echo min([apples, pears, oranges])
 
       <{expr} can be a |List| or a |Dictionary|.  For a Dictionary,
       it returns the minimum of all values in the Dictionary.
@@ -6960,19 +6960,19 @@ M.funcs = {
 
       If {flags} contains "D" then {name} is deleted at the end of
       the current function, as with: >vim
-      	defer delete({name}, 'd')
+              defer delete({name}, 'd')
       <
       If {flags} contains "R" then {name} is deleted recursively at
       the end of the current function, as with: >vim
-      	defer delete({name}, 'rf')
+              defer delete({name}, 'rf')
       <Note that when {name} has more than one part and "p" is used
       some directories may already exist.  Only the first one that
       is created and what it contains is scheduled to be deleted.
       E.g. when using: >vim
-      	call mkdir('subdir/tmp/autoload', 'pR')
+              call mkdir('subdir/tmp/autoload', 'pR')
       <and "subdir" already exists then "subdir/tmp" will be
       scheduled for deletion, like with: >vim
-      	defer delete('subdir/tmp', 'rf')
+              defer delete('subdir/tmp', 'rf')
       <
       If {prot} is given it is used to set the protection bits of
       the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
@@ -6981,7 +6981,7 @@ M.funcs = {
 
       {prot} is applied for all parts of {name}.  Thus if you create
       /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
-      	call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
+              call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
       <This function is not available in the |sandbox|.
 
@@ -7008,45 +7008,45 @@ M.funcs = {
       returned, otherwise only the first letter is returned.
       Also see |state()|.
 
-         n	    Normal
-         no	    Operator-pending
-         nov	    Operator-pending (forced charwise |o_v|)
-         noV	    Operator-pending (forced linewise |o_V|)
+         n        Normal
+         no       Operator-pending
+         nov      Operator-pending (forced charwise |o_v|)
+         noV      Operator-pending (forced linewise |o_V|)
          noCTRL-V Operator-pending (forced blockwise |o_CTRL-V|)
-      		CTRL-V is one character
-         niI	    Normal using |i_CTRL-O| in |Insert-mode|
-         niR	    Normal using |i_CTRL-O| in |Replace-mode|
-         niV	    Normal using |i_CTRL-O| in |Virtual-Replace-mode|
-         nt	    Normal in |terminal-emulator| (insert goes to
-      		Terminal mode)
-         ntT	    Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
-         v	    Visual by character
-         vs	    Visual by character using |v_CTRL-O| in Select mode
-         V	    Visual by line
-         Vs	    Visual by line using |v_CTRL-O| in Select mode
+                      CTRL-V is one character
+         niI      Normal using |i_CTRL-O| in |Insert-mode|
+         niR      Normal using |i_CTRL-O| in |Replace-mode|
+         niV      Normal using |i_CTRL-O| in |Virtual-Replace-mode|
+         nt       Normal in |terminal-emulator| (insert goes to
+                      Terminal mode)
+         ntT      Normal using |t_CTRL-\_CTRL-O| in |Terminal-mode|
+         v        Visual by character
+         vs       Visual by character using |v_CTRL-O| in Select mode
+         V        Visual by line
+         Vs       Visual by line using |v_CTRL-O| in Select mode
          CTRL-V   Visual blockwise
          CTRL-Vs  Visual blockwise using |v_CTRL-O| in Select mode
-         s	    Select by character
-         S	    Select by line
+         s        Select by character
+         S        Select by line
          CTRL-S   Select blockwise
-         i	    Insert
-         ic	    Insert mode completion |compl-generic|
-         ix	    Insert mode |i_CTRL-X| completion
-         R	    Replace |R|
-         Rc	    Replace mode completion |compl-generic|
-         Rx	    Replace mode |i_CTRL-X| completion
-         Rv	    Virtual Replace |gR|
-         Rvc	    Virtual Replace mode completion |compl-generic|
-         Rvx	    Virtual Replace mode |i_CTRL-X| completion
-         c	    Command-line editing
-         cr	    Command-line editing overstrike mode |c_<Insert>|
-         cv	    Vim Ex mode |gQ|
-         cvr	    Vim Ex mode while in overstrike mode |c_<Insert>|
-         r	    Hit-enter prompt
-         rm	    The -- more -- prompt
-         r?	    A |:confirm| query of some sort
-         !	    Shell or external command is executing
-         t	    Terminal mode: keys go to the job
+         i        Insert
+         ic       Insert mode completion |compl-generic|
+         ix       Insert mode |i_CTRL-X| completion
+         R        Replace |R|
+         Rc       Replace mode completion |compl-generic|
+         Rx       Replace mode |i_CTRL-X| completion
+         Rv       Virtual Replace |gR|
+         Rvc      Virtual Replace mode completion |compl-generic|
+         Rvx      Virtual Replace mode |i_CTRL-X| completion
+         c        Command-line editing
+         cr       Command-line editing overstrike mode |c_<Insert>|
+         cv       Vim Ex mode |gQ|
+         cvr      Vim Ex mode while in overstrike mode |c_<Insert>|
+         r        Hit-enter prompt
+         rm       The -- more -- prompt
+         r?       A |:confirm| query of some sort
+         !        Shell or external command is executing
+         t        Terminal mode: keys go to the job
 
       This is useful in the 'statusline' option or RPC calls. In
       most other places it always returns "c" or "n".
@@ -7066,15 +7066,15 @@ M.funcs = {
       Convert a list of Vimscript objects to msgpack. Returned value is a
       |readfile()|-style list. When {type} contains "B", a |Blob| is
       returned instead. Example: >vim
-      	call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
+              call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
       <or, using a |Blob|: >vim
-      	call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
+              call writefile(msgpackdump([{}], 'B'), 'fname.mpack')
       <
       This will write the single 0x80 byte to a `fname.mpack` file
       (dictionary with zero items is represented by 0x80 byte in
       messagepack).
 
-      Limitations:				*E5004* *E5005*
+      Limitations:                            *E5004* *E5005*
       1. |Funcref|s cannot be dumped.
       2. Containers that reference themselves cannot be dumped.
       3. Dictionary keys are always dumped as STR strings.
@@ -7091,9 +7091,9 @@ M.funcs = {
       Convert a |readfile()|-style list or a |Blob| to a list of
       Vimscript objects.
       Example: >vim
-      	let fname = expand('~/.config/nvim/shada/main.shada')
-      	let mpack = readfile(fname, 'b')
-      	let shada_objects = msgpackparse(mpack)
+              let fname = expand('~/.config/nvim/shada/main.shada')
+              let mpack = readfile(fname, 'b')
+              let shada_objects = msgpackparse(mpack)
       <This will read ~/.config/nvim/shada/main.shada file to
       `shada_objects` list.
 
@@ -7105,7 +7105,7 @@ M.funcs = {
          (except for 1.) some strings are parsed to
          |msgpack-special-dict| format which is not convenient to
          use.
-      					*msgpack-special-dict*
+                                              *msgpack-special-dict*
       Some messagepack strings may be parsed to special
       dictionaries. Special dictionaries are dictionaries which
 
@@ -7115,50 +7115,50 @@ M.funcs = {
       3. Value for `_VAL` has the following format (Key column
          contains name of the key from |v:msgpack_types|):
 
-      Key	Value ~
-      nil	Zero, ignored when dumping.  Not returned by
-      	|msgpackparse()| since |v:null| was introduced.
-      boolean	One or zero.  When dumping it is only checked that
-      	value is a |Number|.  Not returned by |msgpackparse()|
-      	since |v:true| and |v:false| were introduced.
-      integer	|List| with four numbers: sign (-1 or 1), highest two
-      	bits, number with bits from 62nd to 31st, lowest 31
-      	bits. I.e. to get actual number one will need to use
-      	code like >
-      		_VAL[0] * ((_VAL[1] << 62)
-      		           & (_VAL[2] << 31)
-      		           & _VAL[3])
-      <	Special dictionary with this type will appear in
-      	|msgpackparse()| output under one of the following
-      	circumstances:
-      	1. |Number| is 32-bit and value is either above
-      	   INT32_MAX or below INT32_MIN.
-      	2. |Number| is 64-bit and value is above INT64_MAX. It
-      	   cannot possibly be below INT64_MIN because msgpack
-      	   C parser does not support such values.
-      float	|Float|. This value cannot possibly appear in
-      	|msgpackparse()| output.
-      string	|readfile()|-style list of strings. This value will
-      	appear in |msgpackparse()| output if string contains
-      	zero byte or if string is a mapping key and mapping is
-      	being represented as special dictionary for other
-      	reasons.
-      binary	|String|, or |Blob| if binary string contains zero
-      	byte. This value cannot appear in |msgpackparse()|
-      	output since blobs were introduced.
-      array	|List|. This value cannot appear in |msgpackparse()|
-      	output.
-      					*msgpack-special-map*
-      map	|List| of |List|s with two items (key and value) each.
-      	This value will appear in |msgpackparse()| output if
-      	parsed mapping contains one of the following keys:
-      	1. Any key that is not a string (including keys which
-      	   are binary strings).
-      	2. String with NUL byte inside.
-      	3. Duplicate key.
-      ext	|List| with two values: first is a signed integer
-      	representing extension type. Second is
-      	|readfile()|-style list of strings.
+      Key     Value ~
+      nil     Zero, ignored when dumping.  Not returned by
+              |msgpackparse()| since |v:null| was introduced.
+      boolean One or zero.  When dumping it is only checked that
+              value is a |Number|.  Not returned by |msgpackparse()|
+              since |v:true| and |v:false| were introduced.
+      integer |List| with four numbers: sign (-1 or 1), highest two
+              bits, number with bits from 62nd to 31st, lowest 31
+              bits. I.e. to get actual number one will need to use
+              code like >
+                      _VAL[0] * ((_VAL[1] << 62)
+                                 & (_VAL[2] << 31)
+                                 & _VAL[3])
+      <       Special dictionary with this type will appear in
+              |msgpackparse()| output under one of the following
+              circumstances:
+              1. |Number| is 32-bit and value is either above
+                 INT32_MAX or below INT32_MIN.
+              2. |Number| is 64-bit and value is above INT64_MAX. It
+                 cannot possibly be below INT64_MIN because msgpack
+                 C parser does not support such values.
+      float   |Float|. This value cannot possibly appear in
+              |msgpackparse()| output.
+      string  |readfile()|-style list of strings. This value will
+              appear in |msgpackparse()| output if string contains
+              zero byte or if string is a mapping key and mapping is
+              being represented as special dictionary for other
+              reasons.
+      binary  |String|, or |Blob| if binary string contains zero
+              byte. This value cannot appear in |msgpackparse()|
+              output since blobs were introduced.
+      array   |List|. This value cannot appear in |msgpackparse()|
+              output.
+                                              *msgpack-special-map*
+      map     |List| of |List|s with two items (key and value) each.
+              This value will appear in |msgpackparse()| output if
+              parsed mapping contains one of the following keys:
+              1. Any key that is not a string (including keys which
+                 are binary strings).
+              2. String with NUL byte inside.
+              3. Duplicate key.
+      ext     |List| with two values: first is a signed integer
+              representing extension type. Second is
+              |readfile()|-style list of strings.
     ]=],
     name = 'msgpackparse',
     params = { { 'data', 'any' } },
@@ -7170,7 +7170,7 @@ M.funcs = {
     desc = [=[
       Return the line number of the first line at or below {lnum}
       that is not blank.  Example: >vim
-      	if getline(nextnonblank(1)) =~ "Java" | endif
+              if getline(nextnonblank(1)) =~ "Java" | endif
       <When {lnum} is invalid or there is no non-blank line at or
       below it, zero is returned.
       {lnum} is used like with |getline()|.
@@ -7187,10 +7187,10 @@ M.funcs = {
     desc = [=[
       Return a string with a single character, which has the number
       value {expr}.  Examples: >vim
-      	echo nr2char(64)		" returns '@'
-      	echo nr2char(32)		" returns ' '
+              echo nr2char(64)                " returns '@'
+              echo nr2char(32)                " returns ' '
       <Example for "utf-8": >vim
-      	echo nr2char(300)		" returns I with bow character
+              echo nr2char(300)               " returns I with bow character
       <
       UTF-8 encoding is always used, {utf8} option has no effect,
       and exists only for backwards-compatibility.
@@ -7232,7 +7232,7 @@ M.funcs = {
       to a number.  A List, Dict or Float argument causes an error.
       Also see `and()` and `xor()`.
       Example: >vim
-      	let bits = or(bits, 0x80)
+              let bits = or(bits, 0x80)
 
       <Rationale: The reason this is a function and not using the "|"
       character like many languages, is that Vi has always used "|"
@@ -7252,11 +7252,11 @@ M.funcs = {
       components in the path are reduced to {len} letters in length.
       If {len} is omitted or smaller than 1 then 1 is used (single
       letters).  Leading '~' and '.' characters are kept.  Examples: >vim
-      	echo pathshorten('~/.config/nvim/autoload/file1.vim')
-      <	~/.c/n/a/file1.vim ~
+              echo pathshorten('~/.config/nvim/autoload/file1.vim')
+      <       ~/.c/n/a/file1.vim ~
       >vim
-      	echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
-      <	~/.co/nv/au/file2.vim ~
+              echo pathshorten('~/.config/nvim/autoload/file2.vim', 2)
+      <       ~/.co/nv/au/file2.vim ~
       It doesn't matter if the path exists or not.
       Returns an empty string on error.
 
@@ -7280,8 +7280,8 @@ M.funcs = {
       Note: If you want an array or hash, {expr} must return a
       reference to it.
       Example: >vim
-      	echo perleval('[1 .. 4]')
-      <	[1, 2, 3, 4]
+              echo perleval('[1 .. 4]')
+      <       [1, 2, 3, 4]
 
     ]=],
     name = 'perleval',
@@ -7296,12 +7296,12 @@ M.funcs = {
       {x} and {y} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {x} or {y} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo pow(3, 3)
-      <	27.0 >vim
-      	echo pow(2, 16)
-      <	65536.0 >vim
-      	echo pow(32, 0.20)
-      <	2.0
+              echo pow(3, 3)
+      <        27.0 >vim
+              echo pow(2, 16)
+      <        65536.0 >vim
+              echo pow(32, 0.20)
+      <        2.0
 
     ]=],
     name = 'pow',
@@ -7314,7 +7314,7 @@ M.funcs = {
     desc = [=[
       Return the line number of the first line at or above {lnum}
       that is not blank.  Example: >vim
-      	let ind = indent(prevnonblank(v:lnum - 1))
+              let ind = indent(prevnonblank(v:lnum - 1))
       <When {lnum} is invalid or there is no non-blank line at or
       above it, zero is returned.
       {lnum} is used like with |getline()|.
@@ -7331,39 +7331,39 @@ M.funcs = {
     desc = [=[
       Return a String with {fmt}, where "%" items are replaced by
       the formatted form of their respective arguments.  Example: >vim
-      	echo printf("%4d: E%d %.30s", lnum, errno, msg)
+              echo printf("%4d: E%d %.30s", lnum, errno, msg)
       <May result in:
-      	"  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
+              "  99: E42 asdfasdfasdfasdfasdfasdfasdfas" ~
 
       When used as a |method| the base is passed as the second
       argument: >vim
-      	Compute()->printf("result: %d")
+              Compute()->printf("result: %d")
       <
       You can use `call()` to pass the items as a list.
 
       Often used items are:
-        %s	string
-        %6S	string right-aligned in 6 display cells
-        %6s	string right-aligned in 6 bytes
-        %.9s	string truncated to 9 bytes
-        %c	single byte
-        %d	decimal number
-        %5d	decimal number padded with spaces to 5 characters
-        %b	binary number
-        %08b	binary number padded with zeros to at least 8 characters
-        %B	binary number using upper case letters
-        %x	hex number
-        %04x	hex number padded with zeros to at least 4 characters
-        %X	hex number using upper case letters
-        %o	octal number
-        %f	floating point number as 12.23, inf, -inf or nan
-        %F	floating point number as 12.23, INF, -INF or NAN
-        %e	floating point number as 1.23e3, inf, -inf or nan
-        %E	floating point number as 1.23E3, INF, -INF or NAN
-        %g	floating point number, as %f or %e depending on value
-        %G	floating point number, as %F or %E depending on value
-        %%	the % character itself
-        %p	representation of the pointer to the container
+        %s    string
+        %6S   string right-aligned in 6 display cells
+        %6s   string right-aligned in 6 bytes
+        %.9s  string truncated to 9 bytes
+        %c    single byte
+        %d    decimal number
+        %5d   decimal number padded with spaces to 5 characters
+        %b    binary number
+        %08b  binary number padded with zeros to at least 8 characters
+        %B    binary number using upper case letters
+        %x    hex number
+        %04x  hex number padded with zeros to at least 4 characters
+        %X    hex number using upper case letters
+        %o    octal number
+        %f    floating point number as 12.23, inf, -inf or nan
+        %F    floating point number as 12.23, INF, -INF or NAN
+        %e    floating point number as 1.23e3, inf, -inf or nan
+        %E    floating point number as 1.23E3, INF, -INF or NAN
+        %g    floating point number, as %f or %e depending on value
+        %G    floating point number, as %F or %E depending on value
+        %%    the % character itself
+        %p    representation of the pointer to the container
 
       Conversion specifications start with '%' and end with the
       conversion type.  All other characters are copied unchanged to
@@ -7372,68 +7372,68 @@ M.funcs = {
       The "%" starts a conversion specification.  The following
       arguments appear in sequence:
 
-      	% [pos-argument] [flags] [field-width] [.precision] type
+              % [pos-argument] [flags] [field-width] [.precision] type
 
       pos-argument
-      	At most one positional argument specifier. These
-      	take the form {n$}, where n is >= 1.
+              At most one positional argument specifier. These
+              take the form {n$}, where n is >= 1.
 
       flags
-      	Zero or more of the following flags:
+              Zero or more of the following flags:
 
-          #	      The value should be converted to an "alternate
-      	      form".  For c, d, and s conversions, this option
-      	      has no effect.  For o conversions, the precision
-      	      of the number is increased to force the first
-      	      character of the output string to a zero (except
-      	      if a zero value is printed with an explicit
-      	      precision of zero).
-      	      For x and X conversions, a non-zero result has
-      	      the string "0x" (or "0X" for X conversions)
-      	      prepended to it.
+          #         The value should be converted to an "alternate
+                    form".  For c, d, and s conversions, this option
+                    has no effect.  For o conversions, the precision
+                    of the number is increased to force the first
+                    character of the output string to a zero (except
+                    if a zero value is printed with an explicit
+                    precision of zero).
+                    For x and X conversions, a non-zero result has
+                    the string "0x" (or "0X" for X conversions)
+                    prepended to it.
 
           0 (zero)  Zero padding.  For all conversions the converted
-      	      value is padded on the left with zeros rather
-      	      than blanks.  If a precision is given with a
-      	      numeric conversion (d, o, x, and X), the 0 flag
-      	      is ignored.
+                    value is padded on the left with zeros rather
+                    than blanks.  If a precision is given with a
+                    numeric conversion (d, o, x, and X), the 0 flag
+                    is ignored.
 
-          -	      A negative field width flag; the converted value
-      	      is to be left adjusted on the field boundary.
-      	      The converted value is padded on the right with
-      	      blanks, rather than on the left with blanks or
-      	      zeros.  A - overrides a 0 if both are given.
+          -         A negative field width flag; the converted value
+                    is to be left adjusted on the field boundary.
+                    The converted value is padded on the right with
+                    blanks, rather than on the left with blanks or
+                    zeros.  A - overrides a 0 if both are given.
 
           ' ' (space)  A blank should be left before a positive
-      	      number produced by a signed conversion (d).
+                    number produced by a signed conversion (d).
 
-          +	      A sign must always be placed before a number
-      	      produced by a signed conversion.  A + overrides
-      	      a space if both are used.
+          +         A sign must always be placed before a number
+                    produced by a signed conversion.  A + overrides
+                    a space if both are used.
 
       field-width
-      	An optional decimal digit string specifying a minimum
-      	field width.  If the converted value has fewer bytes
-      	than the field width, it will be padded with spaces on
-      	the left (or right, if the left-adjustment flag has
-      	been given) to fill out the field width.  For the S
-      	conversion the count is in cells.
+              An optional decimal digit string specifying a minimum
+              field width.  If the converted value has fewer bytes
+              than the field width, it will be padded with spaces on
+              the left (or right, if the left-adjustment flag has
+              been given) to fill out the field width.  For the S
+              conversion the count is in cells.
 
       .precision
-      	An optional precision, in the form of a period '.'
-      	followed by an optional digit string.  If the digit
-      	string is omitted, the precision is taken as zero.
-      	This gives the minimum number of digits to appear for
-      	d, o, x, and X conversions, the maximum number of
-      	bytes to be printed from a string for s conversions,
-      	or the maximum number of cells to be printed from a
-      	string for S conversions.
-      	For floating point it is the number of digits after
-      	the decimal point.
+              An optional precision, in the form of a period '.'
+              followed by an optional digit string.  If the digit
+              string is omitted, the precision is taken as zero.
+              This gives the minimum number of digits to appear for
+              d, o, x, and X conversions, the maximum number of
+              bytes to be printed from a string for s conversions,
+              or the maximum number of cells to be printed from a
+              string for S conversions.
+              For floating point it is the number of digits after
+              the decimal point.
 
       type
-      	A character that specifies the type of conversion to
-      	be applied, see below.
+              A character that specifies the type of conversion to
+              be applied, see below.
 
       A field width or precision, or both, may be indicated by an
       asterisk "*" instead of a digit string.  In this case, a
@@ -7441,7 +7441,7 @@ M.funcs = {
       negative field width is treated as a left adjustment flag
       followed by a positive field width; a negative precision is
       treated as though it were missing.  Example: >vim
-      	echo printf("%d: %.*s", nr, width, line)
+              echo printf("%d: %.*s", nr, width, line)
       <This limits the length of the text used from "line" to
       "width" bytes.
 
@@ -7453,84 +7453,84 @@ M.funcs = {
 
       The conversion specifiers and their meanings are:
 
-      		*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
-      dbBoxX	The Number argument is converted to signed decimal (d),
-      	unsigned binary (b and B), unsigned octal (o), or
-      	unsigned hexadecimal (x and X) notation.  The letters
-      	"abcdef" are used for x conversions; the letters
-      	"ABCDEF" are used for X conversions.  The precision, if
-      	any, gives the minimum number of digits that must
-      	appear; if the converted value requires fewer digits, it
-      	is padded on the left with zeros.  In no case does a
-      	non-existent or small field width cause truncation of a
-      	numeric field; if the result of a conversion is wider
-      	than the field width, the field is expanded to contain
-      	the conversion result.
-      	The 'h' modifier indicates the argument is 16 bits.
-      	The 'l' modifier indicates the argument is a long
-      	integer.  The size will be 32 bits or 64 bits
-      	depending on your platform.
-      	The "ll" modifier indicates the argument is 64 bits.
-      	The b and B conversion specifiers never take a width
-      	modifier and always assume their argument is a 64 bit
-      	integer.
-      	Generally, these modifiers are not useful. They are
-      	ignored when type is known from the argument.
+                      *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
+      dbBoxX  The Number argument is converted to signed decimal (d),
+              unsigned binary (b and B), unsigned octal (o), or
+              unsigned hexadecimal (x and X) notation.  The letters
+              "abcdef" are used for x conversions; the letters
+              "ABCDEF" are used for X conversions.  The precision, if
+              any, gives the minimum number of digits that must
+              appear; if the converted value requires fewer digits, it
+              is padded on the left with zeros.  In no case does a
+              non-existent or small field width cause truncation of a
+              numeric field; if the result of a conversion is wider
+              than the field width, the field is expanded to contain
+              the conversion result.
+              The 'h' modifier indicates the argument is 16 bits.
+              The 'l' modifier indicates the argument is a long
+              integer.  The size will be 32 bits or 64 bits
+              depending on your platform.
+              The "ll" modifier indicates the argument is 64 bits.
+              The b and B conversion specifiers never take a width
+              modifier and always assume their argument is a 64 bit
+              integer.
+              Generally, these modifiers are not useful. They are
+              ignored when type is known from the argument.
 
-      i	alias for d
-      D	alias for ld
-      U	alias for lu
-      O	alias for lo
+      i       alias for d
+      D       alias for ld
+      U       alias for lu
+      O       alias for lo
 
-      					*printf-c*
-      c	The Number argument is converted to a byte, and the
-      	resulting character is written.
+                                              *printf-c*
+      c       The Number argument is converted to a byte, and the
+              resulting character is written.
 
-      					*printf-s*
-      s	The text of the String argument is used.  If a
-      	precision is specified, no more bytes than the number
-      	specified are used.
-      	If the argument is not a String type, it is
-      	automatically converted to text with the same format
-      	as ":echo".
-      					*printf-S*
-      S	The text of the String argument is used.  If a
-      	precision is specified, no more display cells than the
-      	number specified are used.
+                                              *printf-s*
+      s       The text of the String argument is used.  If a
+              precision is specified, no more bytes than the number
+              specified are used.
+              If the argument is not a String type, it is
+              automatically converted to text with the same format
+              as ":echo".
+                                              *printf-S*
+      S       The text of the String argument is used.  If a
+              precision is specified, no more display cells than the
+              number specified are used.
 
-      					*printf-f* *E807*
-      f F	The Float argument is converted into a string of the
-      	form 123.456.  The precision specifies the number of
-      	digits after the decimal point.  When the precision is
-      	zero the decimal point is omitted.  When the precision
-      	is not specified 6 is used.  A really big number
-      	(out of range or dividing by zero) results in "inf"
-      	 or "-inf" with %f (INF or -INF with %F).
-      	 "0.0 / 0.0" results in "nan" with %f (NAN with %F).
-      	Example: >vim
-      		echo printf("%.2f", 12.115)
-      <		12.12
-      	Note that roundoff depends on the system libraries.
-      	Use |round()| when in doubt.
+                                              *printf-f* *E807*
+      f F     The Float argument is converted into a string of the
+              form 123.456.  The precision specifies the number of
+              digits after the decimal point.  When the precision is
+              zero the decimal point is omitted.  When the precision
+              is not specified 6 is used.  A really big number
+              (out of range or dividing by zero) results in "inf"
+               or "-inf" with %f (INF or -INF with %F).
+               "0.0 / 0.0" results in "nan" with %f (NAN with %F).
+              Example: >vim
+                      echo printf("%.2f", 12.115)
+      <               12.12
+              Note that roundoff depends on the system libraries.
+              Use |round()| when in doubt.
 
-      					*printf-e* *printf-E*
-      e E	The Float argument is converted into a string of the
-      	form 1.234e+03 or 1.234E+03 when using 'E'.  The
-      	precision specifies the number of digits after the
-      	decimal point, like with 'f'.
+                                              *printf-e* *printf-E*
+      e E     The Float argument is converted into a string of the
+              form 1.234e+03 or 1.234E+03 when using 'E'.  The
+              precision specifies the number of digits after the
+              decimal point, like with 'f'.
 
-      					*printf-g* *printf-G*
-      g G	The Float argument is converted like with 'f' if the
-      	value is between 0.001 (inclusive) and 10000000.0
-      	(exclusive).  Otherwise 'e' is used for 'g' and 'E'
-      	for 'G'.  When no precision is specified superfluous
-      	zeroes and '+' signs are removed, except for the zero
-      	immediately after the decimal point.  Thus 10000000.0
-      	results in 1.0e7.
+                                              *printf-g* *printf-G*
+      g G     The Float argument is converted like with 'f' if the
+              value is between 0.001 (inclusive) and 10000000.0
+              (exclusive).  Otherwise 'e' is used for 'g' and 'E'
+              for 'G'.  When no precision is specified superfluous
+              zeroes and '+' signs are removed, except for the zero
+              immediately after the decimal point.  Thus 10000000.0
+              results in 1.0e7.
 
-      					*printf-%*
-      %	A '%' is written.  No argument is converted.  The
-      	complete conversion specification is "%%".
+                                              *printf-%*
+      %       A '%' is written.  No argument is converted.  The
+              complete conversion specification is "%%".
 
       When a Number argument is expected a String argument is also
       accepted and automatically converted.
@@ -7538,12 +7538,12 @@ M.funcs = {
       is also accepted and automatically converted.
       Any other argument type results in an error message.
 
-      					*E766* *E767*
+                                              *E766* *E767*
       The number of {exprN} arguments must exactly match the number
       of "%" items.  If there are not sufficient or too many
       arguments an error is given.  Up to 18 arguments can be used.
 
-      					*printf-$*
+                                              *printf-$*
       In certain languages, error and informative messages are
       more readable when the order of words is different from the
       corresponding message in English. To accommodate translations
@@ -7558,13 +7558,13 @@ M.funcs = {
       reversed in the output. >vim
 
           echo printf(
-      	"In The Netherlands, vim's creator's name is: %1$s %2$s",
-      	"Bram", "Moolenaar")
+              "In The Netherlands, vim's creator's name is: %1$s %2$s",
+              "Bram", "Moolenaar")
       <    In The Netherlands, vim's creator's name is: Bram Moolenaar >vim
 
           echo printf(
-      	"In Belgium, vim's creator's name is: %2$s %1$s",
-      	"Bram", "Moolenaar")
+              "In Belgium, vim's creator's name is: %2$s %1$s",
+              "Bram", "Moolenaar")
       <    In Belgium, vim's creator's name is: Moolenaar Bram
 
       Width (and precision) can be specified using the '*' specifier.
@@ -7590,19 +7590,19 @@ M.funcs = {
           echo printf("%1$*2$.*3$f", 1.4142135, 6, 2)
       <      1.41
 
-      					*E1500*
+                                              *E1500*
       You cannot mix positional and non-positional arguments: >vim
           echo printf("%s%1$s", "One", "Two")
       <    E1500: Cannot mix positional and non-positional arguments:
           %s%1$s
 
-      					*E1501*
+                                              *E1501*
       You cannot skip a positional argument in a format string: >vim
           echo printf("%3$s%1$s", "One", "Two", "Three")
       <    E1501: format argument 2 unused in $-style format:
           %3$s%1$s
 
-      					*E1502*
+                                              *E1502*
       You can re-use a [field-width] (or [precision]) argument: >vim
           echo printf("%1$d at width %2$d is: %01$*2$d", 1, 2)
       <    1 at width 2 is: 01
@@ -7612,7 +7612,7 @@ M.funcs = {
       <    E1502: Positional argument 2 used as field width reused as
           different type: long int/int
 
-      					*E1503*
+                                              *E1503*
       When a positional argument is used, but not the correct number
       or arguments is given, an error is raised: >vim
           echo printf("%1$d at width %2$d is: %01$*2$.*3$d", 1, 2)
@@ -7624,7 +7624,7 @@ M.funcs = {
       <    E1503: Positional argument 3 out of bounds: %01$*2$.*3$d
           %4$d
 
-      					*E1504*
+                                              *E1504*
       A positional argument can be used more than once: >vim
           echo printf("%1$s %2$s %1$s", "One", "Two")
       <    One Two One
@@ -7634,14 +7634,14 @@ M.funcs = {
       <    E1504: Positional argument 1 type used inconsistently:
           int/string
 
-      					*E1505*
+                                              *E1505*
       Various other errors that lead to a format string being
       wrongly formatted lead to: >vim
           echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
       <    E1505: Invalid format specifier: %1$d at width %2$d is:
           %01$*2$.3$d
 
-      					*E1507*
+                                              *E1507*
       This internal error indicates that the logic to parse a
       positional format argument ran into a problem that couldn't be
       otherwise reported.  Please file a bug against Vim if you run
@@ -7733,7 +7733,7 @@ M.funcs = {
       {text} to end in a space.
       The result is only visible if {buf} has 'buftype' set to
       "prompt".  Example: >vim
-      	call prompt_setprompt(bufnr(''), 'command: ')
+              call prompt_setprompt(bufnr(''), 'command: ')
       <
     ]=],
     name = 'prompt_setprompt',
@@ -7745,12 +7745,12 @@ M.funcs = {
       If the popup menu (see |ins-completion-menu|) is not visible,
       returns an empty |Dictionary|, otherwise, returns a
       |Dictionary| with the following keys:
-      	height		nr of items visible
-      	width		screen cells
-      	row		top screen row (0 first row)
-      	col		leftmost screen column (0 first col)
-      	size		total nr of items
-      	scrollbar	|TRUE| if scrollbar is visible
+              height          nr of items visible
+              width           screen cells
+              row             top screen row (0 first row)
+              col             leftmost screen column (0 first col)
+              size            total nr of items
+              scrollbar       |TRUE| if scrollbar is visible
 
       The values are the same as in |v:event| during |CompleteChanged|.
     ]=],
@@ -7834,10 +7834,10 @@ M.funcs = {
       Returns -1 if {expr} is invalid.
 
       Examples: >vim
-      	echo rand()
-      	let seed = srand()
-      	echo rand(seed)
-      	echo rand(seed) % 16  " random number 0 - 15
+              echo rand()
+              let seed = srand()
+              echo rand(seed)
+              echo rand(seed) % 16  " random number 0 - 15
       <
     ]=],
     name = 'rand',
@@ -7858,12 +7858,12 @@ M.funcs = {
       empty list.  When the maximum is more than one before the
       start this is an error.
       Examples: >vim
-      	echo range(4)		" [0, 1, 2, 3]
-      	echo range(2, 4)	" [2, 3, 4]
-      	echo range(2, 9, 3)	" [2, 5, 8]
-      	echo range(2, -2, -1)	" [2, 1, 0, -1, -2]
-      	echo range(0)		" []
-      	echo range(2, 0)	" error!
+              echo range(4)           " [0, 1, 2, 3]
+              echo range(2, 4)        " [2, 3, 4]
+              echo range(2, 9, 3)     " [2, 5, 8]
+              echo range(2, -2, -1)   " [2, 1, 0, -1, -2]
+              echo range(0)           " []
+              echo range(2, 0)        " error!
       <
     ]=],
     name = 'range',
@@ -7879,17 +7879,17 @@ M.funcs = {
       If {offset} is specified, read the file from the specified
       offset.  If it is a negative value, it is used as an offset
       from the end of the file.  E.g., to read the last 12 bytes: >vim
-      	echo readblob('file.bin', -12)
+              echo readblob('file.bin', -12)
       <If {size} is specified, only the specified size will be read.
       E.g. to read the first 100 bytes of a file: >vim
-      	echo readblob('file.bin', 0, 100)
+              echo readblob('file.bin', 0, 100)
       <If {size} is -1 or omitted, the whole data starting from
       {offset} will be read.
       This can be also used to read the data from a character device
       on Unix when {size} is explicitly set.  Only if the device
       supports seeking {offset} can be used.  Otherwise it should be
       zero.  E.g. to read 10 bytes from a serial console: >vim
-      	echo readblob('/dev/ttyS0', 0, 10)
+              echo readblob('/dev/ttyS0', 0, 10)
       <When the file can't be opened an error message is given and
       the result is an empty |Blob|.
       When the offset is beyond the end of the file the result is an
@@ -7912,12 +7912,12 @@ M.funcs = {
 
       When {expr} is omitted all entries are included.
       When {expr} is given, it is evaluated to check what to do:
-      	If {expr} results in -1 then no further entries will
-      	be handled.
-      	If {expr} results in 0 then this entry will not be
-      	added to the list.
-      	If {expr} results in 1 then this entry will be added
-      	to the list.
+              If {expr} results in -1 then no further entries will
+              be handled.
+              If {expr} results in 0 then this entry will not be
+              added to the list.
+              If {expr} results in 1 then this entry will be added
+              to the list.
       Each time {expr} is evaluated |v:val| is set to the entry name.
       When {expr} is a function the name is passed as the argument.
       For example, to get a list of files ending in ".txt": >vim
@@ -7960,9 +7960,9 @@ M.funcs = {
       When {max} is given this specifies the maximum number of lines
       to be read.  Useful if you only want to check the first ten
       lines of a file: >vim
-      	for line in readfile(fname, '', 10)
-      	  if line =~ 'Date' | echo line | endif
-      	endfor
+              for line in readfile(fname, '', 10)
+                if line =~ 'Date' | echo line | endif
+              endfor
       <When {max} is negative -{max} lines from the end of the file
       are returned, or as many as there are.
       When {max} is zero the result is an empty list.
@@ -7997,10 +7997,10 @@ M.funcs = {
       result can be computed, an E998 error is given.
 
       Examples: >vim
-      	echo reduce([1, 3, 5], { acc, val -> acc + val })
-      	echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
-      	echo reduce(0z1122, { acc, val -> 2 * acc + val })
-      	echo reduce('xyz', { acc, val -> acc .. ',' .. val })
+              echo reduce([1, 3, 5], { acc, val -> acc + val })
+              echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
+              echo reduce(0z1122, { acc, val -> 2 * acc + val })
+              echo reduce('xyz', { acc, val -> acc .. ',' .. val })
       <
     ]=],
     name = 'reduce',
@@ -8087,9 +8087,9 @@ M.funcs = {
       Return a Float that represents the time value of {time}.
       Unit of time is seconds.
       Example:
-      	let start = reltime()
-      	call MyFunction()
-      	let seconds = reltimefloat(reltime(start))
+              let start = reltime()
+              call MyFunction()
+              let seconds = reltimefloat(reltime(start))
       See the note of reltimestr() about overhead.
       Also see |profiling|.
       If there is an error an empty string is returned
@@ -8107,13 +8107,13 @@ M.funcs = {
       Return a String that represents the time value of {time}.
       This is the number of seconds, a dot and the number of
       microseconds.  Example: >vim
-      	let start = reltime()
-      	call MyFunction()
-      	echo reltimestr(reltime(start))
+              let start = reltime()
+              call MyFunction()
+              echo reltimestr(reltime(start))
       <Note that overhead for the commands will be added to the time.
       Leading spaces are used to make the string align nicely.  You
       can use split() to remove it. >vim
-      	echo split(reltimestr(reltime(start)))[0]
+              echo split(reltimestr(reltime(start)))[0]
       <Also see |profiling|.
       If there is an error an empty string is returned
 
@@ -8143,8 +8143,8 @@ M.funcs = {
       See |list-index| for possible values of {idx} and {end}.
       Returns zero on error.
       Example: >vim
-      	echo "last item: " .. remove(mylist, -1)
-      	call remove(mylist, 0, 9)
+              echo "last item: " .. remove(mylist, -1)
+              call remove(mylist, 0, 9)
       <
       Use |delete()| to remove a file.
 
@@ -8172,8 +8172,8 @@ M.funcs = {
       points to a byte before {idx} this is an error.
       Returns zero on error.
       Example: >vim
-      	echo "last byte: " .. remove(myblob, -1)
-      	call remove(mylist, 0, 9)
+              echo "last byte: " .. remove(myblob, -1)
+              call remove(mylist, 0, 9)
       <
     ]=],
     name = 'remove',
@@ -8186,7 +8186,7 @@ M.funcs = {
     desc = [=[
       Remove the entry from {dict} with key {key} and return it.
       Example: >vim
-      	echo "removed " .. remove(dict, "one")
+              echo "removed " .. remove(dict, "one")
       <If there is no {key} in {dict} this is an error.
       Returns zero on error.
     ]=],
@@ -8216,11 +8216,11 @@ M.funcs = {
     desc = [=[
       Repeat {expr} {count} times and return the concatenated
       result.  Example: >vim
-      	let separator = repeat('-', 80)
+              let separator = repeat('-', 80)
       <When {count} is zero or negative the result is empty.
       When {expr} is a |List| or a |Blob| the result is {expr}
       concatenated {count} times.  Example: >vim
-      	let longlist = repeat(['a', 'b'], 3)
+              let longlist = repeat(['a', 'b'], 3)
       <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
     ]=],
@@ -8263,7 +8263,7 @@ M.funcs = {
       Returns zero if {object} is not a List, Blob or a String.
       If you want a List or Blob to remain unmodified make a copy
       first: >vim
-      	let revlist = reverse(copy(mylist))
+              let revlist = reverse(copy(mylist))
       <
     ]=],
     name = 'reverse',
@@ -8280,12 +8280,12 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo round(0.456)
-      <	0.0  >vim
-      	echo round(4.5)
-      <	5.0 >vim
-      	echo round(-4.5)
-      <	-5.0
+              echo round(0.456)
+      <        0.0  >vim
+              echo round(4.5)
+      <        5.0 >vim
+              echo round(-4.5)
+      <        -5.0
 
     ]=],
     float_func = 'round',
@@ -8299,7 +8299,7 @@ M.funcs = {
       Sends {event} to {channel} via |RPC| and returns immediately.
       If {channel} is 0, the event is broadcast to all channels.
       Example: >vim
-      	au VimLeave call rpcnotify(0, "leaving")
+              au VimLeave call rpcnotify(0, "leaving")
       <
     ]=],
     name = 'rpcnotify',
@@ -8312,7 +8312,7 @@ M.funcs = {
       Sends a request to {channel} to invoke {method} via
       |RPC| and blocks until a response is received.
       Example: >vim
-      	let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
+              let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
       <
     ]=],
     name = 'rpcrequest',
@@ -8323,9 +8323,9 @@ M.funcs = {
     args = { 1, 2 },
     desc = [=[
       Deprecated. Replace  >vim
-      	let id = rpcstart('prog', ['arg1', 'arg2'])
+              let id = rpcstart('prog', ['arg1', 'arg2'])
       <with >vim
-      	let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
+              let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
       <
     ]=],
     name = 'rpcstart',
@@ -8420,9 +8420,9 @@ M.funcs = {
       column inside the command line, which is 1 when the command is
       executed. To get the cursor position in the file use one of
       the following mappings: >vim
-      	nnoremap <expr> GG ":echom " .. screencol() .. "\n"
-      	nnoremap <silent> GG :echom screencol()<CR>
-      	noremap GG <Cmd>echom screencol()<Cr>
+              nnoremap <expr> GG ":echom " .. screencol() .. "\n"
+              nnoremap <silent> GG :echom screencol()<CR>
+              noremap GG <Cmd>echom screencol()<Cr>
       <
     ]=],
     name = 'screencol',
@@ -8437,10 +8437,10 @@ M.funcs = {
       character in window {winid} at buffer line {lnum} and column
       {col}.  {col} is a one-based byte index.
       The Dict has these members:
-      	row	screen row
-      	col	first screen column
-      	endcol	last screen column
-      	curscol	cursor screen column
+              row     screen row
+              col     first screen column
+              endcol  last screen column
+              curscol cursor screen column
       If the specified position is not visible, all values are zero.
       The "endcol" value differs from "col" when the character
       occupies more than one screen cell.  E.g. for a Tab "col" can
@@ -8502,15 +8502,15 @@ M.funcs = {
       move.  No error message is given.
 
       {flags} is a String, which can contain these character flags:
-      'b'	search Backward instead of forward
-      'c'	accept a match at the Cursor position
-      'e'	move to the End of the match
-      'n'	do Not move the cursor
-      'p'	return number of matching sub-Pattern (see below)
-      's'	Set the ' mark at the previous location of the cursor
-      'w'	Wrap around the end of the file
-      'W'	don't Wrap around the end of the file
-      'z'	start searching at the cursor column instead of Zero
+      'b'     search Backward instead of forward
+      'c'     accept a match at the Cursor position
+      'e'     move to the End of the match
+      'n'     do Not move the cursor
+      'p'     return number of matching sub-Pattern (see below)
+      's'     Set the ' mark at the previous location of the cursor
+      'w'     Wrap around the end of the file
+      'W'     don't Wrap around the end of the file
+      'z'     start searching at the cursor column instead of Zero
       If neither 'w' or 'W' is given, the 'wrapscan' option applies.
 
       If the 's' flag is supplied, the ' mark is set, only if the
@@ -8535,8 +8535,8 @@ M.funcs = {
       When the {stopline} argument is given then the search stops
       after searching this line.  This is useful to restrict the
       search to a range of lines.  Examples: >vim
-      	let match = search('(', 'b', line("w0"))
-      	let end = search('END', '', line("w$"))
+              let match = search('(', 'b', line("w0"))
+              let end = search('END', '', line("w$"))
       <When {stopline} is used and it is not zero this also implies
       that the search does not wrap around the end of the file.
       A zero value is equal to not giving the argument.
@@ -8556,7 +8556,7 @@ M.funcs = {
       When {skip} is omitted or empty, every match is accepted.
       When evaluating {skip} causes an error the search is aborted
       and -1 returned.
-      					*search()-sub-match*
+                                              *search()-sub-match*
       With the 'p' flag the returned value is one more than the
       first sub-match in \(\).  One if none of them matched but the
       whole pattern did match.
@@ -8567,7 +8567,7 @@ M.funcs = {
 
       Example (goes over all files in the argument list): >vim
           let n = 1
-          while n <= argc()	    " loop over all files in arglist
+          while n <= argc()       " loop over all files in arglist
             exe "argument " .. n
             " start at the last char in the file and wrap for the
             " first search to find match at start of file
@@ -8577,7 +8577,7 @@ M.funcs = {
               s/foo/bar/g
               let flags = "W"
             endwhile
-            update		    " write the file if modified
+            update                " write the file if modified
             let n = n + 1
           endwhile
       <
@@ -8616,16 +8616,16 @@ M.funcs = {
       This returns a |Dictionary|. The dictionary is empty if the
       previous pattern was not set and "pattern" was not specified.
 
-        key		type		meaning ~
-        current	|Number|	current position of match;
-      				0 if the cursor position is
-      				before the first match
-        exact_match	|Boolean|	1 if "current" is matched on
-      				"pos", otherwise 0
-        total		|Number|	total count of matches found
-        incomplete	|Number|	0: search was fully completed
-      				1: recomputing was timed out
-      				2: max count exceeded
+        key           type            meaning ~
+        current       |Number|        current position of match;
+                                      0 if the cursor position is
+                                      before the first match
+        exact_match   |Boolean|       1 if "current" is matched on
+                                      "pos", otherwise 0
+        total         |Number|        total count of matches found
+        incomplete    |Number|        0: search was fully completed
+                                      1: recomputing was timed out
+                                      2: max count exceeded
 
       For {options} see further down.
 
@@ -8635,99 +8635,99 @@ M.funcs = {
       If it exceeded 99 the result must be max count + 1 (100). If
       you want to get correct information, specify `recompute: 1`: >vim
 
-      	" result == maxcount + 1 (100) when many matches
-      	let result = searchcount(#{recompute: 0})
+              " result == maxcount + 1 (100) when many matches
+              let result = searchcount(#{recompute: 0})
 
-      	" Below returns correct result (recompute defaults
-      	" to 1)
-      	let result = searchcount()
+              " Below returns correct result (recompute defaults
+              " to 1)
+              let result = searchcount()
       <
       The function is useful to add the count to 'statusline': >vim
-      	function! LastSearchCount() abort
-      	  let result = searchcount(#{recompute: 0})
-      	  if empty(result)
-      	    return ''
-      	  endif
-      	  if result.incomplete ==# 1     " timed out
-      	    return printf(' /%s [?/??]', @/)
-      	  elseif result.incomplete ==# 2 " max count exceeded
-      	    if result.total > result.maxcount &&
-      	    \  result.current > result.maxcount
-      	      return printf(' /%s [>%d/>%d]', @/,
-      	      \             result.current, result.total)
-      	    elseif result.total > result.maxcount
-      	      return printf(' /%s [%d/>%d]', @/,
-      	      \             result.current, result.total)
-      	    endif
-      	  endif
-      	  return printf(' /%s [%d/%d]', @/,
-      	  \             result.current, result.total)
-      	endfunction
-      	let &statusline ..= '%{LastSearchCount()}'
+              function! LastSearchCount() abort
+                let result = searchcount(#{recompute: 0})
+                if empty(result)
+                  return ''
+                endif
+                if result.incomplete ==# 1     " timed out
+                  return printf(' /%s [?/??]', @/)
+                elseif result.incomplete ==# 2 " max count exceeded
+                  if result.total > result.maxcount &&
+                  \  result.current > result.maxcount
+                    return printf(' /%s [>%d/>%d]', @/,
+                    \             result.current, result.total)
+                  elseif result.total > result.maxcount
+                    return printf(' /%s [%d/>%d]', @/,
+                    \             result.current, result.total)
+                  endif
+                endif
+                return printf(' /%s [%d/%d]', @/,
+                \             result.current, result.total)
+              endfunction
+              let &statusline ..= '%{LastSearchCount()}'
 
-      	" Or if you want to show the count only when
-      	" 'hlsearch' was on
-      	" let &statusline ..=
-      	" \   '%{v:hlsearch ? LastSearchCount() : ""}'
+              " Or if you want to show the count only when
+              " 'hlsearch' was on
+              " let &statusline ..=
+              " \   '%{v:hlsearch ? LastSearchCount() : ""}'
       <
       You can also update the search count, which can be useful in a
       |CursorMoved| or |CursorMovedI| autocommand: >vim
 
-      	autocmd CursorMoved,CursorMovedI *
-      	  \ let s:searchcount_timer = timer_start(
-      	  \   200, function('s:update_searchcount'))
-      	function! s:update_searchcount(timer) abort
-      	  if a:timer ==# s:searchcount_timer
-      	    call searchcount(#{
-      	    \ recompute: 1, maxcount: 0, timeout: 100})
-      	    redrawstatus
-      	  endif
-      	endfunction
+              autocmd CursorMoved,CursorMovedI *
+                \ let s:searchcount_timer = timer_start(
+                \   200, function('s:update_searchcount'))
+              function! s:update_searchcount(timer) abort
+                if a:timer ==# s:searchcount_timer
+                  call searchcount(#{
+                  \ recompute: 1, maxcount: 0, timeout: 100})
+                  redrawstatus
+                endif
+              endfunction
       <
       This can also be used to count matched texts with specified
       pattern in the current buffer using "pattern":  >vim
 
-      	" Count '\<foo\>' in this buffer
-      	" (Note that it also updates search count)
-      	let result = searchcount(#{pattern: '\<foo\>'})
+              " Count '\<foo\>' in this buffer
+              " (Note that it also updates search count)
+              let result = searchcount(#{pattern: '\<foo\>'})
 
-      	" To restore old search count by old pattern,
-      	" search again
-      	call searchcount()
+              " To restore old search count by old pattern,
+              " search again
+              call searchcount()
       <
       {options} must be a |Dictionary|. It can contain:
-        key		type		meaning ~
-        recompute	|Boolean|	if |TRUE|, recompute the count
-      				like |n| or |N| was executed.
-      				otherwise returns the last
-      				computed result (when |n| or
-      				|N| was used when "S" is not
-      				in 'shortmess', or this
-      				function was called).
-      				(default: |TRUE|)
-        pattern	|String|	recompute if this was given
-      				and different with |@/|.
-      				this works as same as the
-      				below command is executed
-      				before calling this function >vim
-      				  let @/ = pattern
-      <				(default: |@/|)
-        timeout	|Number|	0 or negative number is no
-      				timeout. timeout milliseconds
-      				for recomputing the result
-      				(default: 0)
-        maxcount	|Number|	0 or negative number is no
-      				limit. max count of matched
-      				text while recomputing the
-      				result.  if search exceeded
-      				total count, "total" value
-      				becomes `maxcount + 1`
-      				(default: 0)
-        pos		|List|		`[lnum, col, off]` value
-      				when recomputing the result.
-      				this changes "current" result
-      				value. see |cursor()|, |getpos()|
-      				(default: cursor's position)
+        key           type            meaning ~
+        recompute     |Boolean|         if |TRUE|, recompute the count
+                                      like |n| or |N| was executed.
+                                      otherwise returns the last
+                                      computed result (when |n| or
+                                      |N| was used when "S" is not
+                                      in 'shortmess', or this
+                                      function was called).
+                                      (default: |TRUE|)
+        pattern       |String|          recompute if this was given
+                                      and different with |@/|.
+                                      this works as same as the
+                                      below command is executed
+                                      before calling this function >vim
+                                        let @/ = pattern
+      <                               (default: |@/|)
+        timeout       |Number|          0 or negative number is no
+                                      timeout. timeout milliseconds
+                                      for recomputing the result
+                                      (default: 0)
+        maxcount      |Number|          0 or negative number is no
+                                      limit. max count of matched
+                                      text while recomputing the
+                                      result.  if search exceeded
+                                      total count, "total" value
+                                      becomes `maxcount + 1`
+                                      (default: 0)
+        pos           |List|            `[lnum, col, off]` value
+                                      when recomputing the result.
+                                      this changes "current" result
+                                      value. see |cursor()|, |getpos()|
+                                      (default: cursor's position)
 
     ]=],
     name = 'searchcount',
@@ -8751,9 +8751,9 @@ M.funcs = {
       Moves the cursor to the found match.
       Returns zero for success, non-zero for failure.
       Example: >vim
-      	if searchdecl('myvar') == 0
-      	   echo getline('.')
-      	endif
+              if searchdecl('myvar') == 0
+                 echo getline('.')
+              endif
       <
     ]=],
     name = 'searchdecl',
@@ -8778,15 +8778,15 @@ M.funcs = {
       {middle} is not empty, it is found when searching from either
       direction, but only when not in a nested start-end pair.  A
       typical use is: >vim
-      	echo searchpair('\<if\>', '\<else\>', '\<endif\>')
+              echo searchpair('\<if\>', '\<else\>', '\<endif\>')
       <By leaving {middle} empty the "else" is skipped.
 
       {flags} 'b', 'c', 'n', 's', 'w' and 'W' are used like with
       |search()|.  Additionally:
-      'r'	Repeat until no more matches found; will find the
-      	outer pair.  Implies the 'W' flag.
-      'm'	Return number of matches instead of line number with
-      	the match; will be > 1 when 'r' is used.
+      'r'     Repeat until no more matches found; will find the
+              outer pair.  Implies the 'W' flag.
+      'm'     Return number of matches instead of line number with
+              the match; will be > 1 when 'r' is used.
       Note: it's nearly always a good idea to use the 'W' flag, to
       avoid wrapping around the end of the file.
 
@@ -8809,10 +8809,10 @@ M.funcs = {
       The search starts exactly at the cursor.  A match with
       {start}, {middle} or {end} at the next character, in the
       direction of searching, is the first one found.  Example: >vim
-      	if 1
-      	  if 2
-      	  endif 2
-      	endif 1
+              if 1
+                if 2
+                endif 2
+              endif 1
       <When starting at the "if 2", with the cursor on the "i", and
       searching forwards, the "endif 2" is found.  When starting on
       the character just before the "if 2", the "endif 1" will be
@@ -8826,8 +8826,8 @@ M.funcs = {
 
       Example, to find the "endif" command in a Vim script: >vim
 
-      	echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
-      	\ 'getline(".") =~ "^\\s*\""')
+              echo searchpair('\<if\>', '\<el\%[seif]\>', '\<en\%[dif]\>', 'W',
+              \ 'getline(".") =~ "^\\s*\""')
 
       <The cursor must be at or after the "if" for which a match is
       to be found.  Note that single-quote strings are used to avoid
@@ -8837,14 +8837,14 @@ M.funcs = {
       a match.
       Another example, to search for the matching "{" of a "}": >vim
 
-      	echo searchpair('{', '', '}', 'bW')
+              echo searchpair('{', '', '}', 'bW')
 
       <This works when the cursor is at or before the "}" for which a
       match is to be found.  To reject matches that syntax
       highlighting recognized as strings: >vim
 
-      	echo searchpair('{', '', '}', 'bW',
-      	     \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
+              echo searchpair('{', '', '}', 'bW',
+                   \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
       <
     ]=],
     name = 'searchpair',
@@ -8860,7 +8860,7 @@ M.funcs = {
       the column position of the match.  If no match is found,
       returns [0, 0]. >vim
 
-      	let [lnum,col] = searchpairpos('{', '', '}', 'n')
+              let [lnum,col] = searchpairpos('{', '', '}', 'n')
       <
       See |match-parens| for a bigger and more useful example.
     ]=],
@@ -8878,11 +8878,11 @@ M.funcs = {
       the column position of the match. If no match is found,
       returns [0, 0].
       Example: >vim
-      	let [lnum, col] = searchpos('mypattern', 'n')
+              let [lnum, col] = searchpos('mypattern', 'n')
 
       <When the 'p' flag is given then there is an extra item with
       the sub-pattern match number |search()-sub-match|.  Example: >vim
-      	let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
+              let [lnum, col, submatch] = searchpos('\(\l\)\|\(\u\)', 'np')
       <In this example "submatch" is 2 when a lowercase letter is
       found |/\l|, 3 when an uppercase letter is found |/\u|.
 
@@ -8902,7 +8902,7 @@ M.funcs = {
       Returns a list of server addresses, or empty if all servers
       were stopped. |serverstart()| |serverstop()|
       Example: >vim
-      	echo serverlist()
+              echo serverlist()
       <
     ]=],
     name = 'serverlist',
@@ -8925,24 +8925,24 @@ M.funcs = {
       - Else {address} is the path to a named pipe (except on Windows).
         - If {address} has no slashes ("/") it is treated as the
           "name" part of a generated path in this format: >vim
-      	stdpath("run").."/{name}.{pid}.{counter}"
+              stdpath("run").."/{name}.{pid}.{counter}"
       <  - If {address} is omitted the name is "nvim". >vim
-      	echo serverstart()
+              echo serverstart()
       < >
-      	=> /tmp/nvim.bram/oknANW/nvim.15430.5
+              => /tmp/nvim.bram/oknANW/nvim.15430.5
       <
       Example bash command to list all Nvim servers: >bash
-      	ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
+              ls ${XDG_RUNTIME_DIR:-${TMPDIR}nvim.${USER}}/*/nvim.*.0
 
       <Example named pipe: >vim
-      	if has('win32')
-      	  echo serverstart('\\.\pipe\nvim-pipe-1234')
-      	else
-      	  echo serverstart('nvim.sock')
-      	endif
+              if has('win32')
+                echo serverstart('\\.\pipe\nvim-pipe-1234')
+              else
+                echo serverstart('nvim.sock')
+              endif
       <
       Example TCP/IP address: >vim
-      	echo serverstart('::1:12345')
+              echo serverstart('::1:12345')
       <
     ]=],
     name = 'serverstart',
@@ -9007,8 +9007,8 @@ M.funcs = {
       The {varname} argument is a string.
       Note that the variable name without "b:" must be used.
       Examples: >vim
-      	call setbufvar(1, "&mod", 1)
-      	call setbufvar("todo", "myvar", "foobar")
+              call setbufvar(1, "&mod", 1)
+              call setbufvar("todo", "myvar", "foobar")
       <This function is not available in the |sandbox|.
 
     ]=],
@@ -9025,21 +9025,21 @@ M.funcs = {
       terminal, counted in screen cells.  The values override
       'ambiwidth'.  Example: >vim
          call setcellwidths([
-      		\ [0x111, 0x111, 1],
-      		\ [0x2194, 0x2199, 2],
-      		\ ])
+                      \ [0x111, 0x111, 1],
+                      \ [0x2194, 0x2199, 2],
+                      \ ])
 
       <The {list} argument is a List of Lists with each three
-      numbers: [{low}, {high}, {width}].	*E1109* *E1110*
+      numbers: [{low}, {high}, {width}].      *E1109* *E1110*
       {low} and {high} can be the same, in which case this refers to
       one character.  Otherwise it is the range of characters from
-      {low} to {high} (inclusive).		*E1111* *E1114*
+      {low} to {high} (inclusive).            *E1111* *E1114*
       Only characters with value 0x80 and higher can be used.
 
       {width} must be either 1 or 2, indicating the character width
-      in screen cells.			*E1112*
+      in screen cells.                        *E1112*
       An error is given if the argument is invalid, also when a
-      range overlaps with another.		*E1113*
+      range overlaps with another.            *E1113*
 
       If the new value causes 'fillchars' or 'listchars' to become
       invalid it is rejected and an error is given.
@@ -9066,9 +9066,9 @@ M.funcs = {
 
       Example:
       With the text "여보세요" in line 8: >vim
-      	call setcharpos('.', [0, 8, 4, 0])
+              call setcharpos('.', [0, 8, 4, 0])
       <positions the cursor on the fourth character '요'. >vim
-      	call setpos('.', [0, 8, 4, 0])
+              call setpos('.', [0, 8, 4, 0])
       <positions the cursor on the second character '보'.
 
     ]=],
@@ -9083,20 +9083,20 @@ M.funcs = {
       Set the current character search information to {dict},
       which contains one or more of the following entries:
 
-          char	character which will be used for a subsequent
-      		|,| or |;| command; an empty string clears the
-      		character search
-          forward	direction of character search; 1 for forward,
-      		0 for backward
-          until	type of character search; 1 for a |t| or |T|
-      		character search, 0 for an |f| or |F|
-      		character search
+          char        character which will be used for a subsequent
+                      |,| or |;| command; an empty string clears the
+                      character search
+          forward     direction of character search; 1 for forward,
+                      0 for backward
+          until       type of character search; 1 for a |t| or |T|
+                      character search, 0 for an |f| or |F|
+                      character search
 
       This can be useful to save/restore a user's character search
       from a script: >vim
-      	let prevsearch = getcharsearch()
-      	" Perform a command which clobbers user's search
-      	call setcharsearch(prevsearch)
+              let prevsearch = getcharsearch()
+              " Perform a command which clobbers user's search
+              call setcharsearch(prevsearch)
       <Also see |getcharsearch()|.
 
     ]=],
@@ -9158,9 +9158,9 @@ M.funcs = {
 
       Example:
       With the text "여보세요" in line 4: >vim
-      	call setcursorcharpos(4, 3)
+              call setcursorcharpos(4, 3)
       <positions the cursor on the third character '세'. >vim
-      	call cursor(4, 3)
+              call cursor(4, 3)
       <positions the cursor on the first character '여'.
 
     ]=],
@@ -9173,7 +9173,7 @@ M.funcs = {
     base = 2,
     desc = [=[
       Set environment variable {name} to {val}.  Example: >vim
-      	call setenv('HOME', '/home/myhome')
+              call setenv('HOME', '/home/myhome')
 
       <When {val} is |v:null| the environment variable is deleted.
       See also |expr-env|.
@@ -9227,15 +9227,15 @@ M.funcs = {
       because {lnum} is invalid) TRUE is returned.
 
       Example: >vim
-      	call setline(5, strftime("%c"))
+              call setline(5, strftime("%c"))
 
       <When {text} is a |List| then line {lnum} and following lines
       will be set to the items in the list.  Example: >vim
-      	call setline(5, ['aaa', 'bbb', 'ccc'])
+              call setline(5, ['aaa', 'bbb', 'ccc'])
       <This is equivalent to: >vim
-      	for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
-      	  call setline(n, l)
-      	endfor
+              for [n, l] in [[5, 'aaa'], [6, 'bbb'], [7, 'ccc']]
+                call setline(n, l)
+              endfor
 
       <Note: The '[ and '] marks are not set.
 
@@ -9289,14 +9289,14 @@ M.funcs = {
     base = 2,
     desc = [=[
       Set the position for String {expr}.  Possible values:
-      	.	the cursor
-      	'x	mark x
+              .       the cursor
+              'x      mark x
 
       {list} must be a |List| with four or five numbers:
           [bufnum, lnum, col, off]
           [bufnum, lnum, col, off, curswant]
 
-      "bufnum" is the buffer number.	Zero can be used for the
+      "bufnum" is the buffer number.  Zero can be used for the
       current buffer.  When setting an uppercase mark "bufnum" is
       used for the mark position.  For other marks it specifies the
       buffer to set the mark in.  You can use the |bufnr()| function
@@ -9351,32 +9351,32 @@ M.funcs = {
       only the items listed in {what} are set. The first {list}
       argument is ignored.  See below for the supported items in
       {what}.
-      					*setqflist-what*
+                                              *setqflist-what*
       When {what} is not present, the items in {list} are used.  Each
       item must be a dictionary.  Non-dictionary items in {list} are
       ignored.  Each dictionary item can contain the following
       entries:
 
-          bufnr	buffer number; must be the number of a valid
-      		buffer
-          filename	name of a file; only used when "bufnr" is not
-      		present or it is invalid.
-          module	name of a module; if given it will be used in
-      		quickfix error window instead of the filename.
-          lnum	line number in the file
-          end_lnum	end of lines, if the item spans multiple lines
-          pattern	search pattern used to locate the error
-          col		column number
-          vcol	when non-zero: "col" is visual column
-      		when zero: "col" is byte index
-          end_col	end column, if the item spans multiple columns
-          nr		error number
-          text	description of the error
-          type	single-character error type, 'E', 'W', etc.
-          valid	recognized error message
+          bufnr       buffer number; must be the number of a valid
+                      buffer
+          filename    name of a file; only used when "bufnr" is not
+                      present or it is invalid.
+          module      name of a module; if given it will be used in
+                      quickfix error window instead of the filename.
+          lnum        line number in the file
+          end_lnum    end of lines, if the item spans multiple lines
+          pattern     search pattern used to locate the error
+          col         column number
+          vcol        when non-zero: "col" is visual column
+                      when zero: "col" is byte index
+          end_col     end column, if the item spans multiple columns
+          nr          error number
+          text        description of the error
+          type        single-character error type, 'E', 'W', etc.
+          valid       recognized error message
           user_data
-      		custom data associated with the item, can be
-      		any type.
+                      custom data associated with the item, can be
+                      any type.
 
       The "col", "vcol", "nr", "type" and "text" entries are
       optional.  Either "lnum" or "pattern" entry can be used to
@@ -9393,18 +9393,18 @@ M.funcs = {
       Note that the list is not exactly the same as what
       |getqflist()| returns.
 
-      {action} values:		*setqflist-action* *E927*
-      'a'	The items from {list} are added to the existing
-      	quickfix list. If there is no existing list, then a
-      	new list is created.
+      {action} values:                *setqflist-action* *E927*
+      'a'     The items from {list} are added to the existing
+              quickfix list. If there is no existing list, then a
+              new list is created.
 
-      'r'	The items from the current quickfix list are replaced
-      	with the items from {list}.  This can also be used to
-      	clear the list: >vim
-      		call setqflist([], 'r')
+      'r'     The items from the current quickfix list are replaced
+              with the items from {list}.  This can also be used to
+              clear the list: >vim
+                      call setqflist([], 'r')
       <
-      'f'	All the quickfix lists in the quickfix stack are
-      	freed.
+      'f'     All the quickfix lists in the quickfix stack are
+              freed.
 
       If {action} is not present or is set to ' ', then a new list
       is created. The new quickfix list is added after the current
@@ -9413,32 +9413,32 @@ M.funcs = {
       set "nr" in {what} to "$".
 
       The following items can be specified in dictionary {what}:
-          context	quickfix list context. See |quickfix-context|
-          efm		errorformat to use when parsing text from
-      		"lines". If this is not present, then the
-      		'errorformat' option value is used.
-      		See |quickfix-parse|
-          id		quickfix list identifier |quickfix-ID|
-          idx		index of the current entry in the quickfix
-      		list specified by "id" or "nr". If set to '$',
-      		then the last entry in the list is set as the
-      		current entry.  See |quickfix-index|
-          items	list of quickfix entries. Same as the {list}
-      		argument.
-          lines	use 'errorformat' to parse a list of lines and
-      		add the resulting entries to the quickfix list
-      		{nr} or {id}.  Only a |List| value is supported.
-      		See |quickfix-parse|
-          nr		list number in the quickfix stack; zero
-      		means the current quickfix list and "$" means
-      		the last quickfix list.
+          context     quickfix list context. See |quickfix-context|
+          efm         errorformat to use when parsing text from
+                      "lines". If this is not present, then the
+                      'errorformat' option value is used.
+                      See |quickfix-parse|
+          id          quickfix list identifier |quickfix-ID|
+          idx         index of the current entry in the quickfix
+                      list specified by "id" or "nr". If set to '$',
+                      then the last entry in the list is set as the
+                      current entry.  See |quickfix-index|
+          items       list of quickfix entries. Same as the {list}
+                      argument.
+          lines       use 'errorformat' to parse a list of lines and
+                      add the resulting entries to the quickfix list
+                      {nr} or {id}.  Only a |List| value is supported.
+                      See |quickfix-parse|
+          nr          list number in the quickfix stack; zero
+                      means the current quickfix list and "$" means
+                      the last quickfix list.
           quickfixtextfunc
-      		function to get the text to display in the
-      		quickfix window.  The value can be the name of
-      		a function or a funcref or a lambda.  Refer to
-      		|quickfix-window-function| for an explanation
-      		of how to write the function and an example.
-          title	quickfix list title text. See |quickfix-title|
+                      function to get the text to display in the
+                      quickfix window.  The value can be the name of
+                      a function or a funcref or a lambda.  Refer to
+                      |quickfix-window-function| for an explanation
+                      of how to write the function and an example.
+          title       quickfix list title text. See |quickfix-title|
       Unsupported keys in {what} are ignored.
       If the "nr" item is not present, then the current quickfix list
       is modified. When creating a new quickfix list, "nr" can be
@@ -9477,8 +9477,8 @@ M.funcs = {
       then the value is appended.
 
       {options} can also contain a register type specification:
-          "c" or "v"	      |charwise| mode
-          "l" or "V"	      |linewise| mode
+          "c" or "v"        |charwise| mode
+          "l" or "V"        |linewise| mode
           "b" or "<CTRL-V>" |blockwise-visual| mode
       If a number immediately follows "b" or "<CTRL-V>" then this is
       used as the width of the selection - if it is not specified
@@ -9493,26 +9493,26 @@ M.funcs = {
       mode is never selected automatically.
       Returns zero for success, non-zero for failure.
 
-      					*E883*
+                                              *E883*
       Note: you may not use |List| containing more than one item to
             set search and expression registers. Lists containing no
             items act like empty strings.
 
       Examples: >vim
-      	call setreg(v:register, @*)
-      	call setreg('*', @%, 'ac')
-      	call setreg('a', "1\n2\n3", 'b5')
-      	call setreg('"', { 'points_to': 'a'})
+              call setreg(v:register, @*)
+              call setreg('*', @%, 'ac')
+              call setreg('a', "1\n2\n3", 'b5')
+              call setreg('"', { 'points_to': 'a'})
 
       <This example shows using the functions to save and restore a
       register: >vim
-      	let var_a = getreginfo()
-      	call setreg('a', var_a)
+              let var_a = getreginfo()
+              call setreg('a', var_a)
       <or: >vim
-      	let var_a = getreg('a', 1, 1)
-      	let var_amode = getregtype('a')
-      	" ....
-      	call setreg('a', var_a, var_amode)
+              let var_a = getreg('a', 1, 1)
+              let var_amode = getregtype('a')
+              " ....
+              call setreg('a', var_a, var_amode)
       <Note: you may not reliably restore register value
       without using the third argument to |getreg()| as without it
       newlines are represented as newlines AND Nul bytes are
@@ -9520,7 +9520,7 @@ M.funcs = {
 
       You can also change the type of a register by appending
       nothing: >vim
-      	call setreg('a', '', 'al')
+              call setreg('a', '', 'al')
 
     ]=],
     name = 'setreg',
@@ -9558,8 +9558,8 @@ M.funcs = {
       For a local buffer option the global value is unchanged.
       Note that the variable name without "w:" must be used.
       Examples: >vim
-      	call settabwinvar(1, 1, "&list", 0)
-      	call settabwinvar(3, 2, "myvar", "foobar")
+              call settabwinvar(1, 1, "&list", 0)
+              call settabwinvar(3, 2, "myvar", "foobar")
       <This function is not available in the |sandbox|.
 
     ]=],
@@ -9582,7 +9582,7 @@ M.funcs = {
       For a list of supported items in {dict}, refer to
       |gettagstack()|. "curidx" takes effect before changing the tag
       stack.
-      					*E962*
+                                              *E962*
       How the tag stack is modified depends on the {action}
       argument:
       - If {action} is not present or is set to 'r', then the tag
@@ -9600,13 +9600,13 @@ M.funcs = {
 
       Examples (for more examples see |tagstack-examples|):
           Empty the tag stack of window 3: >vim
-      	call settagstack(3, {'items' : []})
+              call settagstack(3, {'items' : []})
 
       <    Save and restore the tag stack: >vim
-      	let stack = gettagstack(1003)
-      	" do something else
-      	call settagstack(1003, stack)
-      	unlet stack
+              let stack = gettagstack(1003)
+              " do something else
+              call settagstack(1003, stack)
+              unlet stack
       <
     ]=],
     name = 'settagstack',
@@ -9619,8 +9619,8 @@ M.funcs = {
     desc = [=[
       Like |settabwinvar()| for the current tab page.
       Examples: >vim
-      	call setwinvar(1, "&list", 0)
-      	call setwinvar(2, "myvar", "foobar")
+              call setwinvar(1, "&list", 0)
+              call setwinvar(2, "myvar", "foobar")
 
     ]=],
     name = 'setwinvar',
@@ -9686,15 +9686,15 @@ M.funcs = {
       'shiftwidth' value unless it is zero, in which case it is the
       'tabstop' value.  To be backwards compatible in indent
       plugins, use this: >vim
-      	if exists('*shiftwidth')
-      	  func s:sw()
-      	    return shiftwidth()
-      	  endfunc
-      	else
-      	  func s:sw()
-      	    return &sw
-      	  endfunc
-      	endif
+              if exists('*shiftwidth')
+                func s:sw()
+                  return shiftwidth()
+                endfunc
+              else
+                func s:sw()
+                  return &sw
+                endfunc
+              endif
       <And then use s:sw() instead of &sw.
 
       When there is one argument {col} this is used as column number
@@ -9729,17 +9729,17 @@ M.funcs = {
       The {name} can be a String or a Number.  The optional {dict}
       argument specifies the sign attributes.  The following values
       are supported:
-         icon		full path to the bitmap file for the sign.
-         linehl	highlight group used for the whole line the
-      		sign is placed in.
-         numhl	highlight group used for the line number where
-      		the sign is placed.
-         text		text that is displayed when there is no icon
-      		or the GUI is not being used.
-         texthl	highlight group used for the text item
-         culhl	highlight group used for the text item when
-      		the cursor is on the same line as the sign and
-      		'cursorline' is enabled.
+         icon         full path to the bitmap file for the sign.
+         linehl       highlight group used for the whole line the
+                      sign is placed in.
+         numhl        highlight group used for the line number where
+                      the sign is placed.
+         text         text that is displayed when there is no icon
+                      or the GUI is not being used.
+         texthl       highlight group used for the text item
+         culhl        highlight group used for the text item when
+                      the cursor is on the same line as the sign and
+                      'cursorline' is enabled.
 
       If the sign named {name} already exists, then the attributes
       of the sign are updated.
@@ -9753,16 +9753,16 @@ M.funcs = {
       defined sign.
 
       Examples: >vim
-      	call sign_define("mySign", {
-      		\ "text" : "=>",
-      		\ "texthl" : "Error",
-      		\ "linehl" : "Search"})
-      	call sign_define([
-      		\ {'name' : 'sign1',
-      		\  'text' : '=>'},
-      		\ {'name' : 'sign2',
-      		\  'text' : '!!'}
-      		\ ])
+              call sign_define("mySign", {
+                      \ "text" : "=>",
+                      \ "texthl" : "Error",
+                      \ "linehl" : "Search"})
+              call sign_define([
+                      \ {'name' : 'sign1',
+                      \  'text' : '=>'},
+                      \ {'name' : 'sign2',
+                      \  'text' : '!!'}
+                      \ ])
       <
     ]=],
     name = 'sign_define',
@@ -9783,30 +9783,30 @@ M.funcs = {
 
       Each list item in the returned value is a dictionary with the
       following entries:
-         icon		full path to the bitmap file of the sign
-         linehl	highlight group used for the whole line the
-      		sign is placed in; not present if not set.
-         name		name of the sign
-         numhl	highlight group used for the line number where
-      		the sign is placed; not present if not set.
-         text		text that is displayed when there is no icon
-      		or the GUI is not being used.
-         texthl	highlight group used for the text item; not
-      		present if not set.
-         culhl	highlight group used for the text item when
-      		the cursor is on the same line as the sign and
-      		'cursorline' is enabled; not present if not
-      		set.
+         icon         full path to the bitmap file of the sign
+         linehl       highlight group used for the whole line the
+                      sign is placed in; not present if not set.
+         name         name of the sign
+         numhl        highlight group used for the line number where
+                      the sign is placed; not present if not set.
+         text         text that is displayed when there is no icon
+                      or the GUI is not being used.
+         texthl       highlight group used for the text item; not
+                      present if not set.
+         culhl        highlight group used for the text item when
+                      the cursor is on the same line as the sign and
+                      'cursorline' is enabled; not present if not
+                      set.
 
       Returns an empty List if there are no signs and when {name} is
       not found.
 
       Examples: >vim
-      	" Get a list of all the defined signs
-      	echo sign_getdefined()
+              " Get a list of all the defined signs
+              echo sign_getdefined()
 
-      	" Get the attribute of the sign named mySign
-      	echo sign_getdefined("mySign")
+              " Get the attribute of the sign named mySign
+              echo sign_getdefined("mySign")
       <
     ]=],
     name = 'sign_getdefined',
@@ -9825,10 +9825,10 @@ M.funcs = {
       list of signs placed in that buffer is returned.  For the use
       of {buf}, see |bufname()|. The optional {dict} can contain
       the following entries:
-         group	select only signs in this group
-         id		select sign with this identifier
-         lnum		select signs placed in this line. For the use
-      		of {lnum}, see |line()|.
+         group        select only signs in this group
+         id           select sign with this identifier
+         lnum         select signs placed in this line. For the use
+                      of {lnum}, see |line()|.
       If {group} is "*", then signs in all the groups including the
       global group are returned. If {group} is not supplied or is an
       empty string, then only signs in the global group are
@@ -9838,17 +9838,17 @@ M.funcs = {
 
       Each list item in the returned value is a dictionary with the
       following entries:
-      	bufnr	number of the buffer with the sign
-      	signs	list of signs placed in {bufnr}. Each list
-      		item is a dictionary with the below listed
-      		entries
+              bufnr   number of the buffer with the sign
+              signs   list of signs placed in {bufnr}. Each list
+                      item is a dictionary with the below listed
+                      entries
 
       The dictionary for each sign contains the following entries:
-      	group	 sign group. Set to '' for the global group.
-      	id	 identifier of the sign
-      	lnum	 line number where the sign is placed
-      	name	 name of the defined sign
-      	priority sign priority
+              group    sign group. Set to '' for the global group.
+              id       identifier of the sign
+              lnum     line number where the sign is placed
+              name     name of the defined sign
+              priority sign priority
 
       The returned signs in a buffer are ordered by their line
       number and priority.
@@ -9857,25 +9857,25 @@ M.funcs = {
       signs.
 
       Examples: >vim
-      	" Get a List of signs placed in eval.c in the
-      	" global group
-      	echo sign_getplaced("eval.c")
+              " Get a List of signs placed in eval.c in the
+              " global group
+              echo sign_getplaced("eval.c")
 
-      	" Get a List of signs in group 'g1' placed in eval.c
-      	echo sign_getplaced("eval.c", {'group' : 'g1'})
+              " Get a List of signs in group 'g1' placed in eval.c
+              echo sign_getplaced("eval.c", {'group' : 'g1'})
 
-      	" Get a List of signs placed at line 10 in eval.c
-      	echo sign_getplaced("eval.c", {'lnum' : 10})
+              " Get a List of signs placed at line 10 in eval.c
+              echo sign_getplaced("eval.c", {'lnum' : 10})
 
-      	" Get sign with identifier 10 placed in a.py
-      	echo sign_getplaced("a.py", {'id' : 10})
+              " Get sign with identifier 10 placed in a.py
+              echo sign_getplaced("a.py", {'id' : 10})
 
-      	" Get sign with id 20 in group 'g1' placed in a.py
-      	echo sign_getplaced("a.py", {'group' : 'g1',
-      					\  'id' : 20})
+              " Get sign with id 20 in group 'g1' placed in a.py
+              echo sign_getplaced("a.py", {'group' : 'g1',
+                                              \  'id' : 20})
 
-      	" Get a List of all the placed signs
-      	echo sign_getplaced()
+              " Get a List of all the placed signs
+              echo sign_getplaced()
       <
     ]=],
     name = 'sign_getplaced',
@@ -9898,8 +9898,8 @@ M.funcs = {
       arguments are invalid.
 
       Example: >vim
-      	" Jump to sign 10 in the current buffer
-      	call sign_jump(10, '', '')
+              " Jump to sign 10 in the current buffer
+              call sign_jump(10, '', '')
       <
     ]=],
     name = 'sign_jump',
@@ -9927,11 +9927,11 @@ M.funcs = {
       values, see |bufname()|.
 
       The optional {dict} argument supports the following entries:
-      	lnum		line number in the file or buffer
-      			{buf} where the sign is to be placed.
-      			For the accepted values, see |line()|.
-      	priority	priority of the sign. See
-      			|sign-priority| for more information.
+              lnum            line number in the file or buffer
+                              {buf} where the sign is to be placed.
+                              For the accepted values, see |line()|.
+              priority        priority of the sign. See
+                              |sign-priority| for more information.
 
       If the optional {dict} is not specified, then it modifies the
       placed sign {id} in group {group} to use the defined sign
@@ -9940,23 +9940,23 @@ M.funcs = {
       Returns the sign identifier on success and -1 on failure.
 
       Examples: >vim
-      	" Place a sign named sign1 with id 5 at line 20 in
-      	" buffer json.c
-      	call sign_place(5, '', 'sign1', 'json.c',
-      					\ {'lnum' : 20})
+              " Place a sign named sign1 with id 5 at line 20 in
+              " buffer json.c
+              call sign_place(5, '', 'sign1', 'json.c',
+                                              \ {'lnum' : 20})
 
-      	" Updates sign 5 in buffer json.c to use sign2
-      	call sign_place(5, '', 'sign2', 'json.c')
+              " Updates sign 5 in buffer json.c to use sign2
+              call sign_place(5, '', 'sign2', 'json.c')
 
-      	" Place a sign named sign3 at line 30 in
-      	" buffer json.c with a new identifier
-      	let id = sign_place(0, '', 'sign3', 'json.c',
-      					\ {'lnum' : 30})
+              " Place a sign named sign3 at line 30 in
+              " buffer json.c with a new identifier
+              let id = sign_place(0, '', 'sign3', 'json.c',
+                                              \ {'lnum' : 30})
 
-      	" Place a sign named sign4 with id 10 in group 'g3'
-      	" at line 40 in buffer json.c with priority 90
-      	call sign_place(10, 'g3', 'sign4', 'json.c',
-      			\ {'lnum' : 40, 'priority' : 90})
+              " Place a sign named sign4 with id 10 in group 'g3'
+              " at line 40 in buffer json.c with priority 90
+              call sign_place(10, 'g3', 'sign4', 'json.c',
+                              \ {'lnum' : 40, 'priority' : 90})
       <
     ]=],
     name = 'sign_place',
@@ -9978,27 +9978,27 @@ M.funcs = {
       |sign_place()| function.  The {list} argument specifies the
       List of signs to place. Each list item is a dict with the
       following sign attributes:
-          buffer	Buffer name or number. For the accepted
-      		values, see |bufname()|.
-          group	Sign group. {group} functions as a namespace
-      		for {id}, thus two groups can use the same
-      		IDs. If not specified or set to an empty
-      		string, then the global group is used.   See
-      		|sign-group| for more information.
-          id		Sign identifier. If not specified or zero,
-      		then a new unique identifier is allocated.
-      		Otherwise the specified number is used. See
-      		|sign-identifier| for more information.
-          lnum	Line number in the buffer where the sign is to
-      		be placed. For the accepted values, see
-      		|line()|.
-          name	Name of the sign to place. See |sign_define()|
-      		for more information.
-          priority	Priority of the sign. When multiple signs are
-      		placed on a line, the sign with the highest
-      		priority is used. If not specified, the
-      		default value of 10 is used. See
-      		|sign-priority| for more information.
+          buffer      Buffer name or number. For the accepted
+                      values, see |bufname()|.
+          group       Sign group. {group} functions as a namespace
+                      for {id}, thus two groups can use the same
+                      IDs. If not specified or set to an empty
+                      string, then the global group is used.   See
+                      |sign-group| for more information.
+          id          Sign identifier. If not specified or zero,
+                      then a new unique identifier is allocated.
+                      Otherwise the specified number is used. See
+                      |sign-identifier| for more information.
+          lnum        Line number in the buffer where the sign is to
+                      be placed. For the accepted values, see
+                      |line()|.
+          name        Name of the sign to place. See |sign_define()|
+                      for more information.
+          priority    Priority of the sign. When multiple signs are
+                      placed on a line, the sign with the highest
+                      priority is used. If not specified, the
+                      default value of 10 is used. See
+                      |sign-priority| for more information.
 
       If {id} refers to an existing sign, then the existing sign is
       modified to use the specified {name} and/or {priority}.
@@ -10007,29 +10007,29 @@ M.funcs = {
       sign, the corresponding list item is set to -1.
 
       Examples: >vim
-      	" Place sign s1 with id 5 at line 20 and id 10 at line
-      	" 30 in buffer a.c
-      	let [n1, n2] = sign_placelist([
-      		\ {'id' : 5,
-      		\  'name' : 's1',
-      		\  'buffer' : 'a.c',
-      		\  'lnum' : 20},
-      		\ {'id' : 10,
-      		\  'name' : 's1',
-      		\  'buffer' : 'a.c',
-      		\  'lnum' : 30}
-      		\ ])
+              " Place sign s1 with id 5 at line 20 and id 10 at line
+              " 30 in buffer a.c
+              let [n1, n2] = sign_placelist([
+                      \ {'id' : 5,
+                      \  'name' : 's1',
+                      \  'buffer' : 'a.c',
+                      \  'lnum' : 20},
+                      \ {'id' : 10,
+                      \  'name' : 's1',
+                      \  'buffer' : 'a.c',
+                      \  'lnum' : 30}
+                      \ ])
 
-      	" Place sign s1 in buffer a.c at line 40 and 50
-      	" with auto-generated identifiers
-      	let [n1, n2] = sign_placelist([
-      		\ {'name' : 's1',
-      		\  'buffer' : 'a.c',
-      		\  'lnum' : 40},
-      		\ {'name' : 's1',
-      		\  'buffer' : 'a.c',
-      		\  'lnum' : 50}
-      		\ ])
+              " Place sign s1 in buffer a.c at line 40 and 50
+              " with auto-generated identifiers
+              let [n1, n2] = sign_placelist([
+                      \ {'name' : 's1',
+                      \  'buffer' : 'a.c',
+                      \  'lnum' : 40},
+                      \ {'name' : 's1',
+                      \  'buffer' : 'a.c',
+                      \  'lnum' : 50}
+                      \ ])
       <
     ]=],
     name = 'sign_placelist',
@@ -10061,14 +10061,14 @@ M.funcs = {
       sign.
 
       Examples: >vim
-      	" Delete a sign named mySign
-      	call sign_undefine("mySign")
+              " Delete a sign named mySign
+              call sign_undefine("mySign")
 
-      	" Delete signs 'sign1' and 'sign2'
-      	call sign_undefine(["sign1", "sign2"])
+              " Delete signs 'sign1' and 'sign2'
+              call sign_undefine(["sign1", "sign2"])
 
-      	" Delete all the signs
-      	call sign_undefine()
+              " Delete all the signs
+              call sign_undefine()
       <
     ]=],
     name = 'sign_undefine',
@@ -10089,37 +10089,37 @@ M.funcs = {
       The signs in {group} are selected based on the entries in
       {dict}.  The following optional entries in {dict} are
       supported:
-      	buffer	buffer name or number. See |bufname()|.
-      	id	sign identifier
+              buffer  buffer name or number. See |bufname()|.
+              id      sign identifier
       If {dict} is not supplied, then all the signs in {group} are
       removed.
 
       Returns 0 on success and -1 on failure.
 
       Examples: >vim
-      	" Remove sign 10 from buffer a.vim
-      	call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
+              " Remove sign 10 from buffer a.vim
+              call sign_unplace('', {'buffer' : "a.vim", 'id' : 10})
 
-      	" Remove sign 20 in group 'g1' from buffer 3
-      	call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
+              " Remove sign 20 in group 'g1' from buffer 3
+              call sign_unplace('g1', {'buffer' : 3, 'id' : 20})
 
-      	" Remove all the signs in group 'g2' from buffer 10
-      	call sign_unplace('g2', {'buffer' : 10})
+              " Remove all the signs in group 'g2' from buffer 10
+              call sign_unplace('g2', {'buffer' : 10})
 
-      	" Remove sign 30 in group 'g3' from all the buffers
-      	call sign_unplace('g3', {'id' : 30})
+              " Remove sign 30 in group 'g3' from all the buffers
+              call sign_unplace('g3', {'id' : 30})
 
-      	" Remove all the signs placed in buffer 5
-      	call sign_unplace('*', {'buffer' : 5})
+              " Remove all the signs placed in buffer 5
+              call sign_unplace('*', {'buffer' : 5})
 
-      	" Remove the signs in group 'g4' from all the buffers
-      	call sign_unplace('g4')
+              " Remove the signs in group 'g4' from all the buffers
+              call sign_unplace('g4')
 
-      	" Remove sign 40 from all the buffers
-      	call sign_unplace('*', {'id' : 40})
+              " Remove sign 40 from all the buffers
+              call sign_unplace('*', {'id' : 40})
 
-      	" Remove all the placed signs from all the buffers
-      	call sign_unplace('*')
+              " Remove all the placed signs from all the buffers
+              call sign_unplace('*')
 
     ]=],
     name = 'sign_unplace',
@@ -10136,27 +10136,27 @@ M.funcs = {
 
       The {list} argument specifies the List of signs to remove.
       Each list item is a dict with the following sign attributes:
-          buffer	buffer name or number. For the accepted
-      		values, see |bufname()|. If not specified,
-      		then the specified sign is removed from all
-      		the buffers.
-          group	sign group name. If not specified or set to an
-      		empty string, then the global sign group is
-      		used. If set to "*", then all the groups
-      		including the global group are used.
-          id		sign identifier. If not specified, then all
-      		the signs in the specified group are removed.
+          buffer      buffer name or number. For the accepted
+                      values, see |bufname()|. If not specified,
+                      then the specified sign is removed from all
+                      the buffers.
+          group       sign group name. If not specified or set to an
+                      empty string, then the global sign group is
+                      used. If set to "*", then all the groups
+                      including the global group are used.
+          id          sign identifier. If not specified, then all
+                      the signs in the specified group are removed.
 
       Returns a List where an entry is set to 0 if the corresponding
       sign was successfully removed or -1 on failure.
 
       Example: >vim
-      	" Remove sign with id 10 from buffer a.vim and sign
-      	" with id 20 from buffer b.vim
-      	call sign_unplacelist([
-      		\ {'id' : 10, 'buffer' : "a.vim"},
-      		\ {'id' : 20, 'buffer' : 'b.vim'},
-      		\ ])
+              " Remove sign with id 10 from buffer a.vim and sign
+              " with id 20 from buffer b.vim
+              call sign_unplacelist([
+                      \ {'id' : 10, 'buffer' : "a.vim"},
+                      \ {'id' : 20, 'buffer' : 'b.vim'},
+                      \ ])
       <
     ]=],
     name = 'sign_unplacelist',
@@ -10177,7 +10177,7 @@ M.funcs = {
       "///path" is simplified to "/path" (this follows the Posix
       standard).
       Example: >vim
-      	simplify("./dir/.././/file/") == "./file/"
+              simplify("./dir/.././/file/") == "./file/"
       <Note: The combination "dir/.." is only removed if "dir" is
       a searchable directory or does not exist.  On Unix, it is also
       removed when "dir" is a symbolic link within the same
@@ -10197,10 +10197,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo sin(100)
-      <	-0.506366 >vim
-      	echo sin(-4.01)
-      <	0.763301
+              echo sin(100)
+      <        -0.506366 >vim
+              echo sin(-4.01)
+      <        0.763301
 
     ]=],
     float_func = 'sin',
@@ -10217,10 +10217,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo sinh(0.5)
-      <	0.521095 >vim
-      	echo sinh(-0.9)
-      <	-1.026517
+              echo sinh(0.5)
+      <       0.521095 >vim
+              echo sinh(-0.9)
+      <       -1.026517
 
     ]=],
     float_func = 'sinh',
@@ -10267,7 +10267,7 @@ M.funcs = {
         |on_data| : callback invoked when data was read from socket
         data_buffered : read socket data in |channel-buffered| mode.
         rpc     : If set, |msgpack-rpc| will be used to communicate
-      	    over the socket.
+                  over the socket.
       Returns:
         - The channel ID on success (greater than zero)
         - 0 on invalid arguments or connection failure.
@@ -10284,7 +10284,7 @@ M.funcs = {
       Sort the items in {list} in-place.  Returns {list}.
 
       If you want a list to remain unmodified make a copy first: >vim
-      	let sortedlist = sort(copy(mylist))
+              let sortedlist = sort(copy(mylist))
 
       <When {how} is omitted or is a string, then sort() uses the
       string representation of each item to sort on.  Numbers sort
@@ -10301,15 +10301,15 @@ M.funcs = {
       collation locale. |v:collate| can also be used to check the
       current locale. Sorting using the locale typically ignores
       case. Example: >vim
-      	" ö is sorted similarly to o with English locale.
-      	language collate en_US.UTF8
-      	echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-      <	['n', 'o', 'O', 'ö', 'p', 'z'] ~
+              " ö is sorted similarly to o with English locale.
+              language collate en_US.UTF8
+              echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+      <        ['n', 'o', 'O', 'ö', 'p', 'z'] ~
       >vim
-      	" ö is sorted after z with Swedish locale.
-      	language collate sv_SE.UTF8
-      	echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
-      <	['n', 'o', 'O', 'p', 'z', 'ö'] ~
+              " ö is sorted after z with Swedish locale.
+              language collate sv_SE.UTF8
+              echo sort(['n', 'o', 'O', 'ö', 'p', 'z'], 'l')
+      <        ['n', 'o', 'O', 'p', 'z', 'ö'] ~
       This does not work properly on Mac.
 
       When {how} is given and it is 'n' then all items will be
@@ -10340,17 +10340,17 @@ M.funcs = {
 
 
       Example: >vim
-      	func MyCompare(i1, i2)
-      	   return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
-      	endfunc
-      	eval mylist->sort("MyCompare")
+              func MyCompare(i1, i2)
+                 return a:i1 == a:i2 ? 0 : a:i1 > a:i2 ? 1 : -1
+              endfunc
+              eval mylist->sort("MyCompare")
       <A shorter compare version for this specific simple case, which
       ignores overflow: >vim
-      	func MyCompare(i1, i2)
-      	   return a:i1 - a:i2
-      	endfunc
+              func MyCompare(i1, i2)
+                 return a:i1 - a:i2
+              endfunc
       <For a simple expression you can use a lambda: >vim
-      	eval mylist->sort({i1, i2 -> i1 - i2})
+              eval mylist->sort({i1, i2 -> i1 - i2})
       <
     ]=],
     name = 'sort',
@@ -10389,13 +10389,13 @@ M.funcs = {
       The return value is a list with two items:
       - The badly spelled word or an empty string.
       - The type of the spelling error:
-      	"bad"		spelling mistake
-      	"rare"		rare word
-      	"local"		word only valid in another region
-      	"caps"		word should start with Capital
+              "bad"           spelling mistake
+              "rare"          rare word
+              "local"         word only valid in another region
+              "caps"          word should start with Capital
       Example: >vim
-      	echo spellbadword("the quik brown fox")
-      <	['quik', 'bad'] ~
+              echo spellbadword("the quik brown fox")
+      <        ['quik', 'bad'] ~
 
       The spelling information for the current window and the value
       of 'spelllang' are used.
@@ -10449,17 +10449,17 @@ M.funcs = {
       Other empty items are kept when {pattern} matches at least one
       character or when {keepempty} is non-zero.
       Example: >vim
-      	let words = split(getline('.'), '\W\+')
+              let words = split(getline('.'), '\W\+')
       <To split a string in individual characters: >vim
-      	for c in split(mystring, '\zs') | endfor
+              for c in split(mystring, '\zs') | endfor
       <If you want to keep the separator you can also use '\zs' at
       the end of the pattern: >vim
-      	echo split('abc:def:ghi', ':\zs')
+              echo split('abc:def:ghi', ':\zs')
       < >
-      	['abc:', 'def:', 'ghi']
+              ['abc:', 'def:', 'ghi']
       <
       Splitting a table where the first element can be empty: >vim
-      	let items = split(line, ':', 1)
+              let items = split(line, ':', 1)
       <The opposite function is |join()|.
 
     ]=],
@@ -10477,10 +10477,10 @@ M.funcs = {
       is negative the result is NaN (Not a Number).  Returns 0.0 if
       {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo sqrt(100)
-      <	10.0 >vim
-      	echo sqrt(-4.01)
-      <	str2float("nan")
+              echo sqrt(100)
+      <        10.0 >vim
+              echo sqrt(-4.01)
+      <        str2float("nan")
       NaN may be different, it depends on system libraries.
 
     ]=],
@@ -10502,9 +10502,9 @@ M.funcs = {
         when a predictable sequence is intended.
 
       Examples: >vim
-      	let seed = srand()
-      	let seed = srand(userinput)
-      	echo rand(seed)
+              let seed = srand()
+              let seed = srand(userinput)
+              echo rand(seed)
       <
     ]=],
     name = 'srand',
@@ -10525,11 +10525,11 @@ M.funcs = {
       {opts} is a dictionary with these keys:
         |on_stdin| : callback invoked when stdin is written to.
         on_print : callback invoked when Nvim needs to print a
-      	     message, with the message (whose type is string)
-      	     as sole argument.
+                   message, with the message (whose type is string)
+                   as sole argument.
         stdin_buffered : read stdin in |channel-buffered| mode.
         rpc      : If set, |msgpack-rpc| will be used to communicate
-      	     over stdio
+                   over stdio
       Returns:
         - |channel-id| on success (value is always 1)
         - 0 on invalid arguments
@@ -10555,12 +10555,12 @@ M.funcs = {
       data_dirs    List    Other data directories.
       log          String  Logs directory (for use by plugins too).
       run          String  Run directory: temporary, local storage
-      		     for sockets, named pipes, etc.
+                           for sockets, named pipes, etc.
       state        String  Session state directory: storage for file
-      		     drafts, swap, undo, |shada|.
+                           drafts, swap, undo, |shada|.
 
       Example: >vim
-      	echo stdpath("config")
+              echo stdpath("config")
       <
     ]=],
     fast = true,
@@ -10587,20 +10587,20 @@ M.funcs = {
 
       When {what} is given only characters in this string will be
       added.  E.g, this checks if the screen has scrolled: >vim
-      	if state('s') == ''
-      	   " screen has not scrolled
+              if state('s') == ''
+                 " screen has not scrolled
       <
       These characters indicate the state, generally indicating that
       something is busy:
-          m	halfway a mapping, :normal command, feedkeys() or
-      	stuffed command
-          o	operator pending, e.g. after |d|
-          a	Insert mode autocomplete active
-          x	executing an autocommand
-          S	not triggering SafeState, e.g. after |f| or a count
-          c	callback invoked, including timer (repeats for
-      	recursiveness up to "ccc")
-          s	screen has scrolled for messages
+          m   halfway a mapping, :normal command, feedkeys() or
+              stuffed command
+          o   operator pending, e.g. after |d|
+          a   Insert mode autocomplete active
+          x   executing an autocommand
+          S   not triggering SafeState, e.g. after |f| or a count
+          c   callback invoked, including timer (repeats for
+              recursiveness up to "ccc")
+          s   screen has scrolled for messages
     ]=],
     fast = true,
     name = 'state',
@@ -10625,7 +10625,7 @@ M.funcs = {
       set to.  A comma ends the number: "12,345.67" is converted to
       12.0.  You can strip out thousands separators with
       |substitute()|: >vim
-      	let f = str2float(substitute(text, ',', '', 'g'))
+              let f = str2float(substitute(text, ',', '', 'g'))
       <
       Returns 0.0 if the conversion fails.
 
@@ -10640,14 +10640,14 @@ M.funcs = {
     desc = [=[
       Return a list containing the number values which represent
       each character in String {string}.  Examples: >vim
-      	echo str2list(" ")		" returns [32]
-      	echo str2list("ABC")		" returns [65, 66, 67]
+              echo str2list(" ")              " returns [32]
+              echo str2list("ABC")            " returns [65, 66, 67]
       <|list2str()| does the opposite.
 
       UTF-8 encoding is always used, {utf8} option has no effect,
       and exists only for backwards-compatibility.
       With UTF-8 composing characters are handled properly: >vim
-      	echo str2list("á")		" returns [97, 769]
+              echo str2list("á")              " returns [97, 769]
 
     ]=],
     name = 'str2list',
@@ -10666,7 +10666,7 @@ M.funcs = {
       When {base} is omitted base 10 is used.  This also means that
       a leading zero doesn't cause octal conversion to be used, as
       with the default String to Number conversion.  Example: >vim
-      	let nr = str2nr('0123')
+              let nr = str2nr('0123')
       <
       When {base} is 16 a leading "0x" or "0X" is ignored.  With a
       different base the result will be zero. Similarly, when
@@ -10712,7 +10712,7 @@ M.funcs = {
       When a character index is used where a character does not
       exist it is omitted and counted as one character.  For
       example: >vim
-      	echo strcharpart('abc', -1, 2)
+              echo strcharpart('abc', -1, 2)
       <results in 'a'.
 
       Returns an empty string on error.
@@ -10742,15 +10742,15 @@ M.funcs = {
       compatibility, you can define a wrapper function: >vim
           if has("patch-7.4.755")
             function s:strchars(str, skipcc)
-      	return strchars(a:str, a:skipcc)
+              return strchars(a:str, a:skipcc)
             endfunction
           else
             function s:strchars(str, skipcc)
-      	if a:skipcc
-      	  return strlen(substitute(a:str, ".", "x", "g"))
-      	else
-      	  return strchars(a:str)
-      	endif
+              if a:skipcc
+                return strlen(substitute(a:str, ".", "x", "g"))
+              else
+                return strchars(a:str)
+              endif
             endfunction
           endif
       <
@@ -10796,12 +10796,12 @@ M.funcs = {
       See also |localtime()|, |getftime()| and |strptime()|.
       The language can be changed with the |:language| command.
       Examples: >vim
-        echo strftime("%c")		   " Sun Apr 27 11:49:23 1997
-        echo strftime("%Y %b %d %X")	   " 1997 Apr 27 11:53:25
-        echo strftime("%y%m%d %T")	   " 970427 11:53:55
-        echo strftime("%H:%M")		   " 11:55
+        echo strftime("%c")              " Sun Apr 27 11:49:23 1997
+        echo strftime("%Y %b %d %X")     " 1997 Apr 27 11:53:25
+        echo strftime("%y%m%d %T")       " 970427 11:53:55
+        echo strftime("%H:%M")                   " 11:55
         echo strftime("%c", getftime("file.c"))
-      				   " Show mod time of file.c.
+                                         " Show mod time of file.c.
 
     ]=],
     name = 'strftime',
@@ -10835,8 +10835,8 @@ M.funcs = {
       {haystack} of the first occurrence of the String {needle}.
       If {start} is specified, the search starts at index {start}.
       This can be used to find a second match: >vim
-      	let colon1 = stridx(line, ":")
-      	let colon2 = stridx(line, ":", colon1 + 1)
+              let colon1 = stridx(line, ":")
+              let colon2 = stridx(line, ":", colon1 + 1)
       <The search is done case-sensitive.
       For pattern searches use |match()|.
       -1 is returned if the {needle} does not occur in {haystack}.
@@ -10845,7 +10845,7 @@ M.funcs = {
         echo stridx("An Example", "Example")     " 3
         echo stridx("Starting point", "Start")   " 0
         echo stridx("Starting point", "start")   " -1
-      <				*strstr()* *strchr()*
+      <                               *strstr()* *strchr()*
       stridx() works similar to the C function strstr().  When used
       with a single character it works similar to strchr().
 
@@ -10863,15 +10863,15 @@ M.funcs = {
       Return {expr} converted to a String.  If {expr} is a Number,
       Float, String, Blob or a composition of them, then the result
       can be parsed back with |eval()|.
-      	{expr} type	result ~
-      	String		'string'
-      	Number		123
-      	Float		123.123456 or 1.123456e8 or
-      			`str2float('inf')`
-      	Funcref		`function('name')`
-      	Blob		0z00112233.44556677.8899
-      	List		[item, item]
-      	Dictionary	`{key: value, key: value}`
+              {expr} type     result ~
+              String          'string'
+              Number          123
+              Float           123.123456 or 1.123456e8 or
+                              `str2float('inf')`
+              Funcref         `function('name')`
+              Blob            0z00112233.44556677.8899
+              List            [item, item]
+              Dictionary      `{key: value, key: value}`
       Note that in String values the ' character is doubled.
       Also see |strtrans()|.
       Note 2: Output format is mostly compatible with YAML, except
@@ -10924,14 +10924,14 @@ M.funcs = {
       result in an error, the bytes are simply omitted.
       If {len} is missing, the copy continues from {start} till the
       end of the {src}. >vim
-      	echo strpart("abcdefg", 3, 2)    " returns 'de'
-      	echo strpart("abcdefg", -2, 4)   " returns 'ab'
-      	echo strpart("abcdefg", 5, 4)    " returns 'fg'
-      	echo strpart("abcdefg", 3)	 " returns 'defg'
+              echo strpart("abcdefg", 3, 2)    " returns 'de'
+              echo strpart("abcdefg", -2, 4)   " returns 'ab'
+              echo strpart("abcdefg", 5, 4)    " returns 'fg'
+              echo strpart("abcdefg", 3)       " returns 'defg'
 
       <Note: To get the first character, {start} must be 0.  For
       example, to get the character under the cursor: >vim
-      	strpart(getline("."), col(".") - 1, 1, v:true)
+              strpart(getline("."), col(".") - 1, 1, v:true)
       <
       Returns an empty string on error.
 
@@ -10989,15 +10989,15 @@ M.funcs = {
       When {start} is specified, matches beyond this index are
       ignored.  This can be used to find a match before a previous
       match: >vim
-      	let lastcomma = strridx(line, ",")
-      	let comma2 = strridx(line, ",", lastcomma - 1)
+              let lastcomma = strridx(line, ",")
+              let comma2 = strridx(line, ",", lastcomma - 1)
       <The search is done case-sensitive.
       For pattern searches use |match()|.
       -1 is returned if the {needle} does not occur in {haystack}.
       If the {needle} is empty the length of {haystack} is returned.
       See also |stridx()|.  Examples: >vim
-        echo strridx("an angry armadillo", "an")	     3
-      <					*strrchr()*
+        echo strridx("an angry armadillo", "an")           3
+      <                                       *strrchr()*
       When used with a single character it works similar to the C
       function strrchr().
 
@@ -11018,7 +11018,7 @@ M.funcs = {
       The result is a String, which is {string} with all unprintable
       characters translated into printable characters |'isprint'|.
       Like they are shown in a window.  Example: >vim
-      	echo strtrans(@a)
+              echo strtrans(@a)
       <This displays a newline in register a as "^@" instead of
       starting a new line.
 
@@ -11047,11 +11047,11 @@ M.funcs = {
 
       Also see |strlen()| and |strcharlen()|.
       Examples: >vim
-          echo strutf16len('a')		" returns 1
-          echo strutf16len('©')		" returns 1
-          echo strutf16len('😊')		" returns 2
-          echo strutf16len('ą́')		" returns 1
-          echo strutf16len('ą́', v:true)	" returns 3
+          echo strutf16len('a')               " returns 1
+          echo strutf16len('©')               " returns 1
+          echo strutf16len('😊')              " returns 2
+          echo strutf16len('ą́')               " returns 1
+          echo strutf16len('ą́', v:true)       " returns 3
       <
     ]=],
     name = 'strutf16len',
@@ -11105,8 +11105,8 @@ M.funcs = {
       Returns an empty string or list on error.
 
       Examples: >vim
-      	s/\d\+/\=submatch(0) + 1/
-      	echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
+              s/\d\+/\=submatch(0) + 1/
+              echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
       <This finds the first number in the line and adds one to it.
       A line break is included as a newline character.
 
@@ -11142,15 +11142,15 @@ M.funcs = {
       unmodified.
 
       Example: >vim
-      	let &path = substitute(&path, ",\\=[^,]*$", "", "")
+              let &path = substitute(&path, ",\\=[^,]*$", "", "")
       <This removes the last component of the 'path' option. >vim
-      	echo substitute("testing", ".*", "\\U\\0", "")
+              echo substitute("testing", ".*", "\\U\\0", "")
       <results in "TESTING".
 
       When {sub} starts with "\=", the remainder is interpreted as
       an expression. See |sub-replace-expression|.  Example: >vim
-      	echo substitute(s, '%\(\x\x\)',
-      	   \ '\=nr2char("0x" .. submatch(1))', 'g')
+              echo substitute(s, '%\(\x\x\)',
+                 \ '\=nr2char("0x" .. submatch(1))', 'g')
 
       <When {sub} is a Funcref that function is called, with one
       optional argument.  Example: >vim
@@ -11180,10 +11180,10 @@ M.funcs = {
       for the directories to inspect.  If you only want to get a
       list of swap files in the current directory then temporarily
       set 'directory' to a dot: >vim
-      	let save_dir = &directory
-      	let &directory = '.'
-      	let swapfiles = swapfilelist()
-      	let &directory = save_dir
+              let save_dir = &directory
+              let &directory = '.'
+              let swapfiles = swapfilelist()
+              let &directory = save_dir
     ]=],
     name = 'swapfilelist',
     params = {},
@@ -11196,20 +11196,20 @@ M.funcs = {
     desc = [=[
       The result is a dictionary, which holds information about the
       swapfile {fname}. The available fields are:
-      	version Vim version
-      	user	user name
-      	host	host name
-      	fname	original file name
-      	pid	PID of the Nvim process that created the swap
-      		file, or zero if not running.
-      	mtime	last modification time in seconds
-      	inode	Optional: INODE number of the file
-      	dirty	1 if file was modified, 0 if not
+              version Vim version
+              user    user name
+              host    host name
+              fname   original file name
+              pid     PID of the Nvim process that created the swap
+                      file, or zero if not running.
+              mtime   last modification time in seconds
+              inode   Optional: INODE number of the file
+              dirty   1 if file was modified, 0 if not
       In case of failure an "error" item is added with the reason:
-      	Cannot open file: file not found or in accessible
-      	Cannot read file: cannot read first block
-      	Not a swap file: does not contain correct block ID
-      	Magic number mismatch: Info in first block is invalid
+              Cannot open file: file not found or in accessible
+              Cannot read file: cannot read first block
+              Not a swap file: does not contain correct block ID
+              Magic number mismatch: Info in first block is invalid
 
     ]=],
     name = 'swapinfo',
@@ -11257,7 +11257,7 @@ M.funcs = {
       Returns zero on error.
 
       Example (echoes the name of the syntax item under the cursor): >vim
-      	echo synIDattr(synID(line("."), col("."), 1), "name")
+              echo synIDattr(synID(line("."), col("."), 1), "name")
       <
     ]=],
     name = 'synID',
@@ -11277,41 +11277,41 @@ M.funcs = {
       used, the attributes for the currently active highlighting are
       used (GUI or cterm).
       Use synIDtrans() to follow linked highlight groups.
-      {what}		result
-      "name"		the name of the syntax item
-      "fg"		foreground color (GUI: color name used to set
-      		the color, cterm: color number as a string,
-      		term: empty string)
-      "bg"		background color (as with "fg")
-      "font"		font name (only available in the GUI)
-      		|highlight-font|
-      "sp"		special color (as with "fg") |guisp|
-      "fg#"		like "fg", but for the GUI and the GUI is
-      		running the name in "#RRGGBB" form
-      "bg#"		like "fg#" for "bg"
-      "sp#"		like "fg#" for "sp"
-      "bold"		"1" if bold
-      "italic"	"1" if italic
-      "reverse"	"1" if reverse
-      "inverse"	"1" if inverse (= reverse)
-      "standout"	"1" if standout
-      "underline"	"1" if underlined
-      "undercurl"	"1" if undercurled
-      "underdouble"	"1" if double underlined
-      "underdotted"	"1" if dotted underlined
-      "underdashed"	"1" if dashed underlined
-      "strikethrough"	"1" if struckthrough
-      "altfont"	"1" if alternative font
-      "nocombine"	"1" if nocombine
+      {what}          result
+      "name"          the name of the syntax item
+      "fg"            foreground color (GUI: color name used to set
+                      the color, cterm: color number as a string,
+                      term: empty string)
+      "bg"            background color (as with "fg")
+      "font"          font name (only available in the GUI)
+                      |highlight-font|
+      "sp"            special color (as with "fg") |guisp|
+      "fg#"           like "fg", but for the GUI and the GUI is
+                      running the name in "#RRGGBB" form
+      "bg#"           like "fg#" for "bg"
+      "sp#"           like "fg#" for "sp"
+      "bold"          "1" if bold
+      "italic"        "1" if italic
+      "reverse"       "1" if reverse
+      "inverse"       "1" if inverse (= reverse)
+      "standout"      "1" if standout
+      "underline"     "1" if underlined
+      "undercurl"     "1" if undercurled
+      "underdouble"   "1" if double underlined
+      "underdotted"   "1" if dotted underlined
+      "underdashed"   "1" if dashed underlined
+      "strikethrough" "1" if struckthrough
+      "altfont"       "1" if alternative font
+      "nocombine"     "1" if nocombine
 
       Returns an empty string on error.
 
       Example (echoes the color of the syntax item under the
       cursor): >vim
-      	echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
+              echo synIDattr(synIDtrans(synID(line("."), col("."), 1)), "fg")
       <
       Can also be used as a |method|: >vim
-      	echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
+              echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
       <
     ]=],
     name = 'synIDattr',
@@ -11355,13 +11355,13 @@ M.funcs = {
          with the same replacement character.  For an example, if
          the text is "123456" and both "23" and "45" are concealed
          and replaced by the character "X", then:
-      	call			returns ~
-      	synconcealed(lnum, 1)   [0, '', 0]
-      	synconcealed(lnum, 2)   [1, 'X', 1]
-      	synconcealed(lnum, 3)   [1, 'X', 1]
-      	synconcealed(lnum, 4)   [1, 'X', 2]
-      	synconcealed(lnum, 5)   [1, 'X', 2]
-      	synconcealed(lnum, 6)   [0, '', 0]
+              call                    returns ~
+              synconcealed(lnum, 1)   [0, '', 0]
+              synconcealed(lnum, 2)   [1, 'X', 1]
+              synconcealed(lnum, 3)   [1, 'X', 1]
+              synconcealed(lnum, 4)   [1, 'X', 2]
+              synconcealed(lnum, 5)   [1, 'X', 2]
+              synconcealed(lnum, 6)   [0, '', 0]
     ]=],
     name = 'synconcealed',
     params = { { 'lnum', 'integer' }, { 'col', 'integer' } },
@@ -11381,9 +11381,9 @@ M.funcs = {
       transparent item.
       This function is useful for debugging a syntax file.
       Example that shows the syntax stack under the cursor: >vim
-      	for id in synstack(line("."), col("."))
-      	   echo synIDattr(id, "name")
-      	endfor
+              for id in synstack(line("."), col("."))
+                 echo synIDattr(id, "name")
+              endfor
       <When the position specified with {lnum} and {col} is invalid
       an empty list is returned.  The position just after the last
       character in a line and the first column in an empty line are
@@ -11427,7 +11427,7 @@ M.funcs = {
       When {input} is given and is a valid buffer id, the content of
       the buffer is written to the file line by line, each line
       terminated by NL (and NUL where the text has NL).
-      						*E5677*
+                                                      *E5677*
       Note: system() cannot write to or read from backgrounded ("&")
       shell commands, e.g.: >vim
           echo system("cat - &", "foo")
@@ -11469,7 +11469,7 @@ M.funcs = {
 
       To see the difference between "echo hello" and "echo -n hello"
       use |system()| and |split()|: >vim
-      	echo split(system('echo hello'), '\n', 1)
+              echo split(system('echo hello'), '\n', 1)
       <
       Returns an empty string on error.
 
@@ -11495,10 +11495,10 @@ M.funcs = {
       omitted the current tab page is used.
       When {arg} is invalid the number zero is returned.
       To get a list of all buffers in all tabs use this: >vim
-      	let buflist = []
-      	for i in range(tabpagenr('$'))
-      	   call extend(buflist, tabpagebuflist(i + 1))
-      	endfor
+              let buflist = []
+              for i in range(tabpagenr('$'))
+                 call extend(buflist, tabpagebuflist(i + 1))
+              endfor
       <Note that a buffer may appear in more than one window.
 
     ]=],
@@ -11513,11 +11513,11 @@ M.funcs = {
       tab page.  The first tab page has number 1.
 
       The optional argument {arg} supports the following values:
-      	$	the number of the last tab page (the tab page
-      		count).
-      	#	the number of the last accessed tab page
-      		(where |g<Tab>| goes to).  If there is no
-      		previous tab page, 0 is returned.
+              $       the number of the last tab page (the tab page
+                      count).
+              #       the number of the last accessed tab page
+                      (where |g<Tab>| goes to).  If there is no
+                      previous tab page, 0 is returned.
       The number can be used with the |:tab| command.
 
       Returns zero on error.
@@ -11539,7 +11539,7 @@ M.funcs = {
       - When "$" the number of windows is returned.
       - When "#" the previous window nr is returned.
       Useful examples: >vim
-          tabpagewinnr(1)	    " current window of tab page 1
+          tabpagewinnr(1)         " current window of tab page 1
           tabpagewinnr(4, '$')    " number of windows in tab page 4
       <When {tabarg} is invalid zero is returned.
 
@@ -11571,19 +11571,19 @@ M.funcs = {
 
       Each list item is a dictionary with at least the following
       entries:
-      	name		Name of the tag.
-      	filename	Name of the file where the tag is
-      			defined.  It is either relative to the
-      			current directory or a full path.
-      	cmd		Ex command used to locate the tag in
-      			the file.
-      	kind		Type of the tag.  The value for this
-      			entry depends on the language specific
-      			kind values.  Only available when
-      			using a tags file generated by
-      			Universal/Exuberant ctags or hdrtag.
-      	static		A file specific tag.  Refer to
-      			|static-tag| for more information.
+              name            Name of the tag.
+              filename        Name of the file where the tag is
+                              defined.  It is either relative to the
+                              current directory or a full path.
+              cmd             Ex command used to locate the tag in
+                              the file.
+              kind            Type of the tag.  The value for this
+                              entry depends on the language specific
+                              kind values.  Only available when
+                              using a tags file generated by
+                              Universal/Exuberant ctags or hdrtag.
+              static          A file specific tag.  Refer to
+                              |static-tag| for more information.
       More entries may be present, depending on the content of the
       tags file: access, implementation, inherits and signature.
       Refer to the ctags documentation for information about these
@@ -11619,10 +11619,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo tan(10)
-      <	0.648361 >vim
-      	echo tan(-4.01)
-      <	-1.181502
+              echo tan(10)
+      <        0.648361 >vim
+              echo tan(-4.01)
+      <        -1.181502
 
     ]=],
     float_func = 'tan',
@@ -11640,10 +11640,10 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo tanh(0.5)
-      <	0.462117 >vim
-      	echo tanh(-1)
-      <	-0.761594
+              echo tanh(0.5)
+      <        0.462117 >vim
+              echo tanh(-1)
+      <        -0.761594
 
     ]=],
     float_func = 'tanh',
@@ -11657,8 +11657,8 @@ M.funcs = {
       Generates a (non-existent) filename located in the Nvim root
       |tempdir|. Scripts can use the filename as a temporary file.
       Example: >vim
-      	let tmpfile = tempname()
-      	exe "redir > " .. tmpfile
+              let tmpfile = tempname()
+              exe "redir > " .. tmpfile
       <
     ]=],
     name = 'tempname',
@@ -11717,11 +11717,11 @@ M.funcs = {
 
       For each timer the information is stored in a |Dictionary| with
       these items:
-          "id"	    the timer ID
-          "time"	    time the timer was started with
-          "repeat"	    number of times the timer will still fire;
-      		    -1 means forever
-          "callback"	    the callback
+          "id"            the timer ID
+          "time"          time the timer was started with
+          "repeat"        number of times the timer will still fire;
+                          -1 means forever
+          "callback"      the callback
 
     ]=],
     name = 'timer_info',
@@ -11768,19 +11768,19 @@ M.funcs = {
       waiting for input.
 
       {options} is a dictionary.  Supported entries:
-         "repeat"	Number of times to repeat the callback.
-      		-1 means forever.  Default is 1.
-      		If the timer causes an error three times in a
-      		row the repeat is cancelled.
+         "repeat"     Number of times to repeat the callback.
+                      -1 means forever.  Default is 1.
+                      If the timer causes an error three times in a
+                      row the repeat is cancelled.
 
       Returns -1 on error.
 
       Example: >vim
-      	func MyHandler(timer)
-      	  echo 'Handler called'
-      	endfunc
-      	let timer = timer_start(500, 'MyHandler',
-      		\ {'repeat': 3})
+              func MyHandler(timer)
+                echo 'Handler called'
+              endfunc
+              let timer = timer_start(500, 'MyHandler',
+                      \ {'repeat': 3})
       <This invokes MyHandler() three times at 500 msec intervals.
 
     ]=],
@@ -11856,9 +11856,9 @@ M.funcs = {
       Returns an empty string on error.
 
       Examples: >vim
-      	echo tr("hello there", "ht", "HT")
+              echo tr("hello there", "ht", "HT")
       <returns "Hello THere" >vim
-      	echo tr("<blob>", "<>", "{}")
+              echo tr("<blob>", "<>", "{}")
       <returns "{blob}"
 
     ]=],
@@ -11880,22 +11880,22 @@ M.funcs = {
 
       The optional {dir} argument specifies where to remove the
       characters:
-      	0	remove from the beginning and end of {text}
-      	1	remove only at the beginning of {text}
-      	2	remove only at the end of {text}
+              0       remove from the beginning and end of {text}
+              1       remove only at the beginning of {text}
+              2       remove only at the end of {text}
       When omitted both ends are trimmed.
 
       This function deals with multibyte characters properly.
       Returns an empty string on error.
 
       Examples: >vim
-      	echo trim("   some text ")
+              echo trim("   some text ")
       <returns "some text" >vim
-      	echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
+              echo trim("  \r\t\t\r RESERVE \t\n\x0B\xA0") .. "_TAIL"
       <returns "RESERVE_TAIL" >vim
-      	echo trim("rm<Xrm<>X>rrm", "rm<>")
+              echo trim("rm<Xrm<>X>rrm", "rm<>")
       <returns "Xrm<>X" (characters in the middle are not removed) >vim
-      	echo trim("  vim  ", " ", 2)
+              echo trim("  vim  ", " ", 2)
       <returns "  vim"
 
     ]=],
@@ -11913,12 +11913,12 @@ M.funcs = {
       {expr} must evaluate to a |Float| or a |Number|.
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
       Examples: >vim
-      	echo trunc(1.456)
-      <	1.0  >vim
-      	echo trunc(-5.456)
-      <	-5.0  >vim
-      	echo trunc(4.0)
-      <	4.0
+              echo trunc(1.456)
+      <        1.0  >vim
+              echo trunc(-5.456)
+      <        -5.0  >vim
+              echo trunc(4.0)
+      <        4.0
 
     ]=],
     float_func = 'trunc',
@@ -11934,28 +11934,28 @@ M.funcs = {
       The result is a Number representing the type of {expr}.
       Instead of using the number directly, it is better to use the
       v:t_ variable that has the value:
-      	Number:	    0  |v:t_number|
-      	String:	    1  |v:t_string|
-      	Funcref:    2  |v:t_func|
-      	List:	    3  |v:t_list|
-      	Dictionary: 4  |v:t_dict|
-      	Float:	    5  |v:t_float|
-      	Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
-      	Null:	    7  (|v:null|)
-      	Blob:	   10  |v:t_blob|
+              Number:     0  |v:t_number|
+              String:     1  |v:t_string|
+              Funcref:    2  |v:t_func|
+              List:       3  |v:t_list|
+              Dictionary: 4  |v:t_dict|
+              Float:      5  |v:t_float|
+              Boolean:    6  |v:t_bool| (|v:false| and |v:true|)
+              Null:       7  (|v:null|)
+              Blob:      10  |v:t_blob|
       For backward compatibility, this method can be used: >vim
-      	if type(myvar) == type(0) | endif
-      	if type(myvar) == type("") | endif
-      	if type(myvar) == type(function("tr")) | endif
-      	if type(myvar) == type([]) | endif
-      	if type(myvar) == type({}) | endif
-      	if type(myvar) == type(0.0) | endif
-      	if type(myvar) == type(v:true) | endif
+              if type(myvar) == type(0) | endif
+              if type(myvar) == type("") | endif
+              if type(myvar) == type(function("tr")) | endif
+              if type(myvar) == type([]) | endif
+              if type(myvar) == type({}) | endif
+              if type(myvar) == type(0.0) | endif
+              if type(myvar) == type(v:true) | endif
       <In place of checking for |v:null| type it is better to check
       for |v:null| directly as it is the only value of this type: >vim
-      	if myvar is v:null | endif
+              if myvar is v:null | endif
       <To check if the v:t_ variables exist use this: >vim
-      	if exists('v:t_number') | endif
+              if exists('v:t_number') | endif
 
     ]=],
     fast = true,
@@ -11991,45 +11991,45 @@ M.funcs = {
       Return the current state of the undo tree for the current
       buffer, or for a specific buffer if {buf} is given.  The
       result is a dictionary with the following items:
-        "seq_last"	The highest undo sequence number used.
-        "seq_cur"	The sequence number of the current position in
-      		the undo tree.  This differs from "seq_last"
-      		when some changes were undone.
-        "time_cur"	Time last used for |:earlier| and related
-      		commands.  Use |strftime()| to convert to
-      		something readable.
-        "save_last"	Number of the last file write.  Zero when no
-      		write yet.
-        "save_cur"	Number of the current position in the undo
-      		tree.
-        "synced"	Non-zero when the last undo block was synced.
-      		This happens when waiting from input from the
-      		user.  See |undo-blocks|.
-        "entries"	A list of dictionaries with information about
-      		undo blocks.
+        "seq_last"    The highest undo sequence number used.
+        "seq_cur"     The sequence number of the current position in
+                      the undo tree.  This differs from "seq_last"
+                      when some changes were undone.
+        "time_cur"    Time last used for |:earlier| and related
+                      commands.  Use |strftime()| to convert to
+                      something readable.
+        "save_last"   Number of the last file write.  Zero when no
+                      write yet.
+        "save_cur"    Number of the current position in the undo
+                      tree.
+        "synced"      Non-zero when the last undo block was synced.
+                      This happens when waiting from input from the
+                      user.  See |undo-blocks|.
+        "entries"     A list of dictionaries with information about
+                      undo blocks.
 
       The first item in the "entries" list is the oldest undo item.
       Each List item is a |Dictionary| with these items:
-        "seq"		Undo sequence number.  Same as what appears in
-      		|:undolist|.
-        "time"	Timestamp when the change happened.  Use
-      		|strftime()| to convert to something readable.
-        "newhead"	Only appears in the item that is the last one
-      		that was added.  This marks the last change
-      		and where further changes will be added.
-        "curhead"	Only appears in the item that is the last one
-      		that was undone.  This marks the current
-      		position in the undo tree, the block that will
-      		be used by a redo command.  When nothing was
-      		undone after the last change this item will
-      		not appear anywhere.
-        "save"	Only appears on the last block before a file
-      		write.  The number is the write count.  The
-      		first write has number 1, the last one the
-      		"save_last" mentioned above.
-        "alt"		Alternate entry.  This is again a List of undo
-      		blocks.  Each item may again have an "alt"
-      		item.
+        "seq"         Undo sequence number.  Same as what appears in
+                      |:undolist|.
+        "time"        Timestamp when the change happened.  Use
+                      |strftime()| to convert to something readable.
+        "newhead"     Only appears in the item that is the last one
+                      that was added.  This marks the last change
+                      and where further changes will be added.
+        "curhead"     Only appears in the item that is the last one
+                      that was undone.  This marks the current
+                      position in the undo tree, the block that will
+                      be used by a redo command.  When nothing was
+                      undone after the last change this item will
+                      not appear anywhere.
+        "save"        Only appears on the last block before a file
+                      write.  The number is the write count.  The
+                      first write has number 1, the last one the
+                      "save_last" mentioned above.
+        "alt"         Alternate entry.  This is again a List of undo
+                      blocks.  Each item may again have an "alt"
+                      item.
     ]=],
     name = 'undotree',
     params = { { 'buf', 'integer|string' } },
@@ -12043,7 +12043,7 @@ M.funcs = {
       Remove second and succeeding copies of repeated adjacent
       {list} items in-place.  Returns {list}.  If you want a list
       to remain unmodified make a copy first: >vim
-      	let newlist = uniq(copy(mylist))
+              let newlist = uniq(copy(mylist))
       <The default compare function uses the string representation of
       each item.  For the use of {func} and {dict} see |sort()|.
 
@@ -12077,13 +12077,13 @@ M.funcs = {
       character index from the UTF-16 index.
       Refer to |string-offset-encoding| for more information.
       Examples: >vim
-      	echo utf16idx('a😊😊', 3)	" returns 2
-      	echo utf16idx('a😊😊', 7)	" returns 4
-      	echo utf16idx('a😊😊', 1, 0, 1)	" returns 2
-      	echo utf16idx('a😊😊', 2, 0, 1)	" returns 4
-      	echo utf16idx('aą́c', 6)		" returns 2
-      	echo utf16idx('aą́c', 6, 1)	" returns 4
-      	echo utf16idx('a😊😊', 9)	" returns -1
+              echo utf16idx('a😊😊', 3)       " returns 2
+              echo utf16idx('a😊😊', 7)       " returns 4
+              echo utf16idx('a😊😊', 1, 0, 1) " returns 2
+              echo utf16idx('a😊😊', 2, 0, 1) " returns 4
+              echo utf16idx('aą́c', 6)         " returns 2
+              echo utf16idx('aą́c', 6, 1)      " returns 4
+              echo utf16idx('a😊😊', 9)       " returns -1
       <
     ]=],
     name = 'utf16idx',
@@ -12133,16 +12133,16 @@ M.funcs = {
       |'virtualedit'|
 
       The accepted positions are:
-          .	    the cursor position
-          $	    the end of the cursor line (the result is the
-      	    number of displayed characters in the cursor line
-      	    plus one)
-          'x	    position of mark x (if the mark is not set, 0 is
-      	    returned)
+          .       the cursor position
+          $       the end of the cursor line (the result is the
+                  number of displayed characters in the cursor line
+                  plus one)
+          'x      position of mark x (if the mark is not set, 0 is
+                  returned)
           v       In Visual mode: the start of the Visual area (the
-      	    cursor is the end).  When not in Visual mode
-      	    returns the cursor position.  Differs from |'<| in
-      	    that it's updated right away.
+                  cursor is the end).  When not in Visual mode
+                  returns the cursor position.  Differs from |'<| in
+                  that it's updated right away.
 
       If {list} is present and non-zero then virtcol() returns a
       List with the first and last screen position occupied by the
@@ -12153,15 +12153,15 @@ M.funcs = {
 
       Note that only marks in the current file can be used.
       Examples: >vim
-      	" With text "foo^Lbar" and cursor on the "^L":
+              " With text "foo^Lbar" and cursor on the "^L":
 
-      	echo virtcol(".")	" returns 5
-      	echo virtcol(".", 1)	" returns [4, 5]
-      	echo virtcol("$")	" returns 9
+              echo virtcol(".")       " returns 5
+              echo virtcol(".", 1)    " returns [4, 5]
+              echo virtcol("$")       " returns 9
 
-      	" With text "	  there", with 't at 'h':
+              " With text "     there", with 't at 'h':
 
-      	echo virtcol("'t")	" returns 6
+              echo virtcol("'t")      " returns 6
       <The first column is 1.  0 or [0, 0] is returned for an error.
       A more advanced example that echoes the maximum length of
       all lines: >vim
@@ -12212,7 +12212,7 @@ M.funcs = {
       character-wise, line-wise, or block-wise Visual mode
       respectively.
       Example: >vim
-      	exe "normal " .. visualmode()
+              exe "normal " .. visualmode()
       <This enters the same Visual mode as before.  It is also useful
       in scripts if you wish to act differently depending on the
       Visual mode that was used.
@@ -12239,10 +12239,10 @@ M.funcs = {
       every {interval} milliseconds (default: 200).
 
       Returns a status integer:
-      	0 if the condition was satisfied before timeout
-      	-1 if the timeout was exceeded
-      	-2 if the function was interrupted (by |CTRL-C|)
-      	-3 if an error occurred
+              0 if the condition was satisfied before timeout
+              -1 if the timeout was exceeded
+              -2 if the function was interrupted (by |CTRL-C|)
+              -3 if an error occurred
     ]=],
     name = 'wait',
     params = { { 'timeout', 'integer' }, { 'condition', 'any' }, { 'interval', 'any' } },
@@ -12274,7 +12274,7 @@ M.funcs = {
       executing {command} autocommands will be triggered, this may
       have unexpected side effects.  Use `:noautocmd` if needed.
       Example: >vim
-      	call win_execute(winid, 'syntax enable')
+              call win_execute(winid, 'syntax enable')
       <Doing the same with `setwinvar()` would not trigger
       autocommands and not actually show syntax highlighting.
 
@@ -12322,15 +12322,15 @@ M.funcs = {
     base = 1,
     desc = [=[
       Return the type of the window:
-      	"autocmd"	autocommand window. Temporary window
-      			used to execute autocommands.
-      	"command"	command-line window |cmdwin|
-      	(empty)		normal window
-      	"loclist"	|location-list-window|
-      	"popup"		floating window |api-floatwin|
-      	"preview"	preview window |preview-window|
-      	"quickfix"	|quickfix-window|
-      	"unknown"	window {nr} not found
+              "autocmd"       autocommand window. Temporary window
+                              used to execute autocommands.
+              "command"       command-line window |cmdwin|
+              (empty)         normal window
+              "loclist"       |location-list-window|
+              "popup"         floating window |api-floatwin|
+              "preview"       preview window |preview-window|
+              "quickfix"      |quickfix-window|
+              "unknown"       window {nr} not found
 
       When {nr} is omitted return the type of the current window.
       When {nr} is given return the type of this window by number or
@@ -12458,13 +12458,13 @@ M.funcs = {
       Returns zero for success, non-zero for failure.
 
       {options} is a |Dictionary| with the following optional entries:
-        "vertical"	When TRUE, the split is created vertically,
-      		like with |:vsplit|.
-        "rightbelow"	When TRUE, the split is made below or to the
-      		right (if vertical).  When FALSE, it is done
-      		above or to the left (if vertical).  When not
-      		present, the values of 'splitbelow' and
-      		'splitright' are used.
+        "vertical"    When TRUE, the split is created vertically,
+                      like with |:vsplit|.
+        "rightbelow"  When TRUE, the split is made below or to the
+                      right (if vertical).  When FALSE, it is done
+                      above or to the left (if vertical).  When not
+                      present, the values of 'splitbelow' and
+                      'splitright' are used.
 
     ]=],
     name = 'win_splitmove',
@@ -12545,32 +12545,32 @@ M.funcs = {
       returns an empty list.
 
       For a leaf window, it returns: >
-      	["leaf", {winid}]
+              ["leaf", {winid}]
       <
       For horizontally split windows, which form a column, it
       returns: >
-      	["col", [{nested list of windows}]]
+              ["col", [{nested list of windows}]]
       <For vertically split windows, which form a row, it returns: >
-      	["row", [{nested list of windows}]]
+              ["row", [{nested list of windows}]]
       <
       Example: >vim
-      	" Only one window in the tab page
-      	echo winlayout()
+              " Only one window in the tab page
+              echo winlayout()
       < >
-      	['leaf', 1000]
+              ['leaf', 1000]
       < >vim
-      	" Two horizontally split windows
-      	echo winlayout()
+              " Two horizontally split windows
+              echo winlayout()
       < >
-      	['col', [['leaf', 1000], ['leaf', 1001]]]
+              ['col', [['leaf', 1000], ['leaf', 1001]]]
       < >vim
-      	" The second tab page, with three horizontally split
-      	" windows, with two vertically split windows in the
-      	" middle window
-      	echo winlayout(2)
+              " The second tab page, with three horizontally split
+              " windows, with two vertically split windows in the
+              " middle window
+              echo winlayout(2)
       < >
-      	['col', [['leaf', 1002], ['row', [['leaf', 1003],
-      			    ['leaf', 1001]]], ['leaf', 1000]]]
+              ['col', [['leaf', 1002], ['row', [['leaf', 1003],
+                                  ['leaf', 1001]]], ['leaf', 1000]]]
       <
     ]=],
     name = 'winlayout',
@@ -12599,28 +12599,28 @@ M.funcs = {
       Returns zero for a popup window.
 
       The optional argument {arg} supports the following values:
-      	$	the number of the last window (the window
-      		count).
-      	#	the number of the last accessed window (where
-      		|CTRL-W_p| goes to).  If there is no previous
-      		window or it is in another tab page 0 is
-      		returned.
-      	{N}j	the number of the Nth window below the
-      		current window (where |CTRL-W_j| goes to).
-      	{N}k	the number of the Nth window above the current
-      		window (where |CTRL-W_k| goes to).
-      	{N}h	the number of the Nth window left of the
-      		current window (where |CTRL-W_h| goes to).
-      	{N}l	the number of the Nth window right of the
-      		current window (where |CTRL-W_l| goes to).
+              $       the number of the last window (the window
+                      count).
+              #       the number of the last accessed window (where
+                      |CTRL-W_p| goes to).  If there is no previous
+                      window or it is in another tab page 0 is
+                      returned.
+              {N}j    the number of the Nth window below the
+                      current window (where |CTRL-W_j| goes to).
+              {N}k    the number of the Nth window above the current
+                      window (where |CTRL-W_k| goes to).
+              {N}h    the number of the Nth window left of the
+                      current window (where |CTRL-W_h| goes to).
+              {N}l    the number of the Nth window right of the
+                      current window (where |CTRL-W_l| goes to).
       The number can be used with |CTRL-W_w| and ":wincmd w"
       |:wincmd|.
       When {arg} is invalid an error is given and zero is returned.
       Also see |tabpagewinnr()| and |win_getid()|.
       Examples: >vim
-      	let window_count = winnr('$')
-      	let prev_window = winnr('#')
-      	let wnum = winnr('3k')
+              let window_count = winnr('$')
+              let prev_window = winnr('#')
+              let wnum = winnr('3k')
 
     ]=],
     name = 'winnr',
@@ -12634,9 +12634,9 @@ M.funcs = {
       are opened or closed and the current window and tab page is
       unchanged.
       Example: >vim
-      	let cmd = winrestcmd()
-      	call MessWithWindowSizes()
-      	exe cmd
+              let cmd = winrestcmd()
+              call MessWithWindowSizes()
+              exe cmd
       <
     ]=],
     name = 'winrestcmd',
@@ -12678,21 +12678,21 @@ M.funcs = {
       option to temporarily switch off folding, so that folds are
       not opened when moving around. This may have side effects.
       The return value includes:
-      	lnum		cursor line number
-      	col		cursor column (Note: the first column
-      			zero, as opposed to what |getcurpos()|
-      			returns)
-      	coladd		cursor column offset for 'virtualedit'
-      	curswant	column for vertical movement (Note:
-      			the first column is zero, as opposed
-      			to what |getcurpos()| returns).  After
-      			|$| command it will be a very large
-      			number equal to |v:maxcol|.
-      	topline		first line in the window
-      	topfill		filler lines, only in diff mode
-      	leftcol		first column displayed; only used when
-      			'wrap' is off
-      	skipcol		columns skipped
+              lnum            cursor line number
+              col             cursor column (Note: the first column
+                              zero, as opposed to what |getcurpos()|
+                              returns)
+              coladd          cursor column offset for 'virtualedit'
+              curswant        column for vertical movement (Note:
+                              the first column is zero, as opposed
+                              to what |getcurpos()| returns).  After
+                              |$| command it will be a very large
+                              number equal to |v:maxcol|.
+              topline         first line in the window
+              topfill         filler lines, only in diff mode
+              leftcol         first column displayed; only used when
+                              'wrap' is off
+              skipcol         columns skipped
       Note that no option values are saved.
     ]=],
     name = 'winsaveview',
@@ -12728,21 +12728,21 @@ M.funcs = {
       the current buffer.  This is the same info as provided by
       |g_CTRL-G|
       The return value includes:
-      	bytes		Number of bytes in the buffer
-      	chars		Number of chars in the buffer
-      	words		Number of words in the buffer
-      	cursor_bytes    Number of bytes before cursor position
-      			(not in Visual mode)
-      	cursor_chars    Number of chars before cursor position
-      			(not in Visual mode)
-      	cursor_words    Number of words before cursor position
-      			(not in Visual mode)
-      	visual_bytes    Number of bytes visually selected
-      			(only in Visual mode)
-      	visual_chars    Number of chars visually selected
-      			(only in Visual mode)
-      	visual_words    Number of words visually selected
-      			(only in Visual mode)
+              bytes           Number of bytes in the buffer
+              chars           Number of chars in the buffer
+              words           Number of words in the buffer
+              cursor_bytes    Number of bytes before cursor position
+                              (not in Visual mode)
+              cursor_chars    Number of chars before cursor position
+                              (not in Visual mode)
+              cursor_words    Number of words before cursor position
+                              (not in Visual mode)
+              visual_bytes    Number of bytes visually selected
+                              (only in Visual mode)
+              visual_chars    Number of chars visually selected
+                              (only in Visual mode)
+              visual_words    Number of words visually selected
+                              (only in Visual mode)
     ]=],
     name = 'wordcount',
     params = {},
@@ -12769,12 +12769,12 @@ M.funcs = {
            last line in the file to end in a NL.
 
       'a'  Append mode is used, lines are appended to the file: >vim
-      	call writefile(["foo"], "event.log", "a")
-      	call writefile(["bar"], "event.log", "a")
+              call writefile(["foo"], "event.log", "a")
+              call writefile(["bar"], "event.log", "a")
       <
       'D'  Delete the file when the current function ends.  This
            works like: >vim
-      	defer delete({fname})
+              defer delete({fname})
       <     Fails when not in a function.  Also see |:defer|.
 
       's'  fsync() is called after writing the file.  This flushes
@@ -12794,8 +12794,8 @@ M.funcs = {
 
       Also see |readfile()|.
       To copy a file byte for byte: >vim
-      	let fl = readfile("foo", "b")
-      	call writefile(fl, "foocopy", "b")
+              let fl = readfile("foo", "b")
+              call writefile(fl, "foocopy", "b")
 
     ]=],
     name = 'writefile',
@@ -12810,7 +12810,7 @@ M.funcs = {
       to a number.  A List, Dict or Float argument causes an error.
       Also see `and()` and `or()`.
       Example: >vim
-      	let bits = xor(bits, 0x80)
+              let bits = xor(bits, 0x80)
       <
     ]=],
     name = 'xor',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -120,10 +120,10 @@ return {
         letters, Cyrillic letters).
 
         There are currently two possible values:
-        "single":	Use the same width as characters in US-ASCII.  This is
-        		expected by most users.
-        "double":	Use twice the width of ASCII characters.
-        						*E834* *E835*
+        "single":       Use the same width as characters in US-ASCII.  This is
+                        expected by most users.
+        "double":       Use twice the width of ASCII characters.
+                                                        *E834* *E835*
         The value "double" cannot be used if 'listchars' or 'fillchars'
         contains a character that would be double width.  These errors may
         also be given when calling setcellwidths().
@@ -255,7 +255,7 @@ return {
         |timestamp|
         If this option has a local value, use this command to switch back to
         using the global value: >vim
-        	set autoread<
+                set autoread<
         <
       ]=],
       full_name = 'autoread',
@@ -316,7 +316,7 @@ return {
         This option does NOT change the background color, it tells Nvim what
         the "inherited" (terminal/GUI) background looks like.
         See |:hi-normal| if you want to set the background color explicitly.
-        					*g:colors_name*
+                                                *g:colors_name*
         When a color scheme is loaded (the "g:colors_name" variable is set)
         changing 'background' will cause the color scheme to be reloaded.  If
         the color scheme adjusts to the value of 'background' this will work.
@@ -325,10 +325,10 @@ return {
 
         Normally this option would be set in the vimrc file.  Possibly
         depending on the terminal name.  Example: >vim
-        	if $TERM ==# "xterm"
-        	  set background=dark
-        	endif
-        <	When this option is changed, the default settings for the highlight groups
+                if $TERM ==# "xterm"
+                  set background=dark
+                endif
+        <       When this option is changed, the default settings for the highlight groups
         will change.  To use other settings, place ":highlight" commands AFTER
         the setting of the 'background' option.
       ]=],
@@ -348,13 +348,13 @@ return {
         Influences the working of <BS>, <Del>, CTRL-W and CTRL-U in Insert
         mode.  This is a list of items, separated by commas.  Each item allows
         a way to backspace over something:
-        value	effect	~
-        indent	allow backspacing over autoindent
-        eol	allow backspacing over line breaks (join lines)
-        start	allow backspacing over the start of insert; CTRL-W and CTRL-U
-        	stop once at the start of insert.
-        nostop	like start, except CTRL-W and CTRL-U do not stop at the start of
-        	insert.
+        value   effect  ~
+        indent  allow backspacing over autoindent
+        eol     allow backspacing over line breaks (join lines)
+        start   allow backspacing over the start of insert; CTRL-W and CTRL-U
+                stop once at the start of insert.
+        nostop  like start, except CTRL-W and CTRL-U do not stop at the start of
+                insert.
 
         When the value is empty, Vi compatible backspacing is used, none of
         the ways mentioned for the items above are possible.
@@ -398,13 +398,13 @@ return {
         done.  This is a comma-separated list of words.
 
         The main values are:
-        "yes"	make a copy of the file and overwrite the original one
-        "no"	rename the file and write a new one
-        "auto"	one of the previous, what works best
+        "yes"   make a copy of the file and overwrite the original one
+        "no"    rename the file and write a new one
+        "auto"  one of the previous, what works best
 
         Extra values that can be combined with the ones above are:
-        "breaksymlink"	always break symlinks when writing
-        "breakhardlink"	always break hardlinks when writing
+        "breaksymlink"  always break symlinks when writing
+        "breakhardlink" always break hardlinks when writing
 
         Making a copy and overwriting the original file:
         - Takes extra time to copy the file.
@@ -432,7 +432,7 @@ return {
         useful for example in source trees where all the files are symbolic or
         hard links and any changes should stay in the local source tree, not
         be propagated back to the original source.
-        						*crontab*
+                                                        *crontab*
         One situation where "no" and "auto" will cause problems: A program
         that opens a file, invokes Vim to edit that file, and then tests if
         the open file was changed (through the file descriptor) will check the
@@ -501,8 +501,8 @@ return {
         <
         See also 'backup' and 'writebackup' options.
         If you want to hide your backup files on Unix, consider this value: >vim
-        	set backupdir=./.backup,~/.backup,.,/tmp
-        <	You must create a ".backup" directory in each directory and in your
+                set backupdir=./.backup,~/.backup,.,/tmp
+        <       You must create a ".backup" directory in each directory and in your
         home directory for this to work properly.
         The use of |:set+=| and |:set-=| is preferred when adding or removing
         directories from the list.  This avoids problems when a future version
@@ -534,8 +534,8 @@ return {
         If you like to keep a lot of backups, you could use a BufWritePre
         autocommand to change 'backupext' just before writing the file to
         include a timestamp. >vim
-        	au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
-        <	Use 'backupdir' to put the backup in a different directory.
+                au BufWritePre * let &bex = '-' .. strftime("%Y%b%d%X") .. '~'
+        <       Use 'backupdir' to put the backup in a different directory.
       ]=],
       full_name = 'backupext',
       normal_fname_chars = true,
@@ -549,9 +549,11 @@ return {
       abbreviation = 'bsk',
       defaults = {
         if_true = '',
-        doc = [["$TMPDIR/*,$TMP/*,$TEMP/*"
-        Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
-        Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"]],
+        doc = [[
+          "$TMPDIR/*,$TMP/*,$TEMP/*"
+          Unix: "/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
+          Mac: "/private/tmp/*,$TMPDIR/*,$TMP/*,$TEMP/*"
+        ]],
         meta = '/tmp/*',
       },
       deny_duplicates = true,
@@ -571,9 +573,9 @@ return {
 
         Note that environment variables are not expanded.  If you want to use
         $HOME you must expand it explicitly, e.g.: >vim
-        	let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
+                let &backupskip = escape(expand('$HOME'), '\') .. '/tmp/*'
 
-        <	Note that the default also makes sure that "crontab -e" works (when a
+        <       Note that the default also makes sure that "crontab -e" works (when a
         backup would be made by renaming the original file crontab won't see
         the newly created file).  Also see 'backupcopy' and |crontab|.
       ]=],
@@ -595,30 +597,30 @@ return {
         will be silenced. This is most useful to specify specific events in
         insert mode to be silenced.
 
-        item	    meaning when present	~
-        all	    All events.
+        item        meaning when present        ~
+        all         All events.
         backspace   When hitting <BS> or <Del> and deleting results in an
-        	    error.
-        cursor	    Fail to move around using the cursor keys or
-        	    <PageUp>/<PageDown> in |Insert-mode|.
+                    error.
+        cursor      Fail to move around using the cursor keys or
+                    <PageUp>/<PageDown> in |Insert-mode|.
         complete    Error occurred when using |i_CTRL-X_CTRL-K| or
-        	    |i_CTRL-X_CTRL-T|.
-        copy	    Cannot copy char from insert mode using |i_CTRL-Y| or
-        	    |i_CTRL-E|.
-        ctrlg	    Unknown Char after <C-G> in Insert mode.
-        error	    Other Error occurred (e.g. try to join last line)
-        	    (mostly used in |Normal-mode| or |Cmdline-mode|).
-        esc	    hitting <Esc> in |Normal-mode|.
-        hangul	    Ignored.
-        lang	    Calling the beep module for Lua/Mzscheme/TCL.
-        mess	    No output available for |g<|.
+                    |i_CTRL-X_CTRL-T|.
+        copy        Cannot copy char from insert mode using |i_CTRL-Y| or
+                    |i_CTRL-E|.
+        ctrlg       Unknown Char after <C-G> in Insert mode.
+        error       Other Error occurred (e.g. try to join last line)
+                    (mostly used in |Normal-mode| or |Cmdline-mode|).
+        esc         hitting <Esc> in |Normal-mode|.
+        hangul      Ignored.
+        lang        Calling the beep module for Lua/Mzscheme/TCL.
+        mess        No output available for |g<|.
         showmatch   Error occurred for 'showmatch' function.
         operator    Empty region error |cpo-E|.
         register    Unknown register after <C-R> in |Insert-mode|.
-        shell	    Bell from shell output |:!|.
-        spell	    Error happened on spell suggest.
+        shell       Bell from shell output |:!|.
+        spell       Error happened on spell suggest.
         wildmode    More matches in |cmdline-completion| available
-        	    (depends on the 'wildmode' setting).
+                    (depends on the 'wildmode' setting).
 
         This is most useful to fine tune when in Insert mode the bell should
         be rung. For Normal mode and Ex commands, the bell is often rung to
@@ -641,10 +643,10 @@ return {
         This option should be set before editing a binary file.  You can also
         use the |-b| Vim argument.  When this option is switched on a few
         options will be changed (also when it already was on):
-        	'textwidth'  will be set to 0
-        	'wrapmargin' will be set to 0
-        	'modeline'   will be off
-        	'expandtab'  will be off
+                'textwidth'  will be set to 0
+                'wrapmargin' will be set to 0
+                'modeline'   will be off
+                'expandtab'  will be off
         Also, 'fileformat' and 'fileformats' options will not be used, the
         file is read and written like 'fileformat' was "unix" (a single <NL>
         separates lines).
@@ -742,31 +744,31 @@ return {
       desc = [=[
         Settings for 'breakindent'. It can consist of the following optional
         items and must be separated by a comma:
-        	min:{n}	    Minimum text width that will be kept after
-        		    applying 'breakindent', even if the resulting
-        		    text should normally be narrower. This prevents
-        		    text indented almost to the right window border
-        		    occupying lot of vertical space when broken.
-        		    (default: 20)
-        	shift:{n}   After applying 'breakindent', the wrapped line's
-        		    beginning will be shifted by the given number of
-        		    characters.  It permits dynamic French paragraph
-        		    indentation (negative) or emphasizing the line
-        		    continuation (positive).
-        		    (default: 0)
-        	sbr	    Display the 'showbreak' value before applying the
-        		    additional indent.
-        		    (default: off)
-        	list:{n}    Adds an additional indent for lines that match a
-        		    numbered or bulleted list (using the
-        		    'formatlistpat' setting).
-        	list:-1	    Uses the length of a match with 'formatlistpat'
-        		    for indentation.
-        		    (default: 0)
-        	column:{n}  Indent at column {n}. Will overrule the other
-        		    sub-options. Note: an additional indent may be
-        		    added for the 'showbreak' setting.
-        		    (default: off)
+                min:{n}     Minimum text width that will be kept after
+                            applying 'breakindent', even if the resulting
+                            text should normally be narrower. This prevents
+                            text indented almost to the right window border
+                            occupying lot of vertical space when broken.
+                            (default: 20)
+                shift:{n}   After applying 'breakindent', the wrapped line's
+                            beginning will be shifted by the given number of
+                            characters.  It permits dynamic French paragraph
+                            indentation (negative) or emphasizing the line
+                            continuation (positive).
+                            (default: 0)
+                sbr         Display the 'showbreak' value before applying the
+                            additional indent.
+                            (default: off)
+                list:{n}    Adds an additional indent for lines that match a
+                            numbered or bulleted list (using the
+                            'formatlistpat' setting).
+                list:-1     Uses the length of a match with 'formatlistpat'
+                            for indentation.
+                            (default: 0)
+                column:{n}  Indent at column {n}. Will overrule the other
+                            sub-options. Note: an additional indent may be
+                            added for the 'showbreak' setting.
+                            (default: off)
       ]=],
       expand_cb = 'expand_set_breakindentopt',
       full_name = 'breakindentopt',
@@ -784,11 +786,11 @@ return {
       },
       desc = [=[
         Which directory to use for the file browser:
-           last		Use same directory as with last file browser, where a
-        		file was opened or saved.
-           buffer	Use the directory of the related buffer.
-           current	Use the current directory.
-           {path}	Use the specified directory
+           last         Use same directory as with last file browser, where a
+                        file was opened or saved.
+           buffer       Use the directory of the related buffer.
+           current      Use the current directory.
+           {path}       Use the specified directory
       ]=],
       enable_if = false,
       full_name = 'browsedir',
@@ -804,17 +806,17 @@ return {
       desc = [=[
         This option specifies what happens when a buffer is no longer
         displayed in a window:
-          <empty>	follow the global 'hidden' option
-          hide		hide the buffer (don't unload it), even if 'hidden' is
-        		not set
-          unload	unload the buffer, even if 'hidden' is set; the
-        		|:hide| command will also unload the buffer
-          delete	delete the buffer from the buffer list, even if
-        		'hidden' is set; the |:hide| command will also delete
-        		the buffer, making it behave like |:bdelete|
-          wipe		wipe the buffer from the buffer list, even if
-        		'hidden' is set; the |:hide| command will also wipe
-        		out the buffer, making it behave like |:bwipeout|
+          <empty>       follow the global 'hidden' option
+          hide          hide the buffer (don't unload it), even if 'hidden' is
+                        not set
+          unload        unload the buffer, even if 'hidden' is set; the
+                        |:hide| command will also unload the buffer
+          delete        delete the buffer from the buffer list, even if
+                        'hidden' is set; the |:hide| command will also delete
+                        the buffer, making it behave like |:bdelete|
+          wipe          wipe the buffer from the buffer list, even if
+                        'hidden' is set; the |:hide| command will also wipe
+                        out the buffer, making it behave like |:bwipeout|
 
         CAREFUL: when "unload", "delete" or "wipe" is used changes in a buffer
         are lost without a warning.  Also, these values may break autocommands
@@ -856,15 +858,15 @@ return {
       defaults = { if_true = '' },
       desc = [=[
         The value of this option specifies the type of a buffer:
-          <empty>	normal buffer
-          acwrite	buffer will always be written with |BufWriteCmd|s
-          help		help buffer (do not set this manually)
-          nofile	buffer is not related to a file, will not be written
-          nowrite	buffer will not be written
-          quickfix	list of errors |:cwindow| or locations |:lwindow|
-          terminal	|terminal-emulator| buffer
-          prompt	buffer where only the last line can be edited, meant
-        		to be used by a plugin, see |prompt-buffer|
+          <empty>       normal buffer
+          acwrite       buffer will always be written with |BufWriteCmd|s
+          help          help buffer (do not set this manually)
+          nofile        buffer is not related to a file, will not be written
+          nowrite       buffer will not be written
+          quickfix      list of errors |:cwindow| or locations |:lwindow|
+          terminal      |terminal-emulator| buffer
+          prompt        buffer where only the last line can be edited, meant
+                        to be used by a plugin, see |prompt-buffer|
 
         This option is used together with 'bufhidden' and 'swapfile' to
         specify special kinds of buffers.   See |special-buffers|.
@@ -879,21 +881,21 @@ return {
         you are not supposed to change it.
 
         "nofile" and "nowrite" buffers are similar:
-        both:		The buffer is not to be written to disk, ":w" doesn't
-        		work (":w filename" does work though).
-        both:		The buffer is never considered to be |'modified'|.
-        		There is no warning when the changes will be lost, for
-        		example when you quit Vim.
-        both:		A swap file is only created when using too much memory
-        		(when 'swapfile' has been reset there is never a swap
-        		file).
-        nofile only:	The buffer name is fixed, it is not handled like a
-        		file name.  It is not modified in response to a |:cd|
-        		command.
-        both:		When using ":e bufname" and already editing "bufname"
-        		the buffer is made empty and autocommands are
-        		triggered as usual for |:edit|.
-        						*E676*
+        both:           The buffer is not to be written to disk, ":w" doesn't
+                        work (":w filename" does work though).
+        both:           The buffer is never considered to be |'modified'|.
+                        There is no warning when the changes will be lost, for
+                        example when you quit Vim.
+        both:           A swap file is only created when using too much memory
+                        (when 'swapfile' has been reset there is never a swap
+                        file).
+        nofile only:    The buffer name is fixed, it is not handled like a
+                        file name.  It is not modified in response to a |:cd|
+                        command.
+        both:           When using ":e bufname" and already editing "bufname"
+                        the buffer is made empty and autocommands are
+                        triggered as usual for |:edit|.
+                                                        *E676*
         "acwrite" implies that the buffer name is not related to a file, like
         "nofile", but it will be written.  Thus, in contrast to "nofile" and
         "nowrite", ":w" does work and a modified buffer can't be abandoned
@@ -917,13 +919,13 @@ return {
       desc = [=[
         Specifies details about changing the case of letters.  It may contain
         these words, separated by a comma:
-        internal	Use internal case mapping functions, the current
-        		locale does not change the case mapping. When
-        		"internal" is omitted, the towupper() and towlower()
-        		system library functions are used when available.
-        keepascii	For the ASCII characters (0x00 to 0x7f) use the US
-        		case mapping, the current locale is not effective.
-        		This probably only matters for Turkish.
+        internal        Use internal case mapping functions, the current
+                        locale does not change the case mapping. When
+                        "internal" is omitted, the towupper() and towlower()
+                        system library functions are used when available.
+        keepascii       For the ASCII characters (0x00 to 0x7f) use the US
+                        case mapping, the current locale is not effective.
+                        This probably only matters for Turkish.
       ]=],
       expand_cb = 'expand_set_casemap',
       full_name = 'casemap',
@@ -971,7 +973,7 @@ return {
         a modified version of the following command in your vimrc file to
         override it: >vim
           let &cdpath = ',' .. substitute(substitute($CDPATH, '[, ]', '\\\0', 'g'), ':', ',', 'g')
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
+        <       This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
         (parts of 'cdpath' can be passed to the shell to expand file names).
       ]=],
@@ -996,9 +998,9 @@ return {
         Only non-printable keys are allowed.
         The key can be specified as a single character, but it is difficult to
         type.  The preferred way is to use the <> notation.  Examples: >vim
-        	exe "set cedit=\\<C-Y>"
-        	exe "set cedit=\\<Esc>"
-        <	|Nvi| also has this option, but it only uses the first character.
+                exe "set cedit=\\<C-Y>"
+                exe "set cedit=\\<Esc>"
+        <       |Nvi| also has this option, but it only uses the first character.
         See |cmdwin|.
       ]=],
       full_name = 'cedit',
@@ -1044,18 +1046,18 @@ return {
         is done internally by Vim, 'charconvert' is not used for this.
         Also used for Unicode conversion.
         Example: >vim
-        	set charconvert=CharConvert()
-        	fun CharConvert()
-        	  system("recode "
-        		\ .. v:charconvert_from .. ".." .. v:charconvert_to
-        		\ .. " <" .. v:fname_in .. " >" .. v:fname_out)
-        	  return v:shell_error
-        	endfun
-        <	The related Vim variables are:
-        	v:charconvert_from	name of the current encoding
-        	v:charconvert_to	name of the desired encoding
-        	v:fname_in		name of the input file
-        	v:fname_out		name of the output file
+                set charconvert=CharConvert()
+                fun CharConvert()
+                  system("recode "
+                        \ .. v:charconvert_from .. ".." .. v:charconvert_to
+                        \ .. " <" .. v:fname_in .. " >" .. v:fname_out)
+                  return v:shell_error
+                endfun
+        <       The related Vim variables are:
+                v:charconvert_from      name of the current encoding
+                v:charconvert_to        name of the desired encoding
+                v:fname_in              name of the input file
+                v:fname_out             name of the output file
         Note that v:fname_in and v:fname_out will never be the same.
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
@@ -1135,7 +1137,7 @@ return {
         Keywords that are interpreted as a C++ scope declaration by |cino-g|.
         Useful e.g. for working with the Qt framework that defines additional
         scope declarations "signals", "public slots" and "private slots": >vim
-        	set cinscopedecls+=signals,public\ slots,private\ slots
+                set cinscopedecls+=signals,public\ slots,private\ slots
         <
       ]=],
       full_name = 'cinscopedecls',
@@ -1173,25 +1175,25 @@ return {
         This option is a list of comma-separated names.
         These names are recognized:
 
-        					*clipboard-unnamed*
-        unnamed		When included, Vim will use the clipboard register "*"
-        		for all yank, delete, change and put operations which
-        		would normally go to the unnamed register.  When a
-        		register is explicitly specified, it will always be
-        		used regardless of whether "unnamed" is in 'clipboard'
-        		or not.  The clipboard register can always be
-        		explicitly accessed using the "* notation.  Also see
-        		|clipboard|.
+                                                *clipboard-unnamed*
+        unnamed         When included, Vim will use the clipboard register "*"
+                        for all yank, delete, change and put operations which
+                        would normally go to the unnamed register.  When a
+                        register is explicitly specified, it will always be
+                        used regardless of whether "unnamed" is in 'clipboard'
+                        or not.  The clipboard register can always be
+                        explicitly accessed using the "* notation.  Also see
+                        |clipboard|.
 
-        					*clipboard-unnamedplus*
-        unnamedplus	A variant of the "unnamed" flag which uses the
-        		clipboard register "+" (|quoteplus|) instead of
-        		register "*" for all yank, delete, change and put
-        		operations which would normally go to the unnamed
-        		register.  When "unnamed" is also included to the
-        		option, yank and delete operations (but not put)
-        		will additionally copy the text into register
-        		"*". See |clipboard|.
+                                                *clipboard-unnamedplus*
+        unnamedplus     A variant of the "unnamed" flag which uses the
+                        clipboard register "+" (|quoteplus|) instead of
+                        register "*" for all yank, delete, change and put
+                        operations which would normally go to the unnamed
+                        register.  When "unnamed" is also included to the
+                        option, yank and delete operations (but not put)
+                        will additionally copy the text into register
+                        "*". See |clipboard|.
       ]=],
       deny_duplicates = true,
       expand_cb = 'expand_set_clipboard',
@@ -1253,9 +1255,9 @@ return {
         The screen column can be an absolute number, or a number preceded with
         '+' or '-', which is added to or subtracted from 'textwidth'. >vim
 
-        	set cc=+1	  " highlight column after 'textwidth'
-        	set cc=+1,+2,+3  " highlight three columns after 'textwidth'
-        	hi ColorColumn ctermbg=lightgrey guibg=lightgrey
+                set cc=+1         " highlight column after 'textwidth'
+                set cc=+1,+2,+3  " highlight three columns after 'textwidth'
+                hi ColorColumn ctermbg=lightgrey guibg=lightgrey
         <
         When 'textwidth' is zero then the items with '-' and '+' are not used.
         A maximum of 256 columns are highlighted.
@@ -1284,8 +1286,8 @@ return {
         the GUI it is always possible and Vim limits the number of columns to
         what fits on the screen.  You can use this command to get the widest
         window possible: >vim
-        	set columns=9999
-        <	Minimum value is 12, maximum value is 10000.
+                set columns=9999
+        <       Minimum value is 12, maximum value is 10000.
       ]=],
       full_name = 'columns',
       no_mkrc = true,
@@ -1353,25 +1355,25 @@ return {
         when CTRL-P or CTRL-N are used.  It is also used for whole-line
         completion |i_CTRL-X_CTRL-L|.  It indicates the type of completion
         and the places to scan.  It is a comma-separated list of flags:
-        .	scan the current buffer ('wrapscan' is ignored)
-        w	scan buffers from other windows
-        b	scan other loaded buffers that are in the buffer list
-        u	scan the unloaded buffers that are in the buffer list
-        U	scan the buffers that are not in the buffer list
-        k	scan the files given with the 'dictionary' option
+        .       scan the current buffer ('wrapscan' is ignored)
+        w       scan buffers from other windows
+        b       scan other loaded buffers that are in the buffer list
+        u       scan the unloaded buffers that are in the buffer list
+        U       scan the buffers that are not in the buffer list
+        k       scan the files given with the 'dictionary' option
         kspell  use the currently active spell checking |spell|
-        k{dict}	scan the file {dict}.  Several "k" flags can be given,
-        	patterns are valid too.  For example: >vim
-        		set cpt=k/usr/dict/*,k~/spanish
-        <	s	scan the files given with the 'thesaurus' option
-        s{tsr}	scan the file {tsr}.  Several "s" flags can be given, patterns
-        	are valid too.
-        i	scan current and included files
-        d	scan current and included files for defined name or macro
-        	|i_CTRL-X_CTRL-D|
-        ]	tag completion
-        t	same as "]"
-        f	scan the buffer names (as opposed to buffer contents)
+        k{dict} scan the file {dict}.  Several "k" flags can be given,
+                patterns are valid too.  For example: >vim
+                        set cpt=k/usr/dict/*,k~/spanish
+        <       s       scan the files given with the 'thesaurus' option
+        s{tsr}  scan the file {tsr}.  Several "s" flags can be given, patterns
+                are valid too.
+        i       scan current and included files
+        d       scan current and included files for defined name or macro
+                |i_CTRL-X_CTRL-D|
+        ]       tag completion
+        t       same as "]"
+        f       scan the buffer names (as opposed to buffer contents)
 
         Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
         not executed, this may lead to unexpected completions from some files
@@ -1423,35 +1425,35 @@ return {
         A comma-separated list of options for Insert mode completion
         |ins-completion|.  The supported values are:
 
-           menu	    Use a popup menu to show the possible completions.  The
-        	    menu is only shown when there is more than one match and
-        	    sufficient colors are available.  |ins-completion-menu|
+           menu     Use a popup menu to show the possible completions.  The
+                    menu is only shown when there is more than one match and
+                    sufficient colors are available.  |ins-completion-menu|
 
            menuone  Use the popup menu also when there is only one match.
-        	    Useful when there is additional information about the
-        	    match, e.g., what file it comes from.
+                    Useful when there is additional information about the
+                    match, e.g., what file it comes from.
 
            longest  Only insert the longest common text of the matches.  If
-        	    the menu is displayed you can use CTRL-L to add more
-        	    characters.  Whether case is ignored depends on the kind
-        	    of completion.  For buffer text the 'ignorecase' option is
-        	    used.
+                    the menu is displayed you can use CTRL-L to add more
+                    characters.  Whether case is ignored depends on the kind
+                    of completion.  For buffer text the 'ignorecase' option is
+                    used.
 
            preview  Show extra information about the currently selected
-        	    completion in the preview window.  Only works in
-        	    combination with "menu" or "menuone".
+                    completion in the preview window.  Only works in
+                    combination with "menu" or "menuone".
 
            noinsert Do not insert any text for a match until the user selects
-        	    a match from the menu. Only works in combination with
-        	    "menu" or "menuone". No effect if "longest" is present.
+                    a match from the menu. Only works in combination with
+                    "menu" or "menuone". No effect if "longest" is present.
 
            noselect Do not select a match in the menu, force the user to
-        	    select one from the menu. Only works in combination with
-        	    "menu" or "menuone".
+                    select one from the menu. Only works in combination with
+                    "menu" or "menuone".
 
            popup    Show extra information about the currently selected
-        	    completion in a popup window.  Only works in combination
-        	    with "menu" or "menuone".  Overrides "preview".
+                    completion in a popup window.  Only works in combination
+                    with "menu" or "menuone".  Overrides "preview".
       ]=],
       expand_cb = 'expand_set_completeopt',
       full_name = 'completeopt',
@@ -1466,7 +1468,7 @@ return {
       cb = 'did_set_completeslash',
       defaults = { if_true = '' },
       desc = [=[
-        		only for MS-Windows
+                        only for MS-Windows
         When this option is set it overrules 'shellslash' for completion:
         - When this option is set to "slash", a forward slash is used for path
           completion in insert mode. This is useful when editing HTML tag, or
@@ -1494,10 +1496,10 @@ return {
         Sets the modes in which text in the cursor line can also be concealed.
         When the current mode is listed then concealing happens just like in
         other lines.
-          n		Normal mode
-          v		Visual mode
-          i		Insert mode
-          c		Command line editing, for 'incsearch'
+          n             Normal mode
+          v             Visual mode
+          i             Insert mode
+          c             Command line editing, for 'incsearch'
 
         'v' applies to all lines in the Visual area, not only the cursor.
         A useful value is "nc".  This is used in help files.  So long as you
@@ -1522,17 +1524,17 @@ return {
         Determine how text with the "conceal" syntax attribute |:syn-conceal|
         is shown:
 
-        Value		Effect ~
-        0		Text is shown normally
-        1		Each block of concealed text is replaced with one
-        		character.  If the syntax item does not have a custom
-        		replacement character defined (see |:syn-cchar|) the
-        		character defined in 'listchars' is used.
-        		It is highlighted with the "Conceal" highlight group.
-        2		Concealed text is completely hidden unless it has a
-        		custom replacement character defined (see
-        		|:syn-cchar|).
-        3		Concealed text is completely hidden.
+        Value           Effect ~
+        0               Text is shown normally
+        1               Each block of concealed text is replaced with one
+                        character.  If the syntax item does not have a custom
+                        replacement character defined (see |:syn-cchar|) the
+                        character defined in 'listchars' is used.
+                        It is highlighted with the "Conceal" highlight group.
+        2               Concealed text is completely hidden unless it has a
+                        custom replacement character defined (see
+                        |:syn-cchar|).
+        3               Concealed text is completely hidden.
 
         Note: in the cursor line concealed text is not hidden, so that you can
         edit and copy the text.  This can be changed with the 'concealcursor'
@@ -1596,228 +1598,228 @@ return {
         To avoid problems with flags that are added in the future, use the
         "+=" and "-=" feature of ":set" |add-option-flags|.
 
-            contains	behavior	~
-        							*cpo-a*
-        	a	When included, a ":read" command with a file name
-        		argument will set the alternate file name for the
-        		current window.
-        							*cpo-A*
-        	A	When included, a ":write" command with a file name
-        		argument will set the alternate file name for the
-        		current window.
-        							*cpo-b*
-        	b	"\|" in a ":map" command is recognized as the end of
-        		the map command.  The '\' is included in the mapping,
-        		the text after the '|' is interpreted as the next
-        		command.  Use a CTRL-V instead of a backslash to
-        		include the '|' in the mapping.  Applies to all
-        		mapping, abbreviation, menu and autocmd commands.
-        		See also |map_bar|.
-        							*cpo-B*
-        	B	A backslash has no special meaning in mappings,
-        		abbreviations, user commands and the "to" part of the
-        		menu commands.  Remove this flag to be able to use a
-        		backslash like a CTRL-V.  For example, the command
-        		":map X \\<Esc>" results in X being mapped to:
-        			'B' included:	"\^["	 (^[ is a real <Esc>)
-        			'B' excluded:	"<Esc>"  (5 characters)
-        							*cpo-c*
-        	c	Searching continues at the end of any match at the
-        		cursor position, but not further than the start of the
-        		next line.  When not present searching continues
-        		one character from the cursor position.  With 'c'
-        		"abababababab" only gets three matches when repeating
-        		"/abab", without 'c' there are five matches.
-        							*cpo-C*
-        	C	Do not concatenate sourced lines that start with a
-        		backslash.  See |line-continuation|.
-        							*cpo-d*
-        	d	Using "./" in the 'tags' option doesn't mean to use
-        		the tags file relative to the current file, but the
-        		tags file in the current directory.
-        							*cpo-D*
-        	D	Can't use CTRL-K to enter a digraph after Normal mode
-        		commands with a character argument, like |r|, |f| and
-        		|t|.
-        							*cpo-e*
-        	e	When executing a register with ":@r", always add a
-        		<CR> to the last line, also when the register is not
-        		linewise.  If this flag is not present, the register
-        		is not linewise and the last line does not end in a
-        		<CR>, then the last line is put on the command-line
-        		and can be edited before hitting <CR>.
-        							*cpo-E*
-        	E	It is an error when using "y", "d", "c", "g~", "gu" or
-        		"gU" on an Empty region.  The operators only work when
-        		at least one character is to be operated on.  Example:
-        		This makes "y0" fail in the first column.
-        							*cpo-f*
-        	f	When included, a ":read" command with a file name
-        		argument will set the file name for the current buffer,
-        		if the current buffer doesn't have a file name yet.
-        							*cpo-F*
-        	F	When included, a ":write" command with a file name
-        		argument will set the file name for the current
-        		buffer, if the current buffer doesn't have a file name
-        		yet.  Also see |cpo-P|.
-        							*cpo-i*
-        	i	When included, interrupting the reading of a file will
-        		leave it modified.
-        							*cpo-I*
-        	I	When moving the cursor up or down just after inserting
-        		indent for 'autoindent', do not delete the indent.
-        							*cpo-J*
-        	J	A |sentence| has to be followed by two spaces after
-        		the '.', '!' or '?'.  A <Tab> is not recognized as
-        		white space.
-        							*cpo-K*
-        	K	Don't wait for a key code to complete when it is
-        		halfway through a mapping.  This breaks mapping
-        		<F1><F1> when only part of the second <F1> has been
-        		read.  It enables cancelling the mapping by typing
-        		<F1><Esc>.
-        							*cpo-l*
-        	l	Backslash in a [] range in a search pattern is taken
-        		literally, only "\]", "\^", "\-" and "\\" are special.
-        		See |/[]|
-        		   'l' included: "/[ \t]"  finds <Space>, '\' and 't'
-        		   'l' excluded: "/[ \t]"  finds <Space> and <Tab>
-        							*cpo-L*
-        	L	When the 'list' option is set, 'wrapmargin',
-        		'textwidth', 'softtabstop' and Virtual Replace mode
-        		(see |gR|) count a <Tab> as two characters, instead of
-        		the normal behavior of a <Tab>.
-        							*cpo-m*
-        	m	When included, a showmatch will always wait half a
-        		second.  When not included, a showmatch will wait half
-        		a second or until a character is typed.  |'showmatch'|
-        							*cpo-M*
-        	M	When excluded, "%" matching will take backslashes into
-        		account.  Thus in "( \( )" and "\( ( \)" the outer
-        		parenthesis match.  When included "%" ignores
-        		backslashes, which is Vi compatible.
-        							*cpo-n*
-        	n	When included, the column used for 'number' and
-        		'relativenumber' will also be used for text of wrapped
-        		lines.
-        							*cpo-o*
-        	o	Line offset to search command is not remembered for
-        		next search.
-        							*cpo-O*
-        	O	Don't complain if a file is being overwritten, even
-        		when it didn't exist when editing it.  This is a
-        		protection against a file unexpectedly created by
-        		someone else.  Vi didn't complain about this.
-        							*cpo-p*
-        	p	Vi compatible Lisp indenting.  When not present, a
-        		slightly better algorithm is used.
-        							*cpo-P*
-        	P	When included, a ":write" command that appends to a
-        		file will set the file name for the current buffer, if
-        		the current buffer doesn't have a file name yet and
-        		the 'F' flag is also included |cpo-F|.
-        							*cpo-q*
-        	q	When joining multiple lines leave the cursor at the
-        		position where it would be when joining two lines.
-        							*cpo-r*
-        	r	Redo ("." command) uses "/" to repeat a search
-        		command, instead of the actually used search string.
-        							*cpo-R*
-        	R	Remove marks from filtered lines.  Without this flag
-        		marks are kept like |:keepmarks| was used.
-        							*cpo-s*
-        	s	Set buffer options when entering the buffer for the
-        		first time.  This is like it is in Vim version 3.0.
-        		And it is the default.  If not present the options are
-        		set when the buffer is created.
-        							*cpo-S*
-        	S	Set buffer options always when entering a buffer
-        		(except 'readonly', 'fileformat', 'filetype' and
-        		'syntax').  This is the (most) Vi compatible setting.
-        		The options are set to the values in the current
-        		buffer.  When you change an option and go to another
-        		buffer, the value is copied.  Effectively makes the
-        		buffer options global to all buffers.
+            contains    behavior        ~
+                                                                *cpo-a*
+                a       When included, a ":read" command with a file name
+                        argument will set the alternate file name for the
+                        current window.
+                                                                *cpo-A*
+                A       When included, a ":write" command with a file name
+                        argument will set the alternate file name for the
+                        current window.
+                                                                *cpo-b*
+                b       "\|" in a ":map" command is recognized as the end of
+                        the map command.  The '\' is included in the mapping,
+                        the text after the '|' is interpreted as the next
+                        command.  Use a CTRL-V instead of a backslash to
+                        include the '|' in the mapping.  Applies to all
+                        mapping, abbreviation, menu and autocmd commands.
+                        See also |map_bar|.
+                                                                *cpo-B*
+                B       A backslash has no special meaning in mappings,
+                        abbreviations, user commands and the "to" part of the
+                        menu commands.  Remove this flag to be able to use a
+                        backslash like a CTRL-V.  For example, the command
+                        ":map X \\<Esc>" results in X being mapped to:
+                                'B' included:   "\^["    (^[ is a real <Esc>)
+                                'B' excluded:   "<Esc>"  (5 characters)
+                                                                *cpo-c*
+                c       Searching continues at the end of any match at the
+                        cursor position, but not further than the start of the
+                        next line.  When not present searching continues
+                        one character from the cursor position.  With 'c'
+                        "abababababab" only gets three matches when repeating
+                        "/abab", without 'c' there are five matches.
+                                                                *cpo-C*
+                C       Do not concatenate sourced lines that start with a
+                        backslash.  See |line-continuation|.
+                                                                *cpo-d*
+                d       Using "./" in the 'tags' option doesn't mean to use
+                        the tags file relative to the current file, but the
+                        tags file in the current directory.
+                                                                *cpo-D*
+                D       Can't use CTRL-K to enter a digraph after Normal mode
+                        commands with a character argument, like |r|, |f| and
+                        |t|.
+                                                                *cpo-e*
+                e       When executing a register with ":@r", always add a
+                        <CR> to the last line, also when the register is not
+                        linewise.  If this flag is not present, the register
+                        is not linewise and the last line does not end in a
+                        <CR>, then the last line is put on the command-line
+                        and can be edited before hitting <CR>.
+                                                                *cpo-E*
+                E       It is an error when using "y", "d", "c", "g~", "gu" or
+                        "gU" on an Empty region.  The operators only work when
+                        at least one character is to be operated on.  Example:
+                        This makes "y0" fail in the first column.
+                                                                *cpo-f*
+                f       When included, a ":read" command with a file name
+                        argument will set the file name for the current buffer,
+                        if the current buffer doesn't have a file name yet.
+                                                                *cpo-F*
+                F       When included, a ":write" command with a file name
+                        argument will set the file name for the current
+                        buffer, if the current buffer doesn't have a file name
+                        yet.  Also see |cpo-P|.
+                                                                *cpo-i*
+                i       When included, interrupting the reading of a file will
+                        leave it modified.
+                                                                *cpo-I*
+                I       When moving the cursor up or down just after inserting
+                        indent for 'autoindent', do not delete the indent.
+                                                                *cpo-J*
+                J       A |sentence| has to be followed by two spaces after
+                        the '.', '!' or '?'.  A <Tab> is not recognized as
+                        white space.
+                                                                *cpo-K*
+                K       Don't wait for a key code to complete when it is
+                        halfway through a mapping.  This breaks mapping
+                        <F1><F1> when only part of the second <F1> has been
+                        read.  It enables cancelling the mapping by typing
+                        <F1><Esc>.
+                                                                *cpo-l*
+                l       Backslash in a [] range in a search pattern is taken
+                        literally, only "\]", "\^", "\-" and "\\" are special.
+                        See |/[]|
+                           'l' included: "/[ \t]"  finds <Space>, '\' and 't'
+                           'l' excluded: "/[ \t]"  finds <Space> and <Tab>
+                                                                *cpo-L*
+                L       When the 'list' option is set, 'wrapmargin',
+                        'textwidth', 'softtabstop' and Virtual Replace mode
+                        (see |gR|) count a <Tab> as two characters, instead of
+                        the normal behavior of a <Tab>.
+                                                                *cpo-m*
+                m       When included, a showmatch will always wait half a
+                        second.  When not included, a showmatch will wait half
+                        a second or until a character is typed.  |'showmatch'|
+                                                                *cpo-M*
+                M       When excluded, "%" matching will take backslashes into
+                        account.  Thus in "( \( )" and "\( ( \)" the outer
+                        parenthesis match.  When included "%" ignores
+                        backslashes, which is Vi compatible.
+                                                                *cpo-n*
+                n       When included, the column used for 'number' and
+                        'relativenumber' will also be used for text of wrapped
+                        lines.
+                                                                *cpo-o*
+                o       Line offset to search command is not remembered for
+                        next search.
+                                                                *cpo-O*
+                O       Don't complain if a file is being overwritten, even
+                        when it didn't exist when editing it.  This is a
+                        protection against a file unexpectedly created by
+                        someone else.  Vi didn't complain about this.
+                                                                *cpo-p*
+                p       Vi compatible Lisp indenting.  When not present, a
+                        slightly better algorithm is used.
+                                                                *cpo-P*
+                P       When included, a ":write" command that appends to a
+                        file will set the file name for the current buffer, if
+                        the current buffer doesn't have a file name yet and
+                        the 'F' flag is also included |cpo-F|.
+                                                                *cpo-q*
+                q       When joining multiple lines leave the cursor at the
+                        position where it would be when joining two lines.
+                                                                *cpo-r*
+                r       Redo ("." command) uses "/" to repeat a search
+                        command, instead of the actually used search string.
+                                                                *cpo-R*
+                R       Remove marks from filtered lines.  Without this flag
+                        marks are kept like |:keepmarks| was used.
+                                                                *cpo-s*
+                s       Set buffer options when entering the buffer for the
+                        first time.  This is like it is in Vim version 3.0.
+                        And it is the default.  If not present the options are
+                        set when the buffer is created.
+                                                                *cpo-S*
+                S       Set buffer options always when entering a buffer
+                        (except 'readonly', 'fileformat', 'filetype' and
+                        'syntax').  This is the (most) Vi compatible setting.
+                        The options are set to the values in the current
+                        buffer.  When you change an option and go to another
+                        buffer, the value is copied.  Effectively makes the
+                        buffer options global to all buffers.
 
-        		's'    'S'     copy buffer options
-        		no     no      when buffer created
-        		yes    no      when buffer first entered (default)
-        		 X     yes     each time when buffer entered (vi comp.)
-        							*cpo-t*
-        	t	Search pattern for the tag command is remembered for
-        		"n" command.  Otherwise Vim only puts the pattern in
-        		the history for search pattern, but doesn't change the
-        		last used search pattern.
-        							*cpo-u*
-        	u	Undo is Vi compatible.  See |undo-two-ways|.
-        							*cpo-v*
-        	v	Backspaced characters remain visible on the screen in
-        		Insert mode.  Without this flag the characters are
-        		erased from the screen right away.  With this flag the
-        		screen newly typed text overwrites backspaced
-        		characters.
-        							*cpo-W*
-        	W	Don't overwrite a readonly file.  When omitted, ":w!"
-        		overwrites a readonly file, if possible.
-        							*cpo-x*
-        	x	<Esc> on the command-line executes the command-line.
-        		The default in Vim is to abandon the command-line,
-        		because <Esc> normally aborts a command.  |c_<Esc>|
-        							*cpo-X*
-        	X	When using a count with "R" the replaced text is
-        		deleted only once.  Also when repeating "R" with "."
-        		and a count.
-        							*cpo-y*
-        	y	A yank command can be redone with ".".  Think twice if
-        		you really want to use this, it may break some
-        		plugins, since most people expect "." to only repeat a
-        		change.
-        							*cpo-Z*
-        	Z	When using "w!" while the 'readonly' option is set,
-        		don't reset 'readonly'.
-        							*cpo-!*
-        	!	When redoing a filter command, use the last used
-        		external command, whatever it was.  Otherwise the last
-        		used -filter- command is used.
-        							*cpo-$*
-        	$	When making a change to one line, don't redisplay the
-        		line, but put a '$' at the end of the changed text.
-        		The changed text will be overwritten when you type the
-        		new text.  The line is redisplayed if you type any
-        		command that moves the cursor from the insertion
-        		point.
-        							*cpo-%*
-        	%	Vi-compatible matching is done for the "%" command.
-        		Does not recognize "#if", "#endif", etc.
-        		Does not recognize "/*" and "*/".
-        		Parens inside single and double quotes are also
-        		counted, causing a string that contains a paren to
-        		disturb the matching.  For example, in a line like
-        		"if (strcmp("foo(", s))" the first paren does not
-        		match the last one.  When this flag is not included,
-        		parens inside single and double quotes are treated
-        		specially.  When matching a paren outside of quotes,
-        		everything inside quotes is ignored.  When matching a
-        		paren inside quotes, it will find the matching one (if
-        		there is one).  This works very well for C programs.
-        		This flag is also used for other features, such as
-        		C-indenting.
-        							*cpo-+*
-        	+	When included, a ":write file" command will reset the
-        		'modified' flag of the buffer, even though the buffer
-        		itself may still be different from its file.
-        							*cpo->*
-        	>	When appending to a register, put a line break before
-        		the appended text.
-        							*cpo-;*
-        	;	When using |,| or |;| to repeat the last |t| search
-        		and the cursor is right in front of the searched
-        		character, the cursor won't move. When not included,
-        		the cursor would skip over it and jump to the
-        		following occurrence.
-        							*cpo-_*
-        	_	When using |cw| on a word, do not include the
-        		whitespace following the word in the motion.
+                        's'    'S'     copy buffer options
+                        no     no      when buffer created
+                        yes    no      when buffer first entered (default)
+                         X     yes     each time when buffer entered (vi comp.)
+                                                                *cpo-t*
+                t       Search pattern for the tag command is remembered for
+                        "n" command.  Otherwise Vim only puts the pattern in
+                        the history for search pattern, but doesn't change the
+                        last used search pattern.
+                                                                *cpo-u*
+                u       Undo is Vi compatible.  See |undo-two-ways|.
+                                                                *cpo-v*
+                v       Backspaced characters remain visible on the screen in
+                        Insert mode.  Without this flag the characters are
+                        erased from the screen right away.  With this flag the
+                        screen newly typed text overwrites backspaced
+                        characters.
+                                                                *cpo-W*
+                W       Don't overwrite a readonly file.  When omitted, ":w!"
+                        overwrites a readonly file, if possible.
+                                                                *cpo-x*
+                x       <Esc> on the command-line executes the command-line.
+                        The default in Vim is to abandon the command-line,
+                        because <Esc> normally aborts a command.  |c_<Esc>|
+                                                                *cpo-X*
+                X       When using a count with "R" the replaced text is
+                        deleted only once.  Also when repeating "R" with "."
+                        and a count.
+                                                                *cpo-y*
+                y       A yank command can be redone with ".".  Think twice if
+                        you really want to use this, it may break some
+                        plugins, since most people expect "." to only repeat a
+                        change.
+                                                                *cpo-Z*
+                Z       When using "w!" while the 'readonly' option is set,
+                        don't reset 'readonly'.
+                                                                *cpo-!*
+                !       When redoing a filter command, use the last used
+                        external command, whatever it was.  Otherwise the last
+                        used -filter- command is used.
+                                                                *cpo-$*
+                $       When making a change to one line, don't redisplay the
+                        line, but put a '$' at the end of the changed text.
+                        The changed text will be overwritten when you type the
+                        new text.  The line is redisplayed if you type any
+                        command that moves the cursor from the insertion
+                        point.
+                                                                *cpo-%*
+                %       Vi-compatible matching is done for the "%" command.
+                        Does not recognize "#if", "#endif", etc.
+                        Does not recognize "/*" and "*/".
+                        Parens inside single and double quotes are also
+                        counted, causing a string that contains a paren to
+                        disturb the matching.  For example, in a line like
+                        "if (strcmp("foo(", s))" the first paren does not
+                        match the last one.  When this flag is not included,
+                        parens inside single and double quotes are treated
+                        specially.  When matching a paren outside of quotes,
+                        everything inside quotes is ignored.  When matching a
+                        paren inside quotes, it will find the matching one (if
+                        there is one).  This works very well for C programs.
+                        This flag is also used for other features, such as
+                        C-indenting.
+                                                                *cpo-+*
+                +       When included, a ":write file" command will reset the
+                        'modified' flag of the buffer, even though the buffer
+                        itself may still be different from its file.
+                                                                *cpo->*
+                >       When appending to a register, put a line break before
+                        the appended text.
+                                                                *cpo-;*
+                ;       When using |,| or |;| to repeat the last |t| search
+                        and the cursor is right in front of the searched
+                        character, the cursor won't move. When not included,
+                        the cursor would skip over it and jump to the
+                        following occurrence.
+                                                                *cpo-_*
+                _       When using |cw| on a word, do not include the
+                        whitespace following the word in the motion.
       ]=],
       expand_cb = 'expand_set_cpoptions',
       full_name = 'cpoptions',
@@ -1856,8 +1858,8 @@ return {
         slower.
         If you only want the highlighting in the current window you can use
         these autocommands: >vim
-        	au WinLeave * set nocursorline nocursorcolumn
-        	au WinEnter * set cursorline cursorcolumn
+                au WinLeave * set nocursorline nocursorcolumn
+                au WinEnter * set cursorline cursorcolumn
         <
       ]=],
       full_name = 'cursorcolumn',
@@ -1889,15 +1891,15 @@ return {
       desc = [=[
         Comma-separated list of settings for how 'cursorline' is displayed.
         Valid values:
-        "line"		Highlight the text line of the cursor with
-        		CursorLine |hl-CursorLine|.
-        "screenline"	Highlight only the screen line of the cursor with
-        		CursorLine |hl-CursorLine|.
-        "number"	Highlight the line number of the cursor with
-        		CursorLineNr |hl-CursorLineNr|.
+        "line"          Highlight the text line of the cursor with
+                        CursorLine |hl-CursorLine|.
+        "screenline"    Highlight only the screen line of the cursor with
+                        CursorLine |hl-CursorLine|.
+        "number"        Highlight the line number of the cursor with
+                        CursorLineNr |hl-CursorLineNr|.
 
         Special value:
-        "both"		Alias for the values "line,number".
+        "both"          Alias for the values "line,number".
 
         "line" and "screenline" cannot be used together.
       ]=],
@@ -1914,12 +1916,12 @@ return {
       defaults = { if_true = '' },
       desc = [=[
         These values can be used:
-        msg	Error messages that would otherwise be omitted will be given
-        	anyway.
-        throw	Error messages that would otherwise be omitted will be given
-        	anyway and also throw an exception and set |v:errmsg|.
-        beep	A message will be given when otherwise only a beep would be
-        	produced.
+        msg     Error messages that would otherwise be omitted will be given
+                anyway.
+        throw   Error messages that would otherwise be omitted will be given
+                anyway and also throw an exception and set |v:errmsg|.
+        beep    A message will be given when otherwise only a beep would be
+                produced.
         The values can be combined, separated by a comma.
         "msg" and "throw" are useful for debugging 'foldexpr', 'formatexpr' or
         'indentexpr'.
@@ -1940,20 +1942,20 @@ return {
         pattern, just like for the "/" command.  This option is used for the
         commands like "[i" and "[d" |include-search|.  The 'isident' option is
         used to recognize the defined name after the match: >
-        	{match with 'define'}{non-ID chars}{defined name}{non-ID char}
-        <	See |option-backslash| about inserting backslashes to include a space
+                {match with 'define'}{non-ID chars}{defined name}{non-ID char}
+        <       See |option-backslash| about inserting backslashes to include a space
         or backslash.
         For C++ this value would be useful, to include const type declarations: >
-        	^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
-        <	You can also use "\ze" just before the name and continue the pattern
+                ^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
+        <       You can also use "\ze" just before the name and continue the pattern
         to check what is following.  E.g. for Javascript, if a function is
         defined with `func_name = function(args)`: >
-        	^\s*\ze\i\+\s*=\s*function(
-        <	If the function is defined with `func_name : function() {...`: >
+                ^\s*\ze\i\+\s*=\s*function(
+        <       If the function is defined with `func_name : function() {...`: >
                 ^\s*\ze\i\+\s*[:]\s*(*function\s*(
-        <	When using the ":set" command, you need to double the backslashes!
+        <       When using the ":set" command, you need to double the backslashes!
         To avoid that use `:let` with a single quote string: >vim
-        	let &l:define = '^\s*\ze\k\+\s*=\s*function('
+                let &l:define = '^\s*\ze\k\+\s*=\s*function('
         <
       ]=],
       full_name = 'define',
@@ -2062,108 +2064,108 @@ return {
         Option settings for diff mode.  It can consist of the following items.
         All are optional.  Items must be separated by a comma.
 
-        	filler		Show filler lines, to keep the text
-        			synchronized with a window that has inserted
-        			lines at the same position.  Mostly useful
-        			when windows are side-by-side and 'scrollbind'
-        			is set.
+                filler          Show filler lines, to keep the text
+                                synchronized with a window that has inserted
+                                lines at the same position.  Mostly useful
+                                when windows are side-by-side and 'scrollbind'
+                                is set.
 
-        	context:{n}	Use a context of {n} lines between a change
-        			and a fold that contains unchanged lines.
-        			When omitted a context of six lines is used.
-        			When using zero the context is actually one,
-        			since folds require a line in between, also
-        			for a deleted line. Set it to a very large
-        			value (999999) to disable folding completely.
-        			See |fold-diff|.
+                context:{n}     Use a context of {n} lines between a change
+                                and a fold that contains unchanged lines.
+                                When omitted a context of six lines is used.
+                                When using zero the context is actually one,
+                                since folds require a line in between, also
+                                for a deleted line. Set it to a very large
+                                value (999999) to disable folding completely.
+                                See |fold-diff|.
 
-        	iblank		Ignore changes where lines are all blank.  Adds
-        			the "-B" flag to the "diff" command if
-        			'diffexpr' is empty.  Check the documentation
-        			of the "diff" command for what this does
-        			exactly.
-        			NOTE: the diff windows will get out of sync,
-        			because no differences between blank lines are
-        			taken into account.
+                iblank          Ignore changes where lines are all blank.  Adds
+                                the "-B" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
+                                NOTE: the diff windows will get out of sync,
+                                because no differences between blank lines are
+                                taken into account.
 
-        	icase		Ignore changes in case of text.  "a" and "A"
-        			are considered the same.  Adds the "-i" flag
-        			to the "diff" command if 'diffexpr' is empty.
+                icase           Ignore changes in case of text.  "a" and "A"
+                                are considered the same.  Adds the "-i" flag
+                                to the "diff" command if 'diffexpr' is empty.
 
-        	iwhite		Ignore changes in amount of white space.  Adds
-        			the "-b" flag to the "diff" command if
-        			'diffexpr' is empty.  Check the documentation
-        			of the "diff" command for what this does
-        			exactly.  It should ignore adding trailing
-        			white space, but not leading white space.
+                iwhite          Ignore changes in amount of white space.  Adds
+                                the "-b" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.  It should ignore adding trailing
+                                white space, but not leading white space.
 
-        	iwhiteall	Ignore all white space changes.  Adds
-        			the "-w" flag to the "diff" command if
-        			'diffexpr' is empty.  Check the documentation
-        			of the "diff" command for what this does
-        			exactly.
+                iwhiteall       Ignore all white space changes.  Adds
+                                the "-w" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
 
-        	iwhiteeol	Ignore white space changes at end of line.
-        			Adds the "-Z" flag to the "diff" command if
-        			'diffexpr' is empty.  Check the documentation
-        			of the "diff" command for what this does
-        			exactly.
+                iwhiteeol       Ignore white space changes at end of line.
+                                Adds the "-Z" flag to the "diff" command if
+                                'diffexpr' is empty.  Check the documentation
+                                of the "diff" command for what this does
+                                exactly.
 
-        	horizontal	Start diff mode with horizontal splits (unless
-        			explicitly specified otherwise).
+                horizontal      Start diff mode with horizontal splits (unless
+                                explicitly specified otherwise).
 
-        	vertical	Start diff mode with vertical splits (unless
-        			explicitly specified otherwise).
+                vertical        Start diff mode with vertical splits (unless
+                                explicitly specified otherwise).
 
-        	closeoff	When a window is closed where 'diff' is set
-        			and there is only one window remaining in the
-        			same tab page with 'diff' set, execute
-        			`:diffoff` in that window.  This undoes a
-        			`:diffsplit` command.
+                closeoff        When a window is closed where 'diff' is set
+                                and there is only one window remaining in the
+                                same tab page with 'diff' set, execute
+                                `:diffoff` in that window.  This undoes a
+                                `:diffsplit` command.
 
-        	hiddenoff	Do not use diff mode for a buffer when it
-        			becomes hidden.
+                hiddenoff       Do not use diff mode for a buffer when it
+                                becomes hidden.
 
-        	foldcolumn:{n}	Set the 'foldcolumn' option to {n} when
-        			starting diff mode.  Without this 2 is used.
+                foldcolumn:{n}  Set the 'foldcolumn' option to {n} when
+                                starting diff mode.  Without this 2 is used.
 
-        	followwrap	Follow the 'wrap' option and leave as it is.
+                followwrap      Follow the 'wrap' option and leave as it is.
 
-        	internal	Use the internal diff library.  This is
-        			ignored when 'diffexpr' is set.  *E960*
-        			When running out of memory when writing a
-        			buffer this item will be ignored for diffs
-        			involving that buffer.  Set the 'verbose'
-        			option to see when this happens.
+                internal        Use the internal diff library.  This is
+                                ignored when 'diffexpr' is set.  *E960*
+                                When running out of memory when writing a
+                                buffer this item will be ignored for diffs
+                                involving that buffer.  Set the 'verbose'
+                                option to see when this happens.
 
-        	indent-heuristic
-        			Use the indent heuristic for the internal
-        			diff library.
+                indent-heuristic
+                                Use the indent heuristic for the internal
+                                diff library.
 
-        	linematch:{n}   Enable a second stage diff on each generated
-        			hunk in order to align lines. When the total
-        			number of lines in a hunk exceeds {n}, the
-        			second stage diff will not be performed as
-        			very large hunks can cause noticeable lag. A
-        			recommended setting is "linematch:60", as this
-        			will enable alignment for a 2 buffer diff with
-        			hunks of up to 30 lines each, or a 3 buffer
-        			diff with hunks of up to 20 lines each.
+                linematch:{n}   Enable a second stage diff on each generated
+                                hunk in order to align lines. When the total
+                                number of lines in a hunk exceeds {n}, the
+                                second stage diff will not be performed as
+                                very large hunks can cause noticeable lag. A
+                                recommended setting is "linematch:60", as this
+                                will enable alignment for a 2 buffer diff with
+                                hunks of up to 30 lines each, or a 3 buffer
+                                diff with hunks of up to 20 lines each.
 
-        	algorithm:{text} Use the specified diff algorithm with the
-        			internal diff engine. Currently supported
-        			algorithms are:
-        			myers      the default algorithm
-        			minimal    spend extra time to generate the
-        				   smallest possible diff
-        			patience   patience diff algorithm
-        			histogram  histogram diff algorithm
+                algorithm:{text} Use the specified diff algorithm with the
+                                internal diff engine. Currently supported
+                                algorithms are:
+                                myers      the default algorithm
+                                minimal    spend extra time to generate the
+                                           smallest possible diff
+                                patience   patience diff algorithm
+                                histogram  histogram diff algorithm
 
         Examples: >vim
-        	set diffopt=internal,filler,context:4
-        	set diffopt=
-        	set diffopt=internal,filler,foldcolumn:3
-        	set diffopt-=internal  " do NOT use the internal diff parser
+                set diffopt=internal,filler,context:4
+                set diffopt=
+                set diffopt=internal,filler,foldcolumn:3
+                set diffopt-=internal  " do NOT use the internal diff parser
         <
       ]=],
       expand_cb = 'expand_set_diffopt',
@@ -2253,15 +2255,15 @@ return {
       desc = [=[
         Change the way text is displayed.  This is a comma-separated list of
         flags:
-        lastline	When included, as much as possible of the last line
-        		in a window will be displayed.  "@@@" is put in the
-        		last columns of the last screen line to indicate the
-        		rest of the line is not displayed.
-        truncate	Like "lastline", but "@@@" is displayed in the first
-        		column of the last screen line.  Overrules "lastline".
-        uhex		Show unprintable characters hexadecimal as <xx>
-        		instead of using ^C and ~C.
-        msgsep		Obsolete flag. Allowed but takes no effect. |msgsep|
+        lastline        When included, as much as possible of the last line
+                        in a window will be displayed.  "@@@" is put in the
+                        last columns of the last screen line to indicate the
+                        rest of the line is not displayed.
+        truncate        Like "lastline", but "@@@" is displayed in the first
+                        column of the last screen line.  Overrules "lastline".
+        uhex            Show unprintable characters hexadecimal as <xx>
+                        instead of using ^C and ~C.
+        msgsep          Obsolete flag. Allowed but takes no effect. |msgsep|
 
         When neither "lastline" nor "truncate" is included, a last line that
         doesn't fit is replaced with "@" lines.
@@ -2284,9 +2286,9 @@ return {
       defaults = { if_true = 'both' },
       desc = [=[
         Tells when the 'equalalways' option applies:
-        	ver	vertically, width of windows is not affected
-        	hor	horizontally, height of windows is not affected
-        	both	width and height of windows is affected
+                ver     vertically, width of windows is not affected
+                hor     horizontally, height of windows is not affected
+                both    width and height of windows is affected
       ]=],
       expand_cb = 'expand_set_eadirection',
       full_name = 'eadirection',
@@ -2609,24 +2611,24 @@ return {
         in the list is tried.  When an encoding is found that works,
         'fileencoding' is set to it.  If all fail, 'fileencoding' is set to
         an empty string, which means that UTF-8 is used.
-        	WARNING: Conversion can cause loss of information! You can use
-        	the |++bad| argument to specify what is done with characters
-        	that can't be converted.
+                WARNING: Conversion can cause loss of information! You can use
+                the |++bad| argument to specify what is done with characters
+                that can't be converted.
         For an empty file or a file with only ASCII characters most encodings
         will work and the first entry of 'fileencodings' will be used (except
         "ucs-bom", which requires the BOM to be present).  If you prefer
         another encoding use an BufReadPost autocommand event to test if your
         preferred encoding is to be used.  Example: >vim
-        	au BufReadPost * if search('\S', 'w') == 0 |
-        		\ set fenc=iso-2022-jp | endif
-        <	This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
+                au BufReadPost * if search('\S', 'w') == 0 |
+                        \ set fenc=iso-2022-jp | endif
+        <       This sets 'fileencoding' to "iso-2022-jp" if the file does not contain
         non-blank characters.
         When the |++enc| argument is used then the value of 'fileencodings' is
         not used.
         Note that 'fileencodings' is not used for a new file, the global value
         of 'fileencoding' is used instead.  You can set it with: >vim
-        	setglobal fenc=iso-8859-2
-        <	This means that a non-existing file may get a different encoding than
+                setglobal fenc=iso-8859-2
+        <       This means that a non-existing file may get a different encoding than
         an empty file.
         The special value "ucs-bom" can be used to check for a Unicode BOM
         (Byte Order Mark) at the start of the file.  It must not be preceded
@@ -2640,11 +2642,11 @@ return {
         When a file contains an illegal UTF-8 byte sequence it won't be
         recognized as "utf-8".  You can use the |8g8| command to find the
         illegal byte sequence.
-        WRONG VALUES:			WHAT'S WRONG:
-        	latin1,utf-8		"latin1" will always be used
-        	utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
-        				file
-        	cp1250,latin1		"cp1250" will always be used
+        WRONG VALUES:                   WHAT'S WRONG:
+                latin1,utf-8            "latin1" will always be used
+                utf-8,ucs-bom,latin1    BOM won't be recognized in an utf-8
+                                        file
+                cp1250,latin1           "cp1250" will always be used
         If 'fileencodings' is empty, 'fileencoding' is not modified.
         See 'fileencoding' for the possible values.
         Setting this option does not have an effect until the next time a file
@@ -2669,9 +2671,9 @@ return {
       desc = [=[
         This gives the <EOL> of the current buffer, which is used for
         reading/writing the buffer from/to a file:
-            dos	    <CR><NL>
+            dos     <CR><NL>
             unix    <NL>
-            mac	    <CR>
+            mac     <CR>
         When "dos" is used, CTRL-Z at the end of a file is ignored.
         See |file-formats| and |file-read|.
         For the character encoding of the file see 'fileencoding'.
@@ -2762,7 +2764,7 @@ return {
         if_false = false,
         if_true = true,
         doc = [[on for systems where case in file
-   names is normally ignored]],
+names is normally ignored]],
       },
       desc = [=[
         When set case is ignored when using file names and directories.
@@ -2790,12 +2792,12 @@ return {
         Setting this option to a different value is most useful in a modeline,
         for a file for which the file type is not automatically recognized.
         Example, for in an IDL file: >c
-        	/* vim: set filetype=idl : */
-        <	|FileType| |filetypes|
+                /* vim: set filetype=idl : */
+        <       |FileType| |filetypes|
         When a dot appears in the value then this separates two filetype
         names.  Example: >c
-        	/* vim: set filetype=c.doxygen : */
-        <	This will use the "c" filetype first, then the "doxygen" filetype.
+                /* vim: set filetype=c.doxygen : */
+        <       This will use the "c" filetype first, then the "doxygen" filetype.
         This works both for filetype plugins and for syntax files.  More than
         one dot may appear.
         This option is not copied to another buffer, independent of the 's' or
@@ -2822,26 +2824,26 @@ return {
         It is a comma-separated list of items.  Each item has a name, a colon
         and the value of that item:
 
-          item		default		Used for ~
-          stl		' '		statusline of the current window
-          stlnc		' '		statusline of the non-current windows
-          wbr		' '		window bar
-          horiz		'─' or '-'	horizontal separators |:split|
-          horizup	'┴' or '-'	upwards facing horizontal separator
-          horizdown	'┬' or '-'	downwards facing horizontal separator
-          vert		'│' or '|'	vertical separators |:vsplit|
-          vertleft	'┤' or '|'	left facing vertical separator
-          vertright	'├' or '|'	right facing vertical separator
-          verthoriz	'┼' or '+'	overlapping vertical and horizontal
-        				separator
-          fold		'·' or '-'	filling 'foldtext'
-          foldopen	'-'		mark the beginning of a fold
-          foldclose	'+'		show a closed fold
-          foldsep	'│' or '|'      open fold middle marker
-          diff		'-'		deleted lines of the 'diff' option
-          msgsep	' '		message separator 'display'
-          eob		'~'		empty lines at the end of a buffer
-          lastline	'@'		'display' contains lastline/truncate
+          item          default         Used for ~
+          stl           ' '             statusline of the current window
+          stlnc         ' '             statusline of the non-current windows
+          wbr           ' '             window bar
+          horiz         '─' or '-'      horizontal separators |:split|
+          horizup       '┴' or '-'      upwards facing horizontal separator
+          horizdown     '┬' or '-'      downwards facing horizontal separator
+          vert          '│' or '|'      vertical separators |:vsplit|
+          vertleft      '┤' or '|'      left facing vertical separator
+          vertright     '├' or '|'      right facing vertical separator
+          verthoriz     '┼' or '+'      overlapping vertical and horizontal
+                                        separator
+          fold          '·' or '-'      filling 'foldtext'
+          foldopen      '-'             mark the beginning of a fold
+          foldclose     '+'             show a closed fold
+          foldsep       '│' or '|'      open fold middle marker
+          diff          '-'             deleted lines of the 'diff' option
+          msgsep        ' '             message separator 'display'
+          eob           '~'             empty lines at the end of a buffer
+          lastline      '@'             'display' contains lastline/truncate
 
         Any one that is omitted will fall back to the default.
 
@@ -2861,21 +2863,21 @@ return {
         characters are not supported.
 
         The highlighting used for these items:
-          item		highlight group ~
-          stl		StatusLine		|hl-StatusLine|
-          stlnc		StatusLineNC		|hl-StatusLineNC|
-          wbr		WinBar			|hl-WinBar| or |hl-WinBarNC|
-          horiz		WinSeparator		|hl-WinSeparator|
-          horizup	WinSeparator		|hl-WinSeparator|
-          horizdown	WinSeparator		|hl-WinSeparator|
-          vert		WinSeparator		|hl-WinSeparator|
-          vertleft	WinSeparator		|hl-WinSeparator|
-          vertright	WinSeparator		|hl-WinSeparator|
-          verthoriz	WinSeparator		|hl-WinSeparator|
-          fold		Folded			|hl-Folded|
-          diff		DiffDelete		|hl-DiffDelete|
-          eob		EndOfBuffer		|hl-EndOfBuffer|
-          lastline	NonText			|hl-NonText|
+          item          highlight group ~
+          stl           StatusLine              |hl-StatusLine|
+          stlnc         StatusLineNC            |hl-StatusLineNC|
+          wbr           WinBar                  |hl-WinBar| or |hl-WinBarNC|
+          horiz         WinSeparator            |hl-WinSeparator|
+          horizup       WinSeparator            |hl-WinSeparator|
+          horizdown     WinSeparator            |hl-WinSeparator|
+          vert          WinSeparator            |hl-WinSeparator|
+          vertleft      WinSeparator            |hl-WinSeparator|
+          vertright     WinSeparator            |hl-WinSeparator|
+          verthoriz     WinSeparator            |hl-WinSeparator|
+          fold          Folded                  |hl-Folded|
+          diff          DiffDelete              |hl-DiffDelete|
+          eob           EndOfBuffer             |hl-EndOfBuffer|
+          lastline      NonText                 |hl-NonText|
       ]=],
       expand_cb = 'expand_set_chars_option',
       full_name = 'fillchars',
@@ -2934,7 +2936,7 @@ return {
         When and how to draw the foldcolumn. Valid values are:
             "auto":       resize to the minimum amount of folds to display.
             "auto:[1-9]": resize to accommodate multiple folds up to the
-        		  selected level
+                          selected level
             "0":          to disable foldcolumn
             "[1-9]":      to display a fixed number of columns
         See |folding|.
@@ -3072,12 +3074,12 @@ return {
       defaults = { if_true = 'manual' },
       desc = [=[
         The kind of folding used for the current window.  Possible values:
-        |fold-manual|	manual	    Folds are created manually.
-        |fold-indent|	indent	    Lines with equal indent form a fold.
-        |fold-expr|	expr	    'foldexpr' gives the fold level of a line.
-        |fold-marker|	marker	    Markers are used to specify folds.
-        |fold-syntax|	syntax	    Syntax highlighting items specify folds.
-        |fold-diff|	diff	    Fold text that is not changed.
+        |fold-manual|   manual      Folds are created manually.
+        |fold-indent|   indent      Lines with equal indent form a fold.
+        |fold-expr|     expr        'foldexpr' gives the fold level of a line.
+        |fold-marker|   marker      Markers are used to specify folds.
+        |fold-syntax|   syntax      Syntax highlighting items specify folds.
+        |fold-diff|     diff        Fold text that is not changed.
       ]=],
       expand_cb = 'expand_set_foldmethod',
       full_name = 'foldmethod',
@@ -3133,20 +3135,20 @@ return {
         Add the |zv| command to the mapping to get the same effect.
         (rationale: the mapping may want to control opening folds itself)
 
-        	item		commands ~
-        	all		any
-        	block		(, {, [[, [{, etc.
-        	hor		horizontal movements: "l", "w", "fx", etc.
-        	insert		any command in Insert mode
-        	jump		far jumps: "G", "gg", etc.
-        	mark		jumping to a mark: "'m", CTRL-O, etc.
-        	percent		"%"
-        	quickfix	":cn", ":crew", ":make", etc.
-        	search		search for a pattern: "/", "n", "*", "gd", etc.
-        			(not for a search pattern in a ":" command)
-        			Also for |[s| and |]s|.
-        	tag		jumping to a tag: ":ta", CTRL-T, etc.
-        	undo		undo or redo: "u" and CTRL-R
+                item            commands ~
+                all             any
+                block           (, {, [[, [{, etc.
+                hor             horizontal movements: "l", "w", "fx", etc.
+                insert          any command in Insert mode
+                jump            far jumps: "G", "gg", etc.
+                mark            jumping to a mark: "'m", CTRL-O, etc.
+                percent         "%"
+                quickfix        ":cn", ":crew", ":make", etc.
+                search          search for a pattern: "/", "n", "*", "gd", etc.
+                                (not for a search pattern in a ":" command)
+                                Also for |[s| and |]s|.
+                tag             jumping to a tag: ":ta", CTRL-T, etc.
+                undo            undo or redo: "u" and CTRL-R
         When a movement command is used for an operator (e.g., "dl" or "y%")
         this option is not used.  This means the operator will include the
         whole closed fold.
@@ -3204,13 +3206,13 @@ return {
         The |v:lnum|  variable holds the first line to be formatted.
         The |v:count| variable holds the number of lines to be formatted.
         The |v:char|  variable holds the character that is going to be
-        	      inserted if the expression is being evaluated due to
-        	      automatic formatting.  This can be empty.  Don't insert
-        	      it yet!
+                      inserted if the expression is being evaluated due to
+                      automatic formatting.  This can be empty.  Don't insert
+                      it yet!
 
         Example: >vim
-        	set formatexpr=mylang#Format()
-        <	This will invoke the mylang#Format() function in the
+                set formatexpr=mylang#Format()
+        <       This will invoke the mylang#Format() function in the
         autoload/mylang.vim file in 'runtimepath'. |autoload|
 
         The expression is also evaluated when 'textwidth' is set and adding
@@ -3224,9 +3226,9 @@ return {
 
         If the expression starts with s: or |<SID>|, then it is replaced with
         the script ID (|local-function|). Example: >vim
-        	set formatexpr=s:MyFormatExpr()
-        	set formatexpr=<SID>SomeFormatExpr()
-        <	Otherwise, the expression is evaluated in the context of the script
+                set formatexpr=s:MyFormatExpr()
+                set formatexpr=<SID>SomeFormatExpr()
+        <       Otherwise, the expression is evaluated in the context of the script
         where the option was set, thus script-local items are available.
 
         The expression will be evaluated in the |sandbox| when set from a
@@ -3343,10 +3345,10 @@ return {
         is given to a ":substitute" command, this will toggle the substitution
         of all or one match.  See |complex-change|.
 
-        	command		'gdefault' on	'gdefault' off	~
-        	:s///		  subst. all	  subst. one
-        	:s///g		  subst. one	  subst. all
-        	:s///gg		  subst. all	  subst. one
+                command         'gdefault' on   'gdefault' off  ~
+                :s///             subst. all      subst. one
+                :s///g            subst. one      subst. all
+                :s///gg           subst. all      subst. one
 
         NOTE: Setting this option may break plugins that rely on the default
         behavior of the 'g' flag. This will also make the 'g' flag have the
@@ -3380,8 +3382,10 @@ return {
         condition = 'MSWIN',
         if_false = 'grep -n $* /dev/null',
         if_true = 'findstr /n $* nul',
-        doc = [["grep -n ",
-           Unix: "grep -n $* /dev/null"]],
+        doc = [[
+          "grep -n ",
+           Unix: "grep -n $* /dev/null"
+        ]],
       },
       desc = [=[
         Program to use for the |:grep| command.  This option may contain '%'
@@ -3391,8 +3395,8 @@ return {
         |option-backslash| about including spaces and backslashes.
         When your "grep" accepts the "-H" argument, use this to make ":grep"
         also work well with a single file: >vim
-        	set grepprg=grep\ -nH
-        <	Special value: When 'grepprg' is set to "internal" the |:grep| command
+                set grepprg=grep\ -nH
+        <       Special value: When 'grepprg' is set to "internal" the |:grep| command
         works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
         |:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
         See also the section |:make_makeprg|, since most of the comments there
@@ -3418,75 +3422,75 @@ return {
         terminals.  See |tui-cursor-shape|.
 
         To disable cursor-styling, reset the option: >vim
-        	set guicursor=
+                set guicursor=
 
-        <	To enable mode shapes, "Cursor" highlight, and blinking: >vim
-        	set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
-        	  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
-        	  \,sm:block-blinkwait175-blinkoff150-blinkon175
+        <       To enable mode shapes, "Cursor" highlight, and blinking: >vim
+                set guicursor=n-v-c:block,i-ci-ve:ver25,r-cr:hor20,o:hor50
+                  \,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor
+                  \,sm:block-blinkwait175-blinkoff150-blinkon175
 
-        <	The option is a comma-separated list of parts.  Each part consists of a
+        <       The option is a comma-separated list of parts.  Each part consists of a
         mode-list and an argument-list:
-        	mode-list:argument-list,mode-list:argument-list,..
+                mode-list:argument-list,mode-list:argument-list,..
         The mode-list is a dash separated list of these modes:
-        	n	Normal mode
-        	v	Visual mode
-        	ve	Visual mode with 'selection' "exclusive" (same as 'v',
-        		if not specified)
-        	o	Operator-pending mode
-        	i	Insert mode
-        	r	Replace mode
-        	c	Command-line Normal (append) mode
-        	ci	Command-line Insert mode
-        	cr	Command-line Replace mode
-        	sm	showmatch in Insert mode
-        	a	all modes
+                n       Normal mode
+                v       Visual mode
+                ve      Visual mode with 'selection' "exclusive" (same as 'v',
+                        if not specified)
+                o       Operator-pending mode
+                i       Insert mode
+                r       Replace mode
+                c       Command-line Normal (append) mode
+                ci      Command-line Insert mode
+                cr      Command-line Replace mode
+                sm      showmatch in Insert mode
+                a       all modes
         The argument-list is a dash separated list of these arguments:
-        	hor{N}	horizontal bar, {N} percent of the character height
-        	ver{N}	vertical bar, {N} percent of the character width
-        	block	block cursor, fills the whole character
-        		- Only one of the above three should be present.
-        		- Default is "block" for each mode.
-        	blinkwait{N}				*cursor-blinking*
-        	blinkon{N}
-        	blinkoff{N}
-        		blink times for cursor: blinkwait is the delay before
-        		the cursor starts blinking, blinkon is the time that
-        		the cursor is shown and blinkoff is the time that the
-        		cursor is not shown.  Times are in msec.  When one of
-        		the numbers is zero, there is no blinking. E.g.: >vim
-        			set guicursor=n:blinkon0
-        <			- Default is "blinkon0" for each mode.
-        	{group-name}
-        		Highlight group that decides the color and font of the
-        		cursor.
-        		In the |TUI|:
-        		- |inverse|/reverse and no group-name are interpreted
-        		  as "host-terminal default cursor colors" which
-        		  typically means "inverted bg and fg colors".
-        		- |ctermfg| and |guifg| are ignored.
-        	{group-name}/{group-name}
-        		Two highlight group names, the first is used when
-        		no language mappings are used, the other when they
-        		are. |language-mapping|
+                hor{N}  horizontal bar, {N} percent of the character height
+                ver{N}  vertical bar, {N} percent of the character width
+                block   block cursor, fills the whole character
+                        - Only one of the above three should be present.
+                        - Default is "block" for each mode.
+                blinkwait{N}                            *cursor-blinking*
+                blinkon{N}
+                blinkoff{N}
+                        blink times for cursor: blinkwait is the delay before
+                        the cursor starts blinking, blinkon is the time that
+                        the cursor is shown and blinkoff is the time that the
+                        cursor is not shown.  Times are in msec.  When one of
+                        the numbers is zero, there is no blinking. E.g.: >vim
+                                set guicursor=n:blinkon0
+        <                       - Default is "blinkon0" for each mode.
+                {group-name}
+                        Highlight group that decides the color and font of the
+                        cursor.
+                        In the |TUI|:
+                        - |inverse|/reverse and no group-name are interpreted
+                          as "host-terminal default cursor colors" which
+                          typically means "inverted bg and fg colors".
+                        - |ctermfg| and |guifg| are ignored.
+                {group-name}/{group-name}
+                        Two highlight group names, the first is used when
+                        no language mappings are used, the other when they
+                        are. |language-mapping|
 
         Examples of parts:
-           n-c-v:block-nCursor	In Normal, Command-line and Visual mode, use a
-        			block cursor with colors from the "nCursor"
-        			highlight group
+           n-c-v:block-nCursor  In Normal, Command-line and Visual mode, use a
+                                block cursor with colors from the "nCursor"
+                                highlight group
            n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
-        			In Normal et al. modes, use a block cursor
-        			with the default colors defined by the host
-        			terminal.  In Insert-like modes, use
-        			a vertical bar cursor with colors from
-        			"Cursor" highlight group.  In Replace-like
-        			modes, use an underline cursor with
-        			default colors.
+                                In Normal et al. modes, use a block cursor
+                                with the default colors defined by the host
+                                terminal.  In Insert-like modes, use
+                                a vertical bar cursor with colors from
+                                "Cursor" highlight group.  In Replace-like
+                                modes, use an underline cursor with
+                                default colors.
            i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
-        			In Insert and Command-line Insert mode, use a
-        			30% vertical bar cursor with colors from the
-        			"iCursor" highlight group.  Blink a bit
-        			faster.
+                                In Insert and Command-line Insert mode, use a
+                                30% vertical bar cursor with colors from the
+                                "iCursor" highlight group.  Blink a bit
+                                faster.
 
         The 'a' mode is different.  It will set the given argument-list for
         all modes.  It does not reset anything to defaults.  This can be used
@@ -3521,7 +3525,7 @@ return {
         backslash before a space and a backslash.  See also
         |option-backslash|.  For example: >vim
             set guifont=Screen15,\ 7x13,font\\,with\\,commas
-        <	will make Vim try to use the font "Screen15" first, and if it fails it
+        <       will make Vim try to use the font "Screen15" first, and if it fails it
         will try to use "7x13" and then "font,with,commas" instead.
 
         If none of the fonts can be loaded, Vim will keep the current setting.
@@ -3533,32 +3537,32 @@ return {
 
         For Win32 and Mac OS: >vim
             set guifont=*
-        <	will bring up a font requester, where you can pick the font you want.
+        <       will bring up a font requester, where you can pick the font you want.
 
         The font name depends on the GUI used.
 
         For Mac OSX you can use something like this: >vim
             set guifont=Monaco:h10
-        <								*E236*
+        <                                                               *E236*
         Note that the fonts must be mono-spaced (all characters have the same
         width).
 
         To preview a font on X11, you might be able to use the "xfontsel"
         program.  The "xlsfonts" program gives a list of all available fonts.
 
-        For the Win32 GUI					*E244* *E245*
+        For the Win32 GUI                                       *E244* *E245*
         - takes these options in the font name:
-        	hXX - height is XX (points, can be floating-point)
-        	wXX - width is XX (points, can be floating-point)
-        	b   - bold
-        	i   - italic
-        	u   - underline
-        	s   - strikeout
-        	cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
-        	      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
-        	      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
-        	      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
-        	      Normally you would use "cDEFAULT".
+                hXX - height is XX (points, can be floating-point)
+                wXX - width is XX (points, can be floating-point)
+                b   - bold
+                i   - italic
+                u   - underline
+                s   - strikeout
+                cXX - character set XX.  Valid charsets are: ANSI, ARABIC,
+                      BALTIC, CHINESEBIG5, DEFAULT, EASTEUROPE, GB2312, GREEK,
+                      HANGEUL, HEBREW, JOHAB, MAC, OEM, RUSSIAN, SHIFTJIS,
+                      SYMBOL, THAI, TURKISH, VIETNAMESE ANSI and BALTIC.
+                      Normally you would use "cDEFAULT".
 
           Use a ':' to separate the options.
         - A '_' can be used in the place of a space, so you don't need to use
@@ -3614,98 +3618,98 @@ return {
         "+=" and "-=" feature of ":set" |add-option-flags|.
 
         Valid letters are as follows:
-        						*guioptions_a* *'go-a'*
-          'a'	Autoselect:  If present, then whenever VISUAL mode is started,
-        	or the Visual area extended, Vim tries to become the owner of
-        	the windowing system's global selection.  This means that the
-        	Visually highlighted text is available for pasting into other
-        	applications as well as into Vim itself.  When the Visual mode
-        	ends, possibly due to an operation on the text, or when an
-        	application wants to paste the selection, the highlighted text
-        	is automatically yanked into the "* selection register.
-        	Thus the selection is still available for pasting into other
-        	applications after the VISUAL mode has ended.
-        	    If not present, then Vim won't become the owner of the
-        	windowing system's global selection unless explicitly told to
-        	by a yank or delete operation for the "* register.
-        	The same applies to the modeless selection.
-        							*'go-P'*
-          'P'	Like autoselect but using the "+ register instead of the "*
-        	register.
-        							*'go-A'*
-          'A'	Autoselect for the modeless selection.  Like 'a', but only
-        	applies to the modeless selection.
+                                                        *guioptions_a* *'go-a'*
+          'a'   Autoselect:  If present, then whenever VISUAL mode is started,
+                or the Visual area extended, Vim tries to become the owner of
+                the windowing system's global selection.  This means that the
+                Visually highlighted text is available for pasting into other
+                applications as well as into Vim itself.  When the Visual mode
+                ends, possibly due to an operation on the text, or when an
+                application wants to paste the selection, the highlighted text
+                is automatically yanked into the "* selection register.
+                Thus the selection is still available for pasting into other
+                applications after the VISUAL mode has ended.
+                    If not present, then Vim won't become the owner of the
+                windowing system's global selection unless explicitly told to
+                by a yank or delete operation for the "* register.
+                The same applies to the modeless selection.
+                                                                *'go-P'*
+          'P'   Like autoselect but using the "+ register instead of the "*
+                register.
+                                                                *'go-A'*
+          'A'   Autoselect for the modeless selection.  Like 'a', but only
+                applies to the modeless selection.
 
-        	    'guioptions'   autoselect Visual  autoselect modeless ~
-        		 ""		 -			 -
-        		 "a"		yes			yes
-        		 "A"		 -			yes
-        		 "aA"		yes			yes
+                    'guioptions'   autoselect Visual  autoselect modeless ~
+                         ""              -                       -
+                         "a"            yes                     yes
+                         "A"             -                      yes
+                         "aA"           yes                     yes
 
-        							*'go-c'*
-          'c'	Use console dialogs instead of popup dialogs for simple
-        	choices.
-        							*'go-d'*
-          'd'	Use dark theme variant if available.
-        							*'go-e'*
-          'e'	Add tab pages when indicated with 'showtabline'.
-        	'guitablabel' can be used to change the text in the labels.
-        	When 'e' is missing a non-GUI tab pages line may be used.
-        	The GUI tabs are only supported on some systems, currently
-        	Mac OS/X and MS-Windows.
-        							*'go-i'*
-          'i'	Use a Vim icon.
-        							*'go-m'*
-          'm'	Menu bar is present.
-        							*'go-M'*
-          'M'	The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
-        	that this flag must be added in the vimrc file, before
-        	switching on syntax or filetype recognition (when the |gvimrc|
-        	file is sourced the system menu has already been loaded; the
-        	`:syntax on` and `:filetype on` commands load the menu too).
-        							*'go-g'*
-          'g'	Grey menu items: Make menu items that are not active grey.  If
-        	'g' is not included inactive menu items are not shown at all.
-        							*'go-T'*
-          'T'	Include Toolbar.  Currently only in Win32 GUI.
-        							*'go-r'*
-          'r'	Right-hand scrollbar is always present.
-        							*'go-R'*
-          'R'	Right-hand scrollbar is present when there is a vertically
-        	split window.
-        							*'go-l'*
-          'l'	Left-hand scrollbar is always present.
-        							*'go-L'*
-          'L'	Left-hand scrollbar is present when there is a vertically
-        	split window.
-        							*'go-b'*
-          'b'	Bottom (horizontal) scrollbar is present.  Its size depends on
-        	the longest visible line, or on the cursor line if the 'h'
-        	flag is included. |gui-horiz-scroll|
-        							*'go-h'*
-          'h'	Limit horizontal scrollbar size to the length of the cursor
-        	line.  Reduces computations. |gui-horiz-scroll|
+                                                                *'go-c'*
+          'c'   Use console dialogs instead of popup dialogs for simple
+                choices.
+                                                                *'go-d'*
+          'd'   Use dark theme variant if available.
+                                                                *'go-e'*
+          'e'   Add tab pages when indicated with 'showtabline'.
+                'guitablabel' can be used to change the text in the labels.
+                When 'e' is missing a non-GUI tab pages line may be used.
+                The GUI tabs are only supported on some systems, currently
+                Mac OS/X and MS-Windows.
+                                                                *'go-i'*
+          'i'   Use a Vim icon.
+                                                                *'go-m'*
+          'm'   Menu bar is present.
+                                                                *'go-M'*
+          'M'   The system menu "$VIMRUNTIME/menu.vim" is not sourced.  Note
+                that this flag must be added in the vimrc file, before
+                switching on syntax or filetype recognition (when the |gvimrc|
+                file is sourced the system menu has already been loaded; the
+                `:syntax on` and `:filetype on` commands load the menu too).
+                                                                *'go-g'*
+          'g'   Grey menu items: Make menu items that are not active grey.  If
+                'g' is not included inactive menu items are not shown at all.
+                                                                *'go-T'*
+          'T'   Include Toolbar.  Currently only in Win32 GUI.
+                                                                *'go-r'*
+          'r'   Right-hand scrollbar is always present.
+                                                                *'go-R'*
+          'R'   Right-hand scrollbar is present when there is a vertically
+                split window.
+                                                                *'go-l'*
+          'l'   Left-hand scrollbar is always present.
+                                                                *'go-L'*
+          'L'   Left-hand scrollbar is present when there is a vertically
+                split window.
+                                                                *'go-b'*
+          'b'   Bottom (horizontal) scrollbar is present.  Its size depends on
+                the longest visible line, or on the cursor line if the 'h'
+                flag is included. |gui-horiz-scroll|
+                                                                *'go-h'*
+          'h'   Limit horizontal scrollbar size to the length of the cursor
+                line.  Reduces computations. |gui-horiz-scroll|
 
         And yes, you may even have scrollbars on the left AND the right if
         you really want to :-).  See |gui-scrollbars| for more information.
 
-        							*'go-v'*
-          'v'	Use a vertical button layout for dialogs.  When not included,
-        	a horizontal layout is preferred, but when it doesn't fit a
-        	vertical layout is used anyway.  Not supported in GTK 3.
-        							*'go-p'*
-          'p'	Use Pointer callbacks for X11 GUI.  This is required for some
-        	window managers.  If the cursor is not blinking or hollow at
-        	the right moment, try adding this flag.  This must be done
-        	before starting the GUI.  Set it in your |gvimrc|.  Adding or
-        	removing it after the GUI has started has no effect.
-        							*'go-k'*
-          'k'	Keep the GUI window size when adding/removing a scrollbar, or
-        	toolbar, tabline, etc.  Instead, the behavior is similar to
-        	when the window is maximized and will adjust 'lines' and
-        	'columns' to fit to the window.  Without the 'k' flag Vim will
-        	try to keep 'lines' and 'columns' the same when adding and
-        	removing GUI components.
+                                                                *'go-v'*
+          'v'   Use a vertical button layout for dialogs.  When not included,
+                a horizontal layout is preferred, but when it doesn't fit a
+                vertical layout is used anyway.  Not supported in GTK 3.
+                                                                *'go-p'*
+          'p'   Use Pointer callbacks for X11 GUI.  This is required for some
+                window managers.  If the cursor is not blinking or hollow at
+                the right moment, try adding this flag.  This must be done
+                before starting the GUI.  Set it in your |gvimrc|.  Adding or
+                removing it after the GUI has started has no effect.
+                                                                *'go-k'*
+          'k'   Keep the GUI window size when adding/removing a scrollbar, or
+                toolbar, tabline, etc.  Instead, the behavior is similar to
+                when the window is maximized and will adjust 'lines' and
+                'columns' to fit to the window.  Without the 'k' flag Vim will
+                try to keep 'lines' and 'columns' the same when adding and
+                removing GUI components.
       ]=],
       enable_if = false,
       full_name = 'guioptions',
@@ -3746,7 +3750,7 @@ return {
         pages line.  When empty Vim will use a default tooltip.
         This option is otherwise just like 'guitablabel' above.
         You can include a line break.  Simplest method is to use |:let|: >vim
-        	let &guitabtooltip = "line one\nline two"
+                let &guitabtooltip = "line one\nline two"
         <
       ]=],
       enable_if = false,
@@ -3761,8 +3765,10 @@ return {
       cb = 'did_set_helpfile',
       defaults = {
         if_true = macros('DFLT_HELPFILE'),
-        doc = [[(MS-Windows) "$VIMRUNTIME\doc\help.txt"
-                  (others) "$VIMRUNTIME/doc/help.txt"]],
+        doc = [[
+          (MS-Windows) "$VIMRUNTIME\doc\help.txt"
+          (others) "$VIMRUNTIME/doc/help.txt"
+        ]],
       },
       desc = [=[
         Name of the main help file.  All distributed help files should be
@@ -3815,8 +3821,8 @@ return {
         another language, but that will only find tags that exist in that
         language and not in the English help.
         Example: >vim
-        	set helplang=de,it
-        <	This will first search German, then Italian and finally English help
+                set helplang=de,it
+        <       This will first search German, then Italian and finally English help
         files.
         When using |CTRL-]| and ":help!" in a non-English help file Vim will
         try to find the tag in the current language before using this option.
@@ -4027,13 +4033,13 @@ return {
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used in
         Insert mode.  Valid values:
-        	0	:lmap is off and IM is off
-        	1	:lmap is ON and IM is off
-        	2	:lmap is off and IM is ON
+                0       :lmap is off and IM is off
+                1       :lmap is ON and IM is off
+                2       :lmap is off and IM is ON
         To always reset the option to zero when leaving Insert mode with <Esc>
         this can be used: >vim
-        	inoremap <ESC> <ESC>:set iminsert=0<CR>
-        <	This makes :lmap and IM turn off automatically when leaving Insert
+                inoremap <ESC> <ESC>:set iminsert=0<CR>
+        <       This makes :lmap and IM turn off automatically when leaving Insert
         mode.
         Note that this option changes when using CTRL-^ in Insert mode
         |i_CTRL-^|.
@@ -4053,11 +4059,11 @@ return {
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used when
         entering a search pattern.  Valid values:
-        	-1	the value of 'iminsert' is used, makes it look like
-        		'iminsert' is also used when typing a search pattern
-        	0	:lmap is off and IM is off
-        	1	:lmap is ON and IM is off
-        	2	:lmap is off and IM is ON
+                -1      the value of 'iminsert' is used, makes it look like
+                        'iminsert' is also used when typing a search pattern
+                0       :lmap is off and IM is off
+                1       :lmap is ON and IM is off
+                2       :lmap is off and IM is ON
         Note that this option changes when using CTRL-^ in Command-line mode
         |c_CTRL-^|.
         The value is set to 1 when it is not -1 and setting the 'keymap'
@@ -4080,10 +4086,10 @@ return {
         type.
 
         Possible values:
-        	nosplit	Shows the effects of a command incrementally in the
-        		buffer.
-        	split	Like "nosplit", but also shows partial off-screen
-        		results in a preview window.
+                nosplit Shows the effects of a command incrementally in the
+                        buffer.
+                split   Like "nosplit", but also shows partial off-screen
+                        results in a preview window.
 
         If the preview for built-in commands is too slow (exceeds
         'redrawtime') then 'inccommand' is automatically disabled until
@@ -4126,12 +4132,12 @@ return {
       desc = [=[
         Expression to be used to transform the string found with the 'include'
         option to a file name.  Mostly useful to change "." to "/" for Java: >vim
-        	setlocal includeexpr=substitute(v:fname,'\\.','/','g')
-        <	The "v:fname" variable will be set to the file name that was detected.
+                setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+        <       The "v:fname" variable will be set to the file name that was detected.
         Note the double backslash: the `:set` command first halves them, then
         one remains in the value, where "\." matches a dot literally.  For
         simple character replacements `tr()` avoids the need for escaping: >vim
-        	setlocal includeexpr=tr(v:fname,'.','/')
+                setlocal includeexpr=tr(v:fname,'.','/')
         <
         Also used for the |gf| command if an unmodified file name can't be
         found.  Allows doing "gf" on the name after an 'include' statement.
@@ -4139,9 +4145,9 @@ return {
 
         If the expression starts with s: or |<SID>|, then it is replaced with
         the script ID (|local-function|). Example: >vim
-        	setlocal includeexpr=s:MyIncludeExpr(v:fname)
-        	setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
-        <	Otherwise, the expression is evaluated in the context of the script
+                setlocal includeexpr=s:MyIncludeExpr(v:fname)
+                setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
+        <       Otherwise, the expression is evaluated in the context of the script
         where the option was set, thus script-local items are available.
 
         The expression will be evaluated in the |sandbox| when set from a
@@ -4181,11 +4187,11 @@ return {
         If you don't want to turn 'hlsearch' on, but want to highlight all
         matches while searching, you can turn on and off 'hlsearch' with
         autocmd.  Example: >vim
-        	augroup vimrc-incsearch-highlight
-        	  autocmd!
-        	  autocmd CmdlineEnter /,\? :set hlsearch
-        	  autocmd CmdlineLeave /,\? :set nohlsearch
-        	augroup END
+                augroup vimrc-incsearch-highlight
+                  autocmd!
+                  autocmd CmdlineEnter /,\? :set hlsearch
+                  autocmd CmdlineLeave /,\? :set nohlsearch
+                augroup END
         <
         CTRL-L can be used to add one character from after the current match
         to the command line.  If 'ignorecase' and 'smartcase' are set and the
@@ -4218,9 +4224,9 @@ return {
 
         If the expression starts with s: or |<SID>|, then it is replaced with
         the script ID (|local-function|). Example: >vim
-        	set indentexpr=s:MyIndentExpr()
-        	set indentexpr=<SID>SomeIndentExpr()
-        <	Otherwise, the expression is evaluated in the context of the script
+                set indentexpr=s:MyIndentExpr()
+                set indentexpr=<SID>SomeIndentExpr()
+        <       Otherwise, the expression is evaluated in the context of the script
         where the option was set, thus script-local items are available.
 
         The expression must return the number of spaces worth of indent.  It
@@ -4232,8 +4238,8 @@ return {
         not change the text, jump to another window, etc.  Afterwards the
         cursor position is always restored, thus the cursor may be moved.
         Normally this option would be set to call a function: >vim
-        	set indentexpr=GetMyIndent()
-        <	Error messages will be suppressed, unless the 'debug' option contains
+                set indentexpr=GetMyIndent()
+        <       Error messages will be suppressed, unless the 'debug' option contains
         "msg".
         See |indent-expression|.
 
@@ -4304,9 +4310,10 @@ return {
         condition = 'BACKSLASH_IN_FILENAME',
         if_false = '@,48-57,/,.,-,_,+,,,#,$,%,~,=',
         if_true = '@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,=',
-        doc = [[for Windows:
-      "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
-     otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,="]],
+        doc = [[
+          for Windows: "@,48-57,/,\,.,-,_,+,,,#,$,%,{,},[,],@-@,!,~,="
+          otherwise: "@,48-57,/,.,-,_,+,,,#,$,%,~,="
+        ]],
       },
       deny_duplicates = true,
       desc = [=[
@@ -4334,26 +4341,26 @@ return {
         character numbers with '-' in between.  A character number can be a
         decimal number between 0 and 255 or the ASCII character itself (does
         not work for digits).  Example:
-        	"_,-,128-140,#-43"	(include '_' and '-' and the range
-        				128 to 140 and '#' to 43)
+                "_,-,128-140,#-43"      (include '_' and '-' and the range
+                                        128 to 140 and '#' to 43)
         If a part starts with '^', the following character number or range
         will be excluded from the option.  The option is interpreted from left
         to right.  Put the excluded character after the range where it is
         included.  To include '^' itself use it as the last character of the
         option or the end of a range.  Example:
-        	"^a-z,#,^"	(exclude 'a' to 'z', include '#' and '^')
+                "^a-z,#,^"      (exclude 'a' to 'z', include '#' and '^')
         If the character is '@', all characters where isalpha() returns TRUE
         are included.  Normally these are the characters a to z and A to Z,
         plus accented characters.  To include '@' itself use "@-@".  Examples:
-        	"@,^a-z"	All alphabetic characters, excluding lower
-        			case ASCII letters.
-        	"a-z,A-Z,@-@"	All letters plus the '@' character.
+                "@,^a-z"        All alphabetic characters, excluding lower
+                                case ASCII letters.
+                "a-z,A-Z,@-@"   All letters plus the '@' character.
         A comma can be included by using it where a character number is
         expected.  Example:
-        	"48-57,,,_"	Digits, comma and underscore.
+                "48-57,,,_"     Digits, comma and underscore.
         A comma can be excluded by prepending a '^'.  Example:
-        	" -~,^,,9"	All characters from space to '~', excluding
-        			comma, plus <Tab>.
+                " -~,^,,9"      All characters from space to '~', excluding
+                                comma, plus <Tab>.
         See |option-backslash| about including spaces and backslashes.
       ]=],
       full_name = 'isfname',
@@ -4370,9 +4377,10 @@ return {
         condition = 'MSWIN',
         if_false = '@,48-57,_,192-255',
         if_true = '@,48-57,_,128-167,224-235',
-        doc = [[for Windows:
-                    "@,48-57,_,128-167,224-235"
-         otherwise: "@,48-57,_,192-255"]],
+        doc = [[
+          for Windows: "@,48-57,_,128-167,224-235"
+          otherwise: "@,48-57,_,192-255"
+        ]],
       },
       deny_duplicates = true,
       desc = [=[
@@ -4433,12 +4441,12 @@ return {
         'isfname' for a description of the format of this option.
 
         Non-printable characters are displayed with two characters:
-        	  0 -  31	"^@" - "^_"
-        	 32 - 126	always single characters
-        	   127		"^?"
-        	128 - 159	"~@" - "~_"
-        	160 - 254	"| " - "|~"
-        	   255		"~?"
+                  0 -  31       "^@" - "^_"
+                 32 - 126       always single characters
+                   127          "^?"
+                128 - 159       "~@" - "~_"
+                160 - 254       "| " - "|~"
+                   255          "~?"
         Illegal bytes from 128 to 255 (invalid UTF-8) are
         displayed as <xx>, with the hexadecimal value of the byte.
         When 'display' contains "uhex" all unprintable characters are
@@ -4482,14 +4490,14 @@ return {
       desc = [=[
         List of words that change the behavior of the |jumplist|.
           stack         Make the jumplist behave like the tagstack.
-        		Relative location of entries in the jumplist is
-        		preserved at the cost of discarding subsequent entries
-        		when navigating backwards in the jumplist and then
-        		jumping to a location.  |jumplist-stack|
+                        Relative location of entries in the jumplist is
+                        preserved at the cost of discarding subsequent entries
+                        when navigating backwards in the jumplist and then
+                        jumping to a location.  |jumplist-stack|
 
           view          When moving through the jumplist, |changelist|,
-        		|alternate-file| or using |mark-motions| try to
-        		restore the |mark-view| in which the action occurred.
+                        |alternate-file| or using |mark-motions| try to
+                        restore the |mark-view| in which the action occurred.
       ]=],
       expand_cb = 'expand_set_jumpoptions',
       full_name = 'jumpoptions',
@@ -4529,10 +4537,10 @@ return {
       desc = [=[
         List of comma-separated words, which enable special things that keys
         can do.  These values can be used:
-           startsel	Using a shifted special key starts selection (either
-        		Select mode or Visual mode, depending on "key" being
-        		present in 'selectmode').
-           stopsel	Using a not-shifted special key stops selection.
+           startsel     Using a shifted special key starts selection (either
+                        Select mode or Visual mode, depending on "key" being
+                        present in 'selectmode').
+           stopsel      Using a not-shifted special key stops selection.
         Special keys in this context are the cursor keys, <End>, <Home>,
         <PageUp> and <PageDown>.
       ]=],
@@ -4561,9 +4569,9 @@ return {
         a [count] for the "K" command to a section number.
         See |option-backslash| about including spaces and backslashes.
         Example: >vim
-        	set keywordprg=man\ -s
-        	set keywordprg=:Man
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
+                set keywordprg=man\ -s
+                set keywordprg=:Man
+        <       This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
       ]=],
       expand = true,
@@ -4593,9 +4601,9 @@ return {
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
 
-        Example (for Greek, in UTF-8):				*greek*  >vim
+        Example (for Greek, in UTF-8):                          *greek*  >vim
             set langmap=ΑA,ΒB,ΨC,ΔD,ΕE,ΦF,ΓG,ΗH,ΙI,ΞJ,ΚK,ΛL,ΜM,ΝN,ΟO,ΠP,QQ,ΡR,ΣS,ΤT,ΘU,ΩV,WW,ΧX,ΥY,ΖZ,αa,βb,ψc,δd,εe,φf,γg,ηh,ιi,ξj,κk,λl,μm,νn,οo,πp,qq,ρr,σs,τt,θu,ωv,ςw,χx,υy,ζz
-        <	Example (exchanges meaning of z and y for commands): >vim
+        <       Example (exchanges meaning of z and y for commands): >vim
             set langmap=zy,yz,ZY,YZ
         <
         The 'langmap' option is a list of parts, separated with commas.  Each
@@ -4635,22 +4643,22 @@ return {
       desc = [=[
         Language to use for menu translation.  Tells which file is loaded
         from the "lang" directory in 'runtimepath': >vim
-        	"lang/menu_" .. &langmenu .. ".vim"
-        <	(without the spaces).  For example, to always use the Dutch menus, no
+                "lang/menu_" .. &langmenu .. ".vim"
+        <       (without the spaces).  For example, to always use the Dutch menus, no
         matter what $LANG is set to: >vim
-        	set langmenu=nl_NL.ISO_8859-1
-        <	When 'langmenu' is empty, |v:lang| is used.
+                set langmenu=nl_NL.ISO_8859-1
+        <       When 'langmenu' is empty, |v:lang| is used.
         Only normal file name characters can be used, `/\*?[|<>` are illegal.
         If your $LANG is set to a non-English language but you do want to use
         the English menus: >vim
-        	set langmenu=none
-        <	This option must be set before loading menus, switching on filetype
+                set langmenu=none
+        <       This option must be set before loading menus, switching on filetype
         detection or syntax highlighting.  Once the menus are defined setting
         this option has no effect.  But you could do this: >vim
-        	source $VIMRUNTIME/delmenu.vim
-        	set langmenu=de_DE.ISO_8859-1
-        	source $VIMRUNTIME/menu.vim
-        <	Warning: This deletes all menus that you defined yourself!
+                source $VIMRUNTIME/delmenu.vim
+                set langmenu=de_DE.ISO_8859-1
+                source $VIMRUNTIME/menu.vim
+        <       Warning: This deletes all menus that you defined yourself!
       ]=],
       full_name = 'langmenu',
       normal_fname_chars = true,
@@ -4691,10 +4699,10 @@ return {
       desc = [=[
         The value of this option influences when the last window will have a
         status line:
-        	0: never
-        	1: only if there are at least two windows
-        	2: always
-        	3: always and ONLY the last window
+                0: never
+                1: only if there are at least two windows
+                2: always
+                3: always and ONLY the last window
         The screen looks nicer with a status line if you have several
         windows, but it takes another screen line. |status-line|
       ]=],
@@ -4757,8 +4765,8 @@ return {
         to use the size for the GUI, put the command in your |gvimrc| file.
         Vim limits the number of lines to what fits on the screen.  You can
         use this command to get the tallest window possible: >vim
-        	set lines=999
-        <	Minimum value is 2, maximum value is 1000.
+                set lines=999
+        <       Minimum value is 2, maximum value is 1000.
       ]=],
       full_name = 'lines',
       no_mkrc = true,
@@ -4772,7 +4780,7 @@ return {
       abbreviation = 'lsp',
       defaults = { if_true = 0 },
       desc = [=[
-        		only in the GUI
+                        only in the GUI
         Number of pixel lines inserted between characters.  Useful if the font
         uses the full character cell height, making lines touch each other.
         When non-zero there is room for underlining.
@@ -4816,8 +4824,8 @@ return {
         Comma-separated list of items that influence the Lisp indenting when
         enabled with the |'lisp'| option.  Currently only one item is
         supported:
-        	expr:1	use 'indentexpr' for Lisp indenting when it is set
-        	expr:0	do not use 'indentexpr' for Lisp indenting (default)
+                expr:1  use 'indentexpr' for Lisp indenting when it is set
+                expr:0  do not use 'indentexpr' for Lisp indenting (default)
         Note that when using 'indentexpr' the `=` operator indents all the
         lines, otherwise the first line is not indented (Vi-compatible).
       ]=],
@@ -4860,7 +4868,7 @@ return {
         The cursor is displayed at the start of the space a Tab character
         occupies, not at the end as usual in Normal mode.  To get this cursor
         position while displaying Tabs with spaces, use: >vim
-        	set list lcs=tab:\ \
+                set list lcs=tab:\ \
         <
         Note that list mode will also affect formatting (set with 'textwidth'
         or 'wrapmargin') when 'cpoptions' includes 'L'.  See 'listchars' for
@@ -4882,97 +4890,97 @@ return {
         Strings to use in 'list' mode and for the |:list| command.  It is a
         comma-separated list of string settings.
 
-        						*lcs-eol*
-          eol:c		Character to show at the end of each line.  When
-        		omitted, there is no extra character at the end of the
-        		line.
-        						*lcs-tab*
-          tab:xy[z]	Two or three characters to be used to show a tab.
-        		The third character is optional.
+                                                        *lcs-eol*
+          eol:c         Character to show at the end of each line.  When
+                        omitted, there is no extra character at the end of the
+                        line.
+                                                        *lcs-tab*
+          tab:xy[z]     Two or three characters to be used to show a tab.
+                        The third character is optional.
 
-          tab:xy	The 'x' is always used, then 'y' as many times as will
-        		fit.  Thus "tab:>-" displays: >
-        			>
-        			>-
-        			>--
-        			etc.
+          tab:xy        The 'x' is always used, then 'y' as many times as will
+                        fit.  Thus "tab:>-" displays: >
+                                >
+                                >-
+                                >--
+                                etc.
         <
-          tab:xyz	The 'z' is always used, then 'x' is prepended, and
-        		then 'y' is used as many times as will fit.  Thus
-        		"tab:<->" displays: >
-        			>
-        			<>
-        			<->
-        			<-->
-        			etc.
+          tab:xyz       The 'z' is always used, then 'x' is prepended, and
+                        then 'y' is used as many times as will fit.  Thus
+                        "tab:<->" displays: >
+                                >
+                                <>
+                                <->
+                                <-->
+                                etc.
         <
-        		When "tab:" is omitted, a tab is shown as ^I.
-        						*lcs-space*
-          space:c	Character to show for a space.  When omitted, spaces
-        		are left blank.
-        						*lcs-multispace*
+                        When "tab:" is omitted, a tab is shown as ^I.
+                                                        *lcs-space*
+          space:c       Character to show for a space.  When omitted, spaces
+                        are left blank.
+                                                        *lcs-multispace*
           multispace:c...
-        		One or more characters to use cyclically to show for
-        		multiple consecutive spaces.  Overrides the "space"
-        		setting, except for single spaces.  When omitted, the
-        		"space" setting is used.  For example,
-        		`:set listchars=multispace:---+` shows ten consecutive
-        		spaces as: >
-        			---+---+--
+                        One or more characters to use cyclically to show for
+                        multiple consecutive spaces.  Overrides the "space"
+                        setting, except for single spaces.  When omitted, the
+                        "space" setting is used.  For example,
+                        `:set listchars=multispace:---+` shows ten consecutive
+                        spaces as: >
+                                ---+---+--
         <
-        						*lcs-lead*
-          lead:c	Character to show for leading spaces.  When omitted,
-        		leading spaces are blank.  Overrides the "space" and
-        		"multispace" settings for leading spaces.  You can
-        		combine it with "tab:", for example: >vim
-        			set listchars+=tab:>-,lead:.
+                                                        *lcs-lead*
+          lead:c        Character to show for leading spaces.  When omitted,
+                        leading spaces are blank.  Overrides the "space" and
+                        "multispace" settings for leading spaces.  You can
+                        combine it with "tab:", for example: >vim
+                                set listchars+=tab:>-,lead:.
         <
-        						*lcs-leadmultispace*
+                                                        *lcs-leadmultispace*
           leadmultispace:c...
-        		Like the |lcs-multispace| value, but for leading
-        		spaces only.  Also overrides |lcs-lead| for leading
-        		multiple spaces.
-        		`:set listchars=leadmultispace:---+` shows ten
-        		consecutive leading spaces as: >
-        			---+---+--XXX
+                        Like the |lcs-multispace| value, but for leading
+                        spaces only.  Also overrides |lcs-lead| for leading
+                        multiple spaces.
+                        `:set listchars=leadmultispace:---+` shows ten
+                        consecutive leading spaces as: >
+                                ---+---+--XXX
         <
-        		Where "XXX" denotes the first non-blank characters in
-        		the line.
-        						*lcs-trail*
-          trail:c	Character to show for trailing spaces.  When omitted,
-        		trailing spaces are blank.  Overrides the "space" and
-        		"multispace" settings for trailing spaces.
-        						*lcs-extends*
-          extends:c	Character to show in the last column, when 'wrap' is
-        		off and the line continues beyond the right of the
-        		screen.
-        						*lcs-precedes*
-          precedes:c	Character to show in the first visible column of the
-        		physical line, when there is text preceding the
-        		character visible in the first column.
-        						*lcs-conceal*
-          conceal:c	Character to show in place of concealed text, when
-        		'conceallevel' is set to 1.  A space when omitted.
-        						*lcs-nbsp*
-          nbsp:c	Character to show for a non-breakable space character
-        		(0xA0 (160 decimal) and U+202F).  Left blank when
-        		omitted.
+                        Where "XXX" denotes the first non-blank characters in
+                        the line.
+                                                        *lcs-trail*
+          trail:c       Character to show for trailing spaces.  When omitted,
+                        trailing spaces are blank.  Overrides the "space" and
+                        "multispace" settings for trailing spaces.
+                                                        *lcs-extends*
+          extends:c     Character to show in the last column, when 'wrap' is
+                        off and the line continues beyond the right of the
+                        screen.
+                                                        *lcs-precedes*
+          precedes:c    Character to show in the first visible column of the
+                        physical line, when there is text preceding the
+                        character visible in the first column.
+                                                        *lcs-conceal*
+          conceal:c     Character to show in place of concealed text, when
+                        'conceallevel' is set to 1.  A space when omitted.
+                                                        *lcs-nbsp*
+          nbsp:c        Character to show for a non-breakable space character
+                        (0xA0 (160 decimal) and U+202F).  Left blank when
+                        omitted.
 
         The characters ':' and ',' should not be used.  UTF-8 characters can
         be used.  All characters must be single width.
 
         Each character can be specified as hex: >vim
-        	set listchars=eol:\\x24
-        	set listchars=eol:\\u21b5
-        	set listchars=eol:\\U000021b5
-        <	Note that a double backslash is used.  The number of hex characters
+                set listchars=eol:\\x24
+                set listchars=eol:\\u21b5
+                set listchars=eol:\\U000021b5
+        <       Note that a double backslash is used.  The number of hex characters
         must be exactly 2 for \\x, 4 for \\u and 8 for \\U.
 
         Examples: >vim
             set lcs=tab:>-,trail:-
             set lcs=tab:>-,eol:<,nbsp:%
             set lcs=extends:>,precedes:<
-        <	|hl-NonText| highlighting will be used for "eol", "extends" and
+        <       |hl-NonText| highlighting will be used for "eol", "extends" and
         "precedes". |hl-Whitespace| for "nbsp", "space", "tab", "multispace",
         "lead" and "trail".
       ]=],
@@ -5056,7 +5064,7 @@ return {
         This would be mostly useful when you use MS-Windows.  If iconv is
         enabled, setting 'makeencoding' to "char" has the same effect as
         setting to the system locale encoding.  Example: >vim
-        	set makeencoding=char	" system locale is used
+                set makeencoding=char   " system locale is used
         <
       ]=],
       expand_cb = 'expand_set_encoding',
@@ -5080,10 +5088,10 @@ return {
         the interpretation of a command.  When you use a filter called
         "myfilter" do it like this: >vim
             set makeprg=gmake\ \\\|\ myfilter
-        <	The placeholder "$*" can be given (even multiple times) to specify
+        <       The placeholder "$*" can be given (even multiple times) to specify
         where the arguments will be included, for example: >vim
             set makeprg=latex\ \\\\nonstopmode\ \\\\input\\{$*}
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
+        <       This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
       ]=],
       expand = true,
@@ -5108,13 +5116,13 @@ return {
         The characters must be separated by a colon.
         The pairs must be separated by a comma.  Example for including '<' and
         '>' (for HTML): >vim
-        	set mps+=<:>
+                set mps+=<:>
 
-        <	A more exotic example, to jump between the '=' and ';' in an
+        <       A more exotic example, to jump between the '=' and ';' in an
         assignment, useful for languages like C and Java: >vim
-        	au FileType c,cpp,java set mps+==:;
+                au FileType c,cpp,java set mps+==:;
 
-        <	For a more advanced way of using "%", see the matchit.vim plugin in
+        <       For a more advanced way of using "%", see the matchit.vim plugin in
         the $VIMRUNTIME/plugin directory. |add-local-help|
       ]=],
       full_name = 'matchpairs',
@@ -5189,7 +5197,7 @@ return {
       desc = [=[
         Maximum amount of memory (in Kbyte) to use for pattern matching.
         The maximum value is about 2000000.  Use this to work without a limit.
-        						*E363*
+                                                        *E363*
         When Vim runs into the limit it gives an error message and mostly
         behaves like CTRL-C was typed.
         Running into the limit often means that the pattern is very
@@ -5232,7 +5240,7 @@ return {
         this tuning is complicated.
 
         There are three numbers, separated by commas: >
-        	{start},{inc},{added}
+                {start},{inc},{added}
         <
         For most languages the uncompressed word tree fits in memory.  {start}
         gives the amount of memory in Kbyte that can be used before any
@@ -5254,8 +5262,8 @@ return {
         The languages for which these numbers are important are Italian and
         Hungarian.  The default works for when you have about 512 Mbyte.  If
         you have 1 Gbyte you could use: >vim
-        	set mkspellmem=900000,3000,800
-        <	If you have less than 512 Mbyte |:mkspell| may fail for some
+                set mkspellmem=900000,3000,800
+        <       If you have less than 512 Mbyte |:mkspell| may fail for some
         languages, no matter what you set 'mkspellmem' to.
 
         This option cannot be set from a |modeline| or in the |sandbox|, for
@@ -5389,19 +5397,19 @@ return {
       desc = [=[
         Enables mouse support. For example, to enable the mouse in Normal mode
         and Visual mode: >vim
-        	set mouse=nv
+                set mouse=nv
         <
         To temporarily disable mouse support, hold the shift key while using
         the mouse.
 
         Mouse support can be enabled for different modes:
-        	n	Normal mode
-        	v	Visual mode
-        	i	Insert mode
-        	c	Command-line mode
-        	h	all previous modes when editing a help file
-        	a	all previous modes
-        	r	for |hit-enter| and |more-prompt| prompt
+                n       Normal mode
+                v       Visual mode
+                i       Insert mode
+                c       Command-line mode
+                h       all previous modes when editing a help file
+                a       all previous modes
+                r       for |hit-enter| and |more-prompt| prompt
 
         Left-click anywhere in a text buffer to place the cursor there.  This
         works with operators too, e.g. type |d| then left-click to delete text
@@ -5419,10 +5427,10 @@ return {
         "* register if possible. See also 'clipboard'.
 
         Related options:
-        'mousefocus'	window focus follows mouse pointer
-        'mousemodel'	what mouse button does which action
-        'mousehide'	hide mouse pointer while typing text
-        'selectmode'	whether to start Select mode or Visual mode
+        'mousefocus'    window focus follows mouse pointer
+        'mousemodel'    what mouse button does which action
+        'mousehide'     hide mouse pointer while typing text
+        'selectmode'    whether to start Select mode or Visual mode
       ]=],
       expand_cb = 'expand_set_mouse',
       full_name = 'mouse',
@@ -5453,7 +5461,7 @@ return {
       abbreviation = 'mh',
       defaults = { if_true = true },
       desc = [=[
-        		only in the GUI
+                        only in the GUI
         When on, the mouse pointer is hidden when characters are typed.
         The mouse pointer is restored when the mouse is moved.
       ]=],
@@ -5472,26 +5480,26 @@ return {
       desc = [=[
         Sets the model to use for the mouse.  The name mostly specifies what
         the right mouse button is used for:
-           extend	Right mouse button extends a selection.  This works
-        		like in an xterm.
-           popup	Right mouse button pops up a menu.  The shifted left
-        		mouse button extends a selection.  This works like
-        		with Microsoft Windows.
+           extend       Right mouse button extends a selection.  This works
+                        like in an xterm.
+           popup        Right mouse button pops up a menu.  The shifted left
+                        mouse button extends a selection.  This works like
+                        with Microsoft Windows.
            popup_setpos Like "popup", but the cursor will be moved to the
-        		position where the mouse was clicked, and thus the
-        		selected operation will act upon the clicked object.
-        		If clicking inside a selection, that selection will
-        		be acted upon, i.e. no cursor move.  This implies of
-        		course, that right clicking outside a selection will
-        		end Visual mode.
+                        position where the mouse was clicked, and thus the
+                        selected operation will act upon the clicked object.
+                        If clicking inside a selection, that selection will
+                        be acted upon, i.e. no cursor move.  This implies of
+                        course, that right clicking outside a selection will
+                        end Visual mode.
         Overview of what button does what for each model:
-        mouse		    extend		popup(_setpos) ~
-        left click	    place cursor	place cursor
-        left drag	    start selection	start selection
-        shift-left	    search word		extend selection
-        right click	    extend selection	popup menu (place cursor)
-        right drag	    extend selection	-
-        middle click	    paste		paste
+        mouse               extend              popup(_setpos) ~
+        left click          place cursor        place cursor
+        left drag           start selection     start selection
+        shift-left          search word         extend selection
+        right click         extend selection    popup menu (place cursor)
+        right drag          extend selection    -
+        middle click        paste               paste
 
         In the "popup" model the right mouse button produces a pop-up menu.
         Nvim creates a default |popup-menu| but you can redefine it.
@@ -5515,8 +5523,8 @@ return {
         <
         Mouse commands requiring the CTRL modifier can be simulated by typing
         the "g" key before using the mouse:
-            "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
-            "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
+            "g<LeftMouse>"  is "<C-LeftMouse>   (jump to tag under mouse click)
+            "g<RightMouse>" is "<C-RightMouse>  ("CTRL-T")
       ]=],
       expand_cb = 'expand_set_mousemodel',
       full_name = 'mousemodel',
@@ -5550,7 +5558,7 @@ return {
         scrolling with a mouse wheel (|scroll-mouse-wheel|). The option is
         a comma-separated list. Each part consists of a direction and a count
         as follows:
-        	direction:count,direction:count
+                direction:count,direction:count
         Direction is one of either "hor" or "ver". "hor" controls horizontal
         scrolling and "ver" controls vertical scrolling. Count sets the amount
         to scroll by for the given direction, it should be a non negative
@@ -5560,8 +5568,8 @@ return {
         a count of 0.
 
         Example: >vim
-        	set mousescroll=ver:5,hor:2
-        <	Will make Nvim scroll 5 lines at a time when scrolling vertically, and
+                set mousescroll=ver:5,hor:2
+        <       Will make Nvim scroll 5 lines at a time when scrolling vertically, and
         scroll 2 columns at a time when scrolling horizontally.
       ]=],
       expand_cb = 'expand_set_mousescroll',
@@ -5579,57 +5587,59 @@ return {
       deny_duplicates = true,
       defaults = {
         if_true = '',
-        doc = [["i:beam,r:beam,s:updown,sd:cross,
-            m:no,ml:up-arrow,v:rightup-arrow"]],
+        doc = [[
+          "i:beam,r:beam,s:updown,sd:cross,
+           m:no,ml:up-arrow,v:rightup-arrow"
+        ]],
       },
       desc = [=[
         This option tells Vim what the mouse pointer should look like in
         different modes.  The option is a comma-separated list of parts, much
         like used for 'guicursor'.  Each part consist of a mode/location-list
         and an argument-list:
-        	mode-list:shape,mode-list:shape,..
+                mode-list:shape,mode-list:shape,..
         The mode-list is a dash separated list of these modes/locations:
-        		In a normal window: ~
-        	n	Normal mode
-        	v	Visual mode
-        	ve	Visual mode with 'selection' "exclusive" (same as 'v',
-        		if not specified)
-        	o	Operator-pending mode
-        	i	Insert mode
-        	r	Replace mode
+                        In a normal window: ~
+                n       Normal mode
+                v       Visual mode
+                ve      Visual mode with 'selection' "exclusive" (same as 'v',
+                        if not specified)
+                o       Operator-pending mode
+                i       Insert mode
+                r       Replace mode
 
-        		Others: ~
-        	c	appending to the command-line
-        	ci	inserting in the command-line
-        	cr	replacing in the command-line
-        	m	at the 'Hit ENTER' or 'More' prompts
-        	ml	idem, but cursor in the last line
-        	e	any mode, pointer below last window
-        	s	any mode, pointer on a status line
-        	sd	any mode, while dragging a status line
-        	vs	any mode, pointer on a vertical separator line
-        	vd	any mode, while dragging a vertical separator line
-        	a	everywhere
+                        Others: ~
+                c       appending to the command-line
+                ci      inserting in the command-line
+                cr      replacing in the command-line
+                m       at the 'Hit ENTER' or 'More' prompts
+                ml      idem, but cursor in the last line
+                e       any mode, pointer below last window
+                s       any mode, pointer on a status line
+                sd      any mode, while dragging a status line
+                vs      any mode, pointer on a vertical separator line
+                vd      any mode, while dragging a vertical separator line
+                a       everywhere
 
         The shape is one of the following:
-        avail	name		looks like ~
-        w x	arrow		Normal mouse pointer
-        w x	blank		no pointer at all (use with care!)
-        w x	beam		I-beam
-        w x	updown		up-down sizing arrows
-        w x	leftright	left-right sizing arrows
-        w x	busy		The system's usual busy pointer
-        w x	no		The system's usual "no input" pointer
-          x	udsizing	indicates up-down resizing
-          x	lrsizing	indicates left-right resizing
-          x	crosshair	like a big thin +
-          x	hand1		black hand
-          x	hand2		white hand
-          x	pencil		what you write with
-          x	question	big ?
-          x	rightup-arrow	arrow pointing right-up
-        w x	up-arrow	arrow pointing up
-          x	<number>	any X11 pointer number (see X11/cursorfont.h)
+        avail   name            looks like ~
+        w x     arrow           Normal mouse pointer
+        w x     blank           no pointer at all (use with care!)
+        w x     beam            I-beam
+        w x     updown          up-down sizing arrows
+        w x     leftright       left-right sizing arrows
+        w x     busy            The system's usual busy pointer
+        w x     no              The system's usual "no input" pointer
+          x     udsizing        indicates up-down resizing
+          x     lrsizing        indicates left-right resizing
+          x     crosshair       like a big thin +
+          x     hand1           black hand
+          x     hand2           white hand
+          x     pencil          what you write with
+          x     question        big ?
+          x     rightup-arrow   arrow pointing right-up
+        w x     up-arrow        arrow pointing up
+          x     <number>        any X11 pointer number (see X11/cursorfont.h)
 
         The "avail" column contains a 'w' if the shape is available for Win32,
         x for X11.
@@ -5637,8 +5647,8 @@ return {
         pointer.
 
         Example: >vim
-        	set mouseshape=s:udsizing,m:no
-        <	will make the mouse turn to a sizing arrow over the status lines and
+                set mouseshape=s:udsizing,m:no
+        <       will make the mouse turn to a sizing arrow over the status lines and
         indicate no input when the hit-enter prompt is displayed (since
         clicking the mouse has no effect in this state.)
       ]=],
@@ -5673,26 +5683,26 @@ return {
         This defines what bases Vim will consider for numbers when using the
         CTRL-A and CTRL-X commands for adding to and subtracting from a number
         respectively; see |CTRL-A| for more info on these commands.
-        alpha	If included, single alphabetical characters will be
-        	incremented or decremented.  This is useful for a list with a
-        	letter index a), b), etc.		*octal-nrformats*
-        octal	If included, numbers that start with a zero will be considered
-        	to be octal.  Example: Using CTRL-A on "007" results in "010".
-        hex	If included, numbers starting with "0x" or "0X" will be
-        	considered to be hexadecimal.  Example: Using CTRL-X on
-        	"0x100" results in "0x0ff".
-        bin	If included, numbers starting with "0b" or "0B" will be
-        	considered to be binary.  Example: Using CTRL-X on
-        	"0b1000" subtracts one, resulting in "0b0111".
+        alpha   If included, single alphabetical characters will be
+                incremented or decremented.  This is useful for a list with a
+                letter index a), b), etc.               *octal-nrformats*
+        octal   If included, numbers that start with a zero will be considered
+                to be octal.  Example: Using CTRL-A on "007" results in "010".
+        hex     If included, numbers starting with "0x" or "0X" will be
+                considered to be hexadecimal.  Example: Using CTRL-X on
+                "0x100" results in "0x0ff".
+        bin     If included, numbers starting with "0b" or "0B" will be
+                considered to be binary.  Example: Using CTRL-X on
+                "0b1000" subtracts one, resulting in "0b0111".
         unsigned    If included, numbers are recognized as unsigned. Thus a
-        	leading dash or negative sign won't be considered as part of
-        	the number.  Examples:
-        	    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
-        	    (without "unsigned" it would become "9-2021").
-        	    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
-        	    (without "unsigned" it would become "9-2019").
-        	    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
-        	    (2^64 - 1) has no effect, overflow is prevented.
+                leading dash or negative sign won't be considered as part of
+                the number.  Examples:
+                    Using CTRL-X on "2020" in "9-2020" results in "9-2019"
+                    (without "unsigned" it would become "9-2021").
+                    Using CTRL-A on "2020" in "9-2020" results in "9-2021"
+                    (without "unsigned" it would become "9-2019").
+                    Using CTRL-X on "0" or CTRL-A on "18446744073709551615"
+                    (2^64 - 1) has no effect, overflow is prevented.
         Numbers which simply begin with a digit in the range 1-9 are always
         considered decimal.  This also happens for numbers that are not
         recognized as octal or hex.
@@ -5718,13 +5728,13 @@ return {
         characters are put before the number.
         For highlighting see |hl-LineNr|, |hl-CursorLineNr|, and the
         |:sign-define| "numhl" argument.
-        					*number_relativenumber*
+                                                *number_relativenumber*
         The 'relativenumber' option changes the displayed number to be
         relative to the cursor.  Together with 'number' there are these
         four combinations (cursor in line 3):
 
-        	'nonu'          'nu'            'nonu'          'nu'
-        	'nornu'         'nornu'         'rnu'           'rnu'
+                'nonu'          'nu'            'nonu'          'nu'
+                'nornu'         'nornu'         'rnu'           'rnu'
         >
             |apple          |  1 apple      |  2 apple      |  2 apple
             |pear           |  2 pear       |  1 pear       |  1 pear
@@ -5789,7 +5799,7 @@ return {
       abbreviation = 'odev',
       defaults = { if_true = false },
       desc = [=[
-        		only for Windows
+                        only for Windows
         Enable reading and writing from devices.  This may get Vim stuck on a
         device that can be opened but doesn't actually do the I/O.  Therefore
         it is off by default.
@@ -5936,30 +5946,30 @@ return {
         starting with "/", "./" or "../").  The directories in the 'path'
         option may be relative or absolute.
         - Use commas to separate directory names: >vim
-        	set path=.,/usr/local/include,/usr/include
-        <	- Spaces can also be used to separate directory names.  To have a
+                set path=.,/usr/local/include,/usr/include
+        <       - Spaces can also be used to separate directory names.  To have a
           space in a directory name, precede it with an extra backslash, and
           escape the space: >vim
-        	set path=.,/dir/with\\\ space
-        <	- To include a comma in a directory name precede it with an extra
+                set path=.,/dir/with\\\ space
+        <       - To include a comma in a directory name precede it with an extra
           backslash: >vim
-        	set path=.,/dir/with\\,comma
-        <	- To search relative to the directory of the current file, use: >vim
-        	set path=.
-        <	- To search in the current directory use an empty string between two
+                set path=.,/dir/with\\,comma
+        <       - To search relative to the directory of the current file, use: >vim
+                set path=.
+        <       - To search in the current directory use an empty string between two
           commas: >vim
-        	set path=,,
-        <	- A directory name may end in a ':' or '/'.
+                set path=,,
+        <       - A directory name may end in a ':' or '/'.
         - Environment variables are expanded |:set_env|.
         - When using |netrw.vim| URLs can be used.  For example, adding
           "https://www.vim.org" will make ":find index.html" work.
         - Search upwards and downwards in a directory tree using "*", "**" and
           ";".  See |file-searching| for info and syntax.
         - Careful with '\' characters, type two to get one in the option: >vim
-        	set path=.,c:\\include
-        <	  Or just use '/' instead: >vim
-        	set path=.,c:/include
-        <	Don't forget "." or files won't even be found in the same directory as
+                set path=.,c:\\include
+        <         Or just use '/' instead: >vim
+                set path=.,c:/include
+        <       Don't forget "." or files won't even be found in the same directory as
         the file!
         The maximum length is limited.  How much depends on the system, mostly
         it is something like 256 or 1024 characters.
@@ -5968,14 +5978,14 @@ return {
         The use of |:set+=| and |:set-=| is preferred when adding or removing
         directories from the list.  This avoids problems when a future version
         uses another default.  To remove the current directory use: >vim
-        	set path-=
-        <	To add the current directory use: >vim
-        	set path+=
-        <	To use an environment variable, you probably need to replace the
+                set path-=
+        <       To add the current directory use: >vim
+                set path+=
+        <       To use an environment variable, you probably need to replace the
         separator.  Here is an example to append $INCL, in which directory
         names are separated with a semi-colon: >vim
-        	let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
-        <	Replace the ';' with a ':' or whatever separator is used.  Note that
+                let &path = &path .. "," .. substitute($INCL, ';', ',', 'g')
+        <       Replace the ';' with a ':' or whatever separator is used.  Note that
         this doesn't work when $INCL contains a comma or white space.
       ]=],
       expand = true,
@@ -6061,8 +6071,8 @@ return {
         the popupmenu using |highlight-blend|. For instance, to enable
         transparency but force the current selected element to be fully opaque: >vim
 
-        	set pumblend=15
-        	hi PmenuSel blend=0
+                set pumblend=15
+                hi PmenuSel blend=0
         <
         UI-dependent. Works best with RGB colors. 'termguicolors'
       ]=],
@@ -6190,33 +6200,33 @@ return {
         Flags to change the way redrawing works, for debugging purposes.
         Most useful with 'writedelay' set to some reasonable value.
         Supports the following flags:
-            compositor	Indicate each redraw event handled by the compositor
-        		by briefly flashing the redrawn regions in colors
-        		indicating the redraw type. These are the highlight
-        		groups used (and their default colors):
-        	RedrawDebugNormal   gui=reverse   normal redraw passed through
-        	RedrawDebugClear    guibg=Yellow  clear event passed through
-        	RedrawDebugComposed guibg=Green   redraw event modified by the
-        					  compositor (due to
-        					  overlapping grids, etc)
-        	RedrawDebugRecompose guibg=Red    redraw generated by the
-        					  compositor itself, due to a
-        					  grid being moved or deleted.
-            line	introduce a delay after each line drawn on the screen.
-        		When using the TUI or another single-grid UI, "compositor"
-        		gives more information and should be preferred (every
-        		line is processed as a separate event by the compositor)
-            flush	introduce a delay after each "flush" event.
-            nothrottle	Turn off throttling of the message grid. This is an
-        		optimization that joins many small scrolls to one
-        		larger scroll when drawing the message area (with
-        		'display' msgsep flag active).
-            invalid	Enable stricter checking (abort) of inconsistencies
-        		of the internal screen state. This is mostly
-        		useful when running nvim inside a debugger (and
-        		the test suite).
-            nodelta	Send all internally redrawn cells to the UI, even if
-        		they are unchanged from the already displayed state.
+            compositor  Indicate each redraw event handled by the compositor
+                        by briefly flashing the redrawn regions in colors
+                        indicating the redraw type. These are the highlight
+                        groups used (and their default colors):
+                RedrawDebugNormal   gui=reverse   normal redraw passed through
+                RedrawDebugClear    guibg=Yellow  clear event passed through
+                RedrawDebugComposed guibg=Green   redraw event modified by the
+                                                  compositor (due to
+                                                  overlapping grids, etc)
+                RedrawDebugRecompose guibg=Red    redraw generated by the
+                                                  compositor itself, due to a
+                                                  grid being moved or deleted.
+            line        introduce a delay after each line drawn on the screen.
+                        When using the TUI or another single-grid UI, "compositor"
+                        gives more information and should be preferred (every
+                        line is processed as a separate event by the compositor)
+            flush       introduce a delay after each "flush" event.
+            nothrottle  Turn off throttling of the message grid. This is an
+                        optimization that joins many small scrolls to one
+                        larger scroll when drawing the message area (with
+                        'display' msgsep flag active).
+            invalid     Enable stricter checking (abort) of inconsistencies
+                        of the internal screen state. This is mostly
+                        useful when running nvim inside a debugger (and
+                        the test suite).
+            nodelta     Send all internally redrawn cells to the UI, even if
+                        they are unchanged from the already displayed state.
       ]=],
       full_name = 'redrawdebug',
       list = 'onecomma',
@@ -6251,9 +6261,9 @@ return {
       desc = [=[
         This selects the default regexp engine. |two-engines|
         The possible values are:
-        	0	automatic selection
-        	1	old engine
-        	2	NFA engine
+                0       automatic selection
+                1       old engine
+                2       NFA engine
         Note that when using the NFA engine and the pattern contains something
         that is not supported the pattern will not match.  This is only useful
         for debugging the regexp engine.
@@ -6363,7 +6373,7 @@ return {
         Each word in this option enables the command line editing to work in
         right-to-left mode for a group of commands:
 
-        	search		"/" and "?" commands
+                search          "/" and "?" commands
 
         This is useful for languages such as Hebrew, Arabic and Farsi.
         The 'rightleft' option must be set for 'rightleftcmd' to take effect.
@@ -6382,10 +6392,10 @@ return {
         Show the line and column number of the cursor position, separated by a
         comma.  When there is room, the relative position of the displayed
         text in the file is shown on the far right:
-        	Top	first line is visible
-        	Bot	last line is visible
-        	All	first and last line are visible
-        	45%	relative position in the file
+                Top     first line is visible
+                Bot     last line is visible
+                All     first and last line are visible
+                45%     relative position in the file
         If 'rulerformat' is set, it will determine the contents of the ruler.
         Each window has its own ruler.  If a window has a status line, the
         ruler is shown there.  If a window doesn't have a status line and
@@ -6423,7 +6433,7 @@ return {
         The default ruler width is 17 characters.  To make the ruler 15
         characters wide, put "%15(" at the start and "%)" at the end.
         Example: >vim
-        	set rulerformat=%15(%c%V\ %p%%%)
+                set rulerformat=%15(%c%V\ %p%%%)
         <
       ]=],
       full_name = 'rulerformat',
@@ -6439,47 +6449,49 @@ return {
       cb = 'did_set_runtimepackpath',
       defaults = {
         if_true = '',
-        doc = [["$XDG_CONFIG_HOME/nvim,
-                     $XDG_CONFIG_DIRS[1]/nvim,
-                     $XDG_CONFIG_DIRS[2]/nvim,
-                     …
-                     $XDG_DATA_HOME/nvim[-data]/site,
-                     $XDG_DATA_DIRS[1]/nvim/site,
-                     $XDG_DATA_DIRS[2]/nvim/site,
-                     …
-                     $VIMRUNTIME,
-                     …
-                     $XDG_DATA_DIRS[2]/nvim/site/after,
-                     $XDG_DATA_DIRS[1]/nvim/site/after,
-                     $XDG_DATA_HOME/nvim[-data]/site/after,
-                     …
-                     $XDG_CONFIG_DIRS[2]/nvim/after,
-                     $XDG_CONFIG_DIRS[1]/nvim/after,
-                     $XDG_CONFIG_HOME/nvim/after"]],
+        doc = [[
+          "$XDG_CONFIG_HOME/nvim,
+           $XDG_CONFIG_DIRS[1]/nvim,
+           $XDG_CONFIG_DIRS[2]/nvim,
+           …
+           $XDG_DATA_HOME/nvim[-data]/site,
+           $XDG_DATA_DIRS[1]/nvim/site,
+           $XDG_DATA_DIRS[2]/nvim/site,
+           …
+           $VIMRUNTIME,
+           …
+           $XDG_DATA_DIRS[2]/nvim/site/after,
+           $XDG_DATA_DIRS[1]/nvim/site/after,
+           $XDG_DATA_HOME/nvim[-data]/site/after,
+           …
+           $XDG_CONFIG_DIRS[2]/nvim/after,
+           $XDG_CONFIG_DIRS[1]/nvim/after,
+           $XDG_CONFIG_HOME/nvim/after"
+        ]],
         meta = '...',
       },
       deny_duplicates = true,
       desc = [=[
         List of directories to be searched for these runtime files:
-          filetype.lua	filetypes |new-filetype|
-          autoload/	automatically loaded scripts |autoload-functions|
-          colors/	color scheme files |:colorscheme|
-          compiler/	compiler files |:compiler|
-          doc/		documentation |write-local-help|
-          ftplugin/	filetype plugins |write-filetype-plugin|
-          indent/	indent scripts |indent-expression|
-          keymap/	key mapping files |mbyte-keymap|
-          lang/		menu translations |:menutrans|
-          lua/		|Lua| plugins
-          menu.vim	GUI menus |menu.vim|
-          pack/		packages |:packadd|
-          parser/	|treesitter| syntax parsers
-          plugin/	plugin scripts |write-plugin|
-          queries/	|treesitter| queries
-          rplugin/	|remote-plugin| scripts
-          spell/	spell checking files |spell|
-          syntax/	syntax files |mysyntaxfile|
-          tutor/	tutorial files |:Tutor|
+          filetype.lua  filetypes |new-filetype|
+          autoload/     automatically loaded scripts |autoload-functions|
+          colors/       color scheme files |:colorscheme|
+          compiler/     compiler files |:compiler|
+          doc/          documentation |write-local-help|
+          ftplugin/     filetype plugins |write-filetype-plugin|
+          indent/       indent scripts |indent-expression|
+          keymap/       key mapping files |mbyte-keymap|
+          lang/         menu translations |:menutrans|
+          lua/          |Lua| plugins
+          menu.vim      GUI menus |menu.vim|
+          pack/         packages |:packadd|
+          parser/       |treesitter| syntax parsers
+          plugin/       plugin scripts |write-plugin|
+          queries/      |treesitter| queries
+          rplugin/      |remote-plugin| scripts
+          spell/        spell checking files |spell|
+          syntax/       syntax files |mysyntaxfile|
+          tutor/        tutorial files |:Tutor|
 
         And any other file searched for with the |:runtime| command.
 
@@ -6500,12 +6512,12 @@ return {
            viewdir, undodir, etc.
            Given by `stdpath("state")`.  |$XDG_STATE_HOME|
         6. $VIMRUNTIME, for files distributed with Nvim.
-        						*after-directory*
+                                                        *after-directory*
         7, 8, 9, 10. In after/ subdirectories of 1, 2, 3 and 4, with reverse
            ordering.  This is for preferences to overrule or add to the
            distributed defaults or system-wide settings (rarely needed).
 
-        						*packages-runtimepath*
+                                                        *packages-runtimepath*
         "start" packages will also be searched (|runtime-search-path|) for
         runtime files after these, though such packages are not explicitly
         reported in &runtimepath. But "opt" packages are explicitly added to
@@ -6517,8 +6529,8 @@ return {
         wildcards.
         See |:runtime|.
         Example: >vim
-        	set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
-        <	This will use the directory "~/vimruntime" first (containing your
+                set runtimepath=~/vimruntime,/mygroup/vim,$VIMRUNTIME
+        <       This will use the directory "~/vimruntime" first (containing your
         personal Nvim runtime files), then "/mygroup/vim", and finally
         "$VIMRUNTIME" (the default runtime files).
         You can put a directory before $VIMRUNTIME to find files which replace
@@ -6631,9 +6643,9 @@ return {
         when long lines wrap).
         After using the local value, go back the global value with one of
         these two: >vim
-        	setlocal scrolloff<
-        	setlocal scrolloff=-1
-        <	For scrolling horizontally see 'sidescrolloff'.
+                setlocal scrolloff<
+                setlocal scrolloff=-1
+        <       For scrolling horizontally see 'sidescrolloff'.
       ]=],
       full_name = 'scrolloff',
       scope = { 'global', 'window' },
@@ -6651,26 +6663,26 @@ return {
         'scrollbind' windows should behave.  'sbo' stands for ScrollBind
         Options.
         The following words are available:
-            ver		Bind vertical scrolling for 'scrollbind' windows
-            hor		Bind horizontal scrolling for 'scrollbind' windows
-            jump	Applies to the offset between two windows for vertical
-        		scrolling.  This offset is the difference in the first
-        		displayed line of the bound windows.  When moving
-        		around in a window, another 'scrollbind' window may
-        		reach a position before the start or after the end of
-        		the buffer.  The offset is not changed though, when
-        		moving back the 'scrollbind' window will try to scroll
-        		to the desired position when possible.
-        		When now making that window the current one, two
-        		things can be done with the relative offset:
-        		1. When "jump" is not included, the relative offset is
-        		   adjusted for the scroll position in the new current
-        		   window.  When going back to the other window, the
-        		   new relative offset will be used.
-        		2. When "jump" is included, the other windows are
-        		   scrolled to keep the same relative offset.  When
-        		   going back to the other window, it still uses the
-        		   same relative offset.
+            ver         Bind vertical scrolling for 'scrollbind' windows
+            hor         Bind horizontal scrolling for 'scrollbind' windows
+            jump        Applies to the offset between two windows for vertical
+                        scrolling.  This offset is the difference in the first
+                        displayed line of the bound windows.  When moving
+                        around in a window, another 'scrollbind' window may
+                        reach a position before the start or after the end of
+                        the buffer.  The offset is not changed though, when
+                        moving back the 'scrollbind' window will try to scroll
+                        to the desired position when possible.
+                        When now making that window the current one, two
+                        things can be done with the relative offset:
+                        1. When "jump" is not included, the relative offset is
+                           adjusted for the scroll position in the new current
+                           window.  When going back to the other window, the
+                           new relative offset will be used.
+                        2. When "jump" is included, the other windows are
+                           scrolled to keep the same relative offset.  When
+                           going back to the other window, it still uses the
+                           same relative offset.
         Also see |scroll-binding|.
         When 'diff' mode is active there always is vertical scroll binding,
         even when "ver" isn't there.
@@ -6714,10 +6726,10 @@ return {
         This option defines the behavior of the selection.  It is only used
         in Visual and Select mode.
         Possible values:
-           value	past line     inclusive ~
-           old		   no		yes
-           inclusive	   yes		yes
-           exclusive	   yes		no
+           value        past line     inclusive ~
+           old             no           yes
+           inclusive       yes          yes
+           exclusive       yes          no
         "past line" means that the cursor is allowed to be positioned one
         character past the line.
         "inclusive" means that the last character of the selection is included
@@ -6745,9 +6757,9 @@ return {
         This is a comma-separated list of words, which specifies when to start
         Select mode instead of Visual mode, when a selection is started.
         Possible values:
-           mouse	when using the mouse
-           key		when using shifted special keys
-           cmd		when using "v", "V" or CTRL-V
+           mouse        when using the mouse
+           key          when using shifted special keys
+           cmd          when using "v", "V" or CTRL-V
         See |Select-mode|.
       ]=],
       expand_cb = 'expand_set_selectmode',
@@ -6767,35 +6779,35 @@ return {
         Changes the effect of the |:mksession| command.  It is a comma-
         separated list of words.  Each word enables saving and restoring
         something:
-           word		save and restore ~
-           blank	empty windows
-           buffers	hidden and unloaded buffers, not just those in windows
-           curdir	the current directory
-           folds	manually created folds, opened/closed folds and local
-        		fold options
-           globals	global variables that start with an uppercase letter
-        		and contain at least one lowercase letter.  Only
-        		String and Number types are stored.
-           help		the help window
-           localoptions	options and mappings local to a window or buffer (not
-        		global values for local options)
-           options	all options and mappings (also global values for local
-        		options)
-           skiprtp	exclude 'runtimepath' and 'packpath' from the options
-           resize	size of the Vim window: 'lines' and 'columns'
-           sesdir	the directory in which the session file is located
-        		will become the current directory (useful with
-        		projects accessed over a network from different
-        		systems)
-           tabpages	all tab pages; without this only the current tab page
-        		is restored, so that you can make a session for each
-        		tab page separately
-           terminal	include terminal windows where the command can be
-        		restored
-           winpos	position of the whole Vim window
-           winsize	window sizes
-           slash	|deprecated| Always enabled. Uses "/" in filenames.
-           unix		|deprecated| Always enabled. Uses "\n" line endings.
+           word         save and restore ~
+           blank        empty windows
+           buffers      hidden and unloaded buffers, not just those in windows
+           curdir       the current directory
+           folds        manually created folds, opened/closed folds and local
+                        fold options
+           globals      global variables that start with an uppercase letter
+                        and contain at least one lowercase letter.  Only
+                        String and Number types are stored.
+           help         the help window
+           localoptions options and mappings local to a window or buffer (not
+                        global values for local options)
+           options      all options and mappings (also global values for local
+                        options)
+           skiprtp      exclude 'runtimepath' and 'packpath' from the options
+           resize       size of the Vim window: 'lines' and 'columns'
+           sesdir       the directory in which the session file is located
+                        will become the current directory (useful with
+                        projects accessed over a network from different
+                        systems)
+           tabpages     all tab pages; without this only the current tab page
+                        is restored, so that you can make a session for each
+                        tab page separately
+           terminal     include terminal windows where the command can be
+                        restored
+           winpos       position of the whole Vim window
+           winsize      window sizes
+           slash        |deprecated| Always enabled. Uses "/" in filenames.
+           unix         |deprecated| Always enabled. Uses "\n" line endings.
 
         Don't include both "curdir" and "sesdir". When neither is included
         filenames are stored as absolute paths.
@@ -6816,9 +6828,10 @@ return {
       cb = 'did_set_shada',
       defaults = {
         if_true = "!,'100,<50,s10,h",
-        doc = [[for
-               Win32:  !,'100,<50,s10,h,rA:,rB:
-               others: !,'100,<50,s10,h]],
+        doc = [[
+          for Win32:  !,'100,<50,s10,h,rA:,rB:
+              others: !,'100,<50,s10,h
+        ]],
       },
       deny_duplicates = true,
       desc = [=[
@@ -6830,102 +6843,102 @@ return {
         character is left out, then the default value is used for that
         parameter.  The following is a list of the identifying characters and
         the effect of their value.
-        CHAR	VALUE	~
-        						*shada-!*
-        !	When included, save and restore global variables that start
-        	with an uppercase letter, and don't contain a lowercase
-        	letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
-        	and "_K_L_M" are not.  Nested List and Dict items may not be
-        	read back correctly, you end up with an empty item.
-        						*shada-quote*
-        "	Maximum number of lines saved for each register.  Old name of
-        	the '<' item, with the disadvantage that you need to put a
-        	backslash before the ", otherwise it will be recognized as the
-        	start of a comment!
-        						*shada-%*
-        %	When included, save and restore the buffer list.  If Vim is
-        	started with a file name argument, the buffer list is not
-        	restored.  If Vim is started without a file name argument, the
-        	buffer list is restored from the shada file.  Quickfix
-        	('buftype'), unlisted ('buflisted'), unnamed and buffers on
-        	removable media (|shada-r|) are not saved.
-        	When followed by a number, the number specifies the maximum
-        	number of buffers that are stored.  Without a number all
-        	buffers are stored.
-        						*shada-'*
-        '	Maximum number of previously edited files for which the marks
-        	are remembered.  This parameter must always be included when
-        	'shada' is non-empty.
-        	Including this item also means that the |jumplist| and the
-        	|changelist| are stored in the shada file.
-        						*shada-/*
-        /	Maximum number of items in the search pattern history to be
-        	saved.  If non-zero, then the previous search and substitute
-        	patterns are also saved.  When not included, the value of
-        	'history' is used.
-        						*shada-:*
-        :	Maximum number of items in the command-line history to be
-        	saved.  When not included, the value of 'history' is used.
-        						*shada-<*
-        \<	Maximum number of lines saved for each register.  If zero then
-        	registers are not saved.  When not included, all lines are
-        	saved.  '"' is the old name for this item.
-        	Also see the 's' item below: limit specified in KiB.
-        						*shada-@*
-        @	Maximum number of items in the input-line history to be
-        	saved.  When not included, the value of 'history' is used.
-        						*shada-c*
-        c	Dummy option, kept for compatibility reasons.  Has no actual
-        	effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
-        	to UTF-8 as well.
-        						*shada-f*
-        f	Whether file marks need to be stored.  If zero, file marks ('0
-        	to '9, 'A to 'Z) are not stored.  When not present or when
-        	non-zero, they are all stored.  '0 is used for the current
-        	cursor position (when exiting or when doing |:wshada|).
-        						*shada-h*
-        h	Disable the effect of 'hlsearch' when loading the shada
-        	file.  When not included, it depends on whether ":nohlsearch"
-        	has been used since the last search command.
-        						*shada-n*
-        n	Name of the shada file.  The name must immediately follow
-        	the 'n'.  Must be at the end of the option!  If the
-        	'shadafile' option is set, that file name overrides the one
-        	given here with 'shada'.  Environment variables are
-        	expanded when opening the file, not when setting the option.
-        						*shada-r*
-        r	Removable media.  The argument is a string (up to the next
-        	',').  This parameter can be given several times.  Each
-        	specifies the start of a path for which no marks will be
-        	stored.  This is to avoid removable media.  For Windows you
-        	could use "ra:,rb:".  You can also use it for temp files,
-        	e.g., for Unix: "r/tmp".  Case is ignored.
-        						*shada-s*
-        s	Maximum size of an item contents in KiB.  If zero then nothing
-        	is saved.  Unlike Vim this applies to all items, except for
-        	the buffer list and header.  Full item size is off by three
-        	unsigned integers: with `s10` maximum item size may be 1 byte
-        	(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
-        	integer) + 3 bytes (item size: up to 16-bit integer because
-        	2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
-        	contents size) = 10253 bytes.
+        CHAR    VALUE   ~
+                                                        *shada-!*
+        !       When included, save and restore global variables that start
+                with an uppercase letter, and don't contain a lowercase
+                letter.  Thus "KEEPTHIS and "K_L_M" are stored, but "KeepThis"
+                and "_K_L_M" are not.  Nested List and Dict items may not be
+                read back correctly, you end up with an empty item.
+                                                        *shada-quote*
+        "       Maximum number of lines saved for each register.  Old name of
+                the '<' item, with the disadvantage that you need to put a
+                backslash before the ", otherwise it will be recognized as the
+                start of a comment!
+                                                        *shada-%*
+        %       When included, save and restore the buffer list.  If Vim is
+                started with a file name argument, the buffer list is not
+                restored.  If Vim is started without a file name argument, the
+                buffer list is restored from the shada file.  Quickfix
+                ('buftype'), unlisted ('buflisted'), unnamed and buffers on
+                removable media (|shada-r|) are not saved.
+                When followed by a number, the number specifies the maximum
+                number of buffers that are stored.  Without a number all
+                buffers are stored.
+                                                        *shada-'*
+        '       Maximum number of previously edited files for which the marks
+                are remembered.  This parameter must always be included when
+                'shada' is non-empty.
+                Including this item also means that the |jumplist| and the
+                |changelist| are stored in the shada file.
+                                                        *shada-/*
+        /       Maximum number of items in the search pattern history to be
+                saved.  If non-zero, then the previous search and substitute
+                patterns are also saved.  When not included, the value of
+                'history' is used.
+                                                        *shada-:*
+        :       Maximum number of items in the command-line history to be
+                saved.  When not included, the value of 'history' is used.
+                                                        *shada-<*
+        \<      Maximum number of lines saved for each register.  If zero then
+                registers are not saved.  When not included, all lines are
+                saved.  '"' is the old name for this item.
+                Also see the 's' item below: limit specified in KiB.
+                                                        *shada-@*
+        @       Maximum number of items in the input-line history to be
+                saved.  When not included, the value of 'history' is used.
+                                                        *shada-c*
+        c       Dummy option, kept for compatibility reasons.  Has no actual
+                effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
+                to UTF-8 as well.
+                                                        *shada-f*
+        f       Whether file marks need to be stored.  If zero, file marks ('0
+                to '9, 'A to 'Z) are not stored.  When not present or when
+                non-zero, they are all stored.  '0 is used for the current
+                cursor position (when exiting or when doing |:wshada|).
+                                                        *shada-h*
+        h       Disable the effect of 'hlsearch' when loading the shada
+                file.  When not included, it depends on whether ":nohlsearch"
+                has been used since the last search command.
+                                                        *shada-n*
+        n       Name of the shada file.  The name must immediately follow
+                the 'n'.  Must be at the end of the option!  If the
+                'shadafile' option is set, that file name overrides the one
+                given here with 'shada'.  Environment variables are
+                expanded when opening the file, not when setting the option.
+                                                        *shada-r*
+        r       Removable media.  The argument is a string (up to the next
+                ',').  This parameter can be given several times.  Each
+                specifies the start of a path for which no marks will be
+                stored.  This is to avoid removable media.  For Windows you
+                could use "ra:,rb:".  You can also use it for temp files,
+                e.g., for Unix: "r/tmp".  Case is ignored.
+                                                        *shada-s*
+        s       Maximum size of an item contents in KiB.  If zero then nothing
+                is saved.  Unlike Vim this applies to all items, except for
+                the buffer list and header.  Full item size is off by three
+                unsigned integers: with `s10` maximum item size may be 1 byte
+                (type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+                integer) + 3 bytes (item size: up to 16-bit integer because
+                2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
+                contents size) = 10253 bytes.
 
         Example: >vim
             set shada='50,<1000,s100,:0,n~/nvim/shada
         <
-        '50		Marks will be remembered for the last 50 files you
-        		edited.
-        <1000		Contents of registers (up to 1000 lines each) will be
-        		remembered.
-        s100		Items with contents occupying more then 100 KiB are
-        		skipped.
-        :0		Command-line history will not be saved.
-        n~/nvim/shada	The name of the file to use is "~/nvim/shada".
-        no /		Since '/' is not specified, the default will be used,
-        		that is, save all of the search history, and also the
-        		previous search and substitute patterns.
-        no %		The buffer list will not be saved nor read back.
-        no h		'hlsearch' highlighting will be restored.
+        '50             Marks will be remembered for the last 50 files you
+                        edited.
+        <1000           Contents of registers (up to 1000 lines each) will be
+                        remembered.
+        s100            Items with contents occupying more then 100 KiB are
+                        skipped.
+        :0              Command-line history will not be saved.
+        n~/nvim/shada   The name of the file to use is "~/nvim/shada".
+        no /            Since '/' is not specified, the default will be used,
+                        that is, save all of the search history, and also the
+                        previous search and substitute patterns.
+        no %            The buffer list will not be saved nor read back.
+        no h            'hlsearch' highlighting will be restored.
 
         When setting 'shada' from an empty value you can use |:rshada| to
         load the contents of the file, this is not done automatically.
@@ -6983,14 +6996,14 @@ return {
 
         If the name of the shell contains a space, you need to enclose it in
         quotes.  Example with quotes: >vim
-        	set shell=\"c:\program\ files\unix\sh.exe\"\ -f
-        <	Note the backslash before each quote (to avoid starting a comment) and
+                set shell=\"c:\program\ files\unix\sh.exe\"\ -f
+        <       Note the backslash before each quote (to avoid starting a comment) and
         each space (to avoid ending the option value), so better use |:let-&|
         like this: >vim
-        	let &shell='"C:\Program Files\unix\sh.exe" -f'
-        <	Also note that the "-f" is not inside the quotes, because it is not
+                let &shell='"C:\Program Files\unix\sh.exe" -f'
+        <       Also note that the "-f" is not inside the quotes, because it is not
         part of the command name.
-        						*shell-unquoting*
+                                                        *shell-unquoting*
         Rules regarding quotes:
         1. Option is split on space and tab characters that are not inside
            quotes: "abc def" runs shell named "abc" with additional argument
@@ -7009,15 +7022,15 @@ return {
            to escape quote: 'a\"b"' is the same as "a\b".
         Note that such processing is done after |:set| did its own round of
         unescaping, so to keep yourself sane use |:let-&| like shown above.
-        						*shell-powershell*
+                                                        *shell-powershell*
         To use PowerShell: >vim
-        	let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-        	let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
-        	let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-        	let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
-        	set shellquote= shellxquote=
+                let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
+                let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
+                let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
+                let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
+                set shellquote= shellxquote=
 
-        <	This option cannot be set from a |modeline| or in the |sandbox|, for
+        <       This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
       ]=],
       expand = true,
@@ -7106,8 +7119,10 @@ return {
       abbreviation = 'shq',
       defaults = {
         if_true = '',
-        doc = [[""; Windows, when 'shell'
-               contains "sh" somewhere: "\""]],
+        doc = [[
+          ""; Windows, when 'shell'
+          contains "sh" somewhere: "\""
+        ]],
       },
       desc = [=[
         Quoting character(s), put around the command passed to the shell, for
@@ -7172,7 +7187,7 @@ return {
       cb = 'did_set_shellslash',
       defaults = { if_true = false },
       desc = [=[
-        		only for MS-Windows
+                        only for MS-Windows
         When set, a forward slash is used when expanding file names.  This is
         useful when a Unix-like shell is used instead of cmd.exe.  Backward
         slashes can still be typed, but they are changed to forward slashes by
@@ -7182,8 +7197,8 @@ return {
         any file for best results.  This might change in the future.
         'shellslash' only works when a backslash can be used as a path
         separator.  To test if this is so use: >vim
-        	if exists('+shellslash')
-        <	Also see 'completeslash'.
+                if exists('+shellslash')
+        <       Also see 'completeslash'.
       ]=],
       enable_if = 'BACKSLASH_IN_FILENAME',
       full_name = 'shellslash',
@@ -7294,53 +7309,53 @@ return {
         This option helps to avoid all the |hit-enter| prompts caused by file
         messages, for example  with CTRL-G, and to avoid some other messages.
         It is a list of flags:
-         flag	meaning when present	~
-          l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
-          m	use "[+]" instead of "[Modified]"			*shm-m*
-          r	use "[RO]" instead of "[readonly]"			*shm-r*
-          w	use "[w]" instead of "written" for file write message	*shm-w*
-        	and "[a]" instead of "appended" for ':w >> file' command
-          a	all of the above abbreviations				*shm-a*
+         flag   meaning when present    ~
+          l     use "999L, 888B" instead of "999 lines, 888 bytes"      *shm-l*
+          m     use "[+]" instead of "[Modified]"                       *shm-m*
+          r     use "[RO]" instead of "[readonly]"                      *shm-r*
+          w     use "[w]" instead of "written" for file write message   *shm-w*
+                and "[a]" instead of "appended" for ':w >> file' command
+          a     all of the above abbreviations                          *shm-a*
 
-          o	overwrite message for writing a file with subsequent	*shm-o*
-        	message for reading a file (useful for ":wn" or when
-        	'autowrite' on)
-          O	message for reading a file overwrites any previous	*shm-O*
-        	message;  also for quickfix message (e.g., ":cn")
-          s	don't give "search hit BOTTOM, continuing at TOP" or	*shm-s*
-        	"search hit TOP, continuing at BOTTOM" messages; when using
-        	the search count do not show "W" after the count message (see
-        	S below)
-          t	truncate file message at the start if it is too long	*shm-t*
-        	to fit on the command-line, "<" will appear in the left most
-        	column; ignored in Ex mode
-          T	truncate other messages in the middle if they are too	*shm-T*
-        	long to fit on the command line; "..." will appear in the
-        	middle; ignored in Ex mode
-          W	don't give "written" or "[w]" when writing a file	*shm-W*
-          A	don't give the "ATTENTION" message when an existing	*shm-A*
-        	swap file is found
-          I	don't give the intro message when starting Vim,		*shm-I*
-        	see |:intro|
-          c	don't give |ins-completion-menu| messages; for		*shm-c*
-        	example, "-- XXX completion (YYY)", "match 1 of 2", "The only
-        	match", "Pattern not found", "Back at original", etc.
-          C	don't give messages while scanning for ins-completion	*shm-C*
-        	items, for instance "scanning tags"
-          q	use "recording" instead of "recording @a"		*shm-q*
-          F	don't give the file info when editing a file, like	*shm-F*
-        	`:silent` was used for the command
-          S	do not show search count message when searching, e.g.	*shm-S*
-        	"[1/5]"
+          o     overwrite message for writing a file with subsequent    *shm-o*
+                message for reading a file (useful for ":wn" or when
+                'autowrite' on)
+          O     message for reading a file overwrites any previous      *shm-O*
+                message;  also for quickfix message (e.g., ":cn")
+          s     don't give "search hit BOTTOM, continuing at TOP" or    *shm-s*
+                "search hit TOP, continuing at BOTTOM" messages; when using
+                the search count do not show "W" after the count message (see
+                S below)
+          t     truncate file message at the start if it is too long    *shm-t*
+                to fit on the command-line, "<" will appear in the left most
+                column; ignored in Ex mode
+          T     truncate other messages in the middle if they are too   *shm-T*
+                long to fit on the command line; "..." will appear in the
+                middle; ignored in Ex mode
+          W     don't give "written" or "[w]" when writing a file       *shm-W*
+          A     don't give the "ATTENTION" message when an existing     *shm-A*
+                swap file is found
+          I     don't give the intro message when starting Vim,         *shm-I*
+                see |:intro|
+          c     don't give |ins-completion-menu| messages; for          *shm-c*
+                example, "-- XXX completion (YYY)", "match 1 of 2", "The only
+                match", "Pattern not found", "Back at original", etc.
+          C     don't give messages while scanning for ins-completion   *shm-C*
+                items, for instance "scanning tags"
+          q     use "recording" instead of "recording @a"               *shm-q*
+          F     don't give the file info when editing a file, like      *shm-F*
+                `:silent` was used for the command
+          S     do not show search count message when searching, e.g.   *shm-S*
+                "[1/5]"
 
         This gives you the opportunity to avoid that a change between buffers
         requires you to hit <Enter>, but still gives as useful a message as
         possible for the space available.  To get the whole message that you
         would have got with 'shm' empty, use ":file!"
         Useful values:
-            shm=	No abbreviation of message.
-            shm=a	Abbreviation, but no loss of information.
-            shm=at	Abbreviation, and truncate message when necessary.
+            shm=        No abbreviation of message.
+            shm=a       Abbreviation, but no loss of information.
+            shm=at      Abbreviation, and truncate message when necessary.
       ]=],
       expand_cb = 'expand_set_shortmess',
       full_name = 'shortmess',
@@ -7358,9 +7373,9 @@ return {
       desc = [=[
         String to put at the start of lines that have been wrapped.  Useful
         values are "> " or "+++ ": >vim
-        	let &showbreak = "> "
-        	let &showbreak = '+++ '
-        <	Only printable single-cell characters are allowed, excluding <Tab> and
+                let &showbreak = "> "
+                let &showbreak = '+++ '
+        <       Only printable single-cell characters are allowed, excluding <Tab> and
         comma (in a future version the comma might be used to separate the
         part that is shown at the end and at the start of a line).
         The |hl-NonText| highlight group determines the highlighting.
@@ -7369,7 +7384,7 @@ return {
         "n" flag to 'cpoptions'.
         A window-local value overrules a global value.  If the global value is
         set and you want no value in the current window use NONE: >vim
-        	setlocal showbreak=NONE
+                setlocal showbreak=NONE
         <
       ]=],
       full_name = 'showbreak',
@@ -7409,9 +7424,9 @@ return {
       desc = [=[
         This option can be used to display the (partially) entered command in
         another location.  Possible values are:
-          last		Last line of the screen (default).
-          statusline	Status line of the current window.
-          tabline	First line of the screen if 'showtabline' is enabled.
+          last          Last line of the screen (default).
+          statusline    Status line of the current window.
+          tabline       First line of the screen if 'showtabline' is enabled.
         Setting this option to "statusline" or "tabline" means that these will
         be redrawn whenever the command changes, which can be on every key
         pressed.
@@ -7492,9 +7507,9 @@ return {
       desc = [=[
         The value of this option specifies when the line with tab page labels
         will be displayed:
-        	0: never
-        	1: only if there are at least two tab pages
-        	2: always
+                0: never
+                1: only if there are at least two tab pages
+                2: always
         This is both for the GUI and non-GUI implementation of the tab pages
         line.
         See |tab-page| for more information about tab pages.
@@ -7536,15 +7551,15 @@ return {
         close to the beginning of the line.
         After using the local value, go back the global value with one of
         these two: >vim
-        	setlocal sidescrolloff<
-        	setlocal sidescrolloff=-1
+                setlocal sidescrolloff<
+                setlocal sidescrolloff=-1
         <
         Example: Try this together with 'sidescroll' and 'listchars' as
-        	 in the following example to never allow the cursor to move
-        	 onto the "extends" character: >vim
+                 in the following example to never allow the cursor to move
+                 onto the "extends" character: >vim
 
-        	 set nowrap sidescroll=1 listchars=extends:>,precedes:<
-        	 set sidescrolloff=1
+                 set nowrap sidescroll=1 listchars=extends:>,precedes:<
+                 set sidescrolloff=1
         <
       ]=],
       full_name = 'sidescrolloff',
@@ -7560,21 +7575,21 @@ return {
       defaults = { if_true = 'auto' },
       desc = [=[
         When and how to draw the signcolumn. Valid values are:
-           "auto"	only when there is a sign to display
+           "auto"       only when there is a sign to display
            "auto:[1-9]" resize to accommodate multiple signs up to the
                         given number (maximum 9), e.g. "auto:4"
            "auto:[1-8]-[2-9]"
                         resize to accommodate multiple signs up to the
-        		given maximum number (maximum 9) while keeping
-        		at least the given minimum (maximum 8) fixed
-        		space. The minimum number should always be less
-        		than the maximum number, e.g. "auto:2-5"
-           "no"		never
-           "yes"	always
+                        given maximum number (maximum 9) while keeping
+                        at least the given minimum (maximum 8) fixed
+                        space. The minimum number should always be less
+                        than the maximum number, e.g. "auto:2-5"
+           "no"         never
+           "yes"        always
            "yes:[1-9]"  always, with fixed space for signs up to the given
                         number (maximum 9), e.g. "yes:3"
-           "number"	display signs in the 'number' column. If the number
-        		column is not present, then behaves like "auto".
+           "number"     display signs in the 'number' column. If the number
+                        column is not present, then behaves like "auto".
       ]=],
       expand_cb = 'expand_set_signcolumn',
       full_name = 'signcolumn',
@@ -7745,7 +7760,7 @@ return {
         commands.  It must end in ".{encoding}.add".  You need to include the
         path, otherwise the file is placed in the current directory.
         The path may include characters from 'isfname', space, comma and '@'.
-        							*E765*
+                                                                *E765*
         It may also be a comma-separated list of names.  A count before the
         |zg| and |zw| commands can be used to access each.  This allows using
         a personal word list file and a project word list file.
@@ -7781,8 +7796,8 @@ return {
       desc = [=[
         A comma-separated list of word list names.  When the 'spell' option is
         on spellchecking will be done for these languages.  Example: >vim
-        	set spelllang=en_us,nl,medical
-        <	This means US English, Dutch and medical words are recognized.  Words
+                set spelllang=en_us,nl,medical
+        <       This means US English, Dutch and medical words are recognized.  Words
         that are not recognized will be highlighted.
         The word list name must consist of alphanumeric characters, a dash or
         an underscore.  It should not include a comma or dot.  Using a dash is
@@ -7799,7 +7814,7 @@ return {
         words.
         Note that the "medical" dictionary does not exist, it is just an
         example of a longer name.
-        						*E757*
+                                                        *E757*
         As a special case the name of a .spl file can be given as-is.  The
         first "_xx" in the name is removed and used as the region name
         (_xx is an underscore, two letters and followed by a non-letter).
@@ -7832,14 +7847,14 @@ return {
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of options for spell checking:
-        camel		When a word is CamelCased, assume "Cased" is a
-        		separate word: every upper-case character in a word
-        		that comes after a lower case character indicates the
-        		start of a new word.
-        noplainbuffer	Only spellcheck a buffer when 'syntax' is enabled,
-        		or when extmarks are set within the buffer. Only
-        		designated regions of the buffer are spellchecked in
-        		this case.
+        camel           When a word is CamelCased, assume "Cased" is a
+                        separate word: every upper-case character in a word
+                        that comes after a lower case character indicates the
+                        start of a new word.
+        noplainbuffer   Only spellcheck a buffer when 'syntax' is enabled,
+                        or when extmarks are set within the buffer. Only
+                        designated regions of the buffer are spellchecked in
+                        this case.
       ]=],
       expand_cb = 'expand_set_spelloptions',
       full_name = 'spelloptions',
@@ -7860,62 +7875,62 @@ return {
         the |spellsuggest()| function.  This is a comma-separated list of
         items:
 
-        best		Internal method that works best for English.  Finds
-        		changes like "fast" and uses a bit of sound-a-like
-        		scoring to improve the ordering.
+        best            Internal method that works best for English.  Finds
+                        changes like "fast" and uses a bit of sound-a-like
+                        scoring to improve the ordering.
 
-        double		Internal method that uses two methods and mixes the
-        		results.  The first method is "fast", the other method
-        		computes how much the suggestion sounds like the bad
-        		word.  That only works when the language specifies
-        		sound folding.  Can be slow and doesn't always give
-        		better results.
+        double          Internal method that uses two methods and mixes the
+                        results.  The first method is "fast", the other method
+                        computes how much the suggestion sounds like the bad
+                        word.  That only works when the language specifies
+                        sound folding.  Can be slow and doesn't always give
+                        better results.
 
-        fast		Internal method that only checks for simple changes:
-        		character inserts/deletes/swaps.  Works well for
-        		simple typing mistakes.
+        fast            Internal method that only checks for simple changes:
+                        character inserts/deletes/swaps.  Works well for
+                        simple typing mistakes.
 
-        {number}	The maximum number of suggestions listed for |z=|.
-        		Not used for |spellsuggest()|.  The number of
-        		suggestions is never more than the value of 'lines'
-        		minus two.
+        {number}        The maximum number of suggestions listed for |z=|.
+                        Not used for |spellsuggest()|.  The number of
+                        suggestions is never more than the value of 'lines'
+                        minus two.
 
         timeout:{millisec}   Limit the time searching for suggestions to
-        		{millisec} milli seconds.  Applies to the following
-        		methods.  When omitted the limit is 5000. When
-        		negative there is no limit.
+                        {millisec} milli seconds.  Applies to the following
+                        methods.  When omitted the limit is 5000. When
+                        negative there is no limit.
 
         file:{filename} Read file {filename}, which must have two columns,
-        		separated by a slash.  The first column contains the
-        		bad word, the second column the suggested good word.
-        		Example:
-        			theribal/terrible ~
-        		Use this for common mistakes that do not appear at the
-        		top of the suggestion list with the internal methods.
-        		Lines without a slash are ignored, use this for
-        		comments.
-        		The word in the second column must be correct,
-        		otherwise it will not be used.  Add the word to an
-        		".add" file if it is currently flagged as a spelling
-        		mistake.
-        		The file is used for all languages.
+                        separated by a slash.  The first column contains the
+                        bad word, the second column the suggested good word.
+                        Example:
+                                theribal/terrible ~
+                        Use this for common mistakes that do not appear at the
+                        top of the suggestion list with the internal methods.
+                        Lines without a slash are ignored, use this for
+                        comments.
+                        The word in the second column must be correct,
+                        otherwise it will not be used.  Add the word to an
+                        ".add" file if it is currently flagged as a spelling
+                        mistake.
+                        The file is used for all languages.
 
-        expr:{expr}	Evaluate expression {expr}.  Use a function to avoid
-        		trouble with spaces.  |v:val| holds the badly spelled
-        		word.  The expression must evaluate to a List of
-        		Lists, each with a suggestion and a score.
-        		Example:
-        			[['the', 33], ['that', 44]] ~
-        		Set 'verbose' and use |z=| to see the scores that the
-        		internal methods use.  A lower score is better.
-        		This may invoke |spellsuggest()| if you temporarily
-        		set 'spellsuggest' to exclude the "expr:" part.
-        		Errors are silently ignored, unless you set the
-        		'verbose' option to a non-zero value.
+        expr:{expr}     Evaluate expression {expr}.  Use a function to avoid
+                        trouble with spaces.  |v:val| holds the badly spelled
+                        word.  The expression must evaluate to a List of
+                        Lists, each with a suggestion and a score.
+                        Example:
+                                [['the', 33], ['that', 44]] ~
+                        Set 'verbose' and use |z=| to see the scores that the
+                        internal methods use.  A lower score is better.
+                        This may invoke |spellsuggest()| if you temporarily
+                        set 'spellsuggest' to exclude the "expr:" part.
+                        Errors are silently ignored, unless you set the
+                        'verbose' option to a non-zero value.
 
         Only one of "best", "double" or "fast" may be used.  The others may
         appear several times in any order.  Example: >vim
-        	set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
+                set sps=file:~/.config/nvim/sugg,best,expr:MySuggest()
         <
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
@@ -7952,9 +7967,9 @@ return {
         closing or resizing horizontal splits.
 
         Possible values are:
-          cursor	Keep the same relative cursor position.
-          screen	Keep the text on the same screen line.
-          topline	Keep the topline the same.
+          cursor        Keep the same relative cursor position.
+          screen        Keep the text on the same screen line.
+          topline       Keep the topline the same.
 
         For the "screen" and "topline" values, the cursor position will be
         changed when necessary. In this case, the jumplist will be populated
@@ -8017,10 +8032,10 @@ return {
         Some of the items from the 'statusline' format are different for
         'statuscolumn':
 
-        %l	line number of currently drawn line
-        %r	relative line number of currently drawn line
-        %s	sign column for currently drawn line
-        %C	fold column for currently drawn line
+        %l      line number of currently drawn line
+        %r      relative line number of currently drawn line
+        %s      sign column for currently drawn line
+        %C      fold column for currently drawn line
 
         NOTE: To draw the sign and fold columns, their items must be included in
         'statuscolumn'. Even when they are not included, the status column width
@@ -8029,8 +8044,8 @@ return {
         The |v:lnum|    variable holds the line number to be drawn.
         The |v:relnum|  variable holds the relative line number to be drawn.
         The |v:virtnum| variable is negative when drawing virtual lines, zero
-        	      when drawing the actual buffer line, and positive when
-        	      drawing the wrapped part of a buffer line.
+                      when drawing the actual buffer line, and positive when
+                      drawing the wrapped part of a buffer line.
 
         NOTE: The %@ click execute function item is supported as well but the
         specified function will be the same for each row in the same column.
@@ -8038,26 +8053,26 @@ return {
         handler should be written with this in mind.
 
         Examples: >vim
-        	" Relative number with bar separator and click handlers:
-        	set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
+                " Relative number with bar separator and click handlers:
+                set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T
 
-        	" Right aligned relative cursor line number:
-        	let &stc='%=%{v:relnum?v:relnum:v:lnum} '
+                " Right aligned relative cursor line number:
+                let &stc='%=%{v:relnum?v:relnum:v:lnum} '
 
-        	" Line numbers in hexadecimal for non wrapped part of lines:
-        	let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
+                " Line numbers in hexadecimal for non wrapped part of lines:
+                let &stc='%=%{v:virtnum>0?"":printf("%x",v:lnum)} '
 
-        	" Human readable line numbers with thousands separator:
-        	let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
-        		   . '%(\\d\\d\\d\\)\\+$",",","g")}'
+                " Human readable line numbers with thousands separator:
+                let &stc='%{substitute(v:lnum,"\\d\\zs\\ze\\'
+                           . '%(\\d\\d\\d\\)\\+$",",","g")}'
 
-        	" Both relative and absolute line numbers with different
-        	" highlighting for odd and even relative numbers:
-        	let &stc='%#NonText#%{&nu?v:lnum:""}' .
-        	 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
-        	 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
+                " Both relative and absolute line numbers with different
+                " highlighting for odd and even relative numbers:
+                let &stc='%#NonText#%{&nu?v:lnum:""}' .
+                 '%=%{&rnu&&(v:lnum%2)?"\ ".v:relnum:""}' .
+                 '%#LineNr#%{&rnu&&!(v:lnum%2)?"\ ".v:relnum:""}'
 
-        <	WARNING: this expression is evaluated for each screen line so defining
+        <       WARNING: this expression is evaluated for each screen line so defining
         an expensive expression can negatively affect render performance.
       ]=],
       full_name = 'statuscolumn',
@@ -8084,8 +8099,8 @@ return {
 
         When the option starts with "%!" then it is used as an expression,
         evaluated and the result is used as the option value.  Example: >vim
-        	set statusline=%!MyStatusLine()
-        <	The *g:statusline_winid* variable will be set to the |window-ID| of the
+                set statusline=%!MyStatusLine()
+        <       The *g:statusline_winid* variable will be set to the |window-ID| of the
         window that the status line belongs to.
         The result can contain %{} items that will be evaluated too.
         Note that the "%!" expression is evaluated in the context of the
@@ -8100,25 +8115,25 @@ return {
         Note that the only effect of 'ruler' when this option is set (and
         'laststatus' is 2 or 3) is controlling the output of |CTRL-G|.
 
-        field	    meaning ~
-        -	    Left justify the item.  The default is right justified
-        	    when minwid is larger than the length of the item.
-        0	    Leading zeroes in numeric items.  Overridden by "-".
-        minwid	    Minimum width of the item, padding as set by "-" & "0".
-        	    Value must be 50 or less.
-        maxwid	    Maximum width of the item.  Truncation occurs with a "<"
-        	    on the left for text items.  Numeric items will be
-        	    shifted down to maxwid-2 digits followed by ">"number
-        	    where number is the amount of missing digits, much like
-        	    an exponential notation.
-        item	    A one letter code as described below.
+        field       meaning ~
+        -           Left justify the item.  The default is right justified
+                    when minwid is larger than the length of the item.
+        0           Leading zeroes in numeric items.  Overridden by "-".
+        minwid      Minimum width of the item, padding as set by "-" & "0".
+                    Value must be 50 or less.
+        maxwid      Maximum width of the item.  Truncation occurs with a "<"
+                    on the left for text items.  Numeric items will be
+                    shifted down to maxwid-2 digits followed by ">"number
+                    where number is the amount of missing digits, much like
+                    an exponential notation.
+        item        A one letter code as described below.
 
         Following is a description of the possible statusline items.  The
         second character in "item" is the type:
-        	N for number
-        	S for string
-        	F for flags as described below
-        	- not applicable
+                N for number
+                S for string
+                F for flags as described below
+                - not applicable
 
         item  meaning ~
         f S   Path to the file in the buffer, as typed or relative to current
@@ -8166,10 +8181,10 @@ return {
               The expression can contain the "}" character, the end of
               expression is denoted by "%}".
               For example: >vim
-        	func! Stl_filename() abort
-        	    return "%t"
-        	endfunc
-        <	        `stl=%{Stl_filename()}`   results in `"%t"`
+                func! Stl_filename() abort
+                    return "%t"
+                endfunc
+        <               `stl=%{Stl_filename()}`   results in `"%t"`
                 `stl=%{%Stl_filename()%}` results in `"Name of current file"`
         %} -  End of "{%" expression
         ( -   Start of item group.  Can be used for setting the width and
@@ -8233,10 +8248,10 @@ return {
         not set) and a minwid is not set for the group, the whole group will
         become empty.  This will make a group like the following disappear
         completely from the statusline when none of the flags are set. >vim
-        	set statusline=...%(\ [%M%R%H]%)...
-        <	Beware that an expression is evaluated each and every time the status
+                set statusline=...%(\ [%M%R%H]%)...
+        <       Beware that an expression is evaluated each and every time the status
         line is displayed.
-        			*stl-%{* *g:actual_curbuf* *g:actual_curwin*
+                                *stl-%{* *g:actual_curbuf* *g:actual_curwin*
         While evaluating %{} the current buffer and current window will be set
         temporarily to that of the window (and buffer) whose statusline is
         currently being drawn.  The expression will evaluate in this context.
@@ -8266,18 +8281,18 @@ return {
         Examples:
         Emulate standard status line with 'ruler' set >vim
           set statusline=%<%f\ %h%m%r%=%-14.(%l,%c%V%)\ %P
-        <	Similar, but add ASCII value of char under the cursor (like "ga") >vim
+        <       Similar, but add ASCII value of char under the cursor (like "ga") >vim
           set statusline=%<%f%h%m%r%=%b\ 0x%B\ \ %l,%c%V\ %P
-        <	Display byte count and byte value, modified flag in red. >vim
+        <       Display byte count and byte value, modified flag in red. >vim
           set statusline=%<%f%=\ [%1*%M%*%n%R%H]\ %-19(%3l,%02c%03V%)%O'%02b'
           hi User1 term=inverse,bold cterm=inverse,bold ctermfg=red
-        <	Display a ,GZ flag if a compressed file is loaded >vim
+        <       Display a ,GZ flag if a compressed file is loaded >vim
           set statusline=...%r%{VarExists('b:gzflag','\ [GZ]')}%h...
-        <	In the |:autocmd|'s: >vim
+        <       In the |:autocmd|'s: >vim
           let b:gzflag = 1
-        <	And: >vim
+        <       And: >vim
           unlet b:gzflag
-        <	And define this function: >vim
+        <       And define this function: >vim
           function VarExists(var, val)
               if exists(a:var) | return a:val | else | return '' | endif
           endfunction
@@ -8323,7 +8338,7 @@ return {
       desc = [=[
         Comma-separated list of suffixes, which are used when searching for a
         file for the "gf", "[I", etc. commands.  Example: >vim
-        	set suffixesadd=.java
+                set suffixesadd=.java
         <
       ]=],
       full_name = 'suffixesadd',
@@ -8342,8 +8357,8 @@ return {
         swapfile is not wanted for a specific buffer.  For example, with
         confidential information that even root must not be able to access.
         Careful: All text will be in memory:
-        	- Don't use this for big files.
-        	- Recovery will be impossible!
+                - Don't use this for big files.
+                - Recovery will be impossible!
         A swapfile will only be present when |'updatecount'| is non-zero and
         'swapfile' is set.
         When 'swapfile' is reset, the swap file for the current buffer is
@@ -8379,22 +8394,22 @@ return {
         - jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
           |:sbnext|, or |:sbrewind|).
         Possible values (comma-separated list):
-           useopen	If included, jump to the first open window in the
-        		current tab page that contains the specified buffer
-        		(if there is one).  Otherwise: Do not examine other
-        		windows.
-           usetab	Like "useopen", but also consider windows in other tab
-        		pages.
-           split	If included, split the current window before loading
-        		a buffer for a |quickfix| command that display errors.
-        		Otherwise: do not split, use current window (when used
-        		in the quickfix window: the previously used window or
-        		split if there is no other window).
-           vsplit	Just like "split" but split vertically.
-           newtab	Like "split", but open a new tab page.  Overrules
-        		"split" when both are present.
-           uselast	If included, jump to the previously used window when
-        		jumping to errors with |quickfix| commands.
+           useopen      If included, jump to the first open window in the
+                        current tab page that contains the specified buffer
+                        (if there is one).  Otherwise: Do not examine other
+                        windows.
+           usetab       Like "useopen", but also consider windows in other tab
+                        pages.
+           split        If included, split the current window before loading
+                        a buffer for a |quickfix| command that display errors.
+                        Otherwise: do not split, use current window (when used
+                        in the quickfix window: the previously used window or
+                        split if there is no other window).
+           vsplit       Just like "split" but split vertically.
+           newtab       Like "split", but open a new tab page.  Overrules
+                        "split" when both are present.
+           uselast      If included, jump to the previously used window when
+                        jumping to errors with |quickfix| commands.
       ]=],
       expand_cb = 'expand_set_switchbuf',
       full_name = 'switchbuf',
@@ -8434,19 +8449,19 @@ return {
         b:current_syntax variable does).
         This option is most useful in a modeline, for a file which syntax is
         not automatically recognized.  Example, in an IDL file: >c
-        	/* vim: set syntax=idl : */
-        <	When a dot appears in the value then this separates two filetype
+                /* vim: set syntax=idl : */
+        <       When a dot appears in the value then this separates two filetype
         names.  Example: >c
-        	/* vim: set syntax=c.doxygen : */
-        <	This will use the "c" syntax first, then the "doxygen" syntax.
+                /* vim: set syntax=c.doxygen : */
+        <       This will use the "c" syntax first, then the "doxygen" syntax.
         Note that the second one must be prepared to be loaded as an addition,
         otherwise it will be skipped.  More than one dot may appear.
         To switch off syntax highlighting for the current file, use: >vim
-        	set syntax=OFF
-        <	To switch syntax highlighting on according to the current value of the
+                set syntax=OFF
+        <       To switch syntax highlighting on according to the current value of the
         'filetype' option: >vim
-        	set syntax=ON
-        <	What actually happens when setting the 'syntax' option is that the
+                set syntax=ON
+        <       What actually happens when setting the 'syntax' option is that the
         Syntax autocommand event is triggered with the value as argument.
         This option is not copied to another buffer, independent of the 's' or
         'S' flag in 'cpoptions'.
@@ -8578,8 +8593,8 @@ return {
 
         Linear searching is done anyway, for one file, when Vim finds a line
         at the start of the file indicating that it's not sorted: >
-           !_TAG_FILE_SORTED	0	/some comment/
-        <	[The whitespace before and after the '0' must be a single <Tab>]
+           !_TAG_FILE_SORTED    0       /some comment/
+        <       [The whitespace before and after the '0' must be a single <Tab>]
 
         When a binary search was done and no match was found in any of the
         files listed in 'tags', and case is ignored or a pattern is used
@@ -8625,11 +8640,11 @@ return {
       desc = [=[
         This option specifies how case is handled when searching the tags
         file:
-           followic	Follow the 'ignorecase' option
+           followic     Follow the 'ignorecase' option
            followscs    Follow the 'smartcase' and 'ignorecase' options
-           ignore	Ignore case
-           match	Match case
-           smart	Ignore case unless an upper case letter is used
+           ignore       Ignore case
+           match        Match case
+           smart        Ignore case unless an upper case letter is used
       ]=],
       expand_cb = 'expand_set_tagcase',
       full_name = 'tagcase',
@@ -8791,20 +8806,20 @@ return {
         to be removed from the text pasted into the terminal window. The
         supported values are:
 
-           BS	    Backspace
+           BS       Backspace
 
-           HT	    TAB
+           HT       TAB
 
-           FF	    Form feed
+           FF       Form feed
 
-           ESC	    Escape
+           ESC      Escape
 
-           DEL	    DEL
+           DEL      DEL
 
-           C0	    Other control characters, excluding Line feed and
-        	    Carriage return < ' '
+           C0       Other control characters, excluding Line feed and
+                    Carriage return < ' '
 
-           C1	    Control characters 0x80...0x9F
+           C1       Control characters 0x80...0x9F
       ]=],
       expand_cb = 'expand_set_termpastefilter',
       full_name = 'termpastefilter',
@@ -8951,15 +8966,15 @@ return {
       desc = [=[
         When on, the title of the window will be set to the value of
         'titlestring' (if it is not empty), or to:
-        	filename [+=-] (path) - NVIM
+                filename [+=-] (path) - NVIM
         Where:
-        	filename	the name of the file being edited
-        	-		indicates the file cannot be modified, 'ma' off
-        	+		indicates the file was modified
-        	=		indicates the file is read-only
-        	=+		indicates the file is read-only and modified
-        	(path)		is the path of the file being edited
-        	- NVIM		the server name |v:servername| or "NVIM"
+                filename        the name of the file being edited
+                -               indicates the file cannot be modified, 'ma' off
+                +               indicates the file was modified
+                =               indicates the file is read-only
+                =+              indicates the file is read-only and modified
+                (path)          is the path of the file being edited
+                - NVIM          the server name |v:servername| or "NVIM"
       ]=],
       full_name = 'title',
       scope = { 'global' },
@@ -9017,11 +9032,11 @@ return {
         Example: >vim
             auto BufEnter * let &titlestring = hostname() .. "/" .. expand("%:p")
             set title titlestring=%<%F%=%l/%L-%P titlelen=70
-        <	The value of 'titlelen' is used to align items in the middle or right
+        <       The value of 'titlelen' is used to align items in the middle or right
         of the available space.
         Some people prefer to have the file name first: >vim
             set titlestring=%t%(\ %M%)%(\ (%{expand(\"%:~:.:h\")})%)%(\ %a%)
-        <	Note the use of "%{ }" and an expression to get the path of the file,
+        <       Note the use of "%{ }" and an expression to get the path of the file,
         without the file name.  The "%( %)" constructs are used to add a
         separating space only when needed.
         NOTE: Use of special characters in 'titlestring' may cause the display
@@ -9147,14 +9162,14 @@ return {
         Nevertheless, a single change can already use a large amount of memory.
         Set to 0 for Vi compatibility: One level of undo and "u" undoes
         itself: >vim
-        	set ul=0
-        <	But you can also get Vi compatibility by including the 'u' flag in
+                set ul=0
+        <       But you can also get Vi compatibility by including the 'u' flag in
         'cpoptions', and still be able to use CTRL-R to repeat undo.
         Also see |undo-two-ways|.
         Set to -1 for no undo at all.  You might want to do this only for the
         current buffer: >vim
-        	setlocal ul=-1
-        <	This helps when you run out of memory for a single change.
+                setlocal ul=-1
+        <       This helps when you run out of memory for a single change.
 
         The local value is set to -123456 when the global value is to be used.
 
@@ -9239,8 +9254,8 @@ return {
         For example, when editing assembly language files where statements
         start in the 9th column and comments in the 41st, it may be useful
         to use the following: >vim
-        	set varsofttabstop=8,32,8
-        <	This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
+                set varsofttabstop=8,32,8
+        <       This will set soft tabstops with 8 and 8 + 32 spaces, and 8 more
         for every column thereafter.
 
         Note that the value of |'softtabstop'| will be ignored while
@@ -9261,8 +9276,8 @@ return {
         A list of the number of spaces that a <Tab> in the file counts for,
         separated by commas.  Each value corresponds to one tab, with the
         final value applying to all subsequent tabs. For example: >vim
-        	set vartabstop=4,20,10,8
-        <	This will make the first tab 4 spaces wide, the second 20 spaces,
+                set vartabstop=4,20,10,8
+        <       This will make the first tab 4 spaces wide, the second 20 spaces,
         the third 10 spaces, and all following tabs 8 spaces.
 
         Note that the value of |'tabstop'| will be ignored while 'vartabstop'
@@ -9290,19 +9305,19 @@ return {
 
         Level   Messages ~
         ----------------------------------------------------------------------
-        1	Lua assignments to options, mappings, etc.
-        2	When a file is ":source"'ed, or |shada| file is read or written.
-        3	UI info, terminal capabilities.
-        4	Shell commands.
-        5	Every searched tags file and include file.
-        8	Files for which a group of autocommands is executed.
-        9	Executed autocommands.
-        11	Finding items in a path.
-        12	Vimscript function calls.
-        13	When an exception is thrown, caught, finished, or discarded.
-        14	Anything pending in a ":finally" clause.
-        15	Ex commands from a script (truncated at 200 characters).
-        16	Ex commands.
+        1       Lua assignments to options, mappings, etc.
+        2       When a file is ":source"'ed, or |shada| file is read or written.
+        3       UI info, terminal capabilities.
+        4       Shell commands.
+        5       Every searched tags file and include file.
+        8       Files for which a group of autocommands is executed.
+        9       Executed autocommands.
+        11      Finding items in a path.
+        12      Vimscript function calls.
+        13      When an exception is thrown, caught, finished, or discarded.
+        14      Anything pending in a ":finally" clause.
+        15      Ex commands from a script (truncated at 200 characters).
+        16      Ex commands.
 
         If 'verbosefile' is set then the verbose messages are not displayed.
       ]=],
@@ -9360,16 +9375,16 @@ return {
       desc = [=[
         Changes the effect of the |:mkview| command.  It is a comma-separated
         list of words.  Each word enables saving and restoring something:
-           word		save and restore ~
-           cursor	cursor position in file and in window
-           curdir	local current directory, if set with |:lcd|
-           folds	manually created folds, opened/closed folds and local
-        		fold options
-           options	options and mappings local to a window or buffer (not
-        		global values for local options)
+           word         save and restore ~
+           cursor       cursor position in file and in window
+           curdir       local current directory, if set with |:lcd|
+           folds        manually created folds, opened/closed folds and local
+                        fold options
+           options      options and mappings local to a window or buffer (not
+                        global values for local options)
            localoptions same as "options"
-           slash	|deprecated| Always enabled. Uses "/" in filenames.
-           unix		|deprecated| Always enabled. Uses "\n" line endings.
+           slash        |deprecated| Always enabled. Uses "/" in filenames.
+           unix         |deprecated| Always enabled. Uses "\n" line endings.
       ]=],
       expand_cb = 'expand_set_sessionoptions',
       full_name = 'viewoptions',
@@ -9386,14 +9401,14 @@ return {
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of these words:
-            block	Allow virtual editing in Visual block mode.
-            insert	Allow virtual editing in Insert mode.
-            all		Allow virtual editing in all modes.
-            onemore	Allow the cursor to move just past the end of the line
-            none	When used as the local value, do not allow virtual
-        		editing even when the global value is set.  When used
-        		as the global value, "none" is the same as "".
-            NONE	Alternative spelling of "none".
+            block       Allow virtual editing in Visual block mode.
+            insert      Allow virtual editing in Insert mode.
+            all         Allow virtual editing in all modes.
+            onemore     Allow the cursor to move just past the end of the line
+            none        When used as the local value, do not allow virtual
+                        editing even when the global value is set.  When used
+                        as the global value, "none" is the same as "".
+            NONE        Alternative spelling of "none".
 
         Virtual editing means that the cursor can be positioned where there is
         no actual character.  This can be halfway into a tab or beyond the end
@@ -9453,19 +9468,19 @@ return {
         Allow specified keys that move the cursor left/right to move to the
         previous/next line when the cursor is on the first/last character in
         the line.  Concatenate characters to allow this for these keys:
-        	char   key	  mode	~
-        	 b    <BS>	 Normal and Visual
-        	 s    <Space>	 Normal and Visual
-        	 h    "h"	 Normal and Visual (not recommended)
-        	 l    "l"	 Normal and Visual (not recommended)
-        	 <    <Left>	 Normal and Visual
-        	 >    <Right>	 Normal and Visual
-        	 ~    "~"	 Normal
-        	 [    <Left>	 Insert and Replace
-        	 ]    <Right>	 Insert and Replace
+                char   key        mode  ~
+                 b    <BS>       Normal and Visual
+                 s    <Space>    Normal and Visual
+                 h    "h"        Normal and Visual (not recommended)
+                 l    "l"        Normal and Visual (not recommended)
+                 <    <Left>     Normal and Visual
+                 >    <Right>    Normal and Visual
+                 ~    "~"        Normal
+                 [    <Left>     Insert and Replace
+                 ]    <Right>    Insert and Replace
         For example: >vim
-        	set ww=<,>,[,]
-        <	allows wrap only when cursor keys are used.
+                set ww=<,>,[,]
+        <       allows wrap only when cursor keys are used.
         When the movement keys are used in combination with a delete or change
         operator, the <EOL> also counts for a character.  This makes "3h"
         different from "3dh" when the cursor crosses the end of a line.  This
@@ -9502,7 +9517,7 @@ return {
         <Esc> can be used, but hitting it twice in a row will still exit
         command-line as a failsafe measure.
         Although 'wc' is a number option, you can set it to a special key: >vim
-        	set wc=<Tab>
+                set wc=<Tab>
         <
       ]=],
       full_name = 'wildchar',
@@ -9521,9 +9536,9 @@ return {
         keys suitable for this option by looking at |ex-edit-index|.  Normally
         you'll never actually type 'wildcharm', just use it in mappings that
         automatically invoke completion mode, e.g.: >vim
-        	set wcm=<C-Z>
-        	cnoremap ss so $vim/sessions/*.vim<C-Z>
-        <	Then after typing :ss you can use CTRL-P & CTRL-N.
+                set wcm=<C-Z>
+                cnoremap ss so $vim/sessions/*.vim<C-Z>
+        <       Then after typing :ss you can use CTRL-P & CTRL-N.
       ]=],
       full_name = 'wildcharm',
       scope = { 'global' },
@@ -9543,8 +9558,8 @@ return {
         The pattern is used like with |:autocmd|, see |autocmd-pattern|.
         Also see 'suffixes'.
         Example: >vim
-        	set wildignore=*.o,*.obj
-        <	The use of |:set+=| and |:set-=| is preferred when adding or removing
+                set wildignore=*.o,*.obj
+        <       The use of |:set+=| and |:set-=| is preferred when adding or removing
         a pattern from the list.  This avoids problems when a future version
         uses another default.
       ]=],
@@ -9589,26 +9604,26 @@ return {
         a completion.
 
         While the menu is active these keys have special meanings:
-        CTRL-P		- go to the previous entry
-        CTRL-N		- go to the next entry
-        <Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
-        <PageUp>	- select a match several entries back
-        <PageDown>	- select a match several entries further
-        <Up>		- in filename/menu name completion: move up into
-        		  parent directory or parent menu.
-        <Down>		- in filename/menu name completion: move into a
-        		  subdirectory or submenu.
-        <CR>		- in menu completion, when the cursor is just after a
-        		  dot: move into a submenu.
-        CTRL-E		- end completion, go back to what was there before
-        		  selecting a match.
-        CTRL-Y		- accept the currently selected match and stop
-        		  completion.
+        CTRL-P          - go to the previous entry
+        CTRL-N          - go to the next entry
+        <Left> <Right>  - select previous/next match (like CTRL-P/CTRL-N)
+        <PageUp>        - select a match several entries back
+        <PageDown>      - select a match several entries further
+        <Up>            - in filename/menu name completion: move up into
+                          parent directory or parent menu.
+        <Down>          - in filename/menu name completion: move into a
+                          subdirectory or submenu.
+        <CR>            - in menu completion, when the cursor is just after a
+                          dot: move into a submenu.
+        CTRL-E          - end completion, go back to what was there before
+                          selecting a match.
+        CTRL-Y          - accept the currently selected match and stop
+                          completion.
 
         If you want <Left> and <Right> to move the cursor instead of selecting
         a different match, use this: >vim
-        	cnoremap <Left> <Space><BS><Left>
-        	cnoremap <Right> <Space><BS><Right>
+                cnoremap <Left> <Space><BS><Left>
+                cnoremap <Right> <Space><BS><Right>
         <
         |hl-WildMenu| highlights the current match.
       ]=],
@@ -9632,40 +9647,40 @@ return {
 
         Each part consists of a colon separated list consisting of the
         following possible values:
-        ""		Complete only the first match.
-        "full"		Complete the next full match.  After the last match,
-        		the original string is used and then the first match
-        		again.  Will also start 'wildmenu' if it is enabled.
-        "longest"	Complete till longest common string.  If this doesn't
-        		result in a longer string, use the next part.
-        "list"		When more than one match, list all matches.
-        "lastused"	When completing buffer names and more than one buffer
-        		matches, sort buffers by time last used (other than
-        		the current buffer).
+        ""              Complete only the first match.
+        "full"          Complete the next full match.  After the last match,
+                        the original string is used and then the first match
+                        again.  Will also start 'wildmenu' if it is enabled.
+        "longest"       Complete till longest common string.  If this doesn't
+                        result in a longer string, use the next part.
+        "list"          When more than one match, list all matches.
+        "lastused"      When completing buffer names and more than one buffer
+                        matches, sort buffers by time last used (other than
+                        the current buffer).
         When there is only a single match, it is fully completed in all cases.
 
         Examples of useful colon-separated values:
-        "longest:full"	Like "longest", but also start 'wildmenu' if it is
-        		enabled.  Will not complete to the next full match.
-        "list:full"	When more than one match, list all matches and
-        		complete first match.
-        "list:longest"	When more than one match, list all matches and
-        		complete till longest common string.
+        "longest:full"  Like "longest", but also start 'wildmenu' if it is
+                        enabled.  Will not complete to the next full match.
+        "list:full"     When more than one match, list all matches and
+                        complete first match.
+        "list:longest"  When more than one match, list all matches and
+                        complete till longest common string.
         "list:lastused" When more than one buffer matches, list all matches
-        		and sort buffers by time last used (other than the
-        		current buffer).
+                        and sort buffers by time last used (other than the
+                        current buffer).
 
         Examples: >vim
-        	set wildmode=full
-        <	Complete first full match, next match, etc.  (the default) >vim
-        	set wildmode=longest,full
-        <	Complete longest common string, then each full match >vim
-        	set wildmode=list:full
-        <	List all matches and complete each full match >vim
-        	set wildmode=list,full
-        <	List all matches without completing, then each full match >vim
-        	set wildmode=longest,list
-        <	Complete longest common string, then list alternatives.
+                set wildmode=full
+        <       Complete first full match, next match, etc.  (the default) >vim
+                set wildmode=longest,full
+        <       Complete longest common string, then each full match >vim
+                set wildmode=list:full
+        <       List all matches and complete each full match >vim
+                set wildmode=list,full
+        <       List all matches without completing, then each full match >vim
+                set wildmode=longest,list
+        <       Complete longest common string, then list alternatives.
         More info here: |cmdline-completion|.
       ]=],
       expand_cb = 'expand_set_wildmode',
@@ -9684,21 +9699,21 @@ return {
       desc = [=[
         A list of words that change how |cmdline-completion| is done.
         The following values are supported:
-          fuzzy		Use |fuzzy-matching| to find completion matches. When
-        		this value is specified, wildcard expansion will not
-        		be used for completion.  The matches will be sorted by
-        		the "best match" rather than alphabetically sorted.
-        		This will find more matches than the wildcard
-        		expansion. Currently fuzzy matching based completion
-        		is not supported for file and directory names and
-        		instead wildcard expansion is used.
-          pum		Display the completion matches using the popup menu
-        		in the same style as the |ins-completion-menu|.
-          tagfile	When using CTRL-D to list matching tags, the kind of
-        		tag and the file of the tag is listed.	Only one match
-        		is displayed per line.  Often used tag kinds are:
-        			d	#define
-        			f	function
+          fuzzy         Use |fuzzy-matching| to find completion matches. When
+                        this value is specified, wildcard expansion will not
+                        be used for completion.  The matches will be sorted by
+                        the "best match" rather than alphabetically sorted.
+                        This will find more matches than the wildcard
+                        expansion. Currently fuzzy matching based completion
+                        is not supported for file and directory names and
+                        instead wildcard expansion is used.
+          pum           Display the completion matches using the popup menu
+                        in the same style as the |ins-completion-menu|.
+          tagfile       When using CTRL-D to list matching tags, the kind of
+                        tag and the file of the tag is listed.  Only one match
+                        is displayed per line.  Often used tag kinds are:
+                                d       #define
+                                f       function
       ]=],
       expand_cb = 'expand_set_wildoptions',
       full_name = 'wildoptions',
@@ -9713,18 +9728,18 @@ return {
       cb = 'did_set_winaltkeys',
       defaults = { if_true = 'menu' },
       desc = [=[
-        		only used in Win32
+                        only used in Win32
         Some GUI versions allow the access to menu entries by using the ALT
         key in combination with a character that appears underlined in the
         menu.  This conflicts with the use of the ALT key for mappings and
         entering special characters.  This option tells what to do:
-          no	Don't use ALT keys for menus.  ALT key combinations can be
-        	mapped, but there is no automatic handling.
-          yes	ALT key handling is done by the windowing system.  ALT key
-        	combinations cannot be mapped.
-          menu	Using ALT in combination with a character that is a menu
-        	shortcut key, will be handled by the windowing system.  Other
-        	keys can be mapped.
+          no    Don't use ALT keys for menus.  ALT key combinations can be
+                mapped, but there is no automatic handling.
+          yes   ALT key handling is done by the windowing system.  ALT key
+                combinations cannot be mapped.
+          menu  Using ALT in combination with a character that is a menu
+                shortcut key, will be handled by the windowing system.  Other
+                keys can be mapped.
         If the menu is disabled by excluding 'm' from 'guioptions', the ALT
         key is never used for the menu.
         This option is not used for <F10>; on Win32.
@@ -9849,8 +9864,8 @@ return {
         that ":all" will create only two windows.  To avoid "vim -o 1 2 3 4"
         to create only two windows, set the option after startup is done,
         using the |VimEnter| event: >vim
-        	au VimEnter * set winheight=999
-        <	Minimum value is 1.
+                au VimEnter * set winheight=999
+        <       Minimum value is 1.
         The height is not adjusted after one of the commands that change the
         height of the current window.
         'winheight' applies to the current window.  Use 'winminheight' to set
@@ -9885,7 +9900,7 @@ return {
         message area cannot be overridden.
 
         Example: show a different color for non-current windows: >vim
-        	set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
+                set winhighlight=Normal:MyNormal,NormalNC:MyNormalNC
         <
       ]=],
       expand_cb = 'expand_set_winhighlight',
@@ -9975,9 +9990,9 @@ return {
         The line will be broken in the middle of a word if necessary.  See
         'linebreak' to get the break at a word boundary.
         To make scrolling horizontally a bit more useful, try this: >vim
-        	set sidescroll=5
-        	set listchars+=precedes:<,extends:>
-        <	See 'sidescroll', 'listchars' and |wrap-off|.
+                set sidescroll=5
+                set listchars+=precedes:<,extends:>
+        <       See 'sidescroll', 'listchars' and |wrap-off|.
         This option can't be set from a |modeline| when the 'diff' option is
         on.
       ]=],


### PR DESCRIPTION
    - Replaced all tabs with spaces
    - vimdoc tags are not fully right justified
    - fixed formatting for option defaults than span multiple lines
    - refactored gen_eval_files.lua to handle whitespace more consistently

---

This also fixes the whitespace in the Lua `_meta` files since the rendered docs required `tabstop=8`, which shouldn't be required in code annotations.
