### PR TITLE
docs: document ttimeout being enabled

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -80,6 +80,7 @@ Defaults					            *nvim-defaults*
 - 'tags' defaults to "./tags;,tags"
 - 'termguicolors' is enabled by default if Nvim can detect support from the
   host terminal
+- 'ttimeout' is enabled
 - 'ttimeoutlen' defaults to 50
 - 'ttyfast' is always set
 - 'undodir' defaults to ~/.local/state/nvim/undo// (|xdg|), auto-created


### PR DESCRIPTION
Was not documented in list of vim differences that this is enabled by default.
