### PR TITLE
ci: use `--break-system-packages` on mac when installing pynvim

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -31,11 +31,17 @@ if [[ $os == Linux ]]; then
 
   if [[ -n $TEST ]]; then
     sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb fswatch
+
+    # Use default CC to avoid compilation problems when installing Python modules
+    CC=cc python3 -m pip -q install --user --upgrade pynvim
   fi
 elif [[ $os == Darwin ]]; then
   brew update --quiet
   brew install ninja
   if [[ -n $TEST ]]; then
     brew install cpanminus fswatch
+
+    # Use default CC to avoid compilation problems when installing Python modules
+    CC=cc python3 -m pip -q install --user --upgrade --break-system-packages pynvim
   fi
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,10 +134,6 @@ jobs:
       - if: ${{ matrix.test != 'unittest' }}
         name: Set up interpreter packages
         run: |
-          # Use default CC to avoid compilation problems when installing Python modules.
-          echo "Install neovim module for Python."
-          CC=cc python3 -m pip -q install --user --upgrade pynvim
-
           echo "Install neovim RubyGem."
           gem install --no-document --bindir "$BIN_DIR" --user-install --pre neovim
 


### PR DESCRIPTION
Python 3.12+ throws an error if you try to install an externally managed
environment. Using `--break-system-packages` is not recommended for
personal use, but for CI it should be fine and is probably the most
straightforward solution.