### PR TITLE
feat(ui): allow non-zero 'cmdheight' with ext_messages

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2024,9 +2024,6 @@ static const char *did_set_cmdheight(optset_T *args)
 {
   OptInt old_value = args->os_oldval.number;
 
-  if (ui_has(kUIMessages)) {
-    p_ch = 0;
-  }
   if (p_ch > Rows - min_rows() + 1) {
     p_ch = Rows - min_rows() + 1;
   }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -844,7 +844,7 @@ describe('ui/ext_messages', function()
     }
   end)
 
-  it('implies ext_cmdline and ignores cmdheight', function()
+  it("implies ext_cmdline but allows changing 'cmdheight'", function()
     eq(0, eval('&cmdheight'))
     feed(':set cmdheight=1')
     screen:expect {
@@ -864,15 +864,17 @@ describe('ui/ext_messages', function()
     feed('<cr>')
     screen:expect([[
       ^                         |
-      {1:~                        }|*4
+      {1:~                        }|*3
+                               |
     ]])
-    eq(0, eval('&cmdheight'))
+    eq(1, eval('&cmdheight'))
 
     feed(':set cmdheight=0')
     screen:expect {
       grid = [[
       ^                         |
-      {1:~                        }|*4
+      {1:~                        }|*3
+                               |
     ]],
       cmdline = {
         {


### PR DESCRIPTION
Problem:  Arbitrary restriction on 'cmdheight' with ext_messages.
          The 'cmdheight'-area may be desirable for the replacing
          cmdline.
Solution: Allow non-zero 'cmdheight' with ext_messages.