### PR TITLE
vim-patch:9.{0.0581,1.0254}

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2435,7 +2435,8 @@ static void expand_by_function(int type, char *base)
   }
   textlock--;
 
-  curwin->w_cursor = pos;       // restore the cursor position
+  curwin->w_cursor = pos;  // restore the cursor position
+  check_cursor(curwin);  // make sure cursor position is valid, just in case
   validate_cursor(curwin);
   if (!equalpos(curwin->w_cursor, pos)) {
     emsg(_(e_compldel));
@@ -4059,6 +4060,7 @@ static int get_userdefined_compl_info(colnr_T curs_col)
 
   State = save_State;
   curwin->w_cursor = pos;  // restore the cursor position
+  check_cursor(curwin);  // make sure cursor position is valid, just in case
   validate_cursor(curwin);
   if (!equalpos(curwin->w_cursor, pos)) {
     emsg(_(e_compldel));

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -196,7 +196,7 @@ static void redraw_for_cursorcolumn(win_T *wp)
 int sms_marker_overlap(win_T *wp, int extra2)
 {
   // There is no marker overlap when in showbreak mode, thus no need to
-  // account for it.  See grid_put_linebuf().
+  // account for it.  See wlv_put_linebuf().
   if (*get_showbreak_value(wp) != NUL) {
     return 0;
   }
@@ -621,7 +621,7 @@ int cursor_valid(win_T *wp)
 // w_topline must be valid, you may need to call update_topline() first!
 void validate_cursor(win_T *wp)
 {
-  check_cursor(wp);
+  check_cursor_lnum(wp);
   check_cursor_moved(wp);
   if ((wp->w_valid & (VALID_WCOL|VALID_WROW)) != (VALID_WCOL|VALID_WROW)) {
     curs_columns(wp, true);

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -365,7 +365,7 @@ local function test_cmdline(linegrid)
       grid = [[
                                |
       {2:[No Name]                }|
-      {1::}mak^e                    |
+      {1::}make^                    |
       {3:[Command Line]           }|
                                |
     ]],
@@ -377,7 +377,7 @@ local function test_cmdline(linegrid)
       grid = [[
                                |
       {2:[No Name]                }|
-      {1::}mak^e                    |
+      {1::}make^                    |
       {3:[Command Line]           }|
                                |
     ]],
@@ -396,7 +396,7 @@ local function test_cmdline(linegrid)
       grid = [[
                                |
       {2:[No Name]                }|
-      {1::}mak^e                    |
+      {1::}make^                    |
       {3:[Command Line]           }|
                                |
     ]],
@@ -416,7 +416,7 @@ local function test_cmdline(linegrid)
       grid = [[
                                |
       {2:[No Name]                }|
-      {1::}mak^e                    |
+      {1::}make^                    |
       {3:[Command Line]           }|
                                |
     ]],
@@ -1586,7 +1586,7 @@ describe('cmdheight=0', function()
           topline = 0,
           botline = 2,
           curline = 0,
-          curcol = 0,
+          curcol = 1,
           linecount = 1,
           sum_scroll_delta = 0,
         },

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2942,7 +2942,7 @@ describe('builtin popupmenu', function()
                                           |
           {3:[No Name]                       }|
           {1::}sign define                    |
-          {1::}sign defin^e                    |
+          {1::}sign define^                    |
           {1:~                               }|*4
           {4:[Command Line]                  }|
           :sign define                    |

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -53,7 +53,7 @@ describe('search highlighting', function()
           topline = 0,
           botline = 3,
           curline = 0,
-          curcol = 8,
+          curcol = 9,
           linecount = 2,
           sum_scroll_delta = 0,
         },

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2490,4 +2490,26 @@ func Test_complete_changed_complete_info()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_completefunc_first_call_complete_add()
+  new
+
+  func Complete(findstart, base) abort
+    if a:findstart
+      let col = col('.')
+      call complete_add('#')
+      return col - 1
+    else
+      return []
+    endif
+  endfunc
+
+  set completeopt=longest completefunc=Complete
+  " This used to cause heap-buffer-overflow
+  call assert_fails('call feedkeys("ifoo#\<C-X>\<C-U>", "xt")', 'E840:')
+
+  delfunc Complete
+  set completeopt& completefunc&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.0.0581: adding a character for incsearch fails at end of line

Problem:    Adding a character for incsearch fails at end of line.
Solution:   Only check cursor line number.

https://github.com/vim/vim/commit/d4566c14e71c55dcef05fb34ea94eba835831527

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.0254: [security]: Heap buffer overflow when calling complete_add() in 'cfu'

Problem:  [security]: Heap buffer overflow when calling complete_add()
          in the first call of 'completefunc'
Solution: Call check_cursor() after calling 'completefunc' (zeertzjq)

closes: vim/vim#14391

https://github.com/vim/vim/commit/0a419e07a705675ac159218f42c1daa151d2ceea