### PR TITLE
fix(treesitter): make `conceal` consider capture-specific metadata

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -294,7 +294,9 @@ local function on_line_impl(self, buf, line, is_spell_nav)
             hl_group = hl,
             ephemeral = true,
             priority = priority,
-            conceal = metadata.conceal,
+            conceal = (metadata[capture] and metadata[capture].conceal)
+                and metadata[capture].conceal
+              or metadata.conceal,
             spell = spell,
           })
         end

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -696,14 +696,15 @@ function Query:iter_captures(node, source, start, stop)
   start, stop = value_or_node_range(start, stop, node)
 
   local raw_iter = node:_rawquery(self.query, true, start, stop)
+  local metadata = {}
   local function iter(end_line)
     local capture, captured_node, match = raw_iter()
-    local metadata = {}
 
     if match ~= nil then
       local active = self:match_preds(match, match.pattern, source)
       match.active = active
       if not active then
+        metadata = {}
         if end_line and captured_node:range() > end_line then
           return nil, captured_node, nil
         end


### PR DESCRIPTION
Problem:
- `Query:iter_captures` metadata is reset after each capture iteration instead of each match iteration

- Treesitter conceal does not consider the case of conceal being set through `#set! @capture conceal`

Solution:
- Reset metadata each time we try next match
- Treesitter conceal now uses capture-specific conceals first, then tries for match-specific conceals