### PR TITLE
Minor documentation fixes

### DIFF
--- a/runtime/doc/luaref.txt
+++ b/runtime/doc/luaref.txt
@@ -4811,7 +4811,7 @@ debug.setupvalue({func}, {up}, {value})                     *debug.setupvalue()*
         upvalue with the given index. Otherwise, it returns the name of the
         upvalue.
 
-debug.traceback([{thread},] [{message}] [,{level}])          *debug.traceback()*
+debug.traceback([{thread},] [{message} [,{level}]])          *debug.traceback()*
         Returns a string with a traceback of the call stack. An optional
         {message} string is appended at the beginning of the traceback. An
         optional {level} number tells at which level to start the traceback


### PR DESCRIPTION
This PR fixes a function signature in the Lua reference manual, and trims
overhanging lines in the Treesitter manual.  I have made two separate commits
in case you want them separate and possible to revert, but I can also squash
them if you want me to.
