### PR TITLE
vim-patch:9.1.{0054,0056}

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -277,22 +277,20 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
     size += added;
   }
 
-  char *s = cur;
-  colnr_T vcol_start = 0;  // start from where to consider linebreak
+  bool need_lbr = false;
   // If 'linebreak' set check at a blank before a non-blank if the line
-  // needs a break here
-  if (wp->w_p_lbr && wp->w_p_wrap && wp->w_width_inner != 0) {
+  // needs a break here.
+  if (wp->w_p_lbr && wp->w_p_wrap && wp->w_width_inner != 0
+      && vim_isbreak((uint8_t)cur[0]) && !vim_isbreak((uint8_t)cur[1])) {
     char *t = csarg->line;
     while (vim_isbreak((uint8_t)t[0])) {
       t++;
     }
-    vcol_start = (colnr_T)(t - csarg->line);
+    // 'linebreak' is only needed when not in leading whitespace.
+    need_lbr = cur >= t;
   }
-  if (wp->w_p_lbr && vcol_start <= vcol
-      && vim_isbreak((uint8_t)s[0])
-      && !vim_isbreak((uint8_t)s[1])
-      && wp->w_p_wrap
-      && wp->w_width_inner != 0) {
+  if (need_lbr) {
+    char *s = cur;
     // Count all characters from first non-blank after a blank up to next
     // non-blank after a blank.
     int numberextra = win_col_off(wp);

--- a/test/old/testdir/test_listlbr.vim
+++ b/test/old/testdir/test_listlbr.vim
@@ -375,13 +375,13 @@ endfunc
 
 func Test_linebreak_no_break_after_whitespace_only()
   call s:test_windows('setl ts=4 linebreak wrap')
-  call setline(1, "\tabcdefghijklmnopqrstuvwxyz" ..
+  call setline(1, "\t  abcdefghijklmnopqrstuvwxyz" ..
         \ "abcdefghijklmnopqrstuvwxyz")
   let lines = s:screen_lines([1, 4], winwidth(0))
   let expect = [
-\ "    abcdefghijklmnop",
-\ "qrstuvwxyzabcdefghij",
-\ "klmnopqrstuvwxyz    ",
+\ "      abcdefghijklmn",
+\ "opqrstuvwxyzabcdefgh",
+\ "ijklmnopqrstuvwxyz  ",
 \ "~                   ",
 \ ]
   call s:compare_lines(expect, lines)

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -12,6 +12,16 @@ func Test_put_block()
   bwipe!
 endfunc
 
+func Test_put_block_unicode()
+  new
+  call setreg('a', "À\nÀÀ\naaaaaaaaaaaa", "\<C-V>")
+  call setline(1, [' 1', ' 2', ' 3'])
+  exe "norm! \<C-V>jj\"ap"
+  let expected = ['À           1', 'ÀÀ          2', 'aaaaaaaaaaaa3']
+  call assert_equal(expected, getline(1, 3))
+  bw!
+endfunc
+
 func Test_put_char_block()
   new
   call setline(1, ['Line 1', 'Line 2'])


### PR DESCRIPTION
#### vim-patch:9.1.0054: 'linebreak' may still apply to leading whitespace

Problem:  'linebreak' may still apply to leading whitespace
          (VanaIgr)
Solution: Compare pointers instead of virtual columns.
          (zeertzjq)

related: #27180
closes: vim/vim#13915

https://github.com/vim/vim/commit/703f9bc943a29d947869b5cb0370be2ac42d5ac9

Co-authored-by: VanaIgr <vanaigranov@gmail.com>


#### vim-patch:9.1.0056: wrong number of trailing spaces inserted after blockwise put

Problem:  Incorrect number of trailing spaces inserted for multibyte
	  characters when pasting a blockwise register in blockwise visual
          mode (VanaIgr)
Solution: Skip over trailing UTF-8 bytes when computing the number of trailing
          spaces (VanaIgr)

When pasting in blockwise visual mode, and the register type is \<CTRL-V>, Vim
aligns the text after the replaced area by inserting spaces after pasted
lines that are shorter than the longest line. When a shorter line contains
multibyte characters, each trailing UTF-8 byte's width is counted in addition
to the width of the character itself. Each trailing byte counts as being 4
cells wide (since it would be displayed as \<xx>).

closes: vim/vim#13909

https://github.com/vim/vim/commit/6638ec8afa9875ff565020536954c424d5f6f27d

Co-authored-by: VanaIgr <vanaigranov@gmail.com>