### PR TITLE
refactor(options)!: use forward slash as path separator on Windows

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6957,10 +6957,8 @@ sha256({string})                                                      *sha256()*
 shellescape({string} [, {special}])                              *shellescape()*
 		Escape {string} for use as a shell command argument.
 
-		On Windows when 'shellslash' is not set, encloses {string} in
-		double-quotes and doubles all double-quotes within {string}.
-		Otherwise encloses {string} in single-quotes and replaces all
-		"'" with "'\''".
+		On Windows, encloses {string} in single-quotes and replaces
+		all "'" with "'\''".
 
 		If {special} is a |non-zero-arg|:
 		- Special items such as "!", "%", "#" and "<cword>" will be

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -180,10 +180,12 @@ NORMAL COMMANDS
 OPTIONS
 - *cpo-<* *:menu-<special>* *:menu-special* *:map-<special>* *:map-special*
   `<>` notation is always enabled.
+- *'completeslash'*	Path separator is always `/` on Windows.
 - *'fe'*		'fenc'+'enc' before Vim 6.0; no longer used.
 - *'highlight'* *'hl'*	Names of builtin |highlight-groups| cannot be changed.
 - *'langnoremap'*	Deprecated alias to 'nolangremap'.
 - 'sessionoptions'	Flags "unix", "slash" are ignored and always enabled.
+- *'shellslash'*	Path separator is always `/` on Windows.
 - *'vi'*
 - 'viewoptions'		Flags "unix", "slash" are ignored and always enabled.
 - *'viminfo'*		Deprecated alias to 'shada' option.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5226,8 +5226,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'shell' 'sh'		string	(default $SHELL or "sh", Win32: "cmd.exe")
 			global
 	Name of the shell to use for ! and :! commands.  When changing the
-	value also check these options: 'shellpipe', 'shellslash'
-	'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
+	value also check these options: 'shellpipe', 'shellredir',
+	'shellquote', 'shellxquote' and 'shellcmdflag'.
 	It is allowed to give an argument to the command, e.g.  "csh -f".
 	See |option-backslash| about including spaces and backslashes.
 	Environment variables are expanded |:set_env|.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1529,21 +1529,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    completion in a popup window.  Only works in combination
 		    with "menu" or "menuone".  Overrides "preview".
 
-						*'completeslash'* *'csl'*
-'completeslash' 'csl'	string	(default "")
-			local to buffer
-			only for MS-Windows
-	When this option is set it overrules 'shellslash' for completion:
-	- When this option is set to "slash", a forward slash is used for path
-	  completion in insert mode. This is useful when editing HTML tag, or
-	  Makefile with 'noshellslash' on MS-Windows.
-	- When this option is set to "backslash", backslash is used. This is
-	  useful when editing a batch file with 'shellslash' set on MS-Windows.
-	- When this option is empty, same character is used as for
-	  'shellslash'.
-	For Insert mode completion the buffer-local value is used.  For
-	command line completion the global value is used.
-
 					*'concealcursor'* *'cocu'*
 'concealcursor' 'cocu'	string	(default "")
 			local to window
@@ -5373,22 +5358,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	become obsolete (at least for Unix).
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
-
-			*'shellslash'* *'ssl'* *'noshellslash'* *'nossl'*
-'shellslash' 'ssl'	boolean	(default off)
-			global
-			only for MS-Windows
-	When set, a forward slash is used when expanding file names.  This is
-	useful when a Unix-like shell is used instead of cmd.exe.  Backward
-	slashes can still be typed, but they are changed to forward slashes by
-	Vim.
-	Note that setting or resetting this option has no effect for some
-	existing file names, thus this option needs to be set before opening
-	any file for best results.  This might change in the future.
-	'shellslash' only works when a backslash can be used as a path
-	separator.  To test if this is so use: >vim
-		if exists('+shellslash')
-<	Also see 'completeslash'.
 
 			*'shelltemp'* *'stmp'* *'noshelltemp'* *'nostmp'*
 'shelltemp' 'stmp'	boolean	(default on)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5505,8 +5505,8 @@ vim.go.shadafile = vim.o.shadafile
 vim.go.sdf = vim.go.shadafile
 
 --- Name of the shell to use for ! and :! commands.  When changing the
