### PR TITLE
fix(messages): allow more prompt in headless mode with UI

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2713,7 +2713,7 @@ static bool do_more_prompt(int typed_char)
   // If headless mode is enabled and no input is required, this variable
   // will be true. However If server mode is enabled, the message "--more--"
   // should be displayed.
-  bool no_need_more = headless_mode && !embedded_mode;
+  bool no_need_more = headless_mode && !embedded_mode && !ui_active();
 
   // We get called recursively when a timer callback outputs a message. In
   // that case don't show another prompt. Also when at the hit-Enter prompt

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -775,18 +775,23 @@ describe('treesitter highlighting (C)', function()
         declarator: (pointer_declarator) @variable.parameter)
     ]]
 
-    exec_lua([[
+    exec_lua(
+      [[
       local query = ...
       vim.treesitter.query.set('c', 'highlights', query)
       vim.treesitter.highlighter.new(vim.treesitter.get_parser(0, 'c'))
-    ]], query)
+    ]],
+      query
+    )
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         void foo(int {4:*}{11:bar});                                            |
       ^                                                                 |
       {1:~                                                                }|*15
                                                                        |
-    ]]}
+    ]],
+    }
   end)
 end)
 


### PR DESCRIPTION
Problem:  More prompt is not shown in headless mode even if there is a
          UI attached.
Solution: Don't skip more prompt when there is a UI active.
