### PR TITLE
Tweak treesitter groups in default color scheme

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -422,8 +422,9 @@ instance, to highlight comments differently per language: >vim
     hi @comment.lua guifg=DarkBlue
     hi link @comment.documentation.java String
 <
-The following captures are linked by default to standard |group-name|s (use
-|:Inspect| on a group to see the current link):
+The following is a list of standard captures used in queries for Nvim,
+highlighted according to the current colorscheme (use |:Inspect| on one to see
+the exact definition):
 
 @variable               various variable names
 @variable.builtin       built-in variable names (e.g. `this` / `self`)

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -223,89 +223,66 @@ static const char *highlight_init_both[] = {
   "default link DiagnosticUnnecessary      Comment",
 
   // Treesitter standard groups
-  "default link @variable.builtin    Special",
-  "default link @variable.parameter  Identifier",
-  "default link @variable.member     Identifier",
+  "default link @variable.builtin Special",
 
-  "default link @constant          Constant",
-  "default link @constant.builtin  Special",
-  "default link @constant.macro    Define",
+  "default link @constant         Constant",
+  "default link @constant.builtin Special",
 
-  "default link @module  Structure",
-  "default link @label   Label",
+  "default link @module         Structure",
+  "default link @module.builtin Special",
+  "default link @label          Label",
 
-  "default link @string                 String",
-  "default link @string.regexp          SpecialChar",
-  "default link @string.escape          SpecialChar",
-  "default link @string.special         SpecialChar",
-  "default link @string.special.symbol  Constant",
-  "default link @string.special.url     Underlined",
+  "default link @string             String",
+  "default link @string.regexp      @string.special",
+  "default link @string.escape      @string.special",
+  "default link @string.special     SpecialChar",
+  "default link @string.special.url Underlined",
 
-  "default link @character          Character",
-  "default link @character.special  SpecialChar",
+  "default link @character         Character",
+  "default link @character.special SpecialChar",
 
-  "default link @boolean       Boolean",
-  "default link @number        Number",
-  "default link @number.float  Float",
+  "default link @boolean      Boolean",
+  "default link @number       Number",
+  "default link @number.float Float",
 
-  "default link @type             Type",
-  "default link @type.builtin     Special",
-  "default link @type.definition  Typedef",
-  "default link @type.qualifier   StorageClass",
+  "default link @type         Type",
+  "default link @type.builtin Special",
 
-  "default link @attribute  Macro",
-  "default link @property   Identifier",
+  "default link @attribute Macro",
+  "default link @property  Identifier",
 
-  "default link @function          Function",
-  "default link @function.builtin  Special",
-  "default link @function.macro    Macro",
+  "default link @function         Function",
+  "default link @function.builtin Special",
 
-  "default link @constructor   Special",
-  "default link @operator      Operator",
+  "default link @constructor Special",
+  "default link @operator    Operator",
 
-  "default link @keyword            Keyword",
-  "default link @keyword.function   Statement",
-  "default link @keyword.operator   Operator",
-  "default link @keyword.import     Include",
-  "default link @keyword.storage    StorageClass",
-  "default link @keyword.repeat     Repeat",
-  "default link @keyword.debug      Debug",
-  "default link @keyword.exception  Exception",
+  "default link @keyword Keyword",
 
-  "default link @keyword.conditional    Conditional",
+  "default link @punctuation         Delimiter",  // fallback for subgroups; never used itself
+  "default link @punctuation.special Special",
 
-  "default link @keyword.directive         Preproc",
-  "default link @keyword.directive.define  Define",
+  "default link @comment Comment",
 
-  "default link @punctuation.delimiter  Delimiter",
-  "default link @punctuation.bracket    Delimiter",
-  "default link @punctuation.special    Special",
+  "default link @comment.error   DiagnosticError",
+  "default link @comment.warning DiagnosticWarn",
+  "default link @comment.note    DiagnosticInfo",
+  "default link @comment.todo    Todo",
 
-  "default link @comment   Comment",
+  "@markup.strong        gui=bold          cterm=bold",
+  "@markup.italic        gui=italic        cterm=italic",
+  "@markup.strikethrough gui=strikethrough cterm=strikethrough",
+  "@markup.underline     gui=underline     cterm=underline",
 
-  "default link @comment.error    DiagnosticError",
-  "default link @comment.warning  DiagnosticWarn",
-  "default link @comment.note     DiagnosticInfo",
-  "default link @comment.todo     Todo",
+  "default link @markup         Special",  // fallback for subgroups; never used itself
+  "default link @markup.heading Title",
+  "default link @markup.link    Underlined",
 
-  "@markup.strong         gui=bold           cterm=bold",
-  "@markup.italic         gui=italic         cterm=italic",
-  "@markup.strikethrough  gui=strikethrough, cterm=strikethrough",
-  "@markup.underline      gui=underline,     cterm=underline",
+  "default link @diff.plus  Added",
+  "default link @diff.minus Removed",
+  "default link @diff.delta Changed",
 
-  "default link @markup                 Special",  // fallback for subgroups; never used itself
-  "default link @markup.heading         Title",
-  "default link @markup.environment     Structure",
-  "default link @markup.link            Underlined",
-  "default link @markup.list.checked    DiagnosticOk",
-  "default link @markup.list.unchecked  DiagnosticWarn",
-
-  "default link @diff.plus   Added",
-  "default link @diff.minus  Removed",
-  "default link @diff.delta  Changed",
-
-  "default link @tag            Tag",
-  "default link @tag.delimiter  Delimiter",
+  "default link @tag Tag",
 
   // LSP semantic tokens
   "default link @lsp.type.class         @type",

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -146,16 +146,8 @@ static const char *highlight_init_both[] = {
   "RedrawDebugNormal gui=reverse   cterm=reverse",
   "TabLineSel        gui=bold      cterm=bold",
   "TermCursor        gui=reverse   cterm=reverse",
-  "Title             gui=bold      cterm=bold",
-  "Todo              gui=bold      cterm=bold",
   "Underlined        gui=underline cterm=underline",
   "lCursor           guifg=bg      guibg=fg",
-
-  "Constant   guifg=NONE",
-  "Operator   guifg=NONE",
-  "PreProc    guifg=NONE",
-  "Type       guifg=NONE",
-  "Delimiter  guifg=NONE",
 
   // UI
   "default link CursorIM       Cursor",
@@ -231,7 +223,6 @@ static const char *highlight_init_both[] = {
   "default link DiagnosticUnnecessary      Comment",
 
   // Treesitter standard groups
-  "default link @variable            NONE",  // don't highlight to reduce visual overload
   "default link @variable.builtin    Special",
   "default link @variable.parameter  Identifier",
   "default link @variable.member     Identifier",
@@ -382,19 +373,27 @@ static const char *highlight_init_light[] = {
   "SpellRare            guisp=NvimDarkCyan   gui=undercurl                   cterm=undercurl",
   "StatusLine           guifg=NvimLightGrey3 guibg=NvimDarkGrey3             cterm=reverse",
   "StatusLineNC         guifg=NvimDarkGrey3  guibg=NvimLightGrey3            cterm=bold",
+  "Title                guifg=NvimDarkGrey2                        gui=bold  cterm=bold",
   "Visual                                    guibg=NvimLightGrey4            ctermfg=15 ctermbg=0",
   "WarningMsg           guifg=NvimDarkYellow                                 ctermfg=3",
   "WinBar               guifg=NvimDarkGrey4  guibg=NvimLightGrey1  gui=bold  cterm=bold",
   "WinBarNC             guifg=NvimDarkGrey4  guibg=NvimLightGrey1            cterm=bold",
 
   // Syntax
+  "Constant   guifg=NvimDarkGrey2",  // Use only `Normal` foreground to be usable on different background
+  "Operator   guifg=NvimDarkGrey2",
+  "PreProc    guifg=NvimDarkGrey2",
+  "Type       guifg=NvimDarkGrey2",
+  "Delimiter  guifg=NvimDarkGrey2",
+
   "Comment    guifg=NvimDarkGrey4",
   "String     guifg=NvimDarkGreen                    ctermfg=2",
   "Identifier guifg=NvimDarkBlue                     ctermfg=4",
   "Function   guifg=NvimDarkCyan                     ctermfg=6",
-  "Statement  gui=bold                               cterm=bold",
+  "Statement  guifg=NvimDarkGrey2 gui=bold           cterm=bold",
   "Special    guifg=NvimDarkCyan                     ctermfg=6",
   "Error      guifg=NvimDarkGrey1 guibg=NvimLightRed ctermfg=15 ctermbg=1",
+  "Todo       guifg=NvimDarkGrey2 gui=bold           cterm=bold",
 
   // Diagnostic
   "DiagnosticError          guifg=NvimDarkRed                      ctermfg=1",
@@ -408,6 +407,9 @@ static const char *highlight_init_light[] = {
   "DiagnosticUnderlineHint  guisp=NvimDarkBlue   gui=underline     cterm=underline",
   "DiagnosticUnderlineOk    guisp=NvimDarkGreen  gui=underline     cterm=underline",
   "DiagnosticDeprecated     guisp=NvimDarkRed    gui=strikethrough cterm=strikethrough",
+
+  // Treesitter standard groups
+  "@variable guifg=NvimDarkGrey2",
   NULL
 };
 
@@ -456,19 +458,27 @@ static const char *highlight_init_dark[] = {
   "SpellRare            guisp=NvimLightCyan   gui=undercurl                 cterm=undercurl",
   "StatusLine           guifg=NvimDarkGrey3   guibg=NvimLightGrey3          cterm=reverse",
   "StatusLineNC         guifg=NvimLightGrey3  guibg=NvimDarkGrey3           cterm=bold",
+  "Title                guifg=NvimLightGrey2                       gui=bold cterm=bold",
   "Visual                                     guibg=NvimDarkGrey4           ctermfg=0 ctermbg=15",
   "WarningMsg           guifg=NvimLightYellow                               ctermfg=11",
   "WinBar               guifg=NvimLightGrey4  guibg=NvimDarkGrey1  gui=bold cterm=bold",
   "WinBarNC             guifg=NvimLightGrey4  guibg=NvimDarkGrey1           cterm=bold",
 
   // Syntax
+  "Constant   guifg=NvimLightGrey2",  // Use only `Normal` foreground to be usable on different background
+  "Operator   guifg=NvimLightGrey2",
+  "PreProc    guifg=NvimLightGrey2",
+  "Type       guifg=NvimLightGrey2",
+  "Delimiter  guifg=NvimLightGrey2",
+
   "Comment    guifg=NvimLightGrey4",
   "String     guifg=NvimLightGreen                   ctermfg=10",
   "Identifier guifg=NvimLightBlue                    ctermfg=12",
   "Function   guifg=NvimLightCyan                    ctermfg=14",
-  "Statement  gui=bold                               cterm=bold",
+  "Statement  guifg=NvimLightGrey2 gui=bold          cterm=bold",
   "Special    guifg=NvimLightCyan                    ctermfg=14",
   "Error      guifg=NvimLightGrey1 guibg=NvimDarkRed ctermfg=0 ctermbg=9",
+  "Todo       guifg=NvimLightGrey2 gui=bold          cterm=bold",
 
   // Diagnostic
   "DiagnosticError          guifg=NvimLightRed                      ctermfg=9",
@@ -482,6 +492,9 @@ static const char *highlight_init_dark[] = {
   "DiagnosticUnderlineHint  guisp=NvimLightBlue   gui=underline     cterm=underline",
   "DiagnosticUnderlineOk    guisp=NvimLightGreen  gui=underline     cterm=underline",
   "DiagnosticDeprecated     guisp=NvimLightRed    gui=strikethrough cterm=strikethrough",
+
+  // Treesitter standard groups
+  "@variable guifg=NvimLightGrey2",
   NULL
 };
 

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -248,7 +248,7 @@ describe('ui/cursor', function()
         m.attr = { background = Screen.colors.DarkGray }
       end
       if m.id_lm then
-        m.id_lm = 70
+        m.id_lm = 69
       end
     end
 


### PR DESCRIPTION
This is a part of #26369. Related to #27067.

------

Explicitly use normal grey foreground in syntax groups where it was previously implicitly assumed. This is to make it work better with @-groups and their fallback mechanism. More info in commit message.

------

Update default treesitter groups. Basic idea is to define less in default color scheme, yet just enough to be useful. That is:
- All first level groups (`@character`, `@string`, etc.).
- All `@xxx.builtin` groups as a most common subgroup.
- Some special cases (links/URLs, `@diff.xxx`, etc.).

Defining less groups reduces maintenance burden. It also reduces user's surprise when not defining certain group doesn't mean that it will be highlighted based on its fallback (I experienced this myself even though I was aware of how default color scheme defined groups).

@clason, after spending time thinking about this, I'd ask if this ok with you for default color scheme to not define `@markup.environment` at all? Not sure if this significant enough to be part of *default* color scheme.

Note: another extreme would be to document that all highlight groups present in `:h treesitter-highlight-groups` should not be expected to comply with fallback mechanism. To me this feels as somewhat not clean approach.