### PR TITLE
build: do not use cmake -S and -B flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ cmake:
 	$(MAKE) build/.ran-cmake
 
 build/.ran-cmake: | deps
-	$(CMAKE) -B build -G '$(CMAKE_GENERATOR)' $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) $(MAKEFILE_DIR)
+	# Using -S and -B flags causes problems: https://github.com/neovim/neovim/issues/27475
+	cd build && $(CMAKE) -G '$(CMAKE_GENERATOR)' $(CMAKE_FLAGS) $(CMAKE_EXTRA_FLAGS) $(MAKEFILE_DIR)
 	touch $@
 
 deps: | build/.ran-deps-cmake
@@ -91,8 +92,10 @@ ifeq ($(call filter-true,$(USE_BUNDLED)),)
 $(DEPS_BUILD_DIR):
 	mkdir -p "$@"
 build/.ran-deps-cmake:: $(DEPS_BUILD_DIR)
-	$(CMAKE) -S $(MAKEFILE_DIR)/cmake.deps -B $(DEPS_BUILD_DIR) -G '$(CMAKE_GENERATOR)' \
-		$(BUNDLED_CMAKE_FLAG) $(BUNDLED_LUA_CMAKE_FLAG) $(DEPS_CMAKE_FLAGS)
+	# Using -S and -B flags causes problems: https://github.com/neovim/neovim/issues/27475
+	cd $(DEPS_BUILD_DIR) && \
+		$(CMAKE) -G '$(CMAKE_GENERATOR)' $(BUNDLED_CMAKE_FLAG) $(BUNDLED_LUA_CMAKE_FLAG) \
+		$(DEPS_CMAKE_FLAGS) $(MAKEFILE_DIR)/cmake.deps
 endif
 build/.ran-deps-cmake::
 	mkdir -p build


### PR DESCRIPTION
This partially reverts some changes in
ae3eed53d6100598b6d26fe58e3e97541e03f3c1.

Using -S and -B instead of cd:ing causes strange problems for some
users, where the `build` and `.deps` directory aren't created and the
process aborts with `make: cmake: Permission denied`. The cause of this
hasn't been identified yet.

Closes https://github.com/neovim/neovim/issues/27475.
Closes https://github.com/neovim/neovim/issues/27488.