### PR TITLE
docs: fix options type of setreg

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8172,7 +8172,7 @@ function vim.fn.setqflist(list, action, what) end
 ---
 --- @param regname string
 --- @param value any
---- @param options? table
+--- @param options? string
 --- @return any
 function vim.fn.setreg(regname, value, options) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9756,7 +9756,7 @@ M.funcs = {
 
     ]=],
     name = 'setreg',
-    params = { { 'regname', 'string' }, { 'value', 'any' }, { 'options', 'table' } },
+    params = { { 'regname', 'string' }, { 'value', 'any' }, { 'options', 'string' } },
     signature = 'setreg({regname}, {value} [, {options}])',
   },
   settabvar = {


### PR DESCRIPTION
Fixes #27619 

I might be wrong here since my C knowledge is quite rusty, but it seems like `options` is always expected to be a string based on [this bit of the implementation](https://github.com/MariaSolOs/neovim/blob/c860cce8c5228999893550a256599640737ffe27/src/nvim/eval/funcs.c#L7964).