### PR TITLE
feat(lua): enable(enable:boolean, filter:table)

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -372,7 +372,8 @@ Use existing common {verb} names (actions) if possible:
     - create:       Creates a new (non-trivial) thing (TODO: rename to "def"?)
     - del:          Deletes a thing (or group of things)
     - detach:       Dispose attached listener (TODO: rename to "un"?)
-    - enable:       Enables/disables functionality.
+    - enable:       Enables/disables functionality. Signature should be
+                    `enable(enable?:boolean, filter?:table)`.
     - eval:         Evaluates an expression
     - exec:         Executes code
     - fmt:          Formats

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -367,13 +367,6 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {user_data}?  (`any`) arbitrary data plugins can add
       • {namespace}?  (`integer`)
 
-*vim.diagnostic.Filter*
-    Extends: |vim.diagnostic.Opts|
-
-
-    Fields: ~
-      • {ns_id}?  (`integer`) Namespace
-
 *vim.diagnostic.GetOpts*
     A table with the following keys:
 
@@ -623,20 +616,20 @@ count({bufnr}, {opts})                                *vim.diagnostic.count()*
         (`table`) Table with actually present severity values as keys (see
         |diagnostic-severity|) and integer counts as values.
 
-enable({bufnr}, {enable}, {opts})                    *vim.diagnostic.enable()*
+enable({enable}, {filter})                           *vim.diagnostic.enable()*
     Enables or disables diagnostics.
 
     To "toggle", pass the inverse of `is_enabled()`: >lua
-        vim.diagnostic.enable(0, not vim.diagnostic.is_enabled())
+        vim.diagnostic.enable(not vim.diagnostic.is_enabled())
 <
 
     Parameters: ~
-      • {bufnr}   (`integer?`) Buffer number, or 0 for current buffer, or
-                  `nil` for all buffers.
       • {enable}  (`boolean?`) true/nil to enable, false to disable
-      • {opts}    (`vim.diagnostic.Filter?`) Filter by these opts, or `nil`
-                  for all. Only `ns_id` is supported, currently. See
-                  |vim.diagnostic.Filter|.
+      • {filter}  (`table?`) Optional filters |kwargs|, or `nil` for all.
+                  • {ns_id}? (`integer`) Diagnostic namespace, or `nil` for
+                    all.
+                  • {bufnr}? (`integer`) Buffer number, or 0 for current
+                    buffer, or `nil` for all buffers.
 
 fromqflist({list})                               *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.
@@ -745,16 +738,18 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
       • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer. When
                      omitted, hide diagnostics in all buffers.
 
-is_enabled({bufnr}, {namespace})                 *vim.diagnostic.is_enabled()*
+is_enabled({filter})                             *vim.diagnostic.is_enabled()*
     Check whether diagnostics are enabled.
 
     Note: ~
       • This API is pre-release (unstable).
 
     Parameters: ~
-      • {bufnr}      (`integer?`) Buffer number, or 0 for current buffer.
-      • {namespace}  (`integer?`) Diagnostic namespace, or `nil` for all
-                     diagnostics in {bufnr}.
+      • {filter}  (`table?`) Optional filters |kwargs|, or `nil` for all.
+                  • {ns_id}? (`integer`) Diagnostic namespace, or `nil` for
+                    all.
+                  • {bufnr}? (`integer`) Buffer number, or 0 for current
+                    buffer, or `nil` for all buffers.
 
     Return: ~
         (`boolean`)

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1588,19 +1588,21 @@ save({lenses}, {bufnr}, {client_id})                 *vim.lsp.codelens.save()*
 ==============================================================================
 Lua module: vim.lsp.inlay_hint                                *lsp-inlay_hint*
 
-enable({bufnr}, {enable})                        *vim.lsp.inlay_hint.enable()*
+enable({enable}, {filter})                       *vim.lsp.inlay_hint.enable()*
     Enables or disables inlay hints for a buffer.
 
     To "toggle", pass the inverse of `is_enabled()`: >lua
-        vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
+        vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
 <
 
     Note: ~
       • This API is pre-release (unstable).
 
     Parameters: ~
-      • {bufnr}   (`integer?`) Buffer handle, or 0 or nil for current
       • {enable}  (`boolean?`) true/nil to enable, false to disable
+      • {filter}  (`table?`) Optional filters |kwargs|, or `nil` for all.
+                  • {bufnr} (`integer?`) Buffer number, or 0/nil for current
+                    buffer.
 
 get({filter})                                       *vim.lsp.inlay_hint.get()*
     Get the list of inlay hints, (optionally) restricted by buffer or range.
@@ -1639,7 +1641,7 @@ is_enabled({bufnr})                          *vim.lsp.inlay_hint.is_enabled()*
       • This API is pre-release (unstable).
 
     Parameters: ~
