### PR TITLE
test(lsp): fix flaky basic_finish test

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -282,7 +282,8 @@ describe('LSP', function()
       local client
       test_rpc_server {
         test_name = 'basic_finish',
-        on_setup = function()
+        on_init = function(_client)
+          client = _client
           exec_lua [[
             BUFFER = vim.api.nvim_create_buf(false, true)
           ]]
@@ -291,9 +292,6 @@ describe('LSP', function()
           exec_lua [[
             vim.api.nvim_command(BUFFER.."bwipeout")
           ]]
-        end,
-        on_init = function(_client)
-          client = _client
           client.notify('finish')
         end,
         on_exit = function(code, signal)
@@ -1060,7 +1058,8 @@ describe('LSP', function()
       local client
       test_rpc_server {
         test_name = 'basic_finish',
-        on_setup = function()
+        on_init = function(_client)
+          client = _client
           exec_lua [[
             BUFFER = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_lines(BUFFER, 0, -1, false, {
@@ -1074,9 +1073,6 @@ describe('LSP', function()
           exec_lua [[
             vim.api.nvim_command(BUFFER.."bwipeout")
           ]]
-        end,
-        on_init = function(_client)
-          client = _client
           local full_kind = exec_lua("return require'vim.lsp.protocol'.TextDocumentSyncKind.Full")
           eq(full_kind, client.server_capabilities().textDocumentSync.change)
           eq(true, client.server_capabilities().textDocumentSync.openClose)


### PR DESCRIPTION
Problem:
As mentioned in #23002 on_setup and on_init are run concurrently.
However, in basic_finish tests on_setup must attach the client before
on_init finishes.  The other basic_finish test isn't flaky because it
makes an RPC request in on_init.

Solution:
Don't use on_setup in basic_finish tests.