### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/dts.vim
+++ b/runtime/ftplugin/dts.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:             dts/dtsi (device tree files)
+" Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
+" Latest Revision:      2024 Apr 12
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = 'setl inc< cms< com<'
+
+setlocal include=^\\%(#include\\\|/include/\\)
+" same as C
+setlocal commentstring&
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://

--- a/runtime/ftplugin/kconfig.vim
+++ b/runtime/ftplugin/kconfig.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin file
 " Vim syntax file
-" Maintainer:           Christian Brabandt <cb@256bit.org>
-" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2015-05-29
-" License:              Vim (see :h license)
+" Maintainer:		Christian Brabandt <cb@256bit.org>
+" Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
+" Latest Revision:	2024-04-12
+" License:		Vim (see :h license)
 " Repository:		https://github.com/chrisbra/vim-kconfig
 
 if exists("b:did_ftplugin")
@@ -11,17 +11,12 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let s:cpo_save = &cpo
-set cpo&vim
+let b:undo_ftplugin = "setl inc< com< cms< fo<"
 
-let b:undo_ftplugin = "setl com< cms< fo<"
-
+setlocal include=source\\s\\+
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 " For matchit.vim
 if exists("loaded_matchit")
   let b:match_words = '^\<menu\>:\<endmenu\>,^\<if\>:\<endif\>,^\<choice\>:\<endchoice\>'
 endif
-
-let &cpo = s:cpo_save
-unlet s:cpo_save


### PR DESCRIPTION
#### vim-patch:159dc0fcf950

runtime(kconfig): add include to ftplugin (vim/vim#14524)

related: vim/vim#14521

https://github.com/vim/vim/commit/159dc0fcf950e6c21f97cc337bcf19ff90ce73c6

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:0549c503ba20

runtime(dts): include ftplugin support (vim/vim#14522)

https://github.com/vim/vim/commit/0549c503ba20345097a14122f0a18dde69d470c5

Co-authored-by: wzy <32936898+Freed-Wu@users.noreply.github.com>