### PR TITLE
fix(lsp): add snippet regression test

### DIFF
--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -228,4 +228,16 @@ describe('vim.snippet', function()
     feed(',2')
     eq({ 'for i=1,10,2 do', '\t', 'end' }, buf_lines(0))
   end)
+
+  it('updates snippet state when built-in completion menu is visible', function()
+    test_expand_success({ '$1 = function($2)\n$3\nend' }, { ' = function()', '', 'end' })
+    -- Show the completion menu.
+    feed('<C-n>')
+    -- Make sure no item is selected.
+    feed('<C-p>')
+    -- Jump forward (the 2nd tabstop).
+    exec_lua('vim.snippet.jump(1)')
+    feed('foo')
+    eq({ ' = function(foo)', '', 'end' }, buf_lines(0))
+  end)
 end)


### PR DESCRIPTION
Adding a snippet test to prevent #25895 from happening in the future.

Note that the mentioned bug was (unintentionally) fixed on master before.

Fixes #25895.