### PR TITLE
vim-patch:9.1.0253: filetype: typespec files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1052,6 +1052,7 @@ local extension = {
   mts = 'typescript',
   cts = 'typescript',
   tsx = 'typescriptreact',
+  tsp = 'typespec',
   uc = 'uc',
   uit = 'uil',
   uil = 'uil',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -689,6 +689,7 @@ func s:GetFilenameChecks() abort
     \ 'typescript': ['file.mts', 'file.cts'],
     \ 'typescript.glimmer': ['file.gts'],
     \ 'typescriptreact': ['file.tsx'],
+    \ 'typespec': ['file.tsp'],
     \ 'ungrammar': ['file.ungram'],
     \ 'uc': ['file.uc'],
     \ 'udevconf': ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],


### PR DESCRIPTION
Problem:  filetype: typespec files are not recognized
Solution: Detect '*.tsp' files as typespec
          (Hilmar Wiegand)

Specs is at https://typespec.io/

closes: vim/vim#14392

https://github.com/vim/vim/commit/6c9f4f98f1cda3793406724a260cd651210a5d0d

Co-authored-by: Hilmar Wiegand <me@hwgnd.de>
