### PR TITLE
fix(highlight): combine line attributes before column attributes

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2606,6 +2606,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
           int col_attr = base_attr;
 
+          col_attr = hl_combine_attr(col_attr, wlv.line_attr);
+
           if (wp->w_p_cuc && vcol_hlc(wlv) == wp->w_virtcol
               && lnum != wp->w_cursor.lnum) {
             col_attr = hl_combine_attr(col_attr, cuc_attr);
@@ -2616,8 +2618,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
           if (wp->w_buffer->terminal && wlv.vcol < TERM_ATTRS_MAX) {
             col_attr = hl_combine_attr(col_attr, term_attrs[wlv.vcol]);
           }
-
-          col_attr = hl_combine_attr(col_attr, wlv.line_attr);
 
           linebuf_attr[wlv.off] = col_attr;
           // linebuf_vcol[] already filled by the for loop above


### PR DESCRIPTION
Fixes: #28118

TODO: add test
 ```
    nvim --clean -u NONE -c 'color vim' -c 'norm Ia' -c 'norm ob'  -c 'vnew|norm Ia' -c 'norm oc' -c 'windo diffthis|set cc=8'
```
```
    nvim --clean -u NONE -c 'color vim' -c 'hi ColorColumn guibg=blue' -c 'norm Iab' -c 'norm obc'  -c 'vnew|norm Iab' -c 'norm ocd' -c 'windo diffthis|set cc=2'
```

I don't know what other things this could affect, so opening it now before writing a test, in case it's the wrong thing to do.