### PR TITLE
Check if json is decoded before continuing

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -397,6 +397,9 @@ end
 ---@package
 function Client:handle_body(body)
   local ok, decoded = pcall(vim.json.decode, body, { luanil = { object = true } })
+  if not decoded then
+    return
+  end
   if not ok then
     self:on_error(M.client_errors.INVALID_SERVER_JSON, decoded)
     return


### PR DESCRIPTION
Problem:
`decoded` is used throughout `Client:hand_body(body)` without first checking if the json content was decoded first, leading to errors.

Solution:
Check that the json content was decoded before continuing.

Thoughts:
The json content is expected to be decoded throughout the function, the function is used while parsing in `create_read_loop`. Logging would lead to spam while waiting for the content to be decoded.

I'm looking over the commit guidelines and will update appropriately