### PR TITLE
vim-patch:b2e1fee72c45

### DIFF
--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Haskell
 " Maintainer:		Haskell Cafe mailinglist <haskell-cafe@haskell.org>
-" Last Change:		2020 Oct 4 by Marcin Szamotulski <profunctor@pm.me>
+" Last Change:		2024 Mar 28 by Enrico Maria De Angelis <enricomaria.dean6elis@gmail.com>
 " Original Author:	John Williams <jrw@pobox.com>
 "
 " Thanks to Ryan Crumley for suggestions and John Meacham for
@@ -104,8 +104,8 @@ endif
 
 
 " Comments
-syn match   hsLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=@Spell
-syn region  hsBlockComment     start="{-"  end="-}" contains=hsBlockComment,@Spell
+syn match   hsLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=hsTodo,@Spell
+syn region  hsBlockComment     start="{-"  end="-}" contains=hsBlockComment,hsTodo,@Spell
 syn region  hsPragma	       start="{-#" end="#-}"
 
 syn keyword hsTodo	        contained FIXME TODO XXX NOTE
@@ -164,6 +164,7 @@ hi def link hsLiterateComment		  hsComment
 hi def link hsBlockComment		  hsComment
 hi def link hsLineComment			  hsComment
 hi def link hsComment			  Comment
+hi def link hsTodo			  Todo
 hi def link hsPragma			  SpecialComment
 hi def link hsBoolean			  Boolean
 hi def link hsType			  Type


### PR DESCRIPTION
runtime(haskell): allow TODO keywords in comments

closes: vim/vim#14319

https://github.com/vim/vim/commit/b2e1fee72c456bdb2f14bd12e4c06887743ae3a2

Co-authored-by: Enrico Maria De Angelis <enricomaria.dean6elis@gmail.com>
