### PR TITLE
fix(lsp): check the markdown content is empty whic only wrapped by codeblock

### DIFF
--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -126,6 +126,38 @@ describe('vim.lsp.util', function()
     end)
   end)
 
+  describe('convert_input_to_markdown_lines', function()
+    it('correct input', function()
+      eq(
+        { 'test' },
+        exec_lua [[
+        local invalid_input = {kind = 'markdown', value = "test"}
+        return vim.lsp.util.convert_input_to_markdown_lines(invalid_input)
+      ]]
+      )
+    end)
+
+    it('empty value', function()
+      eq(
+        {},
+        exec_lua [[
+        local invalid_input = {kind = 'markdown', value = ""}
+        return vim.lsp.util.convert_input_to_markdown_lines(invalid_input)
+      ]]
+      )
+    end)
+
+    it('code fences with empty line', function()
+      eq(
+        {},
+        exec_lua [[
+        local invalid_input = {kind = 'markdown', value = "```\n\n```"}
+        return vim.lsp.util.convert_input_to_markdown_lines(invalid_input)
+      ]]
+      )
+    end)
+  end)
+
   describe('make_floating_popup_options', function()
     local function assert_anchor(anchor_bias, expected_anchor)
       local opts = exec_lua(


### PR DESCRIPTION
Problem: pylsp return  hover result be like only an empty line which wrapped by codeblock.

Solution: if it's only have an empty line wrapped by codeblock, does not show a float window


Fix #27956
