### PR TITLE
vim-patch:cc7597c1edf4

### DIFF
--- a/runtime/syntax/yaml.vim
+++ b/runtime/syntax/yaml.vim
@@ -2,8 +2,7 @@
 " Language:         YAML (YAML Ain't Markup Language) 1.2
 " Maintainer:       Nikolai Pavlov <zyx.vim@gmail.com>
 " First author:     Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2015-03-28
-" 		    removed duplicate yamlKeyValueDelimiter (pull #4799)
+" Latest Revision:  2024-04-01
 
 if exists('b:current_syntax')
     finish
@@ -15,21 +14,21 @@ set cpo&vim
 " Choose the schema to use
 " TODO: Validate schema
 if !exists('b:yaml_schema')
-  if exists('g:yaml_schema')
-    let b:yaml_schema = g:yaml_schema
-  else
-    let b:yaml_schema = 'core'
-  endif
+    if exists('g:yaml_schema')
+        let b:yaml_schema = g:yaml_schema
+    else
+        let b:yaml_schema = 'core'
+    endif
 endif
 
 let s:ns_char = '\%([\n\r\uFEFF \t]\@!\p\)'
 let s:ns_word_char = '[[:alnum:]_\-]'
 let s:ns_uri_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$,.!~*''()[\]]\)'
 let s:ns_tag_char  = '\%(%\x\x\|'.s:ns_word_char.'\|[#/;?:@&=+$.~*''()]\)'
-let s:c_ns_anchor_char = '\%([\n\r\uFEFF \t,[\]{}]\@!\p\)'
 let s:c_indicator      = '[\-?:,[\]{}#&*!|>''"%@`]'
 let s:c_flow_indicator = '[,[\]{}]'
 
+let s:ns_anchor_char = substitute(s:ns_char, '\v\C[\zs', '\=s:c_flow_indicator[1:-2]', '')
 let s:ns_char_without_c_indicator = substitute(s:ns_char, '\v\C[\zs', '\=s:c_indicator[1:-2]', '')
 
 let s:_collection = '[^\@!\(\%(\\\.\|\[^\\\]]\)\+\)]'
@@ -38,8 +37,8 @@ function s:SimplifyToAssumeAllPrintable(p)
     return substitute(a:p, '\V\C\\%('.s:_collection.'\\@!\\p\\)', '[^\1]', '')
 endfunction
 let s:ns_char = s:SimplifyToAssumeAllPrintable(s:ns_char)
+let s:ns_anchor_char = s:SimplifyToAssumeAllPrintable(s:ns_anchor_char)
 let s:ns_char_without_c_indicator = s:SimplifyToAssumeAllPrintable(s:ns_char_without_c_indicator)
-let s:c_ns_anchor_char = s:SimplifyToAssumeAllPrintable(s:c_ns_anchor_char)
 
 function s:SimplifyAdjacentCollections(p)
     return substitute(a:p, '\V\C'.s:_collection.'\\|'.s:_collection, '[\1\2]', 'g')
@@ -60,9 +59,10 @@ let s:c_ns_tag_property = s:c_verbatim_tag.
             \        '\|'.s:c_ns_shorthand_tag.
             \        '\|'.s:c_non_specific_tag
 
-let s:c_ns_anchor_name = s:c_ns_anchor_char.'\+'
+let s:c_ns_anchor_name = s:ns_anchor_char.'\+'
 let s:c_ns_anchor_property =  '&'.s:c_ns_anchor_name
 let s:c_ns_alias_node      = '\*'.s:c_ns_anchor_name
+let s:c_ns_properties      = '\%(\%('.s:c_ns_tag_property.'\|'.s:c_ns_anchor_property.'\)\s\+\)\+'
 
 let s:ns_directive_name = s:ns_char.'\+'
 
