### PR TITLE
fix: make i_ctrl-] not activate InsertCharPre

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -574,6 +574,7 @@ Autocommands:
   https://github.com/neovim/neovim/issues/23368
 - |TermResponse| is fired for any OSC sequence received from the terminal,
   instead of the Primary Device Attributes response. |v:termresponse|
+- |InsertCharPre| doesn't get activated by |i_CTRL-]|
 
 ==============================================================================
 Missing features					 *nvim-missing*

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4725,6 +4725,10 @@ static char *do_insert_char_pre(int c)
   char buf[MB_MAXBYTES + 1];
   const int save_State = State;
 
+  if (c == Ctrl_RSB) {
+    return NULL;
+  }
+
   // Return quickly when there is nothing to do.
   if (!has_event(EVENT_INSERTCHARPRE)) {
     return NULL;

--- a/test/functional/autocmd/insertcharpre_spec.lua
+++ b/test/functional/autocmd/insertcharpre_spec.lua
@@ -1,0 +1,16 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local feed = helpers.feed
+local command = helpers.command
+local expect = helpers.expect
+
+describe('autocmd InsertCharPre', function()
+  before_each(clear)
+
+  it('Ctrl-] should not activate InsertCharPre', function()
+    command('autocmd InsertCharPre * let v:char="a"')
+    feed('ifoo<C-]>')
+    expect('aaa')
+  end)
+end)


### PR DESCRIPTION
Is just https://github.com/neovim/neovim/pull/26226, but I did something wrong with git, and cause of that, I need to open a new pull request.

Currently pressing `ctrl-]` in insert-mode activates InsertCharPre. This is probably unintended as `ctr-]` doesn't insert a character but does an action.