### PR TITLE
docs(builtin): fix lua types for vim.fn.sign_getplaced

### DIFF
--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -81,10 +81,10 @@
 --- @class vim.fn.sign_getplaced.dict
 --- @field group? string
 --- @field id? integer
---- @field lnum? string
+--- @field lnum? string|integer
 
 --- @class vim.fn.sign_getplaced.ret.item
---- @field buf integer
+--- @field bufnr integer
 --- @field signs vim.fn.sign[]
 
 --- @class vim.fn.sign_place.dict


### PR DESCRIPTION
[Per :help sign_getplaced()](https://neovim.io/doc/user/builtin.html#sign_getplaced()): 

- Parameter {dict}: lnum also accepts integer as well as string
- Return value: item has field bufnr, not buf