### PR TITLE
vim-patch:56b7da3c051f

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -6,7 +6,8 @@
 " Last Change:
 " 	2023 Nov 21 by Vim Project: ignore wildignore when expanding $COMSPEC	(v173a)
 " 	2023 Nov 22 by Vim Project: fix handling of very long filename on longlist style	(v173a)
-"   2024 Feb 19 by Vim Project (announce adoption)
+"   2024 Feb 19 by Vim Project: (announce adoption)
+"   2024 Feb 29 by Vim Project: handle symlinks in tree mode correctly
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -9376,7 +9376,7 @@ fun! s:NetrwTreeDir(islocal)
 "    call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
    elseif curline =~ '@$'
 "    call Decho("handle symbolic link from current line",'~'.expand("<slnum>"))
-    let treedir= resolve(substitute(substitute(getline('.'),'@.*$','','e'),'^|*\s*','','e'))
+    let potentialdir= resolve(substitute(substitute(getline('.'),'@.*$','','e'),'^|*\s*','','e'))
 "    call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
    else
 "    call Decho("do not extract tree subdirectory from current line and set treedir to empty",'~'.expand("<slnum>"))
@@ -9401,7 +9401,6 @@ fun! s:NetrwTreeDir(islocal)
 "  call Decho("COMBAK#23 : mod=".&mod." win#".winnr())
 
 "   call Decho("islocal=".a:islocal." curline<".curline.">",'~'.expand("<slnum>"))
-   let potentialdir= s:NetrwFile(substitute(curline,'^'.s:treedepthstring.'\+ \(.*\)@$','\1',''))
 "   call Decho("potentialdir<".potentialdir."> isdir=".isdirectory(potentialdir),'~'.expand("<slnum>"))
 "  call Decho("COMBAK#24 : mod=".&mod." win#".winnr())
 
@@ -9414,8 +9413,15 @@ fun! s:NetrwTreeDir(islocal)
 " "   call Decho("newdir <".newdir.">",'~'.expand("<slnum>"))
 "   else
 "    call Decho("apply NetrwTreePath to treetop<".w:netrw_treetop.">",'~'.expand("<slnum>"))
-    let treedir = s:NetrwTreePath(w:netrw_treetop)
-"   endif
+    if a:islocal && curline =~ '@$'
+      if isdirectory(s:NetrwFile(potentialdir))
+        let treedir = w:netrw_treetop.'/'.potentialdir.'/'
+        let w:netrw_treetop = treedir
+      endif
+    else
+      let potentialdir= s:NetrwFile(substitute(curline,'^'.s:treedepthstring.'\+ \(.*\)@$','\1',''))
+      let treedir = s:NetrwTreePath(w:netrw_treetop)
+    endif
   endif
 "  call Decho("COMBAK#25 : mod=".&mod." win#".winnr())
 

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1226,5 +1226,11 @@ indent for a continuation line, a line that starts with a backslash: >
 
 Three times shiftwidth is the default value.
 
+YAML							*ft-yaml-indent*
+
+By default, the yaml indent script does not try to detect multiline scalars. 
+If you want to enable this, set the following variable: >
+
+  let g:yaml_indent_multiline_scalar = 1
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1228,7 +1228,7 @@ Three times shiftwidth is the default value.
 
 YAML							*ft-yaml-indent*
 
-By default, the yaml indent script does not try to detect multiline scalars. 
+By default, the yaml indent script does not try to detect multiline scalars.
 If you want to enable this, set the following variable: >
 
   let g:yaml_indent_multiline_scalar = 1

--- a/runtime/indent/yaml.vim
+++ b/runtime/indent/yaml.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Nikolai Pavlov <zyx.vim@gmail.com>
 " Last Updates:	Lukas Reineke, "lacygoill"
 " Last Change:	2022 Jun 17
+"      2024 Feb 29 disable mulitline indent by default (The Vim project)
 
 " Only load this indent file when no other was loaded.
 if exists('b:did_indent')
@@ -138,11 +139,13 @@ function GetYAMLIndent(lnum)
         else
             return indent(prevmapline)
         endif
-    elseif prevline =~# '^\s*- '
+    elseif get(g:, 'yaml_indent_multiline_scalar', 0) &&
+        \  prevline =~# '^\s*- '
         " - List with
         "   multiline scalar
         return previndent+2
-    elseif prevline =~# s:mapkeyregex .. '\v\s*%(%(' .. s:c_ns_tag_property ..
+    elseif get(g:, 'yaml_indent_multiline_scalar', 0) &&
+        \ prevline =~# s:mapkeyregex .. '\v\s*%(%(' .. s:c_ns_tag_property ..
                 \                              '\v|' .. s:c_ns_anchor_property ..
                 \                              '\v|' .. s:block_scalar_header ..
                 \                             '\v)%(\s+|\s*%(\#.*)?$))*'


### PR DESCRIPTION
runtime(netrw): handle file/dir symlinks specifically in tree mode

fixes: vim/vim#2386
related: vim/vim#3609

https://github.com/vim/vim/commit/56b7da3c051fe1a5fd76534998c17b22d83c0899

Co-authored-by: Christian Brabandt <cb@256bit.org>