### PR TITLE
fix(column): pass kFalse when initializing "b_signcols.count"

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -840,14 +840,14 @@ void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState 
 
   // For each row increment "b_signcols.count" at the number of counted signs,
   // and decrement at the previous number of signs. These two operations are
-  // split in separate calls if "clear" is not kNone (surrounding a marktree splice).
+  // split in separate calls if "clear" is not kFalse (surrounding a marktree splice).
   for (int i = 0; i < row2 + 1 - row1; i++) {
-    int width = MIN(SIGN_SHOW_MAX, count[i] - add);
-    if (clear != kNone && width > 0) {
-      buf->b_signcols.count[width - 1]--;
-      assert(buf->b_signcols.count[width - 1] >= 0);
+    int prevwidth = MIN(SIGN_SHOW_MAX, count[i] - add);
+    if (clear != kNone && prevwidth > 0) {
+      buf->b_signcols.count[prevwidth - 1]--;
+      assert(buf->b_signcols.count[prevwidth - 1] >= 0);
     }
-    width = MIN(SIGN_SHOW_MAX, count[i]);
+    int width = MIN(SIGN_SHOW_MAX, count[i]);
     if (clear != kTrue && width > 0) {
       buf->b_signcols.count[width - 1]++;
       if (width > buf->b_signcols.max) {

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1206,7 +1206,7 @@ static bool win_redraw_signcols(win_T *wp)
   if (!buf->b_signcols.autom
       && (*wp->w_p_stc != NUL || (wp->w_maxscwidth > 1 && wp->w_minscwidth != wp->w_maxscwidth))) {
     buf->b_signcols.autom = true;
-    buf_signcols_count_range(buf, 0, buf->b_ml.ml_line_count, MAXLNUM, kNone);
+    buf_signcols_count_range(buf, 0, buf->b_ml.ml_line_count, MAXLNUM, kFalse);
   }
 
   while (buf->b_signcols.max > 0 && buf->b_signcols.count[buf->b_signcols.max - 1] == 0) {

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -539,4 +539,13 @@ describe('Signs', function()
                                                            |
     ]])
   end)
+
+  it('no negative b_signcols.count with undo after initializing', function()
+    exec([[
+      set signcolumn=auto:2
+      call setline(1, 'a')
+      call nvim_buf_set_extmark(0, nvim_create_namespace(''), 0, 0, {'sign_text':'S1'})
+      delete | redraw | undo
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Wrong "clear" argument passed to buf_signcols_count_range
          when initializing "b_signcols.count" for the first time.
Solution: Pass kFalse so that the "nested" counter is not incorrectly
          decremented.