### PR TITLE
vim-patch:9.1.0135: Insufficient testing for 'delcombine'

### DIFF
--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2221,4 +2221,34 @@ func Test_set_wrap()
   set wrap& smoothscroll& scrolloff&
 endfunc
 
+func Test_delcombine()
+  new
+  set backspace=indent,eol,start
+
+  set delcombine
+  call setline(1, 'β̳̈:β̳̈')
+  normal! 0x
+  call assert_equal('β̈:β̳̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal('β̈:β̈', getline(1))
+  normal! 0x
+  call assert_equal('β:β̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal('β:β', getline(1))
+  normal! 0x
+  call assert_equal(':β', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal(':', getline(1))
+
+  set nodelcombine
+  call setline(1, 'β̳̈:β̳̈')
+  normal! 0x
+  call assert_equal(':β̳̈', getline(1))
+  exe "normal! A\<BS>"
+  call assert_equal(':', getline(1))
+
+  set backspace& delcombine&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0135: Insufficient testing for 'delcombine'

Problem:  Insufficient testing for 'delcombine'.
Solution: Add test for both Normal and Insert modes without Arabic.
          (zeertzjq)

closes: vim/vim#14086

https://github.com/vim/vim/commit/cd3a13e774823c44cf2e1e483d9e5b6df2cbcf50