### PR TITLE
feat(lsp): deprecate severity_limit

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1384,6 +1384,7 @@ on_diagnostic({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
+      • {result}  (`lsp.DocumentDiagnosticReport`)
       • {ctx}     (`lsp.HandlerContext`)
       • {config}  (`table`) Configuration table (see
                   |vim.diagnostic.config()|).

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -193,7 +193,7 @@ describe('vim.lsp.diagnostic', function()
           PublishDiagnostics = vim.lsp.with(vim.lsp.diagnostic.on_publish_diagnostics, {
             underline = false,
             virtual_text = {
-              severity_limit = ...
+              severity = { min = ... }
             },
           })
 
@@ -212,11 +212,11 @@ describe('vim.lsp.diagnostic', function()
       end
 
       -- No messages with Error or higher
-      eq(0, get_extmark_count_with_severity('Error'))
+      eq(0, get_extmark_count_with_severity('ERROR'))
 
       -- But now we don't filter it
-      eq(1, get_extmark_count_with_severity('Warning'))
-      eq(1, get_extmark_count_with_severity('Hint'))
+      eq(1, get_extmark_count_with_severity('WARN'))
+      eq(1, get_extmark_count_with_severity('HINT'))
     end)
 
     it('correctly handles UTF-16 offsets', function()


### PR DESCRIPTION
### Problem:
  `vim.lsp.diagnostic.on_diagnostic` accepts an undocumented severity_limit option which is widely used.

### Solution:
  Deprecate it in favour of `{min = severity}` used in `vim.diagnostic`.
  Since this is undocumented, the schedule for removal is accelerated to 0.11.
