### PR TITLE
fix(treesitter): update `@markup` default links

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -302,17 +302,10 @@ static const char *highlight_init_both[] = {
   "@markup.strikethrough  gui=strikethrough, cterm=strikethrough",
   "@markup.underline      gui=underline,     cterm=underline",
 
-  "default link @markup.heading  Title",
-
-  "default link @markup.raw          Comment",
-  "default link @markup.quote        Comment",
-  "default link @markup.math         Comment",
-  "default link @markup.environment  Comment",
-
-  "default link @markup.link        Underlined",
-  "default link @markup.link.label  Identifier",
-
-  "default link @markup.list            Special",
+  "default link @markup                 Special",  // fallback for subgroups; never used itself
+  "default link @markup.heading         Title",
+  "default link @markup.environment     Structure",
+  "default link @markup.link            Underlined",
   "default link @markup.list.checked    DiagnosticOk",
   "default link @markup.list.unchecked  DiagnosticWarn",
 

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -745,6 +745,7 @@ describe('treesitter highlighting (help)', function()
       [3] = { bold = true, foreground = Screen.colors.Brown },
       [4] = { foreground = Screen.colors.Cyan4 },
       [5] = { foreground = Screen.colors.Magenta1 },
+      [6] = { foreground = Screen.colors.SlateBlue },
     }
   end)
 
@@ -763,10 +764,10 @@ describe('treesitter highlighting (help)', function()
 
     screen:expect {
       grid = [[
-      {1:>ruby}                                   |
-      {1:  -- comment}                            |
-      {1:  local this_is = 'actually_lua'}        |
-      {1:<}                                       |
+      {6:>ruby}                                   |
+      {6:  -- comment}                            |
+      {6:  local this_is = 'actually_lua'}        |
+      {6:<}                                       |
       ^                                        |
                                               |
     ]],
@@ -776,10 +777,10 @@ describe('treesitter highlighting (help)', function()
 
     screen:expect {
       grid = [[
-      {1:>lua}                                    |
-      {1:  -- comment}                            |
-      {1:  }{3:local}{1: }{4:this_is}{1: }{3:=}{1: }{5:'actually_lua'}        |
-      {1:<}                                       |
+      {6:>lua}                                    |
+      {6:  }{1:-- comment}                            |
+      {6:  }{3:local}{6: }{4:this_is}{6: }{3:=}{6: }{5:'actually_lua'}        |
+      {6:<}                                       |
       ^                                        |
                                               |
     ]],
@@ -789,10 +790,10 @@ describe('treesitter highlighting (help)', function()
 
     screen:expect {
       grid = [[
-      {1:>ruby}                                   |
-      {1:  -- comment}                            |
-      {1:  local this_is = 'actually_lua'}        |
-      {1:<}                                       |
+      {6:>ruby}                                   |
+      {6:  -- comment}                            |
+      {6:  local this_is = 'actually_lua'}        |
+      {6:<}                                       |
       ^                                        |
                                               |
     ]],


### PR DESCRIPTION
* `Special` for `@markup.raw`
* `Structure` for `@markup.environment`
* derive `@markup.quote` and `@markup.math` from `@markup.raw`
* highlight `@markup.link.label` as `Underlined` as well (looks weird if everything but the label is underlined, and otherwise the link is invisible if concealed, as in LSP hover docs).

followup to #27067 

@echasnovski 