### PR TITLE
fix(lsp): `inlay_hints` disappear when opening the same file several times

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -250,7 +250,7 @@ local function _enable(bufnr)
     bufnr = api.nvim_get_current_buf()
   end
   local bufstate = bufstates[bufnr]
-  if not bufstate then
+  if not bufstate or not bufstate.enabled then
     bufstates[bufnr] = { applied = {}, enabled = true }
     api.nvim_create_autocmd('LspNotify', {
       buffer = bufnr,
@@ -296,7 +296,6 @@ local function _enable(bufnr)
       group = augroup,
     })
   else
-    bufstate.enabled = true
     _refresh(bufnr)
   end
 end


### PR DESCRIPTION
Problems:
- When the buffer is detached, the `_disable` method is invoked, setting the `client_hint` to nil.
  Subsequently, triggering the `on_win` event will result in an assertion failure (you can try `:edit`)

- At this point, reopening `inlay_hints` for this buffer will work as expected.
  However, if the buffer is detached again, the `_disable` method will not be triggered because the event has not been re-registered.
  This will result in `bufstate.applied` being equal to `bufstate.version`, causing `inlay_hints` not to be displayed unless some text is inserted to trigger a refresh.

![20240119013228_rec_](https://github.com/neovim/neovim/assets/17252397/e1418941-45ef-4d88-b559-354a00ad8196)

Solution:
- Remove the assertion in `on_win`.

- When `bufstate.enabled` is false, reset `bufstate.applied` and set the relevant events.