### PR TITLE
fix: vim.validate() order is not deterministic

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2376,7 +2376,8 @@ vim.trim({s})                                                     *vim.trim()*
       • https://www.lua.org/pil/20.2.html
 
 vim.validate({opt})                                           *vim.validate()*
-    Validates a parameter specification (types and values).
+    Validates a parameter specification (types and values). Specs are
+    evaluated in alphanumeric order, until the first failure.
 
     Usage example: >lua
         function user.new(name, age, hobbies)

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -578,7 +578,7 @@ end
 ---@return fun(table: table<K, V>, index?: K):K, V # |for-in| iterator over sorted keys and their values
 ---@return T
 function vim.spairs(t)
-  vim.validate({ t = { t, 't' } })
+  assert(type(t) == 'table', ('expected table, got %s'):format(type(t)))
   --- @cast t table<any,any>
 
   -- collect the keys
@@ -795,7 +795,7 @@ do
       return false, string.format('opt: expected table, got %s', type(opt))
     end
 
-    for param_name, spec in pairs(opt) do
+    for param_name, spec in vim.spairs(opt) do
       if type(spec) ~= 'table' then
         return false, string.format('opt[%s]: expected table, got %s', param_name, type(spec))
       end
@@ -851,7 +851,8 @@ do
     return true
   end
 
-  --- Validates a parameter specification (types and values).
+  --- Validates a parameter specification (types and values). Specs are evaluated in alphanumeric
+  --- order, until the first failure.
   ---
   --- Usage example:
   ---


### PR DESCRIPTION
# Problem:
The order of the validation performed by vim.validate() is unpredictable.
- harder to write reliable tests.
- confusing UX because validation result might return different errors randomly.

# Solution:
Iterate the input using `vim.spairs()`.

# Future:
Ideally, the caller could provide an "ordered dict".