### PR TITLE
fix(lua): refactor `vim.deprecate()` for performance in "Nvim" plugin

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1042,43 +1042,32 @@ end
 ---
 ---@return string|nil # Deprecated message, or nil if no message was shown.
 function vim.deprecate(name, alternative, version, plugin, backtrace)
-  vim.validate {
-    name = { name, 'string' },
-    alternative = { alternative, 'string', true },
-    version = { version, 'string', true },
-    plugin = { plugin, 'string', true },
-  }
   plugin = plugin or 'Nvim'
   local will_be_removed = 'will be removed'
 
   -- Only issue warning if feature is hard-deprecated as specified by MAINTAIN.md.
   -- Example: if removal_version is 0.12 (soft-deprecated since 0.10-dev), show warnings starting at
-  -- 0.11, including 0.11-dev (hard_deprecated_since = 0.11-dev).
+  -- 0.11, including 0.11-dev
   if plugin == 'Nvim' then
-    local current_version = vim.version() ---@type vim.Version
-    local removal_version = assert(vim.version.parse(version))
-    local is_hard_deprecated ---@type boolean
+    local major, minor = version:match('(%d+)%.(%d+)')
+    major, minor = tonumber(major), tonumber(minor)
 
-    if removal_version.minor > 0 then
-      local hard_deprecated_since = assert(vim.version._version({
-        major = removal_version.major,
-        minor = removal_version.minor - 1,
-        patch = 0,
-        prerelease = 'dev', -- Show deprecation warnings in devel (nightly) version as well
-      }))
-      is_hard_deprecated = (current_version >= hard_deprecated_since)
-    else
-      -- Assume there will be no next minor version before bumping up the major version;
-      -- therefore we can always show a warning.
-      assert(removal_version.minor == 0, vim.inspect(removal_version))
-      is_hard_deprecated = true
-    end
-
+    local hard_deprecated_since = string.format('nvim-%d.%d', major, minor - 1)
+    -- Assume there will be no next minor version before bumping up the major version
+    local is_hard_deprecated = minor == 0 or vim.fn.has(hard_deprecated_since) == 1
     if not is_hard_deprecated then
       return
-    elseif current_version >= removal_version then
-      will_be_removed = 'was removed'
     end
+
+    local removal_version = string.format('nvim-%d.%d', major, minor)
+    will_be_removed = vim.fn.has(removal_version) == 1 and 'was removed' or will_be_removed
+  else
+    vim.validate {
+      name = { name, 'string' },
+      alternative = { alternative, 'string', true },
+      version = { version, 'string', true },
+      plugin = { plugin, 'string', true },
+    }
   end
 
   local msg = ('%s is deprecated'):format(name)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -147,8 +147,10 @@ describe('lua stdlib', function()
       end)
 
       it('when plugin = nil', function()
+        local cur = vim.version.parse(current_version)
+        local cur_to_compare = cur.major .. '.' .. cur.minor
         local was_removed = (
-          vim.version.ge(current_version, '0.10') and 'was removed' or 'will be removed'
+          vim.version.ge(cur_to_compare, '0.10') and 'was removed' or 'will be removed'
         )
         eq(
           dedent([[


### PR DESCRIPTION
Problem: `vim.deprecate()` can be relatively significantly slower than
  the deprecated function in "Nvim" plugin.
Solution: Optimize checks for "Nvim" plugin. This also results into not
  distinguishing "xxx-dev" and "xxx" versions when doing checks, which
  is essentially covered by the deprecation logic itself.

Resolve #28459.

------

With this rewrite I get the times from #28459: `{ 0.024827, 0.003797, 0.002024, 0.001774, 0.001703 }`.
For quicker reference:
    -  On current Nightly it is something like `{ 3.72243, 0.918169, 0.968143, 0.763256, 0.783424 }`.
    - On 0.9.5: `{ 0.002955, 0.000361, 0.000281, 0.000251, 0.00019 }`.

------

If these changes are too much, another approach might be to treat `vim.tbl_islist()` as a special case and use custom logic there instead of `vim.deprecate()`. Something along the lines of `if vim.fn.has('nvim-0.11') == 1 then ...`, etc.