### PR TITLE
fix(msgpack): retain grid line event memory

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -289,8 +289,9 @@ static void parse_msgpack(Channel *channel)
     if (p->type == kMessageTypeRedrawEvent) {
       // When exiting, ui_client_stop() has already been called, so don't handle UI events.
       if (ui_client_channel_id && !exiting) {
-        if (p->grid_line_event) {
-          ui_client_event_raw_line(p->grid_line_event);
+        if (p->has_grid_line_event) {
+          ui_client_event_raw_line(&p->grid_line_event);
+          p->has_grid_line_event = false;
         } else if (p->ui_handler.fn != NULL && p->result.type == kObjectTypeArray) {
           p->ui_handler.fn(p->result.data.array);
         }

--- a/src/nvim/msgpack_rpc/unpacker.h
+++ b/src/nvim/msgpack_rpc/unpacker.h
@@ -37,7 +37,8 @@ struct Unpacker {
   int nevents;
   int ncalls;
   UIClientHandler ui_handler;
-  GridLineEvent *grid_line_event;
+  GridLineEvent grid_line_event;
+  bool has_grid_line_event;
 };
 
 // unrecovareble error. unpack_error should be set!


### PR DESCRIPTION
Fix #27859. Still a draft because there are other solutions that might be worthwhile, and I haven't written any tests.

See my comments on that issue (https://github.com/neovim/neovim/issues/27859#issuecomment-2057556931 and https://github.com/neovim/neovim/issues/27859#issuecomment-2057916584) for details on the specific situation that causes the crash. But TLDR:
- there's a hand-rolled msgpack decoder specific to redraw events, implemented as a finite state machine with states 0-16
- the state machine can be interrupted/resumed
- memory for `GridLineEvent`s is allocated in state 11 only
- states 14-16 use the `GridLineEvent` assuming its memory is allocated
- if the state machine completes a cycle (reaches 16) and then executes the redraw event, the grid line event memory is freed ([`channel.c`:288-298](https://github.com/neovim/neovim/blob/5cfdaaaeac0f53a621696d8eb6b5a3ba90438c98/src/nvim/msgpack_rpc/channel.c#L288-L298)):
```c
static void parse_msgpack(Channel *channel) {
  Unpacker *p = channel->rpc.unpacker;
  while (unpacker_advance(p)) {
    if (p->type == kMessageTypeRedrawEvent) { /* ... */
      if (p->grid_line_event) {
        ui_client_event_raw_line(p->grid_line_event);
      } /* ... */
    }
    arena_mem_free(arena_finish(&p->arena)); // <-- freed here
  } /* ... */
}
```
- but if there are any remaining calls (`p->ncalls`) that can be read from the RPC stream, the FSM resumes *directly* at state 14 ([`unpacker.c`:320:326](https://github.com/neovim/neovim/blob/5cfdaaaeac0f53a621696d8eb6b5a3ba90438c98/src/nvim/msgpack_rpc/unpacker.c#L320-L326), [`unpacker.c`:359:368](https://github.com/neovim/neovim/blob/5cfdaaaeac0f53a621696d8eb6b5a3ba90438c98/src/nvim/msgpack_rpc/unpacker.c#L359-L368)):
```c
bool unpacker_advance(Unpacker *p) { /* ... */
  if (!unpacker_parse_redraw(p)) {
    return false;
  } /* ... */
  switch (p->state) { /* ... */
  case 16:
    p->ncalls--;
    if (p->ncalls > 0) {
      p->state = (p->state == 16) ? 14 : 12;
    } /* ... else ... */
    return true;
    /* ... */
  }
}
```
- ...bypassing the reallocation of the event and writing to released memory on the next call to `unpacker_parser_redraw` ([`unpacker.c`:428:437](https://github.com/neovim/neovim/blob/5cfdaaaeac0f53a621696d8eb6b5a3ba90438c98/src/nvim/msgpack_rpc/unpacker.c#L428-L437)):
```c
bool unpacker_parse_redraw(Unpacker *p) { /* ... */
  switch (p->state) { /* ... */
      case 11: // allocation happens here
      // we jump here directly, skipping allocation in state 11
      case 14: // write to p->grid_line_event
      /* ... */
    }
}
```

The bug is sneaky/tricky because it's only *apparent* in very specific cases, i.e. when the pending channel `rstream` is very large (> `8192` bytes), can't be read in a single step, and another event in between the pending redraw is sent and overwrites the `GridLineEvent` memory before the remaining redraw event data is read.

~~**Current approach**: just don't free the memory when returning successfully from `unpacker_advance` midway through a redraw event when the next FSM execution would expect the grid line event memory to be valid.~~

~~**Other approaches**~~ **Current approach**: Don't *ever* allocate/free the grid line event, i.e. store it as a value and not a pointer? It's not that big of a struct..