### PR TITLE
vim-patch:9.1.0265: console dialog cannot save unnamed buffers

### DIFF
--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -252,21 +252,30 @@ func Test_goto_buf_with_confirm()
   CheckUnix
   CheckNotGui
   CheckFeature dialog_con
+  " When dialog_con_gui is defined, Vim is compiled with GUI support
+  " and FEAT_BROWSE will be defined, which causes :confirm :b to
+  " call do_browse(), which will try to use a GUI file browser,
+  " which aborts if a GUI is not available.
+  CheckNotFeature dialog_con_gui
   new XgotoConf
   enew
   call setline(1, 'test')
   call assert_fails('b XgotoConf', 'E37:')
   call feedkeys('c', 'L')
   call assert_fails('confirm b XgotoConf', 'E37:')
-  call assert_equal(1, &modified)
-  call assert_equal('', @%)
+  call assert_true(&modified)
+  call assert_true(empty(bufname('%')))
   call feedkeys('y', 'L')
-  call assert_fails('confirm b XgotoConf', ['', 'E37:'])
-  call assert_equal(1, &modified)
-  call assert_equal('', @%)
+  confirm b XgotoConf
+  call assert_equal('XgotoConf', bufname('%'))
+  call assert_equal(['test'], readfile('Untitled'))
+  e Untitled
+  call setline(2, 'test2')
   call feedkeys('n', 'L')
   confirm b XgotoConf
-  call assert_equal('XgotoConf', @%)
+  call assert_equal('XgotoConf', bufname('%'))
+  call assert_equal(['test'], readfile('Untitled'))
+  call delete('Untitled')
   close!
 endfunc
 


### PR DESCRIPTION
Fix #21682

#### vim-patch:9.1.0265: console dialog cannot save unnamed buffers

Problem:  console dialog cannot save unnamed buffers
Solution: set bufname before save (glepnir). Define dialog_con_gui
          to test for GUI+Console dialog support, use it to skip
          the test when the GUI feature has been defined.

Note: The dialog_changed() function will also try to call the
browse_save_fname() function, when FEAT_BROWSE is defined (which is only
defined in a GUI build of Vim). This will eventually lead to a call of
do_browse(), which causes an error message if a GUI is not currently
running (see the TODO: in do_browse()) and will then lead to a failure
in Test_goto_buf_with_onfirm().

Therefore, we must disable the Test_goto_buf_with_onfirm(), when the
dialog_con_gui feature is enabled (which basically means dialog feature
for GUI and Console builds, in contrast to the dialog_con and dialog_gui
feature).

(Previously this wasn't a problem, because the test aborted in the YES
case for the :confirm :b XgotoConf case and did therefore not run into
the browse function call)

closes: vim/vim#14398

https://github.com/vim/vim/commit/df46115fc839c8912ed60646e86a412e5180ba1d

Co-authored-by: glepnir <glephunter@gmail.com>