### PR TITLE
vim-patch:71d0ba07a33a

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -2074,9 +2074,9 @@ fun! netrw#NetRead(mode,...)
        let wholechoice = wholechoice . " " . choice
        let ichoice     = ichoice + 1
        if ichoice > a:0
-       	if !exists("g:netrw_quiet")
-	 call netrw#ErrorMsg(s:ERROR,"Unbalanced string in filename '". wholechoice ."'",3)
-	endif
+        if !exists("g:netrw_quiet")
+         call netrw#ErrorMsg(s:ERROR,"Unbalanced string in filename '". wholechoice ."'",3)
+        endif
 "        call Dret("netrw#NetRead :2 getcwd<".getcwd().">")
         return
        endif
@@ -2497,9 +2497,9 @@ fun! netrw#NetWrite(...) range
        let wholechoice= wholechoice . " " . choice
        let ichoice    = ichoice + 1
        if choice > a:0
-       	if !exists("g:netrw_quiet")
-	 call netrw#ErrorMsg(s:ERROR,"Unbalanced string in filename '". wholechoice ."'",13)
-	endif
+        if !exists("g:netrw_quiet")
+         call netrw#ErrorMsg(s:ERROR,"Unbalanced string in filename '". wholechoice ."'",13)
+        endif
 "        call Dret("netrw#NetWrite")
         return
        endif
@@ -4956,12 +4956,12 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
       if g:netrw_chgwin >= 1
 "       call Decho("edit-a-file: changing window to #".g:netrw_chgwin.": (due to g:netrw_chgwin)",'~'.expand("<slnum>"))
        if winnr("$")+1 == g:netrw_chgwin
-	" if g:netrw_chgwin is set to one more than the last window, then
-	" vertically split the last window to make that window available.
-	let curwin= winnr()
-	exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
-	vs
-	exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
+       " if g:netrw_chgwin is set to one more than the last window, then
+       " vertically split the last window to make that window available.
+       let curwin= winnr()
+       exe "NetrwKeepj keepalt ".winnr("$")."wincmd w"
+       vs
+       exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd ".curwin
        endif
        exe "NetrwKeepj keepalt ".g:netrw_chgwin."wincmd w"
       endif
@@ -6070,7 +6070,7 @@ fun! s:NetrwServerEdit(islocal,fname)
        " used something like <cr>.
 "       call Decho("user must have closed server AND did not use ctrl-r",'~'.expand("<slnum>"))
        if exists("g:netrw_browse_split")
-	unlet g:netrw_browse_split
+        unlet g:netrw_browse_split
        endif
        let g:netrw_browse_split= 0
        if exists("s:netrw_browse_split_".winnr())
@@ -6104,7 +6104,7 @@ fun! s:NetrwServerEdit(islocal,fname)
       if !ctrlr
 "       call Decho("server<".g:netrw_servername."> not available and ctrl-r not used",'~'.expand("<slnum>"))
        if exists("g:netrw_browse_split")
-	unlet g:netrw_browse_split
+        unlet g:netrw_browse_split
        endif
        let g:netrw_browse_split= 0
        call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname))
@@ -7446,7 +7446,7 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
      for fname in s:netrwmarkfilelist_{curbufnr}
       if a:islocal
        if g:netrw_keepdir
