### PR TITLE
vim-patch:9.1.0138: too many STRLEN calls when getting a memline

### DIFF
--- a/runtime/doc/dev_vimpatch.txt
+++ b/runtime/doc/dev_vimpatch.txt
@@ -209,6 +209,8 @@ information.
   utf_off2cells                                       grid_off2cells
   ml_get_curline                                    get_cursor_line_ptr
   ml_get_cursor                                     get_cursor_pos_ptr
+  ml_get_curline_len                                get_cursor_line_len
+  ml_get_cursor_len                                 get_cursor_pos_len
   screen_char                                             ui_line
   screen_line                                        grid_put_linebuf
   screen_* (most functions)                               grid_*

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -514,3 +514,15 @@ char *get_cursor_pos_ptr(void)
 {
   return ml_get_buf(curbuf, curwin->w_cursor.lnum) + curwin->w_cursor.col;
 }
+
+/// @return  length (excluding the NUL) of the cursor line.
+colnr_T get_cursor_line_len(void)
+{
+  return ml_get_buf_len(curbuf, curwin->w_cursor.lnum);
+}
+
+/// @return  length (excluding the NUL) of the cursor position.
+colnr_T get_cursor_pos_len(void)
+{
+  return ml_get_buf_len(curbuf, curwin->w_cursor.lnum) - curwin->w_cursor.col;
+}

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3785,9 +3785,10 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         if (has_format_option(FO_AUTO)
             && has_format_option(FO_WHITE_PAR)) {
           char *ptr = ml_get_buf_mut(curbuf, curwin->w_cursor.lnum);
-          int len = (int)strlen(ptr);
+          int len = get_cursor_line_len();
           if (len > 0 && ptr[len - 1] == ' ') {
             ptr[len - 1] = NUL;
+            curbuf->b_ml.ml_line_len--;
           }
         }
 
@@ -4411,13 +4412,13 @@ static bool ins_tab(void)
       if (i > 0) {
         STRMOVE(ptr, ptr + i);
         // correct replace stack.
-        if ((State & REPLACE_FLAG)
-            && !(State & VREPLACE_FLAG)) {
+        if ((State & REPLACE_FLAG) && !(State & VREPLACE_FLAG)) {
           for (temp = i; --temp >= 0;) {
             replace_join(repl_off);
           }
         }
         if (!(State & VREPLACE_FLAG)) {
+          curbuf->b_ml.ml_line_len -= i;
           inserted_bytes(fpos.lnum, change_col,
                          cursor->col - change_col, fpos.col - change_col);
         }
@@ -4462,8 +4463,7 @@ bool ins_eol(int c)
   // Strange Vi behaviour: In Replace mode, typing a NL will not delete the
   // character under the cursor.  Only push a NUL on the replace stack,
   // nothing to put back when the NL is deleted.
-  if ((State & REPLACE_FLAG)
-      && !(State & VREPLACE_FLAG)) {
+  if ((State & REPLACE_FLAG) && !(State & VREPLACE_FLAG)) {
     replace_push(NUL);
   }
 

--- a/src/nvim/memline_defs.h
+++ b/src/nvim/memline_defs.h
@@ -56,6 +56,7 @@ typedef struct {
 #define ML_ALLOCATED    0x10    // ml_line_ptr is an allocated copy
   int ml_flags;
 
+  colnr_T ml_line_len;          // length of the cached line + NUL
   linenr_T ml_line_lnum;        // line number of cached line, 0 if not valid
   char *ml_line_ptr;            // pointer to cached line
   size_t ml_line_offset;        // cached byte offset of ml_line_lnum

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3223,8 +3223,7 @@ static void nv_colon(cmdarg_T *cap)
     clearop(cap->oap);
   } else if (cap->oap->op_type != OP_NOP
              && (cap->oap->start.lnum > curbuf->b_ml.ml_line_count
-                 || cap->oap->start.col >
-                 (colnr_T)strlen(ml_get(cap->oap->start.lnum))
+                 || cap->oap->start.col > ml_get_len(cap->oap->start.lnum)
                  || did_emsg)) {
     // The start of the operator has become invalid by the Ex command.
     clearopbeep(cap->oap);
@@ -3592,7 +3591,7 @@ bool get_visual_text(cmdarg_T *cap, char **pp, size_t *lenp)
   }
   if (VIsual_mode == 'V') {
     *pp = get_cursor_line_ptr();
-    *lenp = strlen(*pp);
+    *lenp = (size_t)get_cursor_line_len();
   } else {
     if (lt(curwin->w_cursor, VIsual)) {
       *pp = ml_get_pos(&curwin->w_cursor);
@@ -4527,9 +4526,8 @@ static void nv_replace(cmdarg_T *cap)
   }
 
   // Abort if not enough characters to replace.
-  char *ptr = get_cursor_pos_ptr();
-  if (strlen(ptr) < (unsigned)cap->count1
-      || (mb_charlen(ptr) < cap->count1)) {
+  if ((size_t)get_cursor_pos_len() < (unsigned)cap->count1
+      || (mb_charlen(get_cursor_pos_ptr()) < cap->count1)) {
     clearopbeep(cap->oap);
     return;
   }
@@ -5347,7 +5345,7 @@ static void nv_gi_cmd(cmdarg_T *cap)
   if (curbuf->b_last_insert.mark.lnum != 0) {
     curwin->w_cursor = curbuf->b_last_insert.mark;
     check_cursor_lnum(curwin);
-    int i = (int)strlen(get_cursor_line_ptr());
+    int i = (int)get_cursor_line_len();
     if (curwin->w_cursor.col > (colnr_T)i) {
       if (virtual_active()) {
         curwin->w_cursor.coladd += curwin->w_cursor.col - i;
@@ -6036,7 +6034,7 @@ bool unadjust_for_sel(void)
       mark_mb_adjustpos(curbuf, pp);
     } else if (pp->lnum > 1) {
       pp->lnum--;
-      pp->col = (colnr_T)strlen(ml_get(pp->lnum));
+      pp->col = ml_get_len(pp->lnum);
       return true;
     }
   }

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -86,8 +86,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
 
   // When 'ai' is off we don't want a space under the cursor to be
   // deleted.  Replace it with an 'x' temporarily.
-  if (!curbuf->b_p_ai
-      && !(State & VREPLACE_FLAG)) {
+  if (!curbuf->b_p_ai && !(State & VREPLACE_FLAG)) {
     cc = gchar_cursor();
     if (ascii_iswhite(cc)) {
       save_char = (char)cc;

--- a/test/old/testdir/test_comments.vim
+++ b/test/old/testdir/test_comments.vim
@@ -237,6 +237,12 @@ func Test_comment_autoformat()
   call feedkeys("aone\ntwo\n", 'xt')
   call assert_equal(['one', 'two', ''], getline(1, '$'))
 
+  set backspace=indent,eol,start
+  %d
+  call feedkeys("aone \n\<BS>", 'xt')
+  call assert_equal(['one'], getline(1, '$'))
+  set backspace&
+
   close!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0138: too many STRLEN calls when getting a memline

Problem:  too many STRLEN calls when getting a memline
Solution: Optimize calls to STRLEN(), add a few functions in memline.c
          that return the byte length instead of relying on STRLEN()
          (John Marriott)

closes: vim/vim#14052

https://github.com/vim/vim/commit/02d7a6c6cfceb3faf9c98fcb7c458760cd50d269

Cherry-pick line break changes from patch 8.1.0226.
Cherry-pick ml_line_len from patch 8.1.0579.
Cherry-pick test_comments.vim change from patch 9.1.0153.

Co-authored-by: John Marriott <basilisk@internode.on.net>