### PR TITLE
docs(eval): getline and indent function support string type

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3185,7 +3185,7 @@ function vim.fn.getjumplist(winnr, tabnr) end
 --- <To get lines from another buffer see |getbufline()| and
 --- |getbufoneline()|
 ---
---- @param lnum integer
+--- @param lnum integer|string
 --- @param end_? nil|false
 --- @return string
 function vim.fn.getline(lnum, end_) end
@@ -4246,7 +4246,7 @@ function vim.fn.id(expr) end
 --- |getline()|.
 --- When {lnum} is invalid -1 is returned.
 ---
---- @param lnum integer
+--- @param lnum integer|string
 --- @return integer
 function vim.fn.indent(lnum) end
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3973,7 +3973,7 @@ M.funcs = {
       |getbufoneline()|
     ]=],
     name = 'getline',
-    params = { { 'lnum', 'integer' }, { 'end', 'nil|false' } },
+    params = { { 'lnum', 'integer|string' }, { 'end', 'nil|false' } },
     signature = 'getline({lnum} [, {end}])',
     returns = 'string',
   },
@@ -5220,7 +5220,7 @@ M.funcs = {
 
     ]=],
     name = 'indent',
-    params = { { 'lnum', 'integer' } },
+    params = { { 'lnum', 'integer|string' } },
     returns = 'integer',
     signature = 'indent({lnum})',
   },


### PR DESCRIPTION
Problem: getline and indent function missing string type in param.

Solution: add string type in eval gen.

if there has doc typo collection can migrate to it.