### PR TITLE
fix(buffer.c): delete current buffer when bufhidden=delete is set

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1853,7 +1853,6 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
   char *ffname = ffname_arg;
   char *sfname = sfname_arg;
   buf_T *buf;
-  printf("buflist_new\n");
 
   fname_expand(curbuf, &ffname, &sfname);       // will allocate ffname
 

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1853,6 +1853,7 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
   char *ffname = ffname_arg;
   char *sfname = sfname_arg;
   buf_T *buf;
+  printf("buflist_new\n");
 
   fname_expand(curbuf, &ffname, &sfname);       // will allocate ffname
 
@@ -1894,6 +1895,14 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
   // (A spell file buffer is allocated in spell.c, but that's not a normal
   // buffer.)
   buf = NULL;
+
+  if (curbuf != NULL) {
+    // If bufhidden = delete for the current buffer
+    if (curbuf->b_p_bh[0] == 'd') {
+      // delete it when the new buffer replaces it in the window
+      free_buffer(curbuf);
+    }
+  }
   if ((flags & BLN_CURBUF) && curbuf_reusable()) {
     assert(curbuf != NULL);
     buf = curbuf;

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -338,6 +338,28 @@ describe(':terminal buffer', function()
     eq(termbuf, eval('g:termbuf'))
   end)
 
+  it('deletes the current buffer when bufhidden=delete #27508', function()
+    local screen = Screen.new(50, 4)
+    screen:attach()
+    -- open a terminal buffer
+    command('terminal ls')
+    -- set bufhidden = delete
+    command('set bufhidden=delete')
+    -- open a new buffer
+    command('enew')
+    -- get the buffer list
+    command('ls')
+    -- verify the termnal buffer does not appear in the buffer list
+    screen:expect({
+      grid = [[
+                                                          |*2
+          0 %h   "[No Name]"                    line 1    |
+        Press ENTER or type command to continue^           |
+      ]],
+      attr_ids = {},
+    })
+  end)
+
   it('TermReqeust synchronization #27572', function()
     command('autocmd! nvim_terminal TermRequest')
     local term = exec_lua([[


### PR DESCRIPTION
Bugfix targeting https://github.com/neovim/neovim/issues/27508.
Previously, when a new buffer was created that replaced the current buffer, and bufhidden was set to 'delete', the current buffer would not be deleted when hidden.
Solution: nvim now checks the bufhidden option and frees the current buffer if bufhidden=delete.
