### PR TITLE
fix(lsp): defer writing error msgs

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -603,8 +603,16 @@ local wait_result_reason = { [-1] = 'timeout', [-2] = 'interrupted', [-3] = 'err
 ---
 --- @param ... string List to write to the buffer
 local function err_message(...)
-  api.nvim_err_writeln(table.concat(vim.tbl_flatten({ ... })))
-  api.nvim_command('redraw')
+  local message = table.concat(vim.tbl_flatten({ ... }))
+  if vim.in_fast_event() then
+    vim.schedule(function()
+      api.nvim_err_writeln(message)
+      api.nvim_command('redraw')
+    end)
+  else
+    api.nvim_err_writeln(message)
+    api.nvim_command('redraw')
+  end
 end
 
 --- @private


### PR DESCRIPTION
Context:
Nvim catches errors from the user's `on_exit`callback and prints the error message.

Problem:
Printing the error message uses Nvim api functions. But `on_exit` runs in `:h lua-loop-callbacks` where most of `vim.api` is not allowed, so Nvim itself raises error.

Solution:
`vim.schedule()` the error reporting when necessary.