### PR TITLE
feat: able to change popupmenu ordering(ie. word, kind, extra)

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4617,6 +4617,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Maximum number of items to show in the popup menu
 	(|ins-completion-menu|). Zero means "use available screen space".
 
+
+						*'pumordering'* *'po'*
+'pumordering' 'po'	string (default "012")
+	This option specify how the popup menu should look like
+
+	The default value:
+	0: word
+	1: kind
+	2: extra
+
+	So the popup menu should look like the following
+	"word"  "kind"  "extra"
+
+	If this value is set to 102, the popup menu would look like this:
+	"kind"  "word"  "extra"
+
+	Note: set values > 2 will result in empty value
+
 						*'pumwidth'* *'pw'*
 'pumwidth' 'pw'		number	(default 15)
 			global

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -433,6 +433,7 @@ EXTERN char *p_csl;             ///< 'completeslash'
 #endif
 EXTERN OptInt p_pb;             ///< 'pumblend'
 EXTERN OptInt p_ph;             ///< 'pumheight'
+EXTERN char *p_po;              ///< 'pumordering'
 EXTERN OptInt p_pw;             ///< 'pumwidth'
 EXTERN char *p_com;             ///< 'comments'
 EXTERN char *p_cpo;             ///< 'cpoptions'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6089,6 +6089,31 @@ return {
       varname = 'p_ph',
     },
     {
+      abbreviation = 'pumo',
+      defaults = { if_true = '012' },
+      desc = [=[
+        This option specify how the popup menu should look like
+
+        The default value:
+        0: word
+        1: kind
+        2: extra
+
+        So the popup menu should look like the following
+        "word"  "kind"  "extra"
+
+        If this value is set to 102, the popup menu would look like this:
+        "kind"  "word"  "extra"
+
+        Note: set values > 2 will result in empty value
+      ]=],
+      full_name = 'pumordering',
+      scope = { 'global' },
+      short_desc = N_('popup menu item ordering'),
+      type = 'string',
+      varname = 'p_po'
+    },
+    {
       abbreviation = 'pw',
       defaults = { if_true = 15 },
       desc = [=[


### PR DESCRIPTION
Hi,
I was wondering if we can do this.

https://github.com/neovim/neovim/assets/9444583/c524bba2-4545-48c3-bf16-6ed9db5a35af

Notice that the `kind` is now the first in the popup menu.

I want to be able to change the ordering of popup menu (`word`, `kind`, `extra`) in my way.

I added an option `pumordering` (default value `012`) to specify the ordering, but I'm not sure adding an option is the best choice here.

btw, this is the first PR to neovim (I'm ready to be roasted).