### PR TITLE
fix(defaults): make terminal autoclose not block other events

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -143,14 +143,16 @@ do
 
   vim.api.nvim_create_autocmd({ 'TermClose' }, {
     group = nvim_terminal_augroup,
+    nested = true,
     desc = 'Automatically close terminal buffers when started with no arguments and exiting without an error',
     callback = function(args)
-      if vim.v.event.status == 0 then
-        local info = vim.api.nvim_get_chan_info(vim.bo[args.buf].channel)
-        local argv = info.argv or {}
-        if #argv == 1 and argv[1] == vim.o.shell then
-          vim.cmd({ cmd = 'bdelete', args = { args.buf }, bang = true })
-        end
+      if vim.v.event.status ~= 0 then
+        return
+      end
+      local info = vim.api.nvim_get_chan_info(vim.bo[args.buf].channel)
+      local argv = info.argv or {}
+      if #argv == 1 and argv[1] == vim.o.shell then
+        vim.api.nvim_buf_delete(args.buf, { force = true })
       end
     end,
   })

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1232,3 +1232,22 @@ describe('stdpath()', function()
     end)
   end)
 end)
+
+describe('autocommands', function()
+  it('closes terminal with default shell on success', function()
+    api.nvim_set_option_value('shell', helpers.testprg('shell-test'), {})
+    command('set shellcmdflag=EXIT shellredir= shellpipe= shellquote= shellxquote=')
+
+    -- Should not block other events
+    command('let g:n=0')
+    command('au BufEnter * let g:n = g:n + 1')
+
+    command('terminal')
+    eq(eval('get(g:, "n", 0)'), 1)
+
+    helpers.retry(nil, 1000, function()
+      neq(api.nvim_get_option_value('buftype', { buf = 0 }), 'terminal')
+      eq(eval('get(g:, "n", 0)'), 2)
+    end)
+  end)
+end)


### PR DESCRIPTION
Problem: When terminal is autocloses, it blocks other events, like `BufEnter`.

Solution: Use `nested = true`.