### PR TITLE
ci: also test on macOS M1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   macos-universal:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
             { runner: ubuntu-22.04, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-22.04, cc: gcc },
             { runner: macos-12, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
-            { runner: macos-14, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER -D ENABLE_LIBINTL=OFF, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
+            { runner: macos-14, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-22.04, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
           ]
         test: [unittest, functionaltest, oldtest]
@@ -113,6 +113,8 @@ jobs:
             build: { flavor: tsan }
           - test: unittest
             build: { flavor: puc-lua }
+          - test: unittest
+            build: { runner: macos-14 } # unittests don't work on M1 #26145
           - test: oldtest
             build: { flavor: tsan }
     runs-on: ${{ matrix.build.runner }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
             { runner: ubuntu-22.04, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-22.04, cc: gcc },
             { runner: macos-12, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
+            { runner: macos-14, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER -D ENABLE_LIBINTL=OFF, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-22.04, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
           ]
         test: [unittest, functionaltest, oldtest]


### PR DESCRIPTION
GH Actions run macos-14 on M1 now, giving us our first ARM build.

Test both arches for now; we can eventually drop Intel in favor of ARM to reduce the test load (and will have to, once Apple drops support for Intel completely). M1 runners seem about twice as fast, at least at this moment:

* macos-12:
  - Build 48s
  - functionaltest 7m 7s

* macos-14:
  - Build 24s
  - functionaltest 5m 5s

unittest failure is relevant and due to arch difference, see #26145 

(oldttest failure is also relevant and due to building without `libintl`: one is straight locale failure (though behind `has('gettext')` guard?), the other is in `Wildmode_test()` and unclear)

**Question:** Do we want to move the build/release tests to M1 (once we get the unittest fixed)?

@dundargoc
