### PR TITLE
fix(decor): check decor kind before accessing union field

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -629,9 +629,9 @@ next_mark:
       } else if (item.data.sh.flags & kSHSpellOff) {
         spell = kFalse;
       }
-    }
-    if (active && item.data.sh.url != NULL) {
-      attr = hl_add_url(attr, item.data.sh.url);
+      if (item.data.sh.url != NULL) {
+        attr = hl_add_url(attr, item.data.sh.url);
+      }
     }
     if (item.start_row == state->row && item.start_col <= col
         && decor_virt_pos(&item) && item.draw_col == -10) {


### PR DESCRIPTION
The data.sh.url field is valid only when item.kind is
kDecorKindHighlight. The `if` block just before this line already does
that check (as well as checking `active`) so move the access of
`data.sh.url` into that block.
