### PR TITLE
docs: add lua typing for `vim.NIL`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1829,7 +1829,8 @@ lookup_section({settings}, {section})          *vim.lsp.util.lookup_section()*
       • {section}   (`string`) indicating the field of the settings table
 
     Return: ~
-        (`table|string`) The value of settings accessed via section
+        (`table|string|vim.NIL`) The value of settings accessed via section.
+        `vim.NIL` if not found.
 
                                   *vim.lsp.util.make_floating_popup_options()*
 make_floating_popup_options({width}, {height}, {opts})

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -1,6 +1,7 @@
 ---@meta
-
 -- luacheck: no unused args
+
+error('Cannot require a meta file')
 
 ---@defgroup vim.builtin
 ---
@@ -61,6 +62,12 @@
 ---    vim.log.levels.OFF
 ---
 ---</pre>
+
+---@class vim.NIL
+
+---@type vim.NIL
+---@nodoc
+vim.NIL = ...
 
 --- Returns true if the code is executing as part of a "fast" event handler,
 --- where most of the API is disabled. These are low-level events (e.g.

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -427,7 +427,7 @@ vim.v.msgpack_types = ...
 --- In some places `v:null` can be used for a List, Dict, etc.
 --- that is not set.  That is slightly different than an empty
 --- List, Dict, etc.
---- @type any
+--- @type vim.NIL
 vim.v.null = ...
 
 --- Maximum value of a number.

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2139,7 +2139,7 @@ end
 ---
 ---@param settings table language server settings
 ---@param section  string indicating the field of the settings table
----@return table|string The value of settings accessed via section
+---@return table|string|vim.NIL The value of settings accessed via section. `vim.NIL` if not found.
 function M.lookup_section(settings, section)
   for part in vim.gsplit(section, '.', { plain = true }) do
     settings = settings[part]

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -469,6 +469,7 @@ M.vars = {
     ]=],
   },
   null = {
+    type = 'vim.NIL',
     desc = [=[
       Special value used to put "null" in JSON and NIL in msgpack.
       See |json_encode()|.  This value is converted to "v:null" when


### PR DESCRIPTION
Use case: typing for RPC-related stuffs (e.g., LSP handlers #26968)