### PR TITLE
docs: fix several misleading and superfluous wordings

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2762,21 +2762,16 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                     placed if the line or column value is past the end of the
                     buffer or end of the line respectively. Defaults to true.
                   • sign_text: string of length 1-2 used to display in the
-                    sign column. Note: ranges are unsupported and decorations
-                    are only applied to start_row
+                    sign column.
                   • sign_hl_group: name of the highlight group used to
-                    highlight the sign column text. Note: ranges are
-                    unsupported and decorations are only applied to start_row
+                    highlight the sign column text.
                   • number_hl_group: name of the highlight group used to
-                    highlight the number column. Note: ranges are unsupported
-                    and decorations are only applied to start_row
+                    highlight the number column.
                   • line_hl_group: name of the highlight group used to
-                    highlight the whole line. Note: ranges are unsupported and
-                    decorations are only applied to start_row
+                    highlight the whole line.
                   • cursorline_hl_group: name of the highlight group used to
-                    highlight the line when the cursor is on the same line as
-                    the mark and 'cursorline' is enabled. Note: ranges are
-                    unsupported and decorations are only applied to start_row
+                    highlight the sign column text when the cursor is on the
+                    same line as the mark and 'cursorline' is enabled.
                   • conceal: string which should be either empty or a single
                     character. Enable concealing similar to |:syn-conceal|.
                     When a character is supplied it is used as |:syn-cchar|.
@@ -2863,7 +2858,7 @@ nvim_set_decoration_provider({ns_id}, {*opts})
                  • on_win: called when starting to redraw a specific window.
                    ["win", winid, bufnr, topline, botline]
                  • on_line: called for each buffer line being redrawn. (The
-                   interaction with fold lines is subject to change) ["win",
+                   interaction with fold lines is subject to change) ["line",
                    winid, bufnr, row]
                  • on_end: called at the end of a redraw cycle ["end", tick]
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -584,21 +584,16 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---                 placed if the line or column value is past the end of the
 ---                 buffer or end of the line respectively. Defaults to true.
 ---               • sign_text: string of length 1-2 used to display in the
----                 sign column. Note: ranges are unsupported and decorations
----                 are only applied to start_row
+---                 sign column.
 ---               • sign_hl_group: name of the highlight group used to
----                 highlight the sign column text. Note: ranges are
----                 unsupported and decorations are only applied to start_row
+---                 highlight the sign column text.
 ---               • number_hl_group: name of the highlight group used to
----                 highlight the number column. Note: ranges are unsupported
----                 and decorations are only applied to start_row
+---                 highlight the number column.
 ---               • line_hl_group: name of the highlight group used to
----                 highlight the whole line. Note: ranges are unsupported and
----                 decorations are only applied to start_row
+---                 highlight the whole line.
 ---               • cursorline_hl_group: name of the highlight group used to
----                 highlight the line when the cursor is on the same line as
----                 the mark and 'cursorline' is enabled. Note: ranges are
----                 unsupported and decorations are only applied to start_row
+---                 highlight the sign column text when the cursor is on the
+---                 same line as the mark and 'cursorline' is enabled.
 ---               • conceal: string which should be either empty or a single
 ---                 character. Enable concealing similar to `:syn-conceal`.
 ---                 When a character is supplied it is used as `:syn-cchar`.
@@ -1807,7 +1802,7 @@ function vim.api.nvim_set_current_win(window) end
 ---              • on_win: called when starting to redraw a specific window.
 ---                ["win", winid, bufnr, topline, botline]
 ---              • on_line: called for each buffer line being redrawn. (The
----                interaction with fold lines is subject to change) ["win",
+---                interaction with fold lines is subject to change) ["line",
 ---                winid, bufnr, row]
 ---              • on_end: called at the end of a redraw cycle ["end", tick]
 function vim.api.nvim_set_decoration_provider(ns_id, opts) end

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -467,25 +467,15 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                   buffer or end of the line respectively. Defaults to true.
 ///               - sign_text: string of length 1-2 used to display in the
 ///                   sign column.
-///                   Note: ranges are unsupported and decorations are only
-///                   applied to start_row
 ///               - sign_hl_group: name of the highlight group used to
 ///                   highlight the sign column text.
-///                   Note: ranges are unsupported and decorations are only
-///                   applied to start_row
 ///               - number_hl_group: name of the highlight group used to
 ///                   highlight the number column.
-///                   Note: ranges are unsupported and decorations are only
-///                   applied to start_row
 ///               - line_hl_group: name of the highlight group used to
 ///                   highlight the whole line.
-///                   Note: ranges are unsupported and decorations are only
-///                   applied to start_row
 ///               - cursorline_hl_group: name of the highlight group used to
-///                   highlight the line when the cursor is on the same line
-///                   as the mark and 'cursorline' is enabled.
-///                   Note: ranges are unsupported and decorations are only
-///                   applied to start_row
+///                   highlight the sign column text when the cursor is on
+///                   the same line as the mark and 'cursorline' is enabled.
 ///               - conceal: string which should be either empty or a single
 ///                   character. Enable concealing similar to |:syn-conceal|.
 ///                   When a character is supplied it is used as |:syn-cchar|.
@@ -1058,7 +1048,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 ///                 ["win", winid, bufnr, topline, botline]
 ///             - on_line: called for each buffer line being redrawn.
 ///                 (The interaction with fold lines is subject to change)
-///                 ["win", winid, bufnr, row]
+///                 ["line", winid, bufnr, row]
 ///             - on_end: called at the end of a redraw cycle
 ///                 ["end", tick]
 void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *opts, Error *err)


### PR DESCRIPTION
In `nvim_buf_set_extmark()` the `cursorline_hl_group` is not used to highlight the actual line, but the placed sign text (similar to `culhl` in legacy signs).

First argument of `on_line` in `nvim_set_decoration_provider()` is indeed `"line"` and not `"win"`.