### PR TITLE
fix(lsp): add assertion for explicit bufnr in apply_text_edits

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1280,7 +1280,7 @@ function lsp.formatexpr(opts)
       local response =
         client.request_sync(ms.textDocument_rangeFormatting, params, timeout_ms, bufnr)
       if response and response.result then
-        lsp.util.apply_text_edits(response.result, 0, client.offset_encoding)
+        lsp.util.apply_text_edits(response.result, bufnr, client.offset_encoding)
         return 0
       end
     end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -419,6 +419,11 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
   if not next(text_edits) then
     return
   end
+
+  if not bufnr or bufnr == 0 then
+    bufnr = api.nvim_get_current_buf()
+  end
+
   if not api.nvim_buf_is_loaded(bufnr) then
     vim.fn.bufload(bufnr)
   end
@@ -457,7 +462,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
 
   -- save and restore local marks since they get deleted by nvim_buf_set_lines
   local marks = {}
-  for _, m in pairs(vim.fn.getmarklist(bufnr or vim.api.nvim_get_current_buf())) do
+  for _, m in pairs(vim.fn.getmarklist(bufnr)) do
     if m.mark:match("^'[a-z]$") then
       marks[m.mark:sub(2, 2)] = { m.pos[2], m.pos[3] - 1 } -- api-indexed
     end
@@ -516,7 +521,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
   local max = api.nvim_buf_line_count(bufnr)
 
   -- no need to restore marks that still exist
-  for _, m in pairs(vim.fn.getmarklist(bufnr or vim.api.nvim_get_current_buf())) do
+  for _, m in pairs(vim.fn.getmarklist(bufnr)) do
     marks[m.mark:sub(2, 2)] = nil
   end
   -- restore marks

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -420,9 +420,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     return
   end
 
-  if not bufnr or bufnr == 0 then
-    bufnr = api.nvim_get_current_buf()
-  end
+  assert(bufnr ~= 0, 'Explicit buffer number is required')
 
   if not api.nvim_buf_is_loaded(bufnr) then
     vim.fn.bufload(bufnr)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1808,7 +1808,7 @@ describe('LSP', function()
         make_edit(4, 0, 5, 0, 'barfoo'),
       }
       eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 1, {})'))
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 0, 'utf-16')
       eq({
         'First line of text',
         'foobar line of text',

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1808,7 +1808,7 @@ describe('LSP', function()
         make_edit(4, 0, 5, 0, 'barfoo'),
       }
       eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 1, {})'))
-      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 0, 'utf-16')
+      exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
         'First line of text',
         'foobar line of text',


### PR DESCRIPTION
Assert that the buffer number passed to apply_text_edits is fully
resolved (not 0 or null). Pass the known buffer number to
apply_text_edits from lsp.formatexpr().

Fixes: https://github.com/neovim/neovim/issues/27613