### PR TITLE
feat(api): add `nvim_win_fold` for closing / opening folds

### DIFF
--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -27,6 +27,12 @@ typedef struct {
 } Dict(set_decoration_provider);
 
 typedef struct {
+  OptionalKeys is_set__win_fold_;
+  Boolean recursive;
+  Boolean open;
+} Dict(win_fold);
+
+typedef struct {
   OptionalKeys is_set__set_extmark_;
   Integer id;
   Integer end_line;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -18,6 +18,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/eval/vars.h"
 #include "nvim/ex_eval.h"
+#include "nvim/fold.h"
 #include "nvim/garray_defs.h"
 #include "nvim/globals.h"
 #include "nvim/highlight_group.h"

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -13,8 +13,10 @@
 #include "nvim/cursor.h"
 #include "nvim/drawscreen.h"
 #include "nvim/errors.h"
+#include "nvim/eval/typval.h"
 #include "nvim/eval/window.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/fold.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
 #include "nvim/lua/executor.h"
@@ -27,6 +29,46 @@
 #include "nvim/window.h"
 
 #include "api/window.c.generated.h"  // IWYU pragma: keep
+
+/// Opens or closes the fold at or around the specified line in a window.
+///
+/// @param window   Window handle, or 0 for current window
+/// @param lnum     Line number
+/// @param opts     Dictionary
+///                 - "open": Open or close folds
+///                 - "recurse": Recurse over all folds within the specified fold, like |zC| / |zO|
+/// @param[out] err Error details, if any
+void nvim_win_fold(Window window, Integer lnum, Dict(win_fold) *opts, Error *err)
+  FUNC_API_SINCE(12)
+{
+  bool recurse = HAS_KEY(opts, win_fold, recursive) && opts->recursive;
+  bool open = HAS_KEY(opts, win_fold, open) && opts->open;
+
+  win_T *win = find_window_by_handle(window, err);
+  if (!win) {
+    return;
+  }
+  if (lnum > INT32_MAX || lnum < 0) {
+    api_set_error(err, kErrorTypeValidation, "Line value outside range");
+    return;
+  }
+
+  foldinfo_T fi = fold_info(win, (linenr_T)lnum);
+
+  pos_T start;
+  start.lnum = fi.fi_lnum;
+  start.col = 0;
+  start.coladd = 0;
+
+  pos_T end;
+  end.lnum = fi.fi_lnum + fi.fi_lines;
+  end.col = 0;
+  end.coladd = 0;
+
+  try_start();
+  opFoldRange(start, end, open, recurse, false);
+  try_end(err);
+}
 
 /// Gets the current buffer in a window
 ///


### PR DESCRIPTION
Problem: There is no way to open or close folds via Lua
Solution: Add `nvim_win_fold` to open/close folds

This started as just an experiment but then it kinda just worked.

Still WIP, needs tests and I don't know if this is even wanted but I think I recall seeing some related issues at some point.

Does not yet take non-current windows into account.