### PR TITLE
docs(tutor): include https urls where applicable

### DIFF
--- a/runtime/tutor/en/vim-01-beginner.tutor
+++ b/runtime/tutor/en/vim-01-beginner.tutor
@@ -967,17 +967,17 @@ There are also countless great tutorials and videos to be found online.
 Here's a bunch of them:
 
 - *Learn Vim Progressively*:
-  http://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/
+  https://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/
 - *Learning Vim in 2014*:
-  http://benmccormick.org/learning-vim-in-2014/
+  https://benmccormick.org/learning-vim-in-2014/
 - *Vimcasts*:
   http://vimcasts.org/
 - *Vim Video-Tutorials by Derek Wyatt*:
   http://derekwyatt.org/vim/tutorials/
 - *Learn Vimscript the Hard Way*:
-  http://learnvimscriptthehardway.stevelosh.com/
+  https://learnvimscriptthehardway.stevelosh.com/
 - *7 Habits of Effective Text Editing*:
-  http://www.moolenaar.net/habits.html
+  https://www.moolenaar.net/habits.html
 - *vim-galore*:
   https://github.com/mhinz/vim-galore
 

--- a/runtime/tutor/ja/vim-01-beginner.tutor
+++ b/runtime/tutor/ja/vim-01-beginner.tutor
@@ -958,17 +958,17 @@ Neovim にはさらに多くのコマンドがあり、ここで全てを説明�
 見つけることができます。ここにいくつか紹介します:
 
 - *Learn Vim Progressively*:
-  http://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/
+  https://yannesposito.com/Scratch/en/blog/Learn-Vim-Progressively/
 - *Learning Vim in 2014*:
-  http://benmccormick.org/learning-vim-in-2014/
+  https://benmccormick.org/learning-vim-in-2014/
 - *Vimcasts*:
   http://vimcasts.org/
 - *Vim Video-Tutorials by Derek Wyatt*:
   http://derekwyatt.org/vim/tutorials/
 - *Learn Vimscript the Hard Way*:
-  http://learnvimscriptthehardway.stevelosh.com/
+  https://learnvimscriptthehardway.stevelosh.com/
 - *7 Habits of Effective Text Editing*:
-  http://www.moolenaar.net/habits.html
+  https://www.moolenaar.net/habits.html
 - *vim-galore*:
   https://github.com/mhinz/vim-galore
 - *vim-jp Vim日本語ドキュメント*


### PR DESCRIPTION
### Problem
URLs in `:Tutor` use `http` instead of `https`

### Solution
I've updated the applicable urls which have a valid `https` equivilant.