### PR TITLE
fix: explain that user should run nvim with -V1 to see more information

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2392,7 +2392,7 @@ char *get_scriptname(LastSet last_set, bool *should_free)
   case SID_WINLAYOUT:
     return _("changed window size");
   case SID_LUA:
-    return _("Lua");
+    return _("Lua (run Nvim with -V1 for more details)");
   case SID_API_CLIENT:
     snprintf(IObuff, IOSIZE, _("API client (channel id %" PRIu64 ")"), last_set.channel_id);
     return IObuff;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1600,7 +1600,7 @@ describe('API', function()
       api.nvim_exec_lua('vim.api.nvim_set_option_value("equalalways", true, {})', {})
       status, rv = pcall(command_output, 'verbose set equalalways?')
       eq(true, status)
-      eq('  equalalways\n\tLast set from Lua', rv)
+      eq('  equalalways\n\tLast set from Lua (run Nvim with -V1 for more details)', rv)
     end)
 
     it('updates whether the option has ever been set #25025', function()

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -230,7 +230,7 @@ describe('lua verbose:', function()
     eq(
       [[
 nohlsearch
-	Last set from Lua]],
+	Last set from Lua (run Nvim with -V1 for more details)]],
       result
     )
   end)


### PR DESCRIPTION
It's not obvious for users how to figure out where a mapping is set from
only "Last set from Lua".
