### PR TITLE
fix(man.vim): q quits after jump to different tag in MANPAGER modified

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -24,7 +24,7 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> k             gk
   nnoremap <silent> <buffer> gO            :lua require'man'.show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
-  if get(b:, 'pager')
+  if get(g:, 'pager')
     nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>q
   else
     nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -411,15 +411,13 @@ local function find_man()
   return false
 end
 
----@param pager boolean
-local function set_options(pager)
+local function set_options()
   vim.bo.swapfile = false
   vim.bo.buftype = 'nofile'
   vim.bo.bufhidden = 'unload'
   vim.bo.modified = false
   vim.bo.readonly = true
   vim.bo.modifiable = false
-  vim.b.pager = pager
   vim.bo.filetype = 'man'
 end
 
@@ -475,7 +473,7 @@ local function put_page(page)
   vim.cmd([[silent! keeppatterns keepjumps %s/\s\{199,}/\=repeat(' ', 10)/g]])
   vim.cmd('1') -- Move cursor to first line
   highlight_man_page()
-  set_options(false)
+  set_options()
 end
 
 local function format_candidate(path, psect)
@@ -662,7 +660,8 @@ function M.init_pager()
     vim.cmd.file({ 'man://' .. fn.fnameescape(ref):lower(), mods = { silent = true } })
   end
 
-  set_options(true)
+  vim.g.pager = true
+  set_options()
 end
 
 ---@param count integer
@@ -730,7 +729,7 @@ function M.open_page(count, smods, args)
   if not ok then
     error(ret)
   else
-    set_options(false)
+    set_options()
   end
 
   vim.b.man_sect = sect

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -192,6 +192,7 @@ describe(':Man', function()
       '--headless',
       '+autocmd VimLeave * echo "quit works!!"',
       '+Man!',
+      '+tag ls',
       '+call nvim_input("q")',
     }
     matches('quit works!!', fn.system(args, { 'manpage contents' }))


### PR DESCRIPTION
Problem: In MANPAGER mode, pressing q after jumping to a different tag does not quit, instead E444 is thrown (#25943)

Solution: 
1. Change `b:pager` into `g:pager`, a global
2. Functions in man.lua now will not change the status of `g:pager` if it has already been set.
