### PR TITLE
vim-patch:9.1.0207: No autocommand when writing session file

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -884,6 +884,9 @@ SafeState			When nothing is pending, going to wait for the
 							*SessionLoadPost*
 SessionLoadPost			After loading the session file created using
 				the |:mksession| command.
+							*SessionWritePost*
+SessionWritePost		After writing a session file by calling
+				the |:mksession| command.
 							*ShellCmdPost*
 ShellCmdPost			After executing a shell command with |:!cmd|,
 				|:make| and |:grep|.  Can be used to check for

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -88,6 +88,7 @@ return {
     'SafeState', -- going to wait for a character
     'SearchWrapped', -- after the search wrapped around
     'SessionLoadPost', -- after loading a session file
+    'SessionWritePost', -- after writing a session file
     'ShellCmdPost', -- after ":!cmd"
     'ShellFilterPost', -- after ":1,2!cmd", ":w !cmd", ":r !cmd".
     'Signal', -- after nvim process received a signal

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -12,6 +12,7 @@
 #include "nvim/arglist.h"
 #include "nvim/arglist_defs.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/eval.h"
@@ -1092,6 +1093,8 @@ void ex_mkrc(exarg_T *eap)
   }
 
   xfree(viewFile);
+
+  apply_autocmds(EVENT_SESSIONWRITEPOST, NULL, NULL, false, curbuf);
 }
 
 /// @return  the name of the view file for the current buffer.

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3901,4 +3901,60 @@ func Test_autocmd_creates_new_buffer_on_bufleave()
   bw c.txt
 endfunc
 
+" Ensure `expected` was just recently written as a Vim session
+func s:assert_session_path(expected)
+  call assert_equal(a:expected, v:this_session)
+endfunc
+
+" Check for `expected` after a session is written to-disk.
+func s:watch_for_session_path(expected)
+  execute 'autocmd SessionWritePost * ++once execute "call s:assert_session_path(\"'
+        \ . a:expected
+        \ . '\")"'
+endfunc
+
+" Ensure v:this_session gets the full session path, if explicitly stated
+func Test_explicit_session_absolute_path()
+  %bwipeout!
+
+  let directory = getcwd()
+
+  let v:this_session = ""
+  let name = "some_file.vim"
+  let expected = fnamemodify(name, ":p")
+  call s:watch_for_session_path(expected)
+  execute "mksession! " .. expected
+
+  call delete(expected)
+endfunc
+
+" Ensure v:this_session gets the full session path, if explicitly stated
+func Test_explicit_session_relative_path()
+  %bwipeout!
+
+  let directory = getcwd()
+
+  let v:this_session = ""
+  let name = "some_file.vim"
+  let expected = fnamemodify(name, ":p")
+  call s:watch_for_session_path(expected)
+  execute "mksession! " .. name
+
+  call delete(expected)
+endfunc
+
+" Ensure v:this_session gets the full session path, if not specified
+func Test_implicit_session()
+  %bwipeout!
+
+  let directory = getcwd()
+
+  let v:this_session = ""
+  let expected = fnamemodify("Session.vim", ":p")
+  call s:watch_for_session_path(expected)
+  mksession!
+
+  call delete(expected)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Close #27761

#### vim-patch:9.1.0207: No autocommand when writing session file

Problem:  No autocommand when writing session file
Solution: Add SessionWritePost autocommand
          (Colin Kennedy)

closes: vim/vim#14288

https://github.com/vim/vim/commit/e5f2280381250801a28dcff9823e6f94e7b163fc

Co-authored-by: Colin Kennedy <colinvfx@gmail.com>