### PR TITLE
build: disable conversion warnings for older GCC versions

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -117,6 +117,10 @@ elseif(MINGW)
   # Enable wmain
   target_link_libraries(nvim PRIVATE -municode)
 elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_C_COMPILER_VERSION VERSION_LESS 10)
+    target_compile_options(main_lib INTERFACE -Wno-conversion)
+  endif()
+
   target_compile_options(main_lib INTERFACE -fno-common
     $<$<CONFIG:Release>:-Wno-unused-result>
     $<$<CONFIG:RelWithDebInfo>:-Wno-unused-result>


### PR DESCRIPTION
The conversion warnings from GCC versions 10 and less give too many
false positives and should be disabled.
