### PR TITLE
test: fix off-by-one test IDs in logs

### DIFF
--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -3,7 +3,6 @@
 -- for more information about this.
 local t = require('test.functional.testutil')(nil)
 require('test.functional.ui.screen')
-local busted = require('busted')
 local is_os = t.is_os
 
 if is_os('win') then
@@ -14,26 +13,3 @@ if is_os('win') then
   ]]
   ffi.C._set_fmode(0x8000)
 end
-
-local testid = (function()
-  local id = 0
-  return function()
-    id = id + 1
-    return id
-  end
-end)()
-
--- Global before_each. https://github.com/Olivine-Labs/busted/issues/613
-local function before_each(_element, _parent)
-  local id = ('T%d'):format(testid())
-  _G._nvim_test_id = id
-  return nil, true
-end
-busted.subscribe({ 'test', 'start' }, before_each, {
-  -- Ensure our --helper is handled before --output (see busted/runner.lua).
-  priority = 1,
-  -- Don't generate a test-id for skipped tests. /shrug
-  predicate = function(element, _, status)
-    return not (element.descriptor == 'pending' or status == 'pending')
-  end,
-})

--- a/test/functional/testutil.lua
+++ b/test/functional/testutil.lua
@@ -1022,11 +1022,29 @@ function module.mkdir_p(path)
   return os.execute((is_os('win') and 'mkdir ' .. path or 'mkdir -p ' .. path))
 end
 
+local testid = (function()
+  local id = 0
+  return function()
+    id = id + 1
+    return id
+  end
+end)()
+
 return function()
   local g = getfenv(2)
 
   --- @type function?
+  local before_each = g.before_each
+  --- @type function?
   local after_each = g.after_each
+
+  if before_each then
+    before_each(function()
+      local id = ('T%d'):format(testid())
+      _G._nvim_test_id = id
+      return nil, true
+    end)
+  end
 
   if after_each then
     after_each(function()


### PR DESCRIPTION
Run the global before_each() before all other before_each(), so that
clear() uses the test ID of the current test, not the previous one.