### PR TITLE
fix: call do_autochdir inside ex_win_close

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4872,6 +4872,8 @@ void ex_win_close(int forceit, win_T *win, tabpage_T *tp)
   } else {
     win_close_othertab(win, !need_hide && !buf_hide(buf), tp);
   }
+
+  do_autochdir();
 }
 
 /// ":tabclose": close current tab page, unless it is the last one.

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -680,6 +680,31 @@ describe('API/win', function()
       eq(prevwin, api.nvim_tabpage_get_win(tab))
       assert_alive()
     end)
+
+    it('reset dir after close win', function()
+      local expected = fn.getcwd() .. '/foo'
+      t.mkdir('foo')
+      exec_lua [[
+        vim.opt.autochdir = true
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_name(buf, 'Foo')
+        vim.api.nvim_create_autocmd('CmdlineEnter', {
+          callback = function()
+            local winid = vim.api.nvim_open_win(buf, false, {
+              relative = 'editor',
+              height = 1,
+              width = 1,
+              row = 1,
+              col = 1,
+            })
+            vim.api.nvim_win_close(winid, true)
+          end,
+        })
+      ]]
+      t.feed(':edit foo/bar.txt<CR>')
+      eq(t.is_os('win') and expected:gsub('/', '\\') or expected, fn.getcwd())
+      t.rmdir('foo')
+    end)
   end)
 
   describe('hide', function()


### PR DESCRIPTION
Problem: after nvim_win_close called in event callback on cmdline the autodir not clear

Solution: call do_autochdir inside ex_win_close


Fix #15280 