### PR TITLE
fix(fs): allow backslash characters in unix paths

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2954,13 +2954,14 @@ vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
 
 vim.fs.normalize({path}, {opts})                          *vim.fs.normalize()*
     Normalize a path to a standard format. A tilde (~) character at the
-    beginning of the path is expanded to the user's home directory and any
-    backslash (\) characters are converted to forward slashes (/). Environment
-    variables are also expanded.
+    beginning of the path is expanded to the user's home directory and
+    environment variables are also expanded.
+
+    On Windows, backslash (\) characters are converted to forward slashes (/).
 
     Examples: >lua
         vim.fs.normalize('C:\\\\Users\\\\jdoe')
-        -- 'C:/Users/jdoe'
+        -- On Windows: 'C:/Users/jdoe'
 
         vim.fs.normalize('~/src/neovim')
         -- '/home/jdoe/src/neovim'


### PR DESCRIPTION
Backslashes are valid characters in unix style paths.

This PR aims to fix the conversion of backslashes to forward slashes in several `vim.fs` functions when not on Windows. On Windows, backslashes will still be converted to forward slashes.

closes https://github.com/neovim/neovim/issues/28061