### PR TITLE
fix(ui): don't force 'cmdheight' to zero with ext_messages

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -777,9 +777,10 @@ This UI extension delegates presentation of messages and dialogs. Messages
 that would otherwise render in the message/cmdline screen space, are emitted
 as UI events.
 
-Nvim will not allocate screen space for the cmdline or messages, and
-'cmdheight' will be forced zero. Cmdline state is emitted as |ui-cmdline|
-events, which the UI must handle.
+Nvim will not allocate screen space for the cmdline or messages. 'cmdheight'
+will be set to zero, but can be changed and used for the replacing cmdline or
+message window. Cmdline state is emitted as |ui-cmdline| events, which the UI
+must handle.
 
 ["msg_show", kind, content, replace_last] ~
 	Display a message to the user.

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -227,6 +227,11 @@ void ui_refresh(void)
     if (i < kUIGlobalCount) {
       ext_widgets[i] |= ui_cb_ext[i];
     }
+    // Set 'cmdheight' to zero when ext_messages becomes active.
+    if (i == kUIMessages && !ui_ext[i] && ext_widgets[i]) {
+      set_option_value(kOptCmdheight, NUMBER_OPTVAL(0), 0);
+      command_height();
+    }
     ui_ext[i] = ext_widgets[i];
     if (i < kUIGlobalCount) {
       ui_call_option_set(cstr_as_string(ui_ext_names[i]),
@@ -241,10 +246,6 @@ void ui_refresh(void)
   screen_resize(width, height);
   p_lz = save_p_lz;
 
-  if (ext_widgets[kUIMessages]) {
-    set_option_value(kOptCmdheight, NUMBER_OPTVAL(0), 0);
-    command_height();
-  }
   ui_mode_info_set();
   pending_mode_update = true;
   ui_cursor_shape();

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5899,10 +5899,6 @@ static void frame_setheight(frame_T *curfrp, int height)
 
   if (curfrp->fr_parent == NULL) {
     // topframe: can only change the command line height
-    // Avoid doing so with external messages.
-    if (ui_has(kUIMessages)) {
-      return;
-    }
     if (height > ROWS_AVAIL) {
       // If height is greater than the available space, try to create space for
       // the frame by reducing 'cmdheight' if possible, while making sure
@@ -6241,12 +6237,6 @@ const char *did_set_winminwidth(optset_T *args FUNC_ATTR_UNUSED)
 void win_drag_status_line(win_T *dragwin, int offset)
 {
   frame_T *fr = dragwin->w_frame;
-
-  // Avoid changing command line height with external messages.
-  if (fr->fr_next == NULL && ui_has(kUIMessages)) {
-    return;
-  }
-
   frame_T *curfr = fr;
   if (fr != topframe) {         // more than one window
     fr = fr->fr_parent;

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1705,19 +1705,24 @@ describe('cmdheight=0', function()
     ]])
   end)
 
-  it('cannot be resized at all with external messages', function()
+  it('can be resized with external messages', function()
     clear()
     screen = new_screen({ rgb = true, ext_messages = true })
     command('set laststatus=2 mouse=a')
     command('resize -1')
     screen:expect([[
       ^                         |
+      {1:~                        }|*2
+      {3:[No Name]                }|
+                               |
+    ]])
+    api.nvim_input_mouse('left', 'press', '', 0, 3, 10)
+    poke_eventloop()
+    api.nvim_input_mouse('left', 'drag', '', 0, 4, 10)
+    screen:expect([[
+      ^                         |
       {1:~                        }|*3
       {3:[No Name]                }|
     ]])
-    api.nvim_input_mouse('left', 'press', '', 0, 6, 10)
-    poke_eventloop()
-    api.nvim_input_mouse('left', 'drag', '', 0, 5, 10)
-    screen:expect_unchanged()
   end)
 end)


### PR DESCRIPTION
Remove remaining code that prevents non-zero 'cmdheight' with ext_messages.
Followup to #27812, which was incomplete.