### PR TITLE
feat(fs): add vim.fs.root

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -34,7 +34,7 @@ Follow these steps to get LSP features:
     vim.lsp.start({
       name = 'my-server-name',
       cmd = {'name-of-language-server-executable'},
-      root_dir = vim.fs.dirname(vim.fs.find({'setup.py', 'pyproject.toml'}, { upward = true })[1]),
+      root_dir = vim.fs.findroot(0, {'setup.py', 'pyproject.toml'}),
     })
 <
 3. Check that the server attached to the buffer: >
@@ -836,7 +836,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
         vim.lsp.start({
            name = 'my-server-name',
            cmd = {'name-of-language-server-executable'},
-           root_dir = vim.fs.dirname(vim.fs.find({'pyproject.toml', 'setup.py'}, { upward = true })[1]),
+           root_dir = vim.fs.findroot(0, {'pyproject.toml', 'setup.py'}),
         })
 <
 
@@ -848,9 +848,9 @@ start({config}, {opts})                                      *vim.lsp.start()*
       |vim.lsp.start_client()|.
     • `root_dir` path to the project root. By default this is used to decide
       if an existing client should be re-used. The example above uses
-      |vim.fs.find()| and |vim.fs.dirname()| to detect the root by traversing
-      the file system upwards starting from the current directory until either
-      a `pyproject.toml` or `setup.py` file is found.
+      |vim.fs.findroot()| and |vim.fs.dirname()| to detect the root by
+      traversing the file system upwards starting from the current directory
+      until either a `pyproject.toml` or `setup.py` file is found.
     • `workspace_folders` list of `{ uri:string, name: string }` tables
       specifying the project root folders used by the language server. If
       `nil` the property is derived from `root_dir` for convenience.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -34,7 +34,7 @@ Follow these steps to get LSP features:
     vim.lsp.start({
       name = 'my-server-name',
       cmd = {'name-of-language-server-executable'},
-      root_dir = vim.fs.findroot(0, {'setup.py', 'pyproject.toml'}),
+      root_dir = vim.fs.root(0, {'setup.py', 'pyproject.toml'}),
     })
 <
 3. Check that the server attached to the buffer: >
@@ -836,7 +836,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
         vim.lsp.start({
            name = 'my-server-name',
            cmd = {'name-of-language-server-executable'},
-           root_dir = vim.fs.findroot(0, {'pyproject.toml', 'setup.py'}),
+           root_dir = vim.fs.root(0, {'pyproject.toml', 'setup.py'}),
         })
 <
 
@@ -848,9 +848,9 @@ start({config}, {opts})                                      *vim.lsp.start()*
       |vim.lsp.start_client()|.
     • `root_dir` path to the project root. By default this is used to decide
       if an existing client should be re-used. The example above uses
-      |vim.fs.findroot()| and |vim.fs.dirname()| to detect the root by
-      traversing the file system upwards starting from the current directory
-      until either a `pyproject.toml` or `setup.py` file is found.
+      |vim.fs.root()| and |vim.fs.dirname()| to detect the root by traversing
+      the file system upwards starting from the current directory until either
+      a `pyproject.toml` or `setup.py` file is found.
     • `workspace_folders` list of `{ uri:string, name: string }` tables
       specifying the project root folders used by the language server. If
       `nil` the property is derived from `root_dir` for convenience.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2930,33 +2930,34 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
         (`string[]`) Normalized paths |vim.fs.normalize()| of all matching
         items
 
-vim.fs.findroot({bufnr}, {marker})                         *vim.fs.findroot()*
+vim.fs.findroot({source}, {marker})                        *vim.fs.findroot()*
     Find the first parent directory containing a specific "marker", relative
     to a buffer's directory.
 
     Example: >lua
