### PR TITLE
fix(fswatch): locale dependent parameter

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -303,6 +303,8 @@ function M.fswatch(path, opts, callback)
         fswatch_output_handler(line, opts, callback)
       end
     end,
+    -- --latency is locale dependent but tostring() isn't and will always have '.' as decimal point.
+    env = { LC_NUMERIC = 'C' },
   })
 
   return function()


### PR DESCRIPTION
fixes #27755

The `tostring()` lua function does not repect locale but `fswatch`'s --latency does.

This is my first PR to neovim so let me know if something isn't correct.