### PR TITLE
build(macos): release workflow on M1

### DIFF
--- a/.github/scripts/build_universal_macos.sh
+++ b/.github/scripts/build_universal_macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
+MACOSX_DEPLOYMENT_TARGET=11.0
 export MACOSX_DEPLOYMENT_TARGET
 cmake -S cmake.deps -B .deps -G Ninja \
   -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           printf 'END\n' >> $GITHUB_OUTPUT
 
   macOS:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Follow-up to #27276 

Run the release workflow on macos-14 to use faster M1 runners.

Lock the deployment target to the oldest supported version (11.0,
due to libuv support) instead of relying on the host OS version.