### PR TITLE
feat(ext_messages): add hl_id to ext_messages chunks

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -283,6 +283,8 @@ UI
   |hl-PmenuMatchSel| inherits highlights from both |hl-PmenuSel| and
   |hl-PmenuMatch|.
 
+• |ui-messages| content chunks now also contain the highlight group ID.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -805,10 +805,11 @@ must handle.
 	    kinds as the empty kind.
 
 	content
-	    Array of `[attr_id, text_chunk]` tuples, building up the message
-	    text of chunks of different highlights. No extra spacing should be
-	    added between chunks, the `text_chunk` by itself contains any
-	    necessary whitespace. Messages can contain line breaks "\n".
+	    Array of `[attr_id, text_chunk, hl_id]` tuples, building up the
+	    message text of chunks of different highlights. No extra spacing
+	    should be added between chunks, the `text_chunk` by itself
+	    contains any necessary whitespace. Messages can contain line
+	    breaks "\n".
 
 	replace_last
 	    Decides how multiple messages should be displayed:

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -824,16 +824,15 @@ HlMessage parse_hl_msg(Array chunks, Error *err)
 
     String str = copy_string(chunk.items[0].data.string, NULL);
 
-    int attr = 0;
+    int hl_id = 0;
     if (chunk.size == 2) {
       String hl = chunk.items[1].data.string;
       if (hl.size > 0) {
         // TODO(bfredl): use object_to_hl_id and allow integer
-        int hl_id = syn_check_group(hl.data, hl.size);
-        attr = hl_id > 0 ? syn_id2attr(hl_id) : 0;
+        hl_id = syn_check_group(hl.data, hl.size);
       }
     }
-    kv_push(hl_msg, ((HlMessageChunk){ .text = str, .attr = attr }));
+    kv_push(hl_msg, ((HlMessageChunk){ .text = str, .hl_id = hl_id }));
   }
 
   return hl_msg;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -796,7 +796,7 @@ void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
     verbose_enter();
   }
 
-  msg_multiattr(hl_msg, history ? "echomsg" : "echo", history);
+  msg_multihl(hl_msg, history ? "echomsg" : "echo", history);
 
   if (opts->verbose) {
     verbose_leave();

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -220,14 +220,14 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         // show the group name, if it's not the default group
         if (ac->pat->group != AUGROUP_DEFAULT) {
           if (last_group_name == NULL) {
-            msg_puts_attr(get_deleted_augroup(), HL_ATTR(HLF_E));
+            msg_puts_hl(get_deleted_augroup(), HLF_E + 1, false);
           } else {
-            msg_puts_attr(last_group_name, HL_ATTR(HLF_T));
+            msg_puts_hl(last_group_name, HLF_T + 1, false);
           }
           msg_puts("  ");
         }
         // show the event name
-        msg_puts_attr(event_nr2name(event), HL_ATTR(HLF_T));
+        msg_puts_hl(event_nr2name(event), HLF_T + 1, false);
       }
 
       // Show pattern only if it changed.
@@ -240,7 +240,7 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         }
 
         msg_col = 4;
-        msg_outtrans(ac->pat->pat, 0);
+        msg_outtrans(ac->pat->pat, 0, false);
       }
 
       if (got_int) {
@@ -260,17 +260,17 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         size_t msglen = 100;
         char *msg = xmallocz(msglen);
         if (ac->exec.type == CALLABLE_CB) {
-          msg_puts_attr(exec_to_string, HL_ATTR(HLF_8));
+          msg_puts_hl(exec_to_string, HLF_8 + 1, false);
           snprintf(msg, msglen, " [%s]", ac->desc);
         } else {
           snprintf(msg, msglen, "%s [%s]", exec_to_string, ac->desc);
         }
-        msg_outtrans(msg, 0);
+        msg_outtrans(msg, 0, false);
         XFREE_CLEAR(msg);
       } else if (ac->exec.type == CALLABLE_CB) {
-        msg_puts_attr(exec_to_string, HL_ATTR(HLF_8));
+        msg_puts_hl(exec_to_string, HLF_8 + 1, false);
       } else {
-        msg_outtrans(exec_to_string, 0);
+        msg_outtrans(exec_to_string, 0, false);
       }
       XFREE_CLEAR(exec_to_string);
       if (p_verbose > 0) {

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2902,7 +2902,7 @@ void buflist_list(exarg_T *eap)
                    buf == curbuf ? (int64_t)curwin->w_cursor.lnum : (int64_t)buflist_findlnum(buf));
     }
 
-    msg_outtrans(IObuff, 0);
+    msg_outtrans(IObuff, 0, false);
     line_breakcheck();
   }
 

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -350,7 +350,7 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
     msg_scroll = true;  // Don't overwrite messages here.
     msg_silent = 0;     // Must give this prompt.
     // Don't use emsg() here, don't want to flush the buffers.
-    msg(_("WARNING: The file has been changed since reading it!!!"), HL_ATTR(HLF_E));
+    msg(_("WARNING: The file has been changed since reading it!!!"), HLF_E + 1);
     if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
       return FAIL;
     }
@@ -1150,9 +1150,9 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   if (!filtering) {
     // show that we are busy
 #ifndef UNIX
-    filemess(buf, sfname, "", 0);
+    filemess(buf, sfname, "");
 #else
-    filemess(buf, fname, "", 0);
+    filemess(buf, fname, "");
 #endif
   }
   msg_scroll = false;               // always overwrite the file message now
@@ -1881,11 +1881,9 @@ nofail:
 
     retval = FAIL;
     if (end == 0) {
-      const int attr = HL_ATTR(HLF_E);  // Set highlight for error messages.
-      msg_puts_attr(_("\nWARNING: Original file may be lost or damaged\n"),
-                    attr | MSG_HIST);
-      msg_puts_attr(_("don't quit the editor until the file is successfully written!"),
-                    attr | MSG_HIST);
+      const int hl_id = HLF_E + 1;  // Set highlight for error messages.
+      msg_puts_hl(_("\nWARNING: Original file may be lost or damaged\n"), hl_id, true);
+      msg_puts_hl(_("don't quit the editor until the file is successfully written!"), hl_id, true);
 
       // Update the timestamp to avoid an "overwrite changed file"
       // prompt when writing again.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -89,9 +89,9 @@ void change_warning(buf_T *buf, int col)
     if (msg_row == Rows - 1) {
       msg_col = col;
     }
-    msg_source(HL_ATTR(HLF_W));
+    msg_source(HLF_W + 1);
     msg_ext_set_kind("wmsg");
-    msg_puts_attr(_(w_readonly), HL_ATTR(HLF_W) | MSG_HIST);
+    msg_puts_hl(_(w_readonly), HLF_W + 1, true);
     set_vim_var_string(VV_WARNINGMSG, _(w_readonly), -1);
     msg_clr_eos();
     msg_end();

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -979,20 +979,19 @@ void ExpandCleanup(expand_T *xp)
 /// @param linenr       line number of matches to display
 /// @param maxlen       maximum number of characters in each line
 /// @param showtail     display only the tail of the full path of a file name
-/// @param dir_attr     highlight attribute to use for directory names
 static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, int lines, int linenr,
-                                int maxlen, bool showtail, int dir_attr)
+                                int maxlen, bool showtail)
 {
   char *p;
   int lastlen = 999;
   for (int j = linenr; j < numMatches; j += lines) {
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-      msg_outtrans(matches[j], HL_ATTR(HLF_D));
+      msg_outtrans(matches[j], HLF_D + 1, false);
       p = matches[j] + strlen(matches[j]) + 1;
       msg_advance(maxlen + 1);
       msg_puts(p);
       msg_advance(maxlen + 3);
-      msg_outtrans_long(p + 2, HL_ATTR(HLF_D));
+      msg_outtrans_long(p + 2, HLF_D + 1);
       break;
     }
     for (int i = maxlen - lastlen; --i >= 0;) {
@@ -1029,7 +1028,7 @@ static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, in
       isdir = false;
       p = SHOW_MATCH(j);
     }
-    lastlen = msg_outtrans(p, isdir ? dir_attr : 0);
+    lastlen = msg_outtrans(p, isdir ? HLF_D + 1 : 0, false);
   }
   if (msg_col > 0) {  // when not wrapped around
     msg_clr_eos();
@@ -1119,18 +1118,16 @@ int showmatches(expand_T *xp, bool wildmenu)
       lines = (numMatches + columns - 1) / columns;
     }
 
-    int attr = HL_ATTR(HLF_D);      // find out highlighting for directories
-
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-      msg_puts_attr(_("tagname"), HL_ATTR(HLF_T));
+      msg_puts_hl(_("tagname"), HLF_T + 1, false);
       msg_clr_eos();
       msg_advance(maxlen - 3);
-      msg_puts_attr(_(" kind file\n"), HL_ATTR(HLF_T));
+      msg_puts_hl(_(" kind file\n"), HLF_T + 1, false);
     }
 
     // list the files line by line
     for (int i = 0; i < lines; i++) {
-      showmatches_oneline(xp, matches, numMatches, lines, i, maxlen, showtail, attr);
+      showmatches_oneline(xp, matches, numMatches, lines, i, maxlen, showtail);
       if (got_int) {
         got_int = false;
         break;

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -667,7 +667,7 @@ void ex_history(exarg_T *eap)
           } else {
             xstrlcpy(IObuff + len, hist[i].hisstr, (size_t)(IOSIZE - len));
           }
-          msg_outtrans(IObuff, 0);
+          msg_outtrans(IObuff, 0, false);
         }
         if (i == idx) {
           break;

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -55,7 +55,7 @@ typedef struct {
   schar_T conceal_char;
 } DecorHighlightInline;
 
-#define DECOR_HIGHLIGHT_INLINE_INIT { 0, DECOR_PRIORITY_BASE, 0,  0 }
+#define DECOR_HIGHLIGHT_INLINE_INIT { 0, DECOR_PRIORITY_BASE, 0, 0 }
 
 typedef struct {
   uint16_t flags;

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1707,7 +1707,7 @@ static void digraph_header(const char *msg)
   if (msg_col > 0) {
     msg_putchar('\n');
   }
-  msg_outtrans(msg, HL_ATTR(HLF_CM));
+  msg_outtrans(msg, HLF_CM + 1, false);
   msg_putchar('\n');
 }
 
@@ -1861,7 +1861,7 @@ static void printdigraph(const digr_T *dp, result_T *previous)
   *p++ = (char)dp->char2;
   *p++ = ' ';
   *p = NUL;
-  msg_outtrans(buf, 0);
+  msg_outtrans(buf, 0, false);
   p = buf;
 
   // add a space to draw a composing char on
@@ -1871,14 +1871,14 @@ static void printdigraph(const digr_T *dp, result_T *previous)
   p += utf_char2bytes(dp->result, p);
 
   *p = NUL;
-  msg_outtrans(buf, HL_ATTR(HLF_8));
+  msg_outtrans(buf, HLF_8 + 1, false);
   p = buf;
   if (char2cells(dp->result) == 1) {
     *p++ = ' ';
   }
   assert(p >= buf);
   vim_snprintf(p, sizeof(buf) - (size_t)(p - buf), " %3d", dp->result);
-  msg_outtrans(buf, 0);
+  msg_outtrans(buf, 0, false);
 }
 
 /// Get the two digraph characters from a typval.

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -952,7 +952,7 @@ int showmode(void)
 
     // Position on the last line in the window, column 0
     msg_pos_mode();
-    int attr = HL_ATTR(HLF_CM);                     // Highlight mode
+    int hl_id = HLF_CM + 1;  // Highlight mode
 
     // When the screen is too narrow to show the entire mode message,
     // avoid scrolling and truncate instead.
@@ -961,7 +961,7 @@ int showmode(void)
     lines_left = 0;
 
     if (do_mode) {
-      msg_puts_attr("--", attr);
+      msg_puts_hl("--", hl_id, false);
       // CTRL-X in Insert mode
       if (edit_submode != NULL && !shortmess(SHM_COMPLETIONMENU)) {
         // These messages can get long, avoid a wrap in a narrow window.
@@ -981,52 +981,49 @@ int showmode(void)
           }
           if (length - vim_strsize(edit_submode) > 0) {
             if (edit_submode_pre != NULL) {
-              msg_puts_attr(edit_submode_pre, attr);
+              msg_puts_hl(edit_submode_pre, hl_id, false);
             }
-            msg_puts_attr(edit_submode, attr);
+            msg_puts_hl(edit_submode, hl_id, false);
           }
           if (edit_submode_extra != NULL) {
-            msg_puts_attr(" ", attr);  // Add a space in between.
-            int sub_attr = edit_submode_highl < HLF_COUNT
-                           ? win_hl_attr(curwin, (int)edit_submode_highl)
-                           : attr;
-            msg_puts_attr(edit_submode_extra, sub_attr);
+            msg_puts_hl(" ", hl_id, false);  // Add a space in between.
+            int sub_id = edit_submode_highl < HLF_COUNT ? (int)edit_submode_highl + 1 : hl_id;
+            msg_puts_hl(edit_submode_extra, sub_id, false);
           }
         }
       } else {
         if (State & MODE_TERMINAL) {
-          msg_puts_attr(_(" TERMINAL"), attr);
+          msg_puts_hl(_(" TERMINAL"), hl_id, false);
         } else if (State & VREPLACE_FLAG) {
-          msg_puts_attr(_(" VREPLACE"), attr);
+          msg_puts_hl(_(" VREPLACE"), hl_id, false);
         } else if (State & REPLACE_FLAG) {
-          msg_puts_attr(_(" REPLACE"), attr);
+          msg_puts_hl(_(" REPLACE"), hl_id, false);
         } else if (State & MODE_INSERT) {
           if (p_ri) {
-            msg_puts_attr(_(" REVERSE"), attr);
+            msg_puts_hl(_(" REVERSE"), hl_id, false);
           }
-          msg_puts_attr(_(" INSERT"), attr);
+          msg_puts_hl(_(" INSERT"), hl_id, false);
         } else if (restart_edit == 'I' || restart_edit == 'i'
                    || restart_edit == 'a' || restart_edit == 'A') {
           if (curbuf->terminal) {
-            msg_puts_attr(_(" (terminal)"), attr);
+            msg_puts_hl(_(" (terminal)"), hl_id, false);
           } else {
-            msg_puts_attr(_(" (insert)"), attr);
+            msg_puts_hl(_(" (insert)"), hl_id, false);
           }
         } else if (restart_edit == 'R') {
-          msg_puts_attr(_(" (replace)"), attr);
+          msg_puts_hl(_(" (replace)"), hl_id, false);
         } else if (restart_edit == 'V') {
-          msg_puts_attr(_(" (vreplace)"), attr);
+          msg_puts_hl(_(" (vreplace)"), hl_id, false);
         }
         if (State & MODE_LANGMAP) {
           if (curwin->w_p_arab) {
-            msg_puts_attr(_(" Arabic"), attr);
-          } else if (get_keymap_str(curwin, " (%s)",
-                                    NameBuff, MAXPATHL)) {
-            msg_puts_attr(NameBuff, attr);
+            msg_puts_hl(_(" Arabic"), hl_id, false);
+          } else if (get_keymap_str(curwin, " (%s)", NameBuff, MAXPATHL)) {
+            msg_puts_hl(NameBuff, hl_id, false);
           }
         }
         if ((State & MODE_INSERT) && p_paste) {
-          msg_puts_attr(_(" (paste)"), attr);
+          msg_puts_hl(_(" (paste)"), hl_id, false);
         }
 
         if (VIsual_active) {
@@ -1050,9 +1047,9 @@ int showmode(void)
           default:
             p = N_(" SELECT BLOCK"); break;
           }
-          msg_puts_attr(_(p), attr);
+          msg_puts_hl(_(p), hl_id, false);
         }