-	let fname= s:ShellEscape(netrw#WinPath(s:ComposePath(curdir,fname)))
+        let fname= s:ShellEscape(netrw#WinPath(s:ComposePath(curdir,fname)))
        endif
       else
        let fname= s:ShellEscape(netrw#WinPath(b:netrw_curdir.fname))
@@ -10575,7 +10575,7 @@ fun! s:NetrwRemoteRmFile(path,rmfile,all)
       let ret= system(netrw_rm_cmd)
       if v:shell_error != 0
        if exists("b:netrw_curdir") && b:netrw_curdir != getcwd() && !g:netrw_keepdir
-	call netrw#ErrorMsg(s:ERROR,"remove failed; perhaps due to vim's current directory<".getcwd()."> not matching netrw's (".b:netrw_curdir.") (see :help netrw-cd)",102)
+        call netrw#ErrorMsg(s:ERROR,"remove failed; perhaps due to vim's current directory<".getcwd()."> not matching netrw's (".b:netrw_curdir.") (see :help netrw-cd)",102)
        else
         call netrw#ErrorMsg(s:WARNING,"cmd<".netrw_rm_cmd."> failed",60)
        endif
@@ -11083,16 +11083,16 @@ fun! s:LocalListing()
 "   call Decho("pfile   <".pfile.">",'~'.expand("<slnum>"))
 
    if w:netrw_liststyle == s:LONGLIST
-    let longfile= printf("%-".g:netrw_maxfilenamelen."S",pfile)
-    let sz   = getfsize(filename)
-	let szlen = 15 - (strdisplaywidth(longfile) - g:netrw_maxfilenamelen)
-    let szlen = (szlen > 0) ? szlen : 0
+    let longfile = printf("%-".g:netrw_maxfilenamelen."S",pfile)
+    let sz       = getfsize(filename)
+    let szlen    = 15 - (strdisplaywidth(longfile) - g:netrw_maxfilenamelen)
+    let szlen    = (szlen > 0) ? szlen : 0
 
     if g:netrw_sizestyle =~# "[hH]"
      let sz= s:NetrwHumanReadable(sz)
     endif
     let fsz  = printf("%".szlen."S",sz)
-    let pfile   = longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
+    let pfile= longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
 "    call Decho("longlist support: sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
    endif
 
@@ -12112,7 +12112,7 @@ fun! s:NetrwLcd(newdir)
      if (has("win32") || has("win95") || has("win64") || has("win16")) && !g:netrw_cygwin
        if a:newdir =~ '^\\\\\w\+' || a:newdir =~ '^//\w\+'
          let dirname = '\'
-	 exe 'NetrwKeepj sil lcd '.fnameescape(dirname)
+         exe 'NetrwKeepj sil lcd '.fnameescape(dirname)
        endif
      endif
   catch /^Vim\%((\a\+)\)\=:E472/

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1621,10 +1621,8 @@ A further approach is to delete files which match a pattern.
       This will cause the matching files to be marked.  Then,
       press "D".
 
-If your vim has 7.4 with patch#1107, then |g:netrw_localrmdir| no longer
-is used to remove directories; instead, vim's |delete()| is used with
-the "d" option.  Please note that only empty directories may be deleted
-with the "D" mapping.  Regular files are deleted with |delete()|, too.
+Please note that only empty directories may be deleted with the "D" mapping.
+Regular files are deleted with |delete()|, too.
 
 The |g:netrw_rm_cmd|, |g:netrw_rmf_cmd|, and |g:netrw_rmdir_cmd| variables are
 used to control the attempts to remove remote files and directories.  The
@@ -1643,8 +1641,7 @@ to remove it again using the g:netrw_rmf_cmd variable.  Its default value is:
 	|g:netrw_rmf_cmd|: ssh HOSTNAME rm -f
 
 Related topics: |netrw-d|
-Associated setting variable: |g:netrw_localrmdir| |g:netrw_rm_cmd|
-                             |g:netrw_rmdir_cmd|   |g:netrw_ssh_cmd|
+Associated setting variable: |g:netrw_rm_cmd| |g:netrw_ssh_cmd|
 
 
 *netrw-explore*  *netrw-hexplore* *netrw-nexplore* *netrw-pexplore*
@@ -1687,7 +1684,11 @@ DIRECTORY EXPLORATION COMMANDS  {{{2
 	  to 2; edits will thus preferentially be made in window#2.
 
 	  The [N] specifies a |g:netrw_winsize| just for the new :Lexplore
-	  window.
+	  window. That means that
+	    if [N] < 0 : use |N| columns for the Lexplore window
+	    if [N] = 0 : a normal split is made
+	    if [N] > 0 : use N% of the current window will be used for the
+	                 new window
 
 	  Those who like this method often also like tree style displays;
 	  see |g:netrw_liststyle|.
@@ -2848,14 +2849,6 @@ your browsing preferences.  (see also: |netrw-settings|)
 				=" /c move"                     Windows
 				Options for |g:netrw_localmovecmd|
 
-  *g:netrw_localrmdir*		="rmdir"        Linux/Unix/MacOS/Cygwin
-				=expand("$COMSPEC")             Windows
-				Remove directory command (rmdir)
-				This variable is only used if your vim is
-				earlier than 7.4 or if your vim doesn't
-				have patch#1107.  Otherwise, |delete()|
-				is used with the "d" option.
-
   *g:netrw_maxfilenamelen*	=32 by default, selected so as to make long
 				    listings fit on 80 column displays.
 				If your screen is wider, and you have file
@@ -3766,7 +3759,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	     Netrw uses several system level commands to do things (see
 
 		 |g:netrw_localcopycmd|, |g:netrw_localmovecmd|,
-		 |g:netrw_localrmdir|, |g:netrw_mkdir_cmd|).
+		 |g:netrw_mkdir_cmd|).
 
 	    You may need to adjust the default commands for one or more of
 	    these commands by setting them properly in your .vimrc.  Another
@@ -3892,8 +3885,13 @@ netrw:
 ==============================================================================
 12. History						*netrw-history* {{{1
 
-	v172:	Apr 22, 2023	* removed g:netrw_localrmdiropt
-				  removed g:netrw_localrmdir
+	v172:	Sep 02, 2021	* (Bram Moolenaar) Changed "l:go" to "go"
+				* (Bram Moolenaar) no need for "b" in
+				  netrw-safe guioptions
+		Nov 15, 2021	* removed netrw_localrm and netrw_localrmdir
+				  references
+		Aug 18, 2022	* (Miguel Barro) improving compatability with
+				  powershell
 	v171:	Oct 09, 2020	* included code in s:NetrwOptionsSafe()
 				  to allow |'bh'| to be set to delete when
 				  rather than hide when g:netrw_fastbrowse
@@ -3981,7 +3979,6 @@ netrw:
 				  |g:netrw_localcopydircmdopt|
 				  |g:netrw_localmkdiropt|
 				  |g:netrw_localmovecmdopt|
-				  g:netrw_localrmdiropt
 		Nov 21, 2016	* (mattn) provided a patch for preview; swapped
 				  winwidth() with winheight()
 		Nov 22, 2016	* (glacambre) reported that files containing
@@ -4041,7 +4038,7 @@ netrw:
 				  refreshes.  However, inside a |:map-<expr>|,
 				  tab and window changes are disallowed.  Fixed.
 				  (affects netrw's s:LocalBrowseRefresh())
-				* |g:netrw_localrmdir| not used any more, but
+				* g:netrw_localrmdir not used any more, but
 				  the relevant patch that causes |delete()| to
 				  take over was #1107 (not #1109).
 				* |expand()| is now used on |g:netrw_home|;


### PR DESCRIPTION
runtime(netrw): Sync with netrw 174b (vim/vim#13836)

* Import netrw v174b
* Revert unwanted changes
* Fix indent
* Revert some changes
* Update tags
* Break long line

https://github.com/vim/vim/commit/71d0ba07a33a750e9834cd42b7acc619043dedb1

Co-authored-by: K.Takata <kentkt@csc.jp>
