### PR TITLE
feat(health): checkhealth buffer can be opened in a split window

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -366,6 +366,8 @@ The following changes to existing APIs or features add new behavior.
 • Attempting to set an invalid keycode option (e.g. `set t_foo=123`) no longer
   gives an error.
 
+• |:checkhealth| buffer can now be opened in a split window using |:vertical| or |:horizontal|.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -274,13 +274,13 @@ function M._check(splitmod, plugin_names)
 
   local emptybuf = vim.fn.bufnr('$') == 1 and vim.fn.getline(1) == '' and 1 == vim.fn.line('$')
   local mod = function()
-    if emptybuf then
-      -- if this is the default buffer when Nvim starts, open healthcheck directly
-      return 'buffer'
-    elseif splitmod == 'vertical' then
+    if splitmod == 'vertical' then
       return 'vertical sbuffer'
     elseif splitmod == 'horizontal' then
       return 'horizontal sbuffer'
+    elseif emptybuf then
+      -- if this is the default buffer when Nvim starts, open healthcheck directly
+      return 'buffer'
     else
       -- if not specified otherwise open healthcheck in a tab
       return 'tab sbuffer'

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -268,14 +268,27 @@ end
 
 -- Runs the specified healthchecks.
 -- Runs all discovered healthchecks if plugin_names is empty.
-function M._check(plugin_names)
+-- splitmod controls how the healthcheck window opens: "vertical", "horizontal" or "tab"
+function M._check(splitmod, plugin_names)
   local healthchecks = plugin_names == '' and get_healthcheck('*') or get_healthcheck(plugin_names)
 
-  -- Create buffer and open in a tab, unless this is the default buffer when Nvim starts.
   local emptybuf = vim.fn.bufnr('$') == 1 and vim.fn.getline(1) == '' and 1 == vim.fn.line('$')
-  local mod = emptybuf and 'buffer' or 'tab sbuffer'
+  local mod = function()
+    if emptybuf then
+      -- if this is the default buffer when Nvim starts, open healthcheck directly
+      return 'buffer'
+    elseif splitmod == 'vertical' then
+      return 'vertical sbuffer'
+    elseif splitmod == 'horizontal' then
+      return 'horizontal sbuffer'
+    else
+      -- if not specified otherwise open healthcheck in a tab
+      return 'tab sbuffer'
+    end
+  end
+
   local bufnr = vim.api.nvim_create_buf(true, true)
