### PR TITLE
vim-patch:7c5aeaffa2be

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -330,7 +330,7 @@ syn match	vimEscape	contained	"\\<\*[^>]*>\=>"
 
 syn region	vimString start=+$'+ end=+'+ skip=+''+ oneline contains=vimStringInterpolationBrace,vimStringInterpolationExpr
 syn region	vimString start=+$"+ end=+"+ oneline contains=@vimStringGroup,vimStringInterpolationBrace,vimStringInterpolationExpr
-syn region	vimStringInterpolationExpr matchgroup=vimOperParen start=+{+ end=+}+ oneline contains=vimFunc,vimFuncVar,vimOper,vimNotation,vimOperParen,vimString,vimVar
+syn region	vimStringInterpolationExpr matchgroup=vimSep start=+{+ end=+}+ oneline contains=vimFunc,vimFuncVar,vimOper,vimOperParen,vimNotation,vimNumber,vimString,vimVar
 syn match	vimStringInterpolationBrace "{{"
 syn match	vimStringInterpolationBrace "}}"
 


### PR DESCRIPTION
#### vim-patch:7c5aeaffa2be

runtime(vim): Update syntax file (vim/vim#13969)

Improve string interpolation highlighting.

Use the vimSep group to highlight interpolation braces as vimOperParen
has no highlighting of its own and employs vimSep via matchgroup.

Add vimNumber to the interpolation group's contained list.

https://github.com/vim/vim/commit/7c5aeaffa2bec8f16f36bd33a749a6e965d8ab30

Co-authored-by: dkearns <dougkearns@gmail.com>