### PR TITLE
vim-patch:9.1.0340: Problem: Error with matchaddpos() and empty list

### DIFF
--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -100,7 +100,7 @@ static int match_add(win_T *wp, const char *const grp, const char *const pat, in
 
   // Build new match.
   matchitem_T *m = xcalloc(1, sizeof(matchitem_T));
-  if (pos_list != NULL) {
+  if (tv_list_len(pos_list) > 0) {
     m->mit_pos_array = xcalloc((size_t)tv_list_len(pos_list), sizeof(llpos_T));
     m->mit_pos_count = tv_list_len(pos_list);
   }
@@ -1103,7 +1103,7 @@ void f_matchaddpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   list_T *l;
   l = argvars[1].vval.v_list;
-  if (l == NULL) {
+  if (tv_list_len(l) == 0) {
     return;
   }
 

--- a/test/old/testdir/test_match.vim
+++ b/test/old/testdir/test_match.vim
@@ -310,6 +310,7 @@ func Test_matchaddpos_error()
   " call assert_fails("call matchaddpos('Error', [{}])", 'E290:')
   call assert_fails("call matchaddpos('Error', [{}])", 'E5031:')
   call assert_equal(-1, matchaddpos('Error', v:_null_list))
+  call assert_equal(-1, matchaddpos('Error', []))
   call assert_fails("call matchaddpos('Error', [1], [], 1)", 'E745:')
 endfunc
 
@@ -427,13 +428,11 @@ func Test_match_tab_with_linebreak()
     call setline(1, "\tix")
     call matchadd('ErrorMsg', '\t')
   END
-  call writefile(lines, 'XscriptMatchTabLinebreak')
+  call writefile(lines, 'XscriptMatchTabLinebreak', 'D')
   let buf = RunVimInTerminal('-S XscriptMatchTabLinebreak', #{rows: 10})
   call VerifyScreenDump(buf, 'Test_match_tab_linebreak', {})
 
   call StopVimInTerminal(buf)
-  call delete('XscriptMatchTabLinebreak')
 endfunc
-
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0340: Problem: Error with matchaddpos() and empty list

Problem:  Error with matchaddpos() and empty list
          (@rickhow)
Solution: Return early for an empty list

closes: vim/vim#14563

https://github.com/vim/vim/commit/f7d31adcc22eae852d6e7a5b59e9755ba7b51d35

Co-authored-by: Christian Brabandt <cb@256bit.org>