### PR TITLE
fix(runtime): source c ftplugins in correct order

### DIFF
--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -10,8 +10,7 @@ if exists("b:did_ftplugin")
 endif
 
 " Behaves mostly just like C
-runtime! ftplugin/c.vim ftplugin/c_*.vim ftplugin/c/*.vim
-runtime! ftplugin/c.lua ftplugin/c_*.lua ftplugin/c/*.lua
+runtime! ftplugin/c.{vim,lua} ftplugin/c_*.{vim,lua} ftplugin/c/*.{vim,lua}
 
 " C++ uses templates with <things>
 " Disabled, because it gives an error for typing an unmatched ">".


### PR DESCRIPTION
Hi,

Since 02fd00c042d2b8a66c892dd31c1659ee98a1dbbf, cpp.vim also sources lua ftplugins for C.
However, it does not follow the order of `'rtp'`. For example, <code>\~/.config/nvim/ftplugin/c.<b>lua</b></code> will be sourced after and potentially override settings from <code>~/.config/nvim/<b>after</b>/ftplugin/c.<b>vim</b></code>.
This change addresses that by matching the order from [ftplugin.vim](https://github.com/neovim/neovim/blob/master/runtime/ftplugin.vim#L35).