### PR TITLE
fix: fix double-free in tag stack handling

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -393,6 +393,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
 
         // put the tag name in the tag stack
         tagstack[tagstackidx].tagname = xstrdup(tag);
+        tagstack[tagstackidx].user_data = NULL;
 
         curwin->w_tagstacklen = tagstacklen;
 


### PR DESCRIPTION
Pushing new tag could expose stale "user_data" pointer.

Fixes: 194f7bfac ("vim-patch:8.1.1228: not possible to process tags with a function")
Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
