### PR TITLE
fix(type): allow nil severity field in diagnostic.GotoOpts

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -389,7 +389,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                             |nvim_win_get_cursor()|.
       • {wrap}?             (`boolean`, default: `true`) Whether to loop
                             around file or not. Similar to 'wrapscan'.
-      • {severity}          (`vim.diagnostic.Severity`) See
+      • {severity}?         (`vim.diagnostic.Severity`) See
                             |diagnostic-severity|.
       • {float}?            (`boolean|vim.diagnostic.Opts.Float`, default:
                             `true`) If `true`, call

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1159,7 +1159,7 @@ end
 --- @field wrap? boolean
 ---
 --- See |diagnostic-severity|.
---- @field severity vim.diagnostic.Severity
+--- @field severity? vim.diagnostic.Severity
 ---
 --- If `true`, call |vim.diagnostic.open_float()| after moving.
 --- If a table, pass the table as the {opts} parameter to |vim.diagnostic.open_float()|.


### PR DESCRIPTION
## Problem

A user when using the functions : 
- `vim.diagnostic.goto_next` 
- `vim.diagnostic.goto_prev`

And trying to pass a table e.g., `vim.diagnostic.goto_next({ float = false })` will see a warning reporting missing fields `severity`, despite the field not being needed.

## Solution
Set `severity` field as optional.