### PR TITLE
vim-patch:63833bb0217f

### DIFF
--- a/runtime/indent/json5.vim
+++ b/runtime/indent/json5.vim
@@ -1,0 +1,11 @@
+" Vim indent file
+" Language:     JSON5
+" Maintainer:   The Vim Project <https://github.com/vim/vim>
+" Last Change:  2024-03-26
+
+if exists("b:did_indent")
+  finish
+endif
+
+" Same as jsonc indenting for now
+runtime! indent/jsonc.vim


### PR DESCRIPTION
runtime(json5): add basic indent support (vim/vim#14298)

https://github.com/vim/vim/commit/63833bb0217fbfd5556a77103bd6c1ce78cfd996

Co-authored-by: Rocco Mao <dapeng.mao@qq.com>
