### PR TITLE
fix(treesitter): use 0 as initial value for computing maximum

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -270,7 +270,7 @@ local function on_line_impl(self, buf, line, is_spell_nav)
         :iter_matches(root_node, self.bufnr, line, root_end_row + 1, { all = true })
     end
 
-    local max_pattern_index = -1
+    local max_pattern_index = 0
     while line >= state.next_row do
       local pattern, match, metadata = state.iter()
 


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/27835

Using -1 as the initial value can cause the pattern offset to become negative, which in turn results in a negative subpriority, which fails validation in nvim_buf_set_extmark.
