### PR TITLE
vim-patch:9.1.0194: gcc complains about uninitialized var

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2774,7 +2774,7 @@ static void get_complete_info(list_T *what_list, dict_T *retdict)
   }
 
   if (ret == OK && (what_flag & CI_WHAT_ITEMS || what_flag & CI_WHAT_SELECTED)) {
-    list_T *li;
+    list_T *li = NULL;
     int selected_idx = -1;
     if (what_flag & CI_WHAT_ITEMS) {
       li = tv_list_alloc(kListLenMayKnow);


### PR DESCRIPTION
#### vim-patch:9.1.0194: gcc complains about uninitialized var

Problem:  gcc complains about uninitialized var
          (Tony Mechelynck)
Solution: initialize to NULL

https://github.com/vim/vim/commit/9eb236f455df75af858a37a3d98f190c977deaf4

Co-authored-by: Christian Brabandt <cb@256bit.org>