### PR TITLE
vim-patch:9.1.0205: Cannot use modifiers before :-Ntabmove

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -187,7 +187,7 @@ gt					*i_CTRL-<PageDown>* *i_<C-PageDown>*
 		    :1tabnext	" go to the first tab page
 		    :$tabnext	" go to the last tab page
 		    :tabnext $	" as above
-		    :tabnext #  " go to the last accessed tab page
+		    :tabnext #	" go to the last accessed tab page
 		    :tabnext -	" go to the previous tab page
 		    :tabnext -1	" as above
 		    :tabnext +	" go to the next tab page
@@ -239,18 +239,17 @@ REORDERING TAB PAGES:
 		Move the current tab page to after tab page N.  Use zero to
 		make the current tab page the first one.  N is counted before
 		the move, thus if the second tab is the current one,
-		`:tabmove 1` and `:tabmove 2`  have no effect.
+		`:tabmove 1` and `:tabmove 2` have no effect.
 		Without N the tab page is made the last one. >
-		    :.tabmove   " do nothing
-		    :-tabmove   " move the tab page to the left
-		    :+tabmove   " move the tab page to the right
-		    :0tabmove   " move the tab page to the beginning  of the tab
-				" list
+		    :.tabmove	" do nothing
+		    :-tabmove	" move the tab page to the left
+		    :+tabmove	" move the tab page to the right
+		    :0tabmove	" move the tab page to the first
 		    :tabmove 0	" as above
 		    :tabmove	" move the tab page to the last
 		    :$tabmove	" as above
 		    :tabmove $	" as above
-		    :tabmove #  " move the tab page after the last accessed
+		    :tabmove #	" move the tab page after the last accessed
 				" tab page
 
 :tabm[ove] +[N]

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4368,12 +4368,15 @@ static int get_tabpage_arg(exarg_T *eap)
       tab_number = 0;
     } else {
       tab_number = (int)eap->line2;
-      char *cmdp = eap->cmd;
-      while (--cmdp > *eap->cmdlinep && (*cmdp == ' ' || ascii_isdigit(*cmdp))) {}
-      if (!unaccept_arg0 && *cmdp == '-') {
-        tab_number--;
-        if (tab_number < unaccept_arg0) {
-          eap->errmsg = _(e_invrange);
+      if (!unaccept_arg0) {
+        char *cmdp = eap->cmd;
+        while (--cmdp > *eap->cmdlinep
+               && (ascii_iswhite(*cmdp) || ascii_isdigit(*cmdp))) {}
+        if (*cmdp == '-') {
+          tab_number--;
+          if (tab_number < unaccept_arg0) {
+            eap->errmsg = _(e_invrange);
+          }
         }
       }
     }

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -117,10 +117,16 @@ function Test_tabpage()
   call assert_equal(3, tabpagenr())
   +3tabmove
   call assert_equal(6, tabpagenr())
+  silent -tabmove
+  call assert_equal(5, tabpagenr())
+  silent -2 tabmove
+  call assert_equal(3, tabpagenr())
+  silent	-2	tabmove
+  call assert_equal(1, tabpagenr())
 
-  " The following are a no-op
   norm! 2gt
   call assert_equal(2, tabpagenr())
+  " The following are a no-op
   tabmove 2
   call assert_equal(2, tabpagenr())
   2tabmove


### PR DESCRIPTION
#### vim-patch:9.1.0205: Cannot use modifiers before :-Ntabmove

Problem:  Cannot use modifiers before :-Ntabmove.
Solution: Check backwards from the command instead of checking from the
          start of the command line. Slightly adjust docs to make them
          more consistent (zeertzjq).

closes: vim/vim#14289

https://github.com/vim/vim/commit/076faac5378cf517baa8c331c57488d39efadec0