### PR TITLE
fix(completion): free before info value

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -1,0 +1,19 @@
+funct Omni_test(findstart, base)
+  if a:findstart
+    return col(".") - 1
+  endif
+  return [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "three"}]
+endfunc
+set omnifunc=Omni_test
+set completeopt=menu,popup
+
+let s:count = 0
+funct Set_info()
+  let comp_info = complete_info()
+  if comp_info['selected'] == 2
+    let l:str = s:count == 0 ? "3info" : "4info"
+    let s:count = s:count + 1
+    call nvim_complete_set(comp_info['selected'], {"info": l:str})
+  endif
+endfunc
+autocmd CompleteChanged * call Set_info()

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -762,6 +762,9 @@ win_T *pum_set_info(int pum_idx, char *info)
   if (!pum_is_visible || pum_idx < 0 || pum_idx > pum_size) {
     return NULL;
   }
+  if (pum_array[pum_idx].pum_info) {
+    xfree(pum_array[pum_idx].pum_info);
+  }
   pum_array[pum_idx].pum_info = xstrdup(info);
   compl_set_info(pum_idx);
   bool use_float = strstr(p_cot, "popup") != NULL ? true : false;


### PR DESCRIPTION
Problem: before info value not free when new value set. it's dup string so will have a memory leak.

Solution: xfree it when new value set.


Fix #27768