### PR TITLE
feat(api): `nvim_open_tabpage`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3557,8 +3557,8 @@ nvim_open_tabpage({buffer}, {config})                    *nvim_open_tabpage()*
       • {config}  (`vim.api.keyset.tabpage_config`) Configuration for the new
                   tabpage. Keys:
                   • enter: Whether to enter the new tabpage (default: true)
-                  • after: Position to insert tabpage (default: 0). 0 = after
-                    current, 1 = first, N = before Nth.
+                  • after: Position to insert tabpage (default: -1; after
+                    current). 0 = first, N = after Nth.
 
     Return: ~
         (`integer`) Tabpage handle of the created tabpage

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3545,9 +3545,10 @@ nvim_set_option_value({name}, {value}, {opts})
 Tabpage Functions                                                *api-tabpage*
 
 nvim_open_tabpage({buffer}, {config})                    *nvim_open_tabpage()*
-    Opens a new tabpage
+    Opens a new tabpage.
 
     Attributes: ~
+        not allowed when |textlock| is active
         Since: 0.12.0
 
     Parameters: ~

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3544,7 +3544,7 @@ nvim_set_option_value({name}, {value}, {opts})
 ==============================================================================
 Tabpage Functions                                                *api-tabpage*
 
-nvim_open_tabpage({buffer}, {config})                    *nvim_open_tabpage()*
+nvim_open_tabpage({buffer}, {enter}, {config})           *nvim_open_tabpage()*
     Opens a new tabpage.
 
     Attributes: ~
@@ -3554,9 +3554,9 @@ nvim_open_tabpage({buffer}, {config})                    *nvim_open_tabpage()*
     Parameters: ~
       • {buffer}  (`integer`) Buffer to open in the first window of the new
                   tabpage. Use 0 for current buffer.
+      • {enter}   (`boolean`) Enter the tabpage (make it the current tabpage).
       • {config}  (`vim.api.keyset.tabpage_config`) Configuration for the new
                   tabpage. Keys:
-                  • enter: Whether to enter the new tabpage (default: true)
                   • after: Position to insert tabpage (default: -1; after
                     current). 0 = first, N = after Nth.
 

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3544,6 +3544,24 @@ nvim_set_option_value({name}, {value}, {opts})
 ==============================================================================
 Tabpage Functions                                                *api-tabpage*
 
+nvim_open_tabpage({buffer}, {config})                    *nvim_open_tabpage()*
+    Opens a new tabpage
+
+    Attributes: ~
+        Since: 0.12.0
+
+    Parameters: ~
+      • {buffer}  (`integer`) Buffer to open in the first window of the new
+                  tabpage. Use 0 for current buffer.
+      • {config}  (`vim.api.keyset.tabpage_config`) Configuration for the new
+                  tabpage. Keys:
+                  • enter: Whether to enter the new tabpage (default: true)
+                  • after: Position to insert tabpage (default: 0). 0 = after
+                    current, 1 = first, N = before Nth.
+
+    Return: ~
+        (`integer`) Tabpage handle of the created tabpage
+
 nvim_tabpage_del_var({tabpage}, {name})               *nvim_tabpage_del_var()*
     Removes a tab-scoped (t:) variable
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -165,6 +165,7 @@ API
 • |nvim_echo()| can create |Progress| messages
 • |nvim_get_commands()| returns `preview` and `callback` as Lua functions if
   they were so specified in `nvim_create_user_command()`.
+• |nvim_open_tabpage()| can open a new |tab-page|.
 • |nvim_open_win()| floating windows can show a 'statusline'. Plugins can use
   `style='minimal'` or `:setlocal statusline=` to hide the statusline.
 • |nvim_win_set_config()| can move windows to other tab pages as floats.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1673,6 +1673,17 @@ function vim.api.nvim_load_context(dict) end
 --- @return any
 function vim.api.nvim_notify(msg, log_level, opts) end
 
+--- Opens a new tabpage
+---
+--- @param buffer integer Buffer to open in the first window of the new tabpage.
+--- Use 0 for current buffer.
+--- @param config vim.api.keyset.tabpage_config Configuration for the new tabpage. Keys:
+--- - enter: Whether to enter the new tabpage (default: true)
+--- - after: Position to insert tabpage (default: 0).
+---          0 = after current, 1 = first, N = before Nth.
+--- @return integer # Tabpage handle of the created tabpage
+function vim.api.nvim_open_tabpage(buffer, config) end
+
 --- Open a terminal instance in a buffer
 ---
 --- By default (and currently the only option) the terminal will not be

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1677,12 +1677,12 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 ---
 --- @param buffer integer Buffer to open in the first window of the new tabpage.
 --- Use 0 for current buffer.
+--- @param enter boolean Enter the tabpage (make it the current tabpage).
 --- @param config vim.api.keyset.tabpage_config Configuration for the new tabpage. Keys:
---- - enter: Whether to enter the new tabpage (default: true)
 --- - after: Position to insert tabpage (default: -1; after current).
 ---          0 = first, N = after Nth.
 --- @return integer # Tabpage handle of the created tabpage
-function vim.api.nvim_open_tabpage(buffer, config) end
+function vim.api.nvim_open_tabpage(buffer, enter, config) end
 
 --- Open a terminal instance in a buffer
 ---

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1673,7 +1673,7 @@ function vim.api.nvim_load_context(dict) end
 --- @return any
 function vim.api.nvim_notify(msg, log_level, opts) end
 
---- Opens a new tabpage
+--- Opens a new tabpage.
 ---
 --- @param buffer integer Buffer to open in the first window of the new tabpage.
 --- Use 0 for current buffer.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1679,8 +1679,8 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- Use 0 for current buffer.
 --- @param config vim.api.keyset.tabpage_config Configuration for the new tabpage. Keys:
 --- - enter: Whether to enter the new tabpage (default: true)
---- - after: Position to insert tabpage (default: 0).
----          0 = after current, 1 = first, N = before Nth.
+--- - after: Position to insert tabpage (default: -1; after current).
+---          0 = first, N = after Nth.
 --- @return integer # Tabpage handle of the created tabpage
 function vim.api.nvim_open_tabpage(buffer, config) end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -437,6 +437,10 @@ error('Cannot require a meta file')
 --- @field scoped? boolean
 --- @field _subpriority? integer
 
+--- @class vim.api.keyset.tabpage_config
+--- @field enter? boolean
+--- @field after? integer
+
 --- @class vim.api.keyset.user_command
 --- @field addr? any
 --- @field bang? boolean

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -438,7 +438,6 @@ error('Cannot require a meta file')
 --- @field _subpriority? integer
 
 --- @class vim.api.keyset.tabpage_config
---- @field enter? boolean
 --- @field after? integer
 
 --- @class vim.api.keyset.user_command

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -144,7 +144,6 @@ typedef struct {
 
 typedef struct {
   OptionalKeys is_set__tabpage_config_;
-  Boolean enter;
   Integer after;
 } Dict(tabpage_config);
 

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -143,6 +143,12 @@ typedef struct {
 } Dict(win_config);
 
 typedef struct {
+  OptionalKeys is_set__tabpage_config_;
+  Boolean enter;
+  Integer after;
+} Dict(tabpage_config);
+
+typedef struct {
   Boolean is_lua;
   Boolean do_source;
 } Dict(runtime);

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -1,11 +1,15 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "nvim/api/keysets_defs.h"
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/tabpage.h"
 #include "nvim/api/vim.h"
+#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
+#include "nvim/errors.h"
 #include "nvim/globals.h"
 #include "nvim/memory_defs.h"
 #include "nvim/types_defs.h"
@@ -182,4 +186,93 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
   Boolean ret = find_tab_by_handle(tabpage, &stub) != NULL;
   api_clear_error(&stub);
   return ret;
+}
+
+/// Opens a new tabpage
+///
+/// @param buffer Buffer to open in the first window of the new tabpage.
+///               Use 0 for current buffer.
+/// @param config Configuration for the new tabpage. Keys:
+///   - enter: Whether to enter the new tabpage (default: true)
+///   - after: Position to insert tabpage (default: 0).
+///            0 = after current, 1 = first, N = before Nth.
+/// @param[out] err Error details, if any
+/// @return Tabpage handle of the created tabpage
+Tabpage nvim_open_tabpage(Buffer buffer, Dict(tabpage_config) *config, Error *err)
+  FUNC_API_SINCE(14)
+{
+#define HAS_KEY_X(d, key) HAS_KEY(d, tabpage_config, key)
+
+  // Validate and get the buffer
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (buf == NULL) {
+    return 0;
+  }
+
+  if (buf == cmdwin_buf) {
+    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+    return 0;
+  }
+
+  bool enter = true;  // Default to entering the new tabpage
+  if (HAS_KEY_X(config, enter)) {
+    enter = config->enter;
+  }
+
+  int after = 0;  // Default to after current tabpage
+  if (HAS_KEY_X(config, after)) {
+    after = (int)config->after;
+
+    // Validate the after position
+    if (after < 0) {
+      api_set_error(err, kErrorTypeValidation, "Invalid 'after' position: %d", after);
+      return 0;
+    }
+
+    // Note: No validation for after > number of tabs since the underlying
+    // function handles this by appending at the end
+  }
+
+  tabpage_T *newtp;
+
+  if (enter) {
+    // Use the existing function if we want to enter the tabpage
+    if (win_new_tabpage(after, NULL) == OK) {
+      newtp = curtab;
+    } else {
+      api_set_error(err, kErrorTypeException, "Failed to create new tabpage");
+      return 0;
+    }
+  } else {
+    // Create tabpage without entering it
+    newtp = win_new_tabpage_noenter(after, err);
+    if (newtp == NULL) {
+      api_set_error(err, kErrorTypeException, "Failed to create new tabpage");
+      return 0;
+    }
+  }
+
+  // Set the buffer in the new window if different from current
+  if (newtp->tp_curwin->w_buffer != buf) {
+    TRY_WRAP(err, {
+      win_set_buf(newtp->tp_curwin, buf, err);
+    });
+    if (ERROR_SET(err)) {
+      return 0;
+    }
+  }
+
+  // Ensure tabpage wasn't immediately freed
+  if (find_tab_by_handle(newtp->handle, err) == NULL) {
+    api_clear_error(err);
+    api_set_error(err, kErrorTypeException, "Tabpage was closed immediately");
+    return 0;
+  }
+  if (!buf_valid(buf)) {
+    api_set_error(err, kErrorTypeException, "Buffer was deleted by autocmd");
+    return 0;
+  }
+
+  return newtp->handle;
+#undef HAS_KEY_X
 }

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -5,8 +5,10 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/private/validate.h"
 #include "nvim/api/tabpage.h"
 #include "nvim/api/vim.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/errors.h"
