### PR TITLE
feat(lsp): allow silent if there is no hover result

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1258,9 +1258,14 @@ format({options})                                       *vim.lsp.buf.format()*
                      Defaults to `nil` in other modes, formatting the full
                      buffer
 
-hover()                                                  *vim.lsp.buf.hover()*
+hover({options})                                         *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating
     window. Calling the function twice will jump into the floating window.
+
+    Parameters: ~
+      • {options}  (table|nil) additional options
+                   • silent: (boolean) Do not notify if there is no hover
+                     result.
 
 implementation({options})                       *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -195,6 +195,8 @@ The following new APIs and features were added.
     the original LSP `Location` or `LocationLink`.
   • Added support for connecting to servers using named pipes (Windows) or
     unix domain sockets (Unix) via |vim.lsp.rpc.domain_socket_connect()|.
+  • |vim.lsp.buf.hover()| now allow `silent` the notification if there is no
+    hover result.
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -38,13 +38,6 @@ function M.server_ready()
   return not not vim.lsp.buf_notify(0, 'window/progress', {})
 end
 
---- Displays hover information about the symbol under the cursor in a floating
---- window. Calling the function twice will jump into the floating window.
-function M.hover()
-  local params = util.make_position_params()
-  request(ms.textDocument_hover, params)
-end
-
 local function request_with_options(name, params, options)
   local req_handler --- @type function?
   if options then
@@ -55,6 +48,16 @@ local function request_with_options(name, params, options)
     end
   end
   request(name, params, req_handler)
+end
+
+--- Displays hover information about the symbol under the cursor in a floating
+--- window. Calling the function twice will jump into the floating window.
+---
+--- @param options table|nil additional options
+---      - silent: (boolean) Do not notify if there is no hover result.
+function M.hover(options)
+  local params = util.make_position_params()
+  request_with_options(ms.textDocument_hover, params, options)
 end
 
 --- Jumps to the declaration of the symbol under the cursor.


### PR DESCRIPTION
It could be a bug fix rather than a feature implementation.

There is the implementation already:

https://github.com/neovim/neovim/blob/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac/runtime/lua/vim/lsp/handlers.lua#L373

But the function exposed to users does not pass any parameter:

https://github.com/neovim/neovim/blob/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac/runtime/lua/vim/lsp/buf.lua#L43

And using the request function without options:

https://github.com/neovim/neovim/blob/6fa0f303d7f0823bfc5ba6cc7b4e7a7cd76143ac/runtime/lua/vim/lsp/buf.lua#L45