### PR TITLE
refactor(gen_vimdoc): general refactoring on vimdoc generation

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -73,6 +73,9 @@ function vim.api.nvim__id_dictionary(dct) end
 function vim.api.nvim__id_float(flt) end
 
 --- @private
+--- NB: if your UI doesn't use hlstate, this will not return hlstate first
+--- time.
+---
 --- @param grid integer
 --- @param row integer
 --- @param col integer

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1069,7 +1069,7 @@ function M.show_document(location, offset_encoding, opts)
   -- location may be Location or LocationLink
   local range = location.range or location.targetSelectionRange
   if range then
-    --- Jump to new location (adjusting for encoding of characters)
+    -- Jump to new location (adjusting for encoding of characters)
     local row = range.start.line
     local col = get_line_byte_from_position(bufnr, range.start, offset_encoding)
     api.nvim_win_set_cursor(win, { row + 1, col })

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -579,7 +579,7 @@ function vim.tbl_isarray(t)
   local count = 0
 
   for k, _ in pairs(t) do
-    --- Check if the number k is an integer
+    -- Check if the number k is an integer
     if type(k) == 'number' and k == math.floor(k) then
       count = count + 1
     else

--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -1,4 +1,4 @@
---- Text processing functions.
+-- Text processing functions.
 
 local M = {}
 


### PR DESCRIPTION
**Problem**: gen_vimdoc.py is too difficult to read. 
**Solution**: Do some refactoring. More comments and examples. Benefit from static typing, intellisense, and better readability. 

This PR consists of several (meaningful) commits which would allow reviewers to better and easily keep track of what's being changed. Tested: the generated vim docs and msgpack data are ~~all identical.~~ almost identical except for one place.

I haven't touched the doxygen part because rewriting with lua+treesitter will be another significant, major refactoring; but this improvement with more object-oriented data representation will be still helpful towards that path.

### refactor(gen_vimdoc): use stronger typing for CONFIG, avoid dict
### refactor(gen_vimdoc): use typing for function vimdoc generation

Introduce `FunctionDoc` dataclass.

### refactor(gen_vimdoc): generate function doc from metadata, not from xml

Problem:

For function definitions to be included in the vimdoc (formatted) and
to be exported as mpack data (unformatted), we had two internal
representations of the same function/API metadata in duplicate;
one is FunctionDoc (which was previously a dict), and the other is
doxygen XML DOM from which vimdoc (functions sections) was generated.

Solution:

We should have a single path and unified data representation
(i.e. FunctionDoc) that contains all the metadata and information about
function APIs, from which both of mpack export and vimdoc are generated.
I.e., vimdocs are no longer generated directly from doxygen XML nodes,
but generated via:

```
  (XML DOM Nodes) ------------> FunctionDoc ------> mpack (unformatted)
                   Recursive     Internal     |
                   Formatting    Metadata     +---> vimdoc (formatted)
```

This refactoring eliminates the hacky and ugly use of `fmt_vimhelp` in
`fmt_node_as_vimhelp()` and all other helper functions! This way,
`fmt_node_as_vimhelp()` can simplified as it no longer needs to handle
generating of function docs, which needs to be done only in the topmost
level of recursion.



### refactor(gen_vimdoc): refactor section and defgroup doc generation

Problem: main() has too much logic implemented there, too difficult to
read.

Solution: Do more OOP, introduce `Section` dataclass that stores
information about a "section", with documentation and concrete examples
about what each field and variable would mean. Extract all the lines for
rendering a section into `section.render()` pulled out of `main()`.

### fix(gen_vimdoc): INCLUDE_DEPRECATED not generating docs for deprecateds

Since some point INCLUDE_DEPRECATED stopped working as it is usually
turned off when generating an actual vimdoc. This commit fixes this
hidden feature back again (used for devel purposes only).