### PR TITLE
build: fix `.styluaignore` to make `--respect-ignores` work correctly

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -1,14 +1,15 @@
-/build/
-/.deps/
-/runtime/lua/coxpcall.lua
-/runtime/lua/vim/_meta
-/runtime/lua/vim/re.lua
+# glob patterns are a workaround, see #26866
+build/**/*.lua
+.deps/**/*.lua
+runtime/lua/coxpcall.lua
+runtime/lua/vim/_meta/**/*.lua
+runtime/lua/vim/re.lua
 
 test/functional/ui/decorations_spec.lua
 test/functional/ui/float_spec.lua
 test/functional/ui/multigrid_spec.lua
-/test/functional/fixtures/lua/syntax_error.lua
-/test/functional/legacy/030_fileformats_spec.lua
-/test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
-/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
-/test/functional/lua/luaeval_spec.lua
+test/functional/fixtures/lua/syntax_error.lua
+test/functional/legacy/030_fileformats_spec.lua
+test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
+test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
+test/functional/lua/luaeval_spec.lua


### PR DESCRIPTION
Problem: `stylua --respect-ignores <filename>` does not respect
directory patterns in `.styluaignore` correctly, whereas `stylua .`
(scanning) works fine. This appears to be a bug of stylua as of v0.19.1.

Solution: Use explicit glob patterns.
