### PR TITLE
docs: more accurate typing for `vim.tbl_extend`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2190,8 +2190,8 @@ vim.tbl_deep_extend({behavior}, {...})                 *vim.tbl_deep_extend()*
     Merges recursively two or more tables.
 
     Parameters: ~
-      • {behavior}  (`"error"|"keep"|"force"`) (string) Decides what to do if
-                    a key is found in more than one map:
+      • {behavior}  (`'error'|'keep'|'force'`) Decides what to do if a key is
+                    found in more than one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
@@ -2207,8 +2207,8 @@ vim.tbl_extend({behavior}, {...})                           *vim.tbl_extend()*
     Merges two or more tables.
 
     Parameters: ~
-      • {behavior}  (`string`) Decides what to do if a key is found in more
-                    than one map:
+      • {behavior}  (`'error'|'keep'|'force'`) Decides what to do if a key is
+                    found in more than one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -402,7 +402,7 @@ end
 ---
 ---@see |extend()|
 ---
----@param behavior string Decides what to do if a key is found in more than one map:
+---@param behavior 'error'|'keep'|'force' Decides what to do if a key is found in more than one map:
 ---      - "error": raise an error
 ---      - "keep":  use value from the leftmost map
 ---      - "force": use value from the rightmost map
@@ -418,7 +418,7 @@ end
 ---
 ---@generic T1: table
 ---@generic T2: table
----@param behavior "error"|"keep"|"force" (string) Decides what to do if a key is found in more than one map:
+---@param behavior 'error'|'keep'|'force' Decides what to do if a key is found in more than one map:
 ---      - "error": raise an error
 ---      - "keep":  use value from the leftmost map
 ---      - "force": use value from the rightmost map


### PR DESCRIPTION
Matches the type signatures of `vim.tbl_extend` to `vim.tbl_deep_extend` (namely, it specifies the enum values of the first parameter in the actual signature, rather than just in the parameter's description).