### PR TITLE
feat(treesitter): add optional modeline arguments to query.set

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -226,6 +226,8 @@ The following new APIs and features were added.
   • `:InspectTree` (|vim.treesitter.inspect_tree()|) shows node ranges in
     0-based indexing instead of 1-based indexing.
   • `:InspectTree` (|vim.treesitter.inspect_tree()|) shows root nodes
+  • |vim.treesitter.query.set()| can now inherit and/or extend runtime file
+    queries in addition to overriding.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -968,12 +968,15 @@ edit({lang})                                     *vim.treesitter.query.edit()*
       • {lang}  (`string?`) language to open the query editor for. If omitted,
                 inferred from the current buffer's filetype.
 
-get({lang}, {query_name})                         *vim.treesitter.query.get()*
+get({lang}, {query_name}, {bufnr})                *vim.treesitter.query.get()*
     Returns the runtime query {query_name} for {lang}.
 
     Parameters: ~
       • {lang}        (`string`) Language to use for the query
       • {query_name}  (`string`) Name of the query (e.g. "highlights")
+      • {bufnr}       (`integer?`) Buffer for per-buffer queries applied with
+                      |vim.treesitter.query.set()| (`0`for current buffer,
+                      `nil` for all buffers for lang)
 
     Return: ~
         (`vim.treesitter.Query?`) Parsed query. `nil` if no query files are
@@ -1134,16 +1137,26 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
         (`fun(): integer, table<integer,TSNode>, table`) pattern id, match,
         metadata
 
-set({lang}, {query_name}, {text})                 *vim.treesitter.query.set()*
+set({lang}, {query_name}, {text}, {opts})         *vim.treesitter.query.set()*
     Sets the runtime query named {query_name} for {lang}
 
-    This allows users to override any runtime files and/or configuration set
-    by plugins.
+    This allows users to override or extend any runtime files and/or
+    configuration set by plugins.
 
     Parameters: ~
       • {lang}        (`string`) Language to use for the query
       • {query_name}  (`string`) Name of the query (e.g., "highlights")
-      • {text}        (`string`) Query text (unparsed).
+      • {text}        (`string`) Query text (unparsed)
+      • {opts}        (`table?`) Optional keyword arguments
+                      • inherits (string|string[]|nil) Language(s) this query
+                        should inherit (see
+                        |treesitter-query-modeline-inherits|)
+                      • extends (boolean|nil) If `true`, the query should be
+                        used as an extension query (see
+                        |treesitter-query-modeline-extends|)
+                      • bufnr (integer|nil) Buffer this query should apply to
+                        (`0` for current buffer, `nil` for all buffers for
+                        lang)
 
 
 ==============================================================================

--- a/runtime/lua/vim/func.lua
+++ b/runtime/lua/vim/func.lua
@@ -14,6 +14,11 @@ local M = {}
 --
 --- Memoizes a function {fn} using {hash} to hash the arguments.
 ---
+--- Also returns a function that either:
+--- - Invalidates the entire memoize cache when provided no arguments, or
+--- - Removes a specific function call from the cache when provided that
+---   function call's arguments
+---
 --- Internally uses a |lua-weaktable| to cache the results of {fn} meaning the
 --- cache will be invalidated whenever Lua does garbage collection.
 ---
@@ -33,6 +38,7 @@ local M = {}
 ---
 --- @param fn F Function to memoize.
 --- @return F # Memoized version of {fn}
+--- @return function # Function to clear the memoize cache
 --- @nodoc
 function M._memoize(hash, fn)
   return require('vim.func._memoize')(hash, fn)

