### PR TITLE
vim-patch:4b715bdaf4ca

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -2680,7 +2680,7 @@ fun! netrw#NetWrite(...) range
      let url= g:netrw_choice
      call s:NetrwExe(s:netrw_silentxfer."!".g:netrw_http_put_cmd." ".s:ShellEscape(tmpfile,1)." ".s:ShellEscape(url,1) )
     elseif !exists("g:netrw_quiet")
-     call netrw#ErrorMsg(s:ERROR,"can't write to http using <".g:netrw_http_put_cmd.">".",16)
+     call netrw#ErrorMsg(s:ERROR,"can't write to http using <".g:netrw_http_put_cmd.">",16)
     endif
 
    ".........................................


### PR DESCRIPTION
runtime(netrw): Fix typo in netrw#NetWrite (vim/vim#14283)

Fix typo in netrw#NetWrite (http) error message call.

https://github.com/vim/vim/commit/4b715bdaf4ca08ba0f64475e250c0fe799ab6d9b

Co-authored-by: dkearns <dougkearns@gmail.com>
