### PR TITLE
feat(UI): add ext_elementtype UI extension

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -179,6 +179,7 @@ Nvim exposes its API metadata as a Dictionary with these items:
                           describing the return value and parameters.
 - ui_events               |UI| event signatures
 - ui_options              Supported |ui-option|s
+- ui_element_tags         String to bit number mapping for |ui-elementtype|
 - {fn}.since              API level where function {fn} was introduced
 - {fn}.deprecated_since   API level where function {fn} was deprecated
 - types                   Custom handle types defined by Nvim

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -343,6 +343,9 @@ The following new APIs and features were added.
 
 • |extmarks| option `scoped`: only show the extmarks in its namespace's scope.
 
+• Added a new UI extension `ext_elementtype`, which makes it possible for UIs
+  to track UI elements like floating window borders. |ui-elementtype|
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -38,6 +38,8 @@ with these (optional) keys:
 
 							*ui-ext-options*
 - `ext_cmdline`		Externalize the cmdline. |ui-cmdline|
+- `ext_elementtype`	Gives details about UI element types. |ui-elementtype|
+			Sets `ext_linegrid` implicitly.
 - `ext_hlstate`		Detailed highlight state. |ui-hlstate|
 			Sets `ext_linegrid` implicitly.
 - `ext_linegrid`	Line-based grid events. |ui-linegrid|
@@ -308,7 +310,7 @@ numerical highlight ids to the actual attributes.
 	screen with changed background color itself.
 
 							*ui-event-hl_attr_define*
-["hl_attr_define", id, rgb_attr, cterm_attr, info] ~
+["hl_attr_define", id, rgb_attr, cterm_attr, info, element_tags] ~
 	Add a highlight with `id`  to the highlight table, with the
 	attributes specified by the `rgb_attr` and `cterm_attr` dicts, with the
 	following (all optional) keys.
@@ -356,6 +358,9 @@ numerical highlight ids to the actual attributes.
 
 	`info` is an empty array by default, and will be used by the
 	|ui-hlstate| extension explained below.
+
+	`element_tags` is an empty array by default, and will be used by the
+	|ui-elementtype| extension explained below.
 
 ["hl_group_set", name, hl_id] ~
 	The built-in highlight group `name` was set to use the attributes `hl_id`
@@ -575,6 +580,36 @@ differ, because the builtin group was linked to another group |:hi-link| , or
 because 'winhighlight' was used. UI items will be transmitted, even if the
 highlight group is cleared, so `ui_name` can always be used to reliably identify
 screen elements, even if no attributes have been applied.
+
+==============================================================================
+Details about UI element types				       *ui-elementtype*
+
+Activated by the `ext_elementtype` |ui-option|.
+Activates |ui-linegrid| implicitly.
+
+When this is set the `element_tags` parameter of |ui-event-hl_attr_define|
+contains semantic information about the type of UI element displayed.
+
+`element_tags` is a bitfield integer, with one more of the following tags set:
+    `StatusBar`    Status bars
+    `WinBar`       Winbars
+    `FloatBorder`  Floating window borders, including titles
+    `FloatTitle`   Floating window titles and footers
+    `Top`          A top element, like a floating window top border
+    `Bottom`       A bottom element
+    `Left`         A left element
+    `Right`        A right element
+    `HSplit`       A horizontal split, which also includes StatusBars, since they
+                 act as splits
+    `VSplit`       A vertical split
+
+The name to bit number mapping can be read from |api-metadata|, the bit number is simply the index.
+
+Multiple element tags can be set, so a floating window footer is represented as:
+    `FloatBorder` | `FloatTitle` | `Bottom`
+
+New element types can be added in the future, so UI implementations should be
+prepared to ignore the ones they don't handle.
 
 ==============================================================================
 Multigrid Events						 *ui-multigrid*

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -38,6 +38,7 @@
 #include "nvim/option.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
