### PR TITLE
vim-patch:9.1.0214: Duplicate condition in win_lbr_chartabsize()

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -249,7 +249,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
         }
         csarg->indent_width = head_mid;
       }
-      if (head_mid > 0 && wcol + size > wp->w_width_inner) {
+      if (head_mid > 0) {
         // Calculate effective window width.
         int prev_rem = wp->w_width_inner - wcol;
         int width = width2 - head_mid;


### PR DESCRIPTION
#### vim-patch:9.1.0214: Duplicate condition in win_lbr_chartabsize()

Problem:  Duplicate condition in win_lbr_chartabsize().
Solution: Remove the duplicate condition, as it's already checked above.
          (zeertzjq)

closes: vim/vim#14320

https://github.com/vim/vim/commit/5532d3b3f0c73d4e0fa07122ebbed3bf201870f9