### PR TITLE
fix(vim.system): don't process non-fast events during wait()

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -94,14 +94,14 @@ function SystemObj:wait(timeout)
 
   local done = vim.wait(timeout or state.timeout or MAX_TIMEOUT, function()
     return state.result ~= nil
-  end)
+  end, nil, true)
 
   if not done then
     -- Send sigkill since this cannot be caught
     self:_timeout(SIG.KILL)
     vim.wait(timeout or state.timeout or MAX_TIMEOUT, function()
       return state.result ~= nil
-    end)
+    end, nil, true)
   end
 
   return state.result

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -104,4 +104,18 @@ describe('vim.system', function()
       assert(signal == 2)
     ]])
   end)
+
+  it('SystemObj:wait() does not process non-fast events #27292', function()
+    eq(
+      false,
+      exec_lua([[
+        _G.processed = false
+        local cmd = vim.system({ 'sleep', '1' })
+        vim.schedule(function() _G.processed = true end)
+        cmd:wait()
+        return _G.processed
+      ]])
+    )
+    eq(true, exec_lua([[return _G.processed]]))
+  end)
 end)


### PR DESCRIPTION
Problem:
Processing non-fast events during SystemObj:wait() may cause two pieces
of code to interfere with each other, and is different from jobwait().

Solution:
Don't process non-fast events during SystemObj:wait().

Fix #27292
