### PR TITLE
vim-patch:93197fde0f1d

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1291,8 +1291,9 @@ b:browsefilter variable.  You would most likely set b:browsefilter in a
 filetype plugin, so that the browse dialog would contain entries related to
 the type of file you are currently editing.  Disadvantage: This makes it
 difficult to start editing a file of a different type.  To overcome this, you
-may want to add "All Files\t*.*\n" as the final filter, so that the user can
-still access any desired file.
+may want to add "All Files (*.*)\t*\n" as the final filter on Windows or "All
+Files (*)\t*\n" on other platforms, so that the user can still access any
+desired file.
 
 To avoid setting browsefilter when Vim does not actually support it, you can
 use has("browsefilter"): >

--- a/runtime/ftplugin/aap.vim
+++ b/runtime/ftplugin/aap.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Aap recipe
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2024 Jan 14
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -28,6 +28,11 @@ setlocal commentstring=#\ %s
 setlocal expandtab
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Aap Recipe Files (*.aap)\t*.aap\nAll Files (*.*)\t*.*\n"
+  let b:browsefilter = "Aap Recipe Files (*.aap)\t*.aap\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif

--- a/runtime/ftplugin/abap.vim
+++ b/runtime/ftplugin/abap.vim
@@ -3,7 +3,8 @@
 " Author:	Steven Oliver <oliver.steven@gmail.com>
 " Copyright:	Copyright (c) 2013 Steven Oliver
 " License:	You may redistribute this under the same terms as Vim itself
-" Last Change:  2023 Aug 28 by Vim Project (undo_ftplugin)
+" Last Change:	2023 Aug 28 by Vim Project (undo_ftplugin)
+"               2024 Jan 14 by Vim Project (browsefilter)
 " --------------------------------------------------------------------------
 
 " Only do this when not done yet for this buffer
@@ -21,10 +22,14 @@ setlocal suffixesadd=.abap
 let b:undo_ftplugin = "setl sts< sua< sw<"
 
 " Windows allows you to filter the open file dialog
-if has("gui_win32") && !exists("b:browsefilter")
-  let b:browsefilter = "ABAP Source Files (*.abap)\t*.abap\n" .
-                     \ "All Files (*.*)\t*.*\n"
-  let b:undo_ftplugin .= " | unlet! b:browsefilter"
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "ABAP Source Files (*.abap)\t*.abap\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/abaqus.vim
+++ b/runtime/ftplugin/abaqus.vim
@@ -2,6 +2,7 @@
 " Language:     Abaqus finite element input file (www.abaqus.com)
 " Maintainer:   Carl Osterwisch <costerwi@gmail.com>
 " Last Change:  2022 Oct 08
+"               2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -49,8 +50,12 @@ endif
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Abaqus Input Files (*.inp *.inc)\t*.inp;*.inc\n" .
     \ "Abaqus Results (*.dat)\t*.dat\n" .
-    \ "Abaqus Messages (*.pre *.msg *.sta)\t*.pre;*.msg;*.sta\n" .
-    \ "All Files (*.*)\t*.*\n"
+    \ "Abaqus Messages (*.pre, *.msg, *.sta)\t*.pre;*.msg;*.sta\n"
+    if has("win32")
+        let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+        let b:browsefilter .= "All Files (*)\t*\n"
+    endif
     let b:undo_ftplugin .= "|unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/ant.vim