-        msg_puts_attr(" --", attr);
+        msg_puts_hl(" --", hl_id, false);
       }
 
       need_clear = true;
@@ -1060,7 +1057,7 @@ int showmode(void)
     if (reg_recording != 0
         && edit_submode == NULL             // otherwise it gets too long
         ) {
-      recording_mode(attr);
+      recording_mode(hl_id);
       need_clear = true;
     }
 
@@ -1136,7 +1133,7 @@ void clearmode(void)
   msg_ext_ui_flush();
   msg_pos_mode();
   if (reg_recording != 0) {
-    recording_mode(HL_ATTR(HLF_CM));
+    recording_mode(HLF_CM + 1);
   }
   msg_clr_eos();
   msg_ext_flush_showmode();
@@ -1145,16 +1142,16 @@ void clearmode(void)
   msg_row = save_msg_row;
 }
 
-static void recording_mode(int attr)
+static void recording_mode(int hl_id)
 {
   if (shortmess(SHM_RECORDING)) {
     return;
   }
 
-  msg_puts_attr(_("recording"), attr);
+  msg_puts_hl(_("recording"), hl_id, false);
   char s[4];
   snprintf(s, ARRAY_SIZE(s), " @%c", reg_recording);
-  msg_puts_attr(s, attr);
+  msg_puts_hl(s, hl_id, false);
 }
 
 #define COL_RULER 17        // columns needed by standard ruler

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -126,7 +126,7 @@ bool *eval_lavars_used = NULL;
 #define SCRIPT_SV(id) (SCRIPT_ITEM(id)->sn_vars)
 #define SCRIPT_VARS(id) (SCRIPT_SV(id)->sv_dict.dv_hashtab)
 
-static int echo_attr = 0;   // attributes used for ":echo"
+static int echo_hl_id = 0;   // highlight id used for ":echo"
 
 /// Info used by a ":for" loop.
 typedef struct {
@@ -7876,12 +7876,12 @@ void ex_echo(exarg_T *eap)
           msg_start();
         }
       } else if (eap->cmdidx == CMD_echo) {
-        msg_puts_attr(" ", echo_attr);
+        msg_puts_hl(" ", echo_hl_id, false);
       }
       char *tofree = encode_tv2echo(&rettv, NULL);
       if (*tofree != NUL) {
         msg_ext_set_kind("echo");
-        msg_multiline(tofree, echo_attr, true, &need_clear);
+        msg_multiline(tofree, echo_hl_id, true, false, &need_clear);
       }
       xfree(tofree);
     }
@@ -7907,13 +7907,13 @@ void ex_echo(exarg_T *eap)
 /// ":echohl {name}".
 void ex_echohl(exarg_T *eap)
 {
-  echo_attr = syn_name2attr(eap->arg);
+  echo_hl_id = syn_name2id(eap->arg);
 }
 
-/// Returns the :echo attribute
-int get_echo_attr(void)
+/// Returns the :echo highlight id
+int get_echo_hl_id(void)
 {
-  return echo_attr;
+  return echo_hl_id;
 }
 
 /// ":execute expr1 ..." execute the result of an expression.
@@ -7964,7 +7964,7 @@ void ex_execute(exarg_T *eap)
   if (ret != FAIL && ga.ga_data != NULL) {
     if (eap->cmdidx == CMD_echomsg) {
       msg_ext_set_kind("echomsg");
-      msg(ga.ga_data, echo_attr);
+      msg(ga.ga_data, echo_hl_id);
     } else if (eap->cmdidx == CMD_echoerr) {
       // We don't want to abort following commands, restore did_emsg.
       int save_did_emsg = did_emsg;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1407,7 +1407,7 @@ static void list_one_var_a(const char *prefix, const char *name, const ptrdiff_t
   msg_start();
   msg_puts(prefix);
   if (name != NULL) {  // "a:" vars don't have a name stored
-    msg_puts_len(name, name_len, 0);
+    msg_puts_len(name, name_len, 0, false);
   }
   msg_putchar(' ');
   msg_advance(22);
@@ -1429,7 +1429,7 @@ static void list_one_var_a(const char *prefix, const char *name, const ptrdiff_t
     msg_putchar(' ');
   }
 
-  msg_outtrans(string, 0);
+  msg_outtrans(string, 0, false);
 
   if (type == VAR_FUNC || type == VAR_PARTIAL) {
     msg_puts("()");

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -189,7 +189,7 @@ void do_ascii(exarg_T *eap)
                    transchar(c), buf1, buf2, cval, cval, cval);
     }
 
-    msg_multiline(IObuff, 0, true, &need_clear);
+    msg_multiline(IObuff, 0, true, false, &need_clear);
 
     off += (size_t)utf_ptr2len(data);  // needed for overlong ascii?
   }
@@ -224,7 +224,7 @@ void do_ascii(exarg_T *eap)
                    c, c, c);
     }
 
-    msg_multiline(IObuff, 0, true, &need_clear);
+    msg_multiline(IObuff, 0, true, false, &need_clear);
 
     off += (size_t)utf_ptr2len(data + off);  // needed for overlong ascii?
   }
@@ -1028,7 +1028,7 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     msg_start();
     msg_putchar(':');
     msg_putchar('!');
-    msg_outtrans(newcmd, 0);
+    msg_outtrans(newcmd, 0, false);
     msg_clr_eos();
     ui_cursor_goto(msg_row, msg_col);
 
@@ -1469,7 +1469,7 @@ void print_line_no_prefix(linenr_T lnum, int use_number, bool list)
   if (curwin->w_p_nu || use_number) {
     vim_snprintf(numbuf, sizeof(numbuf), "%*" PRIdLINENR " ",
                  number_width(curwin), lnum);
-    msg_puts_attr(numbuf, HL_ATTR(HLF_N));  // Highlight line nrs.
+    msg_puts_hl(numbuf, HLF_N + 1, false);  // Highlight line nrs.
   }
   msg_prt_line(ml_get(lnum), list);
 }
@@ -3805,7 +3805,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               msg_no_more = true;
               msg_ext_set_kind("confirm_sub");
               // Same highlight as wait_return().
-              smsg(HL_ATTR(HLF_R), _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
+              smsg(HLF_R + 1, _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
               msg_no_more = false;
               msg_scroll = i;
               if (!ui_has(kUIMessages)) {
@@ -4796,7 +4796,7 @@ void ex_oldfiles(exarg_T *eap)
     if (!message_filtered(fname)) {
       msg_outnum(nr);
       msg_puts(": ");
-      msg_outtrans(tv_get_string(TV_LIST_ITEM_TV(li)), 0);
+      msg_outtrans(tv_get_string(TV_LIST_ITEM_TV(li)), 0, false);
       msg_clr_eos();
       msg_putchar('\n');
       os_breakcheck();

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -450,7 +450,7 @@ int buf_write_all(buf_T *buf, bool forceit)
                           1, buf->b_ml.ml_line_count, NULL,
                           false, forceit, true, false));
   if (curbuf != old_curbuf) {
-    msg_source(HL_ATTR(HLF_W));
+    msg_source(HLF_W + 1);
     msg(_("Warning: Entered other buffer unexpectedly (check autocommands)"), 0);
   }
   return retval;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5501,7 +5501,7 @@ static void ex_tabs(exarg_T *eap)
 
     msg_putchar('\n');
     vim_snprintf(IObuff, IOSIZE, _("Tab page %d"), tabcount++);
-    msg_outtrans(IObuff, HL_ATTR(HLF_T));
+    msg_outtrans(IObuff, HLF_T + 1, false);
     os_breakcheck();
 
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
@@ -5519,7 +5519,7 @@ static void ex_tabs(exarg_T *eap)
       } else {
         home_replace(wp->w_buffer, wp->w_buffer->b_fname, IObuff, IOSIZE, true);
       }
-      msg_outtrans(IObuff, 0);
+      msg_outtrans(IObuff, 0, false);
       os_breakcheck();
     }
   }
@@ -7776,7 +7776,7 @@ void verify_command(char *cmd)
   if (strcmp("smile", cmd) != 0) {
     return;  // acceptable non-existing command
   }
-  int a = HL_ATTR(HLF_E);
+  int a = HLF_E + 1;
   msg(" #xxn`          #xnxx`        ,+x@##@Mz;`        .xxx"
       "xxxxxxnz+,      znnnnnnnnnnnnnnnn.", a);
   msg(" n###z          x####`      :x##########W+`      ,###"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -811,7 +811,7 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
     if (!tl_ret && ERROR_SET(&err)) {
       msg_putchar('\n');
       msg_scroll = true;
-      msg_puts_attr(err.msg, HL_ATTR(HLF_E)|MSG_HIST);
+      msg_puts_hl(err.msg, HLF_E + 1, true);
       api_clear_error(&err);
       redrawcmd();
     }
@@ -2657,7 +2657,7 @@ static void do_autocmd_cmdlinechanged(int firstc)
     if (!tl_ret && ERROR_SET(&err)) {
       msg_putchar('\n');
       msg_scroll = true;
-      msg_puts_attr(err.msg, HL_ATTR(HLF_E)|MSG_HIST);
+      msg_puts_hl(err.msg, HLF_E + 1, true);
       api_clear_error(&err);
       redrawcmd();
     }
@@ -2755,13 +2755,13 @@ char *getcmdline(int firstc, int count, int indent, bool do_concat FUNC_ATTR_UNU
 ///
 /// @param[in]  firstc  Prompt type: e.g. '@' for input(), '>' for debug.
 /// @param[in]  prompt  Prompt string: what is displayed before the user text.
-/// @param[in]  attr  Prompt highlighting.
+/// @param[in]  hl_id  Prompt highlight id.
 /// @param[in]  xp_context  Type of expansion.
 /// @param[in]  xp_arg  User-defined expansion argument.
 /// @param[in]  highlight_callback  Callback used for highlighting user input.
 ///
 /// @return [allocated] Command line or NULL.
-char *getcmdline_prompt(const int firstc, const char *const prompt, const int attr,
+char *getcmdline_prompt(const int firstc, const char *const prompt, const int hl_id,
                         const int xp_context, const char *const xp_arg,
                         const Callback highlight_callback)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_MALLOC
@@ -2779,7 +2779,7 @@ char *getcmdline_prompt(const int firstc, const char *const prompt, const int at
   }
   ccline.prompt_id = last_prompt_id++;
   ccline.cmdprompt = (char *)prompt;
-  ccline.cmdattr = attr;
+  ccline.hl_id = hl_id;
   ccline.xp_context = xp_context;
   ccline.xp_arg = (char *)xp_arg;
   ccline.input_fn = (firstc == '@');
@@ -3095,15 +3095,13 @@ static void color_expr_cmdline(const CmdlineInfo *const colored_ccline,
       kv_push(ret_ccline_colors->colors, ((CmdlineColorChunk) {
         .start = (int)prev_end,
         .end = (int)chunk.start.col,
-        .attr = 0,
+        .hl_id = 0,
       }));
     }
-    const int id = syn_name2id(chunk.group);
-    const int attr = (id == 0 ? 0 : syn_id2attr(id));
     kv_push(ret_ccline_colors->colors, ((CmdlineColorChunk) {
       .start = (int)chunk.start.col,
       .end = (int)chunk.end_col,
-      .attr = attr,
+      .hl_id = syn_name2id(chunk.group),
     }));
     prev_end = chunk.end_col;
   }
@@ -3111,7 +3109,7 @@ static void color_expr_cmdline(const CmdlineInfo *const colored_ccline,
     kv_push(ret_ccline_colors->colors, ((CmdlineColorChunk) {
       .start = (int)prev_end,
       .end = colored_ccline->cmdlen,
-      .attr = 0,
+      .hl_id = 0,
     }));
   }
   kvi_destroy(colors);
@@ -3140,7 +3138,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
 #define PRINT_ERRMSG(...) \
   do { \
     msg_putchar('\n'); \
-    msg_printf_attr(HL_ATTR(HLF_E)|MSG_HIST, __VA_ARGS__); \
+    msg_printf_hl(HLF_E + 1, __VA_ARGS__); \
     printed_errmsg = true; \
   } while (0)
   bool ret = true;
@@ -3275,7 +3273,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
       kv_push(ccline_colors->colors, ((CmdlineColorChunk) {
         .start = (int)prev_end,
         .end = (int)start,
-        .attr = 0,
+        .hl_id = 0,
       }));
     }
     const varnumber_T end =
@@ -3299,12 +3297,10 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
     if (group == NULL) {
       goto color_cmdline_error;
     }
-    const int id = syn_name2id(group);
-    const int attr = (id == 0 ? 0 : syn_id2attr(id));
     kv_push(ccline_colors->colors, ((CmdlineColorChunk) {
       .start = (int)start,
       .end = (int)end,
-      .attr = attr,
+      .hl_id = syn_name2id(group),
     }));
     i++;
   });
@@ -3312,7 +3308,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
     kv_push(ccline_colors->colors, ((CmdlineColorChunk) {
       .start = (int)prev_end,
       .end = colored_ccline->cmdlen,
-      .attr = 0,
+      .hl_id = 0,
     }));
   }
   prev_prompt_errors = 0;
@@ -3374,10 +3370,10 @@ static void draw_cmdline(int start, int len)
           continue;
         }
         const int chunk_start = MAX(chunk.start, start);
-        msg_outtrans_len(ccline.cmdbuff + chunk_start, chunk.end - chunk_start, chunk.attr);
+        msg_outtrans_len(ccline.cmdbuff + chunk_start, chunk.end - chunk_start, chunk.hl_id, false);
       }
     } else {
-      msg_outtrans_len(ccline.cmdbuff + start, len, 0);
+      msg_outtrans_len(ccline.cmdbuff + start, len, 0, false);
     }
   }
 }
