### PR TITLE
vim-patch:27a4632af675

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -267,6 +267,7 @@ local extension = {
   crdpro = 'chordpro',
   cho = 'chordpro',
   chordpro = 'chordpro',
+  ck = 'chuck',
   eni = 'cl',
   icl = 'clean',
   cljx = 'clojure',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -140,6 +140,7 @@ func s:GetFilenameChecks() abort
     \ 'chatito': ['file.chatito'],
     \ 'chill': ['file..ch'],
     \ 'chordpro': ['file.chopro', 'file.crd', 'file.cho', 'file.crdpro', 'file.chordpro'],
+    \ 'chuck': ['file.ck'],
     \ 'cl': ['file.eni'],
     \ 'clean': ['file.dcl', 'file.icl'],
     \ 'clojure': ['file.clj', 'file.cljs', 'file.cljx', 'file.cljc'],


### PR DESCRIPTION
runtime(filetype): detect *.ck files as Chuck filetype (vim/vim#13888)

closes vim/vim#13886

https://github.com/vim/vim/commit/27a4632af675345f9d3b4f3d66a63756835df8cc

Co-authored-by: Christian Brabandt <cb@256bit.org>

---

(vim commit lacks test)
