### PR TITLE
docs: deduplicate information in deprecated.txt

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -12,22 +12,100 @@ They should not be used in new scripts, and old scripts should be updated.
 ==============================================================================
 Deprecated features
 
+DEPRECATED IN 0.10 *deprecated-0.10*
+
+• Configuring |diagnostic-signs| using |:sign-define| or |sign_define()|. Use
+  the "signs" key of |vim.diagnostic.config()| instead.
+
+• Checkhealth functions:
+  - *health#report_error* *vim.health.report_error()*	Use |vim.health.error()| instead.
+  - *health#report_info* *vim.health.report_info()*	Use |vim.health.info()| instead.
+  - *health#report_ok* *vim.health.report_ok()*		Use |vim.health.ok()| instead.
+  - *health#report_start* *vim.health.report_start()*	Use |vim.health.start()| instead.
+  - *health#report_warn* *vim.health.report_warn()*	Use |vim.health.warn()| instead.
+
+• |API| functions:
+  - *nvim_buf_get_option()*	Use |nvim_get_option_value()| instead.
+  - *nvim_buf_set_option()*	Use |nvim_set_option_value()| instead.
+  - *nvim_call_atomic()*		Use |nvim_exec_lua()| instead.
+  - *nvim_get_option()*		Use |nvim_get_option_value()| instead.
+  - *nvim_set_option()*		Use |nvim_set_option_value()| instead.
+  - *nvim_win_get_option()*	Use |nvim_get_option_value()| instead.
+  - *nvim_win_set_option()*	Use |nvim_set_option_value()| instead.
+
+• vim.diagnostic functions:
+  - *vim.diagnostic.disable()*		Use |vim.diagnostic.enable()|
+  - *vim.diagnostic.is_disabled()*	Use |vim.diagnostic.is_enabled()|
+  - Legacy signature: `vim.diagnostic.enable(buf:number, namespace:number)`
+
+• vim.lsp functions:
+  - *vim.lsp.util.get_progress_messages()*	Use |vim.lsp.status()| instead.
+  - *vim.lsp.get_active_clients()*		Use |vim.lsp.get_clients()| instead.
+  - *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()| instead.
+  - *vim.lsp.util.trim_empty_lines()*		Use |vim.split()| with `trimempty` instead.
+  - *vim.lsp.util.try_trim_markdown_code_blocks()*
+  - *vim.lsp.util.set_lines()*
+  - *vim.lsp.util.extract_completion_items()*
+  - *vim.lsp.util.parse_snippet()*
+  - *vim.lsp.util.text_document_completion_list_to_complete_items()*
+  - *vim.lsp.util.lookup_section()*		Use |vim.tbl_get()| instead: >
+						local keys = vim.split(section, '.', { plain = true })
+						local  vim.tbl_get(table, unpack(keys))
+
+• *vim.loop*				Use |vim.uv| instead.
+
+• vim.treesitter functions:
+  - *LanguageTree:for_each_child()*		Use |LanguageTree:children()| (non-recursive) instead.
+
+• The "term_background" UI option |ui-ext-options| is deprecated and no longer
+  populated. Background color detection is now performed in Lua by the Nvim
+  core, not the TUI.
+
+• Lua stdlib:
+  - *vim.tbl_add_reverse_lookup()*
+  - *vim.tbl_flatten()*			Use |Iter:flatten()| instead.
+  - *vim.tbl_islist()*			Use |vim.islist()| instead.
+
+DEPRECATED IN 0.9 *deprecated-0.9*
+
+• vim.treesitter functions
+  - *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()| instead.
+  - *vim.treesitter.get_node_at_pos()*			Use |vim.treesitter.get_node()| instead.
+  - *vim.treesitter.get_node_at_cursor()*		Use |vim.treesitter.get_node()|
+							and |TSNode:type()| instead.
+
+• |API| functions:
+  - *nvim_get_hl_by_name()*		Use |nvim_get_hl()| instead.
+  - *nvim_get_hl_by_id()*		Use |nvim_get_hl()| instead.
+
+• The following top level Treesitter functions have been moved:
+  *vim.treesitter.inspect_language()*    -> |vim.treesitter.language.inspect()|
+  *vim.treesitter.get_query_files()*     -> |vim.treesitter.query.get_files()|
+  *vim.treesitter.set_query()*           -> |vim.treesitter.query.set()|
+  *vim.treesitter.query.set_query()*     -> |vim.treesitter.query.set()|
+  *vim.treesitter.get_query()*           -> |vim.treesitter.query.get()|
+  *vim.treesitter.query.get_query()*     -> |vim.treesitter.query.get()|
+  *vim.treesitter.parse_query()*         -> |vim.treesitter.query.parse()|
+  *vim.treesitter.query.parse_query()*   -> |vim.treesitter.query.parse()|
+  *vim.treesitter.add_predicate()*       -> |vim.treesitter.query.add_predicate()|
+  *vim.treesitter.add_directive()*       -> |vim.treesitter.query.add_directive()|
+  *vim.treesitter.list_predicates()*     -> |vim.treesitter.query.list_predicates()|
+  *vim.treesitter.list_directives()*     -> |vim.treesitter.query.list_directives()|
+  *vim.treesitter.query.get_range()*     -> |vim.treesitter.get_range()|
+  *vim.treesitter.query.get_node_text()* -> |vim.treesitter.get_node_text()|
+
+• Lua stdlib:
+  - *nvim_exec()*				Use |nvim_exec2()| instead.
+  - *vim.pretty_print()*			Use |vim.print()| instead.
+
+DEPRECATED IN 0.8 OR EARLIER
+
 API
 - *nvim_buf_clear_highlight()*	Use |nvim_buf_clear_namespace()| instead.
 - *nvim_buf_set_virtual_text()*	Use |nvim_buf_set_extmark()| instead.
 - *nvim_command_output()*	Use |nvim_exec2()| instead.
