### PR TITLE
feat(extmarks): subpriorities (relative to declaration order)

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -274,6 +274,7 @@ error('Cannot require a meta file')
 --- @field ui_watched? boolean
 --- @field undo_restore? boolean
 --- @field url? string
+--- @field _subpriority? integer
 
 --- @class vim.api.keyset.user_command
 --- @field addr? any

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -748,20 +748,32 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       col2 = c;
     }
 
+    DecorPriority subpriority = DECOR_PRIORITY_BASE;
+    if (HAS_KEY(opts, set_extmark, _subpriority)) {
+      VALIDATE_RANGE((opts->_subpriority >= 0 && opts->_subpriority <= UINT16_MAX),
+                     "_subpriority", {
+        goto error;
+      });
+      subpriority = (DecorPriority)opts->_subpriority;
+    }
+
     if (kv_size(virt_text.data.virt_text)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true);
+      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true,
+                           subpriority);
     }
     if (kv_size(virt_lines.data.virt_lines)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
+      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true,
+                           subpriority);
     }
     if (url != NULL) {
       DecorSignHighlight sh = DECOR_SIGN_HIGHLIGHT_INIT;
       sh.url = url;
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0);
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0, subpriority);
     }
     if (has_hl) {
       DecorSignHighlight sh = decor_sh_from_inline(hl);
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id,
+                         subpriority);
     }
   } else {
     if (opts->ephemeral) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -55,6 +55,8 @@ typedef struct {
   Boolean ui_watched;
   Boolean undo_restore;
   String url;
+
+  Integer _subpriority;
 } Dict(set_extmark);
 
 typedef struct {

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -48,7 +48,8 @@ typedef struct {
   int attr_id;  ///< cached lookup of inl.hl_id if it was a highlight
   bool owned;   ///< ephemeral decoration, free memory immediately
   DecorPriority priority;
-  DecorPriority subpriority;  ///< Secondary priority value used for ordering (#27131)
+  DecorPriority subpriority;  ///< Secondary priority value used for ordering (#27131).
+                              ///< Reflects the order of patterns/captures in the query file.
   DecorRangeKind kind;
   /// Screen column to draw the virtual text.
   /// When -1, the virtual text may be drawn after deciding where.

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -48,6 +48,7 @@ typedef struct {
   int attr_id;  ///< cached lookup of inl.hl_id if it was a highlight
   bool owned;   ///< ephemeral decoration, free memory immediately
   DecorPriority priority;
+  DecorPriority subpriority;  ///< Secondary priority value used for ordering (#27131)
   DecorRangeKind kind;
   /// Screen column to draw the virtual text.
   /// When -1, the virtual text may be drawn after deciding where.

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1798,6 +1798,36 @@ describe('API/extmarks', function()
     eq(1, #extmarks)
     eq('https://example.com', extmarks[1][4].url)
   end)
+
+  it('respects priority', function()
+    screen = Screen.new(15, 10)
+    screen:attach()
+
+    set_extmark(ns, marks[1], 0, 0, {
+      hl_group = 'Comment',
+      end_col = 2,
+      priority = 20,
+    })
+
+    -- Extmark defined after first extmark but has lower priority, first extmark "wins"
+    set_extmark(ns, marks[2], 0, 0, {
+      hl_group = 'String',
+      end_col = 2,
+      priority = 10,
+    })
+
+    screen:expect {
+      grid = [[
+      {1:12}34^5          |
+      {2:~              }|*8
+                     |
+    ]],
+      attr_ids = {
+        [1] = { foreground = Screen.colors.Blue1 },
+        [2] = { foreground = Screen.colors.Blue1, bold = true },
+      },
+    }
+  end)
 end)
 
 describe('Extmarks buffer api with many marks', function()

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -687,7 +687,7 @@ describe('decorations providers', function()
     ]]}
   end)
 
-   it('can add new providers during redraw #26652', function()
+  it('can add new providers during redraw #26652', function()
     setup_provider [[
     local ns = api.nvim_create_namespace('test_no_add')
     function on_do(...)
@@ -696,6 +696,47 @@ describe('decorations providers', function()
     ]]
 
     helpers.assert_alive()
+  end)
+
+  it('supports subpriorities', function()
+    insert(mulholland)
+    setup_provider [[
+      local test_ns = api.nvim_create_namespace('mulholland')
+      function on_do(event, ...)
+        if event == "line" then
+          local win, buf, line = ...
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+            end_row = line + 1,
+            hl_eol = true,
+            hl_group = 'Comment',
+            ephemeral = true,
+            priority = 100,
+            _subpriority = 20,
+          })
+
+          -- This extmark is set last but has a lower subpriority, so the first extmark "wins"
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+            end_row = line + 1,
+            hl_eol = true,
+            hl_group = 'String',
+            ephemeral = true,
+            priority = 100,
+            _subpriority = 10,
+          })
+        end
+      end
+    ]]
+
+    screen:expect{grid=[[
+      {4:// just to see if there was an accident }|
+      {4:// on Mulholland Drive                  }|
+      {4:try_start();                            }|
+      {4:bufref_T save_buf;                      }|
+      {4:switch_buffer(&save_buf, buf);          }|
+      {4:posp = getmark(mark, false);            }|
+      {4:restore_buffer(&save_buf);^              }|
+                                              |
+    ]]}
   end)
 end)
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -698,7 +698,7 @@ describe('decorations providers', function()
     helpers.assert_alive()
   end)
 
-  it('supports subpriorities', function()
+  it('supports subpriorities (order of definitions in a query file #27131)', function()
     insert(mulholland)
     setup_provider [[
       local test_ns = api.nvim_create_namespace('mulholland')


### PR DESCRIPTION
The "priority" field of extmarks has been used to set priority of highlights between different subsystems. For example, extmarks from treesitter highlights might have priority 100 while extmarks from LSP semantic highlighting might have priority 105.

However, there is no way to enforce priority of extmarks _within_ a single subsystem. For instance, if all treesitter highlights are meant to have priority 100 (relative to highlights from other subsystems), we cannot use the priority field to sort how individual extmarks within treesitter are displayed.

Today this is handled by the order in which extmarks are defined such that an extmark defined later implicitly has higher priority than an extmark defined earlier. However, there are scenarios where we cannot depend on the ordering of extmarks: extmarks may need to be set in one order, but displayed in a different order.

To support this use case we add a "_subpriority" field which only has any effect when the "priority" between two extmarks is identical. This is not intended to be exposed so it is undocumented and prefixed with an underscore.

---

This change is in preparation for handling the Tree-sitter changes required to support URLs after https://github.com/neovim/neovim/pull/27109 is merged. Consider a query of the form:

    (inline_link
      (link_text) @text.reference
      (link_destination) @text.uri
      (#set! @text.reference "url" @text.uri))

This pattern is "self-referential", i.e. it references a capture within itself. This does not work today because the Tree-sitter highlighter uses `iter_captures` instead of `iter_matches`. Switching to `iter_matches` is not straightforward, however, because the capture indices are not necessarily returned from `iter_matches` in the order they are defined in the query file. We can use the pattern index as the "subpriority" field to enforce that patterns defined later in the query file (i.e. that have a larger pattern index) have priority over patterns defined earlier in the query file, even if the extmarks themselves are set out of order. See https://github.com/neovim/neovim/pull/27132.
