### PR TITLE
ci: allow skipping news workflow with a label

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -1,13 +1,13 @@
 name: "news.txt"
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     branches:
     - 'master'
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:skip-news')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/optional.yml
+++ b/.github/workflows/optional.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   s390x:
-    if: contains(github.event.pull_request.labels.*.name, 'ci-s390x') || github.event_name == 'workflow_dispatch'
+    if: contains(github.event.pull_request.labels.*.name, 'ci:s390x') || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -230,8 +230,9 @@ https://github.com/neovim/neovim-backup
 Some github labels are used to trigger certain jobs:
 
 * `backport release-x.y` - backport to release branch
-* `ci-s390x` - enable s390x CI
-* `needs:response` - Close PR after a certain amount of time if author doesn't
+* `ci:s390x` - enable s390x CI
+* `ci:skip-news` - skip news.yml workflows
+* `needs:response` - close PR after a certain amount of time if author doesn't
   respond
 
 See also


### PR DESCRIPTION
Setting the label `ci:skip-news` will skip the job. This is useful for
maintainers to indicate to contributors that a feature isn't big enough
to warrant a news entry, or for contributors who dislike red CI even if
there's nothing wrong.

Also change label `ci-s390x` to `ci:s390x`; this way it'll be easier to
see that `ci:` are a subcategory of labels that affect CI in some way.