### PR TITLE
ci: issue labeler splits on word boundaries

### DIFF
--- a/.github/workflows/labeler_issue.yml
+++ b/.github/workflows/labeler_issue.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           script: |
             const title = context.payload.issue.title;
-            const titleSplit = title.split(/\s+/).map(e => e.toLowerCase());
+            const titleSplit = title.split(/\b/).map(e => e.toLowerCase());
             const keywords = ['api', 'treesitter', 'ui', 'lsp'];
             var match = new Set();
             for (const keyword of keywords) {


### PR DESCRIPTION
I noticed the issue labeler didn't catch titles such as this one: `treesitter: noisy "Invalid node type" error`

this is because the code splits the title on whitespaces; split it on word boundaries such as punctuation or spaces

match more combinations of the same thing, better right?

a little test: https://github.com/casswedson/issue-labeling/issues/43