### PR TITLE
docs(vvars): fix wrong lua types in vim.v variables

### DIFF
--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -34,14 +34,14 @@ vim.v.charconvert_to = ...
 --- leading space to make it possible to append this variable
 --- directly after the read/write command. Note: "+cmd" isn't
 --- included here, because it will be executed anyway.
---- @type string[]
+--- @type string
 vim.v.cmdarg = ...
 
 --- Set like v:cmdarg for a file read/write command.  When a "!"
 --- was used the value is 1, otherwise it is 0.  Note that this
 --- can only be used in autocommands.  For user commands `<bang>`
 --- can be used.
---- @type any
+--- @type integer
 vim.v.cmdbang = ...
 
 --- The current locale setting for collation order of the runtime
@@ -141,7 +141,7 @@ vim.v.errmsg = ...
 ---
 --- If v:errors is set to anything but a list it is made an empty
 --- list by the assert function.
---- @type any
+--- @type string[]
 vim.v.errors = ...
 
 --- Dictionary of event data for the current `autocommand`.  Valid
@@ -210,7 +210,7 @@ vim.v.event = ...
 --- ```
 ---
 --- Output: "caught oops".
---- @type any
+--- @type string
 vim.v.exception = ...
 
 --- Exit code, or `v:null` before invoking the `VimLeavePre`
@@ -228,7 +228,7 @@ vim.v.exiting = ...
 --- as a String (e.g. in `expr5` with string concatenation
 --- operator) and to zero when used as a Number (e.g. in `expr5`
 --- or `expr7` when used with numeric operators). Read-only.
---- @type any
+--- @type boolean
 vim.v['false'] = ...
 
 --- What should happen after a `FileChangedShell` event was
@@ -608,7 +608,7 @@ vim.v.servername = ...
 ---     echo 'could not rename "foo" to "bar"!'
 ---   endif
 --- ```
---- @type string
+--- @type integer
 vim.v.shell_error = ...
 
 --- Last given status message.
@@ -624,7 +624,7 @@ vim.v.statusmsg = ...
 --- ```vim
 --- :call chansend(v:stderr, "error: toaster empty\n")
 --- ```
---- @type string
+--- @type integer
 vim.v.stderr = ...
 
 --- `SwapExists` autocommands can set this to the selected choice
@@ -726,7 +726,7 @@ vim.v.throwpoint = ...
 --- as a String (e.g. in `expr5` with string concatenation
 --- operator) and to one when used as a Number (e.g. in `expr5` or
 --- `expr7` when used with numeric operators). Read-only.
---- @type any
+--- @type boolean
 vim.v['true'] = ...
 
 --- Value of the current item of a `List` or `Dictionary`.  Only

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -31,7 +31,7 @@ M.vars = {
     ]=],
   },
   cmdarg = {
-    type = 'string[]',
+    type = 'string',
     desc = [=[
       The extra arguments ("++p", "++enc=", "++ff=") given to a file
       read/write command.  This is set before an autocommand event
@@ -54,6 +54,7 @@ M.vars = {
     ]=],
   },
   cmdbang = {
+    type = 'integer',
     desc = [=[
       Set like v:cmdarg for a file read/write command.  When a "!"
       was used the value is 1, otherwise it is 0.  Note that this
@@ -149,6 +150,7 @@ M.vars = {
     ]=],
   },
   errors = {
+    type = 'string[]',
     tags = { 'assert-return' },
     desc = [=[
       Errors found by assert functions, such as |assert_true()|.
@@ -215,6 +217,7 @@ M.vars = {
     ]=],
   },
   exception = {
+    type = 'string',
     desc = [=[
       The value of the exception most recently caught and not
       finished.  See also |v:throwpoint| and |throw-variables|.
@@ -229,6 +232,7 @@ M.vars = {
     ]=],
   },
   ['false'] = {
+    type = 'boolean',
     desc = [=[
       Special value used to put "false" in JSON and msgpack.  See
       |json_encode()|.  This value is converted to "v:false" when used
@@ -669,7 +673,7 @@ M.vars = {
     ]=],
   },
   shell_error = {
-    type = 'string',
+    type = 'integer',
     desc = [=[
       Result of the last shell command.  When non-zero, the last
       shell command had an error.  When zero, there was no problem.
@@ -692,7 +696,7 @@ M.vars = {
     ]=],
   },
   stderr = {
-    type = 'string',
+    type = 'integer',
     desc = [=[
       |channel-id| corresponding to stderr. The value is always 2;
       use this variable to make your code more descriptive.
@@ -805,6 +809,7 @@ M.vars = {
     ]=],
   },
   ['true'] = {
+    type = 'boolean',
     desc = [=[
       Special value used to put "true" in JSON and msgpack.  See
       |json_encode()|.  This value is converted to "v:true" when used


### PR DESCRIPTION
Fixup to #26682
Fixes #26912 

- cmdarg: string[] -> string
- shell_error: string -> int
- stderr: string -> int

Also add types for: cmdbang, errors, exception, false, true

