### PR TITLE
refactor: remove unused "coloff" argument of win_put_linebuf()

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1549,7 +1549,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
       // When only updating the columns and that's done, stop here.
       if (col_rows > 0) {
-        win_put_linebuf(wp, wlv.row, 0, wlv.off, wlv.off, bg_attr, false);
+        win_put_linebuf(wp, wlv.row, wlv.off, wlv.off, bg_attr, false);
         // Need to update more screen lines if:
         // - 'statuscolumn' needs to be drawn, or
         // - LineNrAbove or LineNrBelow is used, or
@@ -1605,7 +1605,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         && lnum == wp->w_cursor.lnum && wlv.vcol >= wp->w_virtcol) {
       draw_virt_text(wp, buf, win_col_offset, &wlv.col, wlv.row);
       // don't clear anything after wlv.col
-      win_put_linebuf(wp, wlv.row, 0, wlv.col, wlv.col, bg_attr, false);
+      win_put_linebuf(wp, wlv.row, wlv.col, wlv.col, bg_attr, false);
       // Pretend we have finished updating the window.  Except when
       // 'cursorcolumn' is set.
       if (wp->w_p_cuc) {
@@ -2638,7 +2638,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         draw_virt_text_item(buf, win_col_offset, fold_vt, kHlModeCombine, grid->cols, 0);
       }
       draw_virt_text(wp, buf, win_col_offset, &wlv.col, wlv.row);
-      win_put_linebuf(wp, wlv.row, 0, wlv.col, grid->cols, bg_attr, false);
+      win_put_linebuf(wp, wlv.row, wlv.col, grid->cols, bg_attr, false);
       wlv.row++;
 
       // Update w_cline_height and w_cline_folded if the cursor line was
@@ -2878,7 +2878,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         draw_virt_text(wp, buf, win_col_offset, &draw_col, wlv.row);
       }
 
-      win_put_linebuf(wp, wlv.row, 0, draw_col, grid->cols, bg_attr, wrap);
+      win_put_linebuf(wp, wlv.row, draw_col, grid->cols, bg_attr, wrap);
       if (wrap) {
         ScreenGrid *current_grid = grid;
         int current_row = wlv.row;
@@ -2938,15 +2938,14 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
   return wlv.row;
 }
 
-static void win_put_linebuf(win_T *wp, int row, int coloff, int endcol, int clear_width,
-                            int bg_attr, bool wrap)
+static void win_put_linebuf(win_T *wp, int row, int endcol, int clear_width, int bg_attr, bool wrap)
 {
   ScreenGrid *grid = &wp->w_grid;
 
-  int start_col = 0;
+  int startcol = 0;
 
   if (wp->w_p_rl) {
-    linebuf_mirror(&start_col, &endcol, &clear_width, grid->cols);
+    linebuf_mirror(&startcol, &endcol, &clear_width, grid->cols);
   }
 
   // Take care of putting "<<<" on the first line for 'smoothscroll'.
@@ -2975,6 +2974,7 @@ static void win_put_linebuf(win_T *wp, int row, int coloff, int endcol, int clea
     }
   }
 
+  int coloff = 0;
   grid_adjust(&grid, &row, &coloff);
-  grid_put_linebuf(grid, row, coloff, start_col, endcol, clear_width, wp->w_p_rl, bg_attr, wrap);
+  grid_put_linebuf(grid, row, coloff, startcol, endcol, clear_width, wp->w_p_rl, bg_attr, wrap);
 }


### PR DESCRIPTION
It isn't really used, and is always passed 0.
Also rename "start_col" to "startcol" for consistency with "endcol".