### PR TITLE
docs: fix some cases where a users gender was assumed

### DIFF
--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -111,7 +111,7 @@ See |45.2| for the basics, esp. using 'langmenu'.
 
 Note that if changes have been made to the menus after the translation was
 done, some of the menus may be shown in English.  Please try contacting the
-maintainer of the translation and ask him to update it.  You can find the
+maintainer of the translation and ask them to update it.  You can find the
 name and e-mail address of the translator in
 "$VIMRUNTIME/lang/menu_<lang>.vim".
 

--- a/runtime/doc/mlang.txt
+++ b/runtime/doc/mlang.txt
@@ -111,7 +111,7 @@ See |45.2| for the basics, esp. using 'langmenu'.
 
 Note that if changes have been made to the menus after the translation was
 done, some of the menus may be shown in English.  Please try contacting the
-maintainer of the translation and ask them to update it.  You can find the
+maintainer of the translation and ask him to update it.  You can find the
 name and e-mail address of the translator in
 "$VIMRUNTIME/lang/menu_<lang>.vim".
 

--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -19,7 +19,7 @@ setlocal noundofile
 setlocal keywordprg=:help
 setlocal iskeyword=@,-,_
 
-" The user will have to enable the folds himself, but we provide the foldexpr
+" The user will have to enable the folds themself, but we provide the foldexpr
 " function.
 setlocal foldmethod=manual
 setlocal foldexpr=tutor#TutorFolds()

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2365,7 +2365,7 @@ void ex_function(exarg_T *eap)
   // Read the body of the function, until ":endfunction" is found.
   if (KeyTyped) {
     // Check if the function already exists, don't let the user type the
-    // whole function before telling him it doesn't work!  For a script we
+    // whole function before telling them it doesn't work!  For a script we
     // need to skip the body to be able to find what follows.
     if (!eap->skip && !eap->forceit) {
       if (fudi.fd_dict != NULL && fudi.fd_newkey == NULL) {


### PR DESCRIPTION
Problem:
Some code comments were assuming a contributor to use the pronoun `he/him`.

Solution:
Now uses the gender neutral form (like in https://github.com/neovim/neovim/commit/ef9d3e6791b0b7d442326e0d4801570704c8e9e4) instead.

EDIT: Removed mention of a change in the documentation, because those belong to upstream vim and have to be addressed there instead.