---- value also check these options: 'shellpipe', 'shellslash'
---- 'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
+--- value also check these options: 'shellpipe', 'shellredir',
+--- 'shellquote', 'shellxquote' and 'shellcmdflag'.
 --- It is allowed to give an argument to the command, e.g.  "csh -f".
 --- See `option-backslash` about including spaces and backslashes.
 --- Environment variables are expanded `:set_env`.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1079,24 +1079,6 @@ vim.o.cot = vim.o.completeopt
 vim.go.completeopt = vim.o.completeopt
 vim.go.cot = vim.go.completeopt
 
---- 		only for MS-Windows
---- When this option is set it overrules 'shellslash' for completion:
---- - When this option is set to "slash", a forward slash is used for path
----   completion in insert mode. This is useful when editing HTML tag, or
----   Makefile with 'noshellslash' on MS-Windows.
---- - When this option is set to "backslash", backslash is used. This is
----   useful when editing a batch file with 'shellslash' set on MS-Windows.
---- - When this option is empty, same character is used as for
----   'shellslash'.
---- For Insert mode completion the buffer-local value is used.  For
---- command line completion the global value is used.
----
---- @type string
-vim.o.completeslash = ""
-vim.o.csl = vim.o.completeslash
-vim.bo.completeslash = vim.o.completeslash
-vim.bo.csl = vim.bo.completeslash
-
 --- Sets the modes in which text in the cursor line can also be concealed.
 --- When the current mode is listed then concealing happens just like in
 --- other lines.
@@ -5680,28 +5662,6 @@ vim.o.shellredir = ">"
 vim.o.srr = vim.o.shellredir
 vim.go.shellredir = vim.o.shellredir
 vim.go.srr = vim.go.shellredir
-
---- 		only for MS-Windows
---- When set, a forward slash is used when expanding file names.  This is
---- useful when a Unix-like shell is used instead of cmd.exe.  Backward
---- slashes can still be typed, but they are changed to forward slashes by
---- Vim.
---- Note that setting or resetting this option has no effect for some
---- existing file names, thus this option needs to be set before opening
---- any file for best results.  This might change in the future.
---- 'shellslash' only works when a backslash can be used as a path
---- separator.  To test if this is so use:
----
---- ```vim
---- 	if exists('+shellslash')
---- ```
---- Also see 'completeslash'.
----
---- @type boolean
-vim.o.shellslash = false
-vim.o.ssl = vim.o.shellslash
-vim.go.shellslash = vim.o.shellslash
-vim.go.ssl = vim.go.shellslash
 
 --- When on, use temp files for shell commands.  When off use a pipe.
 --- When using a pipe is not possible temp files are used anyway.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8288,10 +8288,8 @@ function vim.fn.sha256(string) end
 
 --- Escape {string} for use as a shell command argument.
 ---
---- On Windows when 'shellslash' is not set, encloses {string} in
---- double-quotes and doubles all double-quotes within {string}.
---- Otherwise encloses {string} in single-quotes and replaces all
---- "'" with "'\''".
+--- On Windows, encloses {string} in single-quotes and replaces
+--- all "'" with "'\''".
 ---
 --- If {special} is a |non-zero-arg|:
 --- - Special items such as "!", "%", "#" and "<cword>" will be

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1070,16 +1070,6 @@ if has("quickfix")
   call <SID>OptionG("menc", &menc)
 endif
 
