### PR TITLE
fix(api/buffer): fix handling of viewport of non-current buffer

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1269,10 +1269,13 @@ static void fix_cursor(win_T *win, linenr_T lo, linenr_T hi, linenr_T extra)
     } else if (extra < 0) {
       check_cursor_lnum(win);
     }
-    check_cursor_col_win(win);
+    check_cursor_col(win);
     changed_cline_bef_curs(win);
+    win->w_valid &= ~(VALID_BOTLINE_AP);
+    update_topline(win);
+  } else {
+    invalidate_botline(win);
   }
-  invalidate_botline(win);
 }
 
 /// Fix cursor position after replacing text
@@ -1307,7 +1310,7 @@ static void fix_cursor_cols(win_T *win, linenr_T start_row, colnr_T start_col, l
 
     // it's easier to work with a single value here.
     // col and coladd are fixed by a later call
-    // to check_cursor_col_win when necessary
+    // to check_cursor_col when necessary
     win->w_cursor.col += win->w_cursor.coladd;
     win->w_cursor.coladd = 0;
 
@@ -1343,7 +1346,7 @@ static void fix_cursor_cols(win_T *win, linenr_T start_row, colnr_T start_col, l
     }
   }
 
-  check_cursor_col_win(win);
+  check_cursor_col(win);
   changed_cline_bef_curs(win);
   invalidate_botline(win);
 }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1246,7 +1246,7 @@ Boolean nvim_win_add_ns(Window window, Integer ns_id, Error *err)
 
   set_put(uint32_t, &win->w_ns_set, (uint32_t)ns_id);
 
-  changed_window_setting_win(win);
+  changed_window_setting(win);
 
   return true;
 }
@@ -1291,7 +1291,7 @@ Boolean nvim_win_remove_ns(Window window, Integer ns_id, Error *err)
 
   set_del(uint32_t, &win->w_ns_set, (uint32_t)ns_id);
 
-  changed_window_setting_win(win);
+  changed_window_setting(win);
 
   return true;
 }

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -138,7 +138,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   win->w_cursor.col = (colnr_T)col;
   win->w_cursor.coladd = 0;
   // When column is out of range silently correct it.
-  check_cursor_col_win(win);
+  check_cursor_col(win);
 
   // Make sure we stick in this column.
   win->w_set_curswant = true;
@@ -148,7 +148,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   switchwin_T switchwin;
   switch_win(&switchwin, win, NULL, true);
   update_topline(curwin);
-  validate_cursor();
+  validate_cursor(curwin);
   restore_win(&switchwin, true);
 
   redraw_later(win, UPD_VALID);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1432,7 +1432,7 @@ win_found:
 
     // the buffer contents may have changed
     VIsual_active = aco->save_VIsual_active;
-    check_cursor();
+    check_cursor(curwin);
     if (curwin->w_topline > curbuf->b_ml.ml_line_count) {
       curwin->w_topline = curbuf->b_ml.ml_line_count;
       curwin->w_topfill = 0;
@@ -1464,12 +1464,12 @@ win_found:
       // In case the autocommand moves the cursor to a position that does not
       // exist in curbuf
       VIsual_active = aco->save_VIsual_active;
-      check_cursor();
+      check_cursor(curwin);
     }
   }
 
   VIsual_active = aco->save_VIsual_active;
-  check_cursor();  // just in case lines got deleted
+  check_cursor(curwin);  // just in case lines got deleted
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
   }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1752,7 +1752,7 @@ void enter_buffer(buf_T *buf)
   maketitle();
   // when autocmds didn't change it
   if (curwin->w_topline == 1 && !curwin->w_topline_was_set) {
-    scroll_cursor_halfway(false, false);  // redisplay at correct position
+    scroll_cursor_halfway(curwin, false, false);  // redisplay at correct position
   }
 
   // Change directories when the 'acd' option is set.
@@ -2172,7 +2172,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     // cursor is at to BOL and w_cursor.lnum is checked due to getfile()
     if (!p_sol && col != 0) {
       curwin->w_cursor.col = col;
-      check_cursor_col();
+      check_cursor_col(curwin);
       curwin->w_cursor.coladd = 0;
       curwin->w_set_curswant = true;
     }
@@ -2197,7 +2197,7 @@ void buflist_getfpos(void)
     curwin->w_cursor.col = 0;
   } else {
     curwin->w_cursor.col = fpos->col;
-    check_cursor_col();
+    check_cursor_col(curwin);
     curwin->w_cursor.coladd = 0;
     curwin->w_set_curswant = true;
   }
@@ -3257,7 +3257,7 @@ void fileinfo(int fullname, int shorthelp, bool dont_truncate)
                      (int64_t)curwin->w_cursor.lnum,
                      (int64_t)curbuf->b_ml.ml_line_count,
                      n);
