### PR TITLE
vim-patch:9042bd8b09ba

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -735,6 +735,14 @@ To enable this behavior, set the following variable in your vimrc: >
 	let g:rst_style = 1
 
 
+RNOWEB							      *ft-rnoweb-plugin*
+
+The 'formatexpr' option is set dynamically with different values for R code
+and for LaTeX code. If you prefer that 'formatexpr' is not set, add to your
+|vimrc|: >
+	let rnw_dynamic_comments = 0
+
+
 RPM SPEC						*ft-spec-plugin*
 
 Since the text for this plugin is rather long it has been put in a separate

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1031,8 +1031,8 @@ r_indent_comment_column, as in the example below:
    let r_indent_comment_column = 30
 <
 Any code after a line that ends with "<-" is indented. Emacs/ESS does not
-indent the code if it is a top level function. If you prefer that the
-Vim-R-plugin behaves like Emacs/ESS in this regard, put in your |vimrc|:
+indent the code if it is a top-level function. If you prefer a behavior like
+Emacs/ESS one in this regard, put in your |vimrc|:
 >
    let r_indent_ess_compatible = 1
 <

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2801,10 +2801,20 @@ To highlight R code in knitr chunk headers: >
 	let rmd_syn_hl_chunk = 1
 
 By default, chunks of R code will be highlighted following the rules of R
-language. If you want proper syntax highlighting of chunks of other languages,
-you should add them to either `markdown_fenced_languages` or
-`rmd_fenced_languages`. For example to properly highlight both R and Python,
-you may add this to your |vimrc|: >
+language. Moreover, whenever the buffer is saved, Vim scans the buffer and
+highlights other languages if they are present in new chunks. LaTeX code also
+is automatically recognized and highlighted when the buffer is saved. This
+behavior can be controlled with the variables `rmd_dynamic_fenced_languages`,
+and `rmd_include_latex` whose valid values are: >
+	let rmd_dynamic_fenced_languages = 0 " No autodetection of languages
+	let rmd_dynamic_fenced_languages = 1 " Autodetection of languages
+	let rmd_include_latex = 0 " Don't highlight LaTeX code
+	let rmd_include_latex = 1 " Autodetect LaTeX code
+	let rmd_include_latex = 2 " Always include LaTeX highlighting
+
+If the value of `rmd_dynamic_fenced_languages` is 0, you still can set the
+list of languages whose chunks of code should be properly highlighted, as in
+the example: >
 	let rmd_fenced_languages = ['r', 'python']
 
 

--- a/runtime/indent/r.vim
+++ b/runtime/indent/r.vim
@@ -2,7 +2,7 @@
 " Language:	R
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Mon Feb 27, 2023  07:16PM
+" Last Change:	Sun Oct 08, 2023  10:45AM
 
 
 " Only load this indent file when no other was loaded.
@@ -13,6 +13,7 @@ let b:did_indent = 1
 
 setlocal indentkeys=0{,0},:,!^F,o,O,e
 setlocal indentexpr=GetRIndent()
+setlocal autoindent
 
 let b:undo_indent = "setl inde< indk<"
 
@@ -47,27 +48,23 @@ function s:RDelete_quotes(line)
       if a:line[i] == '"'
         let i += 1
       endif
