### PR TITLE
fix(highlight): don't show CursorColumn on current line

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2594,10 +2594,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
           int col_attr = base_attr;
 
-          if (wp->w_p_cuc && vcol_hlc(wlv) == wp->w_virtcol) {
-            col_attr = cuc_attr;
+          if (wp->w_p_cuc && vcol_hlc(wlv) == wp->w_virtcol
+              && lnum != wp->w_cursor.lnum) {
+            col_attr = hl_combine_attr(col_attr, cuc_attr);
           } else if (wlv.color_cols && vcol_hlc(wlv) == *wlv.color_cols) {
-            col_attr = hl_combine_attr(wlv.line_attr_lowprio, mc_attr);
+            col_attr = hl_combine_attr(col_attr, mc_attr);
           }
 
           col_attr = hl_combine_attr(col_attr, wlv.line_attr);
@@ -2798,7 +2799,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
       wlv.char_attr = vcol_save_attr;
     }
 
-    // restore attributes after "predeces" in 'listchars'
+    // restore attributes after "precedes" in 'listchars'
     if (n_attr3 > 0 && --n_attr3 == 0) {
       wlv.char_attr = saved_attr3;
     }

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1380,6 +1380,8 @@ describe('CursorColumn highlight', function()
       [1] = { background = Screen.colors.Gray90 }, -- CursorColumn
       [2] = { bold = true, foreground = Screen.colors.Blue1 }, -- NonText
       [3] = { bold = true }, -- ModeMsg
+      [4] = { background = Screen.colors.Red },
+      [5] = { background = Screen.colors.Blue },
     })
     screen:attach()
   end)
@@ -1453,6 +1455,47 @@ describe('CursorColumn highlight', function()
                                                         |
     ]],
     })
+  end)
+
+  it('is not shown on current line with virtualedit', function()
+    exec([[
+      hi! CursorColumn guibg=Red
+      hi! CursorLine guibg=Blue
+      set virtualedit=all cursorline cursorcolumn
+    ]])
+    insert('line 1\nline 2\nline 3')
+    feed('k')
+    screen:expect([[
+      line {4:1}                                            |
+      {5:line ^2                                            }|
+      line {4:3}                                            |
+      {2:~                                                 }|*4
+                                                        |
+    ]])
+    feed('l')
+    screen:expect([[
+      line 1{4: }                                           |
+      {5:line 2^                                            }|
+      line 3{4: }                                           |
+      {2:~                                                 }|*4
+                                                        |
+    ]])
+    feed('l')
+    screen:expect([[
+      line 1 {4: }                                          |
+      {5:line 2 ^                                           }|
+      line 3 {4: }                                          |
+      {2:~                                                 }|*4
+                                                        |
+    ]])
+    feed('l')
+    screen:expect([[
+      line 1  {4: }                                         |
+      {5:line 2  ^                                          }|
+      line 3  {4: }                                         |
+      {2:~                                                 }|*4
+                                                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Problem:
CursorColumn highlight behavior is inconsistent with 'virtualedit' set:
- If cursor is on the text, CursorColumn is not shown.
- If cursor is after end of line, CursorColumn is shown.

Solution:
Don't shown CursorColumn on current line if cursor is after end of line.

Vim doesn't have this problem because in most cases it uses the code
path for drawing buffer text when CursorColumn highlight is needed.