### PR TITLE
vim-patch:9.1.0319: Using heredoc in string not tested with :execute

### DIFF
--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -720,31 +720,33 @@ END
   LINES
   call CheckScriptFailure(lines, 'E15:')
 
-  " Test for using heredoc in a single string using execute()
-  call assert_equal("\n['one', 'two']",
-    \ execute("let x =<< trim END\n  one\n  two\nEND\necho x"))
-  call assert_equal("\n['one', '  two']",
-    \ execute("let x =<< trim END\n  one\n    two\nEND\necho x"))
-  call assert_equal("\n['one', 'two']",
-    \ execute("  let x =<< trim END\n    one\n    two\n  END\necho x"))
-  call assert_equal("\n['one', '  two']",
-    \ execute("  let x =<< trim END\n    one\n      two\n  END\necho x"))
-  call assert_equal("\n['  one', '  two']",
-    \ execute("let x =<< END\n  one\n  two\nEND\necho x"))
-  call assert_equal("\n['one', 'two']",
-    \ execute("let x =<< END\none\ntwo\nEND\necho x"))
-  call assert_equal("\n['one', 'two']",
-    \ execute("let x =<< END \" comment\none\ntwo\nEND\necho x"))
-  let cmd = 'execute("let x =<< END\n  one\n  two\necho x")'
-  call assert_fails(cmd, "E990: Missing end marker 'END'")
-  let cmd = 'execute("let x =<<\n  one\n  two\necho x")'
-  call assert_fails(cmd, "E172: Missing marker")
-  let cmd = 'execute("let x =<< trim\n  one\n  two\necho x")'
-  call assert_fails(cmd, "E172: Missing marker")
-  let cmd = 'execute("let x =<< end\n  one\n  two\nend\necho x")'
-  call assert_fails(cmd, "E221: Marker cannot start with lower case letter")
-  let cmd = 'execute("let x =<< eval END\n  one\n  two{y}\nEND\necho x")'
-  call assert_fails(cmd, 'E121: Undefined variable: y')
+  " Test for using heredoc in a single string using :execute or execute()
+  for [cmd, res] in items({
+      \ "let x =<< trim END\n  one\n  two\nEND": ['one', 'two'],
+      \ "let x =<< trim END\n  one\n    two\nEND": ['one', '  two'],
+      \ "  let x =<< trim END\n    one\n    two\n  END": ['one', 'two'],
+      \ "  let x =<< trim END\n    one\n      two\n  END": ['one', '  two'],
+      \ "let x =<< END\n  one\n  two\nEND": ['  one', '  two'],
+      \ "let x =<< END\none\ntwo\nEND": ['one', 'two'],
+      \ "let x =<< END \" comment\none\ntwo\nEND": ['one', 'two'],
+      \ })
+    execute cmd
+    call assert_equal(res, x)
+    unlet x
+    call assert_equal($"\n{string(res)}", execute($"{cmd}\necho x"))
+    unlet x
+  endfor
+  for [cmd, err] in items({
+      \ "let x =<<\none\ntwo": "E172:",
+      \ "let x =<< trim\n  one\n  two": "E172:",
+      \ "let x =<< end\none\ntwo\nend": "E221:",
+      \ "let x =<< END\none\ntwo": "E990: Missing end marker 'END'",
+      \ "let x =<< END !\none\ntwo\nEND": "E488: Trailing characters:  !",
+      \ "let x =<< eval END\none\ntwo{y}\nEND": "E121: Undefined variable: y",
+      \ })
+    call assert_fails('execute cmd', err)
+    call assert_fails('call execute(cmd)', err)
+  endfor
 
   " skipped heredoc
   if 0


### PR DESCRIPTION
#### vim-patch:9.1.0319: Using heredoc in string not tested with :execute

Problem:  Using heredoc in string not tested with :execute.
Solution: Test with both :execute and execute() (zeertzjq).

closes: vim/vim#14546

https://github.com/vim/vim/commit/3d93630605df60e8de5a38918eaff62165b42382