### PR TITLE
vim-patch:9.1.0114: Setting some options may change curswant

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -20,10 +20,10 @@ local redraw_flags = {
   tabline = 'P_RTABL',
   statuslines = 'P_RSTAT',
   current_window = 'P_RWIN',
-  current_window_only = 'P_RWINONLY',
   current_buffer = 'P_RBUF',
   all_windows = 'P_RALL',
   curswant = 'P_CURSWANT',
+  highlight_only = 'P_HLONLY',
 }
 
 local list_flags = {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3029,13 +3029,14 @@ void check_redraw_for(buf_T *buf, win_T *win, uint32_t flags)
   }
 
   if ((flags & P_RBUF) || (flags & P_RWIN) || all) {
-    changed_window_setting_win(win);
+    if (flags & P_HLONLY) {
+      redraw_later(win, UPD_NOT_VALID);
+    } else {
+      changed_window_setting_win(win);
+    }
   }
   if (flags & P_RBUF) {
     redraw_buf_later(buf, UPD_NOT_VALID);
-  }
-  if (flags & P_RWINONLY) {
-    redraw_later(win, UPD_NOT_VALID);
   }
   if (all) {
     redraw_all_later(UPD_NOT_VALID);
@@ -3554,7 +3555,7 @@ static const char *did_set_option(OptIndex opt_idx, void *varp, OptVal old_value
     do_spelllang_source(curwin);
   }
 
-  // In case 'columns' or 'ls' changed.
+  // In case 'ruler' or 'showcmd' or 'columns' or 'ls' changed.
   comp_col();
 
   if (varp == &p_mouse) {
@@ -3568,7 +3569,8 @@ static const char *did_set_option(OptIndex opt_idx, void *varp, OptVal old_value
     set_winbar(true);
   }
 
-  if (curwin->w_curswant != MAXCOL && (opt->flags & (P_CURSWANT | P_RALL)) != 0) {
+  if (curwin->w_curswant != MAXCOL
+      && (opt->flags & (P_CURSWANT | P_RALL)) != 0 && (opt->flags & P_HLONLY) == 0) {
     curwin->w_set_curswant = true;
   }
 

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -27,8 +27,8 @@
 #define P_RSTAT        0x200U       ///< redraw status lines
 #define P_RWIN         0x400U       ///< redraw current window and recompute text
 #define P_RBUF         0x800U       ///< redraw current buffer and recompute text
-#define P_RALL         0xC00U       ///< redraw all windows
-#define P_RCLR         0xE00U       ///< clear and redraw all
+#define P_RALL         0xC00U       ///< redraw all windows and recompute text
+#define P_RCLR         0xE00U       ///< clear and redraw all and recompute text
 
 #define P_COMMA        0x1000U      ///< comma separated list
 #define P_ONECOMMA     0x3000U      ///< P_COMMA and cannot have two consecutive
@@ -47,7 +47,7 @@
 #define P_CURSWANT     0x800000U    ///< update curswant required; not needed
                                     ///< when there is a redraw flag
 #define P_NDNAME       0x1000000U   ///< only normal dir name chars allowed
-#define P_RWINONLY     0x2000000U   ///< only redraw current window
+#define P_HLONLY       0x2000000U   ///< option only changes highlight, not text
 #define P_MLE          0x4000000U   ///< under control of 'modelineexpr'
 #define P_FUNC         0x8000000U   ///< accept a function reference or a lambda
 #define P_COLON        0x10000000U  ///< values use colons to create sublists

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -45,10 +45,10 @@
 --- |'statuslines'
 --- |'tabline'
 --- |'current_window'
---- |'current_window_only'
 --- |'current_buffer'
 --- |'all_windows'
 --- |'curswant'
+--- |'highlight_only'
 --- |'ui_option'
 
 --- @param s string
@@ -1262,7 +1262,7 @@ return {
       ]=],
       full_name = 'colorcolumn',
       list = 'onecomma',
-      redraw = { 'current_window' },
+      redraw = { 'current_window', 'highlight_only' },
       scope = { 'window' },
       short_desc = N_('columns to highlight'),
       type = 'string',
@@ -1859,7 +1859,7 @@ return {
         <
       ]=],
       full_name = 'cursorcolumn',
-      redraw = { 'current_window_only' },
+      redraw = { 'current_window', 'highlight_only' },
       scope = { 'window' },
       short_desc = N_('highlight the screen column of the cursor'),
       type = 'boolean',
@@ -1874,7 +1874,7 @@ return {
         easier to see the selected text.
       ]=],
       full_name = 'cursorline',
