### PR TITLE
feat(ui): 'smoothscroll' marker for hidden virt line above first line

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -181,6 +181,9 @@ void buf_put_decor(buf_T *buf, DecorInline decor, int row, int row2)
       buf_put_decor_sh(buf, sh, row, row2);
       idx = sh->next;
     }
+    if (row == 0 && decor.data.ext.vt && decor.data.ext.vt->flags & kVTLinesAbove) {
+      adjust_topfill(false);
+    }
   }
 }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -103,7 +103,8 @@ typedef struct {
 
   hlf_T diff_hlf;            ///< type of diff highlighting
 
-  int n_virt_lines;          ///< nr of virtual lines
+  int n_virt_lines;          ///< nr of virtual lines that will be be drawn
+  int line_virt_lines;       ///< nr of available virtual lines on this line
   int filler_lines;          ///< nr of filler lines to be drawn
   int filler_todo;           ///< nr of filler lines still to do + 1
   SignTextAttrs sattrs[SIGN_SHOW_MAX];  ///< sign attributes for the sign column
@@ -1154,7 +1155,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     area_highlighting = true;
   }
   VirtLines virt_lines = KV_INITIAL_VALUE;
-  wlv.n_virt_lines = decor_virt_lines(wp, lnum, &virt_lines, has_fold);
+  wlv.line_virt_lines = wlv.n_virt_lines = decor_virt_lines(wp, lnum, &virt_lines, has_fold);
   wlv.filler_lines += wlv.n_virt_lines;
   if (lnum == wp->w_topline) {
     wlv.filler_lines = wp->w_topfill;
@@ -2964,7 +2965,8 @@ static void wlv_put_linebuf(win_T *wp, const winlinevars_T *wlv, int endcol, boo
   }
 
   // Take care of putting "<<<" on the first line for 'smoothscroll'.
-  if (wlv->row == 0 && wp->w_skipcol > 0
+  if (wlv->row == 0
+      && (wp->w_skipcol > 0 || (wlv->lnum == 1 && wlv->line_virt_lines > wp->w_topfill))
       // do not overwrite the 'showbreak' text with "<<<"
       && *get_showbreak_value(wp) == NUL
       // do not overwrite the 'listchars' "precedes" text with "<<<"

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2501,6 +2501,22 @@ describe('extmark decorations', function()
                                                         |
     ]])
   end)
+
+  it("hidden virtual text above first line shows marker", function()
+    fn.setline(1, 'some text')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_lines={{{'Above1', 'String'}}}, virt_lines_above=true})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_lines={{{'Above2', 'String'}}}, virt_lines_above=true})
+    -- Automatically scroll when cursor becomes hidden behind '<<<' marker
+    screen:expect({grid=[[
+      {1:<<<}{13:ve2}                                            |
+      ^some text                                         |
+      {1:~                                                 }|*12
+                                                        |
+    ]]})
+    feed('$<C-E>0')
+    -- Scroll when moving cursor behind '<<<' marker
+    screen:expect_unchanged()
+  end)
 end)
 
 describe('decorations: inline virtual text', function()
@@ -4223,6 +4239,7 @@ if (h->n_buckets < new_n_buckets) { // expand
                                                         |
     ]]}
 
+    feed('$')
     api.nvim_buf_set_extmark(0, ns, 0, 0, {
       virt_lines={
         {{"refactor(khash): ", "Special"}, {"take size of values as parameter"}};
@@ -4233,8 +4250,9 @@ if (h->n_buckets < new_n_buckets) { // expand
     })
 
     -- placing virt_text on topline does not automatically cause a scroll
+    -- if it does not invalidate the cursor, but shows the '<<<' marker.
     screen:expect{grid=[[
-      ^if (h->n_buckets < new_n_buckets) { // expand     |
+      {1:<<<}(h->n_buckets < new_n_buckets) { // expan^d     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
         h->keys = new_keys;                             |


### PR DESCRIPTION
Problem:  There may be hidden virtual lines above the first line
          unbeknownst to the user.
Solution: Show the 'smoothscroll' marker in case there are hidden virtual
          lines above the first line. Scroll up when moving the cursor behind
          the marker and redraw the line when scrolling up by other means.