-- *nvim_call_atomic()*		Use |nvim_exec_lua()| instead.
 - *nvim_execute_lua()*		Use |nvim_exec_lua()| instead.
-- *nvim_get_hl_by_name()*	Use |nvim_get_hl()| instead.
-- *nvim_get_hl_by_id()*		Use |nvim_get_hl()| instead.
-- *nvim_exec()*			Use |nvim_exec2()| instead.
 - *nvim_get_option_info()*	Use |nvim_get_option_info2()| instead.
-- *nvim_buf_get_option()*	Use |nvim_get_option_value()| instead.
-- *nvim_buf_set_option()*	Use |nvim_set_option_value()| instead.
-- *nvim_get_option()*		Use |nvim_get_option_value()| instead.
-- *nvim_set_option()*		Use |nvim_set_option_value()| instead.
-- *nvim_win_get_option()*	Use |nvim_get_option_value()| instead.
-- *nvim_win_set_option()*	Use |nvim_set_option_value()| instead.
 
 COMMANDS
 - *:rv* *:rviminfo*		Deprecated alias to |:rshada| command.
@@ -61,11 +139,6 @@ FUNCTIONS
 - *buffer_name()*	Obsolete name for |bufname()|.
 - *buffer_number()*	Obsolete name for |bufnr()|.
 - *file_readable()*	Obsolete name for |filereadable()|.
-- *health#report_error* *vim.health.report_error()*	Use |vim.health.error()| instead.
-- *health#report_info* *vim.health.report_info()*	Use |vim.health.info()| instead.
-- *health#report_ok* *vim.health.report_ok()*		Use |vim.health.ok()| instead.
-- *health#report_start* *vim.health.report_start()*	Use |vim.health.start()| instead.
-- *health#report_warn* *vim.health.report_warn()*	Use |vim.health.warn()| instead.
 - *highlight_exists()*	Obsolete name for |hlexists()|.
 - *highlightID()*	Obsolete name for |hlID()|.
 - *inputdialog()*	Use |input()| instead.
@@ -81,9 +154,6 @@ HIGHLIGHTS
 - *hl-VertSplit*	Use |hl-WinSeparator| instead.
 
 LSP DIAGNOSTICS