-    else
+    elseif a:line[i] == "'"
+      let i += 1
+      let line1 = line1 . 's'
+      while !(a:line[i] == "'" && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
+        let i += 1
+      endwhile
       if a:line[i] == "'"
         let i += 1
-        let line1 = line1 . 's'
-        while !(a:line[i] == "'" && ((i > 1 && a:line[i-1] == '\' && a:line[i-2] == '\') || a:line[i-1] != '\')) && i < llen
-          let i += 1
-        endwhile
-        if a:line[i] == "'"
-          let i += 1
-        endif
-      else
-        if a:line[i] == "`"
-          let i += 1
-          let line1 = line1 . 's'
-          while a:line[i] != "`" && i < llen
-            let i += 1
-          endwhile
-          if a:line[i] == "`"
-            let i += 1
-          endif
-        endif
+      endif
+    elseif a:line[i] == "`"
+      let i += 1
+      let line1 = line1 . 's'
+      while a:line[i] != "`" && i < llen
+        let i += 1
+      endwhile
+      if a:line[i] == "`"
+        let i += 1
       endif
     endif
     if i == llen
@@ -97,10 +94,8 @@ function s:RDelete_parens(line)
         let i += 1
         if a:line[i] == ')'
           let nop -= 1
-        else
-          if a:line[i] == '('
-            let nop += 1
-          endif
+        elseif a:line[i] == '('
+          let nop += 1
         endif
       endwhile
       let line1 = line1 . a:line[i]
@@ -174,10 +169,8 @@ function s:Get_last_paren_idx(line, o, c, pb)
       if blc == 0
         let theidx = idx
       endif
-    else
-      if line[idx] == a:c
-        let blc += 1
-      endif
+    elseif line[idx] == a:c
+      let blc += 1
     endif
     let idx += 1
   endwhile
@@ -316,6 +309,11 @@ function GetRIndent()
     endif
 
     if pb < 0 && line =~ '.*[,&|\-\*+<>]$'
+      if line =~ '.*[\-\*+>]$'
+        let is_op = v:true
+      else
+        let is_op = v:false
+      endif
       let lnum = s:Get_prev_line(lnum)
       while pb < 1 && lnum > 0
         let line = SanitizeRLine(getline(lnum))
@@ -324,9 +322,10 @@ function GetRIndent()
         while ind > 0
           if line[ind] == ')'
             let pb -= 1
-          else
-            if line[ind] == '('
-              let pb += 1
+          elseif line[ind] == '('
+            let pb += 1
+            if is_op && pb == 0
+              return indent(lnum)
             endif
           endif
           if pb == 1
@@ -367,10 +366,8 @@ function GetRIndent()
       else
         return indent(lnum) + shiftwidth()
       endif
-    else
-      if substitute(oline, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
-        return indent(lnum) - shiftwidth()
-      endif
+    elseif substitute(oline, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
+      return indent(lnum) - shiftwidth()
     endif
   elseif substitute(line, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
     return indent(lnum) + shiftwidth()
@@ -404,12 +401,10 @@ function GetRIndent()
   if cline =~ '^\s*else'
     if line =~ '<-\s*if\s*()'
       return indent(lnum) + shiftwidth()
+    elseif line =~ '\<if\s*()'
+      return indent(lnum)
     else
-      if line =~ '\<if\s*()'
-        return indent(lnum)
-      else
-        return indent(lnum) - shiftwidth()
-      endif
+      return indent(lnum) - shiftwidth()
     endif
   endif
 

--- a/runtime/syntax/r.vim
+++ b/runtime/syntax/r.vim
@@ -5,7 +5,7 @@
 " 		      Tom Payne <tom@tompayne.org>
 " Contributor:        Johannes Ranke <jranke@uni-bremen.de>
 " Homepage:           https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	      Thu Nov 17, 2022  10:13PM
+" Last Change:	      Sun Dec 24, 2023  08:05AM
 " Filenames:	      *.R *.r *.Rhistory *.Rt
 "
 " NOTE: The highlighting of R functions might be defined in
@@ -26,11 +26,7 @@ if exists("b:current_syntax")
   finish
 endif
 
-if has("patch-7.4.1142")
-  syn iskeyword @,48-57,_,.
-else
-  setlocal iskeyword=@,48-57,_,.
-endif
+syn iskeyword @,48-57,_,.
 
 " The variables g:r_hl_roxygen and g:r_syn_minlines were renamed on April 8, 2017.
 if exists("g:r_hl_roxygen")

--- a/runtime/syntax/rmd.vim
+++ b/runtime/syntax/rmd.vim
@@ -1,7 +1,7 @@
 " Language: Markdown with chunks of R, Python and other languages
 " Maintainer: Jakson Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change: Wed May 17, 2023  06:34AM
+" Last Change: Sun Dec 24, 2023  07:21AM
 "
 "   For highlighting pandoc extensions to markdown like citations and TeX and
 "   many other advanced features like folding of markdown sections, it is
@@ -15,6 +15,13 @@ endif
 
 let s:cpo_save = &cpo
 set cpo&vim
+
+let g:rmd_include_latex = get(g:, 'rmd_include_latex', 1)
+if g:rmd_include_latex == 0 || g:rmd_include_latex == 1
+  let b:rmd_has_LaTeX = v:false
+elseif g:rmd_include_latex == 2
+  let b:rmd_has_LaTeX = v:true
+endif
 
 " Highlight the header of the chunks as R code
 let g:rmd_syn_hl_chunk = get(g:, 'rmd_syn_hl_chunk', 0)
@@ -136,7 +143,7 @@ syn match knitrBodyVar '| \zs\S\{-}\ze:' contained containedin=knitrBodyOptions
 let g:rmd_fenced_languages = get(g:, 'rmd_fenced_languages', ['r'])
 
 let s:no_syntax_vim = []
-function IncludeLanguage(lng)
+function s:IncludeLanguage(lng)
   if a:lng =~ '='
     let ftpy = substitute(a:lng, '.*=', '', '')
     let lnm = substitute(a:lng, '=.*', '', '')
@@ -171,11 +178,23 @@ function IncludeLanguage(lng)
 endfunction
 
 for s:type in g:rmd_fenced_languages
-  call IncludeLanguage(s:type)
+  call s:IncludeLanguage(s:type)
 endfor
 unlet! s:type
 
-function CheckRmdFencedLanguages()
+let s:LaTeX_included = v:false
+function s:IncludeLaTeX()
+  let s:LaTeX_included = v:true
+  unlet! b:current_syntax
+  syn include @RmdLaTeX syntax/tex.vim
+  " From vim-pandoc-syntax
+  syn region rmdLaTeXInlineMath start=/\v\\@<!\$\S@=/ end=/\v\\@<!\$\d@!/ keepend contains=@RmdLaTeX
+  syn match rmdLaTeXCmd /\\[[:alpha:]]\+\(\({.\{-}}\)\=\(\[.\{-}\]\)\=\)*/ contains=@RmdLaTeX
+  syn region rmdLaTeX start='\$\$'  end='\$\$' keepend contains=@RmdLaTeX
+  syn region rmdLaTeX start=/\\begin{\z(.\{-}\)}/ end=/\\end{\z1}/ keepend contains=@RmdLaTeX
+endfunction
+
+function s:CheckRmdFencedLanguages()
   let alines = getline(1, '$')
   call filter(alines, "v:val =~ '^```{'")
   call map(alines, "substitute(v:val, '^```{', '', '')")
@@ -193,16 +212,31 @@ function CheckRmdFencedLanguages()
     endfor
     if has_lng == 0
       let g:rmd_fenced_languages += [tpy]
-      call IncludeLanguage(tpy)
+      call s:IncludeLanguage(tpy)
     endif
   endfor
+
+  if hlexists('pandocLaTeXCommand')
+    return
+  endif
+  if g:rmd_include_latex
+    if !b:rmd_has_LaTeX && (search('\$\$', 'wn') > 0 ||
+          \ search('\\begin{', 'wn') > 0) ||
+          \ search('\\[[:alpha:]]\+', 'wn') ||
+          \ search('\$[^\$]\+\$', 'wn')
+      let b:rmd_has_LaTeX = v:true
+    endif
+    if b:rmd_has_LaTeX && !s:LaTeX_included
+      call s:IncludeLaTeX()
+    endif
+  endif
 endfunction
 
 if g:rmd_dynamic_fenced_languages
-  call CheckRmdFencedLanguages()
+  call s:CheckRmdFencedLanguages()
   augroup RmdSyntax
     autocmd!
-    autocmd BufWritePost <buffer> call CheckRmdFencedLanguages()
+    autocmd BufWritePost <buffer> call s:CheckRmdFencedLanguages()
   augroup END
 endif
 
@@ -224,6 +258,8 @@ endif
 unlet s:save_pandoc_lngs
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+syntax iskeyword clear
 
 let b:current_syntax = "rmd"
 


### PR DESCRIPTION
runtime(r): Update R runtime files and docs (vim/vim#13757)

* Update R runtime files
- Fix indentation issue with ggplot().
- Setlocal autoindent in indent/r.vim.
- New syntax option: rmd_include_latex.
- Clear syn iskeyword to recognize _ as keyword.
- Document some options.
- remove the test has("patch-7.4.1142")
- Update changed date of doc files

https://github.com/vim/vim/commit/9042bd8b09bae0051fdf8eb5a57fa4b4420c92a0

Co-authored-by: Jakson Alves de Aquino <jalvesaq@gmail.com>
