### PR TITLE
build(release.sh): regenerate docs after changing NVIM_API_PRERELEASE

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -61,6 +61,8 @@ _do_release_commit() {
     $__sed -i.bk 's/(NVIM_API_PRERELEASE) true/\1 false/' CMakeLists.txt
     build/bin/nvim --api-info > "test/functional/fixtures/api_level_$__API_LEVEL.mpack"
     git add "test/functional/fixtures/api_level_${__API_LEVEL}.mpack"
+    build/bin/nvim -u NONE -l scripts/gen_vimdoc.lua
+    git add -u -- runtime/doc/
   fi
 
   $__sed -i.bk 's,(<releases>),\1\

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -920,7 +920,7 @@ file(GLOB LUA_SOURCES CONFIGURE_DEPENDS
 )
 
 add_target(doc-vim
-  COMMAND $<TARGET_FILE:nvim_bin> -l scripts/gen_vimdoc.lua
+  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l scripts/gen_vimdoc.lua
   DEPENDS
     nvim
     ${API_SOURCES}
@@ -934,7 +934,7 @@ add_target(doc-vim
   )
 
 add_target(doc-eval
-  COMMAND $<TARGET_FILE:nvim_bin> -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
+  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
   DEPENDS
     nvim
     ${FUNCS_METADATA}
@@ -949,7 +949,7 @@ add_custom_target(doc)
 add_dependencies(doc doc-vim doc-eval)
 
 add_target(lintdoc
-  COMMAND $<TARGET_FILE:nvim_bin> --clean -l scripts/lintdoc.lua
+  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l scripts/lintdoc.lua
   DEPENDS ${DOCFILES}
   CUSTOM_COMMAND_ARGS USES_TERMINAL)
 add_dependencies(lintdoc nvim)


### PR DESCRIPTION
After #25574, the value of NVIM_API_PRERELEASE can affect docs, so docs
need to be regenerated after changing NVIM_API_PRERELEASE.
