### PR TITLE
fix(vim.iter): use correct cmp function when truncating tail in `take`

### DIFF
--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -709,7 +709,8 @@ end
 ---@private
 function ListIter:take(n)
   local inc = self._head < self._tail and 1 or -1
-  self._tail = math.min(self._tail, self._head + n * inc)
+  local cmp = self._head < self._tail and math.min or math.max
+  self._tail = cmp(self._tail, self._head + n * inc)
   return self
 end
 

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -139,6 +139,8 @@ describe('vim.iter', function()
 
   it('rev()', function()
     eq({ 3, 2, 1 }, vim.iter({ 1, 2, 3 }):rev():totable())
+    eq({ 3, 2 }, vim.iter({ 1, 2, 3 }):rev():take(2):totable())
+    eq({ 3, 2 }, vim.iter({ 1, 2, 3 }):take(2):rev():totable())
 
     local it = vim.iter(string.gmatch('abc', '%w'))
     matches('rev%(%) requires a list%-like table', pcall_err(it.rev, it))

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -139,8 +139,6 @@ describe('vim.iter', function()
 
   it('rev()', function()
     eq({ 3, 2, 1 }, vim.iter({ 1, 2, 3 }):rev():totable())
-    eq({ 3, 2 }, vim.iter({ 1, 2, 3 }):rev():take(2):totable())
-    eq({ 2, 1 }, vim.iter({ 1, 2, 3 }):take(2):rev():totable())
 
     local it = vim.iter(string.gmatch('abc', '%w'))
     matches('rev%(%) requires a list%-like table', pcall_err(it.rev, it))
@@ -247,6 +245,12 @@ describe('vim.iter', function()
       eq({ 4, 3, 2 }, vim.iter(t):take(3):totable())
       eq({ 4, 3, 2, 1 }, vim.iter(t):take(4):totable())
       eq({ 4, 3, 2, 1 }, vim.iter(t):take(5):totable())
+    end
+
+    do
+      local t = { 4, 3, 2, 1 }
+      eq({ 1, 2, 3 }, vim.iter(t):rev():take(3))
+      eq({ 2, 3, 4 }, vim.iter(t):take(3):rev())
     end
 
     do

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -140,7 +140,7 @@ describe('vim.iter', function()
   it('rev()', function()
     eq({ 3, 2, 1 }, vim.iter({ 1, 2, 3 }):rev():totable())
     eq({ 3, 2 }, vim.iter({ 1, 2, 3 }):rev():take(2):totable())
-    eq({ 3, 2 }, vim.iter({ 1, 2, 3 }):take(2):rev():totable())
+    eq({ 2, 1 }, vim.iter({ 1, 2, 3 }):take(2):rev():totable())
 
     local it = vim.iter(string.gmatch('abc', '%w'))
     matches('rev%(%) requires a list%-like table', pcall_err(it.rev, it))

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -249,8 +249,8 @@ describe('vim.iter', function()
 
     do
       local t = { 4, 3, 2, 1 }
-      eq({ 1, 2, 3 }, vim.iter(t):rev():take(3))
-      eq({ 2, 3, 4 }, vim.iter(t):take(3):rev())
+      eq({ 1, 2, 3 }, vim.iter(t):rev():take(3):totable())
+      eq({ 2, 3, 4 }, vim.iter(t):take(3):rev():totable())
     end
 
     do


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/27997