### PR TITLE
feat(ui): add support for OSC 8 hyperlinks

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2783,6 +2783,9 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                     drawn by a UI. When set, the UI will receive win_extmark
                     events. Note: the mark is positioned by virt_text
                     attributes. Can be used together with virt_text.
+                  • url: A URL to associate with this extmark. In the TUI, the
+                    OSC 8 control sequence is used to generate a clickable
+                    hyperlink to this URL.
 
     Return: ~
         Id of the created/updated extmark

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -301,6 +301,10 @@ The following new APIs and features were added.
 
 • |vim.version.le()| and |vim.version.ge()| are added to |vim.version|.
 
+• |extmarks| can be associated with a URL and URLs are included as a new
+  highlight attribute. The TUI will display URLs using the OSC 8 control
+  sequence, enabling clickable text in supporting terminals.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -328,9 +328,11 @@ numerical highlight ids to the actual attributes.
 	`underdotted`:		underdotted text. The dots have `special` color.
 	`underdashed`:		underdashed text. The dashes have `special` color.
 	`altfont`:		alternative font.
-	`blend`:		Blend level (0-100). Could be used by UIs to
+	`blend`:		blend level (0-100). Could be used by UIs to
 				support blending floating windows to the
 				background or to signal a transparent cursor.
+	`url`:			a URL associated with this highlight. UIs can
+				display this URL however they wish.
 
 	For absent color keys the default color should be used. Don't store
 	the default value in the table, rather a sentinel value, so that

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -607,6 +607,9 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---                 drawn by a UI. When set, the UI will receive win_extmark
 ---                 events. Note: the mark is positioned by virt_text
 ---                 attributes. Can be used together with virt_text.
+---               • url: A URL to associate with this extmark. In the TUI, the
+---                 OSC 8 control sequence is used to generate a clickable
+---                 hyperlink to this URL.
 --- @return integer
 function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -192,6 +192,7 @@ error('Cannot require a meta file')
 --- @field fg_indexed? boolean
 --- @field bg_indexed? boolean
 --- @field force? boolean
+--- @field url? string
 
 --- @class vim.api.keyset.highlight_cterm
 --- @field bold? boolean
@@ -272,6 +273,7 @@ error('Cannot require a meta file')
 --- @field spell? boolean
 --- @field ui_watched? boolean
 --- @field undo_restore? boolean
+--- @field url? string
 
 --- @class vim.api.keyset.user_command
 --- @field addr? any

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -481,6 +481,8 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                   by a UI. When set, the UI will receive win_extmark events.
 ///                   Note: the mark is positioned by virt_text attributes. Can be
 ///                   used together with virt_text.
+///               - url: A URL to associate with this extmark. In the TUI, the OSC 8 control
+///                   sequence is used to generate a clickable hyperlink to this URL.
 ///
 /// @param[out]  err   Error details, if any
 /// @return Id of the created/updated extmark
@@ -494,6 +496,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   DecorSignHighlight sign = DECOR_SIGN_HIGHLIGHT_INIT;
   DecorVirtText virt_text = DECOR_VIRT_TEXT_INIT;
   DecorVirtText virt_lines = DECOR_VIRT_LINES_INIT;
+  String url = STRING_INIT;
   bool has_hl = false;
 
   buf_T *buf = find_buffer_by_handle(buffer, err);
@@ -678,6 +681,10 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     has_hl = true;
   }
 
