### PR TITLE
fix(tui): disable sync output and extended underline check for Apple Terminal

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -410,11 +410,15 @@ static void terminfo_start(TUIData *tui)
 
   // Query support for mode 2026 (Synchronized Output). Some terminals also
   // support an older DCS sequence for synchronized output, but we will only use
-  // mode 2026
-  tui_request_term_mode(tui, kTermModeSynchronizedOutput);
+  // mode 2026.
+  // Some terminals (such as Terminal.app) do not support DECRQM, so skip the query.
+  if (!nsterm) {
+    tui_request_term_mode(tui, kTermModeSynchronizedOutput);
+  }
 
   // Don't use DECRQSS in screen or tmux, as they behave strangely when receiving it.
-  if (tui->unibi_ext.set_underline_style == -1 && !(screen || tmux)) {
+  // Terminal.app also doesn't support DECRQSS.
+  if (tui->unibi_ext.set_underline_style == -1 && !(screen || tmux || nsterm)) {
     // Query the terminal to see if it supports extended underline.
     tui_query_extended_underline(tui);
   }


### PR DESCRIPTION
**Problems**

When launching Neovim on Terminal.app on macOS (Apple Terminal,) it briefly shows like
`p$qm+q5463;524742;73657472676266;73657472676262$qm` in orange background color partially on the screen.

**Solution**

Since Apple Terminal seems not supporting synchronized output and extended underline, calling `tui_request_term_mode` and `tui_query_extended_underline` caused this unexpected output.

Therefore, if we know it's Apple Terminal (when `nsterm` is `true`,) do not call these checks.

Tested on Terminal.app (2.14, 453) on macOS 14.4.1.