### PR TITLE
feat(lsp): allow passing position to lsp.buf functions

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1164,9 +1164,9 @@ completion({context}, {options})                    *vim.lsp.buf.completion()*
                    triggered (how it was triggered, and by which trigger
                    character, if applicable)
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
     See also: ~
@@ -1185,9 +1185,9 @@ declaration({options})                             *vim.lsp.buf.declaration()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 definition({options})                               *vim.lsp.buf.definition()*
@@ -1199,9 +1199,9 @@ definition({options})                               *vim.lsp.buf.definition()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 document_highlight({options})               *vim.lsp.buf.document_highlight()*
@@ -1220,9 +1220,9 @@ document_highlight({options})               *vim.lsp.buf.document_highlight()*
 
     Parameters: ~
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 document_symbol({options})                     *vim.lsp.buf.document_symbol()*
@@ -1232,9 +1232,9 @@ document_symbol({options})                     *vim.lsp.buf.document_symbol()*
       • {options}  (`table?`) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 execute_command({command_params})              *vim.lsp.buf.execute_command()*
@@ -1290,9 +1290,9 @@ hover({options})                                         *vim.lsp.buf.hover()*
 
     Parameters: ~
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 implementation({options})                       *vim.lsp.buf.implementation()*
@@ -1303,9 +1303,9 @@ implementation({options})                       *vim.lsp.buf.implementation()*
       • {options}  (`table?`) additional options
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 incoming_calls({options})                       *vim.lsp.buf.incoming_calls()*
@@ -1315,9 +1315,9 @@ incoming_calls({options})                       *vim.lsp.buf.incoming_calls()*
 
     Parameters: ~
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 list_workspace_folders()                *vim.lsp.buf.list_workspace_folders()*
@@ -1330,9 +1330,9 @@ outgoing_calls({options})                       *vim.lsp.buf.outgoing_calls()*
 
     Parameters: ~
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 references({context}, {options})                    *vim.lsp.buf.references()*
@@ -1344,9 +1344,9 @@ references({context}, {options})                    *vim.lsp.buf.references()*
       • {options}  (`table?`) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
     See also: ~
@@ -1369,9 +1369,9 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
                       Clients matching the predicate are included.
                     • name (string|nil): Restrict clients used for rename to
                       ones where client.name matches this field.
-                    • row: 1-indexed row number of position, defaults to
+                    • row: 0-indexed row number of position, defaults to
                       current line
-                    • col:0-indexed column number of position, defaults to
+                    • col: 0-indexed column number of position, defaults to
                       current character
 
 signature_help({options})                       *vim.lsp.buf.signature_help()*
@@ -1380,9 +1380,9 @@ signature_help({options})                       *vim.lsp.buf.signature_help()*
 
     Parameters: ~
       • {options}  (`table?`) additional options
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 type_definition({options})                     *vim.lsp.buf.type_definition()*
@@ -1394,9 +1394,9 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
-                   • row: 1-indexed row number of position, defaults to
+                   • row: 0-indexed row number of position, defaults to
                      current line
-                   • col:0-indexed column number of position, defaults to
+                   • col: 0-indexed column number of position, defaults to
                      current character
 
 workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
@@ -1962,20 +1962,20 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
         start = `start_position`, end = `end_position` } }
 
                                          *vim.lsp.util.make_position_params()*
-make_position_params({row}, {col}, {window}, {offset_encoding})
+make_position_params({window}, {offset_encoding}, {row}, {col})
     Creates a `TextDocumentPositionParams` object for the current buffer and
     cursor position.
 
     Parameters: ~
-      • {row}              (`integer?`) 1-indexed row number of position,
-                           defaults to current line
-      • {col}              (`integer?`) 0-indexed column number of position,
-                           defaults to current character
       • {window}           (`integer?`) window handle or 0 for current,
                            defaults to current
       • {offset_encoding}  (`string?`) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
+      • {row}              (`integer?`) 1-indexed row number of position,
+                           defaults to current line
+      • {col}              (`integer?`) 0-indexed column number of position,
+                           defaults to current character
 
     Return: ~
         (`table`) `TextDocumentPositionParams` object

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1154,7 +1154,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
       • vim.lsp.protocol.CodeActionTriggerKind
 
-completion({context})                               *vim.lsp.buf.completion()*
+completion({context}, {options})                    *vim.lsp.buf.completion()*
     Retrieves the completion items at the current cursor position. Can only be
     called in Insert mode.
 
@@ -1163,6 +1163,11 @@ completion({context})                               *vim.lsp.buf.completion()*
                    information about the context in which a completion was
                    triggered (how it was triggered, and by which trigger
                    character, if applicable)
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
     See also: ~
       • vim.lsp.protocol.CompletionTriggerKind
