### PR TITLE
fix(ui): flush ext_cmdline events before doing cmdpreview

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2531,6 +2531,10 @@ static bool cmdpreview_may_show(CommandLineState *s)
     goto end;
   }
 
+  // Flush now: external cmdline may itself wish to update the screen which is
+  // currently disallowed during cmdpreview(no longer needed in case that changes).
+  cmdline_ui_flush();
+
   // Swap invalid command range if needed
   if ((ea.argt & EX_RANGE) && ea.line1 > ea.line2) {
     linenr_T lnum = ea.line1;


### PR DESCRIPTION
Problem:  Unable to update the screen for external cmdline during cmdpreview.
Solution: Flush the cmdline UI before cmdpreview state.

Resolve https://github.com/neovim/neovim/issues/20463