### PR TITLE
fix(window): :close crash if WinClosed from float closes window

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2560,6 +2560,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, bool force, tab
       emsg(_("E814: Cannot close window, only autocmd window would remain"));
       return true;
     }
+
     if (force || can_close_floating_windows()) {
       // close the last window until the there are no floating windows
       while (lastwin->w_floating) {
@@ -2572,6 +2573,10 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, bool force, tab
     } else {
       emsg(e_floatonly);
       return true;
+    }
+
+    if (!win_valid_any_tab(win)) {
+      return true;  // window already closed by autocommands
     }
   }
 
@@ -2590,10 +2595,6 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, bool force, tab
   // Don't trigger autocommands yet, they may use wrong values, so do
   // that below.
   goto_tabpage_tp(alt_tabpage(), false, true);
-
-  // save index for tabclosed event
-  char prev_idx[NUMBUFLEN];
-  snprintf(prev_idx, NUMBUFLEN, "%i", tabpage_index(prev_curtab));
 
   // Safety check: Autocommands may have closed the window when jumping
   // to the other tab page.

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -908,6 +908,21 @@ describe('float window', function()
       command('close')
       assert_alive()
     end)
+
+    it('does not crash if WinClosed from floating windows closes it', function()
+      exec([[
+        tabnew
+        let g:buf = bufnr()
+        new
+        let s:win = win_getid()
+        call nvim_win_set_config(s:win,
+              \ #{relative: 'editor', row: 5, col: 5, width: 5, height: 5})
+        wincmd t
+        exe $"autocmd WinClosed {s:win} 1close"
+      ]])
+      command('close')
+      assert_alive()
+    end)
   end)
 
   local function with_ext_multigrid(multigrid)


### PR DESCRIPTION
Problem:  :close crash if WinClosed from float closes window.
Solution: Check if window has already been closed.
