### PR TITLE
build(deps): bump tree-sitter to HEAD - 660481dbf

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -57,5 +57,5 @@ TREESITTER_BASH_URL https://github.com/tree-sitter/tree-sitter-bash/archive/4936
 TREESITTER_BASH_SHA256 99ebe9f2886efecc1a5e9e1360d804a1b49ad89976a66bb5c3871539cca5fb7e
 TREESITTER_MARKDOWN_URL https://github.com/MDeiml/tree-sitter-markdown/archive/v0.1.7.tar.gz
 TREESITTER_MARKDOWN_SHA256 7d0e7f7ed4516ed0816f9c304e2e7fa93b2c16f9280416c2fb64dc4efd9c5f83
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/46af27796a76c72d8466627d499f2bca4af958ee.tar.gz
-TREESITTER_SHA256 2e35fa4c4d66c34d04fdb4a3a6c3abe01a05dff571ed9553b15aabf25d870f69
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/660481dbf71413eba5a928b0b0ab8da50c1109e0.tar.gz
+TREESITTER_SHA256 2881ad14d9559efaa72638740a78fc0d9884f8b2504e6434d525aee06c43bc57


### PR DESCRIPTION
keep prerelease version up-to-date

includes minor bug fixes and preliminary WASM parser support
