### PR TITLE
vim-patch:9.1.0175: wrong window positions with 'winfix{width,height}'

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8898,8 +8898,7 @@ win_screenpos({nr})                                            *win_screenpos()*
 		[1, 1], unless there is a tabline, then it is [2, 1].
 		{nr} can be the window number or the |window-ID|.  Use zero
 		for the current window.
-		Returns [0, 0] if the window cannot be found in the current
-		tabpage.
+		Returns [0, 0] if the window cannot be found.
 
 win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 		Temporarily switch to window {target}, then move window {nr}

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10592,8 +10592,7 @@ function vim.fn.win_move_statusline(nr, offset) end
 --- [1, 1], unless there is a tabline, then it is [2, 1].
 --- {nr} can be the window number or the |window-ID|.  Use zero
 --- for the current window.
---- Returns [0, 0] if the window cannot be found in the current
---- tabpage.
+--- Returns [0, 0] if the window cannot be found.
 ---
 --- @param nr integer
 --- @return any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -12688,9 +12688,7 @@ M.funcs = {
       [1, 1], unless there is a tabline, then it is [2, 1].
       {nr} can be the window number or the |window-ID|.  Use zero
       for the current window.
-      Returns [0, 0] if the window cannot be found in the current
-      tabpage.
-
+      Returns [0, 0] if the window cannot be found.
     ]=],
     name = 'win_screenpos',
     params = { { 'nr', 'integer' } },


### PR DESCRIPTION
Problem:  winframe functions incorrectly recompute window positions if
          the altframe wasn't adjacent to the closed frame, which is
          possible if adjacent windows had 'winfix{width,height}' set.

Solution: recompute for windows within the parent of the altframe and
          closed frame. Skip this (as before) if the altframe was
          top/left, but only if adjacent to the closed frame, as
          positions won't change in that case. Also correct the return
          value documentation for win_screenpos. (Sean Dewar)

<details><summary>blah blah blah</summary>
The issue revealed itself after removing the win_comp_pos call below winframe_restore in win_splitmove. Similarly, wrong positions could result from windows closed in other tabpages, as win_free_mem uses winframe_remove (at least until it is entered later, where enter_tabpage calls win_comp_pos).

NOTE: As win_comp_pos handles only curtab, it's possible via other means for positions in non-current tabpages to be wrong (e.g: after changing 'laststatus', 'showtabline', etc.). Given enter_tabpage recomputes it, maybe it's intentional as an optimization? Should probably be documented in win_screenpos then, but I won't address that here.
</details>

Nvim: don't reuse "wp" for "topleft" in winframe_remove, so the change integrates better with the call to winframe_find_altwin before it.

https://github.com/vim/vim/commit/5866bc3a0f54115d5982fdc09bdbe4c45069265a