+++ b/runtime/ftplugin/ant.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	ant
+" Language:		ant
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "XML Files (*.xml)\t*.xml\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "XML Files (*.xml)\t*.xml\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 
 runtime! ftplugin/xml.vim ftplugin/xml_*.vim ftplugin/xml/*.vim
 let b:did_ftplugin = 1
@@ -30,7 +35,7 @@ if exists("b:browsefilter")
 endif
 
 " Change the :browse e filter to primarily show Ant-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Build Files (build.xml)\tbuild.xml\n" .
 		\	 "Java Files (*.java)\t*.java\n" .
 		\	 "Properties Files (*.prop*)\t*.prop*\n" .

--- a/runtime/ftplugin/aspvbs.vim
+++ b/runtime/ftplugin/aspvbs.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	aspvbs
+" Language:		aspvbs
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "HTML Files (*.html, *.htm)\t*.htm*\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "HTML Files (*.html, *.htm)\t*.htm*\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
@@ -51,7 +56,7 @@ if exists("loaded_matchit")
 endif
 
 " Change the :browse e filter to primarily show ASP-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="ASP Files (*.asp)\t*.asp\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/awk.vim
+++ b/runtime/ftplugin/awk.vim
@@ -2,7 +2,7 @@
 " Language:		awk, nawk, gawk, mawk
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Antonio Colombo <azc100@gmail.com>
-" Last Change:		2020 Sep 28
+" Last Change:		2024 Jan 14
 
 " This plugin was prepared by Mark Sikora
 " This plugin was updated as proposed by Doug Kearns
@@ -25,8 +25,7 @@ setlocal formatoptions-=t formatoptions+=croql
 setlocal define=function
 setlocal suffixesadd+=.awk
 
-let b:undo_ftplugin = "setl fo< com< cms< def< sua<" .
-		    \ " | unlet! b:browsefilter"
+let b:undo_ftplugin = "setl fo< com< cms< def< sua<"
 
 " TODO: set this in scripts.vim?
 if exists("g:awk_is_gawk")
@@ -49,8 +48,13 @@ if exists("g:awk_is_gawk")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Awk Source Files (*.awk,*.gawk)\t*.awk;*.gawk\n" .
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Awk Source Files (*.awk, *.gawk)\t*.awk;*.gawk\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/basic.vim
+++ b/runtime/ftplugin/basic.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	BASIC (QuickBASIC 4.5)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Jun 22
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -45,8 +45,12 @@ endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "BASIC Source Files (*.bas)\t*.bas\n" ..
-		\      "BASIC Include Files (*.bi, *.bm)\t*.bi;*.bm\n" ..
-		\      "All Files (*.*)\t*.*\n"
+		\      "BASIC Include Files (*.bi, *.bm)\t*.bi;*.bm\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:basic_set_browsefilter = 1
   let b:undo_ftplugin ..= " | unlet! b:browsefilter b:basic_set_browsefilter"
 endif

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	C
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2023 Aug 22
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -43,24 +43,26 @@ if !exists("b:match_words")
   let b:undo_ftplugin ..= " | unlet! b:match_skip b:match_words"
 endif
 
-" Win32 can filter files in the browse dialog
+" Win32 and GTK can filter files in the browse dialog
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   if &ft == "cpp"
-    let b:browsefilter = "C++ Source Files (*.cpp *.c++)\t*.cpp;*.c++\n" .
-	  \ "C Header Files (*.h)\t*.h\n" .
-	  \ "C Source Files (*.c)\t*.c\n" .
-	  \ "All Files (*.*)\t*.*\n"
+    let b:browsefilter = "C++ Source Files (*.cpp, *.c++)\t*.cpp;*.c++\n" ..
+	  \ "C Header Files (*.h)\t*.h\n" ..
+	  \ "C Source Files (*.c)\t*.c\n"
   elseif &ft == "ch"
-    let b:browsefilter = "Ch Source Files (*.ch *.chf)\t*.ch;*.chf\n" .
-	  \ "C Header Files (*.h)\t*.h\n" .
-	  \ "C Source Files (*.c)\t*.c\n" .
-	  \ "All Files (*.*)\t*.*\n"
+    let b:browsefilter = "Ch Source Files (*.ch, *.chf)\t*.ch;*.chf\n" ..
+	  \ "C Header Files (*.h)\t*.h\n" ..
+	  \ "C Source Files (*.c)\t*.c\n"
   else
-    let b:browsefilter = "C Source Files (*.c)\t*.c\n" .
-	  \ "C Header Files (*.h)\t*.h\n" .
-	  \ "Ch Source Files (*.ch *.chf)\t*.ch;*.chf\n" .
-	  \ "C++ Source Files (*.cpp *.c++)\t*.cpp;*.c++\n" .
-	  \ "All Files (*.*)\t*.*\n"
+    let b:browsefilter = "C Source Files (*.c)\t*.c\n" ..
+	  \ "C Header Files (*.h)\t*.h\n" ..
+	  \ "Ch Source Files (*.ch, *.chf)\t*.ch;*.chf\n" ..
+	  \ "C++ Source Files (*.cpp, *.c++)\t*.cpp;*.c++\n"
+  endif
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
   endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif

--- a/runtime/ftplugin/clojure.vim
+++ b/runtime/ftplugin/clojure.vim
@@ -6,6 +6,7 @@
 " URL:                https://github.com/clojure-vim/clojure.vim
 " License:            Vim (see :h license)
 " Last Change:        2022-03-24
+"                     2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
 	finish
@@ -66,10 +67,14 @@ endif
 
 " Filter files in the browse dialog
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-	let b:browsefilter = "All Files\t*\n" .
-				\ "Clojure Files\t*.clj;*.cljc;*.cljs;*.cljx\n" .
+	let b:browsefilter = "Clojure Files\t*.clj;*.cljc;*.cljs;*.cljx\n" .
 				\ "EDN Files\t*.edn\n" .
 				\ "Java Files\t*.java\n"
+	if has("win32")
+		let b:browsefilter .= "All Files (*.*)\t*\n"
+	else
+		let b:browsefilter .= "All Files (*)\t*\n"
+	endif
 	let b:undo_ftplugin .= ' | unlet! b:browsefilter'
 endif
 

--- a/runtime/ftplugin/cobol.vim
+++ b/runtime/ftplugin/cobol.vim
@@ -3,6 +3,7 @@
 " Maintainer: Ankit Jain <ajatkj@yahoo.co.in>
 "     (formerly Tim Pope <vimNOSPAM@tpope.info>)
 " Last Update:	By Ankit Jain (add gtk support) on 15.08.2020
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Insert mode mappings: <C-T> <C-D> <Tab>
 " Normal mode mappings: < > << >> [[ ]] [] ][
@@ -39,8 +40,12 @@ endif
 
 " add gtk support
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "COBOL Source Files (*.cbl, *.cob)\t*.cbl;*.cob;*.lib\n".
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "COBOL Source Files (*.cbl, *.cob)\t*.cbl;*.cob;*.lib\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setlocal com< cms< fo< et< tw<" .

--- a/runtime/ftplugin/config.vim
+++ b/runtime/ftplugin/config.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	config
+" Language:		config
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change: 		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "Bourne Shell Files (*.sh)\t*.sh\n" .
-	    \	 "All Files (*.*)\t*.*\n"
+let s:browsefilter = "Bourne Shell Files (*.sh)\t*.sh\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/sh.vim ftplugin/sh_*.vim ftplugin/sh/*.vim
@@ -31,7 +36,7 @@ if exists("b:browsefilter")
 endif
 
 " Change the :browse e filter to primarily show configure-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="Configure Scripts (configure.*, config.*)\tconfigure*;config.*\n" .
 		\	s:browsefilter
 endif

--- a/runtime/ftplugin/cs.vim
+++ b/runtime/ftplugin/cs.vim
@@ -3,6 +3,7 @@
 " Maintainer:          Nick Jensen <nickspoon@gmail.com>
 " Former Maintainer:   Johannes Zellner <johannes@zellner.org>
 " Last Change:         2022-11-16
+"                      2024 Jan 14 by Vim Project (browsefilter)
 " License:             Vim (see :h license)
 " Repository:          https://github.com/nickspoons/vim-cs
 
@@ -31,10 +32,14 @@ if exists('loaded_matchit') && !exists('b:match_words')
 endif
 
 if (has('gui_win32') || has('gui_gtk')) && !exists('b:browsefilter')
-  let b:browsefilter = "C# Source Files (*.cs *.csx)\t*.cs;*.csx\n" .
+  let b:browsefilter = "C# Source Files (*.cs, *.csx)\t*.cs;*.csx\n" .
         \              "C# Project Files (*.csproj)\t*.csproj\n" .
-        \              "Visual Studio Solution Files (*.sln)\t*.sln\n" .
-        \              "All Files (*.*)\t*.*\n"
+        \              "Visual Studio Solution Files (*.sln)\t*.sln\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= ' | unlet! b:browsefilter'
 endif
 

--- a/runtime/ftplugin/csh.vim
+++ b/runtime/ftplugin/csh.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Johannes Zellner <johannes@zellner.org>
-" Last Change:		2023 Oct 09
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -44,8 +44,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "csh Scripts (*.csh)\t*.csh\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "csh Scripts (*.csh)\t*.csh\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:csh_set_browsefilter = 1
   let b:undo_ftplugin ..= " | unlet! b:browsefilter b:csh_set_browsefilter"
 endif

--- a/runtime/ftplugin/diff.vim
+++ b/runtime/ftplugin/diff.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Diff
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2023 Aug 22
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -19,6 +19,11 @@ setlocal nomodeline
 let &l:commentstring = "# %s"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Diff Files (*.diff)\t*.diff\nPatch Files (*.patch)\t*.h\nAll Files (*.*)\t*.*\n"
+  let b:browsefilter = "Diff Files (*.diff)\t*.diff\nPatch Files (*.patch)\t*.h\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif

--- a/runtime/ftplugin/dosbatch.vim
+++ b/runtime/ftplugin/dosbatch.vim
@@ -2,6 +2,7 @@
 " Language:    MS-DOS/Windows .bat files
 " Maintainer:  Mike Williams <mrmrdubya@gmail.com>
 " Last Change: 12th February 2023
+"              2024 Jan 14 by Vim Project (browsefilter)
 "
 " Options Flags:
 " dosbatch_colons_comment       - any value to treat :: as comment line
@@ -37,12 +38,17 @@ if executable('help.exe')
 endif
 
 " Define patterns for the browse file filter
-if has("gui_win32") && !exists("b:browsefilter")
-  let b:browsefilter = "DOS Batch Files (*.bat, *.cmd)\t*.bat;*.cmd\nAll Files (*.*)\t*.*\n"
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "DOS Batch Files (*.bat, *.cmd)\t*.bat;*.cmd\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setlocal comments< formatoptions< keywordprg<"
-    \ . "| unlet! b:browsefiler"
+    \ . "| unlet! b:browsefilter"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/dtd.vim
+++ b/runtime/ftplugin/dtd.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	dtd
+" Language:		dtd
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -27,10 +28,14 @@ if exists("loaded_matchit")
 endif
 
 " Change the :browse e filter to primarily show Java-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="DTD Files (*.dtd)\t*.dtd\n" .
-		\	"XML Files (*.xml)\t*.xml\n" .
-		\	"All Files (*.*)\t*.*\n"
+		\	"XML Files (*.xml)\t*.xml\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 " Undo the stuff we changed.

--- a/runtime/ftplugin/eiffel.vim
+++ b/runtime/ftplugin/eiffel.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Eiffel
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2010 Aug 29
+" Last Change:	2024 Jan 14
 
 if (exists("b:did_ftplugin"))
   finish
@@ -18,8 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "Eiffel Source Files (*.e)\t*.e\n" .
-		     \ "Eiffel Control Files (*.ecf, *.ace, *.xace)\t*.ecf;*.ace;*.xace\n" .
-		     \ "All Files (*.*)\t*.*\n"
+		     \ "Eiffel Control Files (*.ecf, *.ace, *.xace)\t*.ecf;*.ace;*.xace\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 if exists("loaded_matchit") && !exists("b:match_words")

--- a/runtime/ftplugin/eruby.vim
+++ b/runtime/ftplugin/eruby.vim
@@ -4,6 +4,7 @@
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Release Coordinator:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:		2022 May 15
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -15,7 +16,11 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "All Files (*.*)\t*.*\n"
+if has("win32")
+  let s:browsefilter = "All Files (*.*)\t*\n"
+else
+  let s:browsefilter = "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 if !exists("g:eruby_default_subtype")
@@ -109,8 +114,8 @@ exe 'cmap <buffer><script><expr> <Plug><cfile> ErubyAtCursor() ? ' . maparg('<Pl
 exe 'cmap <buffer><script><expr> <Plug><ctag> ErubyAtCursor() ? ' . maparg('<Plug><ctag>', 'c') . ' : ' . get(s:ctagmap, 'rhs', '"\022\027"')
 unlet s:cfilemap s:ctagmap s:include s:path s:suffixesadd
 
-" Change the browse dialog on Win32 to show mainly eRuby-related files
-if has("gui_win32")
+" Change the browse dialog on Win32 and GTK to show mainly eRuby-related files
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter="eRuby Files (*.erb, *.rhtml)\t*.erb;*.rhtml\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/expect.vim
+++ b/runtime/ftplugin/expect.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Expect
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Jul 16
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -14,8 +14,12 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Expect Command Files (*.exp)\t*.exp\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Expect Command Files (*.exp)\t*.exp\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/falcon.vim
+++ b/runtime/ftplugin/falcon.vim
@@ -4,6 +4,7 @@
 " Copyright:    Copyright (c) 2009-2013 Steven Oliver
 " License:      You may redistribute this under the same terms as Vim itself
 " Last Update:  2020 Oct 10
+"               2024 Jan 14 by Vim Project (browsefilter)
 " --------------------------------------------------------------------------
 
 " Only do this when not done yet for this buffer
@@ -34,14 +35,18 @@ endif
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
 " Windows allows you to filter the open file dialog
-if has("gui_win32") && !exists("b:browsefilter")
-  let b:browsefilter = "Falcon Source Files (*.fal *.ftd)\t*.fal;*.ftd\n" .
-                     \ "All Files (*.*)\t*.*\n"
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Falcon Source Files (*.fal, *.ftd)\t*.fal;*.ftd\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setlocal tabstop< shiftwidth< expandtab< fileencoding<"
 	\ . " suffixesadd< comments<"
-	\ . "| unlet! b:browsefiler"
+	\ . "| unlet! b:browsefilter"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/forth.vim
+++ b/runtime/ftplugin/forth.vim
@@ -2,6 +2,7 @@
 " Language:	Forth
 " Maintainer:	Johan Kotlinski <kotlinski@gmail.com>
 " Last Change:	2023 Sep 15
+"		2024 Jan 14 by Vim Project (browsefilter)
 " URL:		https://github.com/jkotlinski/forth.vim
 
 if exists("b:did_ftplugin")
@@ -62,8 +63,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Forth Source Files (*.f *.fs *.ft *.fth *.4th)\t*.f;*.fs;*.ft;*.fth;*.4th\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Forth Source Files (*.f, *.fs, *.ft, *.fth, *.4th)\t*.f;*.fs;*.ft;*.fth;*.4th\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/fortran.vim
+++ b/runtime/ftplugin/fortran.vim
@@ -9,6 +9,8 @@
 "  Since then, useful suggestions and contributions have been made, in order, by:
 "  Stefano Zacchiroli, Hendrik Merx, Ben Fritz, David Barnett, Eisuke Kawashima,
 "  Doug Kearns, and Fritz Reese.
+" Last Change:	2023 Dec 22
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do these settings when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -135,8 +137,12 @@ endif
 
 " File filters for :browse e
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Fortran Files (*.f;*.for;*.f77;*.f90;*.f95;*.f03;*.f08;*.fpp;*.ftn)\t*.f;*.for;*.f77;*.f90;*.f95;*.f03;*.f08;*.fpp;*.ftn\n" .
-    \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Fortran Files (*.f, *.for, *.f77, *.f90, *.f95, *.f03, *.f08, *.fpp, *.ftn)\t*.f;*.for;*.f77;*.f90;*.f95;*.f03;*.f08;*.fpp;*.ftn\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl fo< com< tw< cms< et< inc< sua<"

--- a/runtime/ftplugin/fpcmake.vim
+++ b/runtime/ftplugin/fpcmake.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Free Pascal Makefile Generator
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Apr 23
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -13,11 +13,15 @@ set cpo&vim
 runtime! ftplugin/make.vim
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Free Pascal Makefile Definition Files (*.fpc)\t*.fpc\n" ..
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Free Pascal Makefile Definition Files (*.fpc)\t*.fpc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-let b:undo_ftplugin = b:undo_ftplugin .. " | unlet! b:browsefilter"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/freebasic.vim
+++ b/runtime/ftplugin/freebasic.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	FreeBASIC
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Jun 24
+" Last Change:	2023 Aug 22
 
 " Setup {{{1
 if exists("b:did_ftplugin")
@@ -70,8 +70,12 @@ endif
 
 if (has("gui_win32") || has("gui_gtk")) && exists("b:basic_set_browsefilter")
   let b:browsefilter = "FreeBASIC Source Files (*.bas)\t*.bas\n" ..
-		\      "FreeBASIC Header Files (*.bi)\t*.bi\n" ..
-		\      "All Files (*.*)\t*.*\n"
+		\      "FreeBASIC Header Files (*.bi)\t*.bi\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 " Cleanup {{{1

--- a/runtime/ftplugin/haml.vim
+++ b/runtime/ftplugin/haml.vim
@@ -2,6 +2,7 @@
 " Language:	Haml
 " Maintainer:	Tim Pope <vimNOSPAM@tpope.org>
 " Last Change:	2019 Dec 05
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -13,7 +14,11 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "All Files (*.*)\t*.*\n"
+if has("win32")
+  let s:browsefilter = "All Files (*.*)\t*\n"
+else
+  let s:browsefilter = "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
@@ -44,14 +49,14 @@ if exists("b:undo_ftplugin")
   let s:undo_ftplugin = b:undo_ftplugin . " | " . s:undo_ftplugin
 endif
 if exists ("b:browsefilter")
-  let s:browsefilter = substitute(b:browsefilter,'\cAll Files (\*\.\*)\t\*\.\*\n','','') . s:browsefilter
+  let s:browsefilter = substitute(b:browsefilter,'\cAll Files (.*)\t\*\n','','') . s:browsefilter
 endif
 if exists("b:match_words")
   let s:match_words = b:match_words . ',' . s:match_words
 endif
 
-" Change the browse dialog on Win32 to show mainly Haml-related files
-if has("gui_win32")
+" Change the browse dialog on Win32 and GTK to show mainly Haml-related files
+if has("gui_win32") || has("gui_gtk")
   let b:browsefilter="Haml Files (*.haml)\t*.haml\nSass Files (*.sass)\t*.sass\n" . s:browsefilter
 endif
 
@@ -62,7 +67,7 @@ endif
 
 setlocal comments= commentstring=-#\ %s
 
-let b:undo_ftplugin = "setl def< cms< com< "
+let b:undo_ftplugin = "setl def< cms< com< " .
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
 
 let &cpo = s:save_cpo

--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -2,7 +2,7 @@
 " Language:		HTML
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Changed:		2022 Jul 20
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -43,10 +43,14 @@ endif
 
 " Change the :browse e filter to primarily show HTML-related files.
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let  b:browsefilter = "HTML Files (*.html *.htm)\t*.htm;*.html\n" ..
+  let  b:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n" ..
 	\		"JavaScript Files (*.js)\t*.js\n" ..
-	\		"Cascading StyleSheets (*.css)\t*.css\n" ..
-	\		"All Files (*.*)\t*.*\n"
+	\		"Cascading StyleSheets (*.css)\t*.css\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:html_set_browsefilter = 1
   let b:undo_ftplugin ..= " | unlet! b:browsefilter b:html_set_browsefilter"
 endif

--- a/runtime/ftplugin/icon.vim
+++ b/runtime/ftplugin/icon.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Icon
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Jun 16
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -18,15 +18,19 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl fo< com< cms<"
 
 if exists("loaded_matchit")
-    " let b:match_ignorecase = 0
-    let b:match_words  = '^\s*$\s*if\(def\|ndef\)\=\>:^\s*$\s*elif\>:^\s*$\s*else\>:^\s*$\s*endif\>,' .
+    let b:match_ignorecase = 0
+    let b:match_words  = '^\s*$\s*if\(def\|ndef\)\=\>:^\s*$\s*elif\>:^\s*$\s*else\>:^\s*$\s*endif\>,' ..
 	  \		 '\<procedure\>:\<\%(initial\|return\|suspend\|fail\)\>:\<end\>'
-    let b:undo_ftplugin ..= " | unlet! b:match_words"
+    let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words"
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Icon Source Files (*.icn)\t*.icn\n" .
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Icon Source Files (*.icn)\t*.icn\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/ishd.vim
+++ b/runtime/ftplugin/ishd.vim
@@ -2,7 +2,7 @@
 " Language:		InstallShield (ft=ishd)
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:		2023 Aug 28
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -29,8 +29,12 @@ if exists("loaded_matchit")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-    let b:browsefilter = "InstallShield Files (*.rul)\t*.rul\n" .
-          \              "All Files (*.*)\t*\n"
+    let b:browsefilter = "InstallShield Files (*.rul)\t*.rul\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
     let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/j.vim
+++ b/runtime/ftplugin/j.vim
@@ -3,6 +3,7 @@
 " Maintainer:	David Bürgin <dbuergin@gluet.ch>
 " URL:		https://gitlab.com/glts/vim-j
 " Last Change:	2022-08-06
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 if exists('b:did_ftplugin')
   finish
@@ -67,7 +68,11 @@ endif
 " Browse dialog filter on Windows and GTK (see ":help browsefilter")
 if (has('gui_win32') || has('gui_gtk')) && !exists('b:browsefilter')
   let b:browsefilter = "J Script Files (*.ijs)\t*.ijs\n"
-                   \ . "All Files (*.*)\t*.*\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= ' | unlet! b:browsefilter'
 endif
 

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	Java
+" Language:		Java
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Change:  2012 Mar 11
+" Last Change:  	2012 Mar 11
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -36,11 +37,15 @@ setlocal comments& comments^=sO:*\ -,mO:*\ \ ,exO:*/
 setlocal commentstring=//%s
 
 " Change the :browse e filter to primarily show Java-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="Java Files (*.java)\t*.java\n" .
 		\	"Properties Files (*.prop*)\t*.prop*\n" .
