### PR TITLE
feat(api): add nvim__redraw for more granular redrawing

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1566,6 +1566,35 @@ nvim__invalidate_glyph_cache()                *nvim__invalidate_glyph_cache()*
     For testing. The condition in schar_cache_clear_if_full is hard to reach,
     so this function can be used to force a cache clear in a test.
 
+nvim__redraw({opts})                                          *nvim__redraw()*
+    EXPERIMENTAL: this API may change in the future.
+
+    Instruct Nvim to redraw various components.
+
+    Parameters: ~
+      • {opts}  Optional parameters.
+                • win: Target a specific |window-ID| as described below.
+                • buf: Target a specific buffer number as described below.
+                • flush: Update the screen with pending updates.
+                • valid: When present mark `win`, `buf`, or all windows for
+                  redraw. When `true`, only redraw changed lines (useful for
+                  decoration providers). When `false`, forcefully redraw.
+                • range: Redraw a range in `buf`, the buffer in `win` or the
+                  current buffer (useful for decoration providers). Expects a
+                  tuple `[first, last]` with the first and last line number of
+                  the range, 0-based end-exclusive |api-indexing|.
+                • cursor: Immediately update cursor position on the screen in
+                  `win` or the current window.
+                • statuscolumn: Redraw the 'statuscolumn' in `buf`, `win` or
+                  all windows.
+                • statusline: Redraw the 'statusline' in `buf`, `win` or all
+                  windows.
+                • winbar: Redraw the 'winbar' in `buf`, `win` or all windows.
+                • tabline: Redraw the 'tabline'.
+
+    See also: ~
+      • |:redraw|
+
 nvim__stats()                                                  *nvim__stats()*
     Gets internal stats.
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -14,6 +14,7 @@ Various commands					*various*
 							*CTRL-L*
 CTRL-L			Clears and redraws the screen.  The redraw may happen
 			later, after processing typeahead.
+			See also |nvim__redraw()|.
 							*CTRL-L-default*
 			By default, also clears search highlighting
 			|:nohlsearch| and updates diffs |:diffupdate|.
@@ -21,6 +22,7 @@ CTRL-L			Clears and redraws the screen.  The redraw may happen
 
 							*:mod* *:mode*
 :mod[e]			Clears and redraws the screen.
+			See also |nvim__redraw()|.
 
 							*:redr* *:redraw*
 :redr[aw][!]		Redraws pending screen updates now, or the entire
@@ -28,6 +30,7 @@ CTRL-L			Clears and redraws the screen.  The redraw may happen
 			|:mode| or |CTRL-L|.
 			Useful to update the screen during a script or
 			function (or a mapping if 'lazyredraw' set).
+			See also |nvim__redraw()|.
 
 						*:redraws* *:redrawstatus*
 :redraws[tatus][!]	Redraws the status line and window bar of the current
@@ -35,11 +38,12 @@ CTRL-L			Clears and redraws the screen.  The redraw may happen
 			included. Redraws the commandline instead if it contains
 			the 'ruler'. Useful if 'statusline' or 'winbar' includes
 			an item that doesn't cause automatic updating.
+			See also |nvim__redraw()|.
 
 						*:redrawt* *:redrawtabline*
 :redrawt[abline]	Redraw the tabline.  Useful to update the tabline when
 			'tabline' includes an item that doesn't trigger
-			automatic updating.
+			automatic updating. See also |nvim__redraw()|.
 
 							*N<Del>*
 <Del>			When entering a number: Remove the last digit.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -14,12 +14,6 @@ function vim.api.nvim__buf_debug_extmarks(buffer, keys, dot) end
 
 --- @private
 --- @param buffer integer
---- @param first integer
---- @param last integer
-function vim.api.nvim__buf_redraw_range(buffer, first, last) end
-
---- @private
---- @param buffer integer
 --- @return table<string,any>
 function vim.api.nvim__buf_stats(buffer) end
 
@@ -104,6 +98,32 @@ function vim.api.nvim__inspect_cell(grid, row, col) end
 --- so this function can be used to force a cache clear in a test.
 ---
 function vim.api.nvim__invalidate_glyph_cache() end
