### PR TITLE
fix(lsp): create codelens request parameters for each buffer

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -299,12 +299,12 @@ function M.refresh(opts)
   local bufnr = opts.bufnr and resolve_bufnr(opts.bufnr)
   local buffers = bufnr and { bufnr }
     or vim.tbl_filter(api.nvim_buf_is_loaded, api.nvim_list_bufs())
-  local params = {
-    textDocument = util.make_text_document_params(),
-  }
 
   for _, buf in ipairs(buffers) do
     if not active_refreshes[buf] then
+      local params = {
+        textDocument = util.make_text_document_params(buf),
+      }
       active_refreshes[buf] = true
       vim.lsp.buf_request(buf, ms.textDocument_codeLens, params, M.on_codelens)
     end


### PR DESCRIPTION
The codelens `refresh()` processes the specified buffer or all loaded buffers.
However, it does not create a textDocument parameter for each buffer and does not specify the buffer when creating the textDocument parameter, so the URI of the current buffer is always specified.

To fix this, create a textDocument parameter for each buffer while respecting `bufnr` .