### PR TITLE
vim-patch:9.1.0311: filetype: Some config files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -283,6 +283,7 @@ local extension = {
   cbl = 'cobol',
   atg = 'coco',
   recipe = 'conaryrecipe',
+  ctags = 'conf',
   hook = function(path, bufnr)
     return M._getline(bufnr, 1) == '[Trigger]' and 'confini' or nil
   end,
@@ -1305,6 +1306,9 @@ local filename = {
   ['auto.master'] = 'conf',
   ['texdoc.cnf'] = 'conf',
   ['.x11vncrc'] = 'conf',
+  ['.chktexrc'] = 'conf',
+  ['.ripgreprc'] = 'conf',
+  ripgreprc = 'conf',
   ['configure.in'] = 'config',
   ['configure.ac'] = 'config',
   crontab = 'crontab',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -163,7 +163,7 @@ func s:GetFilenameChecks() abort
     \ 'cobol': ['file.cbl', 'file.cob', 'file.lib'],
     \ 'coco': ['file.atg'],
     \ 'conaryrecipe': ['file.recipe'],
-    \ 'conf': ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc'],
+    \ 'conf': ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     \ 'config': ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
     \ 'confini': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],


### PR DESCRIPTION
#### vim-patch:9.1.0311: filetype: Some config files are not recognized

Problem:  Some config files are not recognized
Solution: Add some patterns for chktex, ripgreprc and ctags config
          files.

See: https://www.nongnu.org/chktex/
See: https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file
See: https://docs.ctags.io/en/latest/option-file.html#order-of-loading-option-files

closes: vim/vim#14506

https://github.com/vim/vim/commit/a1dcd76ce791b5b8bd093765a99b71aa163300a5

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>