### PR TITLE
vim-patch:9.1.0364: tests: test_vim9_builtin is a bit slow

### DIFF
--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -2776,11 +2776,11 @@ func Test_short_option()
   call s:make_buffer_pairs()
 
   set winfixbuf
-  call assert_fails("edit something_else", "E1513")
+  call assert_fails("edit something_else", "E1513:")
 
   set nowinfixbuf
   set wfb
-  call assert_fails("edit another_place", "E1513")
+  call assert_fails("edit another_place", "E1513:")
 
   set nowfb
   edit last_place

--- a/test/old/testdir/vim9.vim
+++ b/test/old/testdir/vim9.vim
@@ -46,49 +46,6 @@ func CheckScriptSuccess(lines)
   endtry
 endfunc
 
-" :source a list of "lines" and check whether it fails with "error"
-func CheckSourceFailure(lines, error, lnum = -3)
-  if get(a:lines, 0, '') ==# 'vim9script'
-    return
-  endif
-  new
-  call setline(1, a:lines)
-  try
-    call assert_fails('source', a:error, a:lines, a:lnum)
-  finally
-    bw!
-  endtry
-endfunc
-
-" :source a list of "lines" and check whether it fails with the list of
-" "errors"
-func CheckSourceFailureList(lines, errors, lnum = -3)
-  if get(a:lines, 0, '') ==# 'vim9script'
-    return
-  endif
-  new
-  call setline(1, a:lines)
-  try
-    call assert_fails('source', a:errors, a:lines, a:lnum)
-  finally
-    bw!
-  endtry
-endfunc
-
-" :source a list of "lines" and check whether it succeeds
-func CheckSourceSuccess(lines)
-  if get(a:lines, 0, '') ==# 'vim9script'
-    return
-  endif
-  new
-  call setline(1, a:lines)
-  try
-    :source
-  finally
-    bw!
-  endtry
-endfunc
-
 func CheckDefAndScriptSuccess(lines)
   return
 endfunc
@@ -185,3 +142,96 @@ func CheckLegacyAndVim9Failure(lines, error)
                               \ })
   call CheckLegacyFailure(legacylines, legacyError)
 endfunc
+
+" :source a list of "lines" and check whether it fails with "error"
+func CheckSourceScriptFailure(lines, error, lnum = -3)
+  if get(a:lines, 0, '') ==# 'vim9script'
+    return
+  endif
+  let cwd = getcwd()
+  new
+  call setline(1, a:lines)
+  let bnr = bufnr()
+  try
+    call assert_fails('source', a:error, a:lines, a:lnum)
+  finally
+    call chdir(cwd)
+    exe $':bw! {bnr}'
+  endtry
+endfunc
+
+" :source a list of "lines" and check whether it fails with the list of
+" "errors"
+func CheckSourceScriptFailureList(lines, errors, lnum = -3)
+  if get(a:lines, 0, '') ==# 'vim9script'
+    return
+  endif
+  let cwd = getcwd()
+  new
+  let bnr = bufnr()
+  call setline(1, a:lines)
+  try
+    call assert_fails('source', a:errors, a:lines, a:lnum)
+  finally
+    call chdir(cwd)
+    exe $':bw! {bnr}'
+  endtry
+endfunc
+
+" :source a list of "lines" and check whether it succeeds
+func CheckSourceScriptSuccess(lines)
+  if get(a:lines, 0, '') ==# 'vim9script'
+    return
+  endif
+  let cwd = getcwd()
+  new
+  let bnr = bufnr()
+  call setline(1, a:lines)
+  try
+    :source
+  finally
+    call chdir(cwd)
+    exe $':bw! {bnr}'
+  endtry
+endfunc
+
+func CheckSourceSuccess(lines)
+  call CheckSourceScriptSuccess(a:lines)
+endfunc
+
+func CheckSourceFailure(lines, error, lnum = -3)
+  call CheckSourceScriptFailure(a:lines, a:error, a:lnum)
+endfunc
+
+func CheckSourceFailureList(lines, errors, lnum = -3)
+  call CheckSourceScriptFailureList(a:lines, a:errors, a:lnum)
+endfunc
+
+func CheckSourceDefSuccess(lines)
+  return
+endfunc
+
+func CheckSourceDefAndScriptSuccess(lines)
+  return
+endfunc
+
+func CheckSourceDefCompileSuccess(lines)
+  return
+endfunc
+
+func CheckSourceDefFailure(lines, error, lnum = -3)
+  return
+endfunc
+
+func CheckSourceDefExecFailure(lines, error, lnum = -3)
+  return
+endfunc
+
+func CheckSourceDefAndScriptFailure(lines, error, lnum = -3)
+  return
+endfunc
+
+func CheckSourceDefExecAndScriptFailure(lines, error, lnum = -3)
+  return
+endfunc
+


### PR DESCRIPTION
#### vim-patch:9.1.0364: tests: test_vim9_builtin is a bit slow

Problem:  tests: test_vim9_builtin is a bit slow
Solution: source tests from a buffer instead of
          writing and sourcing a file (Yegappan Lakshmanan)

closes: vim/vim#14614

https://github.com/vim/vim/commit/22697b6179e38f3d321b1495ef17f06031a9c8f1

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>