### PR TITLE
vim-patch:9.1.0354: runtime(uci): No support for uci file types

### DIFF
--- a/runtime/ftplugin/uci.vim
+++ b/runtime/ftplugin/uci.vim
@@ -1,0 +1,21 @@
+" Vim ftplugin file
+" Language:	OpenWrt Unified Configuration Interface
+" Maintainer:	Colin Caine <complaints@cmcaine.co.uk>
+" Upstream:	https://github.com/cmcaine/vim-uci
+" Last Change:	2024 Apr 17
+"
+" For more information on uci, see https://openwrt.org/docs/guide-user/base-system/uci
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+" UCI files are indented with tabs.
+setl noexpandtab
+setl shiftwidth=0
+setl softtabstop=0
+
+setl commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal et< cms< sts< sw<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -14,7 +14,8 @@ local M = {}
 local function starsetf(ft, opts)
   return {
     function(path, bufnr)
-      local f = type(ft) == 'function' and ft(path, bufnr) or ft
+      -- Note: when `ft` is a function its return value may be nil.
+      local f = type(ft) ~= 'function' and ft or ft(path, bufnr)
       if not vim.g.ft_ignore_pat then
         return f
       end
@@ -2138,6 +2139,7 @@ local pattern = {
   ['.*/%.init/.*%.conf'] = 'upstart',
   ['.*/usr/share/upstart/.*%.override'] = 'upstart',
   ['.*%.[Ll][Oo][Gg]'] = detect.log,
+  ['.*/etc/config/.*'] = starsetf(detect.uci),
   ['.*%.vhdl_[0-9].*'] = starsetf('vhdl'),
   ['.*%.ws[fc]'] = 'wsh',
   ['.*/Xresources/.*'] = starsetf('xdefaults'),

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1584,6 +1584,26 @@ function M.typ(_, bufnr)
   return 'typst'
 end
 
+--- @type vim.filetype.mapfn
+function M.uci(_, bufnr)
+  -- Return "uci" iff the file has a config or package statement near the
+  -- top of the file and all preceding lines were comments or blank.
+  for _, line in ipairs(getlines(bufnr, 1, 3)) do
+    -- Match a config or package statement at the start of the line.
+    if
+      line:find('^%s*[cp]%s+%S')
+      or line:find('^%s*config%s+%S')
+      or line:find('^%s*package%s+%S')
+    then
+      return 'uci'
+    end
+    -- Match a line that is either all blank or blank followed by a comment
+    if not (line:find('^%s*$') or line:find('^%s*#')) then
+      break
+    end
+  end
+end
+
 -- Determine if a .v file is Verilog, V, or Coq
 --- @type vim.filetype.mapfn
 function M.v(_, bufnr)

--- a/runtime/syntax/uci.vim
+++ b/runtime/syntax/uci.vim
@@ -1,0 +1,33 @@
+" Vim syntax file
+" Language:	OpenWrt Unified Configuration Interface
+" Maintainer:	Colin Caine <complaints@cmcaine.co.uk>
+" Upstream:	https://github.com/cmcaine/vim-uci
+" Last Change:	2021 Sep 19
+"
+" For more information on uci, see https://openwrt.org/docs/guide-user/base-system/uci
+
+if exists("b:current_syntax")
+    finish
+endif
+
+" Fancy zero-width non-capturing look-behind to see what the last word was.
+" Would be really nice if there was some less obscure or more efficient way to
+" do this.
+syntax match uciOptionName '\%(\%(option\|list\)\s\+\)\@<=\S*'
+syntax match uciConfigName '\%(\%(package\|config\)\s\+\)\@<=\S*'
+syntax keyword uciConfigDec package config nextgroup=uciConfigName skipwhite
+syntax keyword uciOptionType option list nextgroup=uciOptionName skipwhite
+
+" Standard matches.
+syntax match uciComment "#.*$"
+syntax region uciString start=+"+ end=+"+ skip=+\\"+
+syntax region uciString start=+'+ end=+'+ skip=+\\'+
+
+highlight default link uciConfigName Identifier
+highlight default link uciOptionName Constant
+highlight default link uciConfigDec Statement
+highlight default link uciOptionType Type
+highlight default link uciComment Comment
+highlight default link uciString Normal
+
+let b:current_syntax = "uci"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2439,4 +2439,26 @@ func Test_def_file()
   filetype off
 endfunc
 
+func Test_uci_file()
+  filetype on
+
+  call mkdir('any/etc/config', 'pR')
+  call writefile(['config firewall'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_equal('uci', &filetype)
+  bwipe!
+
+  call writefile(['# config for nginx here'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_notequal('uci', &filetype)
+  bwipe!
+
+  call writefile(['# Copyright Cool Cats 1997', 'config firewall'], 'any/etc/config/firewall', 'D')
+  split any/etc/config/firewall
+  call assert_equal('uci', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0354: runtime(uci): No support for uci file types

Problem:  runtime(uci): No support for uci file types
          (Wu, Zhenyu)
Solution: include basic uci ftplugin and syntax plugins
          (Colin Caine)

closes: vim/vim#14575

https://github.com/vim/vim/commit/4b3fab14dbde971f15d8783e9ef125b19fdbc829

Co-authored-by: Colin Caine <complaints@cmcaine.co.uk>
Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>