### PR TITLE
vim-patch:8.2.0117: crash when using gettabwinvar() with invalid arguments

### DIFF
--- a/test/old/testdir/test_getvar.vim
+++ b/test/old/testdir/test_getvar.vim
@@ -83,6 +83,7 @@ func Test_var()
 
   unlet def_dict
 
+  call assert_equal("", gettabwinvar(9, 2020, ''))
   call assert_equal('', gettabwinvar(2, 3, '&nux'))
   call assert_equal(1, gettabwinvar(2, 3, '&nux', 1))
   tabonly


### PR DESCRIPTION
#### vim-patch:8.2.0117: crash when using gettabwinvar() with invalid arguments

Problem:    Crash when using gettabwinvar() with invalid arguments. (Yilin
            Yang)
Solution:   Use "curtab" if "tp" is NULL.

https://github.com/vim/vim/commit/ee93b737aaa7bf65edc7281f429dd89fcf657a6f

Co-authored-by: Bram Moolenaar <Bram@vim.org>