### PR TITLE
refactor(drawline): reduce size of wlv.extra[]

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -90,7 +90,7 @@ typedef struct {
 
   bool extra_for_extmark;    ///< n_extra set for inline virtual text
 
-  char extra[57];            ///< sign, line number and 'fdc' must fit in here
+  char extra[11];            ///< must be as large as transchar_charbuf[] in charset.c
 
   hlf_T diff_hlf;            ///< type of diff highlighting
 
@@ -2329,9 +2329,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
             mb_c = (uint8_t)(*wlv.p_extra);
             p = get_extra_buf((size_t)wlv.n_extra + 1);
             memset(p, ' ', (size_t)wlv.n_extra);
-            strncpy(p,  // NOLINT(runtime/printf)
-                    wlv.p_extra + 1,
-                    (size_t)strlen(wlv.p_extra) - 1);
+            xstrlcpy(p, wlv.p_extra + 1, strlen(wlv.p_extra));
             p[wlv.n_extra] = NUL;
             wlv.p_extra = p;
           } else {

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2329,7 +2329,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
             mb_c = (uint8_t)(*wlv.p_extra);
             p = get_extra_buf((size_t)wlv.n_extra + 1);
             memset(p, ' ', (size_t)wlv.n_extra);
-            xstrlcpy(p, wlv.p_extra + 1, strlen(wlv.p_extra));
+            memcpy(p, wlv.p_extra + 1, strlen(wlv.p_extra) - 1);
             p[wlv.n_extra] = NUL;
             wlv.p_extra = p;
           } else {

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1837,7 +1837,7 @@ describe('API/win_extmark', function()
           -- notifications from 2nd call
           { {id = 1000}, ns, marks[1], 1, 0 },
           { {id = 1000}, ns, marks[2], 1, 2 },
-          -- notifications from 3nd call
+          -- notifications from 3rd call
           { {id = 1000}, ns, marks[1], 1, 0 },
           { {id = 1000}, ns, marks[2], 1, 2 },
           { {id = 1000}, ns, marks[3], 1, 4 },


### PR DESCRIPTION
It's now only used for transchar_hex(), which only needs 11 bytes.