@@ -188,7 +190,7 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
   return ret;
 }
 
-/// Opens a new tabpage
+/// Opens a new tabpage.
 ///
 /// @param buffer Buffer to open in the first window of the new tabpage.
 ///               Use 0 for current buffer.
@@ -199,80 +201,70 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 /// @param[out] err Error details, if any
 /// @return Tabpage handle of the created tabpage
 Tabpage nvim_open_tabpage(Buffer buffer, Dict(tabpage_config) *config, Error *err)
-  FUNC_API_SINCE(14)
+  FUNC_API_SINCE(14) FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
 #define HAS_KEY_X(d, key) HAS_KEY(d, tabpage_config, key)
-
-  // Validate and get the buffer
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (buf == NULL) {
     return 0;
   }
 
-  if (buf == cmdwin_buf) {
-    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
-    return 0;
-  }
-
-  bool enter = true;  // Default to entering the new tabpage
+  bool enter = true;
   if (HAS_KEY_X(config, enter)) {
     enter = config->enter;
+  }
+  if ((cmdwin_type != 0 && enter) || buf == cmdwin_buf) {
+    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+    return 0;
   }
 
   int after = 0;  // Default to after current tabpage
   if (HAS_KEY_X(config, after)) {
     after = (int)config->after;
-
-    // Validate the after position
-    if (after < 0) {
-      api_set_error(err, kErrorTypeValidation, "Invalid 'after' position: %d", after);
+    VALIDATE_INT(after >= 0, "after", config->after, {
       return 0;
-    }
-
-    // Note: No validation for after > number of tabs since the underlying
-    // function handles this by appending at the end
-  }
-
-  tabpage_T *newtp;
-
-  if (enter) {
-    // Use the existing function if we want to enter the tabpage
-    if (win_new_tabpage(after, NULL) == OK) {
-      newtp = curtab;
-    } else {
-      api_set_error(err, kErrorTypeException, "Failed to create new tabpage");
-      return 0;
-    }
-  } else {
-    // Create tabpage without entering it
-    newtp = win_new_tabpage_noenter(after, err);
-    if (newtp == NULL) {
-      api_set_error(err, kErrorTypeException, "Failed to create new tabpage");
-      return 0;
-    }
-  }
-
-  // Set the buffer in the new window if different from current
-  if (newtp->tp_curwin->w_buffer != buf) {
-    TRY_WRAP(err, {
-      win_set_buf(newtp->tp_curwin, buf, err);
     });
-    if (ERROR_SET(err)) {
-      return 0;
-    }
+    // NOTE: win_new_tabpage will handle after > count by appending to the end.
   }
 
-  // Ensure tabpage wasn't immediately freed
-  if (find_tab_by_handle(newtp->handle, err) == NULL) {
-    api_clear_error(err);
+  tabpage_T *tp;
+  win_T *wp;
+  TRY_WRAP(err, {
+    tp = win_new_tabpage(after, NULL, enter, &wp);
+  });
+  if (!tp) {
+    if (!ERROR_SET(err)) {  // set error maybe more specific
+      api_set_error(err, kErrorTypeException, "Failed to create new tabpage");
+    }
+    return 0;
+  }
+  if (!valid_tabpage(tp)) {
+    api_clear_error(err);  // maybe set by win_new_tabpage, but wasn't fatal
     api_set_error(err, kErrorTypeException, "Tabpage was closed immediately");
     return 0;
   }
-  if (!buf_valid(buf)) {
-    api_set_error(err, kErrorTypeException, "Buffer was deleted by autocmd");
-    return 0;
+
+  // Set the buffer in the new window if different from current
+  if (tabpage_win_valid(tp, wp) && wp->w_buffer != buf) {
+    // win_set_buf temporarily makes `wp` the curwin to set the buffer.
+    // If not entering `wp`, block Enter and Leave events. (cringe)
+    const bool au_no_enter_leave = curwin != wp;
+    if (au_no_enter_leave) {
+      autocmd_no_enter++;
+      autocmd_no_leave++;
+    }
+    win_set_buf(wp, buf, err);
+    if (au_no_enter_leave) {
+      autocmd_no_enter--;
+      autocmd_no_leave--;
+    }
+    if (!valid_tabpage(tp)) {
+      api_clear_error(err);  // maybe set by win_new_tabpage/win_set_buf, but wasn't fatal
+      api_set_error(err, kErrorTypeException, "Tabpage was closed immediately");
+      return 0;
+    }
   }
 
-  return newtp->handle;
+  return tp->handle;
 #undef HAS_KEY_X
 }

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -5,7 +5,6 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
-#include "nvim/api/private/validate.h"
 #include "nvim/api/tabpage.h"
 #include "nvim/api/vim.h"
 #include "nvim/autocmd.h"
@@ -196,8 +195,8 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 ///               Use 0 for current buffer.
 /// @param config Configuration for the new tabpage. Keys:
 ///   - enter: Whether to enter the new tabpage (default: true)
-///   - after: Position to insert tabpage (default: 0).
-///            0 = after current, 1 = first, N = before Nth.
+///   - after: Position to insert tabpage (default: -1; after current).
+///            0 = first, N = after Nth.
 /// @param[out] err Error details, if any
 /// @return Tabpage handle of the created tabpage
 Tabpage nvim_open_tabpage(Buffer buffer, Dict(tabpage_config) *config, Error *err)
@@ -218,19 +217,15 @@ Tabpage nvim_open_tabpage(Buffer buffer, Dict(tabpage_config) *config, Error *er
     return 0;
   }
 
-  int after = 0;  // Default to after current tabpage
+  int after = -1;  // Default to after current tabpage
   if (HAS_KEY_X(config, after)) {
     after = (int)config->after;
-    VALIDATE_INT(after >= 0, "after", config->after, {
-      return 0;
-    });
-    // NOTE: win_new_tabpage will handle after > count by appending to the end.
   }
 
   tabpage_T *tp;
   win_T *wp;
   TRY_WRAP(err, {
-    tp = win_new_tabpage(after, NULL, enter, &wp);
+    tp = win_new_tabpage(after + 1, NULL, enter, &wp);
   });
   if (!tp) {
     if (!ERROR_SET(err)) {  // set error maybe more specific

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -193,24 +193,19 @@ Boolean nvim_tabpage_is_valid(Tabpage tabpage)
 ///
 /// @param buffer Buffer to open in the first window of the new tabpage.
 ///               Use 0 for current buffer.
+/// @param enter  Enter the tabpage (make it the current tabpage).
 /// @param config Configuration for the new tabpage. Keys:
-///   - enter: Whether to enter the new tabpage (default: true)
 ///   - after: Position to insert tabpage (default: -1; after current).
 ///            0 = first, N = after Nth.
 /// @param[out] err Error details, if any
 /// @return Tabpage handle of the created tabpage
-Tabpage nvim_open_tabpage(Buffer buffer, Dict(tabpage_config) *config, Error *err)
+Tabpage nvim_open_tabpage(Buffer buffer, Boolean enter, Dict(tabpage_config) *config, Error *err)
   FUNC_API_SINCE(14) FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
 #define HAS_KEY_X(d, key) HAS_KEY(d, tabpage_config, key)
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (buf == NULL) {
     return 0;
-  }
-
-  bool enter = true;
-  if (HAS_KEY_X(config, enter)) {
-    enter = config->enter;
   }
   if ((cmdwin_type != 0 && enter) || buf == cmdwin_buf) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);

--- a/src/nvim/api/tabpage.h
+++ b/src/nvim/api/tabpage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
 #include "api/tabpage.h.generated.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5646,7 +5646,7 @@ void ex_splitview(exarg_T *eap)
   // Either open new tab page or split the window.
   if (use_tab) {
     if (win_new_tabpage(cmdmod.cmod_tab != 0 ? cmdmod.cmod_tab : eap->addr_count == 0
-                        ? 0 : (int)eap->line2 + 1, eap->arg) != FAIL) {
+                        ? 0 : (int)eap->line2 + 1, eap->arg, true, NULL)) {
       do_exedit(eap, old_curwin);
       apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7827,3 +7827,89 @@ win_T *lastwin_nofloating(tabpage_T *tp)
   }
   return res;
 }
+
+/// Create a new tabpage without switching to it.
+/// @param after Position in tabpage list (0 = after current, 1 = first)
+/// @param[out] err Error details, if any
+/// @return Handle of the created tabpage, or NULL on failure
+tabpage_T *win_new_tabpage_noenter(int after, Error *err)
+{
+  tabpage_T *old_curtab = curtab;
+
+  if (cmdwin_type != 0) {
+    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+    return NULL;
+  }
+
+  tabpage_T *newtp = alloc_tabpage();
+  if (newtp == NULL) {
+    api_set_error(err, kErrorTypeException, "Failed to allocate new tabpage");
+    return NULL;
+  }
+
+  // Remember the current windows in this Tab page.
+  if (leave_tabpage(curbuf, true) == FAIL) {
+    xfree(newtp);
+    api_set_error(err, kErrorTypeException, "Failed to leave current tabpage");
+    return NULL;
+  }
+
+  // Copy localdir from current tabpage
+  newtp->tp_localdir = old_curtab->tp_localdir ? xstrdup(old_curtab->tp_localdir) : NULL;
+
+  // Switch to new tabpage to set it up
+  curtab = newtp;
+
+  // Create the initial window in the new tabpage
+  if (win_alloc_firstwin(old_curtab->tp_curwin) == OK) {
+    // Insert the new tabpage in the correct position
+    if (after == 1) {
+      // New tab page becomes the first one
+      newtp->tp_next = first_tabpage;
+      first_tabpage = newtp;
+    } else {
+      tabpage_T *tp = old_curtab;
+      if (after > 0) {
+        // Put new tab page before tab page "after"
+        int n = 2;
+        for (tp = first_tabpage; tp->tp_next != NULL && n < after; tp = tp->tp_next) {
+          n++;
+        }
+      }
+      newtp->tp_next = tp->tp_next;
+      tp->tp_next = newtp;
+    }
+
+    // Set up the tabpage structure properly
+    newtp->tp_firstwin = newtp->tp_lastwin = newtp->tp_curwin = curwin;
+    win_init_size();
+    firstwin->w_winrow = tabline_height();
+    firstwin->w_prev_winrow = firstwin->w_winrow;
+    win_comp_scroll(curwin);
+    newtp->tp_topframe = topframe;
+    last_status(false);
+
+    if (curbuf->terminal) {
+      terminal_check_size(curbuf->terminal);
+    }
+
+    redraw_all_later(UPD_NOT_VALID);
+    tabpage_check_windows(old_curtab);
+    lastused_tabpage = old_curtab;
+
+    // Fire autocmds for new window and tabpage
+    entering_window(curwin);
+    apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
+    apply_autocmds(EVENT_TABNEW, NULL, NULL, false, curbuf);
+
+    // Now switch back to the original tabpage
+    enter_tabpage(old_curtab, curbuf, true, true);
+
+    return newtp;
+  }
+
+  // Failed, get back the previous Tab page
+  enter_tabpage(old_curtab, curbuf, true, true);
+  api_set_error(err, kErrorTypeException, "Failed to create window in new tabpage");
+  return NULL;
+}

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -494,8 +494,7 @@ newwindow:
       // First create a new tab with the window, then go back to
       // the old tab and close the window there.
       win_T *wp = curwin;
-      if (win_new_tabpage(Prenum, NULL) == OK
-          && valid_tabpage(oldtab)) {
+      if (win_new_tabpage(Prenum, NULL, true, NULL) && valid_tabpage(oldtab)) {
         tabpage_T *newtab = curtab;
         goto_tabpage_tp(oldtab, true, true);
         if (curwin == wp) {
@@ -4471,28 +4470,41 @@ void free_tabpage(tabpage_T *tp)
 /// are not completely setup yet and could cause dereferencing
 /// NULL pointers
 ///
+/// NOTE: `first` and the return value may have already been freed by autocmds!
+///
 /// @param after Put new tabpage after tabpage "after", or after the current
 ///              tabpage in case of 0.
 /// @param filename Will be passed to apply_autocmds().
-/// @return Was the new tabpage created successfully? FAIL or OK.
-int win_new_tabpage(int after, char *filename)
+/// @param enter Whether to enter the new tabpage.
+/// @param first If not NULL, set to the window opened for the new tabpage.
+/// @return pointer to new tabpage on success, NULL otherwise.
+tabpage_T *win_new_tabpage(int after, char *filename, bool enter, win_T **first)
 {
   tabpage_T *old_curtab = curtab;
 
-  if (cmdwin_type != 0) {
+  if (enter && cmdwin_type != 0) {
     emsg(_(e_cmdwin));
-    return FAIL;
+    return NULL;
   }
   if (window_layout_locked(CMD_tabnew)) {
-    return FAIL;
+    return NULL;
   }
 
   tabpage_T *newtp = alloc_tabpage();
 
   // Remember the current windows in this Tab page.
-  if (leave_tabpage(curbuf, true) == FAIL) {
-    xfree(newtp);
-    return FAIL;
+  // Avoid side-effects via unuse_tabpage when not entering.
+  if (enter) {
+    if (leave_tabpage(curbuf, true) == FAIL) {
+      xfree(newtp);
+      return NULL;
+    }
+  } else {
+    unuse_tabpage(curtab);
+    // Save this to tell if we need to make room for the tabline.
+    curtab->tp_old_Rows_avail = ROWS_AVAIL;
+    firstwin = NULL;
+    lastwin = NULL;
   }
 
   newtp->tp_localdir = old_curtab->tp_localdir
@@ -4501,59 +4513,79 @@ int win_new_tabpage(int after, char *filename)
   curtab = newtp;
 
   // Create a new empty window.
-  if (win_alloc_firstwin(old_curtab->tp_curwin) == OK) {
-    // Make the new Tab page the new topframe.
-    if (after == 1) {
-      // New tab page becomes the first one.
-      newtp->tp_next = first_tabpage;
-      first_tabpage = newtp;
-    } else {
-      tabpage_T *tp = old_curtab;
+  const int result = win_alloc_firstwin(old_curtab->tp_curwin);
+  assert(result == OK);  // does not fail for first window of new tabpage
+  (void)result;
+  if (first) {
+    *first = curwin;
+  }
 
-      if (after > 0) {
-        // Put new tab page before tab page "after".
-        int n = 2;
-        for (tp = first_tabpage; tp->tp_next != NULL
-             && n < after; tp = tp->tp_next) {
-          n++;
-        }
+  // Make the new Tab page the new topframe.
+  if (after == 1) {
+    // New tab page becomes the first one.
+    newtp->tp_next = first_tabpage;
+    first_tabpage = newtp;
+  } else {
+    tabpage_T *tp = old_curtab;
+
+    if (after > 0) {
+      // Put new tab page before tab page "after".
+      int n = 2;
+      for (tp = first_tabpage; tp->tp_next != NULL
+           && n < after; tp = tp->tp_next) {
+        n++;
       }
-      newtp->tp_next = tp->tp_next;
-      tp->tp_next = newtp;
     }
-    newtp->tp_firstwin = newtp->tp_lastwin = newtp->tp_curwin = curwin;
+    newtp->tp_next = tp->tp_next;
+    tp->tp_next = newtp;
+  }
+  newtp->tp_firstwin = newtp->tp_lastwin = newtp->tp_curwin = curwin;
 
-    win_init_size();
-    firstwin->w_winrow = tabline_height();
-    firstwin->w_prev_winrow = firstwin->w_winrow;
-    win_comp_scroll(curwin);
+  win_init_size();
+  firstwin->w_winrow = tabline_height();
+  firstwin->w_prev_winrow = firstwin->w_winrow;
+  win_comp_scroll(curwin);
 
-    newtp->tp_topframe = topframe;
-    last_status(false);
+  newtp->tp_topframe = topframe;
+  last_status(false);
 
-    if (curbuf->terminal) {
-      terminal_check_size(curbuf->terminal);
-    }
+  if (curbuf->terminal) {
+    terminal_check_size(curbuf->terminal);
+  }
 
+  if (enter) {
     redraw_all_later(UPD_NOT_VALID);
-
     tabpage_check_windows(old_curtab);
-
     lastused_tabpage = old_curtab;
-
     entering_window(curwin);
 
     apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
     apply_autocmds(EVENT_WINENTER, NULL, NULL, false, curbuf);
     apply_autocmds(EVENT_TABNEW, filename, filename, false, curbuf);
     apply_autocmds(EVENT_TABENTER, NULL, NULL, false, curbuf);
+  } else {
+    unuse_tabpage(curtab);
+    use_tabpage(old_curtab);
+    // Tabline maybe added, or its contents changed.
+    redraw_tabline = true;
+    if (curtab->tp_old_Rows_avail != ROWS_AVAIL) {
+      win_new_screen_rows();
+    }
 
-    return OK;
+    // Trigger autocommands in the context of the new window. Let switch_win_noblock handle stuff
+    // like temporarily resetting VIsual_active.
+    switchwin_T switchwin;
+    const int sw_result = switch_win_noblock(&switchwin, newtp->tp_curwin, newtp, true);
+    assert(sw_result == OK);  // tp_curwin is valid in newtp
+    (void)sw_result;
+
+    apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
+    apply_autocmds(EVENT_TABNEW, filename, filename, false, curbuf);
+
+    restore_win_noblock(&switchwin, true);
   }
 
-  // Failed, get back the previous Tab page
-  enter_tabpage(curtab, curbuf, true, true);
-  return FAIL;
+  return newtp;
 }
 
 // Open a new tab page if ":tab cmd" was used.  It will edit the same buffer,
@@ -4569,7 +4601,7 @@ static int may_open_tabpage(void)
 
   cmdmod.cmod_tab = 0;         // reset it to avoid doing it twice
   postponed_split_tab = 0;
-  int status = win_new_tabpage(n, NULL);
+  int status = win_new_tabpage(n, NULL, true, NULL) ? OK : FAIL;
   if (status == OK) {
     apply_autocmds(EVENT_TABNEWENTERED, NULL, NULL, false, curbuf);
   }
@@ -4591,7 +4623,7 @@ int make_tabpages(int maxcount)
 
   int todo;
   for (todo = count - 1; todo > 0; todo--) {
-    if (win_new_tabpage(0, NULL) == FAIL) {
+    if (!win_new_tabpage(0, NULL, true, NULL)) {
       break;
     }
   }
@@ -7826,90 +7858,4 @@ win_T *lastwin_nofloating(tabpage_T *tp)
     res = res->w_prev;
   }
   return res;
-}
-
-/// Create a new tabpage without switching to it.
-/// @param after Position in tabpage list (0 = after current, 1 = first)
-/// @param[out] err Error details, if any
-/// @return Handle of the created tabpage, or NULL on failure
-tabpage_T *win_new_tabpage_noenter(int after, Error *err)
-{
-  tabpage_T *old_curtab = curtab;
-
-  if (cmdwin_type != 0) {
-    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
-    return NULL;
-  }
-
-  tabpage_T *newtp = alloc_tabpage();
-  if (newtp == NULL) {
-    api_set_error(err, kErrorTypeException, "Failed to allocate new tabpage");
-    return NULL;
-  }
-
-  // Remember the current windows in this Tab page.
-  if (leave_tabpage(curbuf, true) == FAIL) {
-    xfree(newtp);
-    api_set_error(err, kErrorTypeException, "Failed to leave current tabpage");
-    return NULL;
-  }
-
-  // Copy localdir from current tabpage
-  newtp->tp_localdir = old_curtab->tp_localdir ? xstrdup(old_curtab->tp_localdir) : NULL;
-
-  // Switch to new tabpage to set it up
-  curtab = newtp;
-
-  // Create the initial window in the new tabpage
-  if (win_alloc_firstwin(old_curtab->tp_curwin) == OK) {
-    // Insert the new tabpage in the correct position
-    if (after == 1) {
-      // New tab page becomes the first one
-      newtp->tp_next = first_tabpage;
-      first_tabpage = newtp;
-    } else {
-      tabpage_T *tp = old_curtab;
-      if (after > 0) {
-        // Put new tab page before tab page "after"
-        int n = 2;
-        for (tp = first_tabpage; tp->tp_next != NULL && n < after; tp = tp->tp_next) {
-          n++;
-        }
-      }
-      newtp->tp_next = tp->tp_next;
-      tp->tp_next = newtp;
-    }
-
-    // Set up the tabpage structure properly
-    newtp->tp_firstwin = newtp->tp_lastwin = newtp->tp_curwin = curwin;
-    win_init_size();
-    firstwin->w_winrow = tabline_height();
-    firstwin->w_prev_winrow = firstwin->w_winrow;
-    win_comp_scroll(curwin);
-    newtp->tp_topframe = topframe;
-    last_status(false);
-
-    if (curbuf->terminal) {
-      terminal_check_size(curbuf->terminal);
-    }
-
-    redraw_all_later(UPD_NOT_VALID);
-    tabpage_check_windows(old_curtab);
-    lastused_tabpage = old_curtab;
-
-    // Fire autocmds for new window and tabpage
-    entering_window(curwin);
-    apply_autocmds(EVENT_WINNEW, NULL, NULL, false, curbuf);
-    apply_autocmds(EVENT_TABNEW, NULL, NULL, false, curbuf);
-
-    // Now switch back to the original tabpage
-    enter_tabpage(old_curtab, curbuf, true, true);
-
-    return newtp;
-  }
-
-  // Failed, get back the previous Tab page
-  enter_tabpage(old_curtab, curbuf, true, true);
-  api_set_error(err, kErrorTypeException, "Failed to create window in new tabpage");
-  return NULL;
 }

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -173,4 +173,306 @@ describe('api/tabpage', function()
       ok(not api.nvim_tabpage_is_valid(tab))
     end)
   end)
+
+  describe('open_tabpage', function()
+    it('works', function()
+      local tabs = api.nvim_list_tabpages()
+      eq(1, #tabs)
+      local curtab = api.nvim_get_current_tabpage()
+      local tab = api.nvim_open_tabpage(0, {
+        enter = false,
+      })
+      local newtabs = api.nvim_list_tabpages()
+      eq(2, #newtabs)
+      eq(tab, newtabs[2])
+      eq(curtab, api.nvim_get_current_tabpage())
+
+      local tab2 = api.nvim_open_tabpage(0, {
+        enter = true,
+      })
+      local newtabs2 = api.nvim_list_tabpages()
+      eq(3, #newtabs2)
+      eq({
+        tabs[1],
+        tab2, -- new tabs open after the current tab
+        tab,
+      }, newtabs2)
+      eq(tab2, newtabs2[2])
+      eq(tab, newtabs2[3])
+      eq(tab2, api.nvim_get_current_tabpage())
+    end)
+
+    it('respects the `after` option', function()
+      local tab1 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab2 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab3 = api.nvim_get_current_tabpage()
+
+      local newtabs = api.nvim_list_tabpages()
+      eq(3, #newtabs)
+      eq(newtabs, {
+        tab1,
+        tab2,
+        -- new_tab,
+        tab3,
+      })
+
+      local new_tab = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = api.nvim_tabpage_get_number(tab2),
+      })
+
+      local newtabs2 = api.nvim_list_tabpages()
+      eq(4, #newtabs2)
+      eq({
+        tab1,
+        new_tab,
+        tab2,
+        tab3,
+      }, newtabs2)
+      eq(api.nvim_get_current_tabpage(), tab3)
+    end)
+
+    it('respects the `enter` argument', function()
+      eq(1, #api.nvim_list_tabpages())
+      local tab1 = api.nvim_get_current_tabpage()
+
+      local new_tab = api.nvim_open_tabpage(0, {
+        enter = false,
+      })
+
+      local newtabs = api.nvim_list_tabpages()
+      eq(2, #newtabs)
+      eq(newtabs, {
+        tab1,
+        new_tab,
+      })
+      eq(api.nvim_get_current_tabpage(), tab1)
+
+      local new_tab2 = api.nvim_open_tabpage(0, {
+        enter = true,
+      })
+      local newtabs2 = api.nvim_list_tabpages()
+      eq(3, #newtabs2)
+      eq(newtabs2, {
+        tab1,
+        new_tab2,
+        new_tab,
+      })
+
+      eq(api.nvim_get_current_tabpage(), new_tab2)
+    end)
+
+    it('applies `enter` autocmds in the context of the new tabpage', function()
+      api.nvim_create_autocmd('TabEnter', {
+        command = 'let g:entered_tab = nvim_get_current_tabpage()',
+      })
+
+      local new_tab = api.nvim_open_tabpage(0, {
+        enter = true,
+      })
+
+      local entered_tab = assert(tonumber(api.nvim_get_var('entered_tab')))
+
+      eq(new_tab, entered_tab)
+    end)
+
+    it('handles edge cases for positioning', function()
+      -- Start with 3 tabs
+      local tab1 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab2 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab3 = api.nvim_get_current_tabpage()
+
+      local initial_tabs = api.nvim_list_tabpages()
+      eq(3, #initial_tabs)
+      eq({ tab1, tab2, tab3 }, initial_tabs)
+
+      -- Test after=1: should become first tab
+      local first_tab = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 1,
+      })
+      local tabs_after_first = api.nvim_list_tabpages()
+      eq(4, #tabs_after_first)
+      eq({ first_tab, tab1, tab2, tab3 }, tabs_after_first)
+
+      -- Test after=0: should insert after current tab (tab3)
+      local explicit_after_current = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 0,
+      })
+      local tabs_after_current = api.nvim_list_tabpages()
+      eq(5, #tabs_after_current)
+      eq({ first_tab, tab1, tab2, tab3, explicit_after_current }, tabs_after_current)
+
+      -- Test inserting before a middle tab (before tab2, which is now position 3)
+      local before_middle = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 3,
+      })
+      local tabs_after_middle = api.nvim_list_tabpages()
+      eq(6, #tabs_after_middle)
+      eq({ first_tab, tab1, before_middle, tab2, tab3, explicit_after_current }, tabs_after_middle)
+
+      eq(api.nvim_get_current_tabpage(), tab3)
+
+      -- Test default behavior (after current)
+      local default_after_current = api.nvim_open_tabpage(0, {
+        enter = false,
+      })
+      local final_tabs = api.nvim_list_tabpages()
+      eq(7, #final_tabs)
+      eq({
+        first_tab,
+        tab1,
+        before_middle,
+        tab2,
+        tab3,
+        default_after_current,
+        explicit_after_current,
+      }, final_tabs)
+    end)
+
+    it('handles position beyond last tab', function()
+      -- Create a few tabs first
+      local tab1 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab2 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab3 = api.nvim_get_current_tabpage()
+
+      eq(3, #api.nvim_list_tabpages())
+      eq({ tab1, tab2, tab3 }, api.nvim_list_tabpages())
+
+      -- Test that requesting position beyond last tab still works
+      -- (should place it at the end)
+      local new_tab = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 10, -- Way beyond the last tab
+      })
+
+      local final_tabs = api.nvim_list_tabpages()
+      eq(4, #final_tabs)
+      -- Should append at the end
+      eq({ tab1, tab2, tab3, new_tab }, final_tabs)
+    end)
+
+    it('works with specific buffer', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, false, { 'test content' })
+
+      local original_tab = api.nvim_get_current_tabpage()
+      local original_buf = api.nvim_get_current_buf()
+
+      local new_tab = api.nvim_open_tabpage(buf, {
+        enter = true, -- Enter the tab to make testing easier
+      })
+
+      -- Check that new tab has the specified buffer
+      eq(new_tab, api.nvim_get_current_tabpage())
+      eq(buf, api.nvim_get_current_buf())
+      eq({ 'test content' }, api.nvim_buf_get_lines(buf, 0, -1, false))
+
+      -- Switch back and check original tab still has original buffer
+      api.nvim_set_current_tabpage(original_tab)
+      eq(original_buf, api.nvim_get_current_buf())
+    end)
+
+    it('validates buffer parameter', function()
+      -- Test invalid buffer
+      eq('Invalid buffer id: 999', pcall_err(api.nvim_open_tabpage, 999, {}))
+    end)
+
+    it('works with current buffer (0)', function()
+      local current_buf = api.nvim_get_current_buf()
+
+      local new_tab = api.nvim_open_tabpage(0, {
+        enter = false,
+      })
+
+      api.nvim_set_current_tabpage(new_tab)
+      eq(current_buf, api.nvim_get_current_buf())
+    end)
+
+    it('handles complex positioning scenarios', function()
+      -- Create 5 tabs total
+      local tabs = { api.nvim_get_current_tabpage() }
+      for i = 2, 5 do
+        command('tabnew')
+        tabs[i] = api.nvim_get_current_tabpage()
+      end
+
+      eq(5, #api.nvim_list_tabpages())
+
+      -- Go to middle tab (tab 3)
+      api.nvim_set_current_tabpage(tabs[3])
+
+      -- Insert after=0 (after current, which is tab 3)
+      local new_after_current = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 0,
+      })
+
+      local result_tabs = api.nvim_list_tabpages()
+      eq(6, #result_tabs)
+      eq({
+        tabs[1],
+        tabs[2],
+        tabs[3],
+        new_after_current,
+        tabs[4],
+        tabs[5],
+      }, result_tabs)
+
+      -- Insert at position 2 (before tab2, which becomes new position 2)
+      local new_at_pos2 = api.nvim_open_tabpage(0, {
+        enter = false,
+        after = 2,
+      })
+
+      local final_result = api.nvim_list_tabpages()
+      eq(7, #final_result)
+      eq({
+        tabs[1],
+        new_at_pos2,
+        tabs[2],
+        tabs[3],
+        new_after_current,
+        tabs[4],
+        tabs[5],
+      }, final_result)
+    end)
+
+    it('preserves tab order when entering new tabs', function()
+      local tab1 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local tab2 = api.nvim_get_current_tabpage()
+
+      -- Create new tab with enter=true, should insert after current (tab2)
+      local tab3 = api.nvim_open_tabpage(0, {
+        enter = true,
+        after = 0,
+      })
+
+      local tabs = api.nvim_list_tabpages()
+      eq(3, #tabs)
+      eq({ tab1, tab2, tab3 }, tabs)
+      eq(tab3, api.nvim_get_current_tabpage())
+
+      -- Create another with enter=true and specific position
+      api.nvim_set_current_tabpage(tab1)
+      local tab4 = api.nvim_open_tabpage(0, {
+        enter = true,
+        after = 1, -- Should become first tab
+      })
+
+      local final_tabs = api.nvim_list_tabpages()
+      eq(4, #final_tabs)
+      eq({ tab4, tab1, tab2, tab3 }, final_tabs)
+      eq(tab4, api.nvim_get_current_tabpage())
+    end)
+  end)
 end)

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -94,18 +94,18 @@ describe('api/tabpage', function()
     end)
 
     it('checks textlock, cmdwin restrictions', function()
-      command('autocmd TextYankPost * ++once call nvim_open_tabpage(0, #{enter: 0})')
+      command('autocmd TextYankPost * ++once call nvim_open_tabpage(0, 0, {})')
       matches('E565:', pcall_err(command, 'yank'))
       eq(1, fn.tabpagenr('$'))
 
       local other_buf = api.nvim_get_current_buf()
       feed('q:')
       -- OK when not entering and not opening a tabpage with the cmdwin's buffer.
-      matches('E11:', pcall_err(api.nvim_open_tabpage, 0, { enter = false }))
+      matches('E11:', pcall_err(api.nvim_open_tabpage, 0, false, {}))
       eq(1, fn.tabpagenr('$'))
-      matches('E11:', pcall_err(api.nvim_open_tabpage, other_buf, { enter = true }))
+      matches('E11:', pcall_err(api.nvim_open_tabpage, other_buf, true, {}))
       eq(1, fn.tabpagenr('$'))
-      local tp = api.nvim_open_tabpage(other_buf, { enter = false })
+      local tp = api.nvim_open_tabpage(other_buf, false, {})
       eq(other_buf, api.nvim_win_get_buf(api.nvim_tabpage_get_win(tp)))
       eq('command', fn.win_gettype())
     end)
@@ -198,13 +198,13 @@ describe('api/tabpage', function()
       local tabs = api.nvim_list_tabpages()
       eq(1, #tabs)
       local curtab = api.nvim_get_current_tabpage()
-      local tab = api.nvim_open_tabpage(0, { enter = false })
+      local tab = api.nvim_open_tabpage(0, false, {})
       local newtabs = api.nvim_list_tabpages()
       eq(2, #newtabs)
       eq(tab, newtabs[2])
       eq(curtab, api.nvim_get_current_tabpage())
 
-      local tab2 = api.nvim_open_tabpage(0, { enter = true })
+      local tab2 = api.nvim_open_tabpage(0, true, {})
       local newtabs2 = api.nvim_list_tabpages()
       eq(3, #newtabs2)
       eq({
@@ -233,11 +233,7 @@ describe('api/tabpage', function()
         tab3,
       })
 
-      local new_tab = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = api.nvim_tabpage_get_number(tab2),
-      })
-
+      local new_tab = api.nvim_open_tabpage(0, false, { after = api.nvim_tabpage_get_number(tab2) })
       local newtabs2 = api.nvim_list_tabpages()
       eq(4, #newtabs2)
       eq({
@@ -254,7 +250,7 @@ describe('api/tabpage', function()
       eq(1, #api.nvim_list_tabpages())
       local tab1 = api.nvim_get_current_tabpage()
 
-      local new_tab = api.nvim_open_tabpage(0, { enter = false })
+      local new_tab = api.nvim_open_tabpage(0, false, {})
       local newtabs = api.nvim_list_tabpages()
       eq(2, #newtabs)
       eq(newtabs, { tab1, new_tab })
@@ -267,7 +263,7 @@ describe('api/tabpage', function()
                                                           |
       ]])
 
-      local new_tab2 = api.nvim_open_tabpage(0, { enter = true })
+      local new_tab2 = api.nvim_open_tabpage(0, true, {})
       local newtabs2 = api.nvim_list_tabpages()
       eq(3, #newtabs2)
       eq(newtabs2, { tab1, new_tab2, new_tab })
@@ -280,7 +276,7 @@ describe('api/tabpage', function()
                                                           |
       ]])
 
-      api.nvim_open_tabpage(0, { enter = false })
+      api.nvim_open_tabpage(0, false, {})
       -- Tabline redrawn when not entering, and when there's already one.
       screen:expect([[
         {24: [No Name] }{5: [No Name] }{24: [No Name]  [No Name] }{2:     }{24:X}|
@@ -302,7 +298,7 @@ describe('api/tabpage', function()
         autocmd BufWinEnter * let g:events += [['BufWinEnter', nvim_get_current_tabpage(), win_getid()]]
       ]=])
 
-      local new_tab = api.nvim_open_tabpage(0, { enter = true })
+      local new_tab = api.nvim_open_tabpage(0, true, {})
       local new_win = api.nvim_tabpage_get_win(new_tab)
       eq({
         { 'WinNew', new_tab, new_win },
@@ -313,7 +309,7 @@ describe('api/tabpage', function()
       eq(new_win, api.nvim_get_current_win())
 
       api.nvim_set_var('events', {})
-      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), { enter = true })
+      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), true, {})
       new_win = api.nvim_tabpage_get_win(new_tab)
       eq({
         { 'WinNew', new_tab, new_win },
@@ -327,7 +323,7 @@ describe('api/tabpage', function()
 
       local curwin = new_win
       api.nvim_set_var('events', {})
-      new_tab = api.nvim_open_tabpage(0, { enter = false })
+      new_tab = api.nvim_open_tabpage(0, false, {})
       new_win = api.nvim_tabpage_get_win(new_tab)
       eq(
         { { 'WinNew', new_tab, new_win }, { 'TabNew', new_tab, new_win } },
@@ -336,7 +332,7 @@ describe('api/tabpage', function()
       eq(curwin, api.nvim_get_current_win())
 
       api.nvim_set_var('events', {})
-      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), { enter = false })
+      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), false, {})
       new_win = api.nvim_tabpage_get_win(new_tab)
       eq({
         { 'WinNew', new_tab, new_win },
@@ -347,18 +343,18 @@ describe('api/tabpage', function()
     end)
 
     it('handles nasty autocmds', function()
-      command('autocmd WinNewPre * ++once call nvim_open_tabpage(0, #{enter: 0})')
+      command('autocmd WinNewPre * ++once call nvim_open_tabpage(0, 0, {})')
       matches('E1312:', pcall_err(command, 'split'))
 
       command('autocmd TabNew * ++once quit')
-      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, 0, { enter = false }))
+      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, 0, false, {}))
       command('autocmd BufEnter * ++once quit')
       local buf = api.nvim_create_buf(true, true)
-      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, buf, { enter = true }))
+      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, buf, true, {}))
 
       -- No error if autocmds delete target buffer, if new tabpage is still valid to return.
       command('autocmd BufEnter * ++once buffer # | bwipeout! #')
-      local new_tp = api.nvim_open_tabpage(buf, { enter = true })
+      local new_tp = api.nvim_open_tabpage(buf, true, {})
       eq(false, api.nvim_buf_is_valid(buf))
       eq(new_tp, api.nvim_get_current_tabpage())
     end)
@@ -376,19 +372,19 @@ describe('api/tabpage', function()
       eq({ tab1, tab2, tab3 }, initial_tabs)
 
       -- Test after=0: should become first tab
-      local first_tab = api.nvim_open_tabpage(0, { enter = false, after = 0 })
+      local first_tab = api.nvim_open_tabpage(0, false, { after = 0 })
       local tabs_after_first = api.nvim_list_tabpages()
       eq(4, #tabs_after_first)
       eq({ first_tab, tab1, tab2, tab3 }, tabs_after_first)
 
       -- Test after=-1: should insert after current tab (tab3)
-      local explicit_after_current = api.nvim_open_tabpage(0, { enter = false, after = -1 })
+      local explicit_after_current = api.nvim_open_tabpage(0, false, { after = -1 })
       local tabs_after_current = api.nvim_list_tabpages()
       eq(5, #tabs_after_current)
       eq({ first_tab, tab1, tab2, tab3, explicit_after_current }, tabs_after_current)
 
       -- Test inserting before a middle tab (before tab2, which is now number 3)
-      local before_middle = api.nvim_open_tabpage(0, { enter = false, after = 2 })
+      local before_middle = api.nvim_open_tabpage(0, false, { after = 2 })
       local tabs_after_middle = api.nvim_list_tabpages()
       eq(6, #tabs_after_middle)
       eq({ first_tab, tab1, before_middle, tab2, tab3, explicit_after_current }, tabs_after_middle)
@@ -396,7 +392,7 @@ describe('api/tabpage', function()
       eq(api.nvim_get_current_tabpage(), tab3)
 
       -- Test default behavior (after current)
-      local default_after_current = api.nvim_open_tabpage(0, { enter = false })
+      local default_after_current = api.nvim_open_tabpage(0, false, {})
       local final_tabs = api.nvim_list_tabpages()
       eq(7, #final_tabs)
       eq({
@@ -423,11 +419,7 @@ describe('api/tabpage', function()
 
       -- Test that requesting position beyond last tab still works
       -- (should place it at the end)
-      local new_tab = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 10, -- Way beyond the last tab
-      })
-
+      local new_tab = api.nvim_open_tabpage(0, false, { after = 10 }) -- Way beyond the last tab
       local final_tabs = api.nvim_list_tabpages()
       eq(4, #final_tabs)
       -- Should append at the end
@@ -436,7 +428,7 @@ describe('api/tabpage', function()
 
     it('works with specific buffer', function()
       local curbuf = api.nvim_get_current_buf()
-      local new_tab = api.nvim_open_tabpage(0, { enter = false })
+      local new_tab = api.nvim_open_tabpage(0, false, {})
       api.nvim_set_current_tabpage(new_tab)
       eq(curbuf, api.nvim_get_current_buf())
 
@@ -445,9 +437,7 @@ describe('api/tabpage', function()
 
       local original_tab = api.nvim_get_current_tabpage()
       local original_buf = api.nvim_get_current_buf()
-      new_tab = api.nvim_open_tabpage(buf, {
-        enter = true, -- Enter the tab to make testing easier
-      })
+      new_tab = api.nvim_open_tabpage(buf, true, {}) -- Enter the tab to make testing easier
 
       -- Check that new tab has the specified buffer
       eq(new_tab, api.nvim_get_current_tabpage())
@@ -459,7 +449,7 @@ describe('api/tabpage', function()
       eq(original_buf, api.nvim_get_current_buf())
 
       -- Test invalid buffer
-      eq('Invalid buffer id: 999', pcall_err(api.nvim_open_tabpage, 999, {}))
+      eq('Invalid buffer id: 999', pcall_err(api.nvim_open_tabpage, 999, true, {}))
     end)
 
     it('handles complex positioning scenarios', function()
@@ -475,7 +465,7 @@ describe('api/tabpage', function()
       api.nvim_set_current_tabpage(tabs[3])
 
       -- Insert after=0 (after current, which is tab 3)
-      local new_after_current = api.nvim_open_tabpage(0, { enter = false })
+      local new_after_current = api.nvim_open_tabpage(0, false, {})
       local result_tabs = api.nvim_list_tabpages()
       eq(6, #result_tabs)
       eq({
@@ -488,7 +478,7 @@ describe('api/tabpage', function()
       }, result_tabs)
 
       -- Insert as number 2 (before tab2, which will become number 3)
-      local new_at_pos2 = api.nvim_open_tabpage(0, { enter = false, after = 1 })
+      local new_at_pos2 = api.nvim_open_tabpage(0, false, { after = 1 })
       local final_result = api.nvim_list_tabpages()
       eq(7, #final_result)
       eq({
@@ -508,11 +498,7 @@ describe('api/tabpage', function()
       local tab2 = api.nvim_get_current_tabpage()
 
       -- Create new tab with enter=true, should insert after current (tab2)
-      local tab3 = api.nvim_open_tabpage(0, {
-        enter = true,
-        after = -1,
-      })
-
+      local tab3 = api.nvim_open_tabpage(0, true, { after = -1 })
       local tabs = api.nvim_list_tabpages()
       eq(3, #tabs)
       eq({ tab1, tab2, tab3 }, tabs)
@@ -520,11 +506,7 @@ describe('api/tabpage', function()
 
       -- Create another with enter=true and specific position
       api.nvim_set_current_tabpage(tab1)
-      local tab4 = api.nvim_open_tabpage(0, {
-        enter = true,
-        after = 0, -- Should become first tab
-      })
-
+      local tab4 = api.nvim_open_tabpage(0, true, { after = 0 }) -- Should become first tab
       local final_tabs = api.nvim_list_tabpages()
       eq(4, #final_tabs)
       eq({ tab4, tab1, tab2, tab3 }, final_tabs)

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -1,7 +1,9 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local clear, eq, ok = n.clear, t.eq, t.ok
+local matches = t.matches
 local exec = n.exec
 local feed = n.feed
 local api = n.api
@@ -89,6 +91,23 @@ describe('api/tabpage', function()
         string.format('Window does not belong to tabpage %d', tab1),
         pcall_err(api.nvim_tabpage_set_win, tab1, win3)
       )
+    end)
+
+    it('checks textlock, cmdwin restrictions', function()
+      command('autocmd TextYankPost * ++once call nvim_open_tabpage(0, #{enter: 0})')
+      matches('E565:', pcall_err(command, 'yank'))
+      eq(1, fn.tabpagenr('$'))
+
+      local other_buf = api.nvim_get_current_buf()
+      feed('q:')
+      -- OK when not entering and not opening a tabpage with the cmdwin's buffer.
+      matches('E11:', pcall_err(api.nvim_open_tabpage, 0, { enter = false }))
+      eq(1, fn.tabpagenr('$'))
+      matches('E11:', pcall_err(api.nvim_open_tabpage, other_buf, { enter = true }))
+      eq(1, fn.tabpagenr('$'))
+      local tp = api.nvim_open_tabpage(other_buf, { enter = false })
+      eq(other_buf, api.nvim_win_get_buf(api.nvim_tabpage_get_win(tp)))
+      eq('command', fn.win_gettype())
     end)
 
     it('does not switch window when textlocked or in the cmdwin', function()
@@ -179,17 +198,13 @@ describe('api/tabpage', function()
       local tabs = api.nvim_list_tabpages()
       eq(1, #tabs)
       local curtab = api.nvim_get_current_tabpage()
-      local tab = api.nvim_open_tabpage(0, {
-        enter = false,
-      })
+      local tab = api.nvim_open_tabpage(0, { enter = false })
       local newtabs = api.nvim_list_tabpages()
       eq(2, #newtabs)
       eq(tab, newtabs[2])
       eq(curtab, api.nvim_get_current_tabpage())
 
-      local tab2 = api.nvim_open_tabpage(0, {
-        enter = true,
-      })
+      local tab2 = api.nvim_open_tabpage(0, { enter = true })
       local newtabs2 = api.nvim_list_tabpages()
       eq(3, #newtabs2)
       eq({
@@ -235,47 +250,117 @@ describe('api/tabpage', function()
     end)
 
     it('respects the `enter` argument', function()
+      local screen = Screen.new(50, 8)
       eq(1, #api.nvim_list_tabpages())
       local tab1 = api.nvim_get_current_tabpage()
 
-      local new_tab = api.nvim_open_tabpage(0, {
-        enter = false,
-      })
-
+      local new_tab = api.nvim_open_tabpage(0, { enter = false })
       local newtabs = api.nvim_list_tabpages()
       eq(2, #newtabs)
-      eq(newtabs, {
-        tab1,
-        new_tab,
-      })
+      eq(newtabs, { tab1, new_tab })
       eq(api.nvim_get_current_tabpage(), tab1)
+      -- Tabline redrawn when not entering.
+      screen:expect([[
+        {5: [No Name] }{24: [No Name] }{2:                           }{24:X}|
+        ^                                                  |
+        {1:~                                                 }|*5
+                                                          |
+      ]])
 
-      local new_tab2 = api.nvim_open_tabpage(0, {
-        enter = true,
-      })
+      local new_tab2 = api.nvim_open_tabpage(0, { enter = true })
       local newtabs2 = api.nvim_list_tabpages()
       eq(3, #newtabs2)
-      eq(newtabs2, {
-        tab1,
-        new_tab2,
-        new_tab,
-      })
-
+      eq(newtabs2, { tab1, new_tab2, new_tab })
       eq(api.nvim_get_current_tabpage(), new_tab2)
+      -- Tabline redrawn. (when entering)
+      screen:expect([[
+        {24: [No Name] }{5: [No Name] }{24: [No Name] }{2:                }{24:X}|
+        ^                                                  |
+        {1:~                                                 }|*5
+                                                          |
+      ]])
+
+      api.nvim_open_tabpage(0, { enter = false })
+      -- Tabline redrawn when not entering, and when there's already one.
+      screen:expect([[
+        {24: [No Name] }{5: [No Name] }{24: [No Name]  [No Name] }{2:     }{24:X}|
+        ^                                                  |
+        {1:~                                                 }|*5
+                                                          |
+      ]])
     end)
 
-    it('applies `enter` autocmds in the context of the new tabpage', function()
-      api.nvim_create_autocmd('TabEnter', {
-        command = 'let g:entered_tab = nvim_get_current_tabpage()',
-      })
+    it('applies autocmds in the context of the new tabpage', function()
+      exec([=[
+        let g:events = []
+        autocmd WinNew * let g:events += [['WinNew', nvim_get_current_tabpage(), win_getid()]]
+        autocmd WinEnter * let g:events += [['WinEnter', nvim_get_current_tabpage(), win_getid()]]
+        autocmd TabNew * let g:events += [['TabNew', nvim_get_current_tabpage(), win_getid()]]
+        autocmd TabEnter * let g:events += [['TabEnter', nvim_get_current_tabpage(), win_getid()]]
+        autocmd BufEnter * let g:events += [['BufEnter', nvim_get_current_tabpage(), win_getid()]]
+        autocmd BufLeave * let g:events += [['BufLeave', nvim_get_current_tabpage(), win_getid()]]
+        autocmd BufWinEnter * let g:events += [['BufWinEnter', nvim_get_current_tabpage(), win_getid()]]
+      ]=])
 
-      local new_tab = api.nvim_open_tabpage(0, {
-        enter = true,
-      })
+      local new_tab = api.nvim_open_tabpage(0, { enter = true })
+      local new_win = api.nvim_tabpage_get_win(new_tab)
+      eq({
+        { 'WinNew', new_tab, new_win },
+        { 'WinEnter', new_tab, new_win },
+        { 'TabNew', new_tab, new_win },
+        { 'TabEnter', new_tab, new_win },
+      }, api.nvim_get_var('events'))
+      eq(new_win, api.nvim_get_current_win())
 
-      local entered_tab = assert(tonumber(api.nvim_get_var('entered_tab')))
+      api.nvim_set_var('events', {})
+      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), { enter = true })
+      new_win = api.nvim_tabpage_get_win(new_tab)
+      eq({
+        { 'WinNew', new_tab, new_win },
+        { 'WinEnter', new_tab, new_win },
+        { 'TabNew', new_tab, new_win },
+        { 'TabEnter', new_tab, new_win },
+        { 'BufLeave', new_tab, new_win },
+        { 'BufEnter', new_tab, new_win },
+        { 'BufWinEnter', new_tab, new_win },
+      }, api.nvim_get_var('events'))
 
-      eq(new_tab, entered_tab)
+      local curwin = new_win
+      api.nvim_set_var('events', {})
+      new_tab = api.nvim_open_tabpage(0, { enter = false })
+      new_win = api.nvim_tabpage_get_win(new_tab)
+      eq(
+        { { 'WinNew', new_tab, new_win }, { 'TabNew', new_tab, new_win } },
+        api.nvim_get_var('events')
+      )
+      eq(curwin, api.nvim_get_current_win())
+
+      api.nvim_set_var('events', {})
+      new_tab = api.nvim_open_tabpage(api.nvim_create_buf(true, true), { enter = false })
+      new_win = api.nvim_tabpage_get_win(new_tab)
+      eq({
+        { 'WinNew', new_tab, new_win },
+        { 'TabNew', new_tab, new_win },
+        { 'BufWinEnter', new_tab, new_win },
+      }, api.nvim_get_var('events'))
+      eq(curwin, api.nvim_get_current_win())
+    end)
+
+    it('handles nasty autocmds', function()
+      command('autocmd WinNewPre * ++once call nvim_open_tabpage(0, #{enter: 0})')
+      matches('E1312:', pcall_err(command, 'split'))
+
+      command('autocmd TabNew * ++once quit')
+      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, 0, { enter = false }))
+      command('autocmd BufEnter * ++once quit')
+      local buf = api.nvim_create_buf(true, true)
+      eq('Tabpage was closed immediately', pcall_err(api.nvim_open_tabpage, buf, { enter = true }))
+
+      -- No error if autocmds delete target buffer, if new tabpage is still valid to return.
+      command('autocmd BufEnter * ++once buffer # | bwipeout! #')
+      local new_tp = api.nvim_open_tabpage(buf, { enter = true })
+      eq(false, api.nvim_buf_is_valid(buf))
+      eq(new_tp, api.nvim_get_current_tabpage())
     end)
 
     it('handles edge cases for positioning', function()
@@ -291,28 +376,19 @@ describe('api/tabpage', function()
       eq({ tab1, tab2, tab3 }, initial_tabs)
 
       -- Test after=1: should become first tab
-      local first_tab = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 1,
-      })
+      local first_tab = api.nvim_open_tabpage(0, { enter = false, after = 1 })
       local tabs_after_first = api.nvim_list_tabpages()
       eq(4, #tabs_after_first)
       eq({ first_tab, tab1, tab2, tab3 }, tabs_after_first)
 
       -- Test after=0: should insert after current tab (tab3)
-      local explicit_after_current = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 0,
-      })
+      local explicit_after_current = api.nvim_open_tabpage(0, { enter = false, after = 0 })
       local tabs_after_current = api.nvim_list_tabpages()
       eq(5, #tabs_after_current)
       eq({ first_tab, tab1, tab2, tab3, explicit_after_current }, tabs_after_current)
 
       -- Test inserting before a middle tab (before tab2, which is now position 3)
-      local before_middle = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 3,
-      })
+      local before_middle = api.nvim_open_tabpage(0, { enter = false, after = 3 })
       local tabs_after_middle = api.nvim_list_tabpages()
       eq(6, #tabs_after_middle)
       eq({ first_tab, tab1, before_middle, tab2, tab3, explicit_after_current }, tabs_after_middle)
@@ -320,9 +396,7 @@ describe('api/tabpage', function()
       eq(api.nvim_get_current_tabpage(), tab3)
 
       -- Test default behavior (after current)
-      local default_after_current = api.nvim_open_tabpage(0, {
-        enter = false,
-      })
+      local default_after_current = api.nvim_open_tabpage(0, { enter = false })
       local final_tabs = api.nvim_list_tabpages()
       eq(7, #final_tabs)
       eq({
@@ -334,6 +408,8 @@ describe('api/tabpage', function()
         default_after_current,
         explicit_after_current,
       }, final_tabs)
+
+      eq("Invalid 'after': -1", pcall_err(api.nvim_open_tabpage, 0, { after = -1 }))
     end)
 
     it('handles position beyond last tab', function()
@@ -361,13 +437,17 @@ describe('api/tabpage', function()
     end)
 
     it('works with specific buffer', function()
+      local curbuf = api.nvim_get_current_buf()
+      local new_tab = api.nvim_open_tabpage(0, { enter = false })
+      api.nvim_set_current_tabpage(new_tab)
+      eq(curbuf, api.nvim_get_current_buf())
+
       local buf = api.nvim_create_buf(false, false)
       api.nvim_buf_set_lines(buf, 0, -1, false, { 'test content' })
 
       local original_tab = api.nvim_get_current_tabpage()
       local original_buf = api.nvim_get_current_buf()
-
-      local new_tab = api.nvim_open_tabpage(buf, {
+      new_tab = api.nvim_open_tabpage(buf, {
         enter = true, -- Enter the tab to make testing easier
       })
 
@@ -379,22 +459,9 @@ describe('api/tabpage', function()
       -- Switch back and check original tab still has original buffer
       api.nvim_set_current_tabpage(original_tab)
       eq(original_buf, api.nvim_get_current_buf())
-    end)
 
-    it('validates buffer parameter', function()
       -- Test invalid buffer
       eq('Invalid buffer id: 999', pcall_err(api.nvim_open_tabpage, 999, {}))
-    end)
-
-    it('works with current buffer (0)', function()
-      local current_buf = api.nvim_get_current_buf()
-
-      local new_tab = api.nvim_open_tabpage(0, {
-        enter = false,
-      })
-
-      api.nvim_set_current_tabpage(new_tab)
-      eq(current_buf, api.nvim_get_current_buf())
     end)
 
     it('handles complex positioning scenarios', function()
@@ -404,18 +471,13 @@ describe('api/tabpage', function()
         command('tabnew')
         tabs[i] = api.nvim_get_current_tabpage()
       end
-
       eq(5, #api.nvim_list_tabpages())
 
       -- Go to middle tab (tab 3)
       api.nvim_set_current_tabpage(tabs[3])
 
       -- Insert after=0 (after current, which is tab 3)
-      local new_after_current = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 0,
-      })
-
+      local new_after_current = api.nvim_open_tabpage(0, { enter = false, after = 0 })
       local result_tabs = api.nvim_list_tabpages()
       eq(6, #result_tabs)
       eq({
@@ -428,11 +490,7 @@ describe('api/tabpage', function()
       }, result_tabs)
 
       -- Insert at position 2 (before tab2, which becomes new position 2)
-      local new_at_pos2 = api.nvim_open_tabpage(0, {
-        enter = false,
-        after = 2,
-      })
-
+      local new_at_pos2 = api.nvim_open_tabpage(0, { enter = false, after = 2 })
       local final_result = api.nvim_list_tabpages()
       eq(7, #final_result)
       eq({

--- a/test/functional/api/tabpage_spec.lua
+++ b/test/functional/api/tabpage_spec.lua
@@ -242,8 +242,8 @@ describe('api/tabpage', function()
       eq(4, #newtabs2)
       eq({
         tab1,
-        new_tab,
         tab2,
+        new_tab,
         tab3,
       }, newtabs2)
       eq(api.nvim_get_current_tabpage(), tab3)
@@ -375,20 +375,20 @@ describe('api/tabpage', function()
       eq(3, #initial_tabs)
       eq({ tab1, tab2, tab3 }, initial_tabs)
 
-      -- Test after=1: should become first tab
-      local first_tab = api.nvim_open_tabpage(0, { enter = false, after = 1 })
+      -- Test after=0: should become first tab
+      local first_tab = api.nvim_open_tabpage(0, { enter = false, after = 0 })
       local tabs_after_first = api.nvim_list_tabpages()
       eq(4, #tabs_after_first)
       eq({ first_tab, tab1, tab2, tab3 }, tabs_after_first)
 
-      -- Test after=0: should insert after current tab (tab3)
-      local explicit_after_current = api.nvim_open_tabpage(0, { enter = false, after = 0 })
+      -- Test after=-1: should insert after current tab (tab3)
+      local explicit_after_current = api.nvim_open_tabpage(0, { enter = false, after = -1 })
       local tabs_after_current = api.nvim_list_tabpages()
       eq(5, #tabs_after_current)
       eq({ first_tab, tab1, tab2, tab3, explicit_after_current }, tabs_after_current)
 
-      -- Test inserting before a middle tab (before tab2, which is now position 3)
-      local before_middle = api.nvim_open_tabpage(0, { enter = false, after = 3 })
+      -- Test inserting before a middle tab (before tab2, which is now number 3)
+      local before_middle = api.nvim_open_tabpage(0, { enter = false, after = 2 })
       local tabs_after_middle = api.nvim_list_tabpages()
       eq(6, #tabs_after_middle)
       eq({ first_tab, tab1, before_middle, tab2, tab3, explicit_after_current }, tabs_after_middle)
@@ -408,8 +408,6 @@ describe('api/tabpage', function()
         default_after_current,
         explicit_after_current,
       }, final_tabs)
-
-      eq("Invalid 'after': -1", pcall_err(api.nvim_open_tabpage, 0, { after = -1 }))
     end)
 
     it('handles position beyond last tab', function()
@@ -477,7 +475,7 @@ describe('api/tabpage', function()
       api.nvim_set_current_tabpage(tabs[3])
 
       -- Insert after=0 (after current, which is tab 3)
-      local new_after_current = api.nvim_open_tabpage(0, { enter = false, after = 0 })
+      local new_after_current = api.nvim_open_tabpage(0, { enter = false })
       local result_tabs = api.nvim_list_tabpages()
       eq(6, #result_tabs)
       eq({
@@ -489,8 +487,8 @@ describe('api/tabpage', function()
         tabs[5],
       }, result_tabs)
 
-      -- Insert at position 2 (before tab2, which becomes new position 2)
-      local new_at_pos2 = api.nvim_open_tabpage(0, { enter = false, after = 2 })
+      -- Insert as number 2 (before tab2, which will become number 3)
+      local new_at_pos2 = api.nvim_open_tabpage(0, { enter = false, after = 1 })
       local final_result = api.nvim_list_tabpages()
       eq(7, #final_result)
       eq({
@@ -512,7 +510,7 @@ describe('api/tabpage', function()
       -- Create new tab with enter=true, should insert after current (tab2)
       local tab3 = api.nvim_open_tabpage(0, {
         enter = true,
-        after = 0,
+        after = -1,
       })
 
       local tabs = api.nvim_list_tabpages()
@@ -524,7 +522,7 @@ describe('api/tabpage', function()
       api.nvim_set_current_tabpage(tab1)
       local tab4 = api.nvim_open_tabpage(0, {
         enter = true,
-        after = 1, -- Should become first tab
+        after = 0, -- Should become first tab
       })
 
       local final_tabs = api.nvim_list_tabpages()


### PR DESCRIPTION
## Problem
No programmatic interface (analogous to `nvim_open_win`) to open a new tabpage.

[use-cases](https://github.com/neovim/neovim/pull/27223#issuecomment-1963275909)

* `:tab sb bufnr` -> `nvim_open_tabpage(bufnr)`
* `:tabedit nvim_buf_get_name(bufnr)` -> `nvim_open_tabpage(bufnr)`
* `:tabedit new_name` -> `nvim_open_tabpage(fn.bufadd(new_name))`

## Solution
- Introduce `nvim_open_tabpage`. Benefits: 
    1. it returns the tabpage-id (unlke `:tabnew`)
    2. the `enter` parameter (similar to `nvim_open_win`)

fix https://github.com/neovim/neovim/issues/32893