### PR TITLE
docs: clarify what `nvim_buf_set_name()` does

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2447,7 +2447,7 @@ nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
       • |nvim_buf_get_mark()|
 
 nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
-    Sets the full file name for a buffer
+    Sets the full file name for a buffer, like |:file_f|
 
     Parameters: ~
       • {buffer}  Buffer handle, or 0 for current buffer

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -669,7 +669,7 @@ function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replac
 --- @return boolean
 function vim.api.nvim_buf_set_mark(buffer, name, line, col, opts) end
 
---- Sets the full file name for a buffer
+--- Sets the full file name for a buffer, like `:file_f`
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param name string Buffer name

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -968,7 +968,7 @@ String nvim_buf_get_name(Buffer buffer, Error *err)
   return cstr_as_string(buf->b_ffname);
 }
 
-/// Sets the full file name for a buffer
+/// Sets the full file name for a buffer, like |:file_f|
 ///
 /// @param buffer     Buffer handle, or 0 for current buffer
 /// @param name       Buffer name


### PR DESCRIPTION
The main motivation for this update is to provide context as to how users can watch if the buffer changed name. Currently the most reliable approach is to use `BufFilePre` and `BufFilePost` events. Their triggered after `nvim_buf_set_name()` seems to be intended.

Alternative approach: #27804