### PR TITLE
vim-patch:9.1.0341: Problem: a few memory leaks are found

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2019,6 +2019,9 @@ static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, 
 
     action = tv_get_string_chk(&argvars[2]);
     if (action == NULL) {
+      if (is_new) {
+        tv_dict_unref(d1);
+      }
       return;  // Type error; error message already given.
     }
     size_t i;
@@ -2028,6 +2031,9 @@ static void extend_dict(typval_T *argvars, const char *arg_errmsg, bool is_new, 
       }
     }
     if (i == 3) {
+      if (is_new) {
+        tv_dict_unref(d1);
+      }
       semsg(_(e_invarg2), action);
       return;
     }

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1441,4 +1441,10 @@ func Test_indexof()
   delfunc TestIdx
 endfunc
 
+func Test_extendnew_leak()
+  " This used to leak memory
+  for i in range(100) | silent! call extendnew([], [], []) | endfor
+  for i in range(100) | silent! call extendnew({}, {}, {}) | endfor
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0341: Problem: a few memory leaks are found

Problem:  a few memory leaks are found
          (LuMingYinDetect )
Solution: properly free the memory

closes: vim/vim#14517

https://github.com/vim/vim/commit/29269a71b5ac8a87c6c4beca35c173a19a2c9398

Co-authored-by: Christian Brabandt <cb@256bit.org>