### PR TITLE
fix(messages): clear new lines when increasing 'cmdheight'

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -210,7 +210,11 @@ void msg_grid_validate(void)
     msg_grid_adj.target = &default_grid;
     redraw_cmdline = true;
   } else if (msg_grid.chars && !msg_scrolled && msg_grid_pos != max_rows) {
+    int diff = msg_grid_pos - max_rows;
     msg_grid_set_pos(max_rows, false);
+    if (diff > 0) {
+      grid_clear(&msg_grid_adj, Rows - diff, Rows, 0, Columns, HL_ATTR(HLF_MSG));
+    }
   }
   msg_grid_adj.cols = Columns;
 

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -458,7 +458,6 @@ describe('messages', function()
       -- do the same with 'cmdheight' set to 2
       feed('q')
       command('set ch=2')
-      command('mode') -- FIXME: bottom is invalid after scrolling
       screen:expect([[
         ^                                                            |
         {0:~                                                           }|*7
@@ -688,7 +687,6 @@ describe('messages', function()
       tabnew
       set cmdheight=2
     ]])
-    command('mode') -- FIXME: bottom is invalid after scrolling
     screen:expect([[
       {2: [No Name] }{1: [No Name] }{3:                 }{2:X}|
       ^                                        |

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1555,6 +1555,23 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
     ]])
     eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
   end)
+
+  it('bottom of screen is cleared after increasing &cmdheight #20360', function()
+    command('set laststatus=2')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*4
+      {3:[No Name]                                                   }|
+                                                                  |
+    ]])
+    command('set cmdheight=4')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|
+      {3:[No Name]                                                   }|
+                                                                  |*4
+    ]])
+  end)
 end)
 
 it('calling screenstring() after redrawing between messages without UI #20999', function()


### PR DESCRIPTION
Fix #20360
