### PR TITLE
vim-patch:9.1.0232: Conceal test fails when rightleft feature is disabled

### DIFF
--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -197,6 +197,7 @@ endfunc
 
 " Same as Test_conceal_wrapped_cursorline_wincolor(), but with 'rightleft'.
 func Test_conceal_wrapped_cursorline_wincolor_rightleft()
+  CheckFeature rightleft
   CheckScreendump
 
   let code =<< trim [CODE]


### PR DESCRIPTION
#### vim-patch:9.1.0232: Conceal test fails when rightleft feature is disabled

Problem:  Conceal test fails when rightleft feature is disabled.
Solution: Skip test if rightleft feature is missing (Julio B).

closes: vim/vim#14342

https://github.com/vim/vim/commit/5df961a1bc5ed14d0b5aa04ef59e9079313c268d

Co-authored-by: Julio B <julio.bacel@gmail.com>