### PR TITLE
fix(drawline): check filler_todo in place of removed draw_state

### DIFF
--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4065,6 +4065,8 @@ describe('decorations: virtual lines', function()
       [7] = {foreground = Screen.colors.SlateBlue};
       [8] = {background = Screen.colors.WebGray, foreground = Screen.colors.DarkBlue};
       [9] = {foreground = Screen.colors.Brown};
+      [10] = {bold = true, reverse = true};
+      [11] = {reverse = true};
     }
 
     ns = api.nvim_create_namespace 'test'
@@ -4860,6 +4862,22 @@ if (h->n_buckets < new_n_buckets) { // expand
     ]])
   end)
 
+  it('does not break cursor position with concealcursor #27887', function()
+    command('vsplit')
+    insert('\n')
+    api.nvim_set_option_value('conceallevel', 2, {})
+    api.nvim_set_option_value('concealcursor', 'niv', {})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = {{{'VIRT1'}}, {{'VIRT2'}}} })
+    screen:expect([[
+                               │                        |
+      VIRT1                    │VIRT1                   |
+      VIRT2                    │VIRT2                   |
+      ^                         │                        |
+      {1:~                        }│{1:~                       }|*6
+      {10:[No Name] [+]             }{11:[No Name] [+]           }|
+                                                        |
+    ]])
+  end)
 end)
 
 describe('decorations: signs', function()


### PR DESCRIPTION
The only place it matters is the conceal wcol check, but it can avoid
unnecessary computations at other places.

Fix #27887