### PR TITLE
fix(runtime): validate $VIMRUNTIME on startup

### DIFF
--- a/runtime/lua/vim/_core/util.lua
+++ b/runtime/lua/vim/_core/util.lua
@@ -99,4 +99,16 @@ function M.term_exitcode()
   return ''
 end
 
+--- Returns false and notifies if $VIMRUNTIME is inaccessible or invalid.
+---
+--- @return boolean
+function M._validate_vimruntime()
+  local rt = vim.fn.getenv('VIMRUNTIME')
+  if not rt or rt == '' or not vim.uv.fs_stat(rt .. '/filetype.lua') then
+    vim.notify(('E5009: Invalid $VIMRUNTIME: %q'):format(rt), vim.log.levels.ERROR)
+    return false
+  end
+  return true
+end
+
 return M

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -495,11 +495,17 @@ int main(int argc, char **argv)
 
   // If using the runtime (-u is not NONE), enable syntax & filetype plugins.
   if (!vimrc_none || params.clean) {
-    // Sources filetype.lua unless the user explicitly disabled it with :filetype off.
-    filetype_maybe_enable();
-    // Sources syntax/syntax.vim. We do this *after* the user startup scripts so that users can
-    // disable syntax highlighting with `:syntax off` if they wish.
-    syn_maybe_enable();
+    Error err = ERROR_INIT;
+    Object result = NLUA_EXEC_STATIC("return require('vim._core.util')._validate_vimruntime()",
+                                     (Array)ARRAY_DICT_INIT, kRetNilBool, NULL, &err);
+    api_clear_error(&err);
+    if (LUARET_TRUTHY(result)) {
+      // Sources filetype.lua unless the user explicitly disabled it with :filetype off.
+      filetype_maybe_enable();
+      // Sources syntax/syntax.vim. We do this *after* the user startup scripts so that users can
+      // disable syntax highlighting with `:syntax off` if they wish.
+      syn_maybe_enable();
+    }
   }
 
   set_vim_var_nr(VV_VIM_DID_INIT, 1);

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1784,6 +1784,21 @@ describe('runtime:', function()
     command('edit FTDETECT')
     eq('SsABab', eval('g:aseq'))
   end)
+
+  it('shows E5009 when $VIMRUNTIME is inaccessible #27527', function()
+    local logfile = t.tmpname()
+    clear({
+      args_rm = { '-u' },
+      args = { '--clean' },
+      env = { VIMRUNTIME = '/foo/bar', NVIM_LOG_FILE = logfile },
+    })
+    matches('E5009: Invalid %$VIMRUNTIME', exec_capture('messages'))
+    if t.is_os('win') then
+      t.assert_log('neovim%.ico not found', logfile)
+    else
+      t.assert_nolog('.', logfile)
+    end
+  end)
 end)
 
 describe('user session', function()


### PR DESCRIPTION
Problem: When $VIMRUNTIME is inaccessible, there shows a confusing
E484 without explaining the root cause.

Solution: Validate $VIMRUNTIME by sourcing filetype.lua before
enabling filetype/syntax plugins. Show E5009 if it fails.

Fix #27527