### PR TITLE
vim-patch:8.2.4098: typing "interrupt" at debug prompt may keep exception around

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -32,6 +32,7 @@
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/ex_eval.h"
 #include "nvim/ex_getln.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
@@ -1402,6 +1403,12 @@ static int normal_check(VimState *state)
   NormalState *s = (NormalState *)state;
   normal_check_stuff_buffer(s);
   normal_check_interrupt(s);
+
+  // At the toplevel there is no exception handling.  Discard any that
+  // may be hanging around (e.g. from "interrupt" at the debug prompt).
+  if (did_throw && !ex_normal_busy) {
+    discard_current_exception();
+  }
 
   if (!exmode_active) {
     msg_scroll = false;


### PR DESCRIPTION
#### vim-patch:8.2.4098: typing "interrupt" at debug prompt may keep exception around

Problem:    Typing "interrupt" at debug prompt may keep exception around,
            causing function calls to fail.
Solution:   Discard any exception at the toplevel.

https://github.com/vim/vim/commit/069613c9e8645acea3a128c15ebdbf56e2219d44

Co-authored-by: Bram Moolenaar <Bram@vim.org>