### PR TITLE
vim-patch:d3ff129ce8c6

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -461,6 +461,21 @@ nasm_loose_syntax	unofficial parser allowed syntax not as Error
 nasm_ctx_outside_macro	contexts outside macro not as Error
 nasm_no_warn		potentially risky syntax not as ToDo
 
+ASTRO						*astro.vim* *ft-astro-syntax*
+
+Configuration
+
+The following variables control certain syntax highlighting features.
+You can add them to your .vimrc: >
+	let g:astro_typescript = "enable"
+<
+Enables TypeScript and TSX for ".astro" files. Default Value: "disable" >
+	let g:astro_stylus = "enable"
+<
+Enables Stylus for ".astro" files. Default Value: "disable"
+
+NOTE: You need to install an external plugin to support stylus in astro files.
+
 
 ASPPERL and ASPVBS			*ft-aspperl-syntax* *ft-aspvbs-syntax*
 
@@ -5306,6 +5321,5 @@ literal text specify the size of that text (in bytes):
 "<\@<=span"	Matches "span" in "<span".  This tries matching with "<" in
 		many places.
 "<\@1<=span"	Matches the same, but only tries one byte before "span".
-
 
  vim:tw=78:sw=4:ts=8:noet:ft=help:norl:

--- a/runtime/ftplugin/astro.vim
+++ b/runtime/ftplugin/astro.vim
@@ -1,0 +1,186 @@
+" Vim filetype plugin file
+" Language:     Astro
+" Maintainer:   Romain Lafourcade <romainlafourcade@gmail.com>
+" Last Change:  2024 Apr 21
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+function! s:IdentifyScope(start, end) abort
+    let pos_start = searchpairpos(a:start, '', a:end, 'bnW')
+    let pos_end = searchpairpos(a:start, '', a:end, 'nW')
+
+    return pos_start != [0, 0]
+                \ && pos_end != [0, 0]
+                \ && pos_start[0] != getpos('.')[1]
+endfunction
+
+function! s:AstroComments() abort
+    if s:IdentifyScope('^---\n\s*\S', '^---\n\n')
+                \ || s:IdentifyScope('^\s*<script', '^\s*<\/script>')
+        " ECMAScript comments
+        setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+        setlocal commentstring=//%s
+
+    elseif s:IdentifyScope('^\s*<style', '^\s*<\/style>')
+        " CSS comments
+        setlocal comments=s1:/*,mb:*,ex:*/
+        setlocal commentstring=/*%s*/
+
+    else
+        " HTML comments
+        setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
+        setlocal commentstring=<!--%s-->
+    endif
+endfunction
+
+" https://code.visualstudio.com/docs/languages/jsconfig
+function! s:CollectPathsFromConfig() abort
+    let config_json = findfile('tsconfig.json', '.;')
+
+    if empty(config_json)
+        let config_json = findfile('jsconfig.json', '.;')
+
+        if empty(config_json)
+            return
+        endif
+    endif
+
+    let paths_from_config = config_json
+                \ ->readfile()
+                \ ->filter({ _, val -> val =~ '^\s*[\[\]{}"0-9]' })
+                \ ->join()
+                \ ->json_decode()
+                \ ->get('compilerOptions', {})
+                \ ->get('paths', {})
+
+    if !empty(paths_from_config)
+        let b:astro_paths = paths_from_config
+                    \ ->map({key, val -> [
+                    \     key->glob2regpat(),
+                    \     val[0]->substitute('\/\*$', '', '')
+                    \   ]})
+                    \ ->values()
+    endif
+
+    let b:undo_ftplugin ..= " | unlet! b:astro_paths"
+endfunction
+
+function! s:AstroInclude(filename) abort
+    let decorated_filename = a:filename
+                \ ->substitute("^", "@", "")
+
+    let found_path = b:
+                \ ->get("astro_paths", [])
+                \ ->indexof({ key, val -> decorated_filename =~ val[0]})
+
+    if found_path != -1
+        let alias = b:astro_paths[found_path][0]
+        let path  = b:astro_paths[found_path][1]
+                    \ ->substitute('\(\/\)*$', '/', '')
+
+        return decorated_filename
+                    \ ->substitute(alias, path, '')
+    endif
+
+    return a:filename
+endfunction
+
+let b:undo_ftplugin = "setlocal"
+            \ .. " formatoptions<"
+            \ .. " path<"
+            \ .. " suffixesadd<"
+            \ .. " matchpairs<"
+            \ .. " comments<"
+            \ .. " commentstring<"
+            \ .. " iskeyword<"
+            \ .. " define<"
+            \ .. " include<"
+            \ .. " includeexpr<"
+
+" Create self-resetting autocommand group
+augroup Astro
+    autocmd! * <buffer>
+augroup END
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal formatoptions-=t
+setlocal formatoptions+=croql
+
+" Remove irrelevant part of 'path'.
+setlocal path-=/usr/include
+
+" Seed 'path' with default directories for :find, gf, etc.
+setlocal path+=src/**
+setlocal path+=public/**
+
+" Help Vim find extension-less filenames
+let &l:suffixesadd =
+            \ ".astro"
+            \ .. ",.js,.jsx,.es,.es6,.cjs,.mjs,.jsm"
+            \ .. ",.json"
+            \ .. ",.scss,.sass,.css"
+            \ .. ",.svelte"
+            \ .. ",.ts,.tsx,.d.ts"
+            \ .. ",.vue"
+
+" From $VIMRUNTIME/ftplugin/html.vim
+setlocal matchpairs+=<:>
+
+" Matchit configuration
+if exists("loaded_matchit")
+    let b:match_ignorecase = 0
+
+    " From $VIMRUNTIME/ftplugin/javascript.vim
+    let b:match_words =
+                \ '\<do\>:\<while\>,'
+                \ .. '<\@<=\([^ \t>/]\+\)\%(\s\+[^>]*\%([^/]>\|$\)\|>\|$\):<\@<=/\1>,'
+                \ .. '<\@<=\%([^ \t>/]\+\)\%(\s\+[^/>]*\|$\):/>'
+
+    " From $VIMRUNTIME/ftplugin/html.vim
+    let b:match_words ..=
+                \ '<!--:-->,'
+                \ .. '<:>,'
+                \ .. '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,'
+                \ .. '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,'
+                \ .. '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+
+    let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words"
+endif
+
+" Change what constitutes a word, mainly useful for CSS/SASS
+setlocal iskeyword+=-
+setlocal iskeyword+=$
+setlocal iskeyword+=%
+
+" Define paths/aliases for module resolution
+call s:CollectPathsFromConfig()
+
+" Find ESM imports
+setlocal include=^\\s*\\(import\\\|import\\s\\+[^\/]\\+from\\)\\s\\+['\"]
+
+" Process aliases if file can't be found
+setlocal includeexpr=s:AstroInclude(v:fname)
+
+" Set 'define' to a comprehensive value
+" From $VIMRUNTIME/ftplugin/javascript.vim and
+" $VIMRUNTIME/ftplugin/sass.vim
+let &l:define =
+            \ '\(^\s*(*async\s\+function\|(*function\)'
+            \ .. '\|^\s*\(\*\|static\|async\|get\|set\|\i\+\.\)'
+            \ .. '\|^\s*\(\ze\i\+\)\(([^)]*).*{$\|\s*[:=,]\)'
+
+
+" Set &comments and &commentstring according to current scope
+autocmd Astro CursorMoved <buffer> call s:AstroComments()
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: textwidth=78 tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/runtime/indent/astro.vim
+++ b/runtime/indent/astro.vim
@@ -1,0 +1,88 @@
+" Vim indent file (experimental).
+" Language:    Astro
+" Author:      Wuelner Martínez <wuelner.martinez@outlook.com>
+" Maintainer:  Wuelner Martínez <wuelner.martinez@outlook.com>
+" URL:         https://github.com/wuelnerdotexe/vim-astro
+" Last Change: 2022 Aug 07
+" Based On:    Evan Lecklider's vim-svelte
+" Changes:     See https://github.com/evanleck/vim-svelte
+" Credits:     See vim-svelte on github
+
+" Only load this indent file when no other was loaded yet.
+if exists('b:did_indent')
+  finish
+endif
+
+let b:html_indent_script1 = 'inc'
+let b:html_indent_style1 = 'inc'
+
+" Embedded HTML indent.
+runtime! indent/html.vim
+let s:html_indent = &l:indentexpr
+unlet b:did_indent
+
+let b:did_indent = 1
+
+setlocal indentexpr=GetAstroIndent()
+setlocal indentkeys=<>>,/,0{,{,},0},0),0],0\,<<>,,!^F,*<Return>,o,O,e,;
+
+let b:undo_indent = 'setl inde< indk<'
+
+" Only define the function once.
+if exists('*GetAstroIndent')
+  finish
+endif
+
+let s:cpoptions_save = &cpoptions
+setlocal cpoptions&vim
+
+function! GetAstroIndent()
+  let l:current_line_number = v:lnum
+
+  if l:current_line_number == 0
+    return 0
+  endif
+
+  let l:current_line = getline(l:current_line_number)
+
+  if l:current_line =~ '^\s*</\?\(script\|style\)'
+    return 0
+  endif
+
+  let l:previous_line_number = prevnonblank(l:current_line_number - 1)
+  let l:previous_line = getline(l:previous_line_number)
+  let l:previous_line_indent = indent(l:previous_line_number)
+
+  if l:previous_line =~ '^\s*</\?\(script\|style\)'
+    return l:previous_line_indent + shiftwidth()
+  endif
+
+  execute 'let l:indent = ' . s:html_indent
+
+  if searchpair('<style>', '', '</style>', 'bW') &&
+        \ l:previous_line =~ ';$' && l:current_line !~ '}'
+    return l:previous_line_indent
+  endif
+
+  if synID(l:previous_line_number, match(
+        \   l:previous_line, '\S'
+        \ ) + 1, 0) == hlID('htmlTag') && synID(l:current_line_number, match(
+        \  l:current_line, '\S'
+        \ ) + 1, 0) != hlID('htmlEndTag')
+    let l:indents_match = l:indent == l:previous_line_indent
+    let l:previous_closes = l:previous_line =~ '/>$'
+
+    if l:indents_match &&
+          \ !l:previous_closes && l:previous_line =~ '<\(\u\|\l\+:\l\+\)'
+      return l:previous_line_indent + shiftwidth()
+    elseif !l:indents_match && l:previous_closes
+      return l:previous_line_indent
+    endif
+  endif
+
+  return l:indent
+endfunction
+
+let &cpoptions = s:cpoptions_save
+unlet s:cpoptions_save
+" vim: ts=8

--- a/runtime/syntax/astro.vim
+++ b/runtime/syntax/astro.vim
@@ -1,0 +1,190 @@
+" Vim syntax file.
+" Language:    Astro
+" Author:      Wuelner Martínez <wuelner.martinez@outlook.com>
+" Maintainer:  Wuelner Martínez <wuelner.martinez@outlook.com>
+" URL:         https://github.com/wuelnerdotexe/vim-astro
+" Last Change: 2022 Aug 22
+" Based On:    Evan Lecklider's vim-svelte
+" Changes:     See https://github.com/evanleck/vim-svelte
+" Credits:     See vim-svelte on github
+
+" Quit when a (custom) syntax file was already loaded.
+if !exists('main_syntax')
+  if exists('b:current_syntax')
+    finish
+  endif
+  let main_syntax = 'astro'
+elseif exists('b:current_syntax') && b:current_syntax == 'astro'
+  finish
+endif
+
+" Astro syntax variables are initialized.
+let g:astro_typescript = get(g:, 'astro_typescript', 'disable')
+let g:astro_stylus = get(g:, 'astro_stylus', 'disable')
+
+let s:cpoptions_save = &cpoptions
+set cpoptions&vim
+
+" Embedded HTML syntax.
+runtime! syntax/html.vim
+
+" htmlTagName: expand HTML tag names to include mixed case and periods.
+syntax match htmlTagName contained "\<[a-zA-Z\.]*\>"
+
+" astroDirectives: add Astro Directives to HTML arguments.
+syntax match astroDirectives contained '\<[a-z]\+:[a-z|]*\>' containedin=htmlTag
+
+unlet b:current_syntax
+
+if g:astro_typescript == 'enable'
+  " Embedded TypeScript syntax.
+  syntax include @astroJavaScript syntax/typescript.vim
+
+  " javaScriptExpression: a javascript expression is used as an arg value.
+  syntax clear javaScriptExpression
+  syntax region javaScriptExpression
+        \ contained start=+&{+
+        \ keepend end=+};+
+        \ contains=@astroJavaScript,@htmlPreproc
+
+  " javaScript: add TypeScript support to HTML script tag.
+  syntax clear javaScript
+  syntax region javaScript
+        \ start=+<script\_[^>]*>+
+        \ keepend
+        \ end=+</script\_[^>]*>+me=s-1
+        \ contains=htmlScriptTag,@astroJavaScript,@htmlPreproc,htmlCssStyleComment
+else
+  " Embedded JavaScript syntax.
+  syntax include @astroJavaScript syntax/javascript.vim
+endif
+
+" astroFence: detect the Astro fence.
+syntax match astroFence contained +^---$+
+
+" astrojavaScript: add TypeScript support to Astro code fence.
+syntax region astroJavaScript
+      \ start=+^---$+
+      \ keepend
+      \ end=+^---$+
+      \ contains=htmlTag,@astroJavaScript,@htmlPreproc,htmlCssStyleComment,htmlEndTag,astroFence
+      \ fold
+
+unlet b:current_syntax
+
+if g:astro_typescript == 'enable'
+  " Embedded TypeScript React (TSX) syntax.
+  syntax include @astroJavaScriptReact syntax/typescriptreact.vim
+else
+  " Embedded JavaScript React (JSX) syntax.
+  syntax include @astroJavaScriptReact syntax/javascriptreact.vim
+endif
+
+" astroJavaScriptExpression: add {JSX or TSX} support to Astro expresions.
+execute 'syntax region astroJavaScriptExpression start=+{+ keepend end=+}+ ' .
+      \ 'contains=@astroJavaScriptReact, @htmlPreproc containedin=' . join([
+      \   'htmlArg', 'htmlBold', 'htmlBoldItalic', 'htmlBoldItalicUnderline',
+      \   'htmlBoldUnderline', 'htmlBoldUnderlineItalic', 'htmlH1', 'htmlH2',
+      \   'htmlH3', 'htmlH4', 'htmlH5', 'htmlH6', 'htmlHead', 'htmlItalic',
+      \   'htmlItalicBold', 'htmlItalicBoldUnderline', 'htmlItalicUnderline',
+      \   'htmlItalicUnderlineBold', 'htmlLeadingSpace', 'htmlLink',
+      \   'htmlStrike', 'htmlString', 'htmlTag', 'htmlTitle', 'htmlUnderline',
+      \   'htmlUnderlineBold', 'htmlUnderlineBoldItalic',
+      \   'htmlUnderlineItalic', 'htmlUnderlineItalicBold', 'htmlValue'
+      \ ], ',')
+
+" cssStyle: add CSS style tags support in TypeScript React.
+syntax region cssStyle
+      \ start=+<style\_[^>]*>+
+      \ keepend
+      \ end=+</style\_[^>]*>+me=s-1
+      \ contains=htmlTag,@htmlCss,htmlCssStyleComment,@htmlPreproc,htmlEndTag
+      \ containedin=@astroJavaScriptReact
+
+unlet b:current_syntax
+
+" Embedded SCSS syntax.
+syntax include @astroScss syntax/scss.vim
+
+" cssStyle: add SCSS style tags support in Astro.
+syntax region scssStyle
+      \ start=/<style\>\_[^>]*\(lang\)=\("\|''\)[^\2]*scss[^\2]*\2\_[^>]*>/
+      \ keepend
+      \ end=+</style>+me=s-1
+      \ contains=@astroScss,astroSurroundingTag
+      \ fold
+
+unlet b:current_syntax
+
+" Embedded SASS syntax.
+syntax include @astroSass syntax/sass.vim
+
+" cssStyle: add SASS style tags support in Astro.
+syntax region sassStyle
+      \ start=/<style\>\_[^>]*\(lang\)=\("\|''\)[^\2]*sass[^\2]*\2\_[^>]*>/
+      \ keepend
+      \ end=+</style>+me=s-1
+      \ contains=@astroSass,astroSurroundingTag
+      \ fold
+
+unlet b:current_syntax
+
+" Embedded LESS syntax.
+syntax include @astroLess syntax/less.vim
+
+" cssStyle: add LESS style tags support in Astro.
+syntax region lessStyle
+      \ start=/<style\>\_[^>]*\(lang\)=\("\|''\)[^\2]*less[^\2]*\2\_[^>]*>/
+      \ keepend
+      \ end=+</style>+me=s-1
+      \ contains=@astroLess,astroSurroundingTag
+      \ fold
+
+unlet b:current_syntax
+
+" Embedded Stylus syntax.
+" NOTE: Vim does not provide stylus support by default, but you can install
+"       this plugin to support it: https://github.com/wavded/vim-stylus
+if g:astro_stylus == 'enable'
+  try
+    " Embedded Stylus syntax.
+    syntax include @astroStylus syntax/stylus.vim
+
+    " stylusStyle: add Stylus style tags support in Astro.
+    syntax region stylusStyle
+          \ start=/<style\>\_[^>]*\(lang\)=\("\|''\)[^\2]*stylus[^\2]*\2\_[^>]*>/
+          \ keepend
+          \ end=+</style>+me=s-1
+          \ contains=@astroStylus,astroSurroundingTag
+          \ fold
+
+    unlet b:current_syntax
+  catch
+    echomsg "you need install a external plugin for support stylus in .astro files"
+  endtry
+endif
+
+" astroSurroundingTag: add surround HTML tag to script and style.
+syntax region astroSurroundingTag
+      \ start=+<\(script\|style\)+
+      \ end=+>+
+      \ contains=htmlTagError,htmlTagN,htmlArg,htmlValue,htmlEvent,htmlString
+      \ contained
+      \ fold
+
+" Define the default highlighting.
+" Only used when an item doesn't have highlighting yet.
+highlight default link astroDirectives Special
+highlight default link astroFence Comment
+
+let b:current_syntax = 'astro'
+if main_syntax == 'astro'
+  unlet main_syntax
+endif
+
+" Sync from start because of the wacky nesting.
+syntax sync fromstart
+
+let &cpoptions = s:cpoptions_save
+unlet s:cpoptions_save
+" vim: ts=8


### PR DESCRIPTION
runtime(astro): Add filetype, syntax and indent plugin

related: vim/vim#14558
closes: vim/vim#14561

ported from: https://github.com/wuelnerdotexe/vim-astro

https://github.com/vim/vim/commit/d3ff129ce8c68770c47d72ab3f30a21c19530eee

Co-authored-by: Philip H <47042125+pheiduck@users.noreply.github.com>
