### PR TITLE
fix(api): ignore 'autochdir' when renaming other buf

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1340,7 +1340,7 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
       win_config_float(auc_win, auc_win->w_config);
     }
     // Prevent chdir() call in win_enter_ext(), through do_autochdir()
-    int save_acd = p_acd;
+    const int save_acd = p_acd;
     p_acd = false;
     // no redrawing and don't set the window title
     RedrawingDisabled++;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -752,15 +752,20 @@ void win_set_buf(win_T *win, buf_T *buf, Error *err)
     goto cleanup;
   }
 
-  // temporarily disable 'autochdir' when using win_set_buf
-  // on non-current window
-  int save_acd = p_acd;
+  try_start();
+
+  const int save_acd = p_acd;
   if (!switchwin.sw_same_win) {
+    // Temporarily disable 'autochdir' when setting buffer in another window.
     p_acd = false;
   }
-  try_start();
+
   int result = do_buffer(DOBUF_GOTO, DOBUF_FIRST, FORWARD, buf->b_fnum, 0);
-  p_acd = save_acd;
+
+  if (!switchwin.sw_same_win) {
+    p_acd = save_acd;
+  }
+
   if (!try_end(err) && result == FAIL) {
     api_set_error(err,
                   kErrorTypeException,

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -2048,6 +2048,37 @@ describe('api/buf', function()
       eq(1, fn.filereadable(new_name))
       os.remove(new_name)
     end)
+
+    describe("with 'autochdir'", function()
+      local topdir
+      local oldbuf
+      local newbuf
+
+      before_each(function()
+        command('set shellslash')
+        topdir = fn.getcwd()
+        t.mkdir(topdir .. '/Xacd')
+
+        oldbuf = api.nvim_get_current_buf()
+        command('vnew')
+        newbuf = api.nvim_get_current_buf()
+        command('set autochdir')
+      end)
+
+      after_each(function()
+        t.rmdir(topdir .. '/Xacd')
+      end)
+
+      it('does not change cwd with non-current buffer', function()
+        api.nvim_buf_set_name(oldbuf, topdir .. '/Xacd/foo.txt')
+        eq(topdir, fn.getcwd())
+      end)
+
+      it('changes cwd with current buffer', function()
+        api.nvim_buf_set_name(newbuf, topdir .. '/Xacd/foo.txt')
+        eq(topdir .. '/Xacd', fn.getcwd())
+      end)
+    end)
   end)
 
   describe('nvim_buf_is_loaded', function()


### PR DESCRIPTION
Problem:  Renaming non-current buffer changes working directory when
          'autochdir' is set.
Solution: Temporarily disable 'autochdir'.  Add more tests for the
          win_set_buf change.
