### PR TITLE
docs(options): remove misleading sentence

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6807,15 +6807,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
-	Tracing of options in Lua scripts is activated at level 1; Lua scripts
-	are not traced with verbose=0, for performance.
+	Tracing of assignments to options, mappings, etc. in Lua scripts is
+	enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+	for performance.
 
 	If greater than or equal to a given level, Nvim produces the following
 	messages:
 
 	Level   Messages ~
 	----------------------------------------------------------------------
-	1	Lua assignments to options, mappings, etc.
 	2	When a file is ":source"'ed, or |shada| file is read or written.
 	3	UI info, terminal capabilities.
 	4	Shell commands.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7432,15 +7432,15 @@ vim.bo.vts = vim.bo.vartabstop
 
 --- Sets the verbosity level.  Also set by `-V` and `:verbose`.
 ---
---- Tracing of options in Lua scripts is activated at level 1; Lua scripts
---- are not traced with verbose=0, for performance.
+--- Tracing of assignments to options, mappings, etc. in Lua scripts is
+--- enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+--- for performance.
 ---
 --- If greater than or equal to a given level, Nvim produces the following
 --- messages:
 ---
 --- Level   Messages ~
 --- ----------------------------------------------------------------------
---- 1	Lua assignments to options, mappings, etc.
 --- 2	When a file is ":source"'ed, or `shada` file is read or written.
 --- 3	UI info, terminal capabilities.
 --- 4	Shell commands.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9291,15 +9291,15 @@ return {
       desc = [=[
         Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
-        Tracing of options in Lua scripts is activated at level 1; Lua scripts
-        are not traced with verbose=0, for performance.
+        Tracing of assignments to options, mappings, etc. in Lua scripts is
+        enabled at level 1; Lua scripts are not traced when 'verbose' is 0,
+        for performance.
 
         If greater than or equal to a given level, Nvim produces the following
         messages:
 
         Level   Messages ~
         ----------------------------------------------------------------------
-        1	Lua assignments to options, mappings, etc.
         2	When a file is ":source"'ed, or |shada| file is read or written.
         3	UI info, terminal capabilities.
         4	Shell commands.


### PR DESCRIPTION
Close #27126

Setting 'verbose' to 1 doesn't cause Nvim to produce messages. It adds
more information to existing messages, which is documented above.
