### PR TITLE
fix(tui): use buflen to calculate remaining buffer size

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -237,13 +237,13 @@ static size_t handle_termkey_modifiers(TermKeyKey *key, char *buf, size_t buflen
 {
   size_t len = 0;
   if (key->modifiers & TERMKEY_KEYMOD_SHIFT) {  // Shift
-    len += (size_t)snprintf(buf + len, sizeof(buf) - len, "S-");
+    len += (size_t)snprintf(buf + len, buflen - len, "S-");
   }
   if (key->modifiers & TERMKEY_KEYMOD_ALT) {  // Alt
-    len += (size_t)snprintf(buf + len, sizeof(buf) - len, "A-");
+    len += (size_t)snprintf(buf + len, buflen - len, "A-");
   }
   if (key->modifiers & TERMKEY_KEYMOD_CTRL) {  // Ctrl
-    len += (size_t)snprintf(buf + len, sizeof(buf) - len, "C-");
+    len += (size_t)snprintf(buf + len, buflen - len, "C-");
   }
   assert(len < buflen);
   return len;


### PR DESCRIPTION
buf is a pointer argument, not a local char array, so sizeof(buf) is just the size of a pointer type on the platform.  This is always an incorrect value, but on 32-bit platforms it actually has an impact, since sizeof(buf) is just 4 and causes the buffer to get truncated.