### PR TITLE
fix(lua): remove uri fragment from file paths

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -104,6 +104,10 @@ function M.uri_to_fname(uri)
   if scheme ~= 'file' then
     return uri
   end
+  local fragment_index = uri:find('#')
+  if fragment_index ~= nil then
+    uri = uri:sub(1, fragment_index - 1)
+  end
   uri = M.uri_decode(uri)
   --TODO improve this.
   if is_windows_file_uri(uri) then

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -88,6 +88,12 @@ describe('URI methods', function()
 
         eq('/xy/åäö/ɧ/汉语/↥/🤦/🦄/å/بِيَّ.txt', exec_lua(test_case))
       end)
+
+      it('file path with uri fragment', function()
+        exec_lua("uri = 'file:///Foo/Bar/Baz.txt#fragment'")
+
+        eq('/Foo/Bar/Baz.txt', exec_lua('return vim.uri_to_fname(uri)'))
+      end)
     end)
 
     describe('decode Windows filepath', function()
@@ -181,6 +187,15 @@ describe('URI methods', function()
           false,
           exec_lua [[
           return pcall(vim.uri_to_fname, 'foo,://bar')
+        ]]
+        )
+      end)
+
+      it('uri_to_fname returns non-file schema URI with fragment unchanged', function()
+        eq(
+          'scheme://path#fragment',
+          exec_lua [[
+          return vim.uri_to_fname('scheme://path#fragment')
         ]]
         )
       end)


### PR DESCRIPTION
### Context

Some LSP servers return `textDocument/documentLink` responses containing file URIs with line/column numbers in the fragment.

Example:

```
file:///home/icholy/src/github.com/teamdigitale/api-openapi-samples/openapi-v3/petstore.yml#737,7
```

### Problem:

Feeding this URI into `uri_to_fname` returns an invalid file name:

``` lua
vim.uri_to_fname("file:///home/icholy/src/github.com/teamdigitale/api-openapi-samples/openapi-v3/petstore.yml#737,7")

--- output: "/home/icholy/src/github.com/teamdigitale/api-openapi-samples/openapi-v3/petstore.yml#737,7"
```

I hit this problem here: https://github.com/icholy/lsplinks.nvim/blob/6ec8f63789a356ddd85d94ddc00078207006b26e/lua/lsplinks.lua#L106

### Solution:

Remove the fragment.