### PR TITLE
vim-patch:9.1.0182: Can define function with invalid name inside 'formatexpr'

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2309,6 +2309,7 @@ void ex_function(exarg_T *eap)
                                           : eval_isnamec(name_base[i])); i++) {}
       if (name_base[i] != NUL) {
         emsg_funcname(e_invarg2, arg);
+        goto ret_free;
       }
     }
     // Disallow using the g: dict.

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -891,4 +891,23 @@ func Test_multidefer_with_exception()
   delfunc Foo
 endfunc
 
+func Test_func_curly_brace_invalid_name()
+  func Fail()
+    func Foo{'()'}bar()
+    endfunc
+  endfunc
+
+  call assert_fails('call Fail()', 'E475: Invalid argument: Foo()bar')
+
+  silent! call Fail()
+  call assert_equal([], getcompletion('Foo', 'function'))
+
+  set formatexpr=Fail()
+  normal! gqq
+  call assert_equal([], getcompletion('Foo', 'function'))
+
+  set formatexpr&
+  delfunc Fail
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0182: Can define function with invalid name inside 'formatexpr'

Problem:  Can define function with invalid name inside 'formatexpr'.
Solution: Use goto instead of checking for did_emsg later.
          (zeertzjq)

closes: vim/vim#14209

https://github.com/vim/vim/commit/6a04bf5ee523b2d6d01d7290e356a30de219f465