@@ -100,57 +100,71 @@ execute 'syn region yamlDirective oneline start='.string('^\ze%'.s:ns_directive_
             \                                     'yamlReservedDirective '.
             \                            'keepend'
 
-syn match yamlTAGDirective '%TAG\s\+' contained nextgroup=yamlTagHandle
-execute 'syn match yamlTagHandle contained nextgroup=yamlTagPrefix '.string(s:c_tag_handle.'\s\+')
-execute 'syn match yamlTagPrefix contained nextgroup=yamlComment ' . string(s:ns_tag_prefix)
+syn match yamlTAGDirective /%TAG\ze\s/ contained nextgroup=yamlTagHandle skipwhite
+execute 'syn match yamlTagHandle' string(s:c_tag_handle)  'contained nextgroup=yamlTagPrefix skipwhite'
+execute 'syn match yamlTagPrefix' string(s:ns_tag_prefix) 'contained nextgroup=yamlComment skipwhite'
 
-syn match yamlYAMLDirective '%YAML\s\+'  contained nextgroup=yamlYAMLVersion
-syn match yamlYAMLVersion   '\d\+\.\d\+' contained nextgroup=yamlComment
+syn match yamlYAMLDirective /%YAML\ze\s/ contained nextgroup=yamlYAMLVersion skipwhite
+syn match yamlYAMLVersion   /\d\+\.\d\+/ contained nextgroup=yamlComment skipwhite
 
 execute 'syn match yamlReservedDirective contained nextgroup=yamlComment '.
             \string('%\%(\%(TAG\|YAML\)\s\)\@!'.s:ns_directive_name)
 
 syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start='"' skip='\\"' end='"'
-            \ contains=yamlEscape
-            \ nextgroup=yamlKeyValueDelimiter
+            \ contains=yamlEscape contained nextgroup=yamlFlowMappingDelimiter,yamlComment skipwhite
 syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start="'" skip="''"  end="'"
-            \ contains=yamlSingleEscape
-            \ nextgroup=yamlKeyValueDelimiter
+            \ contains=yamlSingleEscape contained nextgroup=yamlFlowMappingDelimiter,yamlComment skipwhite
 syn match  yamlEscape contained '\\\%([\\"abefnrtv\^0_ NLP\n]\|x\x\x\|u\x\{4}\|U\x\{8}\)'
 syn match  yamlSingleEscape contained "''"
 
-syn match yamlBlockScalarHeader contained '\s\+\zs[|>]\%([+-]\=[1-9]\|[1-9]\=[+-]\)\='
-
 syn cluster yamlConstant contains=yamlBool,yamlNull
 
-syn cluster yamlFlow contains=yamlFlowString,yamlFlowMapping,yamlFlowCollection
-syn cluster yamlFlow      add=yamlFlowMappingKey,yamlFlowMappingMerge
-syn cluster yamlFlow      add=@yamlConstant,yamlPlainScalar,yamlFloat
-syn cluster yamlFlow      add=yamlTimestamp,yamlInteger,yamlMappingKeyStart
-syn cluster yamlFlow      add=yamlComment
-syn region yamlFlowMapping    matchgroup=yamlFlowIndicator start='{' end='}' contains=@yamlFlow
-syn region yamlFlowCollection matchgroup=yamlFlowIndicator start='\[' end='\]' contains=@yamlFlow
+syn cluster yamlFlowNode contains=yamlFlowString,yamlFlowMapping,yamlFlowCollection
+syn cluster yamlFlowNode      add=yamlFlowMappingKey,yamlFlowMappingKeyStart,yamlFlowMappingMerge
+syn cluster yamlFlowNode      add=@yamlConstant,yamlPlainScalar,yamlFloat,yamlComment
+syn cluster yamlFlowNode      add=yamlTimestamp,yamlInteger,yamlAlias,yamlFlowNodeProperties
+syn region yamlFlowMapping    matchgroup=yamlFlowIndicator start='{\@<!{{\@!' end='}' contains=@yamlFlowNode
+syn region yamlFlowCollection matchgroup=yamlFlowIndicator start='\[' end='\]' contains=@yamlFlowNode
 
 execute 'syn match yamlPlainScalar /'.s:ns_plain_out.'/'
 execute 'syn match yamlPlainScalar contained /'.s:ns_plain_in.'/'
 
-syn match yamlMappingKeyStart '?\ze\s'
-syn match yamlMappingKeyStart '?' contained
+execute 'syn match yamlFlowMappingKey /'.s:ns_plain_in.'\%(\s\+'.s:ns_plain_in.'\)*\ze\s*:/ contained '.
+            \'nextgroup=yamlFlowMappingDelimiter skipwhite'
+syn match yamlFlowMappingKeyStart      /?/ contained nextgroup=@yamlFlowNode skipwhite
+syn match yamlFlowMappingMerge /<<\ze\s*:/ contained nextgroup=yamlFlowMappingDelimiter skipwhite
+syn match yamlFlowMappingDelimiter     /:/ contained nextgroup=@yamlFlowNode skipwhite
+execute 'syn match yamlFlowNodeProperties' string(s:c_ns_properties)
+            \ 'contained contains=yamlNodeTag,yamlAnchor nextgroup=@yamlFlowNode skipwhite'
 
-execute 'syn match yamlFlowMappingKey /\%#=1'.s:ns_plain_in.'\%(\s\+'.s:ns_plain_in.'\)*\ze\s*:/ contained '.
-            \'nextgroup=yamlKeyValueDelimiter'
-syn match yamlFlowMappingMerge /<<\ze\s*:/ contained nextgroup=yamlKeyValueDelimiter
+execute 'syn match yamlBlockMappingKey /^\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ '.
+            \'nextgroup=yamlBlockMappingDelimiter skipwhite'
+execute 'syn match yamlBlockMappingKey        /'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ contained '.
+            \'nextgroup=yamlBlockMappingDelimiter skipwhite'
+syn match yamlBlockMappingKeyString /^\s*\zs\%("\%([^"]\|\\"\)*"\|'\%([^']\|''\)*'\)\ze\s*:\%(\s\|$\)/
+            \ contains=yamlFlowString nextgroup=yamlBlockMappingDelimiter skipwhite
+syn match yamlBlockMappingKeyString        /\%("\%([^"]\|\\"\)*"\|'\%([^']\|''\)*'\)\ze\s*:\%(\s\|$\)/ contained
+            \ contains=yamlFlowString nextgroup=yamlBlockMappingDelimiter skipwhite
+syn match yamlBlockMappingMerge   /^\s*\zs<<\ze\s*:\%(\s\|$\)/           nextgroup=yamlBlockMappingDelimiter skipwhite
+syn match yamlBlockMappingMerge          /<<\ze\s*:\%(\s\|$\)/ contained nextgroup=yamlBlockMappingDelimiter skipwhite
 
