### PR TITLE
refactor: remove CPO_TO_CPO_FLAGS()

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -912,7 +912,6 @@ def CheckIncludes(filename, lines, error):
             "src/nvim/globals.h",
             "src/nvim/grid.h",
             "src/nvim/highlight.h",
-            "src/nvim/keycodes.h",
             "src/nvim/lua/executor.h",
             "src/nvim/main.h",
             "src/nvim/mark.h",

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -461,7 +461,7 @@ String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Bool
   }
 
   char *ptr = NULL;
-  replace_termcodes(str.data, str.size, &ptr, 0, flags, NULL, CPO_TO_CPO_FLAGS);
+  replace_termcodes(str.data, str.size, &ptr, 0, flags, NULL, p_cpo);
   return cstr_as_string(ptr);
 }
 

--- a/src/nvim/drawline.h
+++ b/src/nvim/drawline.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 
 #include "klib/kvec.h"
-#include "nvim/decoration_defs.h"  // IWYU pragma: keep
 #include "nvim/fold_defs.h"  // IWYU pragma: keep
 #include "nvim/macros_defs.h"
 #include "nvim/pos_defs.h"

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -852,8 +852,8 @@ int get_mouse_button(int code, bool *is_click, bool *is_drag)
 /// K_SPECIAL by itself is replaced by K_SPECIAL KS_SPECIAL KE_FILLER.
 ///
 /// When "flags" has REPTERM_FROM_PART, trailing <C-v> is included, otherwise it is removed (to make
-/// ":map xx ^V" map xx to nothing). When cpo_flags contains FLAG_CPO_BSLASH, a backslash can be
-/// used in place of <C-v>. All other <C-v> characters are removed.
+/// ":map xx ^V" map xx to nothing). When cpo_val contains CPO_BSLASH, a backslash can be used in
+/// place of <C-v>. All other <C-v> characters are removed.
 ///
 /// @param[in]  from  What characters to replace.
 /// @param[in]  from_len  Length of the "from" argument.
@@ -867,20 +867,21 @@ int get_mouse_button(int code, bool *is_click, bool *is_drag)
 ///                    REPTERM_NO_SPECIAL   do not accept <key> notation
 ///                    REPTERM_NO_SIMPLIFY  do not simplify <C-H> into 0x08, etc.
 /// @param[out]  did_simplify  set when some <C-H> code was simplified, unless it is NULL.
-/// @param[in]  cpo_flags  Relevant flags derived from p_cpo, see CPO_TO_CPO_FLAGS.
+/// @param[in]  cpo_val  The value of 'cpoptions' to use. Only CPO_BSLASH matters.
 ///
 /// @return  The same as what `*bufp` is set to.
 char *replace_termcodes(const char *const from, const size_t from_len, char **const bufp,
                         const scid_T sid_arg, const int flags, bool *const did_simplify,
-                        const int cpo_flags)
-  FUNC_ATTR_NONNULL_ARG(1, 3)
+                        const char *const cpo_val)
+  FUNC_ATTR_NONNULL_ARG(1, 3, 7)
 {
   char key;
   size_t dlen = 0;
   const char *src;
   const char *const end = from + from_len - 1;
 
-  const bool do_backslash = !(cpo_flags & FLAG_CPO_BSLASH);  // backslash is a special character
+  // backslash is a special character
+  const bool do_backslash = (vim_strchr(cpo_val, CPO_BSLASH) == NULL);
   const bool do_special = !(flags & REPTERM_NO_SPECIAL);
 
   bool allocated = (*bufp == NULL);

--- a/src/nvim/keycodes.h
+++ b/src/nvim/keycodes.h
@@ -4,7 +4,6 @@
 
 #include "nvim/ascii_defs.h"
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
-#include "nvim/option_vars.h"
 
 // Keycode definitions for special keys.
 //
@@ -474,11 +473,6 @@ enum key_extra {
 ///
 /// This is a total of 6 tokens, and is currently the longest one possible.
 #define MAX_KEY_CODE_LEN    6
-
-#define FLAG_CPO_BSLASH    0x01
-#define CPO_TO_CPO_FLAGS   ((vim_strchr((char *)p_cpo, CPO_BSLASH) == NULL) \
-                            ? 0 \
-                            : FLAG_CPO_BSLASH)
 
 /// Flags for replace_termcodes()
 enum {

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -226,7 +226,7 @@ void ex_menu(exarg_T *eap)
     } else {
       map_buf = NULL;
       map_to = replace_termcodes(map_to, strlen(map_to), &map_buf, 0,
-                                 REPTERM_DO_LT, NULL, CPO_TO_CPO_FLAGS);
+                                 REPTERM_DO_LT, NULL, p_cpo);
     }
     menuarg.modes = modes;
     menuarg.noremap[0] = noremap;

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -872,7 +872,7 @@ int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, 
   char *rep_buf = NULL;
   garray_T *gap;
 
-  replace_termcodes(rep, strlen(rep), &rep_buf, 0, 0, NULL, CPO_TO_CPO_FLAGS);
+  replace_termcodes(rep, strlen(rep), &rep_buf, 0, 0, NULL, p_cpo);
   if (rep_buf == NULL) {
     // Can't replace termcodes - try using the string as is
     rep_buf = xstrdup(rep);


### PR DESCRIPTION
Just pass p_cpo to replace_termcodes() directly.
This allows removing option_vars.h from keycodes.h, and also avoids the
mistake of passing 0 as cpo_flags.