-		\	"Manifest Files (*.mf)\t*.mf\n" .
-		\	"All Files (*.*)\t*.*\n"
+		\	"Manifest Files (*.mf)\t*.mf\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 " Undo the stuff we changed.

--- a/runtime/ftplugin/javascript.vim
+++ b/runtime/ftplugin/javascript.vim
@@ -1,8 +1,8 @@
 " Vim filetype plugin file
 " Language:     Javascript
 " Maintainer:   Doug Kearns <dougkearns@gmail.com>
-" Last Change:  2020 Jun 23
 " Contributor:  Romain Lafourcade <romainlafourcade@gmail.com>
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
     finish
@@ -34,7 +34,11 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
                 \ .. "JavaScript Modules (*.es, *.es6, *.cjs, *.mjs, *.jsm)\t*.es;*.es6;*.cjs;*.mjs;*.jsm\n"
                 \ .. "Vue Templates (*.vue)\t*.vue\n"
                 \ .. "JSON Files (*.json)\t*.json\n"
-                \ .. "All Files (*.*)\t*.*\n"
+    if has("win32")
+        let b:browsefilter ..= "All Files (*.*)\t*\n"
+    else
+        let b:browsefilter ..= "All Files (*)\t*\n"
+    endif
 endif
 
 " The following suffixes should be implied when resolving filenames