-syn match yamlBlockCollectionItemStart '^\s*\zs-\%(\s\+-\)*\s' nextgroup=yamlBlockMappingKey,yamlBlockMappingMerge
-" Use the old regexp engine, the NFA engine doesn't like all the \@ items.
-execute 'syn match yamlBlockMappingKey /\%#=1^\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ '.
-            \'nextgroup=yamlKeyValueDelimiter'
-execute 'syn match yamlBlockMappingKey /\%#=1\s*\zs'.s:ns_plain_out.'\%(\s\+'.s:ns_plain_out.'\)*\ze\s*:\%(\s\|$\)/ contained '.
-            \'nextgroup=yamlKeyValueDelimiter'
-syn match yamlBlockMappingMerge /^\s*\zs<<\ze:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter
-syn match yamlBlockMappingMerge /<<\ze\s*:\%(\s\|$\)/ nextgroup=yamlKeyValueDelimiter contained
+syn match yamlBlockMappingDelimiter    /^\s*\zs:\ze\%(\s\|$\)/           nextgroup=@yamlBlockNode skipwhite
+syn match yamlBlockMappingDelimiter           /:\ze\%(\s\|$\)/ contained nextgroup=@yamlBlockNode skipwhite
+syn match yamlBlockMappingKeyStart     /^\s*\zs?\ze\%(\s\|$\)/           nextgroup=@yamlBlockNode skipwhite
+syn match yamlBlockMappingKeyStart            /?\ze\%(\s\|$\)/ contained nextgroup=@yamlBlockNode skipwhite
 
