### PR TITLE
vim-patch:9.1.0102: settabvar() may change the last accessed tabpage

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -2090,6 +2090,7 @@ void f_settabvar(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   tabpage_T *const save_curtab = curtab;
+  tabpage_T *const save_lu_tp = lastused_tabpage;
   goto_tabpage_tp(tp, false, false);
 
   const size_t varname_len = strlen(varname);
@@ -2099,9 +2100,12 @@ void f_settabvar(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   set_var(tabvarname, varname_len + 2, varp, true);
   xfree(tabvarname);
 
-  // Restore current tabpage.
+  // Restore current tabpage and last accessed tabpage.
   if (valid_tabpage(save_curtab)) {
     goto_tabpage_tp(save_curtab, false, false);
+    if (valid_tabpage(save_lu_tp)) {
+      lastused_tabpage = save_lu_tp;
+    }
   }
 }
 

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -995,4 +995,21 @@ func Test_tabpage_drop_tabmove()
   bwipe!
 endfunc
 
+" Test that settabvar() shouldn't change the last accessed tabpage.
+func Test_lastused_tabpage_settabvar()
+  tabonly!
+  tabnew
+  tabnew
+  tabnew
+  call assert_equal(3, tabpagenr('#'))
+
+  call settabvar(2, 'myvar', 'tabval')
+  call assert_equal('tabval', gettabvar(2, 'myvar'))
+  call assert_equal(3, tabpagenr('#'))
+
+  bwipe!
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0102: settabvar() may change the last accessed tabpage

Problem:  settabvar() may change the last accessed tabpage.
Solution: Save and restore lastused_tabpage.
          (zeertzjq)

closes: vim/vim#14017

https://github.com/vim/vim/commit/b47fbb40837512cdd2d8c25eaf9952154836b99d