### PR TITLE
fix(lsp): directly rename the existing buffers when renaming

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2068,6 +2068,14 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
 rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Rename old_fname to new_fname
 
+    Existing buffers are renamed as well, while maintaining their bufnr.
+
+    It deletes existing buffers that conflict with the renamed file name only
+    when
+    • `opts` requests overwriting; or
+    • the conflicting buffers are not loaded, so that deleting thme does not
+      result in data loss.
+
     Parameters: ~
       • {old_fname}  (`string`)
       • {new_fname}  (`string`)


### PR DESCRIPTION
Problem:
`vim.lsp.util.rename()` deletes the buffers that are affected by renaming. This has undesireable side effects. For example, when renaming a directory, all buffers under that directory are deleted and windows displaying those buffers are closed. Also, buffer options may change after renaming.

Solution:
Rename the buffers with :saveas.

An alternative approach is to record all the relevant states and restore it after renaming, but that seems to be more complex. In fact, the older version was attempting to restore the states but only partially and incorrectly.