### PR TITLE
fix(eval): make has('pythonx') work properly

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3315,7 +3315,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     "path_extra",
     "persistent_undo",
     "profile",
-    "pythonx",
     "reltime",
     "quickfix",
     "rightleft",
@@ -3406,6 +3405,8 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       n = syntax_present(curwin);
     } else if (STRICMP(name, "clipboard_working") == 0) {
       n = eval_has_provider("clipboard");
+    } else if (STRICMP(name, "pythonx") == 0) {
+      n = eval_has_provider("python3");
     } else if (STRICMP(name, "wsl") == 0) {
       n = has_wsl();
 #ifdef UNIX

--- a/test/functional/provider/python3_spec.lua
+++ b/test/functional/provider/python3_spec.lua
@@ -20,6 +20,12 @@ do
       matches(expected, pcall_err(command, 'py3 print("foo")'))
       matches(expected, pcall_err(command, 'py3file foo'))
     end)
+    it('feature test when Python 3 provider is missing', function()
+      eq(0, eval('has("python3")'))
+      eq(0, eval('has("python3_compiled")'))
+      eq(0, eval('has("python3_dynamic")'))
+      eq(0, eval('has("pythonx")'))
+    end)
     pending(
       string.format('Python 3 (or the pynvim module) is broken/missing (%s)', reason),
       function() end
@@ -38,6 +44,7 @@ describe('python3 provider', function()
     eq(1, eval('has("python3")'))
     eq(1, eval('has("python3_compiled")'))
     eq(1, eval('has("python3_dynamic")'))
+    eq(1, eval('has("pythonx")'))
     eq(0, eval('has("python3_dynamic_")'))
     eq(0, eval('has("python3_")'))
   end)


### PR DESCRIPTION
Problem:  has('pythonx') always returns 1.
Solution: Make it the same as has('python3').
