### PR TITLE
build: introduce Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,13 @@
+# Build neovim
+nvim: deps
+        cmake -B build -G Ninja
+        cmake --build build
+
+# Build dependencies
+deps:
+        cmake -S cmake.deps -B .deps -G Ninja
+        cmake --build .deps
+
+# Run functionaltest
+functionaltest: nvim
+	cmake --build build --target functionaltest


### PR DESCRIPTION
A justfile is basically equivalent to a Makefile, except that it works
cross-platform. This helps mitigate the problem of neovim being hard to
build on non-unix. It requires the executable
[just](https://github.com/casey/just) which is readily available on
pretty much all platforms:

The Makefile is not removed as this is supposed to be a trial period,
but it may make sense to remove the Makefile in the future in case the
Justfile can replace all functionality of the makefile.

Running a just target is the same as running a make target:

```
just # builds neovim
just functionaltest # run functionaltest
```

To list all available targets with a summary of what they do:

```
just --list
```

which outputs

```
Available recipes:
    deps           # Build dependencies
    functionaltest # Run functionaltest
    nvim           # Build neovim
```

The documentaiton can be found at https://just.systems/man/en/.