### PR TITLE
vim-patch:9.1.0188: filetype: no support for Vento files

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1063,6 +1063,7 @@ local extension = {
   vdmrt = 'vdmrt',
   vdmsl = 'vdmsl',
   vdm = 'vdmsl',
+  vto = 'vento',
   vr = 'vera',
   vri = 'vera',
   vrh = 'vera',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -701,6 +701,7 @@ func s:GetFilenameChecks() abort
     \ 'vdmpp': ['file.vpp', 'file.vdmpp'],
     \ 'vdmrt': ['file.vdmrt'],
     \ 'vdmsl': ['file.vdm', 'file.vdmsl'],
+    \ 'vento': ['file.vto'],
     \ 'vera': ['file.vr', 'file.vri', 'file.vrh'],
     \ 'verilogams': ['file.va', 'file.vams'],
     \ 'vgrindefs': ['vgrindefs'],


### PR DESCRIPTION
patch 9.1.0188: filetype: no support for Vento files

Problem:  Vento files are not recognized.
Solution: Recognize *.vto files as filetype "vento" (wrapperup)

Vento is a templating engine https://vento.js.org/

closes: vim/vim#14229

https://github.com/vim/vim/commit/9f26e5a9bcedb3caef26e9d77849ea37a3626bbf

Co-authored-by: wrapperup <wrapperup4@gmail.com>
