### PR TITLE
refactor: use vim.deprecate on all deprecated functions

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -75,11 +75,15 @@ When a (non-experimental) feature is slated to be removed it should:
   - Use of the deprecated feature will still work.
   - This means deprecating via documentation and annotation (`@deprecated`) only.
   - Include a note in `news.txt` under `DEPRECATIONS`.
+  - For Lua features, use `vim.deprecate()`. The specified version is the
+    current minor version + 2. For example, if the current version is
+    `v0.10.0-dev-1957+gd676746c33` then use `0.12`.
+  - For Vimscript features, use `v:lua.vim.deprecate()`. Use the same version
+    as described for Lua features.
 2. Be _hard_ deprecated in a following a release in which it was soft deprecated.
-  - Use of the deprecated feature will still work but should issue a warning
-    (typically via `vim.deprecate()` for Lua features).
-  - Features implemented in Vimscript or in C will need bespoke implementations
-    to communicate to users that the feature is deprecated
+  - Use of the deprecated feature will still work but should issue a warning.
+  - Features implemented in C will need bespoke implementations to communicate
+    to users that the feature is deprecated.
 3. Be removed in a release following the release in which it was hard deprecated
   - Usually this will be the next release, but it may be a later release if a
     longer deprecation cycle is desired

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -888,7 +888,7 @@ end
 
 ---@private
 function vim.pretty_print(...)
