### PR TITLE
feat(diagnostic): is_enabled, enable(…, enable:boolean)

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -80,12 +80,15 @@ HIGHLIGHTS
 - *hl-VertSplit*	Use |hl-WinSeparator| instead.
 
 LSP DIAGNOSTICS
+- *vim.diagnostic.disable()*		Use |vim.diagnostic.enable()|
+- *vim.diagnostic.is_disabled()*	Use |vim.diagnostic.is_enabled()|
+
 For each of the functions below, use the corresponding function in
 |vim.diagnostic| instead (unless otherwise noted). For example, use
 |vim.diagnostic.get()| instead of |vim.lsp.diagnostic.get()|.
 
 - *vim.lsp.diagnostic.clear()*		Use |vim.diagnostic.hide()| instead.
-- *vim.lsp.diagnostic.disable()*
+- *vim.lsp.diagnostic.disable()*          Use |vim.diagnostic.enable()| instead.
 - *vim.lsp.diagnostic.display()*	Use |vim.diagnostic.show()| instead.
 - *vim.lsp.diagnostic.enable()*
 - *vim.lsp.diagnostic.get()*

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -372,11 +372,13 @@ Use existing common {verb} names (actions) if possible:
     - create:       Creates a new (non-trivial) thing (TODO: rename to "def"?)
     - del:          Deletes a thing (or group of things)
     - detach:       Dispose attached listener (TODO: rename to "un"?)
+    - enable:       Enables/disables functionality.
     - eval:         Evaluates an expression
     - exec:         Executes code
     - fmt:          Formats
     - get:          Gets things (often by a query)
     - inspect:      Presents a high-level, often interactive, view
+    - is_enabled:   Checks if functionality is enabled.
     - open:         Opens something (a buffer, window, …)
     - parse:        Parses something into a structured form
     - set:          Sets a thing (or group of things)

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -383,9 +383,12 @@ Use existing common {verb} names (actions) if possible:
     - try_{verb}:   Best-effort operation, failure returns null or error obj
 
 Do NOT use these deprecated verbs:
+    - disable:      Prefer `enable(enable: boolean)`.
+    - is_disabled:  Prefer `is_enabled()`.
     - list:         Redundant with "get"
-    - show:         Redundant with "print", "echo"
     - notify:       Redundant with "print", "echo"
+    - show:         Redundant with "print", "echo"
+    - toggle:       Prefer `enable(not is_enabled())`.
 
 Use consistent names for {noun} (nouns) in API functions: buffer is called
 "buf" everywhere, not "buffer" in some places and "buf" in others.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -616,23 +616,19 @@ count({bufnr}, {opts})                                *vim.diagnostic.count()*
         (`table`) Table with actually present severity values as keys (see
         |diagnostic-severity|) and integer counts as values.
 
-disable({bufnr}, {namespace})                       *vim.diagnostic.disable()*
-    Disable diagnostics in the given buffer.
+enable({bufnr}, {namespace}, {enable})               *vim.diagnostic.enable()*
+    Enables or disables diagnostics.
+
+    To "toggle", pass the inverse of `is_enabled()`: >lua
+        vim.diagnostic.enable(0, not vim.diagnostic.is_enabled())
+<
 
     Parameters: ~
-      • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer. When
-                     omitted, disable diagnostics in all buffers.
-      • {namespace}  (`integer?`) Only disable diagnostics for the given
-                     namespace.
-
-enable({bufnr}, {namespace})                         *vim.diagnostic.enable()*
-    Enable diagnostics in the given buffer.
-
-    Parameters: ~
-      • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer. When
-                     omitted, enable diagnostics in all buffers.
-      • {namespace}  (`integer?`) Only enable diagnostics for the given
-                     namespace.
+      • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer, or
+                     `nil` for all buffers.
+      • {namespace}  (`integer?`) Only for the given namespace, or `nil` for
+                     all.
+      • {enable}     (`boolean?`) true/nil to enable, false to disable
 
 fromqflist({list})                               *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.
