### PR TITLE
docs: add parameter type for vim.fn.mode()

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -5829,8 +5829,9 @@ function vim.fn.mkdir(name, flags, prot) end
 --- the leading character(s).
 --- Also see |visualmode()|.
 ---
+--- @param expr? any
 --- @return any
-function vim.fn.mode() end
+function vim.fn.mode(expr) end
 
 --- Convert a list of Vimscript objects to msgpack. Returned value is a
 --- |readfile()|-style list. When {type} contains "B", a |Blob| is

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7057,7 +7057,7 @@ M.funcs = {
 
     ]=],
     name = 'mode',
-    params = {},
+    params = { { 'expr', 'any' } },
     signature = 'mode([expr])',
   },
   msgpackdump = {


### PR DESCRIPTION
According to what `:h mode()` says, we can optionally assign a expr parameter in case that we want to get the full string of result. due to the missing parameter type for this function, we get a lsp warning when we call it with a parameter.