### PR TITLE
fix(terminal): handler cursor shape correctly

### DIFF
--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -35,6 +35,10 @@ void set_title(String title)
   FUNC_API_SINCE(3);
 void set_icon(String icon)
   FUNC_API_SINCE(3);
+void set_cursor(void)
+  FUNC_API_SINCE(3);
+void reset_cursor(void)
+  FUNC_API_SINCE(3);
 void screenshot(String path)
   FUNC_API_SINCE(7);
 void option_set(String name, Object value)

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1671,6 +1671,7 @@ void enter_buffer(buf_T *buf)
     curwin->w_topfill = 0;
     apply_autocmds(EVENT_BUFENTER, NULL, NULL, false, curbuf);
     apply_autocmds(EVENT_BUFWINENTER, NULL, NULL, false, curbuf);
+    ui_call_set_cursor();
   }
 
   // If autocommands did not change the cursor position, restore cursor lnum

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -29,7 +29,7 @@ typedef enum {
 typedef enum {
   SHAPE_BLOCK     = 0,       ///< block cursor
   SHAPE_HOR       = 1,       ///< horizontal bar cursor
-  SHAPE_VER       = 2,  ///< vertical bar cursor
+  SHAPE_VER       = 2,       ///< vertical bar cursor
 } CursorShape;
 
 #define MSHAPE_NUMBERED 1000    // offset for shapes identified by number

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -829,6 +829,7 @@ void setcursor_mayforce(bool force)
 
     grid_adjust(&grid, &row, &col);
     ui_grid_cursor_goto(grid->handle, row, col);
+    ui_call_reset_cursor();
   }
 }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1107,6 +1107,17 @@ void tui_mode_info_set(TUIData *tui, bool guicursor_enabled, Array args)
   tui_set_mode(tui, tui->showing_mode);
 }
 
+void tui_set_cursor(TUIData *tui)
+{
+  tui_set_mode(tui, tui->showing_mode);
+}
+
+void tui_reset_cursor(TUIData *tui)
+{
+  unibi_out_ext(tui, tui->unibi_ext.reset_cursor_color);
+  unibi_out_ext(tui, tui->unibi_ext.reset_cursor_style);
+}
+
 void tui_update_menu(TUIData *tui)
 {
   // Do nothing; menus are for GUI only


### PR DESCRIPTION
use $TERM cursor in terminal buffer and restore our cursor in normal buffer

Fix #3681