### PR TITLE
vim-patch:9.1.0033: Insert mode not stopped if closing prompt buffer modifies hidden buffer

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2320,7 +2320,7 @@ void leaving_window(win_T *const win)
   // When leaving the window (or closing the window) was done from a
   // callback we need to break out of the Insert mode loop and restart Insert
   // mode when entering the window again.
-  if (State & MODE_INSERT) {
+  if ((State & MODE_INSERT) && !stop_insert_mode) {
     stop_insert_mode = true;
     if (win->w_buffer->b_prompt_insert == NUL) {
       win->w_buffer->b_prompt_insert = 'A';

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -4,6 +4,7 @@ local feed = helpers.feed
 local source = helpers.source
 local clear = helpers.clear
 local command = helpers.command
+local expect = helpers.expect
 local poke_eventloop = helpers.poke_eventloop
 local api = helpers.api
 local eq = helpers.eq
@@ -216,5 +217,25 @@ describe('prompt buffer', function()
     eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
     command('call DoAppend()')
     eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
+  end)
+
+  -- oldtest: Test_prompt_close_modify_hidden()
+  it('modifying hidden buffer does not prevent prompt buffer mode change', function()
+    source([[
+      file hidden
+      set bufhidden=hide
+      enew
+      new prompt
+      set buftype=prompt
+
+      inoremap <buffer> q <Cmd>bwipe!<CR>
+      autocmd BufWinLeave prompt call setbufline('hidden', 1, 'Test')
+    ]])
+    feed('a')
+    eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
+    feed('q')
+    eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
+    command('bwipe!')
+    expect('Test')
   end)
 end)


### PR DESCRIPTION
Fix #27038

#### vim-patch:9.1.0033: Insert mode not stopped if closing prompt buffer modifies hidden buffer

Problem:  Insert mode not stopped if an autocommand modifies a hidden
          buffer while closing a prompt buffer.
Solution: Don't set b_prompt_insert if stop_insert_mode is already set.
          (zeertzjq)

closes: vim/vim#13872

https://github.com/vim/vim/commit/96958366ad6159efe708b694055320ed19357e61