### PR TITLE
feat(extmark): window scoped namespace

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2791,6 +2791,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                   • url: A URL to associate with this extmark. In the TUI, the
                     OSC 8 control sequence is used to generate a clickable
                     hyperlink to this URL.
+                  • scoped: boolean that indicates that the extmark should
+                    only be displayed in the namespace scope. (experimental)
 
     Return: ~
         Id of the created/updated extmark
@@ -2864,6 +2866,35 @@ nvim_set_decoration_provider({ns_id}, {*opts})
                    interaction with fold lines is subject to change) ["win",
                    winid, bufnr, row]
                  • on_end: called at the end of a redraw cycle ["end", tick]
+
+nvim_win_add_ns({window}, {ns_id})                         *nvim_win_add_ns()*
+    Adds the namespace scope to the window.
+
+    Parameters: ~
+      • {window}  Window handle, or 0 for current window
+      • {ns_id}   the namespace to add
+
+    Return: ~
+        true if the namespace was added, else false
+
+nvim_win_get_ns({window})                                  *nvim_win_get_ns()*
+    Gets all the namespaces scopes associated with a window.
+
+    Parameters: ~
+      • {window}  Window handle, or 0 for current window
+
+    Return: ~
+        a list of namespaces ids
+
+nvim_win_remove_ns({window}, {ns_id})                   *nvim_win_remove_ns()*
+    Removes the namespace scope from the window.
+
+    Parameters: ~
+      • {window}  Window handle, or 0 for current window
+      • {ns_id}   the namespace to remove
+
+    Return: ~
+        true if the namespace was removed, else false
 
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -318,6 +318,10 @@ The following new APIs and features were added.
 
 • Clicking on a tabpage in the tabline with the middle mouse button closes it.
 
+• |namespace| can now have window scopes. |nvim_win_add_ns()|
+
+• |extmarks| option `scoped`: only show the extmarks in its namespace's scope.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -613,6 +613,8 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---               • url: A URL to associate with this extmark. In the TUI, the
 ---                 OSC 8 control sequence is used to generate a clickable
 ---                 hyperlink to this URL.
+---               • scoped: boolean that indicates that the extmark should
+---                 only be displayed in the namespace scope. (experimental)
 --- @return integer
 function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
 
@@ -1982,6 +1984,13 @@ function vim.api.nvim_tabpage_set_var(tabpage, name, value) end
 --- @param win integer Window handle, must already belong to {tabpage}
 function vim.api.nvim_tabpage_set_win(tabpage, win) end
 
+--- Adds the namespace scope to the window.
+---
+--- @param window integer Window handle, or 0 for current window
+--- @param ns_id integer the namespace to add
+--- @return boolean
+function vim.api.nvim_win_add_ns(window, ns_id) end
+
 --- Calls a function with window as temporary current window.
 ---
 --- @param window integer Window handle, or 0 for current window
@@ -2031,6 +2040,12 @@ function vim.api.nvim_win_get_cursor(window) end
 --- @param window integer Window handle, or 0 for current window
 --- @return integer
 function vim.api.nvim_win_get_height(window) end
+
+--- Gets all the namespaces scopes associated with a window.
+---
+--- @param window integer Window handle, or 0 for current window
+--- @return integer[]
+function vim.api.nvim_win_get_ns(window) end
 
 --- Gets the window number
 ---
@@ -2083,6 +2098,13 @@ function vim.api.nvim_win_hide(window) end
 --- @param window integer Window handle, or 0 for current window
 --- @return boolean
 function vim.api.nvim_win_is_valid(window) end
+
+--- Removes the namespace scope from the window.
+---
+--- @param window integer Window handle, or 0 for current window
+--- @param ns_id integer the namespace to remove
+--- @return boolean
+function vim.api.nvim_win_remove_ns(window, ns_id) end
 
 --- Sets the current buffer in a window, without side effects
 ---

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -252,6 +252,7 @@ error('Cannot require a meta file')
 --- @field ui_watched? boolean
 --- @field undo_restore? boolean
 --- @field url? string
+--- @field scoped? boolean
 --- @field _subpriority? integer
 
 --- @class vim.api.keyset.user_command

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -169,7 +169,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
   DecorInline decor = { .ext = true, .data.ext.vt = vt, .data.ext.sh_idx = DECOR_ID_INVALID };
 
   extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, decor, 0, true,
