### PR TITLE
feat(api): `nvim_get_chan_info` pass 0 for current channel

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -888,6 +888,9 @@ nvim_get_api_info()                                      *nvim_get_api_info()*
 nvim_get_chan_info({chan})                              *nvim_get_chan_info()*
     Gets information about a channel.
 
+    Parameters: ~
+      • {chan}  channel_id, or 0 for current channel
+
     Return: ~
         Dictionary describing a channel, with these keys:
         • "id" Channel id.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -405,6 +405,8 @@ The following changes to existing APIs or features add new behavior.
 • Attempting to set an invalid keycode option (e.g. `set t_foo=123`) no longer
   gives an error.
 
+• Passing 0 to |nvim_get_chan_info()| gets info about the current channel.
+
 • |:checkhealth| buffer can now be opened in a split window using modifiers like
   |:vertical|, |:horizontal| and |:botright|.
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1158,7 +1158,7 @@ function vim.api.nvim_get_autocmds(opts) end
 
 --- Gets information about a channel.
 ---
---- @param chan integer
+--- @param chan integer channel_id, or 0 for current channel
 --- @return table<string,any>
 function vim.api.nvim_get_chan_info(chan) end
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1612,6 +1612,7 @@ void nvim_set_client_info(uint64_t channel_id, String name, Dictionary version, 
 
 /// Gets information about a channel.
 ///
+/// @param chan channel_id, or 0 for current channel
 /// @returns Dictionary describing a channel, with these keys:
 ///    - "id"       Channel id.
 ///    - "argv"     (optional) Job arguments list.
@@ -1633,11 +1634,16 @@ void nvim_set_client_info(uint64_t channel_id, String name, Dictionary version, 
 ///                 the RPC channel), if provided by it via
 ///                 |nvim_set_client_info()|.
 ///
-Dictionary nvim_get_chan_info(Integer chan, Error *err)
+Dictionary nvim_get_chan_info(uint64_t channel_id, Integer chan, Error *err)
   FUNC_API_SINCE(4)
 {
   if (chan < 0) {
     return (Dictionary)ARRAY_DICT_INIT;
+  }
+
+  if (chan == 0 && !is_internal_call(channel_id)) {
+    assert(channel_id <= INT64_MAX);
+    chan = (Integer)channel_id;
   }
   return channel_info((uint64_t)chan);
 }

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2449,7 +2449,6 @@ describe('API', function()
     }
 
     it('returns {} for invalid channel', function()
-      eq({}, api.nvim_get_chan_info(0))
       eq({}, api.nvim_get_chan_info(-1))
       -- more preallocated numbers might be added, try something high
       eq({}, api.nvim_get_chan_info(10))
@@ -2457,6 +2456,8 @@ describe('API', function()
 
     it('stream=stdio channel', function()
       eq({ [1] = testinfo, [2] = stderr }, api.nvim_list_chans())
+      -- 0 should return current channel
+      eq(testinfo, api.nvim_get_chan_info(0))
       eq(testinfo, api.nvim_get_chan_info(1))
       eq(stderr, api.nvim_get_chan_info(2))
 
@@ -2522,6 +2523,7 @@ describe('API', function()
         "Vim:Error invoking 'nvim_set_current_buf' on channel 3 (amazing-cat):\nWrong type for argument 1 when calling nvim_set_current_buf, expecting Buffer",
         pcall_err(eval, 'rpcrequest(3, "nvim_set_current_buf", -1)')
       )
+      eq(info, eval('rpcrequest(3, "nvim_get_chan_info", 0)'))
     end)
 
     it('stream=job :terminal channel', function()


### PR DESCRIPTION
closes #21291

Hi first time doing this. I tried to follow the guidelines. I hope documentation and testing is good enough.

For testing I tried to follow `nvim_get_api_info()` but i did not find unit tests on this. I figured changing some of the `nvim_get_api_info()[1]` should be good enough for such a simple change.

Thanks for the feedback.
 