### PR TITLE
fix(lsp): correct the error message's cmd on spawning

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -821,7 +821,8 @@ function M.start(cmd, dispatchers, extra_spawn_params)
     else
       sfx = string.format(' with error message: %s', err)
     end
-    local msg = string.format('Spawning language server with cmd: `%s` failed%s', cmd, sfx)
+    local msg =
+      string.format('Spawning language server with cmd: `%s` failed%s', vim.inspect(cmd), sfx)
     vim.notify(msg, vim.log.levels.WARN)
     return nil
   end


### PR DESCRIPTION
This PR fixes to show cmd as string in error message.

📝 actual error message
```
Spawning language server with cmd: `table: 0x7fbe28326188` failed. The language server is either not installed, missing from PATH, or not executable.
```
