### PR TITLE
vim-patch:9.1.0279: filetype: roc files are not recognized

### DIFF
--- a/runtime/ftplugin/roc.vim
+++ b/runtime/ftplugin/roc.vim
@@ -1,0 +1,14 @@
+" Roc filetype plugin file
+" Language: Roc
+" Maintainer: nat-418 <93013864+nat-418@users.noreply.github.com>
+" Latest Revision: 2024-04-5
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:##,:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setl com< cms<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -886,6 +886,7 @@ local extension = {
   Snw = 'rnoweb',
   robot = 'robot',
   resource = 'robot',
+  roc = 'roc',
   ron = 'ron',
   rsc = 'routeros',
   x = 'rpcgen',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -566,6 +566,7 @@ func s:GetFilenameChecks() abort
     \ 'rpgle': ['file.rpgle', 'file.rpgleinc'],
     \ 'robot': ['file.robot', 'file.resource'],
     \ 'robots': ['robots.txt'],
+    \ 'roc': ['file.roc'],
     \ 'ron': ['file.ron'],
     \ 'routeros': ['file.rsc'],
     \ 'rpcgen': ['file.x'],


### PR DESCRIPTION
Problem:  filetype: roc files are not recognized
Solution: Detect '*.roc' files as roc filetype,
          add a basic filetype plugin (nat-418)

closes: vim/vim#14416

https://github.com/vim/vim/commit/196b6678c5483217ea5bc7d047b02c915615dae6

Co-authored-by: nat-418 <93013864+nat-418@users.noreply.github.com>
