### PR TITLE
refactor(ui): remove outdated UI vs UIData distinction

### DIFF
--- a/src/nvim/generators/gen_api_ui_events.lua
+++ b/src/nvim/generators/gen_api_ui_events.lua
@@ -110,10 +110,9 @@ for i = 1, #events do
   if not ev.remote_only then
     if not ev.remote_impl and not ev.noexport then
       remote_output:write('void remote_ui_' .. ev.name)
-      write_signature(remote_output, ev, 'UI *ui')
+      write_signature(remote_output, ev, 'RemoteUI *ui')
       remote_output:write('\n{\n')
-      remote_output:write('  UIData *data = ui->data;\n')
-      remote_output:write('  Array args = data->call_buf;\n')
+      remote_output:write('  Array args = ui->call_buf;\n')
       write_arglist(remote_output, ev)
       remote_output:write('  push_call(ui, "' .. ev.name .. '", args);\n')
       remote_output:write('}\n\n')

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -127,7 +127,7 @@ retry: {}
 }
 
 /// When a UI connects, we need to send it the table of highlights used so far.
-void ui_send_all_hls(UI *ui)
+void ui_send_all_hls(RemoteUI *ui)
 {
   for (size_t i = 1; i < set_size(&attr_entries); i++) {
     Arena arena = ARENA_EMPTY;

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -79,13 +79,13 @@ void ui_comp_syn_init(void)
   dbghl_recompose = syn_check_group(S_LEN("RedrawDebugRecompose"));
 }
 
-void ui_comp_attach(UI *ui)
+void ui_comp_attach(RemoteUI *ui)
 {
   composed_uis++;
   ui->composed = true;
 }
 
-void ui_comp_detach(UI *ui)
+void ui_comp_detach(RemoteUI *ui)
 {
   composed_uis--;
   if (composed_uis == 0) {

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -30,9 +30,28 @@ enum {
 
 typedef int LineFlags;
 
-typedef struct ui_t UI;
-
 typedef struct {
+  bool rgb;
+  bool override;  ///< Force highest-requested UI capabilities.
+  bool composed;
+  bool ui_ext[kUIExtCount];  ///< Externalized UI capabilities.
+  int width;
+  int height;
+  int pum_nlines;  /// actual nr. lines shown in PUM
+  bool pum_pos;  /// UI reports back pum position?
+  double pum_row;
+  double pum_col;
+  double pum_height;
+  double pum_width;
+
+  // TUI fields.
+  char *term_name;
+  char *term_background;  ///< Deprecated. No longer needed since background color detection happens
+                          ///< in Lua. To be removed in a future release.
+  int term_colors;
+  bool stdin_tty;
+  bool stdout_tty;
+
   uint64_t channel_id;
 
 #define UI_BUF_SIZE ARENA_BLOCK_SIZE  ///< total buffer size for pending msgpack data.
@@ -40,6 +59,7 @@ typedef struct {
   /// and the header of grid_line will never fail)
 #define EVENT_BUF_SIZE 256
 
+// Fields related to packing
   PackerBuffer packer;
 
   const char *cur_event;  ///< name of current event (might get multiple arglists)
@@ -62,33 +82,7 @@ typedef struct {
   // Position of legacy cursor, used both for drawing and visible user cursor.
   Integer client_row, client_col;
   bool wildmenu_active;
-} UIData;
-
-struct ui_t {
-  bool rgb;
-  bool override;  ///< Force highest-requested UI capabilities.
-  bool composed;
-  bool ui_ext[kUIExtCount];  ///< Externalized UI capabilities.
-  int width;
-  int height;
-  int pum_nlines;  /// actual nr. lines shown in PUM
-  bool pum_pos;  /// UI reports back pum position?
-  double pum_row;
-  double pum_col;
-  double pum_height;
-  double pum_width;
-
-  // TUI fields.
-  char *term_name;
-  char *term_background;  ///< Deprecated. No longer needed since background color detection happens
-                          ///< in Lua. To be removed in a future release.
-  int term_colors;
-  bool stdin_tty;
-  bool stdout_tty;
-
-  // TODO(bfredl): integrate into struct!
-  UIData data[1];
-};
+} RemoteUI;
 
 typedef struct {
   const char *name;


### PR DESCRIPTION
Just some basic spring cleaning.

In the distant past, not all UI:s where remote UI:s. They still aren't, but both of the "UI" and "UIData" structs are now only for remote UI:s. Thus join them as "RemoteUI".