### PR TITLE
vim-patch:9.1.0266: filetype: earthfile files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1293,6 +1293,7 @@ local filename = {
   jbuild = 'dune',
   ['dune-workspace'] = 'dune',
   ['dune-project'] = 'dune',
+  Earthfile = 'earthfile',
   ['.editorconfig'] = 'editorconfig',
   ['elinks.conf'] = 'elinks',
   ['mix.lock'] = 'elixir',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -221,6 +221,7 @@ func s:GetFilenameChecks() abort
     \ 'dylan': ['file.dylan'],
     \ 'dylanintr': ['file.intr'],
     \ 'dylanlid': ['file.lid'],
+    \ 'earthfile': ['Earthfile'],
     \ 'ecd': ['file.ecd'],
     \ 'edif': ['file.edf', 'file.edif', 'file.edo'],
     \ 'editorconfig': ['.editorconfig'],


### PR DESCRIPTION
#### vim-patch:9.1.0266: filetype: earthfile files are not recognized

Problem:  filetype: earthfile files are not recognized
Solution: Detect 'Earthfile' as earthfile
          (Gaëtan Lehmann)

closes: vim/vim#14408

https://github.com/vim/vim/commit/28e5e7c48483254604506dbce5eb61396ff65808

Co-authored-by: Gaëtan Lehmann <gaetan.lehmann@gmail.com>