### PR TITLE
vim-patch:9.1.0043: ml_get: invalid lnum when :s replaces visual selection

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1365,6 +1365,11 @@ static bool reg_match_visual(void)
       top = curbuf->b_visual.vi_end;
       bot = curbuf->b_visual.vi_start;
     }
+    // a substitue command may have
+    // removed some lines
+    if (bot.lnum > curbuf->b_ml.ml_line_count) {
+      bot.lnum = curbuf->b_ml.ml_line_count;
+    }
     mode = curbuf->b_visual.vi_mode;
     curswant = curbuf->b_visual.vi_curswant;
   }

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1626,4 +1626,12 @@ func Test_visual_drag_out_of_window()
   bwipe!
 endfunc
 
+func Test_visual_substitute_visual()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  call feedkeys("Gk\<C-V>j$:s/\\%V\\_.*\\%V/foobar\<CR>", 'tx')
+  call assert_equal(['one', 'foobar'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0043: ml_get: invalid lnum when :s replaces visual selection

Problem:  ml_get: invalid lnum when :s replaces visual selection
          (@ropery)
Solution: substitute may decrement the number of lines in a buffer,
          so validate, that the bottom lines of the visual selection
          stays within the max buffer line

closes: vim/vim#13892

https://github.com/vim/vim/commit/7c71db3a58f658b4329b82ab603efa928d17bdbc

Co-authored-by: Christian Brabandt <cb@256bit.org>