### PR TITLE
docs: explain why TUI is reinitialized on resume 

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -269,6 +269,10 @@ static void tui_query_kitty_keyboard(TUIData *tui)
   out(tui, S_LEN("\x1b[?u\x1b[c"));
 }
 
+/// Enable the alternate screen and emit other control sequences to start the TUI.
+///
+/// This is also called when the TUI is resumed after being suspended. We reinitialize all state
+/// from terminfo just in case the controlling terminal has changed (#27177).
 static void terminfo_start(TUIData *tui)
 {
   tui->scroll_region_is_full_screen = true;
@@ -418,6 +422,7 @@ static void terminfo_start(TUIData *tui)
   flush_buf(tui);
 }
 
+/// Disable the alternate screen and prepare for the TUI to close.
 static void terminfo_stop(TUIData *tui)
 {
   // Destroy output stuff
@@ -489,7 +494,7 @@ static void tui_terminal_after_startup(TUIData *tui)
   flush_buf(tui);
 }
 
-/// stop the terminal but allow it to restart later (like after suspend)
+/// Stop the terminal but allow it to restart later (like after suspend)
 static void tui_terminal_stop(TUIData *tui)
 {
   if (uv_is_closing((uv_handle_t *)&tui->output_handle)) {


### PR DESCRIPTION
Every time the TUI is suspended and resumed we completely reinitialize the TUI's terminfo state: we re-parse the terminfo database file, patch terminfo according to the terminal type, query the terminal for supported capabilities, etc. This is wasteful because in the overwhelming majority of cases nothing about the terminal has changed at all between suspend and resume.

Instead, initialize terminfo and query the terminal only once when Nvim is started and maintain this state between suspends and resumes.

---

Benchmark measuring time to resume after a suspend in milliseconds taken from my 2021 M1 MacBook Pro in a Debug build:

| **master** | **PR** |
| ---------- | ------ |
| 4.679      | 3.272  |
| 4.982      | 3.447  |
| 5.280      | 2.919  |
| 4.697      | 2.974  |

The improvement in milliseconds is not very dramatic (5 ms is well below the human perception threshold), so this is more about simplification than about performance (it also eliminates some unnecessary I/O to the terminal since we are no longer querying for e.g. kitty keyboard or synchronized output support on every resume).
