### PR TITLE
fix(ui): issues controlling cursor position with ext_cmdline

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -148,7 +148,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   switchwin_T switchwin;
   switch_win(&switchwin, win, NULL, true);
   update_topline(curwin);
-  validate_cursor(curwin);
+  setcursor_mayforce(true);
   restore_win(&switchwin, true);
 
   redraw_later(win, UPD_VALID);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -767,7 +767,7 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   }
 
   setmouse();
-  ui_cursor_shape();               // may show different cursor shape
+  setcursor();
 
   TryState tstate;
   Error err = ERROR_INIT;
@@ -927,7 +927,6 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   }
   may_trigger_modechanged();
   setmouse();
-  ui_cursor_shape();            // may show different cursor shape
   sb_text_end_cmdline();
 
 theend:
@@ -3859,7 +3858,6 @@ void cursorcmd(void)
     if (ccline.redraw_state < kCmdRedrawPos) {
       ccline.redraw_state = kCmdRedrawPos;
     }
-    setcursor();
     return;
   }
 
@@ -4553,6 +4551,7 @@ static int open_cmdwin(void)
   State = save_State;
   may_trigger_modechanged();
   setmouse();
+  setcursor();
 
   return cmdwin_result;
 }

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -219,6 +219,21 @@ describe('API/win', function()
 
       -- curwin didn't change back
       neq(win, curwin())
+
+      -- shows updated position after getchar() #20793
+      feed(':call getchar()<CR>')
+      api.nvim_win_set_cursor(win, { 1, 5 })
+      screen:expect {
+        grid = [[
+                                      |
+        {1:~                             }|*2
+        {2:[No Name]                     }|
+        prolo^gue                      |
+                                      |*2
+        {3:[No Name] [+]                 }|
+        :call getchar()               |
+      ]],
+      }
     end)
 
     it('remembers what column it wants to be in', function()

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -824,6 +824,29 @@ local function test_cmdline(linegrid)
                                |
     ]])
   end)
+
+  it('does not move cursor to curwin #20309', function()
+    local win = api.nvim_get_current_win()
+    command('norm icmdlinewin')
+    command('new')
+    command('norm icurwin')
+    feed(':')
+    api.nvim_win_set_cursor(win, { 1, 7 })
+    screen:expect {
+      grid = [[
+      curwin                   |
+      {3:[No Name] [+]            }|
+      cmdline^win               |
+      {2:[No Name] [+]            }|
+                               |
+    ]],
+      cmdline = { {
+        content = { { '' } },
+        firstc = ':',
+        pos = 0,
+      } },
+    }
+  end)
 end
 
 -- the representation of cmdline and cmdline_block contents changed with ext_linegrid


### PR DESCRIPTION
**fix(api): update grid cursor in nvim_win_set_cursor()**

Problem:  Cursor position set by nvim_win_set_cursor() is not reflected
          on the screen when followed by a blocking call like getchar().
Solution: Immediately update the cursor position on the grid.

Fix #20793

**fix(ui): ext_cmdline should not move cursor to curwin**

Problem:  The ext_cmdline cursor position on the screen seems to rely on
          an implicit assumption that the event listener implements a
          cmdline window that is made the current window which is
          problematic (e.g. breaks 'incsearch' in the actual current
          window).
Solution: Remove this assumption and allow nvim_win_set_cursor() to move
          the cursor on the screen to a non-current window (previous
          commit).

Fix #20309