### PR TITLE
fix(css-ftplugin): add whitespace to commentstring

### DIFF
--- a/runtime/ftplugin/css.lua
+++ b/runtime/ftplugin/css.lua
@@ -1,1 +1,1 @@
-vim.bo.commentstring = '/*%s*/'
+vim.bo.commentstring = '/* %s */'


### PR DESCRIPTION
Currently, the CSS ftplugin defines a `commentstring` that has no whitespace padding: `/*%s*/`

However, for CSS, it is the convention to add whitespace padding. For instance, [stylelint has such a rule](https://stylelint.io/user-guide/rules/comment-whitespace-inside/), and [requires it in its standard-config](https://github.com/stylelint/stylelint-config-standard/blob/f399e875cb46099bcac8aaed165a88d95736d328/index.js#L35)

This PR simply adds whitespace to the`commentstring` to fix that: `/* %s */`