@@ -733,7 +729,7 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
     diagnostics, use |vim.diagnostic.reset()|.
 
     To hide diagnostics and prevent them from re-displaying, use
-    |vim.diagnostic.disable()|.
+    |vim.diagnostic.enable()|.
 
     Parameters: ~
       • {namespace}  (`integer?`) Diagnostic namespace. When omitted, hide
@@ -741,14 +737,16 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
       • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer. When
                      omitted, hide diagnostics in all buffers.
 
-is_disabled({bufnr}, {namespace})               *vim.diagnostic.is_disabled()*
-    Check whether diagnostics are disabled in a given buffer.
+is_enabled({bufnr}, {namespace})                 *vim.diagnostic.is_enabled()*
+    Check whether diagnostics are enabled.
+
+    Note: ~
+      • This API is pre-release (unstable).
 
     Parameters: ~
       • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer.
-      • {namespace}  (`integer?`) Diagnostic namespace. When omitted, checks
-                     if all diagnostics are disabled in {bufnr}. Otherwise,
-                     only checks if diagnostics from {namespace} are disabled.
+      • {namespace}  (`integer?`) Diagnostic namespace, or `nil` for all
+                     diagnostics in {bufnr}.
 
     Return: ~
         (`boolean`)

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -367,6 +367,13 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {user_data}?  (`any`) arbitrary data plugins can add
       • {namespace}?  (`integer`)
 
+*vim.diagnostic.Filter*
+    Extends: |vim.diagnostic.Opts|
+
+
+    Fields: ~
+      • {ns_id}?  (`integer`) Namespace
+
 *vim.diagnostic.GetOpts*
     A table with the following keys:
 
@@ -616,7 +623,7 @@ count({bufnr}, {opts})                                *vim.diagnostic.count()*
         (`table`) Table with actually present severity values as keys (see
         |diagnostic-severity|) and integer counts as values.
 
-enable({bufnr}, {namespace}, {enable})               *vim.diagnostic.enable()*
+enable({bufnr}, {enable}, {opts})                    *vim.diagnostic.enable()*
     Enables or disables diagnostics.
 
     To "toggle", pass the inverse of `is_enabled()`: >lua
@@ -624,11 +631,12 @@ enable({bufnr}, {namespace}, {enable})               *vim.diagnostic.enable()*
 <
 
     Parameters: ~
-      • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer, or
-                     `nil` for all buffers.
-      • {namespace}  (`integer?`) Only for the given namespace, or `nil` for
-                     all.
-      • {enable}     (`boolean?`) true/nil to enable, false to disable
+      • {bufnr}   (`integer?`) Buffer number, or 0 for current buffer, or
+                  `nil` for all buffers.
+      • {enable}  (`boolean?`) true/nil to enable, false to disable
+      • {opts}    (`vim.diagnostic.Filter?`) Filter by these opts, or `nil`
+                  for all. Only `ns_id` is supported, currently. See
+                  |vim.diagnostic.Filter|.
 
 fromqflist({list})                               *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.

--- a/runtime/doc/news-0.9.txt
+++ b/runtime/doc/news-0.9.txt
@@ -162,7 +162,7 @@ The following new APIs or features were added.
 • |vim.diagnostic| now supports LSP DiagnosticsTag.
   See: https://microsoft.github.io/language-server-protocol/specification/#diagnosticTag
 
-• |vim.diagnostic.is_disabled()| checks if diagnostics are disabled in a given
+• vim.diagnostic.is_disabled() checks if diagnostics are disabled in a given
   buffer or namespace.
 
 • Treesitter captures can now be transformed by directives. This will allow

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -421,7 +421,8 @@ The following changes to existing APIs or features add new behavior.
 • |vim.diagnostic.get()| and |vim.diagnostic.count()| accept multiple
   namespaces rather than just a single namespace.
 
