### PR TITLE
fix(float): wrong position when bufpos is out of range

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -827,7 +827,8 @@ void ui_ext_win_position(win_T *wp, bool validate)
         row += row_off;
         col += col_off;
         if (c.bufpos.lnum >= 0) {
-          pos_T pos = { c.bufpos.lnum + 1, c.bufpos.col, 0 };
+          int lnum = MIN(c.bufpos.lnum + 1, win->w_buffer->b_ml.ml_line_count);
+          pos_T pos = { lnum, c.bufpos.col, 0 };
           int trow, tcol, tcolc, tcole;
           textpos2screenpos(win, &pos, &trow, &tcol, &tcolc, &tcole, true);
           row += trow - 1;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -221,7 +221,7 @@ void win_config_float(win_T *wp, WinConfig fconfig)
       row += row_off;
       col += col_off;
       if (wp->w_config.bufpos.lnum >= 0) {
-        pos_T pos = { wp->w_config.bufpos.lnum + 1,
+        pos_T pos = { MIN(wp->w_config.bufpos.lnum + 1, parent->w_buffer->b_ml.ml_line_count),
                       wp->w_config.bufpos.col, 0 };
         int trow, tcol, tcolc, tcole;
         textpos2screenpos(parent, &pos, &trow, &tcol, &tcolc, &tcole, true);

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9256,6 +9256,43 @@ describe('float window', function()
       api.nvim_set_current_win(winid)
       eq("floating window cannot be relative to itself", pcall_err(api.nvim_win_set_config, winid, config))
     end)
+
+    it("bufpos out of range", function()
+      local buf = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_lines(0, 0, -1, false, {})
+      local config = { relative='win', width=5, height=2, row=0, col=0, bufpos = { 3, 3 } }
+      api.nvim_open_win(buf, false, config)
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+            ^                                        |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {1:     }|
+            {2:~    }|
+          ]], float_pos={
+          [4] = {1001, "NW", 2, 0, 0, true, 50};
+        }, win_viewport={
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+        }})
+      else
+        screen:expect({
+          grid = [[
+            {1:^     }                                   |
+            {2:~    }{0:                                   }|
+            {0:~                                       }|*4
+                                                    |
+          ]]
+        })
+      end
+    end)
   end
 
   describe('with ext_multigrid', function()


### PR DESCRIPTION
Problem: when lnum in bufpos is out of range the position of float is wired.

Solution: avoid the height value out of buffer line range.

Fix #23120 