### PR TITLE
refactor(window.c): remove duplicate condition

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2555,7 +2555,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, bool force, tab
     return false;
   }
 
-  if (lastwin->w_floating && one_window(win)) {
+  if (lastwin->w_floating) {
     if (is_aucmd_win(lastwin)) {
       emsg(_("E814: Cannot close window, only autocmd window would remain"));
       return true;

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -912,7 +912,6 @@ describe('float window', function()
     it('does not crash if WinClosed from floating windows closes it', function()
       exec([[
         tabnew
-        let g:buf = bufnr()
         new
         let s:win = win_getid()
         call nvim_win_set_config(s:win,


### PR DESCRIPTION
The one_window(win) condition is already checked above.
