### PR TITLE
vim-patch:9.0.2188: cursor wrong after { in single line buffer

### DIFF
--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -213,7 +213,7 @@ bool findpar(bool *pincl, int dir, int count, int what, bool both)
     curr++;
   }
   curwin->w_cursor.lnum = curr;
-  if (curr == curbuf->b_ml.ml_line_count && what != '}') {
+  if (curr == curbuf->b_ml.ml_line_count && what != '}' && dir == FORWARD) {
     char *line = ml_get(curr);
 
     // Put the cursor on the last character in the last line and make the

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4169,4 +4169,21 @@ func Test_normal34_zet_large()
   norm! z9765405999999999999
 endfunc
 
+" Test for { and } paragraph movements in a single line
+func Test_brace_single_line()
+  let text =<< trim [DATA]
+    foobar one two three
+  [DATA]
+
+  new
+  call setline(1, text)
+  1
+  norm! 0}
+
+  call assert_equal([0, 1, 20, 0], getpos('.'))
+  norm! {
+  call assert_equal([0, 1, 1, 0], getpos('.'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2188: cursor wrong after { in single line buffer

Problem:  cursor wrong after { in single line buffer
          (Edwin Chan)
Solution: do not place the cursor at the end for a single
          line buffer when moving backwards
          (Gary Johnson)

closes: vim/vim#13783

https://github.com/vim/vim/commit/9e6549d2fb282c45a2492ea95fe7ba54c2082c3e

Co-authored-by: Gary Johnson <garyjohn@spocom.com>