### PR TITLE
vim-patch:89cc03af71d9

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -400,6 +400,19 @@ So to enable this only for ruby, set the following variable: >
 If both, the global `plugin_exec` and the `<filetype>_exec` specific variable
 are set, the filetype specific variable should have precedent.
 
+
+ASCIIDOC						*ft-asciidoc-plugin*
+
+To enable |folding| use this: >
+	let g:asciidoc_folding = 1
+
+To disable nesting of folded headers use this: >
+	let g:asciidoc_foldnested = 0
+
+To disable folding everything under the title use this: >
+	let asciidoc_fold_under_title = 0
+
+
 AWK							*ft-awk-plugin*
 
 Support for features specific to GNU Awk, like @include, can be enabled by
@@ -525,18 +538,6 @@ After figuring out the current date and user, the file is searched for an
 entry beginning with the current date and user and if found adds another item
 under it.  If not found, a new entry and item is prepended to the beginning of
 the Changelog.
-
-
-ASCIIDOC						*ft-asciidoc-plugin*
-
-To enable |folding| use this: >
-	let g:asciidoc_folding = 1
-
-To disable nesting of folded headers use this: >
-	let g:asciidoc_foldnested = 0
-
-To disable folding everything under the title use this: >
-	let asciidoc_fold_under_title = 0
 
 
 FORTRAN							*ft-fortran-plugin*


### PR DESCRIPTION
#### vim-patch:89cc03af71d9

runtime(doc): sort filetype.txt in the alphabetical order (vim/vim#14395)

https://github.com/vim/vim/commit/89cc03af71d9beb839d296b78a87869e7a0a8996

Co-authored-by: K.Takata <kentkt@csc.jp>