### PR TITLE
refactor(drawline): avoid storing information needed to draw 'statuscolumn'

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -867,7 +867,7 @@ void draw_tabline(void)
 /// the v:lnum and v:relnum variables don't have to be updated.
 ///
 /// @return  The width of the built status column string for line "lnum"
-int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, statuscol_T *stcp)
+int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, char *buf, statuscol_T *stcp)
 {
   // Only update click definitions once per window per redraw.
   // Don't update when current width is 0, since it will be redrawn again if not empty.
@@ -880,7 +880,7 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, statuscol_T *
 
   StlClickRecord *clickrec;
   char *stc = xstrdup(wp->w_p_stc);
-  int width = build_stl_str_hl(wp, stcp->text, MAXPATHL, stc, kOptStatuscolumn, OPT_LOCAL, ' ',
+  int width = build_stl_str_hl(wp, buf, MAXPATHL, stc, kOptStatuscolumn, OPT_LOCAL, ' ',
                                stcp->width, &stcp->hlrec, fillclick ? &clickrec : NULL, stcp);
   xfree(stc);
 
@@ -888,7 +888,7 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, statuscol_T *
     stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
     wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, stcp->width,
                                                       &wp->w_statuscol_click_defs_size);
-    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, stcp->text, stcp->width, false);
+    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, stcp->width, false);
   }
 
   return width;

--- a/src/nvim/statusline_defs.h
+++ b/src/nvim/statusline_defs.h
@@ -57,21 +57,14 @@ struct stl_item {
 };
 
 /// Struct to hold info for 'statuscolumn'
-typedef struct statuscol statuscol_T;
-
-struct statuscol {
+typedef struct {
   int width;                           ///< width of the status column
-  int cur_attr;                        ///< current attributes in text
   int num_attr;                        ///< default highlight attr
   int sign_cul_id;                     ///< cursorline sign highlight id
   int truncate;                        ///< truncated width
   bool draw;                           ///< whether to draw the statuscolumn
   bool use_cul;                        ///< whether to use cursorline attrs
-  char text[MAXPATHL];                 ///< text in status column
-  char *textp;                         ///< current position in text
-  char *text_end;                      ///< end of text (the NUL byte)
   stl_hlrec_t *hlrec;                  ///< highlight groups
-  stl_hlrec_t *hlrecp;                 ///< current highlight group
   foldinfo_T foldinfo;                 ///< fold information
   SignTextAttrs *sattrs;               ///< sign attributes
-};
+} statuscol_T;


### PR DESCRIPTION
We no longer return to the main loop in win_line() to put column
characters on the screen since #26528. Simplify and sync statuscolumn drawing
logic with that of statusline.