### PR TITLE
fix(treesitter): use tree range instead of tree root node range

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1100,7 +1100,14 @@ end
 ---@param range Range
 ---@return boolean
 local function tree_contains(tree, range)
-  return Range.contains({ tree:root():range() }, range)
+  local tree_ranges = tree:included_ranges(false)
+
+  return Range.contains({
+    tree_ranges[1][1],
+    tree_ranges[1][2],
+    tree_ranges[#tree_ranges][3],
+    tree_ranges[#tree_ranges][4],
+  }, range)
 end
 
 --- Determines whether {range} is contained in the |LanguageTree|.

--- a/test/functional/lua/comment_spec.lua
+++ b/test/functional/lua/comment_spec.lua
@@ -495,22 +495,21 @@ describe('commenting', function()
     it("recomputes local 'commentstring' based on cursor position", function()
       setup_treesitter()
       local lines = {
+        '  print(1)',
         'lua << EOF',
         '  print(1)',
         'EOF',
       }
       set_lines(lines)
 
-      -- Vimscript's tree-sitter grammar is (currently) written in a way that Lua's
-      -- injection really starts at the first non-blank character
-      set_cursor(2, 1)
+      set_cursor(1, 1)
       feed('gc_')
-      eq(get_lines()[2], '  "print(1)')
+      eq(get_lines()[1], '  "print(1)')
 
       set_lines(lines)
-      set_cursor(2, 2)
+      set_cursor(3, 2)
       feed('.')
-      eq(get_lines()[2], '  -- print(1)')
+      eq(get_lines()[3], '  -- print(1)')
     end)
 
     it('preserves marks', function()

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -120,6 +120,20 @@ describe('treesitter language API', function()
     eq('<node translation_unit>', exec_lua('return tostring(tree:root())'))
   end)
 
+  it('retrieve the tree given a range when range is out of bounds relative to buffer', function()
+    insert([[
+      int main() {
+        int x = 3;
+      }]])
+
+    exec_lua([[
+      langtree = vim.treesitter.get_parser(0, "c")
+      tree = langtree:tree_for_range({10, 10, 10, 10})
+    ]])
+
+    eq('<node translation_unit>', exec_lua('return tostring(tree:root())'))
+  end)
+
   it('retrieve the node given a range', function()
     insert([[
       int main() {


### PR DESCRIPTION
The tree's root node's range may not equal the tree's range.

Code that shows that root node range is not equal to tree range:
~~~lua
local parser=vim.treesitter.get_string_parser('```lua\n\n```\n','markdown')
parser:parse(true)
vim.print({parser:children().lua:trees()[1]:root():range()})
vim.print(parser:children().lua:trees()[1]:included_ranges(false))
~~~