### PR TITLE
fix(diagnostic): invalid col number  compare in next_diagnostic

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -828,14 +828,14 @@ local function next_diagnostic(position, search_forward, bufnr, opts, namespace)
           return a.col < b.col
         end
         is_next = function(d)
-          return math.min(d.col, line_length - 1) > position[2]
+          return math.min(d.col, math.max(line_length - 1, 0)) > position[2]
         end
       else
         sort_diagnostics = function(a, b)
           return a.col > b.col
         end
         is_next = function(d)
-          return math.min(d.col, line_length - 1) < position[2]
+          return math.min(d.col, math.max(line_length - 1, 0)) < position[2]
         end
       end
       table.sort(line_diagnostics[lnum], sort_diagnostics)

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -978,6 +978,29 @@ describe('vim.diagnostic', function()
       ]]
       )
     end)
+
+    it('works on blank line #28397', function()
+      eq(
+        { 0, 2 },
+        exec_lua [[
+        local test_bufnr = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_buf_set_lines(test_bufnr, 0, -1, false, {
+          'first line',
+          '',
+          '',
+          'end line',
+        })
+        vim.diagnostic.set(diagnostic_ns, test_bufnr, {
+          make_info('Diagnostic #1', 0, 2, 0, 2),
+          make_info('Diagnostic #2', 2, 0, 2, 0),
+          make_info('Diagnostic #3', 2, 0, 2, 0),
+        })
+        vim.api.nvim_win_set_buf(0, test_bufnr)
+        vim.api.nvim_win_set_cursor(0, {3, 0})
+        return vim.diagnostic.get_prev_pos { namespace = diagnostic_ns}
+      ]]
+      )
+    end)
   end)
 
   describe('get()', function()


### PR DESCRIPTION
Problem: when line is a blank line there will got an invalid column number in math.min compare.

Solution: make sure the min col number is 0 not an illegal number.


Fix #26079 