### PR TITLE
Fix `cmake -G Xcode` for new Xcode build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ if(POLICY CMP0092)
   cmake_policy(SET CMP0092 NEW)
 endif()
 
+# Support generating for new Xcode build system
+if(CMAKE_GENERATOR STREQUAL "Xcode" AND POLICY CMP0114)
+  cmake_policy(SET CMP0114 NEW)
+endif()
+
 project(nvim C)
 
 if(POLICY CMP0135)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -902,6 +902,11 @@ add_custom_target(generated-sources DEPENDS
   ${NVIM_GENERATED_SOURCES}
 )
 
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  add_dependencies(nvim_bin generated-sources)
+  add_dependencies(libnvim generated-sources)
+endif()
+
 set(VIMDOC_FILES
   ${NVIM_RUNTIME_DIR}/doc/api.txt
   ${NVIM_RUNTIME_DIR}/doc/diagnostic.txt
@@ -963,3 +968,7 @@ add_custom_command(
   USES_TERMINAL)
 add_custom_target(lintdoc DEPENDS ${lintdoc_touch})
 add_dependencies(lintdoc nvim)
+
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  add_dependencies(lintdoc doc)
+endif()

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -175,6 +175,10 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
       COMMENT "Updating ${LANGUAGE}.po"
       DEPENDS ${NVIM_POT})
 
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+      add_dependencies(update-po-${LANGUAGE} nvim_translations)
+    endif()
+
     CheckPo(${LANGUAGE})
 
     list(APPEND UPDATE_PO_TARGETS update-po-${LANGUAGE})


### PR DESCRIPTION
According to `BUILD.md`, this is supposed to work, but when I tried I got the following error:

```
CMake Error in src/nvim/CMakeLists.txt:
  The custom command generating

    /Users/kaiizen/Dev/github/kaii-zen/neovim/build/cmake.config/auto/versiondef.h

  is attached to multiple targets:

    nvim_bin
    libnvim
    generated-sources

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

Apparently CMake now defaults to Xcode's new build system; and, until Xcode 15, it was still possible to opt back to the old build system to avoid these errors. Xcode 15, however, no longer supports the old build system.

I managed to appease CMake by adding some `add_dependencies()` to fix the above error and the similar ones that followed and the resulting Xcode project seems to build successfully.

Since I'm not super familiar with CMake or the Neovim build, I kept all changes conditional to only when the Xcode generator is used, to avoid potentially affecting other use cases.