### PR TITLE
vim-patch:partial:9.1.0080,c9c2e2d2ff44

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -252,7 +252,9 @@ List concatenation ~
 							*list-concatenation*
 Two lists can be concatenated with the "+" operator: >
 	:let longlist = mylist + [5, 6]
+A list can be concatenated with another one in place using the "+=" operator or |extend()|: >
 	:let mylist += [7, 8]
+	:call extend(mylist, [7, 8])
 
 To prepend or append an item, turn the item into a list by putting [] around
 it.  To change a list in-place, refer to |list-modification| below.
@@ -374,7 +376,8 @@ To change part of a list you can specify the first and last item to be
 modified.  The value must at least have the number of items in the range: >
 	:let list[3:5] = [3, 4, 5]
 
-To add items to a List in-place, you can use the |+=| operator: >
+To add items to a List in-place, you can use the += operator
+|list-concatenation|: >
 	:let listA = [1, 2]
 	:let listA += [3, 4]
 <

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -374,6 +374,18 @@ To change part of a list you can specify the first and last item to be
 modified.  The value must at least have the number of items in the range: >
 	:let list[3:5] = [3, 4, 5]
 
+To add items to a List in-place, you can use the |+=| operator: >
+	:let listA = [1, 2]
+	:let listA += [3, 4]
+<
+When two variables refer to the same List, changing one List in-place will
+cause the referenced List to be changed in-place: >
+	:let listA = [1, 2]
+	:let listB = listA
+	:let listB += [3, 4]
+	:echo listA
+	[1, 2, 3, 4]
+<
 Adding and removing items from a list is done with functions.  Here are a few
 examples: >
 	:call insert(list, 'a')		" prepend item 'a'


### PR DESCRIPTION
#### vim-patch:partial:9.1.0080: unexpected error for modifying final list using +=

Problem:  unexpected error for modifying final list using += operator
          (Ernie Rael)
Solution: Allow List value modification of a final variable using +=
          operator
          (Yegappan Lakshmanan)

closes: vim/vim#13962

https://github.com/vim/vim/commit/1af35631f85d2fcdc83c5d457af8273697f5146a

Only port eval.txt changes.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:c9c2e2d2ff44

runtime(doc): Clarify list-concatenation a bit more

Make doc list-concatenation more clear as for += and extend().

1. describe `+=` for list-concatenation more accurately
2. add `extend()` example for list-concatenation
3. Fix CI errors for missing helptags reference |+=|

closes: vim/vim#13983

https://github.com/vim/vim/commit/c9c2e2d2ff4429a6b5876ee919f15c1dc0018e86

Co-authored-by: qeatzy <qeatzy@users.noreply.github.com>