### PR TITLE
vim-patch:9.1.0251: Filetype test fails

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -367,7 +367,7 @@ static void insert_enter(InsertState *s)
   // ins_redraw() triggers TextChangedI only when no characters
   // are in the typeahead buffer, so reset curbuf->b_last_changedtick
   // if the TextChangedI was not blocked by char_avail() (e.g. using :norm!)
-  // and the TextChangedI autocommand has been triggered
+  // and the TextChangedI autocommand has been triggered.
   if (!char_avail() && curbuf->b_last_changedtick_i == buf_get_changedtick(curbuf)) {
     curbuf->b_last_changedtick = buf_get_changedtick(curbuf);
   }

--- a/test/functional/autocmd/textchanged_spec.lua
+++ b/test/functional/autocmd/textchanged_spec.lua
@@ -194,17 +194,14 @@ end)
 -- oldtest: Test_Changed_ChangedI_2()
 it('TextChanged is triggered after mapping that enters & exits Insert mode', function()
   exec([[
-    let [g:autocmd_i, g:autocmd_n] = ['','']
+    let [g:autocmd_n, g:autocmd_i] = ['','']
 
-    func! TextChangedAutocmdI(char)
+    func TextChangedAutocmd(char)
       let g:autocmd_{tolower(a:char)} = a:char .. b:changedtick
     endfunc
 
-    augroup Test_TextChanged
-      au!
-      au TextChanged  <buffer> :call TextChangedAutocmdI('N')
-      au TextChangedI <buffer> :call TextChangedAutocmdI('I')
-    augroup END
+    au TextChanged  <buffer> :call TextChangedAutocmd('N')
+    au TextChangedI <buffer> :call TextChangedAutocmd('I')
 
     nnoremap <CR> o<Esc>
   ]])


### PR DESCRIPTION
#### vim-patch:9.1.0251: Filetype test fails

Problem:  Filetype test fails.
Solution: Move detection by name before detection by extension.
          Improve TextChanged test and remove wrong test and fix
          a typo in a comment (zeertzjq).

closes: vim/vim#14373

https://github.com/vim/vim/commit/8eb7523802cb51984e2202d08a4fbc1a2cd803c7

The changes to filetype.vim are N/A since Nvim always prefers filename
matches to extension matches.