### PR TITLE
vim-patch:9.1.{0321,0328}

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3966,4 +3966,23 @@ func Test_buffer_completion()
   call assert_equal("\"b Xbuf_complete/Foobar.c Xbuf_complete/MyFoobar.c AFoobar.h", @:)
 endfunc
 
+" :set t_??
+func Test_term_option()
+  throw 'Skipped: Nvim does not support termcap options'
+  set wildoptions&
+  let _cpo = &cpo
+  set cpo-=C
+  let expected='"set t_AB t_AF t_AU t_AL t_al t_bc t_BE t_BD t_cd t_ce t_Ce t_CF t_cl t_cm'
+        \ .. ' t_Co t_CS t_Cs t_cs t_CV t_da t_db t_DL t_dl t_ds t_Ds t_EC t_EI t_fs t_fd t_fe'
+        \ .. ' t_GP t_IE t_IS t_ke t_ks t_le t_mb t_md t_me t_mr t_ms t_nd t_op t_RF t_RB t_RC'
+        \ .. ' t_RI t_Ri t_RK t_RS t_RT t_RV t_Sb t_SC t_se t_Sf t_SH t_SI t_Si t_so t_SR t_sr'
+        \ .. ' t_ST t_Te t_te t_TE t_ti t_TI t_Ts t_ts t_u7 t_ue t_us t_Us t_ut t_vb t_ve t_vi'
+        \ .. ' t_VS t_vs t_WP t_WS t_XM t_xn t_xs t_ZH t_ZR t_8f t_8b t_8u t_xo t_#2 t_#4 t_%i'
+        \ .. ' t_*7 t_@7 t_F1 t_F2 t_k1 t_k2 t_k3 t_k4 t_k5 t_k6 t_k7 t_k8 t_k9 t_k; t_kB t_kD'
+        \ .. ' t_kI t_kN t_kP t_kb t_kd t_kh t_kl t_kr t_ku'
+  call feedkeys(":set t_\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal(expected, @:)
+  let &cpo = _cpo
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3972,16 +3972,15 @@ func Test_term_option()
   set wildoptions&
   let _cpo = &cpo
   set cpo-=C
+  " There may be more, test only until t_xo
   let expected='"set t_AB t_AF t_AU t_AL t_al t_bc t_BE t_BD t_cd t_ce t_Ce t_CF t_cl t_cm'
         \ .. ' t_Co t_CS t_Cs t_cs t_CV t_da t_db t_DL t_dl t_ds t_Ds t_EC t_EI t_fs t_fd t_fe'
         \ .. ' t_GP t_IE t_IS t_ke t_ks t_le t_mb t_md t_me t_mr t_ms t_nd t_op t_RF t_RB t_RC'
         \ .. ' t_RI t_Ri t_RK t_RS t_RT t_RV t_Sb t_SC t_se t_Sf t_SH t_SI t_Si t_so t_SR t_sr'
         \ .. ' t_ST t_Te t_te t_TE t_ti t_TI t_Ts t_ts t_u7 t_ue t_us t_Us t_ut t_vb t_ve t_vi'
-        \ .. ' t_VS t_vs t_WP t_WS t_XM t_xn t_xs t_ZH t_ZR t_8f t_8b t_8u t_xo t_#2 t_#4 t_%i'
-        \ .. ' t_*7 t_@7 t_F1 t_F2 t_k1 t_k2 t_k3 t_k4 t_k5 t_k6 t_k7 t_k8 t_k9 t_k; t_kB t_kD'
-        \ .. ' t_kI t_kN t_kP t_kb t_kd t_kh t_kl t_kr t_ku'
+        \ .. ' t_VS t_vs t_WP t_WS t_XM t_xn t_xs t_ZH t_ZR t_8f t_8b t_8u t_xo .*'
   call feedkeys(":set t_\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal(expected, @:)
+  call assert_match(expected, @:)
   let &cpo = _cpo
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0321: Garbled output on serial terminals with XON/XOFF flow control

Problem:  When used terminal with XON/XOFF flow control, vim tries to
          still make CTRL-S mapping available, which results in severe
          screen corruption, especially on large redraws, and even
          spurious inputs (John Tsiombikas)
Solution: Disallow CTRL-S mapping if such terminal is recognized.
          Don't remove IXON from the bitmask inversion.
          (Anton Sharonov)

*** When started like this:

    TERM=vt420 vim

:set termcap

    shows "t_xon=y"

map <C-S> :echo "abc"<CR>

    does nothing (after <C-S> output freezes and subsequent <C-Q>
    unfreezes it)

*** When started like this:

    TERM=xterm vim

:set termcap

    shows "t_xon="

map <C-S> :echo "abc"<CR>

    works (after <C-S> one see "abc" string echo-ed)

closes: vim/vim#14542

https://github.com/vim/vim/commit/49528da8a60f8fd38ca491d6ccec47dfccf5f23c

Co-authored-by: Anton Sharonov <anton.sharonov@gmail.com>


#### vim-patch:9.1.0328: CI fails with t_?? test

Problem:  CI fails with t_?? test
Solution: use assert_match instead of assert_equal
          and test only until t_xo, depending on system
          there may be several more termcap codes coming

https://github.com/vim/vim/commit/0d87e3c711b46be67cf8f014cc0bca21431599c0

Co-authored-by: Christian Brabandt <cb@256bit.org>