-syn match   yamlKeyValueDelimiter /\s*:/ contained
+syn match yamlBlockCollectionItemStart /^\s*\zs-\ze\%(\s\|$\)/           nextgroup=@yamlBlockNode skipwhite
+syn match yamlBlockCollectionItemStart        /-\ze\%(\s\|$\)/ contained nextgroup=@yamlBlockNode skipwhite
+
+execute 'syn match yamlBlockNodeProperties' string(s:c_ns_properties)
+            \ 'contained contains=yamlNodeTag,yamlAnchor nextgroup=@yamlFlowNode,yamlBlockScalarHeader skipwhite'
+syn match yamlBlockScalarHeader '[|>]\%([1-9][+-]\|[+-]\?[1-9]\?\)\%(\s\+#.*\)\?$' contained
+            \ contains=yamlComment nextgroup=yamlBlockString skipnl
+syn region yamlBlockString start=/^\z(\s\+\)/ skip=/^$/ end=/^\%(\z1\)\@!/ contained
+
+syn cluster yamlBlockNode contains=@yamlFlowNode,yamlBlockMappingKey,yamlBlockMappingKeyString,
+            \yamlBlockMappingMerge,yamlBlockMappingKeyStart,yamlBlockCollectionItemStart,
+            \yamlBlockNodeProperties,yamlBlockScalarHeader
 
 syn cluster yamlScalarWithSpecials contains=yamlPlainScalar,yamlBlockMappingKey,yamlFlowMappingKey
 
