### PR TITLE
refactor: add function attributes to xmemcpyz()

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2986,7 +2986,6 @@ static void expand_shellcmd(char *filepat, char ***matches, int *numMatches, int
   char *path = NULL;
   garray_T ga;
   char *buf = xmalloc(MAXPATHL);
-  char *e;
   int flags = flagsarg;
   bool did_curdir = false;
 
@@ -3022,7 +3021,7 @@ static void expand_shellcmd(char *filepat, char ***matches, int *numMatches, int
   ga_init(&ga, (int)sizeof(char *), 10);
   hashtab_T found_ht;
   hash_init(&found_ht);
-  for (char *s = path;; s = e) {
+  for (char *s = path, *e;; s = e) {
     e = vim_strchr(s, ENV_SEPCHAR);
     if (e == NULL) {
       e = s + strlen(s);
@@ -3047,6 +3046,7 @@ static void expand_shellcmd(char *filepat, char ***matches, int *numMatches, int
     if (l > MAXPATHL - 5) {
       break;
     }
+    assert(l <= strlen(s));
     expand_shellcmd_onedir(buf, s, l, pat, matches, numMatches, flags, &found_ht, &ga);
     if (*e != NUL) {
       e++;

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -222,15 +222,14 @@ void *xmemdupz(const void *data, size_t len)
   return memcpy(xmallocz(len), data, len);
 }
 
-/// Duplicates `len` bytes of `src` to `dst` and zero terminates it.
-/// and returns a pointer to the allocated memory. If the allocation fails,
-/// the program dies.
+/// Copies `len` bytes of `src` to `dst` and zero terminates it.
 ///
 /// @see {xstrlcpy}
 /// @param[out]  dst  Buffer to store the result.
 /// @param[in]  src  Buffer to be copied.
 /// @param[in]  len  Number of bytes to be copied.
 void *xmemcpyz(void *dst, const void *src, size_t len)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
   memcpy(dst, src, len);
   ((char *)dst)[len] = '\0';

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -561,6 +561,7 @@ void spell_suggest(int count)
       xstrlcpy(wcopy, stp->st_word, MAXWLEN + 1);
       int el = sug.su_badlen - stp->st_orglen;
       if (el > 0 && stp->st_wordlen + el <= MAXWLEN) {
+        assert(sug.su_badptr != NULL);
         xmemcpyz(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen, (size_t)el);
       }
       vim_snprintf(IObuff, IOSIZE, "%2d", i + 1);


### PR DESCRIPTION
Also attempt to fix the new coverity warning.
