### PR TITLE
vim-patch:9.1.0161: expand() removes slash after env variable that ends with colon

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -586,9 +586,6 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
   bool copy_char;
   bool mustfree;  // var was allocated, need to free it later
   bool at_start = true;  // at start of a name
-#if defined(BACKSLASH_IN_FILENAME)
-  char *const save_dst = dst;
-#endif
 
   int prefix_len = (prefix == NULL) ? 0 : (int)strlen(prefix);
 
@@ -729,7 +726,7 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
         // with it, skip a character
         if (after_pathsep(dst, dst + c)
 #if defined(BACKSLASH_IN_FILENAME)
-            && (dst == save_dst || dst[-1] != ':')
+            && dst[c - 1] != ':'
 #endif
             && vim_ispathsep(*tail)) {
           tail++;

--- a/test/old/testdir/test_expand.vim
+++ b/test/old/testdir/test_expand.vim
@@ -45,10 +45,23 @@ endfunc
 
 func Test_expand_tilde_filename()
   split ~
-  call assert_equal('~', expand('%')) 
+  call assert_equal('~', expand('%'))
   call assert_notequal(expand('%:p'), expand('~/'))
-  call assert_match('\~', expand('%:p')) 
+  call assert_match('\~', expand('%:p'))
   bwipe!
+endfunc
+
+func Test_expand_env_pathsep()
+  let $FOO = './foo'
+  call assert_equal('./foo/bar', expand('$FOO/bar'))
+  let $FOO = './foo/'
+  call assert_equal('./foo/bar', expand('$FOO/bar'))
+  let $FOO = 'C:'
+  call assert_equal('C:/bar', expand('$FOO/bar'))
+  let $FOO = 'C:/'
+  call assert_equal('C:/bar', expand('$FOO/bar'))
+
+  unlet $FOO
 endfunc
 
 func Test_expandcmd()


### PR DESCRIPTION
#### vim-patch:9.1.0161: expand() removes slash after env variable that ends with colon

Problem:  expand() removes a slash after an environment variable that
          ends with a colon on Windows.
Solution: Check the correct char for a colon (zeertzjq)

closes: vim/vim#14161

Note: Vim still removes the path-separator at the end, if another path separator
follows directly after it, e.g. on:

```
    echo $FOO='/usr/'
    echo expand('$FOO/bar') == '/usr/bar'
```

see:

,----[ misc1.c:1630 ]
|   // if var[] ends in a path separator and tail[] starts
|   // with it, skip a character
|   if (after_pathsep(dst, dst + c)
| #if defined(BACKSLASH_IN_FILENAME) || defined(AMIGA)
| 	  && (dst == save_dst || dst[-1] != ':')
| #endif
| 	  && vim_ispathsep(*tail))
|       ++tail;
`----

https://github.com/vim/vim/commit/13a014452a7a020a119ac555a690c65b41f3126d

Cherry-pick test_expand.vim change from patch 9.0.1257.