### PR TITLE
fix(column): clear "b_signcols" when marktree is cleared

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -309,6 +309,9 @@ void extmark_free_all(buf_T *buf)
 
   marktree_clear(buf->b_marktree);
 
+  buf->b_signcols.max = 0;
+  CLEAR_FIELD(buf->b_signcols.count);
+
   map_destroy(uint32_t, buf->b_extmark_ns);
   *buf->b_extmark_ns = (Map(uint32_t, uint32_t)) MAP_INIT;
 }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4998,6 +4998,29 @@ l5
                           |
     ]]}
   end)
+
+  it('correct width after wiping a buffer', function()
+    screen:try_resize(20, 4)
+    insert(example_test3)
+    feed('gg')
+    local buf = api.nvim_get_current_buf()
+    api.nvim_buf_set_extmark(buf, ns, 0, 0, { sign_text = 'h' })
+    screen:expect{grid=[[
+      h ^l1                |
+      {1:  }l2                |
+      {1:  }l3                |
+                          |
+    ]]}
+    api.nvim_win_set_buf(0, api.nvim_create_buf(false, true))
+    api.nvim_buf_delete(buf, {unload=true, force=true})
+    api.nvim_buf_set_lines(buf, 0, -1, false, {''})
+    api.nvim_win_set_buf(0, buf)
+    screen:expect{grid=[[
+      ^                    |
+      {2:~                   }|*2
+                          |
+    ]]}
+  end)
 end)
 
 describe('decorations: virt_text', function()


### PR DESCRIPTION
Resolve #27127