### PR TITLE
fix(filetype): don't use fnamemodify() with :e for extension

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1472,7 +1472,6 @@ local filename = {
   ['bash.bashrc'] = detect.bash,
   bashrc = detect.bash,
   ['.bashrc'] = detect.bash,
-  ['.env'] = detect.sh,
   ['.kshrc'] = detect.ksh,
   ['.profile'] = detect.sh,
   ['/etc/profile'] = detect.sh,
@@ -2387,7 +2386,9 @@ function M.match(args)
     end
 
     -- Next, check file extension
-    local ext = fn.fnamemodify(name, ':e')
+    -- Don't use fnamemodify() with :e modifier here,
+    -- as that's empty when there is only an extension.
+    local ext = name:match('%.([^.]-)$') or ''
     ft, on_detect = dispatch(extension[ext], path, bufnr)
     if ft then
       return ft, on_detect


### PR DESCRIPTION
Use pattern matching instead, as fnamemodify() with :e produces an empty
string when the file name only has an extension, leading to differences
in behavior from Vim.

Related #16955 #27972
