### PR TITLE
feat(treesitter): get highlight from parser

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -495,4 +495,26 @@ function M.foldexpr(lnum)
   return M._fold.foldexpr(lnum)
 end
 
+---@private
+--- Get highlight information from parser.
+---
+---@param parser vim.treesitter.LanguageTree
+---@return vim.treesitter.highlighter.Info[]
+function M._get_highlight(parser)
+  local highlights = {}
+  parser:for_each_tree(function(tree, ltree)
+    local source = ltree:source()
+    local hl_query = M.query.get(ltree:lang(), 'highlights')
+
+    if not hl_query then
+      return
+    end
+
+    for info in M.highlighter._iter_highlight_info(hl_query, tree:root(), source, 0, -1) do
+      table.insert(highlights, info)
+    end
+  end)
+  return highlights
+end
+
 return M


### PR DESCRIPTION
Sometimes you want to apply treesitter highlighting to non-buffer text (such as foldtext or the message area). The problem is that there is currently no easy way to get the treesitter highlighting except for implementing a function yourself. So let's add such a function.

It has been brought to my attention that this feature is also useful for applying a highlight to a specific region in a buffer, by getting the text in the region, parsing it, getting the highlights, and setting the highlights as extmarks.