### PR TITLE
vim-patch:9.1.0199: Not enough tests for the slice() function

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7411,7 +7411,8 @@ slice({expr}, {start} [, {end}])                                       *slice()*
 		Similar to using a |slice| "expr[start : end]", but "end" is
 		used exclusive.  And for a string the indexes are used as
 		character indexes instead of byte indexes.
-		Also, composing characters are not counted.
+		Also, composing characters are treated as a part of the
+		preceding base character.
 		When {end} is omitted the slice continues to the last item.
 		When {end} is -1 the last item is omitted.
 		Returns an empty value if {start} or {end} are invalid.
@@ -7758,8 +7759,8 @@ strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 		of byte index and length.
 		When {skipcc} is omitted or zero, composing characters are
 		counted separately.
-		When {skipcc} set to 1, Composing characters are ignored,
-		similar to  |slice()|.
+		When {skipcc} set to 1, composing characters are treated as a
+		part of the preceding base character, similar to |slice()|.
 		When a character index is used where a character does not
 		exist it is omitted and counted as one character.  For
 		example: >vim
@@ -7773,7 +7774,7 @@ strchars({string} [, {skipcc}])                                     *strchars()*
 		in String {string}.
 		When {skipcc} is omitted or zero, composing characters are
 		counted separately.
-		When {skipcc} set to 1, Composing characters are ignored.
+		When {skipcc} set to 1, composing characters are ignored.
 		|strcharlen()| always does this.
 
 		Returns zero on error.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8800,7 +8800,8 @@ function vim.fn.sinh(expr) end
 --- Similar to using a |slice| "expr[start : end]", but "end" is
 --- used exclusive.  And for a string the indexes are used as
 --- character indexes instead of byte indexes.
---- Also, composing characters are not counted.
+--- Also, composing characters are treated as a part of the
+--- preceding base character.
 --- When {end} is omitted the slice continues to the last item.
 --- When {end} is -1 the last item is omitted.
 --- Returns an empty value if {start} or {end} are invalid.
@@ -9208,8 +9209,8 @@ function vim.fn.strcharlen(string) end
 --- of byte index and length.
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
---- When {skipcc} set to 1, Composing characters are ignored,
---- similar to  |slice()|.
+--- When {skipcc} set to 1, composing characters are treated as a
+--- part of the preceding base character, similar to |slice()|.
 --- When a character index is used where a character does not
 --- exist it is omitted and counted as one character.  For
 --- example: >vim
@@ -9229,7 +9230,7 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- in String {string}.
 --- When {skipcc} is omitted or zero, composing characters are
 --- counted separately.
---- When {skipcc} set to 1, Composing characters are ignored.
+--- When {skipcc} set to 1, composing characters are ignored.
 --- |strcharlen()| always does this.
 ---
 --- Returns zero on error.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10485,7 +10485,8 @@ M.funcs = {
       Similar to using a |slice| "expr[start : end]", but "end" is
       used exclusive.  And for a string the indexes are used as
       character indexes instead of byte indexes.
-      Also, composing characters are not counted.
+      Also, composing characters are treated as a part of the
+      preceding base character.
       When {end} is omitted the slice continues to the last item.
       When {end} is -1 the last item is omitted.
       Returns an empty value if {start} or {end} are invalid.
@@ -10957,8 +10958,8 @@ M.funcs = {
       of byte index and length.
       When {skipcc} is omitted or zero, composing characters are
       counted separately.
-      When {skipcc} set to 1, Composing characters are ignored,
-      similar to  |slice()|.
+      When {skipcc} set to 1, composing characters are treated as a
+      part of the preceding base character, similar to |slice()|.
       When a character index is used where a character does not
       exist it is omitted and counted as one character.  For
       example: >vim
@@ -10981,7 +10982,7 @@ M.funcs = {
       in String {string}.
       When {skipcc} is omitted or zero, composing characters are
       counted separately.
-      When {skipcc} set to 1, Composing characters are ignored.
+      When {skipcc} set to 1, composing characters are ignored.
       |strcharlen()| always does this.
 
       Returns zero on error.

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3610,4 +3610,55 @@ func Test_glob_extended_mswin()
   call delete('Xtestglob', 'rf')
 endfunc
 
+" Tests for the slice() function.
+func Test_slice()
+  let lines =<< trim END
+    call assert_equal([1, 2, 3, 4, 5], slice(range(6), 1))
+    call assert_equal([2, 3, 4, 5], slice(range(6), 2))
+    call assert_equal([2, 3], slice(range(6), 2, 4))
+    call assert_equal([0, 1, 2, 3], slice(range(6), 0, 4))
+    call assert_equal([1, 2, 3], slice(range(6), 1, 4))
+    call assert_equal([1, 2, 3, 4], slice(range(6), 1, -1))
+    call assert_equal([1, 2], slice(range(6), 1, -3))
+    call assert_equal([1], slice(range(6), 1, -4))
+    call assert_equal([], slice(range(6), 1, -5))
+    call assert_equal([], slice(range(6), 1, -6))
+
+    call assert_equal(0z1122334455, slice(0z001122334455, 1))
+    call assert_equal(0z22334455, slice(0z001122334455, 2))
+    call assert_equal(0z2233, slice(0z001122334455, 2, 4))
+    call assert_equal(0z00112233, slice(0z001122334455, 0, 4))
+    call assert_equal(0z112233, slice(0z001122334455, 1, 4))
+    call assert_equal(0z11223344, slice(0z001122334455, 1, -1))
+    call assert_equal(0z1122, slice(0z001122334455, 1, -3))
+    call assert_equal(0z11, slice(0z001122334455, 1, -4))
+    call assert_equal(0z, slice(0z001122334455, 1, -5))
+    call assert_equal(0z, slice(0z001122334455, 1, -6))
+
+    call assert_equal('12345', slice('012345', 1))
+    call assert_equal('2345', slice('012345', 2))
+    call assert_equal('23', slice('012345', 2, 4))
+    call assert_equal('0123', slice('012345', 0, 4))
+    call assert_equal('123', slice('012345', 1, 4))
+    call assert_equal('1234', slice('012345', 1, -1))
+    call assert_equal('12', slice('012345', 1, -3))
+    call assert_equal('1', slice('012345', 1, -4))
+    call assert_equal('', slice('012345', 1, -5))
+    call assert_equal('', slice('012345', 1, -6))
+
+    #" Composing chars are treated as a part of the preceding base char.
+    call assert_equal('β̳́γ̳̂δ̳̃ε̳̄ζ̳̅', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1))
+    call assert_equal('γ̳̂δ̳̃ε̳̄ζ̳̅', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(2))
+    call assert_equal('γ̳̂δ̳̃', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(2, 4))
+    call assert_equal('ὰ̳β̳́γ̳̂δ̳̃', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(0, 4))
+    call assert_equal('β̳́γ̳̂δ̳̃', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, 4))
+    call assert_equal('β̳́γ̳̂δ̳̃ε̳̄', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -1))
+    call assert_equal('β̳́γ̳̂', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -3))
+    call assert_equal('β̳́', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -4))
+    call assert_equal('', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -5))
+    call assert_equal('', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -6))
+  END
+  call CheckLegacyAndVim9Success(lines)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0199: Not enough tests for the slice() function

Problem:  Not enough tests for the slice() function.
Solution: Test with multibyte chars, and in both Legacy and Vim9 script.
          Update docs to be clearer about how it treats composing chars.
          (zeertzjq)

closes: vim/vim#14275

https://github.com/vim/vim/commit/ad38769030b5fa86aa0e8f1f0b4266690dfad4c9