### PR TITLE
vim-patch:9.1.0218: Unnecessary multiplications in backspace code

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3838,7 +3838,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
 
       bool const use_ts = !curwin->w_p_list || curwin->w_p_lcs_chars.tab1;
       char *const line = get_cursor_line_ptr();
-      char *const end_ptr = line + curwin->w_cursor.col;
+      char *const cursor_ptr = line + curwin->w_cursor.col;
 
       colnr_T vcol = 0;
       colnr_T space_vcol = 0;
@@ -3846,9 +3846,10 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
       StrCharInfo space_sci = sci;
       bool prev_space = false;
 
-      // Find the last whitespace that is preceded by non-whitespace.
+      // Compute virtual column of cursor position, and find the last
+      // whitespace before cursor that is preceded by non-whitespace.
       // Use charsize_nowrap() so that virtual text and wrapping are ignored.
-      while (sci.ptr < end_ptr) {
+      while (sci.ptr < cursor_ptr) {
         bool cur_space = ascii_iswhite(sci.chr.value);
         if (!prev_space && cur_space) {
           space_sci = sci;
@@ -3860,11 +3861,9 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
       }
 
       // Compute the virtual column where we want to be.
-      colnr_T want_vcol = vcol - 1;
-      if (want_vcol <= 0) {
-        want_vcol = 0;
-      } else if (p_sta && in_indent) {
-        want_vcol = want_vcol - want_vcol % get_sw_value(curbuf);
+      colnr_T want_vcol = vcol > 0 ? vcol - 1 : 0;
+      if (p_sta && in_indent) {
+        want_vcol -= want_vcol % get_sw_value(curbuf);
       } else {
         want_vcol = tabstop_start(want_vcol, get_sts_value(), curbuf->b_p_vsts_array);
       }

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -177,7 +177,7 @@ colnr_T tabstop_start(colnr_T col, int ts, colnr_T *vts)
   colnr_T tabcol = 0;
 
   if (vts == NULL || vts[0] == 0) {
-    return ((col / ts) * ts);
+    return col - col % ts;
   }
 
   const int tabcount = vts[0];
@@ -189,7 +189,7 @@ colnr_T tabstop_start(colnr_T col, int ts, colnr_T *vts)
   }
 
   const int excess = (tabcol % vts[tabcount]);
-  return (excess + ((col - excess) / vts[tabcount]) * vts[tabcount]);
+  return col - (col - excess) % vts[tabcount];
 }
 
 /// Find the number of tabs and spaces necessary to get from one column

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2065,7 +2065,10 @@ func Test_edit_revins()
   call setline(1, 'one two three')
   exe "normal! wi\nfour"
   call assert_equal(['one two three', 'ruof'], getline(1, '$'))
-  set revins&
+  set backspace=indent,eol,start
+  exe "normal! ggA\<BS>:"
+  call assert_equal(['one two three:ruof'], getline(1, '$'))
+  set revins& backspace&
   bw!
 endfunc
 
@@ -2156,7 +2159,7 @@ func s:check_backspace(expected)
   inoremap <buffer> <F2> <Cmd>let g:actual += [getline('.')]<CR>
   set backspace=indent,eol,start
 
-  exe "normal $i" .. repeat("\<BS>\<F2>", len(a:expected))
+  exe "normal i" .. repeat("\<BS>\<F2>", len(a:expected))
   call assert_equal(a:expected, g:actual)
 
   set backspace&
@@ -2166,9 +2169,12 @@ endfunc
 
 " Test that backspace works with 'smarttab' and mixed Tabs and spaces.
 func Test_edit_backspace_smarttab_mixed()
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=4 shiftwidth=4
+  setlocal tabstop=4 shiftwidth=4
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2180,15 +2186,19 @@ func Test_edit_backspace_smarttab_mixed()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and 'varsofttabstop'.
 func Test_edit_backspace_smarttab_varsofttabstop()
   CheckFeature vartabs
 
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=8 varsofttabstop=6,2,5,3
+  setlocal tabstop=8 varsofttabstop=6,2,5,3
+
   call setline(1, "a\t    \t a")
+  normal! $
   call s:check_backspace([
         \ "a\t    \ta",
         \ "a\t     a",
@@ -2199,13 +2209,17 @@ func Test_edit_backspace_smarttab_varsofttabstop()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' when a Tab is shown as "^I".
 func Test_edit_backspace_smarttab_list()
+  set smarttab
   call NewWindow(1, 30)
-  setlocal smarttab tabstop=4 shiftwidth=4 list listchars=
+  setlocal tabstop=4 shiftwidth=4 list listchars=
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t        a",
         \ "\t    \t    a",
@@ -2215,15 +2229,19 @@ func Test_edit_backspace_smarttab_list()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and 'breakindent'.
 func Test_edit_backspace_smarttab_breakindent()
   CheckFeature linebreak
 
+  set smarttab
   call NewWindow(3, 17)
-  setlocal smarttab tabstop=4 shiftwidth=4 breakindent breakindentopt=min:5
+  setlocal tabstop=4 shiftwidth=4 breakindent breakindentopt=min:5
+
   call setline(1, "\t    \t         \t a")
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2235,17 +2253,21 @@ func Test_edit_backspace_smarttab_breakindent()
         \ ])
 
   call CloseWindow()
+  set smarttab&
 endfunc
 
 " Test that backspace works with 'smarttab' and virtual text.
 func Test_edit_backspace_smarttab_virtual_text()
   CheckFeature textprop
 
+  set smarttab
   call NewWindow(1, 50)
-  setlocal smarttab tabstop=4 shiftwidth=4
+  setlocal tabstop=4 shiftwidth=4
+
   call setline(1, "\t    \t         \t a")
   call prop_type_add('theprop', {})
   call prop_add(1, 3, {'type': 'theprop', 'text': 'text'})
+  normal! $
   call s:check_backspace([
         \ "\t    \t         \ta",
         \ "\t    \t        a",
@@ -2258,6 +2280,7 @@ func Test_edit_backspace_smarttab_virtual_text()
 
   call CloseWindow()
   call prop_type_delete('theprop')
+  set smarttab&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0218: Unnecessary multiplications in backspace code

Problem:  Unnecessary multiplications in backspace code, as
          "col / ts * ts" is the same as "col - col % ts".
Solution: Change "col / ts * ts" to "col - col % ts".  Adjust the loop
          and the comments ins_bs() to be easier to understand.  Update
          tests to reset 'smarttab' properly.
          (zeertzjq)

closes: vim/vim#14308

https://github.com/vim/vim/commit/8ede7a069419e0e01368c65a2d0c79d6332aa6cd