### PR TITLE
ci(docs): bump doxygen to 1.9.5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - '.github/workflows/docs.yml'
       - 'src/nvim/api/*.[ch]'
       - 'src/nvim/eval.lua'
       - 'runtime/lua/**.lua'
@@ -16,13 +17,29 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      BIN_DIR: ${{ github.workspace }}/bin
+      DOXYGEN_URL: 'https://github.com/doxygen/doxygen/releases/download/Release_1_9_5/doxygen-1.9.5.linux.bin.tar.gz'
+      DOXYGEN_VERSION: 1.9.5
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y doxygen python3-msgpack
+          sudo apt-get install -y python3-msgpack
+
+      - name: Install doxygen
+        run: |
+          curl --retry 5 --silent --show-error --fail -L -o /tmp/doxygen.tar.gz "$DOXYGEN_URL"
+          mkdir -p "$BIN_DIR" /opt/doxygen
+          tar xfz /tmp/doxygen.tar.gz --strip-components=1 -C /opt/doxygen
+          ln -sfn /opt/doxygen/bin/doxygen "$BIN_DIR/doxygen"
+          doxygen_version="$(doxygen -v)"
+          echo "$doxygen_version" | grep -qF "$DOXYGEN_VERSION" || {
+            echo "Unexpected doxygen version: $doxygen_version";
+            exit 1;
+          }
 
       - name: Generate docs
         run: |

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -59,7 +59,7 @@ Element = minidom.Element
 Document = minidom.Document
 
 MIN_PYTHON_VERSION = (3, 7)
-MIN_DOXYGEN_VERSION = (1, 9, 0)
+MIN_DOXYGEN_VERSION = (1, 9, 5)
 
 if sys.version_info < MIN_PYTHON_VERSION:
     print("requires Python {}.{}+".format(*MIN_PYTHON_VERSION))


### PR DESCRIPTION
Docs generation for lua-lpeg would need a recent version of doxygen
(1.9.5+) to avoid some issues and different output. (see #27402)
Hence, the minimum required version for doxygen is bumped from 1.9.0 to 1.9.5.

Bumps doxygen on CI from 1.9.1 (latest in ubuntu-22.04) to 1.9.5,
installed via tarball releases because apt packages are outdated.


### Remarks

Doxygen 1.9.1 is too old; released in January 2021.

Doxygen 1.9.5:

- https://github.com/doxygen/doxygen/releases/tag/Release_1_9_5
- https://www.doxygen.nl/manual/changelog.html#log_1_9_5

~~Doxygen 1.10~~:

- https://github.com/doxygen/doxygen/releases/tag/Release_1_10_0
- https://www.doxygen.nl/manual/changelog.html#log_1_10_0

Ubuntu/Debian

- https://packages.ubuntu.com/search?keywords=doxygen
- https://tracker.debian.org/pkg/doxygen