### PR TITLE
vim-patch:f7f33e3719c8

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1294,11 +1294,14 @@ Stack Overflow -
 
 https://stackoverflow.com/questions/12407800/which-comment-style-should-i-use-in-batch-files
 
-To allow the use of the :: idiom for comments in the Windows Command
-Interpreter or working with MS-DOS bat files, set the
-dosbatch_colons_comment variable to anything: >
+To allow the use of the :: idiom for comments in command blocks with the
+Windows Command Interpreter set the dosbatch_colons_comment variable to
+anything: >
 
    :let dosbatch_colons_comment = 1
+
+If this variable is set then a :: comment that is the last line in a command
+block will be highlighted as an error.
 
 There is an option that covers whether `*.btm` files should be detected as type
 "dosbatch" (MS-DOS batch files) or type "btm" (4DOS batch files).  The latter

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -2,11 +2,11 @@
 " Language:	MS-DOS/Windows batch file (with NT command extensions)
 " Maintainer:	Mike Williams <mrmrdubya@gmail.com>
 " Filenames:    *.bat
-" Last Change:	12th February 2023
+" Last Change:	3rd February 2024
 "
 " Options Flags:
 " dosbatch_cmdextversion	- 1 = Windows NT, 2 = Windows 2000 [default]
-" dosbatch_colons_comment       - any value to treat :: as comment line
+" dosbatch_colons_comment       - any value to allow :: comments in code blocks
 "
 
 " quit when a syntax file was already loaded
@@ -88,18 +88,22 @@ syn match dosbatchLabel		"\<goto\s\+\h\w*\>"lc=4
 syn match dosbatchLabel		":\h\w*\>"
 
 " Comments - usual rem but also two colons as first non-space is an idiom
-syn match dosbatchComment	"^rem\($\|\s.*$\)"lc=3 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-syn match dosbatchComment	"^@rem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-syn match dosbatchComment	"\srem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-syn match dosbatchComment	"\s@rem\($\|\s.*$\)"lc=5 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-if exists("dosbatch_colons_comment")
-  syn match dosbatchComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-else
-  syn match dosbatchError       "\s*:\s*:.*$"
-endif
+syn match dosbatchRemComment	"^rem\($\|\s.*$\)"lc=3 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+syn match dosbatchRemComment	"^@rem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+syn match dosbatchRemComment	"\srem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+syn match dosbatchRemComment	"\s@rem\($\|\s.*$\)"lc=5 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+syn match dosbatchColonComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
 
-" Comments in ()'s - still to handle spaces before rem
-syn match dosbatchComment	"(rem\([^)]\|\^\@<=)\)*"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+" Commands code blocks
+syn cluster dosbatchCodeBlockComment contains=dosbatchRemComment
+if exists("dosbatch_colons_comment")
+  syn cluster dosbatchCodeBlockComment add=dosbatchColonComment
+else
+  syn match dosbatchColonCommentErr contained "\s*:\s*:.*$"
+endif
+syn match dosbatchColonCommentErr contained "\s*:\s*:[^)]*\(\(\n\s*\)\?)\)\@="
+syn region dosbatchCodeBlock	transparent start=+(+ end=+)+ contains=dosbatchString,dosbatchVariable,dosBatchArgument,@dosbatchNumber,dosbatchImplicit,dosbatchStatement,dosbatchConditional,dosbatchRepeat,dosbatchOperator,@dosbatchCodeBlockComment,dosbatchColonCommentErr,dosbatchCodeBlock
+syn match dosbatchCodeBlockErr	")"
 
 syn keyword dosbatchImplicit    append assoc at attrib break cacls cd chcp chdir
 syn keyword dosbatchImplicit    chkdsk chkntfs cls cmd color comp compact convert copy
@@ -116,6 +120,8 @@ syn keyword dosbatchImplicit    vol xcopy
 
 hi def link dosbatchTodo	Todo
 hi def link dosbatchError	Error
+hi def link dosbatchCodeBlockErr dosbatchError
+hi def link dosbatchColonCommentErr dosbatchError
 
 hi def link dosbatchStatement	Statement
 hi def link dosbatchCommands	dosbatchStatement
@@ -140,6 +146,9 @@ hi def link dosbatchBinary	dosbatchNumber
 hi def link dosbatchOctal	dosbatchNumber
 
 hi def link dosbatchComment	Comment
+hi def link dosbatchRemComment	dosbatchComment
+hi def link dosbatchColonComment dosbatchComment
+
 hi def link dosbatchImplicit	Function
 
 hi def link dosbatchSwitch	Special


### PR DESCRIPTION
runtime(dosbatch): improve '::' comment highlighting

Added a syntax region for command blocks so that the highlighting of
`::` comments in them can be controlled.  The `dosbatch_colons_comment`
variable now controls if all `::` comments in a code block are
highlighted as comments or errors.  A `::` comment at the end of a
command block is always highlighted as an error.

This re-enables the highlighting of `::` comments in `.bat` files as
requested in vim/vim#13666, while allowing control of highlighting them in
command blocks requested in vim/vim#11778 and first attempted in vim/vim#11980.

related: vim/vim#11980
fixes: vim/vim#13666

https://github.com/vim/vim/commit/f7f33e3719c87279dfad109b874e2817007a1184

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Mike Williams <mikew@globalgraphics.com>
