### PR TITLE
feat(lsp): add opts to vim.lsp.codelens.refresh

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1428,7 +1428,8 @@ clear({client_id}, {bufnr})                         *vim.lsp.codelens.clear()*
 
     Parameters: ~
       • {client_id}  (`integer?`) filter by client_id. All clients if nil
-      • {bufnr}      (`integer?`) filter by buffer. All buffers if nil
+      • {bufnr}      (`integer?`) filter by buffer. All buffers if nil, 0 for
+                     current buffer
 
 display({lenses}, {bufnr}, {client_id})           *vim.lsp.codelens.display()*
     Display the lenses using virtual text
@@ -1455,14 +1456,20 @@ on_codelens({err}, {result}, {ctx}, {_})
     Parameters: ~
       • {ctx}  (`lsp.HandlerContext`)
 
-refresh()                                         *vim.lsp.codelens.refresh()*
-    Refresh the codelens for the current buffer
+refresh({opts})                                   *vim.lsp.codelens.refresh()*
+    Refresh the lenses.
 
     It is recommended to trigger this using an autocmd or via keymap.
 
     Example: >vim
-        autocmd BufEnter,CursorHold,InsertLeave <buffer> lua vim.lsp.codelens.refresh()
+        autocmd BufEnter,CursorHold,InsertLeave <buffer> lua vim.lsp.codelens.refresh({ bufnr = 0 })
 <
+
+    Parameters: ~
+      • {opts}  (`vim.lsp.codelens.RefreshOptions?`) Table with the following
+                fields:
+                • `bufnr` (integer|nil): filter by buffer. All buffers if nil,
+                  0 for current buffer
 
 run()                                                 *vim.lsp.codelens.run()*
     Run the code lens in the current line

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -116,6 +116,10 @@ The following changes may require adaptations in user config or plugins.
   upstream tree-sitter and Helix to make it easier to share queries. The full
   list is documented in |treesitter-highlight-groups|.
 
+• |vim.lsp.codelens.refresh()| now takes an `opts` argument. With this change,
+  the default behavior of just refreshing the current buffer has been replaced by
+  refreshing all buffers.
+
 
 ==============================================================================
 BREAKING CHANGES IN HEAD                                    *news-breaking-dev*


### PR DESCRIPTION
Closes #26995. As mentioned in the issue, I think this is a reasonable request given that the protocol documents [workspace/codeLens/refresh](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeLens_refresh) as "refreshing the code lenses currently shown in editors" (which IMO should correspond to all open buffers).

This is a breaking (?) change though, since the default behaviour changes (no arguments will be interpreted as refreshing all buffers).