### PR TITLE
fix(contrib): nix flake dependencies

### DIFF
--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
As mentioned in this discussion:

https://github.com/neovim/neovim/discussions/27294

The Nix flake build in the `contrib` folder is currently failing. The discussion mentions that this is likely due to an incompatible `tree-sitter` version. A `nix flake update` resolves this issue bringing in later versions of the dependencies.

For those with nix tooling this can be verified by running:

```
nix run 'github:neovim/neovim?dir=contrib'
```

where you will get the following err:

```
$ nix run 'github:neovim/neovim?dir=contrib'                                               
error: builder for '/nix/store/lzjc50adxxxl21kq9ysgy4sijf78r0sj-neovim-unwrapped-8cca787.drv' failed with exit code 2;
       last 10 log lines:
       > void ts_query_cursor_set_match_limit(TSQueryCursor *, uint32_t);
       >      ^
       > 1 error generated.
       > make[2]: *** [src/nvim/CMakeFiles/nvim_bin.dir/build.make:3433: src/nvim/CMakeFiles/nvim_bin.dir/lua/treesitter.c.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > [ 69%] Building C object src/nvim/CMakeFiles/nvim_bin.dir/map_glyph_cache.c.o
       > [ 69%] Building C object src/nvim/CMakeFiles/nvim_bin.dir/mapping.c.o
       > [ 69%] Building C object src/nvim/CMakeFiles/nvim_bin.dir/mark.c.o
       > make[1]: *** [CMakeFiles/Makefile2:624: src/nvim/CMakeFiles/nvim_bin.dir/all] Error 2
       > make: *** [Makefile:156: all] Error 2
       For full logs, run 'nix log /nix/store/lzjc50adxxxl21kq9ysgy4sijf78r0sj-neovim-unwrapped-8cca787.drv'.
```

Whereas running:

```
nix run 'github:lxsymington/neovim?dir=contrib&ref=fix/contrib/nix-flake'
```

will enter you into a build of neovim