### PR TITLE
fix(lsp): avoid being unable to request again after a request fails once

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -306,7 +306,11 @@ function M.refresh(opts)
         textDocument = util.make_text_document_params(buf),
       }
       active_refreshes[buf] = true
-      vim.lsp.buf_request(buf, ms.textDocument_codeLens, params, M.on_codelens)
+
+      local request_ids = vim.lsp.buf_request(buf, ms.textDocument_codeLens, params, M.on_codelens)
+      if vim.tbl_isempty(request_ids) then
+        active_refreshes[buf] = nil
+      end
     end
   end
 end

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -231,7 +231,7 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
       countdown()
     else
       assert(client)
-      client.request('codeLens/resolve', lens, function(_, result)
+      client.request(ms.codeLens_resolve, lens, function(_, result)
         if api.nvim_buf_is_loaded(bufnr) and result and result.command then
           lens.command = result.command
           -- Eager display to have some sort of incremental feedback


### PR DESCRIPTION
To avoid repeatedly requesting a buffer multiple times before a request is completed, the current implementation puts the requested buffer into the `active_refreshes` table before requesting.

But since we only remove the buffer from `active_refreshes` in the `lsp-handler` of `textDocument/codeLens`, this will cause if the user sends a request that cannot trigger `lsp-handler` (for example, if there is an LSP server attached to the current buffer, and especially when the user creates an autocmd which performs `vim.lsp.codelens.refresh` after the `BufEnter` event is triggered like in the document example), this buffer will be put into `active_refreshes`, and there is no way to remove it, which will result in all subsequent `vim.lsp.codelens.refresh` not requesting `textDocument/codeLens`.
