### PR TITLE
vim-patch:cee034112d41

### DIFF
--- a/runtime/ftplugin/bp.vim
+++ b/runtime/ftplugin/bp.vim
@@ -1,14 +1,14 @@
 " Blueprint build system filetype plugin file
 " Language: Blueprint
 " Maintainer: Bruno BELANYI <bruno.vim@belanyi.fr>
-" Latest Revision: 2024-04-10
+" Latest Revision: 2024-04-19
 
 if exists("b:did_ftplugin")
   finish
 endif
 let b:did_ftplugin = 1
 
-setlocal comments=b:#
-setlocal commentstring=#\ %s
+setlocal comments=b://,s1:/*,mb:*,ex:*/
+setlocal commentstring=//\ %s
 
 let b:undo_ftplugin = "setlocal comments< commentstring<"


### PR DESCRIPTION
runtime(bp): fix comment definition in filetype plugin (vim/vim#14594)

I somehow messed up the previous patch, I think a copy-paste error when
creating the file.

Blueprint files have C and C++ style comments, not shell-like '#'
comments.

https://github.com/vim/vim/commit/cee034112d41372d4c31abc327c6536b24fc25bd

Co-authored-by: Bruno BELANYI <bruno@belanyi.fr>
