### PR TITLE
vim-patch:9.1.0115: Using freed memory with full tag stack and user data

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -388,7 +388,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
           for (int i = 1; i < tagstacklen; i++) {
             tagstack[i - 1] = tagstack[i];
           }
-          tagstackidx--;
+          tagstack[--tagstackidx].user_data = NULL;
         }
 
         // put the tag name in the tag stack


### PR DESCRIPTION
#### vim-patch:9.1.0115: Using freed memory with full tag stack and user data

Problem:  Using freed memory with full tag stack and user data
          (Konstantin Khlebnikov)
Solution: Clear the user data pointer of the newest entry.
          (zeertzjq, Konstantin Khlebnikov)

fixes: neovim/neovim#27498
closes: vim/vim#14053

https://github.com/vim/vim/commit/c86bff1771ed9c340f8f4433ae5530fd6de97980

Cherry-pick Test_tag_stack() changes from patch 9.0.0767.

Co-authored-by: Konstantin Khlebnikov <koct9i@gmail.com>