### PR TITLE
vim-patch:3cb2b3776700

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -634,7 +634,10 @@ list of the current window.
 			Add {name}s to the argument list and edit it.
 			When {name} already exists in the argument list, this
 			entry is edited.
-			This is like using |:argadd| and then |:edit|.
+			This is like using |:argadd| and then |:edit| (with
+			the small exception that |:edit| does not change the
+			argument list, so the argument list pointer isn't
+			changed).
 			Spaces in filenames have to be escaped with "\".
 			[count] is used like with |:argadd|.
 			If the current file cannot be |abandon|ed {name}s will
@@ -653,12 +656,12 @@ list of the current window.
 			If the argument list is "a b c", and "b" is the
 			current argument, then these commands result in:
 				command		new argument list ~
-				:argadd x	a b x c
-				:0argadd x	x a b c
-				:1argadd x	a x b c
-				:$argadd x	a b c x
+				:argadd x	a  [b]  x  c
+				:0argadd x	x   a  [b] c
+				:1argadd x	a   x  [b] c
+				:$argadd x	a  [b]  c  x
 			And after the last one:
-				:+2argadd y	a b c x y
+				:+2argadd y	a  [b]  c  x  y
 			There is no check for duplicates, it is possible to
 			add a file to the argument list twice.  You can use
 			|:argdedupe| to fix it afterwards: >


### PR DESCRIPTION
#### vim-patch:3cb2b3776700

runtime(doc): clarify behaviour or :argadd and :argedit

related: vim/vim#14464

https://github.com/vim/vim/commit/3cb2b3776700988e0c9d4ea37d0b05e371e2bbfd

Co-authored-by: Christian Brabandt <cb@256bit.org>