### PR TITLE
vim-patch:9.1.0220: Few typos in source and test files

### DIFF
--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -203,7 +203,7 @@ static void init_users(void)
   os_get_usernames(&ga_users);
 }
 
-/// Given to ExpandGeneric() to obtain an user names.
+/// Given to ExpandGeneric() to obtain user names.
 char *get_users(expand_T *xp, int idx)
 {
   init_users();

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -133,7 +133,7 @@ func Test_bdelete_cmd()
   call assert_fails('1,1bdelete 1 2', 'E488:')
   call assert_fails('bdelete \)', 'E55:')
 
-  " Deleting a unlisted and unloaded buffer
+  " Deleting an unlisted and unloaded buffer
   edit Xbdelfile1
   let bnr = bufnr()
   set nobuflisted

--- a/test/old/testdir/test_history.vim
+++ b/test/old/testdir/test_history.vim
@@ -254,7 +254,7 @@ func Test_history_crypt_key()
   set key& bs& ts&
 endfunc
 
-" The following used to overflow and causing an use-after-free
+" The following used to overflow and causing a use-after-free
 func Test_history_max_val()
 
   set history=10

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1208,7 +1208,7 @@ func Test_complete_wholeline_unlistedbuf()
   edit Xfile1
   enew
   set complete=U
-  " completing from a unloaded buffer should fail
+  " completing from an unloaded buffer should fail
   exe "normal! ia\<C-X>\<C-L>\<C-P>"
   call assert_equal('a', getline(1))
   %d

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -631,11 +631,11 @@ endfunc
 
 func Test_mkview_no_file_name()
   new
-  " :mkview or :mkview {nr} should fail in a unnamed buffer.
+  " :mkview or :mkview {nr} should fail in an unnamed buffer.
   call assert_fails('mkview', 'E32:')
   call assert_fails('mkview 1', 'E32:')
 
-  " :mkview {file} should succeed in a unnamed buffer.
+  " :mkview {file} should succeed in an unnamed buffer.
   mkview Xview
   help
   source Xview

--- a/test/old/testdir/test_recover.vim
+++ b/test/old/testdir/test_recover.vim
@@ -385,7 +385,7 @@ func Test_recover_encrypted_swap_file()
   call delete('Xfile1')
 endfunc
 
-" Test for :recover using a unreadable swap file
+" Test for :recover using an unreadable swap file
 func Test_recover_unreadable_swap_file()
   CheckUnix
   CheckNotRoot

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -842,7 +842,7 @@ func Regex_Mark()
   %d
 endfunc
 
-" Same test as abobe, but use verymagic
+" Same test as above, but use verymagic
 func Regex_Mark_Verymagic()
   call append(0, ['', '', '', 'Marks:', 'asdfSasdfsadfEasdf', 'asdfSas',
         \ 'dfsadfEasdf', '', '', '', '', ''])

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1151,7 +1151,7 @@ func Test_visual_inner_block()
   " try to select non-existing inner block
   call cursor(5, 1)
   call assert_beeps('normal ViBiBiB')
-  " try to select a unclosed inner block
+  " try to select an unclosed inner block
   8,9d
   call cursor(5, 1)
   call assert_beeps('normal ViBiB')


### PR DESCRIPTION
#### vim-patch:9.1.0220: Few typos in source and test files

Problem:  Typos in code and tests.
Solution: Fix typos (zeertzjq).

closes: vim/vim#14321

https://github.com/vim/vim/commit/c029c131ea7822514d67edb9be2de76d076aa267