### PR TITLE
fix(diagnostic): fix lua doc on field 'wrap'

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1023,7 +1023,7 @@ end
 
 --- @class vim.diagnostic.GotoOpts : vim.diagnostic.GetOpts
 --- @field cursor_position? {[1]:integer,[2]:integer}
---- @field wrap? integer
+--- @field wrap? boolean
 --- @field float? boolean|vim.diagnostic.Opts.Float
 --- @field win_id? integer
 


### PR DESCRIPTION
Problem: vim.diagnostic.goto_next() doc marks wrap as an integer but the doc marks it as a boolean. This commit syncs both to 'boolean'.

Solution: Correct the typing in commen