### PR TITLE
feat(runtime): default treesitter highlighting for Lua

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -300,6 +300,7 @@ The following changes to existing APIs or features add new behavior.
 <
   • Enabled treesitter highlighting for treesitter query files.
   • Enabled treesitter highlighting for help files.
+  • Enabled treesitter highlighting for Lua files.
 
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
   by default.

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,0 +1,2 @@
+-- use treesitter over syntax
+vim.treesitter.start()


### PR DESCRIPTION
2024 is the year of treesitter on the desktop.