### PR TITLE
Fixed broken BUILD.md link in healthcheck module

### DIFF
--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -17,7 +17,7 @@ local shell_error = function()
   return vim.v.shell_error ~= 0
 end
 
-local suggest_faq = 'https://github.com/neovim/neovim/blob/docs/install/BUILD.md#building'
+local suggest_faq = 'https://github.com/neovim/neovim/blob/master/BUILD.md#building'
 
 local function check_runtime()
   health.start('Runtime')


### PR DESCRIPTION
This is a super minor fix that I noticed when running `:healthcheck`. I read through the the contribution guidelines, but I'm not sure how much of it applied, given how small this change is. Please let me know if you'd like me to change the commit message/branch/etc and I can redo it.