### PR TITLE
vim-patch:9.1.{0112,0113}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -843,8 +843,9 @@ void buf_freeall(buf_T *buf, int flags)
   ml_close(buf, true);              // close and delete the memline/memfile
   buf->b_ml.ml_line_count = 0;      // no lines in buffer
   if ((flags & BFA_KEEP_UNDO) == 0) {
-    u_blockfree(buf);               // free the memory allocated for undo
-    u_clearall(buf);                // reset all undo information
+    // free the memory allocated for undo
+    // and reset all undo information
+    u_clearallandblockfree(buf);
   }
   syntax_clear(&buf->b_s);          // reset syntax info
   buf->b_flags &= ~BF_READERR;      // a read error is no longer relevant

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3171,8 +3171,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
       // Mark the buffer as unmodified and free undo info.
       unchanged(buf, true, true);
       if ((flags & READ_KEEP_UNDO) == 0) {
-        u_blockfree(buf);
-        u_clearall(buf);
+        u_clearallandblockfree(buf);
       } else {
         // Mark all undo states as changed.
         u_unchanged(curbuf);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -68,6 +68,7 @@
 #include "nvim/strings.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
+#include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
@@ -4142,6 +4143,12 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     }
 
     // delete all existing lines
+    //
+    // Note: we cannot store undo information, because
+    // qf buffer is usually not allowed to be modified.
+    //
+    // So we need to clean up undo information
+    // otherwise autocommands may invalidate the undo stack
     while ((curbuf->b_ml.ml_flags & ML_EMPTY) == 0) {
       // If deletion fails, this loop may run forever, so
       // signal error and return.
@@ -4150,6 +4157,10 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
         return;
       }
     }
+
+    // Remove all undo information
+    u_blockfree(curbuf);
+    u_clearall(curbuf);
   }
 
   // Check if there is anything to display

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4159,8 +4159,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     }
 
     // Remove all undo information
-    u_blockfree(curbuf);
-    u_clearall(curbuf);
+    u_clearallandblockfree(curbuf);
   }
 
   // Check if there is anything to display

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2988,6 +2988,28 @@ void u_clearall(buf_T *buf)
   buf->b_u_line_lnum = 0;
 }
 
+/// Free all allocated memory blocks for the buffer 'buf'.
+void u_blockfree(buf_T *buf)
+{
+  while (buf->b_u_oldhead != NULL) {
+#ifndef NDEBUG
+    u_header_T *previous_oldhead = buf->b_u_oldhead;
+#endif
+
+    u_freeheader(buf, buf->b_u_oldhead, NULL);
+    assert(buf->b_u_oldhead != previous_oldhead);
+  }
+  xfree(buf->b_u_line_ptr);
+}
+
+/// Free all allocated memory blocks for the buffer 'buf'.
+/// and invalidate the undo buffer
+void u_clearallandblockfree(buf_T *buf)
+{
+  u_blockfree(buf);
+  u_clearall(buf);
+}
+
 /// Save the line "lnum" for the "U" command.
 void u_saveline(buf_T *buf, linenr_T lnum)
 {
@@ -3052,20 +3074,6 @@ void u_undoline(void)
   curwin->w_cursor.col = t;
   curwin->w_cursor.lnum = curbuf->b_u_line_lnum;
   check_cursor_col();
-}
-
-/// Free all allocated memory blocks for the buffer 'buf'.
-void u_blockfree(buf_T *buf)
-{
-  while (buf->b_u_oldhead != NULL) {
-#ifndef NDEBUG
-    u_header_T *previous_oldhead = buf->b_u_oldhead;
-#endif
-
-    u_freeheader(buf, buf->b_u_oldhead, NULL);
-    assert(buf->b_u_oldhead != previous_oldhead);
-  }
-  xfree(buf->b_u_line_ptr);
 }
 
 /// Allocate memory and copy curbuf line into it.

--- a/test/functional/legacy/autocmd_spec.lua
+++ b/test/functional/legacy/autocmd_spec.lua
@@ -1,0 +1,40 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local write_file = helpers.write_file
+local command = helpers.command
+local feed = helpers.feed
+local api = helpers.api
+local eq = helpers.eq
+
+before_each(clear)
+
+-- oldtest: Test_autocmd_invalidates_undo_on_textchanged()
+it('no E440 in quickfix window when autocommand invalidates undo', function()
+  write_file(
+    'XTest_autocmd_invalidates_undo_on_textchanged',
+    [[
+    set hidden
+    " create quickfix list (at least 2 lines to move line)
+    vimgrep /u/j %
+
+    " enter quickfix window
+    cwindow
+
+    " set modifiable
+    setlocal modifiable
+
+    " set autocmd to clear quickfix list
+
+    autocmd! TextChanged <buffer> call setqflist([])
+    " move line
+    move+1
+    ]]
+  )
+  finally(function()
+    os.remove('XTest_autocmd_invalidates_undo_on_textchanged')
+  end)
+  command('edit XTest_autocmd_invalidates_undo_on_textchanged')
+  command('so %')
+  feed('G')
+  eq('', api.nvim_get_vvar('errmsg'))
+end)

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3840,4 +3840,32 @@ func Test_autocmd_shortmess()
   delfunc SetupVimTest_shm
 endfunc
 
+func Test_autocmd_invalidates_undo_on_textchanged()
+  CheckRunVimInTerminal
+  let script =<< trim END
+    set hidden
+    " create quickfix list (at least 2 lines to move line)
+    vimgrep /u/j %
+
+    " enter quickfix window
+    cwindow
+
+    " set modifiable
+    setlocal modifiable
+
+    " set autocmd to clear quickfix list
+
+    autocmd! TextChanged <buffer> call setqflist([])
+    " move line
+    move+1
+  END
+  call writefile(script, 'XTest_autocmd_invalidates_undo_on_textchanged', 'D')
+  let buf = RunVimInTerminal('XTest_autocmd_invalidates_undo_on_textchanged', {'rows': 20})
+  call term_sendkeys(buf, ":so %\<cr>")
+  call term_sendkeys(buf, "G")
+  call WaitForAssert({-> assert_match('^XTest_autocmd_invalidates_undo_on_textchanged\s*$', term_getline(buf, 20))}, 1000)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0112: Remove undo information, when cleaning quickfix buffer

Problem:  When the quickfix buffer has been modified an autocommand
          may invalidate the undo stack (kawarimidoll)
Solution: When clearing the quickfix buffer, also wipe the undo stack

closes: vim/vim#13928

https://github.com/vim/vim/commit/f0d3d4a42657dca996e790aa829de3c6be7fdb63

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.0113: duplicate code when cleaning undo stack

Problem:  duplicate code when cleaning undo stack
Solution: refactor undo cleanup into a single public function

related: vim/vim#13928

https://github.com/vim/vim/commit/9071ed8107244e0c56a16b77d1c28e975cb21dd2

Co-authored-by: Christian Brabandt <cb@256bit.org>