### PR TITLE
vim-patch:9.1.0146: v:echospace wrong with invalid value of 'showcmdloc'

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2100,8 +2100,13 @@ const char *did_set_showbreak(optset_T *args)
 /// The 'showcmdloc' option is changed.
 const char *did_set_showcmdloc(optset_T *args FUNC_ATTR_UNUSED)
 {
-  comp_col();
-  return did_set_opt_strings(p_sloc, p_sloc_values, true);
+  const char *errmsg = did_set_opt_strings(p_sloc, p_sloc_values, false);
+
+  if (errmsg == NULL) {
+    comp_col();
+  }
+
+  return errmsg;
 }
 
 int expand_set_showcmdloc(optexpand_T *args, int *numMatches, char ***matches)

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -171,6 +171,12 @@ func Test_echospace()
   call assert_equal(&columns - 19, v:echospace)
   set showcmdloc=tabline
   call assert_equal(&columns - 19, v:echospace)
+  call assert_fails('set showcmdloc=leap', 'E474:')
+  call assert_equal(&columns - 19, v:echospace)
+  set showcmdloc=last
+  call assert_equal(&columns - 29, v:echospace)
+  call assert_fails('set showcmdloc=jump', 'E474:')
+  call assert_equal(&columns - 29, v:echospace)
 
   set ruler& showcmd& showcmdloc&
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0146: v:echospace wrong with invalid value of 'showcmdloc'

Problem:  v:echospace wrong after setting invalid value to 'showcmdloc'.
Solution: Only call comp_col() if value is valid.
          (zeertzjq)

closes: vim/vim#14119

https://github.com/vim/vim/commit/c27fcf4857228bc650943246ffbba444a085b3e7