### PR TITLE
vim-patch:9.1.0001: when closing window, wincmd p may fail

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4738,10 +4738,14 @@ static void win_enter_ext(win_T *const wp, const int flags)
   if (wp->w_buffer != curbuf) {
     buf_copy_options(wp->w_buffer, BCO_ENTER | BCO_NOHELP);
   }
+
   if (!curwin_invalid) {
     prevwin = curwin;           // remember for CTRL-W p
     curwin->w_redr_status = true;
+  } else if (wp == prevwin) {
+    prevwin = NULL;             // don't want it to be the new curwin
   }
+
   curwin = wp;
   curbuf = wp->w_buffer;
 

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -113,6 +113,64 @@ func Test_window_quit()
   bw Xa Xb
 endfunc
 
+func Test_window_curwin_not_prevwin()
+  botright split
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+  quit
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+
+  botright split
+  botright split
+  call assert_equal(3, winnr())
+  call assert_equal(2, winnr('#'))
+  1quit
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  botright split
+  call assert_equal(1, tabpagenr())
+  call assert_equal(3, winnr())
+  call assert_equal(2, winnr('#'))
+  wincmd T
+  call assert_equal(2, tabpagenr())
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+  tabfirst
+  call assert_equal(1, tabpagenr())
+  call assert_equal(2, winnr())
+  call assert_equal(0, winnr('#'))
+
+  tabonly
+  botright split
+  wincmd t
+  wincmd p
+  call assert_equal(3, winnr())
+  call assert_equal(1, winnr('#'))
+  quit
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  botright split
+  wincmd t
+  wincmd p
+  call assert_equal(1, tabpagenr())
+  call assert_equal(3, winnr())
+  call assert_equal(1, winnr('#'))
+  wincmd T
+  call assert_equal(2, tabpagenr())
+  call assert_equal(1, winnr())
+  call assert_equal(0, winnr('#'))
+  tabfirst
+  call assert_equal(1, tabpagenr())
+  call assert_equal(2, winnr())
+  call assert_equal(1, winnr('#'))
+
+  tabonly
+  only
+endfunc
+
 func Test_window_horizontal_split()
   call assert_equal(1, winnr('$'))
   3wincmd s


### PR DESCRIPTION
Avoid `prevwin == curwin` when closing `curwin`

Problem:  When closing the current window (or when moving it to a tabpage), the
          previous window may refer to the new current window
          (`winnr() == winnr('#')`) if that window is selected as the
          new current window.

Solution: Set `prevwin = NULL` when switching away from an invalid `curwin` and
          the target window was the `prevwin`.
          (Sean Dewar)

related: vim/vim#4537
closes: vim/vim#13762

https://github.com/vim/vim/commit/bf44b69d1f91d9778ae1887128c63d35d9a3d19b

Co-authored-by: Sean Dewar <seandewar@users.noreply.github.com>
