### PR TITLE
fix(vim.is_callable): use `rawget()` to retrieve `__call` from mt

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -862,7 +862,7 @@ function vim.is_callable(f)
   if m == nil then
     return false
   end
-  return type(m.__call) == 'function'
+  return type(rawget(m, '__call')) == 'function'
 end
 
 --- Creates a table whose missing keys are provided by {createfn} (like Python's "defaultdict").


### PR DESCRIPTION
LuaJIT uses a raw get to retrieve `__call` from a metatable to determine if a table is callable.