### PR TITLE
added doc for &channel

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -138,7 +138,7 @@ Example: >vim
   window title or tab title of a graphical terminal emulator. Terminal
   programs can set this by emitting an escape sequence.
 - |'channel'|  Terminal PTY |job-id|.  Can be used with |chansend()| to send
-  input to the terminal.
+  input to the terminal.  Access with *&channel*.
 - The |TermClose| event gives the terminal job exit code in the |v:event|
   "status" field. For example, this autocommand outputs the terminal's exit
   code to |:messages|: >vim


### PR DESCRIPTION
I guess we should expect users to know that we can prefix some options with `&` to access them in vimscript, but I didn't and used chatgpt to figure it out.  Adding reminders like this can't hurt, unless you think it is too verbose.  Another option could be to put the contents of `:h expr-option` in a more prominent place.  Even that is obscure and terse, in my opinion. Sorry if this is presumptuous! Just an idea. 