+  if (HAS_KEY(opts, set_extmark, url)) {
+    url = copy_string(opts->url, NULL);
+  }
+
   if (opts->ui_watched) {
     hl.flags |= kSHUIWatched;
     if (virt_text.pos == kVPosOverlay) {
@@ -747,6 +754,14 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     if (kv_size(virt_lines.data.virt_lines)) {
       decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
     }
+    if (url.data != NULL) {
+      DecorSignHighlight sh = {
+        .priority = DECOR_PRIORITY_BASE,
+        .next = DECOR_ID_INVALID,
+        .url = url,
+      };
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0);
+    }
     if (has_hl) {
       DecorSignHighlight sh = decor_sh_from_inline(hl);
       decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
@@ -772,7 +787,16 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
 
     uint32_t decor_indexed = DECOR_ID_INVALID;
+    if (url.data != NULL) {
+      DecorSignHighlight sh = {
+        .priority = DECOR_PRIORITY_BASE,
+        .url = url,
+      };
+      sh.next = decor_indexed;
+      decor_indexed = decor_put_sh(sh);
+    }
     if (sign.flags & kSHIsSign) {
+      sign.next = decor_indexed;
       decor_indexed = decor_put_sh(sign);
       if (sign.text[0]) {
         decor_flags |= MT_FLAG_DECOR_SIGNTEXT;
@@ -814,6 +838,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 error:
   clear_virttext(&virt_text.data.virt_text);
   clear_virtlines(&virt_lines.data.virt_lines);
+  api_free_string(url);
+
   return 0;
 }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -755,11 +755,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
     }
     if (url != NULL) {
-      DecorSignHighlight sh = {
-        .priority = DECOR_PRIORITY_BASE,
-        .next = DECOR_ID_INVALID,
-        .url = url,
-      };
+      DecorSignHighlight sh = DECOR_SIGN_HIGHLIGHT_INIT;
+      sh.url = url;
       decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0);
     }
     if (has_hl) {
@@ -788,10 +785,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
     uint32_t decor_indexed = DECOR_ID_INVALID;
     if (url != NULL) {
-      DecorSignHighlight sh = {
-        .priority = DECOR_PRIORITY_BASE,
-        .url = url,
-      };
+      DecorSignHighlight sh = DECOR_SIGN_HIGHLIGHT_INIT;
+      sh.url = url;
       sh.next = decor_indexed;
       decor_indexed = decor_put_sh(sh);
     }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -496,7 +496,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   DecorSignHighlight sign = DECOR_SIGN_HIGHLIGHT_INIT;
   DecorVirtText virt_text = DECOR_VIRT_TEXT_INIT;
   DecorVirtText virt_lines = DECOR_VIRT_LINES_INIT;
-  String url = STRING_INIT;
+  char *url = NULL;
   bool has_hl = false;
 
   buf_T *buf = find_buffer_by_handle(buffer, err);
@@ -682,7 +682,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   }
 
   if (HAS_KEY(opts, set_extmark, url)) {
-    url = copy_string(opts->url, NULL);
+    url = string_to_cstr(opts->url);
   }
 
   if (opts->ui_watched) {
@@ -754,7 +754,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     if (kv_size(virt_lines.data.virt_lines)) {
       decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
     }
-    if (url.data != NULL) {
+    if (url != NULL) {
       DecorSignHighlight sh = {
         .priority = DECOR_PRIORITY_BASE,
         .next = DECOR_ID_INVALID,
@@ -787,7 +787,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
 
     uint32_t decor_indexed = DECOR_ID_INVALID;
-    if (url.data != NULL) {
+    if (url != NULL) {
       DecorSignHighlight sh = {
         .priority = DECOR_PRIORITY_BASE,
         .url = url,
@@ -838,7 +838,9 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 error:
   clear_virttext(&virt_text.data.virt_text);
   clear_virtlines(&virt_lines.data.virt_lines);
-  api_free_string(url);
+  if (url != NULL) {
+    xfree(url);
+  }
 
   return 0;
 }

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -54,6 +54,7 @@ typedef struct {
   Boolean spell;
   Boolean ui_watched;
   Boolean undo_restore;
+  String url;
 } Dict(set_extmark);
 
 typedef struct {
@@ -183,6 +184,7 @@ typedef struct {
   Boolean fg_indexed;
   Boolean bg_indexed;
   Boolean force;
+  String url;
 } Dict(highlight);
 
 typedef struct {

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -784,6 +784,12 @@ void remote_ui_hl_attr_define(UI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cte
   MAXSIZE_TEMP_DICT(cterm, HLATTRS_DICT_SIZE);
   hlattrs2dict(&rgb, NULL, rgb_attrs, true, false);
   hlattrs2dict(&cterm, NULL, rgb_attrs, false, false);
+
+  // TODO(gpanders): write a comment if this works
+  if (rgb_attrs.url.data != NULL) {
+    PUT_C(rgb, "url", STRING_OBJ(rgb_attrs.url));
+  }
+
   ADD_C(args, DICTIONARY_OBJ(rgb));
   ADD_C(args, DICTIONARY_OBJ(cterm));
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -786,8 +786,9 @@ void remote_ui_hl_attr_define(UI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cte
   hlattrs2dict(&cterm, NULL, rgb_attrs, false, false);
 
   // TODO(gpanders): write a comment if this works
-  if (rgb_attrs.url != NULL) {
-    PUT_C(rgb, "url", STRING_OBJ(cstr_as_string((char *)rgb_attrs.url)));
+  if (rgb_attrs.url >= 0) {
+    const char *url = hl_get_url((uint32_t)rgb_attrs.url);
+    PUT_C(rgb, "url", STRING_OBJ(cstr_as_string((char *)url)));
   }
 
   ADD_C(args, DICTIONARY_OBJ(rgb));

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -786,8 +786,8 @@ void remote_ui_hl_attr_define(UI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cte
   hlattrs2dict(&cterm, NULL, rgb_attrs, false, false);
 
   // TODO(gpanders): write a comment if this works
-  if (rgb_attrs.url.data != NULL) {
-    PUT_C(rgb, "url", STRING_OBJ(rgb_attrs.url));
+  if (rgb_attrs.url != NULL) {
+    PUT_C(rgb, "url", STRING_OBJ(cstr_as_string((char *)rgb_attrs.url)));
   }
 
   ADD_C(args, DICTIONARY_OBJ(rgb));

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -785,7 +785,8 @@ void remote_ui_hl_attr_define(UI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cte
   hlattrs2dict(&rgb, NULL, rgb_attrs, true, false);
   hlattrs2dict(&cterm, NULL, rgb_attrs, false, false);
 
-  // TODO(gpanders): write a comment if this works
+  // URLs are not added in hlattrs2dict since they are used only by UIs and not by the highlight
+  // system. So we add them here.
   if (rgb_attrs.url >= 0) {
     const char *url = hl_get_url((uint32_t)rgb_attrs.url);
     PUT_C(rgb, "url", STRING_OBJ(cstr_as_string((char *)url)));

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -176,6 +176,12 @@ void nvim_set_hl(Integer ns_id, String name, Dict(highlight) *val, Error *err)
   });
   int link_id = -1;
 
+  // Setting URLs directly through highlight attributes is not supported
+  if (HAS_KEY(val, highlight, url)) {
+    api_free_string(val->url);
+    val->url = NULL_STRING;
+  }
+
   HlAttrs attrs = dict2hlattrs(val, true, &link_id, err);
   if (!ERROR_SET(err)) {
     ns_hl_def((NS)ns_id, hl_id, attrs, link_id, val);

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -118,7 +118,7 @@ void decor_redraw(buf_T *buf, int row1, int row2, DecorInline decor)
 
 void decor_redraw_sh(buf_T *buf, int row1, int row2, DecorSignHighlight sh)
 {
-  if (sh.hl_id || (sh.flags & (kSHIsSign|kSHSpellOn|kSHSpellOff))) {
+  if (sh.hl_id || (sh.url.data != NULL) || (sh.flags & (kSHIsSign|kSHSpellOn|kSHSpellOff))) {
     if (row2 >= row1) {
       redraw_buf_range_later(buf, row1 + 1, row2 + 1);
     }
@@ -253,7 +253,7 @@ void decor_free(DecorInline decor)
   }
 }
 
-void decor_free_inner(DecorVirtText *vt, uint32_t first_idx)
+static void decor_free_inner(DecorVirtText *vt, uint32_t first_idx)
 {
   while (vt) {
     if (vt->flags & kVTIsLines) {
@@ -273,6 +273,7 @@ void decor_free_inner(DecorVirtText *vt, uint32_t first_idx)
       xfree(sh->sign_name);
     }
     sh->flags = 0;
+    api_free_string(sh->url);
     if (sh->next == DECOR_ID_INVALID) {
       sh->next = decor_freelist;
       decor_freelist = first_idx;
@@ -509,7 +510,8 @@ void decor_range_add_sh(DecorState *state, int start_row, int start_col, int end
     .draw_col = -10,
   };
 
-  if (sh->hl_id || (sh->flags & (kSHConceal | kSHSpellOn | kSHSpellOff))) {
+  if (sh->hl_id || (sh->url.data != NULL)
+      || (sh->flags & (kSHConceal | kSHSpellOn | kSHSpellOff))) {
     if (sh->hl_id) {
       range.attr_id = syn_id2attr(sh->hl_id);
     }
@@ -627,15 +629,22 @@ next_mark:
         spell = kFalse;
       }
     }
+    if (active && item.data.sh.url.data != NULL) {
+      attr = hl_add_url(attr, item.data.sh.url);
+    }
     if (item.start_row == state->row && item.start_col <= col
         && decor_virt_pos(&item) && item.draw_col == -10) {
       decor_init_draw_col(win_col, hidden, &item);
     }
     if (keep) {
       kv_A(state->active, j++) = item;
-    } else if (item.owned && item.kind == kDecorKindVirtText) {
-      clear_virttext(&item.data.vt->data.virt_text);
-      xfree(item.data.vt);
+    } else if (item.owned) {
+      if (item.kind == kDecorKindVirtText) {
+        clear_virttext(&item.data.vt->data.virt_text);
+        xfree(item.data.vt);
+      } else if (item.kind == kDecorKindHighlight) {
+        api_free_string(item.data.sh.url);
+      }
     }
   }
   kv_size(state->active) = j;
@@ -960,6 +969,10 @@ void decor_to_dict_legacy(Dictionary *dict, DecorInline decor, bool hl_name)
 
   if (sh_hl.flags & kSHUIWatched) {
     PUT(*dict, "ui_watched", BOOLEAN_OBJ(true));
+  }
+
+  if (sh_hl.url.data != NULL) {
+    PUT(*dict, "url", STRING_OBJ(copy_string(sh_hl.url, NULL)));
   }
 
   if (virt_text) {

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -69,11 +69,11 @@ typedef struct {
   int line_hl_id;
   int cursorline_hl_id;
   uint32_t next;
-  String url;
+  const char *url;
 } DecorSignHighlight;
 
 #define DECOR_SIGN_HIGHLIGHT_INIT { 0, DECOR_PRIORITY_BASE, 0, { 0, 0 }, NULL, 0, 0, 0, 0, \
-                                    DECOR_ID_INVALID, STRING_INIT }
+                                    DECOR_ID_INVALID, NULL }
 
 enum {
   kVTIsLines = 1,

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "klib/kvec.h"
+#include "nvim/api/private/defs.h"
 #include "nvim/types_defs.h"
 
 #define DECOR_ID_INVALID UINT32_MAX
@@ -68,10 +69,11 @@ typedef struct {
   int line_hl_id;
   int cursorline_hl_id;
   uint32_t next;
+  String url;
 } DecorSignHighlight;
 
 #define DECOR_SIGN_HIGHLIGHT_INIT { 0, DECOR_PRIORITY_BASE, 0, { 0, 0 }, NULL, 0, 0, 0, 0, \
-                                    DECOR_ID_INVALID }
+                                    DECOR_ID_INVALID, STRING_INIT }
 
 enum {
   kVTIsLines = 1,

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -978,10 +978,6 @@ void hlattrs2dict(Dictionary *hl, Dictionary *hl_attrs, HlAttrs ae, bool use_rgb
   if (ae.hl_blend > -1 && (use_rgb || !short_keys)) {
     PUT_C(*hl, "blend", INTEGER_OBJ(ae.hl_blend));
   }
-
-  if (ae.url.data != NULL) {
-    PUT_C(*hl, "url", STRING_OBJ(ae.url));
-  }
 }
 
 HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *err)

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -731,8 +731,8 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     }
 
     cattrs.cterm_bg_color = fattrs.cterm_bg_color;
-    cattrs.cterm_fg_color = cterm_blend(ratio, battrs.cterm_fg_color,
-                                        fattrs.cterm_bg_color);
+    cattrs.cterm_fg_color = (int16_t)cterm_blend(ratio, battrs.cterm_fg_color,
+                                                 fattrs.cterm_bg_color);
     cattrs.rgb_ae_attr &= ~(HL_FG_INDEXED | HL_BG_INDEXED);
   } else {
     cattrs = fattrs;
@@ -780,7 +780,7 @@ static int rgb_blend(int ratio, int rgb1, int rgb2)
   return (mr << 16) + (mg << 8) + mb;
 }
 
-static int16_t cterm_blend(int ratio, int16_t c1, int16_t c2)
+static int cterm_blend(int ratio, int16_t c1, int16_t c2)
 {
   // 1. Convert cterm color numbers to RGB.
   // 2. Blend the RGB colors.
@@ -792,11 +792,11 @@ static int16_t cterm_blend(int ratio, int16_t c1, int16_t c2)
 }
 
 /// Converts RGB color to 8-bit color (0-255).
-static int16_t hl_rgb2cterm_color(int rgb)
+static int hl_rgb2cterm_color(int rgb)
 {
-  int16_t r = (rgb & 0xFF0000) >> 16;
-  int16_t g = (rgb & 0x00FF00) >> 8;
-  int16_t b = (rgb & 0x0000FF) >> 0;
+  int r = (rgb & 0xFF0000) >> 16;
+  int g = (rgb & 0x00FF00) >> 8;
+  int b = (rgb & 0x0000FF) >> 0;
 
   return (r * 6 / 256) * 36 + (g * 6 / 256) * 6 + (b * 6 / 256);
 }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -499,7 +499,7 @@ int hl_add_url(int attr, const char *url)
     urls.keys[k] = xstrdup(url);
   }
 
-  attrs.url = (int)k;
+  attrs.url = (int32_t)k;
 
   int new = get_attr_entry((HlEntry){
     .attr = attrs,
@@ -780,7 +780,7 @@ static int rgb_blend(int ratio, int rgb1, int rgb2)
   return (mr << 16) + (mg << 8) + mb;
 }
 
-static int cterm_blend(int ratio, int c1, int c2)
+static int16_t cterm_blend(int ratio, int16_t c1, int16_t c2)
 {
   // 1. Convert cterm color numbers to RGB.
   // 2. Blend the RGB colors.
@@ -792,11 +792,11 @@ static int cterm_blend(int ratio, int c1, int c2)
 }
 
 /// Converts RGB color to 8-bit color (0-255).
-static int hl_rgb2cterm_color(int rgb)
+static int16_t hl_rgb2cterm_color(int rgb)
 {
-  int r = (rgb & 0xFF0000) >> 16;
-  int g = (rgb & 0x00FF00) >> 8;
-  int b = (rgb & 0x0000FF) >> 0;
+  int16_t r = (rgb & 0xFF0000) >> 16;
+  int16_t g = (rgb & 0x00FF00) >> 8;
+  int16_t b = (rgb & 0x0000FF) >> 0;
 
   return (r * 6 / 256) * 36 + (g * 6 / 256) * 6 + (b * 6 / 256);
 }
@@ -1136,12 +1136,12 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     hlattrs.rgb_fg_color = fg;
     hlattrs.rgb_sp_color = sp;
     hlattrs.hl_blend = blend;
-    hlattrs.cterm_bg_color = ctermbg == -1 ? 0 : ctermbg + 1;
-    hlattrs.cterm_fg_color = ctermfg == -1 ? 0 : ctermfg + 1;
+    hlattrs.cterm_bg_color = ctermbg == -1 ? 0 : (int16_t)(ctermbg + 1);
+    hlattrs.cterm_fg_color = ctermfg == -1 ? 0 : (int16_t)(ctermfg + 1);
     hlattrs.cterm_ae_attr = cterm_mask;
   } else {
-    hlattrs.cterm_bg_color = bg == -1 ? 0 : bg + 1;
-    hlattrs.cterm_fg_color = fg == -1 ? 0 : fg + 1;
+    hlattrs.cterm_bg_color = bg == -1 ? 0 : (int16_t)(bg + 1);
+    hlattrs.cterm_fg_color = fg == -1 ? 0 : (int16_t)(fg + 1);
     hlattrs.cterm_ae_attr = mask;
   }
 

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -40,7 +40,7 @@ typedef struct {
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
   int hl_blend;
-  String url;
+  const char *url;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \
@@ -52,7 +52,7 @@ typedef struct {
   .cterm_fg_color = 0, \
   .cterm_bg_color = 0, \
   .hl_blend = -1, \
-  .url = STRING_INIT, \
+  .url = NULL, \
 }
 
 /// Values for index in highlight_attr[].

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -38,9 +38,9 @@ typedef enum {
 typedef struct {
   int16_t rgb_ae_attr, cterm_ae_attr;  ///< HlAttrFlags
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
-  int cterm_fg_color, cterm_bg_color;
-  int hl_blend;
-  int url;
+  int16_t cterm_fg_color, cterm_bg_color;
+  int32_t hl_blend;
+  int32_t url;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -40,7 +40,7 @@ typedef struct {
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
   int hl_blend;
-  const char *url;
+  int url;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \
@@ -52,7 +52,7 @@ typedef struct {
   .cterm_fg_color = 0, \
   .cterm_bg_color = 0, \
   .hl_blend = -1, \
-  .url = NULL, \
+  .url = -1, \
 }
 
 /// Values for index in highlight_attr[].

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -3,6 +3,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "nvim/api/private/defs.h"
+
 typedef int32_t RgbValue;
 
 /// Highlighting attribute bits.
@@ -38,6 +40,7 @@ typedef struct {
   RgbValue rgb_fg_color, rgb_bg_color, rgb_sp_color;
   int cterm_fg_color, cterm_bg_color;
   int hl_blend;
+  String url;
 } HlAttrs;
 
 #define HLATTRS_INIT (HlAttrs) { \
@@ -49,6 +52,7 @@ typedef struct {
   .cterm_fg_color = 0, \
   .cterm_bg_color = 0, \
   .hl_blend = -1, \
+  .url = STRING_INIT, \
 }
 
 /// Values for index in highlight_attr[].

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1912,8 +1912,8 @@ static void set_hl_attr(int idx)
   HlGroup *sgp = hl_table + idx;
 
   at_en.cterm_ae_attr = (int16_t)sgp->sg_cterm;
-  at_en.cterm_fg_color = sgp->sg_cterm_fg;
-  at_en.cterm_bg_color = sgp->sg_cterm_bg;
+  at_en.cterm_fg_color = (int16_t)sgp->sg_cterm_fg;
+  at_en.cterm_bg_color = (int16_t)sgp->sg_cterm_bg;
   at_en.rgb_ae_attr = (int16_t)sgp->sg_gui;
   // FIXME(tarruda): The "unset value" for rgb is -1, but since hlgroup is
   // initialized with 0(by garray functions), check for sg_rgb_{f,b}g_name

--- a/src/nvim/map_defs.h
+++ b/src/nvim/map_defs.h
@@ -33,7 +33,8 @@ static inline bool equal_String(String a, String b)
   if (a.size != b.size) {
     return false;
   }
-  return memcmp(a.data, b.data, a.size) == 0;
+
+  return (a.size == 0) || (memcmp(a.data, b.data, a.size) == 0);
 }
 
 #define Set(type) Set_##type

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -939,6 +939,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *te
         .rgb_bg_color = vt_bg,
         .rgb_sp_color = -1,
         .hl_blend = -1,
+        .url = -1,
       });
     }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -913,8 +913,8 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *te
     bool fg_indexed = VTERM_COLOR_IS_INDEXED(&cell.fg);
     bool bg_indexed = VTERM_COLOR_IS_INDEXED(&cell.bg);
 
-    int vt_fg_idx = ((!fg_default && fg_indexed) ? cell.fg.indexed.idx + 1 : 0);
-    int vt_bg_idx = ((!bg_default && bg_indexed) ? cell.bg.indexed.idx + 1 : 0);
+    int16_t vt_fg_idx = ((!fg_default && fg_indexed) ? cell.fg.indexed.idx + 1 : 0);
+    int16_t vt_bg_idx = ((!bg_default && bg_indexed) ? cell.bg.indexed.idx + 1 : 0);
 
     bool fg_set = vt_fg_idx && vt_fg_idx <= 16 && term->color_set[vt_fg_idx - 1];
     bool bg_set = vt_bg_idx && vt_bg_idx <= 16 && term->color_set[vt_bg_idx - 1];

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1320,14 +1320,24 @@ void tui_grid_scroll(TUIData *tui, Integer g, Integer startrow, Integer endrow, 
   }
 }
 
-uint32_t tui_add_url(TUIData *tui, const char *url)
+/// Add a URL to be used in an OSC 8 hyperlink.
+///
+/// @param tui TUIData
+/// @param url URL to add
+/// @return Index of new URL, or -1 if URL is invalid
+int32_t tui_add_url(TUIData *tui, const char *url)
+  FUNC_ATTR_NONNULL_ARG(1)
 {
+  if (url == NULL) {
+    return -1;
+  }
+
   MHPutStatus status;
   uint32_t k = set_put_idx(cstr_t, &urls, url, &status);
   if (status != kMHExisting) {
     urls.keys[k] = xstrdup(url);
   }
-  return k;
+  return (int32_t)k;
 }
 
 void tui_hl_attr_define(TUIData *tui, Integer id, HlAttrs attrs, HlAttrs cterm_attrs, Array info)
@@ -1352,11 +1362,11 @@ void tui_visual_bell(TUIData *tui)
 void tui_default_colors_set(TUIData *tui, Integer rgb_fg, Integer rgb_bg, Integer rgb_sp,
                             Integer cterm_fg, Integer cterm_bg)
 {
-  tui->clear_attrs.rgb_fg_color = (int)rgb_fg;
-  tui->clear_attrs.rgb_bg_color = (int)rgb_bg;
-  tui->clear_attrs.rgb_sp_color = (int)rgb_sp;
-  tui->clear_attrs.cterm_fg_color = (int)cterm_fg;
-  tui->clear_attrs.cterm_bg_color = (int)cterm_bg;
+  tui->clear_attrs.rgb_fg_color = (RgbValue)rgb_fg;
+  tui->clear_attrs.rgb_bg_color = (RgbValue)rgb_bg;
+  tui->clear_attrs.rgb_sp_color = (RgbValue)rgb_sp;
+  tui->clear_attrs.cterm_fg_color = (int16_t)cterm_fg;
+  tui->clear_attrs.cterm_bg_color = (int16_t)cterm_bg;
 
   tui->print_attr_id = -1;
   invalidate(tui, 0, tui->grid.height, 0, tui->grid.width);

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -140,7 +140,7 @@ struct TUIData {
   int width;
   int height;
   bool rgb;
-  const char *url;  ///< URL currently being printed, if any
+  int url;  ///< Index of URL currently being printed, if any
   StringBuilder urlbuf;  ///< Re-usable buffer for writing OSC 8 control sequences
 };
 
@@ -161,7 +161,7 @@ void tui_start(TUIData **tui_p, int *width, int *height, char **term, bool *rgb)
   tui->stopped = false;
   tui->seen_error_exit = 0;
   tui->loop = &main_loop;
-  tui->url = NULL;
+  tui->url = -1;
   kv_init(tui->invalid_regions);
   kv_init(tui->urlbuf);
   signal_watcher_init(tui->loop, &tui->winch_handle, tui);
@@ -532,7 +532,7 @@ void tui_free_all_mem(TUIData *tui)
 
   const char *url;
   set_foreach(&urls, url, {
-    xfree(url);
+    xfree((void *)url);
   });
   set_destroy(cstr_t, &urls);
 
@@ -565,7 +565,7 @@ static bool attrs_differ(TUIData *tui, int id1, int id2, bool rgb)
   HlAttrs a1 = kv_A(tui->attrs, (size_t)id1);
   HlAttrs a2 = kv_A(tui->attrs, (size_t)id2);
 
-  if (!strequal(a1.url, a2.url)) {
+  if (a1.url != a2.url) {
     return true;
   }
 
@@ -728,10 +728,11 @@ static void update_attrs(TUIData *tui, int attr_id)
     }
   }
 
-  if (!strequal(tui->url, attrs.url)) {
-    if (attrs.url != NULL) {
+  if (tui->url != attrs.url) {
+    if (attrs.url >= 0) {
+      const char *url = urls.keys[attrs.url];
       kv_size(tui->urlbuf) = 0;
-      kv_printf(tui->urlbuf, "\x1b]8;;%s\x1b\\", attrs.url);
+      kv_printf(tui->urlbuf, "\x1b]8;;%s\x1b\\", url);
       out(tui, tui->urlbuf.items, kv_size(tui->urlbuf));
     } else {
       out(tui, S_LEN("\x1b]8;;\x1b\\"));
@@ -818,9 +819,9 @@ static void cursor_goto(TUIData *tui, int row, int col)
   }
 
   // If an OSC 8 sequence is active terminate it before moving the cursor
-  if (tui->url != NULL) {
+  if (tui->url >= 0) {
     out(tui, S_LEN("\x1b]8;;\x1b\\"));
-    tui->url = NULL;
+    tui->url = -1;
   }
 
   if (0 == row && 0 == col) {
@@ -1319,20 +1320,21 @@ void tui_grid_scroll(TUIData *tui, Integer g, Integer startrow, Integer endrow, 
   }
 }
 
+uint32_t tui_add_url(TUIData *tui, const char *url)
+{
+  MHPutStatus status;
+  uint32_t k = set_put_idx(cstr_t, &urls, url, &status);
+  if (status != kMHExisting) {
+    urls.keys[k] = xstrdup(url);
+  }
+  return k;
+}
+
 void tui_hl_attr_define(TUIData *tui, Integer id, HlAttrs attrs, HlAttrs cterm_attrs, Array info)
 {
   attrs.cterm_ae_attr = cterm_attrs.cterm_ae_attr;
   attrs.cterm_fg_color = cterm_attrs.cterm_fg_color;
   attrs.cterm_bg_color = cterm_attrs.cterm_bg_color;
-
-  if (attrs.url != NULL) {
-    const char **url = NULL;
-    if (set_put_ref(cstr_t, &urls, attrs.url, &url)) {
-      *url = xstrdup(attrs.url);
-    }
-    assert(url != NULL);
-    attrs.url = *url;
-  }
 
   kv_a(tui->attrs, (size_t)id) = attrs;
 }

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -179,7 +179,7 @@ static HlAttrs ui_client_dict2hlattrs(Dictionary d, bool rgb)
   HlAttrs attrs = dict2hlattrs(&dict, rgb, NULL, &err);
 
   if (HAS_KEY(&dict, highlight, url)) {
-    attrs.url = (int)tui_add_url(tui, dict.url.data);
+    attrs.url = tui_add_url(tui, dict.url.data);
   }
 
   return attrs;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -179,7 +179,7 @@ static HlAttrs ui_client_dict2hlattrs(Dictionary d, bool rgb)
   HlAttrs attrs = dict2hlattrs(&dict, rgb, NULL, &err);
 
   if (HAS_KEY(&dict, highlight, url)) {
-    attrs.url = dict.url;
+    attrs.url = dict.url.data;
   }
 
   return attrs;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -175,7 +175,14 @@ static HlAttrs ui_client_dict2hlattrs(Dictionary d, bool rgb)
     // TODO(bfredl): log "err"
     return HLATTRS_INIT;
   }
-  return dict2hlattrs(&dict, rgb, NULL, &err);
+
+  HlAttrs attrs = dict2hlattrs(&dict, rgb, NULL, &err);
+
+  if (HAS_KEY(&dict, highlight, url)) {
+    attrs.url = dict.url;
+  }
+
+  return attrs;
 }
 
 void ui_client_event_grid_resize(Array args)

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -179,7 +179,7 @@ static HlAttrs ui_client_dict2hlattrs(Dictionary d, bool rgb)
   HlAttrs attrs = dict2hlattrs(&dict, rgb, NULL, &err);
 
   if (HAS_KEY(&dict, highlight, url)) {
-    attrs.url = dict.url.data;
+    attrs.url = (int)tui_add_url(tui, dict.url.data);
   }
 
   return attrs;

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1791,6 +1791,13 @@ describe('API/extmarks', function()
     feed('vj2ed')
     eq({}, get_extmark_by_id(ns, 4, {}))
   end)
+
+  it('can set a URL', function()
+    set_extmark(ns, 1, 0, 0, { url = 'https://example.com', end_col = 3 })
+    local extmarks = get_extmarks(ns, 0, -1, { details = true })
+    eq(1, #extmarks)
+    eq('https://example.com', extmarks[1][4].url)
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2205,6 +2205,31 @@ describe('extmark decorations', function()
                                               |
     ]]}
   end)
+
+  it('supports URLs', function()
+    insert(example_text)
+    api.nvim_buf_set_extmark(0, ns, 1, 4, {
+      end_col = 14,
+      url = 'https://example.com',
+    })
+    screen:expect{grid=[[
+      for _,item in ipairs(items) do                    |
+          {UNEXPECTED url = https://example.com:local text}, hl_id_cell, count = unpack(item)  |
+          if hl_id_cell ~= nil then                     |
+              hl_id = hl_id_cell                        |
+          end                                           |
+          for _ = 1, (count or 1) do                    |
+              local cell = line[colpos]                 |
+              cell.text = text                          |
+              cell.hl_id = hl_id                        |
+              colpos = colpos+1                         |
+          end                                           |
+      en^d                                               |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]]}
+  end)
 end)
 
 describe('decorations: inline virtual text', function()

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2208,13 +2208,23 @@ describe('extmark decorations', function()
 
   it('supports URLs', function()
     insert(example_text)
+
+    local url = 'https://example.com'
+
+    local attrs = screen:get_default_attr_ids()
+    table.insert(attrs, {
+      url = url,
+    })
+    screen:set_default_attr_ids(attrs)
+
     api.nvim_buf_set_extmark(0, ns, 1, 4, {
       end_col = 14,
-      url = 'https://example.com',
+      url = url,
     })
+
     screen:expect{grid=[[
       for _,item in ipairs(items) do                    |
-          {UNEXPECTED url = https://example.com:local text}, hl_id_cell, count = unpack(item)  |
+          {44:local text}, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
               hl_id = hl_id_cell                        |
           end                                           |

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1890,6 +1890,7 @@ function Screen:_equal_attrs(a, b)
     and a.strikethrough == b.strikethrough
     and a.fg_indexed == b.fg_indexed
     and a.bg_indexed == b.bg_indexed
+    and a.url == b.url
 end
 
 function Screen:_equal_info(a, b)


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/11871

Extmarks can contain URLs which can then be drawn in any supporting UI. In the TUI, for example, URLs are "drawn" by emitting the OSC 8 control sequence to the TTY. On terminals which support the OSC 8 sequence this will create clickable hyperlinks.

URLs are treated as inline highlights in the decoration subsystem, so they are included in the `DecorHighlightInline` and `DecorSignHighlight` structures. However, unlike other inline highlights they use allocated memory which must be freed, so they set the `ext` flag in `DecorInline` so that their lifetimes are managed along with other allocated memory like virtual text.

The decoration subsystem then adds the URLs as a new highlight attribute. The highlight subsystem maintains a set of unique URLs to avoid duplicating allocations for the same string. To attach a URL to an existing highlight attribute we call `hl_add_url` which finds the URL in the set (allocating and adding it if it does not exist) and sets the `url` highlight attribute.

This has the potential to lead to an increase in highlight attributes if a URL is used over a range that contains many different highlight attributes, because now each existing attribute must be combined with the URL. In practice, however, URLs typically span a range containing a single highlight (e.g. link text in Markdown), so this is likely just a pathological edge case.

When a new highlight attribute is defined with a URL it is copied to all attached UIs with the `hl_attr_define` UI event. The TUI manages its own set of URLs (just like the highlight subsystem) to minimize allocations. The TUI keeps track of which URL is "active" for the cell it is printing. If no URL is active and a cell containing a URL is printed, the opening OSC 8 sequence is emitted and that URL becomes the actively tracked URL. If the cursor is moved while in the middle of a URL span, we emit the terminating OSC sequence to prevent the hyperlink from
spanning multiple lines.

This does not support nested hyperlinks, but that is a rare (and, frankly, bizarre) use case. If a valid use case for nested hyperlinks ever presents itself we can address that issue then.

---

TODO:

- [x] ~~Fix `treesitter/highlight_spec.lua` test~~
- [x] Update `news.txt`
