### PR TITLE
build: reset generated doc-{vim,eval} files when make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ iwyu: build/.ran-cmake
 	cmake --build build
 
 clean:
-	+test -d build && $(BUILD_TOOL) -C build clean || true
+	+test -d build && $(BUILD_TOOL) -C build clean && $(BUILD_TOOL) -C build reset-doc || true
 	$(MAKE) -C test/old/testdir clean
 	$(MAKE) -C runtime/indent clean
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -903,6 +903,8 @@ set(VIMDOC_FILES
   ${NVIM_RUNTIME_DIR}/doc/treesitter.mpack
   ${NVIM_RUNTIME_DIR}/doc/treesitter.txt
 )
+set(VIMDOC_TXT_FILES ${VIMDOC_FILES})
+list(FILTER VIMDOC_TXT_FILES EXCLUDE REGEX "\.mpack$")
 
 file(GLOB API_SOURCES CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/src/nvim/api/*.c)
 
@@ -951,3 +953,10 @@ add_custom_target(doc-eval DEPENDS ${GEN_EVAL_FILES})
 add_custom_target(doc-vim DEPENDS ${VIMDOC_FILES})
 add_custom_target(doc)
 add_dependencies(doc doc-vim doc-eval)
+
+# Reset generated doc files (which have been deleted during clean)
+# that are version-controlled by git.
+add_custom_target(reset-doc
+  COMMAND git checkout -- ${GEN_EVAL_FILES} ${VIMDOC_TXT_FILES}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)


### PR DESCRIPTION
Problem: When running `make clean`, auto-generated runtime files
(GEN_EVAL_FILES, VIMDOC_FILES) will be deleted. However, these files
are tracked by git, so the git working tree would become "dirty":

```
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        deleted:    runtime/doc/api.txt
        deleted:    runtime/doc/builtin.txt
        deleted:    runtime/doc/diagnostic.txt
        deleted:    runtime/doc/lsp.txt
        deleted:    runtime/doc/lua.txt
        deleted:    runtime/doc/options.txt
        deleted:    runtime/doc/treesitter.txt
        deleted:    runtime/doc/vvars.txt
        deleted:    runtime/lua/vim/_meta/api.lua
        deleted:    runtime/lua/vim/_meta/api_keysets.lua
        deleted:    runtime/lua/vim/_meta/options.lua
        deleted:    runtime/lua/vim/_meta/vimfn.lua
        deleted:    runtime/lua/vim/_meta/vvars.lua
```

Solution: Run a custom post-clean cmake target that discards local
changes on these auto-generated doc files.
