### PR TITLE
vim-patch:6f438199c92b

### DIFF
--- a/runtime/compiler/dot.vim
+++ b/runtime/compiler/dot.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     ATT dot
 " Maintainer:	Marcos Macedo <bar4ka@bol.com.br>
-" Last Change:	2004 May 16
+" Last Change:	2024 March 21
 
 if exists("current_compiler")
   finish
@@ -13,3 +13,6 @@ if exists(":CompilerSet") != 2		" older Vim always used :setlocal
 endif
 
 CompilerSet makeprg=dot\ -T$*\ \"%:p\"\ -o\ \"%:p:r.$*\"
+" matches error messages as below skipping final part after line number
+" Error: ./file.dot: syntax error in line 1 near 'rankdir'
+CompilerSet errorformat=%trror:\ %f:\ %m\ in\ line\ %l%.%#

--- a/runtime/compiler/neato.vim
+++ b/runtime/compiler/neato.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     ATT neato
 " Maintainer:	Marcos Macedo <bar4ka@bol.com.br>
-" Last Change:	2004 May 16
+" Last Change:	2024 March 21
 
 if exists("current_compiler")
   finish
@@ -13,3 +13,6 @@ if exists(":CompilerSet") != 2		" older Vim always used :setlocal
 endif
 
 CompilerSet makeprg=neato\ -T$*\ \"%:p\"\ -o\ \"%:p:r.$*\"
+" matches error messages as below skipping final part after line number
+" Error: ./file.dot: syntax error in line 1 near 'rankdir'
+CompilerSet errorformat=%trror:\ %f:\ %m\ in\ line\ %l%.%#


### PR DESCRIPTION
runtime(compiler): update errorformat for dot and neato compiler (vim/vim#14257)

* add errorformat for dot compiler
* add errorformat for neato compiler

https://github.com/vim/vim/commit/6f438199c92b3258c1faeba1c5ebddd2ce247658

Co-authored-by: Enno <Konfekt@users.noreply.github.com>
