### PR TITLE
ci: add workflow_dispatch event to testing workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - '**/CMakePresets.json'
       - 'cmake.*/**'
       - '.github/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
+  workflow_dispatch:
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - 'release-[0-9]+.[0-9]+'
     paths-ignore:
       - 'contrib/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -7,6 +7,7 @@ on:
       functionaltest_timeout:
         default: 20
         type: number
+  workflow_dispatch:
 
 jobs:
   windows:


### PR DESCRIPTION
This allows us to easily test the release branch if needed.
