### PR TITLE
fix(column): keep track of number of lines with number of signs

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -757,8 +757,6 @@ void buf_clear(void)
 {
   linenr_T line_count = curbuf->b_ml.ml_line_count;
   extmark_free_all(curbuf);   // delete any extmarks
-  map_destroy(int, curbuf->b_signcols.invalid);
-  *curbuf->b_signcols.invalid = (Map(int, SignRange)) MAP_INIT;
   while (!(curbuf->b_ml.ml_flags & ML_EMPTY)) {
     ml_delete(1, false);
   }
@@ -929,8 +927,6 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
   }
   uc_clear(&buf->b_ucmds);               // clear local user commands
   extmark_free_all(buf);                 // delete any extmarks
-  map_destroy(int, buf->b_signcols.invalid);
-  *buf->b_signcols.invalid = (Map(int, SignRange)) MAP_INIT;
   map_clear_mode(buf, MAP_ALL_MODES, true, false);  // clear local mappings
   map_clear_mode(buf, MAP_ALL_MODES, true, true);   // clear local abbrevs
   XFREE_CLEAR(buf->b_start_fenc);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -685,10 +685,12 @@ struct file_buffer {
                                 // may use a different synblock_T.
 
   struct {
-    int max;                         // maximum number of signs on a single line
-    int max_count;                   // number of lines with max number of signs
-    bool resized;                    // whether max changed at start of redraw
-    Map(int, SignRange) invalid[1];  // map of invalid ranges to be checked
+    int max;                    // maximum number of signs on a single line
+    int count[SIGN_SHOW_MAX];   // number of lines with number of signs
+    bool resized;               // whether max changed at start of redraw
+    bool autom;                 // whether 'signcolumn' is displayed in "auto:n>1"
+                                // configured window. "b_signcols" calculation
+                                // is skipped if false.
   } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer

--- a/src/nvim/map.c
+++ b/src/nvim/map.c
@@ -111,9 +111,6 @@ void mh_clear(MapHash *h)
 #define VAL_NAME(x) quasiquote(x, String)
 #include "nvim/map_value_impl.c.h"
 #undef VAL_NAME
-#define VAL_NAME(x) quasiquote(x, SignRange)
-#include "nvim/map_value_impl.c.h"
-#undef VAL_NAME
 #undef KEY_NAME
 
 #define KEY_NAME(x) x##ptr_t

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -48,7 +48,6 @@ static const uint64_t value_init_uint64_t = 0;
 static const int64_t value_init_int64_t = 0;
 static const String value_init_String = STRING_INIT;
 static const ColorItem value_init_ColorItem = COLOR_ITEM_INITIALIZER;
-static const SignRange value_init_SignRange = SIGNRANGE_INIT;
 
 // layer 0: type non-specific code
 
@@ -151,7 +150,6 @@ KEY_DECLS(uint32_t)
 KEY_DECLS(String)
 KEY_DECLS(HlEntry)
 KEY_DECLS(ColorKey)
-KEY_DECLS(SignRange)
 
 MAP_DECLS(int, int)
 MAP_DECLS(int, ptr_t)
@@ -168,7 +166,6 @@ MAP_DECLS(uint32_t, uint32_t)
 MAP_DECLS(String, int)
 MAP_DECLS(int, String)
 MAP_DECLS(ColorKey, ColorItem)
-MAP_DECLS(int, SignRange)
 
 #define set_has(T, set, key) set_has_##T(set, key)
 #define set_put(T, set, key) set_put_##T(set, key, NULL)

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -48,13 +48,6 @@ typedef enum {
 
 typedef int64_t OptInt;
 
-// Range entry for the "b_signcols.invalid" map in which the keys are the range start.
-typedef struct {
-  int end;  // End of the invalid range.
-  int add;  // Number of signs added in the invalid range, negative for deleted signs.
-} SignRange;
-#define SIGNRANGE_INIT { 0, 0 }
-
 enum { SIGN_WIDTH = 2, };  ///< Number of display cells for a sign in the signcolumn
 
 typedef struct file_buffer buf_T;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -521,8 +521,8 @@ describe('statuscolumn', function()
     command([[set stc=%6s\ %l]])
     exec_lua('vim.api.nvim_buf_set_extmark(0, ns, 7, 0, {sign_text = "𒀀"})')
     screen:expect([[
-      {0:    𒀀  8}^aaaaa                                        |
-      {0:    }{1:  }{0: 9}aaaaa                                        |
+      {0:    𒀀  8 }^aaaaa                                       |
+      {0:    }{1:  }{0: 9 }aaaaa                                       |
                                                            |
     ]])
   end)


### PR DESCRIPTION
Problem:    Some edge cases to the old (pre-#26406) and current "b_signcols"
            structure result in an incorrectly sized "auto" 'signcolumn'.
Solution: 
* Implement a simpler 'signcolumn' validation strategy by immediately
            counting the number of signs in a range upon sign insertion and
            deletion. Decrease in performance here but there is a clear path
            forward to mitigating this performance hit. Either by moving signs to a
            dedicated marktree, or by adding meta-data to the existing
            marktree which may be queried more efficiently?
* Also replace "max_count" and keep track of the number of lines with
            a certain number of signs. This makes it so that it is no longer
            necessary to scan the entire buffer when the maximum number of signs
            decreases. This likely makes the commit a net increase in performance.
* To ensure correctness we also have re-initialize the count for an
            edited region that spans multiple lines. Such an edit may move the
            signs within it. Thus we count and decrement before splicing the
            marktree and count and increment after.