### PR TITLE
fix(lsp): when renaming directory, check path prefix of buffer names

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2003,7 +2003,11 @@ rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Rename old_fname to new_fname
 
     Parameters: ~
-      • {opts}  (`table`)
+      • {old_fname}  (`string`)
+      • {new_fname}  (`string`)
+      • {opts}       (`table?`) options
+                     • overwrite? boolean
+                     • ignoreIfExists? boolean
 
                                                 *vim.lsp.util.show_document()*
 show_document({location}, {offset_encoding}, {opts})


### PR DESCRIPTION
Problem: When renaming `/path/to/dir`, buffers with names like `fern://drawer/file:///path/to/dir`, `/path/to/dir123` are deleted.

Solution: Match each path component.