### PR TITLE
fix(coverity/477623,477624): guard null pointer dereference in kv_concat_len

### DIFF
--- a/src/klib/kvec.h
+++ b/src/klib/kvec.h
@@ -105,11 +105,12 @@
   } while (0)
 
 #define kv_concat_len(v, data, len) \
-  do { \
+  if (len > 0) { \
     kv_ensure_space(v, len); \
+    assert((v).items); \
     memcpy((v).items + (v).size, data, sizeof((v).items[0]) * len); \
     (v).size = (v).size + len; \
-  } while (0)
+  }
 
 #define kv_concat(v, str) kv_concat_len(v, str, strlen(str))
 #define kv_splice(v1, v0) kv_concat_len(v1, (v0).items, (v0).size)


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/pull/22159#discussion_r1451578746

Coverity warns about a possible null pointer dereference in the `memcpy` call in `kv_concat_len`. The `memcpy` follows `kv_ensure_space` which (re)allocates the `items` pointer if the vector's capacity is not large enough to contain all of the items being appended. The only way `items` would be NULL at this point is if `capacity` were mistakenly set to some large number without `items` ever having being set in the first place. This should not happen when using the kvec API so if this condition is ever false it is a bug, which the `assert` will catch.
