### PR TITLE
fix(health): "attempt to concatenate nil"

### DIFF
--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -23,9 +23,15 @@ local function check_runtime()
   health.start('Runtime')
   -- Files from an old installation.
   local bad_files = {
-    ['plugin/man.vim'] = false,
-    ['scripts.vim'] = false,
+    ['plugin/health.vim'] = false,
+    ['autoload/health/nvim.vim'] = false,
+    ['autoload/health/provider.vim'] = false,
     ['autoload/man.vim'] = false,
+    ['plugin/man.vim'] = false,
+    ['queries/help/highlights.scm'] = false,
+    ['queries/help/injections.scm'] = false,
+    ['scripts.vim'] = false,
+    ['syntax/syncolor.vim'] = false,
   }
   local bad_files_msg = ''
   for k, _ in pairs(bad_files) do
@@ -42,10 +48,10 @@ local function check_runtime()
   if not ok then
     health.error(
       string.format(
-        '$VIMRUNTIME has files from an old installation (this can cause weird behavior):\n%s',
+        'Found old files in $VIMRUNTIME (this can cause weird behavior):\n%s',
         bad_files_msg
       ),
-      { 'Delete $VIMRUNTIME (or uninstall Nvim), then reinstall Nvim.' }
+      { 'Delete the $VIMRUNTIME directory (or uninstall Nvim), then reinstall Nvim.' }
     )
   end
 end

--- a/runtime/lua/provider/python/health.lua
+++ b/runtime/lua/provider/python/health.lua
@@ -255,7 +255,7 @@ function M.check()
       'See :help provider-python for more information.',
       'You may disable this provider (and warning) by adding `let g:loaded_python3_provider = 0` to your init.vim',
     })
-  elseif pyname ~= '' and python_exe == '' then
+  elseif pyname and pyname ~= '' and python_exe == '' then
     if not vim.g[host_prog_var] then
       local message = string.format(
         '`g:%s` is not set. Searching for %s in the environment.',
@@ -343,7 +343,7 @@ function M.check()
     end
   end
 
-  if python_exe == '' and pyname ~= '' then
+  if pyname and python_exe == '' and pyname ~= '' then
     -- An error message should have already printed.
     health.error('`' .. pyname .. '` was not found.')
   elseif python_exe ~= '' and not check_bin(python_exe) then

--- a/runtime/lua/provider/ruby/health.lua
+++ b/runtime/lua/provider/ruby/health.lua
@@ -22,7 +22,7 @@ function M.check()
 
   local ruby_detect_table = require('vim.provider.ruby').detect()
   local host = ruby_detect_table[1]
-  if host:find('^%s*$') then
+  if (not host) or host:find('^%s*$') then
     health.warn('`neovim-ruby-host` not found.', {
       'Run `gem install neovim` to ensure the neovim RubyGem is installed.',
       'Run `gem environment` to ensure the gem bin directory is in $PATH.',


### PR DESCRIPTION
## Problem:
If `neovim` module is not installed, python and ruby healthchecks fail:

    - ERROR Failed to run healthcheck for "provider.python" plugin. Exception:
      .../runtime/lua/provider/python/health.lua:348: attempt to concatenate local 'pyname' (a nil value)
    - ERROR Failed to run healthcheck for "provider.ruby" plugin. Exception:
      .../runtime/lua/provider/ruby/health.lua:25: attempt to index local 'host' (a nil value)

## Solution:
Check for non-nil.