### PR TITLE
fix(vim.ui.open): try wslview before explorer.exe

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -149,12 +149,14 @@ function M.open(path)
     else
       return nil, 'vim.ui.open: rundll32 not found'
     end
+  elseif vim.fn.executable('wslview') == 1 then
+    cmd = { 'wslview', path }
   elseif vim.fn.executable('explorer.exe') == 1 then
     cmd = { 'explorer.exe', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
   else
-    return nil, 'vim.ui.open: no handler found (tried: explorer.exe, xdg-open)'
+    return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)'
   end
 
   return vim.system(cmd, { text = true, detach = true }), nil

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -151,7 +151,7 @@ describe('vim.ui', function()
         vim.fn.executable = function() return 0 end
       ]]
       eq(
-        'vim.ui.open: no handler found (tried: explorer.exe, xdg-open)',
+        'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)',
         exec_lua [[local _, err = vim.ui.open('foo') ; return err]]
       )
     end)


### PR DESCRIPTION
Problem:
explorer.exe is unreliable on WSL.

Solution:
Try wslview before explorer.exe.

fix #28410