### PR TITLE
feat(ex_cmds): no error on :lua with {range} and {code}

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1649,12 +1649,12 @@ bool nlua_is_deferred_safe(void)
 void ex_lua(exarg_T *const eap)
   FUNC_ATTR_NONNULL_ALL
 {
-  // ":{range}lua"
-  if (eap->addr_count > 0 || *eap->arg == NUL) {
-    if (eap->addr_count > 0 && *eap->arg == NUL) {
+  // ":{range}lua", only if no {code}
+  if (*eap->arg == NUL) {
+    if (eap->addr_count > 0) {
       cmd_source_buffer(eap, true);
     } else {
-      semsg(_(e_invarg2), "exactly one of {chunk} or {range} required");
+      emsg(_(e_argreq));
     }
     return;
   }

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -56,12 +56,7 @@ describe(':lua', function()
   end)
 
   it('throws catchable errors', function()
-    for _, cmd in ipairs({ 'lua', '1lua chunk' }) do
-      eq(
-        'Vim(lua):E475: Invalid argument: exactly one of {chunk} or {range} required',
-        pcall_err(command, cmd)
-      )
-    end
+    eq('Vim(lua):E471: Argument required', pcall_err(command, 'lua'))
     eq(
       [[Vim(lua):E5107: Error loading lua [string ":lua"]:0: unexpected symbol near ')']],
       pcall_err(command, 'lua ()')
@@ -230,6 +225,10 @@ describe(':lua', function()
         [1] = { foreground = Screen.colors.Blue, bold = true },
       },
     }
+
+    -- ":{range}lua {code}" executes {code}, ignoring {range}
+    eq('', exec_capture('1lua gvar = 42'))
+    eq(42, fn.luaeval('gvar'))
   end)
 end)
 


### PR DESCRIPTION
Problem:  Erroring when both {range} and {code} are supplied to
          :lua is inconvenient and may break mappings.
Solution: Don't error, ignore {range} and execute {code} when both
          are supplied.

Fix #27234