### PR TITLE
fix(move): check for filler lines properly

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2362,7 +2362,7 @@ static int get_scroll_overlap(Direction dir)
   }
 
   loff.lnum = dir == FORWARD ? curwin->w_botline : curwin->w_topline - 1;
-  loff.fill = win_get_fill(curwin, loff.lnum + dir == BACKWARD)
+  loff.fill = win_get_fill(curwin, loff.lnum + (dir == BACKWARD))
               - (dir == FORWARD ? curwin->w_filler_rows : curwin->w_topfill);
   loff.height = loff.fill > 0 ? 1 : plines_win_nofill(curwin, loff.lnum, true);
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4894,6 +4894,88 @@ if (h->n_buckets < new_n_buckets) { // expand
                                                         |
     ]])
   end)
+
+  it('works with full page scrolling #28390', function()
+    screen:try_resize(20, 8)
+    command('call setline(1, range(20))')
+    api.nvim_buf_set_extmark(0, ns, 10, 0, { virt_lines = {{{'VIRT1'}}, {{'VIRT2'}}} })
+    screen:expect([[
+      ^0                   |
+      1                   |
+      2                   |
+      3                   |
+      4                   |
+      5                   |
+      6                   |
+                          |
+    ]])
+    feed('<C-F>')
+    screen:expect([[
+      ^5                   |
+      6                   |
+      7                   |
+      8                   |
+      9                   |
+      10                  |
+      VIRT1               |
+                          |
+    ]])
+    feed('<C-F>')
+    screen:expect([[
+      ^10                  |
+      VIRT1               |
+      VIRT2               |
+      11                  |
+      12                  |
+      13                  |
+      14                  |
+                          |
+    ]])
+    feed('<C-F>')
+    screen:expect([[
+      ^13                  |
+      14                  |
+      15                  |
+      16                  |
+      17                  |
+      18                  |
+      19                  |
+                          |
+    ]])
+    feed('<C-B>')
+    screen:expect([[
+      10                  |
+      VIRT1               |
+      VIRT2               |
+      11                  |
+      12                  |
+      ^13                  |
+      14                  |
+                          |
+    ]])
+    feed('<C-B>')
+    screen:expect([[
+      5                   |
+      6                   |
+      7                   |
+      8                   |
+      9                   |
+      ^10                  |
+      VIRT1               |
+                          |
+    ]])
+    feed('<C-B>')
+    screen:expect([[
+      0                   |
+      1                   |
+      2                   |
+      3                   |
+      4                   |
+      5                   |
+      ^6                   |
+                          |
+    ]])
+  end)
 end)
 
 describe('decorations: signs', function()


### PR DESCRIPTION
vim-patch:9.1.0310: Filler lines not checked properly in get_scroll_overlap()

Fix #28290
