### PR TITLE
fix(diagnostic): open_float on multi-line diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1679,7 +1679,7 @@ function M.open_float(opts, ...)
   if scope == 'line' then
     --- @param d vim.Diagnostic
     diagnostics = vim.tbl_filter(function(d)
-      return d.lnum == lnum
+      return lnum >= d.lnum and lnum <= d.end_lnum
     end, diagnostics)
   elseif scope == 'cursor' then
     -- LSP servers can send diagnostics with `end_col` past the length of the line

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2444,6 +2444,47 @@ describe('vim.diagnostic', function()
       ]]
       )
     end)
+
+    it('works for multi-line diagnostics #21949', function()
+      -- open float failed non diagnostic lnum
+      eq(
+        vim.NIL,
+        exec_lua [[
+        local diagnostics = {
+          make_error("Error in two lines lnum is 1 and end_lnum is 2", 1, 1, 2, 3),
+        }
+        local winids = {}
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        local _, winnr = vim.diagnostic.open_float(0, { header = false })
+        return winnr
+      ]]
+      )
+
+      -- can open a float window on lnum 1
+      eq(
+        { '1. Error in two lines lnum is 1 and end_lnum is 2' },
+        exec_lua [[
+        vim.api.nvim_win_set_cursor(0, {2, 0})
+        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
+        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]]
+      )
+
+      -- can open a float window on end_lnum 2
+      eq(
+        { '1. Error in two lines lnum is 1 and end_lnum is 2' },
+        exec_lua [[
+        vim.api.nvim_win_set_cursor(0, {3, 0})
+        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
+        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]]
+      )
+    end)
   end)
 
   describe('setloclist()', function()


### PR DESCRIPTION
Problem: when diagnostic have a range of line, open_float not work.

Solution: filter diagnsotic by a line number range.


Fix #21949