### PR TITLE
Handle nil response from backend for diagnostics

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -299,6 +299,16 @@ function M.on_diagnostic(_, result, ctx, config)
   local fname = vim.uri_to_fname(uri)
 
   if result == nil then
+    local client_name = vim.lsp.get_client_by_id(client_id).name
+    vim.notify_once(
+      string.format(
+        "LSP: client '%s' (id %s) returned nil to textDocument/diagnostic.\nThis is a bug in the LSP server, and should be fixed within '%s'.",
+        client_name,
+        client_id,
+        client_name
+      ),
+      vim.log.levels.WARN
+    )
     return
   end
 


### PR DESCRIPTION
Some LSP backends (`ruby-lsp` in particular here) can return a `nil` response to the `textDocument/diagnostic` method. This is contrary to the LSP spec, but unfortunately it means that neovim doesn't clear previous diagnostics when the `nil` response is received.

This PR changes the handling of the diagnostic response to treat a `nil` response the same as an empty `[]` response.

Fixes https://github.com/neovim/neovim/issues/26640