### PR TITLE
fix(normal): don't check conceal when pressing 'r'

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -748,7 +748,7 @@ static void normal_get_additional_char(NormalState *s)
     bool langmap_active = false;  // using :lmap mappings
     if (repl) {
       State = MODE_REPLACE;                // pretend Replace mode
-      ui_cursor_shape();              // show different cursor shape
+      ui_cursor_shape_no_check_conceal();  // show different cursor shape
     }
     if (lang && curbuf->b_p_iminsert == B_IMODE_LMAP) {
       // Allow mappings defined with ":lmap".

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -624,7 +624,7 @@ void ui_check_mouse(void)
 /// Check if current mode has changed.
 ///
 /// May update the shape of the cursor.
-void ui_cursor_shape(void)
+void ui_cursor_shape_no_check_conceal(void)
 {
   if (!full_screen) {
     return;
@@ -635,6 +635,15 @@ void ui_cursor_shape(void)
     ui_mode_idx = new_mode_idx;
     pending_mode_update = true;
   }
+}
+
+/// Check if current mode has changed.
+///
+/// May update the shape of the cursor.
+/// With concealing on, may conceal or unconceal the cursor line.
+void ui_cursor_shape(void)
+{
+  ui_cursor_shape_no_check_conceal();
   conceal_check_cursor_line();
 }
 

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -435,6 +435,18 @@ describe('Screen', function()
         {0:~                                                    }|*3
                                                              |
       ]])
+
+      feed('r')
+      screen:expect_unchanged()
+
+      feed('m')
+      screen:expect([[
+        ^moo {1:b} bar {1:b} eggs                                     |
+        foo {1:b} bar {1:b} eggs                                     |*4
+                                                             |
+        {0:~                                                    }|*3
+                                                             |
+      ]])
     end)
 
     it('and open line', function()


### PR DESCRIPTION
Problem:  Cursor line is unconcealed when pressing 'r' in Normal mode
          when 'concealcursor' contains 'n' but not 'i'.
Solution: Don't check conceal when pressing 'r' in Normal mode.

Vim doesn't have this problem because it doesn't call redrawWinline() in
conceal_check_cursor_line() and instead sets a global variable.
