### PR TITLE
ci: remove TSAN job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ env:
   INSTALL_PREFIX: ${{ github.workspace }}/nvim-install
   LOG_DIR: ${{ github.workspace }}/build/log
   NVIM_LOG_FILE: ${{ github.workspace }}/build/.nvimlog
-  TSAN_OPTIONS: log_path=${{ github.workspace }}/build/log/tsan
   VALGRIND_LOG: ${{ github.workspace }}/build/log/valgrind-%p.log
   # TEST_FILE: test/functional/core/startup_spec.lua
   # TEST_FILTER: foo
@@ -101,7 +100,6 @@ jobs:
         build:
           [
             { runner: ubuntu-22.04, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
-            { runner: ubuntu-22.04, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-22.04, cc: gcc },
             { runner: macos-12, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-22.04, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
@@ -109,11 +107,7 @@ jobs:
         test: [unittest, functionaltest, oldtest]
         exclude:
           - test: unittest
-            build: { flavor: tsan }
-          - test: unittest
             build: { flavor: puc-lua }
-          - test: oldtest
-            build: { flavor: tsan }
     runs-on: ${{ matrix.build.runner }}
     timeout-minutes: 45
     env:


### PR DESCRIPTION
TSAN job is now mostly a waste of CI time as Nvim is no longer threaded.
