### PR TITLE
fix(health): fix tmux RGB capability detection (#26886)

### DIFF
--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -327,24 +327,17 @@ local function check_tmux()
   end
 
   -- check for RGB capabilities
-  local info = vim.fn.system({ 'tmux', 'display-message', '-p', '#{client_termfeatures}' })
-  info = vim.split(vim.trim(info), ',', { trimempty = true })
-  if not vim.tbl_contains(info, 'RGB') then
-    local has_rgb = false
-    if #info == 0 then
-      -- client_termfeatures may not be supported; fallback to checking show-messages
-      info = vim.fn.system({ 'tmux', 'show-messages', '-JT' })
-      has_rgb = info:find(' Tc: (flag) true', 1, true) or info:find(' RGB: (flag) true', 1, true)
-    end
-    if not has_rgb then
-      health.report_warn(
-        "Neither Tc nor RGB capability set. True colors are disabled. |'termguicolors'| won't work properly.",
-        {
-          "Put this in your ~/.tmux.conf and replace XXX by your $TERM outside of tmux:\nset-option -sa terminal-features ',XXX:RGB'",
-          "For older tmux versions use this instead:\nset-option -ga terminal-overrides ',XXX:Tc'",
-        }
-      )
-    end
+  local info = vim.fn.system({ 'tmux', 'show-messages', '-T' })
+  local has_setrgbb = vim.fn.stridx(info, ' setrgbb: (string)') ~= -1
+  local has_setrgbf = vim.fn.stridx(info, ' setrgbf: (string)') ~= -1
+  if not has_setrgbb or not has_setrgbf then
+    health.warn(
+      "True color support could not be detected. |'termguicolors'| won't work properly.",
+      {
+        "Add the following to your tmux configuration file, replacing XXX by the value of $TERM outside of tmux:\nset-option -a terminal-features 'XXX:RGB'",
+        "For older tmux versions use this instead:\nset-option -a terminal-overrides 'XXX:Tc'",
+      }
+    )
   end
 end
 


### PR DESCRIPTION
tmux indicates its RGB support via setrgbb and setrgbf. In modern tmux
code, Tc and RGB just set setrgbb and setrgbf, so we can just check for
them.

Link: https://github.com/tmux/tmux/commit/7eb496c00c313c2f8ab8debe6d154d5ac0db277b

(cherry picked from commit 88eb0ad149d353c475455e4013cafa6db2a3f9f1)
