### PR TITLE
vim-patch:9.1.0105: Style: typos found

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1365,8 +1365,7 @@ static bool reg_match_visual(void)
       top = curbuf->b_visual.vi_end;
       bot = curbuf->b_visual.vi_start;
     }
-    // a substitue command may have
-    // removed some lines
+    // a substitute command may have removed some lines
     if (bot.lnum > curbuf->b_ml.ml_line_count) {
       bot.lnum = curbuf->b_ml.ml_line_count;
     }

--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -108,7 +108,7 @@ func Test_map_langmap()
   unmap x
   bwipe!
 
-  " 'langnoremap' follows 'langremap' and vise versa
+  " 'langnoremap' follows 'langremap' and vice versa
   set langremap
   set langnoremap
   call assert_equal(0, &langremap)

--- a/test/old/testdir/test_utf8_comparisons.vim
+++ b/test/old/testdir/test_utf8_comparisons.vim
@@ -93,7 +93,7 @@ func Test_gap()
   call assert_equal(["ABCD", "", "defg"], getline(1,3))
 endfunc
 
-" test that g~, ~ and gU correclty upper-cases ß
+" test that g~, ~ and gU correctly upper-cases ß
 func Test_uppercase_sharp_ss()
   new
   call setline(1, repeat(['ß'], 4))

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1010,7 +1010,7 @@ endfunc
 " Test for changing case
 func Test_visual_change_case()
   new
-  " gUe must uppercase a whole word, also when ß changes to SS
+  " gUe must uppercase a whole word, also when ß changes to ẞ
   exe "normal Gothe youtußeuu end\<Esc>Ypk0wgUe\r"
   " gUfx must uppercase until x, inclusive.
   exe "normal O- youßtußexu -\<Esc>0fogUfx\r"


### PR DESCRIPTION
#### vim-patch:9.1.0105: Style: typos found

Problem:  Style: typos found
Solution: correct them
          (zeertzjq)

closes: vim/vim#14023

https://github.com/vim/vim/commit/e71022082d6a8bd8ec3d7b9dadf3f9ce46ef339c