### PR TITLE
fix(vim.system): wait() timeout, and signal being sent

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1780,15 +1780,16 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
                      will be written to stdin and closed. Defaults to `false`.
                    • stdout: (boolean|function) Handle output from stdout.
                      When passed as a function must have the signature
-                     `fun(err: string, data: string)`. Defaults to `true`
+                     `fun(err: string, data: string)`. Defaults to `true`.
                    • stderr: (boolean|function) Handle output from stderr.
                      When passed as a function must have the signature
                      `fun(err: string, data: string)`. Defaults to `true`.
                    • text: (boolean) Handle stdout and stderr as text.
                      Replaces `\r\n` with `\n`.
-                   • timeout: (integer) Run the command with a time limit.
-                     Upon timeout the process is sent the TERM signal (15) and
-                     the exit code is set to 124.
+                   • timeout: (integer) Run the command with a time limit
+                     (given in milliseconds). Upon timeout the process is sent
+                     the TERM signal (15) and the exit code is set to 124.
+                     `timeout` must be >= 1.
                    • detach: (boolean) If true, spawn the child process in a
                      detached state - this will make it a process group
                      leader, and will effectively enable the child to keep
@@ -1805,11 +1806,12 @@ vim.system({cmd}, {opts}, {on_exit})                            *vim.system()*
         (`vim.SystemObj`) Object with the fields:
         • cmd (string[]) Command name and args
         • pid (integer) Process ID
-        • wait (fun(timeout: integer|nil): SystemCompleted) Wait for the
-          process to complete. Upon timeout the process is sent the KILL
-          signal (9) and the exit code is set to 124. Cannot be called in
-          |api-fast|.
-          • SystemCompleted is an object with the fields:
+        • wait (fun(timeout: integer|nil): vim.SystemCompleted) Wait for the
+          process to complete, for {timeout} milliseconds (if {timeout} is
+          given) or the timeout specified in {opts}. Upon timeout the process
+          is sent the TERM signal (15) and the exit code is set to 124.
+          {timeout} must be >= 1. Cannot be called in |api-fast|.
+          • vim.SystemCompleted is an object with the fields:
             • code: (integer)
             • signal: (integer)
             • stdout: (string), nil if stdout argument is passed

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -105,13 +105,14 @@ vim.log = {
 ---     and closed. Defaults to `false`.
 ---   - stdout: (boolean|function)
 ---     Handle output from stdout. When passed as a function must have the signature `fun(err: string, data: string)`.
----     Defaults to `true`
+---     Defaults to `true`.
 ---   - stderr: (boolean|function)
 ---     Handle output from stderr. When passed as a function must have the signature `fun(err: string, data: string)`.
 ---     Defaults to `true`.
 ---   - text: (boolean) Handle stdout and stderr as text. Replaces `\r\n` with `\n`.
----   - timeout: (integer) Run the command with a time limit. Upon timeout the process is sent the
----     TERM signal (15) and the exit code is set to 124.
+---   - timeout: (integer) Run the command with a time limit (given in milliseconds).
+---     Upon timeout the process is sent the TERM signal (15) and the exit code is set to 124.
+---     `timeout` must be >= 1.
 ---   - detach: (boolean) If true, spawn the child process in a detached state - this will make it
 ---     a process group leader, and will effectively enable the child to keep running after the
 ---     parent exits. Note that the child process will still keep the parent's event loop alive
@@ -123,10 +124,11 @@ vim.log = {
 --- @return vim.SystemObj Object with the fields:
 ---   - cmd (string[]) Command name and args
 ---   - pid (integer) Process ID
----   - wait (fun(timeout: integer|nil): SystemCompleted) Wait for the process to complete. Upon
----     timeout the process is sent the KILL signal (9) and the exit code is set to 124. Cannot
----     be called in |api-fast|.
----     - SystemCompleted is an object with the fields:
+---   - wait (fun(timeout: integer|nil): vim.SystemCompleted) Wait for the process to complete,
+---     for {timeout} milliseconds (if {timeout} is given) or the timeout specified in {opts}.
+---     Upon timeout the process is sent the TERM signal (15) and the exit code is set to 124.
+---     {timeout} must be >= 1. Cannot be called in |api-fast|.
+---     - vim.SystemCompleted is an object with the fields:
 ---       - code: (integer)
 ---       - signal: (integer)
 ---       - stdout: (string), nil if stdout argument is passed

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -75,13 +75,25 @@ describe('vim.system', function()
       it('supports timeout', function()
         eq({
           code = 124,
-          signal = 15,
+          signal = 15, -- SIGTERM
           stdout = '',
           stderr = '',
         }, system({ 'sleep', '10' }, { timeout = 1000 }))
       end)
     end)
   end
+
+  it('(sync) supports timeout on wait(timeout)', function()
+    local ret = exec_lua [[
+      return vim.system({ 'sleep', '10' }):wait(1000)
+    ]]
+    eq({
+      code = 124,
+      signal = 15, -- SIGTERM
+      stdout = '',
+      stderr = '',
+    }, ret)
+  end)
 
   it('kill processes', function()
     exec_lua([[


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/37922


Problem:

- `vim.system(...):wait(0)` was simply returning `nil` rather than a
  valid `vim.SystemCompleted` object.

- Upon timeout after `:wait(timeout)`, SIGKILL (9) would be sent instead
  of SIGTERM (15) as in the case of `vim.system()` with `timeout` being
  set in the `opts` table. It can be confusing to have different
  behaviors (signals) here.

Solution:

- Document that `timeout` needs to be >= 1.

  Even if an invalid timeout is given, wait for at least 1 milliseconds
  so that the asynchronous `on_exit()` callback can be scheduled and
  executed by the uv loop.

- Always send SIGTERM when the process times out, for both use cases of
  `timeout`.