### PR TITLE
fix(column): handle w_redr_statuscol at end filler lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1580,7 +1580,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
           // win_line_start(wp, &wlv);
           wlv.col = 0;
           wlv.off = 0;
-          draw_cols = true;
           continue;
         } else {
           break;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2346,6 +2346,7 @@ static void win_update(win_T *wp)
 
     // 'statuscolumn' width has changed or errored, start from the top.
     if (wp->w_redr_statuscol) {
+redr_statuscol:
       wp->w_redr_statuscol = false;
       idx = 0;
       row = 0;
@@ -2429,6 +2430,10 @@ static void win_update(win_T *wp)
         spellvars_T zero_spv = { 0 };
         foldinfo_T zero_foldinfo = { 0 };
         row = win_line(wp, wp->w_botline, row, wp->w_grid.rows, 0, &zero_spv, zero_foldinfo);
+        if (wp->w_redr_statuscol) {
+          eof = false;
+          goto redr_statuscol;
+        }
       }
     } else if (dollar_vcol == -1) {
       wp->w_botline = lnum;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -515,6 +515,22 @@ describe('statuscolumn', function()
       set cpoptions-=n nocursorline relativenumber
       set stc=%{v:virtnum<0?'virtual':(!v:virtnum?'buffer':'wrapped')}%=%{'\ '.v:virtnum.'\ '.v:lnum.'\ '.v:relnum}
     ]])
+    screen:expect([[
+      {1:buffer  0 12 3}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 1 12 3}aaaaaaaaaaa                            |
+      {1:buffer  0 13 2}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 1 13 2}aaaaaaaaaaa                            |
+      {1:buffer  0 14 1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 1 14 1}aaaaaaaaaaa                            |
+      {1:buffer  0 15 0}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 1 15 0}aaaaaaaaaaa^ aaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {1:wrapped 2 15 0}aaaaaaaaaaaaaaaaaaaaaaa                |
+      {1:virtual-3 15 0}virt_line1                             |
+      {1:virtual-2 15 0}virt_line2                             |
+      {1:virtual-1 15 0}END                                    |
+      {0:~                                                    }|
+                                                           |
+    ]])
     feed('kk')
     screen:expect([[
       {1:buffer  0 12 1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|


### PR DESCRIPTION
There doesn't seem to be an easy solution that doesn't involve a goto.
Also remove duplicate assignment in win_line().
