### PR TITLE
vim-patch:cec44eae82c1

### DIFF
--- a/runtime/compiler/cargo.vim
+++ b/runtime/compiler/cargo.vim
@@ -2,7 +2,7 @@
 " Compiler:         Cargo Compiler
 " Maintainer:       Damien Radtke <damienradtke@gmail.com>
 " Latest Revision:  2023-09-11
-"                   2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"                   2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists('current_compiler')
@@ -15,10 +15,6 @@ let current_compiler = "cargo"
 let s:save_cpo = &cpo
 set cpo&vim
 " vint: +ProhibitAbbreviationOption
-
-if exists(':CompilerSet') != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
 
 if exists('g:cargo_makeprg_params')
     execute 'CompilerSet makeprg=cargo\ '.escape(g:cargo_makeprg_params, ' \|"').'\ $*'

--- a/runtime/compiler/go.vim
+++ b/runtime/compiler/go.vim
@@ -2,16 +2,12 @@
 " Compiler:	Go
 " Maintainer:	David Barnett (https://github.com/google/vim-ft-go)
 " Last Change:	2014 Aug 16
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"             	2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists('current_compiler')
   finish
 endif
 let current_compiler = 'go'
-
-if exists(':CompilerSet') != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 let s:save_cpo = &cpo
 set cpo-=C

--- a/runtime/compiler/hare.vim
+++ b/runtime/compiler/hare.vim
@@ -2,7 +2,7 @@
 " Compiler: Hare Compiler
 " Maintainer: Amelia Clarke <me@rsaihe.dev>
 " Last Change: 2022-09-21
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"              2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists("g:current_compiler")
   finish
@@ -11,10 +11,6 @@ let g:current_compiler = "hare"
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-if exists(':CompilerSet') != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 if filereadable("Makefile") || filereadable("makefile")
   CompilerSet makeprg=make

--- a/runtime/compiler/mcs.vim
+++ b/runtime/compiler/mcs.vim
@@ -3,7 +3,7 @@
 " Maintainer:   Jarek Sobiecki <harijari@go2.pl>
 " Contributors: Peter Collingbourne and Enno Nagel
 " Last Change:  2024 Mar 29
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+"               2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists("current_compiler")
   finish
@@ -12,10 +12,6 @@ let current_compiler = "mcs"
 
 let s:cpo_save = &cpo
 set cpo-=C
-
-if exists(":CompilerSet") != 2 " Older Vim always used :setlocal
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=mcs
 CompilerSet errorformat=

--- a/runtime/compiler/scdoc.vim
+++ b/runtime/compiler/scdoc.vim
@@ -2,16 +2,13 @@
 " Compiler: scdoc
 " Maintainer: Gregory Anders <contact@gpanders.com>
 " Last Updated: 2019-10-24
+"               2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 " Upstream: https://github.com/gpanders/vim-scdoc
 
 if exists('current_compiler')
     finish
 endif
 let current_compiler = 'scdoc'
-
-if exists(':CompilerSet') != 2
-    command -nargs=* CompilerSet setlocal <args>
-endif
 
 CompilerSet makeprg=scdoc\ <\ %\ 2>&1
 CompilerSet errorformat=Error\ at\ %l:%c:\ %m,%-G%.%#

--- a/runtime/compiler/zig_build.vim
+++ b/runtime/compiler/zig_build.vim
@@ -1,6 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build)
 " Upstream: https://github.com/ziglang/zig.vim
+" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists('current_compiler')
   finish
@@ -10,11 +11,6 @@ let current_compiler = 'zig_build'
 
 let s:save_cpo = &cpo
 set cpo&vim
-
-
-if exists(':CompilerSet') != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 if exists('g:zig_build_makeprg_params')
 	execute 'CompilerSet makeprg=zig\ build\ '.escape(g:zig_build_makeprg_params, ' \|"').'\ $*'

--- a/runtime/compiler/zig_build_exe.vim
+++ b/runtime/compiler/zig_build_exe.vim
@@ -1,6 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig build-exe)
 " Upstream: https://github.com/ziglang/zig.vim
+" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists('current_compiler')
   finish
@@ -10,11 +11,6 @@ let current_compiler = 'zig_build_exe'
 
 let s:save_cpo = &cpo
 set cpo&vim
-
-
-if exists(':CompilerSet') != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 if has('patch-7.4.191')
   CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 

--- a/runtime/compiler/zig_test.vim
+++ b/runtime/compiler/zig_test.vim
@@ -1,6 +1,7 @@
 " Vim compiler file
 " Compiler: Zig Compiler (zig test)
 " Upstream: https://github.com/ziglang/zig.vim
+" Last Change: 2024 Apr 05 by The Vim Project (removed :CompilerSet definition)
 
 if exists('current_compiler')
   finish
@@ -10,11 +11,6 @@ let current_compiler = 'zig_test'
 
 let s:save_cpo = &cpo
 set cpo&vim
-
-
-if exists(':CompilerSet') != 2
-  command -nargs=* CompilerSet setlocal <args>
-endif
 
 if has('patch-7.4.191')
   CompilerSet makeprg=zig\ test\ \%:S\ \$* 


### PR DESCRIPTION
runtime: Remove more fallback :CompilerSet definitions from compiler plugins

Continue with vim/vim#14399

vim/vim@cec44ea