-    validate_virtcol();
+    validate_virtcol(curwin);
     size_t len = strlen(buffer);
     col_print(buffer + len, IOSIZE - len,
               (int)curwin->w_cursor.col + 1, (int)curwin->w_virtcol + 1);

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -707,7 +707,7 @@ void ins_char(int c)
 void ins_char_bytes(char *buf, size_t charlen)
 {
   // Break tabs if needed.
-  if (virtual_active() && curwin->w_cursor.coladd > 0) {
+  if (virtual_active(curwin) && curwin->w_cursor.coladd > 0) {
     coladvance_force(getviscol());
   }
 
@@ -815,7 +815,7 @@ void ins_str(char *s)
   int newlen = (int)strlen(s);
   linenr_T lnum = curwin->w_cursor.lnum;
 
-  if (virtual_active() && curwin->w_cursor.coladd > 0) {
+  if (virtual_active(curwin) && curwin->w_cursor.coladd > 0) {
     coladvance_force(getviscol());
   }
 
@@ -918,7 +918,7 @@ int del_bytes(colnr_T count, bool fixpos_arg, bool use_delcombine)
     // fixpos is true, we don't want to end up positioned at the NUL,
     // unless "restart_edit" is set or 'virtualedit' contains "onemore".
     if (col > 0 && fixpos && restart_edit == 0
-        && (get_ve_flags() & VE_ONEMORE) == 0) {
+        && (get_ve_flags(curwin) & VE_ONEMORE) == 0) {
       curwin->w_cursor.col--;
       curwin->w_cursor.coladd = 0;
       curwin->w_cursor.col -= utf_head_off(oldp, oldp + curwin->w_cursor.col);

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -57,7 +57,7 @@ int getviscol2(colnr_T col, colnr_T coladd)
 /// The caller must have saved the cursor line for undo!
 int coladvance_force(colnr_T wcol)
 {
-  int rc = coladvance2(&curwin->w_cursor, true, false, wcol);
+  int rc = coladvance2(curwin, &curwin->w_cursor, true, false, wcol);
 
   if (wcol == MAXCOL) {
     curwin->w_valid &= ~VALID_VIRTCOL;
@@ -76,25 +76,26 @@ int coladvance_force(colnr_T wcol)
 /// beginning at coladd 0.
 ///
 /// @return  OK if desired column is reached, FAIL if not
-int coladvance(colnr_T wcol)
+int coladvance(win_T *wp, colnr_T wcol)
 {
-  int rc = getvpos(&curwin->w_cursor, wcol);
+  int rc = getvpos(wp, &wp->w_cursor, wcol);
 
   if (wcol == MAXCOL || rc == FAIL) {
-    curwin->w_valid &= ~VALID_VIRTCOL;
-  } else if (*get_cursor_pos_ptr() != TAB) {
+    wp->w_valid &= ~VALID_VIRTCOL;
+  } else if (*(ml_get_buf(wp->w_buffer, wp->w_cursor.lnum) + wp->w_cursor.col) != TAB) {
     // Virtcol is valid when not on a TAB
-    curwin->w_valid |= VALID_VIRTCOL;
-    curwin->w_virtcol = wcol;
+    wp->w_valid |= VALID_VIRTCOL;
+    wp->w_virtcol = wcol;
   }
   return rc;
 }
 
-/// @param addspaces  change the text to achieve our goal?
+/// @param addspaces  change the text to achieve our goal? only for wp=curwin!
 /// @param finetune  change char offset for the exact column
 /// @param wcol_arg  column to move to (can be negative)
-static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_arg)
+static int coladvance2(win_T *wp, pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_arg)
 {
+  assert(wp == curwin || !addspaces);
   colnr_T wcol = wcol_arg;
   int idx;
   colnr_T col = 0;
@@ -104,30 +105,30 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
                  || (State & MODE_TERMINAL)
                  || restart_edit != NUL
                  || (VIsual_active && *p_sel != 'o')
-                 || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
+                 || ((get_ve_flags(wp) & VE_ONEMORE) && wcol < MAXCOL);
 
-  char *line = ml_get_buf(curbuf, pos->lnum);
+  char *line = ml_get_buf(wp->w_buffer, pos->lnum);
 
   if (wcol >= MAXCOL) {
     idx = (int)strlen(line) - 1 + one_more;
     col = wcol;
 
     if ((addspaces || finetune) && !VIsual_active) {
-      curwin->w_curswant = linetabsize(curwin, pos->lnum) + one_more;
-      if (curwin->w_curswant > 0) {
-        curwin->w_curswant--;
+      wp->w_curswant = linetabsize(wp, pos->lnum) + one_more;
+      if (wp->w_curswant > 0) {
+        wp->w_curswant--;
       }
     }
   } else {
-    int width = curwin->w_width_inner - win_col_off(curwin);
+    int width = wp->w_width_inner - win_col_off(wp);
     int csize = 0;
 
     if (finetune
-        && curwin->w_p_wrap
-        && curwin->w_width_inner != 0
+        && wp->w_p_wrap
+        && wp->w_width_inner != 0
         && wcol >= (colnr_T)width
         && width > 0) {
-      csize = linetabsize(curwin, pos->lnum);
+      csize = linetabsize(wp, pos->lnum);
       if (csize > 0) {
         csize--;
       }
@@ -143,7 +144,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
     }
 
     CharsizeArg csarg;
-    CSType cstype = init_charsize_arg(&csarg, curwin, pos->lnum, line);
+    CSType cstype = init_charsize_arg(&csarg, wp, pos->lnum, line);
     StrCharInfo ci = utf_ptr2StrCharInfo(line);
     col = 0;
     while (col <= wcol && *ci.ptr != NUL) {
@@ -159,14 +160,14 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
     // is needed to ensure that a virtual position off the end of
     // a line has the correct indexing.  The one_more comparison
     // replaces an explicit add of one_more later on.
-    if (col > wcol || (!virtual_active() && one_more == 0)) {
+    if (col > wcol || (!virtual_active(wp) && one_more == 0)) {
       idx -= 1;
       // Don't count the chars from 'showbreak'.
       csize -= head;
       col -= csize;
     }
 
-    if (virtual_active()
+    if (virtual_active(wp)
         && addspaces
         && wcol >= 0
         && ((col != wcol && col != wcol + 1) || csize > 1)) {
@@ -229,14 +230,14 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
       if (!one_more) {
         colnr_T scol, ecol;
 
-        getvcol(curwin, pos, &scol, NULL, &ecol);
+        getvcol(wp, pos, &scol, NULL, &ecol);
         pos->coladd = ecol - scol;
       }
     } else {
       int b = (int)wcol - (int)col;
 
       // The difference between wcol and col is used to set coladd.
-      if (b > 0 && b < (MAXCOL - 2 * curwin->w_width_inner)) {
+      if (b > 0 && b < (MAXCOL - 2 * wp->w_width_inner)) {
         pos->coladd = b;
       }
 
@@ -245,7 +246,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
   }
 
   // Prevent from moving onto a trail byte.
-  mark_mb_adjustpos(curbuf, pos);
+  mark_mb_adjustpos(wp->w_buffer, pos);
 
   if (wcol < 0 || col < wcol) {
     return FAIL;
@@ -256,9 +257,9 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
 /// Return in "pos" the position of the cursor advanced to screen column "wcol".
 ///
 /// @return  OK if desired column is reached, FAIL if not
-int getvpos(pos_T *pos, colnr_T wcol)
+int getvpos(win_T *wp, pos_T *pos, colnr_T wcol)
 {
-  return coladvance2(pos, false, virtual_active(), wcol);
+  return coladvance2(wp, pos, false, virtual_active(wp), wcol);
 }
 
 /// Increment the cursor position.  See inc() for return values.
@@ -294,7 +295,7 @@ linenr_T get_cursor_rel_lnum(win_T *wp, linenr_T lnum)
   // Loop until we reach to_line, skipping folds.
   for (; from_line < to_line; from_line++, retval++) {
     // If from_line is in a fold, set it to the last line of that fold.
-    hasFoldingWin(wp, from_line, NULL, &from_line, true, NULL);
+    hasFolding(wp, from_line, NULL, &from_line);
   }
 
   // If to_line is in a closed fold, the line count is off by +1. Correct it.
@@ -329,7 +330,7 @@ void check_cursor_lnum(win_T *win)
   if (win->w_cursor.lnum > buf->b_ml.ml_line_count) {
     // If there is a closed fold at the end of the file, put the cursor in
     // its first line.  Otherwise in the last line.
-    if (!hasFolding(buf->b_ml.ml_line_count, &win->w_cursor.lnum, NULL)) {
+    if (!hasFolding(win, buf->b_ml.ml_line_count, &win->w_cursor.lnum, NULL)) {
       win->w_cursor.lnum = buf->b_ml.ml_line_count;
     }
   }
@@ -338,19 +339,13 @@ void check_cursor_lnum(win_T *win)
   }
 }
 
-/// Make sure curwin->w_cursor.col is valid.
-void check_cursor_col(void)
-{
-  check_cursor_col_win(curwin);
-}
-
 /// Make sure win->w_cursor.col is valid. Special handling of insert-mode.
 /// @see mb_check_adjust_col
-void check_cursor_col_win(win_T *win)
+void check_cursor_col(win_T *win)
 {
   colnr_T oldcol = win->w_cursor.col;
   colnr_T oldcoladd = win->w_cursor.col + win->w_cursor.coladd;
-  unsigned cur_ve_flags = get_ve_flags();
+  unsigned cur_ve_flags = get_ve_flags(win);
 
   colnr_T len = (colnr_T)strlen(ml_get_buf(win->w_buffer, win->w_cursor.lnum));
   if (len == 0) {
@@ -363,7 +358,7 @@ void check_cursor_col_win(win_T *win)
     if ((State & MODE_INSERT) || restart_edit
         || (VIsual_active && *p_sel != 'o')
         || (cur_ve_flags & VE_ONEMORE)
-        || virtual_active()) {
+        || virtual_active(win)) {
       win->w_cursor.col = len;
     } else {
       win->w_cursor.col = len - 1;
@@ -403,10 +398,10 @@ void check_cursor_col_win(win_T *win)
 }
 
 /// Make sure curwin->w_cursor in on a valid character
-void check_cursor(void)
+void check_cursor(win_T *wp)
 {
-  check_cursor_lnum(curwin);
-  check_cursor_col();
+  check_cursor_lnum(wp);
+  check_cursor_col(wp);
 }
 
 /// Check if VIsual position is valid, correct it if not.
@@ -453,8 +448,8 @@ bool set_leftcol(colnr_T leftcol)
   changed_cline_bef_curs(curwin);
   // TODO(hinidu): I think it should be colnr_T or int, but p_siso is long.
   // Perhaps we can change p_siso to int.
-  int64_t lastcol = curwin->w_leftcol + curwin->w_width_inner - curwin_col_off() - 1;
-  validate_virtcol();
+  int64_t lastcol = curwin->w_leftcol + curwin->w_width_inner - win_col_off(curwin) - 1;
+  validate_virtcol(curwin);
 
   bool retval = false;
   // If the cursor is right or left of the screen, move it to last or first
@@ -462,10 +457,10 @@ bool set_leftcol(colnr_T leftcol)
   int siso = get_sidescrolloff_value(curwin);
   if (curwin->w_virtcol > (colnr_T)(lastcol - siso)) {
     retval = true;
-    coladvance((colnr_T)(lastcol - siso));
+    coladvance(curwin, (colnr_T)(lastcol - siso));
   } else if (curwin->w_virtcol < curwin->w_leftcol + siso) {
     retval = true;
-    coladvance((colnr_T)(curwin->w_leftcol + siso));
+    coladvance(curwin, (colnr_T)(curwin->w_leftcol + siso));
   }
 
   // If the start of the character under the cursor is not on the screen,
@@ -475,10 +470,10 @@ bool set_leftcol(colnr_T leftcol)
   getvvcol(curwin, &curwin->w_cursor, &s, NULL, &e);
   if (e > (colnr_T)lastcol) {
     retval = true;
-    coladvance(s - 1);
+    coladvance(curwin, s - 1);
   } else if (s < curwin->w_leftcol) {
     retval = true;
-    if (coladvance(e + 1) == FAIL) {    // there isn't another character
+    if (coladvance(curwin, e + 1) == FAIL) {    // there isn't another character
       curwin->w_leftcol = s;            // adjust w_leftcol instead
       changed_cline_bef_curs(curwin);
     }

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -890,9 +890,9 @@ int decor_virt_lines(win_T *wp, linenr_T lnum, VirtLines *lines, TriState has_fo
   }
 
   assert(lnum > 0);
-  bool below_fold = lnum > 1 && hasFoldingWin(wp, lnum - 1, NULL, NULL, true, NULL);
+  bool below_fold = lnum > 1 && hasFolding(wp, lnum - 1, NULL, NULL);
   if (has_fold == kNone) {
-    has_fold = hasFoldingWin(wp, lnum, NULL, NULL, true, NULL);
+    has_fold = hasFolding(wp, lnum, NULL, NULL);
   }
 
   const int row = lnum - 1;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1347,7 +1347,7 @@ void ex_diffsplit(exarg_T *eap)
   set_bufref(&old_curbuf, curbuf);
 
   // Need to compute w_fraction when no redraw happened yet.
-  validate_cursor();
+  validate_cursor(curwin);
   set_fraction(curwin);
 
   // don't use a new tab page, each tab page has its own diffs
@@ -1457,7 +1457,7 @@ void diff_win_options(win_T *wp, bool addbuf)
   foldUpdateAll(wp);
 
   // make sure topline is not halfway through a fold
-  changed_window_setting_win(wp);
+  changed_window_setting(wp);
   if (vim_strchr(p_sbo, 'h') == NULL) {
     do_cmdline_cmd("set sbo+=hor");
   }
@@ -1522,7 +1522,7 @@ void ex_diffoff(exarg_T *eap)
 
       // make sure topline is not halfway a fold and cursor is
       // invalidated
-      changed_window_setting_win(wp);
+      changed_window_setting(wp);
 
       // Note: 'sbo' is not restored, it's a global option.
       diff_buf_adjust(wp);
@@ -2137,7 +2137,7 @@ int diff_check_with_linestatus(win_T *wp, linenr_T lnum, int *linestatus)
   }
 
   // A closed fold never has filler lines.
-  if (hasFoldingWin(wp, lnum, NULL, NULL, true, NULL)) {
+  if (hasFolding(wp, lnum, NULL, NULL)) {
     return 0;
   }
 
@@ -2451,8 +2451,7 @@ void diff_set_topline(win_T *fromwin, win_T *towin)
   changed_line_abv_curs_win(towin);
 
   check_topfill(towin, false);
-  hasFoldingWin(towin, towin->w_topline, &towin->w_topline,
-                NULL, true, NULL);
+  hasFolding(towin, towin->w_topline, &towin->w_topline, NULL);
 }
 
 /// This is called when 'diffopt' is changed.
@@ -2988,7 +2987,7 @@ theend:
   // Check that the cursor is on a valid character and update its
   // position.  When there were filler lines the topline has become
   // invalid.
-  check_cursor();
+  check_cursor(curwin);
   changed_line_abv_curs();
 
   if (diff_need_update) {

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1393,7 +1393,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     // the end of the line may be before the start of the displayed part.
     if (wlv.vcol < start_col && (wp->w_p_cuc
                                  || wlv.color_cols
-                                 || virtual_active()
+                                 || virtual_active(wp)
                                  || (VIsual_active && wp->w_buffer == curwin->w_buffer))) {
       wlv.vcol = start_col;
     }
@@ -2339,7 +2339,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
               && wlv.line_attr == 0
               && wlv.line_attr_lowprio == 0) {
             // In virtualedit, visual selections may extend beyond end of line
-            if (!(area_highlighting && virtual_active()
+            if (!(area_highlighting && virtual_active(wp)
                   && wlv.tocol != MAXCOL && wlv.vcol < wlv.tocol)) {
               wlv.p_extra = "";
             }
@@ -2382,7 +2382,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
           mb_schar = schar_from_ascii(mb_c);
         } else if (VIsual_active
                    && (VIsual_mode == Ctrl_V || VIsual_mode == 'v')
-                   && virtual_active()
+                   && virtual_active(wp)
                    && wlv.tocol != MAXCOL
                    && wlv.vcol < wlv.tocol
                    && wlv.col < grid->cols) {

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -823,7 +823,7 @@ void setcursor(void)
 void setcursor_mayforce(bool force)
 {
   if (force || redrawing()) {
-    validate_cursor();
+    validate_cursor(curwin);
 
     ScreenGrid *grid = &curwin->w_grid;
     int row = curwin->w_wrow;
@@ -851,7 +851,7 @@ void show_cursor_info_later(bool force)
                    && *ml_get_buf(curwin->w_buffer, curwin->w_cursor.lnum) == NUL;
 
   // Only draw when something changed.
-  validate_virtcol_win(curwin);
+  validate_virtcol(curwin);
   if (force
       || curwin->w_cursor.lnum != curwin->w_stl_cursor.lnum
       || curwin->w_cursor.col != curwin->w_stl_cursor.col
@@ -1611,14 +1611,14 @@ static void win_update(win_T *wp)
         }
       }
 
-      hasFoldingWin(wp, mod_top, &mod_top, NULL, true, NULL);
+      hasFolding(wp, mod_top, &mod_top, NULL);
       if (mod_top > lnumt) {
         mod_top = lnumt;
       }
 
       // Now do the same for the bottom line (one above mod_bot).
       mod_bot--;
-      hasFoldingWin(wp, mod_bot, NULL, &mod_bot, true, NULL);
+      hasFolding(wp, mod_bot, NULL, &mod_bot);
       mod_bot++;
       if (mod_bot < lnumb) {
         mod_bot = lnumb;
@@ -1691,7 +1691,7 @@ static void win_update(win_T *wp)
           if (j >= wp->w_grid.rows - 2) {
             break;
           }
-          hasFoldingWin(wp, ln, NULL, &ln, true, NULL);
+          hasFolding(wp, ln, NULL, &ln);
         }
       } else {
         j = wp->w_lines[0].wl_lnum - wp->w_topline;
@@ -1903,7 +1903,7 @@ static void win_update(win_T *wp)
         // Highlight to the end of the line, unless 'virtualedit' has
         // "block".
         if (curwin->w_curswant == MAXCOL) {
-          if (get_ve_flags() & VE_BLOCK) {
+          if (get_ve_flags(curwin) & VE_BLOCK) {
             pos_T pos;
             int cursor_above = curwin->w_cursor.lnum < VIsual.lnum;
 
@@ -2148,7 +2148,7 @@ static void win_update(win_T *wp)
           // rows, and may insert/delete lines
           int j = idx;
           for (l = lnum; l < mod_bot; l++) {
-            if (hasFoldingWin(wp, l, NULL, &l, true, NULL)) {
+            if (hasFolding(wp, l, NULL, &l)) {
               new_rows++;
             } else if (l == wp->w_topline) {
               int n = plines_win_nofill(wp, l, false) + wp->w_topfill;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -185,7 +185,7 @@ static void insert_enter(InsertState *s)
 
       curwin->w_cursor = save_cursor;
       State = MODE_INSERT;
-      check_cursor_col();
+      check_cursor_col(curwin);
       State = save_state;
     }
   }
@@ -282,7 +282,7 @@ static void insert_enter(InsertState *s)
     // correct in very rare cases).
     // Also do this if curswant is greater than the current virtual
     // column.  Eg after "^O$" or "^O80|".
-    validate_virtcol();
+    validate_virtcol(curwin);
     update_curswant();
     if (((ins_at_eol && curwin->w_cursor.lnum == o_lnum)
          || curwin->w_curswant > curwin->w_virtcol)
@@ -468,7 +468,7 @@ static int insert_check(VimState *state)
       && curwin->w_topline == s->old_topline
       && curwin->w_topfill == s->old_topfill) {
     s->mincol = curwin->w_wcol;
-    validate_cursor_col();
+    validate_cursor_col(curwin);
 
     if (curwin->w_wcol < s->mincol - tabstop_at(get_nolist_virtcol(),
                                                 curbuf->b_p_ts,
@@ -478,7 +478,7 @@ static int insert_check(VimState *state)
             || curwin->w_topfill > 0)) {
       if (curwin->w_topfill > 0) {
         curwin->w_topfill--;
-      } else if (hasFolding(curwin->w_topline, NULL, &s->old_topline)) {
+      } else if (hasFolding(curwin, curwin->w_topline, NULL, &s->old_topline)) {
         set_topline(curwin, s->old_topline + 1);
       } else {
         set_topline(curwin, curwin->w_topline + 1);
@@ -491,7 +491,7 @@ static int insert_check(VimState *state)
 
   s->did_backspace = false;
 
-  validate_cursor();                  // may set must_redraw
+  validate_cursor(curwin);                  // may set must_redraw
 
   // Redraw the display when no characters are waiting.
   // Also shows mode, ruler and positions cursor.
@@ -743,7 +743,7 @@ static int insert_handle_key(InsertState *s)
     ins_ctrl_o();
 
     // don't move the cursor left when 'virtualedit' has "onemore".
-    if (get_ve_flags() & VE_ONEMORE) {
+    if (get_ve_flags(curwin) & VE_ONEMORE) {
       ins_at_eol = false;
       s->nomove = true;
     }
@@ -1451,7 +1451,7 @@ void edit_putchar(int c, bool highlight)
 
   int attr;
   update_topline(curwin);  // just in case w_topline isn't valid
-  validate_cursor();
+  validate_cursor(curwin);
   if (highlight) {
     attr = HL_ATTR(HLF_8);
   } else {
@@ -1521,7 +1521,7 @@ static void init_prompt(int cmdchar_todo)
       ml_append(curbuf->b_ml.ml_line_count, prompt, 0, false);
     }
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
     inserted_bytes(curbuf->b_ml.ml_line_count, 0, 0, (colnr_T)strlen(prompt));
   }
 
@@ -1536,13 +1536,13 @@ static void init_prompt(int cmdchar_todo)
   }
 
   if (cmdchar_todo == 'A') {
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
   }
   if (curwin->w_cursor.col < (colnr_T)strlen(prompt)) {
     curwin->w_cursor.col = (colnr_T)strlen(prompt);
   }
   // Make sure the cursor is in a valid position.
-  check_cursor();
+  check_cursor(curwin);
 }
 
 /// @return  true if the cursor is in the editable position of the prompt line.
@@ -2394,7 +2394,7 @@ static void stop_insert(pos_T *end_insert_pos, int esc, int nomove)
       pos_T tpos = curwin->w_cursor;
 
       curwin->w_cursor = *end_insert_pos;
-      check_cursor_col();        // make sure it is not past the line
+      check_cursor_col(curwin);        // make sure it is not past the line
       while (true) {
         if (gchar_cursor() == NUL && curwin->w_cursor.col > 0) {
           curwin->w_cursor.col--;
@@ -2471,7 +2471,7 @@ void free_last_insert(void)
 void beginline(int flags)
 {
   if ((flags & BL_SOL) && !p_sol) {
-    coladvance(curwin->w_curswant);
+    coladvance(curwin, curwin->w_curswant);
   } else {
     curwin->w_cursor.col = 0;
     curwin->w_cursor.coladd = 0;
@@ -2497,13 +2497,13 @@ int oneright(void)
 {
   char *ptr;
 
-  if (virtual_active()) {
+  if (virtual_active(curwin)) {
     pos_T prevpos = curwin->w_cursor;
 
     // Adjust for multi-wide char (excluding TAB)
     ptr = get_cursor_pos_ptr();
-    coladvance(getviscol() + ((*ptr != TAB && vim_isprintc(utf_ptr2char(ptr)))
-                              ? ptr2cells(ptr) : 1));
+    coladvance(curwin, getviscol() + ((*ptr != TAB && vim_isprintc(utf_ptr2char(ptr)))
+                                      ? ptr2cells(ptr) : 1));
     curwin->w_set_curswant = true;
     // Return OK if the cursor moved, FAIL otherwise (at window edge).
     return (prevpos.col != curwin->w_cursor.col
@@ -2519,7 +2519,7 @@ int oneright(void)
 
   // move "l" bytes right, but don't end up on the NUL, unless 'virtualedit'
   // contains "onemore".
-  if (ptr[l] == NUL && (get_ve_flags() & VE_ONEMORE) == 0) {
+  if (ptr[l] == NUL && (get_ve_flags(curwin) & VE_ONEMORE) == 0) {
     return FAIL;
   }
   curwin->w_cursor.col += l;
@@ -2531,7 +2531,7 @@ int oneright(void)
 
 int oneleft(void)
 {
-  if (virtual_active()) {
+  if (virtual_active(curwin)) {
     int v = getviscol();
 
     if (v == 0) {
@@ -2541,7 +2541,7 @@ int oneleft(void)
     // We might get stuck on 'showbreak', skip over it.
     int width = 1;
     while (true) {
-      coladvance(v - width);
+      coladvance(curwin, v - width);
       // getviscol() is slow, skip it when 'showbreak' is empty,
       // 'breakindent' is not set and there are no multi-byte
       // characters
@@ -2590,7 +2590,7 @@ void cursor_up_inner(win_T *wp, linenr_T n)
     // Count each sequence of folded lines as one logical line.
 
     // go to the start of the current fold
-    hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+    hasFolding(wp, lnum, &lnum, NULL);
 
     while (n--) {
       // move up one line
@@ -2602,7 +2602,7 @@ void cursor_up_inner(win_T *wp, linenr_T n)
       // Insert mode or when 'foldopen' contains "all": it will open
       // in a moment.
       if (n > 0 || !((State & MODE_INSERT) || (fdo_flags & FDO_ALL))) {
-        hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+        hasFolding(wp, lnum, &lnum, NULL);
       }
     }
     if (lnum < 1) {
@@ -2625,7 +2625,7 @@ int cursor_up(linenr_T n, bool upd_topline)
   cursor_up_inner(curwin, n);
 
   // try to advance to the column we want to be at
-  coladvance(curwin->w_curswant);
+  coladvance(curwin, curwin->w_curswant);
 
   if (upd_topline) {
     update_topline(curwin);  // make sure curwin->w_topline is valid
@@ -2678,7 +2678,7 @@ int cursor_down(int n, bool upd_topline)
   cursor_down_inner(curwin, n);
 
   // try to advance to the column we want to be at
-  coladvance(curwin->w_curswant);
+  coladvance(curwin, curwin->w_curswant);
 
   if (upd_topline) {
     update_topline(curwin);           // make sure curwin->w_topline is valid
@@ -3274,7 +3274,7 @@ static void ins_reg(void)
 
     // Cursor may be moved back a column.
     curwin->w_cursor = curpos;
-    check_cursor();
+    check_cursor(curwin);
   }
   if (regname == NUL || !valid_yank_reg(regname, false)) {
     vim_beep(BO_REG);
@@ -3466,7 +3466,7 @@ static bool ins_esc(int *count, int cmdchar, bool nomove)
       && (curwin->w_cursor.col != 0 || curwin->w_cursor.coladd > 0)
       && (restart_edit == NUL || (gchar_cursor() == NUL && !VIsual_active))
       && !revins_on) {
-    if (curwin->w_cursor.coladd > 0 || get_ve_flags() == VE_ALL) {
+    if (curwin->w_cursor.coladd > 0 || get_ve_flags(curwin) == VE_ALL) {
       oneleft();
       if (restart_edit != NUL) {
         curwin->w_cursor.coladd++;
@@ -3598,7 +3598,7 @@ static void ins_ctrl_o(void)
   } else {
     restart_edit = 'I';
   }
-  if (virtual_active()) {
+  if (virtual_active(curwin)) {
     ins_at_eol = false;         // cursor always keeps its column
   } else {
     ins_at_eol = (gchar_cursor() == NUL);
@@ -4028,7 +4028,7 @@ static void ins_left(void)
     // always break undo when moving upwards/downwards, else undo may break
     start_arrow(&tpos);
     curwin->w_cursor.lnum--;
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
     curwin->w_set_curswant = true;  // so we stay at the end
   } else {
     vim_beep(BO_CRSR);
@@ -4062,7 +4062,7 @@ static void ins_end(int c)
   if (c == K_C_END) {
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
   }
-  coladvance(MAXCOL);
+  coladvance(curwin, MAXCOL);
   curwin->w_curswant = MAXCOL;
 
   start_arrow(&tpos);
@@ -4096,13 +4096,13 @@ static void ins_right(void)
     foldOpenCursor();
   }
   undisplay_dollar();
-  if (gchar_cursor() != NUL || virtual_active()) {
+  if (gchar_cursor() != NUL || virtual_active(curwin)) {
     start_arrow_with_change(&curwin->w_cursor, end_change);
     if (!end_change) {
       AppendCharToRedobuff(K_RIGHT);
     }
     curwin->w_set_curswant = true;
-    if (virtual_active()) {
+    if (virtual_active(curwin)) {
       oneright();
     } else {
       curwin->w_cursor.col += utfc_ptr2len(get_cursor_pos_ptr());
@@ -4157,7 +4157,7 @@ static void ins_up(bool startcol)
   pos_T tpos = curwin->w_cursor;
   if (cursor_up(1, true) == OK) {
     if (startcol) {
-      coladvance(getvcol_nolist(&Insstart));
+      coladvance(curwin, getvcol_nolist(&Insstart));
     }
     if (old_topline != curwin->w_topline
         || old_topfill != curwin->w_topfill) {
@@ -4202,7 +4202,7 @@ static void ins_down(bool startcol)
   pos_T tpos = curwin->w_cursor;
   if (cursor_down(1, true) == OK) {
     if (startcol) {
-      coladvance(getvcol_nolist(&Insstart));
+      coladvance(curwin, getvcol_nolist(&Insstart));
     }
     if (old_topline != curwin->w_topline
         || old_topfill != curwin->w_topfill) {
@@ -4474,8 +4474,8 @@ bool ins_eol(int c)
 
   // Put cursor on NUL if on the last char and coladd is 1 (happens after
   // CTRL-O).
-  if (virtual_active() && curwin->w_cursor.coladd > 0) {
-    coladvance(getviscol());
+  if (virtual_active(curwin) && curwin->w_cursor.coladd > 0) {
+    coladvance(curwin, getviscol());
   }
 
   // NL in reverse insert will always start in the end of current line.
@@ -4574,7 +4574,7 @@ int ins_copychar(linenr_T lnum)
   }
 
   // try to advance to the cursor column
-  validate_virtcol();
+  validate_virtcol(curwin);
   int const end_vcol = curwin->w_virtcol;
   char *line = ml_get(lnum);
 
@@ -4720,7 +4720,7 @@ colnr_T get_nolist_virtcol(void)
   if (curwin->w_p_list && vim_strchr(p_cpo, CPO_LISTWM) == NULL) {
     return getvcol_nolist(&curwin->w_cursor);
   }
-  validate_virtcol();
+  validate_virtcol(curwin);
   return curwin->w_virtcol;
 }
 

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -197,7 +197,7 @@ static void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, typval_
           && ml_replace(lnum, line, true) == OK) {
         inserted_bytes(lnum, 0, old_len, (int)strlen(line));
         if (is_curbuf && lnum == curwin->w_cursor.lnum) {
-          check_cursor_col();
+          check_cursor_col(curwin);
         }
         rettv->vval.v_number = 0;  // OK
       }
@@ -229,7 +229,7 @@ static void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, typval_
         wp->w_cursor.lnum += (linenr_T)added;
       }
     }
-    check_cursor_col();
+    check_cursor_col(curwin);
     update_topline(curwin);
   }
 
@@ -469,7 +469,7 @@ void f_deletebufline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       }
     }
   }
-  check_cursor_col();
+  check_cursor_col(curwin);
   deleted_lines_mark(first, count);
   rettv->vval.v_number = 0;  // OK
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -727,7 +727,7 @@ static void get_col(typval_T *argvars, typval_T *rettv, bool charcol)
       return;
     }
 
-    check_cursor();
+    check_cursor(curwin);
     winchanged = true;
   }
 
@@ -746,7 +746,7 @@ static void get_col(typval_T *argvars, typval_T *rettv, bool charcol)
       col = fp->col + 1;
       // col(".") when the cursor is on the NUL at the end of the line
       // because of "coladd" can be seen as an extra column.
-      if (virtual_active() && fp == &curwin->w_cursor) {
+      if (virtual_active(curwin) && fp == &curwin->w_cursor) {
         char *p = get_cursor_pos_ptr();
         if (curwin->w_cursor.coladd >=
             (colnr_T)win_chartabsize(curwin, p,
@@ -1191,7 +1191,7 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
   curwin->w_cursor.coladd = coladd;
 
   // Make sure the cursor is in a valid position.
-  check_cursor();
+  check_cursor(curwin);
   // Correct cursor for multi-byte character.
   mb_adjust_cursor();
 
@@ -2890,7 +2890,7 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   curbuf = findbuf;
   curwin->w_buffer = curbuf;
   const TriState save_virtual = virtual_op;
-  virtual_op = virtual_active();
+  virtual_op = virtual_active(curwin);
 
   // NOTE: Adjust is needed.
   p1.col--;
@@ -4643,7 +4643,7 @@ static void f_line(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (wp != NULL && tp != NULL) {
       switchwin_T switchwin;
       if (switch_win_noblock(&switchwin, wp, tp, true) == OK) {
-        check_cursor();
+        check_cursor(curwin);
         fp = var2fpos(&argvars[0], true, &fnum, false);
       }
       restore_win_noblock(&switchwin, true);
@@ -7029,7 +7029,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
     }
     // "/$" will put the cursor after the end of the line, may need to
     // correct that here
-    check_cursor();
+    check_cursor(curwin);
   }
 
   // If 'n' flag is used: restore cursor position.
@@ -7791,7 +7791,7 @@ static void set_position(typval_T *argvars, typval_T *rettv, bool charpos)
       curwin->w_curswant = curswant - 1;
       curwin->w_set_curswant = false;
     }
-    check_cursor();
+    check_cursor(curwin);
     rettv->vval.v_number = 0;
   } else if (name[0] == '\'' && name[1] != NUL && name[2] == NUL) {
     // set mark
@@ -9204,7 +9204,7 @@ static void f_virtcol(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       goto theend;
     }
 
-    check_cursor();
+    check_cursor(curwin);
     winchanged = true;
   }
 

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -516,7 +516,7 @@ bool win_execute_before(win_execute_T *args, win_T *wp, tabpage_T *tp)
   }
 
   if (switch_win_noblock(&args->switchwin, wp, tp, true) == OK) {
-    check_cursor();
+    check_cursor(curwin);
     return true;
   }
   return false;
@@ -540,7 +540,7 @@ void win_execute_after(win_execute_T *args)
 
   // In case the command moved the cursor or changed the Visual area,
   // check it is valid.
-  check_cursor();
+  check_cursor(curwin);
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
   }
@@ -774,7 +774,7 @@ void f_winbufnr(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "wincol()" function
 void f_wincol(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  validate_cursor();
+  validate_cursor(curwin);
   rettv->vval.v_number = curwin->w_wcol + 1;
 }
 
@@ -811,7 +811,7 @@ void f_winlayout(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "winline()" function
 void f_winline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  validate_cursor();
+  validate_cursor(curwin);
   rettv->vval.v_number = curwin->w_wrow + 1;
 }
 
@@ -883,10 +883,10 @@ void f_winrestview(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     curwin->w_skipcol = (colnr_T)tv_get_number(&di->di_tv);
   }
 
-  check_cursor();
+  check_cursor(curwin);
   win_new_height(curwin, curwin->w_height);
   win_new_width(curwin, curwin->w_width);
-  changed_window_setting();
+  changed_window_setting(curwin);
 
   if (curwin->w_topline <= 0) {
     curwin->w_topline = 1;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2638,14 +2638,14 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     if (newcol >= 0) {          // position set by autocommands
       curwin->w_cursor.lnum = newlnum;
       curwin->w_cursor.col = newcol;
-      check_cursor();
+      check_cursor(curwin);
     } else if (newlnum > 0) {  // line number from caller or old position
       curwin->w_cursor.lnum = newlnum;
       check_cursor_lnum(curwin);
       if (solcol >= 0 && !p_sol) {
         // 'sol' is off: Use last known column.
         curwin->w_cursor.col = solcol;
-        check_cursor_col();
+        check_cursor_col(curwin);
         curwin->w_cursor.coladd = 0;
         curwin->w_set_curswant = true;
       } else {
@@ -3787,7 +3787,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               highlight_match = true;
 
               update_topline(curwin);
-              validate_cursor();
+              validate_cursor(curwin);
               redraw_later(curwin, UPD_SOME_VALID);
               show_cursor_info_later(true);
               update_screen();
@@ -4247,7 +4247,7 @@ skip:
       // when interactive leave cursor on the match
       if (!subflags.do_ask) {
         if (endcolumn) {
-          coladvance(MAXCOL);
+          coladvance(curwin, MAXCOL);
         } else {
           beginline(BL_WHITE | BL_FIX);
         }
@@ -4278,7 +4278,7 @@ skip:
 
   if (subflags.do_ask && hasAnyFolding(curwin)) {
     // Cursor position may require updating
-    changed_window_setting();
+    changed_window_setting(curwin);
   }
 
   vim_regfree(regmatch.regprog);
@@ -4514,7 +4514,7 @@ void global_exe(char *cmd)
   if (global_need_beginline) {
     beginline(BL_WHITE | BL_FIX);
   } else {
-    check_cursor();  // cursor may be beyond the end of the line
+    check_cursor(curwin);  // cursor may be beyond the end of the line
   }
 
   // the cursor may not have moved in the text but a change in a previous

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -654,7 +654,7 @@ void ex_listdo(exarg_T *eap)
       }
 
       if (eap->cmdidx == CMD_windo && execute) {
-        validate_cursor();              // cursor may have moved
+        validate_cursor(curwin);              // cursor may have moved
         // required when 'scrollbind' has been set
         if (curwin->w_p_scb) {
           do_check_scrollbind(true);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -510,7 +510,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
 
     s->match_start = curwin->w_cursor;
     set_search_match(&curwin->w_cursor);
-    validate_cursor();
+    validate_cursor(curwin);
     end_pos = curwin->w_cursor;
     s->match_end = end_pos;
     curwin->w_cursor = save_pos;
@@ -530,7 +530,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     ccline.cmdbuff[skiplen + patlen] = next_char;
   }
 
-  validate_cursor();
+  validate_cursor(curwin);
 
   // May redraw the status line to show the cursor position.
   if (p_ru && (curwin->w_status_height > 0 || global_stl_height() > 0)) {
@@ -626,7 +626,7 @@ static void finish_incsearch_highlighting(bool gotesc, incsearch_state_T *s,
 
   magic_overruled = s->magic_overruled_save;
 
-  validate_cursor();          // needed for TAB
+  validate_cursor(curwin);          // needed for TAB
   status_redraw_all();
   redraw_all_later(UPD_SOME_VALID);
   if (call_update_screen) {
@@ -1483,7 +1483,7 @@ static int may_do_command_line_next_incsearch(int firstc, int count, incsearch_s
     curwin->w_cursor = s->match_start;
     changed_cline_bef_curs(curwin);
     update_topline(curwin);
-    validate_cursor();
+    validate_cursor(curwin);
     highlight_match = true;
     save_viewstate(curwin, &s->old_viewstate);
     redraw_later(curwin, UPD_NOT_VALID);
@@ -4623,6 +4623,6 @@ static void set_search_match(pos_T *t)
   t->col = search_match_endcol;
   if (t->lnum > curbuf->b_ml.ml_line_count) {
     t->lnum = curbuf->b_ml.ml_line_count;
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
   }
 }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3197,7 +3197,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
     curwin->w_topline = old_topline;
   }
   curwin->w_cursor = old_cursor;
-  check_cursor();
+  check_cursor(curwin);
   update_topline(curwin);
   keep_filetype = false;
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -143,7 +143,7 @@ void copyFoldingState(win_T *wp_from, win_T *wp_to)
 }
 
 // hasAnyFolding() {{{2
-/// @return  true if there may be folded lines in the current window.
+/// @return  true if there may be folded lines in window "win".
 int hasAnyFolding(win_T *win)
 {
   // very simple now, but can become more complex later
@@ -155,10 +155,10 @@ int hasAnyFolding(win_T *win)
 /// When returning true, *firstp and *lastp are set to the first and last
 /// lnum of the sequence of folded lines (skipped when NULL).
 ///
-/// @return  true if line "lnum" in the current window is part of a closed fold.
-bool hasFolding(linenr_T lnum, linenr_T *firstp, linenr_T *lastp)
+/// @return  true if line "lnum" in window "win" is part of a closed fold.
+bool hasFolding(win_T *win, linenr_T lnum, linenr_T *firstp, linenr_T *lastp)
 {
-  return hasFoldingWin(curwin, lnum, firstp, lastp, true, NULL);
+  return hasFoldingWin(win, lnum, firstp, lastp, true, NULL);
 }
 
 // hasFoldingWin() {{{2
@@ -398,13 +398,13 @@ void opFoldRange(pos_T firstpos, pos_T lastpos, int opening, int recurse, bool h
     // Opening one level only: next fold to open is after the one going to
     // be opened.
     if (opening && !recurse) {
-      hasFolding(lnum, NULL, &lnum_next);
+      hasFolding(curwin, lnum, NULL, &lnum_next);
     }
     setManualFold(temp, opening, recurse, &done);
     // Closing one level only: next line to close a fold is after just
     // closed fold.
     if (!opening && !recurse) {
-      hasFolding(lnum, NULL, &lnum_next);
+      hasFolding(curwin, lnum, NULL, &lnum_next);
     }
   }
   if (done == DONE_NOTHING) {
@@ -477,7 +477,7 @@ static void newFoldLevelWin(win_T *wp)
     }
     wp->w_fold_manual = false;
   }
-  changed_window_setting_win(wp);
+  changed_window_setting(wp);
 }
 
 // foldCheckClose() {{{2
@@ -492,7 +492,7 @@ void foldCheckClose(void)
   checkupdate(curwin);
   if (checkCloseRec(&curwin->w_folds, curwin->w_cursor.lnum,
                     (int)curwin->w_p_fdl)) {
-    changed_window_setting();
+    changed_window_setting(curwin);
   }
 }
 
@@ -661,7 +661,7 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
     fp->fd_small = kNone;
 
     // redraw
-    changed_window_setting_win(wp);
+    changed_window_setting(wp);
   }
 }
 
@@ -735,7 +735,7 @@ void deleteFold(win_T *const wp, const linenr_T start, const linenr_T end, const
       did_one = true;
 
       // redraw window
-      changed_window_setting_win(wp);
+      changed_window_setting(wp);
     }
   }
   if (!did_one) {
@@ -746,7 +746,7 @@ void deleteFold(win_T *const wp, const linenr_T start, const linenr_T end, const
     }
   } else {
     // Deleting markers may make cursor column invalid
-    check_cursor_col_win(wp);
+    check_cursor_col(wp);
   }
 
   if (last_lnum > 0) {
@@ -1009,11 +1009,11 @@ void foldAdjustVisual(void)
     start = &curwin->w_cursor;
     end = &VIsual;
   }
-  if (hasFolding(start->lnum, &start->lnum, NULL)) {
+  if (hasFolding(curwin, start->lnum, &start->lnum, NULL)) {
     start->col = 0;
   }
 
-  if (!hasFolding(end->lnum, NULL, &end->lnum)) {
+  if (!hasFolding(curwin, end->lnum, NULL, &end->lnum)) {
     return;
   }
 
@@ -1028,9 +1028,9 @@ void foldAdjustVisual(void)
 
 // cursor_foldstart() {{{2
 /// Move the cursor to the first line of a closed fold.
-void foldAdjustCursor(void)
+void foldAdjustCursor(win_T *wp)
 {
-  hasFolding(curwin->w_cursor.lnum, &curwin->w_cursor.lnum, NULL);
+  hasFolding(wp, wp->w_cursor.lnum, &wp->w_cursor.lnum, NULL);
 }
 
 // Internal functions for "fold_T" {{{1
@@ -1269,7 +1269,7 @@ static linenr_T setManualFoldWin(win_T *wp, linenr_T lnum, bool opening, bool re
     }
     wp->w_fold_manual = true;
     if (done & DONE_ACTION) {
-      changed_window_setting_win(wp);
+      changed_window_setting(wp);
     }
     done |= DONE_FOLD;
   } else if (donep == NULL && wp == curwin) {
@@ -2117,7 +2117,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
 
   // If some fold changed, need to redraw and position cursor.
   if (fold_changed && wp->w_p_fen) {
-    changed_window_setting_win(wp);
+    changed_window_setting(wp);
   }
 
   // If we updated folds past "bot", need to redraw more lines.  Don't do

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2508,7 +2508,7 @@ static int vgetorpeek(bool advance)
             unshowmode(true);
             mode_deleted = true;
           }
-          validate_cursor();
+          validate_cursor(curwin);
           int old_wcol = curwin->w_wcol;
           int old_wrow = curwin->w_wrow;
 
@@ -2541,7 +2541,7 @@ static int vgetorpeek(bool advance)
                 curwin->w_wrow = curwin->w_cline_row
                                  + curwin->w_wcol / curwin->w_width_inner;
                 curwin->w_wcol %= curwin->w_width_inner;
-                curwin->w_wcol += curwin_col_off();
+                curwin->w_wcol += win_col_off(curwin);
                 col = 0;  // no correction needed
               } else {
                 curwin->w_wcol--;

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1116,7 +1116,7 @@ void ex_retab(exarg_T *eap)
     }
     xfree(new_ts_str);
   }
-  coladvance(curwin->w_curswant);
+  coladvance(curwin, curwin->w_curswant);
 
   u_clearline(curbuf);
 }
@@ -1160,7 +1160,7 @@ int get_expr_indent(void)
   curwin->w_cursor = save_pos;
   curwin->w_curswant = save_curswant;
   curwin->w_set_curswant = save_set_curswant;
-  check_cursor();
+  check_cursor(curwin);
   State = save_State;
 
   // Reset did_throw, unless 'debug' has "throw" and inside a try/catch.

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2436,7 +2436,7 @@ static void expand_by_function(int type, char *base)
   textlock--;
 
   curwin->w_cursor = pos;       // restore the cursor position
-  validate_cursor();
+  validate_cursor(curwin);
   if (!equalpos(curwin->w_cursor, pos)) {
     emsg(_(e_compldel));
     goto theend;
@@ -4096,7 +4096,7 @@ static int get_userdefined_compl_info(colnr_T curs_col)
 
   State = save_State;
   curwin->w_cursor = pos;  // restore the cursor position
-  validate_cursor();
+  validate_cursor(curwin);
   if (!equalpos(curwin->w_cursor, pos)) {
     emsg(_(e_compldel));
     return FAIL;

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1797,7 +1797,7 @@ void ex_luado(exarg_T *const eap)
   }
 
   lua_pop(lstate, 1);
-  check_cursor();
+  check_cursor(curwin);
   redraw_curbuf_later(UPD_NOT_VALID);
 }
 

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -588,7 +588,7 @@ MarkMoveRes mark_move_to(fmark_T *fm, MarkMove flags)
   }
 
   if (res & kMarkSwitchedBuf || res & kMarkChangedCursor) {
-    check_cursor();
+    check_cursor(curwin);
   }
 end:
   return res;

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -533,7 +533,7 @@ void prepare_search_hl(win_T *wp, match_T *search_hl, linenr_T lnum)
         for (shl->first_lnum = lnum;
              shl->first_lnum > wp->w_topline;
              shl->first_lnum--) {
-          if (hasFoldingWin(wp, shl->first_lnum - 1, NULL, NULL, true, NULL)) {
+          if (hasFolding(wp, shl->first_lnum - 1, NULL, NULL)) {
             break;
           }
         }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1192,7 +1192,7 @@ void ml_recover(bool checkext)
     ml_delete(curbuf->b_ml.ml_line_count, false);
   }
   curbuf->b_flags |= BF_RECOVERED;
-  check_cursor();
+  check_cursor(curwin);
 
   recoverymode = false;
   if (got_int) {
@@ -4076,14 +4076,14 @@ void goto_byte(int cnt)
   if (lnum < 1) {         // past the end
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
     curwin->w_curswant = MAXCOL;
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
   } else {
     curwin->w_cursor.lnum = lnum;
     curwin->w_cursor.col = (colnr_T)boff;
     curwin->w_cursor.coladd = 0;
     curwin->w_set_curswant = true;
   }
-  check_cursor();
+  check_cursor(curwin);
 
   // Make sure the cursor is on the first byte of a multi-byte char.
   mb_adjust_cursor();

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1478,11 +1478,11 @@ void execute_menu(const exarg_T *eap, vimmenu_T *menu, int mode_idx)
       // Activate visual mode
       VIsual_active = true;
       VIsual_reselect = true;
-      check_cursor();
+      check_cursor(curwin);
       VIsual = curwin->w_cursor;
       curwin->w_cursor = tpos;
 
-      check_cursor();
+      check_cursor(curwin);
 
       // Adjust the cursor to make sure it is in the correct pos
       // for exclusive mode

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -771,7 +771,7 @@ popupexit:
       // move VIsual to the right column
       start_visual = curwin->w_cursor;              // save the cursor pos
       curwin->w_cursor = end_visual;
-      coladvance(end_visual.col);
+      coladvance(curwin, end_visual.col);
       VIsual = curwin->w_cursor;
       curwin->w_cursor = start_visual;              // restore the cursor
     } else {
@@ -1430,7 +1430,7 @@ retnomove:
           break;
         }
         first = false;
-        hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+        hasFolding(curwin, curwin->w_topline, &curwin->w_topline, NULL);
         if (curwin->w_topfill < win_get_fill(curwin, curwin->w_topline)) {
           curwin->w_topfill++;
         } else {
@@ -1460,7 +1460,7 @@ retnomove:
         if (curwin->w_topfill > 0) {
           curwin->w_topfill--;
         } else {
-          if (hasFolding(curwin->w_topline, NULL, &curwin->w_topline)
+          if (hasFolding(curwin, curwin->w_topline, NULL, &curwin->w_topline)
               && curwin->w_topline == curbuf->b_ml.ml_line_count) {
             break;
           }
@@ -1515,7 +1515,7 @@ retnomove:
 
   curwin->w_curswant = col;
   curwin->w_set_curswant = false;       // May still have been true
-  if (coladvance(col) == FAIL) {        // Mouse click beyond end of line
+  if (coladvance(curwin, col) == FAIL) {        // Mouse click beyond end of line
     if (inclusive != NULL) {
       *inclusive = true;
     }
@@ -1548,7 +1548,7 @@ static bool do_mousescroll_horiz(colnr_T leftcol)
 
   // When the line of the cursor is too short, move the cursor to the
   // longest visible line.
-  if (!virtual_active()
+  if (!virtual_active(curwin)
       && leftcol > scroll_line_len(curwin->w_cursor.lnum)) {
     curwin->w_cursor.lnum = find_longest_lnum();
     curwin->w_cursor.col = 0;
@@ -1637,7 +1637,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
       break;            // Position is in this buffer line.
     }
 
-    hasFoldingWin(win, lnum, NULL, &lnum, true, NULL);
+    hasFolding(win, lnum, NULL, &lnum);
 
     if (lnum == win->w_buffer->b_ml.ml_line_count) {
       retval = true;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -182,7 +182,7 @@ static void redraw_for_cursorcolumn(win_T *wp)
 
   // When current buffer's cursor moves in Visual mode, redraw it with UPD_INVERTED.
   if (VIsual_active && wp->w_buffer == curbuf) {
-    redraw_curbuf_later(UPD_INVERTED);
+    redraw_buf_later(curbuf, UPD_INVERTED);
   }
 }
 
@@ -332,7 +332,7 @@ void update_topline(win_T *wp)
           if (lnum >= wp->w_buffer->b_ml.ml_line_count || n >= halfheight) {
             break;
           }
-          hasFoldingWin(wp, lnum, NULL, &lnum, true, NULL);
+          hasFolding(wp, lnum, NULL, &lnum);
         }
       } else {
         n = wp->w_topline + *so_ptr - wp->w_cursor.lnum;
@@ -342,14 +342,14 @@ void update_topline(win_T *wp)
       // cursor in the middle of the window.  Otherwise put the cursor
       // near the top of the window.
       if (n >= halfheight) {
-        scroll_cursor_halfway(false, false);
+        scroll_cursor_halfway(wp, false, false);
       } else {
-        scroll_cursor_top(scrolljump_value(), false);
+        scroll_cursor_top(wp, scrolljump_value(), false);
         check_botline = true;
       }
     } else {
       // Make sure topline is the first line of a fold.
-      hasFoldingWin(wp, wp->w_topline, &wp->w_topline, NULL, true, NULL);
+      hasFolding(wp, wp->w_topline, &wp->w_topline, NULL);
       check_botline = true;
     }
   }
@@ -377,7 +377,7 @@ void update_topline(win_T *wp)
           int n = wp->w_empty_rows;
           loff.lnum = wp->w_cursor.lnum;
           // In a fold go to its last line.
-          hasFoldingWin(wp, loff.lnum, NULL, &loff.lnum, true, NULL);
+          hasFolding(wp, loff.lnum, NULL, &loff.lnum);
           loff.fill = 0;
           n += wp->w_filler_rows;
           loff.height = 0;
@@ -411,15 +411,15 @@ void update_topline(win_T *wp)
             if (lnum <= 0 || line_count > wp->w_height_inner + 1) {
               break;
             }
-            hasFolding(lnum, &lnum, NULL);
+            hasFolding(wp, lnum, &lnum, NULL);
           }
         } else {
           line_count = wp->w_cursor.lnum - wp->w_botline + 1 + (int)(*so_ptr);
         }
         if (line_count <= wp->w_height_inner + 1) {
-          scroll_cursor_bot(scrolljump_value(), false);
+          scroll_cursor_bot(wp, scrolljump_value(), false);
         } else {
-          scroll_cursor_halfway(false, false);
+          scroll_cursor_halfway(wp, false, false);
         }
       }
     }
@@ -443,7 +443,7 @@ void update_topline(win_T *wp)
 
     // May need to set w_skipcol when cursor in w_topline.
     if (wp->w_cursor.lnum == wp->w_topline) {
-      validate_cursor();
+      validate_cursor(wp);
     }
   }
 
@@ -491,7 +491,7 @@ static bool check_top_offset(void)
 /// Update w_curswant.
 void update_curswant_force(void)
 {
-  validate_virtcol();
+  validate_virtcol(curwin);
   curwin->w_curswant = curwin->w_virtcol;
   curwin->w_set_curswant = false;
 }
@@ -536,12 +536,7 @@ void check_cursor_moved(win_T *wp)
 // Call this function when some window settings have changed, which require
 // the cursor position, botline and topline to be recomputed and the window to
 // be redrawn.  E.g, when changing the 'wrap' option or folding.
-void changed_window_setting(void)
-{
-  changed_window_setting_win(curwin);
-}
-
-void changed_window_setting_win(win_T *wp)
+void changed_window_setting(win_T *wp)
 {
   wp->w_lines_valid = 0;
   changed_line_abv_curs_win(wp);
@@ -555,7 +550,7 @@ void set_topline(win_T *wp, linenr_T lnum)
   linenr_T prev_topline = wp->w_topline;
 
   // go to first of folded lines
-  hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+  hasFolding(wp, lnum, &lnum, NULL);
   // Approximate the value of w_botline
   wp->w_botline += lnum - wp->w_topline;
   wp->w_topline = lnum;
@@ -614,21 +609,21 @@ void approximate_botline_win(win_T *wp)
   wp->w_valid &= ~VALID_BOTLINE;
 }
 
-// Return true if curwin->w_wrow and curwin->w_wcol are valid.
-int cursor_valid(void)
+// Return true if wp->w_wrow and wp->w_wcol are valid.
+int cursor_valid(win_T *wp)
 {
-  check_cursor_moved(curwin);
-  return (curwin->w_valid & (VALID_WROW|VALID_WCOL)) == (VALID_WROW|VALID_WCOL);
+  check_cursor_moved(wp);
+  return (wp->w_valid & (VALID_WROW|VALID_WCOL)) == (VALID_WROW|VALID_WCOL);
 }
 
 // Validate cursor position.  Makes sure w_wrow and w_wcol are valid.
 // w_topline must be valid, you may need to call update_topline() first!
-void validate_cursor(void)
+void validate_cursor(win_T *wp)
 {
-  check_cursor();
-  check_cursor_moved(curwin);
-  if ((curwin->w_valid & (VALID_WCOL|VALID_WROW)) != (VALID_WCOL|VALID_WROW)) {
-    curs_columns(curwin, true);
+  check_cursor(wp);
+  check_cursor_moved(wp);
+  if ((wp->w_valid & (VALID_WCOL|VALID_WROW)) != (VALID_WCOL|VALID_WROW)) {
+    curs_columns(wp, true);
   }
 }
 
@@ -692,26 +687,19 @@ static void curs_rows(win_T *wp)
     } else if (i > wp->w_lines_valid) {
       // a line that is too long to fit on the last screen line
       wp->w_cline_height = 0;
-      wp->w_cline_folded = hasFoldingWin(wp, wp->w_cursor.lnum, NULL,
-                                         NULL, true, NULL);
+      wp->w_cline_folded = hasFolding(wp, wp->w_cursor.lnum, NULL, NULL);
     } else {
       wp->w_cline_height = wp->w_lines[i].wl_size;
       wp->w_cline_folded = wp->w_lines[i].wl_folded;
     }
   }
 
-  redraw_for_cursorline(curwin);
+  redraw_for_cursorline(wp);
   wp->w_valid |= VALID_CROW|VALID_CHEIGHT;
 }
 
-// Validate curwin->w_virtcol only.
-void validate_virtcol(void)
-{
-  validate_virtcol_win(curwin);
-}
-
 // Validate wp->w_virtcol only.
-void validate_virtcol_win(win_T *wp)
+void validate_virtcol(win_T *wp)
 {
   check_cursor_moved(wp);
 
@@ -724,49 +712,48 @@ void validate_virtcol_win(win_T *wp)
   wp->w_valid |= VALID_VIRTCOL;
 }
 
-// Validate curwin->w_cline_height only.
-void validate_cheight(void)
+// Validate wp->w_cline_height only.
+void validate_cheight(win_T *wp)
 {
-  check_cursor_moved(curwin);
+  check_cursor_moved(wp);
 
-  if (curwin->w_valid & VALID_CHEIGHT) {
+  if (wp->w_valid & VALID_CHEIGHT) {
     return;
   }
 
-  curwin->w_cline_height = plines_win_full(curwin, curwin->w_cursor.lnum,
-                                           NULL, &curwin->w_cline_folded,
-                                           true, true);
-  curwin->w_valid |= VALID_CHEIGHT;
+  wp->w_cline_height = plines_win_full(wp, wp->w_cursor.lnum,
+                                       NULL, &wp->w_cline_folded,
+                                       true, true);
+  wp->w_valid |= VALID_CHEIGHT;
 }
 
 // Validate w_wcol and w_virtcol only.
-void validate_cursor_col(void)
+void validate_cursor_col(win_T *wp)
 {
-  validate_virtcol();
+  validate_virtcol(wp);
 
-  if (curwin->w_valid & VALID_WCOL) {
+  if (wp->w_valid & VALID_WCOL) {
     return;
   }
 
-  colnr_T col = curwin->w_virtcol;
-  colnr_T off = curwin_col_off();
+  colnr_T col = wp->w_virtcol;
+  colnr_T off = win_col_off(wp);
   col += off;
-  int width = curwin->w_width_inner - off + curwin_col_off2();
+  int width = wp->w_width_inner - off + win_col_off2(wp);
 
-  // long line wrapping, adjust curwin->w_wrow
-  if (curwin->w_p_wrap && col >= (colnr_T)curwin->w_width_inner
-      && width > 0) {
+  // long line wrapping, adjust wp->w_wrow
+  if (wp->w_p_wrap && col >= (colnr_T)wp->w_width_inner && width > 0) {
     // use same formula as what is used in curs_columns()
-    col -= ((col - curwin->w_width_inner) / width + 1) * width;
+    col -= ((col - wp->w_width_inner) / width + 1) * width;
   }
-  if (col > (int)curwin->w_leftcol) {
-    col -= curwin->w_leftcol;
+  if (col > (int)wp->w_leftcol) {
+    col -= wp->w_leftcol;
   } else {
     col = 0;
   }
-  curwin->w_wcol = col;
+  wp->w_wcol = col;
 
-  curwin->w_valid |= VALID_WCOL;
+  wp->w_valid |= VALID_WCOL;
 }
 
 // Compute offset of a window, occupied by absolute or relative line number,
@@ -779,11 +766,6 @@ int win_col_off(win_T *wp)
          + win_fdccol_count(wp) + (wp->w_scwidth * SIGN_WIDTH);
 }
 
-int curwin_col_off(void)
-{
-  return win_col_off(curwin);
-}
-
 // Return the difference in column offset for the second screen line of a
 // wrapped line.  It's positive if 'number' or 'relativenumber' is on and 'n'
 // is in 'cpoptions'.
@@ -794,11 +776,6 @@ int win_col_off2(win_T *wp)
     return number_width(wp) + (*wp->w_p_stc == NUL);
   }
   return 0;
-}
-
-int curwin_col_off2(void)
-{
-  return win_col_off2(curwin);
 }
 
 // Compute wp->w_wcol and wp->w_virtcol.
@@ -896,7 +873,7 @@ void curs_columns(win_T *wp, int may_scroll)
       // middle of window.
       int new_leftcol;
       if (p_ss == 0 || diff >= width1 / 2 || off_right >= off_left) {
-        new_leftcol = curwin->w_wcol - extra - width1 / 2;
+        new_leftcol = wp->w_wcol - extra - width1 / 2;
       } else {
         if (diff < p_ss) {
           assert(p_ss <= INT_MAX);
@@ -984,9 +961,9 @@ void curs_columns(win_T *wp, int may_scroll)
         n = plines - wp->w_height_inner + 1;
       }
       if (n > 0) {
-        curwin->w_skipcol = width1 + (n - 1) * width2;
+        wp->w_skipcol = width1 + (n - 1) * width2;
       } else {
-        curwin->w_skipcol = 0;
+        wp->w_skipcol = 0;
       }
     } else if (extra == 1) {
       // less than 'scrolloff' lines above, decrease skipcol
@@ -1063,7 +1040,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
 
   linenr_T lnum = pos->lnum;
   if (lnum >= wp->w_topline && lnum <= wp->w_botline) {
-    is_folded = hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+    is_folded = hasFolding(wp, lnum, &lnum, NULL);
     row = plines_m_win(wp, wp->w_topline, lnum - 1, false);
     // "row" should be the screen line where line "lnum" begins, which can
     // be negative if "lnum" is "w_topline" and "w_skipcol" is non-zero.
@@ -1207,128 +1184,128 @@ void f_virtcol2col(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_number = virtcol2col(wp, lnum, screencol);
 }
 
-/// Scroll the current window down by "line_count" logical lines.  "CTRL-Y"
+/// Scroll a window down by "line_count" logical lines.  "CTRL-Y"
 ///
 /// @param line_count number of lines to scroll
 /// @param byfold if true, count a closed fold as one line
-bool scrolldown(linenr_T line_count, int byfold)
+bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
 {
   int done = 0;                // total # of physical lines done
   int width1 = 0;
   int width2 = 0;
-  bool do_sms = curwin->w_p_wrap && curwin->w_p_sms;
+  bool do_sms = wp->w_p_wrap && wp->w_p_sms;
 
   if (do_sms) {
-    width1 = curwin->w_width_inner - curwin_col_off();
-    width2 = width1 + curwin_col_off2();
+    width1 = wp->w_width_inner - win_col_off(wp);
+    width2 = width1 + win_col_off2(wp);
   }
 
   // Make sure w_topline is at the first of a sequence of folded lines.
-  hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
-  validate_cursor();            // w_wrow needs to be valid
+  hasFolding(wp, wp->w_topline, &wp->w_topline, NULL);
+  validate_cursor(wp);            // w_wrow needs to be valid
   for (int todo = line_count; todo > 0; todo--) {
-    if (curwin->w_topfill < win_get_fill(curwin, curwin->w_topline)
-        && curwin->w_topfill < curwin->w_height_inner - 1) {
-      curwin->w_topfill++;
+    if (wp->w_topfill < win_get_fill(wp, wp->w_topline)
+        && wp->w_topfill < wp->w_height_inner - 1) {
+      wp->w_topfill++;
       done++;
     } else {
       // break when at the very top
-      if (curwin->w_topline == 1 && (!do_sms || curwin->w_skipcol < width1)) {
+      if (wp->w_topline == 1 && (!do_sms || wp->w_skipcol < width1)) {
         break;
       }
-      if (do_sms && curwin->w_skipcol >= width1) {
+      if (do_sms && wp->w_skipcol >= width1) {
         // scroll a screen line down
-        if (curwin->w_skipcol >= width1 + width2) {
-          curwin->w_skipcol -= width2;
+        if (wp->w_skipcol >= width1 + width2) {
+          wp->w_skipcol -= width2;
         } else {
-          curwin->w_skipcol -= width1;
+          wp->w_skipcol -= width1;
         }
-        redraw_later(curwin, UPD_NOT_VALID);
+        redraw_later(wp, UPD_NOT_VALID);
         done++;
       } else {
         // scroll a text line down
-        curwin->w_topline--;
-        curwin->w_skipcol = 0;
-        curwin->w_topfill = 0;
+        wp->w_topline--;
+        wp->w_skipcol = 0;
+        wp->w_topfill = 0;
         // A sequence of folded lines only counts for one logical line
         linenr_T first;
-        if (hasFolding(curwin->w_topline, &first, NULL)) {
+        if (hasFolding(wp, wp->w_topline, &first, NULL)) {
           done++;
           if (!byfold) {
-            todo -= curwin->w_topline - first - 1;
+            todo -= wp->w_topline - first - 1;
           }
-          curwin->w_botline -= curwin->w_topline - first;
-          curwin->w_topline = first;
+          wp->w_botline -= wp->w_topline - first;
+          wp->w_topline = first;
         } else {
           if (do_sms) {
-            int size = win_linetabsize(curwin, curwin->w_topline,
-                                       ml_get(curwin->w_topline), MAXCOL);
+            int size = win_linetabsize(wp, wp->w_topline,
+                                       ml_get(wp->w_topline), MAXCOL);
             if (size > width1) {
-              curwin->w_skipcol = width1;
+              wp->w_skipcol = width1;
               size -= width1;
-              redraw_later(curwin, UPD_NOT_VALID);
+              redraw_later(wp, UPD_NOT_VALID);
             }
             while (size > width2) {
-              curwin->w_skipcol += width2;
+              wp->w_skipcol += width2;
               size -= width2;
             }
             done++;
           } else {
-            done += plines_win_nofill(curwin, curwin->w_topline, true);
+            done += plines_win_nofill(wp, wp->w_topline, true);
           }
         }
       }
     }
-    curwin->w_botline--;                // approximate w_botline
-    invalidate_botline(curwin);
+    wp->w_botline--;                // approximate w_botline
+    invalidate_botline(wp);
   }
-  curwin->w_wrow += done;               // keep w_wrow updated
-  curwin->w_cline_row += done;          // keep w_cline_row updated
+  wp->w_wrow += done;               // keep w_wrow updated
+  wp->w_cline_row += done;          // keep w_cline_row updated
 
-  if (curwin->w_cursor.lnum == curwin->w_topline) {
-    curwin->w_cline_row = 0;
+  if (wp->w_cursor.lnum == wp->w_topline) {
+    wp->w_cline_row = 0;
   }
-  check_topfill(curwin, true);
+  check_topfill(wp, true);
 
   // Compute the row number of the last row of the cursor line
   // and move the cursor onto the displayed part of the window.
-  int wrow = curwin->w_wrow;
-  if (curwin->w_p_wrap && curwin->w_width_inner != 0) {
-    validate_virtcol();
-    validate_cheight();
-    wrow += curwin->w_cline_height - 1 -
-            curwin->w_virtcol / curwin->w_width_inner;
+  int wrow = wp->w_wrow;
+  if (wp->w_p_wrap && wp->w_width_inner != 0) {
+    validate_virtcol(wp);
+    validate_cheight(wp);
+    wrow += wp->w_cline_height - 1 -
+            wp->w_virtcol / wp->w_width_inner;
   }
   bool moved = false;
-  while (wrow >= curwin->w_height_inner && curwin->w_cursor.lnum > 1) {
+  while (wrow >= wp->w_height_inner && wp->w_cursor.lnum > 1) {
     linenr_T first;
-    if (hasFolding(curwin->w_cursor.lnum, &first, NULL)) {
+    if (hasFolding(wp, wp->w_cursor.lnum, &first, NULL)) {
       wrow--;
       if (first == 1) {
-        curwin->w_cursor.lnum = 1;
+        wp->w_cursor.lnum = 1;
       } else {
-        curwin->w_cursor.lnum = first - 1;
+        wp->w_cursor.lnum = first - 1;
       }
     } else {
-      wrow -= plines_win(curwin, curwin->w_cursor.lnum--, true);
+      wrow -= plines_win(wp, wp->w_cursor.lnum--, true);
     }
-    curwin->w_valid &=
+    wp->w_valid &=
       ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW|VALID_VIRTCOL);
     moved = true;
   }
   if (moved) {
     // Move cursor to first line of closed fold.
-    foldAdjustCursor();
-    coladvance(curwin->w_curswant);
+    foldAdjustCursor(wp);
+    coladvance(wp, wp->w_curswant);
   }
 
-  if (curwin->w_cursor.lnum == curwin->w_topline && do_sms) {
-    int so = get_scrolloff_value(curwin);
+  if (wp->w_cursor.lnum == wp->w_topline && do_sms) {
+    int so = get_scrolloff_value(wp);
     colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
 
     // make sure the cursor is in the visible text
-    validate_virtcol();
-    colnr_T col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;
+    validate_virtcol(wp);
+    colnr_T col = wp->w_virtcol - wp->w_skipcol + scrolloff_cols;
     int row = 0;
     if (col >= width1) {
       col -= width1;
@@ -1337,32 +1314,32 @@ bool scrolldown(linenr_T line_count, int byfold)
     if (col > width2 && width2 > 0) {
       row += (int)col / width2;
     }
-    if (row >= curwin->w_height_inner) {
-      curwin->w_curswant = curwin->w_virtcol - (row - curwin->w_height_inner + 1) * width2;
-      coladvance(curwin->w_curswant);
+    if (row >= wp->w_height_inner) {
+      wp->w_curswant = wp->w_virtcol - (row - wp->w_height_inner + 1) * width2;
+      coladvance(wp, wp->w_curswant);
     }
   }
   return moved;
 }
 
-/// Scroll the current window up by "line_count" logical lines.  "CTRL-E"
+/// Scroll a window up by "line_count" logical lines.  "CTRL-E"
 ///
 /// @param line_count number of lines to scroll
 /// @param byfold if true, count a closed fold as one line
-bool scrollup(linenr_T line_count, bool byfold)
+bool scrollup(win_T *wp, linenr_T line_count, bool byfold)
 {
-  linenr_T topline = curwin->w_topline;
-  linenr_T botline = curwin->w_botline;
-  bool do_sms = curwin->w_p_wrap && curwin->w_p_sms;
+  linenr_T topline = wp->w_topline;
+  linenr_T botline = wp->w_botline;
+  bool do_sms = wp->w_p_wrap && wp->w_p_sms;
 
-  if (do_sms || (byfold && hasAnyFolding(curwin)) || win_may_fill(curwin)) {
-    int width1 = curwin->w_width_inner - curwin_col_off();
-    int width2 = width1 + curwin_col_off2();
+  if (do_sms || (byfold && hasAnyFolding(wp)) || win_may_fill(wp)) {
+    int width1 = wp->w_width_inner - win_col_off(wp);
+    int width2 = width1 + win_col_off2(wp);
     int size = 0;
-    const colnr_T prev_skipcol = curwin->w_skipcol;
+    const colnr_T prev_skipcol = wp->w_skipcol;
 
     if (do_sms) {
-      size = linetabsize(curwin, curwin->w_topline);
+      size = linetabsize(wp, wp->w_topline);
     }
 
     // diff mode: first consume "topfill"
@@ -1370,93 +1347,93 @@ bool scrollup(linenr_T line_count, bool byfold)
     // the line, then advance to the next line.
     // folding: count each sequence of folded lines as one logical line.
     for (int todo = line_count; todo > 0; todo--) {
-      if (curwin->w_topfill > 0) {
-        curwin->w_topfill--;
+      if (wp->w_topfill > 0) {
+        wp->w_topfill--;
       } else {
-        linenr_T lnum = curwin->w_topline;
+        linenr_T lnum = wp->w_topline;
         if (byfold) {
           // for a closed fold: go to the last line in the fold
-          hasFolding(lnum, NULL, &lnum);
+          hasFolding(wp, lnum, NULL, &lnum);
         }
-        if (lnum == curwin->w_topline && do_sms) {
+        if (lnum == wp->w_topline && do_sms) {
           // 'smoothscroll': increase "w_skipcol" until it goes over
           // the end of the line, then advance to the next line.
-          int add = curwin->w_skipcol > 0 ? width2 : width1;
-          curwin->w_skipcol += add;
-          if (curwin->w_skipcol >= size) {
-            if (lnum == curbuf->b_ml.ml_line_count) {
+          int add = wp->w_skipcol > 0 ? width2 : width1;
+          wp->w_skipcol += add;
+          if (wp->w_skipcol >= size) {
+            if (lnum == wp->w_buffer->b_ml.ml_line_count) {
               // at the last screen line, can't scroll further
-              curwin->w_skipcol -= add;
+              wp->w_skipcol -= add;
               break;
             }
             lnum++;
           }
         } else {
-          if (lnum >= curbuf->b_ml.ml_line_count) {
+          if (lnum >= wp->w_buffer->b_ml.ml_line_count) {
             break;
           }
           lnum++;
         }
 
-        if (lnum > curwin->w_topline) {
+        if (lnum > wp->w_topline) {
           // approximate w_botline
-          curwin->w_botline += lnum - curwin->w_topline;
-          curwin->w_topline = lnum;
-          curwin->w_topfill = win_get_fill(curwin, lnum);
-          curwin->w_skipcol = 0;
+          wp->w_botline += lnum - wp->w_topline;
+          wp->w_topline = lnum;
+          wp->w_topfill = win_get_fill(wp, lnum);
+          wp->w_skipcol = 0;
           if (todo > 1 && do_sms) {
-            size = linetabsize(curwin, curwin->w_topline);
+            size = linetabsize(wp, wp->w_topline);
           }
         }
       }
     }
 
-    if (prev_skipcol > 0 || curwin->w_skipcol > 0) {
+    if (prev_skipcol > 0 || wp->w_skipcol > 0) {
       // need to redraw more, because wl_size of the (new) topline may
       // now be invalid
-      redraw_later(curwin, UPD_NOT_VALID);
+      redraw_later(wp, UPD_NOT_VALID);
     }
   } else {
-    curwin->w_topline += line_count;
-    curwin->w_botline += line_count;            // approximate w_botline
+    wp->w_topline += line_count;
+    wp->w_botline += line_count;            // approximate w_botline
   }
 
-  if (curwin->w_topline > curbuf->b_ml.ml_line_count) {
-    curwin->w_topline = curbuf->b_ml.ml_line_count;
+  if (wp->w_topline > wp->w_buffer->b_ml.ml_line_count) {
+    wp->w_topline = wp->w_buffer->b_ml.ml_line_count;
   }
-  if (curwin->w_botline > curbuf->b_ml.ml_line_count + 1) {
-    curwin->w_botline = curbuf->b_ml.ml_line_count + 1;
+  if (wp->w_botline > wp->w_buffer->b_ml.ml_line_count + 1) {
+    wp->w_botline = wp->w_buffer->b_ml.ml_line_count + 1;
   }
 
-  check_topfill(curwin, false);
+  check_topfill(wp, false);
 
-  if (hasAnyFolding(curwin)) {
+  if (hasAnyFolding(wp)) {
     // Make sure w_topline is at the first of a sequence of folded lines.
-    hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+    hasFolding(wp, wp->w_topline, &wp->w_topline, NULL);
   }
 
-  curwin->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE);
-  if (curwin->w_cursor.lnum < curwin->w_topline) {
-    curwin->w_cursor.lnum = curwin->w_topline;
-    curwin->w_valid &=
+  wp->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE);
+  if (wp->w_cursor.lnum < wp->w_topline) {
+    wp->w_cursor.lnum = wp->w_topline;
+    wp->w_valid &=
       ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW|VALID_VIRTCOL);
-    coladvance(curwin->w_curswant);
+    coladvance(wp, wp->w_curswant);
   }
 
-  if (curwin->w_cursor.lnum == curwin->w_topline && do_sms && curwin->w_skipcol > 0) {
-    int col_off = curwin_col_off();
-    int col_off2 = curwin_col_off2();
+  if (wp->w_cursor.lnum == wp->w_topline && do_sms && wp->w_skipcol > 0) {
+    int col_off = win_col_off(wp);
+    int col_off2 = win_col_off2(wp);
 
-    int width1 = curwin->w_width_inner - col_off;
+    int width1 = wp->w_width_inner - col_off;
     int width2 = width1 + col_off2;
     int extra2 = col_off - col_off2;
-    int so = get_scrolloff_value(curwin);
+    int so = get_scrolloff_value(wp);
     colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
-    int space_cols = (curwin->w_height_inner - 1) * width2;
+    int space_cols = (wp->w_height_inner - 1) * width2;
 
     // If we have non-zero scrolloff, just ignore the marker as we are
     // going past it anyway.
-    int overlap = scrolloff_cols != 0 ? 0 : sms_marker_overlap(curwin, extra2);
+    int overlap = scrolloff_cols != 0 ? 0 : sms_marker_overlap(wp, extra2);
 
     // Make sure the cursor is in a visible part of the line, taking
     // 'scrolloff' into account, but using screen lines.
@@ -1464,26 +1441,26 @@ bool scrollup(linenr_T line_count, bool byfold)
     if (scrolloff_cols > space_cols / 2) {
       scrolloff_cols = space_cols / 2;
     }
-    validate_virtcol();
-    if (curwin->w_virtcol < curwin->w_skipcol + overlap + scrolloff_cols) {
-      colnr_T col = curwin->w_virtcol;
+    validate_virtcol(wp);
+    if (wp->w_virtcol < wp->w_skipcol + overlap + scrolloff_cols) {
+      colnr_T col = wp->w_virtcol;
 
       if (col < width1) {
         col += width1;
       }
-      while (col < curwin->w_skipcol + overlap + scrolloff_cols) {
+      while (col < wp->w_skipcol + overlap + scrolloff_cols) {
         col += width2;
       }
-      curwin->w_curswant = col;
-      coladvance(curwin->w_curswant);
+      wp->w_curswant = col;
+      coladvance(wp, wp->w_curswant);
 
       // validate_virtcol() marked various things as valid, but after
       // moving the cursor they need to be recomputed
-      curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW|VALID_VIRTCOL);
+      wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW|VALID_VIRTCOL);
     }
   }
 
-  bool moved = topline != curwin->w_topline || botline != curwin->w_botline;
+  bool moved = topline != wp->w_topline || botline != wp->w_botline;
 
   return moved;
 }
@@ -1496,16 +1473,16 @@ void adjust_skipcol(void)
     return;
   }
 
-  int width1 = curwin->w_width_inner - curwin_col_off();
+  int width1 = curwin->w_width_inner - win_col_off(curwin);
   if (width1 <= 0) {
     return;  // no text will be displayed
   }
-  int width2 = width1 + curwin_col_off2();
+  int width2 = width1 + win_col_off2(curwin);
   int so = get_scrolloff_value(curwin);
   colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
   bool scrolled = false;
 
-  validate_cheight();
+  validate_cheight(curwin);
   if (curwin->w_cline_height == curwin->w_height_inner
       // w_cline_height may be capped at w_height_inner, check there aren't
       // actually more lines.
@@ -1515,8 +1492,8 @@ void adjust_skipcol(void)
     return;
   }
 
-  validate_virtcol();
-  int overlap = sms_marker_overlap(curwin, curwin_col_off() - curwin_col_off2());
+  validate_virtcol(curwin);
+  int overlap = sms_marker_overlap(curwin, win_col_off(curwin) - win_col_off2(curwin));
   while (curwin->w_skipcol > 0
          && curwin->w_virtcol < curwin->w_skipcol + overlap + scrolloff_cols) {
     // scroll a screen line down
@@ -1528,7 +1505,7 @@ void adjust_skipcol(void)
     scrolled = true;
   }
   if (scrolled) {
-    validate_virtcol();
+    validate_virtcol(curwin);
     redraw_later(curwin, UPD_NOT_VALID);
     return;  // don't scroll in the other direction now
   }
@@ -1572,7 +1549,7 @@ void check_topfill(win_T *wp, bool down)
       }
     }
   }
-  win_check_anchored_floats(curwin);
+  win_check_anchored_floats(wp);
 }
 
 // Use as many filler lines as possible for w_topline.  Make sure w_topline
@@ -1601,7 +1578,7 @@ void scrolldown_clamp(void)
     return;
   }
 
-  validate_cursor();        // w_wrow needs to be valid
+  validate_cursor(curwin);        // w_wrow needs to be valid
 
   // Compute the row number of the last row of the cursor line
   // and make sure it doesn't go off the screen. Make sure the cursor
@@ -1613,8 +1590,8 @@ void scrolldown_clamp(void)
     end_row += plines_win_nofill(curwin, curwin->w_topline - 1, true);
   }
   if (curwin->w_p_wrap && curwin->w_width_inner != 0) {
-    validate_cheight();
-    validate_virtcol();
+    validate_cheight(curwin);
+    validate_virtcol(curwin);
     end_row += curwin->w_cline_height - 1 -
                curwin->w_virtcol / curwin->w_width_inner;
   }
@@ -1626,7 +1603,7 @@ void scrolldown_clamp(void)
       curwin->w_topline--;
       curwin->w_topfill = 0;
     }
-    hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+    hasFolding(curwin, curwin->w_topline, &curwin->w_topline, NULL);
     curwin->w_botline--;            // approximate w_botline
     curwin->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE);
   }
@@ -1641,7 +1618,7 @@ void scrollup_clamp(void)
     return;
   }
 
-  validate_cursor();        // w_wrow needs to be valid
+  validate_cursor(curwin);        // w_wrow needs to be valid
 
   // Compute the row number of the first row of the cursor line
   // and make sure it doesn't go off the screen. Make sure the cursor
@@ -1650,14 +1627,14 @@ void scrollup_clamp(void)
                    - plines_win_nofill(curwin, curwin->w_topline, true)
                    - curwin->w_topfill);
   if (curwin->w_p_wrap && curwin->w_width_inner != 0) {
-    validate_virtcol();
+    validate_virtcol(curwin);
     start_row -= curwin->w_virtcol / curwin->w_width_inner;
   }
   if (start_row >= get_scrolloff_value(curwin)) {
     if (curwin->w_topfill > 0) {
       curwin->w_topfill--;
     } else {
-      hasFolding(curwin->w_topline, NULL, &curwin->w_topline);
+      hasFolding(curwin, curwin->w_topline, NULL, &curwin->w_topline);
       curwin->w_topline++;
     }
     curwin->w_botline++;                // approximate w_botline
@@ -1681,7 +1658,7 @@ static void topline_back_winheight(win_T *wp, lineoff_T *lp, int winheight)
     lp->fill = 0;
     if (lp->lnum < 1) {
       lp->height = MAXCOL;
-    } else if (hasFolding(lp->lnum, &lp->lnum, NULL)) {
+    } else if (hasFolding(wp, lp->lnum, &lp->lnum, NULL)) {
       // Add a closed fold
       lp->height = 1;
     } else {
@@ -1711,7 +1688,7 @@ static void botline_forw(win_T *wp, lineoff_T *lp)
     assert(wp->w_buffer != 0);
     if (lp->lnum > wp->w_buffer->b_ml.ml_line_count) {
       lp->height = MAXCOL;
-    } else if (hasFoldingWin(wp, lp->lnum, NULL, &lp->lnum, true, NULL)) {
+    } else if (hasFolding(wp, lp->lnum, NULL, &lp->lnum)) {
       // Add a closed fold
       lp->height = 1;
     } else {
@@ -1745,12 +1722,12 @@ static void topline_botline(lineoff_T *lp)
 // Recompute topline to put the cursor at the top of the window.
 // Scroll at least "min_scroll" lines.
 // If "always" is true, always set topline (for "zt").
-void scroll_cursor_top(int min_scroll, int always)
+void scroll_cursor_top(win_T *wp, int min_scroll, int always)
 {
-  linenr_T old_topline = curwin->w_topline;
-  int old_skipcol = curwin->w_skipcol;
-  linenr_T old_topfill = curwin->w_topfill;
-  int off = get_scrolloff_value(curwin);
+  linenr_T old_topline = wp->w_topline;
+  int old_skipcol = wp->w_skipcol;
+  linenr_T old_topfill = wp->w_topfill;
+  int off = get_scrolloff_value(wp);
 
   if (mouse_dragging > 0) {
     off = mouse_dragging - 1;
@@ -1761,54 +1738,54 @@ void scroll_cursor_top(int min_scroll, int always)
   // - (part of) the cursor line is moved off the screen or
   // - moved at least 'scrolljump' lines and
   // - at least 'scrolloff' lines above and below the cursor
-  validate_cheight();
+  validate_cheight(wp);
   int scrolled = 0;
-  int used = curwin->w_cline_height;  // includes filler lines above
-  if (curwin->w_cursor.lnum < curwin->w_topline) {
+  int used = wp->w_cline_height;  // includes filler lines above
+  if (wp->w_cursor.lnum < wp->w_topline) {
     scrolled = used;
   }
 
   linenr_T top;  // just above displayed lines
   linenr_T bot;  // just below displayed lines
-  if (hasFolding(curwin->w_cursor.lnum, &top, &bot)) {
+  if (hasFolding(wp, wp->w_cursor.lnum, &top, &bot)) {
     top--;
     bot++;
   } else {
-    top = curwin->w_cursor.lnum - 1;
-    bot = curwin->w_cursor.lnum + 1;
+    top = wp->w_cursor.lnum - 1;
+    bot = wp->w_cursor.lnum + 1;
   }
   linenr_T new_topline = top + 1;
 
   // "used" already contains the number of filler lines above, don't add it
   // again.
   // Hide filler lines above cursor line by adding them to "extra".
-  int extra = win_get_fill(curwin, curwin->w_cursor.lnum);
+  int extra = win_get_fill(wp, wp->w_cursor.lnum);
 
   // Check if the lines from "top" to "bot" fit in the window.  If they do,
   // set new_topline and advance "top" and "bot" to include more lines.
   while (top > 0) {
-    int i = hasFolding(top, &top, NULL)
+    int i = hasFolding(wp, top, &top, NULL)
             ? 1  // count one logical line for a sequence of folded lines
-            : plines_win_nofill(curwin, top, true);
-    if (top < curwin->w_topline) {
+            : plines_win_nofill(wp, top, true);
+    if (top < wp->w_topline) {
       scrolled += i;
     }
 
     // If scrolling is needed, scroll at least 'sj' lines.
-    if ((new_topline >= curwin->w_topline || scrolled > min_scroll) && extra >= off) {
+    if ((new_topline >= wp->w_topline || scrolled > min_scroll) && extra >= off) {
       break;
     }
 
     used += i;
-    if (extra + i <= off && bot < curbuf->b_ml.ml_line_count) {
-      if (hasFolding(bot, NULL, &bot)) {
+    if (extra + i <= off && bot < wp->w_buffer->b_ml.ml_line_count) {
+      if (hasFolding(wp, bot, NULL, &bot)) {
         // count one logical line for a sequence of folded lines
         used++;
       } else {
-        used += plines_win(curwin, bot, true);
+        used += plines_win(wp, bot, true);
       }
     }
-    if (used > curwin->w_height_inner) {
+    if (used > wp->w_height_inner) {
       break;
     }
 
@@ -1821,43 +1798,43 @@ void scroll_cursor_top(int min_scroll, int always)
   // If we don't have enough space, put cursor in the middle.
   // This makes sure we get the same position when using "k" and "j"
   // in a small window.
-  if (used > curwin->w_height_inner) {
-    scroll_cursor_halfway(false, false);
+  if (used > wp->w_height_inner) {
+    scroll_cursor_halfway(wp, false, false);
   } else {
     // If "always" is false, only adjust topline to a lower value, higher
     // value may happen with wrapping lines.
-    if (new_topline < curwin->w_topline || always) {
-      curwin->w_topline = new_topline;
+    if (new_topline < wp->w_topline || always) {
+      wp->w_topline = new_topline;
     }
-    if (curwin->w_topline > curwin->w_cursor.lnum) {
-      curwin->w_topline = curwin->w_cursor.lnum;
+    if (wp->w_topline > wp->w_cursor.lnum) {
+      wp->w_topline = wp->w_cursor.lnum;
     }
-    curwin->w_topfill = win_get_fill(curwin, curwin->w_topline);
-    if (curwin->w_topfill > 0 && extra > off) {
-      curwin->w_topfill -= extra - off;
-      if (curwin->w_topfill < 0) {
-        curwin->w_topfill = 0;
+    wp->w_topfill = win_get_fill(wp, wp->w_topline);
+    if (wp->w_topfill > 0 && extra > off) {
+      wp->w_topfill -= extra - off;
+      if (wp->w_topfill < 0) {
+        wp->w_topfill = 0;
       }
     }
-    check_topfill(curwin, false);
-    if (curwin->w_topline != old_topline) {
-      reset_skipcol(curwin);
-    } else if (curwin->w_topline == curwin->w_cursor.lnum) {
-      validate_virtcol();
-      if (curwin->w_skipcol >= curwin->w_virtcol) {
+    check_topfill(wp, false);
+    if (wp->w_topline != old_topline) {
+      reset_skipcol(wp);
+    } else if (wp->w_topline == wp->w_cursor.lnum) {
+      validate_virtcol(wp);
+      if (wp->w_skipcol >= wp->w_virtcol) {
         // TODO(vim): if the line doesn't fit may optimize w_skipcol instead
         // of making it zero
-        reset_skipcol(curwin);
+        reset_skipcol(wp);
       }
     }
-    if (curwin->w_topline != old_topline
-        || curwin->w_skipcol != old_skipcol
-        || curwin->w_topfill != old_topfill) {
-      curwin->w_valid &=
+    if (wp->w_topline != old_topline
+        || wp->w_skipcol != old_skipcol
+        || wp->w_topfill != old_topfill) {
+      wp->w_valid &=
         ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
     }
-    curwin->w_valid |= VALID_TOPLINE;
-    curwin->w_viewport_invalid = true;
+    wp->w_valid |= VALID_TOPLINE;
+    wp->w_viewport_invalid = true;
   }
 }
 
@@ -1886,79 +1863,79 @@ void set_empty_rows(win_T *wp, int used)
 /// When scrolling scroll at least "min_scroll" lines.
 /// If "set_topbot" is true, set topline and botline first (for "zb").
 /// This is messy stuff!!!
-void scroll_cursor_bot(int min_scroll, bool set_topbot)
+void scroll_cursor_bot(win_T *wp, int min_scroll, bool set_topbot)
 {
   lineoff_T loff;
-  linenr_T old_topline = curwin->w_topline;
-  int old_skipcol = curwin->w_skipcol;
-  int old_topfill = curwin->w_topfill;
-  linenr_T old_botline = curwin->w_botline;
-  int old_valid = curwin->w_valid;
-  int old_empty_rows = curwin->w_empty_rows;
-  linenr_T cln = curwin->w_cursor.lnum;  // Cursor Line Number
-  bool do_sms = curwin->w_p_wrap && curwin->w_p_sms;
+  linenr_T old_topline = wp->w_topline;
+  int old_skipcol = wp->w_skipcol;
+  int old_topfill = wp->w_topfill;
+  linenr_T old_botline = wp->w_botline;
+  int old_valid = wp->w_valid;
+  int old_empty_rows = wp->w_empty_rows;
+  linenr_T cln = wp->w_cursor.lnum;  // Cursor Line Number
+  bool do_sms = wp->w_p_wrap && wp->w_p_sms;
 
   if (set_topbot) {
     bool set_skipcol = false;
 
     int used = 0;
-    curwin->w_botline = cln + 1;
+    wp->w_botline = cln + 1;
     loff.fill = 0;
-    for (curwin->w_topline = curwin->w_botline;
-         curwin->w_topline > 1;
-         curwin->w_topline = loff.lnum) {
-      loff.lnum = curwin->w_topline;
-      topline_back_winheight(curwin, &loff, false);
+    for (wp->w_topline = wp->w_botline;
+         wp->w_topline > 1;
+         wp->w_topline = loff.lnum) {
+      loff.lnum = wp->w_topline;
+      topline_back_winheight(wp, &loff, false);
       if (loff.height == MAXCOL) {
         break;
       }
-      if (used + loff.height > curwin->w_height_inner) {
+      if (used + loff.height > wp->w_height_inner) {
         if (do_sms) {
           // 'smoothscroll' and 'wrap' are set.  The above line is
           // too long to show in its entirety, so we show just a part
           // of it.
-          if (used < curwin->w_height_inner) {
-            int plines_offset = used + loff.height - curwin->w_height_inner;
-            used = curwin->w_height_inner;
-            curwin->w_topfill = loff.fill;
-            curwin->w_topline = loff.lnum;
-            curwin->w_skipcol = skipcol_from_plines(curwin, plines_offset);
+          if (used < wp->w_height_inner) {
+            int plines_offset = used + loff.height - wp->w_height_inner;
+            used = wp->w_height_inner;
+            wp->w_topfill = loff.fill;
+            wp->w_topline = loff.lnum;
+            wp->w_skipcol = skipcol_from_plines(wp, plines_offset);
             set_skipcol = true;
           }
         }
         break;
       }
       used += loff.height;
-      curwin->w_topfill = loff.fill;
+      wp->w_topfill = loff.fill;
     }
-    set_empty_rows(curwin, used);
-    curwin->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;
-    if (curwin->w_topline != old_topline
-        || curwin->w_topfill != old_topfill
+    set_empty_rows(wp, used);
+    wp->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;
+    if (wp->w_topline != old_topline
+        || wp->w_topfill != old_topfill
         || set_skipcol
-        || curwin->w_skipcol != 0) {
-      curwin->w_valid &= ~(VALID_WROW|VALID_CROW);
+        || wp->w_skipcol != 0) {
+      wp->w_valid &= ~(VALID_WROW|VALID_CROW);
       if (set_skipcol) {
-        redraw_later(curwin, UPD_NOT_VALID);
+        redraw_later(wp, UPD_NOT_VALID);
       } else {
-        reset_skipcol(curwin);
+        reset_skipcol(wp);
       }
     }
   } else {
-    validate_botline(curwin);
+    validate_botline(wp);
   }
 
   // The lines of the cursor line itself are always used.
-  int used = plines_win_nofill(curwin, cln, true);
+  int used = plines_win_nofill(wp, cln, true);
 
   int scrolled = 0;
   // If the cursor is on or below botline, we will at least scroll by the
   // height of the cursor line, which is "used".  Correct for empty lines,
   // which are really part of botline.
-  if (cln >= curwin->w_botline) {
+  if (cln >= wp->w_botline) {
     scrolled = used;
-    if (cln == curwin->w_botline) {
-      scrolled -= curwin->w_empty_rows;
+    if (cln == wp->w_botline) {
+      scrolled -= wp->w_empty_rows;
     }
     if (do_sms) {
       // 'smoothscroll' and 'wrap' are set.
@@ -1966,21 +1943,21 @@ void scroll_cursor_bot(int min_scroll, bool set_topbot)
       // occupies. If it is occupying more than the entire window, we
       // need to scroll the additional clipped lines to scroll past the
       // top line before we can move on to the other lines.
-      int top_plines = plines_win_nofill(curwin, curwin->w_topline, false);
+      int top_plines = plines_win_nofill(wp, wp->w_topline, false);
       int skip_lines = 0;
-      int width1 = curwin->w_width_inner - curwin_col_off();
+      int width1 = wp->w_width_inner - win_col_off(wp);
       if (width1 > 0) {
-        int width2 = width1 + curwin_col_off2();
+        int width2 = width1 + win_col_off2(wp);
         // similar formula is used in curs_columns()
-        if (curwin->w_skipcol > width1) {
-          skip_lines += (curwin->w_skipcol - width1) / width2 + 1;
-        } else if (curwin->w_skipcol > 0) {
+        if (wp->w_skipcol > width1) {
+          skip_lines += (wp->w_skipcol - width1) / width2 + 1;
+        } else if (wp->w_skipcol > 0) {
           skip_lines = 1;
         }
 
         top_plines -= skip_lines;
-        if (top_plines > curwin->w_height_inner) {
-          scrolled += (top_plines - curwin->w_height_inner);
+        if (top_plines > wp->w_height_inner) {
+          scrolled += (top_plines - wp->w_height_inner);
         }
       }
     }
@@ -1992,67 +1969,67 @@ void scroll_cursor_bot(int min_scroll, bool set_topbot)
   // - scrolled nothing or at least 'sj' lines
   // - at least 'so' lines below the cursor
   // - lines between botline and cursor have been counted
-  if (!hasFolding(curwin->w_cursor.lnum, &loff.lnum, &boff.lnum)) {
+  if (!hasFolding(wp, wp->w_cursor.lnum, &loff.lnum, &boff.lnum)) {
     loff.lnum = cln;
     boff.lnum = cln;
   }
   loff.fill = 0;
   boff.fill = 0;
-  int fill_below_window = win_get_fill(curwin, curwin->w_botline) - curwin->w_filler_rows;
+  int fill_below_window = win_get_fill(wp, wp->w_botline) - wp->w_filler_rows;
 
   int extra = 0;
-  int so = get_scrolloff_value(curwin);
+  int so = get_scrolloff_value(wp);
   while (loff.lnum > 1) {
     // Stop when scrolled nothing or at least "min_scroll", found "extra"
     // context for 'scrolloff' and counted all lines below the window.
     if ((((scrolled <= 0 || scrolled >= min_scroll)
           && extra >= (mouse_dragging > 0 ? mouse_dragging - 1 : so))
-         || boff.lnum + 1 > curbuf->b_ml.ml_line_count)
-        && loff.lnum <= curwin->w_botline
-        && (loff.lnum < curwin->w_botline
+         || boff.lnum + 1 > wp->w_buffer->b_ml.ml_line_count)
+        && loff.lnum <= wp->w_botline
+        && (loff.lnum < wp->w_botline
             || loff.fill >= fill_below_window)) {
       break;
     }
 
     // Add one line above
-    topline_back(curwin, &loff);
+    topline_back(wp, &loff);
     if (loff.height == MAXCOL) {
       used = MAXCOL;
     } else {
       used += loff.height;
     }
-    if (used > curwin->w_height_inner) {
+    if (used > wp->w_height_inner) {
       break;
     }
-    if (loff.lnum >= curwin->w_botline
-        && (loff.lnum > curwin->w_botline
+    if (loff.lnum >= wp->w_botline
+        && (loff.lnum > wp->w_botline
             || loff.fill <= fill_below_window)) {
       // Count screen lines that are below the window.
       scrolled += loff.height;
-      if (loff.lnum == curwin->w_botline
+      if (loff.lnum == wp->w_botline
           && loff.fill == 0) {
-        scrolled -= curwin->w_empty_rows;
+        scrolled -= wp->w_empty_rows;
       }
     }
 
-    if (boff.lnum < curbuf->b_ml.ml_line_count) {
+    if (boff.lnum < wp->w_buffer->b_ml.ml_line_count) {
       // Add one line below
-      botline_forw(curwin, &boff);
+      botline_forw(wp, &boff);
       used += boff.height;
-      if (used > curwin->w_height_inner) {
+      if (used > wp->w_height_inner) {
         break;
       }
       if (extra < (mouse_dragging > 0 ? mouse_dragging - 1 : so)
           || scrolled < min_scroll) {
         extra += boff.height;
-        if (boff.lnum >= curwin->w_botline
-            || (boff.lnum + 1 == curwin->w_botline
-                && boff.fill > curwin->w_filler_rows)) {
+        if (boff.lnum >= wp->w_botline
+            || (boff.lnum + 1 == wp->w_botline
+                && boff.fill > wp->w_filler_rows)) {
           // Count screen lines that are below the window.
           scrolled += boff.height;
-          if (boff.lnum == curwin->w_botline
+          if (boff.lnum == wp->w_botline
               && boff.fill == 0) {
-            scrolled -= curwin->w_empty_rows;
+            scrolled -= wp->w_empty_rows;
           }
         }
       }
@@ -2060,77 +2037,77 @@ void scroll_cursor_bot(int min_scroll, bool set_topbot)
   }
 
   linenr_T line_count;
-  // curwin->w_empty_rows is larger, no need to scroll
+  // wp->w_empty_rows is larger, no need to scroll
   if (scrolled <= 0) {
     line_count = 0;
     // more than a screenfull, don't scroll but redraw
-  } else if (used > curwin->w_height_inner) {
+  } else if (used > wp->w_height_inner) {
     line_count = used;
     // scroll minimal number of lines
   } else {
     line_count = 0;
-    boff.fill = curwin->w_topfill;
-    boff.lnum = curwin->w_topline - 1;
+    boff.fill = wp->w_topfill;
+    boff.lnum = wp->w_topline - 1;
     int i;
-    for (i = 0; i < scrolled && boff.lnum < curwin->w_botline;) {
-      botline_forw(curwin, &boff);
+    for (i = 0; i < scrolled && boff.lnum < wp->w_botline;) {
+      botline_forw(wp, &boff);
       i += boff.height;
       line_count++;
     }
-    if (i < scrolled) {         // below curwin->w_botline, don't scroll
+    if (i < scrolled) {         // below wp->w_botline, don't scroll
       line_count = 9999;
     }
   }
 
   // Scroll up if the cursor is off the bottom of the screen a bit.
   // Otherwise put it at 1/2 of the screen.
-  if (line_count >= curwin->w_height_inner && line_count > min_scroll) {
-    scroll_cursor_halfway(false, true);
+  if (line_count >= wp->w_height_inner && line_count > min_scroll) {
+    scroll_cursor_halfway(wp, false, true);
   } else if (line_count > 0) {
     if (do_sms) {
-      scrollup(scrolled, true);  // TODO(vim):
+      scrollup(wp, scrolled, true);  // TODO(vim):
     } else {
-      scrollup(line_count, true);
+      scrollup(wp, line_count, true);
     }
   }
 
   // If topline didn't change we need to restore w_botline and w_empty_rows
   // (we changed them).
   // If topline did change, update_screen() will set botline.
-  if (curwin->w_topline == old_topline && curwin->w_skipcol == old_skipcol && set_topbot) {
-    curwin->w_botline = old_botline;
-    curwin->w_empty_rows = old_empty_rows;
-    curwin->w_valid = old_valid;
+  if (wp->w_topline == old_topline && wp->w_skipcol == old_skipcol && set_topbot) {
+    wp->w_botline = old_botline;
+    wp->w_empty_rows = old_empty_rows;
+    wp->w_valid = old_valid;
   }
-  curwin->w_valid |= VALID_TOPLINE;
-  curwin->w_viewport_invalid = true;
+  wp->w_valid |= VALID_TOPLINE;
+  wp->w_viewport_invalid = true;
 }
 
 /// Recompute topline to put the cursor halfway across the window
 ///
 /// @param atend if true, also put the cursor halfway to the end of the file.
 ///
-void scroll_cursor_halfway(bool atend, bool prefer_above)
+void scroll_cursor_halfway(win_T *wp, bool atend, bool prefer_above)
 {
-  linenr_T old_topline = curwin->w_topline;
-  lineoff_T loff = { .lnum = curwin->w_cursor.lnum };
-  lineoff_T boff = { .lnum = curwin->w_cursor.lnum };
-  hasFolding(loff.lnum, &loff.lnum, &boff.lnum);
-  int used = plines_win_nofill(curwin, loff.lnum, true);
+  linenr_T old_topline = wp->w_topline;
+  lineoff_T loff = { .lnum = wp->w_cursor.lnum };
+  lineoff_T boff = { .lnum = wp->w_cursor.lnum };
+  hasFolding(wp, loff.lnum, &loff.lnum, &boff.lnum);
+  int used = plines_win_nofill(wp, loff.lnum, true);
   loff.fill = 0;
   boff.fill = 0;
   linenr_T topline = loff.lnum;
   colnr_T skipcol = 0;
 
   int want_height;
-  bool do_sms = curwin->w_p_wrap && curwin->w_p_sms;
+  bool do_sms = wp->w_p_wrap && wp->w_p_sms;
   if (do_sms) {
     // 'smoothscroll' and 'wrap' are set
     if (atend) {
-      want_height = (curwin->w_height_inner - used) / 2;
+      want_height = (wp->w_height_inner - used) / 2;
       used = 0;
     } else {
-      want_height = curwin->w_height_inner;
+      want_height = wp->w_height_inner;
     }
   }
 
@@ -2139,20 +2116,20 @@ void scroll_cursor_halfway(bool atend, bool prefer_above)
     // If using smoothscroll, we can precisely scroll to the
     // exact point where the cursor is halfway down the screen.
     if (do_sms) {
-      topline_back_winheight(curwin, &loff, false);
+      topline_back_winheight(wp, &loff, false);
       if (loff.height == MAXCOL) {
         break;
       }
       used += loff.height;
-      if (!atend && boff.lnum < curbuf->b_ml.ml_line_count) {
-        botline_forw(curwin, &boff);
+      if (!atend && boff.lnum < wp->w_buffer->b_ml.ml_line_count) {
+        botline_forw(wp, &boff);
         used += boff.height;
       }
       if (used > want_height) {
         if (used - loff.height < want_height) {
           topline = loff.lnum;
           topfill = loff.fill;
-          skipcol = skipcol_from_plines(curwin, used - want_height);
+          skipcol = skipcol_from_plines(wp, used - want_height);
         }
         break;
       }
@@ -2176,10 +2153,10 @@ void scroll_cursor_halfway(bool atend, bool prefer_above)
           ? (round == 2 && below < above)
           : (round == 1 && below <= above)) {
         // add a line below the cursor
-        if (boff.lnum < curbuf->b_ml.ml_line_count) {
-          botline_forw(curwin, &boff);
+        if (boff.lnum < wp->w_buffer->b_ml.ml_line_count) {
+          botline_forw(wp, &boff);
           used += boff.height;
-          if (used > curwin->w_height_inner) {
+          if (used > wp->w_height_inner) {
             done = true;
             break;
           }
@@ -2196,13 +2173,13 @@ void scroll_cursor_halfway(bool atend, bool prefer_above)
           ? (round == 1 && below >= above)
           : (round == 1 && below > above)) {
         // add a line above the cursor
-        topline_back(curwin, &loff);
+        topline_back(wp, &loff);
         if (loff.height == MAXCOL) {
           used = MAXCOL;
         } else {
           used += loff.height;
         }
-        if (used > curwin->w_height_inner) {
+        if (used > wp->w_height_inner) {
           done = true;
           break;
         }
@@ -2216,51 +2193,51 @@ void scroll_cursor_halfway(bool atend, bool prefer_above)
     }
   }
 
-  if (!hasFolding(topline, &curwin->w_topline, NULL)
-      && (curwin->w_topline != topline || skipcol != 0 || curwin->w_skipcol != 0)) {
-    curwin->w_topline = topline;
+  if (!hasFolding(wp, topline, &wp->w_topline, NULL)
+      && (wp->w_topline != topline || skipcol != 0 || wp->w_skipcol != 0)) {
+    wp->w_topline = topline;
     if (skipcol != 0) {
-      curwin->w_skipcol = skipcol;
-      redraw_later(curwin, UPD_NOT_VALID);
+      wp->w_skipcol = skipcol;
+      redraw_later(wp, UPD_NOT_VALID);
     } else if (do_sms) {
-      reset_skipcol(curwin);
+      reset_skipcol(wp);
     }
   }
-  curwin->w_topfill = topfill;
-  if (old_topline > curwin->w_topline + curwin->w_height_inner) {
-    curwin->w_botfill = false;
+  wp->w_topfill = topfill;
+  if (old_topline > wp->w_topline + wp->w_height_inner) {
+    wp->w_botfill = false;
   }
-  check_topfill(curwin, false);
-  curwin->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
-  curwin->w_valid |= VALID_TOPLINE;
+  check_topfill(wp, false);
+  wp->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
+  wp->w_valid |= VALID_TOPLINE;
 }
 
 // Correct the cursor position so that it is in a part of the screen at least
 // 'so' lines from the top and bottom, if possible.
 // If not possible, put it at the same position as scroll_cursor_halfway().
 // When called topline must be valid!
-void cursor_correct(void)
+void cursor_correct(win_T *wp)
 {
   // How many lines we would like to have above/below the cursor depends on
   // whether the first/last line of the file is on screen.
-  int above_wanted = get_scrolloff_value(curwin);
-  int below_wanted = get_scrolloff_value(curwin);
+  int above_wanted = get_scrolloff_value(wp);
+  int below_wanted = get_scrolloff_value(wp);
   if (mouse_dragging > 0) {
     above_wanted = mouse_dragging - 1;
     below_wanted = mouse_dragging - 1;
   }
-  if (curwin->w_topline == 1) {
+  if (wp->w_topline == 1) {
     above_wanted = 0;
-    int max_off = curwin->w_height_inner / 2;
+    int max_off = wp->w_height_inner / 2;
     if (below_wanted > max_off) {
       below_wanted = max_off;
     }
   }
-  validate_botline(curwin);
-  if (curwin->w_botline == curbuf->b_ml.ml_line_count + 1
+  validate_botline(wp);
+  if (wp->w_botline == wp->w_buffer->b_ml.ml_line_count + 1
       && mouse_dragging == 0) {
     below_wanted = 0;
-    int max_off = (curwin->w_height_inner - 1) / 2;
+    int max_off = (wp->w_height_inner - 1) / 2;
     if (above_wanted > max_off) {
       above_wanted = max_off;
     }
@@ -2268,18 +2245,18 @@ void cursor_correct(void)
 
   // If there are sufficient file-lines above and below the cursor, we can
   // return now.
-  linenr_T cln = curwin->w_cursor.lnum;  // Cursor Line Number
-  if (cln >= curwin->w_topline + above_wanted
-      && cln < curwin->w_botline - below_wanted
-      && !hasAnyFolding(curwin)) {
+  linenr_T cln = wp->w_cursor.lnum;  // Cursor Line Number
+  if (cln >= wp->w_topline + above_wanted
+      && cln < wp->w_botline - below_wanted
+      && !hasAnyFolding(wp)) {
     return;
   }
 
-  if (curwin->w_p_sms && !curwin->w_p_wrap) {
+  if (wp->w_p_sms && !wp->w_p_wrap) {
     // 'smoothscroll' is active
-    if (curwin->w_cline_height == curwin->w_height_inner) {
+    if (wp->w_cline_height == wp->w_height_inner) {
       // The cursor line just fits in the window, don't scroll.
-      reset_skipcol(curwin);
+      reset_skipcol(wp);
       return;
     }
     // TODO(vim): If the cursor line doesn't fit in the window then only adjust w_skipcol.
@@ -2289,52 +2266,52 @@ void cursor_correct(void)
   // the top and the bottom until:
   // - the desired context lines are found
   // - the lines from the top is past the lines from the bottom
-  linenr_T topline = curwin->w_topline;
-  linenr_T botline = curwin->w_botline - 1;
+  linenr_T topline = wp->w_topline;
+  linenr_T botline = wp->w_botline - 1;
   // count filler lines as context
-  int above = curwin->w_topfill;  // screen lines above topline
-  int below = curwin->w_filler_rows;  // screen lines below botline
+  int above = wp->w_topfill;  // screen lines above topline
+  int below = wp->w_filler_rows;  // screen lines below botline
   while ((above < above_wanted || below < below_wanted) && topline < botline) {
     if (below < below_wanted && (below <= above || above >= above_wanted)) {
-      if (hasFolding(botline, &botline, NULL)) {
+      if (hasFolding(wp, botline, &botline, NULL)) {
         below++;
       } else {
-        below += plines_win(curwin, botline, true);
+        below += plines_win(wp, botline, true);
       }
       botline--;
     }
     if (above < above_wanted && (above < below || below >= below_wanted)) {
-      if (hasFolding(topline, NULL, &topline)) {
+      if (hasFolding(wp, topline, NULL, &topline)) {
         above++;
       } else {
-        above += plines_win_nofill(curwin, topline, true);
+        above += plines_win_nofill(wp, topline, true);
       }
 
       // Count filler lines below this line as context.
       if (topline < botline) {
-        above += win_get_fill(curwin, topline + 1);
+        above += win_get_fill(wp, topline + 1);
       }
       topline++;
     }
   }
   if (topline == botline || botline == 0) {
-    curwin->w_cursor.lnum = topline;
+    wp->w_cursor.lnum = topline;
   } else if (topline > botline) {
-    curwin->w_cursor.lnum = botline;
+    wp->w_cursor.lnum = botline;
   } else {
-    if (cln < topline && curwin->w_topline > 1) {
-      curwin->w_cursor.lnum = topline;
-      curwin->w_valid &=
+    if (cln < topline && wp->w_topline > 1) {
+      wp->w_cursor.lnum = topline;
+      wp->w_valid &=
         ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW);
     }
-    if (cln > botline && curwin->w_botline <= curbuf->b_ml.ml_line_count) {
-      curwin->w_cursor.lnum = botline;
-      curwin->w_valid &=
+    if (cln > botline && wp->w_botline <= wp->w_buffer->b_ml.ml_line_count) {
+      wp->w_cursor.lnum = botline;
+      wp->w_valid &=
         ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW);
     }
   }
-  curwin->w_valid |= VALID_TOPLINE;
-  curwin->w_viewport_invalid = true;
+  wp->w_valid |= VALID_TOPLINE;
+  wp->w_viewport_invalid = true;
 }
 
 /// Move screen "count" pages up ("dir" is BACKWARD) or down ("dir" is FORWARD)
@@ -2461,7 +2438,7 @@ int onepage(Direction dir, int count)
         botline_forw(curwin, &loff);
         botline_topline(&loff);
         // We're at the wrong end of a fold now.
-        hasFoldingWin(curwin, loff.lnum, &loff.lnum, NULL, true, NULL);
+        hasFolding(curwin, loff.lnum, &loff.lnum, NULL);
 
         // Always scroll at least one line.  Avoid getting stuck on
         // very long lines.
@@ -2491,9 +2468,9 @@ int onepage(Direction dir, int count)
       }
     }
   }
-  foldAdjustCursor();
-  cursor_correct();
-  check_cursor_col();
+  foldAdjustCursor(curwin);
+  cursor_correct(curwin);
+  check_cursor_col(curwin);
   if (retval == OK) {
     beginline(BL_SOL | BL_FIX);
   }
@@ -2504,14 +2481,14 @@ int onepage(Direction dir, int count)
     // But make sure we scroll at least one line (happens with mix of long
     // wrapping lines and non-wrapping line).
     if (check_top_offset()) {
-      scroll_cursor_top(1, false);
+      scroll_cursor_top(curwin, 1, false);
       if (curwin->w_topline <= old_topline
           && old_topline < curbuf->b_ml.ml_line_count) {
         curwin->w_topline = old_topline + 1;
-        hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+        hasFolding(curwin, curwin->w_topline, &curwin->w_topline, NULL);
       }
     } else if (curwin->w_botline > curbuf->b_ml.ml_line_count) {
-      hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+      hasFolding(curwin, curwin->w_topline, &curwin->w_topline, NULL);
     }
   }
 
@@ -2610,7 +2587,7 @@ void halfpage(bool flag, linenr_T Prenum)
         if (n < 0 && scrolled > 0) {
           break;
         }
-        hasFolding(curwin->w_topline, NULL, &curwin->w_topline);
+        hasFolding(curwin, curwin->w_topline, NULL, &curwin->w_topline);
         curwin->w_topline++;
         curwin->w_topfill = win_get_fill(curwin, curwin->w_topline);
 
@@ -2634,7 +2611,7 @@ void halfpage(bool flag, linenr_T Prenum)
           if (i > room) {
             break;
           }
-          hasFolding(curwin->w_botline, NULL, &curwin->w_botline);
+          hasFolding(curwin, curwin->w_botline, NULL, &curwin->w_botline);
           curwin->w_botline++;
           room -= i;
         } while (curwin->w_botline <= curbuf->b_ml.ml_line_count);
@@ -2646,7 +2623,7 @@ void halfpage(bool flag, linenr_T Prenum)
       if (hasAnyFolding(curwin)) {
         while (--n >= 0
                && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-          hasFolding(curwin->w_cursor.lnum, NULL,
+          hasFolding(curwin, curwin->w_cursor.lnum, NULL,
                      &curwin->w_cursor.lnum);
           curwin->w_cursor.lnum++;
         }
@@ -2669,7 +2646,7 @@ void halfpage(bool flag, linenr_T Prenum)
           break;
         }
         curwin->w_topline--;
-        hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
+        hasFolding(curwin, curwin->w_topline, &curwin->w_topline, NULL);
         curwin->w_topfill = 0;
       }
       curwin->w_valid &= ~(VALID_CROW|VALID_WROW|
@@ -2688,7 +2665,7 @@ void halfpage(bool flag, linenr_T Prenum)
       } else if (hasAnyFolding(curwin)) {
         while (--n >= 0 && curwin->w_cursor.lnum > 1) {
           curwin->w_cursor.lnum--;
-          hasFolding(curwin->w_cursor.lnum,
+          hasFolding(curwin, curwin->w_cursor.lnum,
                      &curwin->w_cursor.lnum, NULL);
         }
       } else {
@@ -2697,9 +2674,9 @@ void halfpage(bool flag, linenr_T Prenum)
     }
   }
   // Move cursor to first line of closed fold.
-  foldAdjustCursor();
+  foldAdjustCursor(curwin);
   check_topfill(curwin, !flag);
-  cursor_correct();
+  cursor_correct(curwin);
   beginline(BL_SOL | BL_FIX);
   redraw_later(curwin, UPD_VALID);
 }
@@ -2748,12 +2725,12 @@ void do_check_cursorbind(void)
       {
         int restart_edit_save = restart_edit;
         restart_edit = true;
-        check_cursor();
+        check_cursor(curwin);
 
         // Avoid a scroll here for the cursor position, 'scrollbind' is
         // more important.
         if (!curwin->w_p_scb) {
-          validate_cursor();
+          validate_cursor(curwin);
         }
 
         restart_edit = restart_edit_save;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1937,7 +1937,7 @@ static const char *did_set_arabic(optset_T *args)
       // set rightleft mode
       if (!win->w_p_rl) {
         win->w_p_rl = true;
-        changed_window_setting();
+        changed_window_setting(curwin);
       }
 
       // Enable Arabic shaping (major part of what Arabic requires)
@@ -1968,7 +1968,7 @@ static const char *did_set_arabic(optset_T *args)
       // reset rightleft mode
       if (win->w_p_rl) {
         win->w_p_rl = false;
-        changed_window_setting();
+        changed_window_setting(curwin);
       }
 
       // 'arabicshape' isn't reset, it is a global option and
@@ -3029,7 +3029,7 @@ void check_redraw_for(buf_T *buf, win_T *win, uint32_t flags)
     if (flags & P_HLONLY) {
       redraw_later(win, UPD_NOT_VALID);
     } else {
-      changed_window_setting_win(win);
+      changed_window_setting(win);
     }
   }
   if (flags & P_RBUF) {
@@ -6104,9 +6104,9 @@ char *get_flp_value(buf_T *buf)
 }
 
 /// Get the local or global value of the 'virtualedit' flags.
-unsigned get_ve_flags(void)
+unsigned get_ve_flags(win_T *wp)
 {
-  return (curwin->w_ve_flags ? curwin->w_ve_flags : ve_flags) & ~(VE_NONE | VE_NONEU);
+  return (wp->w_ve_flags ? wp->w_ve_flags : ve_flags) & ~(VE_NONE | VE_NONEU);
 }
 
 /// Get the local or global value of 'showbreak'.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2479,9 +2479,8 @@ const char *did_set_virtualedit(optset_T *args)
     } else if (strcmp(ve, args->os_oldval.string.data) != 0) {
       // Recompute cursor position in case the new 've' setting
       // changes something.
-      validate_virtcol_win(win);
-      // XXX: this only works when win == curwin
-      coladvance(win->w_virtcol);
+      validate_virtcol(win);
+      coladvance(win, win->w_virtcol);
     }
   }
   return NULL;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -540,7 +540,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
     if (ci.chr.value == TAB
         && (State & MODE_NORMAL)
         && !wp->w_p_list
-        && !virtual_active()
+        && !virtual_active(wp)
         && !(VIsual_active && ((*p_sel == 'e') || ltoreq(*pos, VIsual)))) {
       // cursor at end
       *cursor = vcol + incr - 1;
@@ -583,7 +583,7 @@ void getvvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *e
 {
   colnr_T col;
 
-  if (virtual_active()) {
+  if (virtual_active(wp)) {
     // For virtual mode, only want one value
     getvcol(wp, pos, &col, NULL, NULL);
 
@@ -902,7 +902,7 @@ int64_t win_text_height(win_T *const wp, const linenr_T start_lnum, const int64_
 
   if (start_vcol >= 0) {
     linenr_T lnum_next = lnum;
-    const bool folded = hasFoldingWin(wp, lnum, &lnum, &lnum_next, true, NULL);
+    const bool folded = hasFolding(wp, lnum, &lnum, &lnum_next);
     height_cur_nofill = folded ? 1 : plines_win_nofill(wp, lnum, false);
     height_sum_nofill += height_cur_nofill;
     const int64_t row_off = (start_vcol < width1 || width2 <= 0)
@@ -914,7 +914,7 @@ int64_t win_text_height(win_T *const wp, const linenr_T start_lnum, const int64_
 
   while (lnum <= end_lnum) {
     linenr_T lnum_next = lnum;
-    const bool folded = hasFoldingWin(wp, lnum, &lnum, &lnum_next, true, NULL);
+    const bool folded = hasFolding(wp, lnum, &lnum, &lnum_next);
     height_sum_fill += win_get_fill(wp, lnum);
     height_cur_nofill = folded ? 1 : plines_win_nofill(wp, lnum, false);
     height_sum_nofill += height_cur_nofill;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -140,7 +140,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     // to avoid that must_redraw is set when 'cursorcolumn' is on.
     pum_is_visible = true;
     pum_is_drawn = true;
-    validate_cursor_col();
+    validate_cursor_col(curwin);
     int above_row = 0;
     int below_row = cmdline_row;
 
@@ -273,7 +273,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
         context_lines = 0;
       } else {
         // Leave two lines of context if possible
-        validate_cheight();
+        validate_cheight(curwin);
         if (curwin->w_cline_row + curwin->w_cline_height - curwin->w_wrow >= 3) {
           context_lines = 3;
         } else {
@@ -995,7 +995,7 @@ static bool pum_set_selected(int n, int repeat)
             }
 
             // Return cursor to where we were
-            validate_cursor();
+            validate_cursor(curwin);
             redraw_later(curwin, UPD_SOME_VALID);
 
             // When the preview window was resized we need to

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2889,12 +2889,12 @@ static void qf_jump_goto_line(linenr_T qf_lnum, int qf_col, char qf_viscol, char
     if (qf_col > 0) {
       curwin->w_cursor.coladd = 0;
       if (qf_viscol == true) {
-        coladvance(qf_col - 1);
+        coladvance(curwin, qf_col - 1);
       } else {
         curwin->w_cursor.col = qf_col - 1;
       }
       curwin->w_set_curswant = true;
-      check_cursor();
+      check_cursor(curwin);
     } else {
       beginline(BL_WHITE | BL_FIX);
     }
@@ -3831,7 +3831,7 @@ void ex_copen(exarg_T *eap)
 
   curwin->w_cursor.lnum = lnum;
   curwin->w_cursor.col = 0;
-  check_cursor();
+  check_cursor(curwin);
   update_topline(curwin);             // scroll to show the line
 }
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1076,11 +1076,11 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, int count, in
   // If the cursor is in a closed fold, don't find another match in the same
   // fold.
   if (dirc == '/') {
-    if (hasFolding(pos.lnum, NULL, &pos.lnum)) {
+    if (hasFolding(curwin, pos.lnum, NULL, &pos.lnum)) {
       pos.col = MAXCOL - 2;             // avoid overflow when adding 1
     }
   } else {
-    if (hasFolding(pos.lnum, &pos.lnum, NULL)) {
+    if (hasFolding(curwin, pos.lnum, &pos.lnum, NULL)) {
       pos.col = 0;
     }
   }
@@ -1389,7 +1389,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, int count, in
                           show_top_bot_msg, msgbuf,
                           (count != 1 || has_offset
                            || (!(fdo_flags & FDO_SEARCH)
-                               && hasFolding(curwin->w_cursor.lnum, NULL,
+                               && hasFolding(curwin, curwin->w_cursor.lnum, NULL,
                                              NULL))),
                           SEARCH_STAT_DEF_MAX_COUNT,
                           SEARCH_STAT_DEF_TIMEOUT);
@@ -4034,7 +4034,7 @@ search_line:
               setpcmark();
             }
             curwin->w_cursor.lnum = lnum;
-            check_cursor();
+            check_cursor(curwin);
           } else {
             if (!GETFILE_SUCCESS(getfile(0, files[depth].name, NULL, true,
                                          files[depth].lnum, forceit))) {
@@ -4053,7 +4053,7 @@ search_line:
         if (l_g_do_tagpreview != 0
             && curwin != curwin_save && win_valid(curwin_save)) {
           // Return cursor to where we were
-          validate_cursor();
+          validate_cursor(curwin);
           redraw_later(curwin, UPD_VALID);
           win_enter(curwin_save, true);
         }

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -135,9 +135,9 @@ void state_handle_k_event(void)
 }
 
 /// Return true if in the current mode we need to use virtual.
-bool virtual_active(void)
+bool virtual_active(win_T *wp)
 {
-  unsigned cur_ve_flags = get_ve_flags();
+  unsigned cur_ve_flags = get_ve_flags(wp);
 
   // While an operator is being executed we return "virtual_op", because
   // VIsual_active has already been reset, thus we can't check for "block"

--- a/src/nvim/state.h
+++ b/src/nvim/state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nvim/state_defs.h"  // IWYU pragma: keep
+#include "nvim/types_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "state.h.generated.h"

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -449,7 +449,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
         }
         curwin->w_cursor.col = saved_fmark.mark.col;
         curwin->w_set_curswant = true;
-        check_cursor();
+        check_cursor(curwin);
         if ((fdo_flags & FDO_TAG) && old_KeyTyped) {
           foldOpenCursor();
         }
@@ -3002,7 +3002,7 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
 
       // A search command may have positioned the cursor beyond the end
       // of the line.  May need to correct that here.
-      check_cursor();
+      check_cursor(curwin);
     } else {
       const int save_secure = secure;
 
@@ -3047,7 +3047,7 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
     if (l_g_do_tagpreview != 0
         && curwin != curwin_save && win_valid(curwin_save)) {
       // Return cursor to where we were
-      validate_cursor();
+      validate_cursor(curwin);
       redraw_later(curwin, UPD_VALID);
       win_enter(curwin_save, true);
     }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -612,7 +612,7 @@ static void terminal_check_cursor(void)
                               row_to_linenr(term, term->cursor.row));
   // Nudge cursor when returning to normal-mode.
   int off = is_focused(term) ? 0 : (curwin->w_p_rl ? 1 : -1);
-  coladvance(MAX(0, term->cursor.col + off));
+  coladvance(curwin, MAX(0, term->cursor.col + off));
 }
 
 // Function executed before each iteration of terminal mode.
@@ -626,7 +626,7 @@ static int terminal_check(VimState *state)
   }
 
   terminal_check_cursor();
-  validate_cursor();
+  validate_cursor(curwin);
 
   if (must_redraw) {
     update_screen();

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -157,7 +157,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     }
 
     // find column of textwidth border
-    coladvance((colnr_T)textwidth);
+    coladvance(curwin, (colnr_T)textwidth);
     wantcol = curwin->w_cursor.col;
 
     // If startcol is large (a long line), formatting takes too much
@@ -690,9 +690,9 @@ void auto_format(bool trailblank, bool prev_line)
   if (curwin->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
     // "cannot happen"
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
-    coladvance(MAXCOL);
+    coladvance(curwin, MAXCOL);
   } else {
-    check_cursor_col();
+    check_cursor_col(curwin);
   }
 
   // Insert mode: If the cursor is now after the end of the line while it
@@ -715,7 +715,7 @@ void auto_format(bool trailblank, bool prev_line)
     }
   }
 
-  check_cursor();
+  check_cursor(curwin);
 }
 
 /// When an extra space was added to continue a paragraph for auto-formatting,
@@ -839,7 +839,7 @@ void op_format(oparg_T *oap, bool keep_cursor)
     saved_cursor.lnum = 0;
 
     // formatting may have made the cursor position invalid
-    check_cursor();
+    check_cursor(curwin);
   }
 
   if (oap->is_VIsual) {
@@ -1063,7 +1063,7 @@ void format_lines(linenr_T line_count, bool avoid_fex)
 
         // put cursor on last non-space
         State = MODE_NORMAL;  // don't go past end-of-line
-        coladvance(MAXCOL);
+        coladvance(curwin, MAXCOL);
         while (curwin->w_cursor.col && ascii_isspace(gchar_cursor())) {
           dec_cursor();
         }

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -187,7 +187,7 @@ bool findpar(bool *pincl, int dir, int count, int what, bool both)
 
       // skip folded lines
       fold_skipped = false;
-      if (first && hasFolding(curr, &fold_first, &fold_last)) {
+      if (first && hasFolding(curwin, curr, &fold_first, &fold_last)) {
         curr = ((dir > 0) ? fold_last : fold_first) + dir;
         fold_skipped = true;
       }
@@ -318,8 +318,8 @@ int fwd_word(int count, bool bigword, bool eol)
   while (--count >= 0) {
     // When inside a range of folded lines, move to the last char of the
     // last line.
-    if (hasFolding(curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum)) {
-      coladvance(MAXCOL);
+    if (hasFolding(curwin, curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum)) {
+      coladvance(curwin, MAXCOL);
     }
     int sclass = cls();  // starting class
 
@@ -374,7 +374,7 @@ int bck_word(int count, bool bigword, bool stop)
   while (--count >= 0) {
     // When inside a range of folded lines, move to the first char of the
     // first line.
-    if (hasFolding(curwin->w_cursor.lnum, &curwin->w_cursor.lnum, NULL)) {
+    if (hasFolding(curwin, curwin->w_cursor.lnum, &curwin->w_cursor.lnum, NULL)) {
       curwin->w_cursor.col = 0;
     }
     sclass = cls();
@@ -431,8 +431,8 @@ int end_word(int count, bool bigword, bool stop, bool empty)
   while (--count >= 0) {
     // When inside a range of folded lines, move to the last char of the
     // last line.
-    if (hasFolding(curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum)) {
-      coladvance(MAXCOL);
+    if (hasFolding(curwin, curwin->w_cursor.lnum, NULL, &curwin->w_cursor.lnum)) {
+      coladvance(curwin, MAXCOL);
     }
     sclass = cls();
     if (inc_cursor() == -1) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -477,7 +477,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, bool r
     uhp->uh_entry = NULL;
     uhp->uh_getbot_entry = NULL;
     uhp->uh_cursor = curwin->w_cursor;          // save cursor pos. for undo
-    if (virtual_active() && curwin->w_cursor.coladd > 0) {
+    if (virtual_active(curwin) && curwin->w_cursor.coladd > 0) {
       uhp->uh_cursor_vcol = getviscol();
     } else {
       uhp->uh_cursor_vcol = -1;
@@ -2488,8 +2488,8 @@ static void u_undoredo(bool undo, bool do_buf_event)
   if (curwin->w_cursor.lnum <= curbuf->b_ml.ml_line_count) {
     if (curhead->uh_cursor.lnum == curwin->w_cursor.lnum) {
       curwin->w_cursor.col = curhead->uh_cursor.col;
-      if (virtual_active() && curhead->uh_cursor_vcol >= 0) {
-        coladvance(curhead->uh_cursor_vcol);
+      if (virtual_active(curwin) && curhead->uh_cursor_vcol >= 0) {
+        coladvance(curwin, curhead->uh_cursor_vcol);
       } else {
         curwin->w_cursor.coladd = 0;
       }
@@ -2506,7 +2506,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
   }
 
   // Make sure the cursor is on an existing line and column.
-  check_cursor();
+  check_cursor(curwin);
 
   // Remember where we are for "g-" and ":earlier 10s".
   curbuf->b_u_seq_cur = curhead->uh_seq;
@@ -3073,7 +3073,7 @@ void u_undoline(void)
   }
   curwin->w_cursor.col = t;
   curwin->w_cursor.lnum = curbuf->b_u_line_lnum;
-  check_cursor_col();
+  check_cursor_col(curwin);
 }
 
 /// Allocate memory and copy curbuf line into it.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -766,7 +766,7 @@ void win_set_buf(win_T *win, buf_T *buf, bool noautocmd, Error *err)
 
   // If window is not current, state logic will not validate its cursor. So do it now.
   // Still needed if do_buffer returns FAIL (e.g: autocmds abort script after buffer was set).
-  validate_cursor();
+  validate_cursor(curwin);
 
 cleanup:
   restore_win_noblock(&switchwin, true);
@@ -2872,7 +2872,7 @@ int win_close(win_T *win, bool free_buf, bool force)
 
     // The cursor position may be invalid if the buffer changed after last
     // using the window.
-    check_cursor();
+    check_cursor(curwin);
   }
 
   if (!was_floating) {
@@ -4921,8 +4921,8 @@ static void win_enter_ext(win_T *const wp, const int flags)
   curwin = wp;
   curbuf = wp->w_buffer;
 
-  check_cursor();
-  if (!virtual_active()) {
+  check_cursor(curwin);
+  if (!virtual_active(curwin)) {
     curwin->w_cursor.coladd = 0;
   }
   if (*p_spk == 'c') {
@@ -6638,7 +6638,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
       }
     } else if (sline > 0) {
       while (sline > 0 && lnum > 1) {
-        hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+        hasFolding(wp, lnum, &lnum, NULL);
         if (lnum == 1) {
           // first line in buffer is folded
           line_size = 1;
@@ -6658,7 +6658,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
       if (sline < 0) {
         // Line we want at top would go off top of screen.  Use next
         // line instead.
-        hasFoldingWin(wp, lnum, NULL, &lnum, true, NULL);
+        hasFolding(wp, lnum, NULL, &lnum);
         lnum++;
         wp->w_wrow -= line_size + sline;
       } else if (sline > 0) {
@@ -6699,7 +6699,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
       if (wp == curwin && *p_spk == 'c') {
         // w_wrow needs to be valid. When setting 'laststatus' this may
         // call win_new_height() recursively.
-        validate_cursor();
+        validate_cursor(curwin);
       }
       if (wp->w_height_inner != prev_height) {
         return;  // Recursive call already changed the size, bail out.

--- a/test/client/uv_stream.lua
+++ b/test/client/uv_stream.lua
@@ -136,7 +136,7 @@ function ChildProcessStream.spawn(argv, env, io_extra)
   end
   --- @diagnostic disable-next-line:missing-fields
   self._proc, self._pid = uv.spawn(prog, {
-    stdio = { self._child_stdin, self._child_stdout, 2, io_extra },
+    stdio = { self._child_stdin, self._child_stdout, 1, io_extra },
     args = args,
     --- @diagnostic disable-next-line:assign-type-mismatch
     env = env,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -121,6 +121,66 @@ describe('api/buf', function()
       eq({ 5, 2 }, api.nvim_win_get_cursor(win2))
     end)
 
+    it('cursor position is maintained consistently with viewport', function()
+      local screen = Screen.new(20, 12)
+      screen:set_default_attr_ids {
+        [1] = { bold = true, foreground = Screen.colors.Blue1 },
+        [2] = { reverse = true, bold = true },
+        [3] = { reverse = true },
+      }
+      screen:attach()
+
+      local lines = { 'line1', 'line2', 'line3', 'line4', 'line5', 'line6' }
+      local buf = api.nvim_get_current_buf()
+
+      api.nvim_buf_set_lines(buf, 0, -1, true, lines)
+
+      command('6')
+      command('new')
+      screen:expect {
+        grid = [[
+        ^                    |
+        {1:~                   }|*4
+        {2:[No Name]           }|
+        line5               |
+        line6               |
+        {1:~                   }|*2
+        {3:[No Name] [+]       }|
+                            |
+      ]],
+      }
+
+      api.nvim_buf_set_lines(buf, 0, -1, true, lines)
+      screen:expect {
+        grid = [[
+        ^                    |
+        {1:~                   }|*4
+        {2:[No Name]           }|
+        line3               |
+        line4               |
+        line5               |
+        line6               |
+        {3:[No Name] [+]       }|
+                            |
+      ]],
+      }
+
+      command('wincmd w')
+      screen:expect {
+        grid = [[
+                            |
+        {1:~                   }|*4
+        {3:[No Name]           }|
+        line3               |
+        line4               |
+        line5               |
+        ^line6               |
+        {2:[No Name] [+]       }|
+                            |
+      ]],
+      }
+    end)
+
     it('line_count has defined behaviour for unloaded buffers', function()
       -- we'll need to know our bufnr for when it gets unloaded
       local bufnr = api.nvim_buf_get_number(0)
@@ -323,20 +383,20 @@ describe('api/buf', function()
         ]],
         }
 
-        -- inserting just before topline scrolls up
         api.nvim_buf_set_lines(buf, 3, 3, true, { 'mmm' })
         screen:expect {
           grid = [[
           ^                    |
           {1:~                   }|*4
           {2:[No Name]           }|
-          mmm                 |
           wwweeee             |
           xxx                 |
           yyy                 |
+          zzz                 |
           {3:[No Name] [+]       }|
                               |
         ]],
+          unchanged = true,
         }
       end)
 
@@ -402,7 +462,6 @@ describe('api/buf', function()
         ]],
         }
 
-        -- inserting just before topline scrolls up
         api.nvim_buf_set_lines(buf, 3, 3, true, { 'mmm' })
         screen:expect {
           grid = [[
@@ -412,10 +471,10 @@ describe('api/buf', function()
           mmm                 |
           wwweeee             |
           {2:[No Name] [+]       }|
-          mmm                 |
           wwweeee             |
           xxx                 |
           yyy                 |
+          zzz                 |
           {3:[No Name] [+]       }|
                               |
         ]],

--- a/test/functional/lua/ffi_spec.lua
+++ b/test/functional/lua/ffi_spec.lua
@@ -13,15 +13,19 @@ describe('ffi.cdef', function()
 
     eq(
       12,
-      exec_lua [[
+      exec_lua [=[
       local ffi = require('ffi')
 
-      ffi.cdef('int curwin_col_off(void);')
+      ffi.cdef [[
+        typedef struct window_S win_T;
+        int win_col_off(win_T *wp);
+        extern win_T *curwin;
+      ]]
 
       vim.cmd('set number numberwidth=4 signcolumn=yes:4')
 
-      return ffi.C.curwin_col_off()
-    ]]
+      return ffi.C.win_col_off(ffi.C.curwin)
+    ]=]
     )
 
     eq(
@@ -30,7 +34,6 @@ describe('ffi.cdef', function()
       local ffi = require('ffi')
 
       ffi.cdef[[
-        typedef struct window_S win_T;
         typedef struct {} stl_hlrec_t;
         typedef struct {} StlClickRecord;
         typedef struct {} statuscol_T;


### PR DESCRIPTION
A lot of functions in move.c only worked for curwin, alternatively took a `wp` arg but still only work if that happens to be curwin.

Refactor those that are needed for update_topline(wp) to work for any window.

fixes #27723
fixes #27720