### PR TITLE
refactor: minor decor refactors

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -151,7 +151,7 @@ static Array extmark_to_array(MTPair extmark, bool id, bool add_dict, bool hl_na
 
     PUT(dict, "right_gravity", BOOLEAN_OBJ(mt_right(start)));
 
-    if (extmark.end_pos.row >= 0) {
+    if (mt_paired(start)) {
       PUT(dict, "end_row", INTEGER_OBJ(extmark.end_pos.row));
       PUT(dict, "end_col", INTEGER_OBJ(extmark.end_pos.col));
       PUT(dict, "end_right_gravity", BOOLEAN_OBJ(extmark.end_right_gravity));

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -612,10 +612,6 @@ int decor_redraw_col(win_T *wp, int col, int win_col, bool hidden, DecorState *s
     }
 
     MTPos endpos = marktree_get_altpos(buf->b_marktree, mark, NULL);
-    if (endpos.row == -1) {
-      endpos = mark.pos;
-    }
-
     decor_range_add_from_inline(state, mark.pos.row, mark.pos.col, endpos.row, endpos.col,
                                 mt_decor(mark), false, mark.ns, mark.id);
 
@@ -842,7 +838,7 @@ static void buf_signcols_validate_range(buf_T *buf, int row1, int row2, int add)
     // Increment overlap array for the start and range of a paired sign mark.
     if (!mt_invalid(mark) && !mt_end(mark) && (mark.flags & MT_FLAG_DECOR_SIGNTEXT)) {
       MTPos end = marktree_get_altpos(buf->b_marktree, mark, NULL);
-      for (int i = currow; i <= MIN(row2, end.row < 0 ? currow : end.row); i++) {
+      for (int i = currow; i <= MIN(row2, end.row); i++) {
         overlap[i - row1]++;
       }
     }

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -93,20 +93,13 @@ void bufhl_add_hl_pos_offset(buf_T *buf, int src_id, int hl_id, lpos_T pos_start
 
 void decor_redraw(buf_T *buf, int row1, int row2, DecorInline decor)
 {
-  if (row2 >= row1) {
-    redraw_buf_range_later(buf, row1 + 1, row2 + 1);
-  }
-
   if (decor.ext) {
     DecorVirtText *vt = decor.data.ext.vt;
     while (vt) {
-      if (vt->flags & kVTIsLines) {
-        redraw_buf_line_later(buf, row1 + 1 + ((vt->flags & kVTLinesAbove) ? 0 : 1), true);
+      bool below = (vt->flags & kVTIsLines) && !(vt->flags & kVTLinesAbove);
+      redraw_buf_line_later(buf, row1 + 1 + below, true);
+      if (vt->flags & kVTIsLines || vt->pos == kVPosInline) {
         changed_line_display_buf(buf);
-      } else {
-        if (vt->pos == kVPosInline) {
-          changed_line_display_buf(buf);
-        }
       }
       vt = vt->next;
     }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -332,9 +332,6 @@ void extmark_splice_delete(buf_T *buf, int l_row, colnr_T l_col, int u_row, coln
     // Invalidate/delete mark
     if (!only_copy && !mt_invalid(mark) && mt_invalidate(mark) && !mt_end(mark)) {
       MTPos endpos = marktree_get_altpos(buf->b_marktree, mark, NULL);
-      if (endpos.row < 0) {
-        endpos = mark.pos;
-      }
       // Invalidate unpaired marks in deleted lines and paired marks whose entire
       // range has been deleted.
       if ((!mt_paired(mark) && mark.pos.row < u_row)
@@ -404,7 +401,7 @@ void extmark_apply_undo(ExtmarkUndoObject undo_info, bool undo)
         MTKey mark = marktree_lookup(curbuf->b_marktree, pos.mark, itr);
         mt_itr_rawkey(itr).flags &= (uint16_t) ~MT_FLAG_INVALID;
         MTPos end = marktree_get_altpos(curbuf->b_marktree, mark, itr);
-        buf_put_decor(curbuf, mt_decor(mark), mark.pos.row, end.row < 0 ? mark.pos.row : end.row);
+        buf_put_decor(curbuf, mt_decor(mark), mark.pos.row, end.row);
       }
       // Redo
     } else {

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1972,13 +1972,10 @@ MTPos marktree_get_altpos(MarkTree *b, MTKey mark, MarkTreeIter *itr)
   return marktree_get_alt(b, mark, itr).pos;
 }
 
+/// @return alt mark for a paired mark or mark itself for unpaired mark
 MTKey marktree_get_alt(MarkTree *b, MTKey mark, MarkTreeIter *itr)
 {
-  MTKey end = MT_INVALID_KEY;
-  if (mt_paired(mark)) {
-    end = marktree_lookup_ns(b, mark.ns, mark.id, !mt_end(mark), itr);
-  }
-  return end;
+  return mt_paired(mark) ? marktree_lookup_ns(b, mark.ns, mark.id, !mt_end(mark), itr) : mark;
 }
 
 static void marktree_itr_fix_pos(MarkTree *b, MarkTreeIter *itr)


### PR DESCRIPTION
**refactor(decorations): more conservative redraw range**

Problem:  Decor range is being redrawn unconditionally, negating the
          more conservative line redrawing that follows.
Solution: Get rid of unconditional redraw_buf_range_later() call.

**refactor(marktree): unpaired marktree_get_alt() returns itself**

Avoids checking for invalid mark at callsite.