-• |vim.diagnostic.enable()| accepts an `enabled` boolean parameter.
+• |vim.diagnostic.enable()| gained new parameters, and the old signature is
+  deprecated.
 
 • Extmarks now fully support multi-line ranges, and a single extmark can be
   used to highlight a range of arbitrary length. The |nvim_buf_set_extmark()|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -328,6 +328,8 @@ The following new APIs and features were added.
   |vim.diagnostic.get()| when only the number of diagnostics is needed, but
   not the diagnostics themselves.
 
+• Introduced |vim.diagnostic.is_enabled()|
+
 • |vim.deepcopy()| has a `noref` argument to avoid hashing table values.
 
 • Terminal buffers emit a |TermRequest| autocommand event when the child
@@ -418,6 +420,8 @@ The following changes to existing APIs or features add new behavior.
 
 • |vim.diagnostic.get()| and |vim.diagnostic.count()| accept multiple
   namespaces rather than just a single namespace.
+
+• |vim.diagnostic.enable()| accepts an `enabled` boolean parameter.
 
 • Extmarks now fully support multi-line ranges, and a single extmark can be
   used to highlight a range of arbitrary length. The |nvim_buf_set_extmark()|
@@ -519,6 +523,10 @@ release.
   - |nvim_set_option()|		Use |nvim_set_option_value()| instead.
   - |nvim_win_get_option()|	Use |nvim_get_option_value()| instead.
   - |nvim_win_set_option()|	Use |nvim_set_option_value()| instead.
