### PR TITLE
fix(type): remove incorrect arguments from vim.rpc*

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -922,7 +922,7 @@ vim.in_fast_event()                                      *vim.in_fast_event()*
     When this is `false` most API functions are callable (but may be subject
     to other restrictions such as |textlock|).
 
-vim.rpcnotify({channel}, {method}, {args}, {...})            *vim.rpcnotify()*
+vim.rpcnotify({channel}, {method}, {...})                    *vim.rpcnotify()*
     Sends {event} to {channel} via |RPC| and returns immediately. If {channel}
     is 0, the event is broadcast to all channels.
 
@@ -931,10 +931,9 @@ vim.rpcnotify({channel}, {method}, {args}, {...})            *vim.rpcnotify()*
     Parameters: ~
       • {channel}  (`integer`)
       • {method}   (`string`)
-      • {args}     (`any[]?`)
       • {...}      (`any?`)
 
-vim.rpcrequest({channel}, {method}, {args}, {...})          *vim.rpcrequest()*
+vim.rpcrequest({channel}, {method}, {...})                  *vim.rpcrequest()*
     Sends a request to {channel} to invoke {method} via |RPC| and blocks until
     a response is received.
 
@@ -944,7 +943,6 @@ vim.rpcrequest({channel}, {method}, {args}, {...})          *vim.rpcrequest()*
     Parameters: ~
       • {channel}  (`integer`)
       • {method}   (`string`)
-      • {args}     (`any[]?`)
       • {...}      (`any?`)
 
 vim.schedule({fn})                                            *vim.schedule()*

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -91,9 +91,8 @@ function vim.empty_dict() end
 --- This function also works in a fast callback |lua-loop-callbacks|.
 --- @param channel integer
 --- @param method string
---- @param args? any[]
 --- @param ...? any
-function vim.rpcnotify(channel, method, args, ...) end
+function vim.rpcnotify(channel, method, ...) end
 
 --- Sends a request to {channel} to invoke {method} via |RPC| and blocks until
 --- a response is received.
@@ -102,9 +101,8 @@ function vim.rpcnotify(channel, method, args, ...) end
 --- special value
 --- @param channel integer
 --- @param method string
---- @param args? any[]
 --- @param ...? any
-function vim.rpcrequest(channel, method, args, ...) end
+function vim.rpcrequest(channel, method, ...) end
 
 --- Compares strings case-insensitively.
 --- @param a string


### PR DESCRIPTION
`vim.rpcnotify(chan,'nvim_exec_lua','print(1)',{})` is valid but raised type warning, so fixed that.