### PR TITLE
feat(filetype): Add typespec filetype

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1052,6 +1052,7 @@ local extension = {
   mts = 'typescript',
   cts = 'typescript',
   tsx = 'typescriptreact',
+  tsp = 'typespec',
   uc = 'uc',
   uit = 'uil',
   uil = 'uil',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -689,6 +689,7 @@ func s:GetFilenameChecks() abort
     \ 'typescript': ['file.mts', 'file.cts'],
     \ 'typescript.glimmer': ['file.gts'],
     \ 'typescriptreact': ['file.tsx'],
+    \ 'typespec': ['file.tsp'],
     \ 'ungrammar': ['file.ungram'],
     \ 'uc': ['file.uc'],
     \ 'udevconf': ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],


### PR DESCRIPTION
This adds a filetype for the [typespec language](https://typespec.io/), based on the `.tsp` extension.

This is my first time submitting a PR for neovim, please tell me if there's anything missing. There's no syntax/highlighting or anything else at the moment, but I'm writing a tree-sitter parser for the language, which would make use of this filetype.