### PR TITLE
docs: delete commands for removed features

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,11 +160,8 @@ If installing via appimage, the following commands may be helpful in updating de
     # CUSTOM_NVIM_PATH=/usr/local/bin/nvim.appimage
     # Set the above with the correct path, then run the rest of the commands:
     set -u
-    sudo update-alternatives --install /usr/bin/ex ex "${CUSTOM_NVIM_PATH}" 110
     sudo update-alternatives --install /usr/bin/vi vi "${CUSTOM_NVIM_PATH}" 110
-    sudo update-alternatives --install /usr/bin/view view "${CUSTOM_NVIM_PATH}" 110
     sudo update-alternatives --install /usr/bin/vim vim "${CUSTOM_NVIM_PATH}" 110
-    sudo update-alternatives --install /usr/bin/vimdiff vimdiff "${CUSTOM_NVIM_PATH}" 110
 
 ### Exherbo Linux
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,14 +155,6 @@ Python (`:python`) support is installable via the package manager on Debian unst
 
     sudo apt-get install python3-neovim
 
-If installing via appimage, the following commands may be helpful in updating default paths:
-
-    # CUSTOM_NVIM_PATH=/usr/local/bin/nvim.appimage
-    # Set the above with the correct path, then run the rest of the commands:
-    set -u
-    sudo update-alternatives --install /usr/bin/vi vi "${CUSTOM_NVIM_PATH}" 110
-    sudo update-alternatives --install /usr/bin/vim vim "${CUSTOM_NVIM_PATH}" 110
-
 ### Exherbo Linux
 
 Exhereses for scm and released versions are currently available in repository `::medvid`. Python client (with GTK+ GUI included) and Qt5 GUI are also available as suggestions:
@@ -332,17 +324,6 @@ If you're using an older version Ubuntu you must use:
     sudo easy_install3 pip
 
 For instructions to install the Python modules, see [`:help provider-python`].
-
-If you want to use Neovim for some (or all) of the editor alternatives, use the following commands:
-
-    sudo update-alternatives --install /usr/bin/vi vi /usr/bin/nvim 60
-    sudo update-alternatives --config vi
-    sudo update-alternatives --install /usr/bin/vim vim /usr/bin/nvim 60
-    sudo update-alternatives --config vim
-    sudo update-alternatives --install /usr/bin/editor editor /usr/bin/nvim 60
-    sudo update-alternatives --config editor
-
-Note, however, that special interfaces, like `view` for `nvim -R`, are not supported.  (See [#1646](https://github.com/neovim/neovim/issues/1646) and [#2008](https://github.com/neovim/neovim/pull/2008).)
 
 ### Void-Linux
 


### PR DESCRIPTION
The suggested commands to provide Debian alternatives to ex, view, vimdiff depend on the features removed in #2008. With the recent versions of nvim, the commands will not work as intended.

Note that the package at official Debian repository provides the [commands](https://sources.debian.org/src/neovim/0.7.2-8/debian/scripts/) by installing the executable scripts to libexec.