### PR TITLE
refactor: rename `FloatConfig` to `WinConfig`

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1535,7 +1535,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---
 --- @param buffer integer Buffer to display, or 0 for current buffer
 --- @param enter boolean Enter the window (make it the current window)
---- @param config vim.api.keyset.float_config Map defining the window configuration. Keys:
+--- @param config vim.api.keyset.win_config Map defining the window configuration. Keys:
 ---               • relative: Sets the window layout to "floating", placed at
 ---                 (row,col) coordinates relative to:
 ---                 • "editor" The global editor grid
@@ -2093,7 +2093,7 @@ function vim.api.nvim_win_set_buf(window, buffer) end
 --- changed. `row`/`col` and `relative` must be reconfigured together.
 ---
 --- @param window integer Window handle, or 0 for current window
---- @param config vim.api.keyset.float_config Map defining the window configuration, see `nvim_open_win()`
+--- @param config vim.api.keyset.win_config Map defining the window configuration, see `nvim_open_win()`
 function vim.api.nvim_win_set_config(window, config) end
 
 --- Sets the (1,0)-indexed cursor position in the window. `api-indexing` This

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -111,30 +111,6 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.exec_opts
 --- @field output? boolean
 
---- @class vim.api.keyset.float_config
---- @field row? number
---- @field col? number
---- @field width? integer
---- @field height? integer
---- @field anchor? string
---- @field relative? string
---- @field split? string
---- @field win? integer
---- @field bufpos? any[]
---- @field external? boolean
---- @field focusable? boolean
---- @field vertical? boolean
---- @field zindex? integer
---- @field border? any
---- @field title? any
---- @field title_pos? string
---- @field footer? any
---- @field footer_pos? string
---- @field style? string
---- @field noautocmd? boolean
---- @field fixed? boolean
---- @field hide? boolean
-
 --- @class vim.api.keyset.get_autocmds
 --- @field event? any
 --- @field group? any
@@ -291,6 +267,30 @@ error('Cannot require a meta file')
 --- @field preview? any
 --- @field range? any
 --- @field register? boolean
+
+--- @class vim.api.keyset.win_config
+--- @field row? number
+--- @field col? number
+--- @field width? integer
+--- @field height? integer
+--- @field anchor? string
+--- @field relative? string
+--- @field split? string
+--- @field win? integer
+--- @field bufpos? any[]
+--- @field external? boolean
+--- @field focusable? boolean
+--- @field vertical? boolean
+--- @field zindex? integer
+--- @field border? any
+--- @field title? any
+--- @field title_pos? string
+--- @field footer? any
+--- @field footer_pos? string
+--- @field style? string
+--- @field noautocmd? boolean
+--- @field fixed? boolean
+--- @field hide? boolean
 
 --- @class vim.api.keyset.win_text_height
 --- @field start_row? integer

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -108,7 +108,7 @@ typedef struct {
 } Dict(user_command);
 
 typedef struct {
-  OptionalKeys is_set__float_config_;
+  OptionalKeys is_set__win_config_;
   Float row;
   Float col;
   Integer width;
@@ -131,7 +131,7 @@ typedef struct {
   Boolean noautocmd;
   Boolean fixed;
   Boolean hide;
-} Dict(float_config);
+} Dict(win_config);
 
 typedef struct {
   Boolean is_lua;

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -200,10 +200,10 @@
 /// @param[out] err Error details, if any
 ///
 /// @return Window handle, or 0 on error
-Window nvim_open_win(Buffer buffer, Boolean enter, Dict(float_config) *config, Error *err)
+Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Error *err)
   FUNC_API_SINCE(6) FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-#define HAS_KEY_X(d, key) HAS_KEY(d, float_config, key)
+#define HAS_KEY_X(d, key) HAS_KEY(d, win_config, key)
   buf_T *buf = find_buffer_by_handle(buffer, err);
   if (!buf) {
     return 0;
@@ -213,7 +213,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(float_config) *config, E
     return 0;
   }
 
-  FloatConfig fconfig = FLOAT_CONFIG_INIT;
+  WinConfig fconfig = WIN_CONFIG_INIT;
   if (!parse_float_config(config, &fconfig, false, true, err)) {
     return 0;
   }
@@ -332,10 +332,10 @@ static int win_split_flags(WinSplit split, bool toplevel)
 /// @param      config  Map defining the window configuration,
 ///                     see |nvim_open_win()|
 /// @param[out] err     Error details, if any
