### PR TITLE
refactor(lua): "module" => "M"

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1,6 +1,6 @@
 local bit = require 'bit'
 
-local module = {}
+local M = {}
 
 -- Description of the values below is contained in ex_cmds_defs.h file.
 -- "EX_" prefix is omitted.
@@ -32,14 +32,14 @@ local FILES = bit.bor(XFILE, EXTRA)
 local WORD1 = bit.bor(EXTRA, NOSPC)
 local FILE1 = bit.bor(FILES, NOSPC)
 
-module.flags = {
+M.flags = {
   RANGE = RANGE,
   DFLALL = DFLALL,
   PREVIEW = PREVIEW,
 }
 
 -- The following table is described in ex_cmds_defs.h file.
-module.cmds = {
+M.cmds = {
   {
     command = 'append',
     flags = bit.bor(BANG, RANGE, ZEROR, TRLBAR, CMDWIN, LOCK_OK, MODIFY),
@@ -3359,4 +3359,4 @@ module.cmds = {
   },
 }
 
-return module
+return M

--- a/test/cmakeconfig/paths.lua.in
+++ b/test/cmakeconfig/paths.lua.in
@@ -1,22 +1,22 @@
-local module = {}
+local M = {}
 
-module.include_paths = {}
+M.include_paths = {}
 for p in ("${TEST_INCLUDE_DIRS}" .. ";"):gmatch("[^;]+") do
-  table.insert(module.include_paths, p)
+  table.insert(M.include_paths, p)
 end
 
-module.test_build_dir = "${CMAKE_BINARY_DIR}"
-module.test_source_path = "${CMAKE_SOURCE_DIR}"
-module.test_lua_prg = "${LUA_PRG}"
-module.test_luajit_prg = ""
-if module.test_luajit_prg == '' then
-  if module.test_lua_prg:sub(-6) == 'luajit' then
-    module.test_luajit_prg = module.test_lua_prg
+M.test_build_dir = "${CMAKE_BINARY_DIR}"
+M.test_source_path = "${CMAKE_SOURCE_DIR}"
+M.test_lua_prg = "${LUA_PRG}"
+M.test_luajit_prg = ""
+if M.test_luajit_prg == '' then
+  if M.test_lua_prg:sub(-6) == 'luajit' then
+    M.test_luajit_prg = M.test_lua_prg
   else
-    module.test_luajit_prg = nil
+    M.test_luajit_prg = nil
   end
 end
-table.insert(module.include_paths, "${CMAKE_BINARY_DIR}/include")
-table.insert(module.include_paths, "${CMAKE_BINARY_DIR}/src/nvim/auto")
+table.insert(M.include_paths, "${CMAKE_BINARY_DIR}/include")
+table.insert(M.include_paths, "${CMAKE_BINARY_DIR}/src/nvim/auto")
 
-return module
+return M

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -877,7 +877,7 @@ local function is_asan()
 end
 
 --- @class test.unit.testutil.module
-local module = {
+local M = {
   cimport = cimport,
   cppimport = cppimport,
   internalize = internalize,
@@ -907,6 +907,6 @@ local module = {
   is_asan = is_asan,
 }
 --- @class test.unit.testutil: test.unit.testutil.module, test.testutil
-module = vim.tbl_extend('error', module, t_global)
+M = vim.tbl_extend('error', M, t_global)
 
-return module
+return M


### PR DESCRIPTION
Most of the codebase uses the `M` convention for Lua module. Update the last remaining cases.