### PR TITLE
vim-patch:9.1.{0225, 0300}

### DIFF
--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4247,4 +4247,14 @@ func Test_halfpage_scrolloff_eob()
   bwipe!
 endfunc
 
+" Test for Ctrl-U/D moving the cursor at the buffer boundaries.
+func Test_halfpage_cursor_startend()
+  call setline(1, range(1, 100))
+  exe "norm! jztj\<C-U>"
+  call assert_equal(1, line('.'))
+  exe "norm! G\<C-Y>k\<C-D>"
+  call assert_equal(100, line('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
**vim-patch:9.1.0300: Missing test for what patch v9.1.0285 fixes**

Problem:  Missing test for what patch v9.1.0285 fixes
Solution: Add a test for cursor movement at buffer boundaries.
          (Luuk van Baal)

https://github.com/vim/vim/commit/aa8e22b035dd669cb47c9237f9c9a917ec6a0ec4

**vim-patch:9.1.0225: test_matchparen not run in CI**

Problem:  test_matchparen not run in CI
Solution: add test_matchparen.res to NEW_TESTS_RES in Makefile,
          update changed highlighting dump from v9.1.61

https://github.com/vim/vim/commit/059aeac2be1a0d30ff80751215794457c1ef1589

Changes N/A and test result was restored in patch 9.1.0258 (included in #28160).