### PR TITLE
vim-patch:18d730d7b572

### DIFF
--- a/runtime/compiler/bdf.vim
+++ b/runtime/compiler/bdf.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:             BDF to PCF Conversion
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2006-04-19
+" Contributors:         Enno Nagel
+" Last Change:          2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -11,9 +12,12 @@ let current_compiler = "bdf"
 let s:cpo_save = &cpo
 set cpo-=C
 
-setlocal makeprg=bdftopcf\ $*
+if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
 
-setlocal errorformat=%ABDF\ %trror\ on\ line\ %l:\ %m,
+CompilerSet makeprg=bdftopcf\ $*
+CompilerSet errorformat=%ABDF\ %trror\ on\ line\ %l:\ %m,
       \%-Z%p^,
       \%Cbdftopcf:\ bdf\ input\\,\ %f\\,\ corrupt,
       \%-G%.%#

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -1,8 +1,8 @@
 " Vim compiler file
-" Compiler:    Mono C# Compiler
-" Maintainer:  Jarek Sobiecki <harijari@go2.pl>
-" Last Updated By: Peter Collingbourne
-" Latest Revision: 2012 Jul 19
+" Compiler:     Mono C# Compiler
+" Maintainer:   Jarek Sobiecki <harijari@go2.pl>
+" Contributors: Peter Collingbourne and Enno Nagel
+" Last Change:  2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -12,7 +12,12 @@ let current_compiler = "mcs"
 let s:cpo_save = &cpo
 set cpo-=C
 
-setlocal errorformat=
+if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+CompilerSet makeprg=mcs
+CompilerSet errorformat=
          \%D%.%#Project\ \"%f/%[%^/\"]%#\"%.%#,
          \%X%.%#Done\ building\ project\ \"%f/%[%^/\"]%#\"%.%#,
          \%-G%\\s%.%#,

--- a/runtime/compiler/modelsim_vcom.vim
+++ b/runtime/compiler/modelsim_vcom.vim
@@ -1,7 +1,8 @@
 " Vim Compiler File
 " Compiler:	Modelsim Vcom
 " Maintainer:	Paul Baleme <pbaleme@mail.com>
-" Last Change:	September 8, 2003
+" Contributors: Enno Nagel
+" Last Change:	2024 Mar 29
 " Thanks to:    allanherriman@hotmail.com
 
 if exists("current_compiler")
@@ -13,8 +14,9 @@ if exists(":CompilerSet") != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-"setlocal errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
+CompilerSet makeprg=vcom
 
+"setlocal errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
 "setlocal errorformat=%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %m
 CompilerSet errorformat=\*\*\ %tRROR:\ %f(%l):\ %m,\*\*\ %tRROR:\ %m,\*\*\ %tARNING:\ %m,\*\*\ %tOTE:\ %m,%tRROR:\ %f(%l):\ %m,%tARNING\[%*[0-9]\]:\ %f(%l):\ %m,%tRROR:\ %m,%tARNING\[%*[0-9]\]:\ %m
 

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:	powershell
 " URL: https://github.com/PProvost/vim-ps1
-" Last Change: 2020 Mar 30
+" Contributors: Enno Nagel
+" Last Change: 2024 Mar 29
 
 if exists("current_compiler")
   finish
@@ -37,7 +38,7 @@ let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0
 
 " Use absolute path because powershell requires explicit relative paths
 " (./file.ps1 is okay, but # expands to file.ps1)
-let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
+let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 
 " Parse file, line, char from callstacks:
 "     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a
@@ -49,6 +50,8 @@ let &l:makeprg = g:ps1_makeprg_cmd .' %:p:S'
 "     +     ~~~~~~~~~~~
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
+
+execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:     TeX
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
-" Last Change:  2012 Apr 30
+" Contributors: Enno Nagel
+" Last Change:  2024 Mar 29
 
 if exists("current_compiler")
 	finish
@@ -27,7 +28,8 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 	else
 		let current_compiler = "latex"
 	endif
-	let &l:makeprg=current_compiler.' -interaction=nonstopmode'
+	let makeprg=current_compiler .. ' -interaction=nonstopmode'
+	execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
 else
 	let current_compiler = 'make'
 endif


### PR DESCRIPTION
runtime(compilers): ensure compiler! sets global options (vim/vim#14336)

Previously some options were only set locally by
&l:makeprg/errorformat

This suffices for :compiler (without a trailing bang)
but falls short for :compiler! that sets &g:makeprg/errorformat as
well

Also apply kind suggestions by @dkearns and @lifepillar

https://github.com/vim/vim/commit/18d730d7b5728c8f87272ac7047d86354013eeb9

omit context.vim (vim9script only)

Co-authored-by: Enno <Konfekt@users.noreply.github.com>
