### PR TITLE
fix(diagnostic): show valid buffers only

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1269,7 +1269,7 @@ function M.show(namespace, bufnr, diagnostics, opts)
     return
   end
 
-  if api.nvim_buf_is_valid(bufnr) or M.is_disabled(bufnr, namespace) then
+  if not api.nvim_buf_is_valid(bufnr) or M.is_disabled(bufnr, namespace) then
     return
   end
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1269,7 +1269,7 @@ function M.show(namespace, bufnr, diagnostics, opts)
     return
   end
 
-  if M.is_disabled(bufnr, namespace) then
+  if api.nvim_buf_is_valid(bufnr) or M.is_disabled(bufnr, namespace) then
     return
   end
 


### PR DESCRIPTION
Problem:
According to #25628, it's true we have some cases that there are some diagnostic s for unloaded buffer. 
However, we should also check if the buffer that has been retrieved from the diagnostic cache is actually valid. 
Because sometimes we might get a buffer from diagnostic cache that was just temporary, 
but actually isn' t valid at the moment, in which case we get `Invalid buffer id` error.

```
Error executing vim.schedule lua callback: ...tly/nvim-macos/share/nvim/runtime/lua/vim/diagnostic.lua:3
28: Invalid buffer id: 6
stack traceback:
        [C]: in function 'nvim_create_autocmd'
        ...tly/nvim-macos/share/nvim/runtime/lua/vim/diagnostic.lua:328: in function 'schedule_display'
        ...tly/nvim-macos/share/nvim/runtime/lua/vim/diagnostic.lua:1266: in function 'show'
        ...tly/nvim-macos/share/nvim/runtime/lua/vim/diagnostic.lua:648: in function 'config'
        ...nvim-macos/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:263: in function 'handler'
        ...ob/nightly/nvim-macos/share/nvim/runtime/lua/vim/lsp.lua:804: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

Solution:
Call nvim_buf_is_valid(bufnr) to check if the buffer is valid.