### PR TITLE
vim-patch:9.1.0273: filetype: keymap files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -367,6 +367,7 @@ local extension = {
   dtsi = 'dts',
   dtso = 'dts',
   its = 'dts',
+  keymap = 'dts',
   dylan = 'dylan',
   intr = 'dylanintr',
   lid = 'dylanlid',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -216,7 +216,7 @@ func s:GetFilenameChecks() abort
     \ 'dracula': ['file.drac', 'file.drc', 'filelvs', 'filelpe', 'drac.file', 'lpe', 'lvs', 'some-lpe', 'some-lvs'],
     \ 'dtd': ['file.dtd'],
     \ 'dtrace': ['/usr/lib/dtrace/io.d'],
-    \ 'dts': ['file.dts', 'file.dtsi', 'file.dtso', 'file.its'],
+    \ 'dts': ['file.dts', 'file.dtsi', 'file.dtso', 'file.its', 'file.keymap'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace'],
     \ 'dylan': ['file.dylan'],
     \ 'dylanintr': ['file.intr'],


### PR DESCRIPTION
Problem:  filetype: keymap files are not recognized
Solution: Detect '*.keymap' files as Device Tree Files
          (0xadk)

closes: vim/vim#14434

https://github.com/vim/vim/commit/b78753db5fac879a76da3519101e815451d0d455

Co-authored-by: 0xadk <0xadk@users.noreply.github.com>
