### PR TITLE
feat(treesitter): handle quantified fold captures

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -267,6 +267,8 @@ The following new APIs and features were added.
   • The `#set!` directive can set the "url" property of a node to have the
     node emit a hyperlink. Hyperlinks are UI specific: in the TUI, the OSC 8
     control sequence is used.
+  • |vim.treesitter.foldexpr()| now recognizes folds captured using a
+    quantified query pattern.
 
 • |:Man| now supports `:hide` modifier to open page in the current window.
 

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -404,6 +404,28 @@ t3]])
     }, get_fold_levels())
   end)
 
+  it('handles quantified patterns', function()
+    insert([[
+import hello
+import hello
+import hello
+import hello
+import hello
+import hello]])
+
+    exec_lua([[vim.treesitter.query.set('python', 'folds', '(import_statement)+ @fold')]])
+    parse('python')
+
+    eq({
+      [1] = '>1',
+      [2] = '1',
+      [3] = '1',
+      [4] = '1',
+      [5] = '1',
+      [6] = '1',
+    }, get_fold_levels())
+  end)
+
   it('updates folds in all windows', function()
     local screen = Screen.new(60, 48)
     screen:attach()


### PR DESCRIPTION
Allows multiple nodes to be treated as a fold group, e.g.:

```python
# a bunch of import statements
import test1
import test2
import test3
import test4
```

are foldable using:

```query
(import_statement)+ @fold 
```

I am pretty sure this is not blocked by (nor conflicts with) #28417.