### PR TITLE
vim-patch:e43ace558aee

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -266,8 +266,8 @@ syn match	vimEnddef	"\<enddef\>"
 
 if exists("g:vimsyn_folding") && g:vimsyn_folding =~# 'f'
  syn region	vimFuncFold	start="\<fu\%[nction]\>!\=\s*\%(<[sS][iI][dD]>\|[sg]:\)\=\%(\i\|[#.]\|{.\{-1,}}\)\+\s*("	end="\<endf\%[unction]\>" contains=vimFunction fold keepend transparent
- syn region	vimFuncFold	start="\<def\>!\=\s*\%(<[sS][iI][dD]>\|[sg]:\)\=\%(\i\|[#.]\|{.\{-1,}}\)\+("	end="\<enddef\>"	        contains=vimDef      fold keepend transparent
- syn region	vimFuncFold	start="\<def\s\+new\%(\i\|{.\{-1,}}\)\+("			end="\<enddef\>"	        contains=vimDef      fold keepend transparent
+ syn region	vimFuncFold	start="\<def\>!\=\s*\%(<[sS][iI][dD]>\|[sg]:\)\=\%(\i\|[#.]\)\+("		end="\<enddef\>"	        contains=vimDef      fold keepend transparent
+ syn region	vimFuncFold	start="\<def\s\+new\i\+("				end="\<enddef\>"	        contains=vimDef      fold keepend transparent
 endif
 
 syn match	vimFuncVar   contained	"a:\%(\K\k*\|\d\+\)\>"


### PR DESCRIPTION
#### vim-patch:e43ace558aee

runtime(vim): Update base-syntax, no curly-brace names in Vim9 script (vim/vim#14466)

Remove curly-brace name matching for :def functions.  This is not
supported in Vim9 script.

https://github.com/vim/vim/commit/e43ace558aee904f5ebb805daed763961bdbccde

Co-authored-by: dkearns <dougkearns@gmail.com>