### PR TITLE
fix: adjust error message for error in UI event callback

### DIFF
--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -90,7 +90,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   int status;
   if ((status = uv_spawn(&proc->loop->uv, &uvproc->uv, &uvproc->uvopts))) {
-    DLOG("uv_spawn(%s) failed: %s", uvproc->uvopts.file, uv_strerror(status));
+    ILOG("uv_spawn(%s) failed: %s", uvproc->uvopts.file, uv_strerror(status));
     if (uvproc->uvopts.env) {
       os_free_fullenv(uvproc->uvopts.env);
     }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -723,7 +723,7 @@ void ui_call_event(char *name, Array args)
       handled = true;
     }
     if (ERROR_SET(&err)) {
-      ELOG("Error while executing ui_comp_event callback: %s", err.msg);
+      ELOG("Error executing UI event callback: %s", err.msg);
     }
     api_clear_error(&err);
   })

--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -6,6 +6,7 @@ local api = helpers.api
 local exec_lua = helpers.exec_lua
 local retry = helpers.retry
 local assert_alive = helpers.assert_alive
+local check_close = helpers.check_close
 
 local testlog = 'Xtest-server-notify-log'
 
@@ -18,6 +19,7 @@ describe('notify', function()
   end)
 
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 

--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -8,6 +8,7 @@ local fn = helpers.fn
 local exec = helpers.exec
 local feed = helpers.feed
 local assert_log = helpers.assert_log
+local check_close = helpers.check_close
 local is_os = helpers.is_os
 
 local testlog = 'Xtest_autocmd_oldtest_log'
@@ -16,6 +17,7 @@ describe('oldtests', function()
   before_each(clear)
 
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -32,6 +32,7 @@ local dedent = helpers.dedent
 local tbl_map = vim.tbl_map
 local tbl_filter = vim.tbl_filter
 local endswith = vim.endswith
+local check_close = helpers.check_close
 
 local testlog = 'Xtest-startupspec-log'
 
@@ -116,6 +117,7 @@ describe('startup', function()
   before_each(clear)
 
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -20,6 +20,7 @@ local rmdir = helpers.rmdir
 local alter_slashes = helpers.alter_slashes
 local tbl_contains = vim.tbl_contains
 local expect_exit = helpers.expect_exit
+local check_close = helpers.check_close
 local is_os = helpers.is_os
 
 local testlog = 'Xtest-defaults-log'
@@ -274,6 +275,7 @@ describe('XDG defaults', function()
   -- Do not put before_each() here for the same reasons.
 
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 
@@ -866,6 +868,7 @@ end)
 
 describe('stdpath()', function()
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 
@@ -1227,6 +1230,8 @@ describe('stdpath()', function()
   end)
 
   describe('errors', function()
+    before_each(clear)
+
     it('on unknown strings', function()
       eq('Vim(call):E6100: "capybara" is not a valid stdpath', exc_exec('call stdpath("capybara")'))
       eq('Vim(call):E6100: "" is not a valid stdpath', exc_exec('call stdpath("")'))
@@ -1242,6 +1247,7 @@ end)
 
 describe('autocommands', function()
   it('closes terminal with default shell on success', function()
+    clear()
     api.nvim_set_option_value('shell', helpers.testprg('shell-test'), {})
     command('set shellcmdflag=EXIT shellredir= shellpipe= shellquote= shellxquote=')
 

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -14,6 +14,7 @@ local nvim_prog = helpers.nvim_prog
 local retry = helpers.retry
 local write_file = helpers.write_file
 local assert_log = helpers.assert_log
+local check_close = helpers.check_close
 local is_os = helpers.is_os
 
 local testlog = 'Xtest-embed-log'
@@ -98,6 +99,7 @@ end)
 
 describe('--embed UI', function()
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 

--- a/test/functional/vimscript/server_spec.lua
+++ b/test/functional/vimscript/server_spec.lua
@@ -5,6 +5,7 @@ local clear, fn, api = helpers.clear, helpers.fn, helpers.api
 local ok = helpers.ok
 local matches = helpers.matches
 local pcall_err = helpers.pcall_err
+local check_close = helpers.check_close
 local mkdir = helpers.mkdir
 local is_os = helpers.is_os
 
@@ -18,6 +19,7 @@ end
 
 describe('server', function()
   after_each(function()
+    check_close()
     os.remove(testlog)
   end)
 


### PR DESCRIPTION
Also close Nvim instance before removing log file, otherwise the Nvim
instance will still write to the log file.

Also adjust log level in libuv_process_spawn(). Ref #27660
