### PR TITLE
docs(api): remove extra ')}' from vim.api.nvim_open_win() Lua snippet

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3110,7 +3110,6 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
     Example (Lua): buffer-relative float (travels as buffer is scrolled) >lua
         vim.api.nvim_open_win(0, false,
           {relative='win', width=12, height=3, bufpos={100,10}})
-        })
 <
 
     Attributes: ~

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1493,7 +1493,6 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- ```lua
 ---     vim.api.nvim_open_win(0, false,
 ---       {relative='win', width=12, height=3, bufpos={100,10}})
----     })
 --- ```
 ---
 --- @param buffer integer Buffer to display, or 0 for current buffer

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -68,7 +68,6 @@
 /// ```lua
 /// vim.api.nvim_open_win(0, false,
 ///   {relative='win', width=12, height=3, bufpos={100,10}})
-/// })
 /// ```
 ///
 /// @param buffer Buffer to display, or 0 for current buffer


### PR DESCRIPTION
While reading the docs I noticed what looked like an extra right brace and parenthesis in one of `vim.api.nvim_open_win()`'s example Lua snippets. This PR just deletes the associated line.

Apologies if I misread and the example is correct as is. 

Edit: I didn't realize the docs were generated and ended up making the fix in the wrong file. Sorry for the mess!