### PR TITLE
fix(diagnostics): translate legacy signs before diagnostic scheduler

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -953,8 +953,6 @@ M.handlers.signs = {
         api.nvim_create_namespace(string.format('%s/diagnostic/signs', ns.name))
     end
 
-    resolve_legacy_diagnostic_sign_definitions(opts)
-
     local text = {} ---@type table<string, string>
     for k in pairs(M.severity) do
       if opts.signs.text and opts.signs.text[k] then
@@ -1287,6 +1285,7 @@ function M.show(namespace, bufnr, diagnostics, opts)
 
   opts = get_resolved_options(opts, namespace, bufnr)
 
+  -- TODO(#26927): Remove this in 0.12 release cycle
   resolve_legacy_diagnostic_sign_definitions(opts)
 
   if opts.update_in_insert then

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -908,49 +908,6 @@ M.handlers.signs = {
         api.nvim_create_namespace(string.format('%s/diagnostic/signs', ns.name))
     end
 
-    --- Handle legacy diagnostic sign definitions
-    --- These were deprecated in 0.10 and will be removed in 0.12
-    if opts.signs and not opts.signs.text and not opts.signs.numhl and not opts.signs.texthl then
-      for _, v in ipairs({ 'Error', 'Warn', 'Info', 'Hint' }) do
-        local name = string.format('DiagnosticSign%s', v)
-        local sign = vim.fn.sign_getdefined(name)[1]
-        if sign then
-          local severity = M.severity[v:upper()]
-          vim.deprecate(
-            'Defining diagnostic signs with :sign-define or sign_define()',
-            'vim.diagnostic.config()',
-            '0.12',
-            nil,
-            false
-          )
-
-          if not opts.signs.text then
-            opts.signs.text = {}
-          end
-
-          if not opts.signs.numhl then
-            opts.signs.numhl = {}
-          end
-
-          if not opts.signs.linehl then
-            opts.signs.linehl = {}
-          end
-
-          if opts.signs.text[severity] == nil then
-            opts.signs.text[severity] = sign.text or ''
-          end
-
-          if opts.signs.numhl[severity] == nil then
-            opts.signs.numhl[severity] = sign.numhl
-          end
-
-          if opts.signs.linehl[severity] == nil then
-            opts.signs.linehl[severity] = sign.linehl
-          end
-        end
-      end
-    end
-
     local text = {} ---@type table<string, string>
     for k in pairs(M.severity) do
       if opts.signs.text and opts.signs.text[k] then
@@ -1282,6 +1239,49 @@ function M.show(namespace, bufnr, diagnostics, opts)
   end
 
   opts = get_resolved_options(opts, namespace, bufnr)
+
+  --- Handle legacy diagnostic sign definitions
+  --- These were deprecated in 0.10 and will be removed in 0.12
+  if opts.signs and not opts.signs.text and not opts.signs.numhl and not opts.signs.texthl then
+    for _, v in ipairs({ 'Error', 'Warn', 'Info', 'Hint' }) do
+      local name = string.format('DiagnosticSign%s', v)
+      local sign = vim.fn.sign_getdefined(name)[1]
+      if sign then
+        local severity = M.severity[v:upper()]
+        vim.deprecate(
+          'Defining diagnostic signs with :sign-define or sign_define()',
+          'vim.diagnostic.config()',
+          '0.12',
+          nil,
+          false
+        )
+
+        if not opts.signs.text then
+          opts.signs.text = {}
+        end
+
+        if not opts.signs.numhl then
+          opts.signs.numhl = {}
+        end
+
+        if not opts.signs.linehl then
+          opts.signs.linehl = {}
+        end
+
+        if opts.signs.text[severity] == nil then
+          opts.signs.text[severity] = sign.text or ''
+        end
+
+        if opts.signs.numhl[severity] == nil then
+          opts.signs.numhl[severity] = sign.numhl
+        end
+
+        if opts.signs.linehl[severity] == nil then
+          opts.signs.linehl[severity] = sign.linehl
+        end
+      end
+    end
+  end
 
   if opts.update_in_insert then
     clear_scheduled_display(namespace, bufnr)


### PR DESCRIPTION
Changed the location of the legacy diagnostic sign handler.
By doing so the `vim.diagnostic.config().signs` will get converted no matter the `update_in_insert` value.

This will resolve some unexpected behavior in plugins like `neotree` because if `update_in_insert` is set to `false` and once a lsp loads and you are in `insert mode` the signs will not be yet converted but the plugin will get notified of the published diagnostics and expect the `signs.text` to be defined.

https://github.com/nvim-neo-tree/neo-tree.nvim/assets/69250723/706a396d-51d6-47cf-ae47-21eed9dba4c5

more info there
https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1290