### PR TITLE
vim-patch:9.1.0217: regexp: verymagic cannot match before/after a mark

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -4494,7 +4494,7 @@ static uint8_t *regatom(int *flagp)
           n = n * 10 + (uint32_t)(c - '0');
           c = getchr();
         }
-        if (c == '\'' && n == 0) {
+        if (no_Magic(c) == '\'' && n == 0) {
           // "\%'m", "\%<'m" and "\%>'m": Mark
           c = getchr();
           ret = regnode(RE_MARK);
@@ -10218,7 +10218,7 @@ static int nfa_regatom(void)
         }
         EMIT((int)n);
         break;
-      } else if (c == '\'' && n == 0) {
+      } else if (no_Magic(c) == '\'' && n == 0) {
         // \%'m  \%<'m  \%>'m
         EMIT(cmp == '<' ? NFA_MARK_LT
                         : cmp == '>' ? NFA_MARK_GT : NFA_MARK);

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -842,12 +842,26 @@ func Regex_Mark()
   %d
 endfunc
 
+" Same test as abobe, but use verymagic
+func Regex_Mark_Verymagic()
+  call append(0, ['', '', '', 'Marks:', 'asdfSasdfsadfEasdf', 'asdfSas',
+        \ 'dfsadfEasdf', '', '', '', '', ''])
+  call cursor(4, 1)
+  exe "normal jfSmsfEme:.-4,.+6s/\\v.%>'s.*%<'e../here/\<CR>"
+  exe "normal jfSmsj0fEme:.-4,.+6s/\\v.%>'s\\_.*%<'e../again/\<CR>"
+  call assert_equal(['', '', '', 'Marks:', 'asdfhereasdf', 'asdfagainasdf',
+        \ '', '', '', '', '', ''], getline(1, '$'))
+  %d
+endfunc
+
 func Test_matching_marks()
   new
   set regexpengine=1
   call Regex_Mark()
+  call Regex_Mark_Verymagic()
   set regexpengine=2
   call Regex_Mark()
+  call Regex_Mark_Verymagic()
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0217: regexp: verymagic cannot match before/after a mark

Problem:  regexp: verymagic cannot match before/after a mark
Solution: Correctly check for the very magic check (Julio B)

Fix regexp parser for \v%>'m and \v%<'m
Currently \v%'m works fine, but it is unable to match before or after
the position of mark m.

closes: vim/vim#14309

https://github.com/vim/vim/commit/46fa3c7e271eb2abb05a0d9e6dbc9c36c2b2da02

Co-authored-by: Julio B <julio.bacel@gmail.com>