### PR TITLE
vim-patch:ef387c062bb1

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -422,7 +422,7 @@ end
 --- @param bufnr integer
 --- @return boolean
 local function is_modula2(bufnr)
-  return matchregex(nextnonblank(bufnr, 1), [[\<MODULE\s\+\w\+\s*;\|^\s*(\*]])
+  return matchregex(nextnonblank(bufnr, 1), [[\<MODULE\s\+\w\+\s*\%(\[.*]\s*\)\=;\|^\s*(\*]])
 end
 
 --- @param bufnr integer

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1511,82 +1511,89 @@ func Test_mod_file()
   filetype on
 
   " *.mod defaults to Modsim III
-  call writefile(['locks like Modsim III'], 'modfile.mod')
-  split modfile.mod
+  call writefile(['locks like Modsim III'], 'Xfile.mod', 'D')
+  split Xfile.mod
   call assert_equal('modsim3', &filetype)
   bwipe!
 
   " Users preference set by g:filetype_mod
   let g:filetype_mod = 'lprolog'
-  split modfile.mod
+  split Xfile.mod
   call assert_equal('lprolog', &filetype)
   unlet g:filetype_mod
   bwipe!
 
+  " LambdaProlog module
+  call writefile(['module lpromod.'], 'Xfile.mod')
+  split Xfile.mod
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
+  " LambdaProlog with comment and empty lines prior module
+  call writefile(['', '% with',  '% comment', '', 'module lpromod.'], 'Xfile.mod')
+  split Xfile.mod
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
   " RAPID header start with a line containing only "%%%",
   " but is not always present.
-  call writefile(['%%%'], 'modfile.mod')
-  split modfile.mod
+  call writefile(['%%%'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('rapid', &filetype)
   bwipe!
-  call delete('modfile.mod')
 
   " RAPID supports umlauts in module names, leading spaces,
   " the .mod extension is not case sensitive.
-  call writefile(['  module ÜmlautModule'], 'modfile.Mod')
-  split modfile.Mod
+  call writefile(['  module ÜmlautModule'], 'Xfile.Mod', 'D')
+  split Xfile.Mod
   call assert_equal('rapid', &filetype)
   bwipe!
-  call delete('modfile.Mod')
 
   " RAPID is not case sensitive, embedded spaces, sysmodule,
   " file starts with empty line(s).
-  call writefile(['', 'MODULE  rapidmödüle  (SYSMODULE,NOSTEPIN)'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['', 'MODULE  rapidmödüle  (SYSMODULE,NOSTEPIN)'], 'Xfile.MOD', 'D')
+  split Xfile.MOD
   call assert_equal('rapid', &filetype)
   bwipe!
 
   " Modula-2 MODULE not start of line
-  call writefile(['IMPLEMENTATION MODULE Module2Mod;'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['IMPLEMENTATION MODULE Module2Mod;'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('modula2', &filetype)
   call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
   " Modula-2 with comment and empty lines prior MODULE
-  call writefile(['', '(* with',  ' comment *)', '', 'MODULE Module2Mod;'], 'modfile.MOD')
-  split modfile.MOD
+  call writefile(['', '(* with',  ' comment *)', '', 'MODULE Module2Mod;'], 'Xfile.mod')
+  split Xfile.mod
   call assert_equal('modula2', &filetype)
   call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
-  call delete('modfile.MOD')
-
-  " LambdaProlog module
-  call writefile(['module lpromod.'], 'modfile.mod')
-  split modfile.mod
-  call assert_equal('lprolog', &filetype)
+  " Modula-2 program MODULE with priorty (and uppercase extension)
+  call writefile(['MODULE Module2Mod [42];'], 'Xfile.MOD')
+  split Xfile.MOD
+  call assert_equal('modula2', &filetype)
+  call assert_equal('pim', b:modula2.dialect)
   bwipe!
 
-  " LambdaProlog with comment and empty lines prior module
-  call writefile(['', '% with',  '% comment', '', 'module lpromod.'], 'modfile.mod')
-  split modfile.mod
-  call assert_equal('lprolog', &filetype)
+  " Modula-2 implementation MODULE with priorty (and uppercase extension)
+  call writefile(['IMPLEMENTATION MODULE Module2Mod [42];'], 'Xfile.MOD')
+  split Xfile.MOD
+  call assert_equal('modula2', &filetype)
+  call assert_equal('pim', b:modula2.dialect)
   bwipe!
-  call delete('modfile.mod')
 
   " go.mod
-  call writefile(['module example.com/M'], 'go.mod')
+  call writefile(['module example.com/M'], 'go.mod', 'D')
   split go.mod
   call assert_equal('gomod', &filetype)
   bwipe!
-  call delete('go.mod')
 
   call writefile(['module M'], 'go.mod')
   split go.mod
   call assert_equal('gomod', &filetype)
   bwipe!
-  call delete('go.mod')
 
   filetype off
 endfunc


### PR DESCRIPTION
#### vim-patch:ef387c062bb1

runtime(filetype): Modula-2 files with priority not detected (vim/vim#14055)

Problem:  Modula-2 files with a specified priority are not detected.
Solution: Match the priority syntax in module header lines when
          performing heuristic content detection.

Disable the :defcompile debug line.  This was accidentally left enabled
in commit 68a8947.

https://github.com/vim/vim/commit/ef387c062bb1966187d3f307d697d80162051a0d

Co-authored-by: dkearns <dougkearns@gmail.com>