### PR TITLE
vim-patch:9.1.0216: Error on exit with EXITFREE and 'winfixbuf'

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -290,10 +290,6 @@ void set_buflocal_tfu_callback(buf_T *buf)
 /// @param verbose  print "tag not found" message
 void do_tag(char *tag, int type, int count, int forceit, bool verbose)
 {
-  if (postponed_split == 0 && !check_can_set_curbuf_forceit(forceit)) {
-    return;
-  }
-
   taggy_T *tagstack = curwin->w_tagstack;
   int tagstackidx = curwin->w_tagstackidx;
   int tagstacklen = curwin->w_tagstacklen;
@@ -320,11 +316,6 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
   static char **matches = NULL;
   static int flags;
 
-  if (tfu_in_use) {
-    emsg(_(e_cannot_modify_tag_stack_within_tagfunc));
-    return;
-  }
-
 #ifdef EXITFREE
   if (type == DT_FREE) {
     // remove the list of matches
@@ -333,6 +324,15 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
     return;
   }
 #endif
+
+  if (tfu_in_use) {
+    emsg(_(e_cannot_modify_tag_stack_within_tagfunc));
+    return;
+  }
+
+  if (postponed_split == 0 && !check_can_set_curbuf_forceit(forceit)) {
+    return;
+  }
 
   if (type == DT_HELP) {
     type = DT_TAG;

--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -1,6 +1,7 @@
 " Test 'winfixbuf'
 
 source check.vim
+source shared.vim
 
 " Find the number of open windows in the current tab
 func s:get_windows_count()
@@ -3425,6 +3426,17 @@ func Test_bufdo_cnext_splitwin_fails()
   " Ensure the entry didn't change.
   call assert_equal(1, getqflist(#{idx: 0}).idx)
   set winminheight&vim winheight&vim
+endfunc
+
+" Test that exiting with 'winfixbuf' and EXITFREE doesn't cause an error.
+func Test_exitfree_no_error()
+  let lines =<< trim END
+    set winfixbuf
+    qall!
+  END
+  call writefile(lines, 'Xwfb_exitfree', 'D')
+  call assert_notmatch('E1513:',
+        \ system(GetVimCommandClean() .. ' -X -S Xwfb_exitfree'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0216: Error on exit with EXITFREE and 'winfixbuf'

Problem:  Error on exit with EXITFREE and 'winfixbuf'.
Solution: Handle DT_FREE before checking for 'winfixbuf'.
          (zeertzjq)

closes: vim/vim#14314

https://github.com/vim/vim/commit/620e85265ce04654053c64f8058914ecafe4eb38