### PR TITLE
fix(fs): use generics for better typing

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2848,7 +2848,7 @@ vim.fs.basename({file})                                    *vim.fs.basename()*
     Return the basename of the given path
 
     Parameters: ~
-      • {file}  (`string`) Path
+      • {file}  (`string?`) Path
 
     Return: ~
         (`string?`) Basename of {file}
@@ -2876,7 +2876,7 @@ vim.fs.dirname({file})                                      *vim.fs.dirname()*
     Return the parent directory of the given path
 
     Parameters: ~
-      • {file}  (`string`) Path
+      • {file}  (`string?`) Path
 
     Return: ~
         (`string?`) Parent directory of {file}

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -39,8 +39,9 @@ end
 
 --- Return the parent directory of the given path
 ---
----@param file (string) Path
----@return string|nil Parent directory of {file}
+---@generic T : string|nil
+---@param file T Path
+---@return T Parent directory of {file}
 function M.dirname(file)
   if file == nil then
     return nil
@@ -53,6 +54,7 @@ function M.dirname(file)
   elseif file == '/' or file:match('^/[^/]+$') then
     return '/'
   end
+  ---@type string
   local dir = file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')
   if iswin and dir:match('^%w:$') then
     return dir .. '/'
@@ -62,8 +64,9 @@ end
 
 --- Return the basename of the given path
 ---
----@param file string Path
----@return string|nil Basename of {file}
+---@generic T : string|nil
+---@param file T Path
+---@return T Basename of {file}
 function M.basename(file)
   if file == nil then
     return nil


### PR DESCRIPTION
**Problem:**
When using `vim.fs.dirname` (or `vim.fs.basename`) the typing says that it may return `nil` even if `string` was passed in, which causes some unnecessary warnings.
For example, this is a type warning: `vim.notify(vim.fs.dirname('/home/user'))`

**Sulution:**
Use generics.

**Other changes:**
The docs now contain the information that `vim.fs.dirname` and `vim.fs.basename` may take `nil`.