### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -1,7 +1,7 @@
 " Elixir filetype plugin
 " Language: Elixir
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
-" Last Change: 2022 Sep 20
+" Last Change: 2023 Dec 26
 
 if exists("b:did_ftplugin")
   finish
@@ -26,6 +26,12 @@ endif
 setlocal shiftwidth=2 softtabstop=2 expandtab iskeyword+=!,?
 setlocal comments=:#
 setlocal commentstring=#\ %s
+
+setlocal indentkeys=0#,!^F,o,O
+" Enable keys for blocks
+setlocal indentkeys+=0=after,0=catch,0=do,0=else,0=end,0=rescue
+" Enable keys that are usually the first keys in a line
+setlocal indentkeys+=0->,0\|>,0},0],0),>
 
 let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms<'
 

--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -1,7 +1,7 @@
 " Elixir filetype plugin
 " Language: Elixir
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
-" Last Change: 2023 Dec 26
+" Last Change: 2023 Dec 27
 
 if exists("b:did_ftplugin")
   finish
@@ -33,7 +33,7 @@ setlocal indentkeys+=0=after,0=catch,0=do,0=else,0=end,0=rescue
 " Enable keys that are usually the first keys in a line
 setlocal indentkeys+=0->,0\|>,0},0],0),>
 
-let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms<'
+let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms< indk<'
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -378,9 +378,9 @@ hi def link diffBDiffer		Constant
 hi def link diffIsA		Constant
 hi def link diffNoEOL		Constant
 hi def link diffCommon		Constant
-hi def link diffRemoved		Special
-hi def link diffChanged		PreProc
-hi def link diffAdded		Identifier
+hi def link diffRemoved		DiffDelete
+hi def link diffChanged		DiffChange
+hi def link diffAdded		DiffAdd
 hi def link diffLine		Statement
 hi def link diffSubname		PreProc
 hi def link diffComment		Comment

--- a/runtime/syntax/mermaid.vim
+++ b/runtime/syntax/mermaid.vim
@@ -2,7 +2,7 @@
 " Language:     Mermaid
 " Maintainer:   Craig MacEahern <https://github.com/craigmac/vim-mermaid>
 " Filenames:    *.mmd
-" Last Change:  2022 Nov 22
+" Last Change:  2023 Dec 26
 
 if exists("b:current_syntax")
   finish
@@ -85,54 +85,30 @@ syntax keyword mermaidKeyword
 highlight link mermaidKeyword Keyword
 
 syntax match mermaidStatement "|"
-syntax match mermaidStatement "--\?[>x)]>\?+\?-\?"
 syntax match mermaidStatement "\~\~\~"
 syntax match mermaidStatement "--"
-syntax match mermaidStatement "---"
-syntax match mermaidStatement "-->"
+syntax match mermaidStatement "\%(<|\|[<*o]\)\?\%(--\|\.\.\)\%(|>\|[>*o]\)\?"
+syntax match mermaidStatement "-\{2,4}[>ox-]"
+syntax match mermaidStatement "\.-[>ox]"
 syntax match mermaidStatement "-\."
-syntax match mermaidStatement "\.->"
-syntax match mermaidStatement "-\.-"
-syntax match mermaidStatement "-\.\.-"
-syntax match mermaidStatement "-\.\.\.-"
+syntax match mermaidStatement "-\.\{1,3}-"
 syntax match mermaidStatement "=="
-syntax match mermaidStatement "==>"
-syntax match mermaidStatement "===>"
-syntax match mermaidStatement "====>"
+syntax match mermaidStatement "=\{2,4}[>ox=]"
 syntax match mermaidStatement "&"
-syntax match mermaidStatement "--o"
-syntax match mermaidStatement "--x"
+syntax match mermaidStatement "--\?[>x)]>\?[+-]\?"
 syntax match mermaidStatement "x--x"
-syntax match mermaidStatement "-----"
-syntax match mermaidStatement "---->"
-syntax match mermaidStatement "==="
-syntax match mermaidStatement "===="
-syntax match mermaidStatement "====="
+syntax match mermaidStatement "o--o\?"
+syntax match mermaidStatement "<-->\?"
 syntax match mermaidStatement ":::"
-syntax match mermaidStatement "<|--"
-syntax match mermaidStatement "\*--"
-syntax match mermaidStatement "o--"
-syntax match mermaidStatement "o--o"
-syntax match mermaidStatement "<--"
-syntax match mermaidStatement "<-->"
-syntax match mermaidStatement "\.\."
-syntax match mermaidStatement "<\.\."
-syntax match mermaidStatement "<|\.\."
-syntax match mermaidStatement "--|>"
-syntax match mermaidStatement "--\*"
-syntax match mermaidStatement "--o"
-syntax match mermaidStatement "\.\.>"
-syntax match mermaidStatement "\.\.|>"
-syntax match mermaidStatement "<|--|>"
 syntax match mermaidStatement "||--o{"
 highlight link mermaidStatement Statement
 
-syntax match mermaidIdentifier "[\+-]\?\w\+(.*)[\$\*]\?"
-highlight link mermaidIdentifier Identifier
+" FIXME: This unexpectedly matches flow chart node `id1(text)` or others.
+"syntax match mermaidIdentifier "[\+-]\?\w\+(.*)[\$\*]\?"
+"highlight link mermaidIdentifier Identifier
 
-syntax match mermaidType "[\+-\#\~]\?\cint\>"
-syntax match mermaidType "[\+-\#\~]\?\cString\>"
-syntax match mermaidType "[\+-\#\~]\?\cbool\>"
+syntax match mermaidType "[\+-\#\~]\?\c\%(const\s\+\|\*\s*\)*\%(unsigned\s\+\)\?\%(int\|u\?int\%(8\|16\|32\|64\)_t\|char\|long\|long\s\+long\)\>\%(\s\+const\|\s*[\*&]\)*"
+syntax match mermaidType "[\+-\#\~]\?\c\%(const\s\+\|\*\s*\)*\%(double\|float\|String\|bool\)\>\%(\s\+const\|\s*[\*&]\)*"
 syntax match mermaidType "[\+-\#\~]\?\cBigDecimal\>"
 syntax match mermaidType "[\+-\#\~]\?\cList\~.\+\~"
 syntax match mermaidType "<<\w\+>>"


### PR DESCRIPTION
runtime(diff): Update default links (vim/vim#13776)

Problem: Current default links for `diffAdded`, `diffChanged`, and
              `diffRemoved` do not address the diff nature of the filetype.
Solution: Use `DiffAdd`, `DiffChange`, and `DiffDelete`.

closes: vim/vim#13759

https://github.com/vim/vim/commit/00b470052b71ca10d663186d99683e8379b21154

Co-authored-by: Evgeni Chasnovski <evgeni.chasnovski@gmail.com>
