### PR TITLE
Fix error when using custom treesitter directive

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -742,7 +742,9 @@ function M.add_directive(name, handler, opts)
     local function wrapper(match, ...)
       local m = {} ---@type table<integer, TSNode>
       for k, v in pairs(match) do
-        m[k] = v[#v]
+        if type(k) == 'number' then
+          m[k] = v[#v]
+        end
       end
       handler(m, ...)
     end


### PR DESCRIPTION
I got the following error when I used my custom treesitter directive:

```
Error in decoration provider treesitter/highlighter.line:
Error executing lua: /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:741: attempt to get length of local 'v' (a boolean value)
stack traceback:
        /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:741: in function 'handler'
        /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:823: in function 'apply_directives'
        /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:898: in function 'iter'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:266: in function 'fn'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:209: in function 'for_each_highlight_state'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:251: in function 'on_line_impl'
        ...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:320: in function <...al/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:314>
```

through some printing I found out that only the keys that were numbers were actual tables. So only keys that are numbers can be used to take the length of. I also saw that we did a "if key is number" check in de `add_predicate` function so I just copied that. This seemed to fix the issue