### PR TITLE
vim-patch:9.1.{0267,0268,0269}

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -203,7 +203,6 @@ void dialog_changed(buf_T *buf, bool checkall)
     .append = false,
     .forceit = false,
   };
-  bool empty_buf = buf->b_fname == NULL;
 
   dialog_msg(buff, _("Save changes to \"%s\"?"), buf->b_fname);
   if (checkall) {
@@ -213,7 +212,8 @@ void dialog_changed(buf_T *buf, bool checkall)
   }
 
   if (ret == VIM_YES) {
-    if (empty_buf) {
+    bool empty_bufname = buf->b_fname == NULL;
+    if (empty_bufname) {
       buf_set_name(buf->b_fnum, "Untitled");
     }
 
@@ -225,7 +225,7 @@ void dialog_changed(buf_T *buf, bool checkall)
     }
 
     // restore to empty when write failed
-    if (empty_buf) {
+    if (empty_bufname) {
       XFREE_CLEAR(buf->b_fname);
       XFREE_CLEAR(buf->b_ffname);
       XFREE_CLEAR(buf->b_sfname);

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3921,39 +3921,40 @@ func Test_Changed_ChangedI()
         \ {'term_rows': 10})
   call assert_equal('running', term_getstatus(buf))
   call WaitForAssert({-> assert_true(filereadable('XTextChangedI3'))})
+  defer delete('XTextChangedI3')
   call WaitForAssert({-> assert_equal([''], readfile('XTextChangedI3'))})
 
   " TextChanged should trigger if a mapping enters and leaves Insert mode.
   call term_sendkeys(buf, "\<CR>")
-  call WaitForAssert({-> assert_equal('N4,', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,', readfile('XTextChangedI3')->join("\n"))})
 
   call term_sendkeys(buf, "i")
   call WaitForAssert({-> assert_match('^-- INSERT --', term_getline(buf, 10))})
-  call WaitForAssert({-> assert_equal('N4,', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,', readfile('XTextChangedI3')->join("\n"))})
   " TextChangedI should trigger if change is done in Insert mode.
   call term_sendkeys(buf, "f")
-  call WaitForAssert({-> assert_equal('N4,I5', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,I5', readfile('XTextChangedI3')->join("\n"))})
   call term_sendkeys(buf, "o")
-  call WaitForAssert({-> assert_equal('N4,I6', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,I6', readfile('XTextChangedI3')->join("\n"))})
   call term_sendkeys(buf, "o")
-  call WaitForAssert({-> assert_equal('N4,I7', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,I7', readfile('XTextChangedI3')->join("\n"))})
   " TextChanged shouldn't trigger when leaving Insert mode and TextChangedI
   " has been triggered.
   call term_sendkeys(buf, "\<Esc>")
   call WaitForAssert({-> assert_notmatch('^-- INSERT --', term_getline(buf, 10))})
-  call WaitForAssert({-> assert_equal('N4,I7', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N4,I7', readfile('XTextChangedI3')->join("\n"))})
 
   " TextChanged should trigger if change is done in Normal mode.
   call term_sendkeys(buf, "yyp")
-  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')->join("\n"))})
 
   " TextChangedI shouldn't trigger if change isn't done in Insert mode.
   call term_sendkeys(buf, "i")
   call WaitForAssert({-> assert_match('^-- INSERT --', term_getline(buf, 10))})
-  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')->join("\n"))})
   call term_sendkeys(buf, "\<Esc>")
   call WaitForAssert({-> assert_notmatch('^-- INSERT --', term_getline(buf, 10))})
-  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')[0])})
+  call WaitForAssert({-> assert_equal('N8,I7', readfile('XTextChangedI3')->join("\n"))})
 
   " TextChangedI should trigger if change is a mix of Normal and Insert modes.
   func! s:validate_mixed_textchangedi(buf, keys)
@@ -3963,13 +3964,13 @@ func Test_Changed_ChangedI()
     call term_sendkeys(buf, "\<Esc>")
     call WaitForAssert({-> assert_notmatch('^-- INSERT --', term_getline(buf, 10))})
     call term_sendkeys(buf, ":let [g:autocmd_n, g:autocmd_i] = ['', '']\<CR>")
-    call delete('XTextChangedI3')
+    call writefile([], 'XTextChangedI3')
     call term_sendkeys(buf, a:keys)
     call WaitForAssert({-> assert_match('^-- INSERT --', term_getline(buf, 10))})
-    call WaitForAssert({-> assert_match('^,I\d\+', readfile('XTextChangedI3')[0])})
+    call WaitForAssert({-> assert_match('^,I\d\+', readfile('XTextChangedI3')->join("\n"))})
     call term_sendkeys(buf, "\<Esc>")
     call WaitForAssert({-> assert_notmatch('^-- INSERT --', term_getline(buf, 10))})
-    call WaitForAssert({-> assert_match('^,I\d\+', readfile('XTextChangedI3')[0])})
+    call WaitForAssert({-> assert_match('^,I\d\+', readfile('XTextChangedI3')->join("\n"))})
   endfunc
 
   call s:validate_mixed_textchangedi(buf, "o")
@@ -3982,7 +3983,6 @@ func Test_Changed_ChangedI()
 
   " clean up
   bwipe!
-  call delete('XTextChangedI3')
 endfunc
 
 " Test that filetype detection still works when SwapExists autocommand sets

--- a/test/old/testdir/test_filechanged.vim
+++ b/test/old/testdir/test_filechanged.vim
@@ -11,8 +11,12 @@ func Test_FileChangedShell_reload()
   new Xchanged_r
   call setline(1, 'reload this')
   write
-  " Need to wait until the timestamp would change by at least a second.
-  sleep 2
+  " Need to wait until the timestamp would change.
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
   silent !echo 'extra line' >>Xchanged_r
   checktime
   call assert_equal('changed', g:reason)
@@ -50,7 +54,11 @@ func Test_FileChangedShell_reload()
   call assert_equal('new line', getline(1))
 
   " Only time changed
-  sleep 2
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
   silent !touch Xchanged_r
   let g:reason = ''
   checktime
@@ -65,7 +73,11 @@ func Test_FileChangedShell_reload()
     call setline(2, 'before write')
     write
     call setline(2, 'after write')
-    sleep 2
+    if has('nanotime')
+      sleep 10m
+    else
+      sleep 2
+    endif
     silent !echo 'different line' >>Xchanged_r
     let g:reason = ''
     checktime
@@ -198,8 +210,12 @@ func Test_file_changed_dialog()
   new Xchanged_d
   call setline(1, 'reload this')
   write
-  " Need to wait until the timestamp would change by at least a second.
-  sleep 2
+  " Need to wait until the timestamp would change.
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
   silent !echo 'extra line' >>Xchanged_d
   call feedkeys('L', 'L')
   checktime
@@ -234,7 +250,11 @@ func Test_file_changed_dialog()
   call assert_equal('new line', getline(1))
 
   " Only time changed, no prompt
-  sleep 2
+  if has('nanotime')
+    sleep 10m
+  else
+    sleep 2
+  endif
   silent !touch Xchanged_d
   let v:warningmsg = ''
   checktime Xchanged_d


### PR DESCRIPTION
#### vim-patch:9.1.0267: File name entered in GUI dialog is ignored

Problem:  File name entered in GUI dialog is ignored (after v9.1.0265)
Solution: Only set file name to "Untitled" if GUI dialog didn't set it.
          (zeertzjq)

closes: vim/vim#14417

https://github.com/vim/vim/commit/c20bdf1107d48a1c14713709d12d429e761132af


#### vim-patch:9.1.0268: Two tests in test_filechanged.vim are slow

Problem:  Two tests in test_filechanged.vim are slow.
Solution: Sleep for shorter if the +nanotime feature is available.
          (zeertzjq)

closes: vim/vim#14418

https://github.com/vim/vim/commit/83cd2c7bf0c12f05d747dd5fd6abfe103948bf12


#### vim-patch:9.1.0269: Test for TextChanged is still flaky with ASAN

Problem:  Test for TextChanged is still flaky with ASAN.
Solution: Don't index the result of readfile().
          (zeertzjq)

It turns out that with ASAN the file may become empty during a write
even if it's non-empty both before and after the write, in which case
indexing the result of readfile() will error, so use join() instead.

Also don't delete the file halfway the test, just in case it may cause
errors on the next read.

closes: vim/vim#14421

https://github.com/vim/vim/commit/e9ff79a7c9affea970f50de2aa65f62080b55323