### PR TITLE
ci(release): fix broken link

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -48,7 +48,7 @@ https://github.com/neovim/neovim-releases.
 
 ### Other
 
-- Install by [package manager](https://github.com/neovim/neovim/wiki/Installing-Neovim)
+- Install by [package manager](https://github.com/neovim/neovim/blob/master/INSTALL.md#install-from-package)
 
 ## SHA256 Checksums
 


### PR DESCRIPTION
Change the link to point to INSTALL.md.

The contents were moved in https://github.com/neovim/neovim/pull/26533