### PR TITLE
fix(extmarks): redraw new position after deleting lines

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -101,7 +101,6 @@ void decor_redraw(buf_T *buf, int row1, int row2, int col1, DecorInline decor)
       linenr_T vt_lnum = row1 + 1 + below;
       redraw_buf_line_later(buf, vt_lnum, true);
       if (vt->flags & kVTIsLines || vt->pos == kVPosInline) {
-        // changed_lines_redraw_buf(buf, vt_lnum, vt_lnum + 1, 0);
         colnr_T vt_col = vt->flags & kVTIsLines ? 0 : col1;
         changed_lines_invalidate_buf(buf, vt_lnum, vt_col, vt_lnum + 1, 0);
       }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2428,13 +2428,14 @@ static void u_undoredo(bool undo, bool do_buf_event)
   // Adjust Extmarks
   if (undo) {
     for (int i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
-      extmark_apply_undo(kv_A(curhead->uh_extmark, i), undo);
+      extmark_apply_undo(kv_A(curhead->uh_extmark, i), true);
     }
     // redo
   } else {
     for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
-      extmark_apply_undo(kv_A(curhead->uh_extmark, i), undo);
+      extmark_apply_undo(kv_A(curhead->uh_extmark, i), false);
     }
+    extmark_redraw_after_delete(&curhead->uh_extmark, 0);
   }
   if (curhead->uh_flags & UH_RELOAD) {
     // TODO(bfredl): this is a bit crude. When 'undoreload' is used we

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3885,6 +3885,67 @@ describe('decorations: inline virtual text', function()
                                                         |
     ]]}
   end)
+
+  it('is redrawn correctly after delete or redo #27370', function()
+    screen:try_resize(50, 12)
+    exec([[
+      call setline(1, ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff'])
+      call setline(3, repeat('c', winwidth(0) - 1))
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = { { '!!!' } }, virt_text_pos = 'inline' })
+    feed('j')
+    local before_delete = [[
+      aaa                                               |
+      !!!^bbb                                            |
+      ccccccccccccccccccccccccccccccccccccccccccccccccc |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*5
+                                                        |
+    ]]
+    screen:expect(before_delete)
+    feed('dd')
+    local after_delete = [[
+      aaa                                               |
+      !!!^ccccccccccccccccccccccccccccccccccccccccccccccc|
+      cc                                                |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*5
+                                                        |
+    ]]
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('silent redo')
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('set report=100')
+    feed('yypk2P')
+    before_delete = [[
+      aaa                                               |
+      ^bbb                                               |
+      bbb                                               |
+      !!!bbb                                            |
+      bbb                                               |
+      ccccccccccccccccccccccccccccccccccccccccccccccccc |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*2
+                                                        |
+    ]]
+    screen:expect(before_delete)
+    feed('4dd')
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('silent redo')
+    screen:expect(after_delete)
+  end)
 end)
 
 describe('decorations: virtual lines', function()


### PR DESCRIPTION
Problem:
Virtual text not redrawn properly when its extmark's line is deleted.

Solution:
Redraw new positions of extmarks in the range when deleting lines.

Fix #27370
