### PR TITLE
vim-patch:e84d2d4432cd

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Enno Nagel <ennonagel+vim@gmail.com>
 "			Eisuke Kawashima
-" Last Change:		2024 Jan 14
+" Last Change:		2024 Feb 27
 
 if exists("b:did_ftplugin")
   finish
@@ -14,7 +14,7 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo-=C
 
-setlocal comments=:#
+setlocal comments=b:#
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t formatoptions+=croql
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -174,7 +174,7 @@ assign_commit_details() {
 
   vim_commit_url="https://github.com/vim/vim/commit/${vim_commit}"
   vim_message="$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty='format:%B' "${vim_commit}" \
-      | sed -Ee 's/(\W)(#[0-9]{1,})/\1vim\/vim\2/g')"
+      | sed -Ee 's/([^A-Za-z0-9])(#[0-9]{1,})/\1vim\/vim\2/g')"
   local vim_coauthor0
   vim_coauthor0="$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty='format:Co-authored-by: %an <%ae>' "${vim_commit}")"
   # Extract co-authors from the commit message.


### PR DESCRIPTION
runtime(sh): Update ftplugin, fix vim/vim#14101 (vim/vim#14102)

Add the 'b' flag to 'comments', so that the shebang line is not detected as comment.

https://github.com/vim/vim/commit/e84d2d4432cd6e43f2bb300d02abc90d551bcf4a

Co-authored-by: dkearns <dougkearns@gmail.com>