### PR TITLE
fix(defaults): only repeat macro for each selected line if linewise

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -317,8 +317,8 @@ The following new APIs and features were added.
 
 • |nvim_input_mouse()| supports mouse buttons "x1" and "x2".
 
-• |v_Q-default| and |v_@-default| repeat a register for each line of a visual
-  selection.
+• |v_Q-default| and |v_@-default| repeat a register for each line of a linewise
+  visual selection.
 
 • |vim.diagnostic.count()| returns the number of diagnostics for a given
   buffer and/or namespace, by severity. This is a faster alternative to

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -149,8 +149,8 @@ q			Stops recording.
 @@			Repeat the previous @{0-9a-z":*} [count] times.
 
 							*v_@-default*
-{Visual}@{0-9a-z".=*+}	In Visual mode, execute the contents of the register
-{Visual}@@		but for each selected line.
+{Visual}@{0-9a-z".=*+}	In linewise Visual mode, execute the contents of the
+{Visual}@@		register for each selected line.
 			See |visual-repeat|, |default-mappings|.
 
 							*Q*
@@ -158,8 +158,8 @@ Q			Repeat the last recorded register [count] times.
 			See |reg_recorded()|.
 
 							*v_Q-default*
-{Visual}Q		In Visual mode, repeat the last recorded register for
-			each selected line.
+{Visual}Q		In linewise Visual mode, repeat the last recorded
+			register for each selected line.
 			See |visual-repeat|, |default-mappings|.
 
 							*:@*

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -366,15 +366,15 @@ one of the last commands to extend the highlighted text, the repeating will
 be applied up to the rightmost column of the longest line.  Any count passed
 to the `.` command is not used.
 
-Visual mode |default-mappings| "@" and "Q" can repeat commands in a register
-for all selected lines. See |v_@-default| and |v_Q-default| for details. For
-example, given the text:
+Visual mode |default-mappings| "@" and "Q" repeat a register for all selected
+lines if the selection is linewise.  See |v_@-default| and |v_Q-default| for
+details.  For example, given the text:
 
 	123(hello)321
 	456(world)654
 	456(NOT THIS)654
 
-With register "x" containing the commands `yi(VP`, Visually selecting the
+With register "x" containing the commands `yi(VP`, visually selecting the
 first two lines and typing `@x` produces:
 
 	hello

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -78,19 +78,20 @@ do
   --- See |&-default|
   vim.keymap.set('n', '&', ':&&<CR>', { desc = ':help &-default' })
 
-  --- Use Q in visual mode to execute a macro on each line of the selection. #21422
+  --- Use Q in Visual mode to execute a macro on each line of the selection. #21422
+  --- This only make sense in linewise Visual mode. #28287
   ---
   --- Applies to @x and includes @@ too.
   vim.keymap.set(
     'x',
     'Q',
-    ':normal! @<C-R>=reg_recorded()<CR><CR>',
-    { silent = true, desc = ':help v_Q-default' }
+    "mode() == 'V' ? ':normal! @<C-R>=reg_recorded()<CR><CR>' : 'Q'",
+    { silent = true, expr = true, desc = ':help v_Q-default' }
   )
   vim.keymap.set(
     'x',
     '@',
-    "':normal! @'.getcharstr().'<CR>'",
+    "mode() == 'V' ? ':normal! @'.getcharstr().'<CR>' : '@'",
     { silent = true, expr = true, desc = ':help v_@-default' }
   )
 

--- a/test/functional/editor/macro_spec.lua
+++ b/test/functional/editor/macro_spec.lua
@@ -131,43 +131,6 @@ helloFOO123
 helloFOO]]
   end)
 
-  -- XXX: does this really make sense?
-  it('can be replayed with @ in blockwise Visual mode', function()
-    insert [[
-hello
-hello
-hello]]
-    feed [[gg]]
-
-    feed [[qqAFOO<esc>qu]]
-    expect [[
-hello
-hello
-hello]]
-
-    feed [[qwA123<esc>qu]]
-    expect [[
-hello
-hello
-hello]]
-
-    feed [[<C-v>3j@q]]
-    expect [[
-helloFOO
-helloFOO
-helloFOO]]
-
-    feed [[gg<C-v>j@w]]
-    expect [[
-helloFOO123
-helloFOO123
-helloFOO]]
-  end)
-end)
-
-describe('macros without default mappings', function()
-  before_each(clear)
-
   it('can be recorded and replayed in Visual mode', function()
     insert('foo BAR BAR foo BAR foo BAR BAR BAR foo BAR BAR')
     feed('0vqifofRq')


### PR DESCRIPTION
As mentioned in #28287, repeating a macro for each selected line doesn't
really make sense in non-linewise Visual mode.

Fix #28287
