### PR TITLE
vim-patch:9.1.0140: cursor on wrong row after 1 char 'below' virtual text when EOL is shown

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -136,8 +136,10 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
   int is_doublewidth = false;
   if (use_tabstop) {
     size = tabstop_padding(vcol, buf->b_p_ts, buf->b_p_vts_array);
-  } else if (*cur == NUL && !has_lcs_eol) {
-    size = 0;
+  } else if (*cur == NUL) {
+    // 1 cell for EOL list char (if present), as opposed to the two cell ^@
+    // for a NUL character in the text.
+    size = has_lcs_eol ? 1 : 0;
   } else if (cur_char < 0) {
     size = kInvalidByteCells;
   } else {


### PR DESCRIPTION
#### vim-patch:9.1.0140: cursor on wrong row after 1 char 'below' virtual text when EOL is shown

Problem:  The cursor screen row was incorrectly being calculated when the
          cursor follows a 1 character text_align 'below' virtual text line,
          resulting in the cursor being shown on the wrong line.
          This was caused by a cell size of 2 instead of 1 being used for the EOL
          character, which propagated to the calculation of space for putting the
          'below' virtual text on its own line. (rickhowe)
Solution: Fix the size used for the EOL character in calculating the
          cursor's screen position (Dylan Thacker-Smith)

related: vim/vim#12028
closes: vim/vim#14096

https://github.com/vim/vim/commit/da0c9137d1ec96f4d79b818502d2f921a21f710e

Co-authored-by: Dylan Thacker-Smith <dylan.ah.smith@gmail.com>