### PR TITLE
vim-patch:9.1.0344: Cursor wrong after using setcellwidth() in terminal

### DIFF
--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -300,6 +300,28 @@ func Test_setcellwidths_dump()
   call StopVimInTerminal(buf)
 endfunc
 
+" When `setcellwidth` is used on characters that are not targets of `ambiwidth`.
+func Test_setcellwidths_with_non_ambiwidth_character_dump()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, [repeat("\u279c", 60), repeat("\u279c", 60)])
+      set ambiwidth=single
+  END
+  call writefile(lines, 'XCellwidthsWithNonAmbiwidthCharacter', 'D')
+  let buf = RunVimInTerminal('-S XCellwidthsWithNonAmbiwidthCharacter', {'rows': 6, 'cols': 50})
+  call term_sendkeys(buf, ":call setcellwidths([[0x279c, 0x279c, 1]])\<CR>")
+  call term_sendkeys(buf, ":echo\<CR>")
+  call VerifyScreenDump(buf, 'Test_setcellwidths_with_non_ambiwidth_character_dump_1', {})
+
+  call term_sendkeys(buf, ":call setcellwidths([[0x279c, 0x279c, 2]])\<CR>")
+  call term_sendkeys(buf, ":echo\<CR>")
+  call VerifyScreenDump(buf, 'Test_setcellwidths_with_non_ambiwidth_character_dump_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+
 " For some reason this test causes Test_customlist_completion() to fail on CI,
 " so run it as the last test.
 func Test_zz_ambiwidth_hl_dump()
@@ -321,7 +343,6 @@ func Test_zz_ambiwidth_hl_dump()
   call term_sendkeys(buf, ":echo\<CR>")
   call VerifyScreenDump(buf, 'Test_ambiwidth_hl_dump_1', {})
 
-  if 0 " Enable after #14539 is fixed
   call term_sendkeys(buf, ":call setcellwidths([[0x2103, 0x2103, 2]])\<CR>")
   call term_sendkeys(buf, ":echo\<CR>")
   call VerifyScreenDump(buf, 'Test_ambiwidth_hl_dump_2', {})
@@ -329,7 +350,6 @@ func Test_zz_ambiwidth_hl_dump()
   call term_sendkeys(buf, ":call setcellwidths([[0x2103, 0x2103, 1]])\<CR>")
   call term_sendkeys(buf, ":echo\<CR>")
   call VerifyScreenDump(buf, 'Test_ambiwidth_hl_dump_1', {})
-  endif
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0344: Cursor wrong after using setcellwidth() in terminal

Problem:  Cursor wrong after using setcellwidth() in terminal
          (mikoto2000)
Solution: output additional spaces, so the behaviour matches the GUI
          (mikoto2000)

closes: vim/vim#14540

Fix CUI `setcellwidths` characters draw behavior to same GUI behavior.

https://github.com/vim/vim/commit/e20fa59903525e15cecd680a2f32ece8a5d1bc0c

This is already fixed and tested in Nvim in #28322.

Co-authored-by: mikoto2000 <mikoto2000@gmail.com>