### PR TITLE
feat(treesitter): add support for wasm parsers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,21 @@ env:
   INSTALL_PREFIX: ${{ github.workspace }}/nvim-install
 
 jobs:
+  wasmtime:
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.test }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: |
+          cmake -S cmake.deps --preset ci -D ENABLE_WASMTIME=ON
+          cmake --build .deps
+          cmake --preset ci -D ENABLE_WASMTIME=ON
+          cmake --build build
+
   old-cmake:
     name: Test oldest supported cmake
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ else()
   option(ENABLE_LTO "enable link time optimization" ON)
 endif()
 option(ENABLE_LIBINTL "enable libintl" ON)
+option(ENABLE_WASMTIME "enable wasmtime" OFF)
 
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -36,12 +36,26 @@ option(USE_BUNDLED_TS "Use the bundled treesitter runtime." ${USE_BUNDLED})
 option(USE_BUNDLED_TS_PARSERS "Use the bundled treesitter parsers." ${USE_BUNDLED})
 option(USE_BUNDLED_UNIBILIUM "Use the bundled unibilium." ${USE_BUNDLED})
 option(USE_BUNDLED_UTF8PROC "Use the bundled utf8proc library." ${USE_BUNDLED})
+
 if(USE_BUNDLED AND MSVC)
   option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." ON)
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." ON)
 else()
   option(USE_BUNDLED_GETTEXT "Use the bundled version of gettext." OFF)
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." OFF)
+endif()
+
+option(ENABLE_WASMTIME "Use treesitter with wasmtime support." OFF)
+if(ENABLE_WASMTIME)
+  if(USE_BUNDLED)
+    option(USE_BUNDLED_WASMTIME "Use the bundled wasmtime." ON)
+  else()
+    option(USE_BUNDLED_WASMTIME "Use the bundled wasmtime." OFF)
+  endif()
+endif()
+if(NOT ENABLE_WASMTIME AND USE_BUNDLED_WASMTIME)
+  message(FATAL_ERROR "ENABLE_WASMTIME is set to OFF while USE_BUNDLED_WASMTIME is set to ON.\
+  You need set ENABLE_WASMTIME to ON if you want to use wasmtime.")
 endif()
 
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
@@ -125,6 +139,10 @@ endif()
 
 if(USE_BUNDLED_TS_PARSERS)
   include(BuildTreesitterParsers)
+endif()
+
+if(USE_BUNDLED_WASMTIME)
+  include(BuildWasmtime)
 endif()
 
 if(USE_BUNDLED_TS)

--- a/cmake.deps/CMakePresets.json
+++ b/cmake.deps/CMakePresets.json
@@ -17,7 +17,8 @@
       "cacheVariables": {
         "USE_BUNDLED":"OFF",
         "USE_BUNDLED_TS":"ON",
-        "USE_BUNDLED_UTF8PROC":"ON"
+        "USE_BUNDLED_UTF8PROC":"ON",
+        "ENABLE_WASMTIME":"OFF"
       },
       "inherits": ["base"]
     }

--- a/cmake.deps/cmake/BuildTreesitter.cmake
+++ b/cmake.deps/cmake/BuildTreesitter.cmake
@@ -1,8 +1,24 @@
+if(ENABLE_WASMTIME)
+  if(USE_BUNDLED_WASMTIME)
+    set(WASMTIME_CACHE_ARGS "-DCMAKE_C_FLAGS:STRING=-I${DEPS_INSTALL_DIR}/include/wasmtime -I${DEPS_INSTALL_DIR}/include")
+  else()
+    find_package(Wasmtime 24.0.0 EXACT REQUIRED)
+    set(WASMTIME_CACHE_ARGS "-DCMAKE_C_FLAGS:STRING=-I${WASMTIME_INCLUDE_DIR}")
+  endif()
+  string(APPEND WASMTIME_CACHE_ARGS " -DTREE_SITTER_FEATURE_WASM")
+  set(WASMTIME_ARGS -D CMAKE_C_STANDARD=11)
+endif()
+
 get_externalproject_options(treesitter ${DEPS_IGNORE_SHA})
 ExternalProject_Add(treesitter
   DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/treesitter
   PATCH_COMMAND ${CMAKE_COMMAND} -E copy
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TreesitterCMakeLists.txt
     ${DEPS_BUILD_DIR}/src/treesitter/CMakeLists.txt
-  CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+  CMAKE_ARGS ${DEPS_CMAKE_ARGS} ${WASMTIME_ARGS}
+  CMAKE_CACHE_ARGS ${WASMTIME_CACHE_ARGS}
   ${EXTERNALPROJECT_OPTIONS})
+
+if(USE_BUNDLED_WASMTIME)
+  add_dependencies(treesitter wasmtime)
+endif()

