### PR TITLE
vim-patch:9.0.1105: code is indented too much

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -758,11 +758,14 @@ void eval_patch(const char *const origfile, const char *const difffile, const ch
 void fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, bool skip)
 {
   *evalarg = (evalarg_T){ .eval_flags = skip ? 0 : EVAL_EVALUATE };
-  if (eap != NULL) {
-    if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
-      evalarg->eval_getline = eap->getline;
-      evalarg->eval_cookie = eap->cookie;
-    }
+
+  if (eap == NULL) {
+    return;
+  }
+
+  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
+    evalarg->eval_getline = eap->getline;
+    evalarg->eval_cookie = eap->cookie;
   }
 }
 
@@ -2326,20 +2329,22 @@ static int eval_func(char **const arg, evalarg_T *const evalarg, char *const nam
 /// After using "evalarg" filled from "eap": free the memory.
 void clear_evalarg(evalarg_T *evalarg, exarg_T *eap)
 {
-  if (evalarg != NULL) {
-    if (evalarg->eval_tofree != NULL) {
-      if (eap != NULL) {
-        // We may need to keep the original command line, e.g. for
-        // ":let" it has the variable names.  But we may also need the
-        // new one, "nextcmd" points into it.  Keep both.
-        xfree(eap->cmdline_tofree);
-        eap->cmdline_tofree = *eap->cmdlinep;
-        *eap->cmdlinep = evalarg->eval_tofree;
-      } else {
-        xfree(evalarg->eval_tofree);
-      }
-      evalarg->eval_tofree = NULL;
+  if (evalarg == NULL) {
+    return;
+  }
+
+  if (evalarg->eval_tofree != NULL) {
+    if (eap != NULL) {
+      // We may need to keep the original command line, e.g. for
+      // ":let" it has the variable names.  But we may also need the
+      // new one, "nextcmd" points into it.  Keep both.
+      xfree(eap->cmdline_tofree);
+      eap->cmdline_tofree = *eap->cmdlinep;
+      *eap->cmdlinep = evalarg->eval_tofree;
+    } else {
+      xfree(evalarg->eval_tofree);
     }
+    evalarg->eval_tofree = NULL;
   }
 }
 
@@ -3626,12 +3631,14 @@ static int check_can_index(typval_T *rettv, bool evaluate, bool verbose)
 /// slice() function
 void f_slice(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (check_can_index(argvars, true, false) == OK) {
-    tv_copy(argvars, rettv);
-    eval_index_inner(rettv, true, argvars + 1,
-                     argvars[2].v_type == VAR_UNKNOWN ? NULL : argvars + 2,
-                     true, NULL, 0, false);
+  if (check_can_index(argvars, true, false) != OK) {
+    return;
   }
+
+  tv_copy(argvars, rettv);
+  eval_index_inner(rettv, true, argvars + 1,
+                   argvars[2].v_type == VAR_UNKNOWN ? NULL : argvars + 2,
+                   true, NULL, 0, false);
 }
 
 /// Apply index or range to "rettv".
@@ -4248,7 +4255,11 @@ static void partial_free(partial_T *pt)
 /// becomes zero.
 void partial_unref(partial_T *pt)
 {
-  if (pt != NULL && --pt->pt_refcount <= 0) {
+  if (pt == NULL) {
+    return;
+  }
+
+  if (--pt->pt_refcount <= 0) {
     partial_free(pt);
   }
 }
@@ -8241,21 +8252,24 @@ void last_set_msg(sctx_T script_ctx)
 /// Should only be invoked when 'verbose' is non-zero.
 void option_last_set_msg(LastSet last_set)
 {
-  if (last_set.script_ctx.sc_sid != 0) {
-    bool should_free;
-    char *p = get_scriptname(last_set, &should_free);
-    verbose_enter();
-    msg_puts(_("\n\tLast set from "));
-    msg_puts(p);
-    if (last_set.script_ctx.sc_lnum > 0) {
-      msg_puts(_(line_msg));
-      msg_outnum(last_set.script_ctx.sc_lnum);
-    }
-    if (should_free) {
-      xfree(p);
-    }
-    verbose_leave();
+  if (last_set.script_ctx.sc_sid == 0) {
+    return;
   }
+
+  bool should_free;
+  char *p = get_scriptname(last_set, &should_free);
+
+  verbose_enter();
+  msg_puts(_("\n\tLast set from "));
+  msg_puts(p);
+  if (last_set.script_ctx.sc_lnum > 0) {
+    msg_puts(_(line_msg));
+    msg_outnum(last_set.script_ctx.sc_lnum);
+  }
+  if (should_free) {
+    xfree(p);
+  }
+  verbose_leave();
 }
 
 // reset v:option_new, v:option_old, v:option_oldlocal, v:option_oldglobal,

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1937,44 +1937,47 @@ static void extend_list(typval_T *argvars, const char *arg_errmsg, bool is_new, 
 
   list_T *l1 = argvars[0].vval.v_list;
   list_T *const l2 = argvars[1].vval.v_list;
-  if (is_new || !value_check_lock(tv_list_locked(l1), arg_errmsg, TV_TRANSLATE)) {
-    if (is_new) {
-      l1 = tv_list_copy(NULL, l1, false, get_copyID());
-      if (l1 == NULL) {
+
+  if (!is_new && value_check_lock(tv_list_locked(l1), arg_errmsg, TV_TRANSLATE)) {
+    return;
+  }
+
+  if (is_new) {
+    l1 = tv_list_copy(NULL, l1, false, get_copyID());
+    if (l1 == NULL) {
+      return;
+    }
+  }
+
+  listitem_T *item;
+  if (argvars[2].v_type != VAR_UNKNOWN) {
+    int before = (int)tv_get_number_chk(&argvars[2], &error);
+    if (error) {
+      return;  // Type error; errmsg already given.
+    }
+
+    if (before == tv_list_len(l1)) {
+      item = NULL;
+    } else {
+      item = tv_list_find(l1, before);
+      if (item == NULL) {
+        semsg(_(e_list_index_out_of_range_nr), (int64_t)before);
         return;
       }
     }
+  } else {
+    item = NULL;
+  }
+  tv_list_extend(l1, l2, item);
 
-    listitem_T *item;
-    if (argvars[2].v_type != VAR_UNKNOWN) {
-      int before = (int)tv_get_number_chk(&argvars[2], &error);
-      if (error) {
-        return;  // Type error; errmsg already given.
-      }
-
-      if (before == tv_list_len(l1)) {
-        item = NULL;
-      } else {
-        item = tv_list_find(l1, before);
-        if (item == NULL) {
-          semsg(_(e_list_index_out_of_range_nr), (int64_t)before);
-          return;
-        }
-      }
-    } else {
-      item = NULL;
-    }
-    tv_list_extend(l1, l2, item);
-
-    if (is_new) {
-      *rettv = (typval_T){
-        .v_type = VAR_LIST,
-        .v_lock = VAR_UNLOCKED,
-        .vval.v_list = l1,
-      };
-    } else {
-      tv_copy(&argvars[0], rettv);
-    }
+  if (is_new) {
+    *rettv = (typval_T){
+      .v_type = VAR_LIST,
+      .v_lock = VAR_UNLOCKED,
+      .vval.v_list = l1,
+    };
+  } else {
+    tv_copy(&argvars[0], rettv);
   }
 }
 
@@ -1985,54 +1988,61 @@ static void extend_list(typval_T *argvars, const char *arg_errmsg, bool is_new, 
 static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, typval_T *rettv)
 {
   dict_T *d1 = argvars[0].vval.v_dict;
-  dict_T *const d2 = argvars[1].vval.v_dict;
   if (d1 == NULL) {
     const bool locked = value_check_lock(VAR_FIXED, arg_errmsg, TV_TRANSLATE);
     (void)locked;
     assert(locked == true);
-  } else if (d2 == NULL) {
+    return;
+  }
+  dict_T *const d2 = argvars[1].vval.v_dict;
+  if (d2 == NULL) {
     // Do nothing
     tv_copy(&argvars[0], rettv);
-  } else if (is_new || !value_check_lock(d1->dv_lock, arg_errmsg, TV_TRANSLATE)) {
-    if (is_new) {
-      d1 = tv_dict_copy(NULL, d1, false, get_copyID());
-      if (d1 == NULL) {
-        return;
+    return;
+  }
+
+  if (!is_new && value_check_lock(d1->dv_lock, arg_errmsg, TV_TRANSLATE)) {
+    return;
+  }
+
+  if (is_new) {
+    d1 = tv_dict_copy(NULL, d1, false, get_copyID());
+    if (d1 == NULL) {
+      return;
+    }
+  }
+
+  const char *action = "force";
+  // Check the third argument.
+  if (argvars[2].v_type != VAR_UNKNOWN) {
+    const char *const av[] = { "keep", "force", "error" };
+
+    action = tv_get_string_chk(&argvars[2]);
+    if (action == NULL) {
+      return;  // Type error; error message already given.
+    }
+    size_t i;
+    for (i = 0; i < ARRAY_SIZE(av); i++) {
+      if (strcmp(action, av[i]) == 0) {
+        break;
       }
     }
-
-    const char *action = "force";
-    // Check the third argument.
-    if (argvars[2].v_type != VAR_UNKNOWN) {
-      const char *const av[] = { "keep", "force", "error" };
-
-      action = tv_get_string_chk(&argvars[2]);
-      if (action == NULL) {
-        return;  // Type error; error message already given.
-      }
-      size_t i;
-      for (i = 0; i < ARRAY_SIZE(av); i++) {
-        if (strcmp(action, av[i]) == 0) {
-          break;
-        }
-      }
-      if (i == 3) {
-        semsg(_(e_invarg2), action);
-        return;
-      }
+    if (i == 3) {
+      semsg(_(e_invarg2), action);
+      return;
     }
+  }
 
-    tv_dict_extend(d1, d2, action);
+  tv_dict_extend(d1, d2, action);
 
-    if (is_new) {
-      *rettv = (typval_T){
-        .v_type = VAR_DICT,
-        .v_lock = VAR_UNLOCKED,
-        .vval.v_dict = d1,
-      };
-    } else {
-      tv_copy(&argvars[0], rettv);
-    }
+  if (is_new) {
+    *rettv = (typval_T){
+      .v_type = VAR_DICT,
+      .v_lock = VAR_UNLOCKED,
+      .vval.v_dict = d1,
+    };
+  } else {
+    tv_copy(&argvars[0], rettv);
   }
 }
 


### PR DESCRIPTION
#### vim-patch:9.0.1105: code is indented too much

Problem:    Code is indented too much.
Solution:   Use an early return. (Yegappan Lakshmanan, closes vim/vim#11756)

https://github.com/vim/vim/commit/87c1cbbe984e60582f2536e4d3c2ce88cd474bb7

Omit free_eval_tofree_later(): Vim9 script only.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>