@@ -3403,7 +3399,7 @@ static void ui_ext_cmdline_show(CmdlineInfo *line)
     for (size_t i = 0; i < kv_size(line->last_colors.colors); i++) {
       CmdlineColorChunk chunk = kv_A(line->last_colors.colors, i);
       Array item = arena_array(&arena, 2);
-      ADD_C(item, INTEGER_OBJ(chunk.attr));
+      ADD_C(item, INTEGER_OBJ(chunk.hl_id == 0 ? 0 : syn_id2attr(chunk.hl_id)));
 
       assert(chunk.end >= chunk.start);
       ADD_C(item, STRING_OBJ(cbuf_as_string(line->cmdbuff + chunk.start,
@@ -3813,7 +3809,7 @@ static void redrawcmdprompt(void)
     msg_putchar(ccline.cmdfirstc);
   }
   if (ccline.cmdprompt != NULL) {
-    msg_puts_attr(ccline.cmdprompt, ccline.cmdattr);
+    msg_puts_hl(ccline.cmdprompt, ccline.hl_id, false);
     ccline.cmdindent = msg_col + (msg_row - cmdline_row) * Columns;
     // do the reverse of cmd_startcol()
     if (ccline.cmdfirstc != NUL) {
@@ -4801,7 +4797,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
       p = lastnl + 1;
       msg_start();
       msg_clr_eos();
-      msg_puts_len(prompt, p - prompt, get_echo_attr());
+      msg_puts_len(prompt, p - prompt, get_echo_hl_id(), false);
       msg_didout = false;
       msg_starthere();
     }
@@ -4812,7 +4808,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
 
   const int save_ex_normal_busy = ex_normal_busy;
   ex_normal_busy = 0;
-  rettv->vval.v_string = getcmdline_prompt(secret ? NUL : '@', p, get_echo_attr(),
+  rettv->vval.v_string = getcmdline_prompt(secret ? NUL : '@', p, get_echo_hl_id(),
                                            xp_type, xp_arg, input_callback);
   ex_normal_busy = save_ex_normal_busy;
   callback_free(&input_callback);

--- a/src/nvim/ex_getln_defs.h
+++ b/src/nvim/ex_getln_defs.h
@@ -10,8 +10,8 @@
 /// Defines a region which has the same highlighting.
 typedef struct {
   int start;  ///< Colored chunk start.
-  int end;  ///< Colored chunk end (exclusive, > start).
-  int attr;  ///< Highlight attr.
+  int end;    ///< Colored chunk end (exclusive, > start).
+  int hl_id;  ///< Highlight id.
 } CmdlineColorChunk;
 
 /// Command-line colors
@@ -49,7 +49,7 @@ struct cmdline_info {
   int cmdfirstc;                ///< ':', '/', '?', '=', '>' or NUL
   int cmdindent;                ///< number of spaces before cmdline
   char *cmdprompt;              ///< message in front of cmdline
-  int cmdattr;                  ///< attributes for prompt
+  int hl_id;                    ///< highlight id for prompt
   int overstrike;               ///< Typing mode on the command line.  Shared by
                                 ///< getcmdline() and put_on_cmdline().
   expand_T *xpc;                ///< struct being used for expansion, xp_pattern

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -99,7 +99,7 @@
 
 static const char *e_auchangedbuf = N_("E812: Autocommands changed buffer or buffer name");
 
-void filemess(buf_T *buf, char *name, char *s, int attr)
+void filemess(buf_T *buf, char *name, char *s)
 {
   int prev_msg_col = msg_col;
 
@@ -129,7 +129,7 @@ void filemess(buf_T *buf, char *name, char *s, int attr)
   msg_scroll = msg_scroll_save;
   msg_scrolled_ign = true;
   // may truncate the message to avoid a hit-return prompt
-  msg_outtrans(msg_may_trunc(false, IObuff), attr);
+  msg_outtrans(msg_may_trunc(false, IObuff), 0, false);
   msg_clr_eos();
   ui_flush();
   msg_scrolled_ign = false;
@@ -335,7 +335,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
 
     // If the name is too long we might crash further on, quit here.
     if (namelen >= MAXPATHL) {
-      filemess(curbuf, fname, _("Illegal file name"), 0);
+      filemess(curbuf, fname, _("Illegal file name"));
       msg_end();
       msg_scroll = msg_save;
       goto theend;
@@ -346,7 +346,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     // swap file may destroy it!  Reported on MS-DOS and Win 95.
     if (after_pathsep(fname, fname + namelen)) {
       if (!silent) {
-        filemess(curbuf, fname, _(msg_is_a_directory), 0);
+        filemess(curbuf, fname, _(msg_is_a_directory));
       }
       msg_end();
       msg_scroll = msg_save;
@@ -374,11 +374,11 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
         ) {
       if (S_ISDIR(perm)) {
         if (!silent) {
-          filemess(curbuf, fname, _(msg_is_a_directory), 0);
+          filemess(curbuf, fname, _(msg_is_a_directory));
         }
         retval = NOTDONE;
       } else {
-        filemess(curbuf, fname, _("is not a file"), 0);
+        filemess(curbuf, fname, _("is not a file"));
       }
       msg_end();
       msg_scroll = msg_save;
@@ -467,9 +467,9 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
       }
       if (!silent) {
         if (dir_of_file_exists(fname)) {
-          filemess(curbuf, sfname, _("[New]"), 0);
+          filemess(curbuf, sfname, _("[New]"));
         } else {
-          filemess(curbuf, sfname, _("[New DIRECTORY]"), 0);
+          filemess(curbuf, sfname, _("[New DIRECTORY]"));
         }
       }
       // Even though this is a new file, it might have been
@@ -497,10 +497,10 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
                               // open() does not set
                               // EOVERFLOW
                               (fd == -EOVERFLOW) ? _("[File too big]")
-                                                 : _("[Permission Denied]")), 0);
+                                                 : _("[Permission Denied]")));
 #else
     filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]")
-                                               : _("[Permission Denied]")), 0);
+                                               : _("[Permission Denied]")));
 #endif
     curbuf->b_p_ro = true;                  // must use "w!" now
 
@@ -658,7 +658,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
 
   if (!recoverymode && !filtering && !(flags & READ_DUMMY) && !silent) {
     if (!read_stdin && !read_buffer) {
-      filemess(curbuf, sfname, "", 0);
+      filemess(curbuf, sfname, "");
     }
   }
 
@@ -1685,7 +1685,7 @@ failed:
 
     if (got_int) {
       if (!(flags & READ_DUMMY)) {
-        filemess(curbuf, sfname, _(e_interr), 0);
+        filemess(curbuf, sfname, _(e_interr));
         if (newfile) {
           curbuf->b_p_ro = true;                // must use "w!" now
         }
@@ -3035,9 +3035,9 @@ int buf_check_timestamp(buf_T *buf)
     } else {
       if (!autocmd_busy) {
         msg_start();
-        msg_puts_attr(tbuf, HL_ATTR(HLF_E) + MSG_HIST);
+        msg_puts_hl(tbuf, HLF_E + 1, true);
         if (*mesg2 != NUL) {
-          msg_puts_attr(mesg2, HL_ATTR(HLF_W) + MSG_HIST);
+          msg_puts_hl(mesg2, HLF_W + 1, true);
         }
         msg_clr_eos();
         msg_end();

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -156,7 +156,7 @@ EXTERN bool msg_scrolled_ign INIT( = false);
 EXTERN bool msg_did_scroll INIT( = false);
 
 EXTERN char *keep_msg INIT( = NULL);         // msg to be shown after redraw
-EXTERN int keep_msg_attr INIT( = 0);         // highlight attr for keep_msg
+EXTERN int keep_msg_hl_id INIT( = 0);        // highlight id for keep_msg
 EXTERN bool need_fileinfo INIT( = false);    // do fileinfo() after redraw
 EXTERN int msg_scroll INIT( = false);        // msg_start() will scroll
 EXTERN bool msg_didout INIT( = false);       // msg_outstr() was used in line

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1621,9 +1621,9 @@ static void highlight_list_one(const int id)
   if (sgp->sg_link && !got_int) {
     syn_list_header(didh, 0, id, true);
     didh = true;
-    msg_puts_attr("links to", HL_ATTR(HLF_D));
+    msg_puts_hl("links to", HLF_D + 1, false);
     msg_putchar(' ');
-    msg_outtrans(hl_table[hl_table[id - 1].sg_link - 1].sg_name, 0);
+    msg_outtrans(hl_table[hl_table[id - 1].sg_link - 1].sg_name, 0, false);
   }
 
   if (!didh) {
@@ -1751,10 +1751,10 @@ static bool highlight_list_arg(const int id, bool didh, const int type, int iarg
   didh = true;
   if (!got_int) {
     if (*name != NUL) {
-      msg_puts_attr(name, HL_ATTR(HLF_D));
-      msg_puts_attr("=", HL_ATTR(HLF_D));
+      msg_puts_hl(name, HLF_D + 1, false);
+      msg_puts_hl("=", HLF_D + 1, false);
     }
-    msg_outtrans(ts, 0);
+    msg_outtrans(ts, 0, false);
   }
   return didh;
 }
@@ -1884,7 +1884,7 @@ bool syn_list_header(const bool did_header, const int outlen, const int id, bool
     if (got_int) {
       return true;
     }
-    msg_outtrans(hl_table[id - 1].sg_name, 0);
+    msg_outtrans(hl_table[id - 1].sg_name, 0, false);
     name_col = msg_col;
     endcol = 15;
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
@@ -1915,7 +1915,7 @@ bool syn_list_header(const bool did_header, const int outlen, const int id, bool
     if (endcol == Columns - 1 && endcol <= name_col) {
       msg_putchar(' ');
     }
-    msg_puts_attr("xxx", syn_id2attr(id));
+    msg_puts_hl("xxx", id, false);
     msg_putchar(' ');
   }
 
@@ -2047,7 +2047,7 @@ static int syn_add_group(const char *name, size_t len)
       return 0;
     } else if (!ASCII_ISALNUM(c) && c != '_' && c != '.' && c != '@' && c != '-') {
       // '.' and '@' are allowed characters for use with treesitter capture names.
-      msg_source(HL_ATTR(HLF_W));
+      msg_source(HLF_W + 1);
       emsg(_(e_highlight_group_name_invalid_char));
       return 0;
     }
@@ -2361,16 +2361,16 @@ void set_context_in_highlight_cmd(expand_T *xp, const char *arg)
 static void highlight_list(void)
 {
   for (int i = 10; --i >= 0;) {
-    highlight_list_two(i, HL_ATTR(HLF_D));
+    highlight_list_two(i, HLF_D + 1);
   }
   for (int i = 40; --i >= 0;) {
     highlight_list_two(99, 0);
   }
 }
 
-static void highlight_list_two(int cnt, int attr)
+static void highlight_list_two(int cnt, int id)
 {
-  msg_puts_attr(&("N \bI \b!  \b"[cnt / 11]), attr);
+  msg_puts_hl(&("N \bI \b!  \b"[cnt / 11]), id, false);
   msg_clr_eos();
   ui_flush();
   os_delay(cnt == 99 ? 40 : (uint64_t)cnt * 50, false);

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -55,7 +55,7 @@ int ask_yesno(const char *const str, const bool direct)
   int r = ' ';
   while (r != 'y' && r != 'n') {
     // same highlighting as for wait_return()
-    smsg(HL_ATTR(HLF_R), "%s (y/n)?", str);
+    smsg(HLF_R + 1, "%s (y/n)?", str);
     if (direct) {
       r = get_keystroke(NULL);
     } else {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -473,7 +473,7 @@ bool check_compl_option(bool dict_opt)
     ctrl_x_mode = CTRL_X_NORMAL;
     edit_submode = NULL;
     msg((dict_opt ? _("'dictionary' option is empty") : _("'thesaurus' option is empty")),
-        HL_ATTR(HLF_E));
+        HLF_E + 1);
     if (emsg_silent == 0 && !in_assert_fails) {
       vim_beep(BO_COMPL);
       setcursor();
@@ -1564,7 +1564,7 @@ static void ins_compl_files(int count, char **files, bool thesaurus, int flags,
       msg_hist_off = true;  // reset in msg_trunc()
       vim_snprintf(IObuff, IOSIZE,
                    _("Scanning dictionary: %s"), files[i]);
-      msg_trunc(IObuff, true, HL_ATTR(HLF_R));
+      msg_trunc(IObuff, true, HLF_R + 1);
     }
 
     if (fp == NULL) {
@@ -3046,7 +3046,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
                    : st->ins_buf->b_sfname == NULL
                    ? st->ins_buf->b_fname
                    : st->ins_buf->b_sfname);
-      msg_trunc(IObuff, true, HL_ATTR(HLF_R));
+      msg_trunc(IObuff, true, HLF_R + 1);
     }
   } else if (*st->e_cpt == NUL) {
     status = INS_COMPL_CPT_END;
@@ -3074,7 +3074,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
       if (!shortmess(SHM_COMPLETIONSCAN)) {
         msg_hist_off = true;  // reset in msg_trunc()
         vim_snprintf(IObuff, IOSIZE, "%s", _("Scanning tags."));
-        msg_trunc(IObuff, true, HL_ATTR(HLF_R));
+        msg_trunc(IObuff, true, HLF_R + 1);
       }
     }
 
@@ -4568,7 +4568,7 @@ static void ins_compl_show_statusmsg(void)
       if (!p_smd) {
         msg_hist_off = true;
         msg(edit_submode_extra, (edit_submode_highl < HLF_COUNT
-                                 ? HL_ATTR(edit_submode_highl) : 0));
+                                 ? (int)edit_submode_highl + 1 : 0));
         msg_hist_off = false;
       }
     } else {

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -239,9 +239,9 @@ static void showmap(mapblock_T *mp, bool local)
   } while (len < 12);
 
   if (mp->m_noremap == REMAP_NONE) {
-    msg_puts_attr("*", HL_ATTR(HLF_8));
+    msg_puts_hl("*", HLF_8 + 1, false);
   } else if (mp->m_noremap == REMAP_SCRIPT) {
-    msg_puts_attr("&", HL_ATTR(HLF_8));
+    msg_puts_hl("&", HLF_8 + 1, false);
   } else {
     msg_putchar(' ');
   }
@@ -256,10 +256,10 @@ static void showmap(mapblock_T *mp, bool local)
   // the rhs, and not M-x etc, true gets both -- webb
   if (mp->m_luaref != LUA_NOREF) {
     char *str = nlua_funcref_str(mp->m_luaref, NULL);
-    msg_puts_attr(str, HL_ATTR(HLF_8));
+    msg_puts_hl(str, HLF_8 + 1, false);
     xfree(str);
   } else if (mp->m_str[0] == NUL) {
-    msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
+    msg_puts_hl("<Nop>", HLF_8 + 1, false);
   } else {
     msg_outtrans_special(mp->m_str, false, 0);
   }
@@ -2657,7 +2657,7 @@ void ex_map(exarg_T *eap)
   // If we are in a secure mode we print the mappings for security reasons.
   if (secure) {
     secure = 2;
-    msg_outtrans(eap->cmd, 0);
+    msg_outtrans(eap->cmd, 0, false);
     msg_putchar('\n');
   }
   do_exmap(eap, false);

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -957,9 +957,9 @@ static void show_one_mark(int c, char *arg, pos_T *p, char *name_arg, int curren
       msg_putchar('\n');
       if (!got_int) {
         snprintf(IObuff, IOSIZE, " %c %6" PRIdLINENR " %4d ", c, p->lnum, p->col);
-        msg_outtrans(IObuff, 0);
+        msg_outtrans(IObuff, 0, false);
         if (name != NULL) {
-          msg_outtrans(name, current ? HL_ATTR(HLF_D) : 0);
+          msg_outtrans(name, current ? HLF_D + 1 : 0, false);
         }
       }
     }
@@ -1082,9 +1082,8 @@ void ex_jumps(exarg_T *eap)
                i == curwin->w_jumplistidx ? '>' : ' ',
                i > curwin->w_jumplistidx ? i - curwin->w_jumplistidx : curwin->w_jumplistidx - i,
                curwin->w_jumplist[i].fmark.mark.lnum, curwin->w_jumplist[i].fmark.mark.col);
-      msg_outtrans(IObuff, 0);
-      msg_outtrans(name,
-                   curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum ? HL_ATTR(HLF_D) : 0);
+      msg_outtrans(IObuff, 0, false);
+      msg_outtrans(name, curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum ? HLF_D + 1 : 0, false);
       xfree(name);
       os_breakcheck();
     }
