### PR TITLE
refactor(lua): use Arena when converting from lua stack to API args

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2183,8 +2183,7 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
                   only)
 
     Return: ~
-        Return value of function. NB: will deepcopy Lua values currently, use
-        upvalues to send Lua references in and out.
+        Return value of function.
 
 nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
     Unmaps a buffer-local |mapping| for the given mode.
@@ -2879,8 +2878,7 @@ nvim_win_call({window}, {fun})                               *nvim_win_call()*
                   only)
 
     Return: ~
-        Return value of function. NB: will deepcopy Lua values currently, use
-        upvalues to send Lua references in and out.
+        Return value of function.
 
     See also: ~
       • |win_execute()|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -422,6 +422,8 @@ The following changes to existing APIs or features add new behavior.
 
 • |--startuptime| reports the startup times for both processes (TUI + server) as separate sections.
 
+• |nvim_buf_call()| and |nvim_win_call()| now preserves any return value (NB: not multiple return values)
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -297,3 +297,17 @@ error('Cannot require a meta file')
 --- @field end_row? integer
 --- @field start_vcol? integer
 --- @field end_vcol? integer
+
+--- @class vim.api.keyset.xdl_diff
+--- @field on_hunk? function
+--- @field result_type? string
+--- @field algorithm? string
+--- @field ctxlen? integer
+--- @field interhunkctxlen? integer
+--- @field linematch? any
+--- @field ignore_whitespace? boolean
+--- @field ignore_whitespace_change? boolean
+--- @field ignore_whitespace_change_at_eol? boolean
+--- @field ignore_cr_at_eol? boolean
+--- @field ignore_blank_lines? boolean
+--- @field indent_heuristic? boolean

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -431,7 +431,8 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
       });
 
       cb.type = kCallbackLua;
-      cb.data.luaref = api_new_luaref(callback->data.luaref);
+      cb.data.luaref = callback->data.luaref;
+      callback->data.luaref = LUA_NOREF;
       break;
     case kObjectTypeString:
       cb.type = kCallbackFuncref;

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1227,8 +1227,7 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
 /// @param fun        Function to call inside the buffer (currently Lua callable
 ///                   only)
 /// @param[out] err   Error details, if any
-/// @return           Return value of function. NB: will deepcopy Lua values
-///                   currently, use upvalues to send Lua references in and out.
+/// @return           Return value of function.
 Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_LUA_ONLY
@@ -1242,7 +1241,7 @@ Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
   aucmd_prepbuf(&aco, buf);
 
   Array args = ARRAY_DICT_INIT;
-  Object res = nlua_call_ref(fun, NULL, args, true, err);
+  Object res = nlua_call_ref(fun, NULL, args, kRetLuaref, NULL, err);
 
   aucmd_restbuf(&aco);
   try_end(err);
