### PR TITLE
vim-patch:8.2.4944: text properties are wrong after "cc"

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1935,19 +1935,16 @@ theend:
 /// If "fixpos" is true fix the cursor position when done.
 void truncate_line(int fixpos)
 {
-  char *newp;
   linenr_T lnum = curwin->w_cursor.lnum;
   colnr_T col = curwin->w_cursor.col;
+  char *old_line = ml_get(lnum);
+  char *newp = col == 0 ? xstrdup("") : xstrnsave(old_line, (size_t)col);
+  int deleted = (int)strlen(old_line) - col;
 
-  if (col == 0) {
-    newp = xstrdup("");
-  } else {
-    newp = xstrnsave(ml_get(lnum), (size_t)col);
-  }
   ml_replace(lnum, newp, false);
 
   // mark the buffer as changed and prepare for displaying
-  changed_bytes(lnum, curwin->w_cursor.col);
+  inserted_bytes(lnum, curwin->w_cursor.col, deleted, 0);
 
   // If "fixpos" is true we don't want to end up positioned at the NUL.
   if (fixpos && curwin->w_cursor.col > 0) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1613,15 +1613,8 @@ int op_delete(oparg_T *oap)
       } else {
         beginline(0);                       // cursor in column 0
       }
-
-      int old_len = (int)strlen(ml_get(curwin->w_cursor.lnum));
-      truncate_line(false);         // delete the rest of the line
-
-      extmark_splice_cols(curbuf,
-                          (int)curwin->w_cursor.lnum - 1, curwin->w_cursor.col,
-                          old_len - curwin->w_cursor.col, 0, kExtmarkUndo);
-
-      // leave cursor past last char in line
+      truncate_line(false);         // delete the rest of the line,
+                                    // leave cursor past last char in line
       if (oap->line_count > 1) {
         u_clearline(curbuf);  // "U" command not possible after "2cc"
       }

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -541,7 +541,7 @@ describe('lua: nvim_buf_attach on_bytes', function()
 
       feed 'cc'
       check_events {
-        { 'test1', 'bytes', 1, 4, 0, 0, 0, 0, 15, 15, 0, 0, 0 },
+        { 'test1', 'bytes', 1, 3, 0, 0, 0, 0, 15, 15, 0, 0, 0 },
       }
 
       feed '<ESC>'


### PR DESCRIPTION
#### vim-patch:8.2.4944: text properties are wrong after "cc"

Problem:    Text properties are wrong after "cc". (Axel Forsman)
Solution:   Pass the deleted byte count to inserted_bytes(). (closes vim/vim#10412)

https://github.com/vim/vim/commit/d0b1a09f44654bb5e29b09de1311845200f17d90

Co-authored-by: LemonBoy <thatlemon@gmail.com>