### PR TITLE
feat(defaults): use ripgrep (rg) for 'grepprg' if available

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -370,6 +370,7 @@ The following changes to existing APIs or features add new behavior.
     correctly without it. (Use |gF| for filepaths suffixed with ":line:col").
   • 'comments' includes "fb:•".
   • 'shortmess' includes the "C" flag.
+  • 'grepprg' defaults to using ripgrep if available.
   • Automatic linting of treesitter query files (see |ft-query-plugin|).
     Can be disabled via: >lua
       vim.g.query_lint_on = {}

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2851,9 +2851,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This is a scanf-like string that uses the same format as the
 	'errorformat' option: see |errorformat|.
 
+	If ripgrep ('grepprg') is available, this option defaults to `%f:%l:%c:%m`.
+
 						*'grepprg'* *'gp'*
-'grepprg' 'gp'		string	(default "grep -n ",
-                                 Unix: "grep -n $* /dev/null")
+'grepprg' 'gp'		string	(default see below)
 			global or local to buffer |global-local|
 	Program to use for the |:grep| command.  This option may contain '%'
 	and '#' characters, which are expanded like when used in a command-
@@ -2870,6 +2871,16 @@ A jump table for the options with a short description can be found at |Q_op|.
 	apply equally to 'grepprg'.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
+	This option defaults to:
+	- `rg --vimgrep -uuu $* ...` if ripgrep is available (|:checkhealth|),
+	- `grep -n $* /dev/null` on Unix,
+	- `findstr /n $* nul` on Windows.
+	Ripgrep can perform additional filtering such as using .gitignore rules
+	and skipping hidden or binary files. This is disabled by default (see the -u option)
+	to more closely match the behaviour of standard grep.
+	You can make ripgrep match Vim's case handling using the
+	-i/--ignore-case and -S/--smart-case options.
+	An |OptionSet| autocmd can be used to set it up to match automatically.
 
 				*'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
 'guicursor' 'gcr'	string	(default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -52,6 +52,7 @@ Defaults					            *nvim-defaults*
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·,foldsep:│"
 - 'formatoptions' defaults to "tcqj"
+- 'grepprg' defaults to using ripgrep if available
 - 'hidden' is enabled
 - 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is enabled

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -383,6 +383,19 @@ local function check_terminal()
   end
 end
 
+local function check_external_tools()
+  health.start('External Tools')
+
+  if vim.fn.executable('rg') == 1 then
+    local rg = vim.fn.exepath('rg')
+    local cmd = 'rg -V'
+    local out = vim.fn.system(vim.fn.split(cmd))
+    health.ok(('%s (%s)'):format(vim.trim(out), rg))
+  else
+    health.warn('ripgrep not available')
+  end
+end
+
 function M.check()
   check_config()
   check_runtime()
@@ -390,6 +403,7 @@ function M.check()
   check_rplugin_manifest()
   check_terminal()
   check_tmux()
+  check_external_tools()
 end
 
 return M

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -486,3 +486,11 @@ if tty then
     end
   end
 end
+
+--- Default 'grepprg' to ripgrep if available.
+if vim.fn.executable('rg') == 1 then
+  -- Match :grep default, otherwise rg searches cwd by default
+  -- Use -uuu to make ripgrep not do its default filtering
+  vim.o.grepprg = 'rg --vimgrep -uuu $* ' .. (vim.fn.has('unix') == 1 and '/dev/null' or 'nul')
+  vim.o.grepformat = '%f:%l:%c:%m'
+end

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2625,6 +2625,8 @@ vim.go.gd = vim.go.gdefault
 --- This is a scanf-like string that uses the same format as the
 --- 'errorformat' option: see `errorformat`.
 ---
+--- If ripgrep ('grepprg') is available, this option defaults to `%f:%l:%c:%m`.
+---
 --- @type string
 vim.o.grepformat = "%f:%l:%m,%f:%l%m,%f  %l%m"
 vim.o.gfm = vim.o.grepformat
@@ -2649,6 +2651,16 @@ vim.go.gfm = vim.go.grepformat
 --- apply equally to 'grepprg'.
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
+--- This option defaults to:
+--- - `rg --vimgrep -uuu $* ...` if ripgrep is available (`:checkhealth`),
+--- - `grep -n $* /dev/null` on Unix,
+--- - `findstr /n $* nul` on Windows.
+--- Ripgrep can perform additional filtering such as using .gitignore rules
+--- and skipping hidden or binary files. This is disabled by default (see the -u option)
+--- to more closely match the behaviour of standard grep.
+--- You can make ripgrep match Vim's case handling using the
+--- -i/--ignore-case and -S/--smart-case options.
+--- An `OptionSet` autocmd can be used to set it up to match automatically.
 ---
 --- @type string
 vim.o.grepprg = "grep -n $* /dev/null"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3368,6 +3368,8 @@ return {
         Format to recognize for the ":grep" command output.
         This is a scanf-like string that uses the same format as the
         'errorformat' option: see |errorformat|.
+
+        If ripgrep ('grepprg') is available, this option defaults to `%f:%l:%c:%m`.
       ]=],
       full_name = 'grepformat',
       list = 'onecomma',
