### PR TITLE
vim-patch:9.1.{0174,0176}: conceal fixes

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2451,11 +2451,17 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
     // In the cursor line and we may be concealing characters: correct
     // the cursor column when we reach its position.
+    // With 'virtualedit' we may never reach cursor position, but we still
+    // need to correct the cursor column, so do that at end of line.
     if (!did_wcol
         && wp == curwin && lnum == wp->w_cursor.lnum
         && conceal_cursor_line(wp)
-        && (int)wp->w_virtcol <= wlv.vcol + wlv.skip_cells) {
+        && (wlv.vcol + wlv.skip_cells >= wp->w_virtcol || mb_schar == NUL)) {
       wp->w_wcol = wlv.col - wlv.boguscols;
+      if (wlv.vcol + wlv.skip_cells < wp->w_virtcol) {
+        // Cursor beyond end of the line with 'virtualedit'.
+        wp->w_wcol += wp->w_virtcol - wlv.vcol - wlv.skip_cells;
+      }
       wp->w_wrow = wlv.row;
       did_wcol = true;
       wp->w_valid |= VALID_WCOL|VALID_WROW|VALID_VIRTCOL;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2851,6 +2851,19 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
                         && !wp->w_p_rl;               // Not right-to-left.
 
       int draw_col = wlv.col - wlv.boguscols;
+
+      // Apply 'cursorline' highlight.
+      if (wlv.boguscols != 0 && (wlv.line_attr_lowprio != 0 || wlv.line_attr != 0)) {
+        int attr = hl_combine_attr(wlv.line_attr_lowprio, wlv.line_attr);
+        while (draw_col < grid->cols) {
+          linebuf_char[wlv.off] = schar_from_char(' ');
+          linebuf_attr[wlv.off] = attr;
+          linebuf_vcol[wlv.off] = MAXCOL;  // TODO(zeertzjq): this is wrong
+          wlv.off++;
+          draw_col++;
+        }
+      }
+
       if (virt_line_offset >= 0) {
         draw_virt_text_item(buf, virt_line_offset, kv_A(virt_lines, virt_line_index).line,
                             kHlModeReplace, grid->cols, 0);

--- a/test/functional/legacy/conceal_spec.lua
+++ b/test/functional/legacy/conceal_spec.lua
@@ -433,6 +433,68 @@ describe('Conceal', function()
     ]])
   end)
 
