### PR TITLE
build(nix): update flake to prevent build errors

### DIFF
--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703013332,
-        "narHash": "sha256-+tFNwMvlXLbJZXiMHqYq77z/RfmpfpiI3yjL6o/Zo9M=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -88,9 +88,7 @@
 
         # for neovim developers, beware of the slow binary
         neovim-developer = let inherit (final.luaPackages) luacheck;
-        in (final.neovim-debug.override {
-          doCheck = final.stdenv.isLinux;
-        }).overrideAttrs (oa: {
+        in final.neovim-debug.overrideAttrs (oa: {
           cmakeFlags = oa.cmakeFlags ++ [
             "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
             "-DENABLE_LTO=OFF"
@@ -99,6 +97,7 @@
             # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
             "-DENABLE_ASAN_UBSAN=ON"
           ];
+          doCheck = final.stdenv.isLinux;
         });
       };
     } // flake-utils.lib.eachDefaultSystem (system:
@@ -150,7 +149,7 @@
             shellHook = oa.shellHook + ''
               export NVIM_PYTHON_LOG_LEVEL=DEBUG
               export NVIM_LOG_FILE=/tmp/nvim.log
-              export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_11}/bin/llvm-symbolizer
+              export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
 
               # ASAN_OPTIONS=detect_leaks=1
               export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"


### PR DESCRIPTION
- Updates nixpkgs to source a necessary Tree-sitter version
- Updates to a new llvm version as the old one was removed from nixpkgs
- Properly moves `doCheck` from a regular param to an attribute option

I think the documentation may still need an update, because `nix-shell '<nixpkgs>' -A neovim-unwrapped` remains broken, but now the main build works as does `nix develop` (which seems to give basically the same effect as the above command). Sadly I don't think I know enough about nix to provide proper documentation 