### PR TITLE
fix(builtin): parameter mismatch between winsaveview and winrestview

### DIFF
--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -118,7 +118,7 @@
 --- @field topfill? integer
 --- @field topline? integer
 
---- @class vim.fn.winsaveview.ret
+--- @class vim.fn.winsaveview.ret: vim.fn.winrestview.dict
 --- @field col integer
 --- @field coladd integer
 --- @field curswant integer


### PR DESCRIPTION
Problem: Passing the return value from `winsaveview()` to `winrestview()` makes LSP report parameter type mismatch.
Fix: make the class of the parameter type for `winrestview()` a child of the class of the return value type of `winsaveview()`.