### PR TITLE
vim-patch:9.1.0077: Unnecessary call to redraw_for_cursorline() in nv_mousescroll()

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2864,15 +2864,3 @@ bool win_cursorline_standout(const win_T *wp)
 {
   return wp->w_p_cul || (wp->w_p_cole > 0 && !conceal_cursor_line(wp));
 }
-
-/// Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
-/// Also when concealing is on and 'concealcursor' is not active.
-void redraw_for_cursorline(win_T *wp)
-  FUNC_ATTR_NONNULL_ALL
-{
-  if ((wp->w_valid & VALID_CROW) == 0 && !pum_visible()
-      && (wp->w_p_rnu || win_cursorline_standout(wp))) {
-    // win_line() will redraw the number column and cursorline only.
-    redraw_later(wp, UPD_VALID);
-  }
-}

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1571,9 +1571,6 @@ void nv_mousescroll(cmdarg_T *cap)
   // Call the common mouse scroll function shared with other modes.
   do_mousescroll(cap);
 
-  if (curwin != old_curwin && curwin->w_p_cul) {
-    redraw_for_cursorline(curwin);
-  }
   curwin->w_redr_status = true;
   curwin = old_curwin;
   curbuf = curwin->w_buffer;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -135,6 +135,18 @@ static void comp_botline(win_T *wp)
   win_check_anchored_floats(wp);
 }
 
+/// Redraw when w_cline_row changes and 'relativenumber' or 'cursorline' is set.
+/// Also when concealing is on and 'concealcursor' is not active.
+static void redraw_for_cursorline(win_T *wp)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if ((wp->w_valid & VALID_CROW) == 0 && !pum_visible()
+      && (wp->w_p_rnu || win_cursorline_standout(wp))) {
+    // win_line() will redraw the number column and cursorline only.
+    redraw_later(wp, UPD_VALID);
+  }
+}
+
 /// Redraw when w_virtcol changes and
 /// - 'cursorcolumn' is set, or
 /// - 'cursorlineopt' contains "screenline", or


### PR DESCRIPTION
#### vim-patch:9.1.0077: Unnecessary call to redraw_for_cursorline() in nv_mousescroll()

Problem:  The call to redraw_for_cursorline() in nv_mousescroll() is
          unnecessary because redraw_for_cursorline() only sets redraw
          type to UPD_VALID, and all code paths in do_mousescroll()
          already set redraw type to at least UPD_VALID.
Solution: Remove call to redraw_for_cursorline() in nv_mousescroll().
          (zeertzjq)

closes: vim/vim#13979

https://github.com/vim/vim/commit/3f1b5312e0fa0089f255bf9c0c3b27590552119e