### PR TITLE
vim-patch:9.1.0087: Restoring lastused_tabpage too early in do_arg_all()

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -1093,11 +1093,6 @@ static void do_arg_all(int count, int forceit, int keep_tabs)
   // When the ":tab" modifier was used do this for all tab pages.
   arg_all_close_unused_windows(&aall);
 
-  // Now set the last used tabpage to where we started.
-  if (valid_tabpage(new_lu_tp)) {
-    lastused_tabpage = new_lu_tp;
-  }
-
   // Open a window for files in the argument list that don't have one.
   // ARGCOUNT may change while doing this, because of autocommands.
   if (count > aall.opened_len || count <= 0) {
@@ -1134,6 +1129,12 @@ static void do_arg_all(int count, int forceit, int keep_tabs)
   if (valid_tabpage(aall.new_curtab)) {
     goto_tabpage_tp(aall.new_curtab, true, true);
   }
+
+  // Now set the last used tabpage to where we started.
+  if (valid_tabpage(new_lu_tp)) {
+    lastused_tabpage = new_lu_tp;
+  }
+
   if (win_valid(aall.new_curwin)) {
     win_enter(aall.new_curwin, false);
   }

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -156,10 +156,13 @@ func Test_tabpage_drop()
   tab split f3
   normal! gt
   call assert_equal(1, tabpagenr())
+  tab drop f4
+  call assert_equal(1, tabpagenr('#'))
 
   tab drop f3
-  call assert_equal(3, tabpagenr())
-  call assert_equal(1, tabpagenr('#'))
+  call assert_equal(4, tabpagenr())
+  call assert_equal(2, tabpagenr('#'))
+  bwipe!
   bwipe!
   bwipe!
   bwipe!


### PR DESCRIPTION
Problem:  Restore lastused_tabpage too early in do_arg_all() function it
          will change later in the function.
Solution: Restore lastused_tabpage a bit later, when being done with
          tabpages (glepnir)

closes: vim/vim#13992

https://github.com/vim/vim/commit/2975a54f285e5b4bf026c1dc706b5d90777d64e7