### PR TITLE
feat(api): allow lua complete fn to return a string

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1863,7 +1863,9 @@ nvim_create_user_command({name}, {command}, {opts})
                      |nvim_buf_create_user_command()| instead).
                    • "complete" |:command-complete| also accepts a Lua
                      function which works like
-                     |:command-completion-customlist|.
+                     |:command-completion-customlist| if it returns a table,
+                     or like |:command-completion-custom| if it returns a
+                     string.
                    • Other parameters:
                      • desc: (string) Used for listing the command when a Lua
                        function is used for {command}.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -983,7 +983,9 @@ function vim.api.nvim_create_namespace(name) end
 ---               `:command-bar` to true (but not `:command-buffer`, use
 ---               `nvim_buf_create_user_command()` instead).
 ---             • "complete" `:command-complete` also accepts a Lua function
----               which works like `:command-completion-customlist`.
+---               which works like `:command-completion-customlist` if it
+---               returns a table, or like `:command-completion-custom` if it
+---               returns a string.
 ---             • Other parameters:
 ---               • desc: (string) Used for listing the command when a Lua
 ---                 function is used for {command}.

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -870,7 +870,8 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 ///                 - Set boolean attributes such as |:command-bang| or |:command-bar| to true (but
 ///                   not |:command-buffer|, use |nvim_buf_create_user_command()| instead).
 ///                 - "complete" |:command-complete| also accepts a Lua function which works like
-///                   |:command-completion-customlist|.
+///                   |:command-completion-customlist| if it returns a table, or like
+///                   |:command-completion-custom| if it returns a string.
 ///                 - Other parameters:
 ///                   - desc: (string) Used for listing the command when a Lua function is used for
 ///                                    {command}.

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -675,6 +675,22 @@ describe('nvim_create_user_command', function()
     eq('Test bbb', fn.getcmdline())
   end)
 
+  it('can use a Lua complete function which returns string instead of a list', function()
+    exec_lua [[
+      vim.api.nvim_create_user_command('Test', '', {
+        nargs = "*",
+        complete = function(arg, cmdline, pos)
+          return "aaa\nbbb\nccc"
+        end,
+      })
+    ]]
+
+    feed(':Test a<Tab>')
+    eq('Test aaa', fn.getcmdline())
+    feed('<C-U>Test b<Tab>')
+    eq('Test bbb', fn.getcmdline())
+  end)
+
   it('does not allow invalid command names', function()
     eq(
       "Invalid command name (must start with uppercase): 'test'",


### PR DESCRIPTION
Makes it possible to provide completion options without having to also implement filtering logic.

Fixes #25565

This implementation involves one more copy-paste of the same code to create a new function. But as I understand currently that's how `customlist` was implemented for lua before as well (`ExpandUserLua` is almost identical to `ExpandUserList`, see #16752).

Is this still an ok way to do it?