### PR TITLE
test: silence expected errors

### DIFF
--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -35,7 +35,7 @@ static kvec_t(DecorProvider) decor_providers = KV_INITIAL_VALUE;
 static void decor_provider_error(DecorProvider *provider, const char *name, const char *msg)
 {
   const char *ns_name = describe_ns(provider->ns_id, "(UNKNOWN PLUGIN)");
-  ELOG("error in provider %s.%s: %s", ns_name, name, msg);
+  ILOG("error in provider %s.%s: %s", ns_name, name, msg);
   msg_schedule_semsg_multiline("Error in decoration provider %s.%s:\n%s", ns_name, name, msg);
 }
 

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -90,7 +90,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   int status;
   if ((status = uv_spawn(&proc->loop->uv, &uvproc->uv, &uvproc->uvopts))) {
-    ELOG("uv_spawn(%s) failed: %s", uvproc->uvopts.file, uv_strerror(status));
+    DLOG("uv_spawn(%s) failed: %s", uvproc->uvopts.file, uv_strerror(status));
     if (uvproc->uvopts.env) {
       os_free_fullenv(uvproc->uvopts.env);
     }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -339,7 +339,7 @@ static void parse_msgpack(Channel *channel)
   }
 
   if (unpacker_closed(p)) {
-    chan_close_with_error(channel, p->unpack_error.msg, LOGLVL_ERR);
+    chan_close_with_error(channel, p->unpack_error.msg, LOGLVL_INF);
     api_clear_error(&p->unpack_error);
   }
 }

--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -7,9 +7,17 @@ local api = helpers.api
 local fn = helpers.fn
 local exec = helpers.exec
 local feed = helpers.feed
+local assert_log = helpers.assert_log
+local is_os = helpers.is_os
+
+local testlog = 'Xtest_autocmd_oldtest_log'
 
 describe('oldtests', function()
   before_each(clear)
+
+  after_each(function()
+    os.remove(testlog)
+  end)
 
   local exec_lines = function(str)
     return fn.split(fn.execute(str), '\n')
@@ -49,6 +57,7 @@ describe('oldtests', function()
   end)
 
   it('should fire on unload buf', function()
+    clear({ env = { NVIM_LOG_FILE = testlog } })
     fn.writefile({ 'Test file Xxx1' }, 'Xxx1')
     fn.writefile({ 'Test file Xxx2' }, 'Xxx2')
     local fname = 'Xtest_functional_autocmd_unload'
@@ -81,6 +90,10 @@ describe('oldtests', function()
     fn.delete('Xxx2')
     fn.delete(fname)
     fn.delete('Xout')
+
+    if is_os('win') then
+      assert_log('stream write failed. RPC canceled; closing channel', testlog)
+    end
   end)
 
   -- oldtest: Test_delete_ml_get_errors()

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -865,6 +865,10 @@ describe('XDG defaults', function()
 end)
 
 describe('stdpath()', function()
+  after_each(function()
+    os.remove(testlog)
+  end)
+
   -- Windows appends 'nvim-data' instead of just 'nvim' to prevent collisions
   -- due to XDG_CONFIG_HOME, XDG_DATA_HOME and XDG_STATE_HOME being the same.
   local function maybe_data(name)
@@ -890,7 +894,7 @@ describe('stdpath()', function()
 
   it('reacts to $NVIM_APPNAME', function()
     local appname = 'NVIM_APPNAME_TEST' .. ('_'):rep(106)
-    clear({ env = { NVIM_APPNAME = appname } })
+    clear({ env = { NVIM_APPNAME = appname, NVIM_LOG_FILE = testlog } })
     eq(appname, fn.fnamemodify(fn.stdpath('config'), ':t'))
     eq(appname, fn.fnamemodify(fn.stdpath('cache'), ':t'))
     eq(maybe_data(appname), fn.fnamemodify(fn.stdpath('log'), ':t'))
@@ -928,6 +932,9 @@ describe('stdpath()', function()
     -- Valid appnames:
     test_appname('a/b', 0)
     test_appname('a/b\\c', 0)
+    if not is_os('win') then
+      assert_log('Failed to start server: no such file or directory:', testlog)
+    end
   end)
 
   describe('returns a String', function()


### PR DESCRIPTION
This will remove unrelated errors in .nvimlog at the end of test output.