### PR TITLE
Add two libtermkey 0.23 commits

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -370,15 +370,6 @@ static void forward_mouse_event(TermInput *input, TermKeyKey *key)
     button = last_pressed_button;
   }
 
-  if (ev == TERMKEY_MOUSE_UNKNOWN && !(key->code.mouse[0] & 0x20)) {
-    int code = key->code.mouse[0] & ~0x3c;
-    // https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Other-buttons
-    if (code == 66 || code == 67) {
-      ev = TERMKEY_MOUSE_PRESS;
-      button = code + 4 - 64;
-    }
-  }
-
   if ((button == 0 && ev != TERMKEY_MOUSE_RELEASE)
       || (ev != TERMKEY_MOUSE_PRESS && ev != TERMKEY_MOUSE_DRAG && ev != TERMKEY_MOUSE_RELEASE)) {
     return;

--- a/src/termkey/driver-csi.c
+++ b/src/termkey/driver-csi.c
@@ -241,6 +241,8 @@ TermKeyResult termkey_interpret_mouse(TermKey *tk, const TermKeyKey *key, TermKe
 
   case 64:
   case 65:
+  case 66:
+  case 67:
     *event = drag ? TERMKEY_MOUSE_DRAG : TERMKEY_MOUSE_PRESS;
     btn = code + 4 - 64;
     break;


### PR DESCRIPTION
- Ignore key_mouse unless it is exactly \e[M because some terminfos relate to different encoding modes (thanks Ninji)
- Handle mouse buttons 6/7 (often used for horizontal scrolling)
- refactor(tui): remove code that is no longer necessary