@@ -1180,6 +1185,10 @@ declaration({options})                             *vim.lsp.buf.declaration()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 definition({options})                               *vim.lsp.buf.definition()*
     Jumps to the definition of the symbol under the cursor.
@@ -1190,8 +1199,12 @@ definition({options})                               *vim.lsp.buf.definition()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
-document_highlight()                        *vim.lsp.buf.document_highlight()*
+document_highlight({options})               *vim.lsp.buf.document_highlight()*
     Send request to the server to resolve document highlights for the current
     text document position. This request can be triggered by a key mapping or
     by events such as `CursorHold`, e.g.: >vim
@@ -1205,6 +1218,13 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
     highlights. |hl-LspReferenceText| |hl-LspReferenceRead|
     |hl-LspReferenceWrite|
 
+    Parameters: ~
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
+
 document_symbol({options})                     *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the quickfix window.
 
@@ -1212,6 +1232,10 @@ document_symbol({options})                     *vim.lsp.buf.document_symbol()*
       • {options}  (`table?`) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 execute_command({command_params})              *vim.lsp.buf.execute_command()*
     Executes an LSP server command.
@@ -1260,9 +1284,16 @@ format({options})                                       *vim.lsp.buf.format()*
                      Defaults to `nil` in other modes, formatting the full
                      buffer
 
-hover()                                                  *vim.lsp.buf.hover()*
+hover({options})                                         *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating
     window. Calling the function twice will jump into the floating window.
+
+    Parameters: ~
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 implementation({options})                       *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the
@@ -1272,19 +1303,37 @@ implementation({options})                       *vim.lsp.buf.implementation()*
       • {options}  (`table?`) additional options
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
-incoming_calls()                                *vim.lsp.buf.incoming_calls()*
+incoming_calls({options})                       *vim.lsp.buf.incoming_calls()*
     Lists all the call sites of the symbol under the cursor in the |quickfix|
     window. If the symbol can resolve to multiple items, the user can pick one
     in the |inputlist()|.
 
+    Parameters: ~
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
+
 list_workspace_folders()                *vim.lsp.buf.list_workspace_folders()*
     List workspace folders.
 
-outgoing_calls()                                *vim.lsp.buf.outgoing_calls()*
+outgoing_calls({options})                       *vim.lsp.buf.outgoing_calls()*
     Lists all the items that are called by the symbol under the cursor in the
     |quickfix| window. If the symbol can resolve to multiple items, the user
     can pick one in the |inputlist()|.
+
+    Parameters: ~
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 references({context}, {options})                    *vim.lsp.buf.references()*
     Lists all the references to the symbol under the cursor in the quickfix
@@ -1295,6 +1344,10 @@ references({context}, {options})                    *vim.lsp.buf.references()*
       • {options}  (`table?`) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -1316,10 +1369,21 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
                       Clients matching the predicate are included.
                     • name (string|nil): Restrict clients used for rename to
                       ones where client.name matches this field.
+                    • row: 1-indexed row number of position, defaults to
+                      current line
+                    • col:0-indexed column number of position, defaults to
+                      current character
 
-signature_help()                                *vim.lsp.buf.signature_help()*
+signature_help({options})                       *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
     floating window.
+
+    Parameters: ~
+      • {options}  (`table?`) additional options
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 type_definition({options})                     *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
@@ -1330,6 +1394,10 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
                      already open.
                    • on_list: (function) |lsp-on-list-handler| replacing the
                      default handler. Called for any non-empty result.
+                   • row: 1-indexed row number of position, defaults to
+                     current line
+                   • col:0-indexed column number of position, defaults to
+                     current character
 
 workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
     Lists all symbols in the current workspace in the quickfix window.
@@ -1894,11 +1962,15 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
         start = `start_position`, end = `end_position` } }
 
                                          *vim.lsp.util.make_position_params()*
-make_position_params({window}, {offset_encoding})
+make_position_params({row}, {col}, {window}, {offset_encoding})
     Creates a `TextDocumentPositionParams` object for the current buffer and
     cursor position.
 
     Parameters: ~
+      • {row}              (`integer?`) 1-indexed row number of position,
+                           defaults to current line
+      • {col}              (`integer?`) 0-indexed column number of position,
+                           defaults to current character
       • {window}           (`integer?`) window handle or 0 for current,
                            defaults to current
       • {offset_encoding}  (`string?`) utf-8|utf-16|utf-32|nil defaults to

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -422,6 +422,10 @@ The following changes to existing APIs or features add new behavior.
 
 • |--startuptime| reports the startup times for both processes (TUI + server) as separate sections.
 
