### PR TITLE
test(ui/messages_spec): unskip msg_puts_printf test on Unix CI

### DIFF
--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1849,15 +1849,11 @@ describe('ui/msg_puts_printf', function()
         pending('missing japanese language features', function() end)
         return
       else
-        cmd = 'chcp 932 > NULL & '
+        cmd = 'chcp 932 > NUL & '
       end
     else
       if exc_exec('lang ja_JP.UTF-8') ~= 0 then
         pending('Locale ja_JP.UTF-8 not supported', function() end)
-        return
-      elseif is_ci() then
-        -- Fails non--Windows CI. Message catalog directory issue?
-        pending('fails on unix CI', function() end)
         return
       end
     end

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -19,7 +19,6 @@ local poke_eventloop = helpers.poke_eventloop
 local assert_alive = helpers.assert_alive
 local retry = helpers.retry
 local is_os = helpers.is_os
-local is_ci = helpers.is_ci
 local fn = helpers.fn
 local skip = helpers.skip
 


### PR DESCRIPTION
It no longer fails on Unix CI.
