### PR TITLE
vim-patch:partial:d086b8f646a6

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -459,7 +459,7 @@ g:changelog_new_date_format
 				%%	insert a single '%' character
 				%d	insert the date from above
 				%u	insert the user from above
-                                %p	insert result of b:changelog_entry_prefix
+				%p	insert result of b:changelog_entry_prefix
 				%c	where to position cursor when done
 			The default is "%d  %u\n\n\t* %p%c\n\n", which produces
 			something like (| is where cursor will be, unless at
@@ -473,7 +473,7 @@ g:changelog_new_entry_format
 			The format used when creating a new entry.
 			The following table describes special tokens in the
 			string:
-                                %p	insert result of b:changelog_entry_prefix
+				%p	insert result of b:changelog_entry_prefix
 				%c	where to position cursor when done
 			The default is "\t*%c", which produces something
 			similar to >

--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -172,7 +172,7 @@ GNAT OBJECT ~
 							       *g:gnat.Make()*
 g:gnat.Make()
 		Calls |g:gnat.Make_Command| and displays the result inside a
-               |quickfix| window.
+		|quickfix| window.
 
 							     *g:gnat.Pretty()*
 g:gnat.Pretty()

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -375,7 +375,7 @@ This command breaks down as: >
     'sqlKeyword'	   - Display the items for the sqlKeyword highlight
 			     group
     'sqlKeyword\w*'	   - A second option available with Vim 7.4 which
-                             uses a regular expression to determine which
+			     uses a regular expression to determine which
 			     syntax groups to use
     )<CR>		   - Execute the :let command
     <C-X><C-O>		   - Trigger the standard omni completion key stroke.

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -345,8 +345,8 @@ Other commands ~
  *:Asm*	     jump to the window with the disassembly, create it if there
 	     isn't one
  *:Var*	     jump to the window with the local and argument variables,
-             create it if there isn't one. This window updates whenever the
-             program is stopped
+	     create it if there isn't one. This window updates whenever the
+	     program is stopped
 
 Events ~
 							*termdebug-events*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -303,14 +303,14 @@ created, thus they behave slightly differently:
 			shown (but that might change in the future).
 
 :se[t] {option}<	Set the effective value of {option} to its global
-                        value.
+			value.
 			For string |global-local| options, the local value is
 			removed, so that the global value will be used.
 			For all other options, the global value is copied to
 			the local value.
 
 :setl[ocal] {option}<	Set the effective value of {option} to its global
-                        value.
+			value.
 			For number and boolean |global-local| options, the
 			local value is removed, so that the global value will
 			be used.

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -639,7 +639,7 @@ additional prompting.
 	work with your ftp client.  Otherwise the script will
 	prompt for user-id and password.
 
-        (*3) for ftp, "machine" may be machine#port or machine:port
+	(*3) for ftp, "machine" may be machine#port or machine:port
 	if a different port is needed than the standard ftp port
 
 	(*4) for http:..., if wget is available it will be used.  Otherwise,
@@ -785,7 +785,7 @@ below, a {netfile} is a URL to a remote file.
 		(related: |netrw-userpass|)
 
 :NetrwSettings  This command is described in |netrw-settings| -- used to
-                display netrw settings and change netrw behavior.
+		display netrw settings and change netrw behavior.
 
 
 ==============================================================================

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -368,12 +368,12 @@ processing a quickfix or location list command, it will be aborted.
 :cl[ist]! +{count}	List the current and next {count} error lines.  This
 			is useful to see unrecognized lines after the current
 			one.  For example, if ":clist" shows:
-        8384 testje.java:252: error: cannot find symbol ~
+	8384 testje.java:252: error: cannot find symbol ~
 			Then using ":cl! +3" shows the reason:
-        8384 testje.java:252: error: cannot find symbol ~
-        8385:   ZexitCode = Fmainx(); ~
-        8386:               ^ ~
-        8387:   symbol:   method Fmainx() ~
+	8384 testje.java:252: error: cannot find symbol ~
+	8385:   ZexitCode = Fmainx(); ~
+	8386:               ^ ~
+	8387:   symbol:   method Fmainx() ~
 
 :lli[st] [from] [, [to]]				*:lli* *:llist*
 			Same as ":clist", except the location list for the


### PR DESCRIPTION
#### vim-patch:partial:d086b8f646a6

runtime(doc): fix inconsistent indent (vim/vim#14089)

https://github.com/vim/vim/commit/d086b8f646a67f6b16c46061ce773de1011b8ec7