### PR TITLE
vim-patch:fb8f31ea7d7f

### DIFF
--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -46,6 +46,7 @@ execute 'CompilerSet makeprg=pandoc\ --standalone' .
       \ '\ --metadata\ title=%:t:r:S' .
       \ '\ --metadata\ lang=' . matchstr(&spelllang, '^\a\a') .
       \ '\ --from=' . s:PandocFiletype(&filetype) .
+      \ '\ ' . escape(get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', '')), ' ') .
       \ '\ --output\ %:r:S.$*\ %:S'
 
 CompilerSet errorformat="%f",\ line\ %l:\ %m

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1282,6 +1282,15 @@ g:compiler_gcc_ignore_unmatched_lines
 				commands run from make are generating false
 				positives.
 
+PANDOC					*quickfix-pandoc* *compiler-pandoc*
+
+The Pandoc compiler plugin expects that an output file type extension is
+passed to make, say :make html or :make pdf.
+
+Additional arguments can be passed to pandoc:
+
+- either by appending them to make, say `:make html --self-contained` .
+- or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`
 
 PERL					*quickfix-perl* *compiler-perl*
 


### PR DESCRIPTION
#### vim-patch:fb8f31ea7d7f

runtime(doc): document pandoc compiler and enable configuring arguments

closes: vim/vim#14550

https://github.com/vim/vim/commit/fb8f31ea7d7f3f42e9bdce7b4434fd93fba8876f

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>