### PR TITLE
fix: make indentation independent of window options

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -372,6 +372,18 @@ CharSize charsize_fast(CharsizeArg *csarg, colnr_T const vcol, int32_t const cur
   return charsize_fast_impl(csarg->win, csarg->use_tabstop, vcol, cur_char);
 }
 
+/// Get the number of cells taken up on the screen at given virtual column.
+int charsize_nowrap(buf_T *buf, bool use_tabstop, colnr_T vcol, int32_t cur_char)
+{
+  if (cur_char == TAB && use_tabstop) {
+    return tabstop_padding(vcol, buf->b_p_ts, buf->b_p_vts_array);
+  } else if (cur_char < 0) {
+    return kInvalidByteCells;
+  } else {
+    return char2cells(cur_char);
+  }
+}
+
 /// Check that virtual column "vcol" is in the rightmost column of window "wp".
 ///
 /// @param  wp    window

--- a/test/functional/editor/indent_spec.lua
+++ b/test/functional/editor/indent_spec.lua
@@ -1,0 +1,268 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed = helpers.clear, helpers.feed
+local api = helpers.api
+local feed_command = helpers.feed_command
+
+local function set_lines(line_b, line_e, ...)
+  api.nvim_buf_set_lines(0, line_b, line_e, true, { ... })
+end
+
+local function setup(width, height)
+  clear()
+  local screen = Screen.new(width, height + 1)
+  screen:attach()
+  feed_command('setl listchars=space:.,tab:>- list')
+  return screen
+end
+
+describe("i_Tab with 'sw' not equal to 'ts'", function()
+  it('works with mixed tabs and spaces', function()
+    local screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    set_lines(0, 1, '\t\t\t\t' .. (' '):rep(19) .. 'a')
+    feed('^i<Tab>')
+    screen:expect([[
+      >---->---->---->---->---->---->---->----^a         |
+      -- INSERT --                                      |
+    ]])
+
+    screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    set_lines(0, 1, '\t' .. (' '):rep(4) .. '\t' .. (' '):rep(9) .. '\t' .. (' '):rep(8) .. 'a')
+    feed('^6hi<Tab>')
+    screen:expect([[
+      >---->---->---->---->---->---->---->----^......a   |
+      -- INSERT --                                      |
+    ]])
+  end)
+
+  -- no effect, since listchars contains tab
+  it("works with 'cpoptions=L'", function()
+    local screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap cpoptions+=L')
+    set_lines(0, 1, '\t\t\t\t' .. (' '):rep(19) .. 'a')
+    feed('^i<Tab>')
+    screen:expect([[
+      >---->---->---->---->---->---->---->----^a         |
+      -- INSERT --                                      |
+    ]])
+
+    screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap cpoptions+=L')
+    set_lines(0, 1, '\t' .. (' '):rep(4) .. '\t' .. (' '):rep(9) .. '\t' .. (' '):rep(8) .. 'a')
+    feed('^6hi<Tab>')
+    screen:expect([[
+      >---->---->---->---->---->---->---->----^......a   |
+      -- INSERT --                                      |
+    ]])
+  end)
+
+  it("works with 'cpoptions=L' with tab as ^I", function()
+    local screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap cpoptions+=L listchars=space:.')
+    set_lines(0, 1, '\t\t\t\t\t\t\t\t' .. (' '):rep(5) .. 'a')
+    feed('^i<Tab>')
+    screen:expect([[
+      ^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^I^a         |
+      -- INSERT --                                      |
+    ]])
+
+    screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap cpoptions+=L listchars=space:.')
+    set_lines(0, 1, '\t' .. (' '):rep(1) .. '\t' .. (' '):rep(3) .. '\t' .. (' '):rep(4) .. 'a')
+    feed('^3hi<Tab>')
+    screen:expect([[
+      ^I^I^I^I^I^I^I^I^I^I^...a                          |
+      -- INSERT --                                      |
+    ]])
+  end)
+
+  it("works with 'cpoptions=L' with tab as <09>", function()
+    local screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    feed_command('setl display+=uhex cpoptions+=L listchars=space:.')
+    set_lines(0, 1, '\t\t\t\t' .. (' '):rep(5) .. 'a')
+    feed('^i<Tab>')
+    screen:expect([[
+      <09><09><09><09><09><09><09><09><09><09>^a         |
+      -- INSERT --                                      |
+    ]])
+
+    screen = setup(50, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    feed_command('setl display+=uhex cpoptions+=L listchars=space:.')
+    set_lines(0, 1, '\t' .. (' '):rep(3) .. '\t' .. (' '):rep(6) .. '\t' .. (' '):rep(7) .. 'a')
+    feed('^5hi<Tab>')
+    screen:expect([[
+      <09><09><09><09><09><09><09><09><09><09>^.....a    |
+      -- INSERT --                                      |
+    ]])
+  end)
+
+  it('works in replace mode', function()
+    local screen = setup(80, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    set_lines(0, 1, '\t' .. (' '):rep(4) .. '\t' .. (' '):rep(9) .. '\t' .. (' '):rep(8) .. 'a')
+    feed('^6hR<Tab><Tab>')
+    screen:expect([[
+      >----....>.........>..>-->---->---->---->---->---->---->----^....a               |
+      -- REPLACE --                                                                   |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      >----....>.........>..>-->---->---->----^.....a                                  |
+      -- REPLACE --                                                                   |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      >----....>.........>^........a                                                   |
+      -- REPLACE --                                                                   |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      ^>----....>.........>........a                                                   |
+      -- REPLACE --                                                                   |
+    ]])
+  end)
+
+  it('works in virtual replace mode', function()
+    local screen = setup(80, 1)
+    feed_command('setl ts=5 sw=20 nowrap')
+    set_lines(0, 1, '\t    \t         \t        ' .. ('a'):rep(20) .. ('b'):rep(20))
+    feed('^6hgR<Tab><Tab>')
+    screen:expect([[
+      >----....>.........>..>-->---->---->---->---->---->---->----^bbbbbbbb            |
+      -- VREPLACE --                                                                  |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      >----....>.........>..>-->---->---->----^aaaaaaaabbbbbbbbbbbbbbbbbbbb            |
+      -- VREPLACE --                                                                  |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      >----....>.........>^........aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb            |
+      -- VREPLACE --                                                                  |
+    ]])
+
+    feed('<BS>')
+    screen:expect([[
+      ^>----....>.........>........aaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbb            |
+      -- VREPLACE --                                                                  |
+    ]])
+  end)
+
+  it("works with 'bri'", function()
+    pending('skipped (not yet fixed)')
+
+    local screen = setup(20, 4)
+    feed_command('setl ts=5 sw=20 bri briopt=min:10')
+    set_lines(0, 1, '\t\t\t\t' .. (' '):rep(19) .. 'a')
+    feed('^i<Tab>')
+    screen:expect([[
+      >---->---->---->----|
+                >---->----|
+                >---->----|
+                ^a         |
+      -- INSERT --        |
+    ]])
+  end)
+end)
+
+describe('i_CTRL-T inside indentation', function()
+  it("works with 'noexpandtab'", function()
+    local screen = setup(30, 1)
+    feed_command('setl ts=3 sw=3 noexpandtab nowrap')
+    set_lines(0, 1, '\t\t' .. 'a')
+    feed('^hi<C-T>') -- last tab before first non-blank
+    screen:expect([[
+      >-->--^>--a                    |
+      -- INSERT --                  |
+    ]])
+  end)
+
+  it("works with 'noexpandtab' with spaces", function()
+    local screen = setup(30, 1)
+    feed_command('setl ts=5 sw=5 noexpandtab nowrap')
+    local s = (' '):rep(5)
+    local t = '\t'
+    set_lines(0, 1, t .. s .. t .. s .. '    a')
+    feed('^hhhi<C-T>')
+    -- inserts 2 spaces to make cursor 3 cells behind first non-blank
+    screen:expect([[
+      >---->---->---->----..^>--a    |
+      -- INSERT --                  |
+    ]])
+  end)
+
+  it("works with 'noexpandtab' and 'bri'", function()
+    pending('skipped (not yet fixed)')
+
+    local screen = setup(20, 3)
+    feed_command('setl ts=12 sw=12 noexpandtab wrap bri briopt=min:5')
+    local t = '\t'
+    set_lines(0, 1, t .. t .. 'a')
+    feed('^hi<C-T>')
+    screen:expect([[
+      >----------->-------|
+                     ----^>|
+                     -----|
+      -- INSERT --        |
+    ]])
+  end)
+
+  it('works with inline virtual text', function()
+    pending('skipped (not yet fixed)')
+
+    local screen = setup(70, 1)
+    feed_command('setl ts=10 sw=10 nowrap')
+    set_lines(0, 1, '\t\t\t\t' .. 'a')
+    local ns = api.nvim_create_namespace('')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {
+      virt_text = { { ('a'):rep(50) } },
+      virt_text_pos = 'inline',
+    })
+    feed('^hi<C-T>') -- last tab before first non-blank
+    screen:expect([[
+      --------->---------^>---------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      -- INSERT --                                                          |
+    ]])
+  end)
+end)
+
+describe('Shift right in visual block mode', function()
+  it('adds one tab', function()
+    local screen = setup(20, 4)
+    set_lines(0, 1, 'a\t\t\t\t' .. (' '):rep(20) .. 'a')
+    feed_command('setl ts=5 sw=5')
+    helpers.exec([=[execute "norm! 0l\<C-V>>"]=]) -- shift first tab
+    screen:expect([[
+      a^>--->---->---->----|
+      >---->---->---->----|
+      >----a              |
+      ~                   |
+      :setl ts=5 sw=5     |
+    ]])
+  end)
+
+  it("does not work with 'bri'", function()
+    local screen = setup(20, 4)
+    feed_command('setl ts=5 sw=5 bri briopt=min:10')
+    set_lines(0, 1, 'a\t\t\t\t' .. (' '):rep(20) .. 'a')
+    helpers.exec([=[execute "norm! 0l\<C-V>>"]=]) -- shift first tab
+    -- 'breakindent' should have had no effect, since the line starts with "a"
+    screen:expect([[
+      a^>--->---->---->----|
+      >---->---->---->----|
+      >---->---->---->----|
+      >----a              |
+                          |
+    ]])
+  end)
+end)

--- a/test/functional/editor/indent_spec.lua
+++ b/test/functional/editor/indent_spec.lua
@@ -202,8 +202,6 @@ describe('i_CTRL-T inside indentation', function()
   end)
 
   it("works with 'noexpandtab' and 'bri'", function()
-    pending('skipped (not yet fixed)')
-
     local screen = setup(20, 3)
     feed_command('setl ts=12 sw=12 noexpandtab wrap bri briopt=min:5')
     local t = '\t'
@@ -218,20 +216,18 @@ describe('i_CTRL-T inside indentation', function()
   end)
 
   it('works with inline virtual text', function()
-    pending('skipped (not yet fixed)')
-
-    local screen = setup(70, 1)
+    local screen = setup(80, 1)
     feed_command('setl ts=10 sw=10 nowrap')
     set_lines(0, 1, '\t\t\t\t' .. 'a')
     local ns = api.nvim_create_namespace('')
     api.nvim_buf_set_extmark(0, ns, 0, 0, {
-      virt_text = { { ('a'):rep(50) } },
+      virt_text = { { ('a'):rep(20) } },
       virt_text_pos = 'inline',
     })
     feed('^hi<C-T>') -- last tab before first non-blank
     screen:expect([[
-      --------->---------^>---------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      -- INSERT --                                                          |
+      >--------->--------->--------->---------^>---------aaaaaaaaaaaaaaaaaaaaa         |
+      -- INSERT --                                                                    |
     ]])
   end)
 end)

--- a/test/functional/editor/indent_spec.lua
+++ b/test/functional/editor/indent_spec.lua
@@ -159,8 +159,6 @@ describe("i_Tab with 'sw' not equal to 'ts'", function()
   end)
 
   it("works with 'bri'", function()
-    pending('skipped (not yet fixed)')
-
     local screen = setup(20, 4)
     feed_command('setl ts=5 sw=20 bri briopt=min:10')
     set_lines(0, 1, '\t\t\t\t' .. (' '):rep(19) .. 'a')


### PR DESCRIPTION
As a part of #27180, I looked through all the places that use `win_charsize()`, and found a few issues:

1. Tab in insert mode.
When `expandtab` is not set, pressing Tab in insert mode would replace spaces by tabs where possible. This is done by finding the start of the current sequence of whitespace characters, and replacing spaces by tabs until the current virtual column is greater than the cursor's virtual column.
This breaks if `breakindent` is on, since the difference between starting virtual column and cursor's virtual column includes the padding from `breakindent`, and it is not accounted for when the size of the new Tab is calculated.
(This only happens if `shiftwidth` is not equal to `tabstop`. `ins_tab()` [here](https://github.com/neovim/neovim/blob/47cd532bf15d81c913e2c29b4c9a14c3654f85d2/src/nvim/edit.c#L4351) uses `getvcol()` to compute starting vcol and cursor vcol, which uses correct `breakindent`, while tabs are measured on their own line, and different `breakindent` is calculated).    
2. i_CTRL-T.
`change_indent()` is called when pressing CTRL-T in insert mode, and when the cursor is inside the indentation, its position relative to the first non-blank character is preserved by adding spaces at the end. When inline virtual text is added before the cursor, its virtual column includes the width of the text. The loop that finds the column after which spaces should be added doesn't count virtual text ([edit.c:1692](https://github.com/neovim/neovim/blob/47cd532bf15d81c913e2c29b4c9a14c3654f85d2/src/nvim/edit.c#L1692)), and the position stops at the end of the line. After that, the difference between cursor virtual column  and current virtual column is calculated, and this number of spaces is appended to the current position (end of the line).
![image](https://github.com/neovim/neovim/assets/65824523/b9025360-343f-4b41-8eae-352b82248a0c)
![image](https://github.com/neovim/neovim/assets/65824523/44e3ef10-e603-41cc-811b-609b27606f9c)
3. '>' in visual block mode.
In [`shit_block()`](https://github.com/neovim/neovim/blob/47cd532bf15d81c913e2c29b4c9a14c3654f85d2/src/nvim/ops.c#L343), not the full line is used when calculating virtual column, which leads to `breakindent` applying when it shouldn't.


I think these functions should not compute 'breakindent' etc. in the first place, and use `win_chartabsize()` instead.