### PR TITLE
refactor(column): define and use maximum 'statuscolumn' width

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5923,9 +5923,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	%s	sign column for currently drawn line
 	%C	fold column for currently drawn line
 
-	NOTE: To draw the sign and fold columns, their items must be included in
-	'statuscolumn'. Even when they are not included, the status column width
-	will adapt to the 'signcolumn' and 'foldcolumn' width.
+	The 'statuscolumn' width follows that of the default columns and
+	adapts to the |'numberwidth'|, |'signcolumn'| and |'foldcolumn'| option
+	values (regardless of whether the sign and fold items are present).
+	Aditionally, the 'statuscolumn' grows with the size of the evaluated
+	format string, up to a point (following the maximum size of the default
+	fold, sign and number columns). Shrinking only happens when the number
+	of lines in a buffer changes, or the 'statuscolumn' option is set.
 
 	The |v:lnum|    variable holds the line number to be drawn.
 	The |v:relnum|  variable holds the relative line number to be drawn.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6359,9 +6359,13 @@ vim.go.sol = vim.go.startofline
 --- %s	sign column for currently drawn line
 --- %C	fold column for currently drawn line
 ---
---- NOTE: To draw the sign and fold columns, their items must be included in
---- 'statuscolumn'. Even when they are not included, the status column width
---- will adapt to the 'signcolumn' and 'foldcolumn' width.
+--- The 'statuscolumn' width follows that of the default columns and
+--- adapts to the `'numberwidth'`, `'signcolumn'` and `'foldcolumn'` option
+--- values (regardless of whether the sign and fold items are present).
+--- Aditionally, the 'statuscolumn' grows with the size of the evaluated
+--- format string, up to a point (following the maximum size of the default
+--- fold, sign and number columns). Shrinking only happens when the number
+--- of lines in a buffer changes, or the 'statuscolumn' option is set.
 ---
 --- The `v:lnum`    variable holds the line number to be drawn.
 --- The `v:relnum`  variable holds the relative line number to be drawn.

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nvim/macros_defs.h"
+#include "nvim/sign_defs.h"
 #include "nvim/types_defs.h"
 
 // option_vars.h: definition of global variables for settable options
@@ -785,7 +786,10 @@ EXTERN int p_cdh;               ///< 'cdhome'
 
 #define SB_MAX 100000  // Maximum 'scrollback' value.
 
-#define MAX_NUMBERWIDTH 20      // used for 'numberwidth' and 'statuscolumn'
+#define MAX_NUMBERWIDTH 20      // used for 'numberwidth'
+
+// Maximum 'statuscolumn' width: number + sign + fold columns
+#define MAX_STCWIDTH MAX_NUMBERWIDTH + SIGN_SHOW_MAX * SIGN_WIDTH + 9
 
 #define TABSTOP_MAX 9999
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8021,9 +8021,13 @@ return {
         %s	sign column for currently drawn line
         %C	fold column for currently drawn line
 
-        NOTE: To draw the sign and fold columns, their items must be included in
-        'statuscolumn'. Even when they are not included, the status column width
-        will adapt to the 'signcolumn' and 'foldcolumn' width.
+        The 'statuscolumn' width follows that of the default columns and
+        adapts to the |'numberwidth'|, |'signcolumn'| and |'foldcolumn'| option
+        values (regardless of whether the sign and fold items are present).
+        Aditionally, the 'statuscolumn' grows with the size of the evaluated
+        format string, up to a point (following the maximum size of the default
+        fold, sign and number columns). Shrinking only happens when the number
+        of lines in a buffer changes, or the 'statuscolumn' option is set.
 
         The |v:lnum|    variable holds the line number to be drawn.
         The |v:relnum|  variable holds the relative line number to be drawn.

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1964,11 +1964,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
   // What follows is post-processing to handle alignment and highlighting.
 
   int width = vim_strsize(out);
-  // Return truncated width for 'statuscolumn'
-  if (stcp != NULL && width > stcp->width) {
-    stcp->truncate = width - stcp->width;
-  }
-  if (maxwidth > 0 && width > maxwidth) {
+  if (maxwidth > 0 && width > maxwidth && (!stcp || width > MAX_STCWIDTH)) {
     // Result is too long, must truncate somewhere.
     int item_idx = 0;
     char *trunc_p;

--- a/src/nvim/statusline_defs.h
+++ b/src/nvim/statusline_defs.h
@@ -58,7 +58,6 @@ typedef struct {
   int width;                           ///< width of the status column
   int num_attr;                        ///< default highlight attr
   int sign_cul_id;                     ///< cursorline sign highlight id
-  int truncate;                        ///< truncated width
   bool draw;                           ///< whether to draw the statuscolumn
   bool use_cul;                        ///< whether to use cursorline attrs
   stl_hlrec_t *hlrec;                  ///< highlight groups


### PR DESCRIPTION
Problem:  The maximum 'statuscolumn' width and grow behavior is undocumented.
Solution: Define, use and document the maximum 'statuscolumn' width and grow behavior.