### PR TITLE
fix(lsp): empty commands should not be considered executable

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -79,7 +79,7 @@ function M.run()
   local lenses_by_client = lens_cache_by_buf[bufnr] or {}
   for client, lenses in pairs(lenses_by_client) do
     for _, lens in pairs(lenses) do
-      if lens.range.start.line == (line - 1) then
+      if lens.range.start.line == (line - 1) and lens.command and lens.command.command ~= '' then
         table.insert(options, { client = client, lens = lens })
       end
     end


### PR DESCRIPTION
1. `CodeLens.command` will exist only when it is resolved, according to https://github.com/neovim/neovim/blob/067f51e3aadfeb797b38331776f2a6447b565456/runtime/lua/vim/lsp/codelens.lua#L275-L278, there may be a very short time interval in which this field does not exist;
2. Once `resolve_lenses` is done, the `CodeLens.command` and all its subfields will exist, but not all of them will be executable, at this time, `CodeLens.command.command` will be `''`, an empty string. In this case, we should not add them to `options`.