@@ -1119,9 +1118,9 @@ void ex_changes(exarg_T *eap)
                curwin->w_changelistidx ? i - curwin->w_changelistidx : curwin->w_changelistidx - i,
                curbuf->b_changelist[i].mark.lnum,
                curbuf->b_changelist[i].mark.col);
-      msg_outtrans(IObuff, 0);
+      msg_outtrans(IObuff, 0, false);
       char *name = mark_line(&curbuf->b_changelist[i].mark, 17);
-      msg_outtrans(name, HL_ATTR(HLF_D));
+      msg_outtrans(name, HLF_D + 1, false);
       xfree(name);
       os_breakcheck();
     }

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -808,7 +808,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
       msg_puts(" ");
     }
     // Same highlighting as for directories!?
-    msg_outtrans(menu->name, HL_ATTR(HLF_D));
+    msg_outtrans(menu->name, HLF_D + 1, false);
   }
 
   if (menu != NULL && menu->children == NULL) {
@@ -841,7 +841,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
         }
         msg_puts(" ");
         if (*menu->strings[bit] == NUL) {
-          msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
+          msg_puts_hl("<Nop>", HLF_8 + 1, false);
         } else {
           msg_outtrans_special(menu->strings[bit], false, 0);
         }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -139,6 +139,7 @@ static const char *msg_ext_kind = NULL;
 static Array *msg_ext_chunks = NULL;
 static garray_T msg_ext_last_chunk = GA_INIT(sizeof(char), 40);
 static sattr_T msg_ext_last_attr = -1;
+static int msg_ext_hl_id;
 static size_t msg_ext_cur_len = 0;
 
 static bool msg_ext_overwrite = false;  ///< will overwrite last message
@@ -1088,12 +1089,14 @@ void ex_messages(exarg_T *eap)
             Array content_entry = ARRAY_DICT_INIT;
             ADD(content_entry, INTEGER_OBJ(chunk.hl_id ? syn_id2attr(chunk.hl_id) : 0));
             ADD(content_entry, STRING_OBJ(copy_string(chunk.text, NULL)));
+            ADD(content_entry, INTEGER_OBJ(chunk.hl_id));
             ADD(content, ARRAY_OBJ(content_entry));
           }
         } else if (p->msg && p->msg[0]) {
           Array content_entry = ARRAY_DICT_INIT;
           ADD(content_entry, INTEGER_OBJ(p->hl_id ? syn_id2attr(p->hl_id) : 0));
           ADD(content_entry, CSTR_TO_OBJ(p->msg));
+          ADD(content_entry, INTEGER_OBJ(p->hl_id));
           ADD(content, ARRAY_OBJ(content_entry));
         }
         ADD(entry, ARRAY_OBJ(content));
@@ -2125,6 +2128,7 @@ static void msg_ext_emit_chunk(void)
   msg_ext_last_attr = -1;
   String text = ga_take_string(&msg_ext_last_chunk);
   ADD(chunk, STRING_OBJ(text));
+  ADD(chunk, INTEGER_OBJ(msg_ext_hl_id));
   ADD(*msg_ext_chunks, ARRAY_OBJ(chunk));
 }
 
@@ -2141,6 +2145,7 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
 
   if (ui_has(kUIMessages)) {
     if (attr != msg_ext_last_attr) {
+      msg_ext_hl_id = hl_id;
       msg_ext_emit_chunk();
       msg_ext_last_attr = attr;
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -36,6 +36,7 @@
 #include "nvim/grid.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
+#include "nvim/highlight_group.h"
 #include "nvim/indent.h"
 #include "nvim/input.h"
 #include "nvim/keycodes.h"
@@ -73,7 +74,7 @@ struct msgchunk_S {
   msgchunk_T *sb_prev;
   char sb_eol;                  // true when line ends after this text
   int sb_msg_col;               // column in which text starts
-  int sb_attr;                  // text attributes
+  int sb_hl_id;                 // text highlight id
   char sb_text[];               // text to be displayed
 };
 
@@ -118,7 +119,7 @@ bool keep_msg_more = false;    // keep_msg was set by msgmore()
 // msg_scrolled     How many lines the screen has been scrolled (because of
 //                  messages).  Used in update_screen() to scroll the screen
 //                  back.  Incremented each time the screen scrolls a line.
-// msg_scrolled_ign  true when msg_scrolled is non-zero and msg_puts_attr()
+// msg_scrolled_ign  true when msg_scrolled is non-zero and msg_puts_hl_id()
 //                  writes something without scrolling should not make
 //                  need_wait_return to be set.  This is a hack to make ":ts"
 //                  work without an extra prompt.
@@ -231,7 +232,7 @@ void msg_grid_validate(void)
 int verb_msg(const char *s)
 {
   verbose_enter();
-  int n = msg_attr_keep(s, 0, false, false);
+  int n = msg_hl_keep(s, 0, false, false);
   verbose_leave();
 
   return n;
@@ -241,14 +242,14 @@ int verb_msg(const char *s)
 /// When terminal not initialized (yet) printf("%s", ..) is used.
 ///
 /// @return  true if wait_return() not called
-bool msg(const char *s, const int attr)
+bool msg(const char *s, const int hl_id)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  return msg_attr_keep(s, attr, false, false);
+  return msg_hl_keep(s, hl_id, false, false);
 }
 
 /// Similar to msg_outtrans, but support newlines and tabs.
-void msg_multiline(const char *s, int attr, bool check_int, bool *need_clear)
+void msg_multiline(const char *s, int hl_id, bool check_int, bool hist, bool *need_clear)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *next_spec = s;
@@ -261,13 +262,13 @@ void msg_multiline(const char *s, int attr, bool check_int, bool *need_clear)
 
     if (next_spec != NULL) {
       // Printing all char that are before the char found by strpbrk
-      msg_outtrans_len(s, (int)(next_spec - s), attr);
+      msg_outtrans_len(s, (int)(next_spec - s), hl_id, hist);
 
       if (*next_spec != TAB && *need_clear) {
         msg_clr_eos();
         *need_clear = false;
       }
-      msg_putchar_attr((uint8_t)(*next_spec), attr);
+      msg_putchar_hl((uint8_t)(*next_spec), hl_id);
       s = next_spec + 1;
     }
   }
@@ -275,11 +276,11 @@ void msg_multiline(const char *s, int attr, bool check_int, bool *need_clear)
   // Print the rest of the message. We know there is no special
   // character because strpbrk returned NULL
   if (*s != NUL) {
-    msg_outtrans(s, attr);
+    msg_outtrans(s, hl_id, hist);
   }
 }
 
-void msg_multiattr(HlMessage hl_msg, const char *kind, bool history)
+void msg_multihl(HlMessage hl_msg, const char *kind, bool history)
 {
   no_wait_return++;
   msg_start();
@@ -288,17 +289,17 @@ void msg_multiattr(HlMessage hl_msg, const char *kind, bool history)
   msg_ext_set_kind(kind);
   for (uint32_t i = 0; i < kv_size(hl_msg); i++) {
     HlMessageChunk chunk = kv_A(hl_msg, i);
-    msg_multiline(chunk.text.data, chunk.attr, true, &need_clear);
+    msg_multiline(chunk.text.data, chunk.hl_id, true, false, &need_clear);
   }
   if (history && kv_size(hl_msg)) {
-    add_msg_hist_multiattr(NULL, 0, 0, true, hl_msg);
+    add_msg_hist_multihl(NULL, 0, 0, true, hl_msg);
   }
   no_wait_return--;
   msg_end();
 }
 
 /// @param keep set keep_msg if it doesn't scroll
-bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
+bool msg_hl_keep(const char *s, int hl_id, bool keep, bool multiline)
   FUNC_ATTR_NONNULL_ALL
 {
   static int entered = 0;
@@ -316,7 +317,7 @@ bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
     return true;
   }
 
-  if (attr == 0) {
+  if (hl_id == 0) {
     set_vim_var_string(VV_STATUSMSG, s, -1);
   }
 
@@ -335,7 +336,7 @@ bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
           && last_msg_hist != NULL
           && last_msg_hist->msg != NULL
           && strcmp(s, last_msg_hist->msg) != 0)) {
-    add_msg_hist(s, -1, attr, multiline);
+    add_msg_hist(s, -1, hl_id, multiline);
   }
 
   // Truncate the message if needed.
@@ -347,9 +348,9 @@ bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
 
   bool need_clear = true;
   if (multiline) {
-    msg_multiline(s, attr, false, &need_clear);
+    msg_multiline(s, hl_id, false, false, &need_clear);
   } else {
-    msg_outtrans(s, attr);
+    msg_outtrans(s, hl_id, false);
   }
   if (need_clear) {
     msg_clr_eos();
@@ -484,7 +485,7 @@ void trunc_string(const char *s, char *buf, int room_in, int buflen)
   }
 }
 
-/// Shows a printf-style message with attributes.
+/// Shows a printf-style message with highlight id.
 ///
 /// Note: Caller must check the resulting string is shorter than IOSIZE!!!
 ///
@@ -492,7 +493,7 @@ void trunc_string(const char *s, char *buf, int room_in, int buflen)
 /// @see swmsg
 ///
 /// @param s printf-style format message
-int smsg(int attr, const char *s, ...)
+int smsg(int hl_id, const char *s, ...)
   FUNC_ATTR_PRINTF(2, 3)
 {
   va_list arglist;
@@ -500,10 +501,10 @@ int smsg(int attr, const char *s, ...)
   va_start(arglist, s);
   vim_vsnprintf(IObuff, IOSIZE, s, arglist);
   va_end(arglist);
-  return msg(IObuff, attr);
+  return msg(IObuff, hl_id);
 }
 
-int smsg_attr_keep(int attr, const char *s, ...)
+int smsg_hl_keep(int hl_id, const char *s, ...)
   FUNC_ATTR_PRINTF(2, 3)
 {
   va_list arglist;
@@ -511,7 +512,7 @@ int smsg_attr_keep(int attr, const char *s, ...)
   va_start(arglist, s);
   vim_vsnprintf(IObuff, IOSIZE, s, arglist);
   va_end(arglist);
-  return msg_attr_keep(IObuff, attr, true, false);
+  return msg_hl_keep(IObuff, hl_id, true, false);
 }
 
 // Remember the last sourcing name/lnum used in an error message, so that it
@@ -588,7 +589,7 @@ static char *get_emsg_lnum(void)
 /// Display name and line number for the source of an error.
 /// Remember the file name and line number, so that for the next error the info
 /// is only displayed if it changed.
-void msg_source(int attr)
+void msg_source(int hl_id)
 {
   static bool recursive = false;
 
@@ -602,12 +603,12 @@ void msg_source(int attr)
   char *p = get_emsg_source();
   if (p != NULL) {
     msg_scroll = true;  // this will take more than one line
-    msg(p, attr);
+    msg(p, hl_id);
     xfree(p);
   }
   p = get_emsg_lnum();
   if (p != NULL) {
-    msg(p, HL_ATTR(HLF_N));
+    msg(p, HLF_N + 1);
     xfree(p);
     last_sourcing_lnum = SOURCING_LNUM;      // only once for each line
   }
@@ -736,7 +737,7 @@ bool emsg_multiline(const char *s, bool multiline)
   }
 
   emsg_on_display = true;     // remember there is an error message
-  int attr = HL_ATTR(HLF_E);      // set highlight mode for error messages
+  int hl_id = HLF_E + 1;      // set highlight mode for error messages
   if (msg_scrolled != 0) {
     need_wait_return = true;  // needed in case emsg() is called after
   }                           // wait_return() has reset need_wait_return
@@ -748,11 +749,11 @@ bool emsg_multiline(const char *s, bool multiline)
 
   // Display name and line number for the source of the error.
   msg_scroll = true;
-  msg_source(attr);
+  msg_source(hl_id);
 
   // Display the error message itself.
   msg_nowait = false;  // Wait for this msg.
-  return msg_attr_keep(s, attr, false, multiline);
+  return msg_hl_keep(s, hl_id, false, multiline);
 }
 
 /// emsg() - display an error message
@@ -907,15 +908,15 @@ void msg_schedule_semsg_multiline(const char *const fmt, ...)
 /// Careful: The string may be changed by msg_may_trunc()!
 ///
 /// @return  a pointer to the printed message, if wait_return() not called.
