### PR TITLE
docs: don't mention executable() can return -1

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1268,7 +1268,6 @@ executable({expr})                                                *executable()*
 		The result is a Number:
 			1	exists
 			0	does not exist
-			-1	not implemented on this system
 		|exepath()| can be used to get the full path of an executable.
 
 execute({command} [, {silent}])                                      *execute()*

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1598,11 +1598,10 @@ function vim.fn.eventhandler() end
 --- The result is a Number:
 ---   1  exists
 ---   0  does not exist
----   -1  not implemented on this system
 --- |exepath()| can be used to get the full path of an executable.
 ---
 --- @param expr any
---- @return 0|1|-1
+--- @return 0|1
 function vim.fn.executable(expr) end
 
 --- Execute {command} and capture its output.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2071,14 +2071,13 @@ M.funcs = {
       The result is a Number:
       	1	exists
       	0	does not exist
-      	-1	not implemented on this system
       |exepath()| can be used to get the full path of an executable.
 
     ]=],
     fast = true,
     name = 'executable',
     params = { { 'expr', 'any' } },
-    returns = '0|1|-1',
+    returns = '0|1',
     signature = 'executable({expr})',
   },
   execute = {


### PR DESCRIPTION
This cannot happen for neovim.