### PR TITLE
vim-patch:9.1.{0073,0074}

### DIFF
--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -400,7 +400,7 @@ int name_to_mod_mask(int c)
 int simplify_key(const int key, int *modifiers)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  if (!(*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL | MOD_MASK_ALT))) {
+  if (!(*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL))) {
     return key;
   }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2006,22 +2006,6 @@ static const char *did_set_binary(optset_T *args)
   return NULL;
 }
 
-/// Called when the 'breakat' option changes value.
-static const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
-{
-  for (int i = 0; i < 256; i++) {
-    breakat_flags[i] = false;
-  }
-
-  if (p_breakat != NULL) {
-    for (char *p = p_breakat; *p; p++) {
-      breakat_flags[(uint8_t)(*p)] = true;
-    }
-  }
-
-  return NULL;
-}
-
 /// Process the updated 'buflisted' option value.
 static const char *did_set_buflisted(optset_T *args)
 {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -797,6 +797,22 @@ int expand_set_belloff(optexpand_T *args, int *numMatches, char ***matches)
                                matches);
 }
 
+/// The 'breakat' option is changed.
+const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
+{
+  for (int i = 0; i < 256; i++) {
+    breakat_flags[i] = false;
+  }
+
+  if (p_breakat != NULL) {
+    for (char *p = p_breakat; *p; p++) {
+      breakat_flags[(uint8_t)(*p)] = true;
+    }
+  }
+
+  return NULL;
+}
+
 /// The 'breakindentopt' option is changed.
 const char *did_set_breakindentopt(optset_T *args)
 {


### PR DESCRIPTION
#### vim-patch:9.1.0073: Looping over modifier_keys_table unnecessarily

Problem:  Looping over modifier_keys_table[] unnecessarily with only
          MOD_MASK_ALT or MOD_MASK_CMD, as modifier_keys_table[] only
          contains MOD_MASK_SHIFT and MOD_MASK_CTRL, and the loop won't
          do anything.
Solution: Remove MOD_MASK_ALT and MOD_MASK_CMD from the condition.
          (zeertzjq)

closes: vim/vim#13963

https://github.com/vim/vim/commit/0c989e4a3ae50085aa8c6bed5d6701760191bc1d


#### vim-patch:9.1.0074: did_set_breakat() should be in optionstr.c

Problem:  did_set_breakat() should be in optionstr.c as 'breakat' is a
          string option.
Solution: Move did_set_breakat() to optionstr.c.
          (zeertzjq)

closes: vim/vim#13958

https://github.com/vim/vim/commit/eac3fdcfa0b54281c37ffb66b4d4e8d1072cca1c