### PR TITLE
fix(diagnostic): filter diagnostic by using end_lnum

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -373,7 +373,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
     Fields: ~
       • {namespace}?  (`integer[]|integer`) Limit diagnostics to one or more
                       namespaces.
-      • {lnum}?       (`integer`) Limit diagnostics to the given line number.
+      • {lnum}?       (`integer`) Limit diagnostics to those spanning the
+                      specified line number.
       • {severity}?   (`vim.diagnostic.SeverityFilter`) See
                       |diagnostic-severity|.
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -706,7 +706,7 @@ local function get_diagnostics(bufnr, opts, clamp)
   ---@param b integer
   ---@param d vim.Diagnostic
   local function add(b, d)
-    if not opts.lnum or d.lnum == opts.lnum then
+    if not opts.lnum or (opts.lnum >= d.lnum and opts.lnum <= (d.end_lnum or d.lnum)) then
       if clamp and api.nvim_buf_is_loaded(b) then
         local line_count = buf_line_count[b] - 1
         if
@@ -1129,7 +1129,7 @@ end
 --- Limit diagnostics to one or more namespaces.
 --- @field namespace? integer[]|integer
 ---
---- Limit diagnostics to the given line number.
+--- Limit diagnostics to those spanning the specified line number.
 --- @field lnum? integer
 ---
 --- See |diagnostic-severity|.

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1014,13 +1014,13 @@ describe('vim.diagnostic', function()
 
     it('allows filtering by line', function()
       eq(
-        1,
+        2,
         exec_lua [[
         vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
           make_error("Error 1", 1, 1, 1, 5),
           make_warning("Warning on Server 1", 1, 1, 2, 3),
           make_info("Ignored information", 1, 1, 2, 3),
-          make_error("Error On Other Line", 2, 1, 1, 5),
+          make_error("Error On Other Line", 3, 1, 3, 5),
         })
 
         return #vim.diagnostic.get(diagnostic_bufnr, {lnum = 2})
@@ -1130,13 +1130,16 @@ describe('vim.diagnostic', function()
 
     it('allows filtering by line', function()
       eq(
-        exec_lua [[return { [vim.diagnostic.severity.ERROR] = 1 }]],
+        exec_lua [[return {
+          [vim.diagnostic.severity.WARN] = 1,
+          [vim.diagnostic.severity.INFO] = 1,
+        }]],
         exec_lua [[
           vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
             make_error("Error 1", 1, 1, 1, 5),
             make_warning("Warning on Server 1", 1, 1, 2, 3),
             make_info("Ignored information", 1, 1, 2, 3),
-            make_error("Error On Other Line", 2, 1, 1, 5),
+            make_error("Error On Other Line", 3, 1, 3, 5),
           })
 
           return vim.diagnostic.count(diagnostic_bufnr, {lnum = 2})


### PR DESCRIPTION
Problem: opts.lnum in vim.diagnostic.get doesn't support using end_lnum.

Solution: add end_lnum support.


fix #21541 