### PR TITLE
build(manifest): set longPathAware in Manifest on Windows

### DIFF
--- a/src/nvim/os/nvim.manifest
+++ b/src/nvim/os/nvim.manifest
@@ -18,8 +18,9 @@
     </application>
   </compatibility>
   <asmv3:application>
-    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
-      <activeCodePage>UTF-8</activeCodePage>
+    <asmv3:windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </asmv3:windowsSettings>
   </asmv3:application>
 </assembly>


### PR DESCRIPTION
Was briefly mentioned as part of https://github.com/neovim/neovim/issues/28384

Allows Windows file APIs (and anything that uses them) to bypass the 260-character `MAX_PATH` limitation on Windows 10 1607 or later. This does not otherwise effect the behaviours of any File APIs, so this is a strictly backwards compatible change.

NOTE: This change by itself does not change the behaviour of running Neovim. The system must also have the Windows registry key `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled` set to a `REG_DWORD` with value 1.

See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell#enable-long-paths-in-windows-10-version-1607-and-later for more information.