### PR TITLE
vim-patch:2708c0b5854f

### DIFF
--- a/runtime/ftplugin/deb822sources.vim
+++ b/runtime/ftplugin/deb822sources.vim
@@ -1,0 +1,16 @@
+" Language:     Debian sources.list
+" Maintainer:   Debian Vim Maintainers <team+vim@tracker.debian.org>
+" Last Change:  2024 Mar 20
+" License:      Vim License
+" URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/deb822sources.vim
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin=1
+
+setlocal comments=:#
+setlocal commentstring=#%s
+setlocal formatoptions-=t
+
+let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions<'


### PR DESCRIPTION
runtime(deb822sources): Add minimal ftplugin (vim/vim#14240)

Set comment related options and avoid automatic line wrapping.

https://github.com/vim/vim/commit/2708c0b5854faad2844454324431a593c1d2987a

Co-authored-by: James McCoy <jamessan@jamessan.com>
