### PR TITLE
fix(column): correct width after truncated 'statuscolumn' error

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -640,12 +640,12 @@ static void draw_statuscol(win_T *wp, winlinevars_T *wlv, linenr_T lnum, int vir
   int width = build_statuscol_str(wp, lnum, relnum, buf, stcp);
   // Force a redraw in case of error or when truncated
   if (*wp->w_p_stc == NUL || (stcp->truncate > 0 && wp->w_nrwidth < MAX_NUMBERWIDTH)) {
-    if (stcp->truncate > 0) {  // Avoid truncating 'statuscolumn'
-      wp->w_nrwidth = MIN(MAX_NUMBERWIDTH, wp->w_nrwidth + stcp->truncate);
-      wp->w_nrwidth_width = wp->w_nrwidth;
-    } else {  // 'statuscolumn' reset due to error
+    if (*wp->w_p_stc == NUL) {  // 'statuscolumn' reset due to error
       wp->w_nrwidth_line_count = 0;
       wp->w_nrwidth = (wp->w_p_nu || wp->w_p_rnu) * number_width(wp);
+    } else {  // Avoid truncating 'statuscolumn'
+      wp->w_nrwidth_width = wp->w_nrwidth;
+      wp->w_nrwidth = MIN(MAX_NUMBERWIDTH, wp->w_nrwidth + stcp->truncate);
     }
     wp->w_redr_statuscol = true;
     return;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -23,7 +23,7 @@ describe('statuscolumn', function()
   end)
 
   it("fails with invalid 'statuscolumn'", function()
-    command([[set stc=%{v:relnum?v:relnum:(v:lnum==5?invalid:v:lnum)}\ ]])
+    command([[set stc=%{v:relnum?v:relnum:(v:lnum==5?'truncate':v:lnum)}%{!v:relnum&&v:lnum==5?invalid:''}\ ]])
     screen:expect([[
       4  aaaaa                                             |
       3  aaaaa                                             |
@@ -43,6 +43,22 @@ describe('statuscolumn', function()
     command('norm 5G')
     eq('Vim(redraw):E121: Undefined variable: invalid', pcall_err(command, 'redraw!'))
     eq('', eval('&statuscolumn'))
+    screen:expect([[
+       4 aaaaa                                             |
+       5 ^aaaaa                                             |
+       6 aaaaa                                             |
+       7 aaaaa                                             |
+       8 aaaaa                                             |
+       9 aaaaa                                             |
+      10 aaaaa                                             |
+      11 aaaaa                                             |
+      12 aaaaa                                             |
+      13 aaaaa                                             |
+      14 aaaaa                                             |
+      15 aaaaa                                             |
+      16 aaaaa                                             |
+                                                           |
+    ]])
   end)
 
   it("widens with irregular 'statuscolumn' width", function()


### PR DESCRIPTION
Problem:  Default number column has incorrect width after 'statuscolumn'
          is unset due to an error, but was also truncated.
Solution: Reverse 'statuscolumn' error and truncate return logic.