### PR TITLE
vim-patch:9.1.0004: reloading colorscheme when not changing 'background'

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -302,8 +302,6 @@ Options:
   global-local string options work.
 
   'autoread'    works in the terminal (if it supports "focus" events)
-  'background'  colorscheme is only reloaded if value is changed, not every
-                time it is set
   'cpoptions'   flags: |cpo-_|
   'diffopt'     "linematch" feature
   'exrc'        searches for ".nvim.lua", ".nvimrc", or ".exrc" files. The


### PR DESCRIPTION
#### vim-patch:9.1.0004: reloading colorscheme when not changing 'background'

Problem:  reloading colorscheme when not changing 'background'
Solution: Check, if the background option value actually changed,
          if not, return early.

Only reload colorscheme when bg is changed

Currently the highlight groups are re-initialized and the colorscheme
(if any) is reloaded anytime 'background' is set, even if it is not
changed. This is unnecessary, because if the value was not changed then
there is no need to change highlight groups or do anything with the
colorscheme. Instead, only reload the colorscheme if the value of
'background' was actually changed.

closes: vim/vim#13700

https://github.com/vim/vim/commit/83ad2726ff56db70cb2da78e1e4ea0e09941c73b

Co-authored-by: Gregory Anders <greg@gpanders.com>