### PR TITLE
feat(help): hide filename of "gO" outline using conceal

### DIFF
--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -71,7 +71,7 @@ if !exists('g:no_plugin_maps')
 
         if indent(lnum) <= indent(l)
           let level = has_section + has_sub_section
-          let add_text = matchstr(text, '\S.*')
+          let add_text = matchstr(text, '\S.\{-}\ze\s\=\~$')
         endif
       endif
 
@@ -79,7 +79,7 @@ if !exists('g:no_plugin_maps')
       if !empty(add_text) && last_added != lnum
         let last_added = lnum
         call add(toc, {'bufnr': bufnr('%'), 'lnum': lnum,
-              \ 'text': repeat('  ', level) . add_text})
+              \ 'text': repeat("\u00a0\u00a0", level) . add_text})
       endif
       let lnum = nextnonblank(lnum + 1)
     endwhile

--- a/runtime/ftplugin/qf.vim
+++ b/runtime/ftplugin/qf.vim
@@ -16,26 +16,3 @@ if !get(g:, 'qf_disable_statusline')
   " Display the command that produced the list in the quickfix window:
   setlocal stl=%t%{exists('w:quickfix_title')?\ '\ '.w:quickfix_title\ :\ ''}\ %=%-15(%l,%c%V%)\ %P
 endif
-
-function! s:setup_toc() abort
-  if get(w:, 'quickfix_title') !~# '\<TOC$' || &syntax != 'qf'
-    return
-  endif
-
-  let list = getloclist(0)
-  if empty(list)
-    return
-  endif
-
-  let bufnr = list[0].bufnr
-  setlocal modifiable
-  silent %delete _
-  call setline(1, map(list, 'v:val.text'))
-  setlocal nomodifiable nomodified
-  let &syntax = getbufvar(bufnr, '&syntax')
-endfunction
-
-augroup qf_toc
-  autocmd!
-  autocmd Syntax <buffer> call s:setup_toc()
-augroup END

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -15,6 +15,12 @@ syn match	qfSeparator	"|" nextgroup=qfLineNr contained
 syn match	qfLineNr	"[^|]*" contained contains=qfError
 syn match	qfError		"error" contained
 
+" Hide file name and line number for help outline (TOC).
+if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$'
+  setlocal conceallevel=3 concealcursor=nc
+  syn match	Ignore		"^[^|]*|[^|]*| " conceal
+endif
+
 " The default highlighting.
 hi def link qfFileName	Directory
 hi def link qfLineNr	LineNr


### PR DESCRIPTION
Help outlines, invoked by `gO`, displays the help section titles in the location list window. This feature is implemented by setting the buffer lines after opening the window, but this implementation breaks the assumption that the quickfix window texts are consistently constructed by the quickfix list items. I think we can use the conceal feature here. Using conceal here improves interoperability between quickfix plugins, and also simplifies the outline implementation.
Originally reported at https://github.com/itchyny/vim-qfedit/issues/12.