@@ -164,8 +178,8 @@ elseif b:yaml_schema is# 'core'
     syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
     syn keyword yamlBool true True TRUE false False FALSE contained containedin=@yamlScalarWithSpecials
     exe 'syn match   yamlNull /'.s:_bounder.'\@1<!\~'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%([+-]\=\%(0\%(b[0-1_]\+\|[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
-    exe 'syn match   yamlFloat /'.s:_bounder.'\@1<!\%([+-]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][+-]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlInteger /'.s:_bounder.'\@1<!\%([-+]\=\%(\%(0\%(b[0-1_]\+\|o\?[0-7_]\+\|x[0-9a-fA-F_]\+\)\=\|\%([1-9][0-9_]*\%(:[0-5]\=\d\)\+\)\)\|[1-9][0-9_]*\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
+    exe 'syn match   yamlFloat /'.s:_bounder.'\@1<!\%([-+]\=\%(\%(\d[0-9_]*\)\.[0-9_]*\%([eE][-+]\=\d\+\)\=\|\.[0-9_]\+\%([eE][-+]\=[0-9]\+\)\=\|\d[0-9_]*\%(:[0-5]\=\d\)\+\.[0-9_]*\|\.\%(inf\|Inf\|INF\)\)\|\%(\.\%(nan\|NaN\|NAN\)\)\)'.s:_bounder.'\@!/ contained containedin=@yamlScalarWithSpecials'
 elseif b:yaml_schema is# 'pyyaml'
     syn keyword yamlNull null Null NULL contained containedin=@yamlScalarWithSpecials
     syn keyword yamlBool true True TRUE false False FALSE yes Yes YES no No NO on On ON off Off OFF contained containedin=@yamlScalarWithSpecials
@@ -208,16 +222,26 @@ hi def link yamlFlowStringDelimiter      yamlString
 hi def link yamlEscape                   SpecialChar
 hi def link yamlSingleEscape             SpecialChar
 
-hi def link yamlBlockCollectionItemStart Label
-hi def link yamlBlockMappingKey          Identifier
-hi def link yamlBlockMappingMerge        Special
-
-hi def link yamlFlowMappingKey           Identifier
-hi def link yamlFlowMappingMerge         Special
-
+hi def link yamlMappingKey               Identifier
 hi def link yamlMappingKeyStart          Special
-hi def link yamlFlowIndicator            Special
+hi def link yamlMappingMerge             Special
 hi def link yamlKeyValueDelimiter        Special
+
+hi def link yamlFlowIndicator            Special
+hi def link yamlFlowMappingKey           yamlMappingKey
+hi def link yamlFlowMappingKeyStart      yamlMappingKeyStart
+hi def link yamlFlowMappingMerge         yamlMappingMerge
+hi def link yamlFlowMappingDelimiter     yamlKeyValueDelimiter
+
+hi def link yamlBlockMappingKey          yamlMappingKey
+hi def link yamlBlockMappingKeyStart     yamlMappingKeyStart
+hi def link yamlBlockMappingMerge        yamlMappingMerge
+hi def link yamlBlockMappingDelimiter    yamlKeyValueDelimiter
+hi def link yamlBlockCollectionItemStart Label
+hi def link yamlBlockScalarHeader        Special
+" We do not link yamlBlockString to yamlString, because yamlPlainScalar is
+" not highlighted as string neighter, and also due to historical reasons.
+" hi def link yamlBlockString              yamlString
 
 hi def link yamlConstant                 Constant
 
@@ -234,10 +258,18 @@ hi def link yamlTimestamp                Number
 
 let b:current_syntax = "yaml"
 
-unlet s:ns_word_char s:ns_uri_char s:c_verbatim_tag s:c_named_tag_handle s:c_secondary_tag_handle s:c_primary_tag_handle s:c_tag_handle s:ns_tag_char s:c_ns_shorthand_tag s:c_non_specific_tag s:c_ns_tag_property s:c_ns_anchor_char s:c_ns_anchor_name s:c_ns_anchor_property s:c_ns_alias_node s:ns_char s:ns_directive_name s:ns_local_tag_prefix s:ns_global_tag_prefix s:ns_tag_prefix s:c_indicator s:ns_plain_safe_out s:c_flow_indicator s:ns_plain_safe_in s:ns_plain_first_in s:ns_plain_first_out s:ns_plain_char_in s:ns_plain_char_out s:ns_plain_out s:ns_plain_in s:ns_char_without_c_indicator s:ns_plain_safe_in_without_colhash s:ns_plain_safe_out_without_colhash
-unlet s:_collection s:_neg_collection
+unlet s:ns_char s:ns_word_char s:ns_uri_char s:ns_tag_char s:c_indicator s:c_flow_indicator
+            \ s:ns_anchor_char s:ns_char_without_c_indicator s:_collection s:_neg_collection
+            \ s:c_verbatim_tag s:c_named_tag_handle s:c_secondary_tag_handle s:c_primary_tag_handle
+            \ s:c_tag_handle s:c_ns_shorthand_tag s:c_non_specific_tag s:c_ns_tag_property
+            \ s:c_ns_anchor_name s:c_ns_anchor_property s:c_ns_alias_node s:c_ns_properties
+            \ s:ns_directive_name s:ns_local_tag_prefix s:ns_global_tag_prefix s:ns_tag_prefix
+            \ s:ns_plain_safe_out s:ns_plain_safe_in s:ns_plain_safe_in_without_colhash s:ns_plain_safe_out_without_colhash
+            \ s:ns_plain_first_in s:ns_plain_first_out s:ns_plain_char_in s:ns_plain_char_out s:ns_plain_out s:ns_plain_in
 delfunction s:SimplifyAdjacentCollections
 delfunction s:SimplifyToAssumeAllPrintable
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+" vim: set et sw=4 sts=4 ts=8:


### PR DESCRIPTION
runtime(yaml): improve syntax highlighting for YAML

- Recognize block scalar style to avoid unexpected highlighting by `yamlFlowString` (fix vim/vim#11517)
- Improve performance of `yamlFlowMappingKey` by allowing execution by the NFA engine (fix vim/vim#10730)
  - It was intentionally disabled before patterns were optimized by `s:SimplifyToAssumeAllPrintable`.
- Fix detection of flow style mapping indicators (fix vim/vim#8234).
- Enable highlighting of explicit mapping value indicators and node properties in flow style.
- Add syntax highlighting tests

closes: vim/vim#14354

https://github.com/vim/vim/commit/cc7597c1edf478ad912d45b27f17175236f9791e

Co-authored-by: itchyny <itchyny@cybozu.co.jp>
