### PR TITLE
refactor: remove fn_bool

### DIFF
--- a/runtime/lua/provider/clipboard/health.lua
+++ b/runtime/lua/provider/clipboard/health.lua
@@ -1,5 +1,4 @@
 local health = vim.health
-local executable = health.executable
 
 local M = {}
 
@@ -8,8 +7,8 @@ function M.check()
 
   if
     os.getenv('TMUX')
-    and executable('tmux')
-    and executable('pbpaste')
+    and vim.fn.executable('tmux') == 1
+    and vim.fn.executable('pbpaste') == 1
     and not health.cmd_ok('pbpaste')
   then
     local tmux_version = string.match(vim.fn.system('tmux -V'), '%d+%.%d+')

--- a/runtime/lua/provider/node/health.lua
+++ b/runtime/lua/provider/node/health.lua
@@ -1,5 +1,4 @@
 local health = vim.health
-local executable = health.executable
 local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
 
 local M = {}
@@ -12,8 +11,12 @@ function M.check()
   end
 
   if
-    not executable('node')
-    or (not executable('npm') and not executable('yarn') and not executable('pnpm'))
+    vim.fn.executable('node') == 0
+    or (
+      vim.fn.executable('npm') == 0
+      and vim.fn.executable('yarn') == 0
+      and vim.fn.executable('pnpm') == 0
+    )
   then
     health.warn(
       '`node` and `npm` (or `yarn`, `pnpm`) must be in $PATH.',
@@ -50,9 +53,9 @@ function M.check()
   health.info('Nvim node.js host: ' .. host)
 
   local manager = 'npm'
-  if executable('yarn') then
+  if vim.fn.executable('yarn') == 1 then
     manager = 'yarn'
-  elseif executable('pnpm') then
+  elseif vim.fn.executable('pnpm') == 1 then
     manager = 'pnpm'
   end
 

--- a/runtime/lua/provider/python/health.lua
+++ b/runtime/lua/provider/python/health.lua
@@ -1,5 +1,4 @@
 local health = vim.health
-local executable = health.executable
 local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
 
 local M = {}
@@ -60,7 +59,7 @@ local function check_bin(bin)
   if not is(bin, 'file') and (not iswin or not is(bin .. '.exe', 'file')) then
     health.error('"' .. bin .. '" was not found.')
     return false
-  elseif not executable(bin) then
+  elseif vim.fn.executable(bin) == 0 then
     health.error('"' .. bin .. '" is not executable.')
     return false
   end
@@ -69,7 +68,7 @@ end
 
 -- Fetch the contents of a URL.
 local function download(url)
-  local has_curl = executable('curl')
+  local has_curl = vim.fn.executable('curl') == 1
   if has_curl and vim.fn.system({ 'curl', '-V' }):find('Protocols:.*https') then
     local out, rc = health.system({ 'curl', '-sL', url }, { stderr = true, ignore_error = true })
     if rc ~= 0 then
@@ -77,7 +76,7 @@ local function download(url)
     else
       return out
     end
-  elseif executable('python') then
+  elseif vim.fn.executable('python') == 1 then
     local script = "try:\n\
           from urllib.request import urlopen\n\
           except ImportError:\n\
@@ -284,7 +283,7 @@ function M.check()
           if
             path_bin ~= vim.fs.normalize(python_exe)
             and vim.tbl_contains(python_multiple, path_bin)
-            and executable(path_bin)
+            and vim.fn.executable(path_bin) == 1
           then
             python_multiple[#python_multiple + 1] = path_bin
           end
@@ -472,7 +471,7 @@ function M.check()
         bin_dir,
         table.concat(
           vim.tbl_map(function(v)
-            return vim.fn.fnamemodify(v, ':t')
+            return vim.fs.basename(v)
           end, venv_bins),
           ', '
         )

--- a/runtime/lua/provider/ruby/health.lua
+++ b/runtime/lua/provider/ruby/health.lua
@@ -1,5 +1,4 @@
 local health = vim.health
-local executable = health.executable
 local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
 
 local M = {}
@@ -11,7 +10,7 @@ function M.check()
     return
   end
 
-  if not executable('ruby') or not executable('gem') then
+  if vim.fn.executable('ruby') == 0 or vim.fn.executable('gem') == 0 then
     health.warn(
       '`ruby` and `gem` must be in $PATH.',
       'Install Ruby and verify that `ruby` and `gem` commands work.'

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -386,7 +386,7 @@ local path2name = function(path)
     path = path:gsub('^.*/lua/', '')
 
     -- Remove the filename (health.lua)
-    path = vim.fn.fnamemodify(path, ':h')
+    path = vim.fs.dirname(path)
 
     -- Change slashes to dots
     path = path:gsub('/', '.')
@@ -496,12 +496,5 @@ function M._check(mods, plugin_names)
   vim.cmd.redraw()
   vim.print('')
 end
-
-local fn_bool = function(key)
-  return function(...)
-    return vim.fn[key](...) == 1
-  end
-end
-M.executable = fn_bool('executable')
 
 return M


### PR DESCRIPTION
It's better to use vim.fn directly instead of creating minor
abstractions like fn_bool.
