### PR TITLE
refactor(options): require `enable_if = false` iff no variable

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -165,17 +165,22 @@ local function dump_option(i, o)
     w(get_cond(o.enable_if))
   end
 
-  -- Options cannot be both hidden and immutable.
+  -- An option cannot be both hidden and immutable.
   assert(not o.hidden or not o.immutable)
 
+  local has_var = true
   if o.varname then
     w('    .var=&' .. o.varname)
-  -- Hidden and immutable options can directly point to the default value.
   elseif o.hidden or o.immutable then
+    -- Hidden and immutable options can directly point to the default value.
     w(('    .var=&options[%u].def_val'):format(i - 1))
   elseif #o.scope == 1 and o.scope[1] == 'window' then
     w('    .var=VAR_WIN')
+  else
+    has_var = false
   end
+  -- `enable_if = false` should be present iff there is no variable.
+  assert((o.enable_if == false) == not has_var)
   w('    .hidden=' .. (o.hidden and 'true' or 'false'))
   w('    .immutable=' .. (o.immutable and 'true' or 'false'))
   if #o.scope == 1 and o.scope[1] == 'global' then

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -91,6 +91,7 @@ return {
     {
       abbreviation = 'al',
       defaults = { if_true = 224 },
+      enable_if = false,
       full_name = 'aleph',
       scope = { 'global' },
       short_desc = N_('ASCII code of the letter Aleph (Hebrew)'),
@@ -5459,7 +5460,6 @@ return {
         When on, the mouse pointer is hidden when characters are typed.
         The mouse pointer is restored when the mouse is moved.
       ]=],
-      enable_if = false,
       full_name = 'mousehide',
       redraw = { 'ui_option' },
       scope = { 'global' },
@@ -5875,6 +5875,7 @@ return {
     {
       abbreviation = 'pt',
       defaults = { if_true = '' },
+      enable_if = false,
       full_name = 'pastetoggle',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -8767,6 +8768,7 @@ return {
     {
       abbreviation = 'tenc',
       defaults = { if_true = '' },
+      enable_if = false,
       full_name = 'termencoding',
       scope = { 'global' },
       short_desc = N_('Terminal encoding'),


### PR DESCRIPTION
This makes grepping for unsupported options easier.