### PR TITLE
docs: convert BACKERS.md to backers.txt

### DIFF
--- a/runtime/doc/backers.txt
+++ b/runtime/doc/backers.txt
@@ -1,8 +1,15 @@
-# Bountysource Backers
+*backers.txt*          Nvim
 
-Thank you to everyone who backed our [Bountysource fundraiser](https://www.bountysource.com/teams/neovim/fundraiser)!
 
-### Your name and URL in BACKERS.md.
+                     NVIM REFERENCE MANUAL
+
+
+==============================================================================
+Fundraiser Backers
+
+Thank you to everyone who backed the original Neovim Fundraiser.
+
+LIST OF BACKERS
 
 - [Bob Breznak](http://brez.io)
 - [Tim Uruski](http://timuruski.net)
@@ -223,7 +230,7 @@ Thank you to everyone who backed our [Bountysource fundraiser](https://www.bount
 - BenBergman
 - Bengt Lüers
 - Benjamin Bryant
-- Bèr 'berkes' Kessels
+- Bèr "berkes" Kessels
 - Bernd Homuth
 - Bheesham Persaud
 - Bilal Quadri
@@ -459,7 +466,7 @@ Thank you to everyone who backed our [Bountysource fundraiser](https://www.bount
 - Matthias Lehmann
 - Maximilian Gerlach
 - Meryn Stol
-- Michael 'manveru' Fellinger
+- Michael "manveru" Fellinger
 - Michael "beefsack" Alexander
 - Michael Iles
 - Michael Irwin/mdi
@@ -641,6 +648,9 @@ Thank you to everyone who backed our [Bountysource fundraiser](https://www.bount
 - Ziling Zhao
 - Zsolt Botykai
 
-### Anonymous Supporters
+ANONYMOUS SUPPORTERS
 
-There were also 307 other people who didn't claim any level of reward but contributed to the fundraiser. Thank you all for the support!
+There were also 307 other people who didn't claim any level of reward but
+contributed to the fundraiser. Thank you all for the support!
+
+vim:tw=78:ts=8:et:ft=help:norl:

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -37,6 +37,9 @@ local spell_dict = {
   vimL = 'Vimscript',
   viml = 'Vimscript',
 }
+local spell_ignore_files = {
+  ['backers.txt'] = 'true',
+}
 local language = nil
 
 local M = {}
@@ -86,6 +89,7 @@ local exclude_invalid_urls = {
 -- Deprecated, brain-damaged files that I don't care about.
 local ignore_errors = {
   ['pi_netrw.txt'] = true,
+  ['backers.txt'] = true,
 }
 
 local function tofile(fname, text)
@@ -386,9 +390,10 @@ local function visit_validate(root, level, lang_tree, opt, stats)
     and (not vim.tbl_contains({ 'codespan', 'taglink', 'tag' }, parent))
   then
     local text_nopunct = vim.fn.trim(text, '.,', 0) -- Ignore some punctuation.
-    if spell_dict[text_nopunct] then
+    local fname_basename = assert(vim.fs.basename(opt.fname))
+    if spell_dict[text_nopunct] and not spell_ignore_files[fname_basename] then
       invalid_spelling[text_nopunct] = invalid_spelling[text_nopunct] or {}
-      invalid_spelling[text_nopunct][vim.fs.basename(opt.fname)] = node_text(root:parent())
+      invalid_spelling[text_nopunct][fname_basename] = node_text(root:parent())
     end
   elseif node_name == 'url' then
     local fixed_url, _ = fix_url(trim(text))

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -895,18 +895,18 @@ describe('completion', function()
 
   it("'ignorecase' 'infercase' CTRL-X CTRL-N #6451", function()
     feed_command('set ignorecase infercase')
-    feed_command('edit BACKERS.md')
+    feed_command('edit runtime/doc/backers.txt')
     feed('oX<C-X><C-N>')
-    screen:expect([[
-      # Bountysource Backers                                      |
+    screen:expect{grid=[[
+      *backers.txt*          Nvim                                 |
       Xnull^                                                       |
       {2:Xnull          }{6: }                                            |
-      {1:Xoxomoon       }{6: }ryone who backed our [Bountysource fundraise|
-      {1:Xu             }{6: }ountysource.com/teams/neovim/fundraiser)!   |
+      {1:Xoxomoon       }{6: }                                            |
+      {1:Xu             }{6: }     NVIM REFERENCE MANUAL                  |
       {1:Xpayn          }{2: }                                            |
-      {1:Xinity         }{2: }d URL in BACKERS.md.                        |
+      {1:Xinity         }{2: }                                            |
       {3:-- Keyword Local completion (^N^P) }{4:match 1 of 7}             |
-    ]])
+    ]]}
   end)
 
   it('CompleteChanged autocommand', function()


### PR DESCRIPTION
There is no reason for this file to be in project root, which is crowded
as is. This also fits nicely part of the ongoing work towards gathering
as much of the documentation as possible into one place.
