### PR TITLE
refactor: rename `win_T.w_float_config` to `w_config`

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -257,7 +257,7 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
       restore_win(&switchwin, true);
     }
     if (wp) {
-      wp->w_float_config = fconfig;
+      wp->w_config = fconfig;
     }
   } else {
     wp = win_new_float(NULL, false, fconfig, err);
@@ -345,7 +345,7 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
   bool has_split = HAS_KEY_X(config, split);
   bool has_vertical = HAS_KEY_X(config, vertical);
   // reuse old values, if not overridden
-  WinConfig fconfig = win->w_float_config;
+  WinConfig fconfig = win->w_config;
 
   bool to_split = config->relative.size == 0
                   && !(HAS_KEY_X(config, external) ? config->external : fconfig.external)
@@ -387,7 +387,7 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
         }
       }
     }
-    win->w_float_config = fconfig;
+    win->w_config = fconfig;
 
     // If there's no "vertical" or "split" set, or if "split" is unchanged,
     // then we can just change the size of the window.
@@ -477,7 +477,7 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
     } else {
       win_remove(win, win_tp == curtab ? NULL : win_tp);
       ui_comp_remove_grid(&win->w_grid_alloc);
-      if (win->w_float_config.external) {
+      if (win->w_config.external) {
         for (tabpage_T *tp = first_tabpage; tp != NULL; tp = tp->tp_next) {
           if (tp == curtab) {
             continue;
@@ -607,7 +607,7 @@ Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
     return rv;
   }
 
-  WinConfig *config = &wp->w_float_config;
+  WinConfig *config = &wp->w_config;
 
   PUT_KEY_X(rv, focusable, config->focusable);
   PUT_KEY_X(rv, external, config->external);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1335,7 +1335,7 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     if (need_append) {
       win_append(lastwin, auc_win);
       pmap_put(int)(&window_handles, auc_win->handle, auc_win);
-      win_config_float(auc_win, auc_win->w_float_config);
+      win_config_float(auc_win, auc_win->w_config);
     }
     // Prevent chdir() call in win_enter_ext(), through do_autochdir()
     int save_acd = p_acd;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2773,7 +2773,7 @@ void get_winopts(buf_T *buf)
     curwin->w_changelistidx = wip->wi_changelistidx;
   }
 
-  if (curwin->w_float_config.style == kWinStyleMinimal) {
+  if (curwin->w_config.style == kWinStyleMinimal) {
     didset_window_options(curwin, false);
     win_set_minimal_style(curwin);
   }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1278,7 +1278,7 @@ struct window_S {
   bool w_pos_changed;                   // true if window position changed
   bool w_floating;                      ///< whether the window is floating
   bool w_float_is_info;                 // the floating window is info float
-  WinConfig w_float_config;
+  WinConfig w_config;
 
   // w_fraction is the fractional row of the cursor within the window, from
   // 0 at the top row to FRACTION_MULT at the last row.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -913,6 +913,7 @@ typedef enum {
   kBorderTextFooter = 1,
 } BorderTextType;
 
+/// See ":help nvim_open_win()" for documentation.
 typedef struct {
   Window window;
   lpos_T bufpos;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -738,7 +738,7 @@ int win_get_bordertext_col(int total_col, int text_width, AlignTextPos align)
 static void win_redr_border(win_T *wp)
 {
   wp->w_redr_border = false;
-  if (!(wp->w_floating && wp->w_float_config.border)) {
+  if (!(wp->w_floating && wp->w_config.border)) {
     return;
   }
 
@@ -746,9 +746,9 @@ static void win_redr_border(win_T *wp)
 
   schar_T chars[8];
   for (int i = 0; i < 8; i++) {
-    chars[i] = schar_from_str(wp->w_float_config.border_chars[i]);
+    chars[i] = schar_from_str(wp->w_config.border_chars[i]);
   }
-  int *attrs = wp->w_float_config.border_attr;
+  int *attrs = wp->w_config.border_attr;
 
   int *adj = wp->w_border_adj;
   int irow = wp->w_height_inner + wp->w_winbar_height;
@@ -764,10 +764,10 @@ static void win_redr_border(win_T *wp)
       grid_line_put_schar(i + adj[3], chars[1], attrs[1]);
     }
 
-    if (wp->w_float_config.title) {
-      int title_col = win_get_bordertext_col(icol, wp->w_float_config.title_width,
-                                             wp->w_float_config.title_pos);
-      win_redr_bordertext(wp, wp->w_float_config.title_chunks, title_col);
+    if (wp->w_config.title) {
+      int title_col = win_get_bordertext_col(icol, wp->w_config.title_width,
+                                             wp->w_config.title_pos);
+      win_redr_bordertext(wp, wp->w_config.title_chunks, title_col);
     }
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[2], attrs[2]);
@@ -800,10 +800,10 @@ static void win_redr_border(win_T *wp)
       grid_line_put_schar(i + adj[3], chars[ic], attrs[ic]);
     }
 
-    if (wp->w_float_config.footer) {
-      int footer_col = win_get_bordertext_col(icol, wp->w_float_config.footer_width,
-                                              wp->w_float_config.footer_pos);
-      win_redr_bordertext(wp, wp->w_float_config.footer_chunks, footer_col);
+    if (wp->w_config.footer) {
+      int footer_col = win_get_bordertext_col(icol, wp->w_config.footer_width,
+                                              wp->w_config.footer_pos);
+      win_redr_bordertext(wp, wp->w_config.footer_chunks, footer_col);
     }
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[4], attrs[4]);

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -551,7 +551,7 @@ void ex_listdo(exarg_T *eap)
           break;
         }
         assert(wp);
-        execute = !wp->w_floating || wp->w_float_config.focusable;
+        execute = !wp->w_floating || wp->w_config.focusable;
         if (execute) {
           win_goto(wp);
           if (curwin != wp) {

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -912,7 +912,7 @@ void win_grid_alloc(win_T *wp)
     grid_alloc(grid_allocated, total_rows, total_cols,
                wp->w_grid_alloc.valid, false);
     grid_allocated->valid = true;
-    if (wp->w_floating && wp->w_float_config.border) {
+    if (wp->w_floating && wp->w_config.border) {
       wp->w_redr_border = true;
     }
     was_resized = true;

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -369,7 +369,7 @@ void update_window_hl(win_T *wp, bool invalid)
   // wp->w_hl_attr_normal group. HL_ATTR(HLF_NFLOAT) is always named.
 
   // determine window specific background set in 'winhighlight'
-  bool float_win = wp->w_floating && !wp->w_float_config.external;
+  bool float_win = wp->w_floating && !wp->w_config.external;
   if (float_win && hl_def[HLF_NFLOAT] != 0) {
     wp->w_hl_attr_normal = hl_def[HLF_NFLOAT];
   } else if (hl_def[HLF_COUNT] > 0) {
@@ -382,19 +382,19 @@ void update_window_hl(win_T *wp, bool invalid)
     wp->w_hl_attr_normal = hl_apply_winblend(wp, wp->w_hl_attr_normal);
   }
 
-  wp->w_float_config.shadow = false;
-  if (wp->w_floating && wp->w_float_config.border) {
+  wp->w_config.shadow = false;
+  if (wp->w_floating && wp->w_config.border) {
     for (int i = 0; i < 8; i++) {
       int attr = hl_def[HLF_BORDER];
-      if (wp->w_float_config.border_hl_ids[i]) {
+      if (wp->w_config.border_hl_ids[i]) {
         attr = hl_get_ui_attr(ns_id, HLF_BORDER,
-                              wp->w_float_config.border_hl_ids[i], false);
+                              wp->w_config.border_hl_ids[i], false);
       }
       attr = hl_apply_winblend(wp, attr);
       if (syn_attr2entry(attr).hl_blend > 0) {
-        wp->w_float_config.shadow = true;
+        wp->w_config.shadow = true;
       }
-      wp->w_float_config.border_attr[i] = attr;
+      wp->w_config.border_attr[i] = attr;
     }
   }
 

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1722,7 +1722,7 @@ static win_T *mouse_find_grid_win(int *gridp, int *rowp, int *colp)
   } else if (*gridp > 1) {
     win_T *wp = get_win_by_grid_handle(*gridp);
     if (wp && wp->w_grid_alloc.chars
-        && !(wp->w_floating && !wp->w_float_config.focusable)) {
+        && !(wp->w_floating && !wp->w_config.focusable)) {
       *rowp = MIN(*rowp - wp->w_grid.row_offset, wp->w_grid.rows - 1);
       *colp = MIN(*colp - wp->w_grid.col_offset, wp->w_grid.cols - 1);
       return wp;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1790,7 +1790,7 @@ bool valid_name(const char *val, const char *allowed)
 void check_blending(win_T *wp)
 {
   wp->w_grid_alloc.blending =
-    wp->w_p_winbl > 0 || (wp->w_floating && wp->w_float_config.shadow);
+    wp->w_p_winbl > 0 || (wp->w_floating && wp->w_config.shadow);
 }
 
 /// Handle setting `winhighlight' in window "wp"

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -744,16 +744,16 @@ static void pum_adjust_float_position(win_T *wp, int height, int width)
 {
   // when floating window in right and right no enough room to show
   // but left has enough room, adjust floating window to left.
-  if (wp->w_float_config.width < width && wp->w_float_config.col > pum_col) {
+  if (wp->w_config.width < width && wp->w_config.col > pum_col) {
     if ((pum_col - 2) > width) {
-      wp->w_float_config.width = width;
-      wp->w_float_config.col = pum_col - width - 1;
+      wp->w_config.width = width;
+      wp->w_config.col = pum_col - width - 1;
     }
   }
-  wp->w_float_config.width = MIN(wp->w_float_config.width, width);
-  wp->w_float_config.height = MIN(Rows, height);
-  wp->w_float_config.hide = false;
-  win_config_float(wp, wp->w_float_config);
+  wp->w_config.width = MIN(wp->w_config.width, width);
+  wp->w_config.height = MIN(Rows, height);
+  wp->w_config.hide = false;
+  win_config_float(wp, wp->w_config);
 }
 
 /// used in nvim_complete_set

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -692,9 +692,9 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *err)
 
   if (wp->w_floating) {
     if (width != wp->w_width || height != wp->w_height) {
-      wp->w_float_config.width = width;
-      wp->w_float_config.height = height;
-      win_config_float(wp, wp->w_float_config);
+      wp->w_config.width = width;
+      wp->w_config.height = height;
+      win_config_float(wp, wp->w_config);
     }
   } else {
     // non-positive indicates no request

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -161,17 +161,17 @@ void win_config_float(win_T *wp, WinConfig fconfig)
     }
   }
 
-  bool change_external = fconfig.external != wp->w_float_config.external;
-  bool change_border = (fconfig.border != wp->w_float_config.border
+  bool change_external = fconfig.external != wp->w_config.external;
+  bool change_border = (fconfig.border != wp->w_config.border
                         || memcmp(fconfig.border_hl_ids,
-                                  wp->w_float_config.border_hl_ids,
+                                  wp->w_config.border_hl_ids,
                                   sizeof fconfig.border_hl_ids) != 0);
 
-  wp->w_float_config = fconfig;
+  wp->w_config = fconfig;
 
-  bool has_border = wp->w_floating && wp->w_float_config.border;
+  bool has_border = wp->w_floating && wp->w_config.border;
   for (int i = 0; i < 4; i++) {
-    int new_adj = has_border && wp->w_float_config.border_chars[2 * i + 1][0];
+    int new_adj = has_border && wp->w_config.border_chars[2 * i + 1][0];
     if (new_adj != wp->w_border_adj[i]) {
       change_border = true;
       wp->w_border_adj[i] = new_adj;
@@ -193,11 +193,11 @@ void win_config_float(win_T *wp, WinConfig fconfig)
   }
 
   // compute initial position
-  if (wp->w_float_config.relative == kFloatRelativeWindow) {
-    int row = (int)wp->w_float_config.row;
-    int col = (int)wp->w_float_config.col;
+  if (wp->w_config.relative == kFloatRelativeWindow) {
+    int row = (int)wp->w_config.row;
+    int col = (int)wp->w_config.col;
     Error dummy = ERROR_INIT;
-    win_T *parent = find_window_by_handle(wp->w_float_config.window, &dummy);
+    win_T *parent = find_window_by_handle(wp->w_config.window, &dummy);
     if (parent) {
       row += parent->w_winrow;
       col += parent->w_wincol;
@@ -207,9 +207,9 @@ void win_config_float(win_T *wp, WinConfig fconfig)
       grid_adjust(&grid, &row_off, &col_off);
       row += row_off;
       col += col_off;
-      if (wp->w_float_config.bufpos.lnum >= 0) {
-        pos_T pos = { wp->w_float_config.bufpos.lnum + 1,
-                      wp->w_float_config.bufpos.col, 0 };
+      if (wp->w_config.bufpos.lnum >= 0) {
+        pos_T pos = { wp->w_config.bufpos.lnum + 1,
+                      wp->w_config.bufpos.col, 0 };
         int trow, tcol, tcolc, tcole;
         textpos2screenpos(parent, &pos, &trow, &tcol, &tcolc, &tcole, true);
         row += trow - 1;
@@ -233,8 +233,8 @@ void win_config_float(win_T *wp, WinConfig fconfig)
 
 static int float_zindex_cmp(const void *a, const void *b)
 {
-  int za = (*(win_T **)a)->w_float_config.zindex;
-  int zb = (*(win_T **)b)->w_float_config.zindex;
+  int za = (*(win_T **)a)->w_config.zindex;
+  int zb = (*(win_T **)b)->w_config.zindex;
   return za == zb ? 0 : za < zb ? 1 : -1;
 }
 
@@ -265,8 +265,8 @@ void win_check_anchored_floats(win_T *win)
 {
   for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev) {
     // float might be anchored to moved window
-    if (wp->w_float_config.relative == kFloatRelativeWindow
-        && wp->w_float_config.window == win->handle) {
+    if (wp->w_config.relative == kFloatRelativeWindow
+        && wp->w_config.window == win->handle) {
       wp->w_pos_changed = true;
     }
   }
@@ -275,7 +275,7 @@ void win_check_anchored_floats(win_T *win)
 void win_reconfig_floats(void)
 {
   for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev) {
-    win_config_float(wp, wp->w_float_config);
+    win_config_float(wp, wp->w_config);
   }
 }
 


### PR DESCRIPTION
Follows up on rename of `FloatConfig` to `WinConfig` in #27397.

@justinmk