### PR TITLE
docs(lsp): mark `ClientConfig.init_options` as optional

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -21,7 +21,7 @@ local validate = vim.validate
 --- @field handlers? table<string,function>
 --- @field settings? table
 --- @field commands? table<string,fun(command: lsp.Command, ctx: table)>
---- @field init_options table
+--- @field init_options? table
 --- @field name? string
 --- @field get_language_id? fun(bufnr: integer, filetype: string): string
 --- @field offset_encoding? string


### PR DESCRIPTION
Followup to neovim/neovim#27443