### PR TITLE
fix(terminal): disable reflow again

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -179,10 +179,6 @@ The following new APIs and features were added.
 • |'foldtext'| can be set to an empty string to disable and render the line:
   as normal with regular highlighting and no line wrapping.
 
-• The terminal buffer now supports reflow (wrapped lines adapt when the buffer
-  is resized horizontally). Note: Lines that are not visible and kept in
-  |'scrollback'| are not reflown.
-
 • |vim.system()| for running system commands.
 
 • |vim.lpeg| and |vim.re| expose the bundled Lpeg expression grammar parser

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4953,9 +4953,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Minimum is 1, maximum is 100000.
 	Only in |terminal| buffers.
 
-	Note: Lines that are not visible and kept in scrollback are not
-	reflown when the terminal buffer is resized horizontally.
-
 			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
 'scrollbind' 'scb'	boolean	(default off)
 			local to window

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5195,9 +5195,6 @@ vim.wo.scr = vim.wo.scroll
 --- Minimum is 1, maximum is 100000.
 --- Only in `terminal` buffers.
 ---
---- Note: Lines that are not visible and kept in scrollback are not
---- reflown when the terminal buffer is resized horizontally.
----
 --- @type integer
 vim.o.scrollback = -1
 vim.o.scbk = vim.o.scrollback

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -30,6 +30,10 @@
 //  changed (lines appended/deleted/changed) or when it is flushed it gets a
 //  positive number. Use mf_trans_del() to get the new number, before calling
 //  mf_get().
+//
+// "Mom, can we get ropes?"
+// "We have ropes at home."
+// Ropes at home:
 
 #include <assert.h>
 #include <errno.h>

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6573,9 +6573,6 @@ return {
         top are deleted if new lines exceed this limit.
         Minimum is 1, maximum is 100000.
         Only in |terminal| buffers.
-
-        Note: Lines that are not visible and kept in scrollback are not
-        reflown when the terminal buffer is resized horizontally.
       ]=],
       full_name = 'scrollback',
       redraw = { 'current_buffer' },

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -307,7 +307,8 @@ void terminal_open(Terminal **termpp, buf_T *buf, TerminalOptions opts)
   // Set up screen
   term->vts = vterm_obtain_screen(term->vt);
   vterm_screen_enable_altscreen(term->vts, true);
-  vterm_screen_enable_reflow(term->vts, true);
+  // TODO(clason): reenable when https://github.com/neovim/neovim/issues/23762 is fixed
+  // vterm_screen_enable_reflow(term->vts, true);
   // delete empty lines at the end of the buffer
   vterm_screen_set_callbacks(term->vts, &vterm_screen_callbacks, term);
   vterm_screen_set_unrecognised_fallbacks(term->vts, &vterm_fallbacks, term);

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -35,6 +35,7 @@ describe(':terminal window', function()
 
   describe("with 'number'", function()
     it('wraps text', function()
+      skip(is_os('win')) -- todo(clason): unskip when reenabling reflow
       feed([[<C-\><C-N>]])
       feed([[:set numberwidth=1 number<CR>i]])
       screen:expect([[
@@ -64,7 +65,7 @@ describe(':terminal window', function()
         {7:       1 }tty ready                                |
         {7:       2 }rows: 6, cols: 48                        |
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
-        {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
+        {7:       4 }WXYZrows: 6, cols: 41                    |
         {7:       5 }{1: }                                        |
         {7:       6 }                                         |
         {3:-- TERMINAL --}                                    |
@@ -74,7 +75,7 @@ describe(':terminal window', function()
         {7:       1 }tty ready                                |
         {7:       2 }rows: 6, cols: 48                        |
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
-        {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
+        {7:       4 }WXYZrows: 6, cols: 41                    |
         {7:       5 } abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN|
         {7:       6 }OPQRSTUVWXYZ{1: }                            |
         {3:-- TERMINAL --}                                    |
@@ -84,6 +85,7 @@ describe(':terminal window', function()
 
   describe("with 'statuscolumn'", function()
     it('wraps text', function()
+      skip(is_os('win')) -- todo(clason): unskip when reenabling reflow
       command([[set number statuscolumn=++%l\ \ ]])
       screen:expect([[
         {7:++1  }tty ready                                    |
@@ -108,9 +110,9 @@ describe(':terminal window', function()
       screen:expect([[
         {7:++7   }                                            |
         {7:++8   }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
-        {7:++9   }STUVWXYZ                                    |
+        {7:++9   }TUVWXYZ                                     |
         {7:++10  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
-        {7:++11  }STUVWXYZrows: 6, cols: 44                   |
+        {7:++11  }TUVWXYZrows: 6, cols: 44                    |
         {7:++12  }{1: }                                           |
         {3:-- TERMINAL --}                                    |
       ]])


### PR DESCRIPTION
reverts https://github.com/neovim/neovim/commit/c855eee919f2d4edc9b9fa91b277454290fbabfe

This setting introduces constant CI failures on macos (see https://github.com/neovim/neovim/issues/23762). It's also of limited use while our scrollback buffer doesn't support reflow as well.