### PR TITLE
vim-patch:9.1.0155: can only get getregion() from current buffer

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2919,11 +2919,13 @@ getreginfo([{regname}])                                           *getreginfo()*
 		The returned Dictionary can be passed to |setreg()|.
 
 getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
-		Returns the list of strings from {pos1} to {pos2} in current
+		Returns the list of strings from {pos1} to {pos2} from a
 		buffer.
 
 		{pos1} and {pos2} must both be |List|s with four numbers.
-		See |getpos()| for the format of the list.
+		See |getpos()| for the format of the list.  It's possible
+		to specify positions from a different buffer, but please
+		note the limitations at |getregion-notes|
 
 		The optional argument {opts} is a Dict and supports the
 		following items:
@@ -2944,6 +2946,7 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		This function is useful to get text starting and ending in
 		different columns, such as a |charwise-visual| selection.
 
+							*getregion-notes*
 		Note that:
 		- Order of {pos1} and {pos2} doesn't matter, it will always
 		  return content from the upper left position to the lower
@@ -2953,8 +2956,12 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		- If the region is blockwise and it starts or ends in the
 		  middle of a multi-cell character, it is not included but
 		  its selected part is substituted with spaces.
-		- If {pos1} or {pos2} is not current in the buffer, an empty
+		- If {pos1} and {pos2} are not in the same buffer, an empty
 		  list is returned.
+		- {pos1} and {pos2} must belong to a |bufloaded()| buffer.
+		- It is evaluated in current window context, this makes a
+		  different if a buffer is displayed in a different window and
+		  'virtualedit' or 'list' is set
 
 		Examples: >
 			:xnoremap <CR>

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3525,11 +3525,13 @@ function vim.fn.getreg(regname, list) end
 --- @return table
 function vim.fn.getreginfo(regname) end
 
---- Returns the list of strings from {pos1} to {pos2} in current
+--- Returns the list of strings from {pos1} to {pos2} from a
 --- buffer.
 ---
 --- {pos1} and {pos2} must both be |List|s with four numbers.
---- See |getpos()| for the format of the list.
+--- See |getpos()| for the format of the list.  It's possible
+--- to specify positions from a different buffer, but please
+--- note the limitations at |getregion-notes|
 ---
 --- The optional argument {opts} is a Dict and supports the
 --- following items:
@@ -3550,6 +3552,7 @@ function vim.fn.getreginfo(regname) end
 --- This function is useful to get text starting and ending in
 --- different columns, such as a |charwise-visual| selection.
 ---
+---           *getregion-notes*
 --- Note that:
 --- - Order of {pos1} and {pos2} doesn't matter, it will always
 ---   return content from the upper left position to the lower
@@ -3559,8 +3562,12 @@ function vim.fn.getreginfo(regname) end
 --- - If the region is blockwise and it starts or ends in the
 ---   middle of a multi-cell character, it is not included but
 ---   its selected part is substituted with spaces.
---- - If {pos1} or {pos2} is not current in the buffer, an empty
+--- - If {pos1} and {pos2} are not in the same buffer, an empty
 ---   list is returned.
+--- - {pos1} and {pos2} must belong to a |bufloaded()| buffer.
+--- - It is evaluated in current window context, this makes a
+---   different if a buffer is displayed in a different window and
+---   'virtualedit' or 'list' is set
 ---
 --- Examples: >
 ---   :xnoremap <CR>

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4359,11 +4359,13 @@ M.funcs = {
     args = { 2, 3 },
     base = 1,
     desc = [=[
-      Returns the list of strings from {pos1} to {pos2} in current
+      Returns the list of strings from {pos1} to {pos2} from a
       buffer.
 
       {pos1} and {pos2} must both be |List|s with four numbers.
-      See |getpos()| for the format of the list.
+      See |getpos()| for the format of the list.  It's possible
+      to specify positions from a different buffer, but please
+      note the limitations at |getregion-notes|
 
       The optional argument {opts} is a Dict and supports the
       following items:
@@ -4384,6 +4386,7 @@ M.funcs = {
       This function is useful to get text starting and ending in
       different columns, such as a |charwise-visual| selection.
 
+      					*getregion-notes*
       Note that:
       - Order of {pos1} and {pos2} doesn't matter, it will always
         return content from the upper left position to the lower
@@ -4393,8 +4396,12 @@ M.funcs = {
       - If the region is blockwise and it starts or ends in the
         middle of a multi-cell character, it is not included but
         its selected part is substituted with spaces.
-      - If {pos1} or {pos2} is not current in the buffer, an empty
+      - If {pos1} and {pos2} are not in the same buffer, an empty
         list is returned.
+      - {pos1} and {pos2} must belong to a |bufloaded()| buffer.
+      - It is evaluated in current window context, this makes a
+        different if a buffer is displayed in a different window and
+        'virtualedit' or 'list' is set
 
       Examples: >
       	:xnoremap <CR>

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1751,7 +1751,7 @@ func Test_visual_getregion()
     #" using the wrong type
     call assert_fails(':echo "."->getpos()->getregion("$", [])', 'E1211:')
 
-    #" using a mark in another buffer
+    #" using a mark from another buffer to current buffer
     new
     VAR newbuf = bufnr()
     call setline(1, range(10))
@@ -1761,6 +1761,20 @@ func Test_visual_getregion()
     call assert_equal([], getregion(getpos('.'), getpos("'A"), {'type': 'v' }))
     call assert_equal([], getregion(getpos("'A"), getpos('.'), {'type': 'v' }))
     exe $':{newbuf}bwipe!'
+
+    #" using a mark from another buffer to another buffer
+    new
+    VAR anotherbuf = bufnr()
+    call setline(1, range(10))
+    normal! GmA
+    normal! GmB
+    wincmd p
+    call assert_equal([anotherbuf, 10, 1, 0], getpos("'A"))
+    call assert_equal(['9'], getregion(getpos("'B"), getpos("'A"), {'type': 'v' }))
+    exe $':{anotherbuf}bwipe!'
+
+    #" using invalid buffer
+    call assert_equal([], getregion([10000, 10, 1, 0], [10000, 10, 1, 0]))
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -1909,6 +1923,20 @@ func Test_visual_getregion()
     bwipe!
   END
   call CheckLegacyAndVim9Success(lines)
+endfunc
+
+func Test_getregion_invalid_buf()
+  new
+  help
+  call cursor(5, 7)
+  norm! mA
+  call cursor(5, 18)
+  norm! mB
+  call assert_equal(['Move around:'], getregion(getpos("'A"), getpos("'B")))
+  " close the help window
+  q
+  call assert_equal([], getregion(getpos("'A"), getpos("'B")))
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0155: can only get getregion() from current buffer

Problem:  can only call getregion() for current buffer
Solution: Allow to retrieve selections from different buffers
          (Shougo Matsushita)

closes: vim/vim#14131

https://github.com/vim/vim/commit/84bf6e658da51126bdd2e50af1f40cabd149343f

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>