### PR TITLE
fix(health): check unmatching python_glob as empty table

### DIFF
--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -187,7 +187,7 @@ local function check_rplugin_manifest()
   local require_update = false
   local handle_path = function(path)
     local python_glob = vim.fn.glob(path .. '/rplugin/python*', true, true)
-    if python_glob == '' then
+    if vim.tbl_isempty(python_glob)  then
       return
     end
 

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -187,7 +187,7 @@ local function check_rplugin_manifest()
   local require_update = false
   local handle_path = function(path)
     local python_glob = vim.fn.glob(path .. '/rplugin/python*', true, true)
-    if vim.tbl_isempty(python_glob)  then
+    if vim.tbl_isempty(python_glob) then
       return
     end
 


### PR DESCRIPTION
The current health code checking for remote python plugins passes `true` to `vim.fn.glob` indicating a table return type, yet compares it to an empty string.

The following error results:
<img width="1090" alt="image" src="https://github.com/neovim/neovim/assets/62671086/1ab892f4-00e6-4911-a019-a1f17f8e71cd">

Comparing against an empty table fixes the issue, resulting in the following:
<img width="659" alt="image" src="https://github.com/neovim/neovim/assets/62671086/9776221f-eaac-42ad-986c-663ff5dfe10d">

This output does seem quite spammy for that of a default health check - that may be another issue.