### PR TITLE
doc: fix type annotation for lsp.WorkspaceEdit

### DIFF
--- a/runtime/lua/vim/lsp/_meta/protocol.lua
+++ b/runtime/lua/vim/lsp/_meta/protocol.lua
@@ -409,7 +409,7 @@ error('Cannot require a meta file')
 ---
 ---If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then
 ---only plain `TextEdit`s using the `changes` property are supported.
----@field documentChanges? lsp.TextDocumentEdit|lsp.CreateFile|lsp.RenameFile|lsp.DeleteFile[]
+---@field documentChanges? (lsp.TextDocumentEdit|lsp.CreateFile|lsp.RenameFile|lsp.DeleteFile)[]
 ---
 ---A map of change annotations that can be referenced in `AnnotatedTextEdit`s or create, rename and
 ---delete file / folder operations.


### PR DESCRIPTION
A super easy one: the type annotation here is incorrect. LuaLS needs the parens to interpret this as a list of unions, rather than a union with the last item being a list.