### PR TITLE
fix(test/tui_spec): pass the expected NULL-sentinel to execl()

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -24,7 +24,6 @@ local funcs = helpers.funcs
 local meths = helpers.meths
 local is_ci = helpers.is_ci
 local is_os = helpers.is_os
-local is_arch = helpers.is_arch
 local new_pipename = helpers.new_pipename
 local spawn_argv = helpers.spawn_argv
 local set_session = helpers.set_session
@@ -1932,9 +1931,6 @@ describe('TUI', function()
   end)
 
   it('argv[0] can be overridden #23953', function()
-    if is_arch('aarch64') then
-      pending('execl does not work on aarch64')
-    end
     if not exec_lua('return pcall(require, "ffi")') then
       pending('missing LuaJIT FFI')
     end
@@ -1944,7 +1940,7 @@ describe('TUI', function()
       [=[
       local ffi = require('ffi')
       ffi.cdef([[int execl(const char *, const char *, ...);]])
-      ffi.C.execl(vim.v.progpath, 'Xargv0nvim', '--clean')
+      ffi.C.execl(vim.v.progpath, 'Xargv0nvim', '--clean', nil)
     ]=]
     )
     finally(function()


### PR DESCRIPTION
Since execl() is a variadic function, it requries a NULL-terminal to
indicate the end of its argument list, c.f. exec(3)

> The first argument, by convention, should point to the filename
> associated with the file being executed.  The list of arguments *must*
> be terminated by a null pointer

This fixes the failure seen on aarch64 and i386, due to garbage data
being considered part of the variadic arguments.

@gpanders, could you confirm this fixes the issue on aarch64, since you
added that exclusion in #26456?