### PR TITLE
feat(treesitter): use 0-based indexing to show ranges in `:InspectTree`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -224,6 +224,8 @@ The following new APIs and features were added.
   • |vim.treesitter.query.edit()| allows live editing of treesitter
     queries.
   • Improved error messages for query parsing.
+  • `:InspectTree` (|vim.treesitter.inspect_tree()|) shows node ranges in
+    0-based indexing instead of 1-based indexing.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/test/functional/treesitter/inspect_tree_spec.lua
+++ b/test/functional/treesitter/inspect_tree_spec.lua
@@ -1,0 +1,109 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local insert = helpers.insert
+local dedent = helpers.dedent
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+local feed = helpers.feed
+
+describe('vim.treesitter.inspect_tree', function()
+  before_each(clear)
+
+  local expect_tree = function(x)
+    local expected = vim.split(vim.trim(dedent(x)), '\n')
+    local actual = helpers.buf_lines(0) ---@type string[]
+    eq(expected, actual)
+  end
+
+  it('working', function()
+    insert([[
+      print()
+      ]])
+
+    exec_lua([[
+      vim.treesitter.start(0, 'lua')
+      vim.treesitter.inspect_tree()
+    ]])
+
+    expect_tree [[
+      (function_call ; [0, 0] - [0, 7]
+        name: (identifier) ; [0, 0] - [0, 5]
+        arguments: (arguments)) ; [0, 5] - [0, 7]
+      ]]
+  end)
+
+  it('can toggle to show anonymous nodes', function()
+    insert([[
+      print()
+      ]])
+
+    exec_lua([[
+      vim.treesitter.start(0, 'lua')
+      vim.treesitter.inspect_tree()
+    ]])
+    feed('a')
+
+    expect_tree [[
+      (function_call ; [0, 0] - [0, 7]
+        name: (identifier) ; [0, 0] - [0, 5]
+        arguments: (arguments ; [0, 5] - [0, 7]
+          "(" ; [0, 5] - [0, 6]
+          ")")) ; [0, 6] - [0, 7]
+      ]]
+  end)
+
+  it('works for injected trees', function()
+    insert([[
+      ```lua
+      return
+      ```
+      ]])
+
+    exec_lua([[
+      vim.treesitter.start(0, 'markdown')
+      vim.treesitter.get_parser():parse()
+      vim.treesitter.inspect_tree()
+    ]])
+
+    expect_tree [[
+      (section ; [0, 0] - [4, 0]
+        (fenced_code_block ; [0, 0] - [3, 0]
+          (fenced_code_block_delimiter) ; [0, 0] - [0, 3]
+          (info_string ; [0, 3] - [0, 6]
+            (language)) ; [0, 3] - [0, 6]
+          (block_continuation) ; [1, 0] - [1, 0]
+          (code_fence_content ; [1, 0] - [2, 0]
+            (return_statement) ; [1, 0] - [1, 6]
+            (block_continuation)) ; [2, 0] - [2, 0]
+          (fenced_code_block_delimiter))) ; [2, 0] - [2, 3]
+      ]]
+  end)
+
+  it('can toggle to show languages', function()
+    insert([[
+      ```lua
+      return
+      ```
+      ]])
+
+    exec_lua([[
+      vim.treesitter.start(0, 'markdown')
+      vim.treesitter.get_parser():parse()
+      vim.treesitter.inspect_tree()
+    ]])
+    feed('I')
+
+    expect_tree [[
+      (section ; [0, 0] - [4, 0] markdown
+        (fenced_code_block ; [0, 0] - [3, 0] markdown
+          (fenced_code_block_delimiter) ; [0, 0] - [0, 3] markdown
+          (info_string ; [0, 3] - [0, 6] markdown
+            (language)) ; [0, 3] - [0, 6] markdown
+          (block_continuation) ; [1, 0] - [1, 0] markdown
+          (code_fence_content ; [1, 0] - [2, 0] markdown
+            (return_statement) ; [1, 0] - [1, 6] lua
+            (block_continuation)) ; [2, 0] - [2, 0] markdown
+          (fenced_code_block_delimiter))) ; [2, 0] - [2, 3] markdown
+      ]]
+  end)
+end)


### PR DESCRIPTION
## test(treesitter): add test cases for inspect_tree

Based on @altermo's work #26944, but modified to use `eq` instead of `Screen:expect` because it's difficult to write tests and debug.

## feat(treesitter): use 0-based indexing to show ranges in `:InspectTree`

Problem:

- `:InspectTree` was showing node ranges in 1-based indexing, i.e., in
  vim cursor position (lnum, col). However, treesitter API adopts
  0-based indexing to represent ranges (Range4). This can often be
  confusing for developers and plugin authors when debugging code
  written with treesiter APIs.

Solution:

- Change to 0-based indexing from 1-based indexing to show node ranges
  in `:InspectTree`.

- Note: To make things not complicated, we do not provide an option or
  keymap to configure which indexing mode to use.


## Status

~~Will wait until #26944 is merged first, after which I can rebase again and add test cases for #26944 and #27336 together.~~