-      • {bufnr}  (`integer?`) Buffer handle, or 0 or nil for current
+      • {bufnr}  (`integer?`) Buffer handle, or 0 for current
 
     Return: ~
         (`boolean`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -149,6 +149,10 @@ unreleased features on Nvim HEAD.
 • Removed `vim.treesitter.foldtext` as transparent foldtext is now supported
   https://github.com/neovim/neovim/pull/20750
 
+• Changed the signature of `vim.lsp.inlay_hint.enable()`.
+
+• Changed the signature of `vim.diagnostic.enable()`.
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 
@@ -529,6 +533,7 @@ release.
 • vim.diagnostic functions:
   - |vim.diagnostic.disable()|
   - |vim.diagnostic.is_disabled()|
+  - Legacy signature: `vim.diagnostic.enable(buf:number, namespace:number)`
 
 • vim.lsp functions:
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1049,10 +1049,11 @@ function vim.deprecate(name, alternative, version, plugin, backtrace)
     plugin = { plugin, 'string', true },
   }
   plugin = plugin or 'Nvim'
+  local will_be_removed = 'will be removed'
 
   -- Only issue warning if feature is hard-deprecated as specified by MAINTAIN.md.
-  -- e.g., when planned to be removed in version = '0.12' (soft-deprecated since 0.10-dev),
-  -- show warnings since 0.11, including 0.11-dev (hard_deprecated_since = 0.11-dev).
+  -- Example: if removal_version is 0.12 (soft-deprecated since 0.10-dev), show warnings starting at
+  -- 0.11, including 0.11-dev (hard_deprecated_since = 0.11-dev).
   if plugin == 'Nvim' then
     local current_version = vim.version() ---@type vim.Version
     local removal_version = assert(vim.version.parse(version))
@@ -1075,14 +1076,17 @@ function vim.deprecate(name, alternative, version, plugin, backtrace)
 
     if not is_hard_deprecated then
       return
+    elseif current_version >= removal_version then
+      will_be_removed = 'was removed'
     end
   end
 
   local msg = ('%s is deprecated'):format(name)
   msg = alternative and ('%s, use %s instead.'):format(msg, alternative) or (msg .. '.')
-  msg = ('%s%s\nThis feature will be removed in %s version %s'):format(
+  msg = ('%s%s\nFeature %s in %s %s'):format(
     msg,
     (plugin == 'Nvim' and ' :help deprecated' or ''),
+    will_be_removed,
     plugin,
     version
   )

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -349,7 +349,7 @@ api.nvim_set_decoration_provider(namespace, {
   end,
 })
 
---- @param bufnr (integer|nil) Buffer handle, or 0 or nil for current
+--- @param bufnr (integer|nil) Buffer handle, or 0 for current
 --- @return boolean
 --- @since 12
 function M.is_enabled(bufnr)
@@ -360,23 +360,39 @@ function M.is_enabled(bufnr)
   return bufstates[bufnr] and bufstates[bufnr].enabled or false
 end
 
+--- Optional filters |kwargs|, or `nil` for all.
+--- @class vim.lsp.inlay_hint.enable.Filter
+--- @inlinedoc
+--- Buffer number, or 0/nil for current buffer.
+--- @field bufnr integer?
+
 --- Enables or disables inlay hints for a buffer.
 ---
 --- To "toggle", pass the inverse of `is_enabled()`:
 ---
 --- ```lua
---- vim.lsp.inlay_hint.enable(0, not vim.lsp.inlay_hint.is_enabled())
+--- vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
 --- ```
 ---
---- @param bufnr (integer|nil) Buffer handle, or 0 or nil for current
 --- @param enable (boolean|nil) true/nil to enable, false to disable
+--- @param filter vim.lsp.inlay_hint.enable.Filter?
 --- @since 12
-function M.enable(bufnr, enable)
-  vim.validate({ enable = { enable, 'boolean', true }, bufnr = { bufnr, 'number', true } })
+function M.enable(enable, filter)
+  if type(enable) == 'number' or type(filter) == 'boolean' then
+    vim.deprecate(
+      'vim.lsp.inlay_hint.enable(bufnr:number, enable:boolean)',
+      'vim.diagnostic.enable(enable:boolean, filter:table)',
+      '0.10-dev'
+    )
+    error('see :help vim.lsp.inlay_hint.enable() for updated parameters')
+  end
+
+  vim.validate({ enable = { enable, 'boolean', true }, filter = { filter, 'table', true } })
+  filter = filter or {}
   if enable == false then
-    _disable(bufnr)
+    _disable(filter.bufnr)
   else
-    _enable(bufnr)
+    _enable(filter.bufnr)
   end
 end
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -147,10 +147,13 @@ describe('lua stdlib', function()
       end)
 
       it('when plugin = nil', function()
+        local was_removed = (
+          vim.version.ge(current_version, '0.10') and 'was removed' or 'will be removed'
+        )
         eq(
-          dedent [[
+          dedent([[
             foo.bar() is deprecated, use zub.wooo{ok=yay} instead. :help deprecated
-            This feature will be removed in Nvim version 0.10]],
+            Feature %s in Nvim 0.10]]):format(was_removed),
           exec_lua('return vim.deprecate(...)', 'foo.bar()', 'zub.wooo{ok=yay}', '0.10')
         )
         -- Same message, skipped.
@@ -166,7 +169,7 @@ describe('lua stdlib', function()
         eq(
           dedent [[
             foo.hard_dep() is deprecated, use vim.new_api() instead. :help deprecated
-            This feature will be removed in Nvim version 0.11]],
+            Feature will be removed in Nvim 0.11]],
           exec_lua('return vim.deprecate(...)', 'foo.hard_dep()', 'vim.new_api()', '0.11')
         )
 
@@ -174,7 +177,7 @@ describe('lua stdlib', function()
         eq(
           dedent [[
             foo.baz() is deprecated. :help deprecated
-            This feature will be removed in Nvim version 1.0]],
+            Feature will be removed in Nvim 1.0]],
           exec_lua [[ return vim.deprecate('foo.baz()', nil, '1.0') ]]
         )
       end)
