### PR TITLE
refactor(lsp): add typing and docs for LSP handlers

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -158,6 +158,7 @@ to the given buffer. |lsp-buf|
 
 LSP request/response handlers are implemented as Lua functions (see
 |lsp-handler|).
+
                                                                   *lsp-method*
 
 Requests and notifications defined by the LSP specification are referred to as
@@ -169,54 +170,85 @@ Requests and notifications defined by the LSP specification are referred to as
 They are also listed below. Note that handlers depend on server support: they
 won't run if your server doesn't support them.
 
-- callHierarchy/incomingCalls
-- callHierarchy/outgoingCalls
-- textDocument/codeAction
-- textDocument/completion
-- textDocument/declaration*
-- textDocument/definition
-- textDocument/diagnostic
-- textDocument/documentHighlight
-- textDocument/documentSymbol
-- textDocument/formatting
-- textDocument/hover
-- textDocument/implementation*
-- textDocument/inlayHint
-- textDocument/publishDiagnostics
-- textDocument/rangeFormatting
-- textDocument/references
-- textDocument/rename
+    TODO: Make this list auto-generated from vim.lsp.handlers
+    TODO: Include LSP spec version, Nvim version
+
+                                             type
+- $/progress                                 notification
+- workspace/executeCommand                   response
+- window/workDoneProgress/create             request
+- window/showMessageRequest                  request
+- client/registerCapability                  request
+- client/unregisterCapability                request
+- workspace/applyEdit                        request
+- workspace/configuration                    request
+- workspace/workspaceFolders                 request
+- textDocument/publishDiagnostics            notification
+- textDocument/diagnostic                    response
+- textDocument/codeLens                      response
+- textDocument/inlayHint                     response
+- workspace/inlayHint/refresh                request
+- textDocument/references                    response
+- textDocument/documentSymbol                response
+- workspace/symbol                           response
+- textDocument/rename                        response
+- textDocument/formatting                    response
+- textDocument/rangeFormatting               response
+- textDocument/completion                    response
+- textDocument/hover                         response
+- textDocument/declaration*                  response
+- textDocument/definition                    response
+- textDocument/implementation*               response
+- textDocument/typeDefinition*               response
+- textDocument/signatureHelp                 response
+- textDocument/documentHighlight             response
+- callHierarchy/incomingCalls                response
+- callHierarchy/outgoingCalls                response
+- window/logMessage                          notification
+- window/showMessage                         notification
+- window/showDocument                        request
+
+(not implemented in builtin handlers)
+- textDocument/codeAction                    
 - textDocument/semanticTokens/full
 - textDocument/semanticTokens/full/delta
-- textDocument/signatureHelp
-- textDocument/typeDefinition*
-- window/logMessage
-- window/showMessage
-- window/showDocument
-- window/showMessageRequest
-- workspace/applyEdit
-- workspace/configuration
-- workspace/executeCommand
-- workspace/inlayHint/refresh
-- workspace/symbol
-- workspace/workspaceFolders
+- workspace/semanticTokens/refresh
+
+Legend (see |lsp-handler|):
+  "response"    : LSP server sends a reponse to request made by client (Nvim)
+  "request"     : LSP server sends a request to client (Nvim)
+  "notification": LSP server sends a notification to client (Nvim)
+
 
                                                                  *lsp-handler*
