### PR TITLE
vim-patch:9.0.1437: test fails with different error number

### DIFF
--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1321,7 +1321,7 @@ func Test_listdict_index()
   call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[1.1] = 4'], ['E805:', 'E1012:', 'E805:'])
   call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[: i] = [4, 5]'], ['E121:', 'E1001:', 'E121:'])
   call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[: 3.2] = [4, 5]'], ['E805:', 'E1012:', 'E805:'])
-  " call CheckLegacyAndVim9Failure(['VAR t = test_unknown()', 'echo t[0]'], 'E685:')
+  " call CheckLegacyAndVim9Failure(['VAR t = test_unknown()', 'echo t[0]'], ['E685:', 'E909:', 'E685:'])
 endfunc
 
 " Test for a null list


### PR DESCRIPTION
#### vim-patch:9.0.1437: test fails with different error number

Problem:    Test fails with different error number.
Solution:   Adjust the expected error.

https://github.com/vim/vim/commit/3cdd799951b4d08f987a8346a8de544e41fab3d7

Co-authored-by: Bram Moolenaar <Bram@vim.org>