-        -- Find the root of a Python project
-        vim.fs.findroot(0, {'pyproject.toml', 'setup.py' })
+        -- Find the root of a Python project, starting from file 'main.py'
+        vim.fs.findroot(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
 
         -- Find the root of a git repository
         vim.fs.findroot(0, '.git')
 
         -- Find the parent directory containing any file with a .csproj extension
-        vim.fs.findroot(0, function(name, path)
+        vim.fs.findroot(', function(name, path)
           return name:match('%.csproj$') ~= nil
         end)
 <
 
     Parameters: ~
-      • {bufnr}   (`integer`) Buffer number, or 0 for current buffer.
+      • {source}  (`integer|string`) Buffer number (0 for current buffer) or
+                  file path to begin the search from.
       • {marker}  (`string|string[]|fun(name: string, path: string): boolean`)
                   A marker, or list of markers, to search for. If a function,
                   the function is called for each evaluated item and should
                   return true if {name} and {path} are a match.
 
     Return: ~
-        (`string?`) Directory containing one of the given markers, or nil if
-        no directory was found.
+        (`string?`) Directory name containing one of the given markers, or nil
+        if no directory was found.
 
 vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
     Concatenate directories and/or file paths into a single path with

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2930,35 +2930,6 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
         (`string[]`) Normalized paths |vim.fs.normalize()| of all matching
         items
 
-vim.fs.findroot({source}, {marker})                        *vim.fs.findroot()*
-    Find the first parent directory containing a specific "marker", relative
-    to a buffer's directory.
-
-    Example: >lua
-        -- Find the root of a Python project, starting from file 'main.py'
-        vim.fs.findroot(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
-
-        -- Find the root of a git repository
-        vim.fs.findroot(0, '.git')
-
-        -- Find the parent directory containing any file with a .csproj extension
-        vim.fs.findroot(', function(name, path)
-          return name:match('%.csproj$') ~= nil
-        end)
-<
-
-    Parameters: ~
-      • {source}  (`integer|string`) Buffer number (0 for current buffer) or
-                  file path to begin the search from.
-      • {marker}  (`string|string[]|fun(name: string, path: string): boolean`)
-                  A marker, or list of markers, to search for. If a function,
-                  the function is called for each evaluated item and should
-                  return true if {name} and {path} are a match.
-
-    Return: ~
-        (`string?`) Directory name containing one of the given markers, or nil
-        if no directory was found.
-
 vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
     Concatenate directories and/or file paths into a single path with
     normalization (e.g., `"foo/"` and `"bar"` get joined to `"foo/bar"`)
@@ -3034,6 +3005,35 @@ vim.fs.parents({start})                                     *vim.fs.parents()*
         (`fun(_, dir: string): string?`) Iterator
         (`nil`)
         (`string?`)
+
+vim.fs.root({source}, {marker})                                *vim.fs.root()*
+    Find the first parent directory containing a specific "marker", relative
+    to a buffer's directory.
+
+    Example: >lua
+        -- Find the root of a Python project, starting from file 'main.py'
+        vim.fs.root(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
+
+        -- Find the root of a git repository
+        vim.fs.root(0, '.git')
+
+        -- Find the parent directory containing any file with a .csproj extension
+        vim.fs.root(', function(name, path)
+          return name:match('%.csproj$') ~= nil
+        end)
+<
+
+    Parameters: ~
+      • {source}  (`integer|string`) Buffer number (0 for current buffer) or
+                  file path to begin the search from.
+      • {marker}  (`string|string[]|fun(name: string, path: string): boolean`)
+                  A marker, or list of markers, to search for. If a function,
+                  the function is called for each evaluated item and should
+                  return true if {name} and {path} are a match.
+
+    Return: ~
+        (`string?`) Directory name containing one of the given markers, or nil
+        if no directory was found.
 
 
 ==============================================================================

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2891,13 +2891,6 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
     narrow the search to find only that type.
 
     Examples: >lua
-        -- location of Cargo.toml from the current buffer's path
-        local cargo = vim.fs.find('Cargo.toml', {
-          upward = true,
-          stop = vim.uv.os_homedir(),
-          path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
-        })
-
         -- list all test directories under the runtime directory
         local test_dirs = vim.fs.find(
           {'test', 'tst', 'testdir'},
@@ -2936,6 +2929,34 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
     Return: ~
         (`string[]`) Normalized paths |vim.fs.normalize()| of all matching
         items
+
+vim.fs.findroot({bufnr}, {marker})                         *vim.fs.findroot()*
+    Find the first parent directory containing a specific "marker", relative
+    to a buffer's directory.
+
+    Example: >lua
+        -- Find the root of a Python project
+        vim.fs.findroot(0, {'pyproject.toml', 'setup.py' })
+
+        -- Find the root of a git repository
+        vim.fs.findroot(0, '.git')
+
+        -- Find the parent directory containing any file with a .csproj extension
+        vim.fs.findroot(0, function(name, path)
+          return name:match('%.csproj$') ~= nil
+        end)
+<
+
+    Parameters: ~
+      • {bufnr}   (`integer`) Buffer number, or 0 for current buffer.
+      • {marker}  (`string|string[]|fun(name: string, path: string): boolean`)
+                  A marker, or list of markers, to search for. If a function,
+                  the function is called for each evaluated item and should
+                  return true if {name} and {path} are a match.
+
+    Return: ~
+        (`string?`) Directory containing one of the given markers, or nil if
+        no directory was found.
 
 vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
     Concatenate directories and/or file paths into a single path with

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3018,7 +3018,7 @@ vim.fs.root({source}, {marker})                                *vim.fs.root()*
         vim.fs.root(0, '.git')
 
         -- Find the parent directory containing any file with a .csproj extension
-        vim.fs.root(', function(name, path)
+        vim.fs.root(0, function(name, path)
           return name:match('%.csproj$') ~= nil
         end)
 <
@@ -3032,7 +3032,7 @@ vim.fs.root({source}, {marker})                                *vim.fs.root()*
                   return true if {name} and {path} are a match.
 
     Return: ~
-        (`string?`) Directory name containing one of the given markers, or nil
+        (`string?`) Directory path containing one of the given markers, or nil
         if no directory was found.
 
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3012,7 +3012,7 @@ vim.fs.root({source}, {marker})                                *vim.fs.root()*
 
     Example: >lua
         -- Find the root of a Python project, starting from file 'main.py'
-        vim.fs.root(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
+        vim.fs.root(vim.fs.joinpath(vim.env.PWD, 'main.py'), {'pyproject.toml', 'setup.py' })
 
         -- Find the root of a git repository
         vim.fs.root(0, '.git')

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -365,6 +365,9 @@ The following new APIs and features were added.
 
 • Added built-in |commenting| support.
 
+• |vim.fs.root()| finds project root directories from a list of "root
+  markers".
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -340,7 +340,7 @@ end
 --- vim.fs.root(0, '.git')
 ---
 --- -- Find the parent directory containing any file with a .csproj extension
---- vim.fs.root(', function(name, path)
+--- vim.fs.root(0, function(name, path)
 ---   return name:match('%.csproj$') ~= nil
 --- end)
 --- ```
@@ -350,7 +350,7 @@ end
 --- @param marker (string|string[]|fun(name: string, path: string): boolean) A marker, or list
 ---               of markers, to search for. If a function, the function is called for each
 ---               evaluated item and should return true if {name} and {path} are a match.
---- @return string? # Directory name containing one of the given markers, or nil if no directory was
+--- @return string? # Directory path containing one of the given markers, or nil if no directory was
 ---         found.
 function M.root(source, marker)
   assert(source, 'missing required argument: source')

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -334,13 +334,13 @@ end
 ---
 --- ```lua
 --- -- Find the root of a Python project, starting from file 'main.py'
---- vim.fs.findroot(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
+--- vim.fs.root(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
 ---
 --- -- Find the root of a git repository
---- vim.fs.findroot(0, '.git')
+--- vim.fs.root(0, '.git')
 ---
 --- -- Find the parent directory containing any file with a .csproj extension
---- vim.fs.findroot(', function(name, path)
+--- vim.fs.root(', function(name, path)
 ---   return name:match('%.csproj$') ~= nil
 --- end)
 --- ```
@@ -352,7 +352,7 @@ end
 ---               evaluated item and should return true if {name} and {path} are a match.
 --- @return string? # Directory name containing one of the given markers, or nil if no directory was
 ---         found.
-function M.findroot(source, marker)
+function M.root(source, marker)
   assert(source, 'missing required argument: source')
   assert(marker, 'missing required argument: marker')
 
@@ -367,7 +367,7 @@ function M.findroot(source, marker)
 
   local paths = M.find(marker, {
     upward = true,
-    path = path
+    path = path,
   })
 
   if #paths == 0 then

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -350,8 +350,8 @@ end
 --- @param marker (string|string[]|fun(name: string, path: string): boolean) A marker, or list
 ---               of markers, to search for. If a function, the function is called for each
 ---               evaluated item and should return true if {name} and {path} are a match.
---- @return string? # Directory containing one of the given markers, or nil if no directory was
---- found.
+--- @return string? # Directory name containing one of the given markers, or nil if no directory was
+---         found.
 function M.findroot(source, marker)
   assert(source, 'missing required argument: source')
   assert(marker, 'missing required argument: marker')

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -334,7 +334,7 @@ end
 ---
 --- ```lua
 --- -- Find the root of a Python project, starting from file 'main.py'
---- vim.fs.root(vim.env.PWD .. 'main.py', {'pyproject.toml', 'setup.py' })
+--- vim.fs.root(vim.fs.joinpath(vim.env.PWD, 'main.py'), {'pyproject.toml', 'setup.py' })
 ---
 --- -- Find the root of a git repository
 --- vim.fs.root(0, '.git')

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -210,7 +210,7 @@ end
 --- vim.lsp.start({
 ---    name = 'my-server-name',
 ---    cmd = {'name-of-language-server-executable'},
----    root_dir = vim.fs.dirname(vim.fs.find({'pyproject.toml', 'setup.py'}, { upward = true })[1]),
+---    root_dir = vim.fs.findroot(0, {'pyproject.toml', 'setup.py'}),
 --- })
 --- ```
 ---
@@ -219,9 +219,9 @@ end
 --- - `name` arbitrary name for the LSP client. Should be unique per language server.
 --- - `cmd` command string[] or function, described at |vim.lsp.start_client()|.
 --- - `root_dir` path to the project root. By default this is used to decide if an existing client
----   should be re-used. The example above uses |vim.fs.find()| and |vim.fs.dirname()| to detect the
----   root by traversing the file system upwards starting from the current directory until either
----   a `pyproject.toml` or `setup.py` file is found.
+---   should be re-used. The example above uses |vim.fs.findroot()| and |vim.fs.dirname()| to detect
+---   the root by traversing the file system upwards starting from the current directory until
+---   either a `pyproject.toml` or `setup.py` file is found.
 --- - `workspace_folders` list of `{ uri:string, name: string }` tables specifying the project root
 ---   folders used by the language server. If `nil` the property is derived from `root_dir` for
 ---   convenience.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -210,7 +210,7 @@ end
 --- vim.lsp.start({
 ---    name = 'my-server-name',
 ---    cmd = {'name-of-language-server-executable'},
----    root_dir = vim.fs.findroot(0, {'pyproject.toml', 'setup.py'}),
+---    root_dir = vim.fs.root(0, {'pyproject.toml', 'setup.py'}),
 --- })
 --- ```
 ---
@@ -219,7 +219,7 @@ end
 --- - `name` arbitrary name for the LSP client. Should be unique per language server.
 --- - `cmd` command string[] or function, described at |vim.lsp.start_client()|.
 --- - `root_dir` path to the project root. By default this is used to decide if an existing client
----   should be re-used. The example above uses |vim.fs.findroot()| and |vim.fs.dirname()| to detect
+---   should be re-used. The example above uses |vim.fs.root()| and |vim.fs.dirname()| to detect
 ---   the root by traversing the file system upwards starting from the current directory until
 ---   either a `pyproject.toml` or `setup.py` file is found.
 --- - `workspace_folders` list of `{ uri:string, name: string }` tables specifying the project root

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -280,7 +280,7 @@ describe('vim.fs', function()
     end)
   end)
 
-  describe('findroot()', function()
+  describe('root()', function()
     before_each(function()
       command(
         string.format('edit %s', vim.fs.joinpath('test', 'functional', 'fixtures', 'tty-test.c'))
@@ -288,21 +288,21 @@ describe('vim.fs', function()
     end)
 
     it('works with a single marker', function()
-      eq(test_source_path, exec_lua([[return vim.fs.findroot(0, '.git')]]))
+      eq(test_source_path, exec_lua([[return vim.fs.root(0, '.git')]]))
     end)
 
     it('works with multiple markers', function()
       local bufnr = api.nvim_get_current_buf()
       eq(
         vim.fs.joinpath(test_source_path, 'test', 'functional', 'fixtures'),
-        exec_lua([[return vim.fs.findroot(..., {'CMakeLists.txt', '.git'})]], bufnr)
+        exec_lua([[return vim.fs.root(..., {'CMakeLists.txt', '.git'})]], bufnr)
       )
     end)
 
     it('works with a function', function()
       ---@type string
       local result = exec_lua([[
-        return vim.fs.findroot(0, function(name, path)
+        return vim.fs.root(0, function(name, path)
           return name:match('%.txt$')
         end)
       ]])

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -7,6 +7,8 @@ local eq = t.eq
 local mkdir_p = n.mkdir_p
 local rmdir = n.rmdir
 local nvim_dir = n.nvim_dir
+local command = n.command
+local api = n.api
 local test_build_dir = t.paths.test_build_dir
 local test_source_path = t.paths.test_source_path
 local nvim_prog = n.nvim_prog
@@ -275,6 +277,36 @@ describe('vim.fs', function()
           end, opts)
         )
       )
+    end)
+  end)
+
+  describe('findroot()', function()
+    before_each(function()
+      command(
+        string.format('edit %s', vim.fs.joinpath('test', 'functional', 'fixtures', 'tty-test.c'))
+      )
+    end)
+
+    it('works with a single marker', function()
+      eq(test_source_path, exec_lua([[return vim.fs.findroot(0, '.git')]]))
+    end)
+
+    it('works with multiple markers', function()
+      local bufnr = api.nvim_get_current_buf()
+      eq(
+        vim.fs.joinpath(test_source_path, 'test', 'functional', 'fixtures'),
+        exec_lua([[return vim.fs.findroot(..., {'CMakeLists.txt', '.git'})]], bufnr)
+      )
+    end)
+
+    it('works with a function', function()
+      ---@type string
+      local result = exec_lua([[
+        return vim.fs.findroot(0, function(name, path)
+          return name:match('%.txt$')
+        end)
+      ]])
+      eq(vim.fs.joinpath(test_source_path, 'test', 'functional', 'fixtures'), result)
     end)
   end)
 

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -282,9 +282,7 @@ describe('vim.fs', function()
 
   describe('root()', function()
     before_each(function()
-      command(
-        string.format('edit %s', vim.fs.joinpath('test', 'functional', 'fixtures', 'tty-test.c'))
-      )
+      command('edit test/functional/fixtures/tty-test.c')
     end)
 
     it('works with a single marker', function()
@@ -294,7 +292,7 @@ describe('vim.fs', function()
     it('works with multiple markers', function()
       local bufnr = api.nvim_get_current_buf()
       eq(
-        vim.fs.joinpath(test_source_path, 'test', 'functional', 'fixtures'),
+        vim.fs.joinpath(test_source_path, 'test/functional/fixtures'),
         exec_lua([[return vim.fs.root(..., {'CMakeLists.txt', '.git'})]], bufnr)
       )
     end)
@@ -306,7 +304,11 @@ describe('vim.fs', function()
           return name:match('%.txt$')
         end)
       ]])
-      eq(vim.fs.joinpath(test_source_path, 'test', 'functional', 'fixtures'), result)
+      eq(vim.fs.joinpath(test_source_path, 'test/functional/fixtures'), result)
+    end)
+
+    it('works with a filename argument', function()
+      eq(test_source_path, exec_lua([[return vim.fs.root(..., '.git')]], nvim_prog))
     end)
   end)
 


### PR DESCRIPTION
vim.fs.root() is a function for finding a project root relative to a buffer using one or more "root markers". This is useful for LSP and could be useful for other "projects" designs, as well as for any plugins which work with a "projects" concept.
