### PR TITLE
docs: correct function reference for do_sub

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3274,7 +3274,7 @@ static int check_regexp_delim(int c)
 ///
 /// @param cmdpreview_ns  The namespace to show 'inccommand' preview highlights.
 ///                       If <= 0, preview shouldn't be shown.
-/// @return 0, 1 or 2. See show_cmdpreview() for more information on what the return value means.
+/// @return 0, 1 or 2. See cmdpreview_may_show() for more information on what the return value means.
 static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_ns,
                   const handle_T cmdpreview_bufnr)
 {


### PR DESCRIPTION
Hi ! Thank you very much for the great work on this fantastic editor !

While investigating the behavior of the `:substitute` command in the source code. I stumbled on (what I think is) a minor typo in the documentation.

I am proposing this little correction.
I may be perfectly wrong, sorry for the disturbance if that is the case.

I thank you for paying attention to this.