### PR TITLE
vim-patch:9.1.0204: Backspace inserts spaces with virtual text and 'smarttab'

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -44,6 +44,8 @@
 /// @param col
 ///
 /// @return Number of cells.
+///
+/// @see charsize_nowrap()
 int win_chartabsize(win_T *wp, char *p, colnr_T col)
 {
   buf_T *buf = wp->w_buffer;
@@ -376,6 +378,8 @@ CharSize charsize_fast(CharsizeArg *csarg, colnr_T const vcol, int32_t const cur
 }
 
 /// Get the number of cells taken up on the screen at given virtual column.
+///
+/// @see win_chartabsize()
 int charsize_nowrap(buf_T *buf, bool use_tabstop, colnr_T vcol, int32_t cur_char)
 {
   if (cur_char == TAB && use_tabstop) {

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -6,8 +6,6 @@ endif
 
 source check.vim
 source screendump.vim
-
-" Needed for testing basic rightleft: Test_edit_rightleft
 source view_util.vim
 
 " Needs to come first until the bug in getchar() is
@@ -2151,6 +2149,115 @@ func Test_edit_Ctrl_RSB()
   autocmd! InsertCharPre
   unlet g:triggered
   bwipe!
+endfunc
+
+func s:check_backspace(expected)
+  let g:actual = []
+  inoremap <buffer> <F2> <Cmd>let g:actual += [getline('.')]<CR>
+  set backspace=indent,eol,start
+
+  exe "normal $i" .. repeat("\<BS>\<F2>", len(a:expected))
+  call assert_equal(a:expected, g:actual)
+
+  set backspace&
+  iunmap <buffer> <F2>
+  unlet g:actual
+endfunc
+
+" Test that backspace works with 'smarttab' and mixed Tabs and spaces.
+func Test_edit_backspace_smarttab_mixed()
+  call NewWindow(1, 30)
+  setlocal smarttab tabstop=4 shiftwidth=4
+  call setline(1, "\t    \t         \t a")
+  call s:check_backspace([
+        \ "\t    \t         \ta",
+        \ "\t    \t        a",
+        \ "\t    \t    a",
+        \ "\t    \ta",
+        \ "\t    a",
+        \ "\ta",
+        \ "a",
+        \ ])
+
+  call CloseWindow()
+endfunc
+
+" Test that backspace works with 'smarttab' and 'varsofttabstop'.
+func Test_edit_backspace_smarttab_varsofttabstop()
+  CheckFeature vartabs
+
+  call NewWindow(1, 30)
+  setlocal smarttab tabstop=8 varsofttabstop=6,2,5,3
+  call setline(1, "a\t    \t a")
+  call s:check_backspace([
+        \ "a\t    \ta",
+        \ "a\t     a",
+        \ "a\ta",
+        \ "a     a",
+        \ "aa",
+        \ "a",
+        \ ])
+
+  call CloseWindow()
+endfunc
+
+" Test that backspace works with 'smarttab' when a Tab is shown as "^I".
+func Test_edit_backspace_smarttab_list()
+  call NewWindow(1, 30)
+  setlocal smarttab tabstop=4 shiftwidth=4 list listchars=
+  call setline(1, "\t    \t         \t a")
+  call s:check_backspace([
+        \ "\t    \t        a",
+        \ "\t    \t    a",
+        \ "\t    \ta",
+        \ "\t  a",
+        \ "a",
+        \ ])
+
+  call CloseWindow()
+endfunc
+
+" Test that backspace works with 'smarttab' and 'breakindent'.
+func Test_edit_backspace_smarttab_breakindent()
+  CheckFeature linebreak
+
+  call NewWindow(3, 17)
+  setlocal smarttab tabstop=4 shiftwidth=4 breakindent breakindentopt=min:5
+  call setline(1, "\t    \t         \t a")
+  call s:check_backspace([
+        \ "\t    \t         \ta",
+        \ "\t    \t        a",
+        \ "\t    \t    a",
+        \ "\t    \ta",
+        \ "\t    a",
+        \ "\ta",
+        \ "a",
+        \ ])
+
+  call CloseWindow()
+endfunc
+
+" Test that backspace works with 'smarttab' and virtual text.
+func Test_edit_backspace_smarttab_virtual_text()
+  CheckFeature textprop
+
+  call NewWindow(1, 50)
+  setlocal smarttab tabstop=4 shiftwidth=4
+  call setline(1, "\t    \t         \t a")
+  call prop_type_add('theprop', {})
+  call prop_add(1, 3, {'type': 'theprop', 'text': 'text'})
+  call s:check_backspace([
+        \ "\t    \t         \ta",
+        \ "\t    \t        a",
+        \ "\t    \t    a",
+        \ "\t    \ta",
+        \ "\t    a",
+        \ "\ta",
+        \ "a",
+        \ ])
+
+  call CloseWindow()
+  call prop_type_delete('theprop')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0204: Backspace inserts spaces with virtual text and 'smarttab'

Problem:  Backspace inserts spaces with virtual text and 'smarttab'.
Solution: Ignore virtual text and wrapping when backspacing.
          (zeertzjq)

related: neovim/neovim#28005
closes: vim/vim#14296

https://github.com/vim/vim/commit/0185c7701434f1fbbf83fecd6384a19c1d2fc44e

Co-authored-by: VanaIgr <vanaigranov@gmail.com>