--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -142,7 +142,7 @@ local function get_folds_levels(bufnr, info, srow, erow, parse_injections)
   local prev_stop = -1
 
   parser:for_each_tree(function(tree, ltree)
-    local query = ts.query.get(ltree:lang(), 'folds')
+    local query = ts.query.get(ltree:lang(), 'folds', bufnr)
     if not query then
       return
     end

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -7,7 +7,7 @@ local ns = api.nvim_create_namespace('treesitter/highlighter')
 ---@alias vim.treesitter.highlighter.Iter fun(end_line: integer|nil): integer, TSNode, TSMetadata
 
 ---@class vim.treesitter.highlighter.Query
----@field private _query vim.treesitter.query.Query?
+---@field private _query vim.treesitter.Query?
 ---@field private lang string
 ---@field private hl_cache table<integer,integer>
 local TSHighlighterQuery = {}
@@ -16,8 +16,9 @@ TSHighlighterQuery.__index = TSHighlighterQuery
 ---@private
 ---@param lang string
 ---@param query_string string?
+---@param bufnr integer?
 ---@return vim.treesitter.highlighter.Query
-function TSHighlighterQuery.new(lang, query_string)
+function TSHighlighterQuery.new(lang, query_string, bufnr)
   local self = setmetatable({}, TSHighlighterQuery)
   self.lang = lang
   self.hl_cache = {}
@@ -25,7 +26,7 @@ function TSHighlighterQuery.new(lang, query_string)
   if query_string then
     self._query = query.parse(lang, query_string)
   else
-    self._query = query.get(lang, 'highlights')
+    self._query = query.get(lang, 'highlights', bufnr)
   end
 
   return self
@@ -123,7 +124,7 @@ function TSHighlighter.new(tree, opts)
   -- string query... if one is not provided it will be looked up by file.
   if opts.queries then
     for lang, query_string in pairs(opts.queries) do
-      self._queries[lang] = TSHighlighterQuery.new(lang, query_string)
+      self._queries[lang] = TSHighlighterQuery.new(lang, query_string, self.bufnr)
     end
   end
 
@@ -237,7 +238,7 @@ end
 ---@return vim.treesitter.highlighter.Query
 function TSHighlighter:get_query(lang)
   if not self._queries[lang] then
-    self._queries[lang] = TSHighlighterQuery.new(lang)
+    self._queries[lang] = TSHighlighterQuery.new(lang, nil, self.bufnr)
   end
 
   return self._queries[lang]

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -118,6 +118,11 @@ function LanguageTree.new(source, lang, opts, parent_lang)
     source = vim.api.nvim_get_current_buf()
   end
 
+  local bufnr = nil
+  if type(source) == 'number' then
+    bufnr = source
+  end
+
   local injections = opts.injections or {}
 
   --- @type LanguageTree
@@ -129,7 +134,7 @@ function LanguageTree.new(source, lang, opts, parent_lang)
     _trees = {},
     _opts = opts,
     _injection_query = injections[lang] and query.parse(lang, injections[lang])
-      or query.get(lang, 'injections'),
+      or query.get(lang, 'injections', bufnr),
     _has_regions = false,
     _injections_processed = false,
     _valid = false,


### PR DESCRIPTION
# Problem

`vim.treesitter.query.set` only supports overriding queries defined in runtime files. It does not provide a way to extend existing queries. There is not an easy way to customize query behavior based on dynamic configuration (e.g., as a plugin).

# Solution

Add optional arguments to `vim.treesitter.query.set` that correspond to the treesitter query modelines supported in runtime query files.

## Update 2024-02-23

- Support added for query overrides from `vim.treesitter.query.set` to be
  applied for an entire language or for individual buffers by providing
  and optional `bufnr` argument to both `vim.treesitter.query.set` and
  `vim.treesitter.query.get`.

Implementation notes:

- A given query can be extended by multiple callers. For example,
  multiple plugins can provide extensions to the same query. As such,
  parsing of query overrides and extensions has been moved to
  `vim.treesitter.query.get`.
- Queries can be extended (and also now overridden) for an entire
  language or for individual buffers. Buffers with buffer-only overrides
  or extensions will also include any global language extensions.
- Tree-sitter fold, highlighter, and languagetree modules have been
  updated to support buffer-only query overrides and extensions.
- Memoize cache invalidation was necessary to implement this feature
  with consistent behavior (i.e., seeing query changes applied via
  `vim.treesitter.query.set` immediately). The
  `vim.treesitter.query.get` memoize hash is now cleared when calling
  `vim.treesitter.query.set`. When setting buffer-only queries the
  corresponding function call is removed from the memoize cache. When
  setting global lang queries the entire memoize cache is cleared. This
  scheme was picked under the assumption that global lang queries will
  typically be set before getting queries, whereas buffer-only queries
  may be set and changed throughout a session.

Closes #26965.