### PR TITLE
fix(api): handle tab correctly in nvim_err_writeln

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1776,7 +1776,15 @@ static void write_msg(String message, bool to_err, bool writeln)
     if (got_int) {
       break;
     }
-    PUSH_CHAR(message.data[i]);
+    char current_char = message.data[i];
+    if (current_char == '\t') {
+      // Assuming a tab should be replaced by 4 spaces.
+      for (size_t space_count = 0; space_count < 4; space_count++) {
+        PUSH_CHAR(' ');
+      }
+    } else {
+      PUSH_CHAR(message.data[i]);
+    }
   }
   if (writeln) {
     PUSH_CHAR(NL);

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2421,6 +2421,20 @@ describe('API', function()
                                                 |
       ]])
     end)
+
+    it('handle tab character correctly #26466', function()
+      async_meths.nvim_err_writeln('stack traceback:\n\t[string ":lua"]:1: in main chunk')
+      screen:expect {
+        grid = [[
+                                                |
+        {0:~                                       }|*3
+        {3:                                        }|
+        {1:stack traceback:}                        |
+        {1:    [string ":lua"]:1: in main chunk}    |
+        {2:Press ENTER or type command to continue}^ |
+      ]],
+      }
+    end)
   end)
 
   describe('nvim_list_chans, nvim_get_chan_info', function()


### PR DESCRIPTION
Problem: characters are pushed into a buffer and then written out without any specific handling for tab characters in currently nvim_err_writeln

Solutin: handle tab character to 4 spaces.

Fix #26466 