### PR TITLE
refactor: remove redundant struct names

### DIFF
--- a/src/nvim/arglist_defs.h
+++ b/src/nvim/arglist_defs.h
@@ -4,7 +4,7 @@
 
 /// Argument list: Array of file names.
 /// Used for the global argument list and the argument lists local to a window.
-typedef struct arglist {
+typedef struct {
   garray_T al_ga;   ///< growarray with the array of file names
   int al_refcount;  ///< number of windows using this arglist
   int id;           ///< id of this arglist
@@ -13,7 +13,7 @@ typedef struct arglist {
 /// For each argument remember the file name as it was given, and the buffer
 /// number that contains the expanded file name (required for when ":cd" is
 /// used).
-typedef struct argentry {
+typedef struct {
   char *ae_fname;  ///< file name as specified
   int ae_fnum;     ///< buffer number with expanded file name
 } aentry_T;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -88,7 +88,7 @@ typedef struct frame_S frame_T;
 typedef uint64_t disptick_T;  // display tick type
 
 // The taggy struct is used to store the information about a :tag command.
-typedef struct taggy {
+typedef struct {
   char *tagname;                // tag name
   fmark_T fmark;                // cursor position BEFORE ":tag"
   int cur_match;                // match number
@@ -808,7 +808,7 @@ struct tabpage_S {
 // may not reflect what is actually in the buffer.  When wl_valid is false,
 // the entries can only be used to count the number of displayed lines used.
 // wl_lnum and wl_lastlnum are invalid too.
-typedef struct w_line {
+typedef struct {
   linenr_T wl_lnum;             // buffer line number for logical line
   uint16_t wl_size;             // height in screen lines
   char wl_valid;                // true values are valid for text in buffer

--- a/src/nvim/cmdexpand_defs.h
+++ b/src/nvim/cmdexpand_defs.h
@@ -15,7 +15,7 @@ typedef enum {
 enum { EXPAND_BUF_LEN = 256, };
 
 /// used for completion on the command line
-typedef struct expand {
+typedef struct {
   char *xp_pattern;             ///< start of item to expand, guaranteed
                                 ///< to be part of xp_line
   int xp_context;               ///< type of expansion

--- a/src/nvim/cmdhist.h
+++ b/src/nvim/cmdhist.h
@@ -20,7 +20,7 @@ typedef enum {
 enum { HIST_COUNT = HIST_DEBUG + 1, };  ///< Number of history tables
 
 /// History entry definition
-typedef struct hist_entry {
+typedef struct {
   int hisnum;           ///< Entry identifier number.
   char *hisstr;         ///< Actual entry, separator char after the NUL.
   Timestamp timestamp;  ///< Time when entry was added.

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -38,7 +38,7 @@ typedef enum {
 #define SHAPE_MOUSE     1       // used for mouse pointer shape
 #define SHAPE_CURSOR    2       // used for text cursor shape
 
-typedef struct cursor_entry {
+typedef struct {
   char *full_name;        ///< mode description
   CursorShape shape;      ///< cursor shape: one of the SHAPE_ defines
   int mshape;             ///< mouse shape: one of the MSHAPE defines

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -38,7 +38,7 @@
 
 typedef int result_T;
 
-typedef struct digraph {
+typedef struct {
   uint8_t char1;
   uint8_t char2;
   result_T result;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -64,7 +64,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-typedef struct insert_state {
+typedef struct {
   VimState state;
   cmdarg_T *ca;
   int mincol;

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -49,7 +49,7 @@
 //      "exp_name"  NULL or non-NULL, to be freed later.
 //      "tv"        points to the Dictionary typval_T
 //      "newkey"    is the key for the new item.
-typedef struct lval_S {
+typedef struct {
   const char *ll_name;  ///< Start of variable name (can be NULL).
   size_t ll_name_len;   ///< Length of the .ll_name.
   char *ll_exp_name;    ///< NULL or expanded name in allocated memory.

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -74,7 +74,7 @@ typedef struct {
 #define CALLBACK_NONE ((Callback)CALLBACK_INIT)
 
 /// Structure holding dictionary watcher
-typedef struct dict_watcher {
+typedef struct {
   Callback callback;
   char *key_pattern;
   size_t key_pattern_len;

--- a/src/nvim/event/libuv_process.h
+++ b/src/nvim/event/libuv_process.h
@@ -5,7 +5,7 @@
 #include "nvim/event/process.h"
 #include "nvim/types_defs.h"
 
-typedef struct libuv_process {
+typedef struct {
   Process process;
   uv_process_t uv;
   uv_process_options_t uvopts;

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -128,7 +128,7 @@ struct aucmd_executable_t {
 typedef char *(*LineGetter)(int, void *, int, bool);
 
 /// Structure for command definition.
-typedef struct cmdname {
+typedef struct {
   char *cmd_name;                      ///< Name of the command.
   ex_func_T cmd_func;                  ///< Function with implementation of this command.
   ex_preview_func_T cmd_preview_func;  ///< Preview callback function of this command.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -102,7 +102,7 @@ typedef struct {
   optmagic_T magic_overruled_save;
 } incsearch_state_T;
 
-typedef struct command_line_state {
+typedef struct {
   VimState state;
   int firstc;
   int count;
@@ -131,7 +131,7 @@ typedef struct command_line_state {
   buf_T *b_im_ptr_buf;  ///< buffer where b_im_ptr is valid
 } CommandLineState;
 
-typedef struct cmdpreview_undo_info {
+typedef struct {
   u_header_T *save_b_u_oldhead;
   u_header_T *save_b_u_newhead;
   u_header_T *save_b_u_curhead;
@@ -147,7 +147,7 @@ typedef struct cmdpreview_undo_info {
   colnr_T save_b_u_line_colnr;
 } CpUndoInfo;
 
-typedef struct cmdpreview_buf_info {
+typedef struct {
   buf_T *buf;
   OptInt save_b_p_ul;
   int save_b_changed;
@@ -157,7 +157,7 @@ typedef struct cmdpreview_buf_info {
   CpUndoInfo undo_info;
 } CpBufInfo;
 
-typedef struct cmdpreview_win_info {
+typedef struct {
   win_T *win;
   pos_T save_w_cursor;
   viewstate_T save_viewstate;
@@ -165,7 +165,7 @@ typedef struct cmdpreview_win_info {
   int save_w_p_cuc;
 } CpWinInfo;
 
-typedef struct cmdpreview_info {
+typedef struct {
   kvec_t(CpWinInfo) win_info;
   kvec_t(CpBufInfo) buf_info;
   bool save_hls;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -157,7 +157,7 @@ typedef struct ff_visited_list_hdr {
 //   ffsc_stopdirs_v:   array of stop directories for upward search
 //   ffsc_find_what:    FINDFILE_BOTH, FINDFILE_DIR or FINDFILE_FILE
 //   ffsc_tagfile:      searching for tags file, don't use 'suffixesadd'
-typedef struct ff_search_ctx_T {
+typedef struct {
   ff_stack_T *ffsc_stack_ptr;
   ff_visited_list_hdr_T *ffsc_visited_list;
   ff_visited_list_hdr_T *ffsc_dir_visited_list;

--- a/src/nvim/fold_defs.h
+++ b/src/nvim/fold_defs.h
@@ -4,7 +4,7 @@
 
 /// Info used to pass info about a fold from the fold-detection code to the
 /// code that displays the foldcolumn.
-typedef struct foldinfo {
+typedef struct {
   linenr_T fi_lnum;  ///< line number where fold starts
   int fi_level;      ///< level of the fold; when this is zero the
                      ///< other fields are invalid

--- a/src/nvim/garray_defs.h
+++ b/src/nvim/garray_defs.h
@@ -5,7 +5,7 @@
 /// Structure used for growing arrays.
 /// This is used to store information that only grows, is deleted all at
 /// once, and needs to be accessed by index.  See ga_clear() and ga_grow().
-typedef struct growarray {
+typedef struct {
   int ga_len;                       // current number of items used
   int ga_maxlen;                    // maximum number of items possible
   int ga_itemsize;                  // sizeof(item)

--- a/src/nvim/getchar_defs.h
+++ b/src/nvim/getchar_defs.h
@@ -6,22 +6,19 @@
 
 #include "nvim/api/private/defs.h"
 
-typedef struct buffblock buffblock_T;
-typedef struct buffheader buffheader_T;
-
 /// structure used to store one block of the stuff/redo/recording buffers
-struct buffblock {
-  buffblock_T *b_next;  ///< pointer to next buffblock
+typedef struct buffblock {
+  struct buffblock *b_next;  ///< pointer to next buffblock
   char b_str[1];        ///< contents (actually longer)
-};
+} buffblock_T;
 
 /// header used for the stuff buffer and the redo buffer
-struct buffheader {
+typedef struct {
   buffblock_T bh_first;  ///< first (dummy) block of list
   buffblock_T *bh_curr;  ///< buffblock for appending
   size_t bh_index;       ///< index for reading
   size_t bh_space;       ///< space in bh_curr for appending
-};
+} buffheader_T;
 
 typedef struct {
   buffheader_T sr_redobuff;

--- a/src/nvim/hashtab_defs.h
+++ b/src/nvim/hashtab_defs.h
@@ -21,7 +21,7 @@ typedef size_t hash_T;
 /// value, so that you can get a pointer to the value subtracting an offset from
 /// the pointer to the key.
 /// This reduces the size of this item by 1/3.
-typedef struct hashitem_S {
+typedef struct {
   /// Cached hash number for hi_key.
   hash_T hi_hash;
 
@@ -48,7 +48,7 @@ enum {
 /// Values are of any type.
 ///
 /// The hashtable grows to accommodate more entries when needed.
-typedef struct hashtable_S {
+typedef struct {
   hash_T ht_mask;        ///< mask used for hash value
                          ///< (nr of items in array is "ht_mask" + 1)
   size_t ht_used;        ///< number of items used

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -33,7 +33,7 @@ typedef enum {
 
 /// Stores a complete highlighting entry, including colors and attributes
 /// for both TUI and GUI.
-typedef struct attr_entry {
+typedef struct {
   int16_t rgb_ae_attr, cterm_ae_attr;  ///< HlAttrFlags
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -59,7 +59,7 @@ typedef enum {
 #define TAGSTACKSIZE    20
 
 /// Represents view in which the mark was created
-typedef struct fmarkv {
+typedef struct {
   linenr_T topline_offset;  ///< Amount of lines from the mark lnum to the top of the window.
                             ///< Use MAXLNUM to indicate that the mark does not have a view.
 } fmarkv_T;
@@ -67,7 +67,7 @@ typedef struct fmarkv {
 #define INIT_FMARKV { MAXLNUM }
 
 /// Structure defining single local mark
-typedef struct filemark {
+typedef struct {
   pos_T mark;           ///< Cursor position.
   int fnum;             ///< File number.
   Timestamp timestamp;  ///< Time when this mark was last set.
@@ -78,7 +78,7 @@ typedef struct filemark {
 #define INIT_FMARK { { 0, 0, 0 }, 0, 0, INIT_FMARKV, NULL }
 
 /// Structure defining extended mark (mark with file name attached)
-typedef struct xfilemark {
+typedef struct {
   fmark_T fmark;       ///< Actual mark.
   char *fname;  ///< File name, used when fnum == 0.
 } xfmark_T;

--- a/src/nvim/memfile_defs.h
+++ b/src/nvim/memfile_defs.h
@@ -26,7 +26,7 @@ typedef int64_t blocknr_T;
 /// The free list is a single linked list, not sorted.
 /// The blocks in the free list have no block of memory allocated and
 /// the contents of the block in the file (if any) is irrelevant.
-typedef struct bhdr {
+typedef struct {
   blocknr_T bh_bnum;                 ///< key used in hash table
 
   void *bh_data;                     ///< pointer to memory (for used block)
@@ -44,7 +44,7 @@ typedef enum {
 } mfdirty_T;
 
 /// A memory file.
-typedef struct memfile {
+typedef struct {
   char *mf_fname;                    ///< name of the file
   char *mf_ffname;                   ///< idem, full path
   int mf_fd;                         ///< file descriptor

--- a/src/nvim/memline_defs.h
+++ b/src/nvim/memline_defs.h
@@ -7,14 +7,14 @@
 /// are the branches leading to that block. This is stored in ml_stack.  Each
 /// entry is a pointer to info in a block (may be data block or pointer block)
 ///
-typedef struct info_pointer {
+typedef struct {
   blocknr_T ip_bnum;            // block number
   linenr_T ip_low;              // lowest lnum in this block
   linenr_T ip_high;             // highest lnum in this block
   int ip_index;                 // index for block with current lnum
 } infoptr_T;    // block/index pair
 
-typedef struct ml_chunksize {
+typedef struct {
   int mlcs_numlines;
   int mlcs_totalsize;
 } chunksize_T;
@@ -39,7 +39,7 @@ typedef struct ml_chunksize {
 ///             memory.  With this structure it is roughly (N * 128) pointer
 ///             moves, where N is the height (typically 1-3).
 ///
-typedef struct memline {
+typedef struct {
   linenr_T ml_line_count;       // number of lines in the buffer
 
   memfile_T *ml_mfp;          // pointer to associated memfile

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -75,7 +75,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-typedef struct normal_state {
+typedef struct {
   VimState state;
   bool command_finished;
   bool ctrl_w;

--- a/src/nvim/normal_defs.h
+++ b/src/nvim/normal_defs.h
@@ -16,7 +16,7 @@ typedef enum {
 } MotionType;
 
 /// Arguments for operators.
-typedef struct oparg_S {
+typedef struct {
   int op_type;             ///< current pending operator type
   int regname;             ///< register to use for the operator
   MotionType motion_type;  ///< type of the current cursor motion
@@ -42,7 +42,7 @@ typedef struct oparg_S {
 } oparg_T;
 
 /// Arguments for Normal mode commands.
-typedef struct cmdarg_S {
+typedef struct {
   oparg_T *oap;     ///< Operator arguments
   int prechar;      ///< prefix character (optional, always 'g')
   int cmdchar;      ///< command character

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -86,7 +86,7 @@ enum GRegFlags {
 };
 
 /// Definition of one register
-typedef struct yankreg {
+typedef struct {
   char **y_array;           ///< Pointer to an array of line pointers.
   size_t y_size;            ///< Number of lines in y_array.
   MotionType y_type;        ///< Register type

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -42,7 +42,7 @@ typedef enum {
 // buffers.  Indicate this by setting "var" to VAR_WIN.
 #define VAR_WIN ((char *)-1)
 
-typedef struct vimoption {
+typedef struct {
   char *fullname;           ///< full option name
   char *shortname;          ///< permissible abbreviation
   uint32_t flags;           ///< see above

--- a/src/nvim/os/pty_process_unix.h
+++ b/src/nvim/os/pty_process_unix.h
@@ -7,7 +7,7 @@
 #include "nvim/event/process.h"
 #include "nvim/types_defs.h"
 
-typedef struct pty_process {
+typedef struct {
   Process process;
   uint16_t width, height;
   struct winsize winsize;

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -35,7 +35,7 @@
 #endif
 
 /// Struct used in sn_prl_ga for every line of a script.
-typedef struct sn_prl_S {
+typedef struct {
   int snp_count;                ///< nr of times line was executed
   proftime_T sn_prl_total;      ///< time spent in a line + children
   proftime_T sn_prl_self;       ///< time spent in a line itself

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -107,7 +107,7 @@ typedef enum {
 /// Usually the list contains one or more entries. But an empty list can be
 /// created using setqflist()/setloclist() with a title and/or user context
 /// information and entries can be added later using setqflist()/setloclist().
-typedef struct qf_list_S {
+typedef struct {
   unsigned qf_id;         ///< Unique identifier for this list
   qfltype_T qfl_type;
   qfline_T *qf_start;     ///< pointer to the first error
@@ -232,7 +232,7 @@ typedef struct {
 } qffields_T;
 
 /// :vimgrep command arguments
-typedef struct vgr_args_S {
+typedef struct {
   int tomatch;          ///< maximum number of matches to find
   char *spat;          ///< search pattern
   int flags;             ///< search modifier

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -90,7 +90,7 @@ static const char e_search_hit_bottom_without_match_for_str[]
 // one for other searches.  last_idx points to the one that was used the last
 // time.
 
-static struct spat spats[2] = {
+static SearchPattern spats[2] = {
   // Last used search pattern
   [0] = { NULL, true, false, 0, { '/', false, false, 0 }, NULL },
   // Last used substitute pattern
@@ -106,7 +106,7 @@ static char lastc_bytes[MB_MAXBYTES + 1];
 static int lastc_bytelen = 1;             // >1 for multi-byte char
 
 // copy of spats[], for keeping the search patterns while executing autocmds
-static struct spat saved_spats[2];
+static SearchPattern saved_spats[2];
 static char *saved_mr_pattern = NULL;
 static int saved_spats_last_idx = 0;
 static bool saved_spats_no_hlsearch = false;
@@ -116,7 +116,7 @@ static char *mr_pattern = NULL;
 
 // Type used by find_pattern_in_path() to remember which included files have
 // been searched already.
-typedef struct SearchedFile {
+typedef struct {
   FILE *fp;              // File pointer
   char *name;            // Full name of file
   linenr_T lnum;                // Line we were up to in file
@@ -270,7 +270,7 @@ void restore_search_patterns(void)
   set_no_hlsearch(saved_spats_no_hlsearch);
 }
 
-static inline void free_spat(struct spat *const spat)
+static inline void free_spat(SearchPattern *const spat)
 {
   xfree(spat->pat);
   tv_dict_unref(spat->additional_data);
@@ -291,7 +291,7 @@ void free_search_patterns(void)
 
 // copy of spats[RE_SEARCH], for keeping the search patterns while incremental
 // searching
-static struct spat saved_last_search_spat;
+static SearchPattern saved_last_search_spat;
 static int did_save_last_search_spat = 0;
 static int saved_last_idx = 0;
 static bool saved_no_hlsearch = false;
@@ -1047,7 +1047,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, int count, in
 
   // Save the values for when (options & SEARCH_KEEP) is used.
   // (there is no "if ()" around this because gcc wants them initialized)
-  struct soffset old_off = spats[0].off;
+  SearchOffset old_off = spats[0].off;
 
   pos = curwin->w_cursor;       // start searching at the cursor position
 

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -74,7 +74,7 @@ enum {
 ///
 /// @note Only offset for the last search pattern is used, not for the last
 ///       substitute pattern.
-typedef struct soffset {
+typedef struct {
   char dir;     ///< Search direction: forward ('/') or backward ('?')
   bool line;    ///< True if search has line offset.
   bool end;     ///< True if search sets cursor at the end.
@@ -82,7 +82,7 @@ typedef struct soffset {
 } SearchOffset;
 
 /// Structure containing last search pattern and its attributes.
-typedef struct spat {
+typedef struct {
   char *pat;            ///< The pattern (in allocated memory) or NULL.
   bool magic;           ///< Magicness of the pattern.
   bool no_scs;          ///< No smartcase for this pattern.
@@ -99,7 +99,7 @@ typedef struct {
   int sa_wrapped;    ///< search wrapped around
 } searchit_arg_T;
 
-typedef struct searchstat {
+typedef struct {
   int cur;      // current position of found words
   int cnt;      // total count of found words
   bool exact_match;    // true if matched exactly on specified position

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -346,25 +346,25 @@ typedef struct {
   PMap(cstr_t) file_marks;  ///< All file marks.
 } WriteMergerState;
 
-struct sd_read_def;
+typedef struct sd_read_def ShaDaReadDef;
 
 /// Function used to close files defined by ShaDaReadDef
-typedef void (*ShaDaReadCloser)(struct sd_read_def *const sd_reader)
+typedef void (*ShaDaReadCloser)(ShaDaReadDef *const sd_reader)
   REAL_FATTR_NONNULL_ALL;
 
 /// Function used to read ShaDa files
-typedef ptrdiff_t (*ShaDaFileReader)(struct sd_read_def *const sd_reader,
+typedef ptrdiff_t (*ShaDaFileReader)(ShaDaReadDef *const sd_reader,
                                      void *const dest,
                                      const size_t size)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Function used to skip in ShaDa files
-typedef int (*ShaDaFileSkipper)(struct sd_read_def *const sd_reader,
+typedef int (*ShaDaFileSkipper)(ShaDaReadDef *const sd_reader,
                                 const size_t offset)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Structure containing necessary pointers for reading ShaDa files
-typedef struct sd_read_def {
+struct sd_read_def {
   ShaDaFileReader read;   ///< Reader function.
   ShaDaReadCloser close;  ///< Close function.
   ShaDaFileSkipper skip;  ///< Function used to skip some bytes.
@@ -373,27 +373,27 @@ typedef struct sd_read_def {
   const char *error;      ///< Error message in case of error.
   uintmax_t fpos;         ///< Current position (amount of bytes read since
                           ///< reader structure initialization). May overflow.
-} ShaDaReadDef;
+};
 
-struct sd_write_def;
+typedef struct sd_write_def ShaDaWriteDef;
 
 /// Function used to close files defined by ShaDaWriteDef
-typedef void (*ShaDaWriteCloser)(struct sd_write_def *const sd_writer)
+typedef void (*ShaDaWriteCloser)(ShaDaWriteDef *const sd_writer)
   REAL_FATTR_NONNULL_ALL;
 
 /// Function used to write ShaDa files
-typedef ptrdiff_t (*ShaDaFileWriter)(struct sd_write_def *const sd_writer,
+typedef ptrdiff_t (*ShaDaFileWriter)(ShaDaWriteDef *const sd_writer,
                                      const void *const src,
                                      const size_t size)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Structure containing necessary pointers for writing ShaDa files
-typedef struct sd_write_def {
+struct sd_write_def {
   ShaDaFileWriter write;   ///< Writer function.
   ShaDaWriteCloser close;  ///< Close function.
   void *cookie;            ///< Data describing object written to.
   const char *error;       ///< Error message in case of error.
-} ShaDaWriteDef;
+};
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "shada.c.generated.h"

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -9,7 +9,7 @@ typedef struct {
 } SignTextAttrs;
 
 /// Struct to hold the sign properties.
-typedef struct sign {
+typedef struct {
   char *sn_name;   // name of sign
   char *sn_icon;   // name of pixmap
   schar_T sn_text[SIGN_WIDTH];   // text used instead of pixmap

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -124,7 +124,7 @@ slang_T *first_lang = NULL;
 char *int_wordlist = NULL;
 
 // Structure to store info for word matching.
-typedef struct matchinf_S {
+typedef struct {
   langp_T *mi_lp;                   // info for language and region
 
   // pointers to original text to be checked
@@ -163,14 +163,14 @@ typedef struct matchinf_S {
 } matchinf_T;
 
 // Structure used for the cookie argument of do_in_runtimepath().
-typedef struct spelload_S {
+typedef struct {
   char sl_lang[MAXWLEN + 1];            // language name
   slang_T *sl_slang;                    // resulting slang_T struct
   int sl_nobreak;                       // NOBREAK language found
 } spelload_T;
 
 #define SY_MAXLEN   30
-typedef struct syl_item_S {
+typedef struct {
   char sy_chars[SY_MAXLEN];               // the sequence of chars
   int sy_len;
 } syl_item_T;

--- a/src/nvim/spell_defs.h
+++ b/src/nvim/spell_defs.h
@@ -78,7 +78,7 @@ enum {
 /// Info from "REP", "REPSAL" and "SAL" entries in ".aff" file used in si_rep,
 /// si_repsal, sl_rep, and si_sal.  Not for sl_sal!
 /// One replacement: from "ft_from" to "ft_to".
-typedef struct fromto_S {
+typedef struct {
   char *ft_from;
   char *ft_to;
 } fromto_T;
@@ -86,7 +86,7 @@ typedef struct fromto_S {
 /// Info from "SAL" entries in ".aff" file used in sl_sal.
 /// The info is split for quick processing by spell_soundfold().
 /// Note that "sm_oneof" and "sm_rules" point into sm_lead.
-typedef struct salitem_S {
+typedef struct {
   char *sm_lead;    ///< leading letters
   int sm_leadlen;   ///< length of "sm_lead"
   char *sm_oneof;   ///< letters from () or NULL
@@ -192,7 +192,7 @@ struct slang_S {
 };
 
 /// Structure used in "b_langp", filled from 'spelllang'.
-typedef struct langp_S {
+typedef struct {
   slang_T *lp_slang;    ///< info for this language
   slang_T *lp_sallang;  ///< language used for sound folding or NULL
   slang_T *lp_replang;  ///< language used for REP items or NULL
@@ -223,7 +223,7 @@ typedef enum {
   SPELL_ADD_RARE = 2,
 } SpellAddType;
 
-typedef struct wordcount_S {
+typedef struct {
   uint16_t wc_count;  ///< nr of times word was seen
   char wc_word[];     ///< word
 } wordcount_T;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -334,7 +334,7 @@ static const char *msg_compressing = N_("Compressing word tree...");
 #define MAXLINELEN  500         // Maximum length in bytes of a line in a .aff
                                 // and .dic file.
 // Main structure to store the contents of a ".aff" file.
-typedef struct afffile_S {
+typedef struct {
   char *af_enc;                 // "SET", normalized, alloc'ed string or NULL
   int af_flagtype;              // AFT_CHAR, AFT_LONG, AFT_NUM or AFT_CAPLONG
   unsigned af_rare;             // RARE ID for rare word
@@ -376,7 +376,7 @@ struct affentry_S {
 #define AH_KEY_LEN 17          // 2 x 8 bytes + NUL
 
 // Affix header from ".aff" file.  Used for af_pref and af_suff.
-typedef struct affheader_S {
+typedef struct {
   char ah_key[AH_KEY_LEN];      // key for hashtab == name of affix
   unsigned ah_flag;             // affix name as number, uses "af_flagtype"
   int ah_newID;                 // prefix ID after renumbering; 0 if not used
@@ -388,7 +388,7 @@ typedef struct affheader_S {
 #define HI2AH(hi)   ((affheader_T *)(hi)->hi_key)
 
 // Flag used in compound items.
-typedef struct compitem_S {
+typedef struct {
   char ci_key[AH_KEY_LEN];      // key for hashtab == name of compound
   unsigned ci_flag;             // affix name as number, uses "af_flagtype"
   int ci_newID;                 // affix ID after renumbering.
@@ -449,7 +449,7 @@ struct wordnode_S {
 #define HI2WN(hi)    (wordnode_T *)((hi)->hi_key)
 
 // Info used while reading the spell files.
-typedef struct spellinfo_S {
+typedef struct {
   wordnode_T *si_foldroot;     // tree with case-folded words
   int si_foldwcount;           // nr of words in si_foldroot
 

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -63,7 +63,7 @@
 #define WF_MIXCAP   0x20        // mix of upper and lower case: macaRONI
 
 /// Information used when looking for suggestions.
-typedef struct suginfo_S {
+typedef struct {
   garray_T su_ga;                  ///< suggestions, contains "suggest_T"
   int su_maxcount;                 ///< max. number of suggestions displayed
   int su_maxscore;                 ///< maximum score for adding to su_ga
@@ -186,7 +186,7 @@ typedef enum {
 } state_T;
 
 /// Struct to keep the state at each level in suggest_try_change().
-typedef struct trystate_S {
+typedef struct {
   state_T ts_state;          ///< state at this level, STATE_
   int ts_score;              ///< score
   idx_T ts_arridx;           ///< index in tree array, start of node

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -75,7 +75,7 @@ static const char e_trailing_char_after_rsb_str_str[]
 // and for the actually highlighted text (_h_start and _h_end).
 //
 // Note that ordering of members is optimized to reduce padding.
-typedef struct syn_pattern {
+typedef struct {
   char sp_type;                         // see SPTYPE_ defines below
   bool sp_syncing;                      // this item used for syncing
   int16_t sp_syn_match_id;              // highlight group ID of pattern
@@ -95,7 +95,7 @@ typedef struct syn_pattern {
   syn_time_T sp_time;
 } synpat_T;
 
-typedef struct syn_cluster_S {
+typedef struct {
   char *scl_name;           // syntax cluster name
   char *scl_name_u;         // uppercase of scl_name
   int16_t *scl_list;        // IDs in this syntax cluster
@@ -104,7 +104,7 @@ typedef struct syn_cluster_S {
 // For the current state we need to remember more than just the idx.
 // When si_m_endpos.lnum is 0, the items other than si_idx are unknown.
 // (The end positions have the column number of the next char)
-typedef struct state_item {
+typedef struct {
   int si_idx;                           // index of syntax pattern or
                                         // KEYWORD_IDX
   int si_id;                            // highlight group ID for keywords

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -31,7 +31,7 @@ struct keyentry {
 };
 
 // Struct used to store one state of the state stack.
-typedef struct buf_state {
+typedef struct {
   int bs_idx;                    // index of pattern
   int bs_flags;                  // flags for pattern
   int bs_seqnr;                  // stores si_seqnr

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -60,7 +60,7 @@
 #include "nvim/window.h"
 
 // Structure to hold pointers to various items in a tag line.
-typedef struct tag_pointers {
+typedef struct {
   // filled in by parse_tag_line():
   char *tagname;        // start of tag name (skip "file:")
   char *tagname_end;    // char after tag name

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -86,7 +86,7 @@
 #include "nvim/ui.h"
 #include "nvim/vim_defs.h"
 
-typedef struct terminal_state {
+typedef struct {
   VimState state;
   Terminal *term;
   int save_rd;              // saved value of RedrawingDisabled

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -2,12 +2,12 @@
 
 #include "nvim/types_defs.h"
 
-typedef struct ucell {
+typedef struct {
   schar_T data;
   sattr_T attr;
 } UCell;
 
-typedef struct ugrid {
+typedef struct {
   int row, col;
   int width, height;
   UCell **cells;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -37,7 +37,7 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-typedef struct ui_event_callback {
+typedef struct {
   LuaRef cb;
   bool ext_widgets[kUIGlobalCount];
 } UIEventCallback;


### PR DESCRIPTION
A struct can be anonymous if only its typedef is used.
