### PR TITLE
vim-patch:9.1.0022: Coverity complains about improper use of negative value

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3170,7 +3170,7 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
         } else {
           // TODO(@brammool): multi-byte
           if (keytyped == (int)(uint8_t)p[-1]
-              || (icase && keytyped < 256
+              || (icase && keytyped < 256 && keytyped >= 0
                   && TOLOWER_LOC(keytyped) == TOLOWER_LOC((uint8_t)p[-1]))) {
             char *line = get_cursor_pos_ptr();
             assert(p >= look && (uintmax_t)(p - look) <= SIZE_MAX);


### PR DESCRIPTION
#### vim-patch:9.1.0022: Coverity complains about improper use of negative value

Problem:  Coverity complains about improper use of negative value
Solution: Add a condition to validate that keytyped is larger or equal
          to 0

Apparently patch 9.1.0006 made it more explicit for Coverity, that the
TOLOWER_LOC() macros do not handle negative values properly. However,
that condition has always been there even before that, so add a
condition to verify that keytyped is indeed at least 0

closes: vim/vim#13824

https://github.com/vim/vim/commit/49471963fefbdf78239d9066d84e14e1876fb177

Co-authored-by: Christian Brabandt <cb@256bit.org>