### PR TITLE
vim-patch:2357765304e4

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -11477,7 +11477,7 @@ endfun
 "  netrw#RFC2396: converts %xx into characters {{{2
 fun! netrw#RFC2396(fname)
 "  call Dfunc("netrw#RFC2396(fname<".a:fname.">)")
-  let fname = escape(substitute(a:fname,'%\(\x\x\)','\=nr2char("0x".submatch(1))','ge')," \t")
+  let fname = escape(substitute(a:fname,'%\(\x\x\)','\=printf("%c","0x".submatch(1))','ge')," \t")
 "  call Dret("netrw#RFC2396 ".fname)
   return fname
 endfun


### PR DESCRIPTION
runtime(netrw): Decode multibyte percent-encoding filename correctly (vim/vim#13842)

Use `printf("%c")` instead of `nr2char()` to handle '%xx' as a byte.

Close vim/vim#13787

https://github.com/vim/vim/commit/2357765304e4c55935b5cc853ffb98ae82d64a01

Co-authored-by: K.Takata <kentkt@csc.jp>
