### PR TITLE
feat(treesitter): add folding for `InspectTree`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -231,9 +231,10 @@ The following new APIs and features were added.
   • |vim.treesitter.query.edit()| allows live editing of treesitter
     queries.
   • Improved error messages for query parsing.
-  • `:InspectTree` (|vim.treesitter.inspect_tree()|) shows node ranges in
-    0-based indexing instead of 1-based indexing.
-  • `:InspectTree` (|vim.treesitter.inspect_tree()|) shows root nodes
+  • |:InspectTree| shows node ranges in 0-based indexing instead of 1-based
+    indexing.
+  • |:InspectTree| shows root nodes
+  • |:InspectTree| now supports |folding|
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -821,7 +821,7 @@ inspect_tree({opts})                           *vim.treesitter.inspect_tree()*
     While in the window, press "a" to toggle display of anonymous nodes, "I"
     to toggle the display of the source language of each node, "o" to toggle
     the query editor, and press <Enter> to jump to the node under the cursor
-    in the source buffer.
+    in the source buffer. Folding also works (try |zo|, |zc|, etc.).
 
     Can also be shown with `:InspectTree`.                      *:InspectTree*
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -461,7 +461,8 @@ end
 ---
 --- While in the window, press "a" to toggle display of anonymous nodes, "I" to toggle the
 --- display of the source language of each node, "o" to toggle the query editor, and press
---- <Enter> to jump to the node under the cursor in the source buffer.
+--- <Enter> to jump to the node under the cursor in the source buffer. Folding also works
+--- (try |zo|, |zc|, etc.).
 ---
 --- Can also be shown with `:InspectTree`. *:InspectTree*
 ---

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -159,7 +159,10 @@ end
 local function set_dev_properties(w, b)
   vim.wo[w].scrolloff = 5
   vim.wo[w].wrap = false
-  vim.wo[w].foldmethod = 'manual' -- disable folding
+  vim.wo[w].foldmethod = 'expr'
+  vim.wo[w].foldexpr = 'v:lua.vim.treesitter.foldexpr()' -- explicitly set foldexpr
+  vim.wo[w].foldenable = false -- Don't fold on first open InspectTree
+  vim.wo[w].foldlevel = 99
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'


### PR DESCRIPTION
As the InspectTree buffer is now a valid tree-sitter query tree, we can use the bundled fold queries to have folding for the tree.

With a tree of
```
(translation_unit ; [0, 0] - [6, 0]
  (preproc_def ; [0, 0] - [1, 0]
    name: (identifier)) ; [0, 8] - [0, 11]
  (declaration ; [3, 0] - [5, 6]
    type: (struct_specifier ; [3, 0] - [5, 1]
      body: (field_declaration_list ; [3, 7] - [5, 1]
        (field_declaration ; [4, 0] - [4, 16]
          type: (macro_type_specifier ; [4, 0] - [4, 15]
            name: (identifier) ; [4, 0] - [4, 7]
            (ERROR ; [4, 8] - [4, 11]
              (number_literal)) ; [4, 8] - [4, 10]
            type: (type_descriptor ; [4, 12] - [4, 15]
              type: (type_identifier)))))) ; [4, 12] - [4, 15]
    declarator: (identifier))) ; [5, 2] - [5, 5]
```

We will have the folded tree of 
```
(translation_unit ; [0, 0] - [6, 0]
  (preproc_def ; [0, 0] - [1, 0]
    name: (identifier)) ; [0, 8] - [0, 11]
  (declaration ; [3, 0] - [5, 6] .................................
```