### PR TITLE
feat(lsp): set workDoneToken in initialize request

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -579,6 +579,7 @@ function Client:initialize()
     initializationOptions = config.init_options,
     capabilities = self.capabilities,
     trace = self._trace,
+    workDoneToken = '1',
   }
 
   self:_run_callbacks(

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -110,7 +110,8 @@ local tests = {}
 
 function tests.basic_init()
   skeleton {
-    on_init = function(_)
+    on_init = function(params)
+      assert_eq(params.workDoneToken, '1')
       return {
         capabilities = {
           textDocumentSync = protocol.TextDocumentSyncKind.None,


### PR DESCRIPTION
Problem:

Some servers don't report progress during initialize unless the client
sets the `workDoneToken`

See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initiatingWorkDoneProgress

In particular:

> There is no specific client capability signaling whether a client will
> send a progress token per request. The reason for this is that this is
> in many clients not a static aspect and might even change for every
> request instance for the same request type. So the capability is signal
> on every request instance by the presence of a workDoneToken property.

And:

> Servers can also initiate progress reporting using the
> window/workDoneProgress/create request. This is useful if the server
> needs to report progress outside of a request (for example the server
> needs to re-index a database). The token can then be used to report
> progress using the same notifications used as for client initiated
> progress.

So far progress report functionality was relying entirely on the latter.

Solution:

Set a `workDoneToken`

Closes https://github.com/neovim/neovim/issues/27938
