### PR TITLE
vim-patch:8.2.4950: text properties position wrong after shifting text

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -408,6 +408,7 @@ static void shift_block(oparg_T *oap, int amount)
     memset(newp + bd.textcol + tabs, ' ', (size_t)spaces);
     // Note that STRMOVE() copies the trailing NUL.
     STRMOVE(newp + bd.textcol + tabs + spaces, bd.textstart);
+    assert(newlen - oldlen == (colnr_T)new_line_len - get_cursor_line_len());
   } else {  // left
     char *verbatim_copy_end;      // end of the part of the line which is
                                   // copied verbatim
@@ -494,6 +495,7 @@ static void shift_block(oparg_T *oap, int amount)
     memset(newp + verbatim_diff, ' ', fill);
     // Note that STRMOVE() copies the trailing NUL.
     STRMOVE(newp + verbatim_diff + fill, non_white);
+    assert(newlen - oldlen == (colnr_T)new_line_len - get_cursor_line_len());
   }
   // replace the line
   ml_replace(curwin->w_cursor.lnum, newp, false);


### PR DESCRIPTION
#### vim-patch:8.2.4950: text properties position wrong after shifting text

Problem:    Text properties position wrong after shifting text.
Solution:   Adjust the text properties when shifting a block of text.
            (closes vim/vim#10418)

https://github.com/vim/vim/commit/4b93674159d60c985de906c30f45dbaf2b64056f

Most of the patch is already merged. Add an assertion in place of "added".

Co-authored-by: LemonBoy <thatlemon@gmail.com>