### PR TITLE
fix(float): reset pwd after win_set_buf in nvim_open_win

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -752,8 +752,15 @@ void win_set_buf(win_T *win, buf_T *buf, Error *err)
     goto cleanup;
   }
 
+  // temporarily disable 'autochdir' when using win_set_buf
+  // on non-current window
+  int save_acd = p_acd;
+  if (!switchwin.sw_same_win) {
+    p_acd = false;
+  }
   try_start();
   int result = do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, buf->b_fnum, 0);
+  p_acd = save_acd;
   if (!try_end(err) && result == FAIL) {
     api_set_error(err,
                   kErrorTypeException,

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1748,6 +1748,31 @@ describe('API/win', function()
         pcall_err(api.nvim_open_win, 0, true, { split = 'below', win = 0 })
       )
     end)
+
+    it('do not change dir when enter is false', function()
+      local expected = fn.getcwd() .. '/foo'
+      t.mkdir('foo')
+      exec_lua [[
+        vim.opt.autochdir = true
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_name(buf, 'Foo')
+        vim.api.nvim_create_autocmd('CmdlineEnter', {
+          callback = function()
+            local winid = vim.api.nvim_open_win(buf, false, {
+              relative = 'editor',
+              height = 1,
+              width = 1,
+              row = 1,
+              col = 1,
+            })
+            vim.api.nvim_win_close(winid, true)
+          end,
+        })
+      ]]
+      t.feed(':edit foo/bar.txt<CR>')
+      eq(t.is_os('win') and expected:gsub('/', '\\') or expected, fn.getcwd())
+      t.rmdir('foo')
+    end)
   end)
 
   describe('set_config', function()


### PR DESCRIPTION
Problem:  win_set_buf will make buffer as current and do_autochdir when p_acd is true
Solution:  temporarily disable 'autochdir' when using win_set_buf()

Fix #15280