--- a/runtime/ftplugin/json5.vim
+++ b/runtime/ftplugin/json5.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	JSON5
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2023 Oct 19
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -19,8 +19,12 @@ let b:undo_ftplugin = "setl fo< com< cms<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "JSON5 Files (*.json5)\t*.json5\n" ..
-	\	       "JSON Files (*.json)\t*.json\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+	\	       "JSON Files (*.json)\t*.json\n"
+  if has("win32")
+      let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+      let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/jsp.vim
+++ b/runtime/ftplugin/jsp.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	jsp
+" Language:		jsp
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -16,8 +17,12 @@ set cpo-=C
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
 let s:browsefilter = "Java Files (*.java)\t*.java\n" .
-	    \	 "HTML Files (*.html, *.htm)\t*.html;*.htm\n" .
-	    \	 "All Files (*.*)\t*.*\n"
+	    \	 "HTML Files (*.html, *.htm)\t*.html;*.htm\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
@@ -57,7 +62,7 @@ if exists("loaded_matchit")
 endif
 
 " Change the :browse e filter to primarily show JSP-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="JSP Files (*.jsp)\t*.jsp\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/kotlin.vim
+++ b/runtime/ftplugin/kotlin.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Alexander Udalov
 " URL:          https://github.com/udalov/kotlin-vim
 " Last Change:  7 November 2021
-"               2023 Sep 17 by Vim Project (browsefilter)
+"               2024 Jan 14 by Vim Project (browsefilter)
 
 if exists('b:did_ftplugin') | finish | endif
 let b:did_ftplugin = 1
@@ -24,8 +24,12 @@ let b:undo_ftplugin = "setlocal comments< commentstring< ".
     \ "formatoptions< includeexpr< suffixesadd<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Kotlin Source Files (*.kt, *kts)\t*.kt;*.kts\n" .
-	\ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Kotlin Source Files (*.kt, *kts)\t*.kt;*.kts\n"
+  if has("win32")
+      let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+      let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/kwt.vim
+++ b/runtime/ftplugin/kwt.vim
@@ -2,6 +2,7 @@
 " Language:	Kimwitu++
 " Maintainer:	Michael Piefel <entwurf@piefel.de>
 " Last Change:	10 March 2012
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Behaves almost like C++
 runtime! ftplugin/cpp.vim ftplugin/cpp_*.vim ftplugin/cpp/*.vim
@@ -10,11 +11,15 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " Limit the browser to related files
-if has("gui_win32") && !exists("b:browsefilter")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Kimwitu/Kimwitu++ Files (*.k)\t*.k\n" .
 		\ "Lex/Flex Files (*.l)\t*.l\n" .
-		\ "Yacc/Bison Files (*.y)\t*.y\n" .
-		\ "All Files (*.*)\t*.*\n"
+		\ "Yacc/Bison Files (*.y)\t*.y\n"
+    if has("win32")
+	let b:browsefilter ..= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter ..= "All Files (*)\t*\n"
+    endif
 endif
 
 " Set the errorformat for the Kimwitu++ compiler
@@ -22,10 +27,10 @@ set efm+=kc%.%#:\ error\ at\ %f:%l:\ %m
 
 if exists("b:undo_ftplugin")
     let b:undo_ftplugin = b:undo_ftplugin . " | setlocal efm<"
-	\ . "| unlet! b:browsefiler"
+	\ . "| unlet! b:browsefilter"
 else
     let b:undo_ftplugin = "setlocal efm<"
-	\ . "| unlet! b:browsefiler"
+	\ . "| unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -5,7 +5,7 @@
 " Contributor:		Dorai Sitaram <ds26@gte.com>
 "			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
 "			Tyler Miller <tmillr@proton.me>
-" Last Change:		2023 Mar 24
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -39,8 +39,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Lua Source Files (*.lua)\t*.lua\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Lua Source Files (*.lua)\t*.lua\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/lynx.vim
+++ b/runtime/ftplugin/lynx.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Lynx Web Browser Configuration
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2023 Nov 09
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -18,8 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl cms< com< fo<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Lynx Configuration Files (lynx.cfg, .lynxrc)\tlynx.cfg;.lynxrc\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Lynx Configuration Files (lynx.cfg, .lynxrc)\tlynx.cfg;.lynxrc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/m3build.vim
+++ b/runtime/ftplugin/m3build.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Modula-3 Makefile
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 June 12
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -13,8 +13,12 @@ set cpo&vim
 runtime! ftplugin/m3quake.vim
 
 if (has("gui_win32") || has("gui_gtk")) && exists("b:m3quake_set_browsefilter")
-    let b:browsefilter = "Modula-3 Makefile (m3makefile m3overrides)\tm3makefile;m3overrides\n" ..
-	  \		 "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Modula-3 Makefile (m3makefile, m3overrides)\tm3makefile;m3overrides\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/m3quake.vim
+++ b/runtime/ftplugin/m3quake.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Modula-3 Quake
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 June 12
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -23,8 +23,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Modula-3 Quake Source Files (*.quake)\t*.quake\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Modula-3 Quake Source Files (*.quake)\t*.quake\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:m3quake_set_browsefilter = 1
   let b:undo_ftplugin ..= " | unlet! b:browsefilter b:m3quake_set_browsefilter"
 endif

--- a/runtime/ftplugin/meson.vim
+++ b/runtime/ftplugin/meson.vim
@@ -4,6 +4,7 @@
 " Maintainer:   Liam Beguin <liambeguin@gmail.com>
 " Original Author:	Laurent Pinchart <laurent.pinchart@ideasonboard.com>
 " Last Change:		2018 Nov 27
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -30,8 +31,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Meson Build Files (meson.build)\tmeson.build\n" .
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Meson Build Files (meson.build)\tmeson.build\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/modula2.vim
+++ b/runtime/ftplugin/modula2.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Modula-2
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Apr 08
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -26,8 +26,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Modula-2 Source Files (*.def *.mod)\t*.def;*.mod\n" ..
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Modula-2 Source Files (*.def *.mod)\t*.def;*.mod\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl com< cms< fo< " ..

--- a/runtime/ftplugin/modula3.vim
+++ b/runtime/ftplugin/modula3.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Modula-3
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 June 12 
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -31,8 +31,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Modula-3 Source Files (*.m3)\t*.m3\n" ..
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Modula-3 Source Files (*.m3, *.i3, *.mg, *ig)\t*.m3;*.i3;*.mg;*.ig\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/msmessages.vim
+++ b/runtime/ftplugin/msmessages.vim
@@ -2,6 +2,7 @@
 " Language:	MS Message files (*.mc)
 " Maintainer:	Kevin Locke <kwl7@cornell.edu>
 " Last Change:	2008 April 09
+"		2024 Jan 14 by Vim Project (browsefilter)
 " Location:	http://kevinlocke.name/programs/vim/syntax/msmessages.vim
 
 " Based on c.vim
@@ -29,11 +30,15 @@ setlocal fo-=ct fo+=roql
 setlocal comments=:;,:;//,:;\ //,s:;\ /*\ ,m:;\ \ *\ ,e:;\ \ */
 setlocal commentstring=;\ //\ %s
 
