### PR TITLE
fix(treesitter): validate language alias for injections

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -757,6 +757,11 @@ end)
 ---@param alias string language or filetype name
 ---@return string? # resolved parser name
 local function resolve_lang(alias)
+  -- validate that `alias` is a legal language
+  if not (alias and alias:match('[%w_]+') == alias) then
+    return
+  end
+
   if has_parser(alias) then
     return alias
   end


### PR DESCRIPTION
Problem: Parsed language annotations can be random garbage so
`nvim_get_runtime_file` throws an error.

Solution: Validate that `alias` is a valid language name before trying
to find a parser for it.

Uses the same strategy as in `vim.language.add`.

Fixes #27078
