### PR TITLE
vim-patch:9.1.0304: filetype: cgdb config file is not recognized

### DIFF
--- a/runtime/ftplugin/cgdbrc.vim
+++ b/runtime/ftplugin/cgdbrc.vim
@@ -1,0 +1,21 @@
+" Vim filetype plugin file
+" Language:             cgdbrc
+" Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
+" Documentation:        https://cgdb.github.io/docs/Configuring-CGDB.html
+" Latest Revision:      2024-04-09
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:save_cpoptions = &cpoptions
+set cpoptions&vim
+
+let b:undo_ftplugin = 'setl com< cms<'
+
+setlocal commentstring=#%s
+setlocal comments=:#
+
+let &cpoptions = s:save_cpoptions
+unlet s:save_cpoptions

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1257,6 +1257,7 @@ local filename = {
   ['/etc/default/cdrdao'] = 'cdrdaoconf',
   ['/etc/defaults/cdrdao'] = 'cdrdaoconf',
   ['cfengine.conf'] = 'cfengine',
+  cgdbrc = 'cgdbrc',
   ['CMakeLists.txt'] = 'cmake',
   ['.alias'] = detect.csh,
   ['.cshrc'] = detect.csh,

--- a/runtime/syntax/cgdbrc.vim
+++ b/runtime/syntax/cgdbrc.vim
@@ -1,0 +1,16 @@
+" Vim syntax file
+" Language:             cgdbrc
+" Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
+" Documentation:        https://cgdb.github.io/docs/Configuring-CGDB.html
+" Latest Revision:      2024-04-09
+
+if exists('b:current_syntax')
+  finish
+endif
+let b:current_syntax = 'cgdbrc'
+
+runtime! syntax/vim.vim
+
+syn region cgdbComment		start="^\s*\#" skip="\\$" end="$" contains=@Spell
+
+highlight default link cgdbComment Comment

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -145,6 +145,7 @@ func s:GetFilenameChecks() abort
     \ 'cf': ['file.cfm', 'file.cfi', 'file.cfc'],
     \ 'cfengine': ['cfengine.conf'],
     \ 'cfg': ['file.hgrc', 'filehgrc', 'hgrc', 'some-hgrc'],
+    \ 'cgdbrc': ['cgdbrc'],
     \ 'ch': ['file.chf'],
     \ 'chaiscript': ['file.chai'],
     \ 'chaskell': ['file.chs'],


### PR DESCRIPTION
#### vim-patch:9.1.0304: filetype: cgdb config file is not recognized

Problem:  filetype: cgdb config file is not recognized
Solution: Detect cgdbrc files as cgdbrc filetype
          (Wu, Zhenyu)

closes: vim/vim#14458

https://github.com/vim/vim/commit/1492fe69037586b6c625d42205d77dd38ba51640

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>