### PR TITLE
refactor(lsp): deprecate `vim.lsp.util.lookup_section`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -144,6 +144,8 @@ LSP FUNCTIONS
 						`progress` of |vim.lsp.client|
 - *vim.lsp.get_active_clients()*		Use |vim.lsp.get_clients()|
 - *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()|
+- *vim.lsp.util.lookup_section()*		Use |vim.tbl_get()| and
+						|vim.split()| with {plain=true} instead.
 - *vim.lsp.util.trim_empty_lines()*		Use |vim.split()| with `trimempty` instead.
 - *vim.lsp.util.try_trim_markdown_code_blocks()*
 - *vim.lsp.util.set_lines()*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1821,17 +1821,6 @@ locations_to_items({locations}, {offset_encoding})
     Return: ~
         (`vim.lsp.util.LocationItem[]`) list of items
 
-lookup_section({settings}, {section})          *vim.lsp.util.lookup_section()*
-    Helper function to return nested values in language server settings
-
-    Parameters: ~
-      • {settings}  (`table`) language server settings
-      • {section}   (`string`) indicating the field of the settings table
-
-    Return: ~
-        (`table|string|vim.NIL`) The value of settings accessed via section.
-        `vim.NIL` if not found.
-
                                   *vim.lsp.util.make_floating_popup_options()*
 make_floating_popup_options({width}, {height}, {opts})
     Creates a table with sensible default options for a floating window. The

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2140,7 +2140,9 @@ end
 ---@param settings table language server settings
 ---@param section  string indicating the field of the settings table
 ---@return table|string|vim.NIL The value of settings accessed via section. `vim.NIL` if not found.
+---@deprecated
 function M.lookup_section(settings, section)
+  vim.deprecate('vim.lsp.util.lookup_section()', 'vim.tbl_get() with `vim.split`', '0.12')
   for part in vim.gsplit(section, '.', { plain = true }) do
     settings = settings[part]
     if settings == nil then


### PR DESCRIPTION
This function is used only in the `workspace/configuration` handler,
and does not warrant a public API because of its confusing return types.

Related:
- #25272 
- #25400 
- #27015 

Apparently, it's barely used as a public API: https://github.com/search?q=vim.lsp.util.lookup_section+language%3ALua&type=code