### PR TITLE
revert: "fix: correct versions in deprecation warnings"

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -553,7 +553,7 @@ end
 ---@return lsp.CompletionItem[] List of completion items
 ---@see https://microsoft.github.io/language-server-protocol/specification#textDocument_completion
 function M.extract_completion_items(result)
-  vim.deprecate('vim.lsp.util.extract_completion_items()', nil, '0.12')
+  vim.deprecate('vim.lsp.util.extract_completion_items()', nil, '0.11')
   if type(result) == 'table' and result.items then
     -- result is a `CompletionList`
     return result.items
@@ -613,7 +613,7 @@ end
 ---@param input string unparsed snippet
 ---@return string parsed snippet
 function M.parse_snippet(input)
-  vim.deprecate('vim.lsp.util.parse_snippet()', nil, '0.12')
+  vim.deprecate('vim.lsp.util.parse_snippet()', nil, '0.11')
   local ok, parsed = pcall(function()
     return snippet.parse(input)
   end)
@@ -635,7 +635,7 @@ end
 ---@return table[] items
 ---@see complete-items
 function M.text_document_completion_list_to_complete_items(result, prefix)
-  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items()', nil, '0.12')
+  vim.deprecate('vim.lsp.util.text_document_completion_list_to_complete_items()', nil, '0.11')
   return require('vim.lsp._completion')._lsp_to_complete_items(result, prefix)
 end
 


### PR DESCRIPTION
This reverts commit 5cb906e91cb56302d0737aa80e2d890dde452029.

They were intentionally fast-tracked.

- `parse_snippet()` because of limited scope, and given that it's kinda
  semi-broken (arbitrary formatting rules, not that useful for what it
  was used for)
- `extract_completion_items()` doesn't work if we want to add the LSP
  completionlist capability
- `text_document_completion_list_to_complete_items()` also doesn't work
  for completionlist
