### PR TITLE
fix: checkhealth warning even if init.lua exists #25306

### DIFF
--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -54,15 +54,19 @@ local function check_config()
   health.report_start('Configuration')
   local ok = true
 
-  local vimrc = (
-    empty(vim.env.MYVIMRC) and vim.fn.stdpath('config') .. '/init.vim' or vim.env.MYVIMRC
-  )
-  if not filereadable(vimrc) then
+  local init_lua = vim.fn.stdpath('config') .. '/init.lua'
+  local init_vim = vim.fn.stdpath('config') .. '/init.vim'
+  local vimrc = empty(vim.env.MYVIMRC) and init_lua or vim.env.MYVIMRC
+
+  if not filereadable(vimrc) and not filereadable(init_vim) then
     ok = false
     local has_vim = filereadable(vim.fn.expand('~/.vimrc'))
     health.report_warn(
-      (-1 == vim.fn.getfsize(vimrc) and 'Missing' or 'Unreadable') .. ' user config file: ' .. vimrc,
-      { has_vim and ':help nvim-from-vim' or ':help init.vim' }
+      ('%s user config file: %s'):format(
+        -1 == vim.fn.getfsize(vimrc) and 'Missing' or 'Unreadable',
+        vimrc
+      ),
+      { has_vim and ':help nvim-from-vim' or ':help config' }
     )
   end
 


### PR DESCRIPTION
Problem:
`:checkhealth nvim` warns about missing vimrc if `init.lua` exists but `init.vim` does not.

Solution:
Check for any of: init.vim, init.lua, $MYVIMRC.
Fix #25291

Backport of https://github.com/neovim/neovim/pull/25306