### PR TITLE
feat(extmark): support end_col=-1 if strict=false

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3192,7 +3192,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
       • {opts}    (`vim.api.keyset.set_extmark`) Optional parameters.
                   • id : id of the extmark to edit.
                   • end_row : ending line of the mark, 0-based inclusive.
-                  • end_col : ending col of the mark, 0-based exclusive.
+                  • end_col : ending col of the mark, 0-based exclusive, or -1
+                    to extend the range to end of line.
                   • hl_group : highlight group used for the text range. This
                     and below highlight groups can be supplied either as a
                     string or as an integer, the latter of which can be

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -568,7 +568,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- @param opts vim.api.keyset.set_extmark Optional parameters.
 --- - id : id of the extmark to edit.
 --- - end_row : ending line of the mark, 0-based inclusive.
---- - end_col : ending col of the mark, 0-based exclusive.
+--- - end_col : ending col of the mark, 0-based exclusive, or -1 to extend the range to end of line.
 --- - hl_group : highlight group used for the text range. This and below
 ---     highlight groups can be supplied either as a string or as an integer,
 ---     the latter of which can be obtained using `nvim_get_hl_id_by_name()`.

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -402,7 +402,7 @@ ArrayOf(DictAs(get_extmark_item)) nvim_buf_get_extmarks(Buffer buffer, Integer n
 /// @param opts  Optional parameters.
 ///               - id : id of the extmark to edit.
 ///               - end_row : ending line of the mark, 0-based inclusive.
-///               - end_col : ending col of the mark, 0-based exclusive.
+///               - end_col : ending col of the mark, 0-based exclusive, or -1 to extend the range to end of line.
 ///               - hl_group : highlight group used for the text range. This and below
 ///                   highlight groups can be supplied either as a string or as an integer,
 ///                   the latter of which can be obtained using |nvim_get_hl_id_by_name()|.
@@ -586,9 +586,13 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   colnr_T col2 = -1;
   if (HAS_KEY(opts, set_extmark, end_col)) {
     Integer val = opts->end_col;
-    VALIDATE_RANGE((val >= 0 && val <= MAXCOL), "end_col", {
+    VALIDATE_RANGE((val >= -1 && val <= MAXCOL), "end_col", {
       goto error;
     });
+    if (val == -1) {
+      val = MAXCOL;
+    }
+
     col2 = (int)val;
   }
 

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -153,7 +153,7 @@ describe('API/extmarks', function()
     )
   end)
 
-  it('can end extranges past final newline using end_col = 0', function()
+  it('can end extranges past final newline using end_col=0', function()
     set_extmark(ns, marks[1], 0, 0, {
       end_col = 0,
       end_row = 1,
@@ -164,20 +164,39 @@ describe('API/extmarks', function()
     )
   end)
 
-  it('can end extranges past final newline when strict mode is false', function()
-    set_extmark(ns, marks[1], 0, 0, {
+  it('can end extranges past final newline when strict=false', function()
+    local id = set_extmark(ns, marks[1], 0, 0, {
       end_col = 1,
       end_row = 1,
       strict = false,
     })
+    ok(id > 0, 'id > 0', id)
   end)
 
-  it('can end extranges past final column when strict mode is false', function()
-    set_extmark(ns, marks[1], 0, 0, {
+  it('can end extranges past final column when strict=false', function()
+    local id = set_extmark(ns, marks[1], 0, 0, {
       end_col = 6,
       end_row = 0,
       strict = false,
     })
+    ok(id > 0, 'id > 0', id)
+  end)
+
+  it('end_col=-1 means "end of line" when strict=false', function()
+    local function _test(strict)
+      return set_extmark(ns, marks[1], 0, 0, {
+        end_col = -1,
+        end_row = 0,
+        strict = strict,
+      })
+    end
+
+    -- strict=false
+    local id = _test(false)
+    ok(id > 0, 'id > 0', id)
+
+    -- strict=true
+    eq("Invalid 'end_col': out of range", pcall_err(_test, true))
   end)
 
   it('adds, updates  and deletes marks', function()


### PR DESCRIPTION
As mentioned in #27469, there is an inconsistency between extmarks/highlights regarding the `end_col` option. Now the `end_col` option in the `nvim_buf_set_extmark` function can be set to `-1` - meaning to the end of the line.

Closes #27469.