### PR TITLE
fix(highlight): update `IncSearch` to link to `CurSearch`

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -161,7 +161,7 @@ static const char *highlight_init_both[] = {
   "default link FloatFooter    FloatTitle",
   "default link FloatTitle     Title",
   "default link FoldColumn     SignColumn",
-  "default link IncSearch      Search",
+  "default link IncSearch      CurSearch",
   "default link LineNrAbove    LineNr",
   "default link LineNrBelow    LineNr",
   "default link MsgSeparator   StatusLine",


### PR DESCRIPTION
Problem: `IncSearch` is currently linked to `Search` which makes it not
  usable for its purpose of showing current match with 'incsearch' and
  confirming matches after `:s///c`.

Solution: Link it to `CurSearch`.

------

Resolves #26760.