### PR TITLE
vim-patch:9.1.0098: CompletionChanged not triggered when new leader added without matches

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1279,6 +1279,9 @@ void ins_compl_show_pum(void)
   }
 
   if (compl_match_array == NULL) {
+    if (compl_started && has_event(EVENT_COMPLETECHANGED)) {
+      trigger_complete_changed_event(cur);
+    }
     return;
   }
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1142,6 +1142,10 @@ func Test_CompleteChanged()
     let g:event = copy(v:event)
     let g:item = get(v:event, 'completed_item', {})
     let g:word = get(g:item, 'word', v:null)
+    let l:line = getline('.')
+    if g:word == v:null && l:line == "bc"
+      let g:word = l:line
+    endif
   endfunction
   augroup AAAAA_Group
     au!
@@ -1161,6 +1165,8 @@ func Test_CompleteChanged()
   call assert_equal(v:null, g:word)
   call feedkeys("a\<C-N>\<C-N>\<C-N>\<C-N>\<C-P>", 'tx')
   call assert_equal('foobar', g:word)
+  call feedkeys("S\<C-N>bc", 'tx')
+  call assert_equal("bc", g:word)
 
   func Omni_test(findstart, base)
     if a:findstart


### PR DESCRIPTION
Problem:  CompletionChanged not triggered when new leader added causing
          no matching item in the completion menu
Solution: When completion is active but no items matched still trigger
          CompletChanged event
          (glepnir)

closes: vim/vim#13982

https://github.com/vim/vim/commit/0d3c0a66a39570cbc52b9536604c39e324b989b3

Fix #15077