### PR TITLE
fix(messages)!: decouple ext_messages from message grid

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -67,7 +67,10 @@ EDITOR
 
 EVENTS
 
-• todo
+• |ui-messages| no longer emits the `msg_show.return_prompt`, `msg_clear` and
+  `msg_history_clear` events. These events arbitrarily assume a message UI
+  mimicking the legacy message grid. Benefit: reduced UI event traffic and
+  more flexibility for UIs.
 
 HIGHLIGHTS
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -836,7 +836,6 @@ must handle.
 		"lua_error"	Error in |:lua| code
 		"lua_print"	|print()| from |:lua| code
 		"rpc_error"	Error response from |rpcrequest()|
-		"return_prompt"	|press-enter| prompt after a multiple messages
 		"quickfix"	Quickfix navigation message
 		"search_cmd"	Entered search command
 		"search_count"	Search count message ("S" flag of 'shortmess')
@@ -893,8 +892,5 @@ must handle.
 ["msg_history_show", entries] ~
 	Sent when |:messages| command is invoked. History is sent as a list of
 	entries, where each entry is a `[kind, content, append]` tuple.
-
-["msg_history_clear"] ~
-	Clear the |:messages| history.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -174,8 +174,6 @@ void msg_ruler(Array content)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void msg_history_show(Array entries)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void msg_history_clear(void)
-  FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
 
 // This UI event is currently undocumented.
 // - When the server needs to intentionally exit with an exit code, and there is no

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1763,7 +1763,6 @@ restore_backup:
     if (msg_add_fileformat(fileformat)) {
       insert_space = true;
     }
-    msg_ext_set_kind("bufwrite");
     msg_add_lines(insert_space, lnum, nchars);       // add line/char count
     if (!shortmess(SHM_WRITE)) {
       if (append) {
@@ -1773,6 +1772,8 @@ restore_backup:
       }
     }
 
+    msg_ext_set_kind("bufwrite");
+    msg_ext_overwrite = true;
     set_keep_msg(msg_trunc(IObuff, false, 0), 0);
   }
 

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -552,7 +552,6 @@ int update_screen(void)
   }
 
   win_ui_flush(true);
-  msg_ext_check_clear();
 
   // reset cmdline_row now (may have been changed temporarily)
   compute_cmdrow();
@@ -964,10 +963,6 @@ bool skip_showmode(void)
 int showmode(void)
 {
   int length = 0;
-
-  if (ui_has(kUIMessages) && clear_cmdline) {
-    msg_ext_clear(true);
-  }
 
   // Don't make non-flushed message part of the showmode.
   msg_ext_ui_flush();

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -750,9 +750,6 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
     gotocmdline(true);
     redrawcmdprompt();          // draw prompt or indent
     ccline.cmdspos = cmd_startcol();
-    if (!msg_scroll) {
-      msg_ext_clear(false);
-    }
   }
   s->xpc.xp_context = EXPAND_NOTHING;
   s->xpc.xp_backslash = XP_BS_NONE;
@@ -964,7 +961,6 @@ theend:
 
   if (ui_has(kUICmdline)) {
     ui_ext_cmdline_hide(s->gotesc);
-    msg_ext_clear_later();
   }
   if (!cmd_silent) {
     redraw_custom_title_later();

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -31,10 +31,12 @@ enum {
 extern MessageHistoryEntry *msg_hist_last;
 
 EXTERN bool msg_ext_need_clear INIT( = false);
-// Set to true to force grouping a set of message chunks into a single `cmdline_show` event.
+/// Set to true to force grouping a set of message chunks into a single `cmdline_show` event.
 EXTERN bool msg_ext_skip_flush INIT( = false);
-// Set to true when message should be appended to previous message line.
+/// Set to true when message should be appended to previous message line.
 EXTERN bool msg_ext_append INIT( = false);
+/// Set to true when previous message should be overwritten.
+EXTERN bool msg_ext_overwrite INIT( = false);
 
 /// allocated grid for messages. Used unless ext_messages is active.
 /// See also the description at msg_scroll_flush()

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1377,9 +1377,8 @@ static void normal_redraw(NormalState *s)
 
   curbuf->b_last_used = time(NULL);
 
-  // Display message after redraw. If an external message is still visible,
-  // it contains the kept message already.
-  if (keep_msg != NULL && !msg_ext_is_visible()) {
+  // Display message after redraw.
+  if (keep_msg != NULL) {
     char *const p = xstrdup(keep_msg);
 
     // msg_start() will set keep_msg to NULL, make a copy

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2681,6 +2681,7 @@ static void cmdline_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, bool sh
 
   // keep the message even after redraw, but don't put in history
   msg_hist_off = true;
+  msg_ext_overwrite = true;
   msg_ext_set_kind("search_count");
   give_warning(msgbuf, false);
   msg_hist_off = false;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -748,12 +748,6 @@ void ui_call_event(char *name, bool fast, Array args)
   bool handled = false;
   UIEventCallback *event_cb;
 
-  // Return prompt is still a non-fast event, other prompt messages are
-  // followed by a "cmdline_show" event.
-  if (strcmp(name, "msg_show") == 0) {
-    fast = !strequal(args.items[0].data.string.data, "return_prompt");
-  }
-
   map_foreach(&ui_event_cbs, ui_event_ns_id, event_cb, {
     Error err = ERROR_INIT;
     uint32_t ns_id = ui_event_ns_id;

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -700,6 +700,7 @@ screen:redraw_debug() to show all intermediate screen states.]]
     self.cmdline[self.cmdline_hide_level] = nil
     self.cmdline_hide_level = nil
   end
+  self.messages, self.msg_history = {}, {}
 end
 
 function Screen:expect_unchanged(intermediate, waittime_ms)
@@ -1410,10 +1411,6 @@ end
 
 function Screen:_handle_msg_history_show(entries)
   self.msg_history = entries
-end
-
-function Screen:_handle_msg_history_clear()
-  self.msg_history = {}
 end
 
 function Screen:_clear_block(grid, top, bot, left, right)


### PR DESCRIPTION
Problem:  ext_messages is implemented to mimic the message grid
          implementation w.r.t. scrolling messages, clearing scrolled
          messages, hit-enter-prompts and replacing a previous message.
          Meanwhile, an ext_messages UI may not be implemented in a way
          where these events are wanted. Moreover, correctness of these
          events even assuming a "scrolled message" implementation
          depends on fragile "currently visible messages" global state,
          which already isn't correct after a previous message was
          supposed to have been overwritten (because that should not only
          happen when `msg_scroll == false`).

Solution: 
- No longer attempt to keep track of the currently visible
            messages: remove the `msg_ext(_history)_visible` variables.
            UIs may remove messages pre-emptively (timer based), or never
            show messages that don't fit a certain area in the first place.
- No longer emit the `msg(_history)_clear` events to clear
            "scrolled" messages. This opens up the `msg_clear` event to
            be emitted when messages should actually be cleared (e.g.
            when the screen is cleared). May also be useful to emit before
            the first message in an event loop cycle as a hint to the UI
            that it is a new batch of messages (vim._extui currently
            schedules an event to determine that).
- Set `replace_last` explicitly at the few callsites that want
            this to be set to true to replace an incomplete status message.
- Don't store a "keep" message to be re-emitted.

Resolve #20416