### PR TITLE
test: don't use minimal timeout for "intermediate" flag

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2669,10 +2669,9 @@ describe("TUI 'term' option", function()
     })
 
     local full_timeout = screen.timeout
-    screen.timeout = 250 -- We want screen:expect() to fail quickly.
     retry(nil, 2 * full_timeout, function() -- Wait for TUI thread to set 'term'.
       feed_data(":echo 'term='.(&term)\n")
-      screen:expect { any = 'term=' .. term_expected }
+      screen:expect { any = 'term=' .. term_expected, timeout = 250 }
     end)
   end
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -638,7 +638,6 @@ screen:redraw_debug() to show all intermediate screen states.]]
 end
 
 function Screen:expect_unchanged(intermediate, waittime_ms, ignore_attrs)
-  waittime_ms = waittime_ms and waittime_ms or 100
   -- Collect the current screen state.
   local kwargs = self:get_snapshot(nil, ignore_attrs)
 
@@ -689,8 +688,8 @@ function Screen:_wait(check, flags)
 
   -- For an "unchanged" test, flags.timeout is the time during which the state
   -- must not change, so always wait this full time.
-  if (flags.unchanged or flags.intermediate) and flags.timeout then
-    minimal_timeout = timeout
+  if flags.unchanged then
+    minimal_timeout = flags.timeout or default_timeout_factor * 20
   end
 
   assert(timeout >= minimal_timeout)
@@ -711,7 +710,7 @@ function Screen:_wait(check, flags)
       intermediate_seen = true
     end
 
-    if not err then
+    if not err and (not flags.intermediate or intermediate_seen) then
       success_seen = true
       if did_minimal_timeout then
         self._session:stop()

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -715,7 +715,7 @@ function Screen:_wait(check, flags)
       if did_minimal_timeout then
         self._session:stop()
       end
-    elseif success_seen and #args > 0 then
+    elseif err and success_seen and #args > 0 then
       success_seen = false
       failure_after_success = true
       -- print(inspect(args))

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -231,10 +231,6 @@ describe("'wildmenu'", function()
   end)
 
   it('with laststatus=0, :vsplit, :term #2255', function()
-    -- Because this test verifies a _lack_ of activity after screen:sleep(), we
-    -- must wait the full timeout. So make it reasonable.
-    screen.timeout = 1000
-
     if not is_os('win') then
       command('set shell=sh') -- Need a predictable "$" prompt.
       command('let $PS1 = "$"')
@@ -257,7 +253,9 @@ describe("'wildmenu'", function()
     -- Check only the last 2 lines, because the shell output is
     -- system-dependent.
     screen:expect { any = '!  #  &  <  =  >  @  >   |\n:!^' }
-    screen:expect_unchanged()
+    -- Because this test verifies a _lack_ of activity, we must wait the full timeout.
+    -- So make it reasonable.
+    screen:expect_unchanged(false, 1000)
   end)
 
   it('wildmode=list,full and messages interaction #10092', function()


### PR DESCRIPTION
With "intermediate" flag, only using minimal timeout is too short and
may lead to failures.
Also remove the fallback timeout in screen:expect_unchanged(), as having
a different fallback timeout than screen:expect() is confusing.
