### PR TITLE
fix(api): do not update grid position in nvim_win_set_cursor

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -148,7 +148,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   switchwin_T switchwin;
   switch_win(&switchwin, win, NULL, true);
   update_topline(curwin);
-  setcursor_mayforce(true);
+  validate_cursor(curwin);
   restore_win(&switchwin, true);
 
   redraw_later(win, UPD_VALID);

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -219,21 +219,6 @@ describe('API/win', function()
 
       -- curwin didn't change back
       neq(win, curwin())
-
-      -- shows updated position after getchar() #20793
-      feed(':call getchar()<CR>')
-      api.nvim_win_set_cursor(win, { 1, 5 })
-      screen:expect {
-        grid = [[
-                                      |
-        {1:~                             }|*2
-        {2:[No Name]                     }|
-        prolo^gue                      |
-                                      |*2
-        {3:[No Name] [+]                 }|
-        :call getchar()               |
-      ]],
-      }
     end)
 
     it('remembers what column it wants to be in', function()

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -825,7 +825,8 @@ local function test_cmdline(linegrid)
     ]])
   end)
 
-  it('does not move cursor to curwin #20309', function()
+  -- Needs new API
+  pending('does not move cursor to curwin #20309', function()
     local win = api.nvim_get_current_win()
     command('norm icmdlinewin')
     command('new')


### PR DESCRIPTION
Revert commit c971f538ab87b537ae4c97bd44167661c5691a2d.
Forcing grid cursor position will need a new API like originally proposed in #27858.