### PR TITLE
vim-patch:9.1.0334: No test for highlight behavior with 'ambiwidth'

### DIFF
--- a/test/old/testdir/test_regexp_utf8.vim
+++ b/test/old/testdir/test_regexp_utf8.vim
@@ -372,7 +372,7 @@ func Test_multibyte_chars()
 endfunc
 
 " check that 'ambiwidth' does not change the meaning of \p
-func Test_ambiwidth()
+func Test_regexp_ambiwidth()
   set regexpengine=1 ambiwidth=single
   call assert_equal(0, match("\u00EC", '\p'))
   set regexpengine=1 ambiwidth=double


### PR DESCRIPTION
#### vim-patch:9.1.0334: No test for highlight behavior with 'ambiwidth'

Problem:  No test for highlight behavior with 'ambiwidth'.
Solution: Add a screendump test for 'ambiwidth' with 'cursorline'.
          (zeertzjq)

closes: vim/vim#14554

https://github.com/vim/vim/commit/a59e031aa0bdc5cc3d1f4ed719126bf1a1b858ce