### PR TITLE
fix(exitfree): don't use ex commands to close windows in free_all_mem()

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -724,13 +724,6 @@ void free_all_mem(void)
     do_cmdline_cmd("tabonly!");
   }
 
-  if (!ONE_WINDOW) {
-    // to keep things simple, don't perform this
-    // ritual inside a float
-    curwin = firstwin;
-    do_cmdline_cmd("only!");
-  }
-
   // Free all spell info.
   spell_free_all();
 


### PR DESCRIPTION
Attempting to manipulate the window layout via ex commands is not safe here. It is also redundant: `win_free_all()` can free multiple windows by itself perfectly fine.