### PR TITLE
refactor(lsp): merge subtypes and supertypes into typehierarchy

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1431,21 +1431,19 @@ signature_help()                                *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
     floating window.
 
-subtypes()                                            *vim.lsp.buf.subtypes()*
-    Lists all the subtypes of the symbol under the cursor in the |quickfix|
-    window. If the symbol can resolve to multiple items, the user can pick one
-    using |vim.ui.select()|.
-
-supertypes()                                        *vim.lsp.buf.supertypes()*
-    Lists all the supertypes of the symbol under the cursor in the |quickfix|
-    window. If the symbol can resolve to multiple items, the user can pick one
-    using |vim.ui.select()|.
-
 type_definition({options})                     *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
 
     Parameters: ~
       • {options}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
+
+typehierarchy({kind})                            *vim.lsp.buf.typehierarchy()*
+    Lists all the subtypes or supertypes of the symbol under the cursor in the
+    |quickfix| window. If the symbol can resolve to multiple items, the user
+    can pick one using |vim.ui.select()|.
+
+    Parameters: ~
+      • {kind}  (`"subtypes"|"supertypes"`)
 
 workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
     Lists all symbols in the current workspace in the quickfix window.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -217,7 +217,7 @@ The following new APIs and features were added.
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_inlayHint
   • Implemented pull diagnostic textDocument/diagnostic: |vim.lsp.diagnostic.on_diagnostic()|
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_diagnostic
-  • Implemented LSP type hierarchy: |vim.lsp.buf.supertypes()| and |vim.lsp.buf.subtypes()|
+  • Implemented LSP type hierarchy: |vim.lsp.buf.typehierarchy()|
     https://microsoft.github.io/language-server-protocol/specification/#textDocument_prepareTypeHierarchy
   • |vim.lsp.status()| consumes the last progress messages as a string.
   • LSP client now always saves and restores named buffer marks when applying

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -495,11 +495,17 @@ function M.outgoing_calls()
   call_hierarchy(ms.callHierarchy_outgoingCalls)
 end
 
---- @param method string
-local function type_hierarchy(method)
+--- Lists all the subtypes or supertypes of the symbol under the
+--- cursor in the |quickfix| window. If the symbol can resolve to
+--- multiple items, the user can pick one using |vim.ui.select()|.
+---@param kind "subtypes"|"supertypes"
+function M.typehierarchy(kind)
+  local method = kind == 'subtypes' and ms.typeHierarchy_subtypes or ms.typeHierarchy_supertypes
+
   --- Merge results from multiple clients into a single table. Client-ID is preserved.
   ---
   --- @param results table<integer, {error: lsp.ResponseError, result: lsp.TypeHierarchyItem[]?}>
+  --- @return [integer, lsp.TypeHierarchyItem][]
   local function merge_results(results)
     local merged_results = {}
     for client_id, client_result in pairs(results) do
@@ -525,11 +531,9 @@ local function type_hierarchy(method)
     end
 
     if #merged_results == 1 then
-      --- @type {integer, lsp.TypeHierarchyItem}
       local item = merged_results[1]
       local client = vim.lsp.get_client_by_id(item[1])
       if client then
-        --- @type lsp.TypeHierarchyItem
         client.request(method, { item = item[2] }, nil, bufnr)
       else
         vim.notify(
@@ -563,20 +567,6 @@ local function type_hierarchy(method)
       end)
     end
   end)
-end
-
---- Lists all the subtypes of the symbol under the
---- cursor in the |quickfix| window. If the symbol can resolve to
---- multiple items, the user can pick one using |vim.ui.select()|.
-function M.subtypes()
-  type_hierarchy(ms.typeHierarchy_subtypes)
-end
-
---- Lists all the supertypes of the symbol under the
---- cursor in the |quickfix| window. If the symbol can resolve to
---- multiple items, the user can pick one using |vim.ui.select()|.
-function M.supertypes()
-  type_hierarchy(ms.typeHierarchy_supertypes)
 end
 
 --- List workspace folders.

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3461,7 +3461,7 @@ describe('LSP', function()
     end)
   end)
 
-  describe('vim.lsp.buf.subtypes', function()
+  describe('vim.lsp.buf.typehierarchy subtypes', function()
     it('does nothing for an empty response', function()
       local qflist_count = exec_lua([=[
         require'vim.lsp.handlers'['typeHierarchy/subtypes'](nil, nil, {})
@@ -3679,7 +3679,7 @@ describe('LSP', function()
     end)
   end)
 
-  describe('vim.lsp.buf.supertypes', function()
+  describe('vim.lsp.buf.typehierarchy supertypes', function()
     it('does nothing for an empty response', function()
       local qflist_count = exec_lua([=[
         require'vim.lsp.handlers'['typeHierarchy/supertypes'](nil, nil, {})


### PR DESCRIPTION
Both methods had pretty much the same documentation and shared the
implementation.
