### PR TITLE
fix(treesitter): prefix TSHiglighter annotation

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -5,10 +5,10 @@ local Range = require('vim.treesitter._range')
 ---@type table<integer,LanguageTree>
 local parsers = setmetatable({}, { __mode = 'v' })
 
----@class TreesitterModule
----@field highlighter TSHighlighter
----@field query TSQueryModule
----@field language TSLanguageModule
+---@class vim.treesitter
+---@field highlighter vim.treesitter.highlighter
+---@field query vim.treesitter.query
+---@field language vim.treesitter.language
 local M = setmetatable({}, {
   __index = function(t, k)
     ---@diagnostic disable:no-unknown

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -4,9 +4,9 @@ local Range = require('vim.treesitter._range')
 
 local ns = api.nvim_create_namespace('treesitter/highlighter')
 
----@alias vim.TSHlIter fun(end_line: integer|nil): integer, TSNode, TSMetadata
+---@alias vim.treesitter.highlighter.Iter fun(end_line: integer|nil): integer, TSNode, TSMetadata
 
----@class vim.TSHighlighterQuery
+---@class vim.treesitter.highlighter.Query
 ---@field private _query Query?
 ---@field private lang string
 ---@field private hl_cache table<integer,integer>
@@ -16,7 +16,7 @@ TSHighlighterQuery.__index = TSHighlighterQuery
 ---@private
 ---@param lang string
 ---@param query_string string?
----@return vim.TSHighlighterQuery
+---@return vim.treesitter.highlighter.Query
 function TSHighlighterQuery.new(lang, query_string)
   local self = setmetatable({}, TSHighlighterQuery)
   self.lang = lang
@@ -52,20 +52,20 @@ function TSHighlighterQuery:query()
   return self._query
 end
 
----@class vim.TSHighlightState
+---@class vim.treesitter.highlighter.State
 ---@field tstree TSTree
 ---@field next_row integer
----@field iter vim.TSHlIter?
----@field highlighter_query vim.TSHighlighterQuery
+---@field iter vim.treesitter.highlighter.Iter?
+---@field highlighter_query vim.treesitter.highlighter.Query
 
----@class vim.TSHighlighter
----@field active table<integer,vim.TSHighlighter>
+---@class vim.treesitter.highlighter
+---@field active table<integer,vim.treesitter.highlighter>
 ---@field bufnr integer
 ---@field orig_spelloptions string
 --- A map of highlight states.
 --- This state is kept during rendering across each line update.
----@field _highlight_states vim.TSHighlightState[]
----@field _queries table<string,vim.TSHighlighterQuery>
+---@field _highlight_states vim.treesitter.highlighter.State[]
+---@field _queries table<string,vim.treesitter.highlighter.Query>
 ---@field tree LanguageTree
 ---@field redraw_count integer
 local TSHighlighter = {
@@ -81,7 +81,7 @@ TSHighlighter.__index = TSHighlighter
 ---@param tree LanguageTree parser object to use for highlighting
 ---@param opts (table|nil) Configuration of the highlighter:
 ---           - queries table overwrite queries used by the highlighter
----@return vim.TSHighlighter Created highlighter object
+---@return vim.treesitter.highlighter Created highlighter object
 function TSHighlighter.new(tree, opts)
   local self = setmetatable({}, TSHighlighter)
 
@@ -202,7 +202,7 @@ function TSHighlighter:prepare_highlight_states(srow, erow)
   end)
 end
 
----@param fn fun(state: vim.TSHighlightState)
+---@param fn fun(state: vim.treesitter.highlighter.State)
 ---@package
 function TSHighlighter:for_each_highlight_state(fn)
   for _, state in ipairs(self._highlight_states) do
@@ -234,7 +234,7 @@ end
 --
 ---@package
 ---@param lang string Language used by the highlighter.
----@return vim.TSHighlighterQuery
+---@return vim.treesitter.highlighter.Query
 function TSHighlighter:get_query(lang)
   if not self._queries[lang] then
     self._queries[lang] = TSHighlighterQuery.new(lang)
@@ -243,7 +243,7 @@ function TSHighlighter:get_query(lang)
   return self._queries[lang]
 end
 
----@param self vim.TSHighlighter
+---@param self vim.treesitter.highlighter
 ---@param buf integer
 ---@param line integer
 ---@param is_spell_nav boolean

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -1,6 +1,6 @@
 local api = vim.api
 
----@class TSLanguageModule
+---@class vim.treesitter.language
 local M = {}
 
 ---@type table<string,string>
@@ -57,7 +57,7 @@ function M.require_language(lang, path, silent, symbol_name)
   return true
 end
 
----@class treesitter.RequireLangOpts
+---@class vim.treesitter.language.RequireLangOpts
 ---@field path? string
 ---@field silent? boolean
 ---@field filetype? string|string[]
@@ -74,7 +74,7 @@ end
 ---                        - path (string|nil) Optional path the parser is located at
 ---                        - symbol_name (string|nil) Internal symbol name for the language to load
 function M.add(lang, opts)
-  ---@cast opts treesitter.RequireLangOpts
+  ---@cast opts vim.treesitter.language.RequireLangOpts
   opts = opts or {}
   local path = opts.path
   local filetype = opts.filetype or lang

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -12,7 +12,7 @@ Query.__index = Query
 ---@field captures table
 ---@field patterns table<string,any[][]>
 
----@class TSQueryModule
+---@class vim.treesitter.query
 local M = {}
 
 ---@param files string[]


### PR DESCRIPTION
Problem: 
- `vim.treesitter.highlighter` does not have autocompletion

Solution:
- Correct `vim.treesitter.highlighter` types
- Rename and prefix `TSQueryModule` and `TSLanguageModule` with `vim.*` to follow this repo's convention