### PR TITLE
fix(lua): update nvim_win_get_config return type

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2118,7 +2118,7 @@ function vim.api.nvim_win_get_buf(window) end
 --- `relative` is empty for normal windows.
 ---
 --- @param window integer Window handle, or 0 for current window
---- @return vim.api.keyset.float_config
+--- @return vim.api.keyset.win_config
 function vim.api.nvim_win_get_config(window) end
 
 --- Gets the (1,0)-indexed, buffer-relative cursor position for a given window

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -40,7 +40,7 @@ local LUA_API_RETURN_OVERRIDES = {
   nvim_get_option_info = 'vim.api.keyset.get_option_info',
   nvim_get_option_info2 = 'vim.api.keyset.get_option_info',
   nvim_parse_cmd = 'vim.api.keyset.parse_cmd',
-  nvim_win_get_config = 'vim.api.keyset.float_config',
+  nvim_win_get_config = 'vim.api.keyset.win_config',
 }
 
 local LUA_META_HEADER = {


### PR DESCRIPTION
Seems like https://github.com/neovim/neovim/pull/27397 didn't update this return type.