### PR TITLE
vim-patch:9.1.0157: Duplicate assignment in f_getregion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2925,7 +2925,7 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		{pos1} and {pos2} must both be |List|s with four numbers.
 		See |getpos()| for the format of the list.  It's possible
 		to specify positions from a different buffer, but please
-		note the limitations at |getregion-notes|
+		note the limitations at |getregion-notes|.
 
 		The optional argument {opts} is a Dict and supports the
 		following items:
@@ -2959,9 +2959,9 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		- If {pos1} and {pos2} are not in the same buffer, an empty
 		  list is returned.
 		- {pos1} and {pos2} must belong to a |bufloaded()| buffer.
-		- It is evaluated in current window context, this makes a
-		  different if a buffer is displayed in a different window and
-		  'virtualedit' or 'list' is set
+		- It is evaluated in current window context, which makes a
+		  difference if the buffer is displayed in a window with
+		  different 'virtualedit' or 'list' values.
 
 		Examples: >
 			:xnoremap <CR>

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3531,7 +3531,7 @@ function vim.fn.getreginfo(regname) end
 --- {pos1} and {pos2} must both be |List|s with four numbers.
 --- See |getpos()| for the format of the list.  It's possible
 --- to specify positions from a different buffer, but please
---- note the limitations at |getregion-notes|
+--- note the limitations at |getregion-notes|.
 ---
 --- The optional argument {opts} is a Dict and supports the
 --- following items:
@@ -3565,9 +3565,9 @@ function vim.fn.getreginfo(regname) end
 --- - If {pos1} and {pos2} are not in the same buffer, an empty
 ---   list is returned.
 --- - {pos1} and {pos2} must belong to a |bufloaded()| buffer.
---- - It is evaluated in current window context, this makes a
----   different if a buffer is displayed in a different window and
----   'virtualedit' or 'list' is set
+--- - It is evaluated in current window context, which makes a
+---   difference if the buffer is displayed in a window with
+---   different 'virtualedit' or 'list' values.
 ---
 --- Examples: >
 ---   :xnoremap <CR>

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4365,7 +4365,7 @@ M.funcs = {
       {pos1} and {pos2} must both be |List|s with four numbers.
       See |getpos()| for the format of the list.  It's possible
       to specify positions from a different buffer, but please
-      note the limitations at |getregion-notes|
+      note the limitations at |getregion-notes|.
 
       The optional argument {opts} is a Dict and supports the
       following items:
@@ -4399,9 +4399,9 @@ M.funcs = {
       - If {pos1} and {pos2} are not in the same buffer, an empty
         list is returned.
       - {pos1} and {pos2} must belong to a |bufloaded()| buffer.
-      - It is evaluated in current window context, this makes a
-        different if a buffer is displayed in a different window and
-        'virtualedit' or 'list' is set
+      - It is evaluated in current window context, which makes a
+        difference if the buffer is displayed in a window with
+        different 'virtualedit' or 'list' values.
 
       Examples: >
       	:xnoremap <CR>

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2862,7 +2862,7 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  buf_T *save_curbuf = curbuf;
+  buf_T *const save_curbuf = curbuf;
 
   if (fnum1 != 0) {
     buf_T *findbuf = buflist_findnr(fnum1);
@@ -2870,7 +2870,6 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (findbuf == NULL || findbuf->b_ml.ml_mfp == NULL) {
       return;
     }
-    save_curbuf = curbuf;
     curbuf = findbuf;
   }
 

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -588,7 +588,7 @@ funct Test_undofile()
   endif
   call assert_equal('', undofile(''))
 
-  " Test undofile() with 'undodir' set to to an existing directory.
+  " Test undofile() with 'undodir' set to an existing directory.
   call mkdir('Xundodir')
   set undodir=Xundodir
   let cwd = getcwd()


### PR DESCRIPTION
#### vim-patch:9.1.0157: Duplicate assignment in f_getregion()

Problem:  Duplicate assignment in f_getregion().
Solution: Remove the duplicate assignment.  Also improve getregion()
          docs wording and fix an unrelated typo (zeertzjq)

closes: vim/vim#14154

https://github.com/vim/vim/commit/0df8f93bdaea77a1afb9f4eca94fe67ec73e6df2