### PR TITLE
docs(treesitter): improve 'no parser' error message for InspectTree

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -20,15 +20,23 @@ PARSER FILES                                              *treesitter-parsers*
 Parsers are the heart of tree-sitter. They are libraries that tree-sitter will
 search for in the `parser` runtime directory. By default, Nvim bundles parsers
 for C, Lua, Vimscript, Vimdoc and Treesitter query files, but parsers can be
-installed manually or via a plugin like
-https://github.com/nvim-treesitter/nvim-treesitter. Parsers are searched for
-as `parser/{lang}.*` in any 'runtimepath' directory. If multiple parsers for
-the same language are found, the first one is used. (This typically implies
-the priority "user config > plugins > bundled".
+installed via a plugin like https://github.com/nvim-treesitter/nvim-treesitter
+or even manually.
+
+Parsers are searched for as `parser/{lang}.*` in any 'runtimepath' directory.
+If multiple parsers for the same language are found, the first one is used.
+(NOTE: This typically implies the priority "user config > plugins > bundled".)
 A parser can also be loaded manually using a full path: >lua
 
     vim.treesitter.language.add('python', { path = "/path/to/python.so" })
 <
+To associate certain |filetypes| with a treesitter language (name of parser),
+use |vim.treesitter.language.register()|. For example, to use the `xml`
+treesitter parser for buffers with filetype `svg` or `xslt`, use: >lua
+
+    vim.treesitter.language.register('xml', { 'svg', 'xslt' })
+<
+
 ==============================================================================
 TREESITTER TREES                                             *treesitter-tree*
                                                                       *TSTree*
@@ -832,6 +840,9 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
 
 register({lang}, {filetype})              *vim.treesitter.language.register()*
     Register a parser named {lang} to be used for {filetype}(s).
+
+    Note: this adds or overrides the mapping for {filetype}, any existing
+    mappings from other filetypes to {lang} will be preserved.
 
     Parameters: ~
       • {lang}      (string) Name of parser

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -75,7 +75,8 @@ end
 function TSTreeView:new(bufnr, lang)
   local ok, parser = pcall(vim.treesitter.get_parser, bufnr or 0, lang)
   if not ok then
-    return nil, 'No parser available for the given buffer'
+    local err = parser --[[ @as string ]]
+    return nil, 'No parser available for the given buffer:\n' .. err
   end
 
   -- For each child tree (injected language), find the root of the tree and locate the node within

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -119,6 +119,10 @@ local function ensure_list(x)
 end
 
 --- Register a parser named {lang} to be used for {filetype}(s).
+---
+--- Note: this adds or overrides the mapping for {filetype}, any existing mappings from other
+--- filetypes to {lang} will be preserved.
+---
 --- @param lang string Name of parser
 --- @param filetype string|string[] Filetype(s) to associate with lang
 function M.register(lang, filetype)


### PR DESCRIPTION
Improve error messages for `:InspectTree`, when no parsers are available
for the current buffer and filetype. We can show more informative and
helpful error message for users (e.g., which lang was searched for):

```
 ... No parser available for the given buffer:
+... no parser for 'custom_ft' language, see :help treesitter-parsers
```

Also improve the relevant docs for *treesitter-parsers*.
