### PR TITLE
feat(api): allow floats to be opened in non-current tabpage

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -478,7 +478,8 @@ The following changes to existing APIs or features add new behavior.
   |:vertical|, |:horizontal| and |:botright|.
 
 • |nvim_open_win()| and |nvim_win_set_config()| now support opening normal (split)
-  windows, and moving floating windows into split windows.
+  windows, moving floating windows into split windows, and opening windows in
+  non-current tabpages.
 
 • 'errorfile' (|-q|) accepts `-` as an alias for stdin.
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5127,7 +5127,14 @@ win_T *win_alloc(win_T *after, bool hidden)
   block_autocmds();
   // link the window in the window list
   if (!hidden) {
-    win_append(after, new_wp, NULL);
+    tabpage_T *tp = NULL;
+    if (after) {
+      tp = win_find_tabpage(after);
+      if (tp == curtab) {
+        tp = NULL;
+      }
+    }
+    win_append(after, new_wp, tp);
   }
 
   new_wp->w_wincol = 0;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -44,6 +44,7 @@ win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
     tabpage_T *tp = NULL;
     win_T *tp_last = last ? lastwin : lastwin_nofloating();
     if (fconfig.window != 0) {
+      assert(!last);
       win_T *parent_wp = find_window_by_handle(fconfig.window, err);
       if (!parent_wp) {
         return NULL;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -41,7 +41,23 @@
 win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
 {
   if (wp == NULL) {
-    wp = win_alloc(last ? lastwin : lastwin_nofloating(), false);
+    tabpage_T *tp = NULL;
+    win_T *tp_last = last ? lastwin : lastwin_nofloating();
+    if (fconfig.window != 0) {
+      win_T *parent_wp = find_window_by_handle(fconfig.window, err);
+      if (!parent_wp) {
+        return NULL;
+      }
+      tp = win_find_tabpage(parent_wp);
+      if (!tp) {
+        return NULL;
+      }
+      tp_last = tp->tp_lastwin;
+      while (tp_last->w_floating && tp_last->w_prev) {
+        tp_last = tp_last->w_prev;
+      }
+    }
+    wp = win_alloc(tp_last, false);
     win_init(wp, curwin, 0);
   } else {
     assert(!last);

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1454,6 +1454,40 @@ describe('API/win', function()
       }, layout)
     end)
 
+    it('opens floating windows in other tabpages', function()
+      local first_win = api.nvim_get_current_win()
+      local first_tab = api.nvim_get_current_tabpage()
+
+      command('tabnew')
+      local new_tab = api.nvim_get_current_tabpage()
+      local win = api.nvim_open_win(0, false, {
+        relative = 'win',
+        win = first_win,
+        width = 5,
+        height = 5,
+        row = 1,
+        col = 1,
+      })
+      eq(api.nvim_win_get_tabpage(win), first_tab)
+      eq(api.nvim_get_current_tabpage(), new_tab)
+    end)
+
+    it('switches to new windows in non-current tabpages when enter=true', function()
+      local first_win = api.nvim_get_current_win()
+      local first_tab = api.nvim_get_current_tabpage()
+      command('tabnew')
+      local win = api.nvim_open_win(0, true, {
+        relative = 'win',
+        win = first_win,
+        width = 5,
+        height = 5,
+        row = 1,
+        col = 1,
+      })
+      eq(api.nvim_win_get_tabpage(win), first_tab)
+      eq(api.nvim_get_current_tabpage(), first_tab)
+    end)
+
     local function setup_tabbed_autocmd_test()
       local info = {}
       info.orig_buf = api.nvim_get_current_buf()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -532,7 +532,10 @@ describe('float window', function()
     local closed_win = api.nvim_get_current_win()
     command('close')
     local buf = api.nvim_create_buf(false,false)
-    api.nvim_open_win(buf, true, {relative='win', win=closed_win, width=1, height=1, bufpos={0,0}})
+    eq(
+      'Invalid window id: ' .. closed_win,
+      pcall_err(api.nvim_open_win, buf, true, {relative='win', win=closed_win, width=1, height=1, bufpos={0,0}})
+    )
     assert_alive()
   end)
 


### PR DESCRIPTION
Allows floating windows to be opened on non-current tabpages by using `relative = "win"` and assigning `win` to a window in a non-current tabpage. Also prevents `win_set_config` from moving the autocmd win to another tabpage.

fixes #28234