### PR TITLE
perf(treesitter): partial injection and incremental invalidation

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -163,6 +163,9 @@ TREESITTER
     local p = vim.treesitter.get_parser(0, 'c')
     p:parse()
 <
+• |LanguageTree:trees()| no longer guarantees that the returned table is
+  list-like even after a full parse. Always use |next()| or |pairs()| to
+  access it.
 
 TUI
 
@@ -358,6 +361,9 @@ TREESITTER
   descendant itself.
 • |LanguageTree:parse()| optionally supports asynchronous invocation, which is
   activated by passing the `on_parse` callback parameter.
+• |LanguageTree:parse()| runs injection query only on the provided list of
+  ranges as long as the language does not have a combined injection,
+  significantly improving |treesitter-highlight| performance.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1546,7 +1546,7 @@ LanguageTree:invalidate({reload})                  *LanguageTree:invalidate()*
 
     Should only be called when the tracked state of the LanguageTree is not
     valid against the parse tree in treesitter. Doesn't clear filesystem
-    cache. Called often, so needs to be fast.
+    cache.
 
     Parameters: ~
       • {reload}  (`boolean?`)
@@ -1693,10 +1693,7 @@ LanguageTree:tree_for_range({range}, {opts})
 
 LanguageTree:trees()                                    *LanguageTree:trees()*
     Returns all trees of the regions parsed by this parser. Does not include
-    child languages. The result is list-like if
-    • this LanguageTree is the root, in which case the result is empty or a
-      singleton list; or
-    • the root LanguageTree is fully parsed.
+    child languages.
 
     Return: ~
         (`table<integer, TSTree>`)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1554,7 +1554,8 @@ LanguageTree:invalidate({reload})                  *LanguageTree:invalidate()*
 LanguageTree:is_valid({exclude_children})            *LanguageTree:is_valid()*
     Returns whether this LanguageTree is valid, i.e., |LanguageTree:trees()|
     reflects the latest state of the source. If invalid, user should call
-    |LanguageTree:parse()|.
+    |LanguageTree:parse()|. `is_valid(false)` can be slow because it runs
+    injection on the full source.
 
     Parameters: ~
       • {exclude_children}  (`boolean?`) whether to ignore the validity of

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1615,7 +1615,7 @@ LanguageTree:node_for_range({range}, {opts})
     Return: ~
         (`TSNode?`)
 
-LanguageTree:parse({range}, {on_parse})                 *LanguageTree:parse()*
+LanguageTree:parse({ranges}, {on_parse})                *LanguageTree:parse()*
     Recursively parse all regions in the language tree using
     |treesitter-parsers| for the corresponding languages and run injection
     queries on the parsed trees to determine whether child trees should be
@@ -1626,9 +1626,9 @@ LanguageTree:parse({range}, {on_parse})                 *LanguageTree:parse()*
     if {range} is `true`).
 
     Parameters: ~
-      • {range}     (`boolean|Range?`) Parse this range in the parser's
-                    source. Set to `true` to run a complete parse of the
-                    source (Note: Can be slow!) Set to `false|nil` to only
+      • {ranges}    (`boolean|Range|(Range)[]?`) Parse this range(s) in the
+                    parser's source. Set to `true` to run a complete parse of
+                    the source (Note: Can be slow!) Set to `false|nil` to only
                     parse regions with empty ranges (typically only the root
                     tree without injections).
       • {on_parse}  (`fun(err?: string, trees?: table<integer, TSTree>)?`)

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -572,7 +572,8 @@ local function update_editor_highlights(query_win, base_win, lang)
   -- Remove the '@' from the cursor word
   cursor_word = cursor_word:sub(2)
   local topline, botline = vim.fn.line('w0', base_win), vim.fn.line('w$', base_win)
