### PR TITLE
ci: Include universal libintl when building macOS release

### DIFF
--- a/.github/scripts/build_universal_macos.sh
+++ b/.github/scripts/build_universal_macos.sh
@@ -1,7 +1,46 @@
 #!/bin/bash -e
+shopt -s extglob
 
-MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
-export MACOSX_DEPLOYMENT_TARGET
+readonly temp_dir="$(mktemp -d)"
+
+# macOS Monterey, v12, is the earliest macOS version with bottles in brew.
+# See https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gettext.rb
+readonly arm64_bottle="arm64_monterey"
+readonly x86_64_bottle="monterey"
+readonly MACOSX_DEPLOYMENT_TARGET="12"
+
+prepare_universal_libintl() {
+  # We assume that we're in the project root already.
+  declare -r gettext_version="$(brew info gettext --json | jq -r ".[0].versions.stable")"
+
+  echo "Using gettext bottles from brew: ${arm64_bottle} for ARM and ${x86_64_bottle} for Intel"
+  echo "Using temp dir: ${temp_dir}"
+
+  brew fetch --bottle-tag="${arm64_bottle}" gettext
+  brew fetch --bottle-tag="${x86_64_bottle}" gettext
+
+  pushd "${temp_dir}" >/dev/null
+    mkdir "${arm64_bottle}"
+    pushd "${arm64_bottle}" >/dev/null
+      tar xf "$(brew --cache)"/**/*--gettext--${gettext_version}.${arm64_bottle}*.tar.gz
+    popd >/dev/null
+
+    mkdir "${x86_64_bottle}"
+    pushd "${x86_64_bottle}" >/dev/null
+      tar xf "$(brew --cache)"/**/*--gettext--${gettext_version}.${x86_64_bottle}*.tar.gz
+    popd >/dev/null
+
+    mkdir universal
+    cp -r "${arm64_bottle}/gettext/${gettext_version}/include" ./universal/
+    mkdir universal/lib
+    lipo "${arm64_bottle}/gettext/${gettext_version}/lib/libintl.a" "${x86_64_bottle}/gettext/${gettext_version}/lib/libintl.a" -create -output ./universal/lib/libintl.a
+
+    echo "Prepared universal libintl in ${temp_dir}/universal"
+  popd >/dev/null
+}
+
+prepare_universal_libintl
+
 cmake -S cmake.deps -B .deps -G Ninja \
   -D CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
   -D CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
@@ -12,8 +51,9 @@ cmake -B build -G Ninja \
   -D CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
   -D CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
   -D CMAKE_OSX_ARCHITECTURES=arm64\;x86_64 \
-  -D ENABLE_LIBINTL=OFF \
-  -D CMAKE_FIND_FRAMEWORK=NEVER
+  -D LIBINTL_INCLUDE_DIR="${temp_dir}/universal/include" \
+  -D LIBINTL_LIBRARY="${temp_dir}/universal/lib/libintl.a" \
+  -D CMAKE_FIND_FRAMEWORK=LAST
 cmake --build build
 # Make sure we build everything for M1 as well
 for macho in build/bin/* build/lib/nvim/parser/*.so; do


### PR DESCRIPTION
I noticed that, recently, gettext got disabled for release builds for macOS. In this PR, I prepare the universal static library of gettext and include it. Since the earliest version of pre-built gettext of brew is macOS 12, I had to set the `MACOSX_DEPLOYMENT_TARGET` to `12`, Monterey.