### PR TITLE
vim-patch:9.1.0283: Several small issues in doc and tests

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2059,7 +2059,7 @@ can use the "PANDOC=VIM" syntax. For example: >
 
 To use italics and strong in emphases. Default = 1 >
 
-	:let *g:pandoc#syntax#style#emphases = 1
+	:let g:pandoc#syntax#style#emphases = 1
 
 "0" will add "block" to g:pandoc#syntax#conceal#blacklist, because otherwise
 you couldn't tell where the styles are applied.

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -1777,10 +1777,12 @@ func Test_diff_eob_halfpage()
   5new
   call setline(1, ['']->repeat(10) + ['a'])
   diffthis
+  call assert_true(5, winheight(5))
   5new
   call setline(1, ['']->repeat(3) + ['a', 'b'])
   diffthis
   wincmd j
+  resize 7
   exe "norm! G\<C-D>"
   call assert_equal(6, line('w0'))
 


### PR DESCRIPTION
#### vim-patch:9.1.0283: Several small issues in doc and tests

Problem:  Wrong doc style for pandoc syntax description,
          Test_diff_eob_halfpage() may fail depending on
          screen size, using braces in highlight.c when
          not necessary
Solution: Fix pandoc documentation, make sure the window
          for the test has 7 lines, remove the braces.

https://github.com/vim/vim/commit/a040019be68859f0667ae475de8d67bb755596ed

Co-authored-by: Christian Brabandt <cb@256bit.org>