### PR TITLE
vim-patch:9.1.0366: filetype: ondir files are not recognized

### DIFF
--- a/runtime/ftplugin/ondir.vim
+++ b/runtime/ftplugin/ondir.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin file
+" Language:     ondir <https://github.com/alecthomas/ondir>
+" Maintainer:   Jon Parise <jon@indelible.org>
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+let s:cpo_save = &cpoptions
+
+setlocal comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl comments< commentstring<'
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save
+
+" vim: et ts=4 sw=2 sts=2:

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1501,6 +1501,7 @@ local filename = {
   ['.octaverc'] = 'octave',
   octaverc = 'octave',
   ['octave.conf'] = 'octave',
+  ['.ondirrc'] = 'ondir',
   opam = 'opam',
   ['pacman.log'] = 'pacmanlog',
   ['/etc/pam.conf'] = 'pamconf',

--- a/runtime/syntax/ondir.vim
+++ b/runtime/syntax/ondir.vim
@@ -1,0 +1,35 @@
+" Vim syntax file
+" Language:     ondir <https://github.com/alecthomas/ondir>
+" Maintainer:   Jon Parise <jon@indelible.org>
+
+if exists('b:current_syntax')
+  finish
+endif
+
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+syn case match
+
+syn match   ondirComment  "#.*" contains=@Spell
+syn keyword ondirKeyword  final contained skipwhite nextgroup=ondirKeyword
+syn keyword ondirKeyword  enter leave contained skipwhite nextgroup=ondirPath
+syn match   ondirPath     "[^:]\+" contained display
+syn match   ondirColon    ":" contained display
+
+syn include @ondirShell   syntax/sh.vim
+syn region  ondirContent  start="^\s\+" end="^\ze\S.*$" keepend contained contains=@ondirShell
+
+syn region  ondirSection  start="^\(final\|enter\|leave\)" end="^\ze\S.*$" fold contains=ondirKeyword,ondirPath,ondirColon,ondirContent
+
+hi def link ondirComment  Comment
+hi def link ondirKeyword  Keyword
+hi def link ondirPath     Special
+hi def link ondirColon    Operator
+
+let b:current_syntax = 'ondir'
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save
+
+" vim: et ts=4 sw=2 sts=2:

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -519,6 +519,7 @@ func s:GetFilenameChecks() abort
     \ 'octave': ['octaverc', '.octaverc', 'octave.conf', 'any/.local/share/octave/history'],
     \ 'odin': ['file.odin'],
     \ 'omnimark': ['file.xom', 'file.xin'],
+    \ 'ondir': ['.ondirrc'],
     \ 'opam': ['opam', 'file.opam', 'file.opam.template'],
     \ 'openroad': ['file.or'],
     \ 'openscad': ['file.scad'],


### PR DESCRIPTION
Problem:  filetype: ondir files are not recognized
Solution: Detect '.ondirrc' as ondir filetype
          (Jon Parise)

closes: vim/vim#14604

https://github.com/vim/vim/commit/ea999037a41292b3d3e00700a87a82fe5d2c12b2

Co-authored-by: Jon Parise <jon@indelible.org>