-  vim.cmd(mod .. ' ' .. bufnr)
+  vim.cmd(mod() .. ' ' .. bufnr)
 
   if vim.fn.bufexists('health://') == 1 then
     vim.cmd.bwipe('health://')

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8814,7 +8814,14 @@ void eval_fmt_source_name_line(char *buf, size_t bufsize)
 void ex_checkhealth(exarg_T *eap)
 {
   Error err = ERROR_INIT;
-  MAXSIZE_TEMP_ARRAY(args, 1);
+  MAXSIZE_TEMP_ARRAY(args, 2);
+  if (cmdmod.cmod_split & WSP_VERT) {
+    ADD_C(args, CSTR_AS_OBJ("vertical"));
+  } else if (cmdmod.cmod_split & WSP_HOR) {
+    ADD_C(args, CSTR_AS_OBJ("horizontal"));
+  } else {
+    ADD_C(args, CSTR_AS_OBJ("tab"));
+  }
   ADD_C(args, CSTR_AS_OBJ(eap->arg));
   NLUA_EXEC_STATIC("return vim.health._check(...)", args, &err);
   if (!ERROR_SET(&err)) {

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -366,8 +366,6 @@ describe(':checkhealth window', function()
   end)
 
   it("opens in tab", function()
-    local screen = Screen.new(50, 25)
-    screen:attach({ext_multigrid=true})
     -- create an empty buffer called "my_buff"
     exec_lua 'vim.api.nvim_create_buf(false, true)'
     command('file my_buff')

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -371,7 +371,7 @@ describe(':checkhealth window', function()
     command("checkhealth success1")
     screen:expect{grid=[[
     ## grid 1
-      {MATCH: %+ %[No Name%]  h:?//                                X}|
+       + [No Name]  h//                                X|
       [4:--------------------------------------------------]|*23
       [3:--------------------------------------------------]|
     ## grid 2 (hidden)

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -371,7 +371,7 @@ describe(':checkhealth window', function()
     command("checkhealth success1")
     screen:expect{grid=[[
     ## grid 1
-       + [No Name]  h//                                X|
+      {MATCH: %+ %[No Name%]  h:?//                                X}|
       [4:--------------------------------------------------]|*23
       [3:--------------------------------------------------]|
     ## grid 2 (hidden)

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -393,6 +393,6 @@ describe(':checkhealth window', function()
       - OK nothing to see here                          |
                                                         |
       ~                                                 |*11
-]]}
+    ]]}
   end)
 end)

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -6,6 +6,7 @@ local curbuf_contents = helpers.curbuf_contents
 local command = helpers.command
 local eq, neq, matches = helpers.eq, helpers.neq, helpers.matches
 local getcompletion = helpers.funcs.getcompletion
+local feed = helpers.feed
 
 describe(':checkhealth', function()
   it("detects invalid $VIMRUNTIME", function()
@@ -198,5 +199,200 @@ describe(':checkhealth provider', function()
     command('let g:loaded_python3_provider = 0')
     command('checkhealth provider')
     eq(nil, string.match(curbuf_contents(), 'WRONG!!!'))
+  end)
+end)
+
+describe(':checkhealth window', function()
+  before_each(function()
+    clear{args={'-u', 'NORC'}}
+    -- Provides healthcheck functions
+    command("set runtimepath+=test/functional/fixtures")
+    command("set nofoldenable nowrap laststatus=0")
+  end)
+
+  it("opens directly if no buffer created", function()
+    local screen = Screen.new(50, 12)
+    screen:attach({ext_multigrid=true})
+    command("checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+      [2:--------------------------------------------------]|*11
+      [3:--------------------------------------------------]|
+    ## grid 2
+      ^                                                  |
+      ──────────────────────────────────────────────────|
+      ────────────────────────────                      |
+      test_plug.success1: require("test_plug.success1.  |
+      health").check()                                  |
+                                                        |
+      report 1                                          |
+      - OK everything is fine                           |
+                                                        |
+      report 2                                          |
+      - OK nothing to see here                          |
+    ## grid 3
+                                                        |
+    ]]}
+  end)
+
+  it("opens in vsplit window when no buffer created", function()
+    local screen = Screen.new(50, 20)
+    screen:attach({ext_multigrid=true})
+    command("vertical checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+      [4:-------------------------]│[2:------------------------]|*19
+      [3:--------------------------------------------------]|
+    ## grid 2
+                              |
+      ~                       |*18
+    ## grid 3
+                                                        |
+    ## grid 4
+      ^                         |
+      ─────────────────────────|*3
+      ───                      |
+      test_plug.success1:      |
+      require("test_plug.      |
+      success1.health").check()|
+                               |
+      report 1                 |
+      - OK everything is fine  |
+                               |
+      report 2                 |
+      - OK nothing to see here |
+                               |
+      ~                        |*4
+    ]]}
+  end)
+
+  it("opens in split window when no buffer created", function()
+    local screen = Screen.new(50, 25)
+    screen:attach({ext_multigrid=true})
+    command("horizontal checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+      [4:--------------------------------------------------]|*12
+      health://                                         |
+      [2:--------------------------------------------------]|*11
+      [3:--------------------------------------------------]|
+    ## grid 2
+                                                        |
+      ~                                                 |*10
+    ## grid 3
+                                                        |
+    ## grid 4
+      ^                                                  |
+      ──────────────────────────────────────────────────|
+      ────────────────────────────                      |
+      test_plug.success1: require("test_plug.success1.  |
+      health").check()                                  |
+                                                        |
+      report 1                                          |
+      - OK everything is fine                           |
+                                                        |
+      report 2                                          |
+      - OK nothing to see here                          |
+                                                        |
+    ]]}
+  end)
+
+  it("opens in split window", function()
+    local screen = Screen.new(50, 25)
+    screen:attach({ext_multigrid=true})
+    feed('ihello')
+    feed('<esc>')
+    command("horizontal checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+      [4:--------------------------------------------------]|*12
+      health://                                         |
+      [2:--------------------------------------------------]|*11
+      [3:--------------------------------------------------]|
+    ## grid 2
+      hello                                             |
+      ~                                                 |*10
+    ## grid 3
+                                                        |
+    ## grid 4
+      ^                                                  |
+      ──────────────────────────────────────────────────|
+      ────────────────────────────                      |
+      test_plug.success1: require("test_plug.success1.  |
+      health").check()                                  |
+                                                        |
+      report 1                                          |
+      - OK everything is fine                           |
+                                                        |
+      report 2                                          |
+      - OK nothing to see here                          |
+                                                        |
+    ]]}
+  end)
+
+  it("opens in vsplit window", function()
+    local screen = Screen.new(50, 25)
+    screen:attach({ext_multigrid=true})
+    feed('ihello')
+    feed('<esc>')
+    command("vertical checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+      [4:-------------------------]│[2:------------------------]|*24
+      [3:--------------------------------------------------]|
+    ## grid 2
+      hello                   |
+      ~                       |*23
+    ## grid 3
+                                                        |
+    ## grid 4
+      ^                         |
+      ─────────────────────────|*3
+      ───                      |
+      test_plug.success1:      |
+      require("test_plug.      |
+      success1.health").check()|
+                               |
+      report 1                 |
+      - OK everything is fine  |
+                               |
+      report 2                 |
+      - OK nothing to see here |
+                               |
+      ~                        |*9
+    ]]}
+  end)
+
+  it("opens in tab", function()
+    local screen = Screen.new(50, 25)
+    screen:attach({ext_multigrid=true})
+    feed('ihello')
+    feed('<esc>')
+    command("checkhealth success1")
+    screen:expect{grid=[[
+    ## grid 1
+       + [No Name]  h//                                X|
+      [4:--------------------------------------------------]|*23
+      [3:--------------------------------------------------]|
+    ## grid 2 (hidden)
+      hello                                             |
+      ~                                                 |*23
+    ## grid 3
+                                                        |
+    ## grid 4
+      ^                                                  |
+      ──────────────────────────────────────────────────|
+      ────────────────────────────                      |
+      test_plug.success1: require("test_plug.success1.  |
+      health").check()                                  |
+                                                        |
+      report 1                                          |
+      - OK everything is fine                           |
+                                                        |
+      report 2                                          |
+      - OK nothing to see here                          |
+                                                        |
+      ~                                                 |*11
+]]}
   end)
 end)


### PR DESCRIPTION
Adds support for `:vertical` and `:horizontal` for the checkhealth buffer

Fix #26517