### PR TITLE
vim-patch:fcbefe74f161

### DIFF
--- a/runtime/compiler/vimdoc.vim
+++ b/runtime/compiler/vimdoc.vim
@@ -1,0 +1,19 @@
+" Vim Compiler File
+" Language:             vimdoc
+" Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
+" Latest Revision:      2024-04-09
+"
+" you can get it by `pip install vimdoc` or the package manager of your distribution.
+
+if exists('b:current_compiler')
+  finish
+endif
+let b:current_compiler = 'vimdoc'
+
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
+
+CompilerSet makeprg=vimdoc
+
+let &cpoptions = s:save_cpoptions
+unlet s:save_cpoptions

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -15,6 +15,8 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
+compiler vimdoc
+
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()
     setl fo< isk< com< tw< commentstring< keywordprg<


### PR DESCRIPTION
#### vim-patch:fcbefe74f161

runtime(compiler): add vimdoc

closes: vim/vim#14459

https://github.com/google/vimdoc generates vim help files from vimscript files

https://github.com/vim/vim/commit/fcbefe74f1619dfd925033d83a6d233c686409d4

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>