### PR TITLE
refactor(lsp): typings for protocol constants

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -1,6 +1,6 @@
--- Protocol for the Microsoft Language Server Protocol (mslsp)
+--- @diagnostic disable: duplicate-doc-alias
 
-local protocol = {}
+-- Protocol for the Microsoft Language Server Protocol (mslsp)
 
 --[=[
 ---@private
@@ -20,7 +20,7 @@ function transform_schema_to_table()
 end
 --]=]
 
-local constants = {
+local protocol = {
   --- @enum lsp.DiagnosticSeverity
   DiagnosticSeverity = {
     -- Reports an error.
@@ -313,7 +313,7 @@ local constants = {
   },
 }
 
-for k, v in pairs(constants) do
+for k, v in pairs(protocol) do
   local tbl = vim.deepcopy(v, true)
   vim.tbl_add_reverse_lookup(tbl)
   protocol[k] = tbl
@@ -723,7 +723,7 @@ function protocol.make_client_capabilities()
         codeActionLiteralSupport = {
           codeActionKind = {
             valueSet = (function()
-              local res = vim.tbl_values(constants.CodeActionKind)
+              local res = vim.tbl_values(protocol.CodeActionKind)
               table.sort(res)
               return res
             end)(),


### PR DESCRIPTION
There's no completion support when trying to access the protocol constants (like `DiagnosticTag` etc). With this change the respective constants are listed after typing `vim.lsp.protocol.`. These results don't take into account the modifications done by the reverse lookup, but IMO it's better than nothing.