### PR TITLE
ci: enable unittests on macos-14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,6 @@ jobs:
             build: { flavor: tsan }
           - test: unittest
             build: { flavor: puc-lua }
-          - test: unittest
-            build: { runner: macos-14 } # unittests don't work on M1 #26145
           - test: oldtest
             build: { flavor: tsan }
     runs-on: ${{ matrix.build.runner }}

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -146,6 +146,9 @@ local function filter_complex_blocks(body)
         or string.find(line, 'value_init_')
         or string.find(line, 'UUID_NULL') -- static const uuid_t UUID_NULL = {...}
         or string.find(line, 'inline _Bool')
+        -- used by macOS headers
+        or string.find(line, 'typedef enum : ')
+        or string.find(line, 'mach_vm_range_recipe')
       )
     then
       result[#result + 1] = line


### PR DESCRIPTION
Fix the LuaJIT issues by filtering out lines that are too complex.

Then enable CI for macOS 14 on M1! 

This closes #26145.