### PR TITLE
refactor(drawline): remove optional winlinevars argument for foldcolumn

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1642,7 +1642,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
       char *p = NULL;
       if (fold) {
         schar_T fold_buf[10];
-        fill_foldcolumn(NULL, wp, stcp->foldinfo,
+        fill_foldcolumn(wp, stcp->foldinfo,
                         (linenr_T)get_vim_var_nr(VV_LNUM), 0, fdc, fold_buf);
         stl_items[curitem].minwid = -((stcp->use_cul ? HLF_CLF : HLF_FC) + 1);
         size_t buflen = 0;


### PR DESCRIPTION
Problem:  fill_foldcolumn() has an optional winlinevars_T argument.
Solution: Increment wlv->off at callsite.