### PR TITLE
docs: fix broken link in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@ You can install Neovim from [download](#install-from-download), [package](#insta
 ---
 
 - To start Neovim, run `nvim` (not `neovim`).
-    - [Discover plugins](Related-projects#plugins).
+    - [Discover plugins](https://github.com/neovim/neovim/wiki/Related-projects#plugins).
 - Before upgrading to a new version, **check [Breaking Changes](https://neovim.io/doc/user/news.html#news-breaking).**
 - For config (vimrc) see [the FAQ](https://neovim.io/doc/user/faq.html#faq-general).
 


### PR DESCRIPTION
I saw there was some discussion about moving more stuff from the wiki to repo, but figured the link could be fixed in the meantime.