### PR TITLE
vim-patch:8.1.1968: crash when using nested map()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1095,17 +1095,19 @@ bool is_compatht(const hashtab_T *ht)
 }
 
 /// Prepare v: variable "idx" to be used.
-/// Save the current typeval in "save_tv".
+/// Save the current typeval in "save_tv" and clear it.
 /// When not used yet add the variable to the v: hashtable.
 void prepare_vimvar(int idx, typval_T *save_tv)
 {
   *save_tv = vimvars[idx].vv_tv;
+  vimvars[idx].vv_str = NULL;  // don't free it now
   if (vimvars[idx].vv_type == VAR_UNKNOWN) {
     hash_add(&vimvarht, vimvars[idx].vv_di.di_key);
   }
 }
 
 /// Restore v: variable "idx" to typeval "save_tv".
+/// Note that the v: variable must have been cleared already.
 /// When no longer defined, remove the variable from the v: hashtable.
 void restore_vimvar(int idx, typval_T *save_tv)
 {

--- a/test/old/testdir/test_filter_map.vim
+++ b/test/old/testdir/test_filter_map.vim
@@ -56,6 +56,15 @@ func Test_filter_map_list_expr_funcref()
   call assert_equal([0, 2, 4, 6], map([1, 2, 3, 4], function('s:filter4')))
 endfunc
 
+func Test_filter_map_nested()
+  let x = {"x":10}
+  let r = map(range(2), 'filter(copy(x), "1")')
+  call assert_equal([x, x], r)
+
+  let r = map(copy(x), 'filter(copy(x), "1")')
+  call assert_equal({"x": x}, r)
+endfunc
+
 " dict with funcref
 func Test_filter_map_dict_expr_funcref()
   let dict = {"foo": 1, "bar": 2, "baz": 3}

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2671,6 +2671,10 @@ func Test_readdir()
   let files = readdir('Xdir', {x -> len(add(l, x)) == 2 ? -1 : 1})
   call assert_equal(1, len(files))
 
+  " Nested readdir() must not crash
+  let files = readdir('Xdir', 'readdir("Xdir", "1") != []')
+  call sort(files)->assert_equal(['bar.txt', 'dir', 'foo.txt'])
+
   eval 'Xdir'->delete('rf')
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.1.1968: crash when using nested map()

Problem:    Crash when using nested map().
Solution:   Clear the pointer in prepare_vimvar(). (Ozaki Kiichi,
            closes vim/vim#4891)

https://github.com/vim/vim/commit/27da7de7c547dbf983ed7dd901ea59be4e7c9ab2

Cherry-pick Test_filter_map_nested() from patch 8.1.1964.

Co-authored-by: Bram Moolenaar <Bram@vim.org>