### PR TITLE
vim-patch:0049a495c8d4

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -270,6 +270,7 @@ created, thus they behave slightly differently:
 	Option		Reason	~
 	'previewwindow'	there can only be a single one
 	'scroll'	specific to existing window
+	'winfixbuf'	specific to existing window
 	'winfixheight'	specific to existing window
 	'winfixwidth'	specific to existing window
 
@@ -7175,11 +7176,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'winfixbuf'* *'wfb'* *'nowinfixbuf'* *'nowfb'*
 'winfixbuf' 'wfb'	boolean	(default off)
 			local to window
-	If enabled, the buffer and any window that displays it are paired.
+	If enabled, the window and the buffer it is displaying are paired.
 	For example, attempting to change the buffer with |:edit| will fail.
 	Other commands which change a window's buffer such as |:cnext| will
-	also skip any window with 'winfixbuf' enabled. However if a command
-	has an "!" option, a window can be forced to switch buffers.
+	also skip any window with 'winfixbuf' enabled.  However if an Ex
+	command has a "!" modifier, it can force switching buffers.
 
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
 'winfixheight' 'wfh'	boolean	(default off)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7876,11 +7876,11 @@ vim.o.wi = vim.o.window
 vim.go.window = vim.o.window
 vim.go.wi = vim.go.window
 
---- If enabled, the buffer and any window that displays it are paired.
+--- If enabled, the window and the buffer it is displaying are paired.
 --- For example, attempting to change the buffer with `:edit` will fail.
 --- Other commands which change a window's buffer such as `:cnext` will
---- also skip any window with 'winfixbuf' enabled. However if a command
---- has an "!" option, a window can be forced to switch buffers.
+--- also skip any window with 'winfixbuf' enabled.  However if an Ex
+--- command has a "!" modifier, it can force switching buffers.
 ---
 --- @type boolean
 vim.o.winfixbuf = false

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9822,11 +9822,11 @@ return {
       abbreviation = 'wfb',
       defaults = { if_true = false },
       desc = [=[
-        If enabled, the buffer and any window that displays it are paired.
+        If enabled, the window and the buffer it is displaying are paired.
         For example, attempting to change the buffer with |:edit| will fail.
         Other commands which change a window's buffer such as |:cnext| will
-        also skip any window with 'winfixbuf' enabled. However if a command
-        has an "!" option, a window can be forced to switch buffers.
+        also skip any window with 'winfixbuf' enabled.  However if an Ex
+        command has a "!" modifier, it can force switching buffers.
       ]=],
       full_name = 'winfixbuf',
       pv_name = 'p_wfb',


### PR DESCRIPTION
#### vim-patch:0049a495c8d4

runtime(doc): improve 'winfixbuf' docs (vim/vim#14180)

- Make it not sound like a buffer option.
- "!" is called a modifier, not an option.

https://github.com/vim/vim/commit/0049a495c8d4a597773587f622d8cc8573c2eb75