### PR TITLE
vim-patch:6f585da00bda

### DIFF
--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -229,6 +229,14 @@ elseif ctu
   " endif
 endif
 
+" Check that all lines are no longer than 80 chars
+let overlong = search('\%>80v', 'n')
+if overlong > 0
+  echomsg "Lines should be wrapped at 80 columns"
+  if error == 0
+    let error = overlong
+  endif
+endif
 
 if error == 0
   " If all was OK restore the view.


### PR DESCRIPTION
#### vim-patch:6f585da00bda

Overlong translation files may cause repo to become "dirty"

Problem:  Overlong translation files may cause repo to become "dirty"
Solution: Add a test into check.vim to warn for lines being longer than
          80 virt columns

related: vim/vim#14490

https://github.com/vim/vim/commit/6f585da00bda333d079acf77fe8dd8e1019c987d

Co-authored-by: Christian Brabandt <cb@256bit.org>