### PR TITLE
vim-patch:9.0.2187: Visual not drawn with 'breakindent' when line doesn't fit

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -691,11 +691,7 @@ static void handle_breakindent(win_T *wp, winlinevars_T *wlv)
       }
     }
 
-    // Correct end of highlighted area for 'breakindent',
-    // required wen 'linebreak' is also set.
-    if (wlv->tocol == wlv->vcol) {
-      wlv->tocol += num;
-    }
+    colnr_T vcol_before = wlv->vcol;
 
     for (int i = 0; i < num; i++) {
       linebuf_char[wlv->off] = schar_from_ascii(' ');
@@ -708,6 +704,17 @@ static void handle_breakindent(win_T *wp, winlinevars_T *wlv)
       linebuf_attr[wlv->off] = myattr;
       linebuf_vcol[wlv->off] = wlv->vcol++;  // These are vcols, sorry I don't make the rules
       wlv->off++;
+    }
+
+    // Correct start of highlighted area for 'breakindent',
+    if (wlv->fromcol >= vcol_before && wlv->fromcol < wlv->vcol) {
+      wlv->fromcol = wlv->vcol;
+    }
+
+    // Correct end of highlighted area for 'breakindent',
+    // required wen 'linebreak' is also set.
+    if (wlv->tocol == vcol_before) {
+      wlv->tocol = wlv->vcol;
     }
 
     if (wp->w_skipcol > 0 && wlv->startrow == 0 && wp->w_p_wrap && wp->w_briopt_sbr) {
@@ -737,13 +744,13 @@ static void handle_showbreak_and_filler(win_T *wp, winlinevars_T *wlv)
     }
     // Combine 'showbreak' with 'cursorline', prioritizing 'showbreak'.
     int attr = hl_combine_attr(wlv->cul_attr, win_hl_attr(wp, HLF_AT));
-    int vcol_before = wlv->vcol;
+    colnr_T vcol_before = wlv->vcol;
     draw_col_buf(wp, wlv, sbr, strlen(sbr), attr, true);
     wlv->vcol_sbr = wlv->vcol;
 
     // Correct start of highlighted area for 'showbreak'.
-    if (wlv->fromcol >= vcol_before && wlv->fromcol < wlv->vcol_sbr) {
-      wlv->fromcol = wlv->vcol_sbr;
+    if (wlv->fromcol >= vcol_before && wlv->fromcol < wlv->vcol) {
+      wlv->fromcol = wlv->vcol;
     }
 
     // Correct end of highlighted area for 'showbreak',

--- a/test/functional/legacy/breakindent_spec.lua
+++ b/test/functional/legacy/breakindent_spec.lua
@@ -26,6 +26,7 @@ describe('breakindent', function()
       eval repeat('x', &columns - leftcol - 1)->setline(1)
       eval 'second line'->setline(2)
     ]])
+
     feed('AX')
     screen:expect([[
       {1:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX|
@@ -41,20 +42,75 @@ describe('breakindent', function()
     screen:expect_unchanged()
     -- The first line now wraps because of "eol" in 'listchars'.
     command('setlocal list')
-    screen:expect{grid=[[
+    screen:expect([[
       {1:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX|
       {1:  }  {0:+^$}                                                                     |
       {1:  }second line{0:$}                                                             |
       {0:~                                                                          }|*2
       {2:-- INSERT --}                                                               |
-    ]]}
+    ]])
     command('setlocal nobreakindent')
-    screen:expect{grid=[[
+    screen:expect([[
       {1:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX|
       {1:  }{0:+^$}                                                                       |
       {1:  }second line{0:$}                                                             |
       {0:~                                                                          }|*2
       {2:-- INSERT --}                                                               |
-    ]]}
+    ]])
+  end)
+
+  -- oldtest: Test_visual_starts_before_skipcol()
+  it('Visual selection that starts before skipcol shows correctly', function()
+    local screen = Screen.new(75, 6)
+    exec([[
+      1new
+      setlocal breakindent
+      call setline(1, "\t" .. join(range(100)))
+    ]])
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.LightGrey},  -- Visual
+      [2] = {bold = true, reverse = true},  -- StatusLine
+      [3] = {reverse = true},  -- StatusLineNC
+      [4] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+
+    feed('v$')
+    screen:expect([[
+      {0:<<<}     {1: 93 94 95 96 97 98 99}^                                              |
+      {2:[No Name] [+]                                                              }|
+                                                                                 |
+      {0:~                                                                          }|
+      {3:[No Name]                                                                  }|
+      {4:-- VISUAL --}                                                               |
+    ]])
+    command('setlocal showbreak=+++')
+    screen:expect([[
+              {0:+++}{1: 90 91 92 93 94 95 96 97 98 99}^                                  |
+      {2:[No Name] [+]                                                              }|
+                                                                                 |
+      {0:~                                                                          }|
+      {3:[No Name]                                                                  }|
+      {4:-- VISUAL --}                                                               |
+    ]])
+    command('setlocal breakindentopt+=sbr')
+    screen:expect([[
+      {0:+++}     {1: 93 94 95 96 97 98 99}^                                              |
+      {2:[No Name] [+]                                                              }|
+                                                                                 |
+      {0:~                                                                          }|
+      {3:[No Name]                                                                  }|
+      {4:-- VISUAL --}                                                               |
+    ]])
+    command('setlocal nobreakindent')
+    screen:expect([[
+      {0:+++}{1: 98 99}^                                                                  |
+      {2:[No Name] [+]                                                              }|
+                                                                                 |
+      {0:~                                                                          }|
+      {3:[No Name]                                                                  }|
+      {4:-- VISUAL --}                                                               |
+    ]])
   end)
 end)

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -963,6 +963,29 @@ func Test_cursor_position_with_showbreak()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_visual_starts_before_skipcol()
+  CheckScreendump
+
+  let lines =<< trim END
+    1new
+    setlocal breakindent
+    call setline(1, "\t" .. join(range(100)))
+  END
+  call writefile(lines, 'XvisualStartsBeforeSkipcol', 'D')
+  let buf = RunVimInTerminal('-S XvisualStartsBeforeSkipcol', #{rows: 6})
+
+  call term_sendkeys(buf, "v$")
+  call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_1', {})
+  call term_sendkeys(buf, "\<Esc>:setlocal showbreak=+++\<CR>gv")
+  call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_2', {})
+  call term_sendkeys(buf, "\<Esc>:setlocal breakindentopt+=sbr\<CR>gv")
+  call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_3', {})
+  call term_sendkeys(buf, "\<Esc>:setlocal nobreakindent\<CR>gv")
+  call VerifyScreenDump(buf, 'Test_visual_starts_before_skipcol_4', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_no_spurious_match()
   let s:input = printf('- y %s y %s', repeat('x', 50), repeat('x', 50))
   call s:test_windows('setl breakindent breakindentopt=list:-1 formatlistpat=^- hls')


### PR DESCRIPTION
#### vim-patch:9.0.2187: Visual not drawn with 'breakindent' when line doesn't fit

Problem:  Visual selection isn't drawn with 'breakindent' when the line
          doesn't fit in the window (Jaehwang Jung)
Solution: Adjust wlv->fromcol also for 'breakindent' (zeertzjq)

closes: vim/vim#13768

https://github.com/vim/vim/commit/23627722d36b49e38ba6f8dc6bb3ebe19c98a83b