@@ -3382,8 +3384,7 @@ return {
         condition = 'MSWIN',
         if_false = 'grep -n $* /dev/null',
         if_true = 'findstr /n $* nul',
-        doc = [["grep -n ",
-           Unix: "grep -n $* /dev/null"]],
+        doc = [[see below]],
       },
       desc = [=[
         Program to use for the |:grep| command.  This option may contain '%'
@@ -3401,6 +3402,16 @@ return {
         apply equally to 'grepprg'.
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
+        This option defaults to:
+        - `rg --vimgrep -uuu $* ...` if ripgrep is available (|:checkhealth|),
+        - `grep -n $* /dev/null` on Unix,
+        - `findstr /n $* nul` on Windows.
+        Ripgrep can perform additional filtering such as using .gitignore rules
+        and skipping hidden or binary files. This is disabled by default (see the -u option)
+        to more closely match the behaviour of standard grep.
+        You can make ripgrep match Vim's case handling using the
+        -i/--ignore-case and -S/--smart-case options.
+        An |OptionSet| autocmd can be used to set it up to match automatically.
       ]=],
       expand = true,
       full_name = 'grepprg',


### PR DESCRIPTION
Discussed as an idea in https://github.com/neovim/neovim/discussions/28296.

Changes the defaults for `'grepprg'` and `'grepformat'` to use ripgrep and its `--vimgrep` mode, if available on the system.

Points discussed in the thread:

- Zero configuration: This PR provides a better default for an existing vim feature (`:grep`), which the user is free to configure themselves as needed. It adds no additional configuration settings or hooks.
- Low to zero maintenance: The change consists of a single `executable()` check and two option changes. It is very unlikely that ripgrep will experience breaking changes in its CLI that would necessitate adjusting the code or adding version checking.
- Performance: A basic benchmark (running a recursive, fixed string search on the neovim repository) shows significant performance improvements over GNU grep (few seconds vs <1 second).
- Precedence: Many popular plugins already integrate with ripgrep for searching, and ripgrep itself provides features specifically for integrating with vim (`--vimgrep` format, `--smart-case` option). This makes it a promising candidate for a place where Neovim can match the pulse of the community.

This is my first PR to adjust core Neovim code, as such there's a few points I am seeking feedback on:

- Is this change wanted? The discussion thread concluded that the change is promising, but may not be wanted by Neovim users.
- Is the documentation appropriate? I Added a small note to the documentation of `'grepprg'` that points the user toward ripgrep and why they may want to use it. Is it clear enough that this default only takes effect if the *user makes sure* that the `rg` binary is found by Neovim?
- Does this need extra testing? @clason mentioned a `:checkhealth` test, I'm unsure what that should look like.

I'm happy to make any necessary adjustments.