### PR TITLE
perf(extmarks): add metadata for efficient filtering of special decorations

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -32,6 +32,7 @@
 #include "nvim/mapping.h"
 #include "nvim/mark.h"
 #include "nvim/mark_defs.h"
+#include "nvim/marktree.h"
 #include "nvim/memline.h"
 #include "nvim/memline_defs.h"
 #include "nvim/memory.h"
@@ -1282,7 +1283,7 @@ Dictionary nvim__buf_stats(Buffer buffer, Error *err)
   // this exists to debug issues
   PUT(rv, "dirty_bytes", INTEGER_OBJ((Integer)buf->deleted_bytes));
   PUT(rv, "dirty_bytes2", INTEGER_OBJ((Integer)buf->deleted_bytes2));
-  PUT(rv, "virt_blocks", INTEGER_OBJ((Integer)buf->b_virt_line_blocks));
+  PUT(rv, "virt_blocks", INTEGER_OBJ((Integer)buf_meta_total(buf, kMTMetaLines)));
 
   u_header_T *uhp = NULL;
   if (buf->b_u_curhead != NULL) {

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -81,3 +81,8 @@ static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
 {
   return buf->changedtick_di.di_tv.vval.v_number;
 }
+
+static inline uint32_t buf_meta_total(const buf_T *b, MetaIndex m)
+{
+  return b->b_marktree->meta_root[m];
+}

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -701,10 +701,6 @@ struct file_buffer {
 
   MarkTree b_marktree[1];
   Map(uint32_t, uint32_t) b_extmark_ns[1];         // extmark namespaces
-  size_t b_virt_text_inline;                       // number of inline virtual texts
-  size_t b_virt_line_blocks;    // number of virt_line blocks
-  size_t b_signs;               // number of sign extmarks
-  size_t b_signs_with_text;     // number of sign extmarks with text
 
   // array of channel_id:s which have asked to receive updates for this
   // buffer.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -33,6 +33,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/mark.h"
 #include "nvim/mark_defs.h"
+#include "nvim/marktree.h"
 #include "nvim/mbyte.h"
 #include "nvim/mbyte_defs.h"
 #include "nvim/memline.h"
@@ -329,7 +330,7 @@ static void changed_common(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnum
             // changed line may become invalid.
             if (i == 0 || wp->w_lines[i].wl_lnum < lnume
                 || (wp->w_lines[i].wl_lnum == lnume
-                    && wp->w_buffer->b_virt_line_blocks > 0)) {
+                    && buf_meta_total(wp->w_buffer, kMTMetaLines) > 0)) {
               // line included in change
               wp->w_lines[i].wl_valid = false;
             } else if (xtra != 0) {

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -32,6 +32,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/indent.h"
 #include "nvim/mark_defs.h"
+#include "nvim/marktree.h"
 #include "nvim/match.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
@@ -1645,7 +1646,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
                                           &decor_state);
         }
 
-        if (!has_foldtext && wp->w_buffer->b_virt_text_inline > 0) {
+        if (!has_foldtext && buf_meta_total(wp->w_buffer, kMTMetaInline) > 0) {
           handle_inline_virtual_text(wp, &wlv, ptr - line);
           if (wlv.n_extra > 0 && wlv.virt_inline_hl_mode <= kHlModeReplace) {
             // restore search_attr and area_attr when n_extra is down to zero
@@ -1662,9 +1663,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         }
       }
 
-      int *area_attr_p
-        = wlv.extra_for_extmark && wlv.virt_inline_hl_mode <= kHlModeReplace
-          ? &saved_area_attr : &area_attr;
+      int *area_attr_p = wlv.extra_for_extmark && wlv.virt_inline_hl_mode <= kHlModeReplace
+                         ? &saved_area_attr : &area_attr;
 
       // handle Visual or match highlighting in this line
       if (wlv.vcol == wlv.fromcol

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -88,6 +88,7 @@
 #include "nvim/highlight_defs.h"
 #include "nvim/highlight_group.h"
 #include "nvim/insexpand.h"
+#include "nvim/marktree.h"
 #include "nvim/match.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
@@ -1220,7 +1221,7 @@ static bool win_redraw_signcols(win_T *wp)
   if (rebuild_stc) {
     wp->w_nrwidth_line_count = 0;
   } else if (wp->w_minscwidth == 0 && wp->w_maxscwidth == 1) {
-    width = buf->b_signs_with_text > 0;
+    width = buf_meta_total(buf, kMTMetaSignText) > 0;
   }
 
   int scwidth = wp->w_scwidth;
@@ -2628,7 +2629,7 @@ int number_width(win_T *wp)
 
   // If 'signcolumn' is set to 'number' and there is a sign to display, then
   // the minimal width for the number column is 2.
-  if (n < 2 && wp->w_buffer->b_signs_with_text && wp->w_minscwidth == SCL_NUM) {
+  if (n < 2 && buf_meta_total(wp->w_buffer, kMTMetaSignText) && wp->w_minscwidth == SCL_NUM) {
     n = 2;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -41,6 +41,7 @@
 #include "nvim/mapping.h"
 #include "nvim/mark.h"
 #include "nvim/mark_defs.h"
+#include "nvim/marktree.h"
 #include "nvim/mbyte.h"
 #include "nvim/mbyte_defs.h"
 #include "nvim/memline.h"
@@ -240,7 +241,7 @@ static void insert_enter(InsertState *s)
 
   // need to position cursor again when on a TAB and
   // when on a char with inline virtual text
-  if (gchar_cursor() == TAB || curbuf->b_virt_text_inline > 0) {
+  if (gchar_cursor() == TAB || buf_meta_total(curbuf, kMTMetaInline) > 0) {
     curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL);
   }
 
@@ -3472,7 +3473,7 @@ static bool ins_esc(int *count, int cmdchar, bool nomove)
   may_trigger_modechanged();
   // need to position cursor again when on a TAB and
   // when on a char with inline virtual text
-  if (gchar_cursor() == TAB || curbuf->b_virt_text_inline > 0) {
+  if (gchar_cursor() == TAB || buf_meta_total(curbuf, kMTMetaInline) > 0) {
     curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL);
   }
 

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -507,7 +507,7 @@ static dict_T *get_buffer_info(buf_T *buf)
   }
   tv_dict_add_list(dict, S_LEN("windows"), windows);
 
-  if (buf->b_signs) {
+  if (buf_has_signs(buf)) {
     // List of signs placed in this buffer
     tv_dict_add_list(dict, S_LEN("signs"), get_buffer_signs(buf));
   }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -225,7 +225,7 @@ ExtmarkInfoArray extmark_get(buf_T *buf, uint32_t ns_id, int l_row, colnr_T l_co
   } else {
     // Find all the marks beginning with the start position
     marktree_itr_get_ext(buf->b_marktree, MTPos(l_row, l_col),
-                         itr, reverse, false, NULL);
+                         itr, reverse, false, NULL, NULL);
   }
 
   int order = reverse ? -1 : 1;

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -125,6 +125,11 @@ static inline DecorInline mt_decor(MTKey key)
   return (DecorInline){ .ext = key.flags & MT_FLAG_DECOR_EXT, .data = key.decor_data };
 }
 
+static inline DecorVirtText *mt_decor_virt(MTKey mark)
+{
+  return (mark.flags & MT_FLAG_DECOR_EXT) ? mark.decor_data.ext.vt : NULL;
+}
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "marktree.h.generated.h"
 #endif

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -67,6 +67,7 @@
 // Uncomment the next line for including the u_check() function.  This warns
 // for errors in the debug information.
 // #define U_DEBUG 1
+#include "nvim/marktree.h"
 #define UH_MAGIC 0x18dade       // value for uh_magic when in use
 #define UE_MAGIC 0xabc123       // value for ue_magic when in use
 
@@ -2390,7 +2391,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
     // may have SpellCap that should be removed or it needs to be
     // displayed.  Schedule the next line for redrawing just in case.
     // Also just in case the line had a sign which needs to be removed.
-    if ((spell_check_window(curwin) || curbuf->b_signs_with_text)
+    if ((spell_check_window(curwin) || buf_meta_total(curbuf, kMTMetaSignText))
         && bot <= curbuf->b_ml.ml_line_count) {
       redrawWinline(curwin, bot);
     }
@@ -2431,7 +2432,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
   int row3 = -1;
   // Tricky: ExtmarkSavePos may come after ExtmarkSplice which does call
   // buf_signcols_count_range() but then misses the yet unrestored marks.
-  if (curbuf->b_signcols.autom && curbuf->b_signs_with_text) {
+  if (curbuf->b_signcols.autom && buf_meta_total(curbuf, kMTMetaSignText)) {
     for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
       ExtmarkUndoObject undo_info = kv_A(curhead->uh_extmark, i);
       if (undo_info.type == kExtmarkSplice) {


### PR DESCRIPTION
This expands on the global "don't pay for what you don't use" rules for these special extmark decorations:

- inline virtual text, which needs to be processed in plines.c when we calculate the size of text on screen
- virtual lines, which are needed when calculating "filler" lines
- signs, with text and/or highlights, both of which needs to be processed for the entire line already at the beginning of a line.

This adds a count to each node of the marktree, for how many special marks of each kind can be found in the subtree for this node. This makes it possible to quickly handle extra checks, when working in regions of the buffer not containing these kind of marks, instead of before where this could just be skipped if the entire _buffer_ didn't contain such marks.

Note: this PR only covers some of the places where this extra information is useful. For instance I haven't touched the the "b_signcols" code yet as there is ongoing work #26898 by @luukvbaal and it would benefit from some discussion.