### PR TITLE
vim-patch:65672ae1189e

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1292,14 +1292,12 @@ bring you back to the switch statement.
 ]m			Go to [count] next start of a method (for Java or
 			similar structured language).  When not before the
 			start of a method, jump to the start or end of the
-			class.  When no '{' is found after the cursor, this is
-			an error.  |exclusive| motion.
+			class.  |exclusive| motion.
 						*]M*
 ]M			Go to [count] next end of a method (for Java or
 			similar structured language).  When not before the end
 			of a method, jump to the start or end of the class.
-			When no '}' is found after the cursor, this is an
-			error. |exclusive| motion.
+			|exclusive| motion.
 						*[m*
 [m			Go to [count] previous start of a method (for Java or
 			similar structured language).  When not after the


### PR DESCRIPTION
#### vim-patch:65672ae1189e

runtime(doc): clarify behaviour of ]m and ]M motions

In particular remove the sentence, that a missing '{'
(for ]m) or '}' (for ]M) after the cursor is an error, since
currently this is not treated as an error.

https://github.com/vim/vim/commit/65672ae1189e0638fb68856598b98a2b7ee2a0a8

Co-authored-by: Christian Brabandt <cb@256bit.org>