### PR TITLE
vim-patch:9.1.0277: Cannot highlight the Command-line

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4877,7 +4877,7 @@ MatchParen	Character under the cursor or just before it, if it
 							*hl-ModeMsg*
 ModeMsg		'showmode' message (e.g., "-- INSERT --").
 							*hl-MsgArea*
-MsgArea		Area for messages and cmdline.
+MsgArea		Area for messages and command-line, see also 'cmdheight'.
 							*hl-MsgSeparator*
 MsgSeparator	Separator for scrolled messages |msgsep|.
 							*hl-MoreMsg*

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -61,7 +61,7 @@
   "-:Conceal,B:SpellBad,P:SpellCap,R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel," \
   "[:PmenuKind,]:PmenuKindSel,{:PmenuExtra,}:PmenuExtraSel,x:PmenuSbar,X:PmenuThumb," \
   "*:TabLine,#:TabLineSel,_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn," \
-  "q:QuickFixLine,0:Whitespace,I:NormalNC"
+  "q:QuickFixLine,g:MsgArea,0:Whitespace,I:NormalNC"
 
 // Default values for 'errorformat'.
 // The "%f|%l| %m" one is used for when the contents of the quickfix window is

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -825,6 +825,24 @@ func Test_highlight_cmd_errors()
   let &t_fo = ""
 endfunc
 
+" Test for User group highlighting used in the statusline
+func Test_highlight_User()
+  CheckNotGui
+  hi User1 ctermfg=12
+  redraw!
+  call assert_equal('12', synIDattr(synIDtrans(hlID('User1')), 'fg'))
+  hi clear
+endfunc
+
+" Test for MsgArea highlighting
+func Test_highlight_MsgArea()
+  CheckNotGui
+  hi MsgArea ctermfg=20
+  redraw!
+  call assert_equal('20', synIDattr(synIDtrans(hlID('MsgArea')), 'fg'))
+  hi clear
+endfunc
+
 " Test for using RGB color values in a highlight group
 func Test_xxlast_highlight_RGB_color()
   CheckCanRunGui


### PR DESCRIPTION
#### vim-patch:9.1.0277: Cannot highlight the Command-line

Problem:  Cannot highlight the Command-line
Solution: Add the MsgArea highlighting group
          (Shougo Matsushita)

closes: vim/vim#14327

https://github.com/vim/vim/commit/be2b03c6eecea3eae5d460e3c19ee43b73b29928

Cherry-pick Test_highlight_User() from patch 8.2.1077.

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>