### PR TITLE
docs: fix invalid link to FAQ in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,7 +16,7 @@
 
 **Notes**:
 - From the repository's root directory, running `make` will download and build all the needed dependencies and put the `nvim` executable in `build/bin`.
-- Third-party dependencies (libuv, LuaJIT, etc.) are downloaded automatically to `.deps/`. See the [FAQ](FAQ#build-issues) if you have issues.
+- Third-party dependencies (libuv, LuaJIT, etc.) are downloaded automatically to `.deps/`. See the [FAQ](https://neovim.io/doc/user/faq.html#faq-build) if you have issues.
 - After building, you can run the `nvim` executable without installing it by running `VIMRUNTIME=runtime ./build/bin/nvim`.
 - If you plan to develop Neovim, install [Ninja](https://ninja-build.org/) for faster builds. It will automatically be used.
 - Install [ccache](https://ccache.dev/) for faster rebuilds of Neovim. It's used by default. To disable it, use `CCACHE_DISABLE=true make`.


### PR DESCRIPTION
I spotted an invalid link in `BUILD.md` pointing to a non-existing `FAQ` file. I assume it should be pointing to the [FAQ on neovim.io](https://neovim.io/doc/user/faq.html#faq-build).