### PR TITLE
docs(lsp): remove obsolete didChangeConfiguration explanation

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1034,11 +1034,7 @@ start_client({config})                                *vim.lsp.start_client()*
                     example, clangd sends `initialize_result.offsetEncoding`
                     if `capabilities.offsetEncoding` was sent to it. You can
                     only modify the `client.offset_encoding` here before any
-                    notifications are sent. Most language servers expect to be
-                    sent client specified settings after initialization. Nvim
-                    does not make this assumption. A
-                    `workspace/didChangeConfiguration` notification should be
-                    sent to the server during on_init.
+                    notifications are sent.
                   • on_exit Callback (code, signal, client_id) invoked on
                     client exit.
                     • code: exit code of the process

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -641,10 +641,7 @@ end
 ---       the server may send. For example, clangd sends
 ---       `initialize_result.offsetEncoding` if `capabilities.offsetEncoding` was
 ---       sent to it. You can only modify the `client.offset_encoding` here before
----       any notifications are sent. Most language servers expect to be sent client specified settings after
----       initialization. Nvim does not make this assumption. A
----       `workspace/didChangeConfiguration` notification should be sent
----        to the server during on_init.
+---       any notifications are sent.
 ---
 --- - on_exit Callback (code, signal, client_id) invoked on client
 --- exit.


### PR DESCRIPTION
Neovim started making the assumption to call `workspace/didChangeConfiguration` on startup in https://github.com/neovim/neovim/pull/18847. I think this can be removed?