--- a/cmake.deps/cmake/BuildWasmtime.cmake
+++ b/cmake.deps/cmake/BuildWasmtime.cmake
@@ -1,0 +1,11 @@
+# wasmtime is a chungus -- optimize _extra hard_ to keep nvim svelte
+get_externalproject_options(wasmtime ${DEPS_IGNORE_SHA})
+ExternalProject_Add(wasmtime
+  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/wasmtime
+  SOURCE_SUBDIR crates/c-api
+  CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+    -D WASMTIME_FASTEST_RUNTIME=ON       # build with full LTO
+    -D WASMTIME_DISABLE_ALL_FEATURES=ON  # don't need all that crap...
+    -D WASMTIME_FEATURE_CRANELIFT=ON     # ...except this one (compiles wasm to platform code)
+  USES_TERMINAL_BUILD TRUE
+  ${EXTERNALPROJECT_OPTIONS})

--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-w)
 
 add_library(tree-sitter lib/src/lib.c)
 target_include_directories(tree-sitter
-  PRIVATE lib/src lib/include)
+  PRIVATE lib/src lib/src/wasm lib/include)
 
 install(FILES
   lib/include/tree_sitter/api.h

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -53,6 +53,9 @@ TREESITTER_MARKDOWN_SHA256 4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.23.0.tar.gz
 TREESITTER_SHA256 6403b361b0014999e96f61b9c84d6950d42f0c7d6e806be79382e0232e48a11b
 
+WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v24.0.0.tar.gz
+WASMTIME_SHA256 2ccb49bb3bfa4d86907ad4c80d1147aef6156c7b6e3f7f14ed02a39de9761155
+
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.79.0.tar.gz
 UNCRUSTIFY_SHA256 e7afaeabf636b7f0ce4e3e9747b95f7bd939613a8db49579755dddf44fedca5f
 LUA_DEV_DEPS_URL https://github.com/neovim/deps/raw/5a1f71cceb24990a0b15fd9a472a5f549f019248/opt/lua-dev-deps.tar.gz

--- a/cmake/FindWasmtime.cmake
+++ b/cmake/FindWasmtime.cmake
@@ -1,0 +1,22 @@
+find_path2(WASMTIME_INCLUDE_DIR wasmtime.h)
+find_library2(WASMTIME_LIBRARY wasmtime)
+
+if(WASMTIME_INCLUDE_DIR AND EXISTS "${WASMTIME_INCLUDE_DIR}/wasmtime.h")
+  file(STRINGS ${WASMTIME_INCLUDE_DIR}/wasmtime.h WASMTIME_VERSION REGEX "#define WASMTIME_VERSION")
+  string(REGEX MATCH "[0-9]+\.[0-9]\.[0-9]" WASMTIME_VERSION ${WASMTIME_VERSION})
+endif()
+
+find_package_handle_standard_args(Wasmtime
+  REQUIRED_VARS WASMTIME_INCLUDE_DIR WASMTIME_LIBRARY
+  VERSION_VAR WASMTIME_VERSION)
+
+add_library(wasmtime INTERFACE)
+target_include_directories(wasmtime SYSTEM BEFORE INTERFACE ${WASMTIME_INCLUDE_DIR})
+target_link_libraries(wasmtime INTERFACE ${WASMTIME_LIBRARY})
+
+if(MSVC)
+  target_compile_options(wasmtime INTERFACE -DWASM_API_EXTERN= -DWASI_API_EXTERN=)
+  target_link_libraries(wasmtime INTERFACE ws2_32 advapi32 userenv ntdll shell32 ole32 bcrypt)
+endif()
+
+mark_as_advanced(WASMTIME_INCLUDE_DIR WASMTIME_LIBRARY)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -51,6 +51,13 @@ treesitter parser for buffers with filetype `svg` or `xslt`, use: >lua
 
     vim.treesitter.language.register('xml', { 'svg', 'xslt' })
 <
+                                                    *treesitter-parsers-wasm*
+
+If Nvim is built with `ENABLE_WASMTIME`, then wasm parsers can also be
+loaded: >lua
+
+    vim.treesitter.language.add('python', { path = "/path/to/python.wasm" })
+<
 
 ==============================================================================
 TREESITTER TREES                                             *treesitter-tree*

--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -72,7 +72,11 @@ vim._ts_get_language_version = function() end
 --- @param path string
 --- @param lang string
 --- @param symbol_name? string
-vim._ts_add_language = function(path, lang, symbol_name) end
+vim._ts_add_language_from_object = function(path, lang, symbol_name) end
+
+--- @param path string
+--- @param lang string
+vim._ts_add_language_from_wasm = function(path, lang) end
 
 ---@return integer
 vim._ts_get_minimum_language_version = function() end

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -28,6 +28,9 @@ function M.check()
       )
     end
   end
