### PR TITLE
test(terminal/cursor_spec): unskip tests that pass on Windows

### DIFF
--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -189,7 +189,7 @@ describe('buffer cursor position is correct in terminal without number column', 
 
   before_each(clear)
 
-  describe('in a line with no multibyte characters or trailing spaces,', function()
+  describe('in a line with no multibyte chars or trailing spaces,', function()
     before_each(function()
       setup_ex_register('aaaaaaaa')
     end)
@@ -252,7 +252,7 @@ describe('buffer cursor position is correct in terminal without number column', 
     end)
   end)
 
-  describe('in a line with single-cell multibyte characters and no trailing spaces,', function()
+  describe('in a line with single-cell multibyte chars and no trailing spaces,', function()
     before_each(function()
       setup_ex_register('µµµµµµµµ')
     end)
@@ -315,81 +315,72 @@ describe('buffer cursor position is correct in terminal without number column', 
     end)
   end)
 
-  describe(
-    'in a line with single-cell composed multibyte characters and no trailing spaces,',
-    function()
-      if skip(is_os('win'), 'Encoding problem?') then
-        return
-      end
+  describe('in a line with single-cell composed multibyte chars and no trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
+    end)
 
-      before_each(function()
-        setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
-      end)
-
-      it('at the end', function()
-        feed('<C-R>r')
-        screen:expect([[
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{2:^ }                                                            |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 33 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 33 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{4: }                                                            |
                                                                               |
       ]])
-        eq({ 6, 29 }, eval('nvim_win_get_cursor(0)'))
-      end)
+      eq({ 6, 29 }, eval('nvim_win_get_cursor(0)'))
+    end)
 
-      it('near the end', function()
-        feed('<C-R>r<C-X><C-X>')
-        screen:expect([[
+    it('near the end', function()
+      skip(is_os('win'))
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :µ̳µ̳µ̳µ̳µ̳µ̳{2:^µ̳}µ̳                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 25 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 25 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :µ̳µ̳µ̳µ̳µ̳^µ̳{4:µ̳}µ̳                                                             |
                                                                               |
       ]])
-        eq({ 6, 21 }, eval('nvim_win_get_cursor(0)'))
-      end)
+      eq({ 6, 21 }, eval('nvim_win_get_cursor(0)'))
+    end)
 
-      it('near the start', function()
-        feed('<C-R>r<C-B><C-O>')
-        screen:expect([[
+    it('near the start', function()
+      skip(is_os('win'))
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :µ̳{2:^µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 5 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 5 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
                                                                               |*4
         Entering Ex mode.  Type "visual" to go to Normal mode.                |
         :^µ̳{4:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                             |
                                                                               |
       ]])
-        eq({ 6, 1 }, eval('nvim_win_get_cursor(0)'))
-      end)
-    end
-  )
+      eq({ 6, 1 }, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
 
-  describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    if skip(is_os('win'), 'Encoding problem?') then
-      return
-    end
-
+  describe('in a line with double-cell multibyte chars and no trailing spaces,', function()
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')
     end)
@@ -522,7 +513,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
     command('set number')
   end)
 
-  describe('in a line with no multibyte characters or trailing spaces,', function()
+  describe('in a line with no multibyte chars or trailing spaces,', function()
     before_each(function()
       setup_ex_register('aaaaaaaa')
     end)
@@ -603,7 +594,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
     end)
   end)
 
-  describe('in a line with single-cell multibyte characters and no trailing spaces,', function()
+  describe('in a line with single-cell multibyte chars and no trailing spaces,', function()
     before_each(function()
       setup_ex_register('µµµµµµµµ')
     end)
@@ -684,20 +675,14 @@ describe('buffer cursor position is correct in terminal with number column', fun
     end)
   end)
 
-  describe(
-    'in a line with single-cell composed multibyte characters and no trailing spaces,',
-    function()
-      if skip(is_os('win'), 'Encoding problem?') then
-        return
-      end
+  describe('in a line with single-cell composed multibyte chars and no trailing spaces,', function()
+    before_each(function()
+      setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
+    end)
 
-      before_each(function()
-        setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
-      end)
-
-      it('at the end', function()
-        feed('<C-R>r')
-        screen:expect([[
+    it('at the end', function()
+      feed('<C-R>r')
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -706,9 +691,9 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳{2:^ }                                                        |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 33 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 33 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -717,12 +702,13 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳µ̳^µ̳{4: }                                                        |
                                                                               |
       ]])
-        eq({ 6, 29 }, eval('nvim_win_get_cursor(0)'))
-      end)
+      eq({ 6, 29 }, eval('nvim_win_get_cursor(0)'))
+    end)
 
-      it('near the end', function()
-        feed('<C-R>r<C-X><C-X>')
-        screen:expect([[
+    it('near the end', function()
+      skip(is_os('win'))
+      feed('<C-R>r<C-X><C-X>')
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -731,9 +717,9 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:µ̳µ̳µ̳µ̳µ̳µ̳{2:^µ̳}µ̳                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 25 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 25 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -742,12 +728,13 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:µ̳µ̳µ̳µ̳µ̳^µ̳{4:µ̳}µ̳                                                         |
                                                                               |
       ]])
-        eq({ 6, 21 }, eval('nvim_win_get_cursor(0)'))
-      end)
+      eq({ 6, 21 }, eval('nvim_win_get_cursor(0)'))
+    end)
 
-      it('near the start', function()
-        feed('<C-R>r<C-B><C-O>')
-        screen:expect([[
+    it('near the start', function()
+      skip(is_os('win'))
+      feed('<C-R>r<C-B><C-O>')
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -756,9 +743,9 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:µ̳{2:^µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
         {3:-- TERMINAL --}                                                        |
       ]])
-        eq({ 6, 5 }, eval('nvim_win_get_cursor(0)'))
-        feed([[<C-\><C-N>]])
-        screen:expect([[
+      eq({ 6, 5 }, eval('nvim_win_get_cursor(0)'))
+      feed([[<C-\><C-N>]])
+      screen:expect([[
         {7:  1 }                                                                  |
         {7:  2 }                                                                  |
         {7:  3 }                                                                  |
@@ -767,16 +754,11 @@ describe('buffer cursor position is correct in terminal with number column', fun
         {7:  6 }:^µ̳{4:µ̳}µ̳µ̳µ̳µ̳µ̳µ̳                                                         |
                                                                               |
       ]])
-        eq({ 6, 1 }, eval('nvim_win_get_cursor(0)'))
-      end)
-    end
-  )
+      eq({ 6, 1 }, eval('nvim_win_get_cursor(0)'))
+    end)
+  end)
 
-  describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    if skip(is_os('win'), 'Encoding problem?') then
-      return
-    end
-
+  describe('in a line with double-cell multibyte chars and no trailing spaces,', function()
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')
     end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -83,7 +83,6 @@ describe('TUI', function()
   end
 
   it('rapid resize #7572 #7628', function()
-    helpers.skip(helpers.is_asan(), 'Test extra unstable with ASAN. See #23762')
     -- Need buffer rows to provoke the behavior.
     feed_data(':edit test/functional/fixtures/bigfile.txt\n')
     screen:expect([[


### PR DESCRIPTION
Also:
- Make indent of test cases consistent.
- Unskip TUI rapid resize test with ASAN as reflow is now disabled.
