### PR TITLE
 feat(lua): add `vim.fs.mkdir`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2847,6 +2847,24 @@ vim.keymap.set({mode}, {lhs}, {rhs}, {opts})                *vim.keymap.set()*
 ==============================================================================
 Lua module: vim.fs                                                    *vim.fs*
 
+vim.fs.abspath({path}, {opts})                              *vim.fs.abspath()*
+    Convert path to an absolute path. Does not check if the path exists,
+    resolve symlinks or hardlinks (including `.` and `..`), or expand
+    environment variables. If the path is already absolute, it is returned
+    unchanged.
+
+    Parameters: ~
+      • {path}  (`string`) Path
+      • {opts}  (`table?`) Optional keyword arguments:
+                • {cwd}? (`string`, default: |current-directory|) Current
+                  working directory to use as the base for the relative path.
+                  This option is ignored for C:foo\bar style paths on Windows,
+                  as those paths use the current directory of the drive
+                  specified in the path.
+
+    Return: ~
+        (`string`) Absolute path
+
 vim.fs.basename({file})                                    *vim.fs.basename()*
     Return the basename of the given path
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2957,19 +2957,31 @@ vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
 vim.fs.normalize({path}, {opts})                          *vim.fs.normalize()*
     Normalize a path to a standard format. A tilde (~) character at the
     beginning of the path is expanded to the user's home directory and
-    environment variables are also expanded.
+    environment variables are also expanded. "." and ".." components are also
+    resolved, except when the path is relative and trying to resolve it would
+    result in an absolute path.
+    • "." as the only part in a relative path:
+      • "." => "."
+      • "././" => "."
+    • ".." when it leads outside the current directory
+      • "foo/../../bar" => "../bar"
+      • "../../foo" => "../../foo"
+    • ".." in the root directory returns the root directory.
+      • "/../../" => "/"
 
     On Windows, backslash (\) characters are converted to forward slashes (/).
 
     Examples: >lua
-        vim.fs.normalize('C:\\\\Users\\\\jdoe')
-        -- On Windows: 'C:/Users/jdoe'
-
-        vim.fs.normalize('~/src/neovim')
-        -- '/home/jdoe/src/neovim'
-
-        vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
-        -- '/Users/jdoe/.config/nvim/init.vim'
+        [[C:\Users\jdoe]]                         => "C:/Users/jdoe"
+        "~/src/neovim"                            => "/home/jdoe/src/neovim"
+        "$XDG_CONFIG_HOME/nvim/init.vim"          => "/Users/jdoe/.config/nvim/init.vim"
+        "~/src/nvim/api/../tui/./tui.c"           => "/home/jdoe/src/nvim/tui/tui.c"
+        "./foo/bar"                               => "foo/bar"
+        "foo/../../../bar"                        => "../../bar"
+        "/home/jdoe/../../../bar"                 => "/bar"
+        "C:foo/../../baz"                         => "C:../baz"
+        "C:/foo/../../baz"                        => "C:/baz"
+        [[\\?\UNC\server\share\foo\..\..\..\bar]] => "//?/UNC/server/share/bar"
 <
 
     Parameters: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2848,10 +2848,11 @@ vim.keymap.set({mode}, {lhs}, {rhs}, {opts})                *vim.keymap.set()*
 Lua module: vim.fs                                                    *vim.fs*
 
 vim.fs.abspath({path}, {opts})                              *vim.fs.abspath()*
-    Convert path to an absolute path. Does not check if the path exists,
-    resolve symlinks or hardlinks (including `.` and `..`), or expand
-    environment variables. If the path is already absolute, it is returned
-    unchanged.
+    Convert path to an absolute path. A tilde (~) character at the beginning
+    of the path is expanded to the user's home directory. Does not check if
+    the path exists, normalize the path, resolve symlinks or hardlinks
+    (including `.` and `..`), or expand environment variables. If the path is
+    already absolute, it is returned unchanged.
 
     Parameters: ~
       • {path}  (`string`) Path
@@ -2971,6 +2972,16 @@ vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
 
     Return: ~
         (`string`)
+
+vim.fs.mkdir({path}, {opts})                                  *vim.fs.mkdir()*
+    Create a directory at the given path. Does nothing if the path already
+    exists.
+
+    Parameters: ~
+      • {path}  (`string`) Path of the directory to create.
+      • {opts}  (`table?`) Optional keyword arguments:
+                • {parents}? (`boolean`, default: `false`) Recursively create
+                  parent directories if they don't exist.
 
 vim.fs.normalize({path}, {opts})                          *vim.fs.normalize()*
     Normalize a path to a standard format. A tilde (~) character at the

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -42,6 +42,7 @@
 #include "nvim/keycodes.h"
 #include "nvim/lua/converter.h"
 #include "nvim/lua/executor.h"
