### PR TITLE
feat(ex_cmds): support ranged :lua

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -254,6 +254,11 @@ arguments separated by " " (space) instead of "\t" (tab).
 <    To see the LuaJIT version: >vim
         :lua =jit.version
 <
+:{range}lua
+    Executes the |[range]| in the current buffer as Lua code. Unlike |:source|,
+    this will execute the specified lines regardless of the extension or
+    |'filetype'| of the buffer.
+
                                                                 *:lua-heredoc*
 :lua << [trim] [{endmarker}]
 {script}

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -337,6 +337,9 @@ The following changes to existing APIs or features add new behavior.
 • |:source| without arguments treats a buffer with its 'filetype' set to "lua"
   as Lua code regardless of its extension.
 
+• |:lua| with a |[range]| executes that range in the current buffer as Lua code
+  regardless of its extension.
+
 • |:checkhealth| buffer now implements |folding|. The initial folding status is
   defined by the 'foldenable' option.
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1612,7 +1612,7 @@ module.cmds = {
   },
   {
     command = 'lua',
-    flags = bit.bor(RANGE, EXTRA, NEEDARG, CMDWIN, LOCK_OK),
+    flags = bit.bor(RANGE, EXTRA, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_LINES',
     func = 'ex_lua',
   },

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1649,6 +1649,15 @@ bool nlua_is_deferred_safe(void)
 void ex_lua(exarg_T *const eap)
   FUNC_ATTR_NONNULL_ALL
 {
+  if (eap->addr_count > 0 || *eap->arg == NUL) {
+    if (eap->addr_count > 0 && *eap->arg == NUL) {
+      cmd_source_buffer(eap, true);
+    } else {
+      semsg(_(e_invarg2), "exactly one of {chunk} and {range} required");
+    }
+    return;
+  }
+
   size_t len;
   char *code = script_get(eap, &len);
   if (eap->skip || code == NULL) {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1779,7 +1779,7 @@ freeall:
 static void cmd_source(char *fname, exarg_T *eap)
 {
   if (eap != NULL && *fname == NUL) {
-    cmd_source_buffer(eap);
+    cmd_source_buffer(eap, false);
   } else if (eap != NULL && eap->forceit) {
     // ":source!": read Normal mode commands
     // Need to execute the commands directly.  This is required at least
@@ -1989,7 +1989,7 @@ static int source_using_linegetter(void *cookie, LineGetter fgetline, const char
   return retval;
 }
 
-static void cmd_source_buffer(const exarg_T *const eap)
+void cmd_source_buffer(const exarg_T *const eap, bool ex_lua)
   FUNC_ATTR_NONNULL_ALL
 {
   if (curbuf == NULL) {
@@ -2012,9 +2012,10 @@ static void cmd_source_buffer(const exarg_T *const eap)
     .buf = ga.ga_data,
     .offset = 0,
   };
-  if (strequal(curbuf->b_p_ft, "lua")
+  if (ex_lua || strequal(curbuf->b_p_ft, "lua")
       || (curbuf->b_fname && path_with_extension(curbuf->b_fname, "lua"))) {
-    nlua_source_using_linegetter(get_str_line, (void *)&cookie, ":source (no file)");
+    char *name = ex_lua ? ":lua (no file)" : ":source (no file)";
+    nlua_source_using_linegetter(get_str_line, (void *)&cookie, name);
   } else {
     source_using_linegetter((void *)&cookie, get_str_line, ":source (no file)");
   }


### PR DESCRIPTION
:{range}lua executes the specified lines in the current buffer as
Lua code, regardless of its extension or 'filetype'.

Close #27103