### PR TITLE
fix(intro): link showing intro to state at start

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -424,7 +424,7 @@ int update_screen(void)
   static bool still_may_intro = true;
   if (still_may_intro) {
     if (!may_show_intro()) {
-      must_redraw = UPD_NOT_VALID;
+      redraw_later(firstwin, UPD_NOT_VALID);
       still_may_intro = false;
     }
   }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2715,9 +2715,11 @@ void list_version(void)
 /// Whether it still is not too late to show an intro message
 bool may_show_intro(void)
 {
-  return (buf_is_empty(firstwin->w_buffer)
-          && (firstwin->w_buffer->b_fname == NULL)
-          && one_window(firstwin)
+  return (buf_is_empty(curbuf)
+          && (curbuf->b_fname == NULL)
+          && (curbuf->handle == 1)
+          && (curwin->handle == LOWEST_WIN_ID)
+          && one_window(curwin)
           && (vim_strchr(p_shm, SHM_INTRO) == NULL));
 }
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1630,25 +1630,25 @@ describe('ui/ext_messages', function()
       {1:~                }type  :help iccf{5:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
     ]]
+    local showmode = { { '-- INSERT --', 3 } }
     screen:expect(introscreen)
 
     -- <c-l> (same as :mode) does _not_ clear intro message
     feed('<c-l>i')
-    screen:expect { grid = introscreen, showmode = { { '-- INSERT --', 3 } } }
+    screen:expect { grid = introscreen, showmode = showmode }
 
-    -- opening a float also does not
-    local win = api.nvim_open_win(api.nvim_create_buf(false, false), true, {
+    -- opening a float without focus also does not
+    local win = api.nvim_open_win(api.nvim_create_buf(false, false), false, {
       relative = 'editor',
       height = 1,
       width = 5,
       row = 1,
       col = 5,
     })
-    feed('float<esc><c-l>')
     screen:expect {
       grid = [[
-                                                                                      |
-      {1:~    }{8:floa^t}{1:                                                                      }|
+      ^                                                                                |
+      {1:~    }{8:     }{1:                                                                      }|
       {1:~                                                                               }|*3
       {MATCH:.*}|
       {1:~                                                                               }|
@@ -1666,18 +1666,20 @@ describe('ui/ext_messages', function()
       {1:~                }type  :help iccf{5:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
     ]],
+      showmode = showmode,
     }
+
     api.nvim_win_close(win, true)
-    screen:expect { grid = introscreen }
+    screen:expect { grid = introscreen, showmode = showmode }
 
     -- but editing text does..
-    feed('ix')
+    feed('x')
     screen:expect {
       grid = [[
       x^                                                                               |
       {1:~                                                                               }|*23
     ]],
-      showmode = { { '-- INSERT --', 3 } },
+      showmode = showmode,
     }
 
     feed('<esc>:intro<cr>')
@@ -1710,6 +1712,16 @@ describe('ui/ext_messages', function()
     screen:expect {
       grid = [[
       ^x                                                                               |
+      {1:~                                                                               }|*23
+    ]],
+    }
+  end)
+
+  it('clears intro screen when new buffer is active', function()
+    api.nvim_set_current_buf(api.nvim_create_buf(true, false))
+    screen:expect {
+      grid = [[
+      ^                                                                                |
       {1:~                                                                               }|*23
     ]],
     }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1727,6 +1727,48 @@ describe('ui/ext_messages', function()
     }
   end)
 
+  it('clears intro screen when new buffer is active in floating window', function()
+    local win_opts = { relative = 'editor', height = 1, width = 5, row = 1, col = 5 }
+    api.nvim_open_win(api.nvim_create_buf(false, false), true, win_opts)
+    screen:expect {
+      grid = [[
+                                                                                      |
+      {1:~    }{8:^     }{1:                                                                      }|
+      {1:~                                                                               }|*22
+    ]],
+    }
+  end)
+
+  it('clears intro screen when initial buffer is active in floating window', function()
+    local win_opts = { relative = 'editor', height = 1, width = 5, row = 1, col = 5 }
+    api.nvim_open_win(api.nvim_get_current_buf(), true, win_opts)
+    screen:expect {
+      grid = [[
+                                                                                      |
+      {1:~    }{8:^     }{1:                                                                      }|
+      {1:~                                                                               }|*22
+    ]],
+    }
+  end)
+
+  it('clears intro screen when initial window is converted to be floating', function()
+    exec_lua([[
+      local init_win_id = vim.api.nvim_get_current_win()
+      vim.cmd('split')
+      local win_opts = { relative = 'editor', height = 1, width = 5, row = 1, col = 5 }
+      vim.api.nvim_win_set_config(init_win_id, win_opts)
+      vim.api.nvim_set_current_win(init_win_id)
+    ]])
+    screen:expect {
+      grid = [[
+                                                                                      |
+      {1:~    }{8:^     }{1:                                                                      }|
+      {1:~                                                                               }|*21
+      {6:[No Name]                                                                       }|
+    ]],
+    }
+  end)
+
   it('supports global statusline', function()
     feed(':set laststatus=3<cr>')
     feed(':sp<cr>')


### PR DESCRIPTION
Problem: Current behavior of stateful intro message is too persistent.
  For example, it is still drawn if new empty buffer is shown in current
  window (either by explicitly setting it or after `tabnew`). Although
  the buffer is empty, the act of it being shown should be made visible.

Solution: Make intro message persist if all is true:
    - Current buffer is the same as it was just after start, i.e. empty
      nameless with initial handle (set to 1).
    - Current window is the same as it was just after start, i.e. single
      non-floating with initial handle (set to 1000).