### PR TITLE
fix(float): combine bot border attr by stl attr when on it

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4683,6 +4683,7 @@ void win_goto(win_T *wp)
   }
 
   win_enter(wp, true);
+  redraw_float_bot_border();
 
   // Conceal cursor line in previous window, unconceal in current window.
   if (win_valid(owp) && owp->w_p_cole > 0 && !msg_scrolled) {

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -17,6 +17,7 @@
 #include "nvim/mouse.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
+#include "nvim/option_vars.h"
 #include "nvim/optionstr.h"
 #include "nvim/pos_defs.h"
 #include "nvim/strings.h"

--- a/src/nvim/winfloat.h
+++ b/src/nvim/winfloat.h
@@ -10,6 +10,9 @@
 /// SE -> kFloatAnchorSouth | kFloatAnchorEast
 EXTERN const char *const float_anchor_str[] INIT( = { "NW", "NE", "SW", "SE" });
 
+#define FOR_ALL_FLOAT_WINDOWS(wp) \
+  for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev)
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "winfloat.h.generated.h"
 #endif

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9205,6 +9205,66 @@ describe('float window', function()
       eq(restcmd, fn.winrestcmd())
       eq(config, api.nvim_win_get_config(0))
     end)
+
+    it('border of float bottom on statusline', function()
+      screen:try_resize(20, 7)
+      command('set cmdheight=0 laststatus=2 | hi FloatBorder guibg=NONE')
+      api.nvim_open_win(
+        0,
+        true,
+        { relative = 'editor', row = 1, col = 1, width = 5, height = 7, border = 'single' }
+      )
+      if multigrid then
+        screen:expect {
+          grid = [[
+              ## grid 1
+                [2:--------------------]|*6
+                {5:[No Name]           }|
+              ## grid 2
+                                    |
+                {0:~                   }|*5
+              ## grid 3
+              ## grid 4
+                ┌─────┐|
+                │{1:^     }│|
+                │{2:~    }│|*6
+                └─────┘|
+              ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50 },
+          },
+          win_viewport = {
+            [2] = {
+              win = 1000,
+              topline = 0,
+              botline = 2,
+              curline = 0,
+              curcol = 0,
+              linecount = 1,
+              sum_scroll_delta = 0,
+            },
+            [4] = {
+              win = 1001,
+              topline = 0,
+              botline = 2,
+              curline = 0,
+              curcol = 0,
+              linecount = 1,
+              sum_scroll_delta = 0,
+            },
+          },
+        }
+      else
+        screen:expect {
+          grid = [[
+               ┌─────┐            |
+              {0:~}│{1:^     }│{0:            }|
+              {0:~}│{2:~    }│{0:            }|*4
+              {5:[└─────┘]           }|
+            ]],
+        }
+      end
+    end)
   end
 
   describe('with ext_multigrid', function()


### PR DESCRIPTION
Problem: when float bottom border on statusline and Floatborder backgournd is transparency i
t will override statusline highlight

Solution: bot border combine statusline attr when on it.


<details>
<summary>current behavior</summary>

![old](https://github.com/neovim/neovim/assets/41671631/1e0b56d7-7d7b-4cb2-a369-91f7d61ced91)
</details>

<details>
<summary>with patch</summary>

![new](https://github.com/neovim/neovim/assets/41671631/505745ab-428c-43e2-9f05-0431c1ce9366)

</details>
