### PR TITLE
fix(health): vim.health.system stdout/stderr capture, and add tests

### DIFF
--- a/runtime/lua/provider/clipboard/health.lua
+++ b/runtime/lua/provider/clipboard/health.lua
@@ -10,7 +10,7 @@ function M.check()
     os.getenv('TMUX')
     and executable('tmux')
     and executable('pbpaste')
-    and not health.cmd_ok('pbpaste')
+    and not health._cmd_ok('pbpaste')
   then
     local tmux_version = string.match(vim.fn.system('tmux -V'), '%d+%.%d+')
     local advice = {

--- a/runtime/lua/provider/node/health.lua
+++ b/runtime/lua/provider/node/health.lua
@@ -7,7 +7,7 @@ local M = {}
 function M.check()
   health.start('Node.js provider (optional)')
 
-  if health.provider_disabled('node') then
+  if health._provider_disabled('node') then
     return
   end
 
@@ -23,7 +23,7 @@ function M.check()
   end
 
   -- local node_v = vim.fn.split(system({'node', '-v'}), "\n")[1] or ''
-  local ok, node_v = health.cmd_ok({ 'node', '-v' })
+  local ok, node_v = health._cmd_ok({ 'node', '-v' })
   health.info('Node.js: ' .. node_v)
   if not ok or vim.version.lt(node_v, '6.0.0') then
     health.warn('Nvim node.js host does not support Node ' .. node_v)
@@ -60,7 +60,7 @@ function M.check()
     iswin and 'cmd /c ' .. manager .. ' info neovim --json' or manager .. ' info neovim --json'
   )
   local latest_npm
-  ok, latest_npm = health.cmd_ok(vim.split(latest_npm_cmd, ' '))
+  ok, latest_npm = health._cmd_ok(vim.split(latest_npm_cmd, ' '))
   if not ok or latest_npm:find('^%s$') then
     health.error(
       'Failed to run: ' .. latest_npm_cmd,
@@ -78,7 +78,7 @@ function M.check()
 
   local current_npm_cmd = { 'node', host, '--version' }
   local current_npm
-  ok, current_npm = health.cmd_ok(current_npm_cmd)
+  ok, current_npm = health._cmd_ok(current_npm_cmd)
   if not ok then
     health.error(
       'Failed to run: ' .. table.concat(current_npm_cmd, ' '),

--- a/runtime/lua/provider/perl/health.lua
+++ b/runtime/lua/provider/perl/health.lua
@@ -5,7 +5,7 @@ local M = {}
 function M.check()
   health.start('Perl provider (optional)')
 
-  if health.provider_disabled('perl') then
+  if health._provider_disabled('perl') then
     return
   end
 
@@ -29,7 +29,7 @@ function M.check()
 
   -- we cannot use cpanm that is on the path, as it may not be for the perl
   -- set with g:perl_host_prog
-  local ok = health.cmd_ok({ perl_exec, '-W', '-MApp::cpanminus', '-e', '' })
+  local ok = health._cmd_ok({ perl_exec, '-W', '-MApp::cpanminus', '-e', '' })
   if not ok then
     return { perl_exec, '"App::cpanminus" module is not installed' }
   end
@@ -41,7 +41,7 @@ function M.check()
     'my $app = App::cpanminus::script->new; $app->parse_options ("--info", "-q", "Neovim::Ext"); exit $app->doit',
   }
   local latest_cpan
-  ok, latest_cpan = health.cmd_ok(latest_cpan_cmd)
+  ok, latest_cpan = health._cmd_ok(latest_cpan_cmd)
   if not ok or latest_cpan:find('^%s*$') then
     health.error(
       'Failed to run: ' .. table.concat(latest_cpan_cmd, ' '),
@@ -72,7 +72,7 @@ function M.check()
 
   local current_cpan_cmd = { perl_exec, '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION' }
   local current_cpan
-  ok, current_cpan = health.cmd_ok(current_cpan_cmd)
+  ok, current_cpan = health._cmd_ok(current_cpan_cmd)
   if not ok then
     health.error(
       'Failed to run: ' .. table.concat(current_cpan_cmd, ' '),

--- a/runtime/lua/provider/ruby/health.lua
+++ b/runtime/lua/provider/ruby/health.lua
@@ -7,7 +7,7 @@ local M = {}
 function M.check()
   health.start('Ruby provider (optional)')
 
-  if health.provider_disabled('ruby') then
+  if health._provider_disabled('ruby') then
     return
   end
 


### PR DESCRIPTION
fix(health): vim.system.health stdout/stderr capture, and add tests

Problem:
- `vim.system.health()` was not capturing stdout and stderr correctly,
  which results in not showing the error/debug messages.
- file download via python (not via curl) has SyntaxError.
- (Note: These are regression bugs made in #22962 while refactoring into lua)

Solution:
- Refactor using `vim.system()`, and write functional tests.
- Add end-to-end functional tests for the recently refactored provider
  healthcheck implementations. (See #26839)

Other bugfixes:
- python: Fix a few minor errors on error handling.
- python: Fix a bug on parsing `$PYENV_ROOT`.

Other accompanied fixes/refactoring:
- Change utility functions introduced in #26839 as private, e.g.:
  `vim.health.system()` -> `vim.health._system()`
  `vim.health.cmd_ok()` -> `vim.health._cmd_ok()`
  `vim.health.provider_disabled()` -> `vim.health._provider_disabled()`
- Remove `stdin` from `vim.health.system()`, as it is not being used.

