### PR TITLE
fix(linebreak): fix extra line breaks with tabs

### DIFF
--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -21,6 +21,7 @@ typedef struct {
   char *line;                ///< Start of the line.
 
   bool use_tabstop;          ///< Use 'tabstop' instead of char2cells() for a TAB.
+  int8_t lbr_skip_count;     ///< Positive - skip next n line breaks, negative - not calculated.
   int indent_width;          ///< Width of 'showbreak' and 'breakindent' on wrapped
                              ///< parts of lines, INT_MIN if not yet calculated.
 

--- a/test/functional/legacy/listlbr_spec.lua
+++ b/test/functional/legacy/listlbr_spec.lua
@@ -141,10 +141,10 @@ describe('listlbr', function()
       	abcdef hijklmn	pqrstuvwxyz_1060ABCDEFGHIJKLMNOP 
 
       Test 1: set linebreak
-          abcdef          
-      +hijklmn            
+          abcdef hijklmn  
       +pqrstuvwxyz_1060ABC
       +DEFGHIJKLMNOP      
+      ~                   
 
       Test 2: set linebreak + set list
       ^Iabcdef hijklmn^I  
@@ -153,10 +153,10 @@ describe('listlbr', function()
                           
 
       Test 3: set linebreak nolist
-          abcdef          
-      +hijklmn            
+          abcdef hijklmn  
       +pqrstuvwxyz_1060ABC
       +DEFGHIJKLMNOP      
+                          
       1	aaaaaaaaaaaaaaaaaa
 
       Test 4: set linebreak with tab and 1 line as long as screen: should break!

--- a/test/functional/legacy/listlbr_utf8_spec.lua
+++ b/test/functional/legacy/listlbr_utf8_spec.lua
@@ -154,10 +154,10 @@ describe('linebreak', function()
       	abcdef hijklmn	pqrstuvwxyz 1060ABCDEFGHIJKLMNOP 
 
       Test 1: set linebreak + set list + fancy listchars
-      ▕———abcdef          
-      +hijklmn▕———        
+      ▕———abcdef hijklmn▕—
       +pqrstuvwxyz␣1060ABC
       +DEFGHIJKLMNOPˑ¶    
+      ~                   
 
       Test 2: set nolinebreak list
       ▕———abcdef hijklmn▕—

--- a/test/old/testdir/test_listlbr.vim
+++ b/test/old/testdir/test_listlbr.vim
@@ -373,19 +373,95 @@ func Test_ctrl_char_on_wrap_column()
   call s:close_windows()
 endfunc
 
-func Test_linebreak_no_break_after_whitespace_only()
+func Test_linebreak_break_after_whitespace()
   call s:test_windows('setl ts=4 linebreak wrap')
-  call setline(1, "\t  abcdefghijklmnopqrstuvwxyz" ..
+  setl list listchars=tab:>-,space:.
+  call setline(1, "\t abcdefghijklmnopqrstuvwxyz" ..
         \ "abcdefghijklmnopqrstuvwxyz")
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
-\ "      abcdefghijklmn",
-\ "opqrstuvwxyzabcdefgh",
-\ "ijklmnopqrstuvwxyz  ",
-\ "~                   ",
-\ ]
+\ ">---.abcdefghijklmno", 
+\ 'pqrstuvwxyzabcdefghi', 
+\ "jklmnopqrstuvwxyz   ", 
+\ "~                   "]
+
   call s:compare_lines(expect, lines)
   call s:close_windows()
 endfunc
+
+func Test_linebreak_with_breakindent()
+  call s:test_windows('setl ts=4 breakindent briopt=min:15 sbr=>>')
+  setl list listchars=tab:>-,space:.
+  call setline(1, "\t a bcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ ">---.a.bcdefghijklmn", 
+\ "     >>opqrstuvwxyza", 
+\ "     >>bcdefghijklmn", 
+\ "     >>opqrstuvwxyz "]
+
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+
+  call s:test_windows('setl ts=4 breakindent briopt=min:16 sbr=>>')
+  setl list listchars=tab:>-,space:.
+  call setline(1, "\t a bcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ ">---.a.             ", 
+\ "    >>bcdefghijklmno", 
+\ "    >>pqrstuvwxyzabc", 
+\ "    >>defghijklmnopq"]
+
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+endfunc
+
+func Test_linebreak_with_showbreak()
+  call s:test_windows('setl ts=4 linebreak showbreak=123456 wrap')
+  setl list listchars=tab:>-,space:.
+  call setline(1, "!@#$ abcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ '!@#$.abcdefghijklmno',
+\ '123456pqrstuvwxyzabc',
+\ '123456defghijklmnopq',
+\ '123456rstuvwxyz     ']
+
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+
+  call s:test_windows('setl ts=4 linebreak showbreak=12345 wrap')
+  setl list listchars=tab:>-,space:.
+  call setline(1, "!@#$ abcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ '!@#$.abcdefghijklmno',
+\ '12345pqrstuvwxyzabcd',
+\ '12345efghijklmnopqrs',
+\ '12345tuvwxyz        ']
+
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+
+  call s:test_windows('setl ts=4 linebreak showbreak=1234 wrap')
+  setl list listchars=tab:>-,space:.
+  call setline(1, "!@#$ abcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ '!@#$.               ',
+\ '1234abcdefghijklmnop',
+\ '1234qrstuvwxyzabcdef',
+\ '1234ghijklmnopqrstuv']
+
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+endfunc
+	
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_listlbr.vim
+++ b/test/old/testdir/test_listlbr.vim
@@ -33,10 +33,10 @@ func Test_set_linebreak()
   call setline(1, "\tabcdef hijklmn\tpqrstuvwxyz_1060ABCDEFGHIJKLMNOP ")
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
-\ "    abcdef          ",
-\ "+hijklmn            ",
+\ "    abcdef hijklmn  ",
 \ "+pqrstuvwxyz_1060ABC",
 \ "+DEFGHIJKLMNOP      ",
+\ "~                   ",
 \ ]
   call s:compare_lines(expect, lines)
   call s:close_windows()
@@ -64,10 +64,10 @@ func Test_linebreak_with_nolist()
   call setline(1, "\tabcdef hijklmn\tpqrstuvwxyz_1060ABCDEFGHIJKLMNOP ")
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
-\ "    abcdef          ",
-\ "+hijklmn            ",
+\ "    abcdef hijklmn  ",
 \ "+pqrstuvwxyz_1060ABC",
 \ "+DEFGHIJKLMNOP      ",
+\ "~                   ",
 \ ]
   call s:compare_lines(expect, lines)
   call s:close_windows()

--- a/test/old/testdir/test_listlbr_utf8.vim
+++ b/test/old/testdir/test_listlbr_utf8.vim
@@ -46,10 +46,10 @@ func Test_linebreak_with_fancy_listchars()
   redraw!
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
-\ "▕———abcdef          ",
-\ "+hijklmn▕———        ",
+\ "▕———abcdef hijklmn▕—",
 \ "+pqrstuvwxyz␣1060ABC",
 \ "+DEFGHIJKLMNOPˑ¶    ",
+\ "~                   ",
 \ ]
   call s:compare_lines(expect, lines)
   call s:close_windows()

