### PR TITLE
fix(ui_client): check return value of channel_job_start

### DIFF
--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -62,6 +62,9 @@ uint64_t ui_client_start_server(int argc, char **argv)
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, false, kChannelStdinPipe,
                                        NULL, 0, 0, NULL, &exit_status);
+  if (!channel) {
+    return 0;
+  }
 
   // If stdin is not a pty, it is forwarded to the client.
   // Replace stdin in the TUI process with the tty fd.


### PR DESCRIPTION
Problem: null pointer dereference in `ui_client_start_server` if `channel_job_start` returns NULL.

Solution: check for it, return 0 in that case (which is already used to indicate failure and is handled by main).

Happened when trying to run Nvim in an old gdbserver instance after having rebuilt Nvim since. This gave E903 (the nvim binary was deleted, so it gets the " (deleted)" suffix at the end of the exepath), then ASAN complains due to the NPD; instead it then prints "Failed to start Nvim server!", as expected.