### PR TITLE
vim-patch:10b4f75d4c03

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -167,6 +167,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	`*.sh`		g:bash_is_sh		|ft-sh-syntax|
 	`*.tex`		g:tex_flavor		|ft-tex-plugin|
 	`*.typ`		g:filetype_typ
+	`*.v`		g:filetype_v
 	`*.w`		g:filetype_w		|ft-cweb-syntax|
 
 For a few filetypes the global variable is used only when the filetype could

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1530,12 +1530,26 @@ function M.v(_, bufnr)
     -- Filetype was already detected
     return
   end
+  if vim.g.filetype_v then
+    return vim.g.filetype_v
+  end
+  local in_comment = 0
   for _, line in ipairs(getlines(bufnr, 1, 200)) do
-    if not line:find('^%s*/') then
-      if findany(line, { ';%s*$', ';%s*/' }) then
-        return 'verilog'
-      elseif findany(line, { '%.%s*$', '%.%s*%(%*' }) then
+    if line:find('^%s*/%*') then
+      in_comment = 1
+    end
+    if in_comment == 1 then
+      if line:find('%*/') then
+        in_comment = 0
+      end
+    elseif not line:find('^%s*//') then
+      if
+        line:find('%.%s*$') and not line:find('/[/*]')
+        or line:find('%(%*') and not line:find('/[/*].*%(%*')
+      then
         return 'coq'
+      elseif findany(line, { ';%s*$', ';%s*/[/*]' }) then
+        return 'verilog'
       end
     end
   end


### PR DESCRIPTION
#### vim-patch:10b4f75d4c03

runtime(dist/ft): improve filetype detection for *.v (V/Verilog/Coq)

Patch provided by Dan Alt

closes: vim/vim#13793

https://github.com/vim/vim/commit/10b4f75d4c03c1cd4f579be5fdc812ba41b72fef

Co-authored-by: Christian Brabandt <cb@256bit.org>