### PR TITLE
docs(lsp): add `@lsp.type.comment` to default semantic highlights

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -482,6 +482,7 @@ complex highlighting.
 The following groups are linked by default to standard |group-name|s:
 
 @lsp.type.class          Structure
+@lsp.type.comment        Comment
 @lsp.type.decorator      Function
 @lsp.type.enum           Structure
 @lsp.type.enumMember     Constant


### PR DESCRIPTION
https://github.com/neovim/neovim/blob/ee2127363463b89ba9d5071babcb9bd16c4db691/src/nvim/highlight_group.c#L287