### PR TITLE
build: set deps default build type to Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ option(ENABLE_LIBINTL "enable libintl" ON)
 
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
-set_default_buildtype()
+set_default_buildtype(Debug)
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT isMultiConfig)
   # Unlike build dependencies in cmake.deps, we assume we want dev dependencies

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ filter-true = $(strip $(filter-out 1 on ON true TRUE,$1))
 all: nvim
 
 CMAKE ?= $(shell (command -v cmake3 || echo cmake))
-CMAKE_BUILD_TYPE ?= Debug
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
 # Extra CMake flags which extend the default set
 CMAKE_EXTRA_FLAGS ?=

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -17,7 +17,7 @@ include(Deps)
 include(Find)
 include(Util)
 
-set_default_buildtype()
+set_default_buildtype(Release)
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT isMultiConfig)
   list(APPEND DEPS_CMAKE_ARGS -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -148,8 +148,8 @@ function(add_glob_target)
   add_custom_target(${ARG_TARGET} DEPENDS ${touch_list})
 endfunction()
 
-# Set default build type to Debug. Also limit the list of allowable build types
-# to the ones defined in variable allowableBuildTypes.
+# Set default build type to BUILD_TYPE. Also limit the list of allowable build
+# types to the ones defined in variable allowableBuildTypes.
 #
 # The correct way to specify build type (for example Release) for
 # single-configuration generators (Make and Ninja) is to run
@@ -165,21 +165,27 @@ endfunction()
 #
 # Passing CMAKE_BUILD_TYPE for multi-config generators will not only not be
 # used, but also generate a warning for the user.
-function(set_default_buildtype)
+function(set_default_buildtype BUILD_TYPE)
   set(allowableBuildTypes Debug Release MinSizeRel RelWithDebInfo)
+  if(NOT BUILD_TYPE IN_LIST allowableBuildTypes)
+    message(FATAL_ERROR "Invalid build type: ${BUILD_TYPE}")
+  endif()
 
   get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
   if(isMultiConfig)
+    # Multi-config generators use the first element in CMAKE_CONFIGURATION_TYPES as the default build type
+    list(INSERT allowableBuildTypes 0 ${BUILD_TYPE})
+    list(REMOVE_DUPLICATES allowableBuildTypes)
     set(CMAKE_CONFIGURATION_TYPES ${allowableBuildTypes} PARENT_SCOPE)
     if(CMAKE_BUILD_TYPE)
       message(WARNING "CMAKE_BUILD_TYPE specified which is ignored on \
-      multi-configuration generators. Defaulting to Debug build type.")
+      multi-configuration generators. Defaulting to ${BUILD_TYPE} build type.")
     endif()
   else()
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowableBuildTypes}")
     if(NOT CMAKE_BUILD_TYPE)
-      message(STATUS "CMAKE_BUILD_TYPE not specified, default is 'Debug'")
-      set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build" FORCE)
+      message(STATUS "CMAKE_BUILD_TYPE not specified, default is '${BUILD_TYPE}'")
+      set(CMAKE_BUILD_TYPE ${BUILD_TYPE} CACHE STRING "Choose the type of build" FORCE)
     elseif(NOT CMAKE_BUILD_TYPE IN_LIST allowableBuildTypes)
       message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
     else()


### PR DESCRIPTION
Debugging dependencies is rare so a Debug build type is usually not needed. In cases where it _is_ needed it is easy to rebuild in Debug mode. But since Release builds are more common, it makes more sense as a default.

For Neovim itself we stick with a Debug build as a default, since rebuilding and debugging is done _much_ more frequently than with dependencies (which we _mostly_ expect to "just work").