-      redraw = { 'current_window_only' },
+      redraw = { 'current_window', 'highlight_only' },
       scope = { 'window' },
       short_desc = N_('highlight the screen line of the cursor'),
       type = 'boolean',
@@ -1902,7 +1902,7 @@ return {
       expand_cb = 'expand_set_cursorlineopt',
       full_name = 'cursorlineopt',
       list = 'onecomma',
-      redraw = { 'current_window_only' },
+      redraw = { 'current_window', 'highlight_only' },
       scope = { 'window' },
       short_desc = N_("settings for 'cursorline'"),
       type = 'string',
@@ -3926,7 +3926,7 @@ return {
         with the 'h' flag in 'shada' |shada-h|.
       ]=],
       full_name = 'hlsearch',
-      redraw = { 'all_windows' },
+      redraw = { 'all_windows', 'highlight_only' },
       scope = { 'global' },
       short_desc = N_('highlight matches with last search pattern'),
       type = 'boolean',
@@ -7708,7 +7708,7 @@ return {
         The languages are specified with 'spelllang'.
       ]=],
       full_name = 'spell',
-      redraw = { 'current_window' },
+      redraw = { 'current_window', 'highlight_only' },
       scope = { 'window' },
       short_desc = N_('spell checking'),
       type = 'boolean',
@@ -7730,7 +7730,7 @@ return {
         |set-spc-auto|.
       ]=],
       full_name = 'spellcapcheck',
-      redraw = { 'current_buffer' },
+      redraw = { 'current_buffer', 'highlight_only' },
       scope = { 'buffer' },
       short_desc = N_('pattern to locate end of a sentence'),
       type = 'string',
@@ -7821,7 +7821,7 @@ return {
       expand = true,
       full_name = 'spelllang',
       list = 'onecomma',
-      redraw = { 'current_buffer' },
+      redraw = { 'current_buffer', 'highlight_only' },
       scope = { 'buffer' },
       short_desc = N_('language(s) to do spell checking for'),
       type = 'string',
@@ -7846,7 +7846,7 @@ return {
       expand_cb = 'expand_set_spelloptions',
       full_name = 'spelloptions',
       list = 'onecomma',
-      redraw = { 'current_buffer' },
+      redraw = { 'current_buffer', 'highlight_only' },
       scope = { 'buffer' },
       secure = true,
       type = 'string',
@@ -8858,7 +8858,7 @@ return {
         When 'formatexpr' is set it will be used to break the line.
       ]=],
       full_name = 'textwidth',
-      redraw = { 'current_buffer' },
+      redraw = { 'current_buffer', 'highlight_only' },
       scope = { 'buffer' },
       short_desc = N_('maximum width of text that is being inserted'),
       type = 'number',

--- a/test/old/testdir/test_goto.vim
+++ b/test/old/testdir/test_goto.vim
@@ -313,18 +313,23 @@ func Test_gd_string_only()
   call XTest_goto_decl('gd', lines, 5, 10)
 endfunc
 
-" Check that setting 'cursorline' does not change curswant
-func Test_cursorline_keep_col()
+" Check that setting some options does not change curswant
+func Test_set_options_keep_col()
   new
   call setline(1, ['long long long line', 'short line'])
   normal ggfi
   let pos = getcurpos()
   normal j
-  set cursorline
+  set invhlsearch spell spelllang=en,cjk spelloptions=camel textwidth=80
+  set cursorline cursorcolumn cursorlineopt=line colorcolumn=+1
+  set background=dark
+  set background=light
   normal k
   call assert_equal(pos, getcurpos())
   bwipe!
-  set nocursorline
+  set hlsearch& spell& spelllang& spelloptions& textwidth&
+  set cursorline& cursorcolumn& cursorlineopt& colorcolumn&
+  set background&
 endfunc
 
 func Test_gd_local_block()


### PR DESCRIPTION
#### vim-patch:9.1.0114: Setting some options may change curswant

Problem:  Setting some options changes curswant unnecessarily.
Solution: Add a P_HLONLY flag that prevents changing curswant.
          (zeertzjq)

closes: vim/vim#14044

https://github.com/vim/vim/commit/fcaed6a70faf73bff3e5405ada556d726024f866