@@ -1419,7 +1418,7 @@ static void push_linestr(lua_State *lstate, Array *a, const char *s, size_t len,
   } else {
     String str = STRING_INIT;
     if (len > 0) {
-      str = arena_string(arena, cbuf_as_string((char *)s, len));
+      str = CBUF_TO_ARENA_STR(arena, s, len);
       if (replace_nl) {
         // Vim represents NULs as NLs, but this may confuse clients.
         strchrsub(str.data, '\n', '\0');

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -99,7 +99,7 @@
 Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err)
   FUNC_API_SINCE(10) FUNC_API_FAST
 {
-  Dict(cmd) result = { 0 };
+  Dict(cmd) result = KEYDICT_INIT;
 
   // Parse command line
   exarg_T ea;
@@ -514,7 +514,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
   VALIDATE_MOD((!ea.forceit || (ea.argt & EX_BANG)), "bang", cmd->cmd.data);
 
   if (HAS_KEY(cmd, cmd, magic)) {
-    Dict(cmd_magic) magic[1] = { 0 };
+    Dict(cmd_magic) magic[1] = KEYDICT_INIT;
     if (!api_dict_to_keydict(magic, KeyDict_cmd_magic_get_field, cmd->magic, err)) {
       goto end;
     }
@@ -532,13 +532,13 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
   }
 
   if (HAS_KEY(cmd, cmd, mods)) {
-    Dict(cmd_mods) mods[1] = { 0 };
+    Dict(cmd_mods) mods[1] = KEYDICT_INIT;
     if (!api_dict_to_keydict(mods, KeyDict_cmd_mods_get_field, cmd->mods, err)) {
       goto end;
     }
 
     if (HAS_KEY(mods, cmd_mods, filter)) {
-      Dict(cmd_mods_filter) filter[1] = { 0 };
+      Dict(cmd_mods_filter) filter[1] = KEYDICT_INIT;
 
       if (!api_dict_to_keydict(&filter, KeyDict_cmd_mods_filter_get_field,
                                mods->filter, err)) {
@@ -1103,7 +1103,8 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
 
   if (opts->complete.type == kObjectTypeLuaRef) {
     context = EXPAND_USER_LUA;
-    compl_luaref = api_new_luaref(opts->complete.data.luaref);
+    compl_luaref = opts->complete.data.luaref;
+    opts->complete.data.luaref = LUA_NOREF;
   } else if (opts->complete.type == kObjectTypeString) {
     VALIDATE_S(OK == parse_compl_arg(opts->complete.data.string.data,
                                      (int)opts->complete.data.string.size, &context, &argt,
@@ -1123,7 +1124,8 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
     });
 
     argt |= EX_PREVIEW;
-    preview_luaref = api_new_luaref(opts->preview.data.luaref);
+    preview_luaref = opts->preview.data.luaref;
+    opts->preview.data.luaref = LUA_NOREF;
   }
 
   switch (command.type) {

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -51,12 +51,12 @@ String nvim_command_output(uint64_t channel_id, String command, Error *err)
 
 /// @deprecated Use nvim_exec_lua() instead.
 /// @see nvim_exec_lua
-Object nvim_execute_lua(String code, Array args, Error *err)
+Object nvim_execute_lua(String code, Array args, Arena *arena, Error *err)
   FUNC_API_SINCE(3)
   FUNC_API_DEPRECATED_SINCE(7)
   FUNC_API_REMOTE_ONLY
 {
-  return nlua_exec(code, args, err);
+  return nlua_exec(code, args, kRetObject, arena, err);
 }
 
 /// Gets the buffer number

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -358,3 +358,19 @@ typedef struct {
   OptionalKeys is_set__complete_set_;
   String info;
 } Dict(complete_set);
+
+typedef struct {
+  OptionalKeys is_set__xdl_diff_;
+  LuaRef on_hunk;
+  String result_type;
+  String algorithm;
+  Integer ctxlen;
+  Integer interhunkctxlen;
+  Object linematch;
+  Boolean ignore_whitespace;
+  Boolean ignore_whitespace_change;
+  Boolean ignore_whitespace_change_at_eol;
+  Boolean ignore_cr_at_eol;
+  Boolean ignore_blank_lines;
+  Boolean indent_heuristic;
+} Dict(xdl_diff);

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -34,6 +34,7 @@
 #define CSTR_TO_OBJ(s) STRING_OBJ(cstr_to_string(s))
 #define CSTR_TO_ARENA_STR(arena, s) arena_string(arena, cstr_as_string(s))
 #define CSTR_TO_ARENA_OBJ(arena, s) STRING_OBJ(CSTR_TO_ARENA_STR(arena, s))
+#define CBUF_TO_ARENA_STR(arena, s, len) arena_string(arena, cbuf_as_string((char *)(s), len))
 
 #define BUFFER_OBJ(s) ((Object) { \
     .type = kObjectTypeBuffer, \
@@ -118,6 +119,8 @@
 #define api_init_object = NIL
 #define api_init_array = ARRAY_DICT_INIT
 #define api_init_dictionary = ARRAY_DICT_INIT
+
+#define KEYDICT_INIT { 0 }
 
 #define api_free_boolean(value)
 #define api_free_integer(value)

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -600,7 +600,7 @@ Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   /// Keep in sync with WinSplit in buffer_defs.h
   static const char *const win_split_str[] = { "left", "right", "above", "below" };
 
-  Dict(win_config) rv = { 0 };
+  Dict(win_config) rv = KEYDICT_INIT;
 
   win_T *wp = find_window_by_handle(window, err);
   if (!wp) {

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -421,8 +421,7 @@ void nvim_win_close(Window window, Boolean force, Error *err)
 /// @param fun        Function to call inside the window (currently Lua callable
 ///                   only)
 /// @param[out] err   Error details, if any
-/// @return           Return value of function. NB: will deepcopy Lua values
-///                   currently, use upvalues to send Lua references in and out.
+/// @return           Return value of function.
 Object nvim_win_call(Window window, LuaRef fun, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_LUA_ONLY
@@ -438,7 +437,7 @@ Object nvim_win_call(Window window, LuaRef fun, Error *err)
   win_execute_T win_execute_args;
   if (win_execute_before(&win_execute_args, win, tabpage)) {
     Array args = ARRAY_DICT_INIT;
-    res = nlua_call_ref(fun, NULL, args, true, err);
+    res = nlua_call_ref(fun, NULL, args, kRetLuaref, NULL, err);
   }
   win_execute_after(&win_execute_args);
   try_end(err);

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -179,7 +179,7 @@ void buf_updates_unload(buf_T *buf, bool can_reload)
       ADD_C(args, BUFFER_OBJ(buf->handle));
 
       TEXTLOCK_WRAP({
-        nlua_call_ref(thecb, keep ? "reload" : "detach", args, false, NULL);
+        nlua_call_ref(thecb, keep ? "reload" : "detach", args, false, NULL, NULL);
       });
     }
 
@@ -295,10 +295,10 @@ void buf_updates_send_changes(buf_T *buf, linenr_T firstline, int64_t num_added,
 
       Object res;
       TEXTLOCK_WRAP({
-        res = nlua_call_ref(cb.on_lines, "lines", args, false, NULL);
+        res = nlua_call_ref(cb.on_lines, "lines", args, kRetNilBool, NULL, NULL);
       });
 
-      if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+      if (LUARET_TRUTHY(res)) {
         buffer_update_callbacks_free(cb);
         keep = false;
       }
@@ -345,10 +345,10 @@ void buf_updates_send_splice(buf_T *buf, int start_row, colnr_T start_col, bcoun
 
       Object res;
       TEXTLOCK_WRAP({
-        res = nlua_call_ref(cb.on_bytes, "bytes", args, false, NULL);
+        res = nlua_call_ref(cb.on_bytes, "bytes", args, kRetNilBool, NULL, NULL);
       });
 
-      if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+      if (LUARET_TRUTHY(res)) {
         buffer_update_callbacks_free(cb);
         keep = false;
       }
@@ -381,10 +381,10 @@ void buf_updates_changedtick(buf_T *buf)
 
       Object res;
       TEXTLOCK_WRAP({
-        res = nlua_call_ref(cb.on_changedtick, "changedtick", args, false, NULL);
+        res = nlua_call_ref(cb.on_changedtick, "changedtick", args, kRetNilBool, NULL, NULL);
       });
 
-      if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+      if (LUARET_TRUTHY(res)) {
         buffer_update_callbacks_free(cb);
         keep = false;
       }

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2591,7 +2591,7 @@ static char *get_healthcheck_names(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   if (last_gen != get_cmdline_last_prompt_id() || last_gen == 0) {
     Array a = ARRAY_DICT_INIT;
     Error err = ERROR_INIT;
-    Object res = nlua_exec(STATIC_CSTR_AS_STRING("return vim.health._complete()"), a, &err);
+    Object res = NLUA_EXEC_STATIC("return vim.health._complete()", a, kRetObject, NULL, &err);
     api_clear_error(&err);
     api_free_object(names);
     names = res;

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -48,7 +48,7 @@ static bool decor_provider_invoke(int provider_idx, const char *name, LuaRef ref
 
   textlock++;
   provider_active = true;
-  Object ret = nlua_call_ref(ref, name, args, true, &err);
+  Object ret = nlua_call_ref(ref, name, args, kRetNilBool, NULL, &err);
   provider_active = false;
   textlock--;
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6143,8 +6143,8 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
     break;
 
   case kCallbackLua:
-    rv = nlua_call_ref(callback->data.luaref, NULL, args, false, NULL);
-    return (rv.type == kObjectTypeBoolean && rv.data.boolean == true);
+    rv = nlua_call_ref(callback->data.luaref, NULL, args, kRetNilBool, NULL, NULL);
+    return LUARET_TRUTHY(rv);
 
   case kCallbackNone:
     return false;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7445,7 +7445,7 @@ static void ex_checkhealth(exarg_T *eap)
   ADD_C(args, STRING_OBJ(((String){ .data = mods, .size = mods_len })));
   ADD_C(args, CSTR_AS_OBJ(eap->arg));
 
-  NLUA_EXEC_STATIC("return vim.health._check(...)", args, &err);
+  NLUA_EXEC_STATIC("vim.health._check(...)", args, kRetNilBool, NULL, &err);
   if (!ERROR_SET(&err)) {
     return;
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3027,7 +3027,7 @@ bool map_execute_lua(bool may_repeat)
 
   Error err = ERROR_INIT;
   Array args = ARRAY_DICT_INIT;
-  nlua_call_ref(ref, NULL, args, false, &err);
+  nlua_call_ref(ref, NULL, args, kRetNilBool, NULL, &err);
   if (err.type != kErrorTypeNone) {
     semsg_multiline("E5108: %s", err.msg);
     api_clear_error(&err);

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -212,7 +212,7 @@ int ns_get_hl(NS *ns_hl, int hl_id, bool link, bool nodefault)
 
     Error err = ERROR_INIT;
     recursive++;
-    Object ret = nlua_call_ref(p->hl_def, "hl_def", args, true, &err);
+    Object ret = nlua_call_ref(p->hl_def, "hl_def", args, kRetObject, NULL, &err);
     recursive--;
 
     // TODO(bfredl): or "inherit", combine with global value?
@@ -221,7 +221,7 @@ int ns_get_hl(NS *ns_hl, int hl_id, bool link, bool nodefault)
     HlAttrs attrs = HLATTRS_INIT;
     if (ret.type == kObjectTypeDictionary) {
       fallback = false;
-      Dict(highlight) dict = { 0 };
+      Dict(highlight) dict = KEYDICT_INIT;
       if (api_dict_to_keydict(&dict, KeyDict_highlight_get_field,
                               ret.data.dictionary, &err)) {
         attrs = dict2hlattrs(&dict, true, &it.link_id, &err);
@@ -1086,7 +1086,7 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
 
   // Handle cterm attrs
   if (dict->cterm.type == kObjectTypeDictionary) {
-    Dict(highlight_cterm) cterm[1] = { 0 };
+    Dict(highlight_cterm) cterm[1] = KEYDICT_INIT;
     if (!api_dict_to_keydict(cterm, KeyDict_highlight_cterm_get_field,
                              dict->cterm.data.dictionary, err)) {
       return hlattrs;

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -795,8 +795,8 @@ void nlua_push_Object(lua_State *lstate, const Object obj, bool special)
 /// Convert lua value to string
 ///
 /// Always pops one value from the stack.
-String nlua_pop_String(lua_State *lstate, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+String nlua_pop_String(lua_State *lstate, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 3) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (lua_type(lstate, -1) != LUA_TSTRING) {
     lua_pop(lstate, 1);
@@ -807,7 +807,10 @@ String nlua_pop_String(lua_State *lstate, Error *err)
 
   ret.data = (char *)lua_tolstring(lstate, -1, &(ret.size));
   assert(ret.data != NULL);
-  ret.data = xmemdupz(ret.data, ret.size);
+  // TODO(bfredl): it would be "nice" to just use the memory of the lua string
+  // directly, although ensuring the lifetime of such strings is a bit tricky
+  // (an API call could invoke nested lua, which triggers GC, and kaboom?)
+  ret.data = arena_memdupz(arena, ret.data, ret.size);
   lua_pop(lstate, 1);
 
   return ret;
@@ -816,8 +819,8 @@ String nlua_pop_String(lua_State *lstate, Error *err)
 /// Convert lua value to integer
 ///
 /// Always pops one value from the stack.
-Integer nlua_pop_Integer(lua_State *lstate, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+Integer nlua_pop_Integer(lua_State *lstate, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 3) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (lua_type(lstate, -1) != LUA_TNUMBER) {
     lua_pop(lstate, 1);
@@ -840,8 +843,8 @@ Integer nlua_pop_Integer(lua_State *lstate, Error *err)
 /// thus `err` is never set as any lua value can be co-erced into a lua bool
 ///
 /// Always pops one value from the stack.
-Boolean nlua_pop_Boolean(lua_State *lstate, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+Boolean nlua_pop_Boolean(lua_State *lstate, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 3) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   const Boolean ret = lua_toboolean(lstate, -1);
   lua_pop(lstate, 1);
@@ -915,7 +918,7 @@ static inline LuaTableProps nlua_check_type(lua_State *const lstate, Error *cons
 /// Convert lua table to float
 ///
 /// Always pops one value from the stack.
-Float nlua_pop_Float(lua_State *lstate, Error *err)
+Float nlua_pop_Float(lua_State *lstate, Arena *arena, Error *err)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (lua_type(lstate, -1) == LUA_TNUMBER) {
@@ -939,29 +942,29 @@ Float nlua_pop_Float(lua_State *lstate, Error *err)
 /// @param[in]  table_props  nlua_traverse_table() output.
 /// @param[out]  err  Location where error will be saved.
 static Array nlua_pop_Array_unchecked(lua_State *const lstate, const LuaTableProps table_props,
-                                      Error *const err)
+                                      Arena *arena, Error *const err)
 {
-  Array ret = { .size = table_props.maxidx, .items = NULL };
+  Array ret = arena_array(arena, table_props.maxidx);
 
-  if (ret.size == 0) {
+  if (table_props.maxidx == 0) {
     lua_pop(lstate, 1);
     return ret;
   }
 
-  ret.items = xcalloc(ret.size, sizeof(*ret.items));
-  for (size_t i = 1; i <= ret.size; i++) {
+  for (size_t i = 1; i <= table_props.maxidx; i++) {
     Object val;
 
     lua_rawgeti(lstate, -1, (int)i);
 
-    val = nlua_pop_Object(lstate, false, err);
+    val = nlua_pop_Object(lstate, false, arena, err);
     if (ERROR_SET(err)) {
-      ret.size = i - 1;
       lua_pop(lstate, 1);
-      api_free_array(ret);
+      if (!arena) {
+        api_free_array(ret);
+      }
       return (Array) { .size = 0, .items = NULL };
     }
-    ret.items[i - 1] = val;
+    ADD_C(ret, val);
   }
   lua_pop(lstate, 1);
 
@@ -971,15 +974,14 @@ static Array nlua_pop_Array_unchecked(lua_State *const lstate, const LuaTablePro
 /// Convert lua table to array
 ///
 /// Always pops one value from the stack.
-Array nlua_pop_Array(lua_State *lstate, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+Array nlua_pop_Array(lua_State *lstate, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 3) FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  const LuaTableProps table_props = nlua_check_type(lstate, err,
-                                                    kObjectTypeArray);
+  const LuaTableProps table_props = nlua_check_type(lstate, err, kObjectTypeArray);
   if (table_props.type != kObjectTypeArray) {
     return (Array) { .size = 0, .items = NULL };
   }
-  return nlua_pop_Array_unchecked(lstate, table_props, err);
+  return nlua_pop_Array_unchecked(lstate, table_props, arena, err);
 }
 
 /// Convert lua table to dictionary
@@ -991,30 +993,30 @@ Array nlua_pop_Array(lua_State *lstate, Error *err)
 /// @param[in]  table_props  nlua_traverse_table() output.
 /// @param[out]  err  Location where error will be saved.
 static Dictionary nlua_pop_Dictionary_unchecked(lua_State *lstate, const LuaTableProps table_props,
-                                                bool ref, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+                                                bool ref, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 5) FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  Dictionary ret = { .size = table_props.string_keys_num, .items = NULL };
+  Dictionary ret = arena_dict(arena, table_props.string_keys_num);
 
-  if (ret.size == 0) {
+  if (table_props.string_keys_num == 0) {
     lua_pop(lstate, 1);
     return ret;
   }
-  ret.items = xcalloc(ret.size, sizeof(*ret.items));
 
   lua_pushnil(lstate);
-  for (size_t i = 0; lua_next(lstate, -2) && i < ret.size;) {
+  for (size_t i = 0; lua_next(lstate, -2) && i < table_props.string_keys_num;) {
     // stack: dict, key, value
 
     if (lua_type(lstate, -2) == LUA_TSTRING) {
       lua_pushvalue(lstate, -2);
       // stack: dict, key, value, key
 
-      ret.items[i].key = nlua_pop_String(lstate, err);
+      String key = nlua_pop_String(lstate, arena, err);
       // stack: dict, key, value
 
       if (!ERROR_SET(err)) {
-        ret.items[i].value = nlua_pop_Object(lstate, ref, err);
+        Object value = nlua_pop_Object(lstate, ref, arena, err);
+        kv_push_c(ret, ((KeyValuePair) { .key = key, .value = value }));
         // stack: dict, key
       } else {
         lua_pop(lstate, 1);
@@ -1022,8 +1024,9 @@ static Dictionary nlua_pop_Dictionary_unchecked(lua_State *lstate, const LuaTabl
       }
 
       if (ERROR_SET(err)) {
-        ret.size = i;
-        api_free_dictionary(ret);
+        if (!arena) {
+          api_free_dictionary(ret);
+        }
         lua_pop(lstate, 2);
         // stack:
         return (Dictionary) { .size = 0, .items = NULL };
@@ -1042,8 +1045,8 @@ static Dictionary nlua_pop_Dictionary_unchecked(lua_State *lstate, const LuaTabl
 /// Convert lua table to dictionary
 ///
 /// Always pops one value from the stack.
-Dictionary nlua_pop_Dictionary(lua_State *lstate, bool ref, Error *err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+Dictionary nlua_pop_Dictionary(lua_State *lstate, bool ref, Arena *arena, Error *err)
+  FUNC_ATTR_NONNULL_ARG(1, 4) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   const LuaTableProps table_props = nlua_check_type(lstate, err,
                                                     kObjectTypeDictionary);
@@ -1052,7 +1055,7 @@ Dictionary nlua_pop_Dictionary(lua_State *lstate, bool ref, Error *err)
     return (Dictionary) { .size = 0, .items = NULL };
   }
 
-  return nlua_pop_Dictionary_unchecked(lstate, table_props, ref, err);
+  return nlua_pop_Dictionary_unchecked(lstate, table_props, ref, arena, err);
 }
 
 /// Helper structure for nlua_pop_Object
@@ -1064,7 +1067,8 @@ typedef struct {
 /// Convert lua table to object
 ///
 /// Always pops one value from the stack.
-Object nlua_pop_Object(lua_State *const lstate, bool ref, Error *const err)
+Object nlua_pop_Object(lua_State *const lstate, bool ref, Arena *arena, Error *const err)
+  FUNC_ATTR_NONNULL_ARG(1, 4) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   Object ret = NIL;
   const int initial_size = lua_gettop(lstate);
@@ -1099,10 +1103,7 @@ Object nlua_pop_Object(lua_State *const lstate, bool ref, Error *const err)
           size_t len;
           const char *s = lua_tolstring(lstate, -2, &len);
           const size_t idx = cur.obj->data.dictionary.size++;
-          cur.obj->data.dictionary.items[idx].key = (String) {
-            .data = xmemdupz(s, len),
-            .size = len,
-          };
+          cur.obj->data.dictionary.items[idx].key = CBUF_TO_ARENA_STR(arena, s, len);
           kvi_push(stack, cur);
           cur = (ObjPopStackItem){ .obj = &cur.obj->data.dictionary.items[idx].value };
         } else {
@@ -1133,7 +1134,7 @@ Object nlua_pop_Object(lua_State *const lstate, bool ref, Error *const err)
     case LUA_TSTRING: {
       size_t len;
       const char *s = lua_tolstring(lstate, -1, &len);
-      *cur.obj = STRING_OBJ(((String) { .data = xmemdupz(s, len), .size = len }));
+      *cur.obj = STRING_OBJ(CBUF_TO_ARENA_STR(arena, s, len));
       break;
     }
     case LUA_TNUMBER: {
@@ -1151,23 +1152,17 @@ Object nlua_pop_Object(lua_State *const lstate, bool ref, Error *const err)
 
       switch (table_props.type) {
       case kObjectTypeArray:
-        *cur.obj = ARRAY_OBJ(((Array) { .items = NULL, .size = 0, .capacity = 0 }));
+        *cur.obj = ARRAY_OBJ(((Array)ARRAY_DICT_INIT));
         if (table_props.maxidx != 0) {
-          cur.obj->data.array.items =
-            xcalloc(table_props.maxidx,
-                    sizeof(cur.obj->data.array.items[0]));
-          cur.obj->data.array.capacity = table_props.maxidx;
+          cur.obj->data.array = arena_array(arena, table_props.maxidx);
           cur.container = true;
           kvi_push(stack, cur);
         }
         break;
       case kObjectTypeDictionary:
-        *cur.obj = DICTIONARY_OBJ(((Dictionary) { .items = NULL, .size = 0, .capacity = 0 }));
+        *cur.obj = DICTIONARY_OBJ(((Dictionary)ARRAY_DICT_INIT));
         if (table_props.string_keys_num != 0) {
-          cur.obj->data.dictionary.items =
-            xcalloc(table_props.string_keys_num,
-                    sizeof(cur.obj->data.dictionary.items[0]));
-          cur.obj->data.dictionary.capacity = table_props.string_keys_num;
+          cur.obj->data.dictionary = arena_dict(arena, table_props.string_keys_num);
           cur.container = true;
           kvi_push(stack, cur);
           lua_pushnil(lstate);
@@ -1219,7 +1214,9 @@ type_error:
   }
   kvi_destroy(stack);
   if (ERROR_SET(err)) {
-    api_free_object(ret);
+    if (!arena) {
+      api_free_object(ret);
+    }
     ret = NIL;
     lua_pop(lstate, lua_gettop(lstate) - initial_size + 1);
   }
@@ -1227,14 +1224,14 @@ type_error:
   return ret;
 }
 
-LuaRef nlua_pop_LuaRef(lua_State *const lstate, Error *err)
+LuaRef nlua_pop_LuaRef(lua_State *const lstate, Arena *arena, Error *err)
 {
   LuaRef rv = nlua_ref_global(lstate, -1);
   lua_pop(lstate, 1);
   return rv;
 }
 
-handle_T nlua_pop_handle(lua_State *lstate, Error *err)
+handle_T nlua_pop_handle(lua_State *lstate, Arena *arena, Error *err)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   handle_T ret;
@@ -1296,7 +1293,8 @@ void nlua_init_types(lua_State *const lstate)
 }
 
 // lua specific variant of api_dict_to_keydict
-void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, char **err_opt, Error *err)
+void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, char **err_opt, Arena *arena,
+                      Error *err)
 {
   if (!lua_istable(L, -1)) {
     api_set_error(err, kErrorTypeValidation, "Expected Lua table");
@@ -1323,7 +1321,7 @@ void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, char **err_
     char *mem = ((char *)retval + field->ptr_off);
 
     if (field->type == kObjectTypeNil) {
-      *(Object *)mem = nlua_pop_Object(L, true, err);
+      *(Object *)mem = nlua_pop_Object(L, true, arena, err);
     } else if (field->type == kObjectTypeInteger) {
       if (field->is_hlgroup && lua_type(L, -1) == LUA_TSTRING) {
         size_t name_len;
@@ -1331,23 +1329,23 @@ void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, char **err_
         lua_pop(L, 1);
         *(Integer *)mem = name_len > 0 ? syn_check_group(name, name_len) : 0;
       } else {
-        *(Integer *)mem = nlua_pop_Integer(L, err);
+        *(Integer *)mem = nlua_pop_Integer(L, arena, err);
       }
     } else if (field->type == kObjectTypeBoolean) {
       *(Boolean *)mem = nlua_pop_Boolean_strict(L, err);
     } else if (field->type == kObjectTypeString) {
-      *(String *)mem = nlua_pop_String(L, err);
+      *(String *)mem = nlua_pop_String(L, arena, err);
     } else if (field->type == kObjectTypeFloat) {
-      *(Float *)mem = nlua_pop_Float(L, err);
+      *(Float *)mem = nlua_pop_Float(L, arena, err);
     } else if (field->type == kObjectTypeBuffer || field->type == kObjectTypeWindow
                || field->type == kObjectTypeTabpage) {
-      *(handle_T *)mem = nlua_pop_handle(L, err);
+      *(handle_T *)mem = nlua_pop_handle(L, arena, err);
     } else if (field->type == kObjectTypeArray) {
-      *(Array *)mem = nlua_pop_Array(L, err);
+      *(Array *)mem = nlua_pop_Array(L, arena, err);
     } else if (field->type == kObjectTypeDictionary) {
-      *(Dictionary *)mem = nlua_pop_Dictionary(L, false, err);
+      *(Dictionary *)mem = nlua_pop_Dictionary(L, false, arena, err);
     } else if (field->type == kObjectTypeLuaRef) {
-      *(LuaRef *)mem = nlua_pop_LuaRef(L, err);
+      *(LuaRef *)mem = nlua_pop_LuaRef(L, arena, err);
     } else {
       abort();
     }

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -24,7 +24,8 @@ typedef struct {
 #endif
 } nlua_ref_state_t;
 
-#define NLUA_EXEC_STATIC(cstr, arg, err) nlua_exec(STATIC_CSTR_AS_STRING(cstr), arg, err)
+#define NLUA_EXEC_STATIC(cstr, arg, mode, arena, err) \
+  nlua_exec(STATIC_CSTR_AS_STRING(cstr), arg, mode, arena, err)
 
 #define NLUA_CLEAR_REF(x) \
   do { \
@@ -34,6 +35,16 @@ typedef struct {
       (x) = LUA_NOREF; \
     } \
   } while (0)
+
+typedef enum {
+  kRetObject,  ///< any object, but doesn't preserve nested luarefs
+  kRetNilBool,  ///< NIL preserved as such, other values return their booleanness
+                ///< Should also be used when return value is ignored, as it is allocation-free
+  kRetLuaref,  ///< return value becomes a single Luaref, regardless of type (except NIL)
+} LuaRetMode;
+
+/// To use with kRetNilBool for quick thuthyness check
+#define LUARET_TRUTHY(res) ((res).type == kObjectTypeBoolean && (res).data.boolean == true)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "lua/executor.h.generated.h"

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -5,7 +5,9 @@
 #include <string.h>
 
 #include "luaconf.h"
+#include "nvim/api/keysets_defs.h"
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/linematch.h"
 #include "nvim/lua/converter.h"
@@ -187,137 +189,84 @@ static mmfile_t get_string_arg(lua_State *lstate, int idx)
   return mf;
 }
 
-// Helper function for validating option types
-static bool check_xdiff_opt(ObjectType actType, ObjectType expType, const char *name, Error *err)
-{
-  if (actType != expType) {
-    const char *type_str =
-      expType == kObjectTypeString
-      ? "string" : (expType == kObjectTypeInteger
-                    ? "integer" : (expType == kObjectTypeBoolean
-                                   ? "boolean" : (expType == kObjectTypeLuaRef
-                                                  ? "function" : "NA")));
-
-    api_set_error(err, kErrorTypeValidation, "%s is not a %s", name,
-                  type_str);
-    return true;
-  }
-
-  return false;
-}
-
 static NluaXdiffMode process_xdl_diff_opts(lua_State *lstate, xdemitconf_t *cfg, xpparam_t *params,
                                            int64_t *linematch, Error *err)
 {
-  // TODO: this is very much a keydict..
-  const DictionaryOf(LuaRef) opts = nlua_pop_Dictionary(lstate, true, NULL, err);
+  Dict(xdl_diff) opts = KEYDICT_INIT;
+  char *err_param = NULL;
+  KeySetLink *KeyDict_xdl_diff_get_field(const char *str, size_t len);
+  nlua_pop_keydict(lstate, &opts, KeyDict_xdl_diff_get_field, &err_param, NULL, err);
 
   NluaXdiffMode mode = kNluaXdiffModeUnified;
 
-  bool had_on_hunk = false;
   bool had_result_type_indices = false;
-  for (size_t i = 0; i < opts.size; i++) {
-    String k = opts.items[i].key;
-    Object *v = &opts.items[i].value;
-    if (strequal("on_hunk", k.data)) {
-      if (check_xdiff_opt(v->type, kObjectTypeLuaRef, "on_hunk", err)) {
-        goto exit_1;
-      }
-      had_on_hunk = true;
-      nlua_pushref(lstate, v->data.luaref);
-    } else if (strequal("result_type", k.data)) {
-      if (check_xdiff_opt(v->type, kObjectTypeString, "result_type", err)) {
-        goto exit_1;
-      }
-      if (strequal("unified", v->data.string.data)) {
-        // the default
-      } else if (strequal("indices", v->data.string.data)) {
-        had_result_type_indices = true;
-      } else {
-        api_set_error(err, kErrorTypeValidation, "not a valid result_type");
-        goto exit_1;
-      }
-    } else if (strequal("algorithm", k.data)) {
-      if (check_xdiff_opt(v->type, kObjectTypeString, "algorithm", err)) {
-        goto exit_1;
-      }
-      if (strequal("myers", v->data.string.data)) {
-        // default
-      } else if (strequal("minimal", v->data.string.data)) {
-        params->flags |= XDF_NEED_MINIMAL;
-      } else if (strequal("patience", v->data.string.data)) {
-        params->flags |= XDF_PATIENCE_DIFF;
-      } else if (strequal("histogram", v->data.string.data)) {
-        params->flags |= XDF_HISTOGRAM_DIFF;
-      } else {
-        api_set_error(err, kErrorTypeValidation, "not a valid algorithm");
-        goto exit_1;
-      }
-    } else if (strequal("ctxlen", k.data)) {
-      if (check_xdiff_opt(v->type, kObjectTypeInteger, "ctxlen", err)) {
-        goto exit_1;
-      }
-      cfg->ctxlen = (long)v->data.integer;
-    } else if (strequal("interhunkctxlen", k.data)) {
-      if (check_xdiff_opt(v->type, kObjectTypeInteger, "interhunkctxlen",
-                          err)) {
-        goto exit_1;
-      }
-      cfg->interhunkctxlen = (long)v->data.integer;
-    } else if (strequal("linematch", k.data)) {
-      if (v->type == kObjectTypeBoolean) {
-        *linematch = v->data.boolean ? INT64_MAX : 0;
-      } else if (v->type == kObjectTypeInteger) {
-        *linematch = v->data.integer;
-      } else {
-        api_set_error(err, kErrorTypeValidation, "linematch must be a boolean or integer");
-        goto exit_1;
-      }
+
+  if (HAS_KEY(&opts, xdl_diff, result_type)) {
+    if (strequal("unified", opts.result_type.data)) {
+      // the default
+    } else if (strequal("indices", opts.result_type.data)) {
+      had_result_type_indices = true;
     } else {
-      struct {
-        const char *name;
-        unsigned long value;
-      } flags[] = {
-        { "ignore_whitespace", XDF_IGNORE_WHITESPACE },
-        { "ignore_whitespace_change", XDF_IGNORE_WHITESPACE_CHANGE },
-        { "ignore_whitespace_change_at_eol", XDF_IGNORE_WHITESPACE_AT_EOL },
-        { "ignore_cr_at_eol", XDF_IGNORE_CR_AT_EOL },
-        { "ignore_blank_lines", XDF_IGNORE_BLANK_LINES },
-        { "indent_heuristic", XDF_INDENT_HEURISTIC },
-        {  NULL, 0 },
-      };
-      bool key_used = false;
-      for (size_t j = 0; flags[j].name; j++) {
-        if (strequal(flags[j].name, k.data)) {
-          if (check_xdiff_opt(v->type, kObjectTypeBoolean, flags[j].name,
-                              err)) {
-            goto exit_1;
-          }
-          if (v->data.boolean) {
-            params->flags |= flags[j].value;
-          }
-          key_used = true;
-          break;
-        }
-      }
-
-      if (key_used) {
-        continue;
-      }
-
-      api_set_error(err, kErrorTypeValidation, "unexpected key: %s", k.data);
+      api_set_error(err, kErrorTypeValidation, "not a valid result_type");
       goto exit_1;
     }
   }
 
-  if (had_on_hunk) {
+  if (HAS_KEY(&opts, xdl_diff, algorithm)) {
+    if (strequal("myers", opts.algorithm.data)) {
+      // default
+    } else if (strequal("minimal", opts.algorithm.data)) {
+      params->flags |= XDF_NEED_MINIMAL;
+    } else if (strequal("patience", opts.algorithm.data)) {
+      params->flags |= XDF_PATIENCE_DIFF;
+    } else if (strequal("histogram", opts.algorithm.data)) {
+      params->flags |= XDF_HISTOGRAM_DIFF;
+    } else {
+      api_set_error(err, kErrorTypeValidation, "not a valid algorithm");
+      goto exit_1;
+    }
+  }
+
+  if (HAS_KEY(&opts, xdl_diff, ctxlen)) {
+    cfg->ctxlen = (long)opts.ctxlen;
+  }
+
+  if (HAS_KEY(&opts, xdl_diff, interhunkctxlen)) {
+    cfg->interhunkctxlen = (long)opts.interhunkctxlen;
+  }
+
+  if (HAS_KEY(&opts, xdl_diff, linematch)) {
+    if (opts.linematch.type == kObjectTypeBoolean) {
+      *linematch = opts.linematch.data.boolean ? INT64_MAX : 0;
+    } else if (opts.linematch.type == kObjectTypeInteger) {
+      *linematch = opts.linematch.data.integer;
+    } else {
+      api_set_error(err, kErrorTypeValidation, "linematch must be a boolean or integer");
+      goto exit_1;
+    }
+  }
+
+  params->flags |= opts.ignore_whitespace ? XDF_IGNORE_WHITESPACE : 0;
+  params->flags |= opts.ignore_whitespace_change ? XDF_IGNORE_WHITESPACE_CHANGE : 0;
+  params->flags |= opts.ignore_whitespace_change_at_eol ? XDF_IGNORE_WHITESPACE_AT_EOL : 0;
+  params->flags |= opts.ignore_cr_at_eol ? XDF_IGNORE_CR_AT_EOL : 0;
+  params->flags |= opts.ignore_blank_lines ? XDF_IGNORE_BLANK_LINES : 0;
+  params->flags |= opts.indent_heuristic ? XDF_INDENT_HEURISTIC : 0;
+
+  if (HAS_KEY(&opts, xdl_diff, on_hunk)) {
     mode = kNluaXdiffModeOnHunkCB;
+    nlua_pushref(lstate, opts.on_hunk);
+    if (lua_type(lstate, -1) != LUA_TFUNCTION) {
+      api_set_error(err, kErrorTypeValidation, "on_hunk is not a function");
+    }
   } else if (had_result_type_indices) {
     mode = kNluaXdiffModeLocations;
   }
 
 exit_1:
-  api_free_dictionary(opts);
+  api_free_string(opts.result_type);
+  api_free_string(opts.algorithm);
+  api_free_luaref(opts.on_hunk);
   return mode;
 }
 

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -209,7 +209,8 @@ static bool check_xdiff_opt(ObjectType actType, ObjectType expType, const char *
 static NluaXdiffMode process_xdl_diff_opts(lua_State *lstate, xdemitconf_t *cfg, xpparam_t *params,
                                            int64_t *linematch, Error *err)
 {
-  const DictionaryOf(LuaRef) opts = nlua_pop_Dictionary(lstate, true, err);
+  // TODO: this is very much a keydict..
+  const DictionaryOf(LuaRef) opts = nlua_pop_Dictionary(lstate, true, NULL, err);
 
   NluaXdiffMode mode = kNluaXdiffModeUnified;
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1644,7 +1644,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
   if (mp->m_luaref != LUA_NOREF) {
     Error err = ERROR_INIT;
     Array args = ARRAY_DICT_INIT;
-    Object ret = nlua_call_ref(mp->m_luaref, NULL, args, true, &err);
+    Object ret = nlua_call_ref(mp->m_luaref, NULL, args, kRetObject, NULL, &err);
     if (ret.type == kObjectTypeString) {
       p = string_to_cstr(ret.data.string);
     }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -192,7 +192,6 @@ Object rpc_send_call(uint64_t id, const char *method_name, Array args, ArenaMem 
 
   if (!(channel = find_rpc_channel(id))) {
     api_set_error(err, kErrorTypeException, "Invalid channel: %" PRIu64, id);
-    api_free_array(args);
     return NIL;
   }
 
@@ -201,7 +200,6 @@ Object rpc_send_call(uint64_t id, const char *method_name, Array args, ArenaMem 
   uint32_t request_id = rpc->next_request_id++;
   // Send the msgpack-rpc request
   send_request(channel, request_id, method_name, args);
-  api_free_array(args);
 
   // Push the frame
   ChannelCallFrame frame = { request_id, false, false, NIL, NULL };

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -710,8 +710,8 @@ void ui_call_event(char *name, Array args)
   bool handled = false;
   map_foreach_value(&ui_event_cbs, event_cb, {
     Error err = ERROR_INIT;
-    Object res = nlua_call_ref(event_cb->cb, name, args, false, &err);
-    if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
+    Object res = nlua_call_ref(event_cb->cb, name, args, kRetNilBool, NULL, &err);
+    if (LUARET_TRUTHY(res)) {
       handled = true;
     }
     if (ERROR_SET(&err)) {

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -170,7 +170,7 @@ Object handle_ui_client_redraw(uint64_t channel_id, Array args, Arena *arena, Er
 static HlAttrs ui_client_dict2hlattrs(Dictionary d, bool rgb)
 {
   Error err = ERROR_INIT;
-  Dict(highlight) dict = { 0 };
+  Dict(highlight) dict = KEYDICT_INIT;
   if (!api_dict_to_keydict(&dict, KeyDict_highlight_get_field, d, &err)) {
     // TODO(bfredl): log "err"
     return HLATTRS_INIT;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2681,9 +2681,9 @@ void list_in_columns(char **items, int size, int current)
 
 void list_lua_version(void)
 {
-  char *code = "return ((jit and jit.version) and jit.version or _VERSION)";
   Error err = ERROR_INIT;
-  Object ret = nlua_exec(cstr_as_string(code), (Array)ARRAY_DICT_INIT, &err);
+  Object ret = NLUA_EXEC_STATIC("return ((jit and jit.version) and jit.version or _VERSION)",
+                                (Array)ARRAY_DICT_INIT, kRetObject, NULL, &err);
   assert(!ERROR_SET(&err));
   assert(ret.type == kObjectTypeString);
   msg(ret.data.string.data, 0);

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3543,6 +3543,18 @@ describe('lua stdlib', function()
       ]])
       )
     end)
+
+    it('can return values by reference', function()
+      eq(
+        { 4, 7 },
+        exec_lua [[
+        local val = {4, 10}
+        local ref = vim.api.nvim_buf_call(0, function() return val end)
+        ref[2] = 7
+        return val
+      ]]
+      )
+    end)
   end)
 
   describe('vim.api.nvim_win_call', function()
@@ -3639,6 +3651,18 @@ describe('lua stdlib', function()
         {2:[No Name] [+]  20,1         3%}|
                                       |
       ]]
+    end)
+
+    it('can return values by reference', function()
+      eq(
+        { 7, 10 },
+        exec_lua [[
+        local val = {4, 10}
+        local ref = vim.api.nvim_win_call(0, function() return val end)
+        ref[1] = 7
+        return val
+      ]]
+      )
     end)
   end)
 

--- a/test/functional/lua/xdiff_spec.lua
+++ b/test/functional/lua/xdiff_spec.lua
@@ -165,7 +165,7 @@ describe('xdiff bindings', function()
       pcall_err(exec_lua, [[vim.diff('a', 'b', true)]])
     )
 
-    eq([[unexpected key: bad_key]], pcall_err(exec_lua, [[vim.diff('a', 'b', { bad_key = true })]]))
+    eq([[invalid key: bad_key]], pcall_err(exec_lua, [[vim.diff('a', 'b', { bad_key = true })]]))
 
     eq(
       [[on_hunk is not a function]],


### PR DESCRIPTION
and for return value of nlua_exec/nlua_call_ref, as this uses
the same family of functions.

NB: the handling of luaref:s is a bit of a mess.
add api_luarefs_free_XX functions as a stop-gap as refactoring luarefs is a can of worms for another PR:s.

as a minor feature/bug-fix, nvim_buf_call and nvim_win_call now preserves arbitrary return values.