-char *msg_trunc(char *s, bool force, int attr)
+char *msg_trunc(char *s, bool force, int hl_id)
 {
   // Add message to history before truncating.
-  add_msg_hist(s, -1, attr, false);
+  add_msg_hist(s, -1, hl_id, false);
 
   char *ts = msg_may_trunc(force, s);
 
   msg_hist_off = true;
-  bool n = msg(ts, attr);
+  bool n = msg(ts, hl_id);
   msg_hist_off = false;
 
   if (n) {
@@ -965,16 +966,16 @@ void hl_msg_free(HlMessage hl_msg)
 }
 
 /// @param[in]  len  Length of s or -1.
-static void add_msg_hist(const char *s, int len, int attr, bool multiline)
+static void add_msg_hist(const char *s, int len, int hl_id, bool multiline)
 {
-  add_msg_hist_multiattr(s, len, attr, multiline, (HlMessage)KV_INITIAL_VALUE);
+  add_msg_hist_multihl(s, len, hl_id, multiline, (HlMessage)KV_INITIAL_VALUE);
 }
 
-static void add_msg_hist_multiattr(const char *s, int len, int attr, bool multiline,
-                                   HlMessage multiattr)
+static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multiline,
+                                 HlMessage multihl)
 {
   if (msg_hist_off || msg_silent != 0) {
-    hl_msg_free(multiattr);
+    hl_msg_free(multihl);
     return;
   }
 
@@ -1002,9 +1003,9 @@ static void add_msg_hist_multiattr(const char *s, int len, int attr, bool multil
     p->msg = NULL;
   }
   p->next = NULL;
-  p->attr = attr;
+  p->hl_id = hl_id;
   p->multiline = multiline;
-  p->multiattr = multiattr;
+  p->multihl = multihl;
   p->kind = msg_ext_kind;
   if (last_msg_hist != NULL) {
     last_msg_hist->next = p;
@@ -1031,7 +1032,7 @@ int delete_first_msg(void)
     last_msg_hist = NULL;
   }
   xfree(p->msg);
-  hl_msg_free(p->multiattr);
+  hl_msg_free(p->multihl);
   xfree(p);
   msg_hist_len--;
   return OK;
@@ -1077,21 +1078,21 @@ void ex_messages(exarg_T *eap)
     }
     Array entries = ARRAY_DICT_INIT;
     for (; p != NULL; p = p->next) {
-      if (kv_size(p->multiattr) || (p->msg && p->msg[0])) {
+      if (kv_size(p->multihl) || (p->msg && p->msg[0])) {
         Array entry = ARRAY_DICT_INIT;
         ADD(entry, CSTR_TO_OBJ(p->kind));
         Array content = ARRAY_DICT_INIT;
-        if (kv_size(p->multiattr)) {
-          for (uint32_t i = 0; i < kv_size(p->multiattr); i++) {
-            HlMessageChunk chunk = kv_A(p->multiattr, i);
+        if (kv_size(p->multihl)) {
+          for (uint32_t i = 0; i < kv_size(p->multihl); i++) {
+            HlMessageChunk chunk = kv_A(p->multihl, i);
             Array content_entry = ARRAY_DICT_INIT;
-            ADD(content_entry, INTEGER_OBJ(chunk.attr));
+            ADD(content_entry, INTEGER_OBJ(chunk.hl_id ? syn_id2attr(chunk.hl_id) : 0));
             ADD(content_entry, STRING_OBJ(copy_string(chunk.text, NULL)));
             ADD(content, ARRAY_OBJ(content_entry));
           }
         } else if (p->msg && p->msg[0]) {
           Array content_entry = ARRAY_DICT_INIT;
-          ADD(content_entry, INTEGER_OBJ(p->attr));
+          ADD(content_entry, INTEGER_OBJ(p->hl_id ? syn_id2attr(p->hl_id) : 0));
           ADD(content_entry, CSTR_TO_OBJ(p->msg));
           ADD(content, ARRAY_OBJ(content_entry));
         }
@@ -1106,10 +1107,10 @@ void ex_messages(exarg_T *eap)
   } else {
     msg_hist_off = true;
     for (; p != NULL && !got_int; p = p->next) {
-      if (kv_size(p->multiattr)) {
-        msg_multiattr(p->multiattr, p->kind, false);
+      if (kv_size(p->multihl)) {
+        msg_multihl(p->multihl, p->kind, false);
       } else if (p->msg != NULL) {
-        msg_attr_keep(p->msg, p->attr, false, p->multiline);
+        msg_hl_keep(p->msg, p->hl_id, false, p->multiline);
       }
     }
     msg_hist_off = false;
@@ -1338,7 +1339,7 @@ static void hit_return_msg(bool newline_sb)
     msg_puts(_("Interrupt: "));
   }
 
-  msg_puts_attr(_("Press ENTER or type command to continue"), HL_ATTR(HLF_R));
+  msg_puts_hl(_("Press ENTER or type command to continue"), HLF_R + 1, false);
   if (!msg_use_printf()) {
     msg_clr_eos();
   }
@@ -1346,7 +1347,7 @@ static void hit_return_msg(bool newline_sb)
 }
 
 /// Set "keep_msg" to "s".  Free the old value and check for NULL pointer.
-void set_keep_msg(const char *s, int attr)
+void set_keep_msg(const char *s, int hl_id)
 {
   xfree(keep_msg);
   if (s != NULL && msg_silent == 0) {
@@ -1355,7 +1356,7 @@ void set_keep_msg(const char *s, int attr)
     keep_msg = NULL;
   }
   keep_msg_more = false;
-  keep_msg_attr = attr;
+  keep_msg_hl_id = hl_id;
 }
 
 /// Return true if printing messages should currently be done.
@@ -1480,10 +1481,10 @@ void msg_starthere(void)
 
 void msg_putchar(int c)
 {
-  msg_putchar_attr(c, 0);
+  msg_putchar_hl(c, 0);
 }
 
-void msg_putchar_attr(int c, int attr)
+void msg_putchar_hl(int c, int hl_id)
 {
   char buf[MB_MAXCHAR + 1];
 
@@ -1495,7 +1496,7 @@ void msg_putchar_attr(int c, int attr)
   } else {
     buf[utf_char2bytes(c, buf)] = NUL;
   }
-  msg_puts_attr(buf, attr);
+  msg_puts_hl(buf, hl_id, false);
 }
 
 void msg_outnum(int n)
@@ -1508,48 +1509,42 @@ void msg_outnum(int n)
 
 void msg_home_replace(const char *fname)
 {
-  msg_home_replace_attr(fname, 0);
+  msg_home_replace_hl(fname, 0);
 }
 
-void msg_home_replace_hl(const char *fname)
-{
-  msg_home_replace_attr(fname, HL_ATTR(HLF_D));
-}
-
-static void msg_home_replace_attr(const char *fname, int attr)
+static void msg_home_replace_hl(const char *fname, int hl_id)
 {
   char *name = home_replace_save(NULL, fname);
-  msg_outtrans(name, attr);
+  msg_outtrans(name, hl_id, false);
   xfree(name);
 }
 
-/// Output 'len' characters in 'str' (including NULs) with translation
-/// if 'len' is -1, output up to a NUL character.
-/// Use attributes 'attr'.
+/// Output "len" characters in "str" (including NULs) with translation
+/// if "len" is -1, output up to a NUL character. Use highlight "hl_id".
 ///
 /// @return  the number of characters it takes on the screen.
-int msg_outtrans(const char *str, int attr)
+int msg_outtrans(const char *str, int hl_id, bool hist)
 {
-  return msg_outtrans_len(str, (int)strlen(str), attr);
+  return msg_outtrans_len(str, (int)strlen(str), hl_id, hist);
 }
 
 /// Output one character at "p".
 /// Handles multi-byte characters.
 ///
 /// @return  pointer to the next character.
-const char *msg_outtrans_one(const char *p, int attr)
+const char *msg_outtrans_one(const char *p, int hl_id, bool hist)
 {
   int l;
 
   if ((l = utfc_ptr2len(p)) > 1) {
-    msg_outtrans_len(p, l, attr);
+    msg_outtrans_len(p, l, hl_id, hist);
     return p + l;
   }
-  msg_puts_attr(transchar_byte_buf(NULL, (uint8_t)(*p)), attr);
+  msg_puts_hl(transchar_byte_buf(NULL, (uint8_t)(*p)), hl_id, hist);
   return p + 1;
 }
 
-int msg_outtrans_len(const char *msgstr, int len, int attr)
+int msg_outtrans_len(const char *msgstr, int len, int hl_id, bool hist)
 {
   int retval = 0;
   const char *str = msgstr;
@@ -1561,10 +1556,8 @@ int msg_outtrans_len(const char *msgstr, int len, int attr)
   // Only quit when got_int was set in here.
   got_int = false;
 
-  // if MSG_HIST flag set, add message to history
-  if (attr & MSG_HIST) {
-    add_msg_hist(str, len, attr, false);
-    attr &= ~MSG_HIST;
+  if (hist) {
+    add_msg_hist(str, len, hl_id, false);
   }
 
   // When drawing over the command line no need to clear it later or remove
@@ -1588,10 +1581,10 @@ int msg_outtrans_len(const char *msgstr, int len, int attr)
         // Unprintable multi-byte char: print the printable chars so
         // far and the translation of the unprintable char.
         if (str > plain_start) {
-          msg_puts_len(plain_start, str - plain_start, attr);
+          msg_puts_len(plain_start, str - plain_start, hl_id, hist);
         }
         plain_start = str + mb_l;
-        msg_puts_attr(transchar_buf(NULL, c), attr == 0 ? HL_ATTR(HLF_8) : attr);
+        msg_puts_hl(transchar_buf(NULL, c), hl_id == 0 ? HLF_8 + 1 : hl_id, false);
         retval += char2cells(c);
       }
       len -= mb_l - 1;
@@ -1602,10 +1595,10 @@ int msg_outtrans_len(const char *msgstr, int len, int attr)
         // Unprintable char: print the printable chars so far and the
         // translation of the unprintable char.
         if (str > plain_start) {
-          msg_puts_len(plain_start, str - plain_start, attr);
+          msg_puts_len(plain_start, str - plain_start, hl_id, hist);
         }
         plain_start = str + 1;
-        msg_puts_attr(s, attr == 0 ? HL_ATTR(HLF_8) : attr);
+        msg_puts_hl(s, hl_id == 0 ? HLF_8 + 1 : hl_id, false);
         retval += (int)strlen(s);
       } else {
         retval++;
@@ -1616,7 +1609,7 @@ int msg_outtrans_len(const char *msgstr, int len, int attr)
 
   if (str > plain_start && !got_int) {
     // Print the printable chars at the end.
-    msg_puts_len(plain_start, str - plain_start, attr);
+    msg_puts_len(plain_start, str - plain_start, hl_id, hist);
   }
 
   got_int |= save_got_int;
@@ -1666,7 +1659,7 @@ int msg_outtrans_special(const char *strstart, bool from, int maxlen)
   }
   const char *str = strstart;
   int retval = 0;
-  int attr = HL_ATTR(HLF_8);
+  int hl_id = HLF_8 + 1;
 
   while (*str != NUL) {
     const char *text;
@@ -1686,9 +1679,7 @@ int msg_outtrans_special(const char *strstart, bool from, int maxlen)
       break;
     }
     // Highlight special keys
-    msg_puts_attr(text, (len > 1
-                         && utfc_ptr2len(text) <= 1
-                         ? attr : 0));
+    msg_puts_hl(text, (len > 1 && utfc_ptr2len(text) <= 1 ? hl_id : 0), false);
     retval += len;
   }
   return retval;
@@ -1856,7 +1847,7 @@ void msg_prt_line(const char *s, bool list)
   schar_T sc_final = 0;
   const char *p_extra = NULL;  // init to make SASC shut up. ASCII only!
   int n;
-  int attr = 0;
+  int hl_id = 0;
   const char *lead = NULL;
   bool in_multispace = false;
   int multispace_pos = 0;
@@ -1920,7 +1911,7 @@ void msg_prt_line(const char *s, bool list)
       s += l;
       continue;
     } else {
-      attr = 0;
+      hl_id = 0;
       int c = (uint8_t)(*s++);
       sc_extra = NUL;
       sc_final = NUL;
@@ -1944,13 +1935,13 @@ void msg_prt_line(const char *s, bool list)
                : curwin->w_p_lcs_chars.tab1;
           sc_extra = curwin->w_p_lcs_chars.tab2;
           sc_final = curwin->w_p_lcs_chars.tab3;
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         }
       } else if (c == NUL && list && curwin->w_p_lcs_chars.eol != NUL) {
         p_extra = "";
         n_extra = 1;
         sc = curwin->w_p_lcs_chars.eol;
-        attr = HL_ATTR(HLF_AT);
+        hl_id = HLF_AT + 1;
         s--;
       } else if (c != NUL && (n = byte2cells(c)) > 1) {
         n_extra = n - 1;
@@ -1958,7 +1949,7 @@ void msg_prt_line(const char *s, bool list)
         sc = schar_from_ascii(*p_extra++);
         // Use special coloring to be able to distinguish <hex> from
         // the same in plain text.
-        attr = HL_ATTR(HLF_0);
+        hl_id = HLF_0 + 1;
       } else if (c == ' ') {
         if (lead != NULL && s <= lead && in_multispace
             && curwin->w_p_lcs_chars.leadmultispace != NULL) {
@@ -1966,23 +1957,23 @@ void msg_prt_line(const char *s, bool list)
           if (curwin->w_p_lcs_chars.leadmultispace[multispace_pos] == NUL) {
             multispace_pos = 0;
           }
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         } else if (lead != NULL && s <= lead && curwin->w_p_lcs_chars.lead != NUL) {
           sc = curwin->w_p_lcs_chars.lead;
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         } else if (trail != NULL && s > trail) {
           sc = curwin->w_p_lcs_chars.trail;
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         } else if (in_multispace
                    && curwin->w_p_lcs_chars.multispace != NULL) {
           sc = curwin->w_p_lcs_chars.multispace[multispace_pos++];
           if (curwin->w_p_lcs_chars.multispace[multispace_pos] == NUL) {
             multispace_pos = 0;
           }
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         } else if (list && curwin->w_p_lcs_chars.space != NUL) {
           sc = curwin->w_p_lcs_chars.space;
-          attr = HL_ATTR(HLF_0);
+          hl_id = HLF_0 + 1;
         } else {
           sc = schar_from_ascii(' ');  // SPACE!
         }
@@ -1998,7 +1989,7 @@ void msg_prt_line(const char *s, bool list)
     // TODO(bfredl): this is such baloney. need msg_put_schar
     char buf[MAX_SCHAR_SIZE];
     schar_get(buf, sc);
-    msg_puts_attr(buf, attr);
+    msg_puts_hl(buf, hl_id, false);
     col++;
   }
   msg_clr_eos();
@@ -2008,42 +1999,42 @@ void msg_prt_line(const char *s, bool list)
 /// Update msg_row and msg_col for the next message.
 void msg_puts(const char *s)
 {
-  msg_puts_attr(s, 0);
+  msg_puts_hl(s, 0, false);
 }
 
 void msg_puts_title(const char *s)
 {
-  msg_puts_attr(s, HL_ATTR(HLF_T));
+  msg_puts_hl(s, HLF_T + 1, false);
 }
 
 /// Show a message in such a way that it always fits in the line.  Cut out a
 /// part in the middle and replace it with "..." when necessary.
 /// Does not handle multi-byte characters!
-void msg_outtrans_long(const char *longstr, int attr)
+void msg_outtrans_long(const char *longstr, int hl_id)
 {
   int len = (int)strlen(longstr);
   int slen = len;
   int room = Columns - msg_col;
   if (len > room && room >= 20) {
     slen = (room - 3) / 2;
-    msg_outtrans_len(longstr, slen, attr);
-    msg_puts_attr("...", HL_ATTR(HLF_8));
+    msg_outtrans_len(longstr, slen, hl_id, false);
+    msg_puts_hl("...", HLF_8 + 1, false);
   }
-  msg_outtrans_len(longstr + len - slen, slen, attr);
+  msg_outtrans_len(longstr + len - slen, slen, hl_id, len);
 }
 
-/// Basic function for writing a message with highlight attributes.
-void msg_puts_attr(const char *const s, const int attr)
+/// Basic function for writing a message with highlight id.
+void msg_puts_hl(const char *const s, const int hl_id, const bool hist)
 {
-  msg_puts_len(s, -1, attr);
+  msg_puts_len(s, -1, hl_id, hist);
 }
 
-/// Write a message with highlight attributes
+/// Write a message with highlight id.
 ///
 /// @param[in]  str  NUL-terminated message string.
 /// @param[in]  len  Length of the string or -1.
-/// @param[in]  attr  Highlight attribute.
-void msg_puts_len(const char *const str, const ptrdiff_t len, int attr)
+/// @param[in]  hl_id  Highlight id.
+void msg_puts_len(const char *const str, const ptrdiff_t len, int hl_id, bool hist)
   FUNC_ATTR_NONNULL_ALL
 {
   assert(len < 0 || memchr(str, 0, (size_t)len) == NULL);
@@ -2055,10 +2046,8 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int attr)
     return;
   }
 
-  // if MSG_HIST flag set, add message to history
-  if (attr & MSG_HIST) {
-    add_msg_hist(str, (int)len, attr, false);
-    attr &= ~MSG_HIST;
+  if (hist) {
+    add_msg_hist(str, (int)len, hl_id, false);
   }
 
   // When writing something to the screen after it has scrolled, requires a
@@ -2095,7 +2084,7 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int attr)
     }
   }
   if (!msg_use_printf() || (headless_mode && default_grid.chars)) {
-    msg_puts_display(str, (int)len, attr, false);
+    msg_puts_display(str, (int)len, hl_id, false);
   }
 
   need_fileinfo = false;
