### PR TITLE
fix: prevent child processes from inheriting ui channel file descriptors

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -544,8 +544,12 @@ uint64_t channel_from_stdio(bool rpc, CallbackReader on_output, const char **err
   }
 #else
   if (embedded_mode) {
-    stdin_dup_fd = dup(STDIN_FILENO);
-    stdout_dup_fd = dup(STDOUT_FILENO);
+    // In embedded mode redirect stdout and stdin to stderr, since they are used for the UI channel.
+    // NOTE: fnctl with F_DUPFD_CLOEXEC is used instead of dup to prevent child processes from
+    // inheriting the file descriptors, which make it impossible for UIs to detect when nvim exits
+    // while one or more of its child processes are still running.
+    stdin_dup_fd = fcntl(STDIN_FILENO, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
+    stdout_dup_fd = fcntl(STDOUT_FILENO, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
     dup2(STDERR_FILENO, STDOUT_FILENO);
     dup2(STDERR_FILENO, STDIN_FILENO);
   }


### PR DESCRIPTION
On Unix-like systems, all file descriptors are inherited by default when a new process is forked. This causes problems for UIs to reliably detect when nvim has exited and there's no more data to process.

The problem can most commonly be observed when a clipboard tool like `wl-copy` is used. Those tools are spawned and remain active after nvim exit. But because the channel file descriptors are inherited, they remain open until the tools have quite as well, preventing UI's like neovide from detecting the exit. The problem is not limited to these tools though, any process that is spawned in the background and remain active could cause the same issue.

This has been fixed by setting the flag `FD_CLOSEEXEC`, which ensures that the descriptors are closed in the new process.

This fixes #26743, which was caused by a regression in https://github.com/neovim/neovim/pull/11658
