### PR TITLE
vim-patch:8.2.5077: various warnings from clang on MS-Windows

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -586,6 +586,9 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
   bool copy_char;
   bool mustfree;  // var was allocated, need to free it later
   bool at_start = true;  // at start of a name
+#if defined(BACKSLASH_IN_FILENAME)
+  char *const save_dst = dst;
+#endif
 
   int prefix_len = (prefix == NULL) ? 0 : (int)strlen(prefix);
 
@@ -726,7 +729,7 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
         // with it, skip a character
         if (after_pathsep(dst, dst + c)
 #if defined(BACKSLASH_IN_FILENAME)
-            && dst[-1] != ':'
+            && (dst == save_dst || dst[-1] != ':')
 #endif
             && vim_ispathsep(*tail)) {
           tail++;


### PR DESCRIPTION
#### vim-patch:8.2.5077: various warnings from clang on MS-Windows

Problem:    Various warnings from clang on MS-Windows.
Solution:   Avoid the warnings. (Yegappan Lakshmanan, closes vim/vim#10553)

https://github.com/vim/vim/commit/a34b4460c2843c67a35a2d236b01e6cb9bc38734

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>