-  for id, node in query:iter_captures(parser:trees()[1]:root(), base_buf, topline - 1, botline) do
+  local _, tree = next(parser:trees())
+  for id, node in query:iter_captures(tree:root(), base_buf, topline - 1, botline) do
     local capture_name = query.captures[id]
     if capture_name == cursor_word then
       local lnum, col, end_lnum, end_col = node:range()

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -83,14 +83,26 @@ local TSCallbackNames = {
 ---Table of callback queues, keyed by each region for which the callbacks should be run
 ---@field private _cb_queues table<string, fun(err?: string, trees?: table<integer, TSTree>)[]>
 ---@field private _has_regions boolean
----@field private _regions table<integer, Range6[]>?
+---
 ---List of regions this tree should manage and parse. If nil then regions are
 ---taken from _trees. This is mostly a short-lived cache for included_regions()
+---@field private _regions table<integer, Range6[]>?
+---
+---Inverse region table, i.e., a (chaining) hash table from regions to their index in `_region`.
+---Used for checking if an added region is already managed by this parser, so that it can reuse
+---the existing tree for incremental parsing.
+---The hash function is simply `region[1][3]` (the start byte of its first range).
+---Each bucket has the shape of { region1, index of region1, region2, index of region2, ... }.
+---@field private _regions_inv table<integer, (Range6[]|integer)[]>?
+---
 ---@field private _lang string Language name
 ---@field private _parent? vim.treesitter.LanguageTree Parent LanguageTree
 ---@field private _source (integer|string) Buffer or string to parse
----@field private _trees table<integer, TSTree> Reference to parsed tree (one for each language).
+---
+---Reference to parsed tree (one for each language).
 ---Each key is the index of region, which is synced with _regions and _valid.
+---@field private _trees table<integer, TSTree>
+---
 ---@field private _valid boolean|table<integer,boolean> If the parsed tree is valid
 ---@field private _logger? fun(logtype: string, msg: string)
 ---@field private _logfile? file*
@@ -236,7 +248,7 @@ end
 --- Invalidates this parser and its children.
 ---
 --- Should only be called when the tracked state of the LanguageTree is not valid against the parse
---- tree in treesitter. Doesn't clear filesystem cache. Called often, so needs to be fast.
+--- tree in treesitter. Doesn't clear filesystem cache.
 ---@param reload boolean|nil
 function LanguageTree:invalidate(reload)
   self._valid = false
@@ -257,9 +269,6 @@ end
 
 --- Returns all trees of the regions parsed by this parser.
 --- Does not include child languages.
---- The result is list-like if
---- * this LanguageTree is the root, in which case the result is empty or a singleton list; or
---- * the root LanguageTree is fully parsed.
 ---
 ---@return table<integer, TSTree>
 function LanguageTree:trees()
@@ -501,6 +510,14 @@ function LanguageTree:_async_parse(range, on_parse)
   return step()
 end
 
+---@param region (Range)[]
+---@return Range4
+local function region_range(region)
+  local srow, scol, _, _ = Range.unpack4(region[1])
+  local _, _, erow, ecol = Range.unpack4(region[#region])
+  return { srow, scol, erow, ecol }
+end
+
 --- Recursively parse all regions in the language tree using |treesitter-parsers|
 --- for the corresponding languages and run injection queries on the parsed trees
 --- to determine whether child trees should be created and parsed.
@@ -711,6 +728,125 @@ function LanguageTree:_iter_regions(fn)
   end
 end
 
+---Add a region to the inverse region table.
+---@param regions_inv table<integer, (Range6[]|integer)[]>
+---@param i integer
+---@param region Range6[]
+local function regions_inv_insert(regions_inv, i, region)
+  local start_byte = region[1][3]
+  local bucket = regions_inv[start_byte]
+  if not bucket then
+    regions_inv[start_byte] = { region, i }
+  else
+    table.insert(bucket, region)
+    table.insert(bucket, i)
+  end
+end
+
+---Remove a region from the inverse region table.
+---@param regions_inv table<integer, (Range6[]|integer)[]>
+---@param region Range6[]
+local function regions_inv_remove(regions_inv, region)
+  local start_byte = region[1][3]
+  local bucket = assert(regions_inv[start_byte])
+  for e = 1, #bucket, 2 do
+    if vim.deep_equal(bucket[e], region) then
+      table.remove(bucket, e + 1)
+      table.remove(bucket, e)
+      if #bucket == 0 then
+        regions_inv[start_byte] = nil
+      end
+      return
+    end
+  end
+  error('region not found')
+end
+
+---Whether two region values are approximately equal. Should be implied by equality.
+---See the comment in `set_included_regions` on why we use similarity.
+---For now it simply compares the last bytes of the first and the last regions.
+---@param region1 Range6[]
+---@param region2 Range6[]
+---@return boolean
+local function region_similar(region1, region2)
+  return region1[1][6] == region2[1][6] or region1[#region1][6] == region2[#region2][6]
+end
+
+---Find the given region from the inverse region table.
+---If there is no exact match, find an approximately matching region.
+---@param regions_inv table<integer, (Range6[]|integer)[]>
+---@param region Range6[]
+---@return integer?
+---@return boolean? exact
+local function regions_inv_lookup(regions_inv, region)
+  local bucket = regions_inv[region[1][3]]
+  if not bucket then
+    return
+  end
+
+  local i ---@type integer?
+  for e = 1, #bucket, 2 do
+    local old_region = bucket[e] --[[@as Range6[] ]]
+    if region_similar(old_region, region) then
+      i = bucket[e + 1] --[[@as integer]]
+      if vim.deep_equal(old_region, region) then
+        return i, true
+      end
+    end
+  end
+
+  return i, false
+end
+
+---@param i integer
+function LanguageTree:_invalidate_region(i)
+  if self._valid == true then
+    self._valid = {}
+    for j, _ in pairs(self._regions) do
+      self._valid[j] = true
+    end
+    self._valid[i] = false
+  elseif type(self._valid) == 'table' then
+    self._valid[i] = false
+  end
+end
+
+---@param i integer
+function LanguageTree:_discard_region(i)
+  if not self._has_regions then
+    return
+  end
+
+  if self._regions then
+    regions_inv_remove(self._regions_inv, self._regions[i])
+    self._regions[i] = nil
+  end
+
+  if self._trees[i] then
+    local region = self._trees[i]:included_ranges(true)
+    self:_log(function()
+      return 'discarding region', i, region_tostr(region)
+    end)
+    self:_do_callback('changedtree', region, self._trees[i])
+    local discarded_range = region_range(region)
+    self._trees[i] = nil
+    -- Discard children's regions that are included in the discarded region. This is necessary
+    -- because changes that only remove trees in this parser keep the children parsers untouched.
+    for _, child in pairs(self._children) do
+      for child_i, child_region in pairs(child:included_regions()) do
+        if Range.contains(discarded_range, region_range(child_region)) then
+          child:_discard_region(child_i)
+        end
+      end
+    end
+  end
+
+  -- If it's boolean (fully valid/invalid), deleting a region doesn't change its value.
+  if type(self._valid) == 'table' then
+    self._valid[i] = nil
+  end
+end
+
 --- Sets the included regions that should be parsed by this |LanguageTree|.
 --- A region is a set of nodes and/or ranges that will be parsed in the same context.
 ---
@@ -730,7 +866,23 @@ end
 function LanguageTree:set_included_regions(new_regions)
   self._has_regions = true
 
-  -- Transform the tables from 4 element long to 6 element long (with byte offset)
+  -- Refresh self._regions and self._regions_inv
+  self:included_regions()
+
+  local touched = {} ---@type table<integer, true>
+
+  -- Check if the parser already has each region so that they can be parsed incrementally from an
+  -- existing tree. We find the existing regions by "similarity" instead of the exact equality,
+  -- because the values of an existing region and the matching region in `new_regions` may not be
+  -- equal, in which case the existing tree can't be reused.
+  --
+  -- Inequality of matching regions happens because `_edit` does not accurately track changes in the
+  -- existing regions. One (probably the only?) case is when a multi-range region created from a
+  -- non-`include-children` injection or a combined injection is edited in a way that adds a range
+  -- to the region, e.g., when adding a line in markdown fenced code block (with language).
+  --
+  -- Matching the regions doesn't need to precise: the consequence of false match and false
+  -- non-match is just a minor loss in efficiency due to reparsing a region from scratch.
   for _, region in ipairs(new_regions) do
     for i, range in ipairs(region) do
       if type(range) == 'table' and #range == 4 then
@@ -739,26 +891,50 @@ function LanguageTree:set_included_regions(new_regions)
         region[i] = { range:range(true) }
       end
     end
-  end
+    ---@cast region Range6[]
 
-  -- included_regions is not guaranteed to be list-like, but this is still sound, i.e. if
-  -- new_regions is different from included_regions, then outdated regions in included_regions are
-  -- invalidated. For example, if included_regions = new_regions ++ hole ++ outdated_regions, then
-  -- outdated_regions is invalidated by _iter_regions in else branch.
-  if #self:included_regions() ~= #new_regions then
-    -- TODO(lewis6991): inefficient; invalidate trees incrementally
-    for _, t in pairs(self._trees) do
-      self:_do_callback('changedtree', t:included_ranges(true), t)
+    local i, exact = regions_inv_lookup(self._regions_inv, region)
+
+    if not exact then
+      if i then
+        self:_log(function()
+          return 'invalidating inexactly matched region', i, region_tostr(self._regions[i])
+        end)
+        regions_inv_remove(self._regions_inv, self._regions[i])
+      else
+        i = #self._regions + 1 -- this always gives an unoccupied index even if there are holes
+      end
+      self._regions[i] = region
+      regions_inv_insert(self._regions_inv, i, region)
+      self:_invalidate_region(i)
     end
-    self._trees = {}
-    self:invalidate()
-  else
-    self:_iter_regions(function(i, region)
-      return vim.deep_equal(new_regions[i], region)
-    end)
+    ---@cast i integer
+
+    touched[i] = true
   end
 
-  self._regions = new_regions
+  -- Discard stale regions.
+  for i, _ in pairs(self._regions) do
+    if not touched[i] then
+      self:_discard_region(i)
+    end
+  end
+end
+
+--- @param region Range6[]
+local function prune_empty_ranges(region)
+  local cur = 1
+  for i, range in ipairs(region) do
+    if range[3] ~= range[6] then
+      if cur < i then
+        region[cur] = range
+      end
+      cur = cur + 1
+    end
+  end
+  for i = #region, cur, -1 do
+    region[i] = nil
+  end
 end
 
 ---Gets the set of included regions managed by this LanguageTree. This can be different from the
@@ -777,12 +953,27 @@ function LanguageTree:included_regions()
     return { {} }
   end
 
-  local regions = {} ---@type Range6[][]
+  local regions = {} ---@type table<integer, Range6[]>
+  local regions_inv = {} ---@type table<integer, (Range6[]|integer)[]>
   for i, _ in pairs(self._trees) do
-    regions[i] = self._trees[i]:included_ranges(true)
+    local region = self._trees[i]:included_ranges(true)
+    -- If user deletes a range in a region, `tree:edit()` leaves an empty range instead of deleting
+    -- it. This could be a bug in treesitter.
+    prune_empty_ranges(region)
+    if #region > 0 then
+      regions[i] = region
+      regions_inv_insert(regions_inv, i, region)
+    else
+      self._trees[i] = nil
+      -- If it's boolean (fully valid/invalid), deleting a region doesn't change its value.
+      if type(self._valid) == 'table' then
+        self._valid[i] = nil
+      end
+    end
   end
 
   self._regions = regions
+  self._regions_inv = regions_inv
   return regions
 end
 
@@ -1035,6 +1226,7 @@ function LanguageTree:_edit(
 
   self._parser:reset()
   self._regions = nil
+  self._regions_inv = nil
 
   local changed_range = {
     start_row,
@@ -1198,14 +1390,7 @@ end
 ---@param range Range
 ---@return boolean
 local function tree_contains(tree, range)
-  local tree_ranges = tree:included_ranges(false)
-
-  return Range.contains({
-    tree_ranges[1][1],
-    tree_ranges[1][2],
-    tree_ranges[#tree_ranges][3],
-    tree_ranges[#tree_ranges][4],
-  }, range)
+  return Range.contains(region_range(tree:included_ranges(false)), range)
 end
 
 --- Determines whether {range} is contained in the |LanguageTree|.

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -67,6 +67,7 @@ end
 ---@field lang string parser language name
 ---@field captures string[] list of (unique) capture names defined in query
 ---@field info vim.treesitter.QueryInfo query context (e.g. captures, predicates, directives)
+---@field has_combined_injection true? whether this query has a combined injection pattern
 ---@field query TSQuery userdata query object
 ---@field private _processed_patterns table<integer, vim.treesitter.query.ProcessedPattern>
 local Query = {}
@@ -88,6 +89,17 @@ function Query.new(lang, ts_query)
   }
   self.captures = self.info.captures
   self._processed_patterns = process_patterns(self.info.patterns)
+  for _, pattern in pairs(self._processed_patterns) do
+    if
+      vim.tbl_contains(pattern.directives, function(directive)
+        return vim.deep_equal(directive, { 'set!', 'injection.combined' })
+      end, { predicate = true })
+    then
+      self.has_combined_injection = true
+      break
+    end
+  end
+
   return self
 end
 

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -810,7 +810,7 @@ local function validate_one(fname, parser_path)
     parse_errors = {},
   }
   local lang_tree, buf = parse_buf(fname, nil, parser_path)
-  for _, tree in ipairs(lang_tree:trees()) do
+  for _, tree in pairs(lang_tree:trees()) do
     visit_validate(tree:root(), 0, tree, { buf = buf, fname = fname }, stats)
   end
   lang_tree:destroy()
@@ -918,7 +918,7 @@ local function gen_one(fname, text, to_fname, old, commit, parser_path)
   ]]
 
   local main = ''
-  for _, tree in ipairs(lang_tree:trees()) do
+  for _, tree in pairs(lang_tree:trees()) do
     main = main
       .. (
         visit_node(

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1128,6 +1128,23 @@ print()
     )
 
     eq(
+      2,
+      exec_lua [[
+      parser:invalidate()
+      parser:parse({{0, 2}, {2,6}})
+      return vim.tbl_count(parser:children().lua:trees())
+    ]]
+    )
+
+    eq(
+      2,
+      exec_lua [[
+      parser:parse({{0, 5}, {2, 6}})
+      return vim.tbl_count(parser:children().lua:trees())
+    ]]
+    )
+
+    eq(
       7,
       exec_lua(function()
         _G.parser:parse(true)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1118,8 +1118,9 @@ print()
       end)
     )
 
+    -- Regions outside the given range are discarded.
     eq(
-      2,
+      1,
       exec_lua(function()
         _G.parser:parse({ 2, 6 })
         return vim.tbl_count(_G.parser:children().lua:trees())
@@ -1263,19 +1264,7 @@ print()
       end)
     end
 
-    it('is valid excluding, invalid including children initially', function()
-      eq(true, exec_lua('return parser:is_valid(true)'))
-      eq(false, exec_lua('return parser:is_valid()'))
-    end)
-
-    it('is fully valid after a full parse', function()
-      exec_lua('parser:parse(true)')
-      eq(true, exec_lua('return parser:is_valid(true)'))
-      eq(true, exec_lua('return parser:is_valid()'))
-    end)
-
-    it('is fully valid after a parsing a range on parsed tree', function()
-      exec_lua('vim.treesitter.get_parser():parse({5, 7})')
+    it('is valid including children since it does not have one', function()
       eq(true, exec_lua('return parser:is_valid(true)'))
       eq(true, exec_lua('return parser:is_valid()'))
     end)
@@ -1348,17 +1337,30 @@ print()
         eq(false, exec_lua('return parser:is_valid()'))
       end)
 
-      it('is valid excluding, invalid including children after a rangeless parse', function()
-        exec_lua('parser:parse()')
-        eq(true, exec_lua('return parser:is_valid(true)'))
-        eq(false, exec_lua('return parser:is_valid()'))
-      end)
+      it(
+        'is fully valid after a rangeless parse, since the only change to the children was removing a region',
+        function()
+          exec_lua('parser:parse()')
+          eq(true, exec_lua('return parser:is_valid(true)'))
+          eq(true, exec_lua('return parser:is_valid()'))
+        end
+      )
 
       it('is fully valid after a range parse that includes injection region', function()
         exec_lua('parser:parse({5, 7})')
         eq(true, exec_lua('return parser:is_valid(true)'))
         eq(true, exec_lua('return parser:is_valid()'))
       end)
+
+      it(
+        'is valid excluding, invalid including children after a range parse that does not include injection region',
+        function()
+          exec_lua('parser:parse({2, 4})')
+          eq(nil, get_regions())
+          eq(true, exec_lua('return parser:is_valid(true)'))
+          eq(false, exec_lua('return parser:is_valid()'))
+        end
+      )
     end)
 
     describe('when editing an injection region', function()

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -445,20 +445,25 @@ end]]
       local root = _G.parser:parse()[1]:root()
       _G.parser:set_included_regions({ { root:child(0) } })
       _G.parser:invalidate()
-      return { _G.parser:parse(true)[1]:root():range() }
+      local _, tree = next(_G.parser:parse(true))
+      return { tree:root():range() }
     end)
 
     eq({ 0, 0, 18, 1 }, res2)
 
-    eq({ { { 0, 0, 0, 18, 1, 512 } } }, exec_lua [[ return parser:included_regions() ]])
+    eq(
+      { { { 0, 0, 0, 18, 1, 512 } } },
+      exec_lua [[return vim.tbl_values(_G.parser:included_regions())]]
+    )
 
-    local range_tbl = exec_lua(function()
-      _G.parser:set_included_regions { { { 0, 0, 17, 1 } } }
-      _G.parser:parse()
-      return _G.parser:included_regions()
-    end)
-
-    eq({ { { 0, 0, 0, 17, 1, 508 } } }, range_tbl)
+    eq(
+      { { { 0, 0, 0, 17, 1, 508 } } },
+      exec_lua(function()
+        _G.parser:set_included_regions { { { 0, 0, 17, 1 } } }
+        _G.parser:parse()
+        return vim.tbl_values(_G.parser:included_regions())
+      end)
+    )
   end)
 
   it('allows to set complex ranges', function()
@@ -475,7 +480,8 @@ end]]
 
       parser:set_included_regions({ nodes })
 
-      local root = parser:parse(true)[1]:root()
+      local _, tree = next(parser:parse(true))
+      local root = tree:root()
 
       local res = {}
       for i = 0, (root:named_child_count() - 1) do
@@ -1108,7 +1114,7 @@ print()
       1,
       exec_lua(function()
         _G.parser:parse({ 0, 2 })
-        return #_G.parser:children().lua:trees()
+        return vim.tbl_count(_G.parser:children().lua:trees())
       end)
     )
 
