### PR TITLE
docs(developer): cleanup malformed providers C functions

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -103,7 +103,7 @@ The provider framework invokes Vimscript from C.  It is composed of two
 functions in eval.c:
 
 - eval_call_provider({name}, {method}, {arguments}, {discard}): Calls
-  provider {name} with {method} and {arguments}. If {discard} is true, any
+  `provider#{name}#Call` with {method} and {arguments}. If {discard} is true, any
   value returned by the provider will be discarded and empty value will be
   returned.
 - eval_has_provider({name}): Checks the `g:loaded_{name}_provider` variable

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -102,7 +102,7 @@ Examples:
 The provider framework invokes Vimscript from C.  It is composed of two
 functions in eval.c:
 
-- eval_call_provider({name}, {method}, {arguments}, {discard}): Calls 
+- eval_call_provider({name}, {method}, {arguments}, {discard}): Calls
   provider {name} with {method} and {arguments}. If {discard} is true, any
   value returned by the provider will be discarded and empty value will be
   returned.

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -102,11 +102,11 @@ Examples:
 The provider framework invokes Vimscript from C.  It is composed of two
 functions in eval.c:
 
-- eval_call_provider(name, method, arguments, discard): calls
-  provider#{name}#Call with the method and arguments. If discard is true, any
+- eval_call_provider({name}, {method}, {arguments}, {discard}): Calls 
+  provider {name} with {method} and {arguments}. If {discard} is true, any
   value returned by the provider will be discarded and empty value will be
   returned.
-- eval_has_provider(name): Checks the `g:loaded_{name}_provider` variable
+- eval_has_provider({name}): Checks the `g:loaded_{name}_provider` variable
   which must be set to 2 by the provider script to indicate that it is
   "enabled and working". Called by |has()| to check if features are available.
 


### PR DESCRIPTION
Problem: this part of the  doc shows up weird on https://neovim.io/doc/user/develop.html
![image](https://github.com/neovim/neovim/assets/46619169/bd6b40c1-12e7-473b-95ae-e5bfa6b5bbc3)
Solution: fix the malformed part, add bracket wrapping for parameters 