### PR TITLE
vim-patch:9.0.2180: POSIX function name in exarg causes issues

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2078,7 +2078,7 @@ void ex_loadkeymap(exarg_T *eap)
   char buf[KMAP_LLEN + 11];
   char *save_cpo = p_cpo;
 
-  if (!getline_equal(eap->getline, eap->cookie, getsourceline)) {
+  if (!getline_equal(eap->ea_getline, eap->cookie, getsourceline)) {
     emsg(_("E105: Using :loadkeymap not in a sourced file"));
     return;
   }
@@ -2094,7 +2094,7 @@ void ex_loadkeymap(exarg_T *eap)
 
   // Get each line of the sourced file, break at the end.
   while (true) {
-    char *line = eap->getline(0, eap->cookie, 0, true);
+    char *line = eap->ea_getline(0, eap->cookie, 0, true);
 
     if (line == NULL) {
       break;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -764,8 +764,8 @@ void fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, bool skip)
     return;
   }
 
-  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
-    evalarg->eval_getline = eap->getline;
+  if (getline_equal(eap->ea_getline, eap->cookie, getsourceline)) {
+    evalarg->eval_getline = eap->ea_getline;
     evalarg->eval_cookie = eap->cookie;
   }
 }
@@ -8203,7 +8203,7 @@ void ex_execute(exarg_T *eap)
         did_emsg = save_did_emsg;
       }
     } else if (eap->cmdidx == CMD_execute) {
-      do_cmdline(ga.ga_data, eap->getline, eap->cookie, DOCMD_NOWAIT|DOCMD_VERBOSE);
+      do_cmdline(ga.ga_data, eap->ea_getline, eap->cookie, DOCMD_NOWAIT|DOCMD_VERBOSE);
     }
   }
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2409,10 +2409,10 @@ void ex_function(exarg_T *eap)
       }
     } else {
       xfree(line_to_free);
-      if (eap->getline == NULL) {
+      if (eap->ea_getline == NULL) {
         theline = getcmdline(':', 0, indent, do_concat);
       } else {
-        theline = eap->getline(':', eap->cookie, indent, do_concat);
+        theline = eap->ea_getline(':', eap->cookie, indent, do_concat);
       }
       line_to_free = theline;
     }
@@ -2433,7 +2433,7 @@ void ex_function(exarg_T *eap)
     }
 
     // Detect line continuation: SOURCING_LNUM increased more than one.
