### PR TITLE
refactor(options): remove `OPT_FREE`

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -705,7 +705,7 @@ char *au_event_disable(char *what)
   } else {
     STRCAT(new_ei, what);
   }
-  set_string_option_direct(kOptEventignore, new_ei, OPT_FREE, SID_NONE);
+  set_string_option_direct(kOptEventignore, new_ei, 0, SID_NONE);
   xfree(new_ei);
   return save_ei;
 }
@@ -713,7 +713,7 @@ char *au_event_disable(char *what)
 void au_event_restore(char *old_ei)
 {
   if (old_ei != NULL) {
-    set_string_option_direct(kOptEventignore, old_ei, OPT_FREE, SID_NONE);
+    set_string_option_direct(kOptEventignore, old_ei, 0, SID_NONE);
     xfree(old_ei);
   }
 }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1430,7 +1430,7 @@ void diff_win_options(win_T *wp, bool addbuf)
     }
     wp->w_p_fdm_save = xstrdup(wp->w_p_fdm);
   }
-  set_string_option_direct_in_win(wp, kOptFoldmethod, "diff", OPT_LOCAL | OPT_FREE, 0);
+  set_string_option_direct_in_win(wp, kOptFoldmethod, "diff", OPT_LOCAL, 0);
 
   if (!wp->w_p_diff) {
     wp->w_p_fen_save = wp->w_p_fen;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4266,7 +4266,7 @@ skip:
   // Show 'inccommand' preview if there are matched lines.
   if (cmdpreview_ns > 0 && !aborting()) {
     if (got_quit || profile_passed_limit(timeout)) {  // Too slow, disable.
-      set_string_option_direct(kOptInccommand, "", OPT_FREE, SID_NONE);
+      set_string_option_direct(kOptInccommand, "", 0, SID_NONE);
     } else if (*p_icm != NUL && pat != NULL) {
       if (pre_hl_id == 0) {
         pre_hl_id = syn_check_group(S_LEN("Substitute"));
@@ -4546,7 +4546,7 @@ bool prepare_tagpreview(bool undo_sync)
   RESET_BINDING(curwin);                // don't take over 'scrollbind' and 'cursorbind'
   curwin->w_p_diff = false;             // no 'diff'
 
-  set_string_option_direct(kOptFoldcolumn, "0", OPT_FREE, SID_NONE);  // no 'foldcolumn'
+  set_string_option_direct(kOptFoldcolumn, "0", 0, SID_NONE);  // no 'foldcolumn'
   return true;
 }
 
@@ -4565,7 +4565,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
   buf_T *cmdpreview_buf = NULL;
 
   // disable file info message
-  set_string_option_direct(kOptShortmess, "F", OPT_FREE, SID_NONE);
+  set_string_option_direct(kOptShortmess, "F", 0, SID_NONE);
 
   // Update the topline to ensure that main window is on the correct line
   update_topline(curwin);
@@ -4666,7 +4666,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
 
   xfree(str);
 
-  set_string_option_direct(kOptShortmess, save_shm_p, OPT_FREE, SID_NONE);
+  set_string_option_direct(kOptShortmess, save_shm_p, 0, SID_NONE);
   xfree(save_shm_p);
 
   return preview ? 2 : 1;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2654,7 +2654,7 @@ static void apply_cmdmod(cmdmod_T *cmod)
     // Set 'eventignore' to "all".
     // First save the existing option value for restoring it later.
     cmod->cmod_save_ei = xstrdup(p_ei);
-    set_string_option_direct(kOptEventignore, "all", OPT_FREE, SID_NONE);
+    set_string_option_direct(kOptEventignore, "all", 0, SID_NONE);
   }
 }
 
@@ -2674,7 +2674,7 @@ void undo_cmdmod(cmdmod_T *cmod)
 
   if (cmod->cmod_save_ei != NULL) {
     // Restore 'eventignore' to the value before ":noautocmd".
-    set_string_option_direct(kOptEventignore, cmod->cmod_save_ei, OPT_FREE, SID_NONE);
+    set_string_option_direct(kOptEventignore, cmod->cmod_save_ei, 0, SID_NONE);
     free_string_option(cmod->cmod_save_ei);
     cmod->cmod_save_ei = NULL;
   }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -905,7 +905,7 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
     need_wait_return = false;
   }
 
-  set_string_option_direct(kOptInccommand, s->save_p_icm, OPT_FREE, SID_NONE);
+  set_string_option_direct(kOptInccommand, s->save_p_icm, 0, SID_NONE);
   State = s->save_State;
   if (cmdpreview != save_cmdpreview) {
     cmdpreview = save_cmdpreview;  // restore preview state

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1611,7 +1611,7 @@ failed:
     save_file_ff(curbuf);
     // If editing a new file: set 'fenc' for the current buffer.
     // Also for ":read ++edit file".
-    set_string_option_direct(kOptFileencoding, fenc, OPT_FREE | OPT_LOCAL, 0);
+    set_string_option_direct(kOptFileencoding, fenc, OPT_LOCAL, 0);
   }
   if (fenc_alloced) {
     xfree(fenc);
@@ -1959,7 +1959,7 @@ void set_forced_fenc(exarg_T *eap)
   }
 
   char *fenc = enc_canonize(eap->cmd + eap->force_enc);
