### PR TITLE
vim-patch:9.1.0212: CI: MS-Windows fails in test_winfixbuf

### DIFF
--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -1239,30 +1239,34 @@ endfunc
 func Test_edit_same_buffer_in_memory()
   call s:reset_all_buffers()
 
-  let l:current = bufnr()
+  let current = bufnr()
   file same_buffer
 
-  call assert_equal(l:current, bufnr())
+  call assert_equal(current, bufnr())
   set winfixbuf
   edit same_buffer
-  call assert_equal(l:current, bufnr())
+  call assert_equal(current, bufnr())
+  set nowinfixbuf
 endfunc
 
 " Allow :e selecting the current buffer as a full path
 func Test_edit_same_buffer_on_disk_absolute_path()
+  " This fails on CI (Windows builds), why?
+  " CheckNotMSWindows
   call s:reset_all_buffers()
 
-  let l:file = tempname()
-  let l:current = bufnr()
-  execute "edit " . l:file
+  let file = tempname()
+  let current = bufnr()
+  execute "edit " . file
   write!
 
-  call assert_equal(l:current, bufnr())
+  call assert_equal(current, bufnr())
   set winfixbuf
-  execute "edit " l:file
-  call assert_equal(l:current, bufnr())
+  execute "edit " file
+  call assert_equal(current, bufnr())
 
-  call delete(l:file)
+  call delete(file)
+  set nowinfixbuf
 endfunc
 
 " Fail :enew but :enew! is allowed


### PR DESCRIPTION
#### vim-patch:9.1.0212: CI: MS-Windows fails in test_winfixbuf

Problem:  CI: MS-Windows fails in test_winfixbuf
          (after v9.1.208)
Solution: Skip Ms-Windows for now, fix style

related: vim/vim#14286

https://github.com/vim/vim/commit/79b2867ce3f4ed99d8c4e06c2c3b8f105f67c53a

Co-authored-by: Christian Brabandt <cb@256bit.org>