### PR TITLE
vim-patch:9.1.0166: Internal error with blockwise getregion() in another buffer

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2863,16 +2863,10 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  buf_T *const save_curbuf = curbuf;
-  buf_T *findbuf = curbuf;
-
-  if (fnum1 != 0) {
-    findbuf = buflist_findnr(fnum1);
-    // buffer not loaded
-    if (findbuf == NULL || findbuf->b_ml.ml_mfp == NULL) {
-      emsg(_(e_buffer_is_not_loaded));
-      return;
-    }
+  buf_T *findbuf = fnum1 != 0 ? buflist_findnr(fnum1) : curbuf;
+  if (findbuf == NULL || findbuf->b_ml.ml_mfp == NULL) {
+    emsg(_(e_buffer_is_not_loaded));
+    return;
   }
 
   if (p1.lnum < 1 || p1.lnum > findbuf->b_ml.ml_line_count) {
@@ -2892,7 +2886,9 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
+  buf_T *const save_curbuf = curbuf;
   curbuf = findbuf;
+  curwin->w_buffer = curbuf;
   const TriState save_virtual = virtual_op;
   virtual_op = virtual_active();
 
@@ -2975,10 +2971,8 @@ static void f_getregion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     tv_list_append_allocated_string(rettv->vval.v_list, akt);
   }
 
-  if (curbuf != save_curbuf) {
-    curbuf = save_curbuf;
-  }
-
+  curbuf = save_curbuf;
+  curwin->w_buffer = curbuf;
   virtual_op = save_virtual;
 }
 

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1772,11 +1772,11 @@ func Test_visual_getregion()
     for type in ['v', 'V', "\<C-V>"]
       for exclusive in [v:false, v:true]
         call assert_equal(range(10)->mapnew('string(v:val)'),
-              \ getregion([g:buf, 1, 1, 0], [g:buf, 10, 2, 0]),
-              \ {'type': type, 'exclusive': exclusive })
+              \ getregion([g:buf, 1, 1, 0], [g:buf, 10, 2, 0],
+              \ {'type': type, 'exclusive': exclusive }))
         call assert_equal(range(10)->mapnew('string(v:val)'),
-              \ getregion([g:buf, 10, 2, 0], [g:buf, 1, 1, 0]),
-              \ {'type': type, 'exclusive': exclusive })
+              \ getregion([g:buf, 10, 2, 0], [g:buf, 1, 1, 0],
+              \ {'type': type, 'exclusive': exclusive }))
       endfor
     endfor
 


### PR DESCRIPTION
#### vim-patch:9.1.0166: Internal error with blockwise getregion() in another buffer

Problem:  Internal error with blockwise getregion() in another buffer
Solution: Also change curwin->w_buffer when changing curbuf (zeertzjq)

closes: vim/vim#14179

https://github.com/vim/vim/commit/5406eb8722bddb6a04876956f9a53c1752994851