### PR TITLE
refactor(lsp): add typing and docs for LSP handlers

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -143,8 +143,9 @@ creating and managing clients.
 The `vim.lsp.buf_…` functions perform operations for all LSP clients attached
 to the given buffer. |lsp-buf|
 
-LSP request/response handlers are implemented as Lua functions (see
-|lsp-handler|).
+LSP request/response/notification handlers are implemented as Lua functions
+(see |lsp-handler|).
+
                                                                   *lsp-method*
 
 Requests and notifications defined by the LSP specification are referred to as
@@ -156,76 +157,132 @@ Requests and notifications defined by the LSP specification are referred to as
 They are also listed below. Note that handlers depend on server support: they
 won't run if your server doesn't support them.
 
-- callHierarchy/incomingCalls
-- callHierarchy/outgoingCalls
-- textDocument/codeAction
-- textDocument/completion
-- textDocument/declaration*
-- textDocument/definition
-- textDocument/diagnostic
-- textDocument/documentHighlight
-- textDocument/documentSymbol
-- textDocument/formatting
-- textDocument/hover
-- textDocument/implementation*
-- textDocument/inlayHint
-- textDocument/prepareTypeHierarchy
-- textDocument/publishDiagnostics
-- textDocument/rangeFormatting
-- textDocument/references
-- textDocument/rename
-- textDocument/semanticTokens/full
-- textDocument/semanticTokens/full/delta
-- textDocument/signatureHelp
-- textDocument/typeDefinition*
-- typeHierarchy/subtypes
-- typeHierarchy/supertypes
-- window/logMessage
-- window/showMessage
-- window/showDocument
-- window/showMessageRequest
-- workspace/applyEdit
-- workspace/configuration
-- workspace/executeCommand
-- workspace/inlayHint/refresh
-- workspace/symbol
-- workspace/workspaceFolders
+  handler                                    type ~
+  ------------------------------------------ -------------- ~
+  $/progress                                 notification
+  workspace/executeCommand                   response
+  window/workDoneProgress/create             request
+  window/showMessageRequest                  request
+  client/registerCapability                  request
+  client/unregisterCapability                request
+  workspace/applyEdit                        request
+  workspace/configuration                    request
+  workspace/workspaceFolders                 request
+  textDocument/publishDiagnostics            notification
+  textDocument/diagnostic                    response
+  textDocument/codeLens                      response
+  textDocument/inlayHint                     response
+  workspace/inlayHint/refresh                request
+  textDocument/references                    response
+  textDocument/documentSymbol                response
+  workspace/symbol                           response
+  textDocument/rename                        response
+  textDocument/formatting                    response
+  textDocument/rangeFormatting               response
+  textDocument/completion                    response
+  textDocument/hover                         response
+  textDocument/declaration*                  response
+  textDocument/definition                    response
+  textDocument/implementation*               response
+  textDocument/typeDefinition*               response
+  textDocument/signatureHelp                 response
+  textDocument/documentHighlight             response
+  callHierarchy/incomingCalls                response
+  callHierarchy/outgoingCalls                response
+  typeHierarchy/subtypes                     response
+  typeHierarchy/supertypes                   response
+  window/logMessage                          notification
+  window/showMessage                         notification
+  window/showDocument                        request
+  workspace/semanticTokens/refresh           request
+
+Legend (see |lsp-handler|): ~
+  response     : LSP server sends a response to request made by client (Nvim)
+  request      : LSP server sends a request to client (Nvim)
+  notification : LSP server sends a notification to client (Nvim)
+
 
                                                                  *lsp-handler*
