### PR TITLE
fix(treesitter): make iter_captures() return a correct match table

### DIFF
--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -34,21 +34,40 @@ error('Cannot require a meta file')
 ---@field byte_length fun(self: TSNode): integer
 local TSNode = {}
 
+---Execute {query} on the node, and enumerates over the node captures. See |Query:iter_captures()|
+---A capture is represented by capture_id (index in the query), matched TSNode, and an optional
+---table (TSMatch) which is set *only* when a predicate exists in the pattern. For multiple
+---captures within the same match, the identical TSMatch object will be returned.
 ---@param query TSQuery
----@param captures true
+---@param captures true (see query_next_capture() in treesitter.c)
 ---@param start? integer
 ---@param end_? integer
 ---@param opts? table
----@return fun(): integer, TSNode, vim.treesitter.query.TSMatch
+---@return fun(): integer, TSNode, vim.treesitter.query.TSMatch iterator of (capture_id, node, match).
 function TSNode:_rawquery(query, captures, start, end_, opts) end
 
+---Execute {query} on the node, and enumerates the matches by pattern. See |Query:iter_matches()|.
 ---@param query TSQuery
----@param captures false
+---@param captures false (see query_next_match() in treesitter.c)
 ---@param start? integer
 ---@param end_? integer
 ---@param opts? table
----@return fun(): integer, vim.treesitter.query.TSMatch
+---@return fun(): integer, vim.treesitter.query.TSMatch iterator of (pattern_index, match).
+---  match is a mapping from capture index to matched node (see #24738)
 function TSNode:_rawquery(query, captures, start, end_, opts) end
+
+--- Internal data structure for query match. Key is capture_id, value is matched nodes.
+---
+--- For captures, this table additionally includes the following field to process predicates, see
+--- TSNode:_rawquery() and Query:iter_captures():
+---     - active?  (boolean) denotes whether the match will be included, according to predicates.
+---     - pattern? (integer) id of the pattern associated with this match.
+--- TODO: consider removing `match.pattern` to make the data structure consistent
+---       between iter_captures() and iter_matches().
+---@class TSMatch
+---@field pattern? integer
+---@field active? boolean
+---@field [integer] TSNode[]
 
 ---@alias TSLoggerCallback fun(logtype: 'parse'|'lex', msg: string)
 

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -1,0 +1,86 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local insert = helpers.insert
+local exec_lua = helpers.exec_lua
+local eq = helpers.eq
+
+before_each(clear)
+
+describe('Query:iter_captures', function()
+  it('includes metadata for all captured nodes #23664', function()
+    insert([[
+      const char *sql = "SELECT * FROM Students WHERE name = 'Robert'); DROP TABLE Students;--";
+    ]])
+
+    local query = [[
+      (declaration
+        type: (_)
+        declarator: (init_declarator
+          declarator: (pointer_declarator
+            declarator: (identifier)) @_id
+          value: (string_literal
+            (string_content) @injection.content))
+        (#set! injection.language "sql")
+        (#contains? @_id "sql"))
+    ]]
+
+    local result = exec_lua(
+      [[
+      local injections = vim.treesitter.query.parse("c", ...)
+      local parser = vim.treesitter.get_parser(0, "c")
+      local root = parser:parse()[1]:root()
+      local t = {}
+      for id, node, metadata in injections:iter_captures(root, 0) do
+        t[id] = metadata
+      end
+      return t
+    ]],
+      query
+    )
+
+    eq({
+      [1] = { ['injection.language'] = 'sql' },
+      [2] = { ['injection.language'] = 'sql' },
+    }, result)
+  end)
+
+  it('only evaluates predicates once per match', function()
+    insert([[
+      void foo(int x, int y);
+    ]])
+    local query = [[
+      (declaration
+        type: (_)
+        declarator: (function_declarator
+          declarator: (identifier) @function.name
+          parameters: (parameter_list
+            (parameter_declaration
+              type: (_)
+              declarator: (identifier) @argument)))
+        (#eq? @function.name "foo"))
+    ]]
+
+    local result = exec_lua(
+      [[
+      local query = vim.treesitter.query.parse("c", ...)
+      local match_preds = query.match_preds
+      local called = 0
+      function query:match_preds(...)
+        called = called + 1
+        return match_preds(self, ...)
+      end
+      local parser = vim.treesitter.get_parser(0, "c")
+      local root = parser:parse()[1]:root()
+      local captures = {}
+      for id, node in query:iter_captures(root, 0) do
+        captures[#captures + 1] = id
+      end
+      return { called, captures }
+    ]],
+      query
+    )
+
+    eq({ 2, { 1, 1, 2, 2 } }, result)
+  end)
+end)


### PR DESCRIPTION
Should fix #27239, and fix #23664.

### Problem

- When a predicate filters out a match, non-first captures may not be
  correctly excluded (#27239).
- `Query:iter_captures()` does not yield correct a metadata table for
  non-first captures (#23664).

### Analysis & Solution

This PR is still a very early draft and will be rewritten several times.
Until things are settled down, please refer to the commit message for
details and remaining TODOs: 

> "fix(treesitter): make iter_captures() return a correct match table"

### Current Status

* ~~was blocked by #27194~~: will rebase
* I realized that correctness and identity of `match` table are non-trivial. See https://github.com/neovim/neovim/pull/27274#discussion_r1473335027

### Related issues

- #27194 needs to be merged first to avoid a conflict.

- #17099, #24738: rewrites iter_matches() to correctly handle quantifiers.
  - The scope is different: this PR fixes `iter_captures()` whereas 24738 fixes `iter_matches()`, correcting `match` table to contain a list of `TSNode`s instead of a single `TSNode` (see `set_match()`)
  - But a part 24738 make a similar change: `match` should return a different table for each distinct match.

- #27132 can also benefit from this fix if it decides to use `iter_captures()` instead of `iter_matches()`.