### PR TITLE
vim-patch:3d46de703cf6

### DIFF
--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -5,7 +5,8 @@
 " go.vim: Vim syntax file for Go.
 " Language:             Go
 " Maintainer:           Billie Cleek <bhcleek@gmail.com>
-" Latest Revision:      2024-01-21
+" Latest Revision:      2024-03-17
+"  2024-03-17:          - fix goPackageComment highlight (by Vim Project)
 " License:              BSD-style. See LICENSE file in source repository.
 " Repository:           https://github.com/fatih/vim-go
 
@@ -531,12 +532,12 @@ if s:HighlightBuildConstraints() || s:FoldEnable('package_comment')
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
-        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package\s/'
+        \ . ' end=/\v\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:FoldEnable('package_comment') ? ' fold' : '')
-  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
-        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage\s/'
+        \ . ' end=/\v\*\/\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:FoldEnable('package_comment') ? ' fold' : '')
   hi def link goPackageComment    Comment


### PR DESCRIPTION
runtime(go): `goPackageComment` highlighting too broad

Previously this would highlight any comment before a line starting
`package`, for example

    var (
      // This comment would be highlighted as a goPackageComment
      packages []string
    )

The package clause is only valid when followed by a space[1], so include
this restriction

This is upstreaming a change from `go-vim`[2]

[1] https://go.dev/ref/spec#Package_clause
[2] https://github.com/fatih/vim-go/commit/d1c36cc4173093d0be78fd826978a024febe6233

https://github.com/vim/vim/commit/3d46de703cf645032fa4dbcd71259176db1b46b7

Co-authored-by: Matthew Hughes <matthewhughes934@gmail.com>
