### PR TITLE
refactor(screen): simplify grid_clear() and win_draw_end()

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2611,8 +2611,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
       // When the window is too narrow draw all "@" lines.
       if (leftcols_width >= wp->w_grid.cols && wp->w_p_wrap) {
-        win_draw_end(wp, schar_from_ascii('@'), schar_from_ascii(' '), true, wlv.row,
-                     wp->w_grid.rows, HLF_AT);
+        win_draw_end(wp, schar_from_ascii('@'), true, wlv.row, wp->w_grid.rows, HLF_AT);
         set_empty_rows(wp, wlv.row);
         wlv.row = endrow;
       }
@@ -2836,8 +2835,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
       // When the window is too narrow draw all "@" lines.
       if (wlv.col <= leftcols_width) {
-        win_draw_end(wp, schar_from_ascii('@'), schar_from_ascii(' '), true, wlv.row,
-                     wp->w_grid.rows, HLF_AT);
+        win_draw_end(wp, schar_from_ascii('@'), true, wlv.row, wp->w_grid.rows, HLF_AT);
         set_empty_rows(wp, wlv.row);
         wlv.row = endrow;
       }
@@ -2883,8 +2881,7 @@ static void win_put_linebuf(win_T *wp, int row, int coloff, int endcol, int clea
   int start_col = 0;
 
   if (wp->w_p_rl) {
-    linebuf_mirror(&start_col, &clear_width, grid->cols);
-    endcol = grid->cols - 1 - endcol;
+    linebuf_mirror(&start_col, &endcol, &clear_width, grid->cols);
   }
 
   // Take care of putting "<<<" on the first line for 'smoothscroll'.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -204,6 +204,7 @@ void msg_grid_validate(void)
   } else if (msg_grid.chars && !msg_scrolled && msg_grid_pos != max_rows) {
     msg_grid_set_pos(max_rows, false);
   }
+  msg_grid_adj.cols = Columns;
 
   if (msg_grid.chars && !msg_scrolled && cmdline_row < msg_grid_pos) {
     // TODO(bfredl): this should already be the case, but fails in some
@@ -2349,7 +2350,7 @@ void msg_scroll_flush(void)
     for (int i = MAX(Rows - MAX(delta, 1), 0); i < Rows; i++) {
       int row = i - msg_grid_pos;
       assert(row >= 0);
-      ui_line(&msg_grid, row, 0, msg_grid.dirty_col[row], msg_grid.cols,
+      ui_line(&msg_grid, row, false, 0, msg_grid.dirty_col[row], msg_grid.cols,
               HL_ATTR(HLF_MSG), false);
       msg_grid.dirty_col[row] = 0;
     }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -448,13 +448,12 @@ void ui_set_ext_option(UI *ui, UIExtension ext, bool active)
   }
 }
 
-void ui_line(ScreenGrid *grid, int row, int startcol, int endcol, int clearcol, int clearattr,
-             bool wrap)
+void ui_line(ScreenGrid *grid, int row, bool invalid_row, int startcol, int endcol, int clearcol,
+             int clearattr, bool wrap)
 {
   assert(0 <= row && row < grid->rows);
   LineFlags flags = wrap ? kLineFlagWrap : 0;
-  if (startcol == -1) {
-    startcol = 0;
+  if (startcol == 0 && invalid_row) {
     flags |= kLineFlagInvalid;
   }
 


### PR DESCRIPTION
Implement "draw_margin" on a per-row basis which closer reflects how terminals work. Also use the magic mirror.

The end goal was to get rid of `grid_fill()`  although that will be a separate PR due to being a bigger mess.