### PR TITLE
Add nil check in rpc.lua to handle nil json body

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -421,6 +421,10 @@ function Client:handle_body(body)
   end
   log_debug('rpc.receive', decoded)
 
+  if body == nil or decoded == nil then
+    return
+  end
+
   if type(decoded.method) == 'string' and decoded.id then
     local err --- @type lsp.ResponseError|nil
     -- Schedule here so that the users functions don't trigger an error and


### PR DESCRIPTION
When using Omnisharp LSP there seems to be occasions where the following error is encountered when the JSON body is null for whatever reason:

```
Error  10:19:49 msg_show.lua_error Error executing luv callback:
/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:386: attempt to index local 'decoded' (a nil value)
stack traceback:
	/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:386: in function 'handle_body'
	/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:726: in function 'handle_body'
	/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:260: in function </usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:244>
```

This PR aims to address in a simple (or perhaps naive?) way.