### PR TITLE
fix(extmarks): redraw pre-undo position

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -116,6 +116,12 @@ static void extmark_setraw(buf_T *buf, uint64_t mark, int row, colnr_T col, bool
     return;
   }
 
+  // Only the position before undo needs to be redrawn here,
+  // as the position after undo should be marked as changed.
+  if (!invalid && mt_decor_any(key) && key.pos.row != row) {
+    decor_redraw(buf, key.pos.row, key.pos.row, key.pos.col, mt_decor(key));
+  }
+
   int row1 = 0;
   int row2 = 0;
   if (invalid) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2390,9 +2390,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
     // When text has been changed, possibly the start of the next line
     // may have SpellCap that should be removed or it needs to be
     // displayed.  Schedule the next line for redrawing just in case.
-    // Also just in case the line had a sign which needs to be removed.
-    if ((spell_check_window(curwin) || buf_meta_total(curbuf, kMTMetaSignText))
-        && bot <= curbuf->b_ml.ml_line_count) {
+    if (spell_check_window(curwin) && bot <= curbuf->b_ml.ml_line_count) {
       redrawWinline(curwin, bot);
     }
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2230,6 +2230,44 @@ describe('extmark decorations', function()
     ]]}
   end)
 
+  it('virtual text is drawn correctly after delete and undo #27368', function()
+    insert('aaa\nbbb\nccc\nddd\neee')
+    command('vsplit')
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = {{'EOL'}} })
+    feed('3gg')
+    screen:expect{grid=[[
+      aaa                      │aaa                     |
+      bbb                      │bbb                     |
+      ^ccc EOL                  │ccc EOL                 |
+      ddd                      │ddd                     |
+      eee                      │eee                     |
+      {1:~                        }│{1:~                       }|*8
+      {41:[No Name] [+]             }{40:[No Name] [+]           }|
+                                                        |
+    ]]}
+    feed('dd')
+    screen:expect{grid=[[
+      aaa                      │aaa                     |
+      bbb                      │bbb                     |
+      ^ddd EOL                  │ddd EOL                 |
+      eee                      │eee                     |
+      {1:~                        }│{1:~                       }|*9
+      {41:[No Name] [+]             }{40:[No Name] [+]           }|
+                                                        |
+    ]]}
+    command('silent undo')
+    screen:expect{grid=[[
+      aaa                      │aaa                     |
+      bbb                      │bbb                     |
+      ^ccc EOL                  │ccc EOL                 |
+      ddd                      │ddd                     |
+      eee                      │eee                     |
+      {1:~                        }│{1:~                       }|*8
+      {41:[No Name] [+]             }{40:[No Name] [+]           }|
+                                                        |
+    ]]}
+  end)
+
   it('works with both hl_group and sign_hl_group', function()
     screen:try_resize(screen._width, 3)
     insert('abcdefghijklmn')


### PR DESCRIPTION
Problem:
Virtual text not redrawn properly after undo moves its extmark.

Solution:
Redraw the moved extmark's pre-undo position.

Fix #27368
