### PR TITLE
vim-patch:8.2.3915: illegal memory access when completing with invalid bytes

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3557,7 +3557,12 @@ void ins_compl_delete(void)
 /// "in_compl_func" is true when called from complete_check().
 void ins_compl_insert(bool in_compl_func)
 {
-  ins_bytes(compl_shown_match->cp_str + get_compl_len());
+  int compl_len = get_compl_len();
+  // Make sure we don't go over the end of the string, this can happen with
+  // illegal bytes.
+  if (compl_len < (int)strlen(compl_shown_match->cp_str)) {
+    ins_bytes(compl_shown_match->cp_str + compl_len);
+  }
   compl_used_match = !match_at_original_text(compl_shown_match);
 
   dict_T *dict = ins_compl_dict_alloc(compl_shown_match);

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -108,6 +108,19 @@ func Test_ins_complete()
   call delete('Xdir', 'rf')
 endfunc
 
+func Test_ins_complete_invalid_byte()
+  if has('unix') && executable('base64')
+    " this weird command was causing an illegal memory access
+    call writefile(['bm9ybTlvMDCAMM4Dbw4OGA4ODg=='], 'Xinvalid64')
+    call system('base64 -d Xinvalid64 > Xinvalid')
+    call writefile(['qa!'], 'Xexit')
+    call RunVim([], [], " -i NONE -n -X -Z -e -m -s -S Xinvalid -S Xexit")
+    call delete('Xinvalid64')
+    call delete('Xinvalid')
+    call delete('Xexit')
+  endif
+endfunc
+
 func Test_omni_dash()
   func Omni(findstart, base)
     if a:findstart


### PR DESCRIPTION
vim-patch:8.2.3915: illegal memory access when completing with invalid bytes

Problem:    illegal memory access when completing with invalid bytes.
Solution:   Avoid going over the end of the completion text.

https://github.com/vim/vim/commit/4b28ba3245df8274303c79429972f9dc9438e4aa

Co-authored-by: Bram Moolenaar Bram@vim.org