### PR TITLE
refactor(messages): remove condition that is always true

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2281,7 +2281,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
   }
   msg_cursor_goto(msg_row, msg_col);
 
-  if (p_more && !recurse && !(s == sb_str + 1 && *sb_str == '\n')) {
+  if (p_more && !recurse) {
     store_sb_text(&sb_str, s, attr, &sb_col, false);
   }
 


### PR DESCRIPTION
After #25470 the `s` pointer is advanced before calling `store_sb_text()`
when a newline character is found, and `store_sb_text()` sets `sb_str` to
`s`, so it's not possible for `s == sb_str + 1` and `*sb_str == '\n'` to
be satisfied at the same time.
