### PR TITLE
test(lsp): fix flaky basic_finish test again

### DIFF
--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -105,6 +105,11 @@ local function fake_lsp_server_setup(test_name, timeout_ms, options, settings)
           uri = 'file://' .. vim.uv.cwd(),
           name = 'test_folder',
       }};
+      before_init = function(params, config)
+        vim.schedule(function()
+          vim.rpcrequest(1, "setup")
+        end)
+      end,
       on_init = function(client, result)
         TEST_RPC_CLIENT = client
         vim.rpcrequest(1, "init", result)
@@ -173,6 +178,12 @@ function M.test_rpc_server(config)
   --- @type integer, integer
   local code, signal
   local function on_request(method, args)
+    if method == 'setup' then
+      if config.on_setup then
+        config.on_setup()
+      end
+      return NIL
+    end
     if method == 'init' then
       if config.on_init then
         config.on_init(client, unpack(args))
@@ -193,8 +204,8 @@ function M.test_rpc_server(config)
     end
   end
   --  TODO specify timeout?
-  --  run(on_request, on_notify, config.on_setup, 1000)
-  run(on_request, on_notify, config.on_setup)
+  --  run(on_request, on_notify, nil, 1000)
+  run(on_request, on_notify, nil)
   if config.on_exit then
     config.on_exit(code, signal)
   end


### PR DESCRIPTION
Problem:
LSP basic_finish test modified in #27899 is flaky again after #28030.

Solution:
Run on_setup() immediately after setup using a before_init callback.