### PR TITLE
vim-patch:04e5363b8238

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
-" Language:	Vim
-" Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Language:		Vim
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Last Change:		2024 Apr 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -50,7 +50,7 @@ setlocal isk+=#
 setlocal keywordprg=:help
 
 " Comments starts with # in Vim9 script.  We have to guess which one to use.
-if "\n" .. getline(1, 10)->join("\n") =~# '\n\s*vim9\%[script]\>'
+if "\n" .. getline(1, 32)->join("\n") =~# '\n\s*vim9\%[script]\>'
   setlocal commentstring=#%s
 else
   setlocal commentstring=\"%s


### PR DESCRIPTION
#### vim-patch:04e5363b8238

runtime(vim): Improve Vim9 and legacy-script comment highlighting (vim/vim#13104)

This is a first-pass attempt to limit matching of Vim9 and legacy-script
comments to the appropriate syntactic contexts.

Vim9-script comments are highlighted at top level in a Vim9-script file,
in all :def functions, and in all :autocmd and :commmand command blocks.
Legacy-script comments are highlighted at top level in a legacy script
file, in all :func functions and in the Vim9-script preamble before the
:vim9script marker command.

https://github.com/vim/vim/commit/04e5363b823827f144409df011376d00ea6df750

Co-authored-by: dkearns <dougkearns@gmail.com>