### PR TITLE
fix(float): disable title on float when use minimal style

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -302,6 +302,9 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     restore_win_noblock(&switchwin, true);
   }
   if (tp && enter) {
+    if (fconfig.style == kWinStyleMinimal) {
+      win_float_ptitle_onoff(wp, NULL);
+    }
     goto_tabpage_win(tp, wp);
     tp = win_find_tabpage(wp);
   }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1297,6 +1297,9 @@ struct window_S {
   bool w_floating;                      ///< whether the window is floating
   bool w_float_is_info;                 // the floating window is info float
   WinConfig w_config;
+  // store p_title option value. disable title when on floating window and
+  // restore when switch to normal window.
+  bool saved_p_title;
 
   // w_fraction is the fractional row of the cursor within the window, from
   // 0 at the top row to FRACTION_MULT at the last row.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4893,6 +4893,7 @@ static void win_enter_ext(win_T *const wp, const int flags)
       }
     }
     apply_autocmds(EVENT_WINLEAVE, NULL, NULL, false, curbuf);
+    win_float_ptitle_onoff(curwin, wp);
     if (!win_valid(wp)) {
       return;
     }

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -17,6 +17,7 @@
 #include "nvim/mouse.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
+#include "nvim/option_vars.h"
 #include "nvim/optionstr.h"
 #include "nvim/pos_defs.h"
 #include "nvim/strings.h"
@@ -138,6 +139,20 @@ void win_set_minimal_style(win_T *wp)
   if (wp->w_p_stc != NULL && *wp->w_p_stc != NUL) {
     free_string_option(wp->w_p_stc);
     wp->w_p_stc = xstrdup("");
+  }
+}
+
+// save p_title when it enabled and restore before value
+// when switch to normal window.
+void win_float_ptitle_onoff(win_T *wp, win_T *new_win)
+{
+  if (p_title) {
+    wp->saved_p_title = p_title;
+    p_title = false;
+  }
+
+  if (new_win && !new_win->w_floating && wp->saved_p_title) {
+    p_title = wp->saved_p_title;
   }
 }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9229,6 +9229,12 @@ describe('float window', function()
     end)
   end
 
+  it('#title option switch between float and normal', function()
+    api.nvim_set_option_value('title', true, { scope = 'global'})
+    api.nvim_open_win(0, true, {relative = "editor", row = 0, col = 0, width = 5, height = 5})
+    eq(false, api.nvim_get_option_value('title', {scope = 'global'}))
+  end)
+
   describe('with ext_multigrid', function()
     with_ext_multigrid(true)
   end)


### PR DESCRIPTION
Problem: sometimes title in float win not make sense.

Solution: when float win create with minimal style disable title option



Fix #19380 