### PR TITLE
vim-patch:9.1.0103: 'breakindentopt' "min" not correct with 'signcolumn'

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -817,10 +817,7 @@ int get_breakindent_win(win_T *wp, char *line)
   static char *prev_flp = NULL;  // cached formatlistpat value
   int bri = 0;
   // window width minus window margin space, i.e. what rests for text
-  const int eff_wwidth = wp->w_width_inner -
-                         ((wp->w_p_nu || wp->w_p_rnu)
-                          && (vim_strchr(p_cpo, CPO_NUMCOL) == NULL)
-                          ? number_width(wp) + 1 : 0);
+  const int eff_wwidth = wp->w_width_inner - win_col_off(wp) + win_col_off2(wp);
 
   // In list mode, if 'listchars' "tab" isn't set, a TAB is displayed as ^I.
   const bool no_ts = wp->w_p_list && wp->w_p_lcs_chars.tab1 == NUL;

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -1480,7 +1480,7 @@ it("diff mode draws 'breakindent' correctly after filler lines", function()
     [4] = { foreground = Screen.colors.Blue, bold = true },
   })
   exec([[
-    set laststatus=0 diffopt+=followwrap breakindent
+    set laststatus=0 diffopt+=followwrap breakindent breakindentopt=min:0
     call setline(1, ['a', '  ' .. repeat('c', 50)])
     vnew
     call setline(1, ['a', 'b', '  ' .. repeat('c', 50)])

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -773,7 +773,7 @@ func Test_breakindent20_list()
 	\ "shall make no law   ",
 	\ ]
   call s:compare_lines(expect, lines)
-  " set minimum indent
+  " set minimum text width
   setl briopt=min:5
   redraw!
   let lines = s:screen_lines2(1, 6, 20)
@@ -1171,6 +1171,38 @@ func Test_breakindent_list_split()
   call s:compare_lines(expect, lines)
 
   bwipe!
+endfunc
+
+func Test_breakindent_min_with_signcol()
+  call s:test_windows('setl briopt=min:15 signcolumn=yes')
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "     opqrstuvwxyzABC",
+        \ "     DEFGHIJKLMNOP  "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+  setl briopt=min:17
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "   opqrstuvwxyzABCDE",
+        \ "   FGHIJKLMNOP      "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+  setl briopt=min:19
+  redraw!
+  let expect = [
+        \ "      abcdefghijklmn",
+        \ "  opqrstuvwxyzABCDEF",
+        \ "  GHIJKLMNOP        "
+        \ ]
+  let lines = s:screen_lines(line('.'), 20)
+  call s:compare_lines(expect, lines)
+
+  call s:close_windows()
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -1115,7 +1115,7 @@ func Test_diff_breakindent_after_filler()
   CheckScreendump
 
   let lines =<< trim END
-    set laststatus=0 diffopt+=followwrap breakindent
+    set laststatus=0 diffopt+=followwrap breakindent breakindentopt=min:0
     call setline(1, ['a', '  ' .. repeat('c', 50)])
     vnew
     call setline(1, ['a', 'b', '  ' .. repeat('c', 50)])


### PR DESCRIPTION
#### vim-patch:9.1.0103: 'breakindentopt' "min" not correct with 'signcolumn'

Problem:  'breakindentopt' "min" works incorrectly with 'signcolumn'.
Solution: Use win_col_off() and win_col_off2().
          (zeertzjq)

closes: vim/vim#14014

https://github.com/vim/vim/commit/f0a9d65e0a1d693cdfa964aa72de5b93b4cacdea