### PR TITLE
refactor(api): refactor more api functions to use arena return

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1262,28 +1262,27 @@ Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
   return res;
 }
 
-Dictionary nvim__buf_stats(Buffer buffer, Error *err)
+Dictionary nvim__buf_stats(Buffer buffer, Arena *arena, Error *err)
 {
-  Dictionary rv = ARRAY_DICT_INIT;
-
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {
-    return rv;
+    return (Dictionary)ARRAY_DICT_INIT;
   }
 
+  Dictionary rv = arena_dict(arena, 7);
   // Number of times the cached line was flushed.
   // This should generally not increase while editing the same
   // line in the same mode.
-  PUT(rv, "flush_count", INTEGER_OBJ(buf->flush_count));
+  PUT_C(rv, "flush_count", INTEGER_OBJ(buf->flush_count));
   // lnum of current line
-  PUT(rv, "current_lnum", INTEGER_OBJ(buf->b_ml.ml_line_lnum));
+  PUT_C(rv, "current_lnum", INTEGER_OBJ(buf->b_ml.ml_line_lnum));
   // whether the line has unflushed changes.
-  PUT(rv, "line_dirty", BOOLEAN_OBJ(buf->b_ml.ml_flags & ML_LINE_DIRTY));
+  PUT_C(rv, "line_dirty", BOOLEAN_OBJ(buf->b_ml.ml_flags & ML_LINE_DIRTY));
   // NB: this should be zero at any time API functions are called,
   // this exists to debug issues
-  PUT(rv, "dirty_bytes", INTEGER_OBJ((Integer)buf->deleted_bytes));
-  PUT(rv, "dirty_bytes2", INTEGER_OBJ((Integer)buf->deleted_bytes2));
-  PUT(rv, "virt_blocks", INTEGER_OBJ((Integer)buf_meta_total(buf, kMTMetaLines)));
+  PUT_C(rv, "dirty_bytes", INTEGER_OBJ((Integer)buf->deleted_bytes));
+  PUT_C(rv, "dirty_bytes2", INTEGER_OBJ((Integer)buf->deleted_bytes2));
+  PUT_C(rv, "virt_blocks", INTEGER_OBJ((Integer)buf_meta_total(buf, kMTMetaLines)));
 
   u_header_T *uhp = NULL;
   if (buf->b_u_curhead != NULL) {
@@ -1292,7 +1291,7 @@ Dictionary nvim__buf_stats(Buffer buffer, Error *err)
     uhp = buf->b_u_newhead;
   }
   if (uhp) {
-    PUT(rv, "uhp_extmark_size", INTEGER_OBJ((Integer)kv_size(uhp->uh_extmark)));
+    PUT_C(rv, "uhp_extmark_size", INTEGER_OBJ((Integer)kv_size(uhp->uh_extmark)));
   }
 
   return rv;

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -70,15 +70,15 @@ Integer nvim_create_namespace(String name)
 /// Gets existing, non-anonymous |namespace|s.
 ///
 /// @return dict that maps from names to namespace ids.
-Dictionary nvim_get_namespaces(void)
+Dictionary nvim_get_namespaces(Arena *arena)
   FUNC_API_SINCE(5)
 {
-  Dictionary retval = ARRAY_DICT_INIT;
+  Dictionary retval = arena_dict(arena, map_size(&namespace_ids));
   String name;
   handle_T id;
 
   map_foreach(&namespace_ids, name, id, {
-    PUT(retval, name.data, INTEGER_OBJ(id));
+    PUT_C(retval, name.data, INTEGER_OBJ(id));
   })
 
   return retval;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3326,7 +3326,7 @@ void maketitle(void)
     if (*p_titlestring != NUL) {
       if (stl_syntax & STL_IN_TITLE) {
         build_stl_str_hl(curwin, buf, sizeof(buf), p_titlestring,
-                         kOptTitlestring, 0, 0, maxlen, NULL, NULL, NULL);
+                         kOptTitlestring, 0, 0, maxlen, NULL, NULL, NULL, NULL);
         title_str = buf;
       } else {
         title_str = p_titlestring;
@@ -3431,7 +3431,7 @@ void maketitle(void)
     if (*p_iconstring != NUL) {
       if (stl_syntax & STL_IN_ICON) {
         build_stl_str_hl(curwin, icon_str, sizeof(buf), p_iconstring,
-                         kOptIconstring, 0, 0, 0, NULL, NULL, NULL);
+                         kOptIconstring, 0, 0, 0, NULL, NULL, NULL, NULL);
       } else {
         icon_str = p_iconstring;
       }

--- a/src/nvim/highlight_group.h
+++ b/src/nvim/highlight_group.h
@@ -12,7 +12,7 @@ typedef struct {
   char *name;
   RgbValue color;
 } color_name_table_T;
-extern color_name_table_T color_name_table[];
+extern color_name_table_T color_name_table[700];
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "highlight_group.h.generated.h"

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -411,7 +411,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   // might change the option value and free the memory.
   stl = xstrdup(stl);
   build_stl_str_hl(ewp, buf, sizeof(buf), stl, opt_idx, opt_scope,
-                   fillchar, maxwidth, &hltab, &tabtab, NULL);
+                   fillchar, maxwidth, &hltab, NULL, &tabtab, NULL);
 
   xfree(stl);
   ewp->w_p_crb = p_crb_save;
@@ -880,7 +880,7 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, char *buf, st
   StlClickRecord *clickrec;
   char *stc = xstrdup(wp->w_p_stc);
   int width = build_stl_str_hl(wp, buf, MAXPATHL, stc, kOptStatuscolumn, OPT_LOCAL, 0,
-                               stcp->width, &stcp->hlrec, fillclick ? &clickrec : NULL, stcp);
+                               stcp->width, &stcp->hlrec, NULL, fillclick ? &clickrec : NULL, stcp);
   xfree(stc);
 
   if (fillclick) {
@@ -922,7 +922,7 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, linenr_T relnum, char *buf, st
 /// @return  The final width of the statusline
 int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex opt_idx,
                      int opt_scope, schar_T fillchar, int maxwidth, stl_hlrec_t **hltab,
-                     StlClickRecord **tabtab, statuscol_T *stcp)
+                     size_t *hltab_len, StlClickRecord **tabtab, statuscol_T *stcp)
 {
   static size_t stl_items_len = 20;  // Initial value, grows as needed.
   static stl_item_t *stl_items = NULL;
@@ -2131,6 +2131,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
     }
     sp->start = NULL;
     sp->userhl = 0;
+  }
+  if (hltab_len) {
+    *hltab_len = (size_t)itemcnt;
   }
 
   // Store the info about tab pages labels.

--- a/test/unit/statusline_spec.lua
+++ b/test/unit/statusline_spec.lua
@@ -43,6 +43,7 @@ describe('build_stl_str_hl', function()
       maximum_cell_count,
       NULL,
       NULL,
+      NULL,
       NULL
     )
   end


### PR DESCRIPTION
Currently having two separate memory strategies for API return values is a bit unnecessary, and mostly a consequence of converting the hot spot cases which needed it first. But there is really no downside to using arena everywhere (which implies also directly using strings which are allocated earlier or even statically, without copy). 

There only restriction is we need to know the size of arrays in advance, but this info can often be passed on from some earlier stage if it is missing.

This collects some "small" cases. The more complex stuff will get a PR each, some which might use the new `Dict(foo)` return pattern as well.