### PR TITLE
fix(options): use a union for def_val

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -125,31 +125,27 @@ local function get_cond(c, base_string)
   return cond_string
 end
 
-local value_dumpers = {
-  ['function'] = function(v)
-    return v()
-  end,
-  string = cstr,
-  boolean = function(v)
-    return v and 'true' or 'false'
-  end,
-  number = function(v)
-    return ('%iL'):format(v)
-  end,
-  ['nil'] = function(_)
-    return '0'
-  end,
-}
-
-local get_value = function(v)
-  return '(void *) ' .. value_dumpers[type(v)](v)
-end
-
 local get_defaults = function(d, n)
   if d == nil then
     error("option '" .. n .. "' should have a default value")
   end
-  return get_value(d)
+
+  local value_dumpers = {
+    ['function'] = function(v)
+      return v()
+    end,
+    string = function(v)
+      return '.string=' .. cstr(v)
+    end,
+    boolean = function(v)
+      return '.boolean=' .. (v and 'true' or 'false')
+    end,
+    number = function(v)
+      return ('.number=%iL'):format(v)
+    end,
+  }
+
+  return value_dumpers[type(d)](d)
 end
 
 --- @type {[1]:string,[2]:string}[]
@@ -213,11 +209,11 @@ local function dump_option(i, o)
     if o.defaults.condition then
       w(get_cond(o.defaults.condition))
     end
-    w('    .def_val=' .. get_defaults(o.defaults.if_true, o.full_name))
+    w('    .def_val' .. get_defaults(o.defaults.if_true, o.full_name))
     if o.defaults.condition then
       if o.defaults.if_false then
         w('#else')
-        w('    .def_val=' .. get_defaults(o.defaults.if_false, o.full_name))
+        w('    .def_val' .. get_defaults(o.defaults.if_false, o.full_name))
       end
       w('#endif')
     end

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -60,7 +60,12 @@ typedef struct {
   opt_expand_cb_T opt_expand_cb;
 
   // TODO(famiu): Use OptVal for def_val.
-  void *def_val;     ///< default values for variable (neovim!!)
+  union {
+    int boolean;
+    OptInt number;
+    char *string;
+  } def_val;         ///< default value for variable
+
   LastSet last_set;  ///< script in which the option was last set
 } vimoption_T;
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -61,7 +61,7 @@ end
 --- @return fun(): string
 local function macros(s)
   return function()
-    return s
+    return '.string=' .. s
   end
 end
 
@@ -69,7 +69,7 @@ end
 --- @return fun(): string
 local function imacros(s)
   return function()
-    return '(intptr_t)' .. s
+    return '.number=' .. s
   end
 end
 
@@ -1271,7 +1271,7 @@ return {
       abbreviation = 'co',
       cb = 'did_set_lines_or_columns',
       defaults = {
-        if_true = macros('DFLT_COLS'),
+        if_true = imacros('DFLT_COLS'),
         doc = '80 or terminal width',
       },
       desc = [=[
@@ -4024,7 +4024,7 @@ return {
     {
       abbreviation = 'imi',
       cb = 'did_set_iminsert',
-      defaults = { if_true = macros('B_IMODE_NONE') },
+      defaults = { if_true = imacros('B_IMODE_NONE') },
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used in
         Insert mode.  Valid values:
@@ -4050,7 +4050,7 @@ return {
     },
     {
       abbreviation = 'ims',
-      defaults = { if_true = macros('B_IMODE_USE_INSERT') },
+      defaults = { if_true = imacros('B_IMODE_USE_INSERT') },
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used when
         entering a search pattern.  Valid values:
@@ -4747,7 +4747,7 @@ return {
     {
       cb = 'did_set_lines_or_columns',
       defaults = {
-        if_true = macros('DFLT_ROWS'),
+        if_true = imacros('DFLT_ROWS'),
         doc = '24 or terminal height',
       },
       desc = [=[


### PR DESCRIPTION
Problem:
APIs get wrong boolean option default values on big-endian platforms.

Solution:
Use a union for def_val.
Cannot use OptVal or OptValData yet as it needs to have the same types
as option variables.
