### PR TITLE
vim-patch:9.1.0357: Page scrolling should place cursor at window boundaries

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2492,22 +2492,26 @@ int pagescroll(Direction dir, int count, bool half)
     } else {
       cursor_up_inner(curwin, curscount);
     }
-
-    if (get_scrolloff_value(curwin) > 0) {
-      cursor_correct(curwin);
-    }
-    // Move cursor to first line of closed fold.
-    foldAdjustCursor(curwin);
-
-    nochange = nochange
-               && prev_col == curwin->w_cursor.col
-               && prev_lnum == curwin->w_cursor.lnum;
   } else {
     // Scroll [count] times 'window' or current window height lines.
     count *= ((ONE_WINDOW && p_window > 0 && p_window < Rows - 1)
               ? MAX(1, (int)p_window - 2) : get_scroll_overlap(dir));
     nochange = scroll_with_sms(dir, count);
+
+    // Place cursor at top or bottom of window.
+    validate_botline(curwin);
+    curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline : curwin->w_botline - 1);
   }
+
+  if (get_scrolloff_value(curwin) > 0) {
+    cursor_correct(curwin);
+  }
+  // Move cursor to first line of closed fold.
+  foldAdjustCursor(curwin);
+
+  nochange = nochange
+             && prev_col == curwin->w_cursor.col
+             && prev_lnum == curwin->w_cursor.lnum;
 
   // Error if both the viewport and cursor did not change.
   if (nochange) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4268,7 +4268,7 @@ if (h->n_buckets < new_n_buckets) { // expand
     screen:expect{grid=[[
       {16:refactor(khash): }take size of values as parameter |
       Author: Dev Devsson, {18:Tue Aug 31 10:13:37 2021}     |
-      ^if (h->n_buckets < new_n_buckets) { // expand     |
+      if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
         h->keys = new_keys;                             |
@@ -4276,7 +4276,7 @@ if (h->n_buckets < new_n_buckets) { // expand
           char *new_vals = krealloc( h->vals_buf, new_n_|
       buckets * val_size);                              |
           h->vals_buf = new_vals;                       |
-        }                                               |
+        ^}                                               |
                                                         |
     ]]}
   end)
@@ -4949,8 +4949,8 @@ if (h->n_buckets < new_n_buckets) { // expand
       VIRT2               |
       11                  |
       12                  |
-      ^13                  |
-      14                  |
+      13                  |
+      ^14                  |
                           |
     ]])
     feed('<C-B>')

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -3823,8 +3823,8 @@ func Test_normal_vert_scroll_longline()
   call assert_equal(11, line('.'))
   call assert_equal(1, winline())
   exe "normal \<C-B>"
-  call assert_equal(10, line('.'))
-  call assert_equal(4, winline())
+  call assert_equal(11, line('.'))
+  call assert_equal(5, winline())
   exe "normal \<C-B>\<C-B>"
   call assert_equal(5, line('.'))
   call assert_equal(5, winline())
@@ -4254,6 +4254,19 @@ func Test_halfpage_cursor_startend()
   call assert_equal(1, line('.'))
   exe "norm! G\<C-Y>k\<C-D>"
   call assert_equal(100, line('.'))
+  bwipe!
+endfunc
+
+" Test for Ctrl-F/B moving the cursor to the window boundaries.
+func Test_page_cursor_topbot()
+  10new
+  call setline(1, range(1, 100))
+  exe "norm! gg2\<C-F>"
+  call assert_equal(17, line('.'))
+  exe "norm! \<C-B>"
+  call assert_equal(18, line('.'))
+  exe "norm! \<C-B>\<C-F>"
+  call assert_equal(9, line('.'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  Page scrolling does not always place the cursor at the top or
          bottom of the window (Mathias Rav)
Solution: Place the cursor at the top or bottom of the window.
          (Luuk van Baal)

https://github.com/vim/vim/commit/4b6b0c4024df08dd8ce49dff3c76356ff81190c4