### PR TITLE
vim-patch:9.1.0228: Two unrelated things are tested by a single test

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5693,8 +5693,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	highlighted with |hl-NonText|.
 	You may also want to add "lastline" to the 'display' option to show as
 	much of the last line as possible.
-	NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y,
-	CTRL-D, CTRL-U, CTRL-F, CTRL-B and scrolling with the mouse.
+	NOTE: partly implemented, doesn't work yet for |gj| and |gk|.
 
 						*'softtabstop'* *'sts'*
 'softtabstop' 'sts'	number	(default 0)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6075,8 +6075,7 @@ vim.go.sta = vim.go.smarttab
 --- highlighted with `hl-NonText`.
 --- You may also want to add "lastline" to the 'display' option to show as
 --- much of the last line as possible.
---- NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y,
---- CTRL-D, CTRL-U, CTRL-F, CTRL-B and scrolling with the mouse.
+--- NOTE: partly implemented, doesn't work yet for `gj` and `gk`.
 ---
 --- @type boolean
 vim.o.smoothscroll = false

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7663,8 +7663,7 @@ return {
         highlighted with |hl-NonText|.
         You may also want to add "lastline" to the 'display' option to show as
         much of the last line as possible.
-        NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y,
-        CTRL-D, CTRL-U, CTRL-F, CTRL-B and scrolling with the mouse.
+        NOTE: partly implemented, doesn't work yet for |gj| and |gk|.
       ]=],
       full_name = 'smoothscroll',
       pv_name = 'p_sms',

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4184,7 +4184,20 @@ func Test_normal34_zet_large()
   norm! z9765405999999999999
 endfunc
 
-" Test for { and } paragraph movements and Ctrl-B in buffer with a single line
+" Test for { and } paragraph movements in a single line
+func Test_brace_single_line()
+  new
+  call setline(1, ['foobar one two three'])
+  1
+  norm! 0}
+
+  call assert_equal([0, 1, 20, 0], getpos('.'))
+  norm! {
+  call assert_equal([0, 1, 1, 0], getpos('.'))
+  bw!
+endfunc
+
+" Test for Ctrl-B/Ctrl-U in buffer with a single line
 func Test_single_line_scroll()
   CheckFeature textprop
 
@@ -4193,12 +4206,7 @@ func Test_single_line_scroll()
   let vt = 'virt_above'
   call prop_type_add(vt, {'highlight': 'IncSearch'})
   call prop_add(1, 0, {'type': vt, 'text': '---', 'text_align': 'above'})
-  1
-  norm! 0}
-
-  call assert_equal([0, 1, 20, 0], getpos('.'))
-  norm! {
-  call assert_equal([0, 1, 1, 0], getpos('.'))
+  call cursor(1, 1)
 
   " Ctrl-B/Ctrl-U scroll up with hidden "above" virtual text.
   set smoothscroll
@@ -4213,6 +4221,7 @@ func Test_single_line_scroll()
 
   set smoothscroll&
   bw!
+  call prop_type_delete(vt)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -741,6 +741,7 @@ func Test_smoothscroll_mouse_pos()
   let &mouse = save_mouse
   "let &term = save_term
   "let &ttymouse = save_ttymouse
+  bwipe!
 endfunc
 
 " this was dividing by zero
@@ -1002,9 +1003,8 @@ func Test_smoothscroll_textoff_small_winwidth()
 endfunc
 
 func Test_smoothscroll_page()
-  set smoothscroll
-
-  10split | 40vsplit
+  call NewWindow(10, 40)
+  setlocal smoothscroll
   call setline(1, 'abcde '->repeat(150))
 
   exe "norm! \<C-F>"
@@ -1041,7 +1041,7 @@ func Test_smoothscroll_page()
   exe "norm! \<C-U>"
   call assert_equal(0, winsaveview().skipcol)
 
-  set smoothscroll&
+  bwipe!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0228: Two unrelated things are tested by a single test

Problem:  Two unrelated things are tested by a single test.
Solution: Split it into two, restoring the old Test_brace_single_line().
          Add missing cleanup to some tests.
          (zeertzjq)

closes: vim/vim#14323

https://github.com/vim/vim/commit/ad493ef3ea9ef7f2b0badcd2298883b5ab6e4ef4