-    linenr_T sourcing_lnum_off = get_sourced_lnum(eap->getline, eap->cookie);
+    linenr_T sourcing_lnum_off = get_sourced_lnum(eap->ea_getline, eap->cookie);
     if (SOURCING_LNUM < sourcing_lnum_off) {
       sourcing_lnum_off -= SOURCING_LNUM;
     } else {

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -180,7 +180,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
   char *text_indent = NULL;
   char dot[] = ".";
 
-  if (eap->getline == NULL) {
+  if (eap->ea_getline == NULL) {
     emsg(_(e_cannot_use_heredoc_here));
     return NULL;
   }
@@ -247,7 +247,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
     int ti = 0;
 
     xfree(theline);
-    theline = eap->getline(NUL, eap->cookie, 0, false);
+    theline = eap->ea_getline(NUL, eap->cookie, 0, false);
     if (theline == NULL) {
       if (!script_get) {
         semsg(_("E990: Missing end marker '%s'"), marker);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2783,7 +2783,7 @@ void ex_append(exarg_T *eap)
         indent = get_indent_lnum(lnum);
       }
     }
-    if (eap->getline == NULL) {
+    if (eap->ea_getline == NULL) {
       // No getline() function, use the lines that follow. This ends
       // when there is no more.
       if (eap->nextcmd == NULL || *eap->nextcmd == NUL) {
@@ -2803,7 +2803,8 @@ void ex_append(exarg_T *eap)
       // Set State to avoid the cursor shape to be set to MODE_INSERT
       // state when getline() returns.
       State = MODE_CMDLINE;
-      theline = eap->getline(eap->cstack->cs_looplevel > 0 ? -1 : NUL, eap->cookie, indent, true);
+      theline = eap->ea_getline(eap->cstack->cs_looplevel > 0 ? -1 : NUL,
+                                eap->cookie, indent, true);
       State = save_State;
     }
     lines_left = Rows - 1;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -620,7 +620,7 @@ void ex_listdo(exarg_T *eap)
       i++;
       // execute the command
       if (execute) {
-        do_cmdline(eap->arg, eap->getline, eap->cookie, DOCMD_VERBOSE + DOCMD_NOWAIT);
+        do_cmdline(eap->arg, eap->ea_getline, eap->cookie, DOCMD_VERBOSE + DOCMD_NOWAIT);
       }
 
       if (eap->cmdidx == CMD_bufdo) {

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -167,8 +167,8 @@ struct exarg {
   int bad_char;                 ///< BAD_KEEP, BAD_DROP or replacement byte
   int useridx;                  ///< user command index
   char *errmsg;                 ///< returned error message
-  LineGetter getline;           ///< Function used to get the next line
-  void *cookie;                 ///< argument for getline()
+  LineGetter ea_getline;        ///< function used to get the next line
+  void *cookie;                 ///< argument for ea_getline()
   cstack_T *cstack;             ///< condition stack for ":if" etc.
 };
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4587,7 +4587,7 @@ char *script_get(exarg_T *const eap, size_t *const lenp)
 {
   char *cmd = eap->arg;
 
-  if (cmd[0] != '<' || cmd[1] != '<' || eap->getline == NULL) {
+  if (cmd[0] != '<' || cmd[1] != '<' || eap->ea_getline == NULL) {
     *lenp = strlen(eap->arg);
     return eap->skip ? NULL : xmemdupz(eap->arg, *lenp);
   }

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2733,7 +2733,7 @@ void ex_scriptencoding(exarg_T *eap)
   struct source_cookie *sp;
   char *name;
 
-  if (!getline_equal(eap->getline, eap->cookie, getsourceline)) {
+  if (!getline_equal(eap->ea_getline, eap->cookie, getsourceline)) {
     emsg(_("E167: :scriptencoding used outside of a sourced file"));
     return;
   }
@@ -2745,7 +2745,7 @@ void ex_scriptencoding(exarg_T *eap)
   }
 
   // Setup for conversion from the specified encoding to 'encoding'.
-  sp = (struct source_cookie *)getline_cookie(eap->getline, eap->cookie);
+  sp = (struct source_cookie *)getline_cookie(eap->ea_getline, eap->cookie);
   convert_setup(&sp->conv, name, p_enc);
 
   if (name != eap->arg) {
@@ -2756,7 +2756,7 @@ void ex_scriptencoding(exarg_T *eap)
 /// ":finish": Mark a sourced file as finished.
 void ex_finish(exarg_T *eap)
 {
-  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
+  if (getline_equal(eap->ea_getline, eap->cookie, getsourceline)) {
     do_finish(eap, false);
   } else {
     emsg(_("E168: :finish used outside of a sourced file"));
@@ -2769,7 +2769,7 @@ void ex_finish(exarg_T *eap)
 void do_finish(exarg_T *eap, bool reanimate)
 {
   if (reanimate) {
-    ((struct source_cookie *)getline_cookie(eap->getline,
+    ((struct source_cookie *)getline_cookie(eap->ea_getline,
                                             eap->cookie))->finished = false;
   }
 
@@ -2782,7 +2782,7 @@ void do_finish(exarg_T *eap, bool reanimate)
     eap->cstack->cs_pending[idx] = CSTP_FINISH;
     report_make_pending(CSTP_FINISH, NULL);
   } else {
-    ((struct source_cookie *)getline_cookie(eap->getline,
+    ((struct source_cookie *)getline_cookie(eap->ea_getline,
                                             eap->cookie))->finished = true;
   }
 }

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1724,7 +1724,7 @@ int do_ucmd(exarg_T *eap, bool preview)
     save_current_sctx = current_sctx;
     current_sctx.sc_sid = cmd->uc_script_ctx.sc_sid;
   }
-  do_cmdline(buf, eap->getline, eap->cookie,
+  do_cmdline(buf, eap->ea_getline, eap->cookie,
              DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED);
 
   // Careful: Do not use "cmd" here, it may have become invalid if a user


### PR DESCRIPTION
#### vim-patch:9.0.2180: POSIX function name in exarg causes issues

Problem:  POSIX function name in exarg struct causes issues
          on OpenVMS
Solution: Rename getline member in exarg struct to ea_getline,
          remove isinf() workaround for VMS

There are compilers that do not treat well POSIX functions - like
getline - usage in the structs.

Older VMS compilers could digest this... but the newer OpenVMS compilers
( like VSI C x86-64 X7.4-843 (GEM 50XB9) ) cannot deal with these
structs. This could be limited to getline() that is defined via
getdelim() and might not affect all POSIX functions in general - but
avoiding POSIX function names usage in the structs is a "safe side"
practice without compromising the functionality or the code readability.

The previous OpenVMS X86 port used a workaround limiting the compiler
capabilities using __CRTL_VER_OVERRIDE=80400000
In order to make the OpenVMS port future proof, this pull request
proposes a possible solution.

closes: vim/vim#13704

https://github.com/vim/vim/commit/6fdb6280821a822768df5689a5d727e37d38306c

Co-authored-by: Zoltan Arpadffy <zoltan.arpadffy@gmail.com>