### PR TITLE
feat: namespace scoped autocmd

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -86,6 +86,7 @@ error('Cannot require a meta file')
 --- @field nested? boolean
 --- @field once? boolean
 --- @field pattern? any
+--- @field ns_id? integer
 
 --- @class vim.api.keyset.echo_opts
 --- @field verbose? boolean

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -501,7 +501,8 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
                                   opts->once,
                                   opts->nested,
                                   desc,
-                                  aucmd);
+                                  aucmd,
+                                  HAS_KEY(opts, create_autocmd, ns_id) ? (uint32_t)opts->ns_id : 0);
       });
 
       if (retval == FAIL) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -246,6 +246,7 @@ typedef struct {
   Boolean nested;
   Boolean once;
   Object pattern;
+  Integer ns_id;
 } Dict(create_autocmd);
 
 typedef struct {

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -117,6 +117,14 @@ static char *old_termresponse = NULL;
 static Map(String, int) map_augroup_name_to_id = MAP_INIT;
 static Map(int, String) map_augroup_id_to_name = MAP_INIT;
 
+// TODO(altermo): this is very similar to mt_scoped_in_win
+// so maybe refactor all ns_scoped_in into one function
+// which takes the arguments (namespace,win,buf,...)
+static inline bool au_ns_scoped_in_win(uint32_t ns, win_T *wp)
+{
+  return set_has(uint32_t, &wp->w_ns_set, ns);
+}
+
 static void augroup_map_del(int id, const char *name)
 {
   if (name != NULL) {
@@ -961,7 +969,7 @@ int do_autocmd_event(event_T event, const char *pat, bool once, int nested, char
       AucmdExecutable exec = AUCMD_EXECUTABLE_INIT;
       exec.type = CALLABLE_EX;
       exec.callable.cmd = cmd;
-      autocmd_register(0, event, pat, patlen, group, once, nested, NULL, exec);
+      autocmd_register(0, event, pat, patlen, group, once, nested, NULL, exec, 0);
     }
 
     pat = aucmd_next_pattern(pat, (size_t)patlen);
@@ -973,7 +981,7 @@ int do_autocmd_event(event_T event, const char *pat, bool once, int nested, char
 }
 
 int autocmd_register(int64_t id, event_T event, const char *pat, int patlen, int group, bool once,
-                     bool nested, char *desc, AucmdExecutable aucmd)
+                     bool nested, char *desc, AucmdExecutable aucmd, uint32_t ns)
 {
   // 0 is not a valid group.
   assert(group != 0);
@@ -1088,6 +1096,7 @@ int autocmd_register(int64_t id, event_T event, const char *pat, int patlen, int
   ac->once = once;
   ac->nested = nested;
   ac->desc = desc == NULL ? NULL : xstrdup(desc);
+  ac->ns = ns;
 
   return OK;
 }
@@ -1971,6 +1980,11 @@ static void aucmd_next(AutoPatCmd *apc)
       if (ap->buflocal_nr == 0
           ? !match_file_pat(NULL, &ap->reg_prog, apc->fname, apc->sfname, apc->tail, ap->allow_dirs)
           : ap->buflocal_nr != apc->arg_bufnr) {
+        continue;
+      }
+
+      // TODO(altermo): autocmd may trigger in not current window
+      if (ac->ns != 0 && !au_ns_scoped_in_win(ac->ns, curwin)) {
         continue;
       }
 

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -44,6 +44,7 @@ typedef struct {
   sctx_T script_ctx;        ///< Script context where it is defined
   bool once;                ///< "One shot": removed after execution
   bool nested;              ///< If autocommands nest here
+  uint32_t ns;              ///< !=0 for namespace scoped autocmd
 } AutoCmd;
 
 /// Struct used to keep status while executing autocommands for an event.

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -393,6 +393,27 @@ describe('autocmd api', function()
         ]])
       )
     end)
+
+    it('can set namespace scope', function()
+      api.nvim_set_var('called', 0)
+
+      local ns = api.nvim_create_namespace('test')
+      api.nvim_win_add_ns(0, ns)
+
+      api.nvim_create_autocmd('FileType', {
+        command = 'let g:called = g:called + 1',
+        ns_id = ns,
+      })
+
+      command 'set filetype=txt'
+      eq(1, api.nvim_get_var('called'))
+
+      -- switch to a new window
+      command 'vnew'
+      command 'set filetype=python'
+
+      eq(1, api.nvim_get_var('called'))
+    end)
   end)
 
   describe('nvim_get_autocmds', function()


### PR DESCRIPTION
Currently(as of 2024-04-21) the only namespace scope implemented is window scoped so this is only useful for setting window local autocmds. Later on, when more namespace scopes get implemented, this will get way more useful. For example, when buffer scoped namespace gets implemented, plugins could define all the autocmds once with a namespace scope and then apply set the namespace to the plugins buffer (rather than needing to create all the autocmds every time the plugin creates a new buffer).