### PR TITLE
vim-patch:9.1.0320: Wrong cursor position after using setcellwidths()

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -59,6 +59,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
+#include "nvim/move.h"
 #include "nvim/option_vars.h"
 #include "nvim/optionstr.h"
 #include "nvim/os/os.h"
@@ -2878,6 +2879,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   xfree(cw_table_save);
+  changed_window_setting_all();
   redraw_all_later(UPD_NOT_VALID);
 }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -546,6 +546,14 @@ void changed_window_setting(win_T *wp)
   redraw_later(wp, UPD_NOT_VALID);
 }
 
+/// Call changed_window_setting() for every window.
+void changed_window_setting_all(void)
+{
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    changed_window_setting(wp);
+  }
+}
+
 // Set wp->w_topline to a certain number.
 void set_topline(win_T *wp, linenr_T lnum)
 {


### PR DESCRIPTION
#### vim-patch:9.1.0320: Wrong cursor position after using setcellwidths()

Problem:  Wrong cursor position after using setcellwidths().
Solution: Invalidate cursor position in addition to redrawing.
          (zeertzjq)

closes: vim/vim#14545

https://github.com/vim/vim/commit/05aacec6ab5c7ed8a13bbdca2f0005d6a1816230

Reorder functions in test_utf8.vim to match upstream.