### PR TITLE
feat(ui): hide unfocusable floating windows from window lists

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3196,7 +3196,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                   • focusable: Enable focus by user actions (wincmds, mouse
                     events). Defaults to true. Non-focusable windows can be
                     entered by |nvim_set_current_win()|, or, when the `mouse`
-                    field is set to true, by mouse events.
+                    field is set to true, by mouse events. See |focusable|.
                   • mouse: Specify how this window interacts with mouse
                     events. Defaults to `focusable` value.
                     • If false, mouse events pass through this window.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -69,7 +69,8 @@ If a window is focusable, it is part of the "navigation stack", that is,
 editor commands such as :windo, |CTRL-W|, etc., will consider the window as
 one that can be made the "current window". A non-focusable window will be
 skipped by such commands (though it can be explicitly focused by
-|nvim_set_current_win()|).
+|nvim_set_current_win()|). Non-focusable windows are not listed by |:tabs|, and
+are not counted by the default 'tabline'.
 
 Windows (especially floating windows) can have many other |api-win_config|
 properties such as "hide" and "fixed" which also affect behavior.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1768,7 +1768,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- - focusable: Enable focus by user actions (wincmds, mouse events).
 ---     Defaults to true. Non-focusable windows can be entered by
 ---     `nvim_set_current_win()`, or, when the `mouse` field is set to true,
----     by mouse events.
+---     by mouse events. See `focusable`.
 --- - mouse: Specify how this window interacts with mouse events.
 ---     Defaults to `focusable` value.
 ---     - If false, mouse events pass through this window.

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -130,7 +130,7 @@
 ///   - focusable: Enable focus by user actions (wincmds, mouse events).
 ///       Defaults to true. Non-focusable windows can be entered by
 ///       |nvim_set_current_win()|, or, when the `mouse` field is set to true,
-///       by mouse events.
+///       by mouse events. See |focusable|.
 ///   - mouse: Specify how this window interacts with mouse events.
 ///       Defaults to `focusable` value.
 ///       - If false, mouse events pass through this window.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5507,6 +5507,8 @@ static void ex_tabs(exarg_T *eap)
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
       if (got_int) {
         break;
+      } else if (!wp->w_config.focusable) {
+        continue;
       }
 
       msg_putchar('\n');

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -760,7 +760,9 @@ void draw_tabline(void)
       bool modified = false;
 
       for (wincount = 0; wp != NULL; wp = wp->w_next, wincount++) {
-        if (bufIsChanged(wp->w_buffer)) {
+        if (!wp->w_config.focusable) {
+          wincount--;
+        } else if (bufIsChanged(wp->w_buffer)) {
           modified = true;
         }
       }

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -214,4 +214,43 @@ describe('tabline', function()
     api.nvim_input_mouse('middle', 'press', '', 0, 0, 1)
     eq({ 1, 1 }, api.nvim_eval('[tabpagenr(), tabpagenr("$")]'))
   end)
+
+  it('does not show floats with focusable=false', function()
+    screen:set_default_attr_ids({
+      [1] = { background = Screen.colors.Plum1 },
+      [2] = { underline = true, background = Screen.colors.LightGrey },
+      [3] = { bold = true },
+      [4] = { reverse = true },
+      [5] = { bold = true, foreground = Screen.colors.Blue1 },
+      [6] = { foreground = Screen.colors.Fuchsia, bold = true },
+      [7] = { foreground = Screen.colors.SeaGreen, bold = true },
+    })
+    command('tabnew')
+    api.nvim_open_win(0, false, {
+      focusable = false,
+      relative = 'editor',
+      height = 1,
+      width = 1,
+      row = 0,
+      col = 0,
+    })
+    screen:expect {
+      grid = [[
+      {1: }{2:[No Name] }{3: [No Name] }{4:                   }{2:X}|
+      ^                                          |
+      {5:~                                         }|*2
+                                                |
+    ]],
+    }
+    command('tabs')
+    screen:expect {
+      grid = [[
+      {6:Tab page 1}                                |
+      #   [No Name]                             |
+      {6:Tab page 2}                                |
+      >   [No Name]                             |
+      {7:Press ENTER or type command to continue}^   |
+    ]],
+    }
+  end)
 end)


### PR DESCRIPTION
Problem:  Floating windows with focusable set to false can reasonably be
          expected to be UI elements but are listed in some outputs that
          should contain only regular windows.
Solution: Hide unfocusable floating windows from the default tabline and
          :tabs.