### PR TITLE
fix(drawline): don't invoke on_line for filler line

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1030,7 +1030,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
     has_decor = decor_redraw_line(wp, lnum - 1, &decor_state);
 
-    decor_providers_invoke_line(wp, lnum - 1, &has_decor);
+    if (!end_fill) {
+      decor_providers_invoke_line(wp, lnum - 1, &has_decor);
+    }
 
     if (has_decor) {
       extra_check = true;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -667,6 +667,33 @@ describe('decorations providers', function()
     ]])
   end)
 
+  it('on_line is invoked only for buffer lines', function()
+    insert(mulholland)
+    command('vnew')
+    insert(mulholland)
+    feed('dd')
+    command('windo diffthis')
+
+    exec_lua([[
+      out_of_bound = false
+    ]])
+    setup_provider([[
+      local function on_do(kind, _, bufnr, row)
+        if kind == 'line' then
+          if not api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] then
+            out_of_bound = true
+          end
+        end
+      end
+    ]])
+
+    feed('<C-e>')
+
+    exec_lua([[
+      assert(out_of_bound == false)
+    ]])
+  end)
+
   it('errors gracefully', function()
     insert(mulholland)
 


### PR DESCRIPTION
Problem:
Decoration provider `on_line` handler is invoked for diff filler line below the last buffer line. This does not match the documentation: "called for each buffer line".

Solution:
Check `end_fill`.