### PR TITLE
vim-patch:9.1.{0154,0158}: shm=F not respected when reloading buffer with 'autoread'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5474,7 +5474,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		items, for instance "scanning tags"
 	  q	do not show "recording @a" when recording a macro	*shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
-		`:silent` was used for the command
+		`:silent` was used for the command; note that this also
+		affects messages from 'autoread' reloading
 	  S	do not show search count message when searching, e.g.	*shm-S*
 		"[1/5]"
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5799,7 +5799,8 @@ vim.bo.sw = vim.bo.shiftwidth
 --- 	items, for instance "scanning tags"
 ---   q	do not show "recording @a" when recording a macro	*shm-q*
 ---   F	don't give the file info when editing a file, like	*shm-F*
---- 	`:silent` was used for the command
+--- 	`:silent` was used for the command; note that this also
+--- 	affects messages from 'autoread' reloading
 ---   S	do not show search count message when searching, e.g.	*shm-S*
 --- 	"[1/5]"
 ---

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3008,7 +3008,7 @@ int buf_check_timestamp(buf_T *buf)
     can_reload = true;
   }
 
-  if (mesg != NULL) {
+  if (mesg != NULL && !shortmess(SHM_FILEINFO)) {
     char *path = home_replace_save(buf, buf->b_fname);
     if (!helpmesg) {
       mesg2 = "";

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3008,7 +3008,7 @@ int buf_check_timestamp(buf_T *buf)
     can_reload = true;
   }
 
-  if (mesg != NULL && !shortmess(SHM_FILEINFO)) {
+  if (mesg != NULL) {
     char *path = home_replace_save(buf, buf->b_fname);
     if (!helpmesg) {
       mesg2 = "";
@@ -3153,7 +3153,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
     curbuf->b_flags |= BF_CHECK_RO;           // check for RO again
     keep_filetype = true;                     // don't detect 'filetype'
     if (readfile(buf->b_ffname, buf->b_fname, 0, 0,
-                 (linenr_T)MAXLNUM, &ea, flags, false) != OK) {
+                 (linenr_T)MAXLNUM, &ea, flags, shortmess(SHM_FILEINFO)) != OK) {
       if (!aborting()) {
         semsg(_("E321: Could not reload \"%s\""), buf->b_fname);
       }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7331,7 +7331,8 @@ return {
         	items, for instance "scanning tags"
           q	do not show "recording @a" when recording a macro	*shm-q*
           F	don't give the file info when editing a file, like	*shm-F*
-        	`:silent` was used for the command
+        	`:silent` was used for the command; note that this also
+        	affects messages from 'autoread' reloading
           S	do not show search count message when searching, e.g.	*shm-S*
         	"[1/5]"
 

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -86,7 +86,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
       line 3                                            |
       line 4                                            |
       {5:xtest-foo                                         }|
-      "xtest-foo" 4L, 28B                               |
+      :edit xtest-foo                                   |
       {3:-- TERMINAL --}                                    |
     ]],
     }

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1283,6 +1283,26 @@ func Test_shortmess_F2()
   " call assert_fails('call test_getvalue("abc")', 'E475:')
 endfunc
 
+func Test_shortmess_F3()
+  defer delete('X_dummy')
+
+  set hidden
+  set autoread
+  e X_dummy
+  e file
+
+  set shortmess+=F
+  call writefile(["foo"], 'X_dummy')
+  call assert_true(empty(execute('bn', '')))
+  call assert_true(empty(execute('bn', '')))
+
+  set shortmess&
+  set autoread&
+  set hidden&
+  bwipe
+  bwipe
+endfunc
+
 func Test_local_scrolloff()
   set so=5
   set siso=7

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1284,23 +1284,41 @@ func Test_shortmess_F2()
 endfunc
 
 func Test_shortmess_F3()
-  defer delete('X_dummy')
+  call writefile(['foo'], 'X_dummy', 'D')
 
   set hidden
   set autoread
   e X_dummy
-  e file
-
+  e Xotherfile
+  call assert_equal(['foo'], getbufline('X_dummy', 1, '$'))
   set shortmess+=F
-  call writefile(["foo"], 'X_dummy')
-  call assert_true(empty(execute('bn', '')))
-  call assert_true(empty(execute('bn', '')))
+  echo ''
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['bar'], 'X_dummy')
+  bprev
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['bar'], getbufline('X_dummy', 1, '$'))
+
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
+  call writefile(['baz'], 'X_dummy')
+  checktime
+  call assert_equal('', Screenline(&lines))
+  call assert_equal(['baz'], getbufline('X_dummy', 1, '$'))
 
   set shortmess&
   set autoread&
   set hidden&
-  bwipe
-  bwipe
+  bwipe X_dummy
+  bwipe Xotherfile
 endfunc
 
 func Test_local_scrolloff()


### PR DESCRIPTION
#### vim-patch:9.1.0154: shm=F not respected when reloading buffer with 'autoread'

Problem:  shm=F not respected when reloading buffer with 'autoread'
Solution: Check SHM_FILEINFO in buf_check_timestamp()
          (Shougo Matsushita)

closes: vim/vim#14144

https://github.com/vim/vim/commit/9db39b0ec90600bb41faec3a12b934b17c298b1f

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>


#### vim-patch:9.1.0158: 'shortmess' "F" flag doesn't work properly with 'autoread'

Problem:  'shortmess' "F" flag doesn't work properly with 'autoread'
          (after 9.1.0154)
Solution: Hide the file info message instead of the warning dialog
          (zeertzjq)

closes: vim/vim#14159
closes: vim/vim#14158

https://github.com/vim/vim/commit/8a01744c563f615ae7f6b3ab7f5208214a45a8e2