-              false, false, false, NULL);
+              false, false, false, false, NULL);
   return src_id;
 }
 

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -55,6 +55,7 @@ typedef struct {
   Boolean ui_watched;
   Boolean undo_restore;
   String url;
+  Boolean scoped;
 
   Integer _subpriority;
 } Dict(set_extmark);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1020,6 +1020,8 @@ struct window_S {
   int w_ns_hl_active;
   int *w_ns_hl_attr;
 
+  Set(uint32_t) w_ns_set;
+
   int w_hl_id_normal;               ///< 'winhighlight' normal id
   int w_hl_attr_normal;             ///< 'winhighlight' normal final attrs
   int w_hl_attr_normalnc;           ///< 'winhighlight' NormalNC final attrs

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -54,12 +54,12 @@
 /// must not be used during iteration!
 void extmark_set(buf_T *buf, uint32_t ns_id, uint32_t *idp, int row, colnr_T col, int end_row,
                  colnr_T end_col, DecorInline decor, uint16_t decor_flags, bool right_gravity,
-                 bool end_right_gravity, bool no_undo, bool invalidate, Error *err)
+                 bool end_right_gravity, bool no_undo, bool invalidate, bool scoped, Error *err)
 {
   uint32_t *ns = map_put_ref(uint32_t, uint32_t)(buf->b_extmark_ns, ns_id, NULL, NULL);
   uint32_t id = idp ? *idp : 0;
 
-  uint16_t flags = mt_flags(right_gravity, no_undo, invalidate, decor.ext) | decor_flags;
+  uint16_t flags = mt_flags(right_gravity, no_undo, invalidate, decor.ext, scoped) | decor_flags;
   if (id == 0) {
     id = ++*ns;
   } else {

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -2286,7 +2286,7 @@ static void marktree_itr_fix_pos(MarkTree *b, MarkTreeIter *itr)
 void marktree_put_test(MarkTree *b, uint32_t ns, uint32_t id, int row, int col, bool right_gravity,
                        int end_row, int end_col, bool end_right, bool meta_inline)
 {
-  uint16_t flags = mt_flags(right_gravity, false, false, false);
+  uint16_t flags = mt_flags(right_gravity, false, false, false, false);
   // The specific choice is irrelevant here, we pick one counted decor
   // type to test the counting and filtering logic.
   flags |= meta_inline ? MT_FLAG_DECOR_VIRT_TEXT_INLINE : 0;

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -4,6 +4,7 @@
 #include <stddef.h>  // IWYU pragma: keep
 #include <stdint.h>
 
+#include "nvim/buffer_defs.h"
 #include "nvim/decoration_defs.h"
 #include "nvim/marktree_defs.h"  // IWYU pragma: keep
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
@@ -34,6 +35,8 @@
 #define MT_FLAG_DECOR_VIRT_LINES (((uint16_t)1) << 11)
 #define MT_FLAG_DECOR_VIRT_TEXT_INLINE (((uint16_t)1) << 12)
 
+#define MT_FLAG_SCOPED (((uint16_t)1) << 13)
+
 // These _must_ be last to preserve ordering of marks
 #define MT_FLAG_RIGHT_GRAVITY (((uint16_t)1) << 14)
 #define MT_FLAG_LAST (((uint16_t)1) << 15)
@@ -43,7 +46,7 @@
                              | MT_FLAG_DECOR_VIRT_TEXT_INLINE)
 
 #define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_NO_UNDO \
-                               | MT_FLAG_INVALIDATE | MT_FLAG_INVALID)
+                               | MT_FLAG_INVALIDATE | MT_FLAG_INVALID | MT_FLAG_SCOPED)
 
 // this is defined so that start and end of the same range have adjacent ids
 #define MARKTREE_END_FLAG ((uint64_t)1)
@@ -107,12 +110,24 @@ static inline bool mt_decor_sign(MTKey key)
   return key.flags & (MT_FLAG_DECOR_SIGNTEXT | MT_FLAG_DECOR_SIGNHL);
 }
 
-static inline uint16_t mt_flags(bool right_gravity, bool no_undo, bool invalidate, bool decor_ext)
+static inline bool mt_scoped(MTKey key)
+{
+  return key.flags & MT_FLAG_SCOPED;
+}
+
+static inline bool mt_scoped_in_win(MTKey key, win_T *wp)
+{
+  return !mt_scoped(key) || set_has(uint32_t, &wp->w_ns_set, key.ns);
+}
+
+static inline uint16_t mt_flags(bool right_gravity, bool no_undo, bool invalidate, bool decor_ext,
+                                bool scoped)
 {
   return (uint16_t)((right_gravity ? MT_FLAG_RIGHT_GRAVITY : 0)
                     | (no_undo ? MT_FLAG_NO_UNDO : 0)
                     | (invalidate ? MT_FLAG_INVALIDATE : 0)
-                    | (decor_ext ? MT_FLAG_DECOR_EXT : 0));
+                    | (decor_ext ? MT_FLAG_DECOR_EXT : 0)
+                    | (scoped ? MT_FLAG_SCOPED : 0));
 }
 
 static inline MTPair mtpair_from(MTKey start, MTKey end)

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -126,7 +126,7 @@ static void buf_set_sign(buf_T *buf, uint32_t *id, char *group, int prio, linenr
 
   DecorInline decor = { .ext = true, .data.ext = { .vt = NULL, .sh_idx = decor_put_sh(sign) } };
   extmark_set(buf, ns, id, lnum - 1, 0, -1, -1, decor, decor_flags, true,
-              false, true, true, NULL);
+              false, true, true, false, NULL);
 }
 
 /// For an existing, placed sign with "id", modify the sign, group or priority.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4989,6 +4989,9 @@ win_T *win_alloc(win_T *after, bool hidden)
 
   new_wp->w_ns_hl = -1;
 
+  Set(uint32_t) ns_set = SET_INIT;
+  new_wp->w_ns_set = ns_set;
+
   // use global option for global-local options
   new_wp->w_allbuf_opt.wo_so = new_wp->w_p_so = -1;
   new_wp->w_allbuf_opt.wo_siso = new_wp->w_p_siso = -1;
@@ -5026,6 +5029,8 @@ void win_free(win_T *wp, tabpage_T *tp)
 
   // Don't execute autocommands while the window is halfway being deleted.
   block_autocmds();
+
+  set_destroy(uint32_t, &wp->w_ns_set);
 
   clear_winopt(&wp->w_onebuf_opt);
   clear_winopt(&wp->w_allbuf_opt);


### PR DESCRIPTION
By @bfredl suggestion https://github.com/neovim/neovim/pull/27361#issuecomment-1929373396:
Make namespaces have the possibility of being window-local (only show the namespaces's extmarks in specific windows).
Currently, one needs to set a flag on the extmark (called `scoped`) to make this take effect (may be changed).

Closes https://github.com/neovim/neovim/issues/19654