### PR TITLE
fix(cmdline): wrong 'incsearch' highlighting after :redraw

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1167,6 +1167,7 @@ static int command_line_execute(VimState *state, int key)
     return -1;  // get another key
   }
 
+  disptick_T display_tick_saved = display_tick;
   CommandLineState *s = (CommandLineState *)state;
   s->c = key;
 
@@ -1177,6 +1178,10 @@ static int command_line_execute(VimState *state, int key)
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
     } else {
       map_execute_lua(false);
+    }
+    // Re-apply 'incsearch' highlighting in case it was cleared.
+    if (display_tick > display_tick_saved && s->is_state.did_incsearch) {
+      may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
     }
 
     // nvim_select_popupmenu_item() can be called from the handling of

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -674,4 +674,18 @@ describe('search highlighting', function()
       :%g@a/b^                                 |
     ]])
   end)
+
+  it('incsearch is still visible after :redraw from K_EVENT', function()
+    fn.setline(1, { 'foo', 'bar' })
+    feed('/foo<CR>/bar')
+    screen:expect([[
+      foo                                     |
+      {3:bar}                                     |
+      {1:~                                       }|*4
+      /bar^                                    |
+    ]])
+    command('redraw!')
+    -- There is an intermediate state where :redraw! removes 'incsearch' highlight.
+    screen:expect_unchanged(true)
+  end)
 end)


### PR DESCRIPTION
Problem:  Calling :redraw from a timer callback clears 'incsearch' highlighting.
Solution: Re-apply 'incsearch' highlighting if the screen was updated.

Fix #17810