### PR TITLE
ci: stale bot should close the issue with "not planned"

### DIFF
--- a/.github/scripts/close_unresponsive.js
+++ b/.github/scripts/close_unresponsive.js
@@ -41,6 +41,7 @@ module.exports = async ({ github, context }) => {
         owner: owner,
         repo: repo,
         issue_number: number,
+        state_reason: "not_planned",
         state: "closed",
       });
 


### PR DESCRIPTION
Problem: When the stable bot automatically closes an issue, the issue
will be marked as "closed as completed". It'd be better to mark the
as "closed as not planned".

Solution: Use `state_reason: "not_planned"` from the issues REST API.

References (REST API):
https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue