### PR TITLE
docs(lua): update ":{range}lua" docs + error message

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -255,10 +255,13 @@ arguments separated by " " (space) instead of "\t" (tab).
         :lua =jit.version
 <
 :{range}lua
-    Executes the |[range]| in the current buffer as Lua code. Unlike |:source|,
-    this will execute the specified lines regardless of the extension or
-    |'filetype'| of the buffer.
+    Executes buffer lines in {range} as Lua code. Unlike |:source|, this
+    always treats the lines as Lua code.
 
+    Example: select the following code and type ":lua<Enter>" to execute it: >lua
+        print(string.format(
+            'unix time: %s', os.time()))
+<
                                                                 *:lua-heredoc*
 :lua << [trim] [{endmarker}]
 {script}
@@ -271,10 +274,8 @@ arguments separated by " " (space) instead of "\t" (tab).
         function! CurrentLineInfo()
         lua << EOF
         local linenr = vim.api.nvim_win_get_cursor(0)[1]
-        local curline = vim.api.nvim_buf_get_lines(
-                0, linenr - 1, linenr, false)[1]
-        print(string.format("Current line [%d] has %d bytes",
-                linenr, #curline))
+        local curline = vim.api.nvim_buf_get_lines(0, linenr - 1, linenr, false)[1]
+        print(string.format('Line [%d] has %d bytes', linenr, #curline))
         EOF
         endfunction
 <

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -192,11 +192,11 @@ Using Vim scripts					*using-scripts*
 For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 
 					*:so* *:source* *load-vim-script*
-:[range]so[urce] [file]	Runs |Ex| commands or Lua code (".lua" files) from
+:[range]so[urce] [file]	Runs |Ex-commands| or Lua code (".lua" files) from
 			[file].
-			If no [file], the current buffer is used, and it is
-			treated as Lua code if its 'filetype' is "lua" or its
-			file name ends with ".lua".
+			If no [file], the current buffer is used and treated
+			as Lua code if 'filetype' is "lua" or its filename
+			ends with ".lua".
 			Triggers the |SourcePre| autocommand.
 							*:source!*
 :[range]so[urce]! {file}

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2014,7 +2014,7 @@ void cmd_source_buffer(const exarg_T *const eap, bool ex_lua)
   };
   if (ex_lua || strequal(curbuf->b_p_ft, "lua")
       || (curbuf->b_fname && path_with_extension(curbuf->b_fname, "lua"))) {
-    char *name = ex_lua ? ":lua (no file)" : ":source (no file)";
+    char *name = ex_lua ? ":{range}lua" : ":source (no file)";
     nlua_source_using_linegetter(get_str_line, (void *)&cookie, name);
   } else {
     source_using_linegetter((void *)&cookie, get_str_line, ":source (no file)");


### PR DESCRIPTION
(minor followup to https://github.com/neovim/neovim/pull/27167 )

- `:lua (no file)` is misleading because `:lua` never takes a file arg, unlike `:source`.
- Update various related docs.