### PR TITLE
fix(column): clear "b_signcols" before moving saved marks

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -684,15 +684,16 @@ static const uint32_t sign_filter[4] = {[kMTMetaSignText] = kMTFilterSelect,
 void decor_redraw_signs(win_T *wp, buf_T *buf, int row, SignTextAttrs sattrs[], int *line_id,
                         int *cul_id, int *num_id)
 {
-  MarkTreeIter itr[1];
-  if (!marktree_itr_get_overlap(buf->b_marktree, row, 0, itr)) {
+  if (!buf_has_signs(buf)) {
     return;
   }
 
   MTPair pair;
   int num_text = 0;
+  MarkTreeIter itr[1];
   kvec_t(SignItem) signs = KV_INITIAL_VALUE;
   // TODO(bfredl): integrate with main decor loop.
+  marktree_itr_get_overlap(buf->b_marktree, row, 0, itr);
   while (marktree_itr_step_overlap(buf->b_marktree, itr, &pair)) {
     if (!mt_invalid(pair.start) && mt_decor_sign(pair.start)) {
       DecorSignHighlight *sh = decor_find_sign(mt_decor(pair.start));
@@ -771,12 +772,6 @@ void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState 
 {
   if (!buf->b_signcols.autom || !buf_meta_total(buf, kMTMetaSignText)) {
     return;
-  }
-
-  static int nested = 0;
-  // An undo/redo may trigger subsequent calls before its own kNone call.
-  if ((nested += clear) > (0 + (clear == kTrue))) {
-    return;  // Avoid adding signs more than once.
   }
 
   // Allocate an array of integers holding the number of signs in the range.

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1199,7 +1199,7 @@ void comp_col(void)
   set_vim_var_nr(VV_ECHOSPACE, sc_col - 1);
 }
 
-/// Redraw entire window "wp" if configured 'signcolumn' width changes.
+/// Redraw entire window "wp" if "auto" 'signcolumn' width has changed.
 static bool win_redraw_signcols(win_T *wp)
 {
   buf_T *buf = wp->w_buffer;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2427,39 +2427,15 @@ static void u_undoredo(bool undo, bool do_buf_event)
     curbuf->b_op_end.lnum = curbuf->b_ml.ml_line_count;
   }
 
-  int row1 = MAXLNUM;
-  int row2 = -1;
-  int row3 = -1;
-  // Tricky: ExtmarkSavePos may come after ExtmarkSplice which does call
-  // buf_signcols_count_range() but then misses the yet unrestored marks.
-  if (curbuf->b_signcols.autom && buf_meta_total(curbuf, kMTMetaSignText)) {
-    for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
-      ExtmarkUndoObject undo_info = kv_A(curhead->uh_extmark, i);
-      if (undo_info.type == kExtmarkSplice) {
-        ExtmarkSplice s = undo_info.data.splice;
-        if (s.old_row > 0 || s.new_row > 0) {
-          row1 = MIN(row1, s.start_row);
-          row2 = MAX(row2, s.start_row + (undo ? s.new_row : s.old_row) + 1);
-          row3 = MAX(row3, s.start_row + (undo ? s.old_row : s.new_row) + 1);
-        }
-      }
-    }
-    if (row2 != -1) {
-      // Remove signs inside edited region from "b_signcols.count".
-      buf_signcols_count_range(curbuf, row1, row2, 0, kTrue);
-    }
-  }
   // Adjust Extmarks
   if (undo) {
     for (int i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
-      ExtmarkUndoObject undo_info = kv_A(curhead->uh_extmark, i);
-      extmark_apply_undo(undo_info, undo);
+      extmark_apply_undo(kv_A(curhead->uh_extmark, i), undo);
     }
     // redo
   } else {
     for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
-      ExtmarkUndoObject undo_info = kv_A(curhead->uh_extmark, i);
-      extmark_apply_undo(undo_info, undo);
+      extmark_apply_undo(kv_A(curhead->uh_extmark, i), undo);
     }
   }
   if (curhead->uh_flags & UH_RELOAD) {
@@ -2467,10 +2443,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
     // should have all info to send a buffer-reloaing on_lines/on_bytes event
     buf_updates_unload(curbuf, true);
   }
-  // Finish adjusting extmarks: add signs inside edited region to "b_signcols.count".
-  if (row2 != -1) {
-    buf_signcols_count_range(curbuf, row1, row3, 0, kNone);
-  }
+  // Finish adjusting extmarks
 
   curhead->uh_entry = newlist;
   curhead->uh_flags = new_flags;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -5058,6 +5058,33 @@ l5
     ]]}
   end)
 
+  it('correct width with moved marks before undo savepos', function()
+    screen:try_resize(20, 4)
+    insert(example_test3)
+    feed('gg')
+    exec_lua([[
+      local ns = vim.api.nvim_create_namespace('')
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S1' })
+      vim.api.nvim_buf_set_extmark(0, ns, 1, 0, { sign_text = 'S2' })
+      local s3 = vim.api.nvim_buf_set_extmark(0, ns, 2, 0, { sign_text = 'S3' })
+      local s4 = vim.api.nvim_buf_set_extmark(0, ns, 2, 0, { sign_text = 'S4' })
+      vim.schedule(function()
+        vim.cmd('silent d3')
+        vim.api.nvim_buf_set_extmark(0, ns, 2, 0, { id = s3, sign_text = 'S3' })
+        vim.api.nvim_buf_set_extmark(0, ns, 2, 0, { id = s4, sign_text = 'S4' })
+        vim.cmd('silent undo')
+        vim.api.nvim_buf_del_extmark(0, ns, s3)
+      end)
+    ]])
+
+    screen:expect{grid=[[
+      S1^l1                |
+      S2l2                |
+      S4l3                |
+                          |
+    ]]}
+  end)
+
   it('no crash with sign after many marks #27137', function()
     screen:try_resize(20, 4)
     insert('a')


### PR DESCRIPTION
Problem:  Marks moved by undo may be lost to "b_signcols.count".
Solution: Count signs for each undo object separately instead of
          once for the entire undo.