### PR TITLE
fix(treesitter): avoid `#` of `nil` value in _query_linter

### DIFF
--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -92,7 +92,7 @@ local function get_error_entry(err, node)
     end_col = end_col + #underlined
   elseif msg:match('^Invalid') then
     -- Use the length of the problematic type/capture/field
-    end_col = end_col + #msg:match('"([^"]+)"')
+    end_col = end_col + #(msg:match('"([^"]+)"') or '')
   end
 
   return {


### PR DESCRIPTION
I ran into the following error while editing/saving some query files:

```
Error executing lua callback: .../share/nvim/runtime/lua/vim/treesitter/_query_linter.lua:95: attempt to get length of a nil value
stack traceback:
	.../share/nvim/runtime/lua/vim/treesitter/_query_linter.lua:95: in function 'fn'
	/usr/local/share/nvim/runtime/lua/vim/func/_memoize.lua:54: in function 'parse'
	.../share/nvim/runtime/lua/vim/treesitter/_query_linter.lua:144: in function 'lint_match'
	.../share/nvim/runtime/lua/vim/treesitter/_query_linter.lua:182: in function 'fn'
	...l/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:489: in function 'for_each_tree'
	.../share/nvim/runtime/lua/vim/treesitter/_query_linter.lua:174: in function 'lint'
	/usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:804: in function 'lint'
	/usr/local/share/nvim/runtime/ftplugin/query.lua:28: in function </usr/local/share/nvim/runtime/ftplugin/query.lua:27>
```

This should fix that issue. 

Side note: This seems to be an older change, did anything in recent updates change something that might affect this? I updated neovim a few weeks ago and never ran into this, but after updating today I got the error. (Note: Before I build from brew, but that was broken for me today, so I built from source instead, which might make a difference?)