### PR TITLE
fix(lsp): avoid assertion when `client_hints` do not exit

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -311,6 +311,10 @@ api.nvim_set_decoration_provider(namespace, {
     if bufstate.version ~= util.buf_versions[bufnr] then
       return
     end
+
+    if not bufstate.client_hints then
+      return
+    end
     local hints_by_client = assert(bufstate.client_hints)
 
     for lnum = topline, botline do


### PR DESCRIPTION
Because the `client_hint` will only be initialized and updated in the `lsp-handler` for the inlay hint, when a user calls `vim.lsp.inlay_hint.enable()` on a buffer not attached by an LSP server or the server does not support inlay hint, the assertion will be false.

This should not be considered an error, because everything works well after that, and if the user starts a new LSP server after enabling the inlay hint, the inlay hint will work well too. And this assertion is annoying in that case because the callback function that contains the assertion will be called whenever a window is redrawn.

Considering this assertion was added in https://github.com/neovim/neovim/pull/26552 to provide more annotation, its purpose should be to make the lua_ls believe `client_hint` is not optional to avoid diagnostic warning. So instead of removing the assertion, return the function before the assertion is false.