+
+--- @private
+--- EXPERIMENTAL: this API may change in the future.
+---
+--- Instruct Nvim to redraw various components.
+---
+--- @param opts vim.api.keyset.redraw Optional parameters.
+---             • win: Target a specific `window-ID` as described below.
+---             • buf: Target a specific buffer number as described below.
+---             • flush: Update the screen with pending updates.
+---             • valid: When present mark `win`, `buf`, or all windows for
+---               redraw. When `true`, only redraw changed lines (useful for
+---               decoration providers). When `false`, forcefully redraw.
+---             • range: Redraw a range in `buf`, the buffer in `win` or the
+---               current buffer (useful for decoration providers). Expects a
+---               tuple `[first, last]` with the first and last line number of
+---               the range, 0-based end-exclusive `api-indexing`.
+---             • cursor: Immediately update cursor position on the screen in
+---               `win` or the current window.
+---             • statuscolumn: Redraw the 'statuscolumn' in `buf`, `win` or
+---               all windows.
+---             • statusline: Redraw the 'statusline' in `buf`, `win` or all
+---               windows.
+---             • winbar: Redraw the 'winbar' in `buf`, `win` or all windows.
+---             • tabline: Redraw the 'tabline'.
+function vim.api.nvim__redraw(opts) end
 
 --- @private
 --- @return any[]

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -207,6 +207,18 @@ error('Cannot require a meta file')
 --- @field buf? integer
 --- @field filetype? string
 
+--- @class vim.api.keyset.redraw
+--- @field flush? boolean
+--- @field cursor? boolean
+--- @field valid? boolean
+--- @field statuscolumn? boolean
+--- @field statusline? boolean
+--- @field tabline? boolean
+--- @field winbar? boolean
+--- @field range? any[]
+--- @field win? integer
+--- @field buf? integer
+
 --- @class vim.api.keyset.runtime
 --- @field is_lua? boolean
 --- @field do_source? boolean

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -62,7 +62,7 @@ function M.on_inlayhint(err, result, ctx, _)
   if num_unprocessed == 0 then
     client_hints[client_id] = {}
     bufstate.version = ctx.version
-    api.nvim__buf_redraw_range(bufnr, 0, -1)
+    api.nvim__redraw({ buf = bufnr, valid = true })
     return
   end
 
@@ -91,7 +91,7 @@ function M.on_inlayhint(err, result, ctx, _)
 
   client_hints[client_id] = new_lnum_hints
   bufstate.version = ctx.version
-  api.nvim__buf_redraw_range(bufnr, 0, -1)
+  api.nvim__redraw({ buf = bufnr, valid = true })
 end
 
 --- |lsp-handler| for the method `textDocument/inlayHint/refresh`
@@ -224,7 +224,7 @@ local function clear(bufnr)
     end
   end
   api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
-  api.nvim__buf_redraw_range(bufnr, 0, -1)
+  api.nvim__redraw({ buf = bufnr, valid = true })
 end
 
 --- Disable inlay hints for a buffer

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -394,7 +394,7 @@ function STHighlighter:process_response(response, client, version)
   current_result.namespace_cleared = false
 
   -- redraw all windows displaying buffer
-  api.nvim__buf_redraw_range(self.bufnr, 0, -1)
+  api.nvim__redraw({ buf = self.bufnr, valid = true })
 end
 
 --- on_win handler for the decoration provider (see |nvim_set_decoration_provider|)

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -215,7 +215,7 @@ end
 ---@param start_row integer
 ---@param new_end integer
 function TSHighlighter:on_bytes(_, _, start_row, _, _, _, _, _, new_end)
-  api.nvim__buf_redraw_range(self.bufnr, start_row, start_row + new_end + 1)
+  api.nvim__redraw({ buf = self.bufnr, range = { start_row, start_row + new_end + 1 } })
 end
 
 ---@package
@@ -227,7 +227,7 @@ end
 ---@param changes Range6[]
 function TSHighlighter:on_changedtree(changes)
   for _, ch in ipairs(changes) do
-    api.nvim__buf_redraw_range(self.bufnr, ch[1], ch[4] + 1)
+    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 } })
   end
 end
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -230,20 +230,6 @@ Boolean nvim_buf_detach(uint64_t channel_id, Buffer buffer, Error *err)
   return true;
 }
 
