### PR TITLE
ci: don't assign reviewers for "api" and "ui" labels

### DIFF
--- a/.github/scripts/reviewers_add.js
+++ b/.github/scripts/reviewers_add.js
@@ -7,11 +7,6 @@ module.exports = async ({ github, context }) => {
   const labels = pr_data.data.labels.map((e) => e.name);
   const reviewers = new Set();
 
-  if (labels.includes("api")) {
-    reviewers.add("bfredl");
-    reviewers.add("famiu");
-  }
-
   if (labels.includes("build")) {
     reviewers.add("dundargoc");
     reviewers.add("jamessan");
@@ -101,11 +96,6 @@ module.exports = async ({ github, context }) => {
 
   if (labels.includes("typo")) {
     reviewers.add("dundargoc");
-  }
-
-  if (labels.includes("ui")) {
-    reviewers.add("bfredl");
-    reviewers.add("famiu");
   }
 
   if (labels.includes("vim-patch")) {


### PR DESCRIPTION
The labels as they're currently defined are too broad to meaningfully
add specific reviewers for them.
