### PR TITLE
docs(treesitter): fix ambiguous parameter description about `lang`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -782,7 +782,7 @@ get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
     Parameters: ~
       • {bufnr}  (`integer?`) Buffer the parser should be tied to (default:
                  current buffer)
-      • {lang}   (`string?`) Filetype of this parser (default: buffer
+      • {lang}   (`string?`) Language of this parser (default: from buffer
                  filetype)
       • {opts}   (`table?`) Options to pass to the created language tree
 
@@ -829,7 +829,7 @@ inspect_tree({opts})                           *vim.treesitter.inspect_tree()*
       • {opts}  (`table?`) Optional options table with the following possible
                 keys:
                 • lang (string|nil): The language of the source buffer. If
-                  omitted, the filetype of the source buffer is used.
+                  omitted, detect from the filetype of the source buffer.
                 • bufnr (integer|nil): Buffer to draw the tree into. If
                   omitted, a new buffer is created.
                 • winid (integer|nil): Window id to display the tree buffer
@@ -895,7 +895,8 @@ start({bufnr}, {lang})                                *vim.treesitter.start()*
     Parameters: ~
       • {bufnr}  (`integer?`) Buffer to be highlighted (default: current
                  buffer)
-      • {lang}   (`string?`) Language of the parser (default: buffer filetype)
+      • {lang}   (`string?`) Language of the parser (default: from buffer
+                 filetype)
 
 stop({bufnr})                                          *vim.treesitter.stop()*
     Stops treesitter highlighting for a buffer

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -77,7 +77,7 @@ end
 --- If needed, this will create the parser.
 ---
 ---@param bufnr (integer|nil) Buffer the parser should be tied to (default: current buffer)
----@param lang (string|nil) Filetype of this parser (default: buffer filetype)
+---@param lang (string|nil) Language of this parser (default: from buffer filetype)
 ---@param opts (table|nil) Options to pass to the created language tree
 ---
 ---@return vim.treesitter.LanguageTree object to use for parsing
@@ -452,7 +452,7 @@ end
 --- ```
 ---
 ---@param bufnr (integer|nil) Buffer to be highlighted (default: current buffer)
----@param lang (string|nil) Language of the parser (default: buffer filetype)
+---@param lang (string|nil) Language of the parser (default: from buffer filetype)
 function M.start(bufnr, lang)
   bufnr = bufnr or api.nvim_get_current_buf()
   local parser = M.get_parser(bufnr, lang)
@@ -480,8 +480,8 @@ end
 --- Can also be shown with `:InspectTree`. *:InspectTree*
 ---
 ---@param opts table|nil Optional options table with the following possible keys:
----                      - lang (string|nil): The language of the source buffer. If omitted, the
----                        filetype of the source buffer is used.
+---                      - lang (string|nil): The language of the source buffer. If omitted, detect
+---                        from the filetype of the source buffer.
 ---                      - bufnr (integer|nil): Buffer to draw the tree into. If omitted, a new
 ---                        buffer is created.
 ---                      - winid (integer|nil): Window id to display the tree buffer in. If omitted,


### PR DESCRIPTION
There is a wrong description of the parameter `lang`. It is the name of the parser actually instead of the filetype, the wrong description may misguide users to pass `vim.o.filetype` to it, but it will not work in some cases, such as the filetype `typescriptreact` corresponds to parser `tsx`.