### PR TITLE
feat(api)!: block all nvim_open_win autocmds when noautocmd is set

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3271,9 +3271,8 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                   • footer_pos: Footer position. Must be set with `footer`
                     option. Value can be one of "left", "center", or "right".
                     Default is `"left"`.
-                  • noautocmd: If true then autocommands triggered from
-                    setting the `buffer` to display are blocked (e.g:
-                    |BufEnter|, |BufLeave|, |BufWinEnter|).
+                  • noautocmd: If true then all autocommands are blocked for
+                    the duration of the call.
                   • fixed: If true when anchor is NW or SW, the float window
                     would be kept fixed even if the window would be truncated.
                   • hide: If true the floating window will be hidden.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -137,6 +137,9 @@ The following changes may require adaptations in user config or plugins.
 • |:TOhtml| has been rewritten in Lua to support Neovim-specific decorations,
   and many options have been removed.
 
+• |nvim_open_win()| now blocks all autocommands when `noautocmd` is set,
+  rather than just those from setting the `buffer` to display in the window.
+
 ==============================================================================
 BREAKING CHANGES IN HEAD                                    *news-breaking-dev*
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1718,9 +1718,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---               • footer_pos: Footer position. Must be set with `footer`
 ---                 option. Value can be one of "left", "center", or "right".
 ---                 Default is `"left"`.
----               • noautocmd: If true then autocommands triggered from
----                 setting the `buffer` to display are blocked (e.g:
----                 `BufEnter`, `BufLeave`, `BufWinEnter`).
+---               • noautocmd: If true then all autocommands are blocked for
+---                 the duration of the call.
 ---               • fixed: If true when anchor is NW or SW, the float window
 ---                 would be kept fixed even if the window would be truncated.
 ---               • hide: If true the floating window will be hidden.

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -71,7 +71,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return;
   }
-  win_set_buf(win, buf, false, err);
+  win_set_buf(win, buf, err);
 }
 
 /// Gets the (1,0)-indexed, buffer-relative cursor position for a given window

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -666,6 +666,7 @@ void pum_redraw(void)
 }
 
 /// create a floating preview window for info
+/// Autocommands are blocked for the duration of the call.
 /// @return  NULL when no enough room to show
 static win_T *pum_create_float_preview(bool enter)
 {
@@ -690,6 +691,9 @@ static win_T *pum_create_float_preview(bool enter)
   config.height = pum_height;
   config.style = kWinStyleMinimal;
   config.hide = true;
+
+  block_autocmds();
+
   Error err = ERROR_INIT;
   win_T *wp = win_new_float(NULL, true, config, &err);
   // TODO(glepnir): remove win_enter usage
@@ -701,6 +705,7 @@ static win_T *pum_create_float_preview(bool enter)
   Buffer b = nvim_create_buf(false, true, &err);
   if (!b) {
     win_free(wp, NULL);
+    unblock_autocmds();
     return NULL;
   }
   buf_T *buf = find_buffer_by_handle(b, &err);
@@ -709,7 +714,9 @@ static win_T *pum_create_float_preview(bool enter)
   wp->w_float_is_info = true;
   wp->w_p_diff = false;
   buf->b_p_bl = false;
-  win_set_buf(wp, buf, true, &err);
+  win_set_buf(wp, buf, &err);
+
+  unblock_autocmds();
   return wp;
 }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -735,16 +735,13 @@ static void cmd_with_count(char *cmd, char *bufp, size_t bufsize, int64_t Prenum
   }
 }
 
-void win_set_buf(win_T *win, buf_T *buf, bool noautocmd, Error *err)
+void win_set_buf(win_T *win, buf_T *buf, Error *err)
   FUNC_ATTR_NONNULL_ALL
 {
   tabpage_T *tab = win_find_tabpage(win);
 
   // no redrawing and don't set the window title
   RedrawingDisabled++;
-  if (noautocmd) {
-    block_autocmds();
-  }
 
   switchwin_T switchwin;
   if (switch_win_noblock(&switchwin, win, tab, true) == FAIL) {
@@ -770,9 +767,6 @@ void win_set_buf(win_T *win, buf_T *buf, bool noautocmd, Error *err)
 
 cleanup:
   restore_win_noblock(&switchwin, true);
-  if (noautocmd) {
-    unblock_autocmds();
-  }
   RedrawingDisabled--;
 }
 

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1162,27 +1162,6 @@ describe('API/win', function()
   end)
 
   describe('open_win', function()
-    it('noautocmd option works', function()
-      command('autocmd BufEnter,BufLeave,BufWinEnter * let g:fired = 1')
-      api.nvim_open_win(api.nvim_create_buf(true, true), true, {
-        relative = 'win',
-        row = 3,
-        col = 3,
-        width = 12,
-        height = 3,
-        noautocmd = true,
-      })
-      eq(0, fn.exists('g:fired'))
-      api.nvim_open_win(api.nvim_create_buf(true, true), true, {
-        relative = 'win',
-        row = 3,
-        col = 3,
-        width = 12,
-        height = 3,
-      })
-      eq(1, fn.exists('g:fired'))
-    end)
-
     it('disallowed in cmdwin if enter=true or buf=cmdwin_buf', function()
       local new_buf = api.nvim_create_buf(true, true)
       feed('q:')
@@ -1405,6 +1384,24 @@ describe('API/win', function()
       ]=])
       return info
     end
+
+    it('noautocmd option works', function()
+      local info = setup_tabbed_autocmd_test()
+
+      api.nvim_open_win(
+        info.other_buf,
+        true,
+        { split = 'left', win = info.tab2_curwin, noautocmd = true }
+      )
+      eq({}, eval('result'))
+
+      api.nvim_open_win(
+        info.orig_buf,
+        true,
+        { relative = 'editor', row = 0, col = 0, width = 10, height = 10, noautocmd = true }
+      )
+      eq({}, eval('result'))
+    end)
 
     it('fires expected autocmds when creating splits without entering', function()
       local info = setup_tabbed_autocmd_test()


### PR DESCRIPTION
Problem: noautocmd is confusing; despite its name, it doesn't block all autocommands (instead it blocks only those related to setting the buffer), and is commonly used by plugins to open windows while producing minimal side-effects.

Solution: be consistent and block all autocommands when noautocmd is set. This includes WinNew (again), plus autocommands from entering the window (if enter is set) like WinEnter, WinLeave, TabEnter, .etc.

See the discussion at https://github.com/neovim/neovim/pull/14659#issuecomment-2040029517 for more information.

---

Remove win_set_buf's noautocmd argument, as it's no longer needed.

NOTE: pum_create_float_preview sets noautocmd for win_set_buf, but all its callers already use block_autocmds.

Despite that, pum_create_float_preview doesn't actually properly handle autocommands (it has no checks for whether those from win_enter or nvim_create_buf free the window).

For now, ensure autocommands are blocked within it for correctness (in case it's ever called outside of a block_autocmds context; the function seems to have been refactored in #26739 anyway).