### PR TITLE
vim-patch:36e667ab837c

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -590,6 +590,37 @@ The mapping can be disabled with: >
 	let g:no_gprof_maps = 1
 
 
+JAVA							*ft-java-plugin*
+
+Whenever the variable "g:ftplugin_java_source_path" is defined and its value
+is a filename whose extension is either ".jar" or ".zip", e.g.: >
+	let g:ftplugin_java_source_path = '/path/to/src.jar'
+	let g:ftplugin_java_source_path = '/path/to/src.zip'
+<
+and the |zip| plugin has already been sourced, the |gf| command can be used to
+open the archive and the |n| command can be used to look for the selected type
+and the <Return> key can be used to load a listed file.
+
+Note that the effect of using the "gf" command WITHIN a buffer loaded with the
+Zip plugin depends on the version of the Zip plugin.  For the Zip plugin
+versions that do not support Jar type archives, consider creating symbolic
+links with the ".zip" extension for each Jar archive of interest and assigning
+any such file to the variable from now on.
+
+Otherwise, for the defined variable "g:ftplugin_java_source_path", the local
+value of the 'path' option will be further modified by prefixing the value of
+the variable, e.g.: >
+	let g:ftplugin_java_source_path = $JDK_SRC_PATH
+	let &l:path = g:ftplugin_java_source_path . ',' . &l:path
+<
+and the "gf" command can be used on a fully-qualified type to look for a file
+in the "path" and to try to load it.
+
+Remember to manually trigger the |FileType| event from a buffer with a Java
+file loaded in it each time after assigning a new value to the variable: >
+	doautocmd FileType
+<
+
 MAIL							*ft-mail-plugin*
 
 Options:

--- a/runtime/ftplugin/java.vim
+++ b/runtime/ftplugin/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Dan Sharp
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Apr 13
+" Last Change:		2024 Apr 18
 "			2024 Jan 14 by Vim Project (browsefilter)
 
 if exists("b:did_ftplugin") | finish | endif
@@ -22,8 +22,36 @@ set suffixes+=.class
 " name to / and append .java to the name, then search the path.
 setlocal includeexpr=substitute(v:fname,'\\.','/','g')
 setlocal suffixesadd=.java
-if exists("g:ftplugin_java_source_path")
-    let &l:path=g:ftplugin_java_source_path . ',' . &l:path
+
+" Clean up in case this file is sourced again.
+unlet! s:zip_func_upgradable
+
+" Documented in ":help ft-java-plugin".
+if exists("g:ftplugin_java_source_path") &&
+		\ type(g:ftplugin_java_source_path) == type("")
+    if filereadable(g:ftplugin_java_source_path)
+	if exists("#zip") &&
+		    \ g:ftplugin_java_source_path =~# '.\.\%(jar\|zip\)$'
+	    if !exists("s:zip_files")
+		let s:zip_files = {}
+	    endif
+
+	    let s:zip_files[bufnr('%')] = g:ftplugin_java_source_path
+	    let s:zip_files[0] = g:ftplugin_java_source_path
+	    let s:zip_func_upgradable = 1
+
+	    function! JavaFileTypeZipFile() abort
+		let @/ = substitute(v:fname, '\.', '\\/', 'g') . '.java'
+		return get(s:zip_files, bufnr('%'), s:zip_files[0])
+	    endfunction
+
+	    " E120 for "inex=s:JavaFileTypeZipFile()" before v8.2.3900.
+	    setlocal includeexpr=JavaFileTypeZipFile()
+	    setlocal suffixesadd<
+	endif
+    else
+	let &l:path = g:ftplugin_java_source_path . ',' . &l:path
+    endif
 endif
 
 " Set 'formatoptions' to break comment lines but not other lines,
@@ -51,6 +79,25 @@ endif
 let b:undo_ftplugin = "setlocal suffixes< suffixesadd<" .
 		\     " formatoptions< comments< commentstring< path< includeexpr<" .
 		\     " | unlet! b:browsefilter"
+
+" See ":help vim9-mix".
+if !has("vim9script")
+    let &cpo = s:save_cpo
+    unlet s:save_cpo
+    finish
+endif
+
+if exists("s:zip_func_upgradable")
+    delfunction! JavaFileTypeZipFile
+
+    def! s:JavaFileTypeZipFile(): string
+	@/ = substitute(v:fname, '\.', '\\/', 'g') .. '.java'
+	return get(zip_files, bufnr('%'), zip_files[0])
+    enddef
+
+    setlocal includeexpr=s:JavaFileTypeZipFile()
+    setlocal suffixesadd<
+endif
 
 " Restore the saved compatibility options.
 let &cpo = s:save_cpo


### PR DESCRIPTION
#### vim-patch:36e667ab837c

runtime(java): Support "g:ftplugin_java_source_path" with archived files

Also, document for "g:ftplugin_java_source_path" its current
modification of the local value of the 'path' option.

closes: vim/vim#14570

https://github.com/vim/vim/commit/36e667ab837cd27b8c0c9df5c2db8008b2e1b76c

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>