### PR TITLE
vim-patch:partial:9.0.1196: code is indented more than necessary

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5397,35 +5397,37 @@ static void filter_map(typval_T *argvars, typval_T *rettv, filtermap_T filtermap
   // On type errors, the preceding call has already displayed an error
   // message.  Avoid a misleading error message for an empty string that
   // was not passed as argument.
-  if (expr->v_type != VAR_UNKNOWN) {
-    typval_T save_val;
-    prepare_vimvar(VV_VAL, &save_val);
-
-    // We reset "did_emsg" to be able to detect whether an error
-    // occurred during evaluation of the expression.
-    int save_did_emsg = did_emsg;
-    did_emsg = false;
-
-    typval_T save_key;
-    prepare_vimvar(VV_KEY, &save_key);
-    if (argvars[0].v_type == VAR_DICT) {
-      filter_map_dict(argvars[0].vval.v_dict, filtermap, func_name,
-                      arg_errmsg, expr, rettv);
-    } else if (argvars[0].v_type == VAR_BLOB) {
-      filter_map_blob(argvars[0].vval.v_blob, filtermap, expr, arg_errmsg, rettv);
-    } else if (argvars[0].v_type == VAR_STRING) {
-      filter_map_string(tv_get_string(&argvars[0]), filtermap, expr, rettv);
-    } else {
-      assert(argvars[0].v_type == VAR_LIST);
-      filter_map_list(argvars[0].vval.v_list, filtermap, func_name,
-                      arg_errmsg, expr, rettv);
-    }
-
-    restore_vimvar(VV_KEY, &save_key);
-    restore_vimvar(VV_VAL, &save_val);
-
-    did_emsg |= save_did_emsg;
+  if (expr->v_type == VAR_UNKNOWN) {
+    return;
   }
+
+  typval_T save_val;
+  prepare_vimvar(VV_VAL, &save_val);
+
+  // We reset "did_emsg" to be able to detect whether an error
+  // occurred during evaluation of the expression.
+  int save_did_emsg = did_emsg;
+  did_emsg = false;
+
+  typval_T save_key;
+  prepare_vimvar(VV_KEY, &save_key);
+  if (argvars[0].v_type == VAR_DICT) {
+    filter_map_dict(argvars[0].vval.v_dict, filtermap, func_name,
+                    arg_errmsg, expr, rettv);
+  } else if (argvars[0].v_type == VAR_BLOB) {
+    filter_map_blob(argvars[0].vval.v_blob, filtermap, expr, arg_errmsg, rettv);
+  } else if (argvars[0].v_type == VAR_STRING) {
+    filter_map_string(tv_get_string(&argvars[0]), filtermap, expr, rettv);
+  } else {
+    assert(argvars[0].v_type == VAR_LIST);
+    filter_map_list(argvars[0].vval.v_list, filtermap, func_name,
+                    arg_errmsg, expr, rettv);
+  }
+
+  restore_vimvar(VV_KEY, &save_key);
+  restore_vimvar(VV_VAL, &save_val);
+
+  did_emsg |= save_did_emsg;
 }
 
 /// Handle one item for map(), filter(), foreach().

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -623,13 +623,14 @@ tv_list_copy_error:
 listitem_T *tv_list_check_range_index_one(list_T *const l, int *const n1, const bool quiet)
 {
   listitem_T *li = tv_list_find_index(l, n1);
-  if (li == NULL) {
-    if (!quiet) {
-      semsg(_(e_list_index_out_of_range_nr), (int64_t)(*n1));
-    }
-    return NULL;
+  if (li != NULL) {
+    return li;
   }
-  return li;
+
+  if (!quiet) {
+    semsg(_(e_list_index_out_of_range_nr), (int64_t)(*n1));
+  }
+  return NULL;
 }
 
 /// Check that "n2" can be used as the second index in a range of list "l".
@@ -1634,11 +1635,13 @@ static listitem_T *tv_list_find_index(list_T *const l, int *const idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   listitem_T *li = tv_list_find(l, *idx);
-  if (li == NULL) {
-    if (*idx < 0) {
-      *idx = 0;
-      li = tv_list_find(l, *idx);
-    }
+  if (li != NULL) {
+    return li;
+  }
+
+  if (*idx < 0) {
+    *idx = 0;
+    li = tv_list_find(l, *idx);
   }
   return li;
 }
@@ -2130,10 +2133,12 @@ void tv_dict_free_dict(dict_T *const d)
 void tv_dict_free(dict_T *const d)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (!tv_in_free_unref_items) {
-    tv_dict_free_contents(d);
-    tv_dict_free_dict(d);
+  if (tv_in_free_unref_items) {
+    return;
   }
+
+  tv_dict_free_contents(d);
+  tv_dict_free_dict(d);
 }
 
 /// Unreference a dictionary

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -311,7 +311,8 @@ static bool set_maparg_lhs_rhs(const char *const orig_lhs, const size_t orig_lhs
   // replace_termcodes() may move the result to allocated memory, which
   // needs to be freed later (*lhs_buf and *rhs_buf).
   // replace_termcodes() also removes CTRL-Vs and sometimes backslashes.
-  // If something like <C-H> is simplified to 0x08 then mark it as simplified.
+  // If something like <C-H> is simplified to 0x08 then mark it as simplified
+  // and also add en entry with a modifier.
   bool did_simplify = false;
   const int flags = REPTERM_FROM_PART | REPTERM_DO_LT;
   char *bufarg = lhs_buf;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -201,14 +201,16 @@ static int skipcol_from_plines(win_T *wp, int plines_off)
 /// Set wp->w_skipcol to zero and redraw later if needed.
 static void reset_skipcol(win_T *wp)
 {
-  if (wp->w_skipcol != 0) {
-    wp->w_skipcol = 0;
-
-    // Should use the least expensive way that displays all that changed.
-    // UPD_NOT_VALID is too expensive, UPD_REDRAW_TOP does not redraw
-    // enough when the top line gets another screen line.
-    redraw_later(wp, UPD_SOME_VALID);
+  if (wp->w_skipcol == 0) {
+    return;
   }
+
+  wp->w_skipcol = 0;
+
+  // Should use the least expensive way that displays all that changed.
+  // UPD_NOT_VALID is too expensive, UPD_REDRAW_TOP does not redraw
+  // enough when the top line gets another screen line.
+  redraw_later(wp, UPD_SOME_VALID);
 }
 
 // Update curwin->w_topline to move the cursor onto the screen.

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -80,17 +80,21 @@ static char *get_mess_env(void)
   return get_locale_val(LC_MESSAGES);
 #else
   char *p = (char *)os_getenv("LC_ALL");
+  if (p != NULL) {
+    return p;
+  }
+
+  p = (char *)os_getenv("LC_MESSAGES");
+  if (p != NULL) {
+    return p;
+  }
+
+  p = (char *)os_getenv("LANG");
+  if (p != NULL && ascii_isdigit(*p)) {
+    p = NULL;  // ignore something like "1043"
+  }
   if (p == NULL) {
-    p = (char *)os_getenv("LC_MESSAGES");
-    if (p == NULL) {
-      p = (char *)os_getenv("LANG");
-      if (p != NULL && ascii_isdigit(*p)) {
-        p = NULL;  // ignore something like "1043"
-      }
-      if (p == NULL) {
-        p = get_locale_val(LC_CTYPE);
-      }
-    }
+    p = get_locale_val(LC_CTYPE);
   }
   return p;
 #endif


### PR DESCRIPTION
#### vim-patch:partial:9.0.1196: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11813)

https://github.com/vim/vim/commit/e8575988969579f9e1439181ae338b2ff74054a8

Skip list_alloc_with_items().

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>