### PR TITLE
vim-patch:08d2401fbc6d

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -8,6 +8,7 @@
 " 	2023 Nov 22 by Vim Project: fix handling of very long filename on longlist style	(v173a)
 "   2024 Feb 19 by Vim Project: (announce adoption)
 "   2024 Feb 29 by Vim Project: handle symlinks in tree mode correctly
+"   2024 Apr 03 by Vim Project: detect filetypes for remote edited files
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -1761,7 +1762,9 @@ fun! s:NetrwOptionsRestore(vt)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
   if !exists("{a:vt}netrw_optionsave")
 "   call Decho("case ".a:vt."netrw_optionsave : doesn't exist",'~'.expand("<slnum>"))
-   if filereadable(expand("%"))
+
+   " filereadable() returns zero for remote files (e.g. scp://localhost//etc/fstab)
+   if filereadable(expand("%")) || expand("%") =~# '^\w\+://\f\+/'
 "    call Decho("..doing filetype detect anyway")
     filetype detect
 "    call Decho("..settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))


### PR DESCRIPTION
runtime(netrw): filetype not detected when editing remote files

fixes: vim/vim#14400

https://github.com/vim/vim/commit/08d2401fbc6de2606aca69add401e2ffca772aa2

Co-authored-by: Christian Brabandt <cb@256bit.org>
