### PR TITLE
vim-patch:9.1.{0192,0195}: drop: don't rewind when editing the same file

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -866,12 +866,12 @@ void ex_drop(exarg_T *eap)
         const int save_ar = curbuf->b_p_ar;
 
         // reload the file if it is newer
-        curbuf->b_p_ar = 1;
+        curbuf->b_p_ar = true;
         buf_check_timestamp(curbuf);
         curbuf->b_p_ar = save_ar;
       }
-      if (buf->b_ml.ml_flags & ML_EMPTY) {
-        open_buffer(false, eap, 0);
+      if (curbuf->b_ml.ml_flags & ML_EMPTY) {
+        ex_rewind(eap);
       }
       return;
     }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -870,7 +870,9 @@ void ex_drop(exarg_T *eap)
         buf_check_timestamp(curbuf);
         curbuf->b_p_ar = save_ar;
       }
-      ex_rewind(eap);
+      if (buf->b_ml.ml_flags & ML_EMPTY) {
+        open_buffer(false, eap, 0);
+      }
       return;
     }
   }

--- a/test/functional/ex_cmds/drop_spec.lua
+++ b/test/functional/ex_cmds/drop_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local command = helpers.command
 local Screen = require('test.functional.ui.screen')
 local clear, feed, feed_command = helpers.clear, helpers.feed, helpers.feed_command
+local exec = helpers.exec
 
 describe(':drop', function()
   local screen
@@ -16,7 +17,7 @@ describe(':drop', function()
       [2] = { reverse = true },
       [3] = { bold = true },
     })
-    command('set laststatus=2 shortmess-=F')
+    command('set nohidden laststatus=2 shortmess-=F')
   end)
 
   it('works like :e when called with only one window open', function()
@@ -43,7 +44,6 @@ describe(':drop', function()
   end)
 
   it("splits off a new window when a buffer can't be abandoned", function()
-    command('set nohidden')
     feed_command('edit tmp1')
     feed_command('vsplit')
     feed_command('edit tmp2')
@@ -57,6 +57,22 @@ describe(':drop', function()
       {0:~                   }│{0:~             }|*2
       {2:tmp2 [+]             tmp1          }|
       "tmp3" [New]                       |
+    ]])
+  end)
+
+  -- oldtest: Test_drop_modified_file()
+  it('does not cause E37 with modified same file', function()
+    exec([[
+      edit Xdrop_modified.txt
+      call setline(1, 'The quick brown fox jumped over the lazy dogs')
+    ]])
+    feed_command('drop Xdrop_modified.txt')
+    screen:expect([[
+      ^The quick brown fox jumped over the|
+       lazy dogs                         |
+      {0:~                                  }|*6
+      {1:Xdrop_modified.txt [+]             }|
+      "Xdrop_modified.txt" [New]         |
     ]])
   end)
 end)

--- a/test/functional/ex_cmds/drop_spec.lua
+++ b/test/functional/ex_cmds/drop_spec.lua
@@ -72,7 +72,7 @@ describe(':drop', function()
        lazy dogs                         |
       {0:~                                  }|*6
       {1:Xdrop_modified.txt [+]             }|
-      "Xdrop_modified.txt" [New]         |
+      :drop Xdrop_modified.txt           |
     ]])
   end)
 end)

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -3,6 +3,7 @@
 source check.vim
 source shared.vim
 source term_util.vim
+source screendump.vim
 
 func Test_ex_delete()
   new
@@ -756,6 +757,21 @@ endfunc
 " catch address lines overflow
 func Test_ex_address_range_overflow()
   call assert_fails(':--+foobar', 'E492:')
+endfunc
+
+func Test_drop_modified_file()
+  CheckScreendump
+  let lines =<< trim END
+  call setline(1, 'The quick brown fox jumped over the lazy dogs')
+  END
+  call writefile([''], 'Xdrop_modified.txt', 'D')
+  call writefile(lines, 'Xtest_drop_modified', 'D')
+  let buf = RunVimInTerminal('-S Xtest_drop_modified Xdrop_modified.txt', {'rows': 10,'columns': 40})
+  call term_sendkeys(buf, ":drop Xdrop_modified.txt\<CR>")
+  call VerifyScreenDump(buf, 'Test_drop_modified_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0192: drop: don't rewind when editing the same file

Problem:  :drop tries to :rewind the argumentlist, which results in E37
          (after v9.1.0046)
Solution: instead of calling ex_rewind(), call open_buffer() only when
          re-using the initial empty buffer

closes: vim/vim#14220

https://github.com/vim/vim/commit/978178823b7c62a0249411f3d1f584f8a3144c5d

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.0195: memleak with ex_drop, NULL dereference

Problem:  memleak with ex_drop(), NULL dereference
          (zeertzjq)
Solution: revert back to ex_rewind(), use curbuf instead of buf

closes: vim/vim#14251

https://github.com/vim/vim/commit/85a769d466d2009db6a318fd120d9691344664ba

Co-authored-by: Christian Brabandt <cb@256bit.org>