### PR TITLE
vim-patch:9.1.0162: problem with writing extended attributes on failure

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -789,7 +789,7 @@ void os_copy_xattr(const char *from_file, const char *to_file)
   // get the length of the extended attributes
   ssize_t size = listxattr((char *)from_file, NULL, 0);
   // not supported or no attributes to copy
-  if (errno == ENOTSUP || size <= 0) {
+  if (size <= 0) {
     return;
   }
   char *xattr_buf = xmalloc((size_t)size);


### PR DESCRIPTION
#### vim-patch:9.1.0162: problem with writing extended attributes on failure

Problem:  problem with writing extended attributes on failure
Solution: Change return type to ssize_t and check listxattr's return
          value correctly on failure (Paul Tagliamonte)

The existing logic will return when the listxattr call returns with the
errno set to ENOTSUP (or a size of 0 bytes), without checking to see if
listxattr actually failed. listxattr can fail with at least E2BIG,
ENOTSUP, ERANGE, or anything that `stat(2)` can fail with (in my case;
ENOENT from stat).

The returned size is stored to a size_t, but the return type is a
ssize_t. On failure, listxattr returns -1, which will get translated to
size_t's MAX. If the listxattr call failed with anything other than
ENOTSUP, this triggers a request for size_t MAX bytes.

This means that, if the listxattr call fails with anything other than
ENOTSUP on save, vim will error with

`E342: Out of memory!  (allocating 18446744073709551615 bytes)`

(keen observers will note 18446744073709551615 is 0xffffffffffffffff)

In reality, this is likely masking a different (usually filesystem?)
error -- but at least it's an error being pushed to the user now, and we
don't try to allocate size_t MAX bytes.

I've opted to change the type that we store listxattr to from size_t to
ssize_t, to match listxattr(2)'s signature, and to check for the -1
return value. Additionally, I've removed the errno check -- if we get a
listxattr failure for any reason, we may as well bail without trying;
it's not like we can even recover.

closes: vim/vim#14169

https://github.com/vim/vim/commit/14759ded57447345ba11c11a99fd84344797862c

Co-authored-by: Paul R. Tagliamonte <paultag@gmail.com>