### PR TITLE
feat(treesitter): add lang arg to :InspectTree

### DIFF
--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -7,17 +7,26 @@ vim.api.nvim_create_user_command('Inspect', function(cmd)
 end, { desc = 'Inspect highlights and extmarks at the cursor', bang = true })
 
 vim.api.nvim_create_user_command('InspectTree', function(cmd)
+  ---@type string
+  local lang = cmd.fargs and cmd.fargs[1]
   if cmd.mods ~= '' or cmd.count ~= 0 then
     local count = cmd.count ~= 0 and cmd.count or ''
     local new = cmd.mods ~= '' and 'new' or 'vnew'
 
     vim.treesitter.inspect_tree({
       command = ('%s %s%s'):format(cmd.mods, count, new),
+      lang = lang,
     })
   else
-    vim.treesitter.inspect_tree()
+    vim.treesitter.inspect_tree({
+      lang = lang,
+    })
   end
-end, { desc = 'Inspect treesitter language tree for buffer', count = true })
+end, {
+  desc = 'Inspect treesitter language tree for buffer',
+  count = true,
+  nargs = '?',
+})
 
 vim.api.nvim_create_user_command('EditQuery', function(cmd)
   vim.treesitter.query.edit(cmd.fargs[1])


### PR DESCRIPTION
Gives `:InspectTree` an optional argument representing a specific parser to show in the tree, for easier debugging. I'm not sure how to add proper documentation for this, it seems the documentation for the command itself is not fully complete, as it doesn't show that it takes a count.