-/// @nodoc
-void nvim__buf_redraw_range(Buffer buffer, Integer first, Integer last, Error *err)
-{
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-  if (!buf) {
-    return;
-  }
-  if (last < 0) {
-    last = buf->b_ml.ml_line_count;
-  }
-
-  redraw_buf_range_later(buf, (linenr_T)first + 1, (linenr_T)last);
-}
-
 /// Gets a line-range from the buffer.
 ///
 /// Indexing is zero-based, end-exclusive. Negative indices are interpreted

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -373,3 +373,17 @@ typedef struct {
   Boolean ignore_blank_lines;
   Boolean indent_heuristic;
 } Dict(xdl_diff);
+
+typedef struct {
+  OptionalKeys is_set__redraw_;
+  Boolean flush;
+  Boolean cursor;
+  Boolean valid;
+  Boolean statuscolumn;
+  Boolean statusline;
+  Boolean tabline;
+  Boolean winbar;
+  Array range;
+  Window win;
+  Buffer buf;
+} Dict(redraw);

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -821,25 +821,25 @@ static void win_redr_border(win_T *wp)
 /// Set cursor to its position in the current window.
 void setcursor(void)
 {
-  setcursor_mayforce(false);
+  setcursor_mayforce(curwin, false);
 }
 
 /// Set cursor to its position in the current window.
 /// @param force  when true, also when not redrawing.
-void setcursor_mayforce(bool force)
+void setcursor_mayforce(win_T *wp, bool force)
 {
   if (force || redrawing()) {
-    validate_cursor(curwin);
+    validate_cursor(wp);
 
-    ScreenGrid *grid = &curwin->w_grid;
-    int row = curwin->w_wrow;
-    int col = curwin->w_wcol;
-    if (curwin->w_p_rl) {
+    ScreenGrid *grid = &wp->w_grid;
+    int row = wp->w_wrow;
+    int col = wp->w_wcol;
+    if (wp->w_p_rl) {
       // With 'rightleft' set and the cursor on a double-wide character,
       // position it on the leftmost column.
-      col = curwin->w_width_inner - curwin->w_wcol
-            - ((utf_ptr2cells(get_cursor_pos_ptr()) == 2
-                && vim_isprintc(gchar_cursor())) ? 2 : 1);
+      char *cursor = ml_get_buf(wp->w_buffer, wp->w_cursor.lnum) + wp->w_cursor.col;
+      col = wp->w_width_inner - wp->w_wcol - ((utf_ptr2cells(cursor) == 2
+                                               && vim_isprintc(utf_ptr2char(cursor))) ? 2 : 1);
     }
 
     grid_adjust(&grid, &row, &col);

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2713,7 +2713,7 @@ void redraw_buf_line_later(buf_T *buf, linenr_T line, bool force)
   }
 }
 
-void redraw_buf_range_later(buf_T *buf,  linenr_T firstline, linenr_T lastline)
+void redraw_buf_range_later(buf_T *buf, linenr_T firstline, linenr_T lastline)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == buf

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5886,7 +5886,7 @@ static void ex_equal(exarg_T *eap)
 static void ex_sleep(exarg_T *eap)
 {
   if (cursor_valid(curwin)) {
-    setcursor_mayforce(true);
+    setcursor_mayforce(curwin, true);
   }
 
   int64_t len = eap->line2;

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -43,7 +43,7 @@ typedef enum {
   kRetLuaref,  ///< return value becomes a single Luaref, regardless of type (except NIL)
 } LuaRetMode;
 
-/// To use with kRetNilBool for quick thuthyness check
+/// To use with kRetNilBool for quick truthiness check
 #define LUARET_TRUTHY(res) ((res).type == kObjectTypeBoolean && (res).data.boolean == true)
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/math.c
+++ b/src/nvim/math.c
@@ -77,6 +77,23 @@ int xctz(uint64_t x)
 #endif
 }
 
+/// Count number of set bits in bit field.
+int popcount(uint64_t x)
+{
+  // Use compiler builtin if possible.
+#if defined(__clang__) || defined(__GNUC__)
+  return __builtin_popcountll(x);
+#else
+  int count = 0;
+  for (; x != 0; x >>= 1) {
+    if (x & 1) {
+      count++;
+    }
+  }
+  return count;
+#endif
+}
+
 /// For overflow detection, add a digit safely to an int value.
 int vim_append_digit_int(int *value, int digit)
 {

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1281,7 +1281,7 @@ void pum_show_popupmenu(vimmenu_T *menu)
     pum_is_drawn = true;
     pum_grid.zindex = kZIndexCmdlinePopupMenu;  // show above cmdline area #23275
     pum_redraw();
-    setcursor_mayforce(true);
+    setcursor_mayforce(curwin, true);
 
     int c = vgetc();
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -827,14 +827,14 @@ local function test_cmdline(linegrid)
     ]])
   end)
 
