### PR TITLE
vim-patch:9.1.0287: Vim9: comment may be treated as heredoc start

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2576,10 +2576,14 @@ void ex_function(exarg_T *eap)
       //       and ":let [a, b] =<< [trim] EOF"
       arg = p;
       if (checkforcmd(&arg, "let", 2)) {
-        while (vim_strchr("$@&", *arg) != NULL) {
-          arg++;
+        int var_count = 0;
+        int semicolon = 0;
+        const char *argend = skip_var_list(arg, &var_count, &semicolon, true);
+        if (argend == NULL) {
+          // Invalid list assignment: skip to closing bracket.
+          argend = find_name_end(arg, NULL, NULL, FNE_INCL_BR);
         }
-        arg = skipwhite(find_name_end(arg, NULL, NULL, FNE_INCL_BR));
+        arg = skipwhite(argend);
         if (arg[0] == '=' && arg[1] == '<' && arg[2] == '<') {
           p = skipwhite(arg + 3);
           while (true) {

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -397,6 +397,42 @@ func Test_let_heredoc_fails()
     call assert_report('Caught exception: ' .. v:exception)
   endtry
 
+  try
+    let @- =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E730:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let [a b c] =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E475:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let [a; b; c] =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E452:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
   let text =<< trim END
   func WrongSyntax()
     let v =<< that there
@@ -568,6 +604,22 @@ insert
 append
 END
   call assert_equal(['change', 'insert', 'append'], [a, b, c])
+
+  " unpack assignment with semicolon
+  let [a; b] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', ['insert', 'append']], [a, b])
+
+  " unpack assignment with registers
+  let [@/, @", @-] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', 'insert', 'append'], [@/, @", @-])
 
   " curly braces name and list slice assignment
   let foo_3_bar = ['', '', '']


### PR DESCRIPTION
#### vim-patch:9.1.0287: Vim9: comment may be treated as heredoc start

Problem:  Vim9: comment may be treated as heredoc start.
          (Ernie Rael)
Solution: Use skip_var_list() instead of find_name_end().
          (zeertzjq)

closes: vim/vim#14446

https://github.com/vim/vim/commit/9a91d2b72c20f213bbf77f27b7edd01e0e43d5e0