### PR TITLE
vim-patch:9.1.{0007,0012}: can select empty inner text blocks

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -578,7 +578,8 @@ i]						*v_i]* *v_i[* *i]* *i[*
 i[			"inner [] block", select [count] '[' ']' blocks.  This
 			goes backwards to the [count] unclosed '[', and finds
 			the matching ']'.  The enclosed text is selected,
-			excluding the '[' and ']'.  The |cpo-M| option flag
+			excluding the '[' and ']'.  It's an error to select an
+			empty inner block like "[]".  The |cpo-M| option flag
 			is used to handle escaped brackets.
 			When used in Visual mode it is made charwise.
 
@@ -596,7 +597,8 @@ i(							*vib* *v_ib* *v_i(* *ib*
 ib			"inner block", select [count] blocks, from "[count] [("
 			to the matching ')', excluding the '(' and ')' (see
 			|[(|).  If the cursor is not inside a () block, then
-			find the next "(".  The |cpo-M| option flag
+			find the next "(".  It's an error to select an empty
+			inner block like "()".  The |cpo-M| option flag
 			is used to handle escaped parenthesis.
 			When used in Visual mode it is made charwise.
 
@@ -610,8 +612,9 @@ a<			"a <> block", select [count] <> blocks, from the
 i>						*v_i>* *v_i<* *i>* *i<*
 i<			"inner <> block", select [count] <> blocks, from
 			the [count]'th unmatched '<' backwards to the matching
-			'>', excluding the '<' and '>'.  The |cpo-M| option flag
-			is used to handle escaped '<' and '>'.
+			'>', excluding the '<' and '>'.  It's an error to
+			select an empty inner block like "<>".  The |cpo-M|
+			option flag is used to handle escaped '<' and '>'.
 			When used in Visual mode it is made charwise.
 
 						*v_at* *at*
@@ -640,7 +643,8 @@ i}							*v_i}* *i}* *i{*
 i{							*v_iB* *v_i{* *iB*
 iB			"inner Block", select [count] Blocks, from `[count] [{`
 			to the matching "}", excluding the "{" and "}" (see
-			|[{|).  The |cpo-M| option flag is used to handle
+			|[{|).  It"s an error to select an empty inner block
+			like "{}".  The |cpo-M| option flag is used to handle
 			escaped braces.
 			When used in Visual mode it is made charwise.
 

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -955,6 +955,12 @@ int current_block(oparg_T *oap, int count, bool include, int what, int other)
       }
     }
 
+    if (equalpos(start_pos, *end_pos)) {
+      // empty block like this: ()
+      // there is no inner block to select, abort
+      return FAIL;
+    }
+
     // In Visual mode, when the resulting area is not bigger than what we
     // started with, extend it to the next block, and then exclude again.
     // Don't try to expand the area if the area is empty.

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -955,9 +955,10 @@ int current_block(oparg_T *oap, int count, bool include, int what, int other)
       }
     }
 
-    if (equalpos(start_pos, *end_pos)) {
-      // empty block like this: ()
-      // there is no inner block to select, abort
+    // In Visual mode, when resulting area is empty
+    // i.e. there is no inner block to select, abort.
+    if (equalpos(start_pos, *end_pos) && VIsual_active) {
+      curwin->w_cursor = old_pos;
       return FAIL;
     }
 

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -645,7 +645,7 @@ endfunc
 
 func Test_inner_block_empty_paren()
   new
-  call setline(1, ["(text)()", "", "(text)(", ")", "", "()()"])
+  call setline(1, ["(text)()", "", "(text)(", ")", "", "()()", "", "text()"])
 
   " Example 1
   call cursor(1, 1)
@@ -667,12 +667,18 @@ func Test_inner_block_empty_paren()
   call assert_beeps('call feedkeys("0f(viby", "xt")')
   call assert_equal(3, getpos('.')[2])
   call assert_equal('(', @")
+
+  " Change empty inner block
+  call cursor(8, 1)
+  call feedkeys("0cibtext", "xt")
+  call assert_equal("text(text)", getline('.'))
+
   bwipe!
 endfunc
 
 func Test_inner_block_empty_bracket()
   new
-  call setline(1, ["[text][]", "", "[text][", "]", "", "[][]"])
+  call setline(1, ["[text][]", "", "[text][", "]", "", "[][]", "", "text[]"])
 
   " Example 1
   call cursor(1, 1)
@@ -694,12 +700,18 @@ func Test_inner_block_empty_bracket()
   call assert_beeps('call feedkeys("0f[viby", "xt")')
   call assert_equal(3, getpos('.')[2])
   call assert_equal('[', @")
+
+  " Change empty inner block
+  call cursor(8, 1)
+  call feedkeys("0ci[text", "xt")
+  call assert_equal("text[text]", getline('.'))
+
   bwipe!
 endfunc
 
 func Test_inner_block_empty_brace()
   new
-  call setline(1, ["{text}{}", "", "{text}{", "}", "", "{}{}"])
+  call setline(1, ["{text}{}", "", "{text}{", "}", "", "{}{}", "", "text{}"])
 
   " Example 1
   call cursor(1, 1)
@@ -721,6 +733,12 @@ func Test_inner_block_empty_brace()
   call assert_beeps('call feedkeys("0f{viby", "xt")')
   call assert_equal(3, getpos('.')[2])
   call assert_equal('{', @")
+
+  " Change empty inner block
+  call cursor(8, 1)
+  call feedkeys("0ciBtext", "xt")
+  call assert_equal("text{text}", getline('.'))
+
   bwipe!
 endfunc
 

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -402,7 +402,7 @@ func Test_paragraph()
   call assert_beeps("normal Vipip")
   exe "normal \<C-C>"
 
-  close!
+  bw!
 endfunc
 
 " Tests for text object aw
@@ -608,7 +608,7 @@ func Test_textobj_quote()
   normal $hhyi"
   call assert_equal('bar', @")
 
-  close!
+  bw!
 endfunc
 
 " Test for i(, i<, etc. when cursor is in front of a block
@@ -640,7 +640,115 @@ func Test_textobj_find_paren_forward()
   normal 0di)
   call assert_equal('foo ()', getline(1))
 
-  close!
+  bw!
+endfunc
+
+func Test_inner_block_empty_paren()
+  new
+  call setline(1, ["(text)()", "", "(text)(", ")", "", "()()"])
+
+  " Example 1
+  call cursor(1, 1)
+  let @" = ''
+  call assert_beeps(':call feedkeys("0f(viby","xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('(', @")
+
+  " Example 2
+  call cursor(3, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f(viby", "xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('(', @")
+
+  " Example 3
+  call cursor(6, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f(viby", "xt")')
+  call assert_equal(3, getpos('.')[2])
+  call assert_equal('(', @")
+  bwipe!
+endfunc
+
+func Test_inner_block_empty_bracket()
+  new
+  call setline(1, ["[text][]", "", "[text][", "]", "", "[][]"])
+
+  " Example 1
+  call cursor(1, 1)
+  let @" = ''
+  call assert_beeps(':call feedkeys("0f[viby","xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('[', @")
+
+  " Example 2
+  call cursor(3, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f[viby", "xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('[', @")
+
+  " Example 3
+  call cursor(6, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f[viby", "xt")')
+  call assert_equal(3, getpos('.')[2])
+  call assert_equal('[', @")
+  bwipe!
+endfunc
+
+func Test_inner_block_empty_brace()
+  new
+  call setline(1, ["{text}{}", "", "{text}{", "}", "", "{}{}"])
+
+  " Example 1
+  call cursor(1, 1)
+  let @" = ''
+  call assert_beeps(':call feedkeys("0f{viby","xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('{', @")
+
+  " Example 2
+  call cursor(3, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f{viby", "xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('{', @")
+
+  " Example 3
+  call cursor(6, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f{viby", "xt")')
+  call assert_equal(3, getpos('.')[2])
+  call assert_equal('{', @")
+  bwipe!
+endfunc
+
+func Test_inner_block_empty_lessthan()
+  new
+  call setline(1, ["<text><>", "", "<text><", ">", "", "<><>"])
+
+  " Example 1
+  call cursor(1, 1)
+  let @" = ''
+  call assert_beeps(':call feedkeys("0f<viby","xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('<', @")
+
+  " Example 2
+  call cursor(3, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f<viby", "xt")')
+  call assert_equal(7, getpos('.')[2])
+  call assert_equal('<', @")
+
+  " Example 3
+  call cursor(6, 1)
+  let @" = ''
+  call assert_beeps('call feedkeys("0f<viby", "xt")')
+  call assert_equal(3, getpos('.')[2])
+  call assert_equal('<', @")
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0007: can select empty inner text blocks

Problem:  can select empty inner text blocks
          (laurentalacoque)
Solution: make selecting empty inner text blocks an error

textobjects: Make selecting inner empty blocks an error

closes: vim/vim#13523

https://github.com/vim/vim/commit/ad4d7f446dc6754bde212234d46f4849b520b6e0

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.0012: regression with empty inner blocks introduced

Problem:  regression with empty inner blocks introduced
          (after v9.1.0007)
Solution: Set correct cursor position, Check for visual mode
          being active (Maxim Kim)

relates: vim/vim#13514
closes: vim/vim#13819

https://github.com/vim/vim/commit/3779516988f14f2070d827514c79383334a0946b

Co-authored-by: Maxim Kim <habamax@gmail.com>