### PR TITLE
vim-patch:e13b665a6e2a

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -873,7 +873,7 @@ SafeState			When nothing is pending, going to wait for the
 				- Command line completion is active
 				You can use `mode()` to find out what state
 				Vim is in.  That may be:
-				- VIsual mode
+				- Visual mode
 				- Normal mode
 				- Insert mode
 				- Command-line mode


### PR DESCRIPTION
#### vim-patch:e13b665a6e2a

runtime(doc): change "VIsual mode" to "Visual mode" in :h SafeState (vim/vim#13901)

"Visual mode" is used everywhere else in the help when not referring to
something in the source code.

https://github.com/vim/vim/commit/e13b665a6e2a32910ff5c3fec330bef4a10f8f23