### PR TITLE
feat(lsp): conditionally send a work done progress token on initialize

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1012,6 +1012,9 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                   request before sending kill -15. If set to
                                   false, nvim exits immediately after sending
                                   the "shutdown" request to the server.
+                                • {progress_on_init}? (`boolean`, default:
+                                  `true`) Send a progress token on
+                                  initialization
       • {get_language_id}       (`fun(bufnr: integer, filetype: string): string`)
       • {capabilities}          (`lsp.ClientCapabilities`) The capabilities
                                 provided by the client (editor or tool)
@@ -1183,6 +1186,9 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 request before sending kill -15. If set to
                                 false, nvim exits immediately after sending
                                 the "shutdown" request to the server.
+                              • {progress_on_init}? (`boolean`, default:
+                                `true`) Send a progress token on
+                                initialization
       • {root_dir}?           (`string`) Directory where the LSP server will
                               base its workspaceFolders, rootUri, and rootPath
                               on initialization.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -40,7 +40,7 @@ The following changes may require adaptations in user config or plugins.
     set selection=exclusive
     set selectmode=mouse,key
     set mousemodel=popup
-    set keymodel=startsel,stopsel
+    setn keymodel=startsel,stopsel
 <
 • When switching windows, |CursorMoved| autocommands trigger when Nvim is back
   in the main loop rather than immediately. This is more compatible with Vim.
@@ -228,6 +228,9 @@ The following new APIs and features were added.
     (e.g. `commitCharacters`). Note that this might affect plugins and
     language servers that don't support the feature, and in such cases the
     respective capability can be unset.
+  • LSP client now supports sending a progress token on initialization via
+    the `progress_on_init` flag in `ClientConfig`
+
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -40,7 +40,7 @@ The following changes may require adaptations in user config or plugins.
     set selection=exclusive
     set selectmode=mouse,key
     set mousemodel=popup
-    setn keymodel=startsel,stopsel
+    set keymodel=startsel,stopsel
 <
 • When switching windows, |CursorMoved| autocommands trigger when Nvim is back
   in the main loop rather than immediately. This is more compatible with Vim.

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -28,6 +28,10 @@ local validate = vim.validate
 --- immediately after sending the "shutdown" request to the server.
 --- (default: `false`)
 --- @field exit_timeout integer|false
+---
+--- Send a progress token on initialization
+--- (default: `true`)
+--- @field progress_on_init? boolean
 
 --- @class vim.lsp.ClientConfig
 --- command string[] that launches the language
@@ -370,6 +374,7 @@ local function validate_config(config)
     offset_encoding = { config.offset_encoding, 's', true },
     flags = { config.flags, 't', true },
     get_language_id = { config.get_language_id, 'f', true },
+    progress_on_init = { config.progress}
   })
 
   assert(
@@ -580,6 +585,10 @@ function Client:initialize()
     capabilities = self.capabilities,
     trace = self._trace,
   }
+
+  if vim.F.if_nil(config.flags.progress_on_init, true) then
+    initialize_params.work_done_token = "1"
+  end
 
   self:_run_callbacks(
     { self._before_init_cb },


### PR DESCRIPTION
Problem:
https://github.com/neovim/neovim/issues/27938 we don't send a progress token on initialize

Solution:
Conditionally send a progress token if a flag is set. 


Apparently there's no harm in sending one, but since the LSP doesn't require one to be sent, I'm guessing disabling this feature might come in handy in case some servers aren't expecting it on initialize. 