### PR TITLE
refactor!: implement augroups as namespaces

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -65,7 +65,7 @@ EDITOR
 
 EVENTS
 
-• TODO
+• |autocmd-groups| are |namespace|s.
 
 LSP
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -58,8 +58,6 @@ enum {
   AUGROUP_DEFAULT = -1,  ///< default autocmd group
   AUGROUP_ERROR   = -2,  ///< erroneous autocmd group
   AUGROUP_ALL     = -3,  ///< all autocmd groups
-  AUGROUP_DELETED = -4,  ///< all autocmd groups
-  // AUGROUP_NS      = -5,  // TODO(tjdevries): Support namespaced based augroups
 };
 
 enum { BUFLOCAL_PAT_LEN = 25, };

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1424,13 +1424,11 @@ describe('API/extmarks', function()
 
   it('throws consistent error codes', function()
     local ns_invalid = ns2 + 1
-    eq(
-      "Invalid 'ns_id': 3",
-      pcall_err(set_extmark, ns_invalid, marks[1], positions[1][1], positions[1][2])
-    )
-    eq("Invalid 'ns_id': 3", pcall_err(api.nvim_buf_del_extmark, 0, ns_invalid, marks[1]))
-    eq("Invalid 'ns_id': 3", pcall_err(get_extmarks, ns_invalid, positions[1], positions[2]))
-    eq("Invalid 'ns_id': 3", pcall_err(get_extmark_by_id, ns_invalid, marks[1]))
+    local errmsg = "Invalid 'ns_id': " .. ns_invalid
+    eq(errmsg, pcall_err(set_extmark, ns_invalid, marks[1], positions[1][1], positions[1][2]))
+    eq(errmsg, pcall_err(api.nvim_buf_del_extmark, 0, ns_invalid, marks[1]))
+    eq(errmsg, pcall_err(get_extmarks, ns_invalid, positions[1], positions[2]))
+    eq(errmsg, pcall_err(get_extmark_by_id, ns_invalid, marks[1]))
   end)
 
   it('when col = line-length, set the mark on eol', function()
@@ -1533,7 +1531,7 @@ describe('API/extmarks', function()
         0,
         0,
         {
-          ns_id = 1,
+          ns_id = ns,
           end_col = 0,
           end_row = 1,
           right_gravity = true,
@@ -1596,7 +1594,7 @@ describe('API/extmarks', function()
         hl_group = 'String',
         hl_mode = 'blend',
         line_hl_group = 'Statement',
-        ns_id = 1,
+        ns_id = ns,
         number_hl_group = 'Statement',
         priority = 0,
         right_gravity = false,
@@ -1619,7 +1617,7 @@ describe('API/extmarks', function()
       0,
       0,
       {
-        ns_id = 1,
+        ns_id = ns,
         right_gravity = true,
         priority = 0,
         virt_text = { { '', 'Macro' }, { '', { 'Type', 'Search' } }, { '' } },
@@ -1634,7 +1632,7 @@ describe('API/extmarks', function()
       0,
       0,
       {
-        ns_id = 1,
+        ns_id = ns,
         cursorline_hl_group = 'Statement',
         priority = 4096,
         right_gravity = true,
@@ -1653,7 +1651,7 @@ describe('API/extmarks', function()
         end_col = 1,
         end_right_gravity = false,
         end_row = 0,
-        ns_id = 1,
+        ns_id = ns,
         right_gravity = true,
         spell = true,
       },
@@ -1669,7 +1667,7 @@ describe('API/extmarks', function()
         end_col = 1,
         end_right_gravity = false,
         end_row = 0,
-        ns_id = 1,
+        ns_id = ns,
         right_gravity = true,
         spell = false,
       },

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3141,14 +3141,23 @@ describe('API', function()
 
   describe('nvim_create_namespace', function()
     it('works', function()
-      eq({}, api.nvim_get_namespaces())
-      eq(1, api.nvim_create_namespace('ns-1'))
-      eq(2, api.nvim_create_namespace('ns-2'))
-      eq(1, api.nvim_create_namespace('ns-1'))
-      eq({ ['ns-1'] = 1, ['ns-2'] = 2 }, api.nvim_get_namespaces())
-      eq(3, api.nvim_create_namespace(''))
-      eq(4, api.nvim_create_namespace(''))
-      eq({ ['ns-1'] = 1, ['ns-2'] = 2 }, api.nvim_get_namespaces())
+      local augoup_ns =
+        { nvim_cmdwin = 3, nvim_popupmenu = 1, nvim_swapfile = 4, nvim_terminal = 2 }
+      eq(augoup_ns, api.nvim_get_namespaces())
+      local ns_offset = vim.tbl_count(augoup_ns)
+      eq(1 + ns_offset, api.nvim_create_namespace('ns-1'))
+      eq(2 + ns_offset, api.nvim_create_namespace('ns-2'))
+      eq(1 + ns_offset, api.nvim_create_namespace('ns-1'))
+      eq(
+        vim.tbl_extend('error', { ['ns-1'] = 1 + ns_offset, ['ns-2'] = 2 + ns_offset }, augoup_ns),
+        api.nvim_get_namespaces()
+      )
+      eq(3 + ns_offset, api.nvim_create_namespace(''))
+      eq(4 + ns_offset, api.nvim_create_namespace(''))
+      eq(
+        vim.tbl_extend('error', { ['ns-1'] = 1 + ns_offset, ['ns-2'] = 2 + ns_offset }, augoup_ns),
+        api.nvim_get_namespaces()
+      )
     end)
   end)
 

--- a/test/functional/lua/inspector_spec.lua
+++ b/test/functional/lua/inspector_spec.lua
@@ -12,7 +12,7 @@ describe('vim.inspect_pos', function()
   end)
 
   it('it returns items', function()
-    local buf, items, other_buf_syntax = exec_lua(function()
+    local buf, items, other_buf_syntax, ns1 = exec_lua(function()
       local buf = vim.api.nvim_create_buf(true, false)
       local buf1 = vim.api.nvim_create_buf(true, false)
       local ns1 = vim.api.nvim_create_namespace('ns1')
@@ -25,7 +25,7 @@ describe('vim.inspect_pos', function()
       vim.api.nvim_buf_set_extmark(buf, ns1, 0, 10, { hl_group = 'Normal' })
       vim.api.nvim_buf_set_extmark(buf, ns2, 0, 10, { hl_group = 'Normal' })
       vim.cmd('syntax on')
-      return buf, vim.inspect_pos(0, 0, 10), vim.inspect_pos(buf1, 0, 10).syntax
+      return buf, vim.inspect_pos(0, 0, 10), vim.inspect_pos(buf1, 0, 10).syntax, ns1
     end)
 
     eq('', eval('v:errmsg'))
@@ -40,12 +40,12 @@ describe('vim.inspect_pos', function()
           end_row = 0,
           id = 1,
           ns = 'ns1',
-          ns_id = 1,
+          ns_id = ns1,
           opts = {
             hl_eol = false,
             hl_group = 'Normal',
             hl_group_link = 'Normal',
-            ns_id = 1,
+            ns_id = ns1,
             priority = 4096,
             right_gravity = true,
           },
@@ -57,12 +57,12 @@ describe('vim.inspect_pos', function()
           end_row = 0,
           id = 1,
           ns = '',
-          ns_id = 2,
+          ns_id = ns1 + 1,
           opts = {
             hl_eol = false,
             hl_group = 'Normal',
             hl_group_link = 'Normal',
-            ns_id = 2,
+            ns_id = ns1 + 1,
             priority = 4096,
             right_gravity = true,
           },

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -703,14 +703,14 @@ describe('Buffer highlighting', function()
       local s1 = { { 'Köttbullar', 'Comment' }, { 'Kräuterbutter' } }
       local s2 = { { 'こんにちは', 'Comment' } }
 
-      set_virtual_text(0, id1, 0, s1, {})
+      local ns = set_virtual_text(0, id1, 0, s1, {})
       eq({
         {
           1,
           0,
           0,
           {
-            ns_id = 1,
+            ns_id = ns,
             priority = 0,
             virt_text = s1,
             -- other details
@@ -730,7 +730,7 @@ describe('Buffer highlighting', function()
           lastline,
           0,
           {
-            ns_id = 1,
+            ns_id = ns,
             priority = 0,
             virt_text = s2,
             -- other details
@@ -899,11 +899,12 @@ describe('Buffer highlighting', function()
   end)
 
   it('and virtual text use the same namespace counter', function()
-    eq(1, add_highlight(0, 0, 'String', 0, 0, -1))
-    eq(2, set_virtual_text(0, 0, 0, { { '= text', 'Comment' } }, {}))
-    eq(3, api.nvim_create_namespace('my-ns'))
-    eq(4, add_highlight(0, 0, 'String', 0, 0, -1))
-    eq(5, set_virtual_text(0, 0, 0, { { '= text', 'Comment' } }, {}))
-    eq(6, api.nvim_create_namespace('other-ns'))
+    local ns = api.nvim_create_namespace('')
+    eq(1 + ns, add_highlight(0, 0, 'String', 0, 0, -1))
+    eq(2 + ns, set_virtual_text(0, 0, 0, { { '= text', 'Comment' } }, {}))
+    eq(3 + ns, api.nvim_create_namespace('my-ns'))
+    eq(4 + ns, add_highlight(0, 0, 'String', 0, 0, -1))
+    eq(5 + ns, set_virtual_text(0, 0, 0, { { '= text', 'Comment' } }, {}))
+    eq(6 + ns, api.nvim_create_namespace('other-ns'))
   end)
 end)

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2104,7 +2104,7 @@ describe('extmark decorations', function()
 
     eq({ { 1, 0, 8, { end_col = 13, end_right_gravity = false, end_row = 0,
                        hl_eol = false, hl_group = "NonText", undo_restore = false,
-                       ns_id = 1, priority = 4096, right_gravity = true } } },
+                       ns_id = ns, priority = 4096, right_gravity = true } } },
        api.nvim_buf_get_extmarks(0, ns, {0,0}, {0, -1}, {details=true}))
   end)
 


### PR DESCRIPTION
From https://github.com/neovim/neovim/pull/28436#issuecomment-2068036755:
> The proposed change is to remove the separation, i.e. augroups are now implemented as namespaces instead of their own special, separate address space.

##### Implementation details:

**Deleting augroups:**
*Background:*
Deleting named namespaces is not allowed, while there are 2 ways of deleting augroups (normal and legacy). Legacy deleted augroups change their id to `augroup_deleted` but do not change their name, which also is not allowed for named namespaces. augroups with the id `augroup_deleted` or which don't have a name are considered deleted, have the name `"--Deleted--"` and error when trying to access them (most of the time). There are some other important differences which will be noted later.
*Implementation:*
When an augroup gets deleted, its id is appended to the set `deleted_augroup_map`. Any augroup in the `deleted_augroup_map` or doesn't have an associated name (e.g. an anonymous namespace) is considered deleted. When legacy deleting augroups the same steps happen as with normal deletion but all the autocmds associated with the augroup change their group to the id returned by `get_deleted_augroup_id()`. This is the special deleted augroup and has the name `"--Deleted--"` and there is only one of these (This is a BREAKING-CHANGE, see *Example 1*).

**Creating augroups:**
*Implementation:*
Creating augroups will use `nvim_create_namespace()` to create augroups (This is a BREAKING-CHANGE as augroups now can't have the name `""`(empty string)). If the returned id is in `deleted_augroup_map` then it will be removed from there.

**Listing augroups:**
*Background:*
There are two (or more) ways of listing augroups: using `:augroup` (which I will refer to as normal listing) and using `getcompletion('','augroup')` (which I will refer to as completion listing). Whether a deleted augroup gets listed depends on what listing method you use (normal or completion) and whether the augroup was normal or legacy deleted. Completion listing lists all augroups, including normal deleted ones (all deleted/legacy deleted augroups have the name `"--Deleted--"`). Normal listing will only list legacy deleted augroups.
*Implementation:*
Listing augroups will also list all other named namespaces, as there is no difference between named namespaces and augroups (This might break some plugin tests). Normal deleted augroups will never be listed (not even in completion listings) and there will only be one `"--Deleted--"` listed after any number of augroups get legacy deleted (these are BREAKING-CHANGEs).

**Other:**
The first-ever namespaces created with `nvim_create_namespace()` after initializing the runtime files will now not be 1 as the runtime files create some augroups on initialization (This might break some plugin tests).

##### Examples (click to expand):
<details><summary>Example 1</summary>

```lua
local group=vim.api.nvim_create_augroup('test',{})
vim.api.nvim_create_autocmd('FileType',{group=group,command='',pattern='foo'})
vim.cmd'augroup! test'
assert(vim.api.nvim_get_autocmds({pattern='foo'})[1].group==group)
```

</details>