### PR TITLE
feat(quickfix): support -q - to read 'errorfile' from stdin

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -409,6 +409,8 @@ The following changes to existing APIs or features add new behavior.
 • |nvim_open_win()| and |nvim_win_set_config()| now support opening normal (split)
   windows, and moving floating windows into split windows.
 
+• 'errorfile' (|-q|) accepts `-` as an alias for stdin.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1016,6 +1016,7 @@ static bool edit_stdin(mparm_T *parmp)
                   && !(embedded_mode && stdin_fd <= 0)
                   && (!exmode_active || parmp->input_istext)
                   && !stdin_isatty
+                  && parmp->edit_type <= EDIT_STDIN
                   && parmp->scriptin == NULL;  // `-s -` was not given.
   return parmp->had_stdin_file || implicit;
 }

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -25,10 +25,6 @@
 #include "nvim/rbuffer_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef MSWIN
-# include "nvim/os/os_win_console.h"
-#endif
-
 #ifdef HAVE_SYS_UIO_H
 # include <sys/uio.h>
 #endif
@@ -179,17 +175,7 @@ FileDescriptor *file_open_stdin(void)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
   int error;
-  int stdin_dup_fd;
-  if (stdin_fd > 0) {
-    stdin_dup_fd = stdin_fd;
-  } else {
-    stdin_dup_fd = os_dup(STDIN_FILENO);
-#ifdef MSWIN
-    // Replace the original stdin with the console input handle.
-    os_replace_stdin_to_conin();
-#endif
-  }
-  FileDescriptor *const stdin_dup = file_open_fd_new(&error, stdin_dup_fd,
+  FileDescriptor *const stdin_dup = file_open_fd_new(&error, os_open_stdin_fd(),
                                                      kFileReadOnly|kFileNonBlocking);
   assert(stdin_dup != NULL);
   if (error != 0) {

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -55,6 +55,7 @@
 #ifdef MSWIN
 # include "nvim/mbyte.h"
 # include "nvim/option.h"
+# include "nvim/os/os_win_console.h"
 # include "nvim/strings.h"
 #endif
 
@@ -539,6 +540,22 @@ os_dup_dup:
     }
   }
   return ret;
+}
+
+/// Open the file descriptor for stdin.
+int os_open_stdin_fd(void)
+{
+  int stdin_dup_fd;
+  if (stdin_fd > 0) {
+    stdin_dup_fd = stdin_fd;
+  } else {
+    stdin_dup_fd = os_dup(STDIN_FILENO);
+#ifdef MSWIN
+    // Replace the original stdin with the console input handle.
+    os_replace_stdin_to_conin();
+#endif
+  }
+  return stdin_dup_fd;
 }
 
 /// Read from a file

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1065,7 +1065,9 @@ static int qf_setup_state(qfstate_T *pstate, char *restrict enc, const char *res
   }
 
   if (efile != NULL
-      && (pstate->fd = os_fopen(efile, "r")) == NULL) {
+      && (pstate->fd = (strequal(efile, "-")
+                        ? fdopen(os_open_stdin_fd(), "r")
+                        : os_fopen(efile, "r"))) == NULL) {
     semsg(_(e_openerrf), efile);
     return FAIL;
   }


### PR DESCRIPTION
Close #17523
Close #17543

Note that this only works when stdin is a pipe.