### PR TITLE
fix(filetype): use unexpanded file name

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -11,7 +11,12 @@ vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
     if not vim.api.nvim_buf_is_valid(args.buf) then
       return
     end
-    local ft, on_detect = vim.filetype.match({ filename = args.match, buf = args.buf })
+    local ft, on_detect = vim.filetype.match({
+      -- The unexpanded file name is needed here. #27914
+      -- Neither args.file nor args.match are guaranteed to be unexpanded.
+      filename = vim.fn.bufname(args.buf),
+      buf = args.buf,
+    })
     if not ft then
       -- Generic configuration file used as fallback
       ft = require('vim.filetype.detect').conf(args.file, args.buf)

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -5,6 +5,10 @@ local api = helpers.api
 local clear = helpers.clear
 local pathroot = helpers.pathroot
 local command = helpers.command
+local mkdir = helpers.mkdir
+local rmdir = helpers.rmdir
+local write_file = helpers.write_file
+local uv = vim.uv
 
 local root = pathroot()
 
@@ -161,10 +165,30 @@ describe('vim.filetype', function()
 end)
 
 describe('filetype.lua', function()
+  before_each(function()
+    mkdir('Xfiletype')
+  end)
+
+  after_each(function()
+    rmdir('Xfiletype')
+  end)
+
   it('does not override user autocommands that set filetype #20333', function()
     clear({
       args = { '--clean', '--cmd', 'autocmd BufRead *.md set filetype=notmarkdown', 'README.md' },
     })
     eq('notmarkdown', api.nvim_get_option_value('filetype', {}))
+  end)
+
+  it('uses unexpanded path for matching when editing a symlink #27914', function()
+    mkdir('Xfiletype/.config')
+    mkdir('Xfiletype/actual')
+    write_file('Xfiletype/actual/config', '')
+    uv.fs_symlink(assert(uv.fs_realpath('Xfiletype/actual')), 'Xfiletype/.config/git')
+    finally(function()
+      uv.fs_unlink('Xfiletype/.config/git')
+    end)
+    clear({ args = { '--clean', 'Xfiletype/.config/git/config' } })
+    eq('gitconfig', api.nvim_get_option_value('filetype', {}))
   end)
 end)


### PR DESCRIPTION
When the edited file is a symlink, the unexpanded file name is needed to
to achieve the same behavior as the autocommand pattern matching in Vim.
Neither args.file nor args.match are guaranteed to be unexpanded, so use
bufname() instead.

Fix #27914
