### PR TITLE
fix(lua): return after assert returns assert message

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -180,10 +180,8 @@ local all_namespaces = {}
 ---@return vim.diagnostic.Severity?
 local function to_severity(severity)
   if type(severity) == 'string' then
-    return assert(
-      M.severity[string.upper(severity)],
-      string.format('Invalid severity: %s', severity)
-    )
+    assert(M.severity[string.upper(severity)], string.format('Invalid severity: %s', severity))
+    return M.severity[string.upper(severity)]
   end
   return severity
 end

--- a/runtime/lua/vim/glob.lua
+++ b/runtime/lua/vim/glob.lua
@@ -77,7 +77,8 @@ function M.to_lpeg(pattern)
   })
 
   local lpeg_pattern = p:match(pattern) --[[@as vim.lpeg.Pattern?]]
-  return assert(lpeg_pattern, 'Invalid glob')
+  assert(lpeg_pattern, 'Invalid glob')
+  return lpeg_pattern
 end
 
 return M

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -1123,10 +1123,8 @@ function M._test()
       'if "expected" is given, "actual" is also required'
     )
     if expected then
-      return assert(
-        cond,
-        ('expected %s, got: %s'):format(vim.inspect(expected), vim.inspect(actual))
-      )
+      assert(cond, ('expected %s, got: %s'):format(vim.inspect(expected), vim.inspect(actual)))
+      return cond
     else
       return assert(cond)
     end


### PR DESCRIPTION
`assert()` returns all its arguments (including the message). This is typically fine, as the value of the assert is used so that that extra value is discarded, but not when being returned.
This can be confusing, for example `lua=vim.glob.to_lpeg('*')` prints out the pattern, but also the string `Invalid glob` which may lead the user to think that they have passed in something wrong.