### PR TITLE
fix(treesitter): outdated highlight due to tree with outdated region

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -348,7 +348,13 @@ function LanguageTree:_parse_regions(range)
   -- If there are no ranges, set to an empty list
   -- so the included ranges in the parser are cleared.
   for i, ranges in pairs(self:included_regions()) do
-    if not self._valid[i] and intercepts_region(ranges, range) then
+    if
+      not self._valid[i]
+      and (
+        intercepts_region(ranges, range)
+        or (self._trees[i] and intercepts_region(self._trees[i]:included_ranges(false), range))
+      )
+    then
       self._parser:set_included_ranges(ranges)
       local parse_time, tree, tree_changes =
         tcall(self._parser.parse, self._parser, self._trees[i], self._source, true)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -693,6 +693,18 @@ int x = INT_MAX;
           {2, 26, 3, 66}  -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
                           -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
+
+        helpers.feed('7ggI//<esc>')
+        exec_lua([[parser:parse({6, 7})]])
+        eq("table", exec_lua("return type(parser:children().c)"))
+        eq(2, exec_lua("return #parser:children().c:trees()"))
+        eq({
+          {0, 0, 8, 0},   -- root tree
+          {4, 14, 5, 18}, -- VALUE 123
+                          -- VALUE1 123
+          {2, 26, 3, 66}  -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+                          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
+        }, get_ranges())
       end)
     end)
 


### PR DESCRIPTION
Problem:
A region managed by an injected parser may shrink after re-running the injection query. If the updated region goes out of the range to be parsed, then the corresponding tree will remain outdated, possibly retaining the nodes that shouldn't exist anymore. This results in outdated highlights.

Solution:
Re-parse an invalid tree if its region intersects the range to be parsed.

---

Here is a more realistic example (but can't be included in the test because it uses html parser which isn't shipped with nvim). Consider a markdown buffer containing the following text. Only the lines 1-5 are visible in the window. If you comment out line 1 and then uncomment it, the line 1 will remain highlighted as comment.
```
line 1
line 2
line 3
line 4
line 5

<!-- comment -->
```

This script shows what happens under the hood. Run with `nvim --clean -u repro.lua`
```lua
for name, url in pairs {
  ['nvim-treesitter'] = 'https://github.com/nvim-treesitter/nvim-treesitter',
} do
  local install_path = vim.fn.fnamemodify('nvim_issue/' .. name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end

require('nvim-treesitter.configs').setup({
  ensure_installed = { 'html' },
  sync_install = true,
})

function log()
  print('root:', parser._trees[1]:root():sexpr())
  for lang, child in pairs(parser._children) do
    print(lang .. ':')
    for i, tree in pairs(child._trees) do
      local valid = child._valid
      if type(valid) == 'table' then
        valid = valid[i]
      end
      print(i, tree:root():sexpr(), vim.inspect(child._regions[i]), valid)
    end
  end
end

vim.api.nvim_buf_set_lines(0, 0, -1, true, {
  'line 1',
  'line 2',
  'line 3',
  'line 4',
  'line 5',
  '',
  '<!-- comment -->',
})

print('[init]')
parser = vim.treesitter.get_parser(0, 'markdown')
parser:parse(true)
log()

print('\n[comment]')
vim.fn.setline('.', '<!-- ' .. vim.fn.getline('.') .. ' -->')
parser:parse({ 1 - 1, 5 })
log()

print('\n[uncomment]')
vim.fn.setline('.', vim.fn.getline('.'):sub(6, -5))
parser:parse({ 1 - 1, 5 })
log()
```

**output before this patch**
```
[init]
root: (document (section (paragraph (inline)) (html_block)))
markdown_inline:
1 (inline) { { 0, 0, 0, 4, 6, 34 } } true
html:
1 (fragment (comment)) { { 6, 0, 36, 7, 0, 53 } } true

[comment]
root: (document (section (html_block) (paragraph (inline)) (html_block)))
markdown_inline:
1 (inline) { { 1, 0, 16, 4, 6, 43 } } true
html:
1 (fragment (comment) (comment)) { { 0, 0, 0, 1, 0, 16 }, { 6, 0, 45, 7, 0, 62 } } true

[uncomment]
root: (document (section (paragraph (inline)) (html_block)))
markdown_inline:
1 (inline) { { 0, 0, 0, 4, 6, 34 } } true
html:
1 (fragment (comment) (comment)) { { 6, 0, 36, 7, 0, 53 } } false
```
The html tree initially has one comment node, and the commenting out the first line adds a comment node. After uncommenting, however, the comment node is not removed from the tree. The injection query updated the region for the html parser to the set of ranges that do not include the uncommented line, which does not intersect the range passed to `parse()`, so the tree was not re-parsed.


**output with this patch**
```
...
[uncomment]
root: (document (section (paragraph (inline)) (html_block)))
markdown_inline:
1 (inline) { { 0, 0, 0, 4, 6, 34 } } true
html:
1 (fragment (comment)) { { 6, 0, 36, 7, 0, 53 } } true
```
This patch checks that the region of the html tree intersects the requested region and re-parses it, removing the outdated comment node.
