### PR TITLE
Increase support of LSP semantic tokens highlight groups

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -454,30 +454,44 @@ You probably want these inside a |ColorScheme| autocommand.
 Use |LspTokenUpdate| and |vim.lsp.semantic_tokens.highlight_token()| for more
 complex highlighting.
 
-The following groups are linked by default to standard |group-name|s:
+The following is a list of standard captures used in queries for Nvim,
+highlighted according to the current colorscheme (use |:Inspect| on one to see
+the exact definition):
 
-@lsp.type.class          Structure
-@lsp.type.decorator      Function
-@lsp.type.enum           Structure
-@lsp.type.enumMember     Constant
-@lsp.type.event          Type
-@lsp.type.function       Function
-@lsp.type.interface      Structure
-@lsp.type.keyword        Keyword
-@lsp.type.macro          Macro
-@lsp.type.method         Function
-@lsp.type.modifier       Type
-@lsp.type.namespace      Structure
-@lsp.type.number         Number
-@lsp.type.operator       Operator
-@lsp.type.parameter      Identifier
-@lsp.type.property       Identifier
-@lsp.type.regexp         SpecialChar
-@lsp.type.string         String
-@lsp.type.struct         Structure
-@lsp.type.type           Type
-@lsp.type.typeParameter  TypeDef
-@lsp.type.variable       Identifier
+@lsp.type.class          Identifiers that declare or reference a class type
+@lsp.type.comment        Tokens that represent a comment
+@lsp.type.decorator      Identifiers that declare or reference decorators and annotations
+@lsp.type.enum           Identifiers that declare or reference an enumeration type
+@lsp.type.enumMember     Identifiers that declare or reference an enumeration property, constant, or member
+@lsp.type.event          Identifiers that declare an event property
+@lsp.type.function       Identifiers that declare a function
+@lsp.type.interface      Identifiers that declare or reference an interface type
+@lsp.type.keyword        Tokens that represent a language keyword
+@lsp.type.macro          Identifiers that declare a macro
+@lsp.type.method         Identifiers that declare a member function or method
+@lsp.type.modifier       Tokens that represent a modifier
+@lsp.type.namespace      Identifiers that declare or reference a namespace, module, or package
+@lsp.type.number         Tokens that represent a number literal
+@lsp.type.operator       Tokens that represent an operator
+@lsp.type.parameter      Identifiers that declare or reference a function or method parameters
+@lsp.type.property       Identifiers that declare or reference a member property, member field, or member variable
+@lsp.type.regexp         Tokens that represent a regular expression literal
+@lsp.type.string         Tokens that represent a string literal
+@lsp.type.struct         Identifiers that declare or reference a struct type
+@lsp.type.type           Identifiers that declare or reference a type that is not covered above
+@lsp.type.typeParameter  Identifiers that declare or reference a type parameter
+@lsp.type.variable       Identifiers that declare or reference a local or global variable
+
+@lsp.mod.abstract        Types and member functions that are abstract
+@lsp.mod.async           Functions that are marked async
+@lsp.mod.declaration     Declarations of symbols
+@lsp.mod.defaultLibrary  Symbols that are part of the standard library
+@lsp.mod.definition      Definitions of symbols, for example, in header files
+@lsp.mod.deprecated      Symbols that should no longer be used
+@lsp.mod.documentation   Occurrences of symbols in documentation
+@lsp.mod.modification    Variable references where the variable is assigned to
+@lsp.mod.readonly        Readonly variables and member fields (constants)
+@lsp.mod.static          Class members (static members)
 
 ==============================================================================
 EVENTS                                                            *lsp-events*

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -312,6 +312,8 @@ static const char *highlight_init_both[] = {
   "default link @lsp.type.typeParameter @type.definition",
   "default link @lsp.type.variable      @variable",
 
+  "default link @lsp.mod.deprecated DiagnosticDeprecated",
+
   NULL
 };
 


### PR DESCRIPTION
1. Update descriptions in help. Wordings are taken almost verbatim from [here](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers). With (slightly annoying) differences:
    1. That table contains `label` token type which is missing in [spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens). Did not include it, assuming specification has higher priority.
    1. Specification contains `modifier` token type. Decided to include it in help file with a vague description.
1. Add support for some token modifiers:
    1. `@lsp.mod.defaultLibrary` links to `Special` so as to consistently highlight anything "built-in" as `Special`.
    2. `@lsp.mod.deprecated` links to `DiagnosticDeprecated` as the closest alternative.