### PR TITLE
fix(column): ignore empty signcols range

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -792,12 +792,11 @@ static const uint32_t signtext_filter[4] = {[kMTMetaSignText] = kMTFilterSelect 
 /// @param clear  kFalse, kTrue or kNone for an, added/deleted, cleared, or initialized range.
 void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState clear)
 {
-  if (!buf->b_signcols.autom || !buf_meta_total(buf, kMTMetaSignText)) {
+  if (!buf->b_signcols.autom || row2 < row1 || !buf_meta_total(buf, kMTMetaSignText)) {
     return;
   }
 
   // Allocate an array of integers holding the number of signs in the range.
-  assert(row2 >= row1);
   int *count = xcalloc(sizeof(int), (size_t)(row2 + 1 - row1));
   MarkTreeIter itr[1];
   MTPair pair = { 0 };


### PR DESCRIPTION
Problem:  Invalid assert for empty signcols range. The empty range
          should already be removed from "b_signcols" at this point.
          The "clear" == kTrue call before the splice that made the
          range empty will have removed it, and the "clear" == kNone
          call after the splice already ignores the empty range.
Solution: Return early when "row2" < "row1".