### PR TITLE
fix(dialog): save unamed buffer correctly

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -212,8 +212,12 @@ void dialog_changed(buf_T *buf, bool checkall)
   }
 
   if (ret == VIM_YES) {
-    if (buf->b_fname != NULL
-        && check_overwrite(&ea, buf, buf->b_fname, buf->b_ffname, false) == OK) {
+    if (buf->b_fname == NULL) {
+      buf->b_fname = "Untitled";
+      buf->b_ffname = xstrdup(NameBuff);
+    }
+
+    if (check_overwrite(&ea, buf, buf->b_fname, buf->b_ffname, false) == OK) {
       // didn't hit Cancel
       buf_write_all(buf, false);
     }

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -167,6 +167,35 @@ describe(':confirm command dialog', function()
     os.remove('Xbar')
   end)
 
+  it('can save Untitled #21682', function()
+    write_file('Xfoo', 'foo1\n')
+    start_new()
+    screen:try_resize(75, 10)
+    exec([[
+    set nohidden confirm
+    new
+    call setline(1, 'abc')
+    ]])
+    feed(':e Xfoo<CR>')
+    screen:expect({
+      grid = [[
+        abc                                                                        |
+        {1:~                                                                          }|*3
+        {3:[No Name] [+]                                                              }|
+                                                                                   |
+        {3:                                                                           }|
+        :e Xfoo                                                                    |
+        {6:Save changes to "Untitled"?}                                                |
+        {6:[Y]es, (N)o, (C)ancel: }^                                                    |
+      ]],
+    })
+    feed('Y')
+
+    eq('abc\n', read_file('Untitled'))
+    os.remove('Untitled')
+    os.remove('Xfoo')
+  end)
+
   -- oldtest: Test_confirm_cmd_cancel()
   it('can be cancelled', function()
     -- Test for closing a window with a modified buffer


### PR DESCRIPTION
Problem: when bufname is empty it can not save correctly

Solution: set bufname before save.


Fix #21682 