### PR TITLE
Allow template variable values to be passed to `vim.snippet.expand()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4245,7 +4245,7 @@ vim.snippet.active()                                    *vim.snippet.active()*
 vim.snippet.exit()                                        *vim.snippet.exit()*
     Exits the current snippet.
 
-vim.snippet.expand({input})                             *vim.snippet.expand()*
+vim.snippet.expand({input}, {opts})                     *vim.snippet.expand()*
     Expands the given snippet text. Refer to https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax for
     the specification of valid input.
 
@@ -4253,6 +4253,14 @@ vim.snippet.expand({input})                             *vim.snippet.expand()*
 
     Parameters: ~
       • {input}  (`string`)
+      • {opts}   (`table?`) Options table with keys:
+                 • `variables` (`table`): table containing values for the
+                   template variables. Each of the entries can be either a
+                   string, or a function that returns a string. In either case
+                   if the result is `nil` then the template variables's
+                   default will be used, or an empty string. The function
+                   recieves two arguments, the name of the variable and the
+                   default value from the template.
 
 vim.snippet.jump({direction})                             *vim.snippet.jump()*
     Jumps within the active snippet in the given direction. If the jump isn't


### PR DESCRIPTION
This is an extension to the existing `vim.snippet.expand()` api introduced in #25301 (see also: #25696)

The idea with this PR is that the caller can specify the values of variables defined in the templates by passing them in a second `options` argument to `vim.snippet.expand()`:

```lua
vim.snippet.expand(snippet, {
  variables: {
    A = "value for $A",
    B = function(name)
      return "value for $" .. name
    end
  }
})
```

The logic is as follows:
* If the variable is not defined, the variable's default (as defined in the template) is used, falling back to an empty string. **NOTE** This is different to the original behaviour, where an undefined variable would become a tabstop. This seemed awkward, and would override other existing tabstops of the same index. For e.g. `$A` would clobber `$1` if it came first in the template.
* If the variable is a function, the function is called with the variable's name as the first argument. The result is used as the variable's value. If the function returns `nil`, then the variable's default is used, falling back to an empty string.
* If the variable is a string, the string is used as the variable's value, or if `nil` falling back to the variable's default, and then to an empty string.

One usecase for this is to implement `TM_SELECTED_TEXT` in userland, the simplest approach being something like:

```lua
vim.snippet.expand(snippet, {
  variables: {
    TM_SELECTED_TEXT = function(name)
      return vim.fn.getreg('"')
    end
  }
})
```

**NOTE**: The use of`vim.fn.getreg('"')` here is pretty simplistic and has some odd edge cases, but it's good to use as an example here.

- [ ] test coverage