### PR TITLE
vim-patch:0cc6108fea21

### DIFF
--- a/runtime/syntax/ant.vim
+++ b/runtime/syntax/ant.vim
@@ -1,9 +1,9 @@
 " Vim syntax file
-" Language:	ANT build file (xml)
-" Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:	Tue Apr 27 13:05:59 CEST 2004
-" Filenames:	build.xml
-" $Id: ant.vim,v 1.1 2004/06/13 18:13:18 vimboss Exp $
+" Language:		ANT build file (xml)
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
+" Last Change:		2024 Jan 27
+" Filenames:		build.xml
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -44,48 +44,48 @@ call AntSyntaxScript('jpython', 'python.vim')
 
 syn cluster xmlTagHook add=antElement
 
-syn keyword antElement display WsdlToDotnet addfiles and ant antcall antstructure apply archives arg argument
-syn keyword antElement display assertions attrib attribute available basename bcc blgenclient bootclasspath
-syn keyword antElement display borland bottom buildnumber buildpath buildpathelement bunzip2 bzip2 cab
-syn keyword antElement display catalogpath cc cccheckin cccheckout cclock ccmcheckin ccmcheckintask ccmcheckout
-syn keyword antElement display ccmcreatetask ccmkattr ccmkbl ccmkdir ccmkelem ccmklabel ccmklbtype
-syn keyword antElement display ccmreconfigure ccrmtype ccuncheckout ccunlock ccupdate checksum chgrp chmod
-syn keyword antElement display chown classconstants classes classfileset classpath commandline comment
-syn keyword antElement display compilerarg compilerclasspath concat concatfilter condition copy copydir
-syn keyword antElement display copyfile coveragepath csc custom cvs cvschangelog cvspass cvstagdiff cvsversion
-syn keyword antElement display daemons date defaultexcludes define delete deletecharacters deltree depend
-syn keyword antElement display depends dependset depth description different dirname dirset disable dname
-syn keyword antElement display doclet doctitle dtd ear echo echoproperties ejbjar element enable entity entry
-syn keyword antElement display env equals escapeunicode exclude excludepackage excludesfile exec execon
-syn keyword antElement display existing expandproperties extdirs extension extensionSet extensionset factory
-syn keyword antElement display fail filelist filename filepath fileset filesmatch filetokenizer filter
-syn keyword antElement display filterchain filterreader filters filterset filtersfile fixcrlf footer format
-syn keyword antElement display from ftp generic genkey get gjdoc grant group gunzip gzip header headfilter http
-syn keyword antElement display ignoreblank ilasm ildasm import importtypelib include includesfile input iplanet
-syn keyword antElement display iplanet-ejbc isfalse isreference isset istrue jar jarlib-available
-syn keyword antElement display jarlib-manifest jarlib-resolve java javac javacc javadoc javadoc2 jboss jdepend
-syn keyword antElement display jjdoc jjtree jlink jonas jpcoverage jpcovmerge jpcovreport jsharpc jspc
-syn keyword antElement display junitreport jvmarg lib libfileset linetokenizer link loadfile loadproperties
-syn keyword antElement display location macrodef mail majority manifest map mapper marker mergefiles message
-syn keyword antElement display metainf method mimemail mkdir mmetrics modified move mparse none not options or
-syn keyword antElement display os outputproperty package packageset parallel param patch path pathconvert
-syn keyword antElement display pathelement patternset permissions prefixlines present presetdef project
-syn keyword antElement display property propertyfile propertyref propertyset pvcs pvcsproject record reference
-syn keyword antElement display regexp rename renameext replace replacefilter replaceregex replaceregexp
-syn keyword antElement display replacestring replacetoken replacetokens replacevalue replyto report resource
-syn keyword antElement display revoke rmic root rootfileset rpm scp section selector sequential serverdeploy
-syn keyword antElement display setproxy signjar size sleep socket soscheckin soscheckout sosget soslabel source
-syn keyword antElement display sourcepath sql src srcfile srcfilelist srcfiles srcfileset sshexec stcheckin
-syn keyword antElement display stcheckout stlabel stlist stringtokenizer stripjavacomments striplinebreaks
-syn keyword antElement display striplinecomments style subant substitution support symlink sync sysproperty
-syn keyword antElement display syspropertyset tabstospaces tag taglet tailfilter tar tarfileset target
-syn keyword antElement display targetfile targetfilelist targetfileset taskdef tempfile test testlet text title
-syn keyword antElement display to token tokenfilter touch transaction translate triggers trim tstamp type
-syn keyword antElement display typedef unjar untar unwar unzip uptodate url user vbc vssadd vsscheckin
-syn keyword antElement display vsscheckout vsscp vsscreate vssget vsshistory vsslabel waitfor war wasclasspath
-syn keyword antElement display webapp webinf weblogic weblogictoplink websphere whichresource wlclasspath
-syn keyword antElement display wljspc wsdltodotnet xmlcatalog xmlproperty xmlvalidate xslt zip zipfileset
-syn keyword antElement display zipgroupfileset
+syn keyword antElement WsdlToDotnet addfiles and ant antcall antstructure apply archives arg argument
+syn keyword antElement assertions attrib attribute available basename bcc blgenclient bootclasspath
+syn keyword antElement borland bottom buildnumber buildpath buildpathelement bunzip2 bzip2 cab
+syn keyword antElement catalogpath cc cccheckin cccheckout cclock ccmcheckin ccmcheckintask ccmcheckout
+syn keyword antElement ccmcreatetask ccmkattr ccmkbl ccmkdir ccmkelem ccmklabel ccmklbtype
+syn keyword antElement ccmreconfigure ccrmtype ccuncheckout ccunlock ccupdate checksum chgrp chmod
+syn keyword antElement chown classconstants classes classfileset classpath commandline comment
+syn keyword antElement compilerarg compilerclasspath concat concatfilter condition copy copydir
+syn keyword antElement copyfile coveragepath csc custom cvs cvschangelog cvspass cvstagdiff cvsversion
+syn keyword antElement daemons date defaultexcludes define delete deletecharacters deltree depend
+syn keyword antElement depends dependset depth description different dirname dirset disable dname
+syn keyword antElement doclet doctitle dtd ear echo echoproperties ejbjar element enable entity entry
+syn keyword antElement env equals escapeunicode exclude excludepackage excludesfile exec execon
+syn keyword antElement existing expandproperties extdirs extension extensionSet extensionset factory
+syn keyword antElement fail filelist filename filepath fileset filesmatch filetokenizer filter
+syn keyword antElement filterchain filterreader filters filterset filtersfile fixcrlf footer format
+syn keyword antElement from ftp generic genkey get gjdoc grant group gunzip gzip header headfilter http
+syn keyword antElement ignoreblank ilasm ildasm import importtypelib include includesfile input iplanet
+syn keyword antElement iplanet-ejbc isfalse isreference isset istrue jar jarlib-available
+syn keyword antElement jarlib-manifest jarlib-resolve java javac javacc javadoc javadoc2 jboss jdepend
+syn keyword antElement jjdoc jjtree jlink jonas jpcoverage jpcovmerge jpcovreport jsharpc jspc
+syn keyword antElement junitreport jvmarg lib libfileset linetokenizer link loadfile loadproperties
+syn keyword antElement location macrodef mail majority manifest map mapper marker mergefiles message
+syn keyword antElement metainf method mimemail mkdir mmetrics modified move mparse none not options or
+syn keyword antElement os outputproperty package packageset parallel param patch path pathconvert
+syn keyword antElement pathelement patternset permissions prefixlines present presetdef project
+syn keyword antElement property propertyfile propertyref propertyset pvcs pvcsproject record reference
+syn keyword antElement regexp rename renameext replace replacefilter replaceregex replaceregexp
+syn keyword antElement replacestring replacetoken replacetokens replacevalue replyto report resource
+syn keyword antElement revoke rmic root rootfileset rpm scp section selector sequential serverdeploy
+syn keyword antElement setproxy signjar size sleep socket soscheckin soscheckout sosget soslabel source
+syn keyword antElement sourcepath sql src srcfile srcfilelist srcfiles srcfileset sshexec stcheckin
+syn keyword antElement stcheckout stlabel stlist stringtokenizer stripjavacomments striplinebreaks
+syn keyword antElement striplinecomments style subant substitution support symlink sync sysproperty
+syn keyword antElement syspropertyset tabstospaces tag taglet tailfilter tar tarfileset target
+syn keyword antElement targetfile targetfilelist targetfileset taskdef tempfile test testlet text title
+syn keyword antElement to token tokenfilter touch transaction translate triggers trim tstamp type
+syn keyword antElement typedef unjar untar unwar unzip uptodate url user vbc vssadd vsscheckin
+syn keyword antElement vsscheckout vsscp vsscreate vssget vsshistory vsslabel waitfor war wasclasspath
+syn keyword antElement webapp webinf weblogic weblogictoplink websphere whichresource wlclasspath
+syn keyword antElement wljspc wsdltodotnet xmlcatalog xmlproperty xmlvalidate xslt zip zipfileset
+syn keyword antElement zipgroupfileset
 
 hi def link antElement Statement
 


### PR DESCRIPTION
runtime(ant): Update syntax file (vim/vim#13926)

Remove invalid display option from syn-keyword commands.

Take over maintenance of this file.

https://github.com/vim/vim/commit/0cc6108fea216f597e38d1a88463fa6f28aded61

Co-authored-by: dkearns <dougkearns@gmail.com>