-LSP handlers are functions that handle |lsp-response|s to requests made by Nvim
-to the server. (Notifications, as opposed to requests, are fire-and-forget:
-there is no response, so they can't be handled. |lsp-notification|)
+LSP handlers are functions executed on the Nvim's side (LSP client):
+(i)  that handle |lsp-response|s to requests made by Nvim to LSP server
+     (Lua type: vim.lsp.ResponseHandler), or
+(ii) that handle |lsp-request|s or |lsp-notification|s made by LSP server
+     (Lua type: vim.lsp.RequestHandler or vim.lsp.NotificationHandler)
 
-Each response handler has this signature: >
+Notifications (|lsp-notification|) made by Nvim, as opposed to requests, are
+fire-and-forget: there is no response from LSP server, so they can't be
+handled.
 
-    function(err, result, ctx, config)
+Each LSP handler has this signature (vim.lsp.Handler): >
+
+    vim.lsp.ResponseHandler:
+        function(err, result, ctx, config)
+
+    vim.lsp.RequestHandler or vim.lsp.NotificationHandler:
+        function(err, params, ctx, config)
 <
     Parameters: ~
-        - {err}     (table|nil) Error info dict, or `nil` if the request
-                    completed.
-        - {result}  (Result | Params | nil) `result` key of the |lsp-response| or
-                    `nil` if the request failed.
+        - {err}     (table | nil) Error info table (lsp.LspResponseError), or
+                    `nil` if the request completed without errors.
+        - {result}  (Result | nil) `result` key of the |lsp-response|,
+                    or `nil` if the request failed; or
+          {request} (Params | nil) `params` key of the |lsp-request| or
+                    |lsp-notification|, or `nil` if the method does not
+                    require params.
         - {ctx}     (table) Table of calling state associated with the
-                    handler, with these keys:
+                    handler (lsp.HandlerContext), with these keys:
                     - {method}  (string) |lsp-method| name.
                     - {client_id} (number) |vim.lsp.client| identifier.
                     - {bufnr}   (Buffer) Buffer handle.
@@ -233,7 +265,18 @@ Each response handler has this signature: >
                         |lsp-handler-configuration|
 
     Returns: ~
-        Two values `result, err` where `err` is shaped like an RPC error: >
+        TODO: branch among request/response/notification.
+              For response & notification handlers, return type is not needed
+              except for the error handling.
+        TODO: the doc was wrong; LSP response message != handler response.
+        TODO: Document vim.NIL behavior on error, see #16472
+        TODO: vim.NIL in nested result table (e.g. LSPAny)
+              what if it returns nil instead of vim.NIL?
+        TODO: Document the behavior when user handler function throws error.
+
+        For |lsp-request| handlers, Nvim (client) should respond to the server
+        with two values `result, error` where `error` (lsp.ResponseError) is
+        structured like: >
             { code, message, data? }
 <        You can use |vim.lsp.rpc.rpc_response_error()| to create this object.
 
@@ -357,14 +400,22 @@ name: >lua
     vim.lsp.protocol.TextDocumentSyncKind.Full == 1
     vim.lsp.protocol.TextDocumentSyncKind[1] == "Full"
 <
+                                                                *lsp-request*
+LSP request shape: >
+    { id: integer|string, method: string, params?: Params }
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage
 
                                                                 *lsp-response*
-LSP response shape:
-https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
+LSP response shape: >
+    { id: integer|string|nil, result: Response, error: nil }       (on success)
+    { id: integer|string|nil, result: nil, error: ResponseError }  (on error)
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
 
                                                                 *lsp-notification*
-LSP notification shape:
-https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
+LSP notification shape: >
+    { method: string, params?: Params }
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
+
 
                                                                 *lsp-on-list-handler*
 
@@ -1107,7 +1158,7 @@ with({handler}, {override_config})                            *vim.lsp.with()*
     Function to manage overriding defaults for LSP handlers.
 
     Parameters: ~
-      • {handler}          (`lsp.Handler`) See |lsp-handler|
+      • {handler}          (`vim.lsp.Handler`) See |lsp-handler|
       • {override_config}  (`table`) Table containing the keys to override
                            behavior of the {handler}
 
@@ -1384,12 +1435,13 @@ on_diagnostic({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
+      • {result}  (`lsp.DocumentDiagnosticReport`) TODO verify partial results
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`table`) Configuration table (see
                   |vim.diagnostic.config()|).
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
-on_publish_diagnostics({_}, {result}, {ctx}, {config})
+on_publish_diagnostics({_}, {params}, {ctx}, {config})
     |lsp-handler| for the method "textDocument/publishDiagnostics"
 
     See |vim.diagnostic.config()| for configuration options. Handler-specific
@@ -1414,6 +1466,7 @@ on_publish_diagnostics({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
+      • {params}  (`lsp.PublishDiagnosticsParams`)
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`table`) Configuration table (see
                   |vim.diagnostic.config()|).
@@ -1452,7 +1505,9 @@ on_codelens({err}, {result}, {ctx}, {_})
     |lsp-handler| for the method `textDocument/codeLens`
 
     Parameters: ~
-      • {ctx}  (`lsp.HandlerContext`)
+      • {err}     (`lsp.ResponseError?`)
+      • {result}  (`lsp.CodeLens[]?`)
+      • {ctx}     (`lsp.HandlerContext`)
 
 refresh()                                         *vim.lsp.codelens.refresh()*
     Refresh the codelens for the current buffer
@@ -1624,7 +1679,7 @@ stop({bufnr}, {client_id})                    *vim.lsp.semantic_tokens.stop()*
 Lua module: vim.lsp.handlers                                    *lsp-handlers*
 
 hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
-    |lsp-handler| for the method "textDocument/hover" >lua
+    >lua
         vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
           vim.lsp.handlers.hover, {
             -- Use a sharp border with `FloatBorder` highlights
@@ -1636,6 +1691,7 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
 <
 
     Parameters: ~
+      • {result}  (`lsp.Hover?`)
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`table`) Configuration table.
                   • border: (default=nil)
@@ -1657,7 +1713,7 @@ signature_help({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-      • {result}  (`table`) Response from the language server
+      • {result}  (`lsp.SignatureHelp?`) Response from the language server
       • {ctx}     (`lsp.HandlerContext`) Client context
       • {config}  (`table`) Configuration table.
                   • border: (default=nil)
@@ -1687,7 +1743,7 @@ apply_text_edits({text_edits}, {bufnr}, {offset_encoding})
     Applies a list of text edits to a buffer.
 
     Parameters: ~
-      • {text_edits}       (`table`) list of `TextEdit` objects
+      • {text_edits}       (`lsp.TextEdit[]`) list of `TextEdit` objects
       • {bufnr}            (`integer`) Buffer id
       • {offset_encoding}  (`string`) utf-8|utf-16|utf-32
 
@@ -1714,8 +1770,8 @@ buf_highlight_references({bufnr}, {references}, {offset_encoding})
 
     Parameters: ~
       • {bufnr}            (`integer`) Buffer id
-      • {references}       (`table`) List of `DocumentHighlight` objects to
-                           highlight
+      • {references}       (`lsp.DocumentHighlight[]`) List of
+                           `DocumentHighlight` objects to highlight
       • {offset_encoding}  (`string`) One of "utf-8", "utf-16", "utf-32".
 
     See also: ~
@@ -2043,7 +2099,11 @@ symbols_to_items({symbols}, {bufnr})         *vim.lsp.util.symbols_to_items()*
     Converts symbols to quickfix list items.
 
     Parameters: ~
-      • {symbols}  (`table`) DocumentSymbol[] or SymbolInformation[]
+      • {symbols}  (`lsp.DocumentSymbol[]|lsp.WorkspaceSymbol[]|lsp.SymbolInformation[]`)
+      • {bufnr}    (`integer?`)
+
+    Return: ~
+        (`vim.lsp.util.LocationItem[]`)
 
 
 ==============================================================================

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -799,7 +799,8 @@ function lsp.start_client(config)
   --- Returns the default handler if the user hasn't set a custom one.
   ---
   ---@param method (string) LSP method name
-  ---@return lsp.Handler|nil handler for the given method, if defined, or the default from |vim.lsp.handlers|
+  ---@return vim.lsp.Handler|nil handler for the given method, if defined,
+  ---                            or the default from |vim.lsp.handlers|
   local function resolve_handler(method)
     return handlers[method] or default_handlers[method]
   end
@@ -814,7 +815,7 @@ function lsp.start_client(config)
     if log.trace() then
       log.trace('notification', method, params)
     end
-    local handler = resolve_handler(method)
+    local handler = resolve_handler(method) --[[ @as vim.lsp.NotificationHandler ]]
     if handler then
       -- Method name is provided here for convenience.
       handler(nil, params, { method = method, client_id = client_id })
@@ -832,7 +833,7 @@ function lsp.start_client(config)
     if log.trace() then
       log.trace('server_request', method, params)
     end
-    local handler = resolve_handler(method)
+    local handler = resolve_handler(method) --[[ @as vim.lsp.RequestHandler ]]
     if handler then
       if log.trace() then
         log.trace('server_request: found handler for', method)
@@ -1159,7 +1160,7 @@ function lsp.start_client(config)
   ---
   ---@param method string LSP method name.
   ---@param params table|nil LSP request params.
-  ---@param handler lsp.Handler|nil Response |lsp-handler| for this method.
+  ---@param handler vim.lsp.ResponseHandler|nil Response |lsp-handler| for this method.
   ---@param bufnr integer Buffer handle (0 for current).
   ---@return boolean status, integer|nil request_id {status} is a bool indicating
   ---whether the request was successful. If it is `false`, then it will
@@ -1353,7 +1354,7 @@ function lsp.start_client(config)
   ---
   ---@param command lsp.Command
   ---@param context? {bufnr: integer}
-  ---@param handler? lsp.Handler only called if a server command
+  ---@param handler? vim.lsp.ResponseHandler only called if a server command
   function client._exec_cmd(command, context, handler)
     context = vim.deepcopy(context or {}, true) --[[@as lsp.HandlerContext]]
     context.bufnr = context.bufnr or api.nvim_get_current_buf()
@@ -1811,10 +1812,10 @@ api.nvim_create_autocmd('VimLeavePre', {
 --- Sends an async request for all active clients attached to the
 --- buffer.
 ---
----@param bufnr (integer) Buffer handle, or 0 for current.
----@param method (string) LSP method name
+---@param bufnr integer Buffer handle, or 0 for current.
+---@param method string LSP method name, see |vim.lsp.protocol.Methods|
 ---@param params table|nil Parameters to send to the server
----@param handler? lsp.Handler See |lsp-handler|
+---@param handler? vim.lsp.ResponseHandler See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
@@ -1866,9 +1867,9 @@ end
 --- Sends an async request for all active clients attached to the buffer and executes the `handler`
 --- callback with the combined result.
 ---
----@param bufnr (integer) Buffer handle, or 0 for current.
----@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
+---@param bufnr integer Buffer handle, or 0 for current.
+---@param method string LSP method name
+---@param params table|nil Parameters to send to the server
 ---@param handler fun(results: table<integer, {error: lsp.ResponseError, result: any}>) (function)
 --- Handler called after all requests are completed. Server results are passed as
 --- a `client_id:result` map.
@@ -2119,7 +2120,7 @@ function lsp.for_each_buffer_client(bufnr, fn)
 end
 
 --- Function to manage overriding defaults for LSP handlers.
----@param handler (lsp.Handler) See |lsp-handler|
+---@param handler vim.lsp.Handler See |lsp-handler|
 ---@param override_config (table) Table containing the keys to override behavior of the {handler}
 function lsp.with(handler, override_config)
   return function(err, result, ctx, config)

--- a/runtime/lua/vim/lsp/_meta.lua
+++ b/runtime/lua/vim/lsp/_meta.lua
@@ -1,7 +1,19 @@
 ---@meta
 error('Cannot require a meta file')
 
----@alias lsp.Handler fun(err: lsp.ResponseError?, result: any, context: lsp.HandlerContext, config?: table): ...any
+-- TODO: Consider moving this to vim/lsp/handlers.lua; or stay here?
+
+---LSP Handlers, see |lsp-handler| for documentation. see also |lsp-handler-resolution|
+---@alias vim.lsp.Handler vim.lsp.ResponseHandler | vim.lsp.RequestHandler | vim.lsp.NotificationHandler
+---
+---Handles response sent from the server, see |lsp-response|
+---@alias vim.lsp.ResponseHandler fun(err: lsp.ResponseError?, result: any, context: lsp.HandlerContext, config?: table)
+---
+---Handles request sent from the server, see |lsp-request|
+---@alias vim.lsp.RequestHandler fun(err: lsp.ResponseError?, params: any, context: lsp.HandlerContext, config?: table): ...any
+---
+---Handles notification sent from the server, see |lsp-notification|
+---@alias vim.lsp.NotificationHandler fun(err: lsp.ResponseError?, params: any, context: lsp.HandlerContext, config?: table): vim.NIL|nil
 
 ---@class lsp.HandlerContext
 ---@field method string
@@ -14,10 +26,3 @@ error('Cannot require a meta file')
 ---@field code integer
 ---@field message string
 ---@field data string|number|boolean|table[]|table|nil
-
---- @class lsp.DocumentFilter
---- @field language? string
---- @field scheme? string
---- @field pattern? string
-
---- @alias lsp.RegisterOptions any | lsp.StaticRegistrationOptions | lsp.TextDocumentRegistrationOptions

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -9,10 +9,10 @@ local M = {}
 --- Sends an async request to all active clients attached to the current
 --- buffer.
 ---
----@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
----@param handler (function|nil) See |lsp-handler|. Follows |lsp-handler-resolution|
---
+---@param method string LSP method name
+---@param params table|nil Parameters to send to the server
+---@param handler vim.lsp.Handler|nil See |lsp-handler|. Follows |lsp-handler-resolution|
+---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
 ---for all successful requests.
 ---@return function _cancel_all_requests Function which can be used to

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -258,6 +258,8 @@ end
 
 --- |lsp-handler| for the method `textDocument/codeLens`
 ---
+---@param err lsp.ResponseError?
+---@param result lsp.CodeLens[]?
 ---@param ctx lsp.HandlerContext
 function M.on_codelens(err, result, ctx, _)
   if err then

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -229,13 +229,15 @@ end
 --- )
 --- ```
 ---
+---@param params lsp.PublishDiagnosticsParams
 ---@param ctx lsp.HandlerContext
 ---@param config table Configuration table (see |vim.diagnostic.config()|).
-function M.on_publish_diagnostics(_, result, ctx, config)
+---@type vim.lsp.NotificationHandler
+function M.on_publish_diagnostics(_, params, ctx, config)
   local client_id = ctx.client_id
-  local uri = result.uri
+  local uri = params.uri
   local fname = vim.uri_to_fname(uri)
-  local diagnostics = result.diagnostics
+  local diagnostics = params.diagnostics
   if #diagnostics == 0 and vim.fn.bufexists(fname) == 0 then
     return
   end
@@ -291,8 +293,10 @@ end
 --- )
 --- ```
 ---
+---@param result lsp.DocumentDiagnosticReport  TODO verify partial results
 ---@param ctx lsp.HandlerContext
 ---@param config table Configuration table (see |vim.diagnostic.config()|).
+---@type vim.lsp.ResponseHandler
 function M.on_diagnostic(_, result, ctx, config)
   local client_id = ctx.client_id
   local uri = ctx.params.textDocument.uri

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -20,6 +20,7 @@ local augroup = api.nvim_create_augroup('vim_lsp_inlayhint', {})
 ---@param result lsp.InlayHint[]?
 ---@param ctx lsp.HandlerContext
 ---@private
+---@type vim.lsp.ResponseHandler
 function M.on_inlayhint(err, result, ctx, _)
   if err then
     if log.error() then
@@ -83,9 +84,11 @@ function M.on_inlayhint(err, result, ctx, _)
   api.nvim__buf_redraw_range(bufnr, 0, -1)
 end
 
+---@private
 --- |lsp-handler| for the method `textDocument/inlayHint/refresh`
 ---@param ctx lsp.HandlerContext
----@private
+---@return any void TODO verify vim.NIL?
+---@type vim.lsp.RequestHandler
 function M.on_refresh(err, _, ctx, _)
   if err then
     return vim.NIL

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -51,6 +51,8 @@ local constants = {
     Info = 3,
     -- A log message.
     Log = 4,
+    -- A deug message.
+    Debug = 5,
   },
 
   -- The file event type.


### PR DESCRIPTION
**Still WIP**. This one is going to be a heavy one with some TODOs still left :P

## Description

Add lua type annotations for LSP handler functions:

- `vim.lsp.Handler`
- `vim.lsp.RequestHandler` (see |lsp-request|)
- `vim.lsp.ResponseHandler` (see |lsp-response|)
- `vim.lsp.NotificationHandler` (see |lsp-notification|)

There are three types of LSP handlers: request handler, response
handler, and notification handler, having slightly different parameters
(`result` v.s. `params`) and return types (returns something or no
return expected). Previously, they were all using the same signature
(response handler) and hence wrong parameter names, which is now fixed.

Lots of type checking warnings were fixed by adding handler-specific
type annotatinos for either `result` or `params`.

Changes on doc/lsp.txt:

- Add section |lsp-request|. Make data structure more explicit on
  |lsp-response| and |lsp-notification|.

- Update docs for |lsp-handler| to explain the three types of LSP
  handlers, and better clarify parameters and return values.



## Related

- #26552 (initial write of `lsp.Handler`, this PR changes to `vim.lsp.Handler`)
- #23958
   - (initial write of `lsp.HandlerContext`, this PR changes to `vim.lsp.HandlerContext`)
   - `LspProgress` autocmd has `data = { ..., result = result }`, but the name of the field might be changed.
- #23681 This remove unused annotations in `lsp._meta`
- #16472 (discusses vim.NIL behavior)


## Tasks and TODO for this PR

- ~~This PR is blocked by: wait for #26971 (which should be merged first)~~
- Semantic Tokens
- Figure out the mystery of `vim.NIL` return values, which is used for RPC protocol. (Can anyone enlighten me please?)
- Document the behavior on the return values of `*lsp-handler*`.
- Fix a few potential bugs (marked as TODO).