### PR TITLE
vim-patch:9.1.{0172,0177}: more code can use ml_get_buf_len()

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1044,7 +1044,7 @@ bool copy_indent(int size, char *src)
     if (p == NULL) {
       // Allocate memory for the result: the copied indent, new indent
       // and the rest of the line.
-      line_len = (int)strlen(get_cursor_line_ptr()) + 1;
+      line_len = get_cursor_line_len() + 1;
       assert(ind_len + line_len >= 0);
       size_t line_size;
       STRICT_ADD(ind_len, line_len, &line_size, size_t);
@@ -1865,7 +1865,7 @@ bool open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   }
   if (did_append) {
     // bail out and just get the final length of the line we just manipulated
-    bcount_t extra = (bcount_t)strlen(ml_get(curwin->w_cursor.lnum));
+    bcount_t extra = ml_get_len(curwin->w_cursor.lnum);
     extmark_splice(curbuf, (int)curwin->w_cursor.lnum - 1, 0,
                    0, 0, 0, 1, 0, 1 + extra, kExtmarkUndo);
     changed_lines(curbuf, curwin->w_cursor.lnum, 0, curwin->w_cursor.lnum, 1, true);

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -108,9 +108,10 @@ static int coladvance2(win_T *wp, pos_T *pos, bool addspaces, bool finetune, col
                  || ((get_ve_flags(wp) & VE_ONEMORE) && wcol < MAXCOL);
 
   char *line = ml_get_buf(wp->w_buffer, pos->lnum);
+  int linelen = ml_get_buf_len(wp->w_buffer, pos->lnum);
 
   if (wcol >= MAXCOL) {
-    idx = (int)strlen(line) - 1 + one_more;
+    idx = linelen - 1 + one_more;
     col = wcol;
 
     if ((addspaces || finetune) && !VIsual_active) {
@@ -188,7 +189,6 @@ static int coladvance2(win_T *wp, pos_T *pos, bool addspaces, bool finetune, col
         col = wcol;
       } else {
         // Break a tab
-        int linelen = (int)strlen(line);
         int correct = wcol - col - csize + 1;             // negative!!
         char *newline;
 
@@ -315,8 +315,7 @@ void check_pos(buf_T *buf, pos_T *pos)
   }
 
   if (pos->col > 0) {
-    char *line = ml_get_buf(buf, pos->lnum);
-    colnr_T len = (colnr_T)strlen(line);
+    colnr_T len = ml_get_buf_len(buf, pos->lnum);
     if (pos->col > len) {
       pos->col = len;
     }
@@ -347,7 +346,7 @@ void check_cursor_col(win_T *win)
   colnr_T oldcoladd = win->w_cursor.col + win->w_cursor.coladd;
   unsigned cur_ve_flags = get_ve_flags(win);
 
-  colnr_T len = (colnr_T)strlen(ml_get_buf(win->w_buffer, win->w_cursor.lnum));
+  colnr_T len = ml_get_buf_len(win->w_buffer, win->w_cursor.lnum);
   if (len == 0) {
     win->w_cursor.col = 0;
   } else if (win->w_cursor.col >= len) {
@@ -413,7 +412,7 @@ void check_visual_pos(void)
     VIsual.col = 0;
     VIsual.coladd = 0;
   } else {
-    int len = (int)strlen(ml_get(VIsual.lnum));
+    int len = ml_get_len(VIsual.lnum);
 
     if (VIsual.col > len) {
       VIsual.col = len;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -756,7 +756,7 @@ static int diff_write_buffer(buf_T *buf, mmfile_t *m, linenr_T start, linenr_T e
 
   // xdiff requires one big block of memory with all the text.
   for (linenr_T lnum = start; lnum <= end; lnum++) {
-    len += strlen(ml_get_buf(buf, lnum)) + 1;
+    len += (size_t)ml_get_buf_len(buf, lnum) + 1;
   }
   char *ptr = try_malloc(len);
   if (ptr == NULL) {

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2968,7 +2968,7 @@ static void replace_do_bs(int limit_col)
     }
     del_char_after_col(limit_col);
     if (l_State & VREPLACE_FLAG) {
-      orig_len = (int)strlen(get_cursor_pos_ptr());
+      orig_len = get_cursor_pos_len();
     }
     replace_push(cc);
     replace_pop_ins();
@@ -2976,7 +2976,7 @@ static void replace_do_bs(int limit_col)
     if (l_State & VREPLACE_FLAG) {
       // Get the number of screen cells used by the inserted characters
       char *p = get_cursor_pos_ptr();
-      int ins_len = (int)strlen(p) - orig_len;
+      int ins_len = get_cursor_pos_len() - orig_len;
       int vcol = start_vcol;
       for (int i = 0; i < ins_len; i++) {
         vcol += win_chartabsize(curwin, p + i, vcol);
@@ -3760,7 +3760,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         return false;
       }
       Insstart.lnum--;
-      Insstart.col = (colnr_T)strlen(ml_get(Insstart.lnum));
+      Insstart.col = ml_get_len(Insstart.lnum);
     }
     // In replace mode:
     // cc < 0: NL was inserted, delete it
@@ -4480,7 +4480,7 @@ bool ins_eol(int c)
 
   // NL in reverse insert will always start in the end of current line.
   if (revins_on) {
-    curwin->w_cursor.col += (colnr_T)strlen(get_cursor_pos_ptr());
+    curwin->w_cursor.col += get_cursor_pos_len();
   }
 
   AppendToRedobuff(NL_STR);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -541,7 +541,7 @@ void ex_sort(exarg_T *eap)
   // Also get the longest line length for allocating "sortbuf".
   for (linenr_T lnum = eap->line1; lnum <= eap->line2; lnum++) {
     char *s = ml_get(lnum);
-    int len = (int)strlen(s);
+    int len = ml_get_len(lnum);
     if (maxlen < len) {
       maxlen = len;
     }
@@ -643,8 +643,8 @@ void ex_sort(exarg_T *eap)
     }
 
     char *s = ml_get(get_lnum);
-    size_t bytelen = strlen(s) + 1;  // include EOL in bytelen
-    old_count += (bcount_t)bytelen;
+    colnr_T bytelen = ml_get_len(get_lnum) + 1;  // include EOL in bytelen
+    old_count += bytelen;
     if (!unique || i == 0 || string_compare(s, sortbuf1) != 0) {
       // Copy the line into a buffer, it may become invalid in
       // ml_append(). And it's needed for "unique".
@@ -652,7 +652,7 @@ void ex_sort(exarg_T *eap)
       if (ml_append(lnum++, sortbuf1, 0, false) == FAIL) {
         break;
       }
-      new_count += (bcount_t)bytelen;
+      new_count += bytelen;
     }
     fast_breakcheck();
     if (got_int) {
@@ -740,7 +740,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
     return FAIL;
   }
   for (extra = 0, l = line1; l <= line2; l++) {
-    char *str = xstrdup(ml_get(l + extra));
+    char *str = xstrnsave(ml_get(l + extra), (size_t)ml_get_len(l + extra));
     ml_append(dest + l - line1, str, 0, false);
     xfree(str);
     if (dest < line1) {
@@ -876,9 +876,8 @@ void ex_copy(linenr_T line1, linenr_T line2, linenr_T n)
 
   curwin->w_cursor.lnum = n;
   while (line1 <= line2) {
-    // need to use xstrdup() because the line will be unlocked within
-    // ml_append()
-    char *p = xstrdup(ml_get(line1));
+    // need to make a copy because the line will be unlocked within ml_append()
+    char *p = xstrnsave(ml_get(line1), (size_t)ml_get_len(line1));
     ml_append(curwin->w_cursor.lnum, p, 0, false);
     xfree(p);
 
@@ -3300,7 +3299,8 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
     if (nmatch > 1) { \
       sub_firstlnum += (linenr_T)nmatch - 1; \
       xfree(sub_firstline); \
-      sub_firstline = xstrdup(ml_get(sub_firstlnum)); \
+      sub_firstline = xstrnsave(ml_get(sub_firstlnum), \
+                                (size_t)ml_get_len(sub_firstlnum)); \
       /* When going beyond the last line, stop substituting. */ \
       if (sub_firstlnum <= line2) { \
         do_again = true; \
@@ -3628,7 +3628,8 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
           break;
         }
         if (sub_firstline == NULL) {
-          sub_firstline = xstrdup(ml_get(sub_firstlnum));
+          sub_firstline = xstrnsave(ml_get(sub_firstlnum),
+                                    (size_t)ml_get_len(sub_firstlnum));
         }
 
         // Save the line number of the last change for the final
@@ -3765,7 +3766,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
                 // really update the line, it would change
                 // what matches.  Temporarily replace the line
                 // and change it back afterwards.
-                orig_line = xstrdup(ml_get(lnum));
+                orig_line = xstrnsave(ml_get(lnum), (size_t)ml_get_len(lnum));
                 char *new_line = concat_str(new_start, sub_firstline + copycol);
 
                 // Position the cursor relative to the end of the line, the
@@ -4626,8 +4627,8 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
   }
 
   char *str = NULL;  // construct the line to show in here
-  size_t old_line_size = 0;
-  size_t line_size = 0;
+  colnr_T old_line_size = 0;
+  colnr_T line_size = 0;
   linenr_T linenr_preview = 0;  // last line added to preview buffer
   linenr_T linenr_origbuf = 0;  // last line added to original buffer
   linenr_T next_linenr = 0;     // next line to show for the match
@@ -4666,21 +4667,21 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
           line = "";
         } else {
           line = ml_get_buf(orig_buf, next_linenr);
-          line_size = strlen(line) + (size_t)col_width + 1;
+          line_size = ml_get_buf_len(orig_buf, next_linenr) + col_width + 1;
 
           // Reallocate if line not long enough
           if (line_size > old_line_size) {
-            str = xrealloc(str, line_size * sizeof(char));
+            str = xrealloc(str, (size_t)line_size * sizeof(char));
             old_line_size = line_size;
           }
         }
         // Put "|lnum| line" into `str` and append it to the preview buffer.
-        snprintf(str, line_size, "|%*" PRIdLINENR "| %s", col_width - 3,
+        snprintf(str, (size_t)line_size, "|%*" PRIdLINENR "| %s", col_width - 3,
                  next_linenr, line);
         if (linenr_preview == 0) {
           ml_replace_buf(cmdpreview_buf, 1, str, true, false);
         } else {
-          ml_append_buf(cmdpreview_buf, linenr_preview, str, (colnr_T)line_size, false);
+          ml_append_buf(cmdpreview_buf, linenr_preview, str, line_size, false);
         }
         linenr_preview += 1;
       }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -957,7 +957,7 @@ retry:
             int tlen = 0;
             while (true) {
               p = (uint8_t *)ml_get(read_buf_lnum) + read_buf_col;
-              int n = (int)strlen((char *)p);
+              int n = ml_get_len(read_buf_lnum) - read_buf_col;
               if (tlen + n + 1 > size) {
                 // Filled up to "size", append partial line.
                 // Change NL to NUL to reverse the effect done

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1017,8 +1017,7 @@ void foldAdjustVisual(void)
     return;
   }
 
-  char *ptr = ml_get(end->lnum);
-  end->col = (colnr_T)strlen(ptr);
+  end->col = ml_get_len(end->lnum);
   if (end->col > 0 && *p_sel == 'o') {
     end->col--;
   }
@@ -1605,7 +1604,7 @@ static void foldAddMarker(buf_T *buf, pos_T pos, const char *marker, size_t mark
 
   // Allocate a new line: old-line + 'cms'-start + marker + 'cms'-end
   char *line = ml_get_buf(buf, lnum);
-  size_t line_len = strlen(line);
+  size_t line_len = (size_t)ml_get_buf_len(buf, lnum);
   size_t added = 0;
 
   if (u_save(lnum - 1, lnum + 1) != OK) {
@@ -1686,7 +1685,7 @@ static void foldDelMarker(buf_T *buf, linenr_T lnum, char *marker, size_t marker
     }
     if (u_save(lnum - 1, lnum + 1) == OK) {
       // Make new line: text-before-marker + text-after-marker
-      char *newline = xmalloc(strlen(line) - len + 1);
+      char *newline = xmalloc((size_t)ml_get_buf_len(buf, lnum) - len + 1);
       assert(p >= line);
       memcpy(newline, line, (size_t)(p - line));
       STRCPY(newline + (p - line), p + len);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -518,7 +518,7 @@ static bool checkCloseRec(garray_T *gap, linenr_T lnum, int level)
   return retval;
 }
 
-// foldCreateAllowed() {{{2
+// foldManualAllowed() {{{2
 /// @return  true if it's allowed to manually create or delete a fold or,
 ///          give an error message and return false if not.
 int foldManualAllowed(bool create)
@@ -1025,7 +1025,7 @@ void foldAdjustVisual(void)
   mb_adjust_cursor();
 }
 
-// cursor_foldstart() {{{2
+// foldAdjustCursor() {{{2
 /// Move the cursor to the first line of a closed fold.
 void foldAdjustCursor(win_T *wp)
 {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2937,7 +2937,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
       // buffer, so that word at start of buffer is found
       // correctly.
       st->first_match_pos.lnum = st->ins_buf->b_ml.ml_line_count;
-      st->first_match_pos.col = (colnr_T)strlen(ml_get(st->first_match_pos.lnum));
+      st->first_match_pos.col = ml_get_len(st->first_match_pos.lnum);
     }
     st->last_match_pos = st->first_match_pos;
     compl_type = 0;

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1715,7 +1715,7 @@ void mark_mb_adjustpos(buf_T *buf, pos_T *lp)
 {
   if (lp->col > 0 || lp->coladd > 1) {
     const char *const p = ml_get_buf(buf, lp->lnum);
-    if (*p == NUL || (int)strlen(p) < lp->col) {
+    if (*p == NUL || ml_get_buf_len(buf, lp->lnum) < lp->col) {
       lp->col = 0;
     } else {
       lp->col -= utf_head_off(p, p + lp->col);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1840,6 +1840,12 @@ colnr_T ml_get_len(linenr_T lnum)
   return ml_get_buf_len(curbuf, lnum);
 }
 
+/// @return  length (excluding the NUL) of the text after position "pos".
+colnr_T ml_get_pos_len(pos_T *pos)
+{
+  return ml_get_buf_len(curbuf, curwin->w_cursor.lnum) - pos->col;
+}
+
 /// @return  length (excluding the NUL) of the given line in the given buffer.
 colnr_T ml_get_buf_len(buf_T *buf, linenr_T lnum)
 {
@@ -4133,7 +4139,7 @@ int dec(pos_T *lp)
   if (lp->col == MAXCOL) {
     // past end of line
     char *p = ml_get(lp->lnum);
-    lp->col = (colnr_T)strlen(p);
+    lp->col = ml_get_len(lp->lnum);
     lp->col -= utf_head_off(p, p + lp->col);
     return 0;
   }
@@ -4149,7 +4155,7 @@ int dec(pos_T *lp)
     // there is a prior line
     lp->lnum--;
     char *p = ml_get(lp->lnum);
-    lp->col = (colnr_T)strlen(p);
+    lp->col = ml_get_len(lp->lnum);
     lp->col -= utf_head_off(p, p + lp->col);
     return 1;
   }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1843,7 +1843,7 @@ colnr_T ml_get_len(linenr_T lnum)
 /// @return  length (excluding the NUL) of the text after position "pos".
 colnr_T ml_get_pos_len(pos_T *pos)
 {
-  return ml_get_buf_len(curbuf, curwin->w_cursor.lnum) - pos->col;
+  return ml_get_buf_len(curbuf, pos->lnum) - pos->col;
 }
 
 /// @return  length (excluding the NUL) of the given line in the given buffer.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1616,7 +1616,7 @@ int op_delete(oparg_T *oap)
         beginline(0);                       // cursor in column 0
       }
       truncate_line(false);         // delete the rest of the line,
-                                    // leave cursor past last char in line
+                                    // leaving cursor past last char in line
       if (oap->line_count > 1) {
         u_clearline(curbuf);  // "U" command not possible after "2cc"
       }
@@ -2232,7 +2232,6 @@ void op_insert(oparg_T *oap, int count1)
     ind_pre_col = (colnr_T)getwhitecols_curline();
     ind_pre_vcol = get_indent();
     pre_textlen = ml_get_len(oap->start.lnum) - bd.textcol;
-
     if (oap->op_type == OP_APPEND) {
       pre_textlen -= bd.textlen;
     }
@@ -4452,9 +4451,10 @@ bool do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
 
   curwin->w_cursor = *pos;
   char *ptr = ml_get(pos->lnum);
+  int linelen = ml_get_len(pos->lnum);
   int col = pos->col;
 
-  if (*ptr == NUL || col + !!save_coladd >= (int)strlen(ptr)) {
+  if (col + !!save_coladd >= linelen) {
     goto theend;
   }
 
@@ -4593,9 +4593,7 @@ bool do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
 
     // get the number value (unsigned)
     if (visual && VIsual_mode != 'V') {
-      maxlen = (curbuf->b_visual.vi_curswant == MAXCOL
-                ? (int)strlen(ptr) - col
-                : length);
+      maxlen = curbuf->b_visual.vi_curswant == MAXCOL ? linelen - col : length;
     }
 
     bool overflow = false;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -593,7 +593,7 @@ void getvvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *e
     // Cannot put the cursor on part of a wide character.
     char *ptr = ml_get_buf(wp->w_buffer, pos->lnum);
 
-    if (pos->col < (colnr_T)strlen(ptr)) {
+    if (pos->col < ml_get_buf_len(wp->w_buffer, pos->lnum)) {
       int c = utf_ptr2char(ptr + pos->col);
       if ((c != TAB) && vim_isprintc(c)) {
         endadd = (colnr_T)(char2cells(c) - 1);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5362,7 +5362,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
       }
     } else {
       char *const str = ml_get_buf(buf, lnum);
-      const int line_len = ml_get_buf_len(buf, lnum);
+      const colnr_T linelen = ml_get_buf_len(buf, lnum);
       int score;
       uint32_t matches[MAX_FUZZY_MATCHES];
       const size_t sz = sizeof(matches) / sizeof(matches[0]);
@@ -5401,7 +5401,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
           break;
         }
         col = (colnr_T)matches[pat_len - 1] + col + 1;
-        if (col > line_len) {
+        if (col > linelen) {
           break;
         }
       }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -773,9 +773,9 @@ static int qf_get_next_buf_line(qfstate_T *state)
     return QF_END_OF_INPUT;
   }
   char *p_buf = ml_get_buf(state->buf, state->buflnum);
+  size_t len = (size_t)ml_get_buf_len(state->buf, state->buflnum);
   state->buflnum += 1;
 
-  size_t len = strlen(p_buf);
   if (len > IOSIZE - 2) {
     state->linebuf = qf_grow_linebuf(state, len);
   } else {
@@ -5356,12 +5356,13 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
           break;
         }
         col = regmatch->endpos[0].col + (col == regmatch->endpos[0].col);
-        if (col > (colnr_T)strlen(ml_get_buf(buf, lnum))) {
+        if (col > ml_get_buf_len(buf, lnum)) {
           break;
         }
       }
     } else {
       char *const str = ml_get_buf(buf, lnum);
+      const int line_len = ml_get_buf_len(buf, lnum);
       int score;
       uint32_t matches[MAX_FUZZY_MATCHES];
       const size_t sz = sizeof(matches) / sizeof(matches[0]);
@@ -5400,7 +5401,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
           break;
         }
         col = (colnr_T)matches[pat_len - 1] + col + 1;
-        if (col > (colnr_T)strlen(str)) {
+        if (col > line_len) {
           break;
         }
       }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -604,7 +604,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
                && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
       ptr = ml_get_buf(buf, pos->lnum);
-      if ((int)strlen(ptr) <= pos->col) {
+      if (ml_get_buf_len(buf, pos->lnum) <= pos->col) {
         start_char_len = 1;
       } else {
         start_char_len = utfc_ptr2len(ptr + pos->col);
@@ -851,7 +851,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
             if (endpos.col == 0) {
               if (pos->lnum > 1) {              // just in case
                 pos->lnum--;
-                pos->col = (colnr_T)strlen(ml_get_buf(buf, pos->lnum));
+                pos->col = ml_get_buf_len(buf, pos->lnum);
               }
             } else {
               pos->col--;
@@ -969,7 +969,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
   // A pattern like "\n\zs" may go past the last line.
   if (pos->lnum > buf->b_ml.ml_line_count) {
     pos->lnum = buf->b_ml.ml_line_count;
-    pos->col = (int)strlen(ml_get_buf(buf, pos->lnum));
+    pos->col = ml_get_buf_len(buf, pos->lnum);
     if (pos->col > 0) {
       pos->col--;
     }
@@ -1554,7 +1554,7 @@ int searchc(cmdarg_T *cap, bool t_cmd)
 
   char *p = get_cursor_line_ptr();
   int col = curwin->w_cursor.col;
-  int len = (int)strlen(p);
+  int len = get_cursor_line_len();
 
   while (count--) {
     while (true) {
@@ -1958,7 +1958,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         }
 
         linep = ml_get(pos.lnum);
-        pos.col = (colnr_T)strlen(linep);         // pos.col on trailing NUL
+        pos.col = ml_get_len(pos.lnum);  // pos.col on trailing NUL
         do_quotes = -1;
         line_breakcheck();
 
@@ -2105,7 +2105,7 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         }
         if (pos.lnum > 1) {
           ptr = ml_get(pos.lnum - 1);
-          if (*ptr && *(ptr + strlen(ptr) - 1) == '\\') {
+          if (*ptr && *(ptr + ml_get_len(pos.lnum - 1) - 1) == '\\') {
             do_quotes = 1;
             if (start_in_quotes == kNone) {
               inquote = at_start;
@@ -2472,7 +2472,7 @@ int current_search(int count, bool forward)
       } else {  // try again from end of buffer
                 // searching backwards, so set pos to last line and col
         pos.lnum = curwin->w_buffer->b_ml.ml_line_count;
-        pos.col = (colnr_T)strlen(ml_get(curwin->w_buffer->b_ml.ml_line_count));
+        pos.col = ml_get_len(curwin->w_buffer->b_ml.ml_line_count);
       }
     }
   }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1342,7 +1342,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
   while (!got_int) {
     char *line = ml_get_buf(wp->w_buffer, lnum);
 
-    len = strlen(line);
+    len = (size_t)ml_get_buf_len(wp->w_buffer, lnum);
     if (buflen < len + MAXWLEN + 2) {
       xfree(buf);
       buflen = len + MAXWLEN + 2;
@@ -2682,7 +2682,7 @@ void ex_spellrepall(exarg_T *eap)
     char *line = get_cursor_line_ptr();
     if (addlen <= 0
         || strncmp(line + curwin->w_cursor.col, repl_to, repl_to_len) != 0) {
-      char *p = xmalloc(strlen(line) + (size_t)addlen + 1);
+      char *p = xmalloc((size_t)get_cursor_line_len() + (size_t)addlen + 1);
       memmove(p, line, (size_t)curwin->w_cursor.col);
       STRCPY(p + curwin->w_cursor.col, repl_to);
       STRCAT(p, line + curwin->w_cursor.col + repl_from_len);

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5114,13 +5114,12 @@ static void sug_write(spellinfo_T *spin, char *fname)
   for (linenr_T lnum = 1; lnum <= wcount; lnum++) {
     // <sugline>: <sugnr> ... NUL
     char *line = ml_get_buf(spin->si_spellbuf, lnum);
-    size_t len = strlen(line) + 1;
-    if (fwrite(line, len, 1, fd) == 0) {
+    int len = ml_get_buf_len(spin->si_spellbuf, lnum) + 1;
+    if (fwrite(line, (size_t)len, 1, fd) == 0) {
       emsg(_(e_write));
       goto theend;
     }
-    assert((size_t)spin->si_memtot + len <= INT_MAX);
-    spin->si_memtot += (int)len;
+    spin->si_memtot += len;
   }
 
   // Write another byte to check for errors.

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -480,9 +480,8 @@ void spell_suggest(int count)
     badlen++;
     end_visual_mode();
     // make sure we don't include the NUL at the end of the line
-    char *line = get_cursor_line_ptr();
-    if (badlen > (int)strlen(line) - (int)curwin->w_cursor.col) {
-      badlen = (int)strlen(line) - (int)curwin->w_cursor.col;
+    if (badlen > get_cursor_line_len() - curwin->w_cursor.col) {
+      badlen = get_cursor_line_len() - curwin->w_cursor.col;
     }
     // Find the start of the badly spelled word.
   } else if (spell_move_to(curwin, FORWARD, true, true, NULL) == 0
@@ -514,7 +513,7 @@ void spell_suggest(int count)
   int need_cap = check_need_cap(curwin, curwin->w_cursor.lnum, curwin->w_cursor.col);
 
   // Make a copy of current line since autocommands may free the line.
-  char *line = xstrdup(get_cursor_line_ptr());
+  char *line = xstrnsave(get_cursor_line_ptr(), (size_t)get_cursor_line_len());
   spell_suggest_timeout = 5000;
 
   // Get the list of suggestions.  Limit to 'lines' - 2 or the number in

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1002,11 +1002,11 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
   // Get the byte value now, in case we need it below. This is more
   // efficient than making a copy of the line.
   int byteval;
-  const size_t len = strlen(line_ptr);
-  if (wp->w_cursor.col > (colnr_T)len) {
+  const colnr_T len = ml_get_buf_len(wp->w_buffer, lnum);
+  if (wp->w_cursor.col > len) {
     // Line may have changed since checking the cursor column, or the lnum
     // was adjusted above.
-    wp->w_cursor.col = (colnr_T)len;
+    wp->w_cursor.col = len;
     wp->w_cursor.coladd = 0;
     byteval = 0;
   } else {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -549,8 +549,8 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
 
     // Skip lines that end in a backslash.
     for (; start_lnum > 1; start_lnum--) {
-      char *line = ml_get(start_lnum - 1);
-      if (*line == NUL || *(line + strlen(line) - 1) != '\\') {
+      char *l = ml_get(start_lnum - 1);
+      if (*l == NUL || *(l + ml_get_len(start_lnum - 1) - 1) != '\\') {
         break;
       }
     }
@@ -2352,7 +2352,6 @@ static void find_endpos(int idx, lpos_T *startpos, lpos_T *m_endpos, lpos_T *hl_
   regmmatch_T regmatch;
   regmmatch_T best_regmatch;        // startpos/endpos of best match
   lpos_T pos;
-  char *line;
   bool had_match = false;
   char buf_chartab[32];  // chartab array for syn option iskeyword
 
@@ -2457,8 +2456,7 @@ static void find_endpos(int idx, lpos_T *startpos, lpos_T *m_endpos, lpos_T *hl_
           break;
         }
 
-        line = ml_get_buf(syn_buf, startpos->lnum);
-        int line_len = (int)strlen(line);
+        int line_len = ml_get_buf_len(syn_buf, startpos->lnum);
 
         // take care of an empty match or negative offset
         if (pos.col <= matchcol) {
@@ -2635,7 +2633,7 @@ static void syn_add_start_off(lpos_T *result, regmmatch_T *regmatch, synpat_T *s
   if (result->lnum > syn_buf->b_ml.ml_line_count) {
     // a "\n" at the end of the pattern may take us below the last line
     result->lnum = syn_buf->b_ml.ml_line_count;
-    col = (int)strlen(ml_get_buf(syn_buf, result->lnum));
+    col = ml_get_buf_len(syn_buf, result->lnum);
   }
   if (off != 0) {
     base = ml_get_buf(syn_buf, result->lnum);

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -445,7 +445,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
       // Check if cursor is not past the NUL off the line, cindent
       // may have added or removed indent.
       curwin->w_cursor.col += startcol;
-      colnr_T len = (colnr_T)strlen(get_cursor_line_ptr());
+      colnr_T len = get_cursor_line_len();
       if (curwin->w_cursor.col > len) {
         curwin->w_cursor.col = len;
       }
@@ -506,12 +506,11 @@ static int fmt_check_par(linenr_T lnum, int *leader_len, char **leader_flags, bo
 static bool ends_in_white(linenr_T lnum)
 {
   char *s = ml_get(lnum);
-  size_t l;
 
   if (*s == NUL) {
     return false;
   }
-  l = strlen(s) - 1;
+  colnr_T l = ml_get_len(lnum) - 1;
   return ascii_iswhite((uint8_t)s[l]);
 }
 
@@ -544,7 +543,7 @@ static bool same_leader(linenr_T lnum, int leader1_len, char *leader1_flags, int
         return false;
       }
       if (*p == COM_START) {
-        int line_len = (int)strlen(ml_get(lnum));
+        int line_len = ml_get_len(lnum);
         if (line_len <= leader1_len) {
           return false;
         }
@@ -647,7 +646,7 @@ void auto_format(bool trailblank, bool prev_line)
   // in 'formatoptions' and there is a single character before the cursor.
   // Otherwise the line would be broken and when typing another non-white
   // next they are not joined back together.
-  int wasatend = (pos.col == (colnr_T)strlen(old));
+  bool wasatend = (pos.col == get_cursor_line_len());
   if (*old != NUL && !trailblank && wasatend) {
     dec_cursor();
     int cc = gchar_cursor();
@@ -701,7 +700,7 @@ void auto_format(bool trailblank, bool prev_line)
   // formatted.
   if (!wasatend && has_format_option(FO_WHITE_PAR)) {
     char *linep = get_cursor_line_ptr();
-    colnr_T len = (colnr_T)strlen(linep);
+    colnr_T len = get_cursor_line_len();
     if (curwin->w_cursor.col == len) {
       char *plinep = xstrnsave(linep, (size_t)len + 2);
       plinep[len] = ' ';
@@ -1119,7 +1118,7 @@ void format_lines(linenr_T line_count, bool avoid_fex)
         }
         first_par_line = false;
         // If the line is getting long, format it next time
-        if (strlen(get_cursor_line_ptr()) > (size_t)max_len) {
+        if (get_cursor_line_len() > max_len) {
           force_format = true;
         } else {
           force_format = false;

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -218,7 +218,7 @@ bool findpar(bool *pincl, int dir, int count, int what, bool both)
 
     // Put the cursor on the last character in the last line and make the
     // motion inclusive.
-    if ((curwin->w_cursor.col = (colnr_T)strlen(line)) != 0) {
+    if ((curwin->w_cursor.col = ml_get_len(curr)) != 0) {
       curwin->w_cursor.col--;
       curwin->w_cursor.col -= utf_head_off(line, line + curwin->w_cursor.col);
       *pincl = true;

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -2370,6 +2370,14 @@ func Test_normal30_changecase()
   %d
   call assert_beeps('norm! ~')
 
+  " Test with multiple lines
+  call setline(1, ['AA', 'BBBB', 'CCCCCC', 'DDDDDDDD'])
+  norm! ggguG
+  call assert_equal(['aa', 'bbbb', 'cccccc', 'dddddddd'], getline(1, '$'))
+  norm! GgUgg
+  call assert_equal(['AA', 'BBBB', 'CCCCCC', 'DDDDDDDD'], getline(1, '$'))
+  %d
+
   " Test for changing case across lines using 'whichwrap'
   call setline(1, ['aaaaaa', 'aaaaaa'])
   normal! gg10~


### PR DESCRIPTION
#### vim-patch:9.1.0172: More code can use ml_get_buf_len() instead of STRLEN()

Problem:  More code can use ml_get_buf_len() instead of STRLEN().
Solution: Change more STRLEN() calls to ml_get_buf_len().  Also do not
          set ml_line_textlen in ml_replace_len() if "has_props" is set,
          because "len_arg" also includes the size of text properties in
          that case. (zeertzjq)

closes: vim/vim#14183

https://github.com/vim/vim/commit/94b7c3233ef534acc669b3083ed1fe59cf3a090b


#### vim-patch:9.1.0177: Coverity reports dead code

Problem:  Coverity reports dead code.
Solution: Remove the dead code. Also fix a mistake in ml_get_pos_len()
          and update some comments (zeertzjq).

closes: vim/vim#14189

https://github.com/vim/vim/commit/8c55d60658b7ee3458dca57fc5eec90ca9bb9bf3