### PR TITLE
fix(deps): bump luv to 1.48.0-2

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -16,8 +16,8 @@ UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b953665559679748
 LIBVTERM_URL https://github.com/neovim/libvterm/archive/v0.3.3.tar.gz
 LIBVTERM_SHA256 0babe3ab42c354925dadede90d352f054aa9c4ae6842ea803a20c9741e172e56
 
-LUV_URL https://github.com/luvit/luv/archive/1.48.0-1.tar.gz
-LUV_SHA256 99042665a3fb486b8d0c80d0130e62b918abbad069e908eb333765462245e275
+LUV_URL https://github.com/luvit/luv/releases/download/1.48.0-2/luv-1.48.0-2.tar.gz
+LUV_SHA256 2c3a1ddfebb4f6550293a40ee789f7122e97647eede51511f57203de48c03b7a
 
 LPEG_URL https://github.com/neovim/deps/raw/d495ee6f79e7962a53ad79670cb92488abe0b9b4/opt/lpeg-1.1.0.tar.gz
 LPEG_SHA256 4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a


### PR DESCRIPTION
close #27678

Return a userdata wrapper around the uv_req_t to allow it to be garbage collected before the program exits. Previously, the returned userdata held a reference to itself in the Lua registry, meaning it would never be able to be garbage collected until the process ended.

This reverts commit 0e4a895, which attempted a workaround for the same underlying problem, but introduced a use-after-free.

```
Application Specific Information:
abort() called

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x18cde20dc __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x18ce19cc0 pthread_kill + 288
2   libsystem_c.dylib             	       0x18cd25a40 abort + 180
3   libsystem_malloc.dylib        	       0x18cc3cb08 malloc_vreport + 908
4   libsystem_malloc.dylib        	       0x18cc403f4 malloc_report + 64
5   libsystem_malloc.dylib        	       0x18cc54ebc find_zone_and_free + 308
6   nvim                          	       0x100eb13b8 uv__fs_scandir_cleanup + 84
7   nvim                          	       0x100eb7e68 uv_fs_req_cleanup + 120
8   nvim                          	       0x100e03634 luv_fs_gc + 132
9   nvim                          	       0x100e42aec lj_BC_FUNCC + 44
10  nvim                          	       0x100e44cc8 gc_call_finalizer + 148 (lj_gc.c:521)
11  nvim                          	       0x100b7fdb4 nlua_push_Object + 320 (converter.c:781)
12  nvim                          	       0x100b7fc48 nlua_push_Dictionary + 332 (converter.c:722)
13  nvim                          	       0x100992228 nlua_api_nvim_get_mode + 160 (lua_api_c_bindings.generated.c:6379)
14  nvim                          	       0x100e42aec lj_BC_FUNCC + 44
15  nvim                          	       0x100e590b4 lua_pcall + 228 (lj_api.c:1150)
```