### PR TITLE
revert: "feat(health): fold successful healthchecks #22866"

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -393,9 +393,6 @@ The following changes to existing APIs or features add new behavior.
 • |:lua| with a |[range]| executes that range in the current buffer as Lua code
   regardless of its extension.
 
-• |:checkhealth| buffer now implements |folding|. The initial folding status is
-  defined by the 'foldenable' option.
-
 • |:Man| now respects 'wrapmargin'
 
 • |gx| now uses |vim.ui.open()| and not netrw. To customize, you can redefine

--- a/runtime/ftplugin/checkhealth.vim
+++ b/runtime/ftplugin/checkhealth.vim
@@ -9,9 +9,6 @@ endif
 runtime! ftplugin/help.vim
 
 setlocal wrap breakindent linebreak
-setlocal foldexpr=getline(v:lnum-1)=~'^=\\{78}$'?'>1':(getline(v:lnum)=~'^=\\{78}'?0:'=')
-setlocal foldmethod=expr
-setlocal foldtext=v:lua.require('vim.health').foldtext()
 let &l:iskeyword='!-~,^*,^|,^",192-255'
 
 if exists("b:undo_ftplugin")

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -2,42 +2,7 @@ local M = {}
 
 local s_output = {} ---@type string[]
 
---- Returns the fold text of the current healthcheck section
-function M.foldtext()
-  local foldtext = vim.fn.foldtext()
-
-  if vim.bo.filetype ~= 'checkhealth' then
-    return foldtext
-  end
-
-  if vim.b.failedchecks == nil then
-    vim.b.failedchecks = vim.empty_dict()
-  end
-
-  if vim.b.failedchecks[foldtext] == nil then
-    local warning = '- WARNING '
-    local warninglen = string.len(warning)
-    local err = '- ERROR '
-    local errlen = string.len(err)
-    local failedchecks = vim.b.failedchecks
-    failedchecks[foldtext] = false
-
-    local foldcontent = vim.api.nvim_buf_get_lines(0, vim.v.foldstart - 1, vim.v.foldend, false)
-    for _, line in ipairs(foldcontent) do
-      if string.sub(line, 1, warninglen) == warning or string.sub(line, 1, errlen) == err then
-        failedchecks[foldtext] = true
-        break
-      end
-    end
-
-    vim.b.failedchecks = failedchecks
-  end
-
-  return vim.b.failedchecks[foldtext] and '+WE' .. foldtext:sub(4) or foldtext
-end
-
---- @param path string path to search for the healthcheck
---- @return string[] { name, func, type } representing a healthcheck
+-- From a path return a list [{name}, {func}, {type}] representing a healthcheck
 local function filepath_to_healthcheck(path)
   path = vim.fs.normalize(path)
   local name --- @type string

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -159,24 +159,6 @@ describe('health.vim', function()
       }
     end)
 
-    it('fold healthchecks', function()
-      local screen = Screen.new(50, 7)
-      screen:attach()
-      command('checkhealth foo success1')
-      command('set nowrap laststatus=0')
-      screen:expect {
-        grid = [[
-        ^                                                  |
-        {14:──────────────────────────────────────────────────}|
-        {13:+WE  4 lines: foo: ·······························}|
-        {14:──────────────────────────────────────────────────}|
-        {13:+--  8 lines: test_plug.success1: require("test_pl}|
-        {1:~                                                 }|
-                                                          |
-      ]],
-      }
-    end)
-
     it('gracefully handles invalid healthcheck', function()
       command('checkhealth non_existent_healthcheck')
       -- luacheck: ignore 613


### PR DESCRIPTION
This reverts commit 4382d2ed564b80944345785d780cf1b19fb23ba8.

The story for this feature was left in an incomplete state. It was never
the intention to unilaterally fold all information, only the ones that
did not contain relevant information. This feature does more harm than
good in its incomplete state.