### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/asm.vim
+++ b/runtime/ftplugin/asm.vim
@@ -1,13 +1,23 @@
 " Vim filetype plugin file
 " Language:	asm
 " Maintainer:	Colin Caine <cmcaine at the common googlemail domain>
-" Last Change:  23 May 2020
+" Last Change:	2020 May 23
 " 		2023 Aug 28 by Vim Project (undo_ftplugin)
+" 		2024 Apr 09 by Vim Project (add Matchit support)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
+setl include=^\\s*%\\s*include
 setl comments=:;,s1:/*,mb:*,ex:*/,://
 setl commentstring=;%s
 
-let b:undo_ftplugin = "setl commentstring< comments<"
+let b:undo_ftplugin = "setl commentstring< comments< include<"
+
+" Matchit support
+if !exists('b:match_words')
+  let b:match_skip = 's:comment\|string\|character\|special'
+  let b:match_words = '^\s*%\s*if\%(\|num\|idn\|nidn\)\>:^\s*%\s*elif\>:^\s*%\s*else\>:^\s*%\s*endif\>,^\s*%\s*macro\>:^\s*%\s*endmacro\>,^\s*%\s*rep\>:^\s*%\s*endrep\>'
+  let b:match_ignorecase = 1
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:match_skip"
+endif

--- a/runtime/ftplugin/gdb.vim
+++ b/runtime/ftplugin/gdb.vim
@@ -1,12 +1,20 @@
 " Vim filetype plugin file
 " Language:	gdb
 " Maintainer:	Michaël Peeters <NOSPAMm.vim@noekeon.org>
-" Last Changed: 26 Oct 2017
+" Last Changed: 2017-10-26
+"               2024-04-10:	- add Matchit support (by Vim Project)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
 
 setlocal commentstring=#%s
+setlocal include=^\\s*source
 
 " Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal cms<"
+let b:undo_ftplugin = "setlocal cms< include<"
+
+" Matchit support
+if !exists('b:match_words')
+  let b:match_words = '\<\%(if\|while\|define\|document\)\>:\<else\>:\<end\>'
+  let b:undo_ftplugin ..= " | unlet! b:match_words"
+endif

--- a/runtime/indent/asm.vim
+++ b/runtime/indent/asm.vim
@@ -1,0 +1,28 @@
+" Vim indent file
+" Language:             asm
+" Maintainer:           Philip Jones <philj56@gmail.com>
+" Upstream:             https://github.com/philj56/vim-asm-indent
+" Latest Revision:      2017-07-01
+
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=s:getAsmIndent()
+setlocal indentkeys=<:>,!^F,o,O
+
+let b:undo_ftplugin .= "indentexpr< indentkeys<"
+
+function! s:getAsmIndent()
+  let line = getline(v:lnum)
+  let ind = shiftwidth()
+
+  " If the line is a label (starts with ':' terminated keyword), 
+  " then don't indent
+  if line =~ '^\s*\k\+:'
+    let ind = 0
+  endif
+
+  return ind
+endfunction


### PR DESCRIPTION
#### vim-patch:556c62165963

ftplugin(gdb): add matchit support

closes: vim/vim#14462

https://github.com/vim/vim/commit/556c62165963359f1b35f17a49913fc61c43f937

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>


#### vim-patch:27f17a6d3493

runtime(asm): add basic indent support

closes: vim/vim#14383

https://github.com/vim/vim/commit/27f17a6d3493f611f5bdc376217535f9c49b479b

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>


#### vim-patch:dbca7d80457d

ftplugin(asm): add Matchit support

closes: vim/vim#14461

Refer https://github.com/vim/vim/blob/master/runtime/ftplugin/masm.vim#L18-L29

https://github.com/vim/vim/commit/dbca7d80457d026f6d6a5cc7e916b94df0ca6e03

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>