### PR TITLE
fix(types): move IterMod type definition

### DIFF
--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -1140,9 +1140,8 @@ function M.map(f, src, ...)
   return Iter.new(src, ...):map(f):totable()
 end
 
----@type IterMod
 return setmetatable(M, {
   __call = function(_, ...)
     return Iter.new(...)
   end,
-})
+}) --[[@as IterMod]]


### PR DESCRIPTION
Problem: `vim.iter`'s call operator is not being detected by lua_ls, so there's no completion or type hints for any `Iter` methods. 
Solution: Move type annotation to after the return statement so that it properly affects the value.

tldr makes `vim.iter()` actually return an `Iter`

fixes #27711