### PR TITLE
feat(extmark): `nvim_buf_clear_namespace` can specify column bounds

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -236,10 +236,12 @@ function vim.api.nvim_buf_clear_highlight(buffer, ns_id, line_start, line_end) e
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param ns_id integer Namespace to clear, or -1 to clear all namespaces.
---- @param line_start integer Start of range of lines to clear
---- @param line_end integer End of range of lines to clear (exclusive) or -1 to
----                   clear to end of buffer.
-function vim.api.nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end) end
+--- @param start any Start of range of lines to clear: a 0-indexed (row, col) or
+---               a 0-indexed integer for the starting row
+--- @param end_ any End of range of lines to clear: a 0-indexed (row, col) or
+---               a 0-indexed integer for the end row (exclusive) or -1 to
+---               clear to end of buffer.
+function vim.api.nvim_buf_clear_namespace(buffer, ns_id, start, end_) end
 
 --- Creates a buffer-local command `user-commands`.
 ---

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -93,7 +93,11 @@ void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, 
   FUNC_API_SINCE(1)
   FUNC_API_DEPRECATED_SINCE(7)
 {
-  nvim_buf_clear_namespace(buffer, ns_id, line_start, line_end, err);
+  Object start;
+  start.data.integer = line_start;
+  Object end;
+  end.data.integer = line_end;
+  nvim_buf_clear_namespace(buffer, ns_id, start, end, err);
 }
 
 /// Set the virtual text (annotation) for a buffer line.

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -95,8 +95,10 @@ void nvim_buf_clear_highlight(Buffer buffer, Integer ns_id, Integer line_start, 
 {
   Object start;
   start.data.integer = line_start;
+  start.type = kObjectTypeInteger;
   Object end;
   end.data.integer = line_end;
+  end.type = kObjectTypeInteger;
   nvim_buf_clear_namespace(buffer, ns_id, start, end, err);
 }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -953,8 +953,7 @@ Integer nvim_buf_add_highlight(Buffer buffer, Integer ns_id, String hl_group, In
 /// @param line_end   End of range of lines to clear (exclusive) or -1 to clear
 ///                   to end of buffer.
 /// @param[out] err   Error details, if any
-void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, Integer line_end,
-                              Error *err)
+void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Object start, Object end, Error *err)
   FUNC_API_SINCE(5)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
@@ -962,16 +961,76 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
     return;
   }
 
-  VALIDATE_RANGE((line_start >= 0 && line_start < MAXLNUM), "line number", {
+  VALIDATE_INT(ns_id == -1 || ns_initialized((uint32_t)ns_id), "ns_id", ns_id, {
     return;
   });
 
-  if (line_end < 0 || line_end > MAXLNUM) {
-    line_end = MAXLNUM;
+  int l_row;
+  colnr_T l_col;
+  if (start.type == kObjectTypeInteger) {
+    Integer start_row = start.data.integer;
+    if (start_row < 0) {
+      return;
+    } else {
+      l_row = (int)start_row;
+      l_col = 0;
+    }
+  } else if (start.type == kObjectTypeArray) {
+    Array pos = start.data.array;
+    VALIDATE_EXP((pos.size == 2
+                  && pos.items[0].type == kObjectTypeInteger
+                  && pos.items[1].type == kObjectTypeInteger),
+                 "mark position", "2 Integer items", NULL, {
+      return;
+    });
+
+    Integer pos_row = pos.items[0].data.integer;
+    Integer pos_col = pos.items[1].data.integer;
+    l_row = (int)(pos_row >= 0 ? pos_row : MAXLNUM);
+    l_col = (int)(pos_col >= 0 ? pos_col : MAXCOL);
+  } else {
+    return;
   }
+
+  int u_row;
+  colnr_T u_col;
+  if (end.type == kObjectTypeInteger) {
+    Integer end_row = end.data.integer;
+    if (end_row < 0) {
+      u_row = MAXLNUM;
+      u_col = MAXCOL;
+    } else {
+      u_row = (int)end_row;
+      u_col = MAXCOL;
+    }
+  } else if (end.type == kObjectTypeArray) {
+    Array pos = end.data.array;
+    VALIDATE_EXP((pos.size == 2
+                  && pos.items[0].type == kObjectTypeInteger
+                  && pos.items[1].type == kObjectTypeInteger),
+                 "mark position", "2 Integer items", NULL, {
+      return;
+    });
+
+    Integer pos_row = pos.items[0].data.integer;
+    Integer pos_col = pos.items[1].data.integer;
+    u_row = (int)(pos_row >= 0 ? pos_row : MAXLNUM);
+    u_col = (int)(pos_col >= 0 ? pos_col : MAXCOL);
+  } else {
+    return;
+  }
+
+  VALIDATE_RANGE((l_row >= 0 && l_row < MAXLNUM), "line number", {
+    return;
+  });
+
+  if (u_row < 0 || u_row > MAXLNUM) {
+    u_row = MAXLNUM;
+  }
+
   extmark_clear(buf, (ns_id < 0 ? 0 : (uint32_t)ns_id),
-                (int)line_start, 0,
-                (int)line_end - 1, MAXCOL);
+                l_row, l_col,
+                u_row - 1, u_col);
 }
 
 /// Set or change decoration provider for a |namespace|


### PR DESCRIPTION
## Problem

Some plugins use one namespace per language for extmarks, but when languages like c, c++ or rust use language injections to parse macros, it can be hard to control the extmarks precisely without column information (i.e. purely by the rows as it is now).

E.g., say I want to do some highlighting for each treesitter tree. If I want to refresh the highlights after a change, I can use `on_changedtree` to capture a change with row, column and tree information, but if I then use this change to highlight by

1. clear the current (language) namespace for the changed rows
2. highlight the changed rows based on the given information

I can accidentally clear too much highlighting because `nvim_buf_clear_namespace` clears whole rows (and not just parts of rows).

As a simple example, consider
```c
#define min(X,Y) ((X) < (Y) ? (X) : (Y))
```
Here `((X) < (Y) ? (X) : (Y))` is injected `c` code, so if I get a change in this part and clear the highlighting with `nvim_buf_clear_namespace`, I will also accidentally clear my highlighting of min(X,Y). (Similarly the other way around too.)

## Solution

Allow for use of both rows and columns when clearing a buffer namespace, instead of just rows. For backward compatibility, the code still allows for entering just the rows.

NOTE: I have not updated all docs/comments/tests yet. I will do that after receiving feedback on the code. (Also, I am not sure how to fix the test complaining that this is incompatible with earlier versions.)