+  -- oldtest: Test_conceal_wrapped_cursorline_wincolor()
+  it('CursorLine highlight on wrapped lines', function()
+    local screen = Screen.new(40, 4)
+    screen:set_default_attr_ids({
+      [0] = { bold = true, foreground = Screen.colors.Blue }, -- NonText
+      [1] = { background = Screen.colors.Green }, -- CursorLine (low-priority)
+      [2] = { foreground = Screen.colors.Red }, -- CursorLine (high-priority)
+    })
+    screen:attach()
+    exec([[
+      call setline(1, 'one one one |hidden| one one one one one one one one')
+      syntax match test /|hidden|/ conceal
+      set conceallevel=2 concealcursor=n cursorline
+      normal! g$
+      hi! CursorLine guibg=Green
+    ]])
+    screen:expect([[
+      {1:one one one  one one one one on^e        }|
+      {1: one one one                            }|
+      {0:~                                       }|
+                                              |
+    ]])
+    command('hi! CursorLine guibg=NONE guifg=Red')
+    screen:expect([[
+      {2:one one one  one one one one on^e        }|
+      {2: one one one                            }|
+      {0:~                                       }|
+                                              |
+    ]])
+  end)
+
+  -- oldtest: Test_conceal_wrapped_cursorline_wincolor_rightleft()
+  it('CursorLine highlight on wrapped lines with rightleft', function()
+    local screen = Screen.new(40, 4)
+    screen:set_default_attr_ids({
+      [0] = { bold = true, foreground = Screen.colors.Blue }, -- NonText
+      [1] = { background = Screen.colors.Green }, -- CursorLine (low-priority)
+      [2] = { foreground = Screen.colors.Red }, -- CursorLine (high-priority)
+    })
+    screen:attach()
+    exec([[
+      call setline(1, 'one one one |hidden| one one one one one one one one')
+      syntax match test /|hidden|/ conceal
+      set conceallevel=2 concealcursor=n cursorline rightleft
+      normal! g$
+      hi! CursorLine guibg=Green
+    ]])
+    screen:expect([[
+      {1:        ^eno eno eno eno eno  eno eno eno}|
+      {1:                            eno eno eno }|
+      {0:                                       ~}|
+                                              |
+    ]])
+    command('hi! CursorLine guibg=NONE guifg=Red')
+    screen:expect([[
+      {2:        ^eno eno eno eno eno  eno eno eno}|
+      {2:                            eno eno eno }|
+      {0:                                       ~}|
+                                              |
+    ]])
+  end)
+
   -- oldtest: Test_conceal_resize_term()
   it('resize editor', function()
     local screen = Screen.new(75, 6)

--- a/test/functional/legacy/conceal_spec.lua
+++ b/test/functional/legacy/conceal_spec.lua
@@ -632,4 +632,92 @@ describe('Conceal', function()
     feed('$')
     expect_pos(9, 26)
   end)
+
+  -- oldtest: Test_conceal_virtualedit_after_eol()
+  it('cursor drawn at correct column with virtualedit', function()
+    local screen = Screen.new(75, 3)
+    screen:set_default_attr_ids({
+      [0] = { bold = true, foreground = Screen.colors.Blue }, -- NonText
+    })
+    screen:attach()
+    exec([[
+      call setline(1, 'abcdefgh|hidden|ijklmnpop')
+      syntax match test /|hidden|/ conceal
+      set conceallevel=2 concealcursor=n virtualedit=all
+      normal! $
+    ]])
+    screen:expect([[
+      abcdefghijklmnpo^p                                                          |
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+    feed('l')
+    screen:expect([[
+      abcdefghijklmnpop^                                                          |
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+    feed('l')
+    screen:expect([[
+      abcdefghijklmnpop ^                                                         |
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+    feed('l')
+    screen:expect([[
+      abcdefghijklmnpop  ^                                                        |
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+    feed('rr')
+    screen:expect([[
+      abcdefghijklmnpop  ^r                                                       |
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+  end)
+
+  -- oldtest: Test_conceal_virtualedit_after_eol_rightleft()
+  it('cursor drawn correctly with virtualedit and rightleft', function()
+    local screen = Screen.new(75, 3)
+    screen:set_default_attr_ids({
+      [0] = { bold = true, foreground = Screen.colors.Blue }, -- NonText
+    })
+    screen:attach()
+    exec([[
+      call setline(1, 'abcdefgh|hidden|ijklmnpop')
+      syntax match test /|hidden|/ conceal
+      set conceallevel=2 concealcursor=n virtualedit=all rightleft
+      normal! $
+    ]])
+    screen:expect([[
+                                                                ^popnmlkjihgfedcba|
+      {0:                                                                          ~}|
+                                                                                 |
+    ]])
+    feed('h')
+    screen:expect([[
+                                                               ^ popnmlkjihgfedcba|
+      {0:                                                                          ~}|
+                                                                                 |
+    ]])
+    feed('h')
+    screen:expect([[
+                                                              ^  popnmlkjihgfedcba|
+      {0:                                                                          ~}|
+                                                                                 |
+    ]])
+    feed('h')
+    screen:expect([[
+                                                             ^   popnmlkjihgfedcba|
+      {0:                                                                          ~}|
+                                                                                 |
+    ]])
+    feed('rr')
+    screen:expect([[
+                                                             ^r  popnmlkjihgfedcba|
+      {0:                                                                          ~}|
+                                                                                 |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -460,4 +460,58 @@ func Test_conceal_mouse_click()
   set mouse& virtualedit&
 endfunc
 
+" Test that cursor is drawn at the correct column when it is after end of the
+" line with 'virtualedit' and concealing.
+func Test_conceal_virtualedit_after_eol()
+  CheckScreendump
+
+  let code =<< trim [CODE]
+    call setline(1, 'abcdefgh|hidden|ijklmnpop')
+    syntax match test /|hidden|/ conceal
+    set conceallevel=2 concealcursor=n virtualedit=all
+    normal! $
+  [CODE]
+  call writefile(code, 'XTest_conceal_ve_after_eol', 'D')
+  let buf = RunVimInTerminal('-S XTest_conceal_ve_after_eol', {'rows': 3})
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_1', {})
+  call term_sendkeys(buf, "l")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_2', {})
+  call term_sendkeys(buf, "l")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_3', {})
+  call term_sendkeys(buf, "l")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_4', {})
+  call term_sendkeys(buf, "rr")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_5', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
+" Same as Test_conceal_virtualedit_after_eol(), but with 'rightleft' set.
+func Test_conceal_virtualedit_after_eol_rightleft()
+  CheckFeature rightleft
+  CheckScreendump
+
+  let code =<< trim [CODE]
+    call setline(1, 'abcdefgh|hidden|ijklmnpop')
+    syntax match test /|hidden|/ conceal
+    set conceallevel=2 concealcursor=n virtualedit=all rightleft
+    normal! $
+  [CODE]
+  call writefile(code, 'XTest_conceal_ve_after_eol_rl', 'D')
+  let buf = RunVimInTerminal('-S XTest_conceal_ve_after_eol_rl', {'rows': 3})
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_rl_1', {})
+  call term_sendkeys(buf, "h")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_rl_2', {})
+  call term_sendkeys(buf, "h")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_rl_3', {})
+  call term_sendkeys(buf, "h")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_rl_4', {})
+  call term_sendkeys(buf, "rr")
+  call VerifyScreenDump(buf, 'Test_conceal_ve_after_eol_rl_5', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -169,6 +169,57 @@ func Test_conceal_with_cursorcolumn()
   call StopVimInTerminal(buf)
 endfunc
 
+" Check that 'cursorline' and 'wincolor' apply to the whole line in presence
+" of wrapped lines containing concealed text.
+func Test_conceal_wrapped_cursorline_wincolor()
+  CheckScreendump
+
+  let code =<< trim [CODE]
+    call setline(1, 'one one one |hidden| one one one one one one one one')
+    syntax match test /|hidden|/ conceal
+    set conceallevel=2 concealcursor=n cursorline
+    normal! g$
+  [CODE]
+
+  call writefile(code, 'XTest_conceal_cul_wcr', 'D')
+  let buf = RunVimInTerminal('-S XTest_conceal_cul_wcr', {'rows': 4, 'cols': 40})
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_01', {})
+
+  call term_sendkeys(buf, ":set wincolor=ErrorMsg\n")
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_02', {})
+
+  call term_sendkeys(buf, ":set nocursorline\n")
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_03', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
+" Same as Test_conceal_wrapped_cursorline_wincolor(), but with 'rightleft'.
+func Test_conceal_wrapped_cursorline_wincolor_rightleft()
+  CheckScreendump
+
+  let code =<< trim [CODE]
+    call setline(1, 'one one one |hidden| one one one one one one one one')
+    syntax match test /|hidden|/ conceal
+    set conceallevel=2 concealcursor=n cursorline rightleft
+    normal! g$
+  [CODE]
+
+  call writefile(code, 'XTest_conceal_cul_wcr_rl', 'D')
+  let buf = RunVimInTerminal('-S XTest_conceal_cul_wcr_rl', {'rows': 4, 'cols': 40})
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_rl_01', {})
+
+  call term_sendkeys(buf, ":set wincolor=ErrorMsg\n")
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_rl_02', {})
+
+  call term_sendkeys(buf, ":set nocursorline\n")
+  call VerifyScreenDump(buf, 'Test_conceal_cul_wcr_rl_03', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_conceal_resize_term()
   CheckScreendump
 


### PR DESCRIPTION
#### vim-patch:9.1.0174: 'cursorline' and 'wincolor' hl missing with conceal and wrap

Problem:  'cursorline' and 'wincolor' highlight missing with concealed and
          wrapped lines.
Solution: Apply 'cursorline' and 'wincolor' highlight to boguscols.
          (zeertzjq)

Since 'cursorline' and 'wincolor' highlight apply after the end of the
line, it is more consistent to have them also apply to boguscols.

Assigning MAXCOL to values in ScreenCols[] make mouse click behave the
same with 'cursorline' and 'nocursorline', but such behavior may be
incorrect, as it puts the cursor on the next screen line.  That may be
fixed in a future PR.

closes: vim/vim#14192

https://github.com/vim/vim/commit/21b0a3df8c4abb884489dfcc0c92b1bbe058f291


#### vim-patch:9.1.0176: Cursor column wrong with 'virtualedit' and conceal

Problem:  Cursor column wrong with 'virtualedit' and conceal.
Solution: Correct cursor column at end of line if never reached.
          (zeertzjq)

closes: vim/vim#14190

https://github.com/vim/vim/commit/253ff4dece4e6cc4a9ff3ed935bc78f832b6fb7c