### PR TITLE
feat(diagnostic): add support for many namespaces filtering in GetOpts

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -371,7 +371,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
     A table with the following keys:
 
     Fields: ~
-      • {namespace}?  (`integer`) Limit diagnostics to the given namespace.
+      • {namespace}?  (`integer[]|integer`) Limit diagnostics to one or more
+                      namespaces.
       • {lnum}?       (`integer`) Limit diagnostics to the given line number.
       • {severity}?   (`vim.diagnostic.SeverityFilter`) See
                       |diagnostic-severity|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -408,6 +408,9 @@ The following changes to existing APIs or features add new behavior.
   "virtual_text" table, which gives users more control over how diagnostic
   virtual text is displayed.
 
+• |vim.diagnostic.get()| and |vim.diagnostic.count()| accept multiple
+  namespaces rather than just a single namespace.
+
 • Extmarks now fully support multi-line ranges, and a single extmark can be
   used to highlight a range of arbitrary length. The |nvim_buf_set_extmark()|
   API function already allowed you to define such ranges, but highlight regions

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -682,6 +682,13 @@ local function get_diagnostics(bufnr, opts, clamp)
   opts = opts or {}
 
   local namespace = opts.namespace
+
+  if type(namespace) == 'number' then
+    namespace = { namespace }
+  end
+
+  ---@cast namespace integer[]
+
   local diagnostics = {}
 
   -- Memoized results of buf_line_count per bufnr
@@ -742,11 +749,15 @@ local function get_diagnostics(bufnr, opts, clamp)
     end
   elseif bufnr == nil then
     for b, t in pairs(diagnostic_cache) do
-      add_all_diags(b, t[namespace] or {})
+      for _, iter_namespace in ipairs(namespace) do
+        add_all_diags(b, t[iter_namespace] or {})
+      end
     end
   else
     bufnr = get_bufnr(bufnr)
-    add_all_diags(bufnr, diagnostic_cache[bufnr][namespace] or {})
+    for _, iter_namespace in ipairs(namespace) do
+      add_all_diags(bufnr, diagnostic_cache[bufnr][iter_namespace] or {})
+    end
   end
 
   if opts.severity then
@@ -785,7 +796,7 @@ end
 --- @param search_forward boolean
 --- @param bufnr integer
 --- @param opts vim.diagnostic.GotoOpts
---- @param namespace integer
+--- @param namespace integer[]|integer
 --- @return vim.Diagnostic?
 local function next_diagnostic(position, search_forward, bufnr, opts, namespace)
   position[1] = position[1] - 1
@@ -1115,8 +1126,8 @@ end
 --- A table with the following keys:
 --- @class vim.diagnostic.GetOpts
 ---
---- Limit diagnostics to the given namespace.
---- @field namespace? integer
+--- Limit diagnostics to one or more namespaces.
+--- @field namespace? integer[]|integer
 ---
 --- Limit diagnostics to the given line number.
 --- @field lnum? integer


### PR DESCRIPTION
Implements #28024 by making `vim.diagnostic.GetOpts.namespace` `integer[]|integer`.
I am a very inexperienced with Neovim development so I am not sure if this is a breaking change or not (this type is never returned from Neovim API, but if someone uses this type in his API it could cause problems as now it could receive an array and not expect it). If it is a breaking change another approach could be adding a disallow List instead.