+* |vim.lsp.start()| now maps |K| to use |vim.lsp.buf.hover()| if the server
+  supports it, unless |'keywordprg'| was customized before calling
+  |vim.lsp.start()|.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -41,11 +41,11 @@ end
 --- Displays hover information about the symbol under the cursor in a floating
 --- window. Calling the function twice will jump into the floating window.
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.hover(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request(ms.textDocument_hover, params)
 end
 
@@ -68,11 +68,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---        Called for any non-empty result.
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.declaration(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request_with_options(ms.textDocument_declaration, params, options)
 end
 
@@ -82,11 +82,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.definition(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request_with_options(ms.textDocument_definition, params, options)
 end
 
@@ -96,11 +96,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.type_definition(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request_with_options(ms.textDocument_typeDefinition, params, options)
 end
 
@@ -110,22 +110,22 @@ end
 ---@param options table|nil additional options
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.implementation(options)
   options = options or {}
-  local params = util.make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request_with_options(ms.textDocument_implementation, params, options)
 end
 
 --- Displays signature information about the symbol under the cursor in a
 --- floating window.
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.signature_help(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request(ms.textDocument_signatureHelp, params)
 end
 
@@ -137,12 +137,12 @@ end
 --- and by which trigger character, if applicable)
 ---
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 ---@see vim.lsp.protocol.CompletionTriggerKind
 function M.completion(context, options)
   options = options or {}
-  local params = util.make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   params.context = context
   return request(ms.textDocument_completion, params)
 end
@@ -290,8 +290,8 @@ end
 ---     - name (string|nil):
 ---         Restrict clients used for rename to ones where client.name matches
 ---         this field.
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.rename(new_name, options)
   options = options or {}
   local bufnr = options.bufnr or api.nvim_get_current_buf()
@@ -332,7 +332,8 @@ function M.rename(new_name, options)
 
     --- @param name string
     local function rename(name)
-      local params = util.make_position_params(options.row, options.col, win, client.offset_encoding)
+      local params =
+        util.make_position_params(win, client.offset_encoding, options.row, options.col)
       params.newName = name
       local handler = client.handlers[ms.textDocument_rename]
         or vim.lsp.handlers[ms.textDocument_rename]
@@ -343,7 +344,8 @@ function M.rename(new_name, options)
     end
 
     if client.supports_method(ms.textDocument_prepareRename) then
-      local params = util.make_position_params(options.row, options.col, win, client.offset_encoding)
+      local params =
+        util.make_position_params(win, client.offset_encoding, options.row, options.col)
       client.request(ms.textDocument_prepareRename, params, function(err, result)
         if err or result == nil then
           if next(clients, idx) then
@@ -413,12 +415,12 @@ end
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 ---@param options table|nil additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.references(context, options)
   validate({ context = { context, 't', true } })
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   params.context = context or {
     includeDeclaration = true,
   }
@@ -429,8 +431,8 @@ end
 ---
 ---@param options table|nil additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.document_symbol(options)
   local params = { textDocument = util.make_text_document_params() }
   request_with_options(ms.textDocument_documentSymbol, params, options)
@@ -479,22 +481,22 @@ end
 --- |quickfix| window. If the symbol can resolve to multiple
 --- items, the user can pick one in the |inputlist()|.
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.incoming_calls(options)
   options = options or {}
-  call_hierarchy(ms.callHierarchy_incomingCalls, options.row, options.col)
+  call_hierarchy(ms.callHierarchy_incomingCalls, nil, nil, options.row, options.col)
 end
 
 --- Lists all the items that are called by the symbol under the
 --- cursor in the |quickfix| window. If the symbol can resolve to
 --- multiple items, the user can pick one in the |inputlist()|.
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.outgoing_calls(options)
   options = options or {}
-  call_hierarchy(ms.callHierarchy_outgoingCalls, options.row, options.col)
+  call_hierarchy(ms.callHierarchy_outgoingCalls, nil, nil, options.row, options.col)
 end
 
 --- List workspace folders.
@@ -609,11 +611,11 @@ end
 ---         |hl-LspReferenceRead|
 ---         |hl-LspReferenceWrite|
 ---@param options table|nil additional options
----     - row: 1-indexed row number of position, defaults to current line
----     - col:0-indexed column number of position, defaults to current character
+---     - row: 0-indexed row number of position, defaults to current line
+---     - col: 0-indexed column number of position, defaults to current character
 function M.document_highlight(options)
   options = options or {}
-  local params = make_position_params(options.row, options.col)
+  local params = util.make_position_params(nil, nil, options.row, options.col)
   request(ms.textDocument_documentHighlight, params)
 end
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -40,8 +40,12 @@ end
 
 --- Displays hover information about the symbol under the cursor in a floating
 --- window. Calling the function twice will jump into the floating window.
-function M.hover()
-  local params = util.make_position_params()
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
+function M.hover(options)
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request(ms.textDocument_hover, params)
 end
 
@@ -64,8 +68,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---        Called for any non-empty result.
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.declaration(options)
-  local params = util.make_position_params()
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request_with_options(ms.textDocument_declaration, params, options)
 end
 
@@ -75,8 +82,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.definition(options)
-  local params = util.make_position_params()
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request_with_options(ms.textDocument_definition, params, options)
 end
 
@@ -86,8 +96,11 @@ end
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.type_definition(options)
-  local params = util.make_position_params()
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request_with_options(ms.textDocument_typeDefinition, params, options)
 end
 
@@ -97,15 +110,22 @@ end
 ---@param options table|nil additional options
 ---     - on_list: (function) |lsp-on-list-handler| replacing the default handler.
 ---       Called for any non-empty result.
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.implementation(options)
-  local params = util.make_position_params()
+  options = options or {}
+  local params = util.make_position_params(options.row, options.col)
   request_with_options(ms.textDocument_implementation, params, options)
 end
 
 --- Displays signature information about the symbol under the cursor in a
 --- floating window.
-function M.signature_help()
-  local params = util.make_position_params()
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
+function M.signature_help(options)
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request(ms.textDocument_signatureHelp, params)
 end
 
@@ -116,9 +136,13 @@ end
 --- about the context in which a completion was triggered (how it was triggered,
 --- and by which trigger character, if applicable)
 ---
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 ---@see vim.lsp.protocol.CompletionTriggerKind
-function M.completion(context)
-  local params = util.make_position_params()
+function M.completion(context, options)
+  options = options or {}
+  local params = util.make_position_params(options.row, options.col)
   params.context = context
   return request(ms.textDocument_completion, params)
 end
@@ -266,6 +290,8 @@ end
 ---     - name (string|nil):
 ---         Restrict clients used for rename to ones where client.name matches
 ---         this field.
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.rename(new_name, options)
   options = options or {}
   local bufnr = options.bufnr or api.nvim_get_current_buf()
@@ -306,7 +332,7 @@ function M.rename(new_name, options)
 
     --- @param name string
     local function rename(name)
-      local params = util.make_position_params(win, client.offset_encoding)
+      local params = util.make_position_params(options.row, options.col, win, client.offset_encoding)
       params.newName = name
       local handler = client.handlers[ms.textDocument_rename]
         or vim.lsp.handlers[ms.textDocument_rename]
@@ -317,7 +343,7 @@ function M.rename(new_name, options)
     end
 
     if client.supports_method(ms.textDocument_prepareRename) then
-      local params = util.make_position_params(win, client.offset_encoding)
+      local params = util.make_position_params(options.row, options.col, win, client.offset_encoding)
       client.request(ms.textDocument_prepareRename, params, function(err, result)
         if err or result == nil then
           if next(clients, idx) then
@@ -387,9 +413,12 @@ end
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 ---@param options table|nil additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.references(context, options)
   validate({ context = { context, 't', true } })
-  local params = util.make_position_params()
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   params.context = context or {
     includeDeclaration = true,
   }
@@ -400,6 +429,8 @@ end
 ---
 ---@param options table|nil additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
 function M.document_symbol(options)
   local params = { textDocument = util.make_text_document_params() }
   request_with_options(ms.textDocument_documentSymbol, params, options)
@@ -424,8 +455,8 @@ local function pick_call_hierarchy_item(call_hierarchy_items)
   return choice
 end
 
-local function call_hierarchy(method)
-  local params = util.make_position_params()
+local function call_hierarchy(method, row, col)
+  local params = util.make_position_params(nil, nil, row, col)
   request(ms.textDocument_prepareCallHierarchy, params, function(err, result, ctx)
     if err then
       vim.notify(err.message, vim.log.levels.WARN)
@@ -447,15 +478,23 @@ end
 --- Lists all the call sites of the symbol under the cursor in the
 --- |quickfix| window. If the symbol can resolve to multiple
 --- items, the user can pick one in the |inputlist()|.
-function M.incoming_calls()
-  call_hierarchy(ms.callHierarchy_incomingCalls)
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
+function M.incoming_calls(options)
+  options = options or {}
+  call_hierarchy(ms.callHierarchy_incomingCalls, options.row, options.col)
 end
 
 --- Lists all the items that are called by the symbol under the
 --- cursor in the |quickfix| window. If the symbol can resolve to
 --- multiple items, the user can pick one in the |inputlist()|.
-function M.outgoing_calls()
-  call_hierarchy(ms.callHierarchy_outgoingCalls)
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
+function M.outgoing_calls(options)
+  options = options or {}
+  call_hierarchy(ms.callHierarchy_outgoingCalls, options.row, options.col)
 end
 
 --- List workspace folders.
@@ -569,8 +608,12 @@ end
 ---         |hl-LspReferenceText|
 ---         |hl-LspReferenceRead|
 ---         |hl-LspReferenceWrite|
-function M.document_highlight()
-  local params = util.make_position_params()
+---@param options table|nil additional options
+---     - row: 1-indexed row number of position, defaults to current line
+---     - col:0-indexed column number of position, defaults to current character
+function M.document_highlight(options)
+  options = options or {}
+  local params = make_position_params(options.row, options.col)
   request(ms.textDocument_documentHighlight, params)
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1947,12 +1947,12 @@ local function make_position_param(window, offset_encoding, row, col)
   local buf = api.nvim_win_get_buf(window)
   if not row then
     row, _ = unpack(api.nvim_win_get_cursor(window))
+    row = row - 1
   end
   if not col then
     _, col = unpack(api.nvim_win_get_cursor(window))
   end
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)
-  row = row - 1
   local line = api.nvim_buf_get_lines(buf, row, row + 1, true)[1]
   if not line then
     return { line = 0, character = 0 }

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1945,8 +1945,11 @@ end
 local function make_position_param(window, offset_encoding, row, col)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
-  if not (row or col) then
-    row, col = unpack(api.nvim_win_get_cursor(window))
+  if not row then
+    row, _ = unpack(api.nvim_win_get_cursor(window))
+  end
+  if not col then
+    _, col = unpack(api.nvim_win_get_cursor(window))
   end
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)
   row = row - 1
@@ -1961,13 +1964,13 @@ local function make_position_param(window, offset_encoding, row, col)
 end
 
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
----@param row integer|nil 1-indexed row number of position, defaults to current line
----@param col integer|nil 0-indexed column number of position, defaults to current character
 ---@param window integer|nil: window handle or 0 for current, defaults to current
 ---@param offset_encoding string|nil utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
+---@param row integer|nil 1-indexed row number of position, defaults to current line
+---@param col integer|nil 0-indexed column number of position, defaults to current character
 ---@return table `TextDocumentPositionParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
-function M.make_position_params(row, col, window, offset_encoding)
+function M.make_position_params(window, offset_encoding, row, col)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1946,7 +1946,7 @@ local function make_position_param(window, offset_encoding, row, col)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
   if not row then
-    row, _ = unpack(api.nvim_win_get_cursor(window))
+    row = unpack(api.nvim_win_get_cursor(window))
     row = row - 1
   end
   if not col then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1939,10 +1939,15 @@ end
 
 ---@param window integer|nil: window handle or 0 for current, defaults to current
 ---@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
-local function make_position_param(window, offset_encoding)
+---@param row integer|nil 1-indexed row number of position, defaults to current line
+---@param col integer|nil 0-indexed column number of position, defaults to current character
+---@return table position line and character number within buffer
+local function make_position_param(window, offset_encoding, row, col)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
-  local row, col = unpack(api.nvim_win_get_cursor(window))
+  if not (row or col) then
+    row, col = unpack(api.nvim_win_get_cursor(window))
+  end
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)
   row = row - 1
   local line = api.nvim_buf_get_lines(buf, row, row + 1, true)[1]
@@ -1956,18 +1961,19 @@ local function make_position_param(window, offset_encoding)
 end
 
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
----
+---@param row integer|nil 1-indexed row number of position, defaults to current line
+---@param col integer|nil 0-indexed column number of position, defaults to current character
 ---@param window integer|nil: window handle or 0 for current, defaults to current
 ---@param offset_encoding string|nil utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@return table `TextDocumentPositionParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
-function M.make_position_params(window, offset_encoding)
+function M.make_position_params(row, col, window, offset_encoding)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
   offset_encoding = offset_encoding or M._get_offset_encoding(buf)
   return {
     textDocument = M.make_text_document_params(buf),
-    position = make_position_param(window, offset_encoding),
+    position = make_position_param(window, offset_encoding, row, col),
   }
 end
 


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/27400 

I considered also making `window` an option that could be passed here, but that seems like it could run against the grain of this module being requests for the "current buffer" 