### PR TITLE
feature(diagnostic): add `vim.diagnostic.count()`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -90,7 +90,7 @@ For each of the functions below, use the corresponding function in
 - *vim.lsp.diagnostic.enable()*
 - *vim.lsp.diagnostic.get()*
 - *vim.lsp.diagnostic.get_all()*	Use |vim.diagnostic.get()| instead.
-- *vim.lsp.diagnostic.get_count()*	Use |vim.diagnostic.get()| instead.
+- *vim.lsp.diagnostic.get_count()*	Use |vim.diagnostic.count()| instead.
 - *vim.lsp.diagnostic.get_line_diagnostics()* Use |vim.diagnostic.get()| instead.
 - *vim.lsp.diagnostic.get_next()*
 - *vim.lsp.diagnostic.get_next_pos()*

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -481,6 +481,22 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
     Return: ~
         (table|nil) table of current diagnostic config if `opts` is omitted.
 
+count({bufnr}, {opts})                                *vim.diagnostic.count()*
+    Get current diagnostics count.
+
+    Parameters: ~
+      • {bufnr}  (integer|nil) Buffer number to get diagnostics from. Use 0
+                 for current buffer or nil for all buffers.
+      • {opts}   (table|nil) A table with the following keys:
+                 • namespace: (number) Limit diagnostics to the given
+                   namespace.
+                 • lnum: (number) Limit diagnostics to the given line number.
+                 • severity: See |diagnostic-severity|.
+
+    Return: ~
+        (table) A table with actually present severity values as keys (see
+        |diagnostic-severity|) and integer counts as values.
+
 disable({bufnr}, {namespace})                       *vim.diagnostic.disable()*
     Disable diagnostics in the given buffer.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -275,6 +275,11 @@ The following new APIs and features were added.
 • |v_Q-default| and |v_@-default| repeat a register for each line of a visual
   selection.
 
+• |vim.diagnostic.count()| returns the number of diagnostics for a given
+  buffer and/or namespace, by severity. This is a faster alternative to
+  |vim.diagnostic.get()| when only the number of diagnostics is needed, but
+  not the diagnostics themselves.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -362,7 +362,6 @@ local function get_diagnostics(bufnr, opts, clamp)
 
   local function add(b, d)
     if not opts.lnum or d.lnum == opts.lnum then
-      d = vim.deepcopy(d)
       if clamp and api.nvim_buf_is_loaded(b) then
         local line_count = buf_line_count[b] - 1
         if
@@ -373,6 +372,7 @@ local function get_diagnostics(bufnr, opts, clamp)
           or d.col < 0
           or d.end_col < 0
         then
+          d = vim.deepcopy(d)
           d.lnum = math.max(math.min(d.lnum, line_count), 0)
           d.end_lnum = math.max(math.min(d.end_lnum, line_count), 0)
           d.col = math.max(d.col, 0)
@@ -755,7 +755,31 @@ function M.get(bufnr, opts)
     opts = { opts, 't', true },
   })
 
-  return get_diagnostics(bufnr, opts, false)
+  return vim.deepcopy(get_diagnostics(bufnr, opts, false))
+end
+
+--- Get current diagnostics count.
+---
+---@param bufnr integer|nil Buffer number to get diagnostics from. Use 0 for
+---                        current buffer or nil for all buffers.
+---@param opts table|nil A table with the following keys:
+---                        - namespace: (number) Limit diagnostics to the given namespace.
+---                        - lnum: (number) Limit diagnostics to the given line number.
+---                        - severity: See |diagnostic-severity|.
+---@return table A table with actually present severity values as keys (see |diagnostic-severity|) and integer counts as values.
+function M.count(bufnr, opts)
+  vim.validate({
+    bufnr = { bufnr, 'n', true },
+    opts = { opts, 't', true },
+  })
+
+  local diagnostics = get_diagnostics(bufnr, opts, false)
+  local count = {}
+  for i = 1, #diagnostics do
+    local severity = diagnostics[i].severity
+    count[severity] = (count[severity] or 0) + 1
+  end
+  return count
 end
 
 --- Get the previous diagnostic closest to the cursor position.


### PR DESCRIPTION
Problem: Getting diagnostic count based on the output of
  `vim.diagnostic.get()` might become costly as number of diagnostic
  entries grows. This is because it returns a copy of diagnostic cache
  entries (so as to not allow users to change them in place).
  Getting information about diagnostic count is frequently used in
  statusline, so it is important to be as fast as reasonbly possible.

Solution: Add `vim.diagnostic.count()` which computes severity
  counts without making copies.

------

Related to [this comment](https://github.com/neovim/neovim/pull/25010#issuecomment-1870500448).