### PR TITLE
fix(intro): still show intro message with floating window

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -34,6 +34,7 @@
 #include "nvim/strings.h"
 #include "nvim/ui.h"
 #include "nvim/version.h"
+#include "nvim/window.h"
 
 // for ":version", ":intro", and "nvim --version"
 #ifndef NVIM_VERSION_MEDIUM
@@ -2714,9 +2715,9 @@ void list_version(void)
 /// Whether it still is not too late to show an intro message
 bool may_show_intro(void)
 {
-  return (buf_is_empty(curbuf)
-          && (curbuf->b_fname == NULL)
-          && (firstwin->w_next == NULL)
+  return (buf_is_empty(firstwin->w_buffer)
+          && (firstwin->w_buffer->b_fname == NULL)
+          && one_window(firstwin)
           && (vim_strchr(p_shm, SHM_INTRO) == NULL));
 }
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1604,13 +1604,14 @@ describe('ui/ext_messages', function()
       [5] = { foreground = Screen.colors.Blue1 },
       [6] = { reverse = true },
       [7] = { bold = true, reverse = true },
+      [8] = { background = Screen.colors.Plum1 },
     })
   end)
 
   it('supports intro screen', function()
     -- intro message is not externalized. But check that it still works.
     -- Note parts of it depends on version or is indeterministic. We ignore those parts.
-    screen:expect([[
+    local introscreen = [[
       ^                                                                                |
       {1:~                                                                               }|*4
       {MATCH:.*}|
@@ -1628,14 +1629,27 @@ describe('ui/ext_messages', function()
       {1:~                        }Help poor children in Uganda!{1:                          }|
       {1:~                }type  :help iccf{5:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
-    ]])
+    ]]
+    screen:expect(introscreen)
 
     -- <c-l> (same as :mode) does _not_ clear intro message
     feed('<c-l>i')
+    screen:expect { grid = introscreen, showmode = { { '-- INSERT --', 3 } } }
+
+    -- opening a float also does not
+    local win = api.nvim_open_win(api.nvim_create_buf(false, false), true, {
+      relative = 'editor',
+      height = 1,
+      width = 5,
+      row = 1,
+      col = 5,
+    })
+    feed('float<esc><c-l>')
     screen:expect {
       grid = [[
-      ^                                                                                |
-      {1:~                                                                               }|*4
+                                                                                      |
+      {1:~    }{8:floa^t}{1:                                                                      }|
+      {1:~                                                                               }|*3
       {MATCH:.*}|
       {1:~                                                                               }|
       {1:~                 }Nvim is open source and freely distributable{1:                  }|
@@ -1652,11 +1666,12 @@ describe('ui/ext_messages', function()
       {1:~                }type  :help iccf{5:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
     ]],
-      showmode = { { '-- INSERT --', 3 } },
     }
+    api.nvim_win_close(win, true)
+    screen:expect { grid = introscreen }
 
     -- but editing text does..
-    feed('x')
+    feed('ix')
     screen:expect {
       grid = [[
       x^                                                                               |


### PR DESCRIPTION
Stop drawing the intro only after a split is opened.