### PR TITLE
fix: metatables dropped in `tbl_extend`

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -356,7 +356,9 @@ end
 
 --- We only merge empty tables or tables that are not an array (indexed by integers)
 local function can_merge(v)
-  return type(v) == 'table' and (vim.tbl_isempty(v) or not vim.tbl_isarray(v))
+  return type(v) == 'table'
+    and (vim.tbl_isempty(v) or not vim.tbl_isarray(v))
+    and getmetatable(v) == nil
 end
 
 local function tbl_extend(behavior, deep_extend, ...)
@@ -391,6 +393,17 @@ local function tbl_extend(behavior, deep_extend, ...)
           end -- Else behavior is "keep".
         else
           ret[k] = v
+        end
+      end
+
+      local mt = getmetatable(tbl)
+      if mt ~= nil then
+        if behavior ~= 'force' and getmetatable(ret) ~= nil then
+          if behavior == 'error' then
+            error('metatable found in more than one map.')
+          end
+        else
+          setmetatable(ret, mt)
         end
       end
     end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -926,7 +926,7 @@ describe('lua stdlib', function()
       local b = vim.empty_dict()
       local c = vim.tbl_extend("keep", a, b)
 
-      return vim.tbl_islist(c) and vim.tbl_count(c) == 0
+      return not vim.tbl_islist(c) and vim.tbl_count(c) == 0
     ]]))
 
     ok(exec_lua([[
@@ -938,6 +938,26 @@ describe('lua stdlib', function()
       for _ in pairs(c) do count = count + 1 end
 
       return c.x.a == 1 and c.x.b == 2 and c.x.c == nil and count == 1
+    ]]))
+
+    ok(exec_lua([[
+      local a = { x = 1 }
+      local b = { y = 2 }
+      setmetatable(a, { __tostring = function() return "table a" end })
+      setmetatable(b, { __tostring = function() return "table b" end })
+      local c = vim.tbl_extend("force", a, b)
+
+      return c.x == 1 and c.y == 2 and tostring(c) == "table b"
+    ]]))
+
+    ok(exec_lua([[
+      local a = { x = 1 }
+      local b = { y = 2 }
+      setmetatable(a, { __tostring = function() return "table a" end })
+      setmetatable(b, { __tostring = function() return "table b" end })
+      local c = vim.tbl_extend("keep", a, b)
+
+      return c.x == 1 and c.y == 2 and tostring(c) == "table a"
     ]]))
 
     matches(
@@ -977,10 +997,7 @@ describe('lua stdlib', function()
       local b = {x = {a = 2, c = {y = 3}}}
       local c = vim.tbl_deep_extend("keep", a, b)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
-
-      return c.x.a == 1 and c.x.b == 2 and c.x.c.y == 3 and count == 1
+      return c.x.a == 1 and c.x.b == 2 and c.x.c.y == 3 and vim.tbl_count(c) == 1
     ]]))
 
     ok(exec_lua([[
@@ -988,10 +1005,7 @@ describe('lua stdlib', function()
       local b = {x = {a = 2, c = {y = 3}}}
       local c = vim.tbl_deep_extend("force", a, b)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
-
-      return c.x.a == 2 and c.x.b == 2 and c.x.c.y == 3 and count == 1
+      return c.x.a == 2 and c.x.b == 2 and c.x.c.y == 3 and vim.tbl_count(c) == 1
     ]]))
 
     ok(exec_lua([[
@@ -1000,10 +1014,7 @@ describe('lua stdlib', function()
       local c = {x = {c = 4, d = {y = 4}}}
       local d = vim.tbl_deep_extend("keep", a, b, c)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
-
-      return d.x.a == 1 and d.x.b == 2 and d.x.c.y == 3 and d.x.d.y == 4 and count == 1
+      return d.x.a == 1 and d.x.b == 2 and d.x.c.y == 3 and d.x.d.y == 4 and vim.tbl_count(c) == 1
     ]]))
 
     ok(exec_lua([[
@@ -1012,10 +1023,7 @@ describe('lua stdlib', function()
       local c = {x = {c = 4, d = {y = 4}}}
       local d = vim.tbl_deep_extend("force", a, b, c)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
-
-      return d.x.a == 2 and d.x.b == 2 and d.x.c == 4 and d.x.d.y == 4 and count == 1
+      return d.x.a == 2 and d.x.b == 2 and d.x.c == 4 and d.x.d.y == 4 and vim.tbl_count(c) == 1
     ]]))
 
     ok(exec_lua([[
@@ -1023,10 +1031,7 @@ describe('lua stdlib', function()
       local b = {}
       local c = vim.tbl_deep_extend("keep", a, b)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
-
-      return not vim.tbl_islist(c) and count == 0
+      return not vim.tbl_islist(c) and vim.tbl_count(c) == 0
     ]]))
 
     ok(exec_lua([[
@@ -1034,10 +1039,27 @@ describe('lua stdlib', function()
       local b = vim.empty_dict()
       local c = vim.tbl_deep_extend("keep", a, b)
 
-      local count = 0
-      for _ in pairs(c) do count = count + 1 end
+      return not vim.tbl_islist(c) and vim.tbl_count(c) == 0
+    ]]))
 
-      return vim.tbl_islist(c) and count == 0
+    ok(exec_lua([[
+      local a = { a = { x = 1 } }
+      local b = { a = { y = 2 } }
+      setmetatable(a.a, { __tostring = function() return "table a" end })
+      setmetatable(b.a, { __tostring = function() return "table b" end })
+      local c = vim.tbl_deep_extend("keep", a, b)
+
+      return c.a.x == 1 and c.a.y == nil and tostring(c.a) == "table a"
+    ]]))
+
+    ok(exec_lua([[
+      local a = { a = { x = 1 } }
+      local b = { a = { y = 2 } }
+      setmetatable(a.a, { __tostring = function() return "table a" end })
+      setmetatable(b.a, { __tostring = function() return "table b" end })
+      local c = vim.tbl_deep_extend("force", a, b)
+
+      return c.a.x == nil and c.a.y == 2 and tostring(c.a) == "table b"
     ]]))
 
     eq(


### PR DESCRIPTION
The returned table from `tbl_extend` doesn't keep the metatable of any input table (except for `vim.empty_dict`), which I think is not expected in most cases.

Merging tables can be complicated and IMHO the desired behavior is very debatable. so I gave my solution in this pr while am open to discussions.