### PR TITLE
fix(loader): remove cyclic dependency on vim.fs (when --luamod-dev)

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -1,3 +1,4 @@
+local fs = vim.fs -- "vim.fs" is a dependency, so must be loaded early.
 local uv = vim.uv
 local uri_encode = vim.uri_encode --- @type function
 
@@ -63,7 +64,7 @@ function Loader.get_hash(path)
 end
 
 local function normalize(path)
-  return vim.fs.normalize(path, { expand_env = false })
+  return fs.normalize(path, { expand_env = false })
 end
 
 --- Gets the rtp excluding after directories.
@@ -432,7 +433,7 @@ end
 function Loader.lsmod(path)
   if not Loader._indexed[path] then
     Loader._indexed[path] = {}
-    for name, t in vim.fs.dir(path .. '/lua') do
+    for name, t in fs.dir(path .. '/lua') do
       local modpath = path .. '/lua/' .. name
       -- HACK: type is not always returned due to a bug in luv
       t = t or Loader.get_hash(modpath).type


### PR DESCRIPTION
Fixes #27413

Problem: Loading `vim.fs` via the `vim.loader` Lua package loader will
result in a stack overflow due to a cyclic dependency. This may happen
when the `vim.fs` module isn't byte-compiled, i.e. when `--luamod-dev`
is used (#27413).

Solution: `vim.loader` depends on `vim.fs`. Therefore `vim.fs` should
be loaded in advance.