### PR TITLE
fix(startup): remove extra newline at the end of `--startuptime` report

### DIFF
--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -981,7 +981,7 @@ void time_finish(void)
     return;
   }
   assert(startuptime_buf != NULL);
-  TIME_MSG("--- NVIM STARTED ---\n");
+  TIME_MSG("--- NVIM STARTED ---");
 
   // flush buffer to disk
   fclose(time_fd);


### PR DESCRIPTION
After 8e739af064dec28886694aa448f60a570acd2173, I noticed an extra newline was added to the end of the startup profile report. It affected my tool: https://github.com/rhysd/vim-startuptime/issues/4

I think this is a misuse of `TIME_MSG` macro. `\n` is output twice from both [`time_msg` function](https://github.com/neovim/neovim/blob/84b6ade41510ffad7d712abe2b010e4027b7033c/src/nvim/profile.c#L946) and `profile.c`.