### PR TITLE
docs: guide users to include backtrace for bug-crash

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,8 +9,8 @@ body:
         *Before reporting:*
         - Confirm the problem is reproducible on [**master**](https://github.com/neovim/neovim/releases/nightly) or [**latest stable**](https://github.com/neovim/neovim/releases/stable) release
         - run `make distclean` when encountering build issues
-        - search [existing issues](https://github.com/neovim/neovim/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
-        - check the [FAQ](https://github.com/neovim/neovim/wiki/FAQ)
+        - search [existing issues](https://github.com/neovim/neovim/issues?q=is%3Aissue+is%3Aopen+label%3Abug,bug-crash) (including [closed](https://github.com/neovim/neovim/issues?q=is%3Aissue+is%3Aclosed+label%3Abug%2Cbug-crash))
+        - check the [FAQ](https://github.com/neovim/neovim/wiki/FAQ) and ["Reporting Problems" in CONTRIBUTING.md](https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#reporting-problems).
 
         Usage or "How to" questions belong on the [stackoverflow](https://vi.stackexchange.com/) and will be closed.
   - type: textarea
@@ -24,6 +24,7 @@ body:
       label: "Steps to reproduce"
       description: |
         - For build failures: list the exact steps including CMake flags (if any).
+        - If the bug pertains to crashing (or segfault), please include a [stacktrace](https://neovim.io/doc/user/dev_tools.html#dev-tools-backtrace).
         - For startup or shell-related problems: try `env -i TERM=ansi-256color "$(which nvim)"`.
         - Use the provided [minimal reproduction template](https://github.com/neovim/neovim/blob/master/contrib/minimal.lua) to create a minimal configuration. After you fill it out with necessary information, run with `nvim --clean -u minimal.lua`.
         - Please do **not** include a package manager in the reproduction steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ Reporting problems
 - If a specific configuration or plugin is necessary to recreate the problem, use the minimal template in `contrib/minimal.lua` with `nvim --clean -u contrib/minimal.lua` after making the necessary changes.
 - [Bisect](https://neovim.io/doc/user/starting.html#bisect) your config: disable plugins incrementally, to narrow down the cause of the issue.
 - [Bisect][git-bisect] Neovim's source code to find the cause of a regression, if you can. This is _extremely_ helpful.
-- When reporting a crash, [include a stacktrace](https://neovim.io/doc/user/faq.html#backtrace-linux).
-- Use [ASAN/UBSAN](#clang-sanitizers-asan-and-ubsan) to get detailed errors for segfaults and undefined behavior.
+- When reporting a crash, [include a stacktrace](https://neovim.io/doc/user/dev_tools.html#dev-tools-backtrace).
+- Use [ASAN/UBSAN](#sanitizers-asan-and-ubsan) to get detailed errors for segfaults and undefined behavior.
 - Check the logs. `:edit $NVIM_LOG_FILE`
 - Include `cmake --system-information` for build-related issues.
 


### PR DESCRIPTION
Github Issue template:

- Add pointers to |dev-tools-backtrace|.
- Add pointers to CONTRIBUTING.md (Reporting Problems), which includes
  additional helpful instructions for issue reporting.
- Search existing issues: include label `bug-crash` as well as `bug`.

CONTRIBUTING.md:

- Fix broken link on "stacktrace" after moving to help from wiki.
