### PR TITLE
perf(internal_format): optimize gq for long lines

### DIFF
--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -106,9 +106,14 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     colnr_T col;
     bool did_do_comment = false;
 
-    colnr_T virtcol = get_nolist_virtcol() + char2cells(c != NUL ? c : gchar_cursor());
-    if (virtcol <= (colnr_T)textwidth) {
-      break;
+    // Cursor is currently at the end of line. No need to format
+    // if line length is less than textwidth (8 * textwidth for
+    // utf safety)
+    if (curwin->w_cursor.col < 8 * textwidth) {
+      colnr_T virtcol = get_nolist_virtcol() + char2cells(c != NUL ? c : gchar_cursor());
+      if (virtcol <= (colnr_T)textwidth) {
+        break;
+      }
     }
 
     if (no_leader) {
@@ -156,18 +161,25 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     coladvance((colnr_T)textwidth);
     wantcol = curwin->w_cursor.col;
 
-    curwin->w_cursor.col = startcol;
+    // If startcol is large (a long line), formatting takes too much
+    // time. The algorithm is O(n^2), it walks from the end of the
+    // line to textwidth border every time for each line break.
+    //
+    // Ceil to 8 * textwidth to optimize.
+    curwin->w_cursor.col = startcol < 8 * textwidth ? startcol : 8 * textwidth;
     foundcol = 0;
     int skip_pos = 0;
 
+    bool first_pass = true;
     // Find position to break at.
     // Stop at first entered white when 'formatoptions' has 'v'
     while ((!fo_ins_blank && !has_format_option(FO_INS_VI))
            || (flags & INSCHAR_FORMAT)
            || curwin->w_cursor.lnum != Insstart.lnum
            || curwin->w_cursor.col >= Insstart.col) {
-      if (curwin->w_cursor.col == startcol && c != NUL) {
+      if (first_pass && c != NUL) {
         cc = c;
+        first_pass = false;
       } else {
         cc = gchar_cursor();
       }


### PR DESCRIPTION
I was editing a relatively big text file with a single line (4 Mb). I tried to format the line with `gq` and neovim stuck. Profiling with callgrind, I found out that the culprits were the `n^2` nature of the algorithm (going backwards from the end of the line each time) and the expensive utf check for whether the line is longer than textwidth.

I implemented kind of hacky workarounds for both problems, involving a magic `8 * textwidth` constant, and the time is now relatively ok (the new bottleneck is `open_line`, but I won't go there).

Benchmark:
`python -c "print((('a' * 79 + ' ') * 750)[:-1])" > line60000.txt`
`time nvim --clean -c 'normal gqgq' -c 'q!' line60000.txt`

Original:
```
real	0m0.359s
user	0m0.344s
sys	0m0.015s
```

Optimized:
```
real	0m0.048s
user	0m0.034s
sys	0m0.015s
```
The difference only grows with the line getting longer.

I manually tested to see whether `8 * textwidth` limit made the difference on the actual formatting done and found none.

Question: this same problem appears in `vim`, should I make a pull request to both repositories? 
