### PR TITLE
fix(health): correctly expand and resolve PYENV_ROOT

### DIFF
--- a/runtime/lua/provider/python/health.lua
+++ b/runtime/lua/provider/python/health.lua
@@ -35,7 +35,7 @@ local function check_for_pyenv()
 
   health.info('pyenv: Path: ' .. pyenv_path)
 
-  local pyenv_root = os.getenv('PYENV_ROOT') and vim.fn.resolve('$PYENV_ROOT') or ''
+  local pyenv_root = vim.fn.resolve(os.getenv('PYENV_ROOT') or '')
 
   if pyenv_root == '' then
     pyenv_root = vim.fn.system({ pyenv_path, 'root' })


### PR DESCRIPTION
The [current pyenv health code](https://github.com/neovim/neovim/blob/c4acbb87babf9c06198e56d85d113067fd705795/runtime/lua/provider/python/health.lua#L38) incorrectly resolves pyenv root by passing an un-expanded string (`'$PYENV_ROOT'`) to `vim.fn.resolve`, which does not automatically expand variables. Furthermore, the [fallthrough attempt](https://github.com/neovim/neovim/blob/c4acbb87babf9c06198e56d85d113067fd705795/runtime/lua/provider/python/health.lua#L40) to resolve the root using `pyenv root` fails because `vim.fn.resolve('$PYENV_ROOT') == '$PYENV_ROOT'` - not an empty string.

What results is the following erroneous health result:

<img width="1118" alt="image" src="https://github.com/neovim/neovim/assets/62671086/0b6987ac-74fb-4bfc-b63a-fde36128c596">

The changed code expands `PYENV_ROOT` before calling `vim.fn.resolve()`. Also, `vim.fn.resolve('') == ''`, so the default empty string resolves as well, and the aforementioned fallthrough is now functional.
