### PR TITLE
fix: set full_screen when in ex_mode

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -363,7 +363,7 @@ int main(int argc, char **argv)
 
   setbuf(stdout, NULL);  // NOLINT(bugprone-unsafe-functions)
 
-  full_screen = !silent_mode;
+  full_screen = !silent_mode || exmode_active;
 
   // Set the default values for the options that use Rows and Columns.
   win_init_size();

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -73,6 +73,18 @@ describe('command-line option', function()
       eq(#'100500\n', attrs.size)
     end)
 
+    it('does not crash when run completion in ex mode', function()
+      fn.system({
+        nvim_prog_abs(),
+        '--clean',
+        '-e',
+        '-s',
+        '--cmd',
+        'exe "norm! i\\<C-X>\\<C-V>"',
+      })
+      eq(0, eval('v:shell_error'))
+    end)
+
     it('does not crash after reading from stdin in non-headless mode', function()
       skip(is_os('win'))
       local screen = Screen.new(40, 8)


### PR DESCRIPTION
Problem Description: In ex_mode, the default_grid.chars are not allocated, and subsequently,
the w_grid.target in curwin is not allocated to default_grid in update_screen. This leads to
a null pointer crash when the completion function is executed in ex_mode.

Solution: Set full_screen when in ex_mode to ensure that default_grid is allocated.

Fix #14565 