-  -- Needs new API
-  pending('does not move cursor to curwin #20309', function()
+  it('does not move cursor to curwin #20309', function()
     local win = api.nvim_get_current_win()
     command('norm icmdlinewin')
     command('new')
     command('norm icurwin')
     feed(':')
     api.nvim_win_set_cursor(win, { 1, 7 })
+    api.nvim__redraw({ win = win, cursor = true })
     screen:expect {
       grid = [[
       curwin                   |

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2594,6 +2594,12 @@ it(':substitute with inccommand, timer-induced :redraw #9777', function()
     {2:[Preview]                     }|
     :%s/foo/ZZZ^                   |
   ]])
+
+  -- Also with nvim__redraw()
+  command('call timer_start(10, {-> nvim__redraw(#{flush:1})}, {"repeat":-1})')
+  command('call timer_start(10, {-> nvim__redraw(#{statusline:1})}, {"repeat":-1})')
+  sleep(20) -- Allow some timer activity.
+  screen:expect_unchanged()
 end)
 
 it(':substitute with inccommand, allows :redraw before first separator is typed #18857', function()

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -918,4 +918,57 @@ describe('statuscolumn', function()
                                        |
     ]])
   end)
+
+  it('forces a rebuild with nvim__redraw', function()
+    screen:try_resize(40, 4)
+    -- Current window
+    command([[
+      let g:insert = v:false
+      set nonu stc=%{g:insert?'insert':''}
+      vsplit
+      au InsertEnter * let g:insert = v:true | call nvim__redraw(#{statuscolumn:1, win:0})
+      au InsertLeave * let g:insert = v:false | call nvim__redraw(#{statuscolumn:1, win:0})
+    ]])
+    feed('i')
+    screen:expect({
+      grid = [[
+        {8:insert}^aaaaa         │aaaaa              |
+        {8:insert}aaaaa         │aaaaa              |
+        {3:[No Name] [+]        }{2:[No Name] [+]      }|
+        {5:-- INSERT --}                            |
+      ]],
+    })
+    feed('<esc>')
+    screen:expect({
+      grid = [[
+        ^aaaaa               │aaaaa              |
+        aaaaa               │aaaaa              |
+        {3:[No Name] [+]        }{2:[No Name] [+]      }|
+                                                |
+      ]],
+    })
+    -- All windows
+    command([[
+      au! InsertEnter * let g:insert = v:true | call nvim__redraw(#{statuscolumn:1})
+      au! InsertLeave * let g:insert = v:false | call nvim__redraw(#{statuscolumn:1})
+    ]])
+    feed('i')
+    screen:expect({
+      grid = [[
+        {8:insert}^aaaaa         │{8:insert}aaaaa        |
+        {8:insert}aaaaa         │{8:insert}aaaaa        |
+        {3:[No Name] [+]        }{2:[No Name] [+]      }|
+        {5:-- INSERT --}                            |
+      ]],
+    })
+    feed('<esc>')
+    screen:expect({
+      grid = [[
+        ^aaaaa               │aaaaa              |
+        aaaaa               │aaaaa              |
+        {3:[No Name] [+]        }{2:[No Name] [+]      }|
+                                                |
+      ]],
+    })
+  end)
 end)


### PR DESCRIPTION
Experimental and subject to future changes.
Add a way to redraw certain elements that are not redrawn while Nvim is waiting
for input, or currently have no API to do so. This API covers all that can be
done with the :redraw* commands, in addition to the following new features:
- Immediately move the cursor to a (non-current) window.
- Target a specific window or buffer to mark for redraw.
- Mark a buffer range for redraw (replaces nvim__buf_redraw_range()).
- Redraw the 'statuscolumn'.

Resolve #20793
Closes #26071