### PR TITLE
fix(flake): clang-tools moved to nativeBuildInputs

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -142,6 +142,10 @@
                 jq # jq for scripts/vim-patch.sh -r
                 shellcheck # for `make shlint`
                 doxygen # for script/gen_vimdoc.py
+              ];
+
+            nativeBuildInputs = with pkgs;
+              oa.nativeBuildInputs ++ [
                 clang-tools # for clangd to find the correct headers
               ];
 

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -134,7 +134,6 @@
 
             buildInputs = with pkgs;
               oa.buildInputs ++ [
-                cmake
                 lua.pkgs.luacheck
                 sumneko-lua-language-server
                 pythonEnv


### PR DESCRIPTION
Buildtime binaries should go in `nativeBuildInputs` 
Before `clang-tools` version was overwriten breaking the Lsp.

Relevant issues:
https://github.com/NixOS/nixpkgs/issues/76486