### PR TITLE
ci: write the correct cherry-picked commit id when backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,3 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create backport PRs
         uses: korthout/backport-action@v2
+        with:
+          # https://github.com/korthout/backport-action/pull/399
+          experimental: >
+            {
+              "detect_merge_method": true
+            }


### PR DESCRIPTION
Problem: Commits backport-merged to release branches are cherry-picked
from the original commits in the PR from a fork repository, NOT the
actual commit that are merged to neovim/neovim (HEAD). Therefore the
commit reference in the commit message `cherry picked from commit ...`
usually refers to a commit that does NOT exist in the repository,
given that our preferred way of merging PR (rebasing, squashing, etc.)
would rewrite commits.

Solution: Turn on new feature 'detect_merge_method' of backport-action
workflow.
