### PR TITLE
fix(lsp): rename undofile when renaming

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -724,6 +724,13 @@ function M.rename(old_fname, new_fname, opts)
   local ok, err = os.rename(old_fname_full, new_fname)
   assert(ok, err)
 
+  local old_undofile = vim.fn.undofile(old_fname_full)
+  if uv.fs_stat(old_undofile) ~= nil then
+    local new_undofile = vim.fn.undofile(new_fname)
+    vim.fn.mkdir(assert(vim.fs.dirname(new_undofile)), 'p')
+    os.rename(old_undofile, new_undofile)
+  end
+
   if vim.fn.isdirectory(new_fname) == 0 then
     local newbuf = vim.fn.bufadd(new_fname)
     if win then


### PR DESCRIPTION
Problem:
After `rename()`, the undo information for the renamed file(s) are lost.

Solution:
Rename the undofile as well.