### PR TITLE
vim-patch:9.1.0137: <Del> in cmdline mode doesn't delete composing chars

### DIFF
--- a/runtime/doc/dev_vimpatch.txt
+++ b/runtime/doc/dev_vimpatch.txt
@@ -204,7 +204,6 @@ information.
   mb_ptr2char                                          utf_ptr2char
   mb_head_off                                          utf_head_off
   mb_tail_off                                          utf_cp_bounds
-  mb_off_next                                          utf_cp_bounds
   mb_lefthalve                                        grid_lefthalve
   mb_fix_col                                           grid_fix_col
   utf_off2cells                                       grid_off2cells

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1510,10 +1510,8 @@ static int command_line_erase_chars(CommandLineState *s)
   if (s->c == K_DEL && ccline.cmdpos != ccline.cmdlen) {
     ccline.cmdpos++;
   }
-
   if (s->c == K_DEL) {
-    CharBoundsOff bounds = utf_cp_bounds(ccline.cmdbuff, ccline.cmdbuff + ccline.cmdpos);
-    ccline.cmdpos += bounds.begin_off != 0 ? bounds.end_off : 0;
+    ccline.cmdpos += mb_off_next(ccline.cmdbuff, ccline.cmdbuff + ccline.cmdpos);
   }
 
   if (ccline.cmdpos > 0) {

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1884,6 +1884,20 @@ void mb_copy_char(const char **const fp, char **const tp)
   *fp += l;
 }
 
+/// Return the offset from "p" to the first byte of a character.  When "p" is
+/// at the start of a character 0 is returned, otherwise the offset to the next
+/// character.  Can start anywhere in a stream of bytes.
+int mb_off_next(const char *base, const char *p)
+{
+  int head_off = utf_head_off(base, p);
+
+  if (head_off == 0) {
+    return 0;
+  }
+
+  return utfc_ptr2len(p - head_off) - head_off;
+}
+
 /// Returns the offset in bytes from "p_in" to the first and one-past-end bytes
 /// of the codepoint it points to.
 /// "p_in" can point anywhere in a stream of bytes.

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -864,10 +864,28 @@ func Test_cmdline_remove_char()
   let &encoding = encoding_save
 endfunc
 
-func Test_cmdline_keymap_ctrl_hat()
-  if !has('keymap')
-    return
+func Test_cmdline_del_utf8()
+  let @s = '⒌'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  let @s = 'a̳'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  let @s = 'β̳'
+  call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+  call assert_equal('",,', @:)
+
+  if has('arabic')
+    let @s = 'لا'
+    call feedkeys(":\"\<C-R>s,,\<C-B>\<Right>\<Del>\<CR>", 'tx')
+    call assert_equal('",,', @:)
   endif
+endfunc
+
+func Test_cmdline_keymap_ctrl_hat()
+  CheckFeature keymap
 
   set keymap=esperanto
   call feedkeys(":\"Jxauxdo \<C-^>Jxauxdo \<C-^>Jxauxdo\<CR>", 'tx')


### PR DESCRIPTION
#### vim-patch:9.1.0137: \<Del> in cmdline mode doesn't delete composing chars

Problem:  \<Del> in cmdline mode doesn't delete composing chars
Solution: Use mb_head_off() and mb_ptr2len() (zeertzjq)

closes: vim/vim#14095

https://github.com/vim/vim/commit/ff2b79d23956263ab0120623c37e0b4498be01db