### PR TITLE
vim-patch:9.1.0332: tests: some assert_equal() calls have wrong order of args

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3907,9 +3907,9 @@ func Test_custom_completion()
   call assert_fails("call getcompletion('', 'custom')", 'E475:')
   call assert_fails("call getcompletion('', 'customlist')", 'E475:')
 
-  call assert_equal(getcompletion('', 'custom,CustomComplete1'), ['a', 'b', 'c'])
-  call assert_equal(getcompletion('', 'customlist,CustomComplete2'), ['a', 'b'])
-  call assert_equal(getcompletion('b', 'customlist,CustomComplete2'), ['b'])
+  call assert_equal(['a', 'b', 'c'], getcompletion('', 'custom,CustomComplete1'))
+  call assert_equal(['a', 'b'], getcompletion('', 'customlist,CustomComplete2'))
+  call assert_equal(['b'], getcompletion('b', 'customlist,CustomComplete2'))
 
   delcom Test1
   delcom Test2

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -597,13 +597,13 @@ func Test_digraph_getlist_function()
   call digraph_setlist([['aa', 'き'], ['bb', 'く']])
 
   for pair in digraph_getlist(1)
-    call assert_equal(digraph_get(pair[0]), pair[1])
+    call assert_equal(pair[1], digraph_get(pair[0]))
   endfor
 
   " We don't know how many digraphs are registered before, so check the number
   " of digraphs returned.
   call assert_equal(digraph_getlist()->len(), digraph_getlist(0)->len())
-  call assert_notequal((digraph_getlist()->len()), digraph_getlist(1)->len())
+  call assert_notequal(digraph_getlist()->len(), digraph_getlist(1)->len())
 
   call assert_fails('call digraph_getlist(0z12)', 'E974: Using a Blob as a Number')
 endfunc

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -758,13 +758,13 @@ func Test_ve_blockpaste()
   call cursor(1,1)
   exe ":norm! \<C-V>3ljdP"
   call assert_equal(1, col('.'))
-  call assert_equal(getline(1, 2), ['QWERTZ', 'ASDFGH'])
+  call assert_equal(['QWERTZ', 'ASDFGH'], getline(1, 2))
   call cursor(1,1)
   exe ":norm! \<C-V>3ljd"
   call cursor(1,1)
   norm! $3lP
   call assert_equal(5, col('.'))
-  call assert_equal(getline(1, 2), ['TZ  QWER', 'GH  ASDF'])
+  call assert_equal(['TZ  QWER', 'GH  ASDF'], getline(1, 2))
   set ve&vim
   bwipe!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0332: tests: some assert_equal() calls have wrong order of args

Problem:  tests: some assert_equal() calls have wrong order of args
Solution: Correct the order (zeertzjq).

closes: vim/vim#14555

https://github.com/vim/vim/commit/757f32141bb8ce797f71e7e22e59ba368e0f4952