-
-if has("win32")
-  call <SID>Header(gettext("system specific"))
-  call <SID>AddOption("shellslash", gettext("use forward slashes in file names; for Unix-like shells"))
-  call <SID>BinOptionG("ssl", &ssl)
-  call <SID>AddOption("completeslash", gettext("specifies slash/backslash used for completion"))
-  call <SID>OptionG("csl", &csl)
-endif
-
-
 call <SID>Header(gettext("language specific"))
 call <SID>AddOption("isfname", gettext("specifies the characters in a file name"))
 call <SID>OptionG("isf", &isf)

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -81,7 +81,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
   *opt_idxp = find_option(name);
   int flags = get_option_attrs(*opt_idxp);
   if (flags == 0) {
-    // hidden or unknown option
+    // unknown option
     api_set_error(err, kErrorTypeValidation, "Unknown option '%s'", name);
   } else if (*req_scope == kOptReqBuf || *req_scope == kOptReqWin) {
     // if 'buf' or 'win' is passed, make sure the option supports it
@@ -176,7 +176,6 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   }
 
   OptVal value = get_option_value_for(opt_idx, scope, req_scope, from, err);
-  bool hidden = is_option_hidden(opt_idx);
 
   if (ftbuf != NULL) {
     // restore curwin/curbuf and a few other things
@@ -190,7 +189,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
     goto err;
   }
 
