### PR TITLE
vim-patch:b73faa1c02d0

### DIFF
--- a/runtime/compiler/context.vim
+++ b/runtime/compiler/context.vim
@@ -16,11 +16,12 @@ if get(b:, 'context_ignore_makefile', get(g:, 'context_ignore_makefile', 0)) ||
   let current_compiler = 'context'
   " The following assumes that the current working directory is set to the
   " directory of the file to be typeset
-  let &l:makeprg = get(b:, 'context_mtxrun', get(g:, 'context_mtxrun', 'mtxrun'))
+  let s:makeprg = get(b:, 'context_mtxrun', get(g:, 'context_mtxrun', 'mtxrun'))
         \ . ' --script context --autogenerate --nonstopmode --synctex='
         \ . (get(b:, 'context_synctex', get(g:, 'context_synctex', 0)) ? '1' : '0')
         \ . ' ' . get(b:, 'context_extra_options', get(g:, 'context_extra_options', ''))
         \ . ' ' . shellescape(expand('%:p:t'))
+  execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
 else
   let current_compiler = 'make'
 endif

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -4,6 +4,7 @@
 " Contributors: Enno Nagel
 " Last Change: 2024 Mar 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
 
 if exists("current_compiler")
   finish
@@ -35,7 +36,7 @@ let g:ps1_efm_show_error_categories = get(g:, 'ps1_efm_show_error_categories', 0
 
 " Use absolute path because powershell requires explicit relative paths
 " (./file.ps1 is okay, but # expands to file.ps1)
-let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
+let s:makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 
 " Parse file, line, char from callstacks:
 "     Write-Ouput : The term 'Write-Ouput' is not recognized as the name of a
@@ -48,7 +49,7 @@ let makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
 
-execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
+execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -4,6 +4,7 @@
 " Contributors: Enno Nagel
 " Last Change:  2024 Mar 29
 "		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
 
 if exists("current_compiler")
 	finish
@@ -25,8 +26,8 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 	else
 		let current_compiler = "latex"
 	endif
-	let makeprg=current_compiler .. ' -interaction=nonstopmode'
-	execute 'CompilerSet makeprg=' .. escape(makeprg, ' ')
+	let s:makeprg=current_compiler .. ' -interaction=nonstopmode'
+	execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
 else
 	let current_compiler = 'make'
 endif


### PR DESCRIPTION
#### vim-patch:b73faa1c02d0

runtime: fix :compiler leaving behind a g:makeprg variable (vim/vim#14414)

Problem:  :compiler may leave behind a g:makeprg variable after vim/vim#14336.
Solution: Use a script local variable.

https://github.com/vim/vim/commit/b73faa1c02d0911a60bddd1ba343cf620f2cd124

Also apply previously omitted change to compiler/context.vim.