### PR TITLE
vim-patch:d96f25bd69c1

### DIFF
--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -708,15 +708,16 @@ clojure-mode.el:
 
 FORTRAN							*ft-fortran-indent*
 
-Block if, select case, where, and forall constructs are indented.  So are
-type, interface, associate, block, and enum constructs.  The indenting of
-subroutines, functions, modules, and program blocks is optional.  Comments,
-labeled statements, and continuation lines are indented if the Fortran is in
-free source form, whereas they are not indented if the Fortran is in fixed
-source form because of the left margin requirements.  Hence manual indent
-corrections will be necessary for labeled statements and continuation lines
-when fixed source form is being used.  For further discussion of the method
-used for the detection of source format see |ft-fortran-syntax|.
+Block if, select case, select type, select rank,  where, forall, type,
+interface, associate, block, enum, critical, and change team constructs are
+indented. The indenting of subroutines, functions, modules, and program blocks
+is optional. Comments, labeled statements, and continuation lines are indented
+if the Fortran is in free source form, whereas they are not indented if the
+Fortran is in fixed source form because of the left margin requirements. Hence
+manual indent corrections will be necessary for labeled statements and
+continuation lines when fixed source form is being used.  For further
+discussion of the method used for the detection of source format see
+|ft-fortran-syntax|.
 
 Do loops ~
 All do loops are left unindented by default.  Do loops can be unstructured in

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1633,21 +1633,22 @@ fortran_fold with a command such as >
     :let fortran_fold=1
 to instruct the syntax script to define fold regions for program units, that
 is main programs starting with a program statement, subroutines, function
-subprograms, block data subprograms, interface blocks, and modules.  If you
-also set the variable fortran_fold_conditionals with a command such as >
+subprograms, modules, submodules, and block data units. Block, interface,
+associate, critical, type definition, and change team constructs will also be
+folded.  If you also set the variable fortran_fold_conditionals with a command
+such as >
     :let fortran_fold_conditionals=1
-then fold regions will also be defined for do loops, if blocks, and select
-case constructs.  If you also set the variable fortran_fold_multilinecomments
-with a command such as >
+then fold regions will also be defined for do loops, if blocks, select case,
+select type, and select rank constructs.  If you also set the variable
+fortran_fold_multilinecomments with a command such as >
     :let fortran_fold_multilinecomments=1
 then fold regions will also be defined for three or more consecutive comment
 lines.  Note that defining fold regions can be slow for large files.
 
 If fortran_fold, and possibly fortran_fold_conditionals and/or
-fortran_fold_multilinecomments, have been set, then vim will fold your file if
-you set foldmethod=syntax.  Comments or blank lines placed between two program
-units are not folded because they are seen as not belonging to any program
-unit.
+fortran_fold_multilinecomments, have been set, then vim will fold your file.
+Comments or blank lines placed between two program units are not folded
+because they are seen as not belonging to any program unit.
 
 The syntax/fortran.vim script contains embedded comments that tell you how to
 comment and/or uncomment some lines to (a) activate recognition of some

--- a/runtime/syntax/fortran.vim
+++ b/runtime/syntax/fortran.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	Fortran 2023 (and Fortran 2018, 2008, 2003, 95, 90, and 77)
-" Version:	(v108) 2023 December 22
+" Version:	(v109) 2023 December 29
 " Maintainers:	Ajit J. Thakkar <ajit@unb.ca>; <https://ajit.ext.unb.ca/>
 " 	        Joshua Hollett <j.hollett@uwinnipeg.ca>
 " Usage:	For instructions, do :help fortran-syntax from Vim
@@ -133,8 +133,8 @@ syn keyword fortranAttribute    abstract external private public protected inten
 syn keyword fortranAttribute	pointer target allocatable dimension codimension sequence parameter save
 
 syn keyword fortranUnitHeader	result operator assignment
-syn match fortranUnitHeader     "\(end\s*\)\?\(subroutine\|function\|module\|program\|submodule\)\>"
-syn match fortranBlock          "\(end\s*\)\?\(block\|critical\|associate\)\>"
+syn match fortranUnitHeader     "\<\(end\s*\)\?\(subroutine\|function\|module\|program\|submodule\)\>"
+syn match fortranBlock          "\<\(end\s*\)\?\(block\|critical\|associate\)\>"
 syn match fortranCalled		"\(call\s\+\)\@7<=\a\w*"
 syn match fortranRepeat		"\<do\>"
 syn keyword fortranRepeat       concurrent
@@ -349,6 +349,9 @@ endif
 
 if exists("fortran_fold")
 
+  if has("folding")
+    setlocal foldmethod=syntax
+  endif
   if (b:fortran_fixed_source == 1)
     syn region fortranProgram transparent fold keepend start="^\s*program\s\+\z(\a\w*\)" skip="^\([!c*]\|\s*#\).*$" excludenl end="\<end\s*\(program\(\s\+\z1\>\)\=\|$\)" contains=ALLBUT,fortranModule
     syn region fortranModule transparent fold keepend start="^\s*submodule\s\+(\a\w*\s*\(:\a\w*\s*\)*)\s*\z\(\a\w*\)" skip="^\([!c*]\|\s*#\).*$" excludenl end="\<end\s*\(submodule\(\s\+\z1\>\)\=\|$\)" contains=ALLBUT,fortranProgram,fortranModule


### PR DESCRIPTION
runtime(fortran): update syntax and documentation (vim/vim#13784)

* Update Fortran section of indent.txt
* Small addition to fortran syntax

* Update Fortran section of syntax.txt

* Runtime (Fortran)

Fix regression

* Combine two expressions

https://github.com/vim/vim/commit/d96f25bd69c14bc257281a580f344240c72f4999

Co-authored-by: Ajit-Thakkar <142174202+Ajit-Thakkar@users.noreply.github.com>
