### PR TITLE
vim-patch:9.1.0040: issue with prompt buffer and hidden buffer

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1302,9 +1302,11 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
   }
 
   aco->save_curwin_handle = curwin->handle;
-  aco->save_curbuf = curbuf;
   aco->save_prevwin_handle = prevwin == NULL ? 0 : prevwin->handle;
   aco->save_State = State;
+  if (bt_prompt(curbuf)) {
+    aco->save_prompt_insert = curbuf->b_prompt_insert;
+  }
 
   if (win != NULL) {
     // There is a window for "buf" in the current tab page, make it the
@@ -1417,6 +1419,9 @@ win_found:
     curbuf = curwin->w_buffer;
     // May need to restore insert mode for a prompt buffer.
     entering_window(curwin);
+    if (bt_prompt(curbuf)) {
+      curbuf->b_prompt_insert = aco->save_prompt_insert;
+    }
 
     prevwin = win_find_by_handle(aco->save_prevwin_handle);
     vars_clear(&awp->w_vars->dv_hashtab);         // free all w: variables

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -14,7 +14,6 @@
 /// Struct to save values in before executing autocommands for a buffer that is
 /// not the current buffer.
 typedef struct {
-  buf_T *save_curbuf;             ///< saved curbuf
   int use_aucmd_win_idx;          ///< index in aucmd_win[] if >= 0
   handle_T save_curwin_handle;    ///< ID of saved curwin
   handle_T new_curwin_handle;     ///< ID of new curwin
@@ -23,6 +22,7 @@ typedef struct {
   char *globaldir;                ///< saved value of globaldir
   bool save_VIsual_active;        ///< saved VIsual_active
   int save_State;                 ///< saved State
+  int save_prompt_insert;         ///< saved b_prompt_insert
 } aco_save_T;
 
 typedef struct {

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -219,7 +219,7 @@ describe('prompt buffer', function()
     eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
   end)
 
-  -- oldtest: Test_prompt_close_modify_hidden()
+  -- oldtest: Test_prompt_leave_modify_hidden()
   it('modifying hidden buffer does not prevent prompt buffer mode change', function()
     source([[
       file hidden
@@ -228,14 +228,26 @@ describe('prompt buffer', function()
       new prompt
       set buftype=prompt
 
+      inoremap <buffer> w <Cmd>wincmd w<CR>
       inoremap <buffer> q <Cmd>bwipe!<CR>
-      autocmd BufWinLeave prompt call setbufline('hidden', 1, 'Test')
+      autocmd BufLeave prompt call appendbufline('hidden', '$', 'Leave')
+      autocmd BufEnter prompt call appendbufline('hidden', '$', 'Enter')
+      autocmd BufWinLeave prompt call appendbufline('hidden', '$', 'Close')
     ]])
     feed('a')
+    eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
+    feed('w')
+    eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
+    feed('<C-W>w')
     eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
     feed('q')
     eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
     command('bwipe!')
-    expect('Test')
+    expect([[
+
+      Leave
+      Enter
+      Leave
+      Close]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:9.1.0040: issue with prompt buffer and hidden buffer

Problem:  Modifying a hidden buffer still interferes with prompt buffer
          mode changes.
Solution: Save and restore b_prompt_insert.
          (zeertzjq)

closes: vim/vim#13875

Modifying hidden buffer still interferes with prompt buffer mode changes

https://github.com/vim/vim/commit/f267847017976ab85117bdf75b45e769836f8d69