### PR TITLE
vim-patch:9ecf02cd5f5f

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -2,7 +2,7 @@
 " Language:	Java
 " Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " URL:          https://github.com/fleiner/vim/blob/master/runtime/syntax/java.vim
-" Last Change:	2023 Aug 13
+" Last Change:	2024 Feb 27
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -37,9 +37,17 @@ syn keyword javaBoolean		true false
 syn keyword javaConstant	null
 syn keyword javaTypedef		this super
 syn keyword javaOperator	var new instanceof
+" Since the yield statement, which could take a parenthesised operand,
+" and _qualified_ yield methods get along within the switch block
+" (JLS-17, §3.8), it seems futile to make a region definition for this
+" block; instead look for the _yield_ word alone, and if found,
+" backtrack (arbitrarily) 80 bytes, at most, on the matched line and,
+" if necessary, on the line before that (h: \@<=), trying to match
+" neither a method reference nor a qualified method invocation.
+syn match   javaOperator	"\%(\%(::\|\.\)[[:space:]\n]*\)\@80<!\<yield\>"
 syn keyword javaType		boolean char byte short int long float double
 syn keyword javaType		void
-syn keyword javaStatement	return yield
+syn keyword javaStatement	return
 syn keyword javaStorageClass	static synchronized transient volatile final strictfp serializable
 syn keyword javaExceptions	throw try catch finally
 syn keyword javaAssert		assert
@@ -56,6 +64,7 @@ syn keyword javaBranch		break continue nextgroup=javaUserLabelRef skipwhite
 syn match   javaUserLabelRef	"\k\+" contained
 syn match   javaVarArg		"\.\.\."
 syn keyword javaScopeDecl	public protected private abstract
+syn match   javaConceptKind	"\<default\>\%(\s*\%(:\|->\)\)\@!"
 
 function s:isModuleInfoDeclarationCurrentBuffer() abort
     return fnamemodify(bufname("%"), ":t") =~ '^module-info\%(\.class\>\)\@!'
@@ -142,15 +151,30 @@ if exists("java_space_errors")
   endif
 endif
 
-syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaNumber,javaCharacter,javaString
-syn match   javaUserLabel	"^\s*[_$a-zA-Z][_$a-zA-Z0-9_]*\s*:"he=e-1 contains=javaLabel
-syn keyword javaLabel		default
+syn match   javaUserLabel	"^\s*\<\K\k*\>\%(\<default\>\)\@<!\s*:"he=e-1
+syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaLabelCastType,javaLabelNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaLabelDefault,javaLabelVarType,javaLabelWhenClause
+syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<default\>\%(\s*\%(:\|->\)\)\@=" matchgroup=NONE end=":\|->" oneline
+" Consider grouped _default_ _case_ labels, i.e.
+" case null, default ->
+" case null: default:
+syn keyword javaLabelDefault	contained default
+syn keyword javaLabelVarType	contained var
+syn keyword javaLabelCastType	contained char byte short int
+" Allow for the contingency of the enclosing region not being able to
+" _keep_ its _end_, e.g. case ':':.
+syn region  javaLabelWhenClause	contained transparent matchgroup=javaLabel start="\<when\>" matchgroup=NONE end=":"me=e-1 end="->"me=e-2 contains=TOP,javaExternal
+syn match   javaLabelNumber	contained "\<0\>[lL]\@!"
+syn match   javaLabelNumber	contained "\<\%(0\%([xX]\x\%(_*\x\)*\|_*\o\%(_*\o\)*\|[bB][01]\%(_*[01]\)*\)\|[1-9]\%(_*\d\)*\)\>[lL]\@!"
+hi def link javaLabelDefault	javaLabel
+hi def link javaLabelVarType	javaOperator
+hi def link javaLabelNumber	javaNumber
+hi def link javaLabelCastType	javaType
 
 " highlighting C++ keywords as errors removed, too many people find it
 " annoying.  Was: if !exists("java_allow_cpp_keywords")
 
 " The following cluster contains all java groups except the contained ones
-syn cluster javaTop add=javaExternal,javaError,javaBranch,javaLabelRegion,javaLabel,javaConditional,javaRepeat,javaBoolean,javaConstant,javaTypedef,javaOperator,javaType,javaStatement,javaStorageClass,javaAssert,javaExceptions,javaMethodDecl,javaClassDecl,javaScopeDecl,javaError2,javaUserLabel,javaLangObject,javaAnnotation,javaVarArg
+syn cluster javaTop add=javaExternal,javaError,javaBranch,javaLabelRegion,javaConditional,javaRepeat,javaBoolean,javaConstant,javaTypedef,javaOperator,javaType,javaStatement,javaStorageClass,javaAssert,javaExceptions,javaMethodDecl,javaClassDecl,javaScopeDecl,javaConceptKind,javaError2,javaUserLabel,javaLangObject,javaAnnotation,javaVarArg
 
 
 " Comments
