### PR TITLE
fix(intro): make intro explicitly stateful

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -421,7 +421,14 @@ bool redrawing(void)
 /// and redraw_all_later() to mark parts of the screen as needing a redraw.
 int update_screen(void)
 {
-  static bool did_intro = false;
+  static bool still_may_intro = true;
+  if (still_may_intro) {
+    if (!may_show_intro()) {
+      must_redraw = UPD_NOT_VALID;
+      still_may_intro = false;
+    }
+  }
+
   bool is_stl_global = global_stl_height() > 0;
 
   // Don't do anything if the screen structures are (not yet) valid.
@@ -673,10 +680,9 @@ int update_screen(void)
   }
 
   // May put up an introductory message when not editing a file
-  if (!did_intro) {
-    maybe_intro_message();
+  if (still_may_intro) {
+    intro_message(false);
   }
-  did_intro = true;
 
   decor_providers_invoke_end();
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2710,15 +2710,13 @@ void list_version(void)
                  : "\nRun \":verbose version\" for more info"));
 }
 
-/// Show the intro message when not editing a file.
-void maybe_intro_message(void)
+/// Whether it still is not too late to show an intro message
+bool may_show_intro(void)
 {
-  if (buf_is_empty(curbuf)
-      && (curbuf->b_fname == NULL)
-      && (firstwin->w_next == NULL)
-      && (vim_strchr(p_shm, SHM_INTRO) == NULL)) {
-    intro_message(false);
-  }
+  return (buf_is_empty(curbuf)
+          && (curbuf->b_fname == NULL)
+          && (firstwin->w_next == NULL)
+          && (vim_strchr(p_shm, SHM_INTRO) == NULL));
 }
 
 /// Give an introductory message about Vim.

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1627,13 +1627,41 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|*5
     ]])
 
-    feed('<c-l>')
-    screen:expect([[
+    -- <c-l> (same as :mode) does _not_ clear intro message
+    feed('<c-l>i')
+    screen:expect {
+      grid = [[
       ^                                                                                |
-      {1:~                                                                               }|*23
-    ]])
+      {1:~                                                                               }|*4
+      {MATCH:.*}|
+      {1:~                                                                               }|
+      {1:~                 }Nvim is open source and freely distributable{1:                  }|
+      {1:~                           }https://neovim.io/#chat{1:                             }|
+      {1:~                                                                               }|
+      {1:~                }type  :help nvim{5:<Enter>}       if you are new! {1:                 }|
+      {1:~                }type  :checkhealth{5:<Enter>}     to optimize Nvim{1:                 }|
+      {1:~                }type  :q{5:<Enter>}               to exit         {1:                 }|
+      {1:~                }type  :help{5:<Enter>}            for help        {1:                 }|
+      {1:~                                                                               }|
+      {1:~{MATCH: +}}type  :help news{5:<Enter>} to see changes in v{MATCH:%d+%.%d+}{1:{MATCH: +}}|
+      {1:~                                                                               }|
+      {MATCH:.*}|*2
+      {1:~                                                                               }|*5
+    ]],
+      showmode = { { '-- INSERT --', 3 } },
+    }
 
-    feed(':intro<cr>')
+    -- but editing text does..
+    feed('x')
+    screen:expect {
+      grid = [[
+      x^                                                                               |
+      {1:~                                                                               }|*23
+    ]],
+      showmode = { { '-- INSERT --', 3 } },
+    }
+
+    feed('<esc>:intro<cr>')
     screen:expect {
       grid = [[
       ^                                                                                |
@@ -1656,6 +1684,14 @@ describe('ui/ext_messages', function()
       messages = {
         { content = { { 'Press ENTER or type command to continue', 4 } }, kind = 'return_prompt' },
       },
+    }
+
+    feed('<cr>')
+    screen:expect {
+      grid = [[
+      ^x                                                                               |
+      {1:~                                                                               }|*23
+    ]],
     }
   end)
 


### PR DESCRIPTION
Instead of randomly disappearing because some random event might have caused mid_start or bot_scroll_start to randomly take a low value, treat intro message as a _first class stateful_ thing.

This means that intro message will kept being _redrawn_ as long as we are in the state it should be shown. This also includes screen resizes. you will not lose the intro message because there was a delay in detecting terminal features.