### PR TITLE
fix(vim.ui.open): use explorer.exe instead of wslview

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -143,12 +143,12 @@ function M.open(path)
     else
       return nil, 'vim.ui.open: rundll32 not found'
     end
-  elseif vim.fn.executable('wslview') == 1 then
-    cmd = { 'wslview', path }
+  elseif vim.fn.executable('explorer.exe') == 1 then
+    cmd = { 'explorer.exe', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
   else
-    return nil, 'vim.ui.open: no handler found (tried: wslview, xdg-open)'
+    return nil, 'vim.ui.open: no handler found (tried: explorer.exe, xdg-open)'
   end
 
   local rv = vim.system(cmd, { text = true, detach = true }):wait()

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -152,7 +152,7 @@ describe('vim.ui', function()
         vim.fn.executable = function() return 0 end
       ]]
       eq(
-        'vim.ui.open: no handler found (tried: wslview, xdg-open)',
+        'vim.ui.open: no handler found (tried: explorer.exe, xdg-open)',
         exec_lua [[local _, err = vim.ui.open('foo') ; return err]]
       )
     end)


### PR DESCRIPTION
`vim.ui.open` uses `wslview`, which is slow and require [a package from external PPA](https://wslutiliti.es/wslu/install.html#ubuntu). 
WSL has [builtin](https://learn.microsoft.com/en-us/windows/wsl/filesystems#view-your-current-directory-in-windows-file-explorer) way to open : `explorer.exe`