### PR TITLE
docs(builtin): remove signatures of undocumented functions

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1880,7 +1880,7 @@ foreach({expr1}, {expr2})                                            *foreach()*
 		the current item.  For a |Blob| |v:key| has the index of the
 		current byte. For a |String| |v:key| has the index of the
 		current character.
-		Examples: >
+		Examples: >vim
 			call foreach(mylist, 'let used[v:val] = v:true')
 <		This records the items that are in the {expr1} list.
 
@@ -1900,7 +1900,6 @@ foreach({expr1}, {expr2})                                            *foreach()*
 		further items in {expr1} are processed.
 		When {expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
-
 
 fullcommand({name})                                              *fullcommand()*
 		Get the full command name from a short abbreviated command
@@ -8362,7 +8361,6 @@ test_garbagecollect_now()                            *test_garbagecollect_now()*
 		only be called directly to avoid any structure to exist
 		internally, and |v:testing| must have been set before calling
 		any function.
-
 
 timer_info([{id}])                                                *timer_info()*
 		Return a list with information about timers.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2321,7 +2321,7 @@ function vim.fn.foldtextresult(lnum) end
 --- the current item.  For a |Blob| |v:key| has the index of the
 --- current byte. For a |String| |v:key| has the index of the
 --- current character.
---- Examples: >
+--- Examples: >vim
 ---   call foreach(mylist, 'let used[v:val] = v:true')
 --- <This records the items that are in the {expr1} list.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2940,7 +2940,7 @@ M.funcs = {
       the current item.  For a |Blob| |v:key| has the index of the
       current byte. For a |String| |v:key| has the index of the
       current character.
-      Examples: >
+      Examples: >vim
       	call foreach(mylist, 'let used[v:val] = v:true')
       <This records the items that are in the {expr1} list.
 
@@ -2968,7 +2968,6 @@ M.funcs = {
   foreground = {
     args = 0,
     params = {},
-    signature = '',
     lua = false,
   },
   fullcommand = {
@@ -11887,7 +11886,6 @@ M.funcs = {
   test_write_list_log = {
     args = 1,
     params = { { 'fname', 'string' } },
-    signature = '',
     lua = false,
   },
   timer_info = {


### PR DESCRIPTION
Having an empty signature causes an empty line in generated docs,  so
remove it.

Also change ">" to ">vim" in foreach() docs.
