### PR TITLE
vim-patch:9.1.0145: v:echospace not correct when 'showcmdloc' != last

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1178,7 +1178,7 @@ void comp_col(void)
       sc_col = ru_col;
     }
   }
-  if (p_sc) {
+  if (p_sc && *p_sloc == 'l') {
     sc_col += SHOWCMD_COLS;
     if (!p_ru || last_has_status) {         // no need for separating space
       sc_col++;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2100,6 +2100,7 @@ const char *did_set_showbreak(optset_T *args)
 /// The 'showcmdloc' option is changed.
 const char *did_set_showcmdloc(optset_T *args FUNC_ATTR_UNUSED)
 {
+  comp_col();
   return did_set_opt_strings(p_sloc, p_sloc_values, true);
 }
 

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -167,8 +167,12 @@ func Test_echospace()
   call assert_equal(&columns - 12, v:echospace)
   set showcmd ruler
   call assert_equal(&columns - 29, v:echospace)
+  set showcmdloc=statusline
+  call assert_equal(&columns - 19, v:echospace)
+  set showcmdloc=tabline
+  call assert_equal(&columns - 19, v:echospace)
 
-  set ruler& showcmd&
+  set ruler& showcmd& showcmdloc&
 endfunc
 
 func Test_warning_scroll()


### PR DESCRIPTION
#### vim-patch:9.1.0145: v:echospace not correct when 'showcmdloc' != last

Problem:  the amount of available space (v:echospace) on the command
          line is not correct when showcmdloc is drawn into the
          statusline or tabline.
Solution: only add SHOWCMD_COLS to the shown command column when
          'showcmdloc' is set to last (Sam-programs)

closes: vim/vim#14108

https://github.com/vim/vim/commit/062141b1a70cf5364e6983ec901282e0111745c1

Co-authored-by: Sam-programs <130783534+Sam-programs@users.noreply.github.com>