### PR TITLE
vim-patch:9.0.1643: filetype detection fails if file name ends in many '~'

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2064,7 +2064,7 @@ local pattern = {
   ['%.?zsh.*'] = starsetf('zsh'),
   -- Ignored extension
   ['.*~'] = function(path, bufnr)
-    local short = path:gsub('~$', '', 1)
+    local short = path:gsub('~+$', '', 1)
     if path ~= short and short ~= '' then
       return M.match({ buf = bufnr, filename = fn.fnameescape(short) })
     end

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1,5 +1,16 @@
 " Test :setfiletype
 
+func Test_backup_strip()
+  filetype on
+  let fname = 'Xdetect.js~~~~~~~~~~~'
+  call writefile(['one', 'two', 'three'], fname, 'D')
+  exe 'edit ' .. fname
+  call assert_equal('javascript', &filetype)
+
+  bwipe!
+  filetype off
+endfunc
+
 func Test_detection()
   filetype on
   augroup filetypedetect


### PR DESCRIPTION
#### vim-patch:9.0.1643: filetype detection fails if file name ends in many '~'

Problem:    Filetype detection fails if file name ends in many '\~'.
Solution:   Strip multiple '\~' at the same time.

https://github.com/vim/vim/commit/c12e4eecbb26cedca96e0810d3501043356eebaa

In Nvim this already works as Lua filetype detection isn't subject to
such a small recursion limit as autocommands, but it still makes sense
to avoid unnecessary recursion.

Co-authored-by: Bram Moolenaar <Bram@vim.org>