### PR TITLE
vim-patch:9.1.0141: Put in Visual mode wrong if it replaces fold marker

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6446,6 +6446,7 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
   bool was_visual = false;
   int dir;
   int flags = 0;
+  const int save_fen = curwin->w_p_fen;
 
   if (cap->oap->op_type != OP_NOP) {
     // "dp" is ":diffput"
@@ -6495,6 +6496,10 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
       // The delete might overwrite the register we want to put, save it first
       savereg = copy_register(regname);
     }
+
+    // Temporarily disable folding, as deleting a fold marker may cause
+    // the cursor to be included in a fold.
+    curwin->w_p_fen = false;
 
     // To place the cursor correctly after a blockwise put, and to leave the
     // text in the correct position when putting over a selection with
@@ -6546,9 +6551,12 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
     xfree(savereg);
   }
 
-  // What to reselect with "gv"?  Selecting the just put text seems to
-  // be the most useful, since the original text was removed.
   if (was_visual) {
+    if (save_fen) {
+      curwin->w_p_fen = true;
+    }
+    // What to reselect with "gv"?  Selecting the just put text seems to
+    // be the most useful, since the original text was removed.
     curbuf->b_visual.vi_start = curbuf->b_op_start;
     curbuf->b_visual.vi_end = curbuf->b_op_end;
     // need to adjust cursor position

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -294,5 +294,33 @@ func Test_put_in_last_displayed_line()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_put_visual_replace_whole_fold()
+  new
+  let lines = repeat(['{{{1', 'foo', 'bar', ''], 2)
+  call setline(1, lines)
+  setlocal foldmethod=marker
+  call setreg('"', 'baz')
+  call setreg('1', '')
+  normal! Vp
+  call assert_equal("{{{1\nfoo\nbar\n\n", getreg('1'))
+  call assert_equal(['baz', '{{{1', 'foo', 'bar', ''], getline(1, '$'))
+
+  bwipe!
+endfunc
+
+func Test_put_visual_replace_fold_marker()
+  new
+  let lines = repeat(['{{{1', 'foo', 'bar', ''], 4)
+  call setline(1, lines)
+  setlocal foldmethod=marker
+  normal! Gkzo
+  call setreg('"', '{{{1')
+  call setreg('1', '')
+  normal! Vp
+  call assert_equal("{{{1\n", getreg('1'))
+  call assert_equal(lines, getline(1, '$'))
+
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0141: Put in Visual mode wrong if it replaces fold marker

Problem:  Put in Visual mode wrong if it replaces fold marker.
Solution: Temporarily disable folding during put in Visual mode.
          (zeertzjq)

closes: vim/vim#14100

https://github.com/vim/vim/commit/4e141c66b9104136ddcf9cc240d2fbc83d825a5a