### PR TITLE
vim-patch:63c39e4ef749

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -252,7 +252,7 @@ if exists("c_gnu")
   syn keyword	cOperator	typeof __typeof__
   syn keyword	cOperator	__real__ __imag__
   syn keyword	cStorageClass	__attribute__ __const__ __extension__
-  syn keyword	cStorageClass	inline __inline__
+  syn keyword	cStorageClass	inline __inline __inline__
   syn keyword	cStorageClass	__restrict__ __volatile__ __noreturn__
 endif
 syn keyword	cType		int long short char void


### PR DESCRIPTION
runtime(c): Recognize "__inline" (vim/vim#14145)

`__inline` is recognized by GCC, and may even be preferred, as MSVC does
not recognize `__inline__`.

https://github.com/vim/vim/commit/63c39e4ef749883e96a83b9f647ac91516c0d1be

Co-authored-by: Wu Yongwei <wuyongwei@gmail.com>
