### PR TITLE
vim-patch:d3c0ff5d5a90

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1679,7 +1679,7 @@ func s:CreateBreakpoint(id, subid, enabled)
       endif
     endif
     call sign_define('debugBreakpoint' .. nr,
-          \ #{text: strpart(label, 0, 2),
+          \ #{text: slice(label, 0, 2),
           \ texthl: hiName})
   endif
 endfunc


### PR DESCRIPTION
runtime(termdebug): allow multibyte characters as breakpoint signs (vim/vim#14274)

Allow multibyte characters as termdebug signs using slice() function

https://github.com/vim/vim/commit/d3c0ff5d5a9076999a8504ee4d23a2c5abaf494e

Co-authored-by: Mihai Ciuraru <mihai.ciuraru@gmail.com>
Co-authored-by: zeertzjq <zeertzjq@outlook.com>
