### PR TITLE
vim-patch:9.1.0035: i_CTRL-] triggers InsertCharPre

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4725,6 +4725,10 @@ static char *do_insert_char_pre(int c)
   char buf[MB_MAXBYTES + 1];
   const int save_State = State;
 
+  if (c == Ctrl_RSB) {
+    return NULL;
+  }
+
   // Return quickly when there is nothing to do.
   if (!has_event(EVENT_INSERTCHARPRE)) {
     return NULL;

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2118,5 +2118,40 @@ func Test_edit_overlong_file_name()
   bwipe!
 endfunc
 
+func Test_edit_Ctrl_RSB()
+  new
+  let g:triggered = []
+  autocmd InsertCharPre <buffer> let g:triggered += [v:char]
+
+  " i_CTRL-] should not trigger InsertCharPre
+  exe "normal! A\<C-]>"
+  call assert_equal([], g:triggered)
+
+  " i_CTRL-] should expand abbreviations but not trigger InsertCharPre
+  inoreabbr <buffer> f foo
+  exe "normal! Af\<C-]>a"
+  call assert_equal(['f', 'f', 'o', 'o', 'a'], g:triggered)
+  call assert_equal('fooa', getline(1))
+
+  " CTRL-] followed by i_CTRL-V should not expand abbreviations
+  " i_CTRL-V doesn't trigger InsertCharPre
+  call setline(1, '')
+  exe "normal! Af\<C-V>\<C-]>"
+  call assert_equal("f\<C-]>", getline(1))
+
+  let g:triggered = []
+  call setline(1, '')
+
+  " Also test assigning to v:char
+  autocmd InsertCharPre <buffer> let v:char = 'f'
+  exe "normal! Ag\<C-]>h"
+  call assert_equal(['g', 'f', 'o', 'o', 'h'], g:triggered)
+  call assert_equal('ffff', getline(1))
+
+  autocmd! InsertCharPre
+  unlet g:triggered
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2153,5 +2153,4 @@ func Test_edit_Ctrl_RSB()
   bwipe!
 endfunc
 
-
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0035: i_CTRL-] triggers InsertCharPre

Problem:  i_CTRL-] triggers InsertCharPre
Solution: Return if CTRL-] is received. InsertCharPre
          is supposed to be only used for chars to be inserted
          but i_CTRL-] triggers expansion and is not inserted
          into the buffer (altermo)

closes: vim/vim#13853
closes: vim/vim#13864

https://github.com/vim/vim/commit/7d711fe2092d0438d2df5054df735ec34926e2bc

Co-authored-by: altermo <>