### PR TITLE
vim-patch:9.1.0178: E1513 might be confusing

### DIFF
--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -115,7 +115,7 @@ You cannot have two buffers with exactly the same name.  This includes the
 path leading to the file.
 
 							*E1513* >
-  Cannot edit buffer. 'winfixbuf' is enabled
+  Cannot switch buffer. 'winfixbuf' is enabled
 
 If a window has 'winfixbuf' enabled, you cannot change that window's current
 buffer. You need to set 'nowinfixbuf' before continuing. You may use [!] to

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -972,7 +972,7 @@ EXTERN const char e_undobang_cannot_redo_or_move_branch[]
 INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
 
 EXTERN const char e_winfixbuf_cannot_go_to_buffer[]
-INIT(= N_("E1513: Cannot edit buffer. 'winfixbuf' is enabled"));
+INIT(= N_("E1513: Cannot switch buffer. 'winfixbuf' is enabled"));
 
 EXTERN const char e_trustfile[] INIT(= N_("E5570: Cannot update trust file: %s"));
 

--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -493,7 +493,7 @@ func Test_browse_edit_fail()
   try
     browse edit! other
     call assert_equal(l:other, bufnr())
-  catch /E338:/
+  catch /^Vim\%((\a\+)\)\=:E338:/
     " Ignore E338, which occurs if console Vim is built with +browse.
     " Console Vim without +browse will treat this as a regular :edit.
   endtry
@@ -511,7 +511,7 @@ func Test_browse_edit_pass()
 
   try
     browse write other
-  catch /E338:/
+  catch /^Vim\%((\a\+)\)\=:E338:/
     " Ignore E338, which occurs if console Vim is built with +browse.
     " Console Vim without +browse will treat this as a regular :write.
   endtry
@@ -2532,7 +2532,7 @@ EOF
 
   try
     pyxdo test_winfixbuf_Test_pythonx_pyxdo_set_buffer()
-  catch /pynvim\.api\.common\.NvimError: E1513: Cannot edit buffer\. 'winfixbuf' is enabled/
+  catch /pynvim\.api\.common\.NvimError: E1513:/
     let l:caught = 1
   endtry
 
@@ -2563,7 +2563,7 @@ func Test_pythonx_pyxfile()
 
   try
     pyxfile file.py
-  catch /pynvim\.api\.common\.NvimError: E1513: Cannot edit buffer\. 'winfixbuf' is enabled/
+  catch /pynvim\.api\.common\.NvimError: E1513:/
     let l:caught = 1
   endtry
 
@@ -2596,7 +2596,7 @@ import vim
 buffer = vim.vars["_previous_buffer"]
 vim.current.buffer = vim.buffers[buffer]
 EOF
-  catch /pynvim\.api\.common\.NvimError: E1513: Cannot edit buffer\. 'winfixbuf' is enabled/
+  catch /pynvim\.api\.common\.NvimError: E1513:/
     let l:caught = 1
   endtry
 


### PR DESCRIPTION
#### vim-patch:9.1.0178: E1513 might be confusing

Problem:  E1513 might be confusing
          (Christoph Thoma)
Solution: reword error message, fix test to not
          depend on the actual message

fixes: vim/vim#14189

https://github.com/vim/vim/commit/0a32b8854b52381fd17a6fcc5e38a3b9e77c8923

Co-authored-by: Christian Brabandt <cb@256bit.org>