--- a/test/old/testdir/test_vartabs.vim
+++ b/test/old/testdir/test_vartabs.vim
@@ -294,14 +294,14 @@ func Test_vartabs_linebreak()
   call setline(1, "\tx\tx\tx\tx")
 
   let expect = ['          x                             ',
-        \       'x                   x                   ',
-        \       'x                                       ']
+        \       'x                                       ',
+        \       'x                   x                   ']
   let lines = ScreenLines([1, 3], winwidth(0))
   call s:compare_lines(expect, lines)
   setl list listchars=tab:>-
   let expect = ['>---------x>------------------          ',
-        \       'x>------------------x>------------------',
-        \       'x                                       ']
+        \       'x>------------------                    ',
+        \       'x>------------------x                   ']
   let lines = ScreenLines([1, 3], winwidth(0))
   call s:compare_lines(expect, lines)
   setl linebreak vartabstop=40


### PR DESCRIPTION
### 1. Extra line break after leading whitespace.

Linebreak should not be applied after leading whitespace (#25276). This issue was fixed by checking if the current virtual column is less than virtual column of the first non-breakat character. But the loop for computing this virtual column computes regular column instead of virtual column. Usually this still works, since most characters are 1 byte long and 1 cell wide, but tab can take multiple cells, and if it is not the last indentation character, then the calculated column will be smaller than the current virtual column, and linebreak would still be applied. The same issue can also happen inline virtual text is placed inside the leading whitespace, or if `breakindent` is enabled and leading spaces take more than one line on the screen.

![image](https://github.com/neovim/neovim/assets/65824523/a011dfed-bf5f-4eac-9cc3-1013bfa40296)
![image](https://github.com/neovim/neovim/assets/65824523/48fb3563-a2dd-4699-b088-633d1f99e309)
![image](https://github.com/neovim/neovim/assets/65824523/aaf2477e-a751-49d1-89aa-a5a3fe3c3ffb)

Solution: compare the computed column with the regular column of the current character.

### 2. Inconsistent behavior for tabs

The code that checks if a line break should be created subtracts size of the current (`breakat`) character from the maximum virtual column (end of the current screen row) instead of adding it to the current virtual column. This doesn't work for tabs, since their width depends on the current virtual column.

For example, in [`Test_set_linebreak()`](https://github.com/neovim/neovim/blob/ae3eed53d6100598b6d26fe58e3e97541e03f3c1/test/old/testdir/test_listlbr.vim#L31), the `\t` after 'hijklmn' stops at the end of the line (window width = 20, tabstop = 4), and in [`Test_breakindent20_list()`](https://github.com/neovim/neovim/blob/8df7978fe31635ede12f6dae224e6a6c8f1ba882/test/old/testdir/test_breakindent.vim#L792), the space after 'no' also stops at the end of the line, but tab creates a line break, while the space doesn't.
This happens because both words are offset by one column (since the size of the space before them wasn't added), but tab increases its width by that size, while space doesn't.

The same also applies to [`Test_vartabs_linebreak()`](https://github.com/neovim/neovim/blob/ae3eed53d6100598b6d26fe58e3e97541e03f3c1/test/old/testdir/test_vartabs.vim#L286C6-L286C28). The third tab should have width 29 (30 from the third tabstop - width of 'x') and create a line break, but since the size of preceding tab wasn't added, it uses the same tabstop width, and its size is calculated to be 18 (20 from the second tabstop - 2 * width of 'x').

Solution: add the size of the current character to the virtual column before starting to check for a line break.

I didn't add `enum` for the values of `skip_next_linebreak` since I plan to remove it and either store the position of the next match, or just a bool if reinitialization for the same line could be removed. 