+
+  local can_wasm = vim._ts_add_language_from_wasm ~= nil
+  health.info(string.format('Can load WASM parsers: %s', tostring(can_wasm)))
 end
 
 return M

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -109,7 +109,14 @@ function M.add(lang, opts)
     path = paths[1]
   end
 
-  vim._ts_add_language(path, lang, symbol_name)
+  if vim.endswith(path, '.wasm') then
+    if not vim._ts_add_language_from_wasm then
+      error(string.format("Unable to load wasm parser '%s': not built with ENABLE_WASMTIME ", path))
+    end
+    vim._ts_add_language_from_wasm(path, lang)
+  else
+    vim._ts_add_language_from_object(path, lang, symbol_name)
+  end
   M.register(lang, filetype)
 end
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})
 find_package(Iconv REQUIRED)
 find_package(Libuv 1.28.0 REQUIRED)
 find_package(Lpeg REQUIRED)
-find_package(Treesitter 0.22.6 REQUIRED)
+find_package(Treesitter 0.23.0 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 find_package(UTF8proc REQUIRED)
 
@@ -46,6 +46,12 @@ target_link_libraries(nlua0 PUBLIC lpeg)
 if(ENABLE_LIBINTL)
   find_package(Libintl REQUIRED) # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
   target_link_libraries(main_lib INTERFACE libintl)
+endif()
+
+if(ENABLE_WASMTIME)
+  find_package(Wasmtime 24.0.0 EXACT REQUIRED)
+  target_link_libraries(main_lib INTERFACE wasmtime)
+  target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()
 
 target_compile_definitions(main_lib INTERFACE HAVE_UNIBILIUM)

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -924,6 +924,7 @@ void nlua_free_all_mem(void)
   lua_State *lstate = global_lstate;
   nlua_unref_global(lstate, require_ref);
   nlua_common_free_all_mem(lstate);
+  tslua_free();
 }
 
 static void nlua_common_free_all_mem(lua_State *lstate)
@@ -1902,8 +1903,13 @@ static void nlua_add_treesitter(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_pushcfunction(lstate, tslua_push_querycursor);
   lua_setfield(lstate, -2, "_create_ts_querycursor");
 
-  lua_pushcfunction(lstate, tslua_add_language);
-  lua_setfield(lstate, -2, "_ts_add_language");
+  lua_pushcfunction(lstate, tslua_add_language_from_object);
+  lua_setfield(lstate, -2, "_ts_add_language_from_object");
+
+#ifdef HAVE_WASMTIME
+  lua_pushcfunction(lstate, tslua_add_language_from_wasm);
+  lua_setfield(lstate, -2, "_ts_add_language_from_wasm");
+#endif
 
   lua_pushcfunction(lstate, tslua_has_language);
   lua_setfield(lstate, -2, "_ts_has_language");

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -57,8 +57,12 @@ describe('treesitter language API', function()
     local keys, fields, symbols = unpack(exec_lua(function()
       local lang = vim.treesitter.language.inspect('c')
       local keys, symbols = {}, {}
-      for k, _ in pairs(lang) do
-        keys[k] = true
+      for k, v in pairs(lang) do
+        if type(v) == 'boolean' then
+          keys[k] = v
+        else
+          keys[k] = true
+        end
       end
 
       -- symbols array can have "holes" and is thus not a valid msgpack array
@@ -69,7 +73,7 @@ describe('treesitter language API', function()
       return { keys, lang.fields, symbols }
     end))
 
-    eq({ fields = true, symbols = true, _abi_version = true }, keys)
+    eq({ fields = true, symbols = true, _abi_version = true, _wasm = false }, keys)
 
     local fset = {}
     for _, f in pairs(fields) do


### PR DESCRIPTION
### Problem

Treesitter parsers are currently distributed as compiled shared objects which need to be compiled by the users (with the help of nvim-treesitter).

### Solution

Allow loading wasm built parsers.

Notes:
- For now this is an optional build-time feature (via `ENABLE_WASMTIME`) which will be dynamically linked.
  - Builds with `make CMAKE_EXTRA_FLAGS=-DENABLE_WASMTIME=ON DEPS_CMAKE_FLAGS=-DENABLE_WASMTIME=ON`
- Treesitter requires being built with `TREE_SITTER_FEATURE_WASM` and also requires `wasmtime` at build time. So no `[uv_]dlopen` 😢 
- `wasmtime` has includes that require C11 (`static_assert`).
- To reduce re-compilation times, install `sccache` and build with `RUSTC_WRAPPER=sccache make ...`.

### Status

Waiting for the next tree-sitter release with the commit we're pulling in here to allow us to build against a wasmtime release with the build changes required to avoid unacceptable regressions on macOS. (Ideally, that release would also be built against the same version we use, but that is blocked by the same build system changes; luckily so far the versions have not become incompatible for our purpose.)