### PR TITLE
fix(colorscheme): default statusline groups usability

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -99,8 +99,8 @@ The following changes may require adaptations in user config or plugins.
   a meaningfully different way and might need an update:
   • |hl-FloatBorder| is linked to |hl-NormalFloat| instead of |hl-WinSeparator|.
   • |hl-NormalFloat| is not linked to |hl-Pmenu|.
-  • |hl-WinBar| is linked to |hl-StatusLine|.
-  • |hl-WinBarNC| is linked to |hl-StatusLineNC| instead of |hl-WinBar|.
+  • |hl-WinBar| has different background.
+  • |hl-WinBarNC| is similar to |hl-WinBar| but not bold.
   • |hl-WinSeparator| is linked to |hl-Normal| instead of |hl-VertSplit|.
 
   This also might result into some color schemes looking differently due to

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -173,15 +173,13 @@ static const char *highlight_init_both[] = {
   "default link PmenuKindSel   PmenuSel",
   "default link PmenuSbar      Pmenu",
   "default link Substitute     Search",
-  "default link TabLine        StatusLine",
+  "default link TabLine        StatusLineNC",
   "default link TabLineFill    TabLine",
   "default link TermCursorNC   NONE",
   "default link VertSplit      WinSeparator",
   "default link VisualNOS      Visual",
   "default link Whitespace     NonText",
   "default link WildMenu       PmenuSel",
-  "default link WinBar         StatusLine",
-  "default link WinBarNC       StatusLineNC",
   "default link WinSeparator   Normal",
 
   // Syntax
@@ -343,10 +341,12 @@ static const char *highlight_init_light[] = {
   "SpellCap             guisp=NvimDarkYellow gui=undercurl                   cterm=undercurl",
   "SpellLocal           guisp=NvimDarkGreen  gui=undercurl                   cterm=undercurl",
   "SpellRare            guisp=NvimDarkCyan   gui=undercurl                   cterm=undercurl",
-  "StatusLine           guifg=NvimDarkGrey3  guibg=NvimLightGrey1            cterm=reverse",
-  "StatusLineNC         guifg=NvimDarkGrey4  guibg=NvimLightGrey1            cterm=bold",
+  "StatusLine           guifg=NvimLightGrey3 guibg=NvimDarkGrey3             cterm=reverse",
+  "StatusLineNC         guifg=NvimDarkGrey3  guibg=NvimLightGrey3            cterm=bold",
   "Visual                                    guibg=NvimLightGrey4            ctermfg=15 ctermbg=0",
   "WarningMsg           guifg=NvimDarkYellow                                 ctermfg=3",
+  "WinBar               guifg=NvimDarkGrey4  guibg=NvimLightGrey1  gui=bold  cterm=bold",
+  "WinBarNC             guifg=NvimDarkGrey4  guibg=NvimLightGrey1            cterm=bold",
 
   // Syntax
   "Comment    guifg=NvimDarkGrey4",
@@ -412,10 +412,12 @@ static const char *highlight_init_dark[] = {
   "SpellCap             guisp=NvimLightYellow gui=undercurl                 cterm=undercurl",
   "SpellLocal           guisp=NvimLightGreen  gui=undercurl                 cterm=undercurl",
   "SpellRare            guisp=NvimLightCyan   gui=undercurl                 cterm=undercurl",
-  "StatusLine           guifg=NvimLightGrey3  guibg=NvimDarkGrey1           cterm=reverse",
-  "StatusLineNC         guifg=NvimLightGrey4  guibg=NvimDarkGrey1           cterm=bold",
+  "StatusLine           guifg=NvimDarkGrey3   guibg=NvimLightGrey3          cterm=reverse",
+  "StatusLineNC         guifg=NvimLightGrey3  guibg=NvimDarkGrey3           cterm=bold",
   "Visual                                     guibg=NvimDarkGrey4           ctermfg=0 ctermbg=15",
   "WarningMsg           guifg=NvimLightYellow                               ctermfg=11",
+  "WinBar               guifg=NvimLightGrey4  guibg=NvimDarkGrey1  gui=bold cterm=bold",
+  "WinBarNC             guifg=NvimLightGrey4  guibg=NvimDarkGrey1           cterm=bold",
 
   // Syntax
   "Comment    guifg=NvimLightGrey4",

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -26,7 +26,7 @@ local function test_embed(ext_linegrid)
       [3] = { bold = true, foreground = Screen.colors.Blue1 },
       [4] = { bold = true, foreground = Screen.colors.Green },
       [5] = { bold = true, reverse = true },
-      [6] = { foreground = Screen.colors.NvimDarkGrey3, background = Screen.colors.NvimLightGrey1 },
+      [6] = { foreground = Screen.colors.NvimLightGrey3, background = Screen.colors.NvimDarkGrey3 },
       [7] = { foreground = Screen.colors.NvimDarkRed },
       [8] = { foreground = Screen.colors.NvimDarkCyan },
     })


### PR DESCRIPTION
Problem: Current values of `StatusLine` and `StatusLineNC` are currently
  designed to be visually distinctive while being not intrusive.
  However, the compromise was more shifted towards "not intrusive".
  After the feedback, statusline highlight groups should be designed to:
  - Make current window clearly noticeable. Meaning `StatusLine` and `StatusLineNC` should obviously differ.
  - Make non-current windows clearly separable. Meaning `StatusLineNC` and `Normal`/`NormalNC` should obviously differ.

Solution:
  - Update `StatusLineNC` to have more visible background.
  - Update `StatusLine` to be inverted variant of `StatusLineNC`.
  - Update `WinBar` and `WinBarNC` to not link to `StatusLine` and `StatusLineNC` because it makes two goals harder to achieve.
  - Update `TabLine` to link to `StatusLineNC` instead of `StatusLine` to not be very visually intrusive.

------

Screenshots:

<details><summary>Many windows with tabline and winbar</summary>

![screenshot_2024-01-06_17:43:27](https://github.com/neovim/neovim/assets/24854248/20d5d4a8-58c1-40fd-8157-1aa5163fc3f5)
![screenshot_2024-01-06_17:43:41](https://github.com/neovim/neovim/assets/24854248/4537cb39-a09b-460c-997e-b13bdec045a2)

</details>

<details><summary>Single window with tabline and winbar</summary>

![screenshot_2024-01-06_17:43:51](https://github.com/neovim/neovim/assets/24854248/4721b7f6-6838-46e3-93c5-2144778f4ae9)
![screenshot_2024-01-06_17:44:00](https://github.com/neovim/neovim/assets/24854248/e7c8e8bb-353a-40c4-bf9f-0ee7793d984f)

</details>

This is a follow-up to [this comment](https://github.com/neovim/neovim/pull/26540#issuecomment-1874465785). Some notes:

- The `NvimLightGrey3` and `NvimDarkGrey3` are chosen again to strike a balance between not very intrusive while clearly distinguishable. The contrast ratio is ~7.96 which is a AAA type of accessibility.
- @justinmk, I really hope that using different color for `StatusLineNC` is enough for making windows separable. Using underlined text makes not much distinction to `Normal` and it would still need some sort of foreground/background adjustment if clear window separation is a goal. Besides, it is less likely to have a good rendering across terminals than different background color.