### PR TITLE
vim-patch:9.1.0014: incorrect use of W_WINROW in edit.c

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -458,8 +458,7 @@ static int insert_check(VimState *state)
     if (curwin->w_wcol < s->mincol - tabstop_at(get_nolist_virtcol(),
                                                 curbuf->b_p_ts,
                                                 curbuf->b_p_vts_array)
-        && curwin->w_wrow == curwin->w_winrow
-        + curwin->w_height_inner - 1 - get_scrolloff_value(curwin)
+        && curwin->w_wrow == curwin->w_height_inner - 1 - get_scrolloff_value(curwin)
         && (curwin->w_cursor.lnum != curwin->w_topline
             || curwin->w_topfill > 0)) {
       if (curwin->w_topfill > 0) {


### PR DESCRIPTION
#### vim-patch:9.1.0014: incorrect use of W_WINROW in edit.c

Problem:  incorrect use of W_WINROW in edit.c
Solution: compare against curwin->w_height instead

Remove incorrect use of W_WINROW

In structs.h it is mentioned that w_wrow is relative to w_winrow, so
using W_WINROW doesn't make sense when comparing with window height.

This change won't lead to any observable behavior change:

The condition intends to check if there are 'scrolloff' lines between
the current cursor when the bottom of the window. When W_WINROW(curwin)
is added to curwin->w_height - 1 - get_scrolloff_value(), the condition
is instead satisfied when the cursor is on some screen line below that
position. However,
- If 'scrolloff' is smaller than half the window height, this condition
  can only be satisfied when W_WINROW(curwin) == 0. And if it is not
  satisfied, update_topline() does the actual scrolling.
- If 'scrolloff' is larger than half the window height, update_topline()
  will put the cursor at the center of the window soon afterwards
  anyway, because set_topline() now unsets VALID_TOPLINE flag starting
  from https://github.com/vim/vim-history/commit/7db7bb45b0f919ff0615d463ebd4fde881c69d1f.

To put it in another way, https://github.com/vim/vim-history/commit/7db7bb45b0f919ff0615d463ebd4fde881c69d1f
makes the update_topline() just below correct the mistakes made in this
block, so this incorrect use of W_WINROW() no longer affects observable
behavior.

closes: vim/vim#12331

https://github.com/vim/vim/commit/b1ed7ec9f7d1a0142d4f1c8c83bab9172bc92c7c