### PR TITLE
fix(treesitter): highlight injections properly

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -252,6 +252,44 @@ function TSHighlighter:get_query(lang)
   return self._queries[lang]
 end
 
+--- @param match table<integer,TSNode[]>
+--- @param bufnr integer
+--- @param capture integer
+--- @param metadata vim.treesitter.query.TSMetadata
+--- @return string?
+local function get_url(match, bufnr, capture, metadata)
+  ---@type string|number|nil
+  local url = metadata[capture] and metadata[capture].url
+
+  if not url or type(url) == 'string' then
+    return url
+  end
+
+  if not match or not match[url] then
+    return
+  end
+
+  -- Assume there is only one matching node. If there is more than one, take the URL
+  -- from the first.
+  local other_node = match[url][1]
+
+  return vim.treesitter.get_node_text(other_node, bufnr, {
+    metadata = metadata[url],
+  })
+end
+
+--- @param capture_name string
+--- @return boolean?, integer
+local function get_spell(capture_name)
+  if capture_name == 'spell' then
+    return true, 0
+  elseif capture_name == 'nospell' then
+    -- Give nospell a higher priority so it always overrides spell captures.
+    return false, 1
+  end
+  return nil, 0
+end
+
 ---@param self vim.treesitter.highlighter
 ---@param buf integer
 ---@param line integer
@@ -284,17 +322,9 @@ local function on_line_impl(self, buf, line, is_spell_nav)
 
       for capture, nodes in pairs(match or {}) do
         local capture_name = state.highlighter_query:query().captures[capture]
-        local spell = nil ---@type boolean?
-        if capture_name == 'spell' then
-          spell = true
-        elseif capture_name == 'nospell' then
-          spell = false
-        end
+        local spell, spell_pri_offset = get_spell(capture_name)
 
         local hl = state.highlighter_query:get_hl_from_capture(capture)
-
-        -- Give nospell a higher priority so it always overrides spell captures.
-        local spell_pri_offset = capture_name == 'nospell' and 1 or 0
 
         -- The "priority" attribute can be set at the pattern level or on a particular capture
         local priority = (
@@ -302,19 +332,7 @@ local function on_line_impl(self, buf, line, is_spell_nav)
           or vim.highlight.priorities.treesitter
         ) + spell_pri_offset
 
-        local url = metadata[capture] and metadata[capture].url ---@type string|number|nil
-        if type(url) == 'number' then
-          if match and match[url] then
-            -- Assume there is only one matching node. If there is more than one, take the URL
-            -- from the first.
-            local other_node = match[url][1]
-            url = vim.treesitter.get_node_text(other_node, buf, {
-              metadata = metadata[url],
-            })
-          else
-            url = nil
-          end
-        end
+        local url = get_url(match, buf, capture, metadata)
 
         -- The "conceal" attribute can be set at the pattern level or on a particular capture
         local conceal = metadata.conceal or metadata[capture] and metadata[capture].conceal

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -867,6 +867,40 @@ describe('treesitter highlighting (help)', function()
     ]],
     }
   end)
+
+  it('correctly redraws injections subpriorities', function()
+    -- The top level string node will be highlighted first
+    -- with an extmark spanning multiple lines.
+    -- When the next line is drawn, which includes an injection,
+    -- make sure the highlight appears above the base tree highlight
+
+    insert([=[
+    local s = [[
+      local also = lua
+    ]]
+    ]=])
+
+    exec_lua [[
+      parser = vim.treesitter.get_parser(0, "lua", {
+        injections = {
+          lua = '(string content: (_) @injection.content (#set! injection.language lua))'
+        }
+      })
+
+      vim.treesitter.highlighter.new(parser)
+    ]]
+
+    screen:expect {
+      grid = [=[
+      {3:local} {4:s} {3:=} {5:[[}                            |
+      {5:  }{3:local}{5: }{4:also}{5: }{3:=}{5: }{4:lua}                      |
+      {5:]]}                                      |
+      ^                                        |
+      {2:~                                       }|
+                                              |
+    ]=],
+    }
+  end)
 end)
 
 describe('treesitter highlighting (nested injections)', function()


### PR DESCRIPTION
`on_line_impl` doesn't highlight single lines, so using pattern indexes to offset priority doesn't work on its own. Need to also use the injection level.