@@ -184,7 +187,7 @@ describe('lua stdlib', function()
         eq(
           dedent [[
             foo.bar() is deprecated, use zub.wooo{ok=yay} instead.
-            This feature will be removed in my-plugin.nvim version 0.3.0]],
+            Feature will be removed in my-plugin.nvim 0.3.0]],
           exec_lua(
             'return vim.deprecate(...)',
             'foo.bar()',
@@ -199,7 +202,7 @@ describe('lua stdlib', function()
         eq(
           dedent [[
             foo.bar() is deprecated, use zub.wooo{ok=yay} instead.
-            This feature will be removed in my-plugin.nvim version 0.11.0]],
+            Feature will be removed in my-plugin.nvim 0.11.0]],
           exec_lua(
             'return vim.deprecate(...)',
             'foo.bar()',

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -84,7 +84,7 @@ before_each(function()
   )
 
   insert(text)
-  exec_lua([[vim.lsp.inlay_hint.enable(bufnr)]])
+  exec_lua([[vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })]])
   screen:expect({ grid = grid_with_inlay_hints })
 end)
 
@@ -111,7 +111,7 @@ describe('vim.lsp.inlay_hint', function()
         }
       })
       client2 = vim.lsp.start({ name = 'dummy2', cmd = server2.cmd })
-      vim.lsp.inlay_hint.enable(bufnr)
+      vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
     ]])
 
     exec_lua([[ vim.lsp.stop_client(client2) ]])
@@ -119,17 +119,36 @@ describe('vim.lsp.inlay_hint', function()
   end)
 
   describe('enable()', function()
+    it('validation', function()
+      t.matches(
+        'enable: expected boolean, got table',
+        t.pcall_err(exec_lua, [[vim.lsp.inlay_hint.enable({}, { bufnr = bufnr })]])
+      )
+      t.matches(
+        'filter: expected table, got number',
+        t.pcall_err(exec_lua, [[vim.lsp.inlay_hint.enable(true, 42)]])
+      )
+
+      exec_lua [[vim.notify = function() end]]
+      t.matches(
+        'see %:help vim%.lsp%.inlay_hint%.enable',
+        t.pcall_err(exec_lua, [[vim.lsp.inlay_hint.enable(42)]])
+      )
+    end)
+
     it('clears/applies inlay hints when passed false/true/nil', function()
-      exec_lua([[vim.lsp.inlay_hint.enable(bufnr, false)]])
+      exec_lua([[vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })]])
       screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
 
-      exec_lua([[vim.lsp.inlay_hint.enable(bufnr, true)]])
+      exec_lua([[vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })]])
       screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
 
-      exec_lua([[vim.lsp.inlay_hint.enable(bufnr, not vim.lsp.inlay_hint.is_enabled(bufnr))]])
+      exec_lua(
+        [[vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled(bufnr), { bufnr = bufnr })]]
+      )
       screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
 
-      exec_lua([[vim.lsp.inlay_hint.enable(bufnr)]])
+      exec_lua([[vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })]])
       screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
     end)
   end)
@@ -163,7 +182,7 @@ describe('vim.lsp.inlay_hint', function()
           }
         })
         client2 = vim.lsp.start({ name = 'dummy2', cmd = server2.cmd })
-        vim.lsp.inlay_hint.enable(bufnr)
+        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
       ]],
         expected2
       )

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1328,7 +1328,7 @@ describe('LSP', function()
         on_handler = function(err, result, ctx)
           if ctx.method == 'start' then
             exec_lua [[
-              vim.lsp.inlay_hint.enable(BUFFER)
+              vim.lsp.inlay_hint.enable(true, { bufnr = BUFFER })
             ]]
           end
           if ctx.method == 'textDocument/inlayHint' then


### PR DESCRIPTION
# Problem:
We need to establish a pattern for `enable()`. Followup to https://github.com/neovim/neovim/pull/28227 . 

# Solution:
- [x] First `enable()` parameter is always `enable:boolean`. "kwargs" filter is the 2nd param.
- [x] Update `vim.diagnostic.enable()`
    - The "breaking" changes in this PR are just a continuation of [#28227](https://github.com/neovim/neovim/pull/28227) which wasn't released.
- [x] Update `vim.lsp.inlay_hint.enable()`. 
    - It was not released yet, so no deprecation is needed. But to help HEAD users, it will show an informative error.

# Note

I kept the `bufnr` name (should be `buf`) even though it violates `:help dev-naming` , because it is pervasive throughout these modules already. Sigh.