-LSP handlers are functions that handle |lsp-response|s to requests made by Nvim
-to the server. (Notifications, as opposed to requests, are fire-and-forget:
-there is no response, so they can't be handled. |lsp-notification|)
+LSP handlers are functions executed on the Nvim's side (LSP client):
+(i)  that handle |lsp-response|s to requests made by Nvim to LSP server
+     (Lua type: `vim.lsp.ResponseHandler`), or
+(ii) that handle |lsp-request|s or |lsp-notification|s made by LSP server
+     (Lua type: `vim.lsp.RequestHandler` or `vim.lsp.NotificationHandler`).
 
-Each response handler has this signature: >
+Notifications (|lsp-notification|) made by Nvim, as opposed to requests, are
+fire-and-forget: there is no response from LSP server, so they can't be
+handled.
 
-    function(err, result, ctx, config)
+Each type of the LSP handlers has the following signature (`vim.lsp.Handler`):
+>
+    vim.lsp.ResponseHandler:
+        fun(err, result, ctx, config)
+
+    vim.lsp.NotificationHandler:
+        fun(err, params, ctx, config)
+
+    vim.lsp.RequestHandler:
+        fun(err, params, ctx, config): Result?, lsp.ResponseError?
 <
     Parameters: ~
-        - {err}     (table|nil) Error info dict, or `nil` if the request
-                    completed.
-        - {result}  (Result | Params | nil) `result` key of the |lsp-response| or
-                    `nil` if the request failed.
-        - {ctx}     (table) Table of calling state associated with the
-                    handler, with these keys:
-                    - {method}  (string) |lsp-method| name.
-                    - {client_id} (number) |vim.lsp.Client| identifier.
-                    - {bufnr}   (Buffer) Buffer handle.
-                    - {params}  (table|nil) Request parameters table.
-                    - {version} (number) Document version at time of
+        • {err}     (`lsp.LspResponseError?`) Error info table, or `nil` if
+                    the request completed without errors.
+        • {result}  (`Result`) readout of `result` key in the |lsp-response|,
+                    or `nil` if the request failed (i.e. {err} `~= nil`); or
+          {request} (`Params`) readout of `params` key in the |lsp-request| or
+                    |lsp-notification|, or `nil` if the method does not
+                    require params.
+        • {ctx}     (`lsp.HandlerContext`) table of calling state associated
+                    with the handler, with these keys:
+                    • {method}  (`string`) |lsp-method| name.
+                    • {client_id} (`number`) |vim.lsp.Client| identifier.
+                    • {bufnr}   (`number`) Buffer handle.
+                    • {params}  (`table?`) Request parameters table.
+                    • {version} (`number`) Document version at time of
                                 request. Handlers can compare this to the
                                 current document version to check if the
                                 response is "stale". See also |b:changedtick|.
-        - {config}  (table) Handler-defined configuration table, which allows
+        • {config}  (`table`) Handler-defined configuration table, which allows
                     users to customize handler behavior.
                     For an example, see:
                         |vim.lsp.diagnostic.on_publish_diagnostics()|
                     To configure a particular |lsp-handler|, see:
-                        |lsp-handler-configuration|
+                        |lsp-handler-configuration| |vim.lsp.with()|
 
-    Returns: ~
-        Two values `result, err` where `err` is shaped like an RPC error: >
+    Return (multiple): ~
+        (`Result?`) `result` on successful request, or `nil` otherwise.
+                         See |lsp-handler-return|
+        (`lsp.ResponseError?`) `error` on unsuccessful request, or `nil` otherwise.
+
+        |lsp-response| and |lsp-notification| handlers do not have return
+        values, i.e., equivalent to both being `nil`.
+
+                                                          *lsp-handler-return*
+Return values and error handling of |lsp-handler|:
+
+    For |lsp-response| and |lsp-notification| handlers, there are no return values
+    (i.e. both `result` and `error` are `nil`).
+
+    For |lsp-request| handlers, return either non-nil `result` (on success) or
+    `error` (on failure), but not both.
+
+    Request handlers |lsp-request| should return a valid `result` object as
+    specified in the LSP protocol, which will be sent back to the LSP server
+    via JSON RPC (as a part of |lsp-response| message), indicating the request
+    was handled successfully. Any null or void values in the result (the
+    entire `result` or any null values contained in a list, table, etc.) must
+    be converted to and represented by |vim.NIL|, rather than `nil`.
+
+    If an error happens and the request is not succesful, handler functions
+    must return `nil` for `result` and an `lsp.ResponseError` object for `error`.
+    The first return value `nil` (not `vim.NIL`) of a LSP response handler means
+    that the LSP request was not successful. `error` (`lsp.ResponseError`) is
+    structured like: >
             { code, message, data? }
-<        You can use |vim.lsp.rpc.rpc_response_error()| to create this object.
+<    You can use |vim.lsp.rpc.rpc_response_error()| to create this object.
+
+    See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
+
 
                                                    *lsp-handler-configuration*
 
@@ -335,6 +392,7 @@ in the following order:
 Log levels are defined in |vim.log.levels|
 
 
+------------------------------------------------------------------------------
 VIM.LSP.PROTOCOL                                              *vim.lsp.protocol*
 
 Module `vim.lsp.protocol` defines constants dictated by the LSP specification,
@@ -347,14 +405,22 @@ name: >lua
     vim.lsp.protocol.TextDocumentSyncKind.Full == 1
     vim.lsp.protocol.TextDocumentSyncKind[1] == "Full"
 <
+                                                                *lsp-request*
+LSP request shape: >
+    { id: integer|string, method: string, params?: Params }
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage
 
                                                                 *lsp-response*
-LSP response shape:
-https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
+LSP response shape: >
+    { id: integer|string|nil, result: Result, error: nil }       (on success)
+    { id: integer|string|nil, result: nil, error: ResponseError }  (on error)
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
 
                                                                 *lsp-notification*
-LSP notification shape:
-https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
+LSP notification shape: >
+    { method: string, params?: Params }
+< https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
+
 
 ================================================================================
 LSP HIGHLIGHT                                                    *lsp-highlight*
@@ -923,7 +989,7 @@ with({handler}, {override_config})                            *vim.lsp.with()*
     Function to manage overriding defaults for LSP handlers.
 
     Parameters: ~
-      • {handler}          (`lsp.Handler`) See |lsp-handler|
+      • {handler}          (`vim.lsp.Handler`) See |lsp-handler|
       • {override_config}  (`table`) Table containing the keys to override
                            behavior of the {handler}
 
@@ -945,7 +1011,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 with the server. You can modify this in the
                                 `config`'s `on_init` method before text is
                                 sent to the server.
-      • {handlers}              (`table<string,lsp.Handler>`) The handlers
+      • {handlers}              (`table<string,vim.lsp.Handler>`) The handlers
                                 used by the client as described in
                                 |lsp-handler|.
       • {requests}              (`table<integer,{ type: string, bufnr: integer, method: string}>`)
@@ -1009,7 +1075,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {capabilities}          (`lsp.ClientCapabilities`) The capabilities
                                 provided by the client (editor or tool)
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`)
-      • {request}               (`fun(method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?`)
+      • {request}               (`fun(method: string, params: table?, handler: vim.lsp.Handler?, bufnr: integer): boolean, integer?`)
                                 Sends a request to the server. This is a thin
                                 wrapper around {client.rpc.request} with some
                                 additional checking. If {handler} is not
@@ -1205,7 +1271,8 @@ Lua module: vim.lsp.buf                                              *lsp-buf*
                         vim.lsp.buf.definition({ loclist = true })
                         vim.lsp.buf.references(nil, { loclist = true })
 <
-      • {loclist}?  (`boolean`)
+      • {loclist}?  (`boolean`) whether use the location list (defaults to
+                    `false`, i.e. using the quickfix list by default)
 
 *vim.lsp.LocationOpts*
     Extends: |vim.lsp.ListOpts|
@@ -1485,13 +1552,13 @@ on_diagnostic({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-      • {result}  (`lsp.DocumentDiagnosticReport`)
+      • {result}  (`lsp.DocumentDiagnosticReport`) TODO verify partial results
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`vim.diagnostic.Opts`) Configuration table (see
                   |vim.diagnostic.config()|).
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
-on_publish_diagnostics({_}, {result}, {ctx}, {config})
+on_publish_diagnostics({_}, {params}, {ctx}, {config})
     |lsp-handler| for the method "textDocument/publishDiagnostics"
 
     See |vim.diagnostic.config()| for configuration options. Handler-specific
@@ -1516,7 +1583,7 @@ on_publish_diagnostics({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-      • {result}  (`lsp.PublishDiagnosticsParams`)
+      • {params}  (`lsp.PublishDiagnosticsParams`)
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`vim.diagnostic.Opts?`) Configuration table (see
                   |vim.diagnostic.config()|).
@@ -1556,7 +1623,7 @@ on_codelens({err}, {result}, {ctx})           *vim.lsp.codelens.on_codelens()*
 
     Parameters: ~
       • {err}     (`lsp.ResponseError?`)
-      • {result}  (`lsp.CodeLens[]`)
+      • {result}  (`lsp.CodeLens[]?`)
       • {ctx}     (`lsp.HandlerContext`)
 
 refresh({opts})                                   *vim.lsp.codelens.refresh()*
@@ -1746,7 +1813,7 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
 <
 
     Parameters: ~
-      • {result}  (`lsp.Hover`)
+      • {result}  (`lsp.Hover?`)
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`table`) Configuration table.
                   • border: (default=nil)
@@ -1768,7 +1835,7 @@ signature_help({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-      • {result}  (`lsp.SignatureHelp`) Response from the language server
+      • {result}  (`lsp.SignatureHelp?`) Response from the language server
       • {ctx}     (`lsp.HandlerContext`) Client context
       • {config}  (`table`) Configuration table.
                   • border: (default=nil)
@@ -1799,7 +1866,7 @@ apply_text_edits({text_edits}, {bufnr}, {offset_encoding})
     Applies a list of text edits to a buffer.
 
     Parameters: ~
-      • {text_edits}       (`table`) list of `TextEdit` objects
+      • {text_edits}       (`lsp.TextEdit[]`) list of `TextEdit` objects
       • {bufnr}            (`integer`) Buffer id
       • {offset_encoding}  (`string`) utf-8|utf-16|utf-32
 
@@ -1829,8 +1896,8 @@ buf_highlight_references({bufnr}, {references}, {offset_encoding})
 
     Parameters: ~
       • {bufnr}            (`integer`) Buffer id
-      • {references}       (`table`) List of `DocumentHighlight` objects to
-                           highlight
+      • {references}       (`lsp.DocumentHighlight[]`) List of
+                           `DocumentHighlight` objects to highlight
       • {offset_encoding}  (`string`) One of "utf-8", "utf-16", "utf-32".
 
     See also: ~
@@ -2170,8 +2237,11 @@ symbols_to_items({symbols}, {bufnr})         *vim.lsp.util.symbols_to_items()*
     Converts symbols to quickfix list items.
 
     Parameters: ~
-      • {symbols}  (`table`) DocumentSymbol[] or SymbolInformation[]
-      • {bufnr}    (`integer`)
+      • {symbols}  (`lsp.DocumentSymbol[]|lsp.WorkspaceSymbol[]|lsp.SymbolInformation[]`)
+      • {bufnr}    (`integer?`)
+
+    Return: ~
+        (`vim.lsp.util.LocationItem[]`)
 
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -46,7 +46,7 @@ EVENTS
 
 LSP
 
-• TODO
+• Lua type annotations for LSP protocol and |lsp-handler|s.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -839,10 +839,10 @@ api.nvim_create_autocmd('VimLeavePre', {
 --- Sends an async request for all active clients attached to the
 --- buffer.
 ---
----@param bufnr (integer) Buffer handle, or 0 for current.
----@param method (string) LSP method name
+---@param bufnr integer Buffer handle, or 0 for current.
+---@param method string LSP method name, see |vim.lsp.protocol.Methods|
 ---@param params table|nil Parameters to send to the server
----@param handler? lsp.Handler See |lsp-handler|
+---@param handler? vim.lsp.ResponseHandler See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
@@ -894,9 +894,9 @@ end
 --- Sends an async request for all active clients attached to the buffer and executes the `handler`
 --- callback with the combined result.
 ---
----@param bufnr (integer) Buffer handle, or 0 for current.
----@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
+---@param bufnr integer Buffer handle, or 0 for current.
+---@param method string LSP method name
+---@param params table|nil Parameters to send to the server
 ---@param handler fun(results: table<integer, {error: lsp.ResponseError?, result: any}>) (function)
 --- Handler called after all requests are completed. Server results are passed as
 --- a `client_id:result` map.
@@ -1153,7 +1153,7 @@ function lsp.for_each_buffer_client(bufnr, fn)
 end
 
 --- Function to manage overriding defaults for LSP handlers.
----@param handler (lsp.Handler) See |lsp-handler|
+---@param handler vim.lsp.Handler See |lsp-handler|
 ---@param override_config (table) Table containing the keys to override behavior of the {handler}
 function lsp.with(handler, override_config)
   return function(err, result, ctx, config)

--- a/runtime/lua/vim/lsp/_meta.lua
+++ b/runtime/lua/vim/lsp/_meta.lua
@@ -1,7 +1,21 @@
 ---@meta
 error('Cannot require a meta file')
 
----@alias lsp.Handler fun(err: lsp.ResponseError?, result: any, context: lsp.HandlerContext, config?: table): ...any
+-- TODO: Consider moving this to vim/lsp/handlers.lua; or stay here?
+
+---LSP Handlers on the Nvim side, see |lsp-handler| for documentation.
+---See also |lsp-handler-resolution|
+---@alias vim.lsp.Handler vim.lsp.ResponseHandler | vim.lsp.RequestHandler | vim.lsp.NotificationHandler
+---
+---Handles a response from the server, see |lsp-response|
+---@alias vim.lsp.ResponseHandler fun(err: lsp.ResponseError?, result: any, context: lsp.HandlerContext, config?: table)
+---
+---Handles a request made from the server, see |lsp-request| and |lsp-handler|.
+---Returns either an `result` object or a `ResponseError` object to send back to LSP. see |lsp-handler-return|
+---@alias vim.lsp.RequestHandler fun(err: lsp.ResponseError?, params: any, context: lsp.HandlerContext, config?: table): lsp.LSPAny?, lsp.ResponseError?
+---
+---Handles a notification sent from the server, see |lsp-notification|
+---@alias vim.lsp.NotificationHandler fun(err: lsp.ResponseError?, params: any, context: lsp.HandlerContext, config?: table)
 
 ---@class lsp.HandlerContext
 ---@field method string
@@ -10,7 +24,8 @@ error('Cannot require a meta file')
 ---@field params? any
 ---@field version? integer
 
+-- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
 ---@class lsp.ResponseError
----@field code integer
+---@field code integer see `lsp.ErrorCodes` and `lsp.LSPErrorCodes`.
 ---@field message string
 ---@field data string|number|boolean|table[]|table|nil

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -11,8 +11,7 @@ local M = {}
 ---
 ---@param method (string) LSP method name
 ---@param params (table|nil) Parameters to send to the server
----@param handler lsp.Handler? See |lsp-handler|. Follows |lsp-handler-resolution|
----
+---@param handler vim.lsp.Handler? See |lsp-handler|. Follows |lsp-handler-resolution|
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
 ---for all successful requests.
 ---@return function _cancel_all_requests Function which can be used to
@@ -68,7 +67,7 @@ end
 --- vim.lsp.buf.references(nil, { loclist = true })
 --- ```
 --- @field on_list? fun(t: vim.lsp.LocationOpts.OnList)
---- @field loclist? boolean
+--- @field loclist? boolean whether use the location list (defaults to `false`, i.e. using the quickfix list by default)
 
 --- @class vim.lsp.LocationOpts.OnList
 --- @field items table[] Structured like |setqflist-what|
@@ -825,7 +824,7 @@ end
 --- cursor position.
 ---
 ---@param opts? vim.lsp.buf.code_action.Opts
----@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
+---@see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 ---@see vim.lsp.protocol.CodeActionTriggerKind
 function M.code_action(opts)
   validate({ options = { opts, 't', true } })
@@ -859,9 +858,11 @@ function M.code_action(opts)
   ---@type table<integer, vim.lsp.CodeActionResultEntry>
   local results = {}
 
+  --- Handler for textDocument/codeAction
   ---@param err? lsp.ResponseError
   ---@param result? (lsp.Command|lsp.CodeAction)[]
   ---@param ctx lsp.HandlerContext
+  ---@type vim.lsp.ResponseHandler
   local function on_result(err, result, ctx)
     results[ctx.client_id] = { error = err, result = result, ctx = ctx }
     remaining = remaining - 1

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -153,7 +153,7 @@ local validate = vim.validate
 --- @field offset_encoding string
 ---
 --- The handlers used by the client as described in |lsp-handler|.
---- @field handlers table<string,lsp.Handler>
+--- @field handlers table<string,vim.lsp.Handler>
 ---
 --- The current pending requests in flight to the server. Entries are key-value
 --- pairs with the key being the request id while the value is a table with
@@ -229,7 +229,7 @@ local validate = vim.validate
 --- If {status} is `true`, the function returns {request_id} as the second
 --- result. You can use this with `client.cancel_request(request_id)` to cancel
 --- the request.
---- @field request fun(method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?
+--- @field request fun(method: string, params: table?, handler: vim.lsp.Handler?, bufnr: integer): boolean, integer?
 ---
 --- Sends a request to the server and synchronously waits for the response.
 --- This is a wrapper around {client.request}
@@ -628,7 +628,7 @@ end
 --- Returns the default handler if the user hasn't set a custom one.
 ---
 --- @param method (string) LSP method name
---- @return lsp.Handler|nil handler for the given method, if defined, or the default from |vim.lsp.handlers|
+--- @return vim.lsp.Handler|nil handler for the given method, if defined, or the default from |vim.lsp.handlers|
 function Client:_resolve_handler(method)
   return self.handlers[method] or lsp.handlers[method]
 end
@@ -653,7 +653,7 @@ end
 ---
 --- @param method string LSP method name.
 --- @param params? table LSP request params.
---- @param handler? lsp.Handler Response |lsp-handler| for this method.
+--- @param handler? vim.lsp.Handler Response |lsp-handler| for this method.
 --- @param bufnr? integer Buffer handle (0 for current).
 --- @return boolean status, integer? request_id {status} is a bool indicating
 --- whether the request was successful. If it is `false`, then it will
@@ -865,7 +865,7 @@ end
 ---
 --- @param command lsp.Command
 --- @param context? {bufnr: integer}
---- @param handler? lsp.Handler only called if a server command
+--- @param handler? vim.lsp.Handler only called if a server command
 function Client:_exec_cmd(command, context, handler)
   context = vim.deepcopy(context or {}, true) --[[@as lsp.HandlerContext]]
   context.bufnr = context.bufnr or api.nvim_get_current_buf()
@@ -999,7 +999,7 @@ end
 --- @param params table The parameters for that method.
 function Client:_notification(method, params)
   log.trace('notification', method, params)
-  local handler = self:_resolve_handler(method)
+  local handler = self:_resolve_handler(method) --[[@as vim.lsp.NotificationHandler]]
   if handler then
     -- Method name is provided here for convenience.
     handler(nil, params, { method = method, client_id = self.id })
@@ -1012,10 +1012,10 @@ end
 --- @param method (string) LSP method name
 --- @param params (table) The parameters for that method
 --- @return any result
---- @return lsp.ResponseError error code and message set in case an exception happens during the request.
+--- @return lsp.ResponseError? error code and message set in case an exception happens during the request.
 function Client:_server_request(method, params)
   log.trace('server_request', method, params)
-  local handler = self:_resolve_handler(method)
+  local handler = self:_resolve_handler(method) --[[@as vim.lsp.RequestHandler]]
   if handler then
     log.trace('server_request: found handler for', method)
     return handler(nil, params, { method = method, client_id = self.id })

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -258,9 +258,10 @@ end
 
 --- |lsp-handler| for the method `textDocument/codeLens`
 ---
----@param err lsp.ResponseError?
----@param result lsp.CodeLens[]
----@param ctx lsp.HandlerContext
+--- @param err lsp.ResponseError?
+--- @param result lsp.CodeLens[]?
+--- @param ctx lsp.HandlerContext
+--- @type vim.lsp.ResponseHandler
 function M.on_codelens(err, result, ctx, _)
   if err then
     active_refreshes[assert(ctx.bufnr)] = nil

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -228,7 +228,7 @@ end
 
 --- @param uri string
 --- @param client_id? integer
---- @param diagnostics vim.Diagnostic[]
+--- @param diagnostics vim.Diagnostic[]|lsp.Diagnostic[] TODO: review type
 --- @param is_pull boolean
 --- @param config? vim.diagnostic.Opts
 local function handle_diagnostics(uri, client_id, diagnostics, is_pull, config)
@@ -286,11 +286,12 @@ end
 --- ```
 ---
 ---@param _ lsp.ResponseError?
----@param result lsp.PublishDiagnosticsParams
+---@param params lsp.PublishDiagnosticsParams
 ---@param ctx lsp.HandlerContext
 ---@param config? vim.diagnostic.Opts Configuration table (see |vim.diagnostic.config()|).
-function M.on_publish_diagnostics(_, result, ctx, config)
-  handle_diagnostics(result.uri, ctx.client_id, result.diagnostics, false, config)
+---@type vim.lsp.NotificationHandler
+function M.on_publish_diagnostics(_, params, ctx, config)
+  handle_diagnostics(params.uri, ctx.client_id, params.diagnostics, false, config)
 end
 
 --- |lsp-handler| for the method "textDocument/diagnostic"
@@ -319,9 +320,10 @@ end
 --- ```
 ---
 ---@param _ lsp.ResponseError?
----@param result lsp.DocumentDiagnosticReport
+---@param result lsp.DocumentDiagnosticReport  TODO verify partial results
 ---@param ctx lsp.HandlerContext
 ---@param config vim.diagnostic.Opts Configuration table (see |vim.diagnostic.config()|).
+---@type vim.lsp.ResponseHandler
 function M.on_diagnostic(_, result, ctx, config)
   if result == nil or result.kind == 'unchanged' then
     return

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -37,6 +37,7 @@ local augroup = api.nvim_create_augroup('vim_lsp_inlayhint', {})
 ---@param result lsp.InlayHint[]?
 ---@param ctx lsp.HandlerContext
 ---@private
+---@type vim.lsp.ResponseHandler
 function M.on_inlayhint(err, result, ctx, _)
   if err then
     log.error('inlayhint', err)
@@ -99,10 +100,12 @@ function M.on_inlayhint(err, result, ctx, _)
 end
 
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
----@param ctx lsp.HandlerContext
----@private
+--- @param ctx lsp.HandlerContext
+--- @private
+--- @type vim.lsp.RequestHandler
 function M.on_refresh(err, _, ctx, _)
   if err then
+    -- TODO(wookayin): error case; should not return NIL but return an error.
     return vim.NIL
   end
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
@@ -113,7 +116,7 @@ function M.on_refresh(err, _, ctx, _)
     end
   end
 
-  return vim.NIL
+  return vim.NIL -- successful
 end
 
 --- Optional filters |kwargs|:

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -46,6 +46,8 @@ local constants = {
     Info = 3,
     -- A log message.
     Log = 4,
+    -- A debug message.
+    Debug = 5,
   },
 
   -- The file event type.

--- a/test/functional/plugin/lsp/handler_spec.lua
+++ b/test/functional/plugin/lsp/handler_spec.lua
@@ -1,12 +1,14 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
+local clear = t.clear
 local eq = t.eq
 local exec_lua = n.exec_lua
 local pcall_err = t.pcall_err
 local matches = t.matches
 
 describe('lsp-handlers', function()
+  before_each(clear)
   describe('vim.lsp._with_extend', function()
     it('should return a table with the default keys', function()
       eq(


### PR DESCRIPTION
Add lua type annotations for LSP handler functions:

- `vim.lsp.Handler`
- `vim.lsp.RequestHandler` (see |lsp-request|)
- `vim.lsp.ResponseHandler` (see |lsp-response|)
- `vim.lsp.NotificationHandler` (see |lsp-notification|)

There are three types of LSP handlers: request handler, response
handler, and notification handler, having slightly different parameters
(`result` v.s. `params`) and return types (returns something or no
return expected). Previously, all the handler functions were all using
the same signature for response handler, and therefore had incorrect
parameter names (e.g., `result` instead of `params`).

Lots of type checking warnings are fixed by adding handler-specific
type annotations for either `result` or `params`.

Documentation changes (doc/lsp.txt):

- |lsp-method|: List the implemented handlers in `vim.lsp.handlers` with
  the type of the handler (either request, response, or notification).

- Add a new section |lsp-request|. Make data structure for LSP JSON-RPC
  messages more explicit, for |lsp-response| and |lsp-notification|).

- Update docs for |lsp-handler| to explain the three types of LSP
  handlers, and clarify parameters and the correct meaning of return
  values of LSP request handler functions: `result` and `error`.

- Discuss and clarify the meaning of `vim.NIL` in LSP handlers.
  NOTE: There appear to be a few places where the return value of LSP
  handler is incorrect, which are marked as TODO.

Note: `lsp.Handler` -> `vim.lsp.Handler` because handler functions are
Nvim-specific rather than a part of the LSP protocol.

Minor improvements to tests:

- handler_spec: be sure to clear the session, otherwise tests may fail
  when executed solely.


### Tasks remaining for this PR

- [x] codeAction handler.
- [ ] Check: `lsp.null` -> should be `nil` or `vim.NIL`?
- [ ] Check: vim.Diagnostic v.s. lsp.Diagnostic #27420
- [ ] lsp.DocumentDiagnosticReport: verify partial results

### Relevant tasks, backlog for the future improvements 


- [x] LspProgress #23958
   - [x] **Breaking change needed**: change field name `result` -> `params` #28632 
- [ ] Document (or test) the behavior when a handler functions throws an error.
- [ ] It's unclear `params` will have `vim.NIL` instead of `nil` when invoked via JSON-RPC.
- [ ] Add more unit tests for handlers? (non-trivial work)
- [ ] There are some suspicious errors or violation of |lsp-handler| specification, all marked as `TODO`. Such as returning a valid result when error. (Related: #16472) This might change the LSP behavior, so a thorough testing will be needed.
