### PR TITLE
vim-patch:9.1.0131: buffer-completion may not always find all matches

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -679,7 +679,7 @@ func Test_getcompletion()
     bw Xtest\
   endif
 
-  call assert_fails("call getcompletion('\\\\@!\\\\@=', 'buffer')", 'E871:')
+  call assert_fails("call getcompletion('\\\\@!\\\\@=', 'buffer')", 'E866:')
   call assert_fails('call getcompletion("", "burp")', 'E475:')
   call assert_fails('call getcompletion("abc", [])', 'E1174:')
 endfunc
@@ -3916,6 +3916,36 @@ func Test_custom_completion_with_glob()
 
   delcommand TestGlobComplete
   delfunc TestGlobComplete
+endfunc
+
+func Test_window_size_stays_same_after_changing_cmdheight()
+  set laststatus=2
+  let expected = winheight(0)
+  function! Function_name() abort
+    call feedkeys(":"..repeat('x', &columns), 'x')
+    let &cmdheight=2
+    let &cmdheight=1
+    redraw
+  endfunction
+  call Function_name()
+  call assert_equal(expected, winheight(0))
+endfunc
+
+" verify that buffer-completion finds all buffer names matching a pattern
+func Test_buffer_completion()
+  " should return empty list
+  call assert_equal([], getcompletion('', 'buffer'))
+
+  call mkdir('Xbuf_complete', 'R')
+  e Xbuf_complete/Foobar.c
+  e Xbuf_complete/MyFoobar.c
+  e AFoobar.h
+  let expected = ["Xbuf_complete/Foobar.c", "Xbuf_complete/MyFoobar.c", "AFoobar.h"]
+
+  call assert_equal(3, len(getcompletion('Foo', 'buffer')))
+  call assert_equal(expected, getcompletion('Foo', 'buffer'))
+  call feedkeys(":b Foo\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"b Xbuf_complete/Foobar.c Xbuf_complete/MyFoobar.c AFoobar.h", @:)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0131: buffer-completion may not always find all matches

Problem:  buffer-completion code too complicated and does not always
          find all matches (irisjae)
Solution: do not try to anchor pattern to beginning of line or
          directory-separator, always return all matches

Note: we are considering the non-fuzzy buffer-matching here.

Currently, the buffer-completion code makes 2 attempts to match a
pattern against the list of available patterns. First try is to match
the pattern and anchor it to either the beginning of the file name or
at a directory-separator (// or \\).

When a match is found, Vim returns the matching buffers and does not try
to find a match anywhere within a buffer name. So if you have opened two
buffers like /tmp/Foobar.c and /tmp/MyFoobar.c using `:b Foo` will only
complete to the first filename, but not the second (the same happens
with `getcompletion('Foo', 'buffer')`).

It may make sense, that completion priorities buffer names at directory
boundaries, but it inconsistent, may cause confusion why a certain
buffer name is not completed when typing `:b Foo<C-D>` which returns
only a single file name and then pressing Enter (to switch to that
buffer), Vim will error with 'E93: More than one match for Foo').
Similar things may happen when wiping the /tmp/Foobar.c pattern and
afterwards the completion starts completing other buffers.

So let's simplify the code and always match the pattern anywhere in the
buffer name, do not try to favor matches at directory boundaries. This
is also simplifies the code a bit, we do not need to run over the list
of buffers several times, but only twice.

closes: vim/vim#14082

https://github.com/vim/vim/commit/0dc0bff000fd804c6b0778ccc4554a4e4c82c8c9

Cherry-pick test_cmdline.vim from patch 9.1.0019 as it already passes.

Co-authored-by: Christian Brabandt <cb@256bit.org>