### PR TITLE
vim-patch:9.1.0002: a closing fold expr, may start a new fold

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2980,7 +2980,9 @@ static void foldlevelExpr(fline_T *flp)
 
   // "<1", "<2", .. : end a fold with a certain level
   case '<':
-    flp->lvl_next = n - 1;
+    // To prevent an unexpected start of a new fold, the next
+    // level must not exceed the level of the current fold.
+    flp->lvl_next = MIN(flp->lvl, n - 1);
     flp->end = n;
     break;
 

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1578,4 +1578,17 @@ func Test_foldexpr_return_empty_string()
   bwipe!
 endfunc
 
+" Make sure that when ending a fold that hasn't been started, it does not
+" start a new fold.
+func Test_foldexpr_end_fold()
+  new
+  setlocal foldmethod=expr
+  let &l:foldexpr = 'v:lnum == 2 ? "<2" : "="'
+  call setline(1, range(1, 3))
+  redraw
+  call assert_equal([0, 0, 0], range(1, 3)->map('foldlevel(v:val)'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0002: a closing fold expr, may start a new fold

Problem:  a closing fold expression may unexpectedly start a new fold
          when it should end a fold
          (reported by Shota Nozaki)
Solution: if a fold hasn't started yet, do not immediately
          start a new fold with level 1
          (Shota Nozaki)

closes: vim/vim#13748

https://github.com/vim/vim/commit/0689b870595c687a23e102913ce5037f65d03748

Co-authored-by: Shota Nozaki <emonkak@gmail.com>