### PR TITLE
vim-patch:9.1.0088: TextChanged not triggered for :norm! commands

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -363,7 +363,13 @@ static void insert_enter(InsertState *s)
     ins_apply_autocmds(EVENT_INSERTLEAVE);
   }
   did_cursorhold = false;
-  curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
+
+  // ins_redraw() triggers TextChangedI only when no characters
+  // are in the typeahead buffer, so only reset curbuf->b_last_changedtick
+  // if the TextChangedI was not blocked by char_avail() (e.g. using :norm!)
+  if (!char_avail()) {
+    curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
+  }
 }
 
 static int insert_check(VimState *state)

--- a/test/functional/autocmd/textchanged_spec.lua
+++ b/test/functional/autocmd/textchanged_spec.lua
@@ -180,3 +180,14 @@ it('TextChangedI and TextChanged', function()
   validate_mixed_textchangedi({ 's', '<esc>' })
   validate_mixed_textchangedi({ 'S', '<esc>' })
 end)
+
+-- oldtest: Test_TextChanged_with_norm()
+it('TextChanged is triggered after :norm that enters Insert mode', function()
+  exec([[
+    let g:a = 0
+    au TextChanged * let g:a += 1
+  ]])
+  eq(0, eval('g:a'))
+  feed(':norm! ia<CR>')
+  eq(1, eval('g:a'))
+end)

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2533,7 +2533,25 @@ func Test_TextChangedI_with_setline()
   call assert_equal('', getline(1))
   call assert_equal('', getline(2))
 
-  call test_override('starting', 0)
+  call test_override('char_avail', 0)
+  bwipe!
+endfunc
+
+func Test_TextChanged_with_norm()
+  " For unknown reason this fails on MS-Windows
+  CheckNotMSWindows
+  CheckFeature terminal
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
+  call assert_equal('running', term_getstatus(buf))
+  call term_sendkeys(buf, ":let g:a=0\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":au! TextChanged * :let g:a+=1\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":norm! ia\<cr>")
+  call term_wait(buf, 50)
+  call term_sendkeys(buf, ":echo g:a\<cr>")
+  call term_wait(buf, 50)
+  call WaitForAssert({-> assert_match('^1.*$', term_getline(buf, 3))})
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0088: TextChanged not triggered for :norm! commands

Problem:  TextChanged not triggered for :norm! commands
          (machakann, after v9.0.2031)
Solution: Only reset curbuf->b_last_changedtick if TextChangedI
          was triggered in insert mode (and not blocked)

Note: for unknown reasons, the test fails on Windows (but seems to work
fine when running interactively)

closes: vim/vim#13984

https://github.com/vim/vim/commit/c9e79e52845d51f48f5ea3753a62ab3fe0e40184

Cherry-pick test_autocmd.vim change from patch 8.2.4149.

Co-authored-by: Christian Brabandt <cb@256bit.org>