### PR TITLE
refactor(argedit): check duplicate and insert in correct index

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -637,9 +637,6 @@ list of the current window.
 			This is like using |:argadd| and then |:edit|.
 			Spaces in filenames have to be escaped with "\".
 			[count] is used like with |:argadd|.
-			If the current file cannot be |abandon|ed {name}s will
-			still be added to the argument list, but won't be
-			edited. No check for duplicates is done.
 			Also see |++opt| and |+cmd|.
 
 :[count]arga[dd] {name} ..			*:arga* *:argadd* *E479*

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -372,32 +372,32 @@ func Test_argedit()
   call assert_equal(['a', 'b'], argv())
   call assert_equal('b', expand('%:t'))
   argedit a
-  call assert_equal(['a', 'b', 'a'], argv())
+  call assert_equal(['a', 'b'], argv())
   call assert_equal('a', expand('%:t'))
   " When file name case is ignored, an existing buffer with only case
   " difference is re-used.
   argedit C D
   call assert_equal('C', expand('%:t'))
-  call assert_equal(['a', 'b', 'a', 'C', 'D'], argv())
+  call assert_equal(['a', 'C', 'D', 'b'], argv())
   argedit c
   if has('fname_case')
-    call assert_equal(['a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['a', 'C', 'D', 'b'], argv())
   endif
   0argedit x
   if has('fname_case')
-    call assert_equal(['x', 'a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['x', 'a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['x', 'a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['x', 'a', 'C', 'D', 'b'], argv())
   endif
   enew! | set modified
   call assert_fails('argedit y', 'E37:')
   argedit! y
   if has('fname_case')
-    call assert_equal(['x', 'y', 'y', 'a', 'b', 'a', 'C', 'c', 'D'], argv())
+    call assert_equal(['x', 'y', 'a', 'C', 'c', 'D', 'b'], argv())
   else
-    call assert_equal(['x', 'y', 'y', 'a', 'b', 'a', 'C', 'C', 'D'], argv())
+    call assert_equal(['x', 'y', 'a', 'C', 'D', 'b'], argv())
   endif
   %argd
   bwipe! C


### PR DESCRIPTION
Problem: 
1. when a filename already exists in the argument list, that entry should be edited. However, argedit does not check for duplicates and instead inserts a new one.  duplicate items not make sense in arglist.

2. it does work like argadd. For instance, in the test case Test_argedit,  after `argedit a` current file is `a`, then executing `argedit C D` should insert C and D after a. However, the expected result is `a b C D`, similar to the behavior observed with argadd in help doc where the current file is b: executing `:argadd x` results in the argument list `a b x c`.  `x` after current `b`.

Solution: Refactor argedit to avoid inserting duplicate items and to insert new items at the correct position.

Note breakchange. Not compatible with vim.  Maybe some discussion is needed. Does duplicate files items in arglist make any sense. i don't use arg relate command. but i see some issues both in vim/neovim. so i guess it make more confuse.

Fix #11705