### PR TITLE
perf(treesitter): bound `has-ancestor?` for highlighter

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1130,7 +1130,7 @@ parse({lang}, {query})                          *vim.treesitter.query.parse()*
       • |vim.treesitter.query.get()|
 
                                                        *Query:iter_captures()*
-Query:iter_captures({node}, {source}, {start}, {stop})
+Query:iter_captures({node}, {source}, {start}, {stop}, {opts})
     Iterate over all captures from all matches inside {node}
 
     {source} is needed if the query contains predicates; then the caller must
@@ -1164,6 +1164,12 @@ Query:iter_captures({node}, {source}, {start}, {stop})
                   `node:start()`.
       • {stop}    (`integer?`) Stopping line for the search (end-exclusive).
                   Defaults to `node:end_()`.
+      • {opts}    (`table?`) Optional keyword arguments:
+                  • max_start_depth (integer) if non-zero, sets the maximum
+                    start depth for each match. This is used to prevent
+                    traversing too deep into a tree.
+                  • max_traverse_length (integer) if non-zero, sets the
+                    maximum travseral length of `has-ancestor?` predicate
 
     Return: ~
         (`fun(end_line: integer?): integer, TSNode, vim.treesitter.query.TSMetadata, table<integer,TSNode[]>?`)
@@ -1217,6 +1223,8 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
                     iter_matches incorrectly mapped capture IDs to a single
                     node, which is incorrect behavior. This option will
                     eventually become the default and removed.
+                  • max_traverse_length (integer) if non-zero, sets the
+                    maximum travseral length of `has-ancestor?` predicate
 
     Return: ~
         (`fun(): integer, table<integer, TSNode[]>, table`) pattern id, match,

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -296,8 +296,13 @@ local function on_line_impl(self, buf, line, is_spell_nav)
     end
 
     if state.iter == nil or state.next_row < line then
-      state.iter =
-        state.highlighter_query:query():iter_captures(root_node, self.bufnr, line, root_end_row + 1)
+      state.iter = state.highlighter_query:query():iter_captures(
+        root_node,
+        self.bufnr,
+        line,
+        root_end_row + 1,
+        { max_traverse_length = 15 }
+      )
     end
 
     while line >= state.next_row do


### PR DESCRIPTION
Problem:
`has-ancestor?` predicate can take long when the match is deep in the tree, e.g., long `else if` chain in C. This may slow down highlighting and thus redrawing significantly.
See #24965.

Solution:
Add option for limiting `has-ancestor?`'s search length, and use it for highlighter.
The limit `15` is arbitrary, but seems to be good enough:
* Existing use of `has-ancestor?` in highlight queries are quite local. For example in cpp, it searches for a call expression above a quantified identifier to highlight the function name.
* Scrolling is reponsive enough in the long `else if` chain example.

See #24965 for other approaches. 