### PR TITLE
vim-patch:e92ed1b45c54

### DIFF
--- a/runtime/compiler/vimdoc.vim
+++ b/runtime/compiler/vimdoc.vim
@@ -1,9 +1,10 @@
 " Vim Compiler File
 " Language:             vimdoc
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
-" Latest Revision:      2024-04-09
+" Latest Revision:      2024-04-13
 "
-" you can get it by `pip install vimdoc` or the package manager of your distribution.
+" If you can not find 'vimdoc' in the package manager of your distribution e.g
+" 'pip', then you may need to build it from its source.
 
 if exists('b:current_compiler')
   finish

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:		Vim
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2024 Apr 08
+" Last Change:		2024 Apr 13
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -14,8 +14,6 @@ let b:did_ftplugin = 1
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-compiler vimdoc
 
 if !exists('*VimFtpluginUndo')
   func VimFtpluginUndo()


### PR DESCRIPTION
#### vim-patch:e92ed1b45c54

runtime(vim): don't set compiler, update a comment for vimdoc compiler (vim/vim#14532)

https://github.com/vim/vim/commit/e92ed1b45c5432235b0541521124d965b9d6a9a2

Co-authored-by: Shane-XB-Qian <shane.qian@foxmail.com>