### PR TITLE
vim-patch: reverts mswin.vim changes

### DIFF
--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -70,7 +70,7 @@ endif
 " Uses the paste.vim autoload script.
 " Use CTRL-G u to have CTRL-Z only undo the paste.
 
-if has("clipboard_working")
+if has("clipboard")
     exe 'inoremap <script> <C-V> <C-G>u' . paste#paste_cmd['i']
     exe 'vnoremap <script> <C-V> ' . paste#paste_cmd['v']
 endif

--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -1,7 +1,7 @@
 " Set options and add mapping such that Vim behaves a lot like MS-Windows
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2024 Mar 3
+" Last Change:	2024 Mar 13
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Bail out if this isn't wanted.
@@ -27,7 +27,10 @@ set backspace=indent,eol,start whichwrap+=<,>,[,]
 " backspace in Visual mode deletes selection
 vnoremap <BS> d
 
-if has("clipboard_working")
+" the better solution would be to use has("clipboard_working"),
+" but that may not be available yet while starting up, so let's just check if
+" clipboard support has been compiled in and assume it will be working :/
+if has("clipboard")
     " CTRL-X and SHIFT-Del are Cut
     vnoremap <C-X> "+x
     vnoremap <S-Del> "+x
@@ -43,7 +46,7 @@ if has("clipboard_working")
     cmap <C-V>		<C-R>+
     cmap <S-Insert>		<C-R>+
 else
-    " Use unnamed register while clipboard not exist
+		" Use the unnamed register when clipboard support not available
 
     " CTRL-X and SHIFT-Del are Cut
     vnoremap <C-X>   x


### PR DESCRIPTION
#### vim-patch:760f664213de

runtime(mswin): revert back the check for clipboard_working support

Commit d9ebd46bd090c598adc82e6 changed the condition to
check if the clipboard is available from:
```
has('clipboard')
```
to
```
has('clipboard_working')
```
Assuming that is the more accurate test because even when clipboard
support is enabled at compile time it may not be actually working (e.g.
if no X11 environment is available, or when working on a remote server).

However it seems that condition does not evaluate to true, when the GUI
has not been started up yet (and there was no X11 Connection yet possible).

So let's just revert back the check to `has('clipboard')`, since that
has been proven to be working well enough.

related: vim/vim#13809

https://github.com/vim/vim/commit/760f664213dea9a300454992ba1589f4601d622f

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:45da32964d6e

runtime(mswin): still another clipboard_working test

Commit 760f664213dea9a300454992ba1589f4601d622f missed to revert back
another test for `if has('clipboard_working')`

So change the remaining check around the inoremap <c-v> mappings.

https://github.com/vim/vim/commit/45da32964d6e7e635af8fcf0b42e974b0b536ed3

Co-authored-by: Christian Brabandt <cb@256bit.org>