-  set_string_option_direct(kOptFileencoding, fenc, OPT_FREE|OPT_LOCAL, 0);
+  set_string_option_direct(kOptFileencoding, fenc, OPT_LOCAL, 0);
   xfree(fenc);
 }
 

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -607,7 +607,7 @@ void cleanup_help_tags(int num_file, char **file)
 void prepare_help_buffer(void)
 {
   curbuf->b_help = true;
-  set_string_option_direct(kOptBuftype, "help", OPT_FREE|OPT_LOCAL, 0);
+  set_string_option_direct(kOptBuftype, "help", OPT_LOCAL, 0);
 
   // Always set these options after jumping to a help tag, because the
   // user may have an autocommand that gets in the way.
@@ -616,13 +616,13 @@ void prepare_help_buffer(void)
   // Only set it when needed, buf_init_chartab() is some work.
   char *p = "!-~,^*,^|,^\",192-255";
   if (strcmp(curbuf->b_p_isk, p) != 0) {
-    set_string_option_direct(kOptIskeyword, p, OPT_FREE|OPT_LOCAL, 0);
+    set_string_option_direct(kOptIskeyword, p, OPT_LOCAL, 0);
     check_buf_options(curbuf);
     buf_init_chartab(curbuf, false);
   }
 
   // Don't use the global foldmethod.
-  set_string_option_direct(kOptFoldmethod, "manual", OPT_FREE|OPT_LOCAL, 0);
+  set_string_option_direct(kOptFoldmethod, "manual", OPT_LOCAL, 0);
 
   curbuf->b_p_ts = 8;         // 'tabstop' is 8.
   curwin->w_p_list = false;   // No list mode.

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1075,7 +1075,7 @@ void ex_retab(exarg_T *eap)
     colnr_T *old_vts_ary = curbuf->b_p_vts_array;
 
     if (tabstop_count(old_vts_ary) > 0 || tabstop_count(new_vts_array) > 1) {
-      set_string_option_direct(kOptVartabstop, new_ts_str, OPT_FREE | OPT_LOCAL, 0);
+      set_string_option_direct(kOptVartabstop, new_ts_str, OPT_LOCAL, 0);
       curbuf->b_p_vts_array = new_vts_array;
       xfree(old_vts_ary);
     } else {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1542,7 +1542,7 @@ static void handle_quickfix(mparm_T *paramp)
 {
   if (paramp->edit_type == EDIT_QF) {
     if (paramp->use_ef != NULL) {
-      set_string_option_direct(kOptErrorfile, paramp->use_ef, OPT_FREE, SID_CARG);
+      set_string_option_direct(kOptErrorfile, paramp->use_ef, 0, SID_CARG);
     }
     vim_snprintf(IObuff, IOSIZE, "cfile %s", p_ef);
     if (qf_init(NULL, p_ef, p_efm, true, IObuff, p_menc) < 0) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -370,9 +370,6 @@ void set_init_1(bool clean_arg)
   check_win_options(curwin);
   check_options();
 
-  // Set all options to their default value
-  set_options_default(OPT_FREE);
-
   // set 'laststatus'
   last_status(false);
 
@@ -433,7 +430,7 @@ static void set_option_default(const OptIndex opt_idx, int opt_flags)
       if (opt->indir != PV_NONE) {
         set_string_option_direct(opt_idx, opt->def_val, opt_flags, 0);
       } else {
-        if ((opt_flags & OPT_FREE) && (flags & P_ALLOCED)) {
+        if (flags & P_ALLOCED) {
           free_string_option(*(char **)(varp));
         }
         *(char **)varp = opt->def_val;
@@ -482,7 +479,7 @@ static void set_option_default(const OptIndex opt_idx, int opt_flags)
 
 /// Set all options (except terminal options) to their default value.
 ///
-/// @param opt_flags  OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL
+/// @param  opt_flags  Option flags.
 static void set_options_default(int opt_flags)
 {
   for (OptIndex opt_idx = 0; opt_idx < kOptIndexCount; opt_idx++) {
@@ -1431,7 +1428,7 @@ int do_set(char *arg, int opt_flags)
         if (*arg == '&') {
           arg++;
           // Only for :set command set global value of local options.
-          set_options_default(OPT_FREE | opt_flags);
+          set_options_default(opt_flags);
           didset_options();
           didset_options2();
           ui_refresh_options();
@@ -6216,7 +6213,7 @@ void set_fileformat(int eol_style, int opt_flags)
 
   // p is NULL if "eol_style" is EOL_UNKNOWN.
   if (p != NULL) {
-    set_string_option_direct(kOptFileformat, p, OPT_FREE | opt_flags, 0);
+    set_string_option_direct(kOptFileformat, p, opt_flags, 0);
   }
 
   // This may cause the buffer to become (un)modified.

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -79,16 +79,14 @@ enum {
 /// When OPT_GLOBAL and OPT_LOCAL are both missing, set both local and global
 /// values, get local value.
 typedef enum {
-  // TODO(famiu): See if `OPT_FREE` is really necessary and remove it if not.
-  OPT_FREE      = 0x01,   ///< Free old value if it was allocated.
-  OPT_GLOBAL    = 0x02,   ///< Use global value.
-  OPT_LOCAL     = 0x04,   ///< Use local value.
-  OPT_MODELINE  = 0x08,   ///< Option in modeline.
-  OPT_WINONLY   = 0x10,   ///< Only set window-local options.
-  OPT_NOWIN     = 0x20,   ///< Don’t set window-local options.
-  OPT_ONECOLUMN = 0x40,   ///< list options one per line
-  OPT_NO_REDRAW = 0x80,   ///< ignore redraw flags on option
-  OPT_SKIPRTP   = 0x100,  ///< "skiprtp" in 'sessionoptions'
+  OPT_GLOBAL    = 0x01,  ///< Use global value.
+  OPT_LOCAL     = 0x02,  ///< Use local value.
+  OPT_MODELINE  = 0x04,  ///< Option in modeline.
+  OPT_WINONLY   = 0x08,  ///< Only set window-local options.
+  OPT_NOWIN     = 0x10,  ///< Don’t set window-local options.
+  OPT_ONECOLUMN = 0x20,  ///< list options one per line
+  OPT_NO_REDRAW = 0x40,  ///< ignore redraw flags on option
+  OPT_SKIPRTP   = 0x80,  ///< "skiprtp" in 'sessionoptions'
 } OptionSetFlags;
 
 /// Return value from get_option_attrs().

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -289,7 +289,7 @@ static void set_string_option_global(vimoption_T *opt, char **varp)
 /// "set_sid" is SID_NONE don't set the scriptID.  Otherwise set the scriptID to
 /// "set_sid".
 ///
-/// @param opt_flags  OPT_FREE, OPT_LOCAL and/or OPT_GLOBAL.
+/// @param  opt_flags  Option flags.
 ///
 /// TODO(famiu): Remove this and its win/buf variants.
 void set_string_option_direct(OptIndex opt_idx, const char *val, int opt_flags, scid_T set_sid)
@@ -306,7 +306,7 @@ void set_string_option_direct(OptIndex opt_idx, const char *val, int opt_flags, 
   char *s = xstrdup(val);
   char **varp = (char **)get_varp_scope(opt, both ? OPT_LOCAL : opt_flags);
 
-  if ((opt_flags & OPT_FREE) && (opt->flags & P_ALLOCED)) {
+  if (opt->flags & P_ALLOCED) {
     free_string_option(*varp);
   }
   *varp = s;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -697,7 +697,7 @@ static win_T *pum_create_float_preview(bool enter)
     return NULL;
   }
   buf_T *buf = find_buffer_by_handle(b, &err);
-  set_string_option_direct_in_buf(buf, kOptBufhidden, "wipe", OPT_FREE | OPT_LOCAL, 0);
+  set_string_option_direct_in_buf(buf, kOptBufhidden, "wipe", OPT_LOCAL, 0);
   wp->w_float_is_info = true;
   wp->w_p_diff = false;
   buf->b_p_bl = false;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5091,7 +5091,7 @@ void ex_cfile(exarg_T *eap)
     }
   }
   if (*eap->arg != NUL) {
-    set_string_option_direct(kOptErrorfile, eap->arg, OPT_FREE, 0);
+    set_string_option_direct(kOptErrorfile, eap->arg, 0, 0);
   }
 
   char *enc = (*curbuf->b_p_menc != NUL) ? curbuf->b_p_menc : p_menc;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -2174,7 +2174,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
   // matter?
   // if (called_emsg > called_emsg_before)
   if (opt_idx != kOptInvalid && did_emsg > did_emsg_before) {
-    set_string_option_direct(opt_idx, "", OPT_FREE | opt_scope, SID_ERROR);
+    set_string_option_direct(opt_idx, "", opt_scope, SID_ERROR);
   }
 
   // A user function may reset KeyTyped, restore it.


### PR DESCRIPTION
Problem: `OPT_FREE` macro doesn't seem to do anything as `P_ALLOCED` already handles allocations.

Solution: Remove `OPT_FREE`.