### PR TITLE
vim-patch:9.1.0213: CI: MS-Windows fails in test_winfixbuf

### DIFF
--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -1251,11 +1251,12 @@ endfunc
 
 " Allow :e selecting the current buffer as a full path
 func Test_edit_same_buffer_on_disk_absolute_path()
-  " This fails on CI (Windows builds), why?
-  " CheckNotMSWindows
   call s:reset_all_buffers()
 
   let file = tempname()
+  " file must exist for expansion of 8.3 paths to succeed
+  call writefile([], file, 'D')
+  let file = fnamemodify(file, ':p')
   let current = bufnr()
   execute "edit " . file
   write!
@@ -1265,7 +1266,6 @@ func Test_edit_same_buffer_on_disk_absolute_path()
   execute "edit " file
   call assert_equal(current, bufnr())
 
-  call delete(file)
   set nowinfixbuf
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0213: CI: MS-Windows fails in test_winfixbuf

Problem:  CI: MS-Windows fails in test_winfixbuf
          (after v9.1.208)
Solution: Instead of skipping the test, write the file
          so it exists on disk, to verify that MS-Windows
          short filename expansion is successful.
          (Sean Dewar)

related: vim/vim#14286

https://github.com/vim/vim/commit/aed6554b46bbba39bcb22e49cc731176cd75789b

Co-authored-by: Sean Dewar <6256228+seandewar@users.noreply.github.com>