-" Win32 can filter files in the browse dialog
-if has("gui_win32") && !exists("b:browsefilter")
+" Win32 and GTK can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "MS Message Files (*.mc)\t*.mc\n" .
-	\ "Resource Files (*.rc)\t*.rc\n" .
-	\ "All Files (*.*)\t*.*\n"
+	\ "Resource Files (*.rc)\t*.rc\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/occam.vim
+++ b/runtime/ftplugin/occam.vim
@@ -3,6 +3,7 @@
 " Copyright:	Christian Jacobsen <clj3@kent.ac.uk>, Mario Schweigler <ms44@kent.ac.uk>
 " Maintainer:	Mario Schweigler <ms44@kent.ac.uk>
 " Last Change:	23 April 2003
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -30,19 +31,23 @@ setlocal textwidth=78
 "}}}
 
 "{{{  File browsing filters
-" Win32 can filter files in the browse dialog
-if has("gui_win32") && !exists("b:browsefilter")
-  let b:browsefilter = "All Occam Files (*.occ *.inc)\t*.occ;*.inc\n" .
+" Win32 and GTK can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "All Occam Files (*.occ, *.inc)\t*.occ;*.inc\n" .
 	\ "Occam Include Files (*.inc)\t*.inc\n" .
-	\ "Occam Source Files (*.occ)\t*.occ\n" .
-	\ "All Files (*.*)\t*.*\n"
+	\ "Occam Source Files (*.occ)\t*.occ\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 "}}}
 
 "{{{  Undo settings
 let b:undo_ftplugin = "setlocal shiftwidth< softtabstop< expandtab<"
 	\ . " formatoptions< comments< textwidth<"
-	\ . "| unlet! b:browsefiler"
+	\ . "| unlet! b:browsefilter"
 "}}}
 
 let &cpo = s:keepcpo

--- a/runtime/ftplugin/octave.vim
+++ b/runtime/ftplugin/octave.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	GNU Octave
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Sep 02
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -50,8 +50,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "GNU Octave Source Files (*.m)\t*.m\n" ..
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "GNU Octave Source Files (*.m)\t*.m\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl com< cms< fo< kp< " ..

--- a/runtime/ftplugin/pascal.vim
+++ b/runtime/ftplugin/pascal.vim
@@ -2,7 +2,7 @@
 " Language:		Pascal
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Change:		2021 Apr 23
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -37,8 +37,12 @@ if exists("loaded_matchit")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Pascal Source Files (*.pas *.pp *.inc)\t*.pas;*.pp;*.inc\n" .
-		     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Pascal Source Files (*.pas, *.pp, *.inc)\t*.pas;*.pp;*.inc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl fo< cms< com< " ..

--- a/runtime/ftplugin/perl.vim
+++ b/runtime/ftplugin/perl.vim
@@ -7,6 +7,7 @@
 " Last Change:   2021 Nov 10
 "                2023 Sep 07 by Vim Project (safety check: don't execute perl
 "                    from current directory)
+"                2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -95,8 +96,12 @@ let b:undo_ftplugin .= " | setlocal pa<"
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Perl Source Files (*.pl)\t*.pl\n" .
 		       \ "Perl Modules (*.pm)\t*.pm\n" .
-		       \ "Perl Documentation Files (*.pod)\t*.pod\n" .
-		       \ "All Files (*.*)\t*.*\n"
+		       \ "Perl Documentation Files (*.pod)\t*.pod\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
     let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -2,7 +2,7 @@
 " Language:		PHP
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Changed:		2022 Jul 20
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -15,8 +15,12 @@ set cpo&vim
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n" ..
-      \		     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n"
+if has("win32")
+    let s:browsefilter ..= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter ..= "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim

--- a/runtime/ftplugin/pod.vim
+++ b/runtime/ftplugin/pod.vim
@@ -6,6 +6,8 @@
 " Bugs/requests: https://github.com/vim-perl/vim-perl/issues
 " License:       Vim License (see :help license)
 " Last Change:   2023 Jul 05
+" Last Change:   2021 Oct 19
+"                2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
   finish
@@ -33,8 +35,12 @@ endif
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "POD Source Files (*.pod)\t*.pod\n" .
         \              "Perl Source Files (*.pl)\t*.pl\n" .
-        \              "Perl Modules (*.pm)\t*.pm\n" .
-        \              "All Files (*.*)\t*.*\n"
+        \              "Perl Modules (*.pm)\t*.pm\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/poke.vim
+++ b/runtime/ftplugin/poke.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	GNU Poke
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 March 11
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
     finish
@@ -18,13 +18,17 @@ setlocal formatoptions-=t formatoptions+=croql
 setlocal include=load
 setlocal suffixesadd=.pk
 
-if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Poke Files (*.pk)\t*.pk\n" .
-		     \ "All Files (*.*)\t*.*\n"
-endif
+let b:undo_ftplugin = "setl fo< com< cms< inc< sua<"
 
-let b:undo_ftplugin = "setl fo< com< cms< inc< sua<" .
-		    \ " | unlet! b:browsefilter"
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Poke Files (*.pk)\t*.pk\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter"
+endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/postscr.vim
+++ b/runtime/ftplugin/postscr.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	PostScript
 " Maintainer:	Mike Williams <mrw@eandem.co.uk>
-" Last Change:  24th April 2012
+" Last Change:	24th April 2012
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -25,14 +26,18 @@ if !exists("b:match_words")
 endif
 
 " Define patterns for the browse file filter
-if has("gui_win32") && !exists("b:browsefilter")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "PostScript Files (*.ps)\t*.ps\n" .
-    \ "EPS Files (*.eps)\t*.eps\n" .
-    \ "All Files (*.*)\t*.*\n"
+    \ "EPS Files (*.eps)\t*.eps\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setlocal comments< formatoptions<"
-    \ . "| unlet! b:browsefiler b:match_ignorecase b:match_words"
+    \ . "| unlet! b:browsefilter b:match_ignorecase b:match_words"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -2,6 +2,7 @@
 " Language:    Windows PowerShell
 " URL:         https://github.com/PProvost/vim-ps1
 " Last Change: 2021 Apr 02
+"              2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -19,14 +20,18 @@ setlocal formatoptions=tcqro
 " e.g. Get-Content or Get-ADUser
 setlocal iskeyword+=-
 
-" Change the browse dialog on Win32 to show mainly PowerShell-related files
-if has("gui_win32")
+" Change the browse dialog on Win32 and GTK to show mainly PowerShell-related files
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 	let b:browsefilter =
 				\ "All PowerShell Files (*.ps1, *.psd1, *.psm1, *.ps1xml)\t*.ps1;*.psd1;*.psm1;*.ps1xml\n" .
 				\ "PowerShell Script Files (*.ps1)\t*.ps1\n" .
 				\ "PowerShell Module Files (*.psd1, *.psm1)\t*.psd1;*.psm1\n" .
-				\ "PowerShell XML Files (*.ps1xml)\t*.ps1xml\n" .
-				\ "All Files (*.*)\t*.*\n"
+				\ "PowerShell XML Files (*.ps1xml)\t*.ps1xml\n"
+	if has("win32")
+		let b:browsefilter .= "All Files (*.*)\t*\n"
+	else
+		let b:browsefilter .= "All Files (*)\t*\n"
+	endif
 endif
 
 " Look up keywords by Get-Help:

--- a/runtime/ftplugin/ps1xml.vim
+++ b/runtime/ftplugin/ps1xml.vim
@@ -2,6 +2,7 @@
 " Language:    Windows PowerShell
 " URL:         https://github.com/PProvost/vim-ps1
 " Last Change: 2021 Apr 02
+"              2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -16,14 +17,18 @@ setlocal tw=0
 setlocal commentstring=#%s
 setlocal formatoptions=tcqro
 
-" Change the browse dialog on Win32 to show mainly PowerShell-related files
-if has("gui_win32")
+" Change the browse dialog on Win32 and GTK to show mainly PowerShell-related files
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = 
         \ "All PowerShell Files (*.ps1, *.psd1, *.psm1, *.ps1xml)\t*.ps1;*.psd1;*.psm1;*.ps1xml\n" .
         \ "PowerShell Script Files (*.ps1)\t*.ps1\n" .
         \ "PowerShell Module Files (*.psd1, *.psm1)\t*.psd1;*.psm1\n" .
