### PR TITLE
feat(decor): allow nvim_set_decoration_provider to skip initial redraw

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2859,6 +2859,8 @@ nvim_set_decoration_provider({ns_id}, {*opts})
                    interaction with fold lines is subject to change) ["win",
                    winid, bufnr, row]
                  • on_end: called at the end of a redraw cycle ["end", tick]
+                 • redraw (boolean): redraw immediately after this function is
+                   called (default true)
 
 
 ==============================================================================

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1805,6 +1805,8 @@ function vim.api.nvim_set_current_win(window) end
 ---                interaction with fold lines is subject to change) ["win",
 ---                winid, bufnr, row]
 ---              • on_end: called at the end of a redraw cycle ["end", tick]
+---              • redraw (boolean): redraw immediately after this function is
+---                called (default true)
 function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 
 --- Sets a highlight group.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -241,6 +241,7 @@ error('Cannot require a meta file')
 --- @field on_win? function
 --- @field on_line? function
 --- @field on_end? function
+--- @field redraw? boolean
 --- @field _on_hl_def? function
 --- @field _on_spell_nav? function
 

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -355,6 +355,9 @@ api.nvim_set_decoration_provider(namespace, {
       end
     end
   end,
+
+  -- Prevent redraw when module is first loaded (#27266)
+  redraw = false,
 })
 
 --- @param bufnr (integer|nil) Buffer handle, or 0 or nil for current

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -799,6 +799,9 @@ api.nvim_set_decoration_provider(namespace, {
       highlighter:on_win(topline, botline)
     end
   end,
+
+  -- Prevent redraw when module is first loaded (#27266)
+  redraw = false,
 })
 
 --- for testing only! there is no guarantee of API stability with this!

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -357,6 +357,9 @@ api.nvim_set_decoration_provider(ns, {
   on_win = TSHighlighter._on_win,
   on_line = TSHighlighter._on_line,
   _on_spell_nav = TSHighlighter._on_spell_nav,
+
+  -- Prevent redraw when module is first loaded (#27266)
+  redraw = false,
 })
 
 return TSHighlighter

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1038,6 +1038,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 ///                 ["win", winid, bufnr, row]
 ///             - on_end: called at the end of a redraw cycle
 ///                 ["end", tick]
+///             - redraw (boolean): redraw immediately after this function is called (default true)
 void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *opts, Error *err)
   FUNC_API_SINCE(7) FUNC_API_LUA_ONLY
 {
@@ -1045,8 +1046,9 @@ void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *
   assert(p != NULL);
   decor_provider_clear(p);
 
-  // regardless of what happens, it seems good idea to redraw
-  redraw_all_later(UPD_NOT_VALID);  // TODO(bfredl): too soon?
+  if (GET_BOOL_OR_TRUE(opts, set_decoration_provider, redraw)) {
+    redraw_all_later(UPD_NOT_VALID);
+  }
 
   struct {
     const char *name;

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -18,6 +18,7 @@ typedef struct {
   LuaRef on_win;
   LuaRef on_line;
   LuaRef on_end;
+  Boolean redraw;
   LuaRef _on_hl_def;
   LuaRef _on_spell_nav;
 } Dict(set_decoration_provider);

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -738,6 +738,45 @@ describe('decorations providers', function()
                                               |
     ]]}
   end)
+
+  it('can avoid an initial redraw if unwanted #27266', function()
+    clear({ args_rm = { '--headless' }, args = { '--cmd', 'set shortmess-=I' }})
+    screen = Screen.new(80, 24)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = { bold = true, foreground = Screen.colors.Blue1 },
+      [2] = { foreground = Screen.colors.Blue1 },
+    })
+
+    screen:expect([[
+      ^                                                                                |
+      {1:~                                                                               }|*4
+      {MATCH:.*}|
+      {1:~                                                                               }|
+      {1:~                 }Nvim is open source and freely distributable{1:                  }|
+      {1:~                           }https://neovim.io/#chat{1:                             }|
+      {1:~                                                                               }|
+      {1:~                }type  :help nvim{2:<Enter>}       if you are new! {1:                 }|
+      {1:~                }type  :checkhealth{2:<Enter>}     to optimize Nvim{1:                 }|
+      {1:~                }type  :q{2:<Enter>}               to exit         {1:                 }|
+      {1:~                }type  :help{2:<Enter>}            for help        {1:                 }|
+      {1:~                                                                               }|
+      {1:~{MATCH: +}}type  :help news{2:<Enter>} to see changes in v{MATCH:%d+%.%d+}{1:{MATCH: +}}|
+      {1:~                                                                               }|
+      {MATCH:.*}|*2
+      {1:~                                                                               }|*4
+                                                                                      |
+    ]])
+
+    exec_lua([[
+      local ns = vim.api.nvim_create_namespace("ns1")
+      vim.api.nvim_set_decoration_provider(ns, {
+        redraw = false,
+      })
+    ]])
+
+    screen:expect_unchanged()
+  end)
 end)
 
 local example_text = [[


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/27266

This enables the initial call to nvim_set_decoration_provider to skip a redraw. It has no effect on subsequent redraws. This is useful when a decoration provider is first installed, but a redraw may not yet be wanted (for example, on startup we want to prevent an immediate redraw to avoid clearing the intro text).