### PR TITLE
vim-patch:9.1.0101: upper-case of German sharp s should be U+1E9E

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1323,6 +1323,9 @@ int utf_fold(int a)
 // invalid values or can't handle latin1 when the locale is C.
 // Speed is most important here.
 
+// Note: UnicodeData.txt does not define U+1E9E as being the corresponding upper
+// case letter for U+00DF (ß), however it is part of the toLower table
+
 /// Return the upper-case equivalent of "a", which is a UCS-4 character.  Use
 /// simple case folding.
 int mb_toupper(int a)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2165,16 +2165,16 @@ bool swapchar(int op_type, pos_T *pos)
     return false;
   }
 
-  if (op_type == OP_UPPER && c == 0xdf) {
+  // ~ is OP_NOP, g~ is OP_TILDE, gU is OP_UPPER
+  if ((op_type == OP_UPPER || op_type == OP_NOP || op_type == OP_TILDE) && c == 0xdf) {
     pos_T sp = curwin->w_cursor;
 
-    // Special handling of German sharp s: change to "SS".
+    // Special handling for lowercase German sharp s (ß): convert to uppercase (ẞ).
     curwin->w_cursor = *pos;
     del_char(false);
-    ins_char('S');
-    ins_char('S');
+    ins_char(0x1E9E);
     curwin->w_cursor = sp;
-    inc(pos);
+    return true;
   }
 
   int nc = c;

--- a/test/functional/legacy/039_visual_block_mode_commands_spec.lua
+++ b/test/functional/legacy/039_visual_block_mode_commands_spec.lua
@@ -134,7 +134,7 @@ describe('Visual block mode', function()
   end)
 
   it('should make a selected part uppercase', function()
-    -- GUe must uppercase a whole word, also when ß changes to SS.
+    -- GUe must uppercase a whole word, also when ß changes to ẞ.
     feed('Gothe youtußeuu end<ESC>Ypk0wgUe<CR>')
     -- GUfx must uppercase until x, inclusive.
     feed('O- youßtußexu -<ESC>0fogUfx<CR>')
@@ -150,13 +150,13 @@ describe('Visual block mode', function()
 
     expect([[
       
-      the YOUTUSSEUU end
-      - yOUSSTUSSEXu -
-      THE YOUTUSSEUU END
-      111THE YOUTUSSEUU END
+      the YOUTUẞEUU end
+      - yOUẞTUẞEXu -
+      THE YOUTUẞEUU END
+      111THE YOUTUẞEUU END
       BLAH DI
       DOH DUT
-      222the yoUTUSSEUU END
+      222the yoUTUẞEUU END
       333THE YOUTUßeuu end]])
   end)
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -2353,19 +2353,19 @@ func Test_normal30_changecase()
   norm! 1ggVu
   call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! VU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! guu
-  call assert_equal('this is a simple test: äüöss', getline('.'))
+  call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! gUgU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! gugu
-  call assert_equal('this is a simple test: äüöss', getline('.'))
+  call assert_equal('this is a simple test: äüöß', getline('.'))
   norm! gUU
-  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('THIS IS A SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! 010~
-  call assert_equal('this is a SIMPLE TEST: ÄÜÖSS', getline('.'))
+  call assert_equal('this is a SIMPLE TEST: ÄÜÖẞ', getline('.'))
   norm! V~
-  call assert_equal('THIS IS A simple test: äüöss', getline('.'))
+  call assert_equal('THIS IS A simple test: äüöß', getline('.'))
   call assert_beeps('norm! c~')
   %d
   call assert_beeps('norm! ~')

--- a/test/old/testdir/test_utf8_comparisons.vim
+++ b/test/old/testdir/test_utf8_comparisons.vim
@@ -92,3 +92,40 @@ func Test_gap()
   call feedkeys("gg0g~ap", "tx")
   call assert_equal(["ABCD", "", "defg"], getline(1,3))
 endfunc
+
+" test that g~, ~ and gU correclty upper-cases ß
+func Test_uppercase_sharp_ss()
+  new
+  call setline(1, repeat(['ß'], 4))
+
+  call cursor(1, 1)
+  norm! ~
+  call assert_equal('ẞ', getline(line('.')))
+  norm! ~
+  call assert_equal('ß', getline(line('.')))
+
+  call cursor(2, 1)
+  norm! g~l
+  call assert_equal('ẞ', getline(line('.')))
+  norm! g~l
+  call assert_equal('ß', getline(line('.')))
+
+  call cursor(3, 1)
+  norm! gUl
+  call assert_equal('ẞ', getline(line('.')))
+  norm! vgU
+  call assert_equal('ẞ', getline(line('.')))
+  norm! vgu
+  call assert_equal('ß', getline(line('.')))
+  norm! gul
+  call assert_equal('ß', getline(line('.')))
+
+  call cursor(4, 1)
+  norm! vgU
+  call assert_equal('ẞ', getline(line('.')))
+  norm! vgu
+  call assert_equal('ß', getline(line('.')))
+  bw!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1022,9 +1022,9 @@ func Test_visual_change_case()
   exe "normal Oblah di\rdoh dut\<Esc>VkUj\r"
   " Uppercase part of two lines
   exe "normal ddppi333\<Esc>k0i222\<Esc>fyllvjfuUk"
-  call assert_equal(['the YOUTUSSEUU end', '- yOUSSTUSSEXu -',
-        \ 'THE YOUTUSSEUU END', '111THE YOUTUSSEUU END', 'BLAH DI', 'DOH DUT',
-        \ '222the yoUTUSSEUU END', '333THE YOUTUßeuu end'], getline(2, '$'))
+  call assert_equal(['the YOUTUẞEUU end', '- yOUẞTUẞEXu -',
+        \ 'THE YOUTUẞEUU END', '111THE YOUTUẞEUU END', 'BLAH DI', 'DOH DUT',
+        \ '222the yoUTUẞEUU END', '333THE YOUTUßeuu end'], getline(2, '$'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0101: upper-case of German sharp s should be U+1E9E

Problem:  upper-case of ß should be U+1E9E (CAPITAL LETTER SHARP S)
          (fenuks)
Solution: Make gU, ~ and g~ convert the U+00DF LATIN SMALL LETTER SHARP S (ß)
          to U+1E9E LATIN CAPITAL LETTER SHARP S (ẞ), update tests
          (glepnir)

This is part of Unicode 5.1.0 from April 2008, so should be fairly safe
to use now and since 2017 is part of the German standard orthography,
according to Wikipedia:
https://en.wikipedia.org/wiki/Capital_%E1%BA%9E#cite_note-auto-12

There is however one exception: UnicodeData.txt for U+00DF
LATIN SMALL LETTER SHARP S does NOT define U+1E9E LATIN CAPITAL LETTER
SHARP S as its upper case version. Therefore, toupper() won't be able
to convert from lower sharp s to upper case sharp s (the other way
around however works, since U+00DF is considered the lower case
character of U+1E9E and therefore tolower() works correctly for the
upper case version).

closes: vim/vim#14018

https://github.com/vim/vim/commit/bd1232a1faf56b614a1e74c4ce51bc6e0650ae00

Fix #11813

Co-authored-by: glepnir <glephunter@gmail.com>