### PR TITLE
vim-patch:a35235e824bb

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4437,6 +4437,7 @@ match({expr}, {pat} [, {start} [, {count}]])                           *match()*
 		Note that when {count} is added the way {start} works changes,
 		see above.
 
+						*match-pattern*
 		See |pattern| for the patterns that are accepted.
 		The 'ignorecase' option is used to set the ignore-caseness of
 		the pattern.  'smartcase' is NOT used.  The matching is always
@@ -4572,6 +4573,9 @@ matchbufline({buf}, {pat}, {lnum}, {end}, [, {dict}])           *matchbufline()*
 
 		This function works only for loaded buffers. First call
 		|bufload()| if needed.
+
+		See |match-pattern| for information about the effect of some
+		option settings on the pattern.
 
 		When {buf} is not a valid buffer, the buffer is not loaded or
 		{lnum} or {end} is not valid then an error is given and an
@@ -4746,6 +4750,9 @@ matchstrlist({list}, {pat} [, {dict}])                          *matchstrlist()*
 		    text	matched string
 		    submatches	a List of submatches.  Present only if
 				"submatches" is set to v:true in {dict}.
+
+		See |match-pattern| for information about the effect of some
+		option settings on the pattern.
 
 		Example: >vim
 		    :echo matchstrlist(['tik tok'], '\<\k\+\>')

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -5356,6 +5356,7 @@ function vim.fn.mapset(dict) end
 --- Note that when {count} is added the way {start} works changes,
 --- see above.
 ---
+---         *match-pattern*
 --- See |pattern| for the patterns that are accepted.
 --- The 'ignorecase' option is used to set the ignore-caseness of
 --- the pattern.  'smartcase' is NOT used.  The matching is always
@@ -5513,6 +5514,9 @@ function vim.fn.matcharg(nr) end
 ---
 --- This function works only for loaded buffers. First call
 --- |bufload()| if needed.
+---
+--- See |match-pattern| for information about the effect of some
+--- option settings on the pattern.
 ---
 --- When {buf} is not a valid buffer, the buffer is not loaded or
 --- {lnum} or {end} is not valid then an error is given and an
@@ -5726,6 +5730,9 @@ function vim.fn.matchstr(expr, pat, start, count) end
 ---     text  matched string
 ---     submatches  a List of submatches.  Present only if
 ---     "submatches" is set to v:true in {dict}.
+---
+--- See |match-pattern| for information about the effect of some
+--- option settings on the pattern.
 ---
 --- Example: >vim
 ---     :echo matchstrlist(['tik tok'], '\<\k\+\>')

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -6546,6 +6546,7 @@ M.funcs = {
       Note that when {count} is added the way {start} works changes,
       see above.
 
+      				*match-pattern*
       See |pattern| for the patterns that are accepted.
       The 'ignorecase' option is used to set the ignore-caseness of
       the pattern.  'smartcase' is NOT used.  The matching is always
@@ -6725,6 +6726,9 @@ M.funcs = {
 
       This function works only for loaded buffers. First call
       |bufload()| if needed.
+
+      See |match-pattern| for information about the effect of some
+      option settings on the pattern.
 
       When {buf} is not a valid buffer, the buffer is not loaded or
       {lnum} or {end} is not valid then an error is given and an
@@ -6959,6 +6963,9 @@ M.funcs = {
           text	matched string
           submatches	a List of submatches.  Present only if
       		"submatches" is set to v:true in {dict}.
+
+      See |match-pattern| for information about the effect of some
+      option settings on the pattern.
 
       Example: >vim
           :echo matchstrlist(['tik tok'], '\<\k\+\>')


### PR DESCRIPTION
#### vim-patch:a35235e824bb

runtime(doc) Update help text for matchbufline() and matchstrlist()

closes: vim/vim#14080

https://github.com/vim/vim/commit/a35235e824bb77df0cebdb2bd290e13f1201b292

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>