### PR TITLE
fix(tui): don't set cursor color when there is none

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1237,7 +1237,7 @@ static void tui_set_mode(TUIData *tui, ModeShape mode)
       // We interpret "inverse" as "default" (no termcode for "inverse"...).
       // Hopefully the user's default cursor color is inverse.
       unibi_out_ext(tui, tui->unibi_ext.reset_cursor_color);
-    } else {
+    } else if (!tui->want_invisible && aep.rgb_bg_color >= 0) {
       char hexbuf[8];
       if (tui->set_cursor_color_as_str) {
         snprintf(hexbuf, 7 + 1, "#%06x", aep.rgb_bg_color);


### PR DESCRIPTION
*Presumably* Fixes: https://github.com/neovim/neovim/issues/27611
I say presumably, because i guessed since last time (https://github.com/neovim/neovim/issues/6584) writing the color from an undefined highlight caused a similar issue, it might be the same problem.