-- *vim.diagnostic.disable()*		Use |vim.diagnostic.enable()|
-- *vim.diagnostic.is_disabled()*	Use |vim.diagnostic.is_enabled()|
-
 For each of the functions below, use the corresponding function in
 |vim.diagnostic| instead (unless otherwise noted). For example, use
 |vim.diagnostic.get()| instead of |vim.lsp.diagnostic.get()|.
@@ -144,39 +214,9 @@ LSP FUNCTIONS
 						{async=false} instead.
 - *vim.lsp.buf.range_formatting()*		Use |vim.lsp.formatexpr()|
 						or |vim.lsp.buf.format()| instead.
-- *vim.lsp.util.get_progress_messages()*	Use |vim.lsp.status()| or access
-						`progress` of |vim.lsp.Client|
-- *vim.lsp.get_active_clients()*		Use |vim.lsp.get_clients()|
-- *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()|
-- *vim.lsp.util.lookup_section()*		Use |vim.tbl_get()| instead: >
-						local keys = vim.split(section, '.', { plain = true })
-						local  vim.tbl_get(table, unpack(keys))
-- *vim.lsp.util.trim_empty_lines()*		Use |vim.split()| with `trimempty` instead.
-- *vim.lsp.util.try_trim_markdown_code_blocks()*
-- *vim.lsp.util.set_lines()*
-- *vim.lsp.util.extract_completion_items()*
-- *vim.lsp.util.parse_snippet()*
-- *vim.lsp.util.text_document_completion_list_to_complete_items()*
-
-TREESITTER FUNCTIONS
-- *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|
-						instead.
-- *vim.treesitter.get_node_at_pos()*		Use |vim.treesitter.get_node()|
-						instead.
-- *vim.treesitter.get_node_at_cursor()*		Use |vim.treesitter.get_node()|
-						and |TSNode:type()| instead.
-- *vim.treesitter.query.get_query()*		Use |vim.treesitter.query.get()|
-						instead.
-- *LanguageTree:for_each_child()*		Use |LanguageTree:children()|
-						(non-recursive) instead.
 
 LUA
 - vim.register_keystroke_callback()	Use |vim.on_key()| instead.
