### PR TITLE
vim-patch:9.1.0301: Vim9: heredoc start may be recognized in string

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2578,13 +2578,11 @@ void ex_function(exarg_T *eap)
       if (checkforcmd(&arg, "let", 2)) {
         int var_count = 0;
         int semicolon = 0;
-        const char *argend = skip_var_list(arg, &var_count, &semicolon, true);
-        if (argend == NULL) {
-          // Invalid list assignment: skip to closing bracket.
-          argend = find_name_end(arg, NULL, NULL, FNE_INCL_BR);
+        arg = (char *)skip_var_list(arg, &var_count, &semicolon, true);
+        if (arg != NULL) {
+          arg = skipwhite(arg);
         }
-        arg = skipwhite(argend);
-        if (arg[0] == '=' && arg[1] == '<' && arg[2] == '<') {
+        if (arg != NULL && strncmp(arg, "=<<", 3) == 0) {
           p = skipwhite(arg + 3);
           while (true) {
             if (strncmp(p, "trim", 4) == 0) {

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -410,10 +410,16 @@ func Test_let_heredoc_fails()
   endtry
 
   try
+    let [] =<< trim TEXT
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E475:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
     let [a b c] =<< trim TEXT
-      change
-      insert
-      append
     TEXT
     call assert_report('No exception thrown')
   catch /E475:/
@@ -423,9 +429,6 @@ func Test_let_heredoc_fails()
 
   try
     let [a; b; c] =<< trim TEXT
-      change
-      insert
-      append
     TEXT
     call assert_report('No exception thrown')
   catch /E452:/


### PR DESCRIPTION
#### vim-patch:9.1.0301: Vim9: heredoc start may be recognized in string

Problem:  Vim9: heredoc start may be recognized in string.
Solution: Don't skip to closing bracket for invalid list assignment.
          (zeertzjq)

closes: vim/vim#14472

https://github.com/vim/vim/commit/1817ccdb107ceeaf5c48fe193da5146682c15ca6