### PR TITLE
vim-patch:9.1.0132: "C" doesn't include composing chars with 'virtualedit'

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1770,8 +1770,13 @@ static void mb_adjust_opend(oparg_T *oap)
     return;
   }
 
-  char *p = ml_get(oap->end.lnum);
-  oap->end.col += utf_cp_tail_off(p, p + oap->end.col);
+  const char *line = ml_get(oap->end.lnum);
+  const char *ptr = line + oap->end.col;
+  if (*ptr != NUL) {
+    ptr -= utf_head_off(line, ptr);
+    ptr += utfc_ptr2len(ptr) - 1;
+    oap->end.col = (colnr_T)(ptr - line);
+  }
 }
 
 /// Put character 'c' at position 'lp'

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -77,13 +77,30 @@ endfunc
 func Test_edit_change()
   new
   set virtualedit=all
+
   call setline(1, "\t⒌")
   normal Cx
   call assert_equal('x', getline(1))
+
+  call setline(1, "\ta̳")
+  normal Cx
+  call assert_equal('x', getline(1))
+
+  call setline(1, "\tβ̳")
+  normal Cx
+  call assert_equal('x', getline(1))
+
+  if has('arabic')
+    call setline(1, "\tلا")
+    normal Cx
+    call assert_equal('x', getline(1))
+  endif
+
   " Do a visual block change
   call setline(1, ['a', 'b', 'c'])
   exe "normal gg3l\<C-V>2jcx"
   call assert_equal(['a  x', 'b  x', 'c  x'], getline(1, '$'))
+
   bwipe!
   set virtualedit=
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0132: "C" doesn't include composing chars with 'virtualedit'

Problem:  using "C" and 've=all' set, doesn't include composing chars
          when changing a line, keeps the composing chars for whatever
          is typed afterwards.
Solution: Use mb_head_off() and mb_ptr2len() instead of mb_tail_off().
          (zeertzjq)

closes: vim/vim#14083

https://github.com/vim/vim/commit/048761bcd40ec630fd3e039f0066cf4e484ceabd