### PR TITLE
fix(float): allow floating window in cmdline area

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -817,9 +817,10 @@ void ui_ext_win_position(win_T *wp, bool validate)
 
       int comp_row = (int)row - (south ? wp->w_height_outer : 0);
       int comp_col = (int)col - (east ? wp->w_width_outer : 0);
+      int above_ch = wp->w_config.zindex < kZIndexMessages ? (int)p_ch : 0;
       comp_row += grid->comp_row;
       comp_col += grid->comp_col;
-      comp_row = MAX(MIN(comp_row, Rows - wp->w_height_outer - (p_ch > 0 ? 1 : 0)), 0);
+      comp_row = MAX(MIN(comp_row, Rows - wp->w_height_outer - above_ch), 0);
       if (!c.fixed || east) {
         comp_col = MAX(MIN(comp_col, Columns - wp->w_width_outer), 0);
       }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9030,6 +9030,77 @@ describe('float window', function()
         ]])
       end
     end)
+
+    it('correctly placed in or above message area', function()
+      local float_opts = {relative='editor', width=5, height=1, row=100, col=1, border = 'single'}
+      api.nvim_set_option_value('cmdheight', 3, {})
+      command("echo 'cmdline'")
+      local win = api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
+      -- Not hidden behind message area but placed above it.
+      if multigrid then
+        screen:expect{grid=[[
+          ## grid 1
+            [2:----------------------------------------]|*4
+            [3:----------------------------------------]|*3
+          ## grid 2
+                                                    |
+            {0:~                                       }|*3
+          ## grid 3
+            cmdline                                 |
+                                                    |*2
+          ## grid 4
+            {5:┌─────┐}|
+            {5:│}{1:^     }{5:│}|
+            {5:└─────┘}|
+          ]], float_pos={
+            [4] = {1001, "NW", 1, 100, 1, true, 50};
+          }, win_viewport={
+            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+            [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+        }}
+      else
+        screen:expect{grid=[[
+                                                  |
+          {0:~}{5:┌─────┐}{0:                                }|
+          {0:~}{5:│}{1:^     }{5:│}{0:                                }|
+          {0:~}{5:└─────┘}{0:                                }|
+          cmdline                                 |
+                                                  |*2
+        ]]}
+      end
+      -- Not placed above message area and visible on top of it.
+      api.nvim_win_set_config(win, {zindex = 300})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|*4
+          [3:----------------------------------------]|*3
+        ## grid 2
+                                                  |
+          {0:~                                       }|*3
+        ## grid 3
+          cmdline                                 |
+                                                  |*2
+        ## grid 4
+          {5:┌─────┐}|
+          {5:│}{1:^     }{5:│}|
+          {5:└─────┘}|
+        ]], float_pos={
+          [4] = {1001, "NW", 1, 100, 1, true, 300};
+        }, win_viewport={
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+        }}
+      else
+        screen:expect{grid=[[
+                                                  |
+          {0:~                                       }|*3
+          c{5:┌─────┐}                                |
+           {5:│}{1:^     }{5:│}                                |
+           {5:└─────┘}                                |
+        ]]}
+      end
+    end)
   end
 
   describe('with ext_multigrid', function()


### PR DESCRIPTION
Problem:  Floats are arbitrarily positioned at 1 row above screen size.
Solution: Position at 1 row above 'cmdheight', only if window is hidden behind the message area.