+#include "nvim/lua/fs.h"
 #include "nvim/lua/stdlib.h"
 #include "nvim/lua/treesitter.h"
 #include "nvim/macros_defs.h"
@@ -613,6 +614,9 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread, bool is_stan
   lua_pushvalue(lstate, -3);
   lua_setfield(lstate, -2, "luv");
   lua_pop(lstate, 3);
+
+  // internal vim._fs... API
+  nlua_add_fs(lstate);
 }
 
 static int nlua_module_preloader(lua_State *lstate)
@@ -1932,6 +1936,13 @@ static void nlua_add_treesitter(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 
   lua_pushcfunction(lstate, tslua_get_minimum_language_version);
   lua_setfield(lstate, -2, "_ts_get_minimum_language_version");
+}
+
+static void nlua_add_fs(lua_State *const lstate)
+  FUNC_ATTR_NONNULL_ALL
+{
+  lua_pushcfunction(lstate, fslua_get_drive_cwd);
+  lua_setfield(lstate, -2, "_fs_get_drive_cwd");
 }
 
 int nlua_expand_pat(expand_T *xp, char *pat, int *num_results, char ***results)

--- a/src/nvim/lua/fs.c
+++ b/src/nvim/lua/fs.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <lauxlib.h>
+#include <stdlib.h>
+
+#include "nvim/lua/fs.h"
+#include "nvim/vim_defs.h"
+
+#ifdef MSWIN
+// uncrustify:off
+# include <windows.h>  // NOLINT(llvm-include-order)
+# include <fileapi.h>
+// uncrustify:on
+#endif
+
+/// Get the current directory of a drive in Windows.
+int fslua_get_drive_cwd(lua_State *L)
+{
+#ifdef MSWIN
+  const char *drive = luaL_checkstring(L, 1);
+  assert(isupper(drive[0]) && drive[1] == ':' && drive[2] == '\0');
+
+  char buf[MAX_PATH];
+  size_t len = GetFullPathNameA(drive, sizeof(buf), buf, NULL);
+
+  lua_pushlstring(L, buf, len);
+  return 1;
+#else
+  luaL_error(L, "Drive CWD is only supported on Windows");
+  return 0;
+#endif
+}

--- a/src/nvim/lua/fs.h
+++ b/src/nvim/lua/fs.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <lua.h>  // IWYU pragma: keep
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "lua/fs.h.generated.h"
+#endif

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -424,4 +424,39 @@ describe('vim.fs', function()
       end)
     end)
   end)
+
+  describe('abspath', function()
+    local cwd = vim.uv.cwd()
+    local home = vim.uv.os_homedir()
+
+    it('works', function()
+      eq(cwd .. '/foo', vim.fs.abspath('foo'))
+      eq(cwd .. '/././foo', vim.fs.abspath('././foo'))
+      eq(cwd .. '/.././../foo', vim.fs.abspath('.././../foo'))
+    end)
+
+    it('works with absolute paths', function()
+      if is_os('win') then
+        eq([[C:\foo]], vim.fs.abspath([[C:\foo]]))
+        eq([[C:\foo\..\.]], vim.fs.abspath([[C:\foo\..\.]]))
+      else
+        eq('/foo/../.', vim.fs.abspath('/foo/../.'))
+        eq('/foo/bar', vim.fs.abspath('/foo/bar'))
+      end
+    end)
+
+    it('works with ~', function()
+      eq(home .. '/foo', vim.fs.abspath('~/foo'))
+      eq(home .. '/./.././foo', vim.fs.abspath('~/./.././foo'))
+    end)
+
+    if is_os('win') then
+      it('works with drive-specific cwd on Windows', function()
+        local cwd_drive = cwd:match('^%w:')
+        assert(cwd_drive ~= nil)
+
+        eq(cwd .. '/foo', vim.fs.abspath(cwd_drive .. 'foo'))
+      end)
+    end
+  end)
 end)


### PR DESCRIPTION
Problem: `vim.uv.fs_mkdir` does not allow recursively creating the directory structure. https://github.com/libuv/libuv/issues/923

Solution: Add `vim.fs.mkdir` which accepts a `parents` optional argument, which creates the directory structure recursively.

(Depends on #28203 and #28187)

TODO: Add tests