### PR TITLE
vim-patch:9.1.0164: Internal error when passing invalid position to getregion()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2859,20 +2859,40 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   } else if (type[0] == Ctrl_V && type[1] == NUL) {
     region_type = kMTBlockWise;
   } else {
+    semsg(_(e_invargNval), "type", type);
     return;
   }
 
   buf_T *const save_curbuf = curbuf;
+  buf_T *findbuf = curbuf;
 
   if (fnum1 != 0) {
-    buf_T *findbuf = buflist_findnr(fnum1);
+    findbuf = buflist_findnr(fnum1);
     // buffer not loaded
     if (findbuf == NULL || findbuf->b_ml.ml_mfp == NULL) {
+      emsg(_(e_buffer_is_not_loaded));
       return;
     }
-    curbuf = findbuf;
   }
 
+  if (p1.lnum < 1 || p1.lnum > findbuf->b_ml.ml_line_count) {
+    semsg(_(e_invalid_line_number_nr), p1.lnum);
+    return;
+  }
+  if (p1.col < 1 || p1.col > ml_get_buf_len(findbuf, p1.lnum) + 1) {
+    semsg(_(e_invalid_column_number_nr), p1.col);
+    return;
+  }
+  if (p2.lnum < 1 || p2.lnum > findbuf->b_ml.ml_line_count) {
+    semsg(_(e_invalid_line_number_nr), p2.lnum);
+    return;
+  }
+  if (p2.col < 1 || p2.col > ml_get_buf_len(findbuf, p2.lnum) + 1) {
+    semsg(_(e_invalid_column_number_nr), p2.col);
+    return;
+  }
+
+  curbuf = findbuf;
   const TriState save_virtual = virtual_op;
   virtual_op = virtual_active();
 
@@ -2900,7 +2920,7 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         mark_mb_adjustpos(curbuf, &p2);
       } else if (p2.lnum > 1) {
         p2.lnum--;
-        p2.col = (colnr_T)strlen(ml_get(p2.lnum));
+        p2.col = ml_get_len(p2.lnum);
         if (p2.col > 0) {
           p2.col--;
           mark_mb_adjustpos(curbuf, &p2);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -958,6 +958,7 @@ EXTERN const char e_highlight_group_name_invalid_char[] INIT(= N_("E5248: Invali
 
 EXTERN const char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
 
+EXTERN const char e_invalid_column_number_nr[] INIT( = N_("E964: Invalid column number: %ld"));
 EXTERN const char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line number: %ld"));
 
 EXTERN const char e_stray_closing_curly_str[]


### PR DESCRIPTION
#### vim-patch:9.1.0164: Internal error when passing invalid position to getregion()

Problem:  Internal error or crash when passing invalid position to
          getregion().
Solution: Give an error for invalid position (zeertzjq).

closes: vim/vim#14172

https://github.com/vim/vim/commit/26dd09ad5e86f4e2179be0181421bfab9a6b3b75