@@ -2104,11 +2093,11 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int attr)
 /// Print a formatted message
 ///
 /// Message printed is limited by #IOSIZE. Must not be used from inside
-/// msg_puts_attr().
+/// msg_puts_hl_id().
 ///
-/// @param[in]  attr  Highlight attributes.
+/// @param[in]  hl_id  Highlight id.
 /// @param[in]  fmt  Format string.
-void msg_printf_attr(const int attr, const char *const fmt, ...)
+void msg_printf_hl(const int hl_id, const char *const fmt, ...)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_PRINTF(2, 3)
 {
   static char msgbuf[IOSIZE];
@@ -2119,7 +2108,7 @@ void msg_printf_attr(const int attr, const char *const fmt, ...)
   va_end(ap);
 
   msg_scroll = true;
-  msg_puts_len(msgbuf, (ptrdiff_t)len, attr);
+  msg_puts_len(msgbuf, (ptrdiff_t)len, hl_id, true);
 }
 
 static void msg_ext_emit_chunk(void)
@@ -2141,11 +2130,12 @@ static void msg_ext_emit_chunk(void)
 
 /// The display part of msg_puts_len().
 /// May be called recursively to display scroll-back text.
-static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
+static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse)
 {
   const char *s = str;
   const char *sb_str = str;
   int sb_col = msg_col;
+  int attr = hl_id ? syn_id2attr(hl_id) : 0;
 
   did_wait_return = false;
 
@@ -2172,7 +2162,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
     if (msg_col >= Columns) {
       if (p_more && !recurse) {
         // Store text for scrolling back.
-        store_sb_text(&sb_str, s, attr, &sb_col, true);
+        store_sb_text(&sb_str, s, hl_id, &sb_col, true);
       }
       if (msg_no_more && lines_left == 0) {
         break;
@@ -2262,7 +2252,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
         msg_row++;
         if (p_more && !recurse) {
           // Store text for scrolling back.
-          store_sb_text(&sb_str, s, attr, &sb_col, true);
+          store_sb_text(&sb_str, s, hl_id, &sb_col, true);
         }
       } else if (c == '\r') {  // go to column 0
         msg_col = 0;
@@ -2291,7 +2281,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
   msg_cursor_goto(msg_row, msg_col);
 
   if (p_more && !recurse) {
-    store_sb_text(&sb_str, s, attr, &sb_col, false);
+    store_sb_text(&sb_str, s, hl_id, &sb_col, false);
   }
 
   msg_check();
@@ -2481,7 +2471,7 @@ static sb_clear_T do_clear_sb_text = SB_CLEAR_NONE;
 /// @param sb_str  start of string
 /// @param s  just after string
 /// @param finish  line ends
-static void store_sb_text(const char **sb_str, const char *s, int attr, int *sb_col, int finish)
+static void store_sb_text(const char **sb_str, const char *s, int hl_id, int *sb_col, int finish)
 {
   msgchunk_T *mp;
 
@@ -2499,7 +2489,7 @@ static void store_sb_text(const char **sb_str, const char *s, int attr, int *sb_
     mp = xmalloc(offsetof(msgchunk_T, sb_text) + (size_t)(s - *sb_str) + 1);
     mp->sb_eol = (char)finish;
     mp->sb_msg_col = *sb_col;
-    mp->sb_attr = attr;
+    mp->sb_hl_id = hl_id;
     memcpy(mp->sb_text, *sb_str, (size_t)(s - *sb_str));
     mp->sb_text[s - *sb_str] = NUL;
 
@@ -2637,7 +2627,7 @@ static msgchunk_T *disp_sb_line(int row, msgchunk_T *smp)
     msg_row = row;
     msg_col = mp->sb_msg_col;
     char *p = mp->sb_text;
-    msg_puts_display(p, -1, mp->sb_attr, true);
+    msg_puts_display(p, -1, mp->sb_hl_id, true);
     if (mp->sb_eol || mp->sb_next == NULL) {
       break;
     }
@@ -3321,17 +3311,17 @@ void give_warning(const char *message, bool hl)
   set_vim_var_string(VV_WARNINGMSG, message, -1);
   XFREE_CLEAR(keep_msg);
   if (hl) {
-    keep_msg_attr = HL_ATTR(HLF_W);
+    keep_msg_hl_id = HLF_W + 1;
   } else {
-    keep_msg_attr = 0;
+    keep_msg_hl_id = 0;
   }
 
   if (msg_ext_kind == NULL) {
     msg_ext_set_kind("wmsg");
   }
 
-  if (msg(message, keep_msg_attr) && msg_scrolled == 0) {
-    set_keep_msg(message, keep_msg_attr);
+  if (msg(message, keep_msg_hl_id) && msg_scrolled == 0) {
+    set_keep_msg(message, keep_msg_hl_id);
   }
   msg_didout = false;  // Overwrite this message.
   msg_nowait = true;   // Don't wait for this message.
@@ -3664,7 +3654,7 @@ void display_confirm_msg(void)
   confirm_msg_used++;
   if (confirm_msg != NULL) {
     msg_ext_set_kind("confirm");
-    msg_puts_attr(confirm_msg, HL_ATTR(HLF_M));
+    msg_puts_hl(confirm_msg, HLF_M + 1, false);
   }
   confirm_msg_used--;
 }

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -28,8 +28,6 @@ enum {
   VIM_DISCARDALL = 6,
 };
 
-enum { MSG_HIST = 0x1000, };  ///< special attribute addition: Put message in history
-
 /// First message
 extern MessageHistoryEntry *first_msg_hist;
 /// Last message

--- a/src/nvim/message_defs.h
+++ b/src/nvim/message_defs.h
@@ -6,7 +6,7 @@
 
 typedef struct {
   String text;
-  int attr;
+  int hl_id;
 } HlMessageChunk;
 
 typedef kvec_t(HlMessageChunk) HlMessage;
@@ -16,7 +16,7 @@ typedef struct msg_hist {
   struct msg_hist *next;  ///< Next message.
   char *msg;              ///< Message text.
   const char *kind;       ///< Message kind (for msg_ext)
-  int attr;               ///< Message highlighting.
+  int hl_id;               ///< Message highlighting.
   bool multiline;         ///< Multiline message.
-  HlMessage multiattr;    ///< multiattr message.
+  HlMessage multihl;      ///< Multihl message.
 } MessageHistoryEntry;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2081,11 +2081,12 @@ static void display_showcmd(void)
 
   if (ui_has(kUIMessages)) {
     MAXSIZE_TEMP_ARRAY(content, 1);
-    MAXSIZE_TEMP_ARRAY(chunk, 2);
+    MAXSIZE_TEMP_ARRAY(chunk, 3);
     if (!showcmd_is_clear) {
       // placeholder for future highlight support
       ADD_C(chunk, INTEGER_OBJ(0));
       ADD_C(chunk, CSTR_AS_OBJ(showcmd_buf));
+      ADD_C(chunk, INTEGER_OBJ(0));
       ADD_C(content, ARRAY_OBJ(chunk));
     }
     ui_call_msg_showcmd(content);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -693,7 +693,7 @@ static void normal_redraw_mode_message(NormalState *s)
     keep_msg = kmsg;
 
     kmsg = xstrdup(keep_msg);
-    msg(kmsg, keep_msg_attr);
+    msg(kmsg, keep_msg_hl_id);
     xfree(kmsg);
   }
   setcursor();
@@ -1388,7 +1388,7 @@ static void normal_redraw(NormalState *s)
     // check for duplicates.  Never put this message in
     // history.
     msg_hist_off = true;
-    msg(p, keep_msg_attr);
+    msg(p, keep_msg_hl_id);
     msg_hist_off = false;
     xfree(p);
   }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -257,7 +257,7 @@ void op_shift(oparg_T *oap, bool curs_top, int amount)
     vim_snprintf(IObuff, IOSIZE,
                  NGETTEXT(msg_line_single, msg_line_plural, oap->line_count),
                  (int64_t)oap->line_count, op, amount);
-    msg_attr_keep(IObuff, 0, true, false);
+    msg_hl_keep(IObuff, 0, true, false);
   }
 
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
@@ -3653,7 +3653,7 @@ void ex_display(exarg_T *eap)
   if (arg != NULL && *arg == NUL) {
     arg = NULL;
   }
-  int attr = HL_ATTR(HLF_8);
+  int hl_id = HLF_8 + 1;
 
   // Highlight title
   msg_puts_title(_("\nType Name Content"));
@@ -3709,18 +3709,18 @@ void ex_display(exarg_T *eap)
         int n = Columns - 11;
         for (size_t j = 0; j < yb->y_size && n > 1; j++) {
           if (j) {
-            msg_puts_attr("^J", attr);
+            msg_puts_hl("^J", hl_id, false);
             n -= 2;
           }
           for (p = yb->y_array[j].data;
                *p != NUL && (n -= ptr2cells(p)) >= 0; p++) {
             int clen = utfc_ptr2len(p);
-            msg_outtrans_len(p, clen, 0);
+            msg_outtrans_len(p, clen, 0, false);
             p += clen - 1;
           }
         }
         if (n > 1 && yb->y_type == kMTLineWise) {
-          msg_puts_attr("^J", attr);
+          msg_puts_hl("^J", hl_id, false);
         }
       }
       os_breakcheck();
@@ -3790,10 +3790,10 @@ static void dis_msg(const char *p, bool skip_esc)
          && (n -= ptr2cells(p)) >= 0) {
     int l;
     if ((l = utfc_ptr2len(p)) > 1) {
-      msg_outtrans_len(p, l, 0);
+      msg_outtrans_len(p, l, 0, false);
       p += l;
     } else {
-      msg_outtrans_len(p++, 1, 0);
+      msg_outtrans_len(p++, 1, 0, false);
     }
   }
   os_breakcheck();

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1903,8 +1903,8 @@ static const char *did_set_arabic(optset_T *args)
     if (strcmp(p_enc, "utf-8") != 0) {
       static char *w_arabic = N_("W17: Arabic requires UTF-8, do ':set encoding=utf-8'");
 
-      msg_source(HL_ATTR(HLF_W));
-      msg(_(w_arabic), HL_ATTR(HLF_W));
+      msg_source(HLF_W + 1);
+      msg(_(w_arabic), HLF_W + 1);
       set_vim_var_string(VV_WARNINGMSG, _(w_arabic), -1);
     }
 
@@ -4187,7 +4187,7 @@ static void showoneopt(vimoption_T *opt, int opt_flags)
     msg_putchar('=');
     // put value string in NameBuff
     option_value2string(opt, opt_flags);
-    msg_outtrans(NameBuff, 0);
+    msg_outtrans(NameBuff, 0, false);
   }
 
   silent_mode = save_silent;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -885,9 +885,9 @@ static int do_os_system(char **argv, const char *input, size_t len, char **outpu
     // Failed, probably 'shell' is not executable.
     if (!silent) {
       msg_puts(_("\nshell failed to start: "));
-      msg_outtrans(os_strerror(status), 0);
+      msg_outtrans(os_strerror(status), 0, false);
       msg_puts(": ");
-      msg_outtrans(prog, 0);
+      msg_outtrans(prog, 0, false);
       msg_putchar('\n');
     }
     multiqueue_free(events);
@@ -1102,7 +1102,7 @@ static void out_data_append_to_screen(const char *output, size_t *count, bool eo
   const char *end = output + *count;
   while (p < end) {
     if (*p == '\n' || *p == '\r' || *p == TAB || *p == BELL) {
-      msg_putchar_attr((uint8_t)(*p), 0);
+      msg_putchar_hl((uint8_t)(*p), 0);
       p++;
     } else {
       // Note: this is not 100% precise:
@@ -1118,7 +1118,7 @@ static void out_data_append_to_screen(const char *output, size_t *count, bool eo
         goto end;
       }
 
-      msg_outtrans_len(p, i, 0);
+      msg_outtrans_len(p, i, 0, false);
       p += i;
     }
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2937,7 +2937,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
     msg_scroll = false;
   }
   msg_ext_set_kind("quickfix");
-  msg_attr_keep(gap->ga_data, 0, true, false);
+  msg_hl_keep(gap->ga_data, 0, true, false);
   msg_scroll = (int)i;
 
   qfga_clear();
@@ -3144,10 +3144,10 @@ theend:
   decr_quickfix_busy();
 }
 
-// Highlight attributes used for displaying entries from the quickfix list.
-static int qfFileAttr;
-static int qfSepAttr;
-static int qfLineAttr;
+// Highlight ids used for displaying entries from the quickfix list.
+static int qfFile_hl_id;
+static int qfSep_hl_id;
+static int qfLine_hl_id;
 
 /// Display information about a single entry from the quickfix/location list.
 /// Used by ":clist/:llist" commands.
@@ -3195,10 +3195,10 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   }
 
   msg_putchar('\n');
-  msg_outtrans(IObuff, cursel ? HL_ATTR(HLF_QFL) : qfFileAttr);
+  msg_outtrans(IObuff, cursel ? HLF_QFL + 1 : qfFile_hl_id, false);
 
   if (qfp->qf_lnum != 0) {
-    msg_puts_attr(":", qfSepAttr);
+    msg_puts_hl(":", qfSep_hl_id, false);
   }
   garray_T *gap = qfga_get();
   if (qfp->qf_lnum != 0) {
@@ -3206,14 +3206,14 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   }
   ga_concat(gap, qf_types(qfp->qf_type, qfp->qf_nr));
   ga_append(gap, NUL);
-  msg_puts_attr(gap->ga_data, qfLineAttr);
-  msg_puts_attr(":", qfSepAttr);
+  msg_puts_hl(gap->ga_data, qfLine_hl_id, false);
+  msg_puts_hl(":", qfSep_hl_id, false);
   if (qfp->qf_pattern != NULL) {
     gap = qfga_get();
     qf_fmt_text(gap, qfp->qf_pattern);
     ga_append(gap, NUL);
     msg_puts(gap->ga_data);
-    msg_puts_attr(":", qfSepAttr);
+    msg_puts_hl(":", qfSep_hl_id, false);
   }
   msg_puts(" ");
 
@@ -3275,17 +3275,17 @@ void qf_list(exarg_T *eap)
 
   // Get the attributes for the different quickfix highlight items.  Note
   // that this depends on syntax items defined in the qf.vim syntax file