@@ -231,9 +255,9 @@ if exists("java_highlight_functions")
     "	1. class names are always capitalized (ie: Button)
     "	2. method names are never capitalized (except constructors, of course)
     "syn region javaFuncDef start=+^\s\+\(\(public\|protected\|private\|static\|abstract\|final\|native\|synchronized\)\s\+\)*\(\(void\|boolean\|char\|byte\|short\|int\|long\|float\|double\|\([A-Za-z_][A-Za-z0-9_$]*\.\)*[A-Z][A-Za-z0-9_$]*\)\(<[^>]*>\)\=\(\[\]\)*\s\+[a-z][A-Za-z0-9_$]*\|[A-Z][A-Za-z0-9_$]*\)\s*([^0-9]+ end=+)+ contains=javaScopeDecl,javaType,javaStorageClass,javaComment,javaLineComment,@javaClasses
-    syn region javaFuncDef start=+^\s\+\(\(public\|protected\|private\|static\|abstract\|final\|native\|synchronized\)\s\+\)*\(<.*>\s\+\)\?\(\(void\|boolean\|char\|byte\|short\|int\|long\|float\|double\|\([A-Za-z_][A-Za-z0-9_$]*\.\)*[A-Z][A-Za-z0-9_$]*\)\(<[^(){}]*>\)\=\(\[\]\)*\s\+[a-z][A-Za-z0-9_$]*\|[A-Z][A-Za-z0-9_$]*\)\s*(+ end=+)+ contains=javaScopeDecl,javaType,javaStorageClass,javaComment,javaLineComment,@javaClasses,javaAnnotation
+    syn region javaFuncDef start=+^\s\+\%(\%(public\|protected\|private\|static\|\%(abstract\|default\)\|final\|native\|synchronized\)\s\+\)*\%(<.*>\s\+\)\?\%(\%(void\|boolean\|char\|byte\|short\|int\|long\|float\|double\|\%([A-Za-z_][A-Za-z0-9_$]*\.\)*[A-Z][A-Za-z0-9_$]*\)\%(<[^(){}]*>\)\=\%(\[\]\)*\s\+[a-z][A-Za-z0-9_$]*\|[A-Z][A-Za-z0-9_$]*\)\s*(+ end=+)+ contains=javaScopeDecl,javaType,javaStorageClass,javaComment,javaLineComment,@javaClasses,javaAnnotation
   endif
-  syn match javaLambdaDef "[a-zA-Z_][a-zA-Z0-9_]*\s*->"
+  syn match   javaLambdaDef "\<\K\k*\>\%(\<default\>\)\@<!\s*->"
   syn match  javaBraces  "[{}]"
   syn cluster javaTop add=javaFuncDef,javaBraces,javaLambdaDef
 endif
@@ -326,6 +350,7 @@ hi def link javaStorageClass		StorageClass
 hi def link javaMethodDecl		javaStorageClass
 hi def link javaClassDecl		javaStorageClass
 hi def link javaScopeDecl		javaStorageClass
+hi def link javaConceptKind		NonText
 
 hi def link javaBoolean		Boolean
 hi def link javaSpecial		Special


### PR DESCRIPTION
runtime(java): Recognise _when_ clauses in _switch_ blocks

Also:

- distinguish _yield_ when used as a contextual keyword from
  when used qualified as a method or a method reference (as
  can be seen in testdir/input/java_switch.java, variables
  and method declarations named _yield_ will be recognised
  as the namesake keyword--consider picking other names for
  variables, and defining g:java_highlight_functions to have
  method names painted; since _yield_ statements can have
  trailing parens, they must be recognised as statements,
  for only qualified _yield_ method calls are supported);

- recognise grouped _default_ _case_ labels;

- describe primitive types for _case_ labels (JLS, §14.11,
  §3.10.1);

- recognise some non-ASCII identifiers (see javaLambdaDef,
  javaUserLabel) (further improvement for better recognition
  of identifiers will be arranged in a separate PR).

Because the arrow '->' is used in two kinds of expressions,
lambda (abstractions) and _switch_, necessary changes were
made for the recognition of either (and further improvement
touching lambda expressions will be separately arranged).

Because 'default' is used for instance method declarations
in interfaces and in _switch_ labels, necessary changes were
made for the recognition of either (and further improvement
touching method declarations will be separately arranged).

Finally, it deemed appropriate to put 'yield' in the syntax
group of javaOperator rather than javaStatement, for its
member 'var' is also another contextual keyword (e.g., this
is valid syntax: "var var = var(test.var);").

References:
https://openjdk.org/jeps/361 (Switch Expressions)
https://openjdk.org/jeps/440 (Record Patterns)
https://openjdk.org/jeps/441 (Pattern Matching for switch)

Also, add a Java specific filetype plugin for the syntax
test, so that no soft-wrapping of long indented lines occur.

Otherwise the syntax scripts would miss a few lines during
scrolling and verification of the screen dumps.

closes: vim/vim#14105

https://github.com/vim/vim/commit/9ecf02cd5f5feabe096f66cd5f503a822c78793f

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>