-void nvim_win_set_config(Window window, Dict(float_config) *config, Error *err)
+void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
   FUNC_API_SINCE(6)
 {
-#define HAS_KEY_X(d, key) HAS_KEY(d, float_config, key)
+#define HAS_KEY_X(d, key) HAS_KEY(d, win_config, key)
   win_T *win = find_window_by_handle(window, err);
   if (!win) {
     return;
@@ -345,7 +345,7 @@ void nvim_win_set_config(Window window, Dict(float_config) *config, Error *err)
   bool has_split = HAS_KEY_X(config, split);
   bool has_vertical = HAS_KEY_X(config, vertical);
   // reuse old values, if not overridden
-  FloatConfig fconfig = win->w_float_config;
+  WinConfig fconfig = win->w_float_config;
 
   bool to_split = config->relative.size == 0
                   && !(HAS_KEY_X(config, external) ? config->external : fconfig.external)
@@ -539,8 +539,8 @@ void nvim_win_set_config(Window window, Dict(float_config) *config, Error *err)
 #undef HAS_KEY_X
 }
 
-#define PUT_KEY_X(d, key, value) PUT_KEY(d, float_config, key, value)
-static void config_put_bordertext(Dict(float_config) *config, FloatConfig *fconfig,
+#define PUT_KEY_X(d, key, value) PUT_KEY(d, win_config, key, value)
+static void config_put_bordertext(Dict(win_config) *config, WinConfig *fconfig,
                                   BorderTextType bordertext_type, Arena *arena)
 {
   VirtText vt;
@@ -591,7 +591,7 @@ static void config_put_bordertext(Dict(float_config) *config, FloatConfig *fconf
 /// @param      window Window handle, or 0 for current window
 /// @param[out] err Error details, if any
 /// @return     Map defining the window configuration, see |nvim_open_win()|
-Dict(float_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
+Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   FUNC_API_SINCE(6)
 {
   /// Keep in sync with FloatRelative in buffer_defs.h
@@ -600,14 +600,14 @@ Dict(float_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   /// Keep in sync with WinSplit in buffer_defs.h
   static const char *const win_split_str[] = { "left", "right", "above", "below" };
 
-  Dict(float_config) rv = { 0 };
+  Dict(win_config) rv = { 0 };
 
   win_T *wp = find_window_by_handle(window, err);
   if (!wp) {
     return rv;
   }
 
-  FloatConfig *config = &wp->w_float_config;
+  WinConfig *config = &wp->w_float_config;
 
   PUT_KEY_X(rv, focusable, config->focusable);
   PUT_KEY_X(rv, external, config->external);
@@ -734,8 +734,8 @@ static bool parse_float_bufpos(Array bufpos, lpos_T *out)
   return true;
 }
 
-static void parse_bordertext(Object bordertext, BorderTextType bordertext_type,
-                             FloatConfig *fconfig, Error *err)
+static void parse_bordertext(Object bordertext, BorderTextType bordertext_type, WinConfig *fconfig,
+                             Error *err)
 {
   if (bordertext.type != kObjectTypeString && bordertext.type != kObjectTypeArray) {
     api_set_error(err, kErrorTypeValidation, "title/footer must be string or array");
@@ -793,7 +793,7 @@ static void parse_bordertext(Object bordertext, BorderTextType bordertext_type,
 }
 
 static bool parse_bordertext_pos(String bordertext_pos, BorderTextType bordertext_type,
-                                 FloatConfig *fconfig, Error *err)
+                                 WinConfig *fconfig, Error *err)
 {
   AlignTextPos *align;
   switch (bordertext_type) {
@@ -832,7 +832,7 @@ static bool parse_bordertext_pos(String bordertext_pos, BorderTextType bordertex
   return true;
 }
 
-static void parse_border_style(Object style, FloatConfig *fconfig, Error *err)
+static void parse_border_style(Object style, WinConfig *fconfig, Error *err)
 {
   struct {
     const char *name;
@@ -937,10 +937,10 @@ static void parse_border_style(Object style, FloatConfig *fconfig, Error *err)
   }
 }
 
-static bool parse_float_config(Dict(float_config) *config, FloatConfig *fconfig, bool reconf,
+static bool parse_float_config(Dict(win_config) *config, WinConfig *fconfig, bool reconf,
                                bool new_win, Error *err)
 {
-#define HAS_KEY_X(d, key) HAS_KEY(d, float_config, key)
+#define HAS_KEY_X(d, key) HAS_KEY(d, win_config, key)
   bool has_relative = false, relative_is_win = false, is_split = false;
   if (config->relative.size > 0) {
     if (!parse_float_relative(config->relative, &fconfig->relative)) {

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -941,19 +941,19 @@ typedef struct {
   bool noautocmd;
   bool fixed;
   bool hide;
-} FloatConfig;
+} WinConfig;
 
-#define FLOAT_CONFIG_INIT ((FloatConfig){ .height = 0, .width = 0, \
-                                          .bufpos = { -1, 0 }, \
-                                          .row = 0, .col = 0, .anchor = 0, \
-                                          .relative = 0, .external = false, \
-                                          .focusable = true, \
-                                          .split = 0, \
-                                          .zindex = kZIndexFloatDefault, \
-                                          .style = kWinStyleUnused, \
-                                          .noautocmd = false, \
-                                          .hide = false, \
-                                          .fixed = false })
+#define WIN_CONFIG_INIT ((WinConfig){ .height = 0, .width = 0, \
+                                      .bufpos = { -1, 0 }, \
+                                      .row = 0, .col = 0, .anchor = 0, \
+                                      .relative = 0, .external = false, \
+                                      .focusable = true, \
+                                      .split = 0, \
+                                      .zindex = kZIndexFloatDefault, \
+                                      .style = kWinStyleUnused, \
+                                      .noautocmd = false, \
+                                      .hide = false, \
+                                      .fixed = false })
 
 // Structure to store last cursor position and topline.  Used by check_lnums()
 // and reset_lnums().
@@ -1278,7 +1278,7 @@ struct window_S {
   bool w_pos_changed;                   // true if window position changed
   bool w_floating;                      ///< whether the window is floating
   bool w_float_is_info;                 // the floating window is info float
-  FloatConfig w_float_config;
+  WinConfig w_float_config;
 
   // w_fraction is the fractional row of the cursor within the window, from
   // 0 at the top row to FRACTION_MULT at the last row.

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -669,7 +669,7 @@ void pum_redraw(void)
 /// @return  NULL when no enough room to show
 static win_T *pum_create_float_preview(bool enter)
 {
-  FloatConfig config = FLOAT_CONFIG_INIT;
+  WinConfig config = WIN_CONFIG_INIT;
   config.relative = kFloatRelativeEditor;
   // when pum_above is SW otherwise is NW
   config.anchor = pum_above ? kFloatAnchorSouth : 0;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -669,7 +669,7 @@ wingotofile:
         beep_flush();
         break;
       }
-      FloatConfig config = FLOAT_CONFIG_INIT;
+      WinConfig config = WIN_CONFIG_INIT;
       config.width = curwin->w_width;
       config.height = curwin->w_height;
       config.external = true;
@@ -763,7 +763,7 @@ void ui_ext_win_position(win_T *wp, bool validate)
     return;
   }
 
-  FloatConfig c = wp->w_float_config;
+  WinConfig c = wp->w_float_config;
   if (!c.external) {
     ScreenGrid *grid = &default_grid;
     Float row = c.row;
@@ -1213,7 +1213,7 @@ win_T *win_split_ins(int size, int flags, win_T *new_wp, int dir)
     new_frame(wp);
     wp->w_floating = false;
     // non-floating window doesn't store float config or have a border.
-    wp->w_float_config = FLOAT_CONFIG_INIT;
+    wp->w_float_config = WIN_CONFIG_INIT;
     CLEAR_FIELD(wp->w_border_adj);
   }
 
@@ -3879,7 +3879,7 @@ void win_alloc_first(void)
 void win_alloc_aucmd_win(int idx)
 {
   Error err = ERROR_INIT;
-  FloatConfig fconfig = FLOAT_CONFIG_INIT;
+  WinConfig fconfig = WIN_CONFIG_INIT;
   fconfig.width = Columns;
   fconfig.height = 5;
   fconfig.focusable = false;
@@ -4983,7 +4983,7 @@ win_T *win_alloc(win_T *after, bool hidden)
   new_wp->w_cursor.lnum = 1;
   new_wp->w_scbind_pos = 1;
   new_wp->w_floating = 0;
-  new_wp->w_float_config = FLOAT_CONFIG_INIT;
+  new_wp->w_float_config = WIN_CONFIG_INIT;
   new_wp->w_viewport_invalid = true;
   new_wp->w_viewport_last_topline = 1;
 

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -38,7 +38,7 @@
 /// @param last    make the window the last one in the window list.
 ///                Only used when allocating the autocommand window.
 /// @param config  must already have been validated!
-win_T *win_new_float(win_T *wp, bool last, FloatConfig fconfig, Error *err)
+win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
 {
   if (wp == NULL) {
     wp = win_alloc(last ? lastwin : lastwin_nofloating(), false);
@@ -138,7 +138,7 @@ int win_border_width(win_T *wp)
   return wp->w_border_adj[1] + wp->w_border_adj[3];
 }
 
-void win_config_float(win_T *wp, FloatConfig fconfig)
+void win_config_float(win_T *wp, WinConfig fconfig)
 {
   wp->w_width = MAX(fconfig.width, 1);
   wp->w_height = MAX(fconfig.height, 1);


### PR DESCRIPTION
`FloatConfig` is no longer used only for floats, so the name is counterintuitive.

Follows up on discussion in #25550.

Needs discussion: Should `win_T->w_float_config` be renamed to `w_config`? Left that out of this PR for now as I'm not sure.