-  qfFileAttr = syn_name2attr("qfFileName");
-  if (qfFileAttr == 0) {
-    qfFileAttr = HL_ATTR(HLF_D);
+  qfFile_hl_id = syn_name2id("qfFileName");
+  if (qfFile_hl_id == 0) {
+    qfFile_hl_id = HLF_D + 1;
   }
-  qfSepAttr = syn_name2attr("qfSeparator");
-  if (qfSepAttr == 0) {
-    qfSepAttr = HL_ATTR(HLF_D);
+  qfSep_hl_id = syn_name2id("qfSeparator");
+  if (qfSep_hl_id == 0) {
+    qfSep_hl_id = HLF_D + 1;
   }
-  qfLineAttr = syn_name2attr("qfLineNr");
-  if (qfLineAttr == 0) {
-    qfLineAttr = HL_ATTR(HLF_N);
+  qfLine_hl_id = syn_name2id("qfLineNr");
+  if (qfLine_hl_id == 0) {
+    qfLine_hl_id = HLF_N + 1;
   }
 
   if (qfl->qf_nonevalid) {
@@ -4396,7 +4396,7 @@ static char *make_get_fullcmd(const char *makecmd, const char *fname)
   }
   msg_start();
   msg_puts(":!");
-  msg_outtrans(cmd, 0);  // show what we are doing
+  msg_outtrans(cmd, 0, false);  // show what we are doing
 
   return cmd;
 }
@@ -5243,9 +5243,9 @@ static void vgr_display_fname(char *fname)
   msg_start();
   char *p = msg_strtrunc(fname, true);
   if (p == NULL) {
-    msg_outtrans(fname, 0);
+    msg_outtrans(fname, 0, false);
   } else {
-    msg_outtrans(p, 0);
+    msg_outtrans(p, 0, false);
     xfree(p);
   }
   msg_clr_eos();

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2348,7 +2348,7 @@ void ex_scriptnames(exarg_T *eap)
       vim_snprintf(IObuff, IOSIZE, "%3d: %s", i, NameBuff);
       if (!message_filtered(IObuff)) {
         msg_putchar('\n');
-        msg_outtrans(IObuff, 0);
+        msg_outtrans(IObuff, 0, false);
         line_breakcheck();
       }
     }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1304,7 +1304,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
             memset(msgbuf + pat_len, ' ', (size_t)(r - msgbuf));
           }
         }
-        msg_outtrans(msgbuf, 0);
+        msg_outtrans(msgbuf, 0, false);
         msg_clr_eos();
         msg_check();
 
@@ -3731,7 +3731,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
                 && action == ACTION_SHOW_ALL && files[i].matched) {
               msg_putchar('\n');  // cursor below last one
               if (!got_int) {  // don't display if 'q' typed at "--more--" message
-                msg_home_replace_hl(new_fname);
+                msg_home_replace(new_fname);
                 msg_puts(_(" (includes previously listed match)"));
                 prev_fname = NULL;
               }
@@ -3772,7 +3772,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
           if (new_fname != NULL) {
             // using "new_fname" is more reliable, e.g., when
             // 'includeexpr' is set.
-            msg_outtrans(new_fname, HL_ATTR(HLF_D));
+            msg_outtrans(new_fname, HLF_D + 1, false);
           } else {
             // Isolate the file name.
             // Include the surrounding "" or <> if present.
@@ -3806,7 +3806,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
             }
             char save_char = p[i];
             p[i] = NUL;
-            msg_outtrans(p, HL_ATTR(HLF_D));
+            msg_outtrans(p, HLF_D + 1, false);
             p[i] = save_char;
           }
 
@@ -3858,7 +3858,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
             vim_snprintf(IObuff, IOSIZE,
                          _("Scanning included file: %s"),
                          new_fname);
-            msg_trunc(IObuff, true, HL_ATTR(HLF_R));
+            msg_trunc(IObuff, true, HLF_R + 1);
           } else if (p_verbose >= 5) {
             verbose_enter();
             smsg(0, _("Searching included file %s"), new_fname);
@@ -4032,7 +4032,7 @@ search_line:
           }
           if (!got_int) {             // don't display if 'q' typed
                                       // at "--more--" message
-            msg_home_replace_hl(curr_fname);
+            msg_home_replace(curr_fname);
           }
           prev_fname = curr_fname;
         }
@@ -4233,7 +4233,7 @@ static void show_pat_in_path(char *line, int type, bool did_show, int action, FI
       msg_puts(IObuff);
       snprintf(IObuff, IOSIZE, "%4" PRIdLINENR, *lnum);  // Show line nr.
       // Highlight line numbers.
-      msg_puts_attr(IObuff, HL_ATTR(HLF_N));
+      msg_puts_hl(IObuff, HLF_N + 1, false);
       msg_puts(" ");
     }
     msg_prt_line(line, false);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -270,7 +270,7 @@ static void sign_list_placed(buf_T *rbuf, char *group)
   while (buf != NULL && !got_int) {
     if (buf_has_signs(buf)) {
       vim_snprintf(lbuf, MSG_BUF_LEN, _("Signs for %s:"), buf->b_fname);
-      msg_puts_attr(lbuf, HL_ATTR(HLF_D));
+      msg_puts_hl(lbuf, HLF_D + 1, false);
       msg_putchar('\n');
     }
 
@@ -481,14 +481,14 @@ static void sign_list_defined(sign_T *sp)
   smsg(0, "sign %s", sp->sn_name);
   if (sp->sn_icon != NULL) {
     msg_puts(" icon=");
-    msg_outtrans(sp->sn_icon, 0);
+    msg_outtrans(sp->sn_icon, 0, false);
     msg_puts(_(" (not supported)"));
   }
   if (sp->sn_text[0]) {
     msg_puts(" text=");
     char buf[SIGN_WIDTH * MAX_SCHAR_SIZE];
     describe_sign_text(buf, sp->sn_text);
-    msg_outtrans(buf, 0);
+    msg_outtrans(buf, 0, false);
   }
   if (sp->sn_priority > 0) {
     char lbuf[MSG_BUF_LEN];

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -582,9 +582,11 @@ void win_redr_ruler(win_T *wp)
 
   if (ui_has(kUIMessages) && !part_of_status) {
     MAXSIZE_TEMP_ARRAY(content, 1);
-    MAXSIZE_TEMP_ARRAY(chunk, 2);
+    MAXSIZE_TEMP_ARRAY(chunk, 3);
     ADD_C(chunk, INTEGER_OBJ(attr));
     ADD_C(chunk, CSTR_AS_OBJ(buffer));
+    ADD_C(chunk, INTEGER_OBJ(HLF_MSG + 1));
+    assert(attr == HL_ATTR(HLF_MSG));
     ADD_C(content, ARRAY_OBJ(chunk));
     ui_call_msg_ruler(content);
     did_show_ext_ruler = true;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -736,7 +736,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
         }
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {
-          msg(IObuff, ic ? HL_ATTR(HLF_W) : 0);
+          msg(IObuff, ic ? HLF_W + 1 : 0);
           msg_scroll = true;  // Don't overwrite this message.
         } else {
           give_warning(IObuff, ic);
@@ -815,10 +815,10 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
     msg_didout = false;     // overwrite previous message
   }
   msg_start();
-  msg_puts_attr(_("  # pri kind tag"), HL_ATTR(HLF_T));
+  msg_puts_hl(_("  # pri kind tag"), HLF_T + 1, false);
   msg_clr_eos();
   taglen_advance(taglen);
-  msg_puts_attr(_("file\n"), HL_ATTR(HLF_T));
+  msg_puts_hl(_("file\n"), HLF_T + 1, false);
 
   for (int i = 0; i < num_matches && !got_int; i++) {
     parse_match(matches[i], &tagp);
@@ -836,10 +836,10 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
                  mt_names[matches[i][0] & MT_MASK]);
     msg_puts(IObuff);
     if (tagp.tagkind != NULL) {
-      msg_outtrans_len(tagp.tagkind, (int)(tagp.tagkind_end - tagp.tagkind), 0);
+      msg_outtrans_len(tagp.tagkind, (int)(tagp.tagkind_end - tagp.tagkind), 0, false);
     }
     msg_advance(13);
-    msg_outtrans_len(tagp.tagname, (int)(tagp.tagname_end - tagp.tagname), HL_ATTR(HLF_T));
+    msg_outtrans_len(tagp.tagname, (int)(tagp.tagname_end - tagp.tagname), HLF_T + 1, false);
     msg_putchar(' ');
     taglen_advance(taglen);
 
@@ -847,7 +847,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
     // it and put "..." in the middle
     const char *p = tag_full_fname(&tagp);
     if (p != NULL) {
-      msg_outtrans(p, HL_ATTR(HLF_D));
+      msg_outtrans(p, HLF_D + 1, false);
       XFREE_CLEAR(p);
     }
     if (msg_col > 0) {
@@ -880,7 +880,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
           continue;
         }
         // print all other extra fields
-        int attr = HL_ATTR(HLF_CM);
+        int hl_id = HLF_CM + 1;
         while (*p && *p != '\r' && *p != '\n') {
           if (msg_col + ptr2cells(p) >= Columns) {
             msg_putchar('\n');
@@ -889,13 +889,13 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
             }
             msg_advance(15);
           }
-          p = msg_outtrans_one(p, attr);
+          p = msg_outtrans_one(p, hl_id, false);
           if (*p == TAB) {
-            msg_puts_attr(" ", attr);
+            msg_puts_hl(" ", hl_id, false);
             break;
           }
           if (*p == ':') {
-            attr = 0;
+            hl_id = 0;
           }
         }
       }
@@ -947,7 +947,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
         msg_putchar(' ');
         p++;
       } else {
-        p = msg_outtrans_one(p, 0);
+        p = msg_outtrans_one(p, 0, false);
       }
 
       // don't display the "$/;\"" and "$?;\""
@@ -1125,8 +1125,8 @@ void do_tags(exarg_T *eap)
                    tagstack[i].cur_match + 1,
                    tagstack[i].tagname,
                    tagstack[i].fmark.mark.lnum);
-      msg_outtrans(IObuff, 0);
-      msg_outtrans(name, tagstack[i].fmark.fnum == curbuf->b_fnum ? HL_ATTR(HLF_D) : 0);
+      msg_outtrans(IObuff, 0, false);
+      msg_outtrans(name, tagstack[i].fmark.fnum == curbuf->b_fnum ? HLF_D + 1 : 0, false);
       xfree(name);
     }
   }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -358,8 +358,8 @@ void vim_beep(unsigned val)
   // a script or executing a function give the user a hint where the beep
   // comes from.
   if (vim_strchr(p_debug, 'e') != NULL) {
-    msg_source(HL_ATTR(HLF_W));
-    msg(_("Beep!"), HL_ATTR(HLF_W));
+    msg_source(HLF_W + 1);
+    msg(_("Beep!"), HLF_W + 1);
   }
 }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2595,13 +2595,12 @@ static void u_undo_end(bool did_undo, bool absolute, bool quiet)
     check_pos(curbuf, &VIsual);
   }
 
-  smsg_attr_keep(0,
-                 _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
-                 u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
-                 _(msgstr),
-                 did_undo ? _("before") : _("after"),
-                 uhp == NULL ? 0 : (int64_t)uhp->uh_seq,
-                 msgbuf);
+  smsg_hl_keep(0, _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
+               u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
+               _(msgstr),
+               did_undo ? _("before") : _("after"),
+               uhp == NULL ? 0 : (int64_t)uhp->uh_seq,
+               msgbuf);
 }
 
 /// Put the timestamp of an undo header in "buf[buflen]" in a nice format.
@@ -2713,8 +2712,7 @@ void ex_undolist(exarg_T *eap)
     sort_strings(ga.ga_data, ga.ga_len);
 
     msg_start();
-    msg_puts_attr(_("number changes  when               saved"),
-                  HL_ATTR(HLF_T));
+    msg_puts_hl(_("number changes  when               saved"), HLF_T + 1, false);
     for (int i = 0; i < ga.ga_len && !got_int; i++) {
       msg_putchar('\n');
       if (got_int) {

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -464,8 +464,7 @@ static void uc_list(char *name, size_t name_len)
 
       // Put out the title first time
       if (!found) {
-        msg_puts_title(_("\n    Name              Args Address "
-                         "Complete    Definition"));
+        msg_puts_title(_("\n    Name              Args Address Complete    Definition"));
       }
       found = true;
       msg_putchar('\n');
@@ -495,7 +494,7 @@ static void uc_list(char *name, size_t name_len)
         msg_putchar(' ');
       }
 
-      msg_outtrans(cmd->uc_name, HL_ATTR(HLF_D));
+      msg_outtrans(cmd->uc_name, HLF_D + 1, false);
       len = strlen(cmd->uc_name) + 4;
 
       do {
@@ -582,11 +581,11 @@ static void uc_list(char *name, size_t name_len)
       } while ((int64_t)len < 25 - over);
 
       IObuff[len] = NUL;
-      msg_outtrans(IObuff, 0);
+      msg_outtrans(IObuff, 0, false);
 
       if (cmd->uc_luaref != LUA_NOREF) {
         char *fn = nlua_funcref_str(cmd->uc_luaref, NULL);
-        msg_puts_attr(fn, HL_ATTR(HLF_8));
+        msg_puts_hl(fn, HLF_8 + 1, false);
         xfree(fn);
         // put the description on a new line
         if (*cmd->uc_rep != NUL) {

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -151,9 +151,9 @@ describe('vim.ui_attach', function()
       {
         'msg_history_show',
         {
-          { 'echomsg', { { 0, 'message1' } } },
-          { '', { { 0, 'message2' } } },
-          { 'echomsg', { { 0, 'message3' } } },
+          { 'echomsg', { { 0, 'message1', 0 } } },
+          { '', { { 0, 'message2', 0 } } },
+          { 'echomsg', { { 0, 'message3', 0 } } },
         },
       },
     }, actual, vim.inspect(actual))

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -44,9 +44,9 @@ local function test_embed(ext_linegrid)
     screen:expect([[
                                                                   |*4
       {6:                                                            }|
-      {7:Error detected while processing pre-vimrc command line:}     |
-      {7:E121: Undefined variable: invalid}                           |
-      {8:Press ENTER or type command to continue}^                     |
+      {1:Error detected while processing pre-vimrc command line:}     |
+      {1:E121: Undefined variable: invalid}                           |
+      {2:Press ENTER or type command to continue}^                     |
     ]])
 
     feed('<cr>')
@@ -65,8 +65,8 @@ local function test_embed(ext_linegrid)
     screen:expect([[
                                                                   |*3
       {6:                                                            }|
-      {7:Error detected while processing pre-vimrc command line:}     |
-      {7:foo}                                                         |
+      {1:Error detected while processing pre-vimrc command line:}     |
+      {1:foo}                                                         |
       {7:bar}                                                         |
       {8:Press ENTER or type command to continue}^                     |
     ]])
@@ -78,10 +78,10 @@ local function test_embed(ext_linegrid)
       grid = [[
                                                                   |*3
       {6:                                                            }|
-      {7:Error detected while processing pre-vimrc command line:}     |
-      {7:foo}                                                         |
-      {7:bar}                                                         |
-      {8:Press ENTER or type command to continue}^                     |
+      {1:Error detected while processing pre-vimrc command line:}     |
+      {1:foo}                                                         |
+      {1:bar}                                                         |
+      {2:Press ENTER or type command to continue}^                     |
     ]],
       condition = function()
         eq(Screen.colors.Green, screen.default_colors.rgb_bg)

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -33,42 +33,42 @@ describe('ext_hlstate detailed highlights', function()
     api.nvim_buf_add_highlight(0, -1, 'Statement', 1, 5, -1)
     command('/th co')
 
-    screen:expect(
-      [[
+    screen:expect {
+      grid = [[
       these are {1:some} lines                    |
       ^wi{2:th }{4:co}{3:lorful text}                      |
       {5:~                                       }|*5
-      {8:search hit BOTTOM, continuing at TOP}{7:    }|
+      {8:search hit BOTTOM, continuing at TOP}{6:    }|
     ]],
-      {
+      attr_ids = {
         [1] = {
-          { foreground = Screen.colors.Magenta },
-          { { hi_name = 'Constant', kind = 'syntax' } },
+          { foreground = Screen.colors.Magenta1 },
+          { { kind = 'syntax', hi_name = 'Constant' } },
         },
         [2] = {
-          { background = Screen.colors.Yellow },
-          { { hi_name = 'Search', ui_name = 'Search', kind = 'ui' } },
+          { background = Screen.colors.Yellow1 },
+          { { kind = 'ui', ui_name = 'Search', hi_name = 'Search' } },
         },
         [3] = {
-          { bold = true, foreground = Screen.colors.Brown },
-          { { hi_name = 'Statement', kind = 'syntax' } },
+          { foreground = Screen.colors.Brown, bold = true },
+          { { kind = 'syntax', hi_name = 'Statement' } },
         },
         [4] = {
-          { bold = true, background = Screen.colors.Yellow, foreground = Screen.colors.Brown },
+          { background = Screen.colors.Yellow1, bold = true, foreground = Screen.colors.Brown },
           { 3, 2 },
         },
         [5] = {
-          { bold = true, foreground = Screen.colors.Blue1 },
-          { { hi_name = 'NonText', ui_name = 'EndOfBuffer', kind = 'ui' } },
+          { foreground = Screen.colors.Blue, bold = true },
+          { { kind = 'ui', ui_name = 'EndOfBuffer', hi_name = 'NonText' } },
         },
-        [6] = {
-          { foreground = Screen.colors.Red },
-          { { hi_name = 'WarningMsg', ui_name = 'WarningMsg', kind = 'ui' } },
+        [6] = { {}, { { kind = 'ui', ui_name = 'MsgArea', hi_name = 'MsgArea' } } },
+        [7] = {
+          { foreground = Screen.colors.Red1 },
+          { { kind = 'syntax', hi_name = 'WarningMsg' } },
         },
-        [7] = { {}, { { hi_name = 'MsgArea', ui_name = 'MsgArea', kind = 'ui' } } },
-        [8] = { { foreground = Screen.colors.Red }, { 7, 6 } },
-      }
-    )
+        [8] = { { foreground = Screen.colors.Red1 }, { 6, 7 } },
+      },
+    }
   end)
 
   it('work with cleared UI highlights', function()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -50,7 +50,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6 } },
+          content = { { '\ntest\n[O]k: ', 6, 11 } },
           kind = 'confirm',
         },
       },
@@ -78,7 +78,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6 } },
+          content = { { '\ntest\n[O]k: ', 6, 11 } },
           kind = 'confirm',
         },
       },
