### PR TITLE
docs: update fedora 39 build prerequisite

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -293,10 +293,10 @@ Platform-specific requirements are listed below.
 sudo apt-get install ninja-build gettext cmake unzip curl build-essential
 ```
 
-### CentOS / RHEL / Fedora
+### RHEL / Fedora
 
 ```
-sudo dnf -y install ninja-build cmake gcc make unzip gettext curl
+sudo dnf -y install ninja-build cmake gcc make unzip gettext curl glibc-gconv-extra
 ```
 
 ### openSUSE


### PR DESCRIPTION
Will trying to install Neovim on Fedora 39 while following the guidance I got this error:

```
"nvim.pot" "nvim.pot" 9358L, 181124B written[386/415] Generating cs.cp1250.moines

FAILED: src/nvim/po/cs.cp1250.mo /neovim/build/src/nvim/po/cs.cp1250.mo
cd /neovim/build/src/nvim/po && /usr/bin/msgfmt -o /neovim/build/src/nvim/po/cs.cp1250.mo /neovim/src/nvim/po/cs.cp1250.po
/neovim/src/nvim/po/cs.cp1250.po: warning: Charset "CP1250" is not supported. msgfmt relies on iconv(),
                                           and iconv() does not support "CP1250".
                                           Installing GNU libiconv and then reinstalling GNU gettext
                                           would fix this problem.
                                           Continuing anyway.
/usr/bin/msgfmt: Cannot convert from "CP1250" to "UTF-8". msgfmt relies on iconv(), and iconv() does not support this conversion.
[387/415] Generating cs.mo
FAILED: src/nvim/po/cs.mo /neovim/build/src/nvim/po/cs.mo
cd /neovim/build/src/nvim/po && /usr/bin/msgfmt -o /neovim/build/src/nvim/po/cs.mo /neovim/src/nvim/po/cs.po
/neovim/src/nvim/po/cs.po: warning: Charset "ISO-8859-2" is not supported. msgfmt relies on iconv(),
                                    and iconv() does not support "ISO-8859-2".
                                    Installing GNU libiconv and then reinstalling GNU gettext
                                    would fix this problem.
                                    Continuing anyway.
/usr/bin/msgfmt: Cannot convert from "ISO-8859-2" to "UTF-8". msgfmt relies on iconv(), and iconv() does not support this conversion.
```