### PR TITLE
fix(spell): always accept ':' as filename char in 'spellfile'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5729,7 +5729,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Name of the word list file where words are added for the |zg| and |zw|
 	commands.  It must end in ".{encoding}.add".  You need to include the
 	path, otherwise the file is placed in the current directory.
-	The path may include characters from 'isfname', space, comma and '@'.
+	The path may include characters from 'isfname', ' ', ',', '@' and ':'.
 								*E765*
 	It may also be a comma-separated list of names.  A count before the
 	|zg| and |zw| commands can be used to access each.  This allows using

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6135,7 +6135,7 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- Name of the word list file where words are added for the `zg` and `zw`
 --- commands.  It must end in ".{encoding}.add".  You need to include the
 --- path, otherwise the file is placed in the current directory.
---- The path may include characters from 'isfname', space, comma and '@'.
+--- The path may include characters from 'isfname', ' ', ',', '@' and ':'.
 --- 							*E765*
 --- It may also be a comma-separated list of names.  A count before the
 --- `zg` and `zw` commands can be used to access each.  This allows using

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -849,11 +849,11 @@ bool vim_isfilec(int c)
 }
 
 /// Check if "c" is a valid file-name character, including characters left
-/// out of 'isfname' to make "gf" work, such as comma, space, '@', etc.
+/// out of 'isfname' to make "gf" work, such as ',', ' ', '@', ':', etc.
 bool vim_is_fname_char(int c)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  return vim_isfilec(c) || c == ',' || c == ' ' || c == '@';
+  return vim_isfilec(c) || c == ',' || c == ' ' || c == '@' || c == ':';
 }
 
 /// Check that "c" is a valid file-name character or a wildcard character

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7746,7 +7746,7 @@ return {
         Name of the word list file where words are added for the |zg| and |zw|
         commands.  It must end in ".{encoding}.add".  You need to include the
         path, otherwise the file is placed in the current directory.
-        The path may include characters from 'isfname', space, comma and '@'.
+        The path may include characters from 'isfname', ' ', ',', '@' and ':'.
         							*E765*
         It may also be a comma-separated list of names.  A count before the
         |zg| and |zw| commands can be used to access each.  This allows using

--- a/test/functional/core/spellfile_spec.lua
+++ b/test/functional/core/spellfile_spec.lua
@@ -4,6 +4,7 @@ local eq = helpers.eq
 local clear = helpers.clear
 local api = helpers.api
 local exc_exec = helpers.exc_exec
+local fn = helpers.fn
 local rmdir = helpers.rmdir
 local write_file = helpers.write_file
 local mkdir = helpers.mkdir
@@ -104,5 +105,15 @@ describe('spellfile', function()
     write_file(testdir .. '/spell/en.ascii.spl', spellheader:sub(1, -3) .. '\000\000')
     api.nvim_set_option_value('spelllang', 'en', {})
     eq('Vim(set):E757: This does not look like a spell file', exc_exec('set spell'))
+  end)
+
+  it('can be set to a relative path', function()
+    local fname = testdir .. '/spell/spell.add'
+    api.nvim_set_option_value('spellfile', fname, {})
+  end)
+
+  it('can be set to an absolute path', function()
+    local fname = fn.fnamemodify(testdir .. '/spell/spell.add', ':p')
+    api.nvim_set_option_value('spellfile', fname, {})
   end)
 end)


### PR DESCRIPTION
Follow-up to #25236