@@ -92,7 +92,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6 } },
+          content = { { '\ntest\n[O]k: ', 6, 11 } },
           kind = 'confirm',
         },
         {
@@ -100,7 +100,7 @@ describe('ui/ext_messages', function()
           kind = 'echo',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -117,7 +117,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6 } },
+          content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 19 } },
           kind = 'confirm_sub',
         },
       },
@@ -136,7 +136,7 @@ describe('ui/ext_messages', function()
       ]],
       messages = {
         {
-          content = { { 'W10: Warning: Changing a readonly file', 19 } },
+          content = { { 'W10: Warning: Changing a readonly file', 19, 27 } },
           kind = 'wmsg',
         },
       },
@@ -152,7 +152,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'search hit BOTTOM, continuing at TOP', 19 } },
+          content = { { 'search hit BOTTOM, continuing at TOP', 19, 27 } },
           kind = 'wmsg',
         },
       },
@@ -168,15 +168,15 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'Error detected while processing :', 9 } },
+          content = { { 'Error detected while processing :', 9, 7 } },
           kind = 'emsg',
         },
         {
-          content = { { 'E605: Exception not caught: foo', 9 } },
+          content = { { 'E605: Exception not caught: foo', 9, 7 } },
           kind = '',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -209,7 +209,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'raa', 9 } },
+        content = { { 'raa', 9, 7 } },
         kind = 'echoerr',
       } },
     }
@@ -236,15 +236,15 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'bork', 9 } },
+          content = { { 'bork', 9, 7 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'fail', 9 } },
+          content = { { 'fail', 9, 7 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -258,19 +258,19 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'bork', 9 } },
+          content = { { 'bork', 9, 7 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'fail', 9 } },
+          content = { { 'fail', 9, 7 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'extrafail', 9 } },
+          content = { { 'extrafail', 9, 7 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -292,7 +292,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'problem', 9 } },
+        content = { { 'problem', 9, 7 } },
         kind = 'echoerr',
       } },
       cmdline = {
@@ -320,15 +320,15 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       msg_history = {
-        { kind = 'echoerr', content = { { 'raa', 9 } } },
-        { kind = 'echoerr', content = { { 'bork', 9 } } },
-        { kind = 'echoerr', content = { { 'fail', 9 } } },
-        { kind = 'echoerr', content = { { 'extrafail', 9 } } },
-        { kind = 'echoerr', content = { { 'problem', 9 } } },
+        { kind = 'echoerr', content = { { 'raa', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'bork', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'fail', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'extrafail', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'problem', 9, 7 } } },
       },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -351,10 +351,12 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      messages = { {
-        content = { { 'bork\nfail', 9 } },
-        kind = 'echoerr',
-      } },
+      messages = {
+        {
+          content = { { 'bork\nfail', 9, 7 } },
+          kind = 'echoerr',
+        },
+      },
     }
 
     feed(':messages<cr>')
@@ -365,13 +367,13 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
       msg_history = {
         {
-          content = { { 'bork\nfail', 9 } },
+          content = { { 'bork\nfail', 9, 7 } },
           kind = 'echoerr',
         },
       },
@@ -418,15 +420,15 @@ describe('ui/ext_messages', function()
         {
           content = {
             { '\nErrorMsg      ' },
-            { 'xxx', 9 },
+            { 'xxx', 9, 0 },
             { ' ' },
-            { 'ctermfg=', 18 },
+            { 'ctermfg=', 18, 0 },
             { '15 ' },
-            { 'ctermbg=', 18 },
+            { 'ctermbg=', 18, 0 },
             { '1 ' },
-            { 'guifg=', 18 },
+            { 'guifg=', 18, 0 },
             { 'White ' },
-            { 'guibg=', 18 },
+            { 'guibg=', 18, 0 },
             { 'Red' },
           },
           kind = '',
@@ -446,7 +448,10 @@ describe('ui/ext_messages', function()
       messages = {
         { content = { { 'x                     #1' } }, kind = '' },
         { content = { { 'y                     #2' } }, kind = '' },
-        { content = { { 'Press ENTER or type command to continue', 6 } }, kind = 'return_prompt' },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          kind = 'return_prompt',
+        },
       },
     }
   end)
@@ -459,7 +464,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --', 5 } },
+      showmode = { { '-- INSERT --', 5, 12 } },
     }
 
     feed('alphpabet<cr>alphanum<cr>')
@@ -470,7 +475,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*2
     ]],
-      showmode = { { '-- INSERT --', 5 } },
+      showmode = { { '-- INSERT --', 5, 12 } },
     }
 
     feed('<c-x>')
@@ -481,7 +486,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*2
     ]],
-      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)', 5 } },
+      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)', 5, 12 } },
     }
 
     feed('<c-p>')
@@ -497,7 +502,7 @@ describe('ui/ext_messages', function()
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 1,
       },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5 }, { 'match 1 of 2', 6 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 19 }, { 'match 1 of 2', 6, 19 } },
     }
 
     -- echomsg and showmode don't overwrite each other, this is the same
@@ -519,7 +524,7 @@ describe('ui/ext_messages', function()
         content = { { 'stuff' } },
         kind = 'echomsg',
       } },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5 }, { 'match 1 of 2', 6 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 19 }, { 'match 1 of 2', 6, 19 } },
     }
 
     feed('<c-p>')
@@ -539,7 +544,7 @@ describe('ui/ext_messages', function()
         content = { { 'stuff' } },
         kind = 'echomsg',
       } },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5 }, { 'match 2 of 2', 6 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 19 }, { 'match 2 of 2', 6, 19 } },
     }
 
     feed('<esc>:messages<cr>')
@@ -556,7 +561,7 @@ describe('ui/ext_messages', function()
       } },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -570,7 +575,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5 } },
+      showmode = { { 'recording @q', 5, 12 } },
     }
 
     feed('i')
@@ -579,7 +584,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --recording @q', 5 } },
+      showmode = { { '-- INSERT --recording @q', 5, 12 } },
     }
 
     feed('<esc>')
@@ -588,7 +593,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5 } },
+      showmode = { { 'recording @q', 5, 12 } },
     }
 
     feed('q')
@@ -607,7 +612,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5 } },
+      showmode = { { 'recording @q', 5, 12 } },
       mode = 'normal',
     }
 
@@ -617,7 +622,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5 } },
+      showmode = { { 'recording @q', 5, 12 } },
       mode = 'insert',
     }
 
@@ -627,7 +632,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5 } },
+      showmode = { { 'recording @q', 5, 12 } },
       mode = 'normal',
     }
 
@@ -643,20 +648,22 @@ describe('ui/ext_messages', function()
 
   it('supports &showcmd and &ruler', function()
     command('set showcmd ruler')
-    screen:expect {
+    command('hi link MsgArea ErrorMsg')
+    screen:expect({
       grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      ruler = { { '0,0-1   All' } },
-    }
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      ruler = { { '0,0-1   All', 9, 62 } },
+    })
+    command('hi clear MsgArea')
     feed('i')
     screen:expect {
       grid = [[
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --', 5 } },
+      showmode = { { '-- INSERT --', 5, 12 } },
       ruler = { { '0,1     All' } },
     }
     feed('abcde<cr>12345<esc>')
@@ -694,7 +701,7 @@ describe('ui/ext_messages', function()
         {17:123}45                    |
         {1:~                        }|*3
       ]],
-      showmode = { { '-- VISUAL BLOCK --', 5 } },
+      showmode = { { '-- VISUAL BLOCK --', 5, 12 } },
       showcmd = { { '2x3' } },
       ruler = { { '1,3     All' } },
     })
@@ -775,7 +782,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'bork', 9 } },
+        content = { { 'bork', 9, 7 } },
         kind = 'echoerr',
       } },
     }
@@ -800,7 +807,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'E117: Unknown function: nosuchfunction', 9 } },
+          content = { { 'E117: Unknown function: nosuchfunction', 9, 7 } },
           kind = 'emsg',
         },
       },
@@ -815,12 +822,12 @@ describe('ui/ext_messages', function()
       msg_history = {
         { kind = 'echomsg', content = { { 'howdy' } } },
         { kind = '', content = { { 'Type  :qa  and press <Enter> to exit Nvim' } } },
-        { kind = 'echoerr', content = { { 'bork', 9 } } },
-        { kind = 'emsg', content = { { 'E117: Unknown function: nosuchfunction', 9 } } },
+        { kind = 'echoerr', content = { { 'bork', 9, 7 } } },
+        { kind = 'emsg', content = { { 'E117: Unknown function: nosuchfunction', 9, 7 } } },
       },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6 } },
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
           kind = 'return_prompt',
         },
       },
@@ -893,6 +900,7 @@ stack traceback:
 	[C]: in function 'error'
 	[string ":lua"]:1: in main chunk]],
               9,
+              7,
             },
           },
           kind = 'lua_error',
@@ -912,7 +920,7 @@ stack traceback:
       messages = {
         {
           content = {
-            { "Error invoking 'test_method' on channel 1:\ncomplete\nerror\n\nmessage", 9 },
+            { "Error invoking 'test_method' on channel 1:\ncomplete\nerror\n\nmessage", 9, 7 },
           },
           kind = 'rpc_error',
         },
@@ -937,7 +945,7 @@ stack traceback:
         {
           content = {
             { '\nn  Q             @@\nn  Y             y$\nn  j           ' },
-            { '*', 18 },
+            { '*', 18, 0 },
             { ' k' },
           },
           kind = '',
@@ -1035,7 +1043,10 @@ stack traceback:
       {1:~                        }|*4
     ]],
       messages = {
-        { content = { { 'wow, ', 10 }, { 'such\n\nvery ', 9 }, { 'color', 8 } }, kind = 'echomsg' },
+        {
+          content = { { 'wow, ', 10, 7 }, { 'such\n\nvery ', 9, 13 }, { 'color', 8, 13 } },
+          kind = 'echomsg',
+        },
       },
     }
 
@@ -1057,10 +1068,16 @@ stack traceback:
       {1:~                        }|*4
     ]],
       messages = {
-        { content = { { 'Press ENTER or type command to continue', 6 } }, kind = 'return_prompt' },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          kind = 'return_prompt',
+        },
       },
       msg_history = {
-        { content = { { 'wow, ', 10 }, { 'such\n\nvery ', 9 }, { 'color', 8 } }, kind = 'echomsg' },
+        {
+          content = { { 'wow, ', 10, 9 }, { 'such\n\nvery ', 9, 7 }, { 'color', 8, 13 } },
+          kind = 'echomsg',
+        },
       },
     }
 
@@ -1678,7 +1695,7 @@ describe('ui/ext_messages', function()
       {1:~                }type  :help iccf{18:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
     ]]
-    local showmode = { { '-- INSERT --', 5 } }
+    local showmode = { { '-- INSERT --', 5, 12 } }
     screen:expect(introscreen)
 
     -- <c-l> (same as :mode) does _not_ clear intro message
@@ -1752,7 +1769,10 @@ describe('ui/ext_messages', function()
                                                                                       |*5
     ]],
       messages = {
-        { content = { { 'Press ENTER or type command to continue', 6 } }, kind = 'return_prompt' },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          kind = 'return_prompt',
+        },
       },
     }
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1524,7 +1524,7 @@ end
 function Screen:_chunks_repr(chunks, attr_state)
   local repr_chunks = {}
   for i, chunk in ipairs(chunks) do
-    local hl, text = unpack(chunk)
+    local hl, text, id = unpack(chunk)
     local attrs
     if self._options.ext_linegrid then
       attrs = self._attr_table[hl][1]
@@ -1532,7 +1532,7 @@ function Screen:_chunks_repr(chunks, attr_state)
       attrs = hl
     end
     local attr_id = self:_get_attr_id(attr_state, attrs, hl)
-    repr_chunks[i] = { text, attr_id }
+    repr_chunks[i] = { text, attr_id, attr_id and id or nil }
   end
   return repr_chunks
 end


### PR DESCRIPTION
**refactor(message): propagate highlight id instead of attrs**

Problem:  Highlight group id is not propagated to the end of the message call
          stack, where ext_messages are emitted.
Solution: Refactor message functions to pass along highlight group id
          instead of attr id.

**feat(ext_messages): add hl_id to ext_messages chunks**

Problem:  Ext_messages chunks only contain the highlight attr id, which
          is not very useful for vim.ui_attach().
Solotion: Add highlight group id to message chunks, which can easily be
          used to highlight text in the TUI through nvim_buf_set_extmark():
          hl_group = hl_id.

Resolve #20310