### PR TITLE
docs: remove mention of foreground/background/special keys in nvim_set_hl

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1473,9 +1473,9 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
                  activate them.
       • {name}   Highlight group name, e.g. "ErrorMsg"
       • {val}    Highlight definition map, accepts the following keys:
-                 • fg (or foreground): color name or "#RRGGBB", see note.
-                 • bg (or background): color name or "#RRGGBB", see note.
-                 • sp (or special): color name or "#RRGGBB"
+                 • fg: color name or "#RRGGBB", see note.
+                 • bg: color name or "#RRGGBB", see note.
+                 • sp: color name or "#RRGGBB"
                  • blend: integer between 0 and 100
                  • bold: boolean
                  • standout: boolean

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1819,9 +1819,9 @@ function vim.api.nvim_set_decoration_provider(ns_id, opts) end
 ---              activate them.
 --- @param name string Highlight group name, e.g. "ErrorMsg"
 --- @param val vim.api.keyset.highlight Highlight definition map, accepts the following keys:
----              • fg (or foreground): color name or "#RRGGBB", see note.
----              • bg (or background): color name or "#RRGGBB", see note.
----              • sp (or special): color name or "#RRGGBB"
+---              • fg: color name or "#RRGGBB", see note.
+---              • bg: color name or "#RRGGBB", see note.
+---              • sp: color name or "#RRGGBB"
 ---              • blend: integer between 0 and 100
 ---              • bold: boolean
 ---              • standout: boolean

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -141,9 +141,9 @@ Dictionary nvim_get_hl(Integer ns_id, Dict(get_highlight) *opts, Arena *arena, E
 ///              |nvim_set_hl_ns()| or |nvim_win_set_hl_ns()| to activate them.
 /// @param name  Highlight group name, e.g. "ErrorMsg"
 /// @param val   Highlight definition map, accepts the following keys:
-///                - fg (or foreground): color name or "#RRGGBB", see note.
-///                - bg (or background): color name or "#RRGGBB", see note.
-///                - sp (or special): color name or "#RRGGBB"
+///                - fg: color name or "#RRGGBB", see note.
+///                - bg: color name or "#RRGGBB", see note.
+///                - sp: color name or "#RRGGBB"
 ///                - blend: integer between 0 and 100
 ///                - bold: boolean
 ///                - standout: boolean


### PR DESCRIPTION
To align the output of `nvim_get_hl` with its documentation -- which points to `nvim_set_hl`, remove mentions of the keys `foreground`, `background` and `special`.

The long keys are are still supported (via fallback checks inside `dict2hlattrs`), but the `fg`, `bg` and `sp` keys are preferenced.

Closes #27524.