### PR TITLE
fix: move fswatch linux check inside of vim.schedule

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -289,10 +289,11 @@ function M.fswatch(path, opts, callback)
       end
 
       if data and #vim.trim(data) > 0 then
-        if vim.fn.has('linux') == 1 and vim.startswith(data, 'Event queue overflow') then
-          data = 'inotify(7) limit reached, see :h fswatch-limitations for more info.'
-        end
         vim.schedule(function()
+          if vim.fn.has('linux') == 1 and vim.startswith(data, 'Event queue overflow') then
+            data = 'inotify(7) limit reached, see :h fswatch-limitations for more info.'
+          end
+
           vim.notify('fswatch: ' .. data, vim.log.levels.ERROR)
         end)
       end


### PR DESCRIPTION
Fixes issue reported in the original PR:
https://github.com/neovim/neovim/pull/27810