### PR TITLE
fix(eval): skip over v:lua properly

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1726,7 +1726,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       n = false;  // Trailing garbage.
     }
   } else if (*p == '*') {  // Internal or user defined function.
-    n = strncmp(p, "*v:lua.", 7) == 0 ? nlua_func_exists(p + 7) : function_exists(p + 1, false);
+    n = strnequal(p, "*v:lua.", 7) ? nlua_func_exists(p + 7) : function_exists(p + 1, false);
   } else if (*p == ':') {
     n = cmd_exists(p + 1);
   } else if (*p == '#') {

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -538,6 +538,8 @@ describe('v:lua', function()
     eq('\tbadval', eval("v:lua.require'leftpad'('badval')"))
     eq(9003, eval("v:lua.require'bar'.doit()"))
     eq(9004, eval("v:lua.require'baz-quux'.doit()"))
+    eq(9003, eval("1 ? v:lua.require'bar'.doit() : v:lua.require'baz-quux'.doit()"))
+    eq(9004, eval("0 ? v:lua.require'bar'.doit() : v:lua.require'baz-quux'.doit()"))
   end)
 
   it('throw errors for invalid use', function()


### PR DESCRIPTION
Problem:  Error when parsing v:lua in a ternary expression.
Solution: Set rettv->v_type for v:lua even if not evaluating.