### PR TITLE
refactor(completion): improve popup window position 

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1307,26 +1307,30 @@ void ins_compl_show_pum(void)
   }
 }
 
-/// used for set or update info
-void compl_set_info(int pum_idx)
+/// check selected is current match.
+///
+/// @param selected the item which is selected.
+/// @return bool    return true when is current match otherwise is false.
+bool compl_match_curr_select(int selected)
 {
-  compl_T *comp = compl_first_match;
-  char *pum_text = compl_match_array[pum_idx].pum_text;
-
-  while (comp != NULL) {
-    if (pum_text == comp->cp_str
-        || pum_text == comp->cp_text[CPT_ABBR]) {
-      comp->cp_text[CPT_INFO] = compl_match_array[pum_idx].pum_info;
-
-      // if comp is current match update completed_item value
-      if (comp == compl_curr_match) {
-        dict_T *dict = ins_compl_dict_alloc(compl_curr_match);
-        set_vim_var_dict(VV_COMPLETED_ITEM, dict);
-      }
-      break;
-    }
-    comp = comp->cp_next;
+  if (selected < 0) {
+    return false;
   }
+  compl_T *match = compl_first_match;
+  int selected_idx = -1, list_idx = 0;
+  do {
+    if (!match_at_original_text(match)) {
+      if (compl_curr_match != NULL
+          && compl_curr_match->cp_number == match->cp_number) {
+        selected_idx = list_idx;
+        break;
+      }
+      list_idx += 1;
+    }
+    match = match->cp_next;
+  } while (match != NULL && !is_first_match(match));
+
+  return selected == selected_idx;
 }
 
 #define DICT_FIRST      (1)     ///< use just first element in "dict"

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -6,7 +6,9 @@
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/vim.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/drawscreen.h"
 #include "nvim/globals.h"
@@ -17,6 +19,7 @@
 #include "nvim/mouse.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
+#include "nvim/option_defs.h"
 #include "nvim/optionstr.h"
 #include "nvim/pos_defs.h"
 #include "nvim/strings.h"
@@ -336,4 +339,53 @@ win_T *win_float_find_altwin(const win_T *win, const tabpage_T *tp)
   assert(tp != curtab);
   return (tabpage_win_valid(tp, tp->tp_prevwin) && tp->tp_prevwin != win) ? tp->tp_prevwin
                                                                           : tp->tp_firstwin;
+}
+
+/// create a floating preview window.
+///
+/// @param[in] bool enter floating window.
+/// @param[in] bool create a new buffer for window.
+///
+/// @return win_T
+win_T *win_float_create(bool enter, bool new_buf)
+{
+  WinConfig config = WIN_CONFIG_INIT;
+  config.col = curwin->w_wcol;
+  config.row = curwin->w_wrow;
+  config.relative = kFloatRelativeEditor;
+  config.focusable = false;
+  config.anchor = 0;  // NW
+  config.noautocmd = true;
+  config.hide = true;
+  config.style = kWinStyleMinimal;
+  Error err = ERROR_INIT;
+
+  block_autocmds();
+  win_T *wp = win_new_float(NULL, false, config, &err);
+  if (!wp) {
+    unblock_autocmds();
+    return NULL;
+  }
+
+  if (new_buf) {
+    Buffer b = nvim_create_buf(false, true, &err);
+    if (!b) {
+      win_remove(wp, NULL);
+      win_free(wp, NULL);
+      unblock_autocmds();
+      return NULL;
+    }
+    buf_T *buf = find_buffer_by_handle(b, &err);
+    buf->b_p_bl = false;  // unlist
+    set_option_direct_for(kOptBufhidden, STATIC_CSTR_AS_OPTVAL("wipe"), OPT_LOCAL, 0, kOptReqBuf,
+                          buf);
+    win_set_buf(wp, buf, &err);
+  }
+  unblock_autocmds();
+  wp->w_p_diff = false;
+  wp->w_float_is_info = true;
+  if (enter) {
+    win_enter(wp, false);
+  }
+  return wp;
 }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1592,13 +1592,13 @@ describe('builtin popupmenu', function()
     describe('floating window preview #popup', function()
       it('pum popup preview', function()
         --row must > 10
-        screen:try_resize(30, 11)
+        screen:try_resize(40, 11)
         exec([[
           funct Omni_test(findstart, base)
             if a:findstart
               return col(".") - 1
             endif
-            return [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "three"}]
+            return [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "looooooooooooooong"}]
           endfunc
           set omnifunc=Omni_test
           set completeopt=menu,popup
@@ -1612,115 +1612,29 @@ describe('builtin popupmenu', function()
           autocmd CompleteChanged * call Set_info()
         ]])
         feed('Gi<C-x><C-o>')
-
         --floating preview in right
         if multigrid then
           screen:expect {
             grid = [[
           ## grid 1
-            [2:------------------------------]|*10
-            [3:------------------------------]|
+            [2:----------------------------------------]|*10
+            [3:----------------------------------------]|
           ## grid 2
-            one^                           |
-            {1:~                             }|*9
+            one^                                     |
+            {1:~                                       }|*9
           ## grid 3
-            {2:-- }{5:match 1 of 3}               |
+            {2:-- }{5:match 1 of 3}                         |
           ## grid 4
             {n:1info}|
             {n:     }|
           ## grid 5
-            {s:one            }|
-            {n:two            }|
-            {n:three          }|
+            {s:one                }|
+            {n:two                }|
+            {n:looooooooooooooong }|
           ]],
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 15, true, 50 },
-            },
-          }
-        else
-          screen:expect {
-            grid = [[
-            one^                           |
-            {s:one            }{n:1info}{1:          }|
-            {n:two                 }{1:          }|
-            {n:three          }{1:               }|
-            {1:~                             }|*6
-            {2:-- }{5:match 1 of 3}               |
-          ]],
-            unchanged = true,
-          }
-        end
-
-        -- test nvim_complete_set_info
-        feed('<C-N><C-N>')
-        vim.uv.sleep(10)
-        if multigrid then
-          screen:expect {
-            grid = [[
-          ## grid 1
-            [2:------------------------------]|*10
-            [3:------------------------------]|
-          ## grid 2
-            three^                         |
-            {1:~                             }|*9
-          ## grid 3
-            {2:-- }{5:match 3 of 3}               |
-          ## grid 4
-            {n:3info}|
-            {n:     }|
-          ## grid 5
-            {n:one            }|
-            {n:two            }|
-            {s:three          }|
-          ]],
-            float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 15, true, 50 },
-            },
-          }
-        else
-          screen:expect {
-            grid = [[
-            three^                         |
-            {n:one            3info}{1:          }|
-            {n:two                 }{1:          }|
-            {s:three          }{1:               }|
-            {1:~                             }|*6
-            {2:-- }{5:match 3 of 3}               |
-          ]],
-          }
-        end
-        -- make sure info has set
-        feed('<C-y>')
-        eq('3info', exec_lua('return vim.v.completed_item.info'))
-
-        -- preview in left
-        feed('<ESC>cc')
-        insert(('test'):rep(5))
-        feed('i<C-x><C-o>')
-        if multigrid then
-          screen:expect {
-            grid = [[
-          ## grid 1
-            [2:------------------------------]|*10
-            [3:------------------------------]|
-          ## grid 2
-            itesttesttesttesttesone^t      |
-            {1:~                             }|*9
-          ## grid 3
-            {2:-- }{5:match 1 of 3}               |
-          ## grid 5
-            {s: one      }|
-            {n: two      }|
-            {n: three    }|
-          ## grid 6
-            {n:1info}|
-            {n:     }|
-          ]],
-            float_pos = {
-              [5] = { -1, 'NW', 2, 1, 19, false, 100 },
-              [6] = { 1002, 'NW', 1, 1, 1, true, 50 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50 },
             },
             win_viewport = {
               [2] = {
@@ -1728,7 +1642,123 @@ describe('builtin popupmenu', function()
                 topline = 0,
                 botline = 2,
                 curline = 0,
-                curcol = 23,
+                curcol = 3,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+              [4] = {
+                win = 1001,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 0,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+            },
+          }
+        else
+          screen:expect {
+            grid = [[
+            one^                                     |
+            {s:one                }{n:1info}{1:                }|
+            {n:two                     }{1:                }|
+            {n:looooooooooooooong }{1:                     }|
+            {1:~                                       }|*6
+            {2:-- }{5:match 1 of 3}                         |
+          ]],
+          }
+        end
+
+        -- info window position should be adjusted when new leader add
+        feed('<C-P>o')
+        if multigrid then
+          screen:expect {
+            grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*10
+            [3:----------------------------------------]|
+          ## grid 2
+            o^                                       |
+            {1:~                                       }|*9
+          ## grid 3
+            {2:-- }{8:Back at original}                     |
+          ## grid 4
+            {n:1info}|
+            {n:     }|
+          ## grid 5
+            {n:one            }|
+          ]],
+            float_pos = {
+              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
+              [4] = { 1001, 'NW', 1, 1, 15, false, 50 },
+            },
+            win_viewport = {
+              [2] = {
+                win = 1000,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 1,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+              [4] = {
+                win = 1001,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 0,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+            },
+          }
+        else
+          screen:expect {
+            grid = [[
+            o^                                       |
+            {n:one            1info}{1:                    }|
+            {1:~              }{n:     }{1:                    }|
+            {1:~                                       }|*7
+            {2:-- }{8:Back at original}                     |
+          ]],
+          }
+        end
+
+        -- test nvim_complete_set_info
+        feed('<ESC>cc<C-X><C-O><C-N><C-N>')
+        vim.uv.sleep(10)
+        if multigrid then
+          screen:expect {
+            grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*10
+            [3:----------------------------------------]|
+          ## grid 2
+            looooooooooooooong^                      |
+            {1:~                                       }|*9
+          ## grid 3
+            {2:-- }{5:match 3 of 3}                         |
+          ## grid 5
+            {n:one                }|
+            {n:two                }|
+            {s:looooooooooooooong }|
+          ## grid 6
+            {n:3info}|
+            {n:     }|
+          ]],
+            float_pos = {
+              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
+              [6] = { 1002, 'NW', 1, 1, 19, false, 50 },
+            },
+            win_viewport = {
+              [2] = {
+                win = 1000,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 18,
                 linecount = 1,
                 sum_scroll_delta = 0,
               },
@@ -1746,12 +1776,73 @@ describe('builtin popupmenu', function()
         else
           screen:expect {
             grid = [[
-            itesttesttesttesttesone^t      |
-            {1:~}{n:1info}{1:             }{s: one      }{1: }|
-            {1:~}{n:     }{1:             }{n: two      }{1: }|
-            {1:~                  }{n: three    }{1: }|
-            {1:~                             }|*6
-            {2:-- }{5:match 1 of 3}               |
+            looooooooooooooong^                      |
+            {n:one                3info}{1:                }|
+            {n:two                     }{1:                }|
+            {s:looooooooooooooong }{1:                     }|
+            {1:~                                       }|*6
+            {2:-- }{5:match 3 of 3}                         |
+          ]],
+          }
+        end
+
+        -- preview in left
+        feed('<ESC>cc')
+        insert(('test'):rep(5))
+        feed('i<C-x><C-o>')
+        if multigrid then
+          screen:expect {
+            grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*10
+            [3:----------------------------------------]|
+          ## grid 2
+            itesttesttesttesttesone^t                |
+            {1:~                                       }|*9
+          ## grid 3
+            {2:-- }{5:match 1 of 3}                         |
+          ## grid 5
+            {s: one                }|
+            {n: two                }|
+            {n: looooooooooooooong }|
+          ## grid 7
+            {n:1info}|
+            {n:     }|
+          ]],
+            float_pos = {
+              [7] = { 1003, 'NW', 1, 1, 14, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 19, false, 100 },
+            },
+            win_viewport = {
+              [2] = {
+                win = 1000,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 23,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+              [7] = {
+                win = 1003,
+                topline = 0,
+                botline = 2,
+                curline = 0,
+                curcol = 0,
+                linecount = 1,
+                sum_scroll_delta = 0,
+              },
+            },
+          }
+        else
+          screen:expect {
+            grid = [[
+            itesttesttesttesttesone^t                |
+            {1:~             }{n:1info}{s: one                }{1: }|
+            {1:~             }{n:      two                }{1: }|
+            {1:~                  }{n: looooooooooooooong }{1: }|
+            {1:~                                       }|*6
+            {2:-- }{5:match 1 of 3}                         |
           ]],
           }
         end


### PR DESCRIPTION
Problem: 
1. when new leader add and selected is -1 the pum window width changed like (be small) the info floating window position not changed.
2.  correct selected check avoid memory leak.
3. The info string does not need to be stored in compl, it is usually a very long byte string. So a large amount of memory needs to be allocated. We just need to write them into the info buffer.

Solutioin: when new leader add and selected is -1 we still need adjust info window width. And don't store info value. 

Fix https://github.com/neovim/neovim/issues/27768