### PR TITLE
vim-patch:9.1.0335: String interpolation fails for List type

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -88,7 +88,7 @@ char *eval_one_expr_in_str(char *p, garray_T *gap, bool evaluate)
   }
   if (evaluate) {
     *block_end = NUL;
-    char *expr_val = eval_to_string(block_start, true);
+    char *expr_val = eval_to_string(block_start, false);
     *block_end = '}';
     if (expr_val == NULL) {
       return NULL;

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -907,6 +907,18 @@ func Test_string_interp()
     #" Dict interpolation
     VAR d = {'a': 10, 'b': [1, 2]}
     call assert_equal("{'a': 10, 'b': [1, 2]}", $'{d}')
+    VAR emptydict = {}
+    call assert_equal("a{}b", $'a{emptydict}b')
+    VAR nulldict = v:_null_dict
+    call assert_equal("a{}b", $'a{nulldict}b')
+
+    #" List interpolation
+    VAR l = ['a', 'b', 'c']
+    call assert_equal("['a', 'b', 'c']", $'{l}')
+    VAR emptylist = []
+    call assert_equal("a[]b", $'a{emptylist}b')
+    VAR nulllist = v:_null_list
+    call assert_equal("a[]b", $'a{nulllist}b')
 
     #" Stray closing brace.
     call assert_fails('echo $"moo}"', 'E1278:')

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -694,6 +694,41 @@ END
   END
   call assert_equal(["let d2 = {'a': 10, 'b': 'ss', 'c': {}}"], code)
 
+  " Empty dictionary
+  let d1 = {}
+  let code =<< eval trim END
+    let d2 = {d1}
+  END
+  call assert_equal(["let d2 = {}"], code)
+
+  " null dictionary
+  let d1 = v:_null_dict
+  let code =<< eval trim END
+    let d2 = {d1}
+  END
+  call assert_equal(["let d2 = {}"], code)
+
+  " Evaluate a List
+  let l1 = ['a', 'b', 'c']
+  let code =<< eval trim END
+    let l2 = {l1}
+  END
+  call assert_equal(["let l2 = ['a', 'b', 'c']"], code)
+
+  " Empty List
+  let l1 = []
+  let code =<< eval trim END
+    let l2 = {l1}
+  END
+  call assert_equal(["let l2 = []"], code)
+
+  " Null List
+  let l1 = v:_null_list
+  let code =<< eval trim END
+    let l2 = {l1}
+  END
+  call assert_equal(["let l2 = []"], code)
+
   let code = 'xxx'
   let code =<< eval trim END
     let n = {5 +

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -332,4 +332,12 @@ func Test_put_dict()
   bw!
 endfunc
 
+func Test_put_list()
+  new
+  let l = ['a', 'b', 'c']
+  put! =l
+  call assert_equal(['a', 'b', 'c', ''], getline(1, '$'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0335: String interpolation fails for List type

Problem:  String interpolation fails for List type
Solution: use implicit string(list) for string interpolation and :put =
          (Yegappan Lakshmanan)

related: vim/vim#14529
closes: vim/vim#14556

https://github.com/vim/vim/commit/bce51d9005dd1c5bc002acbac2e12b649abcb013

Cherry-pick eval_to_string_eap() from patch 8.2.1914.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>