### PR TITLE
vim-patch:9.1.0060: Recorded register cannot be translated using keytrans()

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1146,10 +1146,10 @@ static void gotchars(const uint8_t *chars, size_t len)
   maptick++;
 }
 
-/// Record a <Nop> key.
-void gotchars_nop(void)
+/// Record an <Ignore> key.
+void gotchars_ignore(void)
 {
-  uint8_t nop_buf[3] = { K_SPECIAL, KS_EXTRA, KE_NOP };
+  uint8_t nop_buf[3] = { K_SPECIAL, KS_EXTRA, KE_IGNORE };
   gotchars(nop_buf, 3);
 }
 
@@ -2746,9 +2746,9 @@ static int vgetorpeek(bool advance)
   }
 
   if (timedout && c == ESC) {
-    // When recording there will be no timeout.  Add a <Nop> after the ESC
-    // to avoid that it forms a key code with following characters.
-    gotchars_nop();
+    // When recording there will be no timeout.  Add an <Ignore> after the
+    // ESC to avoid that it forms a key code with following characters.
+    gotchars_ignore();
   }
 
   vgetc_busy--;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -845,10 +845,10 @@ static void normal_get_additional_char(NormalState *s)
       no_mapping++;
       // Vim may be in a different mode when the user types the next key,
       // but when replaying a recording the next key is already in the
-      // typeahead buffer, so record a <Nop> before that to prevent the
-      // vpeekc() above from applying wrong mappings when replaying.
+      // typeahead buffer, so record an <Ignore> before that to prevent
+      // the vpeekc() above from applying wrong mappings when replaying.
       no_u_sync++;
-      gotchars_nop();
+      gotchars_ignore();
       no_u_sync--;
     }
   }

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -829,6 +829,8 @@ func Test_replay_charsearch_omap()
   call timer_start(10, {-> feedkeys(",bar\<Esc>q", 't')})
   call feedkeys('qrct[', 'xt!')
   call assert_equal(',bar[blah]', getline(1))
+  call assert_equal("ct[\<Ignore>,bar\<Esc>", @r)
+  call assert_equal('ct[<Ignore>,bar<Esc>', keytrans(@r))
   undo
   call assert_equal('foo[blah]', getline(1))
   call feedkeys('@r', 'xt!')


### PR DESCRIPTION
#### vim-patch:9.1.0060: Recorded register cannot be translated using keytrans()

Problem:  Recorded register cannot be translated using keytrans() when
          it involves character search (iddqd505)
Solution: Record a K_IGNORE instead of a K_NOP (zeertzjq)

related: vim/vim#13916
closes: vim/vim#13925

https://github.com/vim/vim/commit/bf321806bf44d59f108fd7e5a0eaead04682701d