### PR TITLE
vim-patch:9.1.0167: Changing buffer in another window causes it to show matchparen

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -22,7 +22,8 @@ let s:has_matchaddpos = exists('*matchaddpos')
 
 augroup matchparen
   " Replace all matchparen autocommands
-  autocmd! CursorMoved,CursorMovedI,WinEnter,BufWinEnter,WinScrolled * call s:Highlight_Matching_Pair()
+  autocmd! CursorMoved,CursorMovedI,WinEnter,WinScrolled * call s:Highlight_Matching_Pair()
+  autocmd! BufWinEnter * autocmd SafeState * ++once call s:Highlight_Matching_Pair()
   autocmd! WinLeave,BufLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()

--- a/test/old/testdir/test_matchparen.vim
+++ b/test/old/testdir/test_matchparen.vim
@@ -61,6 +61,31 @@ func Test_matchparen_clear_highlight()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for matchparen highlight when switching buffer in win_execute()
+func Test_matchparen_win_execute()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    let s:win = win_getid()
+    call setline(1, '{}')
+    split
+
+    func SwitchBuf()
+      call win_execute(s:win, 'enew | buffer #')
+    endfunc
+  END
+  call writefile(lines, 'XMatchparenWinExecute', 'D')
+  let buf = RunVimInTerminal('-S XMatchparenWinExecute', #{rows: 5})
+  call VerifyScreenDump(buf, 'Test_matchparen_win_execute_1', {})
+
+  " Switching buffer away and back shouldn't change matchparen highlight.
+  call term_sendkeys(buf, ":call SwitchBuf()\<CR>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_win_execute_1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test for scrolling that modifies buffer during visual block
 func Test_matchparen_pum_clear()
   CheckScreendump


### PR DESCRIPTION
Fix #25099

#### vim-patch:9.1.0167: Changing buffer in another window causes it to show matchparen

Problem:  Changing buffer in another window using win_execute() causes
          it to show matchparen (after 9.0.0969).
Solution: Delay highlighting with SafeState in BufWinEnter.
          (zeertzjq)

closes: vim/vim#14177

https://github.com/vim/vim/commit/49ffb6b428e1e053446ec0209558a8f9d0963ae7