### PR TITLE
vim-patch:9.1.0351: No test that completing a partial mapping clears 'showcmd'

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -64,6 +64,7 @@
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 
+/// State for adding bytes to a recording or 'showcmd'.
 typedef struct {
   int prev_c;
   uint8_t buf[MB_MAXBYTES * 3 + 4];

--- a/test/functional/legacy/mapping_spec.lua
+++ b/test/functional/legacy/mapping_spec.lua
@@ -214,8 +214,7 @@ describe('mapping', function()
         {1:~                                                           }|*4
                                                          %s          |
       ]]):format(c))
-      feed('<C-C>')
-      command('echo')
+      feed('a')
       screen:expect([[
         ^                                                            |
         {1:~                                                           }|*4
@@ -229,8 +228,7 @@ describe('mapping', function()
       {1:~                                                           }|*4
                                                        ^W         |
     ]])
-    feed('<C-C>')
-    command('echo')
+    feed('a')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*4
@@ -243,8 +241,7 @@ describe('mapping', function()
       {1:~                                                           }|*4
                                                        ^W         |
     ]])
-    feed('<C-C>')
-    command('echo')
+    feed('a')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*4

--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -1716,7 +1716,7 @@ endfunc
 func Test_showcmd_part_map()
   CheckRunVimInTerminal
 
-  let lines =<< trim eval END
+  let lines =<< trim END
     set notimeout showcmd
     nnoremap ,a <Ignore>
     nnoremap ;a <Ignore>
@@ -1736,20 +1736,21 @@ func Test_showcmd_part_map()
   for c in [',', ';', 'À', 'Ë', 'β', 'ω', '…']
     call term_sendkeys(buf, c)
     call WaitForAssert({-> assert_equal(c, trim(term_getline(buf, 6)))})
-    call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-    call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+    call term_sendkeys(buf, 'a')
+    call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
   endfor
 
   call term_sendkeys(buf, "\<C-W>")
   call WaitForAssert({-> assert_equal('^W', trim(term_getline(buf, 6)))})
-  call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-  call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'a')
+  call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
 
-  " Use feedkeys() as terminal buffer cannot forward this
+  " Use feedkeys() as terminal buffer cannot forward unsimplified Ctrl-W.
+  " This is like typing Ctrl-W with modifyOtherKeys enabled.
   call term_sendkeys(buf, ':call feedkeys("\<*C-W>", "m")' .. " | echo\<CR>")
   call WaitForAssert({-> assert_equal('^W', trim(term_getline(buf, 6)))})
-  call term_sendkeys(buf, "\<C-C>:echo\<CR>")
-  call WaitForAssert({-> assert_equal('', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'a')
+  call WaitForAssert({-> assert_equal('', trim(term_getline(buf, 6)))})
 
   call StopVimInTerminal(buf)
 endfunc

--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -300,7 +300,7 @@ func Test_setcellwidths_dump()
   call StopVimInTerminal(buf)
 endfunc
 
-" When `setcellwidth` is used on characters that are not targets of `ambiwidth`.
+" Test setcellwidths() on characters that are not targets of 'ambiwidth'.
 func Test_setcellwidths_with_non_ambiwidth_character_dump()
   CheckRunVimInTerminal
 
@@ -320,7 +320,6 @@ func Test_setcellwidths_with_non_ambiwidth_character_dump()
 
   call StopVimInTerminal(buf)
 endfunc
-
 
 " For some reason this test causes Test_customlist_completion() to fail on CI,
 " so run it as the last test.


### PR DESCRIPTION
#### vim-patch:9.1.0351: No test that completing a partial mapping clears 'showcmd'

Problem:  No test that completing a partial mapping clears 'showcmd'.
Solution: Complete partial mappings in Test_showcmd_part_map() instead
          of using :echo.  Adjust some comments (zeertzjq).

closes: vim/vim#14580

https://github.com/vim/vim/commit/094c4390bdf3473fab122aa02883e63ce4e66cdb