-        \ "PowerShell XML Files (*.ps1xml)\t*.ps1xml\n" .
-        \ "All Files (*.*)\t*.*\n"
+        \ "PowerShell XML Files (*.ps1xml)\t*.ps1xml\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 " Undo the stuff we changed

--- a/runtime/ftplugin/pyrex.vim
+++ b/runtime/ftplugin/pyrex.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Marco Barisione <marco.bari@people.it>
 " URL:		http://marcobari.altervista.org/pyrex_vim.html
 " Last Change:	2012 May 18
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -14,13 +15,17 @@ set cpo&vim
 " Behaves just like Python
 runtime! ftplugin/python.vim ftplugin/python_*.vim ftplugin/python/*.vim
 
-if has("gui_win32") && exists("b:browsefilter")
-    let  b:browsefilter = "Pyrex files (*.pyx,*.pxd)\t*.pyx;*.pxd\n" .
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+    let  b:browsefilter = "Pyrex files (*.pyx, *.pxd)\t*.pyx;*.pxd\n" .
 			\ "Python Files (*.py)\t*.py\n" .
 			\ "C Source Files (*.c)\t*.c\n" .
 			\ "C Header Files (*.h)\t*.h\n" .
-			\ "C++ Source Files (*.cpp *.c++)\t*.cpp;*.c++\n" .
-			\ "All Files (*.*)\t*.*\n"
+			\ "C++ Source Files (*.cpp, *.c++)\t*.cpp;*.c++\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 let &cpo = s:keepcpo

--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
 " Last Change:	Mon, 5 October 2020
+"		2024 Jan 14 by Vim Project (browsefilter)
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -110,8 +111,12 @@ if !exists('*<SID>Python_jump')
 endif
 
 if has("browsefilter") && !exists("b:browsefilter")
-    let b:browsefilter = "Python Files (*.py)\t*.py\n" .
-                \ "All Files (*.*)\t*.*\n"
+    let b:browsefilter = "Python Files (*.py)\t*.py\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 if !exists("g:python_recommended_style") || g:python_recommended_style != 0

--- a/runtime/ftplugin/qml.vim
+++ b/runtime/ftplugin/qml.vim
@@ -2,6 +2,7 @@
 " Language: QML
 " Maintainer: Chase Knowlden <haroldknowlden@gmail.com>
 " Last Change: 2023 Aug 16
+" 	       2023 Aug 23 by Vim Project (browsefilter)
 
 if exists( 'b:did_ftplugin' )
    finish
@@ -14,10 +15,15 @@ set cpoptions&vim
 " command for undo
 let b:undo_ftplugin = "setlocal formatoptions< comments< commentstring<"
 
-if (has("gui_win32") || has("gui_gtk")) && !exists( 'b:browsefilter' )
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
    let b:browsefilter =
-      \ 'QML Files (*.qml,*.qbs)\t*.qml;*.qbs\n' .
-      \ 'All Files\t*\n'
+      \ "QML Files (*.qml, *.qbs)\t*.qml;*.qbs\n"
+   if has("win32")
+      let b:browsefilter .= "All Files (*.*)\t*\n"
+   else
+      let b:browsefilter .= "All Files (*)\t*\n"
+   endif
+   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 
 " Set 'comments' to format dashed lists in comments.

--- a/runtime/ftplugin/r.vim
+++ b/runtime/ftplugin/r.vim
@@ -3,6 +3,7 @@
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
 " Last Change:	Sun Apr 24, 2022  09:14AM
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -22,8 +23,12 @@ setlocal comments=:#',:###,:##,:#
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "R Source Files (*.R)\t*.R\n" .
-        \ "Files that include R (*.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
-        \ "All Files (*.*)\t*.*\n"
+        \ "Files that include R (*.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl cms< com< fo< isk< | unlet! b:browsefilter"

--- a/runtime/ftplugin/racket.vim
+++ b/runtime/ftplugin/racket.vim
@@ -4,6 +4,7 @@
 " Previous Maintainer:  Will Langstroth <will@langstroth.com>
 " URL:                  https://github.com/benknoble/vim-racket
 " Last Change:          2022 Aug 29
+"                       2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
   finish
@@ -68,8 +69,12 @@ endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter =
-        \  "Racket Source Files (*.rkt *.rktl)\t*.rkt;*.rktl\n"
-        \. "All Files (*.*)\t*.*\n"
+        \  "Racket Source Files (*.rkt, *.rktl)\t*.rkt;*.rktl\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -2,7 +2,7 @@
 " Language:		readline(3) configuration file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Last Change:		2022 Dec 09
+" Last Change:		2023 Aug 22
 
 if exists("b:did_ftplugin")
   finish
@@ -25,8 +25,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Readline Initialization Files (inputrc .inputrc)\tinputrc;*.inputrc\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Readline Intialization Files (inputrc, .inputrc)\tinputrc;*.inputrc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/registry.vim
+++ b/runtime/ftplugin/registry.vim
@@ -2,6 +2,7 @@
 " Language:         Windows Registry export with regedit (*.reg)
 " Maintainer:       Cade Forester <ahx2323@gmail.com>
 " Latest Revision:  2014-01-09
+"                   2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
   finish
@@ -12,18 +13,22 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 let b:undo_ftplugin =
-  \ 'let b:browsefilter = "" | ' .
   \ 'setlocal ' .
   \    'comments< '.
   \    'commentstring< ' .
-  \    'formatoptions< '
+  \    'formatoptions<'
 
 
-if has( 'gui_win32' )
+if ( has( 'gui_win32' ) || has( 'gui_gtk' ) )
 \ && !exists( 'b:browsefilter' )
    let b:browsefilter =
-      \ 'registry files (*.reg)\t*.reg\n' .
-      \ 'All files (*.*)\t*.*\n'
+      \ "registry files (*.reg)\t*.reg\n"
+   if has("win32")
+      let b:browsefilter .= "All Files (*.*)\t*\n"
+   else
+      let b:browsefilter .= "All Files (*)\t*\n"
+   endif
+   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 
 setlocal comments=:;

--- a/runtime/ftplugin/rhelp.vim
+++ b/runtime/ftplugin/rhelp.vim
@@ -3,6 +3,7 @@
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
 " Last Change:	Sun Apr 24, 2022  09:12AM
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -18,8 +19,12 @@ set cpo&vim
 setlocal iskeyword=@,48-57,_,.
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
-        \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl isk< | unlet! b:browsefilter"

--- a/runtime/ftplugin/rmd.vim
+++ b/runtime/ftplugin/rmd.vim
@@ -3,6 +3,7 @@
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
 " Last Change:	Mon May 29, 2023  06:31AM
+"		2024 Jan 14 by Vim Project (browsefilter)
 " Original work by Alex Zvoleff (adjusted from R help for rmd by Michel Kuhlmann)
 
 " Only do this when not yet done for this buffer
@@ -64,8 +65,12 @@ runtime ftplugin/pandoc.vim
 let b:did_ftplugin = 1
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
-        \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 if exists('b:undo_ftplugin')

--- a/runtime/ftplugin/rnoweb.vim
+++ b/runtime/ftplugin/rnoweb.vim
@@ -3,6 +3,7 @@
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
 " Last Change:	Mon Feb 27, 2023  07:16PM
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -25,8 +26,12 @@ setlocal suffixesadd=.bib,.tex
 setlocal comments=b:%,b:#,b:##,b:###,b:#'
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
-        \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 function SetRnwCommentStr()

--- a/runtime/ftplugin/routeros.vim
+++ b/runtime/ftplugin/routeros.vim
@@ -2,6 +2,7 @@
 " Language:	MikroTik RouterOS Script
 " Maintainer:	zainin <z@wintr.dev>
 " Last Change:	2021 Nov 14
+"		2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
   finish
@@ -18,8 +19,12 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setlocal com< cms< fo<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "RouterOS Script Files (*.rsc)\t*.rsc\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "RouterOS Script Files (*.rsc)\t*.rsc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/rrst.vim
+++ b/runtime/ftplugin/rrst.vim
@@ -3,6 +3,7 @@
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
 " Last Change:	Mon Feb 27, 2023  07:16PM
+"		2024 Jan 14 by Vim Project (browsefilter)
 " Original work by Alex Zvoleff
 
 " Only do this when not yet done for this buffer
@@ -38,8 +39,12 @@ if !exists("g:rrst_dynamic_comments") || (exists("g:rrst_dynamic_comments") && g
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
-        \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 if exists('b:undo_ftplugin')

--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Tim Pope <vimNOSPAM@tpope.org>
 " URL:			https://github.com/vim-ruby/vim-ruby
 " Last Change:		2023 Dec 31
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if (exists("b:did_ftplugin"))
   finish
@@ -147,8 +148,12 @@ if exists('s:ruby_paths') && stridx(&l:tags, join(map(copy(s:ruby_paths),'v:val.
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Ruby Source Files (*.rb)\t*.rb\n" .
-                     \ "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Ruby Source Files (*.rb)\t*.rb\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 let b:undo_ftplugin = "setl inc= sua= path= tags= fo< com< cms< kp="

--- a/runtime/ftplugin/sed.vim
+++ b/runtime/ftplugin/sed.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	sed
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Apr 1
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
     finish
@@ -18,8 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl com< cms< fo<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "sed Script Files (*.sed)\t*.sed\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "sed Script Files (*.sed)\t*.sed\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/sgml.vim
+++ b/runtime/ftplugin/sgml.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	sgml
+" Language:		sgml
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "XML Files (*.xml)\t*.xml\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "XML Files (*.xml)\t*.xml\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 
 runtime! ftplugin/xml.vim ftplugin/xml_*.vim ftplugin/xml/*.vim
 let b:did_ftplugin = 1
@@ -30,7 +35,7 @@ if exists("b:browsefilter")
 endif
 
 " Change the :browse e filter to primarily show xml-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="SGML Files (*.sgml,*.sgm)\t*.sgm*\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Enno Nagel <ennonagel+vim@gmail.com>
 "			Eisuke Kawashima
-" Last Change:		2023 Sep 28
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -33,10 +33,14 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Bourne Shell Scripts (*.sh)\t*.sh\n" ..
-	\	       "Korn Shell Scripts (*.ksh)\t*.ksh\n" ..
-	\	       "Bash Shell Scripts (*.bash)\t*.bash\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let  b:browsefilter = "Bourne Shell Scripts (*.sh)\t*.sh\n" ..
+	\		"Korn Shell Scripts (*.ksh)\t*.ksh\n" ..
+	\		"Bash Shell Scripts (*.bash)\t*.bash\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/solution.vim
+++ b/runtime/ftplugin/solution.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Microsoft Visual Studio Solution
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2021 Dec 15
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -26,8 +26,12 @@ if exists("loaded_matchit") && !exists("b:match_words")
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Microsoft Visual Studio Solution Files\t*.sln\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Microsoft Visual Studio Solution Files(*.sln)\t*.sln\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/sql.vim
+++ b/runtime/ftplugin/sql.vim
@@ -3,6 +3,7 @@
 " Version:     12.0
 " Maintainer:  David Fishburn <dfishburn dot vim at gmail dot com>
 " Last Change: 2017 Mar 07
+"              2024 Jan 14 by Vim Project (browsefilter)
 " Download:    http://vim.sourceforge.net/script.php?script_id=454
 
 " For more details please use:
@@ -272,10 +273,14 @@ let b:undo_ftplugin = "setl comments< formatoptions< define< omnifunc<" .
 let b:did_ftplugin     = 1
 let b:current_ftplugin = 'sql'
 
-" Win32 can filter files in the browse dialog
-if has("gui_win32") && !exists("b:browsefilter")
-    let b:browsefilter = "SQL Files (*.sql)\t*.sql\n" .
-                \ "All Files (*.*)\t*.*\n"
+" Win32 and GTK can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+    let b:browsefilter = "SQL Files (*.sql)\t*.sql\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 " Some standard expressions for use with the matchit strings

--- a/runtime/ftplugin/svg.vim
+++ b/runtime/ftplugin/svg.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	svg
+" Language:		svg
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Change:		2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "XML Files (*.xml)\t*.xml\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "XML Files (*.xml)\t*.xml\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 
 runtime! ftplugin/xml.vim ftplugin/xml_*.vim ftplugin/xml/*.vim
 let b:did_ftplugin = 1
@@ -30,7 +35,7 @@ if exists("b:browsefilter")
 endif
 
 " Change the :browse e filter to primarily show xml-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="SVG Files (*.svg)\t*.svg\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/tcl.vim
+++ b/runtime/ftplugin/tcl.vim
@@ -2,6 +2,7 @@
 " Language:         Tcl
 " Maintainer:       Robert L Hicks <sigzero@gmail.com>
 " Latest Revision:  2009-05-01
+"                   2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin")
   finish
@@ -18,10 +19,14 @@ setlocal commentstring=#%s
 setlocal formatoptions+=croql
 
 " Change the browse dialog on Windows to show mainly Tcl-related files
-if has("gui_win32")
-    let b:browsefilter = "Tcl Source Files (.tcl)\t*.tcl\n" .
-                \ "Tcl Test Files (.test)\t*.test\n" .
-                \ "All Files (*.*)\t*.*\n"
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+    let b:browsefilter = "Tcl Source Files (*.tcl)\t*.tcl\n" .
+                \ "Tcl Test Files (*.test)\t*.test\n"
+    if has("win32")
+        let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+        let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 "-----------------------------------------------------------------------------

--- a/runtime/ftplugin/tcsh.vim
+++ b/runtime/ftplugin/tcsh.vim
@@ -2,7 +2,7 @@
 " Language:		tcsh
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Change:		2023 Oct 09
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -13,8 +13,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "csh Files (*.csh)\t*.csh\n" ..
-      \		     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "csh Files (*.csh)\t*.csh\n"
+if has("win32")
+    let s:browsefilter ..= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter ..= "All Files (*)\t*\n"
+endif
 
 runtime! ftplugin/csh.vim ftplugin/csh_*.vim ftplugin/csh/*.vim
 let b:did_ftplugin = 1

--- a/runtime/ftplugin/tidy.vim
+++ b/runtime/ftplugin/tidy.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	HTML Tidy Configuration
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2020 Sep 4
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -15,16 +15,20 @@ setlocal comments=:#,://
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t formatoptions+=croql
 
+let b:undo_ftplugin = "setl fo< com< cms<"
+
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "HTML Tidy Files (tidyrc, .tidyrc, tidy.conf)\ttidyrc;.tidyrc;tidy.conf\n" .
 		     \ "HTML Files (*.html, *.htm)\t*.html;*.htm\n" .
 		     \ "XHTML Files (*.xhtml, *.xhtm)\t*.xhtml;*.xhtm\n" .
-		     \ "XML Files (*.xml)\t*.xml\n" .
-		     \ "All Files (*.*)\t*.*\n"
+		     \ "XML Files (*.xml)\t*.xml\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
+  let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
-
-let b:undo_ftplugin = "setl fo< com< cms<" .
-		    \ " | unlet! b:browsefilter"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/typescript.vim
+++ b/runtime/ftplugin/typescript.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	TypeScript
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2019 Aug 30
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -22,6 +22,8 @@ setlocal commentstring=//%s
 
 setlocal suffixesadd+=.ts,.d.ts,.tsx,.js,.jsx,.cjs,.mjs
 
+let b:undo_ftplugin = "setl fo< com< cms< sua<"
+
 " Change the :browse e filter to primarily show TypeScript-related files.
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="TypeScript Files (*.ts)\t*.ts\n" .
@@ -29,11 +31,14 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 		\	"TSX Files (*.tsx)\t*.tsx\n" .
 		\	"JavaScript Files (*.js)\t*.js\n" .
 		\	"JavaScript Modules (*.es, *.cjs, *.mjs)\t*.es;*.cjs;*.mjs\n" .
-		\	"JSON Files (*.json)\t*.json\n" .
-		\	"All Files (*.*)\t*.*\n"
+		\	"JSON Files (*.json)\t*.json\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
+    let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
        
-let b:undo_ftplugin = "setl fo< com< cms< sua< | unlet! b:browsefilter" 
-
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/vb.vim
+++ b/runtime/ftplugin/vb.vim
@@ -2,7 +2,7 @@
 " Language:		Visual Basic (ft=vb)
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:		2021 Nov 17
+" Last Change:		2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -62,8 +62,12 @@ endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "Visual Basic Source Files (*.bas)\t*.bas\n" .
-	\	       "Visual Basic Form Files (*.frm)\t*.frm\n" .
-	\	       "All Files (*.*)\t*.*\n"
+	\	       "Visual Basic Form Files (*.frm)\t*.frm\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/verilog.vim
+++ b/runtime/ftplugin/verilog.vim
@@ -2,6 +2,7 @@
 " Language:	Verilog HDL
 " Maintainer:	Chih-Tsun Huang <cthuang@cs.nthu.edu.tw>
 " Last Change:	2017 Aug 25 by Chih-Tsun Huang
+"		2024 Jan 14 by Vim Project (browsefilter)
 " URL:	    	http://www.cs.nthu.edu.tw/~cthuang/vim/ftplugin/verilog.vim
 "
 " Credits:
@@ -36,10 +37,14 @@ if &textwidth == 0
   setlocal tw=78
 endif
 
-" Win32 can filter files in the browse dialog
-if has("gui_win32") && !exists("b:browsefilter")
-  let b:browsefilter = "Verilog Source Files (*.v)\t*.v\n" .
-	\ "All Files (*.*)\t*.*\n"
+" Win32 and GTK can filter files in the browse dialog
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Verilog Source Files (*.v)\t*.v\n"
+  if has("win32")
+    let b:browsefilter .= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter .= "All Files (*)\t*\n"
+  endif
 endif
 
 " Let the matchit plugin know what items can be matched.

--- a/runtime/ftplugin/vhdl.vim
+++ b/runtime/ftplugin/vhdl.vim
@@ -3,6 +3,7 @@
 " Maintainer:  R.Shankar <shankar.pec?gmail.com>
 " Modified By: Gerald Lai <laigera+vim?gmail.com>
 " Last Change: 2011 Dec 11
+"              2024 Jan 14 by Vim Project (browsefilter)
 "              2023 Aug 28 by Vim Project (undo_ftplugin, commentstring)
 
 " Only do this when not done yet for this buffer
@@ -28,14 +29,15 @@ setlocal commentstring=--\ %s
 " Format comments to be up to 78 characters long
 "setlocal tw=75
 
-" let b:undo_ftplugin = "setl cms< com< fo< tw<"
-
 let b:undo_ftplugin = "setl cms< "
 
-" Win32 can filter files in the browse dialog
-"if has("gui_win32") && !exists("b:browsefilter")
-"  let b:browsefilter = "Verilog Source Files (*.v)\t*.v\n" .
-"   \ "All Files (*.*)\t*.*\n"
+" Win32 and GTK can filter files in the browse dialog
+"if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+"  if has("win32")
+"    let b:browsefilter ..= "All Files (*.*)\t*\n"
+"  else
+"    let b:browsefilter ..= "All Files (*)\t*\n"
+"  endif
 "  let b:undo_ftplugin .= " | unlet! b:browsefilter"
 "endif
 

--- a/runtime/ftplugin/wget.vim
+++ b/runtime/ftplugin/wget.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Wget configuration file (/etc/wgetrc ~/.wgetrc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Apr 28
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -18,8 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl fo< com< cms<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Wget Configuration File (wgetrc, .wgetrc)\twgetrc;.wgetrc\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Wget Configuration File (wgetrc, .wgetrc)\twgetrc;.wgetrc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/wget2.vim
+++ b/runtime/ftplugin/wget2.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	Wget2 configuration file (/etc/wget2rc ~/.wget2rc)
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2022 Apr 28
+" Last Change:	2024 Jan 14
 
 if exists("b:did_ftplugin")
   finish
@@ -18,8 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl fo< com< cms<"
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "Wget2 Configuration File (wget2rc, .wget2rc)\twget2rc;.wget2rc\n" ..
-	\	       "All Files (*.*)\t*.*\n"
+  let b:browsefilter = "Wget2 Configuration File (wget2rc, .wget2rc)\twget2rc;.wget2rc\n"
+  if has("win32")
+    let b:browsefilter ..= "All Files (*.*)\t*\n"
+  else
+    let b:browsefilter ..= "All Files (*)\t*\n"
+  endif
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 

--- a/runtime/ftplugin/xhtml.vim
+++ b/runtime/ftplugin/xhtml.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	xhtml
+" Language:		xhtml
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Changed: 	2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -16,8 +17,12 @@ set cpo-=C
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
 let s:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n" .
-	    \	     "XML Files (*.xml)\t*.xml\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+	    \	     "XML Files (*.xml)\t*.xml\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 let s:match_words = ""
 
 runtime! ftplugin/xml.vim ftplugin/xml_*.vim ftplugin/xml/*.vim
@@ -57,7 +62,7 @@ if exists("loaded_matchit")
 endif
 
 " Change the :browse e filter to primarily show tcsh-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="XHTML files (*.xhtml, *.xhtm)\t*.xhtml;*.xhtm\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/xml.vim
+++ b/runtime/ftplugin/xml.vim
@@ -2,6 +2,7 @@
 "     Language:	xml
 "   Maintainer:	Christian Brabandt <cb@256bit.org>
 " Last Changed: Dec 07th, 2018
+"		2024 Jan 14 by Vim Project (browsefilter)
 "   Repository: https://github.com/chrisbra/vim-xml-ftplugin
 " Previous Maintainer:	Dan Sharp
 "          URL:		      http://dwsharp.users.sourceforge.net/vim/ftplugin
@@ -52,8 +53,12 @@ command! -nargs=? XMLent call xmlcomplete#CreateEntConnection(<f-args>)
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="XML Files (*.xml)\t*.xml\n" .
     \ "DTD Files (*.dtd)\t*.dtd\n" .
-    \ "XSD Files (*.xsd)\t*.xsd\n" .
-    \ "All Files (*.*)\t*.*\n"
+    \ "XSD Files (*.xsd)\t*.xsd\n"
+    if has("win32")
+	let b:browsefilter .= "All Files (*.*)\t*\n"
+    else
+	let b:browsefilter .= "All Files (*)\t*\n"
+    endif
 endif
 
 " Undo the stuff we changed.

--- a/runtime/ftplugin/xsd.vim
+++ b/runtime/ftplugin/xsd.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
-" Language:	xsd
+" Language:		xsd
 "
 " This runtime file is looking for a new maintainer.
 "
 " Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Last Changed: 	2009 Jan 20
+"			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
 
@@ -15,8 +16,12 @@ set cpo-=C
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "XML Files (*.xml)\t*.xml\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "XML Files (*.xml)\t*.xml\n"
+if has("win32")
+    let s:browsefilter .= "All Files (*.*)\t*\n"
+else
+    let s:browsefilter .= "All Files (*)\t*\n"
+endif
 
 runtime! ftplugin/xml.vim ftplugin/xml_*.vim ftplugin/xml/*.vim
 let b:did_ftplugin = 1
@@ -30,7 +35,7 @@ if exists("b:browsefilter")
 endif
 
 " Change the :browse e filter to primarily show xsd-related files.
-if has("gui_win32")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let  b:browsefilter="XSD Files (*.xsd)\t*.xsd\n" . s:browsefilter
 endif
 

--- a/runtime/ftplugin/xslt.vim
+++ b/runtime/ftplugin/xslt.vim
@@ -14,5 +14,5 @@ let b:did_ftplugin = 1
 
 " Change the :browse e filter to primarily show xsd-related files.
 if (has("gui_win32") || has("gui_gtk")) && exists("b:browsefilter")
-  let b:browsefilter = "XSLT Files (*.xsl,*.xslt)\t*.xsl;*.xslt\n" . b:browsefilter
+  let b:browsefilter = "XSLT Files (*.xsl, *.xslt)\t*.xsl;*.xslt\n" . b:browsefilter
 endif


### PR DESCRIPTION
runtime(ftplugin): Use "*" browsefilter pattern to match "All Files"

Problem:  The "*.*" browsefilter pattern only matches all files on
	  Windows (Daryl Lee)
Solution: Use "*" to filter on all platforms but keep "*.*" as the label
	  text on Windows. (Fixes vim/vim#12685, Doug Kearns)

The *.* browsefilter pattern used to match "All Files" on Windows is a
legacy of the DOS 8.3 filename wildcard matching algorithm.  For reasons
of backward compatibility this still works on Windows to match all
files, even those without an extension.

However, this pattern only matches filenames containing a dot on other
platforms.  This often makes files without an extension difficult to
access from the file dialog, e.g., "Makefile"

On Windows it is still standard practice to use "*.*" for the filter
label so ftplugins should use "All Files (*.*)" on Windows and "All
Files (*)" on other platforms.  This matches Vim's default browsefilter
values.

This commit also normalises the browsefilter conditional test to check
for the Win32 and GTK GUI features and an unset b:browsefilter.

closes: vim/vim#12759

https://github.com/vim/vim/commit/93197fde0f1db09b1e495cf3eb14a8f42c318b80

Co-authored-by: Doug Kearns <dougkearns@gmail.com>

---

Skip mf.vim, mp.vim (previously rewritten in vim9script; frozen before addition of `browsefilter`)