-  VALIDATE_S(!hidden && value.type != kOptValTypeNil, "option", name.data, {
+  VALIDATE_S(value.type != kOptValTypeNil, "option", name.data, {
     goto err;
   });
 

--- a/src/nvim/ascii_defs.h
+++ b/src/nvim/ascii_defs.h
@@ -74,13 +74,8 @@
 #define Ctrl__          31
 
 // Character that separates dir names in a path.
-#ifdef BACKSLASH_IN_FILENAME
-# define PATHSEP        psepc
-# define PATHSEPSTR     pseps
-#else
-# define PATHSEP        '/'
-# define PATHSEPSTR     "/"
-#endif
+#define PATHSEP        '/'
+#define PATHSEPSTR     "/"
 
 static inline bool ascii_iswhite(int c)
   REAL_FATTR_CONST

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -801,15 +801,7 @@ void do_autocmd(exarg_T *eap, char *arg_in, int forceit)
     // Expand environment variables in the pattern.  Set 'shellslash', we want
     // forward slashes here.
     if (vim_strchr(pat, '$') != NULL || vim_strchr(pat, '~') != NULL) {
-#ifdef BACKSLASH_IN_FILENAME
-      int p_ssl_save = p_ssl;
-
-      p_ssl = true;
-#endif
       envpat = expand_env_save(pat);
-#ifdef BACKSLASH_IN_FILENAME
-      p_ssl = p_ssl_save;
-#endif
       if (envpat != NULL) {
         pat = envpat;
       }

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1728,9 +1728,9 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
   // Replace all backslashes with forward slashes. This makes the
   // autocommand patterns portable between Unix and Windows.
   if (sfname != NULL) {
-    forward_slash(sfname);
+    slash_adjust(sfname);
   }
-  forward_slash(fname);
+  slash_adjust(fname);
 #endif
 
   // Set the name to be used for <amatch>.
@@ -2146,8 +2146,8 @@ bool has_autocmd(event_T event, char *sfname, buf_T *buf)
   // Replace all backslashes with forward slashes. This makes the
   // autocommand patterns portable between Unix and Windows.
   sfname = xstrdup(sfname);
-  forward_slash(sfname);
-  forward_slash(fname);
+  slash_adjust(sfname);
+  slash_adjust(fname);
 #endif
 
   AutoCmdVec *const acs = &autocmds[(int)event];

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -534,9 +534,6 @@ struct file_buffer {
   char *b_p_com;                ///< 'comments'
   char *b_p_cms;                ///< 'commentstring'
   char *b_p_cpt;                ///< 'complete'
-#ifdef BACKSLASH_IN_FILENAME
-  char *b_p_csl;                ///< 'completeslash'
-#endif
   char *b_p_cfu;                ///< 'completefunc'
   Callback b_cfu_cb;            ///< 'completefunc' callback
   char *b_p_ofu;                ///< 'omnifunc'

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2503,21 +2503,6 @@ static int expand_files_and_dirs(expand_T *xp, char *pat, char ***matches, int *
   if (free_pat) {
     xfree(pat);
   }
-#ifdef BACKSLASH_IN_FILENAME
-  if (p_csl[0] != NUL && (options & WILD_IGNORE_COMPLETESLASH) == 0) {
-    for (int j = 0; j < *numMatches; j++) {
-      char *ptr = (*matches)[j];
-      while (*ptr != NUL) {
-        if (p_csl[0] == 's' && *ptr == '\\') {
-          *ptr = '/';
-        } else if (p_csl[0] == 'b' && *ptr == '/') {
-          *ptr = '\\';
-        }
-        ptr += utfc_ptr2len(ptr);
-      }
-    }
-  }
-#endif
   return ret;
 }
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9895,10 +9895,8 @@ M.funcs = {
     desc = [=[
       Escape {string} for use as a shell command argument.
 
-      On Windows when 'shellslash' is not set, encloses {string} in
-      double-quotes and doubles all double-quotes within {string}.
-      Otherwise encloses {string} in single-quotes and replaces all
-      "'" with "'\''".
+      On Windows, encloses {string} in single-quotes and replaces
+      all "'" with "'\''".
 
       If {special} is a |non-zero-arg|:
       - Special items such as "!", "%", "#" and "<cword>" will be

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1747,12 +1747,6 @@ static void f_expand(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   int options = WILD_SILENT|WILD_USE_NL|WILD_LIST_NOTFOUND;
   bool error = false;
-#ifdef BACKSLASH_IN_FILENAME
-  char *p_csl_save = p_csl;
-
-  // avoid using 'completeslash' here
-  p_csl = empty_string_option;
-#endif
 
   rettv->v_type = VAR_STRING;
   if (argvars[1].v_type != VAR_UNKNOWN
@@ -1812,9 +1806,6 @@ static void f_expand(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       rettv->vval.v_string = NULL;
     }
   }
-#ifdef BACKSLASH_IN_FILENAME
-  p_csl = p_csl_save;
-#endif
 }
 
 /// "menu_get(path [, modes])" function

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3242,22 +3242,6 @@ void write_lnum_adjust(linenr_T offset)
   }
 }
 
-#if defined(BACKSLASH_IN_FILENAME)
-/// Convert all backslashes in fname to forward slashes in-place,
-/// unless when it looks like a URL.
-void forward_slash(char *fname)
-{
-  if (path_with_url(fname)) {
-    return;
-  }
-  for (char *p = fname; *p != NUL; p++) {
-    if (*p == '\\') {
-      *p = '/';
-    }
-  }
-}
-#endif
-
 /// Path to Nvim's own temp dir. Ends in a slash.
 static char *vim_tempdir = NULL;
 #ifdef HAVE_DIRFD_AND_FLOCK

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -776,12 +776,6 @@ EXTERN bool no_hlsearch INIT( = false);
 EXTERN bool typebuf_was_filled INIT( = false);     // received text from client
                                                    // or from feedkeys()
 
-#ifdef BACKSLASH_IN_FILENAME
-EXTERN char psepc INIT( = '\\');            // normal path separator character
-EXTERN char psepcN INIT( = '/');            // abnormal path separator character
-EXTERN char pseps[2] INIT( = { '\\', 0 });  // normal path separator string
-#endif
-
 // Set to kTrue when an operator is being executed with virtual editing
 // kNone when no operator is being executed, kFalse otherwise.
 EXTERN TriState virtual_op INIT( = kNone);

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3046,21 +3046,6 @@ static void get_next_filename_completion(void)
 
   // May change home directory back to "~".
   tilde_replace(compl_pattern, num_matches, matches);
-#ifdef BACKSLASH_IN_FILENAME
-  if (curbuf->b_p_csl[0] != NUL) {
-    for (int i = 0; i < num_matches; i++) {
-      char *ptr = matches[i];
-      while (*ptr != NUL) {
-        if (curbuf->b_p_csl[0] == 's' && *ptr == '\\') {
-          *ptr = '/';
-        } else if (curbuf->b_p_csl[0] == 'b' && *ptr == '/') {
-          *ptr = '\\';
-        }
-        ptr += utfc_ptr2len(ptr);
-      }
-    }
-  }
-#endif
   ins_compl_add_matches(num_matches, matches, p_fic || p_wic);
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2463,28 +2463,6 @@ static const char *did_set_scrollbind(optset_T *args)
   return NULL;
 }
 
-#ifdef BACKSLASH_IN_FILENAME
-/// Process the updated 'shellslash' option value.
-static const char *did_set_shellslash(optset_T *args FUNC_ATTR_UNUSED)
-{
-  if (p_ssl) {
-    psepc = '/';
-    psepcN = '\\';
-    pseps[0] = '/';
-  } else {
-    psepc = '\\';
-    psepcN = '/';
-    pseps[0] = '\\';
-  }
-
-  // need to adjust the file name arguments and buffer names.
-  buflist_slash_adjust();
-  alist_slash_adjust();
-  scriptnames_slash_adjust();
-  return NULL;
-}
-#endif
-
 /// Process the new 'shiftwidth' or the 'tabstop' option value.
 static const char *did_set_shiftwidth_tabstop(optset_T *args)
 {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4753,10 +4753,6 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(buf->b_p_cms);
   case PV_CPT:
     return &(buf->b_p_cpt);
-#ifdef BACKSLASH_IN_FILENAME
-  case PV_CSL:
-    return &(buf->b_p_csl);
-#endif
   case PV_CFU:
     return &(buf->b_p_cfu);
   case PV_OFU:
@@ -5179,10 +5175,6 @@ void buf_copy_options(buf_T *buf, int flags)
       }
       buf->b_p_cpt = xstrdup(p_cpt);
       COPY_OPT_SCTX(buf, BV_CPT);
-#ifdef BACKSLASH_IN_FILENAME
-      buf->b_p_csl = xstrdup(p_csl);
-      COPY_OPT_SCTX(buf, BV_CSL);
-#endif
       buf->b_p_cfu = xstrdup(p_cfu);
       COPY_OPT_SCTX(buf, BV_CFU);
       set_buflocal_cfu_callback(buf);

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -430,9 +430,6 @@ EXTERN char *p_cpt;             ///< 'complete'
 EXTERN OptInt p_columns;        ///< 'columns'
 EXTERN int p_confirm;           ///< 'confirm'
 EXTERN char *p_cot;             ///< 'completeopt'
-#ifdef BACKSLASH_IN_FILENAME
-EXTERN char *p_csl;             ///< 'completeslash'
-#endif
 EXTERN OptInt p_pb;             ///< 'pumblend'
 EXTERN OptInt p_ph;             ///< 'pumheight'
 EXTERN OptInt p_pw;             ///< 'pumwidth'
@@ -642,9 +639,6 @@ EXTERN char *p_sxq;             ///< 'shellxquote'
 EXTERN char *p_sxe;             ///< 'shellxescape'
 EXTERN char *p_srr;             ///< 'shellredir'
 EXTERN int p_stmp;              ///< 'shelltemp'
-#ifdef BACKSLASH_IN_FILENAME
-EXTERN int p_ssl;               ///< 'shellslash'
-#endif
 EXTERN char *p_stl;             ///< 'statusline'
 EXTERN char *p_wbr;             ///< 'winbar'
 EXTERN int p_sr;                ///< 'shiftround'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7165,7 +7165,7 @@ return {
     },
     {
       abbreviation = 'ssl',
-      defaults = { if_true = false },
+      defaults = { if_true = true },
       full_name = 'shellslash',
       scope = { 'global' },
       short_desc = N_('No description'),

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6971,8 +6971,8 @@ return {
       },
       desc = [=[
         Name of the shell to use for ! and :! commands.  When changing the
-        value also check these options: 'shellpipe', 'shellslash'
-        'shellredir', 'shellquote', 'shellxquote' and 'shellcmdflag'.
+        value also check these options: 'shellpipe', 'shellredir',
+        'shellquote', 'shellxquote' and 'shellcmdflag'.
         It is allowed to give an argument to the command, e.g.  "csh -f".
         See |option-backslash| about including spaces and backslashes.
         Environment variables are expanded |:set_env|.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -91,11 +91,11 @@ return {
     {
       abbreviation = 'al',
       defaults = { if_true = 224 },
-      enable_if = false,
       full_name = 'aleph',
       scope = { 'global' },
       short_desc = N_('ASCII code of the letter Aleph (Hebrew)'),
       type = 'number',
+      hidden = true,
     },
     {
       abbreviation = 'ari',
@@ -791,11 +791,11 @@ return {
            current	Use the current directory.
            {path}	Use the specified directory
       ]=],
-      enable_if = false,
       full_name = 'browsedir',
       scope = { 'global' },
       short_desc = N_('which directory to start browsing in'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'bh',
@@ -3720,12 +3720,12 @@ return {
         	try to keep 'lines' and 'columns' the same when adding and
         	removing GUI components.
       ]=],
-      enable_if = false,
       full_name = 'guioptions',
       list = 'flags',
       scope = { 'global' },
       short_desc = N_('GUI: Which components and options are used'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'gtl',
@@ -3744,13 +3744,13 @@ return {
         present in 'guioptions'.  For the non-GUI tab pages line 'tabline' is
         used.
       ]=],
-      enable_if = false,
       full_name = 'guitablabel',
       modelineexpr = true,
       redraw = { 'current_window' },
       scope = { 'global' },
       short_desc = N_('GUI: custom label for a tab page'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'gtt',
@@ -3762,12 +3762,12 @@ return {
         	let &guitabtooltip = "line one\nline two"
         <
       ]=],
-      enable_if = false,
       full_name = 'guitabtooltip',
       redraw = { 'current_window' },
       scope = { 'global' },
       short_desc = N_('GUI: custom tooltip for a tab page'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'hf',
@@ -4009,11 +4009,11 @@ return {
         English characters directly, e.g., when it's used to type accented
         characters with dead keys.
       ]=],
-      enable_if = false,
       full_name = 'imcmdline',
       scope = { 'global' },
       short_desc = N_('use IM when starting to edit a command line'),
       type = 'boolean',
+      hidden = true,
     },
     {
       abbreviation = 'imd',
@@ -4027,11 +4027,11 @@ return {
         Currently this option is on by default for SGI/IRIX machines.  This
         may change in later releases.
       ]=],
-      enable_if = false,
       full_name = 'imdisable',
       scope = { 'global' },
       short_desc = N_('do not use the IM in any mode'),
       type = 'boolean',
+      hidden = true,
     },
     {
       abbreviation = 'imi',
@@ -5655,13 +5655,13 @@ return {
         indicate no input when the hit-enter prompt is displayed (since
         clicking the mouse has no effect in this state.)
       ]=],
-      enable_if = false,
       full_name = 'mouseshape',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('shape of the mouse pointer in different modes'),
       tags = { 'E547' },
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'mouset',
@@ -5809,11 +5809,11 @@ return {
         Note that on Windows editing "aux.h", "lpt1.txt" and the like also
         result in editing a device.
       ]=],
-      enable_if = false,
       full_name = 'opendevice',
       scope = { 'global' },
       short_desc = N_('allow reading/writing devices on MS-Windows'),
       type = 'boolean',
+      hidden = true,
     },
     {
       abbreviation = 'opfunc',
@@ -5886,11 +5886,11 @@ return {
     {
       abbreviation = 'pt',
       defaults = { if_true = '' },
-      enable_if = false,
       full_name = 'pastetoggle',
       scope = { 'global' },
       short_desc = N_('No description'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'pex',
@@ -8778,11 +8778,11 @@ return {
     {
       abbreviation = 'tenc',
       defaults = { if_true = '' },
-      enable_if = false,
       full_name = 'termencoding',
       scope = { 'global' },
       short_desc = N_('Terminal encoding'),
       type = 'string',
+      hidden = true,
     },
     {
       abbreviation = 'tgc',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1465,27 +1465,12 @@ return {
     },
     {
       abbreviation = 'csl',
-      cb = 'did_set_completeslash',
       defaults = { if_true = '' },
-      desc = [=[
-        		only for MS-Windows
-        When this option is set it overrules 'shellslash' for completion:
-        - When this option is set to "slash", a forward slash is used for path
-          completion in insert mode. This is useful when editing HTML tag, or
-          Makefile with 'noshellslash' on MS-Windows.
-        - When this option is set to "backslash", backslash is used. This is
-          useful when editing a batch file with 'shellslash' set on MS-Windows.
-        - When this option is empty, same character is used as for
-          'shellslash'.
-        For Insert mode completion the buffer-local value is used.  For
-        command line completion the global value is used.
-      ]=],
-      enable_if = 'BACKSLASH_IN_FILENAME',
-      expand_cb = 'expand_set_completeslash',
       full_name = 'completeslash',
       scope = { 'buffer' },
+      short_desc = N_('No description'),
       type = 'string',
-      varname = 'p_csl',
+      hidden = true,
     },
     {
       abbreviation = 'cocu',
@@ -7180,28 +7165,12 @@ return {
     },
     {
       abbreviation = 'ssl',
-      cb = 'did_set_shellslash',
       defaults = { if_true = false },
-      desc = [=[
-        		only for MS-Windows
-        When set, a forward slash is used when expanding file names.  This is
-        useful when a Unix-like shell is used instead of cmd.exe.  Backward
-        slashes can still be typed, but they are changed to forward slashes by
-        Vim.
-        Note that setting or resetting this option has no effect for some
-        existing file names, thus this option needs to be set before opening
-        any file for best results.  This might change in the future.
-        'shellslash' only works when a backslash can be used as a path
-        separator.  To test if this is so use: >vim
-        	if exists('+shellslash')
-        <	Also see 'completeslash'.
-      ]=],
-      enable_if = 'BACKSLASH_IN_FILENAME',
       full_name = 'shellslash',
       scope = { 'global' },
-      short_desc = N_('use forward slash for shell file names'),
+      short_desc = N_('No description'),
       type = 'boolean',
-      varname = 'p_ssl',
+      hidden = true,
     },
     {
       abbreviation = 'stmp',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1008,28 +1008,6 @@ int expand_set_completeopt(optexpand_T *args, int *numMatches, char ***matches)
                                matches);
 }
 
-#ifdef BACKSLASH_IN_FILENAME
-/// The 'completeslash' option is changed.
-const char *did_set_completeslash(optset_T *args)
-{
-  buf_T *buf = (buf_T *)args->os_buf;
-  if (check_opt_strings(p_csl, p_csl_values, false) != OK
-      || check_opt_strings(buf->b_p_csl, p_csl_values, false) != OK) {
-    return e_invarg;
-  }
-  return NULL;
-}
-
-int expand_set_completeslash(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               p_csl_values,
-                               ARRAY_SIZE(p_csl_values) - 1,
-                               numMatches,
-                               matches);
-}
-#endif
-
 /// The 'concealcursor' option is changed.
 const char *did_set_concealcursor(optset_T *args)
 {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -123,10 +123,6 @@ static char *(p_fdm_values[]) = { "manual", "expr", "marker", "indent",
 static char *(p_fcl_values[]) = { "all", NULL };
 static char *(p_cot_values[]) = { "menu", "menuone", "longest", "preview", "noinsert", "noselect",
                                   "popup", NULL };
-#ifdef BACKSLASH_IN_FILENAME
-static char *(p_csl_values[]) = { "slash", "backslash", NULL };
-#endif
-
 static char *(p_scl_values[]) = { "yes", "no", "auto", "auto:1", "auto:2", "auto:3", "auto:4",
                                   "auto:5", "auto:6", "auto:7", "auto:8", "auto:9", "yes:1",
                                   "yes:2", "yes:3", "yes:4", "yes:5", "yes:6", "yes:7", "yes:8",

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -691,9 +691,8 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
       }
 
 #ifdef BACKSLASH_IN_FILENAME
-      // If 'shellslash' is set change backslashes to forward slashes.
-      // Can't use slash_adjust(), p_ssl may be set temporarily.
-      if (p_ssl && var != NULL && vim_strchr(var, '\\') != NULL) {
+      // Change backslashes to forward slashes.
+      if (var != NULL && vim_strchr(var, '\\') != NULL) {
         char *p = xstrdup(var);
 
         if (mustfree) {

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -701,7 +701,7 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
         }
         var = p;
         mustfree = true;
-        forward_slash(var);
+        slash_adjust(var);
       }
 #endif
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1409,37 +1409,23 @@ static int expand_backtick(garray_T *gap, char *pat, int flags)
   return cnt;
 }
 
-#ifdef BACKSLASH_IN_FILENAME
-/// Replace all slashes by backslashes.
-/// This used to be the other way around, but MS-DOS sometimes has problems
-/// with slashes (e.g. in a command name).  We can't have mixed slashes and
-/// backslashes, because comparing file names will not work correctly.  The
-/// commands that use a file name should try to avoid the need to type a
-/// backslash twice.
-/// When 'shellslash' set do it the other way around.
-/// When the path looks like a URL leave it unmodified.
-void slash_adjust(char *p)
+/// Replace backslashes with slashes, except when the path looks like a URL.
+/// Does nothing if the OS is not Windows.
+void slash_adjust(char *fname)
+  FUNC_ATTR_NONNULL_ALL
 {
-  if (path_with_url(p)) {
+#ifdef BACKSLASH_IN_FILENAME
+  if (path_with_url(fname)) {
     return;
   }
 
-  if (*p == '`') {
-    // don't replace backslash in backtick quoted strings
-    const size_t len = strlen(p);
-    if (len > 2 && *(p + len - 1) == '`') {
-      return;
+  for (char *p = fname; *p != NUL; MB_PTR_ADV(p)) {
+    if (*p == '\\') {
+      *p = '/';
     }
   }
-
-  while (*p) {
-    if (*p == psepcN) {
-      *p = psepc;
-    }
-    MB_PTR_ADV(p);
-  }
-}
 #endif
+}
 
 /// Add a file to a file list.  Accepted flags:
 /// EW_DIR      add directories

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -200,13 +200,6 @@ char *vim_strsave_shellescape(const char *string, bool do_special, bool do_newli
   // First count the number of extra bytes required.
   size_t length = strlen(string) + 3;       // two quotes and a trailing NUL
   for (const char *p = string; *p != NUL; MB_PTR_ADV(p)) {
-#ifdef MSWIN
-    if (!p_ssl) {
-      if (*p == '"') {
-        length++;                       // " -> ""
-      }
-    } else
-#endif
     if (*p == '\'') {
       length += 3;                      // ' => '\''
     }
@@ -231,24 +224,9 @@ char *vim_strsave_shellescape(const char *string, bool do_special, bool do_newli
   char *d = escaped_string;
 
   // add opening quote
-#ifdef MSWIN
-  if (!p_ssl) {
-    *d++ = '"';
-  } else
-#endif
   *d++ = '\'';
 
   for (const char *p = string; *p != NUL;) {
-#ifdef MSWIN
-    if (!p_ssl) {
-      if (*p == '"') {
-        *d++ = '"';
-        *d++ = '"';
-        p++;
-        continue;
-      }
-    } else
-#endif
     if (*p == '\'') {
       *d++ = '\'';
       *d++ = '\\';
@@ -283,11 +261,6 @@ char *vim_strsave_shellescape(const char *string, bool do_special, bool do_newli
   }
 
   // add terminating quote and finish with a NUL
-#ifdef MSWIN
-  if (!p_ssl) {
-    *d++ = '"';
-  } else
-#endif
   *d++ = '\'';
   *d = NUL;
 


### PR DESCRIPTION
Problem: All modern Windows versions support using a forward slash as path separator on most applications, including the two most common shells, cmd.exe and PowerShell. Therefore, using backward slash as path separator is largely useless.

Solution: Use forward slash as path separator on every platform. Also remove `completeslash` and `shellslash` as they are no longer needed.