### PR TITLE
vim-patch:9.1.{0312,0313}

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1045,13 +1045,27 @@ char *skiptowhite(const char *p)
   return (char *)p;
 }
 
+/// Skip over text until ' ' or '\t' or newline or NUL
+///
+/// @param[in]  p  Text to skip over.
+///
+/// @return Pointer to the next whitespace or newline or NUL character.
+char *skiptowhite_or_nl(const char *p)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
+{
+  while (*p != ' ' && *p != '\t' && *p != NL && *p != NUL) {
+    p++;
+  }
+  return (char *)p;
+}
+
 /// skiptowhite_esc: Like skiptowhite(), but also skip escaped chars
 ///
 /// @param p
 ///
 /// @return Pointer to the next whitespace character.
 char *skiptowhite_esc(const char *p)
-  FUNC_ATTR_PURE
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
 {
   while (*p != ' ' && *p != '\t' && *p != NUL) {
     if (((*p == '\\') || (*p == Ctrl_V)) && (*(p + 1) != NUL)) {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1045,20 +1045,6 @@ char *skiptowhite(const char *p)
   return (char *)p;
 }
 
-/// Skip over text until ' ' or '\t' or newline or NUL
-///
-/// @param[in]  p  Text to skip over.
-///
-/// @return Pointer to the next whitespace or newline or NUL character.
-char *skiptowhite_or_nl(const char *p)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
-{
-  while (*p != ' ' && *p != '\t' && *p != NL && *p != NUL) {
-    p++;
-  }
-  return (char *)p;
-}
-
 /// skiptowhite_esc: Like skiptowhite(), but also skip escaped chars
 ///
 /// @param p

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -179,8 +179,15 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
   int text_indent_len = 0;
   char *text_indent = NULL;
   char dot[] = ".";
+  bool heredoc_in_string = false;
+  char *line_arg = NULL;
+  char *nl_ptr = vim_strchr(cmd, '\n');
 
-  if (eap->ea_getline == NULL && vim_strchr(cmd, '\n') == NULL) {
+  if (nl_ptr != NULL) {
+    heredoc_in_string = true;
+    line_arg = nl_ptr + 1;
+    *nl_ptr = NUL;
+  } else if (eap->ea_getline == NULL) {
     emsg(_(e_cannot_use_heredoc_here));
     return NULL;
   }
@@ -217,17 +224,11 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
   }
 
   const char comment_char = '"';
-  bool heredoc_in_string = false;
-  char *line_arg = NULL;
   // The marker is the next word.
   if (*cmd != NUL && *cmd != comment_char) {
     marker = skipwhite(cmd);
-    char *p = skiptowhite_or_nl(marker);
-    if (*p == NL) {
-      // heredoc in a string
-      line_arg = p + 1;
-      heredoc_in_string = true;
-    } else if (*skipwhite(p) != NUL && *skipwhite(p) != comment_char) {
+    char *p = skiptowhite(marker);
+    if (*skipwhite(p) != NUL && *skipwhite(p) != comment_char) {
       semsg(_(e_trailing_arg), p);
       return NULL;
     }

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -713,6 +713,20 @@ END
   LINES
   call CheckScriptFailure(lines, 'E15:')
 
+  " Test for using heredoc in a single string using execute()
+  call assert_equal(["['one', 'two']"],
+    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x")->split("\n"))
+  call assert_equal(["['  one', '  two']"],
+    \ execute("let x =<< END\n  one\n  two\nEND\necho x")->split("\n"))
+  let cmd = 'execute("let x =<< END\n  one\n  two\necho x")'
+  call assert_fails(cmd, "E990: Missing end marker 'END'")
+  let cmd = 'execute("let x =<<\n  one\n  two\necho x")'
+  call assert_fails(cmd, "E990: Missing end marker ''")
+  let cmd = 'execute("let x =<< trim\n  one\n  two\necho x")'
+  call assert_fails(cmd, "E221: Marker cannot start with lower case letter")
+  let cmd = 'execute("let x =<< eval END\n  one\n  two{y}\nEND\necho x")'
+  call assert_fails(cmd, 'E121: Undefined variable: y')
+
   " skipped heredoc
   if 0
     let msg =<< trim eval END

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -542,6 +542,13 @@ END
   XX
   call assert_equal(['Line1'], var1)
 
+  let var1 =<< trim XX " comment
+    Line1
+      Line2
+    Line3
+  XX
+  call assert_equal(['Line1', '  Line2', 'Line3'], var1)
+
   " ignore "endfunc"
   let var1 =<< END
 something
@@ -714,15 +721,27 @@ END
   call CheckScriptFailure(lines, 'E15:')
 
   " Test for using heredoc in a single string using execute()
-  call assert_equal(["['one', 'two']"],
-    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x")->split("\n"))
-  call assert_equal(["['  one', '  two']"],
-    \ execute("let x =<< END\n  one\n  two\nEND\necho x")->split("\n"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x"))
+  call assert_equal("\n['one', '  two']",
+    \ execute("let x =<< trim END\n  one\n    two\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("  let x =<< trim END\n    one\n    two\n  END\necho x"))
+  call assert_equal("\n['one', '  two']",
+    \ execute("  let x =<< trim END\n    one\n      two\n  END\necho x"))
+  call assert_equal("\n['  one', '  two']",
+    \ execute("let x =<< END\n  one\n  two\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< END\none\ntwo\nEND\necho x"))
+  call assert_equal("\n['one', 'two']",
+    \ execute("let x =<< END \" comment\none\ntwo\nEND\necho x"))
   let cmd = 'execute("let x =<< END\n  one\n  two\necho x")'
   call assert_fails(cmd, "E990: Missing end marker 'END'")
   let cmd = 'execute("let x =<<\n  one\n  two\necho x")'
-  call assert_fails(cmd, "E990: Missing end marker ''")
+  call assert_fails(cmd, "E172: Missing marker")
   let cmd = 'execute("let x =<< trim\n  one\n  two\necho x")'
+  call assert_fails(cmd, "E172: Missing marker")
+  let cmd = 'execute("let x =<< end\n  one\n  two\nend\necho x")'
   call assert_fails(cmd, "E221: Marker cannot start with lower case letter")
   let cmd = 'execute("let x =<< eval END\n  one\n  two{y}\nEND\necho x")'
   call assert_fails(cmd, 'E121: Undefined variable: y')


### PR DESCRIPTION
#### vim-patch:9.1.0312: heredocs are not supported for :commands

Problem:  heredocs are not supported for :commands
          (balki)
Solution: Add heredoc support
          (Yegappan Lakshmanan)

closes: vim/vim#14528

https://github.com/vim/vim/commit/e74cad3321ce1dcefc1fc64f617511275b6cd930

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.0313: Crash when using heredoc with comment in command block

Problem:  Crash when using heredoc with comment in command block.
Solution: Handle a newline more like the end of the line, fix coverity
          warning (zeertzjq).

closes: vim/vim#14535

https://github.com/vim/vim/commit/1f5175d9af3d3f37e19f23e0e6f84caec47390f2