-- *vim.pretty_print()*			Use |vim.print()| instead.
-- *vim.loop*				Use |vim.uv| instead.
-- *vim.tbl_add_reverse_lookup()*
-- *vim.tbl_flatten()*			Use |Iter:flatten()| instead.
-- *vim.tbl_islist()*			Use |vim.islist()| instead.
 
 NORMAL COMMANDS
 - *]f* *[f*		Same as "gf".

--- a/runtime/doc/news-0.9.txt
+++ b/runtime/doc/news-0.9.txt
@@ -290,34 +290,6 @@ The following deprecated functions or APIs were removed.
 ==============================================================================
 DEPRECATIONS
 
-The following functions are now deprecated and will be removed in the next
-release.
-
-• |vim.treesitter.language.add()| replaces `vim.treesitter.language.require_language()`
-
-• |vim.treesitter.get_node_at_pos()| and |vim.treesitter.get_node_at_cursor()|
-  are both deprecated in favor of |vim.treesitter.get_node()|.
-
-• `vim.api.nvim_get_hl_by_name()`, `vim.api.nvim_get_hl_by_id()` were deprecated, use |nvim_get_hl()| instead.
-
-• The following top level Treesitter functions have been moved:
-  `vim.treesitter.inspect_language()`    -> `vim.treesitter.language.inspect()`
-  `vim.treesitter.get_query_files()`     -> `vim.treesitter.query.get_files()`
-  `vim.treesitter.set_query()`           -> `vim.treesitter.query.set()`
-  `vim.treesitter.query.set_query()`     -> `vim.treesitter.query.set()`
-  `vim.treesitter.get_query()`           -> `vim.treesitter.query.get()`
-  `vim.treesitter.query.get_query()`     -> `vim.treesitter.query.get()`
-  `vim.treesitter.parse_query()`         -> `vim.treesitter.query.parse()`
-  `vim.treesitter.query.parse_query()`   -> `vim.treesitter.query.parse()`
-  `vim.treesitter.add_predicate()`       -> `vim.treesitter.query.add_predicate()`
-  `vim.treesitter.add_directive()`       -> `vim.treesitter.query.add_directive()`
-  `vim.treesitter.list_predicates()`     -> `vim.treesitter.query.list_predicates()`
-  `vim.treesitter.list_directives()`     -> `vim.treesitter.query.list_directives()`
-  `vim.treesitter.query.get_range()`     -> `vim.treesitter.get_range()`
-  `vim.treesitter.query.get_node_text()` -> `vim.treesitter.get_node_text()`
-
-• |nvim_exec()| is now deprecated in favor of |nvim_exec2()|.
-
-• Renamed |vim.pretty_print()| to |vim.print()|.
+See |deprecated-0.9|.
 
  vim:tw=78:ts=8:sw=2:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -556,56 +556,6 @@ The following deprecated functions or APIs were removed.
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 
-The following functions are now deprecated and will be removed in a future
-release.
-
-• Configuring |diagnostic-signs| using |:sign-define| or |sign_define()|. Use
-  the "signs" key of |vim.diagnostic.config()| instead.
-
-• Checkhealth functions:
-  - |health#report_error|, |vim.health.report_error()|	Use |vim.health.error()| instead.
-  - |health#report_info|, |vim.health.report_info()|	Use |vim.health.info()| instead.
-  - |health#report_ok|, |vim.health.report_ok()|	Use |vim.health.ok()| instead.
-  - |health#report_start|, |vim.health.report_start()|	Use |vim.health.start()| instead.
-  - |health#report_warn|, |vim.health.report_warn()|	Use |vim.health.warn()| instead.
-
-• |API| functions:
-  - |nvim_buf_get_option()|	Use |nvim_get_option_value()| instead.
-  - |nvim_buf_set_option()|	Use |nvim_set_option_value()| instead.
-  - nvim_call_atomic()		Use |nvim_exec_lua()| instead.
-  - |nvim_get_option()|		Use |nvim_get_option_value()| instead.
-  - |nvim_set_option()|		Use |nvim_set_option_value()| instead.
-  - |nvim_win_get_option()|	Use |nvim_get_option_value()| instead.
-  - |nvim_win_set_option()|	Use |nvim_set_option_value()| instead.
-
-• vim.diagnostic functions:
-  - |vim.diagnostic.disable()|
-  - |vim.diagnostic.is_disabled()|
-  - Legacy signature: `vim.diagnostic.enable(buf:number, namespace:number)`
-
-• vim.lsp functions:
-  - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
-  - |vim.lsp.get_active_clients()|		Use |vim.lsp.get_clients()| instead.
-  - |vim.lsp.for_each_buffer_client()|		Use |vim.lsp.get_clients()| instead.
-  - |vim.lsp.util.trim_empty_lines()|		Use |vim.split()| with `trimempty` instead.
-  - |vim.lsp.util.try_trim_markdown_code_blocks()|
-  - |vim.lsp.util.set_lines()|
-  - |vim.lsp.util.extract_completion_items()|
-  - |vim.lsp.util.parse_snippet()|
-  - |vim.lsp.util.text_document_completion_list_to_complete_items()|
-
-• `vim.loop` has been renamed to |vim.uv|.
-
-• vim.treesitter functions:
-  - |LanguageTree:for_each_child()|	Use |LanguageTree:children()| (non-recursive) instead.
-
-• The "term_background" UI option |ui-ext-options| is deprecated and no longer
-  populated. Background color detection is now performed in Lua by the Nvim
-  core, not the TUI.
-
-• Lua stdlib:
-  - |vim.tbl_add_reverse_lookup()|
-  - |vim.tbl_flatten()|
-  - |vim.tbl_islist()|
+See |deprecated-0.10|.
 
  vim:tw=78:ts=8:sw=2:et:ft=help:norl:


### PR DESCRIPTION
Refer to `deprecated.txt` in `news.txt` in the deprecated section and
order `deprecated.txt` according to which version a feature was
deprecated in.