### PR TITLE
refactor(indent): refactor functions for computing indent size of a string 

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1150,9 +1150,7 @@ bool open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   // indent to use for the new line.
   if (curbuf->b_p_ai || do_si) {
     // count white space on current line
-    newindent = get_indent_str_vtab(saved_line,
-                                    curbuf->b_p_ts,
-                                    curbuf->b_p_vts_array, false);
+    newindent = indent_size_ts(saved_line, curbuf->b_p_ts, curbuf->b_p_vts_array);
     if (newindent == 0 && !(flags & OPENLINE_COM_LIST)) {
       newindent = second_line_indent;  // for ^^D command in insert mode
     }
@@ -1594,9 +1592,7 @@ bool open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
 
         // Recompute the indent, it may have changed.
         if (curbuf->b_p_ai || do_si) {
-          newindent = get_indent_str_vtab(leader,
-                                          curbuf->b_p_ts,
-                                          curbuf->b_p_vts_array, false);
+          newindent = indent_size_ts(leader, curbuf->b_p_ts, curbuf->b_p_vts_array);
         }
 
         // Add the indent offset

--- a/test/unit/indent_spec.lua
+++ b/test/unit/indent_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require('test.unit.helpers')(after_each)
 local itp = helpers.gen_itp(it)
 
+local to_cstr = helpers.to_cstr
+local ffi = helpers.ffi
 local eq = helpers.eq
 
 local indent = helpers.cimport('./src/nvim/indent.h')
@@ -26,5 +28,33 @@ describe('get_sts_value', function()
     shiftwidth = 0
     globals.curbuf.b_p_sw = shiftwidth
     eq(tabstop, indent.get_sts_value())
+  end)
+end)
+
+describe('get_indent_str_vtab()', function()
+  itp('works for spaces', function()
+    local line = to_cstr((' '):rep(7) .. 'a ')
+    eq(7, indent.get_indent_str_vtab(line, 100, nil, false))
+  end)
+
+  itp('works for tabs and spaces', function()
+    local line = to_cstr('   \t  \t \t\t   a ')
+    eq(19, indent.get_indent_str_vtab(line, 4, nil, false))
+  end)
+
+  itp('works for tabs and spaces with empty vts', function()
+    local vts = ffi.new('int[1]') -- zero initialized => first element (size) == 0
+    local line = to_cstr('   \t  \t \t\t       a ')
+    eq(23, indent.get_indent_str_vtab(line, 4, vts, false))
+  end)
+
+  itp('works for tabs and spaces with vts', function()
+    local vts = ffi.new('int[3]')
+    vts[0] = 2  -- zero indexed
+    vts[1] = 7
+    vts[2] = 2
+
+    local line = to_cstr('      \t  \t \t\t   a ')
+    eq(18, indent.get_indent_str_vtab(line, 4, vts, false))
   end)
 end)

--- a/test/unit/indent_spec.lua
+++ b/test/unit/indent_spec.lua
@@ -31,30 +31,30 @@ describe('get_sts_value', function()
   end)
 end)
 
-describe('get_indent_str_vtab()', function()
+describe('indent_size_ts()', function()
   itp('works for spaces', function()
     local line = to_cstr((' '):rep(7) .. 'a ')
-    eq(7, indent.get_indent_str_vtab(line, 100, nil, false))
+    eq(7, indent.indent_size_ts(line, 100, nil))
   end)
 
   itp('works for tabs and spaces', function()
     local line = to_cstr('   \t  \t \t\t   a ')
-    eq(19, indent.get_indent_str_vtab(line, 4, nil, false))
+    eq(19, indent.indent_size_ts(line, 4, nil))
   end)
 
   itp('works for tabs and spaces with empty vts', function()
     local vts = ffi.new('int[1]') -- zero initialized => first element (size) == 0
     local line = to_cstr('   \t  \t \t\t       a ')
-    eq(23, indent.get_indent_str_vtab(line, 4, vts, false))
+    eq(23, indent.indent_size_ts(line, 4, vts))
   end)
 
   itp('works for tabs and spaces with vts', function()
     local vts = ffi.new('int[3]')
-    vts[0] = 2  -- zero indexed
+    vts[0] = 2 -- zero indexed
     vts[1] = 7
     vts[2] = 2
 
     local line = to_cstr('      \t  \t \t\t   a ')
-    eq(18, indent.get_indent_str_vtab(line, 4, vts, false))
+    eq(18, indent.indent_size_ts(line, 4, vts))
   end)
 end)


### PR DESCRIPTION
The `get_indent_str_vtab()` function currently calls to `tabstop_padding()` every time a tab is encountered (unless tabstops aren't used). `tabstop_padding()` either does a division by `tabstop` If `vartabstop` is not set, or it iterates through the `vartabstop` list to find current tab width. 

Since the virtual column only increases, we can keep track of where the next tabstop would be, and update this information once it was reached.

`get_indent_str_vtab()`  also depends on `listchars` 'tab1' value from the current window, even though it could be called for for a line from the buffer in a different window. In majority of cases, it is called with tabstops enabled (last argument was `false`), so I split the function into one that uses tabstops and the other that doesn't.

I removed `get_indent_str()` since I couldn't find any calls to it, including outside 'src/'.