### PR TITLE
vim-patch:9.1.0302: filetype: blueprint files are not recognized

### DIFF
--- a/runtime/ftplugin/bp.vim
+++ b/runtime/ftplugin/bp.vim
@@ -1,0 +1,14 @@
+" Blueprint build system filetype plugin file
+" Language: Blueprint
+" Maintainer: Bruno BELANYI <bruno.vim@belanyi.fr>
+" Latest Revision: 2024-04-10
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=b:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -236,6 +236,7 @@ local extension = {
   bbclass = 'bitbake',
   bl = 'blank',
   blp = 'blueprint',
+  bp = 'bp',
   bsd = 'bsdl',
   bsdl = 'bsdl',
   bst = 'bst',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -127,6 +127,7 @@ func s:GetFilenameChecks() abort
     \ 'blade': ['file.blade.php'],
     \ 'blank': ['file.bl'],
     \ 'blueprint': ['file.blp'],
+    \ 'bp': ['Android.bp'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
     \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE', 'WORKSPACE.bzlmod'],


### PR DESCRIPTION
#### vim-patch:9.1.0302: filetype: blueprint files are not recognized

Problem:  filetype: blueprint files are not recognized
Solution: Detect '*.bp' files as blueprint files, add
          a minimal filetype plugin (Bruno Belanyi)

See: https://source.android.com/docs/setup/build

closes: vim/vim#14488

https://github.com/vim/vim/commit/6be7ef5bc734ce6045d6f919f1a8559a3fa7f2fd

Co-authored-by: Bruno BELANYI <bruno@belanyi.fr>