@@ -1116,7 +1122,7 @@ print()
       2,
       exec_lua(function()
         _G.parser:parse({ 2, 6 })
-        return #_G.parser:children().lua:trees()
+        return vim.tbl_count(_G.parser:children().lua:trees())
       end)
     )
 
@@ -1124,9 +1130,104 @@ print()
       7,
       exec_lua(function()
         _G.parser:parse(true)
-        return #_G.parser:children().lua:trees()
+        return vim.tbl_count(_G.parser:children().lua:trees())
       end)
     )
+  end)
+
+  it('reuses similar existing regions', function()
+    insert(dedent [[
+      * line1
+        line2]])
+
+    exec_lua(function()
+      _G.parser = vim.treesitter.get_parser(0, 'markdown', {
+        injections = {
+          markdown = '((inline) @injection.content (#set! injection.language "markdown_inline"))',
+        },
+      })
+    end)
+
+    local function get_regions()
+      return exec_lua(function()
+        _G.parser:parse(true)
+        local result = {}
+        for i, tree in pairs(_G.parser:children().markdown_inline:trees()) do
+          result[i] = tree:included_ranges()
+        end
+        return result
+      end)
+    end
+
+    eq({
+      [1] = { { 0, 2, 1, 0 }, { 1, 2, 1, 7 } },
+    }, get_regions())
+
+    feed('2ggyyp')
+    -- region index does not change
+    eq({
+      [1] = { { 0, 2, 1, 0 }, { 1, 2, 2, 0 }, { 2, 2, 2, 7 } },
+    }, get_regions())
+
+    feed('2ggdd')
+    eq({
+      [1] = { { 0, 2, 1, 0 }, { 1, 2, 1, 7 } },
+    }, get_regions())
+
+    feed('ggyGP')
+    -- the old region moves while maintaining its index
+    eq({
+      [1] = { { 2, 2, 3, 0 }, { 3, 2, 3, 7 } },
+      [2] = { { 0, 2, 1, 0 }, { 1, 2, 1, 7 } },
+    }, get_regions())
+  end)
+
+  it("recursively discards children's regions contained in a parent's discarded region", function()
+    insert(dedent [[
+      `return`
+
+      ```
+      line 4
+      ```
+      line 6 `return`
+      ```]])
+
+    exec_lua(function()
+      _G.parser = vim.treesitter.get_parser(0, 'markdown', {
+        injections = {
+          -- inject code span to lua
+          markdown_inline = '((code_span) @injection.content (#offset! @injection.content 0 1 0 -1) (#set! injection.language "lua"))',
+        },
+      })
+    end)
+
+    local function get_regions()
+      return exec_lua(function()
+        _G.parser:parse(true)
+        local result = {}
+        for i, tree in pairs(_G.parser:children().markdown_inline:children().lua:trees()) do
+          result[i] = tree:included_ranges()
+        end
+        return result
+      end)
+    end
+
+    -- Initially, "line 4" is in the fenced code block, and "line 6 `return`" is a normal paragraph
+    -- with a inline code span.
+    eq({
+      [1] = { { 0, 1, 0, 7 } },
+      [2] = { { 5, 8, 5, 14 } },
+    }, get_regions())
+
+    -- Extend the code block to "line 6 `return`". Note that the only effect to markdown_inline
+    -- parser is removing a region, so it does not parse anything in markdown_inline parser.
+    feed('5ggD')
+    -- Despite not parsing at the parent (markdown_inline) parser, the regions in children (lua)
+    -- parser that are included in the parent's removed region should be removed as well.
+    -- The "`return`" at the first line is just for preventing the lua parser from being removed.
+    eq({
+      [1] = { { 0, 1, 0, 7 } },
+    }, get_regions())
   end)
 
   describe('languagetree is_valid()', function()
@@ -1139,34 +1240,44 @@ print()
 
       ]])
 
-      feed(':set ft=help<cr>')
-
       exec_lua(function()
-        vim.treesitter
-          .get_parser(0, 'vimdoc', {
-            injections = {
-              vimdoc = '((codeblock (language) @injection.language (code) @injection.content) (#set! injection.include-children))',
-            },
-          })
-          :parse()
+        _G.parser = vim.treesitter.get_parser(0, 'vimdoc', {
+          injections = {
+            vimdoc = '((codeblock (language) @injection.language (code) @injection.content) (#set! injection.include-children))',
+          },
+        })
+        _G.parser:parse()
       end)
     end)
 
+    local function get_regions()
+      return exec_lua(function()
+        if not _G.parser:children().lua then
+          return nil
+        end
+        local result = {}
+        for i, tree in pairs(_G.parser:children().lua:trees()) do
+          result[i] = tree:included_ranges()
+        end
+        return result
+      end)
+    end
+
     it('is valid excluding, invalid including children initially', function()
-      eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-      eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+      eq(true, exec_lua('return parser:is_valid(true)'))
+      eq(false, exec_lua('return parser:is_valid()'))
     end)
 
     it('is fully valid after a full parse', function()
-      exec_lua('vim.treesitter.get_parser():parse(true)')
-      eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-      eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+      exec_lua('parser:parse(true)')
+      eq(true, exec_lua('return parser:is_valid(true)'))
+      eq(true, exec_lua('return parser:is_valid()'))
     end)
 
     it('is fully valid after a parsing a range on parsed tree', function()
       exec_lua('vim.treesitter.get_parser():parse({5, 7})')
-      eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-      eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+      eq(true, exec_lua('return parser:is_valid(true)'))
+      eq(true, exec_lua('return parser:is_valid()'))
     end)
 
     describe('when adding content with injections', function()
@@ -1181,36 +1292,36 @@ print()
       end)
 
       it('is fully invalid after changes', function()
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+        eq(false, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
       end)
 
       it('is valid excluding, invalid including children after a rangeless parse', function()
-        exec_lua('vim.treesitter.get_parser():parse()')
-        eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+        exec_lua('parser:parse()')
+        eq(true, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
       end)
 
       it(
         'is fully valid after a range parse that leads to parsing not parsed injections',
         function()
-          exec_lua('vim.treesitter.get_parser():parse({5, 7})')
-          eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-          eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+          exec_lua('parser:parse({5, 7})')
+          eq(true, exec_lua('return parser:is_valid(true)'))
+          eq(true, exec_lua('return parser:is_valid()'))
         end
       )
 
       it(
         'is valid excluding, invalid including children after a range parse that does not lead to parsing not parsed injections',
         function()
-          exec_lua('vim.treesitter.get_parser():parse({2, 4})')
-          eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-          eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+          exec_lua('parser:parse({2, 4})')
+          eq(true, exec_lua('return parser:is_valid(true)'))
+          eq(false, exec_lua('return parser:is_valid()'))
         end
       )
     end)
 
-    describe('when removing content with injections', function()
+    describe('when removing an injection region', function()
       before_each(function()
         feed('G')
         insert(dedent [[
@@ -1219,41 +1330,67 @@ print()
           <
 
           >lua
-            local a = {}
+            local b = {}
           <
 
         ]])
 
-        exec_lua('vim.treesitter.get_parser():parse(true)')
+        exec_lua('parser:parse(true)')
+        eq({ [1] = { { 6, 0, 7, 0 } }, [2] = { { 10, 0, 11, 0 } } }, get_regions())
 
         feed('Gd3k')
+        -- the empty region is pruned
+        eq({ [1] = { { 6, 0, 7, 0 } } }, get_regions())
       end)
 
       it('is fully invalid after changes', function()
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+        eq(false, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
       end)
 
       it('is valid excluding, invalid including children after a rangeless parse', function()
-        exec_lua('vim.treesitter.get_parser():parse()')
-        eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-        eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+        exec_lua('parser:parse()')
+        eq(true, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
       end)
 
-      it('is fully valid after a range parse that leads to parsing modified child tree', function()
-        exec_lua('vim.treesitter.get_parser():parse({5, 7})')
-        eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-        eq(true, exec_lua('return vim.treesitter.get_parser():is_valid()'))
+      it('is fully valid after a range parse that includes injection region', function()
+        exec_lua('parser:parse({5, 7})')
+        eq(true, exec_lua('return parser:is_valid(true)'))
+        eq(true, exec_lua('return parser:is_valid()'))
+      end)
+    end)
+
+    describe('when editing an injection region', function()
+      before_each(function()
+        feed('G')
+        insert(dedent [[
+          >lua
+            local a = 1
+          <
+        ]])
+
+        exec_lua('parser:parse(true)')
+
+        feed('G2kA<BS>2<ESC>') -- 1 → 2
       end)
 
-      it(
-        'is valid excluding, invalid including children after a range parse that does not lead to parsing modified child tree',
-        function()
-          exec_lua('vim.treesitter.get_parser():parse({2, 4})')
-          eq(true, exec_lua('return vim.treesitter.get_parser():is_valid(true)'))
-          eq(false, exec_lua('return vim.treesitter.get_parser():is_valid()'))
-        end
-      )
+      it('is fully invalid after changes', function()
+        eq(false, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
+      end)
+
+      it('is valid excluding, invalid including children after a rangeless parse', function()
+        exec_lua('parser:parse()')
+        eq(true, exec_lua('return parser:is_valid(true)'))
+        eq(false, exec_lua('return parser:is_valid()'))
+      end)
+
+      it('is fully valid after a range parse that includes modified region', function()
+        exec_lua('parser:parse({5, 7})')
+        eq(true, exec_lua('return parser:is_valid(true)'))
+        eq(true, exec_lua('return parser:is_valid()'))
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
The two main bottlenecks in editing big files with many injections are (1) parsing and (2) processing the injection queries. This PR resolves (2) by applying injection query to only visible regions.

<!--
Status:
* Seems to work, but probably needs more testing.
* There are some TODOs regarding changes that may affect API users (maybe related to failing test cases).
-->

Benchmark:
1. download <https://raw.githubusercontent.com/torvalds/linux/master/drivers/gpu/drm/amd/include/asic_reg/dcn/dcn_3_2_0_sh_mask.h>
1. setup nvim-treesitter for `cpp` (`.h` file is recognized as `cpp` filetype by default)
1. `:let g:__ts_debug = 1`
1. `:e dcn_3_2_0_sh_mask.h`, `:lua vim.treesitter.start()`
1. go to the last comment in the file (`G?//<CR>`), then append a space (`A<Space><Esc>`)
1. go to the next line (`j`) and append 0 (`A0<Esc>`)
1. see log at `~/.local/state/nvim/treesitter.log`

<details>
<summary>before</summary>

```
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 2923.453483, query_time = 0, regions_parsed = 1 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, regions_parsed = 0 }
1:comment:(nvim) new:145: (#regions=1)  START
1:cpp:(nvim) new:145: (#regions=1)  START
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 1004.06346, range = { 0, 56 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 1.506477, query_time = 0.17726, range = { 0, 56 }, regions_parsed = 25 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 1.215564, query_time = 0.001373, range = { 0, 56 }, regions_parsed = 5 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 2.845539, query_time = 0.450294, range = { 222837, 222893 }, regions_parsed = 50 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0.266351, query_time = 0.001112, range = { 222837, 222893 }, regions_parsed = 4 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) _on_bytes:984: (#regions=1)  on_bytes 1 4 222884 62 23943921 0 0 0 0 1 1
1:cpp:(nvim) _iter_regions:571: (#regions=1)  was valid true
1:cpp:(nvim) _iter_regions:581: (#regions=1)  invalidating region 1 []
1:comment:(nvim) _iter_regions:581: (#regions=9)  invalidating region 27859 [222884:0-222884:63]
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 366.826656, query_time = 1008.172019, range = { 222837, 222893 }, regions_parsed = 1 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 3.726473, query_time = 0.987651, range = { 222837, 222893 }, regions_parsed = 50 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0.193249, query_time = 0.006221, range = { 222837, 222893 }, regions_parsed = 4 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) _on_bytes:984: (#regions=1)  on_bytes 1 5 222885 113 23944036 0 0 0 0 1 1
1:cpp:(nvim) _iter_regions:571: (#regions=1)  was valid true
1:cpp:(nvim) _iter_regions:581: (#regions=1)  invalidating region 1 []
1:cpp:(nvim) _iter_regions:581: (#regions=50)  invalidating region 194397 [222885:110-222885:114]
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 391.276224, query_time = 1176.385789, range = { 222837, 222893 }, regions_parsed = 1 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 3.136393, query_time = 0.262249, range = { 222837, 222893 }, regions_parsed = 50 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0.135404, query_time = 0.000935, range = { 222837, 222893 }, regions_parsed = 4 }
1:cpp:(nvim) parse:450: (#regions=1)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:450: (#regions=194402)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:450: (#regions=27859)  { parse_time = 0, query_time = 0, range = { 222837, 222893 }, regions_parsed = 0 }
```
</details>

<details>
<summary>after</summary>

```
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 2782.294202, query_time = 0, regions_parsed = 1 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 0, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 0, regions_parsed = 0 }
1:comment:(nvim) new:162: (#regions=1)  START
1:cpp:(nvim) new:162: (#regions=1)  START
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 0.38573, range = { 0, 56 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=5)  { parse_time = 0.725387, query_time = 0.000461, range = { 0, 56 }, regions_parsed = 5 }
1:cpp:(nvim) parse:484: (#regions=25)  { parse_time = 0.898121, query_time = 0.061065, range = { 0, 56 }, regions_parsed = 25 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.598029, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=9)  { parse_time = 0.354243, query_time = 0.001245, range = { 222837, 222893 }, regions_parsed = 4 }
1:cpp:(nvim) parse:484: (#regions=75)  { parse_time = 10.392799, query_time = 0.823553, range = { 222837, 222893 }, regions_parsed = 50 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 0.96193, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.003102, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.720424, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.32763, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.0019, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.661419, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.424348, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.001834, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.769533, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.261363, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.001738, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.596901, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) _on_bytes:1144: (#regions=1)  on_bytes 1 4 222884 62 23943921 0 0 0 0 1 1
1:cpp:(nvim) _iter_regions:606: (#regions=1)  was valid true
1:cpp:(nvim) _iter_regions:616: (#regions=1)  invalidating region 1 []
1:comment:(nvim) _iter_regions:606: (#regions=4)  was valid true
1:comment:(nvim) _iter_regions:616: (#regions=4)  invalidating region 9 [222884:0-222884:63]
1:cpp:(nvim) _iter_regions:606: (#regions=50)  was valid true
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 399.244173, query_time = 0.407459, range = { 222837, 222893 }, regions_parsed = 1 }
1:comment:(nvim) parse:484: (#regions=4)  { changes = { { 222884, 62, 23943921, 222884, 63, 23943922 } }, parse_time = 0.046848, query_time = 0.00045, range = { 222837, 222893 }, regions_parsed = 1 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.197181, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 0.976214, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.002079, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.655016, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.166834, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.00189, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.893842, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.057452, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.001859, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.650981, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) _on_bytes:1144: (#regions=1)  on_bytes 1 5 222885 113 23944036 0 0 0 0 1 1
1:cpp:(nvim) _iter_regions:606: (#regions=1)  was valid true
1:cpp:(nvim) _iter_regions:616: (#regions=1)  invalidating region 1 []
1:comment:(nvim) _iter_regions:606: (#regions=4)  was valid true
1:cpp:(nvim) _iter_regions:606: (#regions=50)  was valid true
1:cpp:(nvim) _iter_regions:616: (#regions=50)  invalidating region 70 [222885:110-222885:114]
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 376.665228, query_time = 0.288334, range = { 222837, 222893 }, regions_parsed = 1 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.000528, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0.076109, query_time = 0.217351, range = { 222837, 222893 }, regions_parsed = 1 }
1:cpp:(nvim) parse:484: (#regions=1)  { parse_time = 0, query_time = 1.539355, range = { 222837, 222893 }, regions_parsed = 0 }
1:comment:(nvim) parse:484: (#regions=4)  { parse_time = 0, query_time = 0.002121, range = { 222837, 222893 }, regions_parsed = 0 }
1:cpp:(nvim) parse:484: (#regions=50)  { parse_time = 0, query_time = 0.945593, range = { 222837, 222893 }, regions_parsed = 0 }
```
</details>

Evaluation
* Major benefit: The query time becomes negligible. Now the only bottleneck is the parsing of the root cpp parser.
* Minor additional benefit: less reparsing of injections
* Minor downside: It runs the injection query more frequently, for example when scrolling and when multiple windows show the same buffer (not shown in the above logs). But the cost is negligible.