+#include "nvim/ui_defs.h"
 
 #define BUF_POS(ui) ((size_t)((ui)->packer.ptr - (ui)->packer.startptr))
 
@@ -161,7 +162,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height, Dictiona
     }
   }
 
-  if (ui->ui_ext[kUIHlState] || ui->ui_ext[kUIMultigrid]) {
+  if (ui->ui_ext[kUIHlState] || ui->ui_ext[kUIMultigrid] || ui->ui_ext[kUIElementType]) {
     ui->ui_ext[kUILinegrid] = true;
   }
 
@@ -672,7 +673,7 @@ void remote_ui_default_colors_set(RemoteUI *ui, Integer rgb_fg, Integer rgb_bg, 
 }
 
 void remote_ui_hl_attr_define(RemoteUI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs,
-                              Array info)
+                              Array info, Integer element_tags)
 {
   if (!ui->ui_ext[kUILinegrid]) {
     return;
@@ -700,6 +701,8 @@ void remote_ui_hl_attr_define(RemoteUI *ui, Integer id, HlAttrs rgb_attrs, HlAtt
   } else {
     ADD_C(args, ARRAY_OBJ((Array)ARRAY_DICT_INIT));
   }
+
+  ADD_C(args, INTEGER_OBJ(element_tags));
 
   push_call(ui, "hl_attr_define", args);
 }

--- a/src/nvim/api/ui.h
+++ b/src/nvim/api/ui.h
@@ -17,8 +17,22 @@ EXTERN const char *ui_ext_names[] INIT( = {
   "ext_linegrid",
   "ext_multigrid",
   "ext_hlstate",
+  "ext_elementtype",
   "ext_termcolors",
   "_debug_float",
+});
+
+EXTERN const char *ui_element_tag_names[] INIT( = {
+  "StatusBar",
+  "WinBar",
+  "FloatBorder",
+  "FloatTitle",
+  "Top",
+  "Bottom",
+  "Left",
+  "Right",
+  "HSplit",
+  "VSplit",
 });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -73,7 +73,8 @@ void scroll(Integer count)
 void default_colors_set(Integer rgb_fg, Integer rgb_bg, Integer rgb_sp, Integer cterm_fg,
                         Integer cterm_bg)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_IMPL;
-void hl_attr_define(Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs, Array info)
+void hl_attr_define(Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs, Array info,
+                    Integer element_tags)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL;
 void hl_group_set(String name, Integer id)
   FUNC_API_SINCE(6) FUNC_API_CLIENT_IGNORE;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2034,7 +2034,7 @@ Array nvim__inspect_cell(Integer grid, Integer row, Integer col, Arena *arena, E
   int attr = g->attrs[off];
   ADD_C(ret, DICTIONARY_OBJ(hl_get_attr_by_id(attr, true, arena, err)));
   // will not work first time
-  if (!highlight_use_hlstate()) {
+  if (!highlight_ext_enable(true, false)) {
     ADD_C(ret, ARRAY_OBJ(hl_inspect(attr, arena)));
   }
   return ret;

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -100,6 +100,7 @@ local function add_keyset(val)
 end
 
 local ui_options_text = nil
+local ui_element_tags_text = nil
 
 -- read each input file, parse and append to the api metadata
 for i = pre_args + 1, #arg do
@@ -124,6 +125,9 @@ for i = pre_args + 1, #arg do
   end
 
   ui_options_text = ui_options_text or string.match(text, 'ui_ext_names%[][^{]+{([^}]+)}')
+  ui_element_tags_text = ui_element_tags_text
+    or string.match(text, 'ui_element_tag_names%[][^{]+{([^}]+)}')
+
   input:close()
 end
 
@@ -229,6 +233,11 @@ for x in string.gmatch(ui_options_text, '"([a-z][a-z_]+)"') do
   table.insert(ui_options, x)
 end
 
+local ui_element_tags = {}
+for x in string.gmatch(ui_element_tags_text, '"(%a+)"') do
+  table.insert(ui_element_tags, x)
+end
+
 local version = require 'nvim_version'
 local git_version = io.open(git_version_inputf):read '*a'
 local version_build = string.match(git_version, '#define NVIM_VERSION_BUILD "([^"]+)"') or vim.NIL
@@ -253,7 +262,7 @@ local function put(item, item2)
   end
 end
 
-fixdict(6)
+fixdict(7)
 
 put('version')
 fixdict(1 + #version)
@@ -268,6 +277,7 @@ put('functions', exported_functions)
 put('ui_events')
 table.insert(pieces, io.open(ui_metadata_inputf, 'rb'):read('*all'))
 put('ui_options', ui_options)
+put('ui_element_tags', ui_element_tags)
 
 put('error_types')
 fixdict(2)

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -139,12 +139,32 @@ typedef enum {
   kHlInvalid,
 } HlKind;
 
+/// When making changes, also update element_tag_names in apy/ui.h!
+/// Only add new elements to the end, and keep the ordering for protocol compatibility.
+/// Only 32 tags are supported at the moment.
+/// 64 would be possible, but the rpc protocol only supports signed Integers
+/// And Lua can only do bit operations on 32 bit values
+// So if more tags are needed another field in HLEntry is probably the best option
+typedef enum {
+  ET_STATUSBAR = 1U << 0,
+  ET_WINBAR = 1U << 1,
+  ET_FLOATBORDER = 1U << 2,
+  ET_FLOATTITLE = 1U << 3,
+  ET_TOP = 1U << 4,
+  ET_BOTTOM = 1U << 5,
+  ET_LEFT = 1U << 6,
+  ET_RIGHT = 1U << 7,
+  ET_HSPLIT = 1U << 8,
+  ET_VSPLIT = 1U << 9,
+} element_type_tag_t;
+
 typedef struct {
   HlAttrs attr;
   HlKind kind;
   int id1;
   int id2;
   int winid;
+  uint32_t element_tags;
 } HlEntry;
 
 typedef struct {

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -93,6 +93,7 @@ void win_redr_status(win_T *wp)
     redraw_custom_statusline(wp);
   } else {
     schar_T fillchar = fillchar_status(&attr, wp);
+    attr = hl_add_element_tags(attr, ET_STATUSBAR | ET_HSPLIT);
     const int stl_width = is_stl_global ? Columns : wp->w_width;
 
     get_trans_bufname(wp->w_buffer);
@@ -180,8 +181,10 @@ void win_redr_status(win_T *wp)
     schar_T fillchar;
     if (stl_connected(wp)) {
       fillchar = fillchar_status(&attr, wp);
+      attr = hl_add_element_tags(attr, ET_STATUSBAR | ET_HSPLIT | ET_VSPLIT);
     } else {
       attr = win_hl_attr(wp, HLF_C);
+      attr = hl_add_element_tags(attr, ET_HSPLIT | ET_VSPLIT);
       fillchar = wp->w_p_fcs_chars.vert;
     }
     grid_line_start(&default_grid, W_ENDROW(wp));
@@ -344,6 +347,8 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
 
     fillchar = wp->w_p_fcs_chars.wbr;
     attr = (wp == curwin) ? win_hl_attr(wp, HLF_WBR) : win_hl_attr(wp, HLF_WBRNC);
+    attr = hl_add_element_tags(attr, ET_WINBAR);
+
     maxwidth = wp->w_width_inner;
     stl_clear_click_defs(wp->w_winbar_click_defs, wp->w_winbar_click_defs_size);
     wp->w_winbar_click_defs = stl_alloc_click_defs(wp->w_winbar_click_defs, maxwidth,
@@ -390,6 +395,8 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
       opt_idx = kOptStatusline;
       stl = ((*wp->w_p_stl != NUL) ? wp->w_p_stl : p_stl);
       opt_scope = ((*wp->w_p_stl != NUL) ? OPT_LOCAL : 0);
+
+      attr = hl_add_element_tags(attr, ET_STATUSBAR | ET_HSPLIT);
     }
 
     if (in_status_line && !is_stl_global) {
@@ -441,6 +448,11 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
       curattr = highlight_stlnc[hltab[n].userhl - 1];
     } else {
       curattr = highlight_user[hltab[n].userhl - 1];
+    }
+    if (opt_idx == kOptStatusline) {
+      curattr = hl_add_element_tags(curattr, ET_STATUSBAR | ET_HSPLIT);
+    } else if (opt_idx == kOptWinbar) {
+      curattr = hl_add_element_tags(curattr, ET_WINBAR);
     }
   }
   // Make sure to use an empty string instead of p, if p is beyond buf + len.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1345,7 +1345,8 @@ int32_t tui_add_url(TUIData *tui, const char *url)
   return (int32_t)k;
 }
 
-void tui_hl_attr_define(TUIData *tui, Integer id, HlAttrs attrs, HlAttrs cterm_attrs, Array info)
+void tui_hl_attr_define(TUIData *tui, Integer id, HlAttrs attrs, HlAttrs cterm_attrs, Array info,
+                        Integer element_tags)
 {
   attrs.cterm_ae_attr = cterm_attrs.cterm_ae_attr;
   attrs.cterm_fg_color = cterm_attrs.cterm_fg_color;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -395,10 +395,7 @@ void ui_attach_impl(RemoteUI *ui, uint64_t chanid)
     ui_set_ext_option(ui, i, ui->ui_ext[i]);
   }
 
-  bool sent = false;
-  if (ui->ui_ext[kUIHlState]) {
-    sent = highlight_use_hlstate();
-  }
+  bool sent = highlight_ext_enable(ui->ui_ext[kUIHlState], ui->ui_ext[kUIElementType]);
   if (!sent) {
     ui_send_all_hls(ui);
   }

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -18,6 +18,7 @@ typedef enum {
   kUILinegrid,
   kUIMultigrid,
   kUIHlState,
+  kUIElementType,
   kUITermColors,
   kUIFloatDebug,
   kUIExtCount,

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2966,6 +2966,7 @@ describe('API', function()
         {
           chan = 1,
           ext_cmdline = false,
+          ext_elementtype = false,
           ext_hlstate = false,
           ext_linegrid = screen._options.ext_linegrid or false,
           ext_messages = false,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1594,6 +1594,7 @@ describe('TUI', function()
       {
         chan = 1,
         ext_cmdline = false,
+        ext_elementtype = false,
         ext_hlstate = false,
         ext_linegrid = true,
         ext_messages = false,

--- a/test/functional/ui/elementtype_spec.lua
+++ b/test/functional/ui/elementtype_spec.lua
@@ -1,0 +1,351 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+
+local clear = helpers.clear
+local command = helpers.command
+local api = helpers.api
+
+describe('ext_elementtype returns the correct information with', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(40, 8)
+    screen:attach({ ext_elementtype = true })
+    command('set laststatus=2')
+  end)
+
+  after_each(function()
+    screen:detach()
+  end)
+
+  it('default element types', function()
+    screen:expect {
+      grid = [[
+      ^                                        |
+      {1:~                                       }|*5
+      {2:[No Name]                               }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue, bold = true }, {} },
+        [2] = { { reverse = true, bold = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('custom highlight', function()
+    api.nvim_set_option_value('statusline', 'hello %#Normal#world', {})
+    screen:expect {
+      grid = [[
+      ^                                        |
+      {1:~                                       }|*5
+      {2:hello }{3:world                             }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue, bold = true }, {} },
+        [2] = { { reverse = true, bold = true }, { 'StatusBar', 'HSplit' } },
+        [3] = { {}, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('vertical split without statusbar', function()
+    command('set laststatus=3')
+    command('split')
+    screen:expect {
+      grid = [[
+      ^                                        |
+      {1:~                                       }|*2
+      {2:────────────────────────────────────────}|
+                                              |
+      {1:~                                       }|
+      {3:[No Name]                               }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue1, bold = true }, {} },
+        [2] = { {}, { 'VSplit' } },
+        [3] = { { reverse = true, bold = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('vertical and horizontal split without statusbar', function()
+    command('set laststatus=3')
+    command('split')
+    command('vsplit')
+    screen:expect {
+      grid = [[
+    ^                    {1:│}                   |
+    {2:~                   }{1:│}{2:~                  }|*2
+    {1:────────────────────}{3:┴}{1:───────────────────}|
+                                            |
+    {2:~                                       }|
+    {4:[No Name]                               }|
+                                            |
+  ]],
+      attr_ids = {
+        [1] = { {}, { 'VSplit' } },
+        [2] = { { bold = true, foreground = Screen.colors.Blue1 }, {} },
+        [3] = { {}, { 'HSplit', 'VSplit' } },
+        [4] = { { reverse = true, bold = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('split and two statusbars', function()
+    command('split')
+    screen:expect {
+      grid = [[
+      ^                                        |
+      {1:~                                       }|*2
+      {2:[No Name]                               }|
+                                              |
+      {1:~                                       }|
+      {3:[No Name]                               }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue1, bold = true }, {} },
+        [2] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit' } },
+        [3] = { { reverse = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('vsplit and two statusbars', function()
+    command('vsplit')
+    screen:expect {
+      grid = [[
+      ^                    {1:│}                   |
+      {2:~                   }{1:│}{2:~                  }|*5
+      {3:[No Name]           }{4: }{5:[No Name]          }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { {}, { 'VSplit' } },
+        [2] = { { bold = true, foreground = Screen.colors.Blue1 }, {} },
+        [3] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit' } },
+        [4] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit', 'VSplit' } },
+        [5] = { { reverse = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('vsplit and two statusbars with custom highlight', function()
+    api.nvim_set_option_value('statusline', 'hello %#Normal#world', {})
+    command('vsplit')
+    screen:expect {
+      grid = [[
+      ^                    {1:│}                   |
+      {2:~                   }{1:│}{2:~                  }|*5
+      {3:hello }{4:world         }{5: }{6:hello }{4:world        }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { {}, { 'VSplit' } },
+        [2] = { { foreground = Screen.colors.Blue1, bold = true }, {} },
+        [3] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit' } },
+        [4] = { {}, { 'StatusBar', 'HSplit' } },
+        [5] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit', 'VSplit' } },
+        [6] = { { reverse = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('winbar', function()
+    api.nvim_set_option_value('winbar', 'hello', {})
+    screen:expect {
+      grid = [[
+      {1:hello                                   }|
+      ^                                        |
+      {2:~                                       }|*4
+      {3:[No Name]                               }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { bold = true }, { 'WinBar' } },
+        [2] = { { bold = true, foreground = Screen.colors.Blue1 }, {} },
+        [3] = { { bold = true, reverse = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('winbar with custom highlights', function()
+    api.nvim_set_option_value('winbar', 'hello %#Normal#world', {})
+    screen:expect {
+      grid = [[
+      {1:hello }{2:world                             }|
+      ^                                        |
+      {3:~                                       }|*4
+      {4:[No Name]                               }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { bold = true }, { 'WinBar' } },
+        [2] = { {}, { 'WinBar' } },
+        [3] = { { bold = true, foreground = Screen.colors.Blue1 }, {} },
+        [4] = { { reverse = true, bold = true }, { 'StatusBar', 'HSplit' } },
+      },
+    }
+  end)
+
+  it('floating window borders and titles', function()
+    api.nvim_open_win(0, true, {
+      relative = 'editor',
+      width = 20,
+      height = 3,
+      row = 2,
+      col = 5,
+      border = 'single',
+      title = 'Title',
+      footer = 'Footer',
+    })
+
+    command('hi FloatBorder guibg=Red guifg=Blue')
+    screen:expect {
+      grid = [[
+                                              |
+      {1:~                                       }|
+      {1:~    }{2:┌}{3:Title}{4:───────────────}{5:┐}{1:             }|
+      {1:~    }{6:│}{7:^                    }{8:│}{1:             }|
+      {1:~    }{6:│}{9:~                   }{8:│}{1:             }|*2
+      {10:[No N}{11:└}{12:Footer}{13:──────────────}{14:┘}{10:             }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue1, bold = true }, {} },
+        [2] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Top', 'Left' },
+        },
+        [3] = {
+          { foreground = Screen.colors.Magenta1, bold = true },
+          { 'FloatBorder', 'FloatTitle', 'Top' },
+        },
+        [4] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Top' },
+        },
+        [5] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Top', 'Right' },
+        },
+        [6] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Left' },
+        },
+        [7] = { { background = Screen.colors.LightMagenta }, {} },
+        [8] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Right' },
+        },
+        [9] = {
+          {
+            foreground = Screen.colors.Blue1,
+            background = Screen.colors.LightMagenta,
+            bold = true,
+          },
+          {},
+        },
+        [10] = { { reverse = true }, { 'StatusBar', 'HSplit' } },
+        [11] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Bottom', 'Left' },
+        },
+        [12] = {
+          { foreground = Screen.colors.Magenta1, bold = true },
+          { 'FloatBorder', 'FloatTitle', 'Bottom' },
+        },
+        [13] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Bottom' },
+        },
+        [14] = {
+          { background = Screen.colors.Red1, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Bottom', 'Right' },
+        },
+      },
+    }
+  end)
+
+  it('floating window borders and titles with custom highlights', function()
+    api.nvim_open_win(0, true, {
+      relative = 'editor',
+      width = 20,
+      height = 3,
+      row = 2,
+      col = 5,
+      border = { { '+', 'MyCorner' }, { 'x', 'MyBorder' } },
+      title = { { 'Title', 'MyTitle' } },
+      footer = { { 'Footer', 'MyFooter' } },
+    })
+
+    command('hi MyCorner guibg=Red guifg=Blue')
+    command('hi MyBorder guibg=Blue guifg=Red')
+    command('hi MyTitle guibg=Red guifg=Yellow')
+    command('hi MyFooter guibg=Blue guifg=Green')
+    screen:expect {
+      grid = [[
+                                              |
+      {1:~                                       }|
+      {1:~    }{2:+}{3:Title}{4:xxxxxxxxxxxxxxx}{5:+}{1:             }|
+      {1:~    }{6:x}{7:^                    }{8:x}{1:             }|
+      {1:~    }{6:x}{9:~                   }{8:x}{1:             }|*2
+      {10:[No N}{11:+}{12:Footer}{13:xxxxxxxxxxxxxx}{14:+}{10:             }|
+                                              |
+    ]],
+      attr_ids = {
+        [1] = { { foreground = Screen.colors.Blue1, bold = true }, {} },
+        [2] = {
+          { background = Screen.colors.Red, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Top', 'Left' },
+        },
+        [3] = {
+          { background = Screen.colors.Red, foreground = Screen.colors.Yellow },
+          { 'FloatBorder', 'FloatTitle', 'Top' },
+        },
+        [4] = {
+          { background = Screen.colors.Blue1, foreground = Screen.colors.Red },
+          { 'FloatBorder', 'Top' },
+        },
+        [5] = {
+          { background = Screen.colors.Red, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Top', 'Right' },
+        },
+        [6] = {
+          { background = Screen.colors.Blue1, foreground = Screen.colors.Red },
+          { 'FloatBorder', 'Left' },
+        },
+        [7] = { { background = Screen.colors.Plum1 }, {} },
+        [8] = {
+          { background = Screen.colors.Blue1, foreground = Screen.colors.Red },
+          { 'FloatBorder', 'Right' },
+        },
+        [9] = {
+          { background = Screen.colors.Plum1, bold = true, foreground = Screen.colors.Blue1 },
+          {},
+        },
+        [10] = { { reverse = true }, { 'StatusBar', 'HSplit' } },
+        [11] = {
+          { background = Screen.colors.Red, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Bottom', 'Left' },
+        },
+        [12] = {
+          { background = Screen.colors.Blue1, foreground = Screen.colors.WebGreen },
+          { 'FloatBorder', 'FloatTitle', 'Bottom' },
+        },
+        [13] = {
+          { background = Screen.colors.Blue1, foreground = Screen.colors.Red },
+          { 'FloatBorder', 'Bottom' },
+        },
+        [14] = {
+          { background = Screen.colors.Red, foreground = Screen.colors.Blue1 },
+          { 'FloatBorder', 'Bottom', 'Right' },
+        },
+      },
+    }
+  end)
+end)

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -28,6 +28,7 @@ describe('UI receives option updates', function()
       ttimeoutlen = 50,
       verbose = 0,
       ext_cmdline = false,
+      ext_elementtype = false,
       ext_popupmenu = false,
       ext_tabline = false,
       ext_wildmenu = false,
@@ -209,6 +210,15 @@ describe('UI receives option updates', function()
   end)
   it('from startup options with --embed', function()
     startup_test(false)
+  end)
+
+  it('ext_elementtype sets linegrid', function()
+    local expected = reset({ ext_elementtype = true })
+    expected.ext_elementtype = true
+    expected.ext_linegrid = true
+    screen:expect(function()
+      eq(expected, screen.options)
+    end)
   end)
 end)
 

--- a/test/functional/vimscript/api_functions_spec.lua
+++ b/test/functional/vimscript/api_functions_spec.lua
@@ -185,7 +185,15 @@ describe('eval-API', function()
 
   it('have metadata accessible with api_info()', function()
     local api_keys = eval('sort(keys(api_info()))')
-    eq({ 'error_types', 'functions', 'types', 'ui_events', 'ui_options', 'version' }, api_keys)
+    eq({
+      'error_types',
+      'functions',
+      'types',
+      'ui_element_tags',
+      'ui_events',
+      'ui_options',
+      'version',
+    }, api_keys)
   end)
 
   it('are highlighted by vim.vim syntax file', function()

--- a/test/functional/vimscript/msgpack_functions_spec.lua
+++ b/test/functional/vimscript/msgpack_functions_spec.lua
@@ -478,7 +478,15 @@ describe('msgpackparse() function', function()
       pending('msgpackparse() has a bug on windows')
       return
     end
-    eq({ 'error_types', 'functions', 'types', 'ui_events', 'ui_options', 'version' }, api_info)
+    eq({
+      'error_types',
+      'functions',
+      'types',
+      'ui_element_tags',
+      'ui_events',
+      'ui_options',
+      'version',
+    }, api_info)
   end)
 
   it('fails when called with no arguments', function()


### PR DESCRIPTION
This adds a new UI extension that contains adds element type information to the highlight attributes. This information can be used to for example detect floating window borders and winbars for a smooth scrolling implementation. Another example use case is to detect the splits, so that the mouse cursor can be changed when hovering it.

I guess that the original idea of `ext_hlstate` and it's `ui` key was similar, but currently that is useless since it does not encode the original highlight groups of linked groups. It also does not nearly capture the same information as this addition does.

See the documentation for further description.

A Neovide example implementation is here:
* https://github.com/neovide/neovide/pull/2438

Fixes https://github.com/neovim/neovim/issues/23610

NOTE: I have only implemented a few element types now, since I think it's better that we get a first implementation that fixes the immediate problem before making it perfect.

The screen.lua had to be reworked quite extensively to support this, because the tests themselves, are using a different format than the internal ui attribute definition. I hope that does not infer with the work that @bfredl is doing, I noticed that since I had to do some fixes myself, due to yesterday's refactoring.