### PR TITLE
fix issues with s390x CI on master (xdiff and others)

### DIFF
--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -11,7 +11,7 @@ concurrency:
 env:
   INSTALL_PREFIX: ${{ github.workspace }}/nvim-install
   # Double test timeout since it's running via qemu
-  TEST_TIMEOUT: 2400
+  TEST_TIMEOUT: 3600
   # TEST_FILE: test/functional/shada
   # TEST_FILTER: foo
 
@@ -23,7 +23,7 @@ jobs:
       matrix:
         test: [functionaltest, oldtest]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - uses: docker://multiarch/ubuntu-core:s390x-focal
@@ -34,7 +34,7 @@ jobs:
             bash -c
             "
             apt-get -y update &&
-            DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake curl gettext ninja-build locales-all cpanminus git attr libattr1-dev  &&
+            time DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake curl gettext ninja-build locales-all cpanminus git attr libattr1-dev xdg-utils &&
             useradd --create-home qemuci &&
             chown -R qemuci. . &&
             runuser -u qemuci -- git clone --depth=1 https://github.com/neovim/neovim.git &&

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -185,7 +185,12 @@ static mmfile_t get_string_arg(lua_State *lstate, int idx)
     luaL_argerror(lstate, idx, "expected string");
   }
   mmfile_t mf;
-  mf.ptr = (char *)lua_tolstring(lstate, idx, (size_t *)&mf.size);
+  size_t size;
+  mf.ptr = (char *)lua_tolstring(lstate, idx, &size);
+  if (size > INT_MAX) {
+    luaL_argerror(lstate, idx, "string too long");
+  }
+  mf.size = (int)size;
   return mf;
 }
 


### PR DESCRIPTION
no code yet, but tracks the following error on master s390x CI:
```
FAILED   4 tests, listed below:
FAILED   test/functional/lua/xdiff_spec.lua @ 23: xdiff bindings can diff text w
ith no callback
test/functional/lua/xdiff_spec.lua:24: Expected objects to be the same.
Passed in:
(string) ''
Expected:
(string) '@@ -1 +1 @@
-Hello
+Helli
'

stack traceback:
        (tail call): ?
        test/functional/lua/xdiff_spec.lua:24: in function <test/functional/lua/
xdiff_spec.lua:23>

FAILED   test/functional/lua/xdiff_spec.lua @ 49: xdiff bindings can diff text w
ith callback
test/functional/lua/xdiff_spec.lua:54: Expected objects to be the same.
Passed in:
(table: 0x40009bb2b0) { }
Expected:
(table: 0x40009baaf0) {
 *[1] = {
    [1] = 1
    [2] = 1
    [3] = 1
    [4] = 1 } }

stack traceback:
        (tail call): ?
        test/functional/lua/xdiff_spec.lua:54: in function <test/functional/lua/
xdiff_spec.lua:49>

FAILED   test/functional/lua/xdiff_spec.lua @ 96: xdiff bindings can diff text w
ith hunk_lines
test/functional/lua/xdiff_spec.lua:97: Expected objects to be the same.
Passed in:
(table: 0x40009d9760) { }
Expected:
(table: 0x40009d9020) {
 *[1] = {
    [1] = 1
    [2] = 1
    [3] = 1
    [4] = 1 } }

stack traceback:
        (tail call): ?
        test/functional/lua/xdiff_spec.lua:97: in function <test/functional/lua/
xdiff_spec.lua:96>

FAILED   test/functional/lua/xdiff_spec.lua @ 105: xdiff bindings can diff text 
can run different algorithms
test/functional/lua/xdiff_spec.lua:129: Expected objects to be the same.
Passed in:
(string) ''
Expected:
(string) '@@ -1,4 +0,0 @@
-.foo1 {
-    margin: 0;
-}
-
@@ -7,0 +4,5 @@
+
+.foo1 {
+    margin: 0;
+    color: green;
+}
'

stack traceback:
        (tail call): ?
        test/functional/lua/xdiff_spec.lua:129: in function <test/functional/lua
/xdiff_spec.lua:105>

ERROR    1 error, listed below:
ERROR    test/functional/lua/xdiff_spec.lua @ 83: xdiff bindings can diff text w
ith error callback
test/helpers.lua:244: expected failure, but got success

stack traceback:
        test/helpers.lua:244: in function 'pcall_err_withfile'
        test/helpers.lua:250: in function 'pcall_err_withtrace'
        test/helpers.lua:259: in function 'pcall_err'
        test/functional/lua/xdiff_spec.lua:92: in function <test/functional/lua/
xdiff_spec.lua:83>


 4 FAILED TESTS
 1 ERROR
```