### PR TITLE
vim-patch:9.1.0275: filetype: R history files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1471,6 +1471,7 @@ local filename = {
   ['.pythonrc'] = 'python',
   SConstruct = 'python',
   qmldir = 'qmldir',
+  ['.Rhistory'] = 'r',
   ['.Rprofile'] = 'r',
   Rprofile = 'r',
   ['Rprofile.site'] = 'r',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -540,7 +540,7 @@ func s:GetFilenameChecks() abort
     \ 'qmldir': ['qmldir'],
     \ 'quake': ['anybaseq2/file.cfg', 'anyid1/file.cfg', 'quake3/file.cfg', 'baseq2/file.cfg', 'id1/file.cfg', 'quake1/file.cfg', 'some-baseq2/file.cfg', 'some-id1/file.cfg', 'some-quake1/file.cfg'],
     \ 'quarto': ['file.qmd'],
-    \ 'r': ['file.r', '.Rprofile', 'Rprofile', 'Rprofile.site'],
+    \ 'r': ['file.r', '.Rhistory', '.Rprofile', 'Rprofile', 'Rprofile.site'],
     \ 'racket': ['file.rkt', 'file.rktd', 'file.rktl'],
     \ 'radiance': ['file.rad', 'file.mat'],
     \ 'raku': ['file.pm6', 'file.p6', 'file.t6', 'file.pod6', 'file.raku', 'file.rakumod', 'file.rakudoc', 'file.rakutest'],


### PR DESCRIPTION
Problem:  filetype: R history files are not recognized
Solution: Detect '.Rhistory' files as r filetype
          (Wu, Zhenyu)

closes: vim/vim#14440

https://github.com/vim/vim/commit/fc21b6437ce91368c2d53437177083b8bc375720

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
