### PR TITLE
vim-patch:8.2.{2318,2605}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7523,16 +7523,30 @@ int check_luafunc_name(const char *const str, const bool paren)
 /// "index" is out of range NULL is returned.
 char *char_from_string(const char *str, varnumber_T index)
 {
-  size_t nbyte = 0;
   varnumber_T nchar = index;
 
-  if (str == NULL || index < 0) {
+  if (str == NULL) {
     return NULL;
   }
   size_t slen = strlen(str);
-  while (nchar > 0 && nbyte < slen) {
+
+  // do the same as for a list: a negative index counts from the end
+  if (index < 0) {
+    int clen = 0;
+
+    for (size_t nbyte = 0; nbyte < slen; clen++) {
+      nbyte += (size_t)utf_ptr2len(str + nbyte);
+    }
+    nchar = clen + index;
+    if (nchar < 0) {
+      // unlike list: index out of range results in empty string
+      return NULL;
+    }
+  }
+
+  size_t nbyte = 0;
+  for (; nchar > 0 && nbyte < slen; nchar--) {
     nbyte += (size_t)utf_ptr2len(str + nbyte);
-    nchar--;
   }
   if (nbyte >= slen) {
     return NULL;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7519,8 +7519,9 @@ int check_luafunc_name(const char *const str, const bool paren)
   return (int)(p - str);
 }
 
-/// Return the character "str[index]" where "index" is the character index.  If
-/// "index" is out of range NULL is returned.
+/// Return the character "str[index]" where "index" is the character index,
+/// including composing characters.
+/// If "index" is out of range NULL is returned.
 char *char_from_string(const char *str, varnumber_T index)
 {
   varnumber_T nchar = index;
@@ -7535,7 +7536,7 @@ char *char_from_string(const char *str, varnumber_T index)
     int clen = 0;
 
     for (size_t nbyte = 0; nbyte < slen; clen++) {
-      nbyte += (size_t)utf_ptr2len(str + nbyte);
+      nbyte += (size_t)utfc_ptr2len(str + nbyte);
     }
     nchar = clen + index;
     if (nchar < 0) {
@@ -7546,16 +7547,16 @@ char *char_from_string(const char *str, varnumber_T index)
 
   size_t nbyte = 0;
   for (; nchar > 0 && nbyte < slen; nchar--) {
-    nbyte += (size_t)utf_ptr2len(str + nbyte);
+    nbyte += (size_t)utfc_ptr2len(str + nbyte);
   }
   if (nbyte >= slen) {
     return NULL;
   }
-  return xmemdupz(str + nbyte, (size_t)utf_ptr2len(str + nbyte));
+  return xmemdupz(str + nbyte, (size_t)utfc_ptr2len(str + nbyte));
 }
 
 /// Get the byte index for character index "idx" in string "str" with length
-/// "str_len".
+/// "str_len".  Composing characters are included.
 /// If going over the end return "str_len".
 /// If "idx" is negative count from the end, -1 is the last character.
 /// When going over the start return -1.
@@ -7566,7 +7567,7 @@ static ssize_t char_idx2byte(const char *str, size_t str_len, varnumber_T idx)
 
   if (nchar >= 0) {
     while (nchar > 0 && nbyte < str_len) {
-      nbyte += (size_t)utf_ptr2len(str + nbyte);
+      nbyte += (size_t)utfc_ptr2len(str + nbyte);
       nchar--;
     }
   } else {
@@ -7583,7 +7584,8 @@ static ssize_t char_idx2byte(const char *str, size_t str_len, varnumber_T idx)
   return (ssize_t)nbyte;
 }
 
-/// Return the slice "str[first:last]" using character indexes.
+/// Return the slice "str[first : last]" using character indexes.  Composing
+/// characters are included.
 ///
 /// @param exclusive  true for slice().
 ///
@@ -7605,7 +7607,7 @@ char *string_slice(const char *str, varnumber_T first, varnumber_T last, bool ex
     end_byte = char_idx2byte(str, slen, last);
     if (!exclusive && end_byte >= 0 && end_byte < (ssize_t)slen) {
       // end index is inclusive
-      end_byte += utf_ptr2len(str + end_byte);
+      end_byte += utfc_ptr2len(str + end_byte);
     }
   }
 

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -859,7 +859,7 @@ int tv_list_slice_or_index(list_T *list, bool range, varnumber_T n1_arg, varnumb
     // A list index out of range is an error.
     if (!range) {
       if (verbose) {
-        semsg(_(e_list_index_out_of_range_nr), (int64_t)n1);
+        semsg(_(e_list_index_out_of_range_nr), (int64_t)n1_arg);
       }
       return FAIL;
     }


### PR DESCRIPTION
#### vim-patch:8.2.2318: Vim9: string and list index work differently

Problem:    Vim9: string and list index work differently.
Solution:   Make string index work like list index.

https://github.com/vim/vim/commit/e7525c552060dd04aacdbca6bb5fe6460cf4da60

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2605: Vim9: string index and slice does not include composing chars

Problem:    Vim9: string index and slice does not include composing chars.
Solution:   Include composing characters. (issue vim/vim#6563)

https://github.com/vim/vim/commit/0289a093a4d65c6280a3be118d1d3696d1aa74da

Co-authored-by: Bram Moolenaar <Bram@vim.org>