### PR TITLE
vim-patch:9.1.0262: Test for TextChanged is flaky with ASAN

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3912,7 +3912,7 @@ func Test_Changed_ChangedI()
       au TextChangedI <buffer> :call TextChangedAutocmd('I')
 
       nnoremap <CR> o<Esc>
-      call writefile([''], 'XTextChangedI3')
+      autocmd SafeState * ++once call writefile([''], 'XTextChangedI3')
   END
 
   call writefile(before, 'Xinit', 'D')
@@ -3921,6 +3921,7 @@ func Test_Changed_ChangedI()
         \ {'term_rows': 10})
   call assert_equal('running', term_getstatus(buf))
   call WaitForAssert({-> assert_true(filereadable('XTextChangedI3'))})
+  call WaitForAssert({-> assert_equal([''], readfile('XTextChangedI3'))})
 
   " TextChanged should trigger if a mapping enters and leaves Insert mode.
   call term_sendkeys(buf, "\<CR>")


### PR DESCRIPTION
#### vim-patch:9.1.0262: Test for TextChanged is flaky with ASAN

Problem:  Test for TextChanged is flaky with ASAN.
Solution: Wait for the file to be non-empty.
          (zeertzjq)

closes: vim/vim#14404

https://github.com/vim/vim/commit/4a65391ca273f2eca84f5ec7bd846693232dfacc