### PR TITLE
fix(defaults): auto-close terminal for &shell with args

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -174,7 +174,7 @@ do
       end
       local info = vim.api.nvim_get_chan_info(vim.bo[args.buf].channel)
       local argv = info.argv or {}
-      if #argv == 1 and argv[1] == vim.o.shell then
+      if table.concat(argv, ' ') == vim.o.shell then
         vim.api.nvim_buf_delete(args.buf, { force = true })
       end
     end,


### PR DESCRIPTION
Problem:
The `:terminal` auto-close logic does not support `&shell` that has arguments, e.g., `/bin/bash -O globstar`.

Solution:
Join `argv` and match `&shell`. This is not perfect since `&shell` may contain irregular spaces and quotes, but it seems to be good enough.