+
+• vim.diagnostic functions:
+  - |vim.diagnostic.disable()|
+  - |vim.diagnostic.is_disabled()|
 
 • vim.lsp functions:
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -329,7 +329,7 @@ describe('vim.diagnostic', function()
     eq(
       { 1, 1, 2, 0, 2 },
       exec_lua [[
-      vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
       return {
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
@@ -371,7 +371,7 @@ describe('vim.diagnostic', function()
       vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
       vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
 
-      vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
 
       return {
         count_extmarks(diagnostic_bufnr, diagnostic_ns),
@@ -384,7 +384,7 @@ describe('vim.diagnostic', function()
       { 4, 0 },
       exec_lua [[
       vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
-      vim.diagnostic.disable(diagnostic_bufnr, other_ns)
+      vim.diagnostic.enable(diagnostic_bufnr, other_ns, false)
 
       return {
         count_extmarks(diagnostic_bufnr, diagnostic_ns),
@@ -500,7 +500,7 @@ describe('vim.diagnostic', function()
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.disable()
+        vim.diagnostic.enable(nil, nil, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
@@ -561,7 +561,7 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.disable(diagnostic_bufnr)
+        vim.diagnostic.enable(diagnostic_bufnr, nil, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -573,7 +573,7 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.disable(other_bufnr)
+        vim.diagnostic.enable(other_bufnr, nil, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -610,7 +610,7 @@ describe('vim.diagnostic', function()
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.disable(nil, diagnostic_ns)
+        vim.diagnostic.enable(nil, diagnostic_ns, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
@@ -620,7 +620,7 @@ describe('vim.diagnostic', function()
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.disable(nil, other_ns)
+        vim.diagnostic.enable(nil, other_ns, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
@@ -663,13 +663,13 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.disable(diagnostic_bufnr, other_ns)
+        vim.diagnostic.enable(diagnostic_bufnr, other_ns, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -682,7 +682,7 @@ describe('vim.diagnostic', function()
                              count_extmarks(other_bufnr, diagnostic_ns))
 
         -- Should have no effect
-        vim.diagnostic.disable(other_bufnr, other_ns)
+        vim.diagnostic.enable(other_bufnr, other_ns, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -1742,7 +1742,7 @@ describe('vim.diagnostic', function()
       eq(
         0,
         exec_lua [[
-        vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
           make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
         })
@@ -2711,7 +2711,39 @@ describe('vim.diagnostic', function()
       )
     end)
 
-    it('checks if diagnostics are disabled in a buffer', function()
+    it('is_enabled', function()
+      eq(
+        { false, false, false, false },
+        exec_lua [[
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+          make_error('Diagnostic #1', 1, 1, 1, 1),
+        })
+        vim.api.nvim_set_current_buf(diagnostic_bufnr)
+        vim.diagnostic.enable(nil, nil, false)
+        return {
+          vim.diagnostic.is_enabled(),
+          vim.diagnostic.is_enabled(diagnostic_bufnr),
+          vim.diagnostic.is_enabled(diagnostic_bufnr, diagnostic_ns),
+          vim.diagnostic.is_enabled(_, diagnostic_ns),
+        }
+      ]]
+      )
+
+      eq(
+        { true, true, true, true },
+        exec_lua [[
+        vim.diagnostic.enable()
+        return {
+          vim.diagnostic.is_enabled(),
+          vim.diagnostic.is_enabled(diagnostic_bufnr),
+          vim.diagnostic.is_enabled(diagnostic_bufnr, diagnostic_ns),
+          vim.diagnostic.is_enabled(_, diagnostic_ns),
+        }
+      ]]
+      )
+    end)
+
+    it('is_disabled (deprecated)', function()
       eq(
         { true, true, true, true },
         exec_lua [[

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -329,7 +329,7 @@ describe('vim.diagnostic', function()
     eq(
       { 1, 1, 2, 0, 2 },
       exec_lua [[
-      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
+      vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = diagnostic_ns })
       return {
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
@@ -344,7 +344,7 @@ describe('vim.diagnostic', function()
     eq(
       all_highlights,
       exec_lua([[
-      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
+      vim.diagnostic.enable(diagnostic_bufnr, true, { ns_id = diagnostic_ns })
       return {
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
         count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
@@ -371,7 +371,7 @@ describe('vim.diagnostic', function()
       vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
       vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
 
-      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
+      vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = diagnostic_ns })
 
       return {
         count_extmarks(diagnostic_bufnr, diagnostic_ns),
@@ -383,8 +383,8 @@ describe('vim.diagnostic', function()
     eq(
       { 4, 0 },
       exec_lua [[
-      vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
-      vim.diagnostic.enable(diagnostic_bufnr, other_ns, false)
+      vim.diagnostic.enable(diagnostic_bufnr, true, { ns_id = diagnostic_ns })
+      vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = other_ns })
 
       return {
         count_extmarks(diagnostic_bufnr, diagnostic_ns),
@@ -478,7 +478,7 @@ describe('vim.diagnostic', function()
   end)
 
   describe('enable() and disable()', function()
-    it('works without arguments', function()
+    it('without arguments', function()
       local result = exec_lua [[
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
 
@@ -500,7 +500,7 @@ describe('vim.diagnostic', function()
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.enable(nil, nil, false)
+        vim.diagnostic.enable(nil, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
@@ -532,7 +532,7 @@ describe('vim.diagnostic', function()
       eq(4, result[4])
     end)
 
-    it('works with only a buffer argument', function()
+    it('with buffer argument', function()
       local result = exec_lua [[
         local other_bufnr = vim.api.nvim_create_buf(true, false)
 
@@ -561,7 +561,7 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.enable(diagnostic_bufnr, nil, false)
+        vim.diagnostic.enable(diagnostic_bufnr, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -573,7 +573,7 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.enable(other_bufnr, nil, false)
+        vim.diagnostic.enable(other_bufnr, false)
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
@@ -588,7 +588,7 @@ describe('vim.diagnostic', function()
       eq(3, result[4])
     end)
 
-    it('works with only a namespace argument', function()
+    it('with a namespace argument', function()
       local result = exec_lua [[
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
 
@@ -610,17 +610,17 @@ describe('vim.diagnostic', function()
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.enable(nil, diagnostic_ns, false)
+        vim.diagnostic.enable(nil, false, { ns_id = diagnostic_ns })
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.enable(nil, diagnostic_ns)
+        vim.diagnostic.enable(nil, true, { ns_id = diagnostic_ns })
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
 
-        vim.diagnostic.enable(nil, other_ns, false)
+        vim.diagnostic.enable(nil, false, { ns_id = other_ns })
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns))
@@ -634,8 +634,11 @@ describe('vim.diagnostic', function()
       eq(2, result[4])
     end)
 
-    it('works with both a buffer and a namespace argument', function()
-      local result = exec_lua [[
+    --- @return table
+    local function test_enable(legacy)
+      local result = exec_lua(
+        [[
+        local legacy = ...
         local other_bufnr = vim.api.nvim_create_buf(true, false)
 
         vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
@@ -663,34 +666,68 @@ describe('vim.diagnostic', function()
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
+        if legacy then
+          vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+        else
+          vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = diagnostic_ns })
+        end
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.enable(diagnostic_bufnr, other_ns, false)
+        if legacy then
+          vim.diagnostic.disable(diagnostic_bufnr, other_ns)
+        else
+          vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = other_ns })
+        end
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
+        if legacy then
+          vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
+        else
+          vim.diagnostic.enable(diagnostic_bufnr, true, { ns_id = diagnostic_ns })
+        end
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
-        -- Should have no effect
-        vim.diagnostic.enable(other_bufnr, other_ns, false)
+        if legacy then
+          -- Should have no effect
+          vim.diagnostic.disable(other_bufnr, other_ns)
+        else
+          -- Should have no effect
+          vim.diagnostic.enable(other_bufnr, false, { ns_id = other_ns })
+        end
 
         table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
                              count_extmarks(diagnostic_bufnr, other_ns) +
                              count_extmarks(other_bufnr, diagnostic_ns))
 
         return result
-      ]]
+      ]],
+        legacy
+      )
 
+      return result
+    end
+
+    it('with both buffer and namespace arguments', function()
+      local result = test_enable(false)
+      eq(4, result[1])
+      eq(2, result[2])
+      eq(1, result[3])
+      eq(3, result[4])
+      eq(3, result[5])
+    end)
+
+    it('with both buffer and namespace arguments (deprecated signature)', function()
+      -- Exercise the legacy/deprecated signature.
+      local result = test_enable(true)
       eq(4, result[1])
       eq(2, result[2])
       eq(1, result[3])
@@ -1742,7 +1779,7 @@ describe('vim.diagnostic', function()
       eq(
         0,
         exec_lua [[
-        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns, false)
+        vim.diagnostic.enable(diagnostic_bufnr, false, { ns_id = diagnostic_ns })
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
           make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
         })
@@ -1753,7 +1790,7 @@ describe('vim.diagnostic', function()
       eq(
         2,
         exec_lua [[
-        vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
+        vim.diagnostic.enable(diagnostic_bufnr, true, { ns_id = diagnostic_ns })
         return count_extmarks(diagnostic_bufnr, diagnostic_ns)
       ]]
       )
@@ -2719,7 +2756,7 @@ describe('vim.diagnostic', function()
           make_error('Diagnostic #1', 1, 1, 1, 1),
         })
         vim.api.nvim_set_current_buf(diagnostic_bufnr)
-        vim.diagnostic.enable(nil, nil, false)
+        vim.diagnostic.enable(nil, false)
         return {
           vim.diagnostic.is_enabled(),
           vim.diagnostic.is_enabled(diagnostic_bufnr),


### PR DESCRIPTION
## Problem:
`vim.diagnostic.is_disabled` and `vim.diagnostic.disable` are unnecessary and inconsistent with the "toggle" pattern established by `vim.lsp.inlay_hint`, see https://github.com/neovim/neovim/pull/25512#pullrequestreview-1676750276

As a reminder, the rationale is:
- we always need `enable()`
- we always end up needing `is_enabled()`
- "toggle" can be achieved via `enable(not is_enabled())`
- therefore,
    - `toggle()` and `disable()` are redundant
    - `is_disabled()` is a needless inconsistency

## Solution:
- Introduce `vim.diagnostic.is_enabled`, and `vim.diagnostic.enable(…, enable:boolean)`
    - Deprecate `vim.diagnostic.is_disabled`, `vim.diagnostic.disable`
- Introduce overload `enable(buf:number, enable:boolean, opts: table)`.
    - Deprecate legacy signature  `enable(buf:number, namespace:number)`

cc @glepnir @gpanders 