### PR TITLE
fix(completion): update complete item value before event trigger

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1286,6 +1286,10 @@ void ins_compl_show_pum(void)
   pum_display(compl_match_array, compl_match_arraysize, cur, array_changed, 0);
   curwin->w_cursor.col = col;
 
+  if (compl_started && compl_curr_match != compl_shown_match) {
+    compl_curr_match = compl_shown_match;
+  }
+
   if (has_event(EVENT_COMPLETECHANGED)) {
     trigger_complete_changed_event(cur);
   }

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1027,6 +1027,29 @@ describe('completion', function()
     feed('<esc>')
   end)
 
+  it('correct set completed_item in CompleteChanged', function()
+    source([[
+      funct Omni_test(findstart, base)
+        if a:findstart
+          return col(".")
+        endif
+        return [#{word: "one"}, #{word: "two"}, #{word: "five"}]
+      endfunc
+      set omnifunc=Omni_test
+      set complete=.
+      function! OnChange()
+        let g:event = copy(v:event)
+        let g:item = get(v:event, 'completed_item', {})
+        let g:word = get(g:item, 'word', v:null)
+      endfunction
+      autocmd CompleteChanged * call OnChange()
+    ]])
+    feed('i<C-X><C-O>')
+    eq('one', eval('g:word'))
+    feed('<BS><BS><BS>f')
+    eq('five', eval('g:word'))
+  end)
+
   it('is stopped by :stopinsert from timer #12976', function()
     screen:try_resize(32,14)
     command([[call setline(1, ['hello', 'hullo', 'heeee', ''])]])

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1162,9 +1162,21 @@ func Test_CompleteChanged()
   call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-P>", 'tx')
   call assert_equal('foobar', g:word)
 
+  func Omni_test(findstart, base)
+    if a:findstart
+      return col(".")
+    endif
+    return [#{word: "one"}, #{word: "two"}, #{word: "five"}]
+  endfunc
+  set omnifunc=Omni_test
+  set completeopt=menu,menuone
+  call feedkeys("i\<C-X>\<C-O>\<BS>\<BS>\<BS>f", 'tx')
+  call assert_equal('five', g:word)
+
   autocmd! AAAAA_Group
   set complete& completeopt&
   delfunc! OnPumChange
+  delfunc! Omni_test
   bw!
 endfunc
 


### PR DESCRIPTION
Problem: when new leader add there will invoke `ins_compl_del_pum` and rebuild a pum match array. but the `compl_curr_match` value not update to `compl_shown_match`. this will cause `completed_item` in `v:event` not same as current select item in pum when `CompleteChanged` event trigger.

Solution:  update compl_curr_match value when new leader add