### PR TITLE
fix(treesitter): inspect-tree remember opts on buf change

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -460,7 +460,9 @@ function M.inspect_tree(opts)
         return true
       end
 
+      local treeview_opts = treeview.opts
       treeview = assert(TSTreeView:new(buf, opts.lang))
+      treeview.opts = treeview_opts
       treeview:draw(b)
     end,
   })


### PR DESCRIPTION
**Problem:**
When in a treeview `treeview.opts.anon==true` or `treeview.opts.lang==true` is set (e.g. `a` or `I` is pressed) and after that, the buffer is modified, then these options get reset to `false`.
**Solution:**
Save `treeview.opts` into a temp var; and after creating a new `treeview` restore `treeview.opts`.