### PR TITLE
refactor: quadratic behavior in backslash_halve()

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1457,10 +1457,23 @@ bool rem_backslash(const char *str)
 /// @param p
 void backslash_halve(char *p)
 {
-  for (; *p; p++) {
-    if (rem_backslash(p)) {
-      STRMOVE(p, p + 1);
+  for (; *p && !rem_backslash(p); p++) {}
+  if (*p != NUL) {
+    char *dst = p;
+    goto start;
+    for (;;) {
+      if (rem_backslash(p)) {
+start:
+        *dst++ = *(p + 1);
+        p += 2;
+      } else {
+        *dst++ = *p++;
+        if (*p == NUL) {
+          break;
+        }
+      }
     }
+    *dst = '\0';
   }
 }
 
@@ -1472,8 +1485,19 @@ void backslash_halve(char *p)
 char *backslash_halve_save(const char *p)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
-  // TODO(philix): simplify and improve backslash_halve_save algorithm
-  char *res = xstrdup(p);
-  backslash_halve(res);
+  char *res = xmalloc(strlen(p) + 1);
+  char *dst = res;
+  for (;;) {
+    if (rem_backslash(p)) {
+      *dst++ = *(p + 1);
+      p += 2;
+    } else {
+      *dst++ = *p++;
+      if (*p == NUL) {
+        break;
+      }
+    }
+  }
+  *dst = '\0';
   return res;
 }

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1466,11 +1466,10 @@ void backslash_halve(char *p)
 start:
         *dst++ = *(p + 1);
         p += 2;
+      } else if (*p == NUL) {
+        break;
       } else {
         *dst++ = *p++;
-        if (*p == NUL) {
-          break;
-        }
       }
     }
     *dst = '\0';
@@ -1491,11 +1490,10 @@ char *backslash_halve_save(const char *p)
     if (rem_backslash(p)) {
       *dst++ = *(p + 1);
       p += 2;
+    } else if (*p == NUL) {
+      break;
     } else {
       *dst++ = *p++;
-      if (*p == NUL) {
-        break;
-      }
     }
   }
   *dst = '\0';

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1461,13 +1461,11 @@ void backslash_halve(char *p)
   if (*p != NUL) {
     char *dst = p;
     goto start;
-    for (;;) {
+    while (*p != NUL) {
       if (rem_backslash(p)) {
 start:
         *dst++ = *(p + 1);
         p += 2;
-      } else if (*p == NUL) {
-        break;
       } else {
         *dst++ = *p++;
       }
@@ -1486,12 +1484,10 @@ char *backslash_halve_save(const char *p)
 {
   char *res = xmalloc(strlen(p) + 1);
   char *dst = res;
-  for (;;) {
+  while (*p != NUL) {
     if (rem_backslash(p)) {
       *dst++ = *(p + 1);
       p += 2;
-    } else if (*p == NUL) {
-      break;
     } else {
       *dst++ = *p++;
     }


### PR DESCRIPTION
The current implementation has a worst-case of O(n^2). Every time rem_backslash() is true, it calculates the length of the rest of the string, and shift the rest of it to the left. backslash_halve_save() copies the original string before doing backslash_halve().

The new implementation is O(n). It will find the first character where rem_backslash() is true (it will do nothing if it's always false), and shift the characters in-place. backslash_halve_save() avoids unnecessarily copying the original string before doing backslash_halve().