### PR TITLE
ci: remove winget workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,33 +204,3 @@ jobs:
             gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos/* nvim-linux64/* appimage/* nvim-win64/*
           fi
           gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos/* nvim-linux64/* appimage/* nvim-win64/*
-
-  publish-winget:
-    needs: publish
-    runs-on: windows-latest
-    steps:
-      - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
-        name: Publish stable
-        uses: vedantmgoyal2009/winget-releaser@v2
-        with:
-          identifier: Neovim.Neovim
-          release-tag: ${{ github.event.inputs.tag_name || github.ref_name }}
-          token: ${{ secrets.WINGET_TOKEN }}
-      - name: Fetch nightly build msi from previous job
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
-        uses: actions/download-artifact@v3
-      - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
-        name: Get version from nightly build msi
-        id: get-version
-        run: |
-          Install-Module -Name 'Carbon.Windows.Installer' -Force
-          $VERSION = (Get-CMsi (Resolve-Path .\nvim-win64\nvim-win64.msi).Path).ProductVersion
-          "version=$VERSION" >> $env:GITHUB_OUTPUT
-      - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
-        name: Publish nightly
-        uses: vedantmgoyal2009/winget-releaser@v2
-        with:
-          identifier: Neovim.Neovim.Nightly
-          version: ${{ steps.get-version.outputs.version }}
-          release-tag: nightly
-          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
All releases that aren't directly maintained by us should live in the `neovim/neovim-releases` repository to make it clear that neovim isn't directly responsible for it and to correctly manage expectations that it's provided on a best-effort case.

Closes https://github.com/neovim/neovim/issues/26717.