### PR TITLE
test(old): sleep for 1 second on non-Windows in test_stat.vim

### DIFF
--- a/test/old/testdir/test_stat.vim
+++ b/test/old/testdir/test_stat.vim
@@ -55,7 +55,7 @@ func SleepForTimestamp()
   if has('win32')
     sleep 2
   else
-    sleep 2
+    sleep 1
   endif
 endfunc
 


### PR DESCRIPTION
Now that Nvim always supports nanotime, sleeping for some milliseconds
is actually enough, but for test_stat.vim keeping some longer sleeps may
increase test coverage, so just match the upstream test.
