### PR TITLE
vim-patch:9.1.0025: A few typos in tests and justify.vim

### DIFF
--- a/runtime/pack/dist/opt/justify/plugin/justify.vim
+++ b/runtime/pack/dist/opt/justify/plugin/justify.vim
@@ -80,7 +80,7 @@
 " conformant with :left, :right and :center.
 "
 " If joinspaces is set, an extra space is added after '.', '?' and  '!'.
-" If 'cpooptions' include 'j', extra space  is  only  added  after  '.'.
+" If 'cpoptions' include 'j', extra space  is  only  added  after  '.'.
 " (This may on occasion conflict with maxspaces.)
 
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -2240,7 +2240,7 @@ func Test_normal29_brace()
   [DATA]
   call assert_equal(expected, getline(1, '$'))
 
-  " Test with { in cpooptions
+  " Test with { in cpoptions
   %d
   call append(0, text)
   " Nvim: no "{" flag in 'cpoptions'.


### PR DESCRIPTION
Problem:  A few typos in tests and justify.vim
Solution: fix them

closes: vim/vim#13848

https://github.com/vim/vim/commit/dc4c37b9d5130c777b377287b8b38cd24da084cb

Co-authored-by: dundargoc <gocdundar@gmail.com>