-  vim.deprecate('vim.pretty_print', 'vim.print', '0.10')
+  vim.deprecate('vim.pretty_print()', 'vim.print()', '0.10')
   return vim.print(...)
 end
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -891,15 +891,13 @@ M.handlers.signs = {
         local sign = vim.fn.sign_getdefined(name)[1]
         if sign then
           local severity = M.severity[v:upper()]
-          if vim.fn.has('nvim-0.11') == 1 then
-            vim.deprecate(
-              'Defining diagnostic signs with :sign-define or sign_define()',
-              'vim.diagnostic.config()',
-              '0.12',
-              nil,
-              false
-            )
-          end
+          vim.deprecate(
+            'Defining diagnostic signs with :sign-define or sign_define()',
+            'vim.diagnostic.config()',
+            '0.12',
+            nil,
+            false
+          )
 
           if not opts.signs.text then
             opts.signs.text = {}

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1740,7 +1740,7 @@ end
 ---@private
 ---@deprecated
 function lsp.get_active_clients(filter)
-  -- TODO: add vim.deprecate call after 0.10 is out for removal in 0.12
+  vim.deprecate('vim.lsp.get_active_clients()', 'vim.lsp.get_clients()', '0.12')
   return lsp.get_clients(filter)
 end
 
@@ -2051,6 +2051,7 @@ end
 ---@return table result is table of (client_id, client) pairs
 ---@deprecated Use |vim.lsp.get_clients()| instead.
 function lsp.buf_get_clients(bufnr)
+  vim.deprecate('vim.lsp.buf_get_clients()', 'vim.lsp.get_clients()', '0.12')
   local result = {} --- @type table<integer,lsp.Client>
   for _, client in ipairs(lsp.get_clients({ bufnr = resolve_bufnr(bufnr) })) do
     result[client.id] = client
@@ -2101,6 +2102,11 @@ end
 ---                   buffer number as arguments.
 ---@deprecated use lsp.get_clients({ bufnr = bufnr }) with regular loop
 function lsp.for_each_buffer_client(bufnr, fn)
+  vim.deprecate(
+    'vim.lsp.for_each_buffer_client()',
+    'lsp.get_clients({ bufnr = bufnr }) with regular loop',
+    '0.12'
+  )
   return for_each_buffer_client(bufnr, fn)
 end
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -34,7 +34,7 @@ end
 ---@return boolean if server responds.
 ---@deprecated
 function M.server_ready()
-  vim.deprecate('vim.lsp.buf.server_ready', nil, '0.10.0')
+  vim.deprecate('vim.lsp.buf.server_ready()', nil, '0.10')
   return not not vim.lsp.buf_notify(0, 'window/progress', {})
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -180,6 +180,7 @@ local _str_byteindex_enc = M._str_byteindex_enc
 ---@param new_lines (table) list of strings to replace the original
 ---@return table The modified {lines} object
 function M.set_lines(lines, A, B, new_lines)
+  vim.deprecate('vim.lsp.util.set_lines()', 'nil', '0.12')
   -- 0-indexing to 1-indexing
   local i_0 = A[1] + 1
   -- If it extends past the end, truncate it to the end. This is because the
@@ -346,7 +347,7 @@ end
 ---@private
 ---@deprecated Use vim.lsp.status() or access client.progress directly
 function M.get_progress_messages()
-  vim.deprecate('vim.lsp.util.get_progress_messages', 'vim.lsp.status', '0.11.0')
+  vim.deprecate('vim.lsp.util.get_progress_messages()', 'vim.lsp.status()', '0.11')
   local new_messages = {}
   local progress_remove = {}
 
@@ -552,7 +553,7 @@ end
 ---@return lsp.CompletionItem[] List of completion items
 ---@see https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 function M.extract_completion_items(result)
-  vim.deprecate('vim.lsp.util.extract_completion_items', nil, '0.11')
+  vim.deprecate('vim.lsp.util.extract_completion_items()', nil, '0.11')
   if type(result) == 'table' and result.items then
     -- result is a `CompletionList`
     return result.items
@@ -612,7 +613,7 @@ end
 ---@param input string unparsed snippet
 ---@return string parsed snippet
 function M.parse_snippet(input)
-  vim.deprecate('vim.lsp.util.parse_snippet', nil, '0.11')
+  vim.deprecate('vim.lsp.util.parse_snippet()', nil, '0.11')
   local ok, parsed = pcall(function()
     return snippet.parse(input)
   end)
@@ -634,7 +635,7 @@ end
 ---@return table[] items
 ---@see complete-items
 function M.text_document_completion_list_to_complete_items(result, prefix)
-  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items', nil, '0.11')
+  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items()', nil, '0.11')
   return require('vim.lsp._completion')._lsp_to_complete_items(result, prefix)
 end
 
@@ -1885,6 +1886,7 @@ end
 ---@param lines table list of lines to trim
 ---@return table trimmed list of lines
 function M.trim_empty_lines(lines)
+  vim.deprecate('vim.lsp.util.trim_empty_lines()', 'vim.split() with `trimempty`', '0.12')
   local start = 1
   for i = 1, #lines do
     if lines[i] ~= nil and #lines[i] > 0 then
@@ -1911,6 +1913,7 @@ end
 ---@param lines table list of lines
 ---@return string filetype or "markdown" if it was unchanged.
 function M.try_trim_markdown_code_blocks(lines)
+  vim.deprecate('vim.lsp.util.try_trim_markdown_code_blocks()', 'nil', '0.12')
   local language_id = lines[1]:match('^```(.*)')
   if language_id then
     local has_inner_code_fence = false

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -553,7 +553,7 @@ end
 ---@return lsp.CompletionItem[] List of completion items
 ---@see https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 function M.extract_completion_items(result)
-  vim.deprecate('vim.lsp.util.extract_completion_items()', nil, '0.11')
+  vim.deprecate('vim.lsp.util.extract_completion_items()', nil, '0.12')
   if type(result) == 'table' and result.items then
     -- result is a `CompletionList`
     return result.items
@@ -613,7 +613,7 @@ end
 ---@param input string unparsed snippet
 ---@return string parsed snippet
 function M.parse_snippet(input)
-  vim.deprecate('vim.lsp.util.parse_snippet()', nil, '0.11')
+  vim.deprecate('vim.lsp.util.parse_snippet()', nil, '0.12')
   local ok, parsed = pcall(function()
     return snippet.parse(input)
   end)
@@ -635,7 +635,7 @@ end
 ---@return table[] items
 ---@see complete-items
 function M.text_document_completion_list_to_complete_items(result, prefix)
-  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items()', nil, '0.11')
+  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items()', nil, '0.12')
   return require('vim.lsp._completion')._lsp_to_complete_items(result, prefix)
 end
 

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -37,6 +37,11 @@ end
 
 ---@deprecated
 function M.require_language(lang, path, silent, symbol_name)
+  vim.deprecate(
+    'vim.treesitter.language.require_language()',
+    'vim.treesitter.language.add()',
+    '0.12'
+  )
   local opts = {
     silent = silent,
     path = path,


### PR DESCRIPTION
- refactor: use vim.deprecate on all deprecated functions

- fix: correct versions in deprecation warnings

The following functions should be removed in 0.12 according to the
deprecation strategy in MAINTAIN.md:

- vim.lsp.util.extract_completion_items()
- vim.lsp.util.parse_snippet()
- vim.lsp.util.text_document_completion_list_to_complete_items()