### PR TITLE
refactor: add vim_str[n]cpy_up and use them in vim_str[n]save_up

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1149,7 +1149,8 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         error = true;
         break;
       }
-      vim_strcpy_up(key, key_start);
+      vim_memcpy_up(key, key_start, key_len);
+      key[key_len] = '\0';
       linep = skipwhite(linep);
 
       if (strcmp(key, "NONE") == 0) {
@@ -1941,7 +1942,8 @@ int syn_name2id_len(const char *name, size_t len)
 
   // Avoid using stricmp() too much, it's slow on some systems */
   // Avoid alloc()/free(), these are slow too.
-  vim_strcpy_up(name_u, name);
+  vim_memcpy_up(name_u, name, len);
+  name_u[len] = '\0';
 
   // map_get(..., int) returns 0 when no key is present, which is
   // the expected value for missing highlight group.

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1149,9 +1149,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         error = true;
         break;
       }
-      memcpy(key, key_start, key_len);
-      key[key_len] = NUL;
-      vim_strup(key);
+      vim_strcpy_up(key, key_start);
       linep = skipwhite(linep);
 
       if (strcmp(key, "NONE") == 0) {
@@ -1943,9 +1941,7 @@ int syn_name2id_len(const char *name, size_t len)
 
   // Avoid using stricmp() too much, it's slow on some systems */
   // Avoid alloc()/free(), these are slow too.
-  memcpy(name_u, name, len);
-  name_u[len] = '\0';
-  vim_strup(name_u);
+  vim_strcpy_up(name_u, name);
 
   // map_get(..., int) returns 0 when no key is present, which is
   // the expected value for missing highlight group.

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -346,6 +346,18 @@ void vim_strncpy_up(char *restrict dst, const char *restrict src, size_t n)
   *dst = '\0';
 }
 
+// memcpy (does not NUL-terminate) plus vim_strup.
+void vim_memcpy_up(char *restrict dst, const char *restrict src, size_t n)
+  FUNC_ATTR_NONNULL_ALL
+{
+  uint8_t c;
+  while (n--) {
+    c = (uint8_t)(*src++);
+    *dst++ = (char)(uint8_t)(c < 'a' || c > 'z' ? c : c - 0x20);
+  }
+  *dst = '\0';
+}
+
 /// Make given string all upper-case or all lower-case
 ///
 /// Handles multi-byte characters as good as possible.

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -299,8 +299,8 @@ char *vim_strsave_shellescape(const char *string, bool do_special, bool do_newli
 char *vim_strsave_up(const char *string)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
-  char *p1 = xstrdup(string);
-  vim_strup(p1);
+  char *p1 = xmalloc(strlen(string) + 1);
+  vim_strcpy_up(p1, string);
   return p1;
 }
 
@@ -309,8 +309,8 @@ char *vim_strsave_up(const char *string)
 char *vim_strnsave_up(const char *string, size_t len)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_MALLOC FUNC_ATTR_NONNULL_ALL
 {
-  char *p1 = xstrnsave(string, len);
-  vim_strup(p1);
+  char *p1 = xmalloc(len + 1);
+  vim_strncpy_up(p1, string, len);
   return p1;
 }
 
@@ -322,6 +322,28 @@ void vim_strup(char *p)
   while ((c = (uint8_t)(*p)) != NUL) {
     *p++ = (char)(uint8_t)(c < 'a' || c > 'z' ? c : c - 0x20);
   }
+}
+
+// strcpy plus vim_strup.
+void vim_strcpy_up(char *restrict dst, const char *restrict src)
+  FUNC_ATTR_NONNULL_ALL
+{
+  uint8_t c;
+  while ((c = (uint8_t)(*src++)) != NUL) {
+    *dst++ = (char)(uint8_t)(c < 'a' || c > 'z' ? c : c - 0x20);
+  }
+  *dst = '\0';
+}
+
+// strncpy (NUL-terminated) plus vim_strup.
+void vim_strncpy_up(char *restrict dst, const char *restrict src, size_t n)
+  FUNC_ATTR_NONNULL_ALL
+{
+  uint8_t c;
+  while (n-- && (c = (uint8_t)(*src++)) != NUL) {
+    *dst++ = (char)(uint8_t)(c < 'a' || c > 'z' ? c : c - 0x20);
+  }
+  *dst = '\0';
 }
 
 /// Make given string all upper-case or all lower-case

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -355,7 +355,6 @@ void vim_memcpy_up(char *restrict dst, const char *restrict src, size_t n)
     c = (uint8_t)(*src++);
     *dst++ = (char)(uint8_t)(c < 'a' || c > 'z' ? c : c - 0x20);
   }
-  *dst = '\0';
 }
 
 /// Make given string all upper-case or all lower-case


### PR DESCRIPTION
Current uses of vim_strup() calls memcpy()/strcpy() before calling vim_strup(). This results in 2 * strlen(string) operations.

We can trivially convert to lowercase while copying the string instead.