### PR TITLE
fix(tohtml): set filetype of generated HTML to `html`

### DIFF
--- a/runtime/plugin/tohtml.lua
+++ b/runtime/plugin/tohtml.lua
@@ -8,4 +8,5 @@ vim.api.nvim_create_user_command('TOhtml', function(args)
   local html = require('tohtml').tohtml()
   vim.fn.writefile(html, outfile)
   vim.cmd.split(outfile)
+  vim.bo.filetype = 'html'
 end, { bar = true, nargs = '?' })


### PR DESCRIPTION
Problem: `:TOhtml` opens the generated HTML code in a split, meaning it
inherits the `help` filetype if a help buffer is to be converted.

Solution: Explicitly set the filetype to `html`.

Fixup for #27097
