### PR TITLE
docs(vim.iter): correct `bool` to `boolean`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3753,9 +3753,9 @@ filter({f}, {src}, {...})                                  *vim.iter.filter()*
 <
 
     Parameters: ~
-      • {f}    (`fun(...):bool`) Filter function. Accepts the current iterator
-               or table values as arguments and returns true if those values
-               should be kept in the final table
+      • {f}    (`fun(...):boolean`) Filter function. Accepts the current
+               iterator or table values as arguments and returns true if those
+               values should be kept in the final table
       • {src}  (`table|function`) Table or iterator function to filter
 
     Return: ~
@@ -3768,7 +3768,7 @@ Iter:all({pred})                                                  *Iter:all()*
     Returns true if all items in the iterator match the given predicate.
 
     Parameters: ~
-      • {pred}  (`fun(...):bool`) Predicate function. Takes all values
+      • {pred}  (`fun(...):boolean`) Predicate function. Takes all values
                 returned from the previous stage in the pipeline as arguments
                 and returns true if the predicate matches.
 
@@ -3777,7 +3777,7 @@ Iter:any({pred})                                                  *Iter:any()*
     predicate.
 
     Parameters: ~
-      • {pred}  (`fun(...):bool`) Predicate function. Takes all values
+      • {pred}  (`fun(...):boolean`) Predicate function. Takes all values
                 returned from the previous stage in the pipeline as arguments
                 and returns true if the predicate matches.
 
@@ -3826,7 +3826,7 @@ Iter:filter({f})                                               *Iter:filter()*
 <
 
     Parameters: ~
-      • {f}  (`fun(...):bool`) Takes all values returned from the previous
+      • {f}  (`fun(...):boolean`) Takes all values returned from the previous
              stage in the pipeline and returns false or nil if the current
              iterator element should be removed.
 

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -181,7 +181,7 @@ end
 --- local bufs = vim.iter(vim.api.nvim_list_bufs()):filter(vim.api.nvim_buf_is_loaded)
 --- ```
 ---
----@param f fun(...):bool Takes all values returned from the previous stage
+---@param f fun(...):boolean Takes all values returned from the previous stage
 ---                       in the pipeline and returns false or nil if the
 ---                       current iterator element should be removed.
 ---@return Iter
@@ -884,7 +884,7 @@ end
 
 --- Returns true if any of the items in the iterator match the given predicate.
 ---
----@param pred fun(...):bool Predicate function. Takes all values returned from the previous
+---@param pred fun(...):boolean Predicate function. Takes all values returned from the previous
 ---                          stage in the pipeline as arguments and returns true if the
 ---                          predicate matches.
 function Iter.any(self, pred)
@@ -908,7 +908,7 @@ end
 
 --- Returns true if all items in the iterator match the given predicate.
 ---
----@param pred fun(...):bool Predicate function. Takes all values returned from the previous
+---@param pred fun(...):boolean Predicate function. Takes all values returned from the previous
 ---                          stage in the pipeline as arguments and returns true if the
 ---                          predicate matches.
 function Iter.all(self, pred)
@@ -1106,7 +1106,7 @@ end
 ---
 ---@see |Iter:filter()|
 ---
----@param f fun(...):bool Filter function. Accepts the current iterator or table values as
+---@param f fun(...):boolean Filter function. Accepts the current iterator or table values as
 ---                       arguments and returns true if those values should be kept in the
 ---                       final table
 ---@param src table|function Table or iterator function to filter


### PR DESCRIPTION
This fixes the following lua-language-server warning.

```lua
vim.iter({}):filter(function(e)
  return e ~= "" -- Annotations specify that return value #1 has a type of `bool`, returning value of type `boolean` here instead. - `boolean` cannot match `bool` - Type `boolean` cannot match `bool`
end)
```
