### PR TITLE
fix(spell): Moved Python @spell to (string_content)

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -204,19 +204,19 @@
   (comment)*
   .
   (expression_statement
-    (string) @string.documentation @spell))
+    (string (string_content) @spell) @string.documentation))
 
 (class_definition
   body: (block
     .
     (expression_statement
-      (string) @string.documentation @spell)))
+      (string (string_content) @spell) @string.documentation)))
 
 (function_definition
   body: (block
     .
     (expression_statement
-      (string) @string.documentation @spell)))
+      (string (string_content) @spell) @string.documentation)))
 
 ; Tokens
 [


### PR DESCRIPTION
Closes: https://github.com/neovim/neovim/issues/28365

## Before
![image](https://github.com/neovim/neovim/assets/10103049/17e8df8e-65e3-428c-af04-f0df629e6f5d)

## After
![image](https://github.com/neovim/neovim/assets/10103049/13f6000c-aa30-4208-a189-41096ac47fe5)


For those that use nvim-treesitter, their parser has the same problem (which I can also make a PR for).