### PR TITLE
feat(shortmess): q fully hides recording message

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -120,7 +120,7 @@ The following changes may require adaptations in user config or plugins.
   the default behavior of just refreshing the current buffer has been replaced by
   refreshing all buffers.
 
-• |shm-q| now completely hides recording macro message instead of only shortening it.
+• |shm-q| now fully hides macro recording message instead of only shortening it.
 
 ==============================================================================
 BREAKING CHANGES IN HEAD                                    *news-breaking-dev*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -120,6 +120,7 @@ The following changes may require adaptations in user config or plugins.
   the default behavior of just refreshing the current buffer has been replaced by
   refreshing all buffers.
 
+• |shm-q| now completely hides recording macro message instead of only shortening it.
 
 ==============================================================================
 BREAKING CHANGES IN HEAD                                    *news-breaking-dev*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5459,7 +5459,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		match", "Pattern not found", "Back at original", etc.
 	  C	don't give messages while scanning for ins-completion	*shm-C*
 		items, for instance "scanning tags"
-	  q	do not show "recording @a" when recording a macro       *shm-q*
+	  q	do not show "recording @a" when recording a macro	
+*shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
 		`:silent` was used for the command
 	  S	do not show search count message when searching, e.g.	*shm-S*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5459,7 +5459,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		match", "Pattern not found", "Back at original", etc.
 	  C	don't give messages while scanning for ins-completion	*shm-C*
 		items, for instance "scanning tags"
-	  q	use "recording" instead of "recording @a"		*shm-q*
+	  q	do not show "recording @a" when recording a macro       *shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
 		`:silent` was used for the command
 	  S	do not show search count message when searching, e.g.	*shm-S*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5459,8 +5459,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		match", "Pattern not found", "Back at original", etc.
 	  C	don't give messages while scanning for ins-completion	*shm-C*
 		items, for instance "scanning tags"
-	  q	do not show "recording @a" when recording a macro	
-*shm-q*
+	  q	do not show "recording @a" when recording a macro	*shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
 		`:silent` was used for the command
 	  S	do not show search count message when searching, e.g.	*shm-S*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -581,6 +581,9 @@ Autocommands:
 - |TermResponse| is fired for any OSC sequence received from the terminal,
   instead of the Primary Device Attributes response. |v:termresponse|
 
+Options:
+- |shm-q| completely hides recording macro message instead of only shortening it.
+
 ==============================================================================
 Missing features					 *nvim-missing*
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -582,7 +582,7 @@ Autocommands:
   instead of the Primary Device Attributes response. |v:termresponse|
 
 Options:
-- |shm-q| completely hides recording macro message instead of only shortening it.
+- |shm-q| fully hides macro recording message instead of only shortening it.
 
 ==============================================================================
 Missing features					 *nvim-missing*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5797,8 +5797,7 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	match", "Pattern not found", "Back at original", etc.
 ---   C	don't give messages while scanning for ins-completion	*shm-C*
 --- 	items, for instance "scanning tags"
----   q	do not show "recording @a" when recording a macro	
-*shm-q*
+---   q	do not show "recording @a" when recording a macro	*shm-q*
 ---   F	don't give the file info when editing a file, like	*shm-F*
 --- 	`:silent` was used for the command
 ---   S	do not show search count message when searching, e.g.	*shm-S*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5797,7 +5797,7 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	match", "Pattern not found", "Back at original", etc.
 ---   C	don't give messages while scanning for ins-completion	*shm-C*
 --- 	items, for instance "scanning tags"
----   q	use "recording" instead of "recording @a"		*shm-q*
+---   q	do not show "recording @a" when recording a macro       *shm-q*
 ---   F	don't give the file info when editing a file, like	*shm-F*
 --- 	`:silent` was used for the command
 ---   S	do not show search count message when searching, e.g.	*shm-S*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5797,7 +5797,8 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	match", "Pattern not found", "Back at original", etc.
 ---   C	don't give messages while scanning for ins-completion	*shm-C*
 --- 	items, for instance "scanning tags"
----   q	do not show "recording @a" when recording a macro       *shm-q*
+---   q	do not show "recording @a" when recording a macro	
+*shm-q*
 ---   F	don't give the file info when editing a file, like	*shm-F*
 --- 	`:silent` was used for the command
 ---   S	do not show search count message when searching, e.g.	*shm-S*

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1149,11 +1149,11 @@ void clearmode(void)
 
 static void recording_mode(int attr)
 {
-  msg_puts_attr(_("recording"), attr);
   if (shortmess(SHM_RECORDING)) {
     return;
   }
 
+  msg_puts_attr(_("recording"), attr);
   char s[4];
   snprintf(s, ARRAY_SIZE(s), " @%c", reg_recording);
   msg_puts_attr(s, attr);

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -218,7 +218,7 @@ enum {
   SHM_INTRO          = 'I',  ///< Intro messages.
   SHM_COMPLETIONMENU = 'c',  ///< Completion menu messages.
   SHM_COMPLETIONSCAN = 'C',  ///< Completion scanning messages.
-  SHM_RECORDING      = 'q',  ///< Short recording message.
+  SHM_RECORDING      = 'q',  ///< No recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
   SHM_SEARCHCOUNT    = 'S',  ///< No search stats: '[1/10]'
 };

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7329,7 +7329,7 @@ return {
         	match", "Pattern not found", "Back at original", etc.
           C	don't give messages while scanning for ins-completion	*shm-C*
         	items, for instance "scanning tags"
-          q	use "recording" instead of "recording @a"		*shm-q*
+          q	do not show "recording @a" when recording a macro       *shm-q*
           F	don't give the file info when editing a file, like	*shm-F*
         	`:silent` was used for the command
           S	do not show search count message when searching, e.g.	*shm-S*

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7329,7 +7329,8 @@ return {
         	match", "Pattern not found", "Back at original", etc.
           C	don't give messages while scanning for ins-completion	*shm-C*
         	items, for instance "scanning tags"
-          q	do not show "recording @a" when recording a macro       *shm-q*
+          q	do not show "recording @a" when recording a macro	
+*shm-q*
           F	don't give the file info when editing a file, like	*shm-F*
         	`:silent` was used for the command
           S	do not show search count message when searching, e.g.	*shm-S*

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7329,8 +7329,7 @@ return {
         	match", "Pattern not found", "Back at original", etc.
           C	don't give messages while scanning for ins-completion	*shm-C*
         	items, for instance "scanning tags"
-          q	do not show "recording @a" when recording a macro	
-*shm-q*
+          q	do not show "recording @a" when recording a macro	*shm-q*
           F	don't give the file info when editing a file, like	*shm-F*
         	`:silent` was used for the command
           S	do not show search count message when searching, e.g.	*shm-S*

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -175,7 +175,7 @@ func Test_recording_status_in_ex_line()
   call assert_equal('recording @x', Screenline(&lines))
   set shortmess=q
   redraw!
-  call assert_equal('recording', Screenline(&lines))
+  call assert_equal('', Screenline(&lines)) " Nvim: shm+=q fully hides message
   set shortmess&
   norm q
   redraw!


### PR DESCRIPTION
When 'q' is set in the shortmess and cmdheight=1 it will now fully hide showing
if you are recording a macro instead of just shortening to "recording". This
  removes duplication when using `cmdheight=1` and `vim.fn.reg_recording()` in
  the statusline.

Relates to #19193
