### PR TITLE
fix(path): check return value of append_path()

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -375,7 +375,7 @@ static bool is_executable_in_path(const char *name, char **abspath)
 
     // Combine the $PATH segment with `name`.
     xstrlcpy(buf, p, (size_t)(e - p) + 1);
-    append_path(buf, name, buf_len);
+    (void)append_path(buf, name, buf_len);
 
 #ifdef MSWIN
     if (is_executable_ext(buf, abspath)) {

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2301,7 +2301,9 @@ int path_full_dir_name(char *directory, char *buffer, size_t len)
       retval = FAIL;
     } else {
       xstrlcpy(buffer, old_dir, len);
-      append_path(buffer, directory, len);
+      if (append_path(buffer, directory, len) == FAIL) {
+        retval = FAIL;
+      }
     }
   } else if (os_dirname(buffer, len) == FAIL) {
     // Do not return immediately since we are in the wrong directory.

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -413,12 +413,15 @@ describe('path.c', function()
     end)
 
     itp('fails and uses filename if given filename contains non-existing directory', function()
-      local filename = 'non_existing_dir/test.file'
-      local buflen = string.len(filename) + 1
-      local do_expand = 1
-      local buf, result = vim_FullName(filename, buflen, do_expand)
-      eq(filename, ffi.string(buf))
-      eq(FAIL, result)
+      -- test with different filename lengths
+      for rep = 1, 10 do
+        local filename = ('non_existing_'):rep(rep) .. 'dir/test.file'
+        local buflen = string.len(filename) + 1
+        local do_expand = 1
+        local buf, result = vim_FullName(filename, buflen, do_expand)
+        eq(filename, ffi.string(buf))
+        eq(FAIL, result)
+      end
     end)
 
     itp('concatenates filename if it does not contain a slash', function()


### PR DESCRIPTION
If the filename passed to vim_FullName() is a relative directory, and does not exist, it is appended to the current working directory. Since the return value of append_path() was ignored, and if the buffer length was too small to fit getcwd() + dirname(filename), we would still try to append the basename(filename).

This was manifesting as a failure in test/unit/path_spec.lua in:
    itp('fails and uses filename if given filename contains non-existing directory', ..

This failure occurs when running the tests from directory with a short path such as: /work/src/nv

    test/unit/path_spec.lua:420: Expected objects to be the same.
    Passed in:
    (string) '/work/src/nv/test.file'
    Expected:
    (string) 'non_existing_dir/test.file'

This return value for the second call to append_path() to append basename(filename) was checked, and this is where it would fail for normal / longer getcwd()s.