### PR TITLE
vim-patch:8.2.4395: some code lines not covered by tests

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -57,6 +57,8 @@ typedef int (*ex_unletlock_callback)(lval_T *, char *, exarg_T *, int);
 #define DICT_MAXNEST 100        // maximum nesting of lists and dicts
 
 static const char *e_letunexp = N_("E18: Unexpected characters in :let");
+static const char e_double_semicolon_in_list_of_variables[]
+  = N_("E452: Double ; in list of variables");
 static const char *e_lock_unlock = N_("E940: Cannot lock or unlock variable %s");
 static const char e_setting_v_str_to_value_with_wrong_type[]
   = N_("E963: Setting v:%s to value with wrong type");
@@ -541,7 +543,9 @@ const char *skip_var_list(const char *arg, int *var_count, int *semicolon, bool 
         break;
       } else if (*p == ';') {
         if (*semicolon == 1) {
-          emsg(_("E452: Double ; in list of variables"));
+          if (!silent) {
+            emsg(_(e_double_semicolon_in_list_of_variables));
+          }
           return NULL;
         }
         *semicolon = 1;


### PR DESCRIPTION
#### vim-patch:8.2.4395: some code lines not covered by tests

Problem:    Some code lines not covered by tests.
Solution:   Add a few more test cases.  Fix getting more than one error for
            invalid assignment.

https://github.com/vim/vim/commit/8b716f5f2204f938769de283d43bcb2f77d403e7

Co-authored-by: Bram Moolenaar <Bram@vim.org>