### PR TITLE
test: reduce `exec_lua` calls

### DIFF
--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -1374,12 +1374,7 @@ describe('api/buf', function()
           -- immediate call to nvim_win_get_cursor should have returned the same position
           eq({ 2, 12 }, cursor)
           -- coladd should be 0
-          eq(
-            0,
-            exec_lua([[
-            return vim.fn.winsaveview().coladd
-          ]])
-          )
+          eq(0, fn.winsaveview().coladd)
         end)
 
         it('does not change cursor screen column when cursor >EOL and row got shorter', function()
@@ -1393,9 +1388,7 @@ describe('api/buf', function()
           -- turn on virtualedit
           command('set virtualedit=all')
           -- move cursor after eol
-          exec_lua([[
-            vim.fn.winrestview({ coladd = 5 })
-          ]])
+          fn.winrestview({ coladd = 5 })
 
           local cursor = exec_lua([[
             vim.api.nvim_buf_set_text(0, 0, 15, 2, 11, {
@@ -1414,12 +1407,7 @@ describe('api/buf', function()
           -- immediate call to nvim_win_get_cursor should have returned the same position
           eq({ 2, 26 }, cursor)
           -- coladd should be increased so that cursor stays in the same screen column
-          eq(
-            13,
-            exec_lua([[
-            return vim.fn.winsaveview().coladd
-          ]])
-          )
+          eq(13, fn.winsaveview().coladd)
         end)
 
         it(
@@ -1435,9 +1423,7 @@ describe('api/buf', function()
             -- turn on virtualedit
             command('set virtualedit=all')
             -- move cursor after eol
-            exec_lua([[
-            vim.fn.winrestview({ coladd = 21 })
-          ]])
+            fn.winrestview({ coladd = 21 })
 
             local cursor = exec_lua([[
             vim.api.nvim_buf_set_text(0, 0, 15, 2, 11, {
@@ -1456,12 +1442,7 @@ describe('api/buf', function()
             -- immediate call to nvim_win_get_cursor should have returned the same position
             eq({ 1, 38 }, cursor)
             -- coladd should be increased so that cursor stays in the same screen column
-            eq(
-              2,
-              exec_lua([[
-            return vim.fn.winsaveview().coladd
-          ]])
-            )
+            eq(2, fn.winsaveview().coladd)
           end
         )
 
@@ -1478,9 +1459,7 @@ describe('api/buf', function()
             -- turn on virtualedit
             command('set virtualedit=all')
             -- move cursor after eol just a bit
-            exec_lua([[
-            vim.fn.winrestview({ coladd = 3 })
-          ]])
+            fn.winrestview({ coladd = 3 })
 
             local cursor = exec_lua([[
             vim.api.nvim_buf_set_text(0, 0, 15, 2, 11, {
@@ -1499,12 +1478,7 @@ describe('api/buf', function()
             -- immediate call to nvim_win_get_cursor should have returned the same position
             eq({ 1, 22 }, cursor)
             -- coladd should become 0
-            eq(
-              0,
-              exec_lua([[
-            return vim.fn.winsaveview().coladd
-          ]])
-            )
+            eq(0, fn.winsaveview().coladd)
           end
         )
 
@@ -1522,9 +1496,7 @@ describe('api/buf', function()
             -- turn on virtualedit
             command('set virtualedit=all')
             -- move cursor after eol
-            exec_lua([[
-            vim.fn.winrestview({ coladd = 28 })
-          ]])
+            fn.winrestview({ coladd = 28 })
 
             local cursor = exec_lua([[
             vim.api.nvim_buf_set_text(0, 0, 15, 3, 11, {
@@ -1543,12 +1515,7 @@ describe('api/buf', function()
             -- immediate call to nvim_win_get_cursor should have returned the same position
             eq({ 2, 26 }, cursor)
             -- coladd should be increased so that cursor stays in the same screen column
-            eq(
-              13,
-              exec_lua([[
-            return vim.fn.winsaveview().coladd
-          ]])
-            )
+            eq(13, fn.winsaveview().coladd)
           end
         )
       end)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -8,6 +8,7 @@ local eq = helpers.eq
 local matches = helpers.matches
 local api = helpers.api
 local pcall_err = helpers.pcall_err
+local fn = helpers.fn
 
 describe('vim.diagnostic', function()
   before_each(function()
@@ -109,7 +110,7 @@ describe('vim.diagnostic', function()
       'DiagnosticVirtualTextOk',
       'DiagnosticVirtualTextWarn',
       'DiagnosticWarn',
-    }, exec_lua([[return vim.fn.getcompletion('Diagnostic', 'highlight')]]))
+    }, fn.getcompletion('Diagnostic', 'highlight'))
   end)
 
   it('retrieves diagnostics from all buffers and namespaces', function()

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -5,6 +5,7 @@ local ok = helpers.ok
 local exec_lua = helpers.exec_lua
 local matches = helpers.matches
 local pcall_err = helpers.pcall_err
+local fn = helpers.fn
 
 local function v(ver)
   return vim.version._version(ver)
@@ -17,7 +18,7 @@ describe('version', function()
   end)
 
   it('version() returns Nvim version', function()
-    local expected = exec_lua('return vim.fn.api_info().version')
+    local expected = fn.api_info().version
     local actual = exec_lua('return vim.version()')
     eq(expected.major, actual.major)
     eq(expected.minor, actual.minor)

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -8,7 +8,8 @@ local eq, neq, matches = helpers.eq, helpers.neq, helpers.matches
 local getcompletion = helpers.fn.getcompletion
 local insert = helpers.insert
 local source = helpers.source
-local exec_lua = helpers.exec_lua
+local fn = helpers.fn
+local api = helpers.api
 
 describe(':checkhealth', function()
   it('detects invalid $VIMRUNTIME', function()
@@ -381,7 +382,7 @@ describe(':checkhealth window', function()
 
   it('opens in tab', function()
     -- create an empty buffer called "my_buff"
-    exec_lua 'vim.api.nvim_create_buf(false, true)'
+    api.nvim_create_buf(false, true)
     command('file my_buff')
     command('checkhealth success1')
     -- define a function that collects all buffers in each tab
@@ -400,7 +401,7 @@ describe(':checkhealth window', function()
                 return buffs
         endfunction
     ]])
-    local buffers_per_tab = exec_lua('return vim.fn.CollectBuffersPerTab()')
+    local buffers_per_tab = fn.CollectBuffersPerTab()
     eq(buffers_per_tab, { tab1 = { 'my_buff' }, tab2 = { 'health://' } })
   end)
 end)

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -4,6 +4,7 @@ local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local run = helpers.run
 local stop = helpers.stop
+local api = helpers.api
 local NIL = vim.NIL
 
 local M = {}
@@ -211,7 +212,7 @@ function M.test_rpc_server(config)
   end
   stop()
   if config.test_name then
-    exec_lua("vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })")
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
   end
 end
 

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -6,6 +6,7 @@ local eq = helpers.eq
 local dedent = helpers.dedent
 local exec_lua = helpers.exec_lua
 local insert = helpers.insert
+local api = helpers.api
 
 local clear_notrace = lsp_helpers.clear_notrace
 local create_server_definition = lsp_helpers.create_server_definition
@@ -88,7 +89,7 @@ before_each(function()
 end)
 
 after_each(function()
-  exec_lua("vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })")
+  api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
 end)
 
 describe('vim.lsp.inlay_hint', function()

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -10,6 +10,7 @@ local feed = helpers.feed
 local feed_command = helpers.feed_command
 local insert = helpers.insert
 local matches = helpers.matches
+local api = helpers.api
 
 local clear_notrace = lsp_helpers.clear_notrace
 local create_server_definition = lsp_helpers.create_server_definition
@@ -19,7 +20,7 @@ before_each(function()
 end)
 
 after_each(function()
-  exec_lua("vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })")
+  api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
 end)
 
 describe('semantic token highlighting', function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -83,7 +83,7 @@ describe('LSP', function()
   end)
 
   after_each(function()
-    exec_lua("vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })")
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
     -- exec_lua("lsp.stop_all_clients(true)")
   end)
 
@@ -146,7 +146,7 @@ describe('LSP', function()
     after_each(function()
       stop()
       exec_lua('lsp.stop_client(lsp.get_clients(), true)')
-      exec_lua("vim.api.nvim_exec_autocmds('VimLeavePre', { modeline = false })")
+      api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
     end)
 
     it('should run correctly', function()
@@ -1803,7 +1803,7 @@ describe('LSP', function()
         make_edit(1, 0, 2, 5, 'foobar'),
         make_edit(4, 0, 5, 0, 'barfoo'),
       }
-      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 1, {})'))
+      eq(true, api.nvim_buf_set_mark(1, 'a', 2, 1, {}))
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
         'First line of text',
@@ -1811,7 +1811,7 @@ describe('LSP', function()
         'Fourth line of text',
         'barfoo',
       }, buf_lines(1))
-      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      local mark = api.nvim_buf_get_mark(1, 'a')
       eq({ 2, 1 }, mark)
     end)
 
@@ -1820,7 +1820,7 @@ describe('LSP', function()
         make_edit(1, 0, 2, 15, 'foobar'),
         make_edit(4, 0, 5, 0, 'barfoo'),
       }
-      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 2, 10, {})'))
+      eq(true, api.nvim_buf_set_mark(1, 'a', 2, 10, {}))
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
         'First line of text',
@@ -1828,7 +1828,7 @@ describe('LSP', function()
         'Fourth line of text',
         'barfoo',
       }, buf_lines(1))
-      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      local mark = api.nvim_buf_get_mark(1, 'a')
       eq({ 2, 9 }, mark)
     end)
 
@@ -1837,13 +1837,13 @@ describe('LSP', function()
         make_edit(1, 0, 4, 5, 'foobar'),
         make_edit(4, 0, 5, 0, 'barfoo'),
       }
-      eq(true, exec_lua('return vim.api.nvim_buf_set_mark(1, "a", 4, 1, {})'))
+      eq(true, api.nvim_buf_set_mark(1, 'a', 4, 1, {}))
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
         'First line of text',
         'foobaro',
       }, buf_lines(1))
-      local mark = exec_lua('return vim.api.nvim_buf_get_mark(1, "a")')
+      local mark = api.nvim_buf_get_mark(1, 'a')
       eq({ 2, 1 }, mark)
     end)
 
@@ -1911,7 +1911,7 @@ describe('LSP', function()
 
       it('fix the cursor col', function()
         -- append empty last line. See #22636
-        exec_lua('vim.api.nvim_buf_set_lines(...)', 1, -1, -1, true, { '' })
+        api.nvim_buf_set_lines(1, -1, -1, true, { '' })
 
         api.nvim_win_set_cursor(0, { 2, 11 })
         local edits = {
@@ -2263,7 +2263,7 @@ describe('LSP', function()
         },
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
+      eq(true, vim.uv.fs_stat(tmpfile) ~= nil)
     end)
     it(
       'Supports file creation in folder that needs to be created with CreateFile payload',
@@ -2281,7 +2281,7 @@ describe('LSP', function()
           },
         }
         exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-        eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
+        eq(true, vim.uv.fs_stat(tmpfile) ~= nil)
       end
     )
     it('createFile does not touch file if it exists and ignoreIfExists is set', function()
@@ -2300,7 +2300,7 @@ describe('LSP', function()
         },
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
+      eq(true, vim.uv.fs_stat(tmpfile) ~= nil)
       eq('Dummy content', read_file(tmpfile))
     end)
     it('createFile overrides file if overwrite is set', function()
@@ -2320,7 +2320,7 @@ describe('LSP', function()
         },
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
+      eq(true, vim.uv.fs_stat(tmpfile) ~= nil)
       eq('', read_file(tmpfile))
     end)
     it('DeleteFile delete file and buffer', function()
@@ -2344,8 +2344,8 @@ describe('LSP', function()
         },
       }
       eq(true, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16'))
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
-      eq(false, exec_lua('return vim.api.nvim_buf_is_loaded(vim.fn.bufadd(...))', tmpfile))
+      eq(false, vim.uv.fs_stat(tmpfile) ~= nil)
+      eq(false, api.nvim_buf_is_loaded(fn.bufadd(tmpfile)))
     end)
     it('DeleteFile fails if file does not exist and ignoreIfNotExists is false', function()
       local tmpfile = tmpname()
@@ -2363,7 +2363,7 @@ describe('LSP', function()
         },
       }
       eq(false, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit))
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
+      eq(false, vim.uv.fs_stat(tmpfile) ~= nil)
     end)
   end)
 
@@ -2391,9 +2391,9 @@ describe('LSP', function()
         new
       )
       eq({ 'Test content' }, lines)
-      local exists = exec_lua('return vim.uv.fs_stat(...) ~= nil', old)
+      local exists = vim.uv.fs_stat(old) ~= nil
       eq(false, exists)
-      exists = exec_lua('return vim.uv.fs_stat(...) ~= nil', new)
+      exists = vim.uv.fs_stat(new) ~= nil
       eq(true, exists)
       os.remove(new)
     end)
@@ -2429,9 +2429,9 @@ describe('LSP', function()
         file
       )
       eq({ 'Test content' }, lines)
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old_dir))
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new_dir))
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new_dir .. pathsep .. file))
+      eq(false, vim.uv.fs_stat(old_dir) ~= nil)
+      eq(true, vim.uv.fs_stat(new_dir) ~= nil)
+      eq(true, vim.uv.fs_stat(new_dir .. pathsep .. file) ~= nil)
 
       os.remove(new_dir)
     end)
@@ -2495,7 +2495,7 @@ describe('LSP', function()
           new
         )
 
-        eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
+        eq(true, vim.uv.fs_stat(old) ~= nil)
         eq('New file', read_file(new))
 
         exec_lua(
@@ -2509,7 +2509,7 @@ describe('LSP', function()
           new
         )
 
-        eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
+        eq(true, vim.uv.fs_stat(old) ~= nil)
         eq('New file', read_file(new))
       end
     )
@@ -2539,8 +2539,8 @@ describe('LSP', function()
         old,
         new
       )
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new))
+      eq(false, vim.uv.fs_stat(old) ~= nil)
+      eq(true, vim.uv.fs_stat(new) ~= nil)
       eq(true, undo_kept)
     end)
     it('Maintains undo information for unloaded buffer', function()
@@ -2566,8 +2566,8 @@ describe('LSP', function()
         old,
         new
       )
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new))
+      eq(false, vim.uv.fs_stat(old) ~= nil)
+      eq(true, vim.uv.fs_stat(new) ~= nil)
       eq(true, undo_kept)
     end)
     it('Does not rename file when it conflicts with a buffer without file', function()
@@ -2611,8 +2611,8 @@ describe('LSP', function()
         new
       )
 
-      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
-      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new))
+      eq(false, vim.uv.fs_stat(old) ~= nil)
+      eq(true, vim.uv.fs_stat(new) ~= nil)
       eq('Old file', read_file(new))
     end)
   end)
@@ -2991,10 +2991,10 @@ describe('LSP', function()
 
     local jump = function(msg)
       eq(true, exec_lua('return vim.lsp.util.jump_to_location(...)', msg, 'utf-16'))
-      eq(target_bufnr, exec_lua [[return vim.fn.bufnr('%')]])
+      eq(target_bufnr, fn.bufnr('%'))
       return {
-        line = exec_lua [[return vim.fn.line('.')]],
-        col = exec_lua [[return vim.fn.col('.')]],
+        line = fn.line('.'),
+        col = fn.col('.'),
       }
     end
 
@@ -3024,7 +3024,7 @@ describe('LSP', function()
       local pos = jump(location(1, 2, 1, 2))
       eq(2, pos.line)
       eq(4, pos.col)
-      eq('å', exec_lua [[return vim.fn.expand('<cword>')]])
+      eq('å', fn.expand('<cword>'))
     end)
 
     it('adds current position to jumplist before jumping', function()
@@ -3081,11 +3081,11 @@ describe('LSP', function()
         )
       )
       if focus == true or focus == nil then
-        eq(target_bufnr, exec_lua([[return vim.fn.bufnr('%')]]))
+        eq(target_bufnr, fn.bufnr('%'))
       end
       return {
-        line = exec_lua([[return vim.fn.line('.')]]),
-        col = exec_lua([[return vim.fn.col('.')]]),
+        line = fn.line('.'),
+        col = fn.col('.'),
       }
     end
 


### PR DESCRIPTION
`exec_lua` makes code slighly harder to read, so it's beneficial to
remove it in cases where it's possible or convenient.

Not all `exec_lua` calls should be removed even if the test passes as it
changes the semantics of the test even if it happens to pass.

From https://github.com/neovim/neovim/pull/28155#discussion_r1548185779:

"Note for tests like this, which fundamentally are about conversion, you
end up changing what conversion you are testing. Even if the result
happens to be same (as they often are, as we like the rules to be
consistent if possible), you are now testing the RPC conversion rules
instead of the vim script to in-process lua conversion rules."

From https://github.com/neovim/neovim/pull/28155#discussion_r1548190152:

"A test like this specifies that the cursor is valid immediately and not
after a separate cycle of normal (or an other input-processing) mode."