### PR TITLE
vim-patch:9.1.0230: TextChanged autocommand not triggered under some circumstances

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -365,9 +365,10 @@ static void insert_enter(InsertState *s)
   did_cursorhold = false;
 
   // ins_redraw() triggers TextChangedI only when no characters
-  // are in the typeahead buffer, so only reset curbuf->b_last_changedtick
+  // are in the typeahead buffer, so reset curbuf->b_last_changedtick
   // if the TextChangedI was not blocked by char_avail() (e.g. using :norm!)
-  if (!char_avail()) {
+  // and the TextChangedI autocommand has been triggered
+  if (!char_avail() && curbuf->b_last_changedtick_i == buf_get_changedtick(curbuf)) {
     curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   }
 }

--- a/test/functional/autocmd/textchanged_spec.lua
+++ b/test/functional/autocmd/textchanged_spec.lua
@@ -155,10 +155,9 @@ it('TextChangedI and TextChanged', function()
   feed('yypi<esc>')
   eq('', eval('g:autocmd_i'))
 
-  -- TextChanged should only trigger if change was done in Normal mode
   command([[let g:autocmd_n = '']])
   feed('ibar<esc>')
-  eq('', eval('g:autocmd_n'))
+  eq('N8', eval('g:autocmd_n'))
 
   local function validate_mixed_textchangedi(keys)
     feed('ifoo<esc>')
@@ -190,4 +189,27 @@ it('TextChanged is triggered after :norm that enters Insert mode', function()
   eq(0, eval('g:a'))
   feed(':norm! ia<CR>')
   eq(1, eval('g:a'))
+end)
+
+-- oldtest: Test_Changed_ChangedI_2()
+it('TextChanged is triggered after mapping that enters & exits Insert mode', function()
+  exec([[
+    let [g:autocmd_i, g:autocmd_n] = ['','']
+
+    func! TextChangedAutocmdI(char)
+      let g:autocmd_{tolower(a:char)} = a:char .. b:changedtick
+    endfunc
+
+    augroup Test_TextChanged
+      au!
+      au TextChanged  <buffer> :call TextChangedAutocmdI('N')
+      au TextChangedI <buffer> :call TextChangedAutocmdI('I')
+    augroup END
+
+    nnoremap <CR> o<Esc>
+  ]])
+
+  feed('<CR>')
+  eq('N3', eval('g:autocmd_n'))
+  eq('', eval('g:autocmd_i'))
 end)

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3957,4 +3957,24 @@ func Test_implicit_session()
   call delete(expected)
 endfunc
 
+" Test TextChangedI and TextChanged
+func Test_Changed_ChangedI_2()
+  CheckRunVimInTerminal
+  call writefile(['one', 'two', 'three'], 'XTextChangedI2', 'D')
+  let before =<< trim END
+      autocmd TextChanged,TextChangedI * call writefile([b:changedtick], 'XTextChangedI3')
+      nnoremap <CR> o<Esc>
+      call writefile([], 'XTextChangedI3')
+  END
+
+  call writefile(before, 'Xinit', 'D')
+  let buf = RunVimInTerminal('-S Xinit XtextChangedI2', {})
+  call term_sendkeys(buf, "\<cr>")
+  call term_wait(buf)
+  call StopVimInTerminal(buf)
+  call assert_equal(['4'], readfile('XTextChangedI3'))
+
+  call delete('XTextChangedI3')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0230: TextChanged autocommand not triggered under some circumstances

Problem:  TextChanged autocommand not triggered under some circumstances
          (Sergey Vlasov)
Solution: Trigger TextChanged when TextChangedI has not been triggered

closes: vim/vim#14339

https://github.com/vim/vim/commit/86032702932995db74fed265ba99ae0c823cb75d

Co-authored-by: Christian Brabandt <cb@256bit.org>