### PR TITLE
vim-patch:3a5b3df7764d

### DIFF
--- a/runtime/plugin/tarPlugin.vim
+++ b/runtime/plugin/tarPlugin.vim
@@ -45,7 +45,7 @@ augroup tar
   au BufReadCmd   *.tar.xz		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.txz			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.zst		call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tzs			call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tzst			call tar#Browse(expand("<amatch>"))
 augroup END
 
 " ---------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:3a5b3df7764d

runtime(tar): fix a few problems with the tar plugin

From: vim/vim#138331:
  - Updating .tar.zst files was broken.
  - Extracting files from .tar.zst / .tzs files was also broken and
    works now.
From: vim/vim#12637:
  - Fixes variable assignment and typo
From: vim/vim#8109:
  - Rename .tzs to the more standard .tzst

closes: vim/vim#8109
closes: vim/vim#12637
closes: vim/vim#13831

https://github.com/vim/vim/commit/3a5b3df7764daa058a3e779183e8f38a8418b164

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Martin Rys <martin@rys.pw>
Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
Co-authored-by: Carlo Teubner <carlo@cteubner.net>