### PR TITLE
fix(defaults): remove tmux background detection passthrough

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -343,17 +343,7 @@ if tty then
       end,
     })
 
-    local query = '\027]11;?\007'
-
-    -- tmux 3.3a and earlier do not query the parent terminal for background color. As of the
-    -- writing of this comment, 3.3a is the latest release, so a passthrough sequence is necessary.
-    -- The passthrough should be removed as soon as a tmux version later than 3.3a is released.
-    -- See: https://github.com/neovim/neovim/pull/26557
-    if os.getenv('TMUX') then
-      query = string.format('\027Ptmux;%s\027\\', query:gsub('\027', '\027\027'))
-    end
-
-    io.stdout:write(query)
+    io.stdout:write('\027]11;?\007')
 
     timer:start(1000, 0, function()
       -- Delete the autocommand if no response was received


### PR DESCRIPTION
There is now a new tmux 3.4 release that queries background color from
the parent terminal if background is not set in tmux, so removing the
passthrough still works when background is not set in tmux, and fixes
the incorrect detection when background is set in tmux.

This reverts PR #26557.