### PR TITLE
refactor(vim.iter)!: rename xxback() => rxx()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4051,6 +4051,9 @@ Iter:last()                                                      *Iter:last()*
     Return: ~
         (`any`)
 
+    See also: ~
+      • Iter.rpeek
+
 Iter:map({f})                                                     *Iter:map()*
     Maps the items of an iterator pipeline to the values returned by `f`.
 
@@ -4092,53 +4095,28 @@ Iter:next()                                                      *Iter:next()*
     Return: ~
         (`any`)
 
-Iter:nextback()                                              *Iter:nextback()*
-    "Pops" a value from a |list-iterator| (gets the last value and decrements
-    the tail).
-
-    Example: >lua
-        local it = vim.iter({1, 2, 3, 4})
-        it:nextback()
-        -- 4
-        it:nextback()
-        -- 3
-<
-
-    Return: ~
-        (`any`)
-
 Iter:nth({n})                                                     *Iter:nth()*
     Gets the nth value of an iterator (and advances to it).
 
-    Example: >lua
+    If `n` is negative, offsets from the end of a |list-iterator|.
 
+    Example: >lua
         local it = vim.iter({ 3, 6, 9, 12 })
         it:nth(2)
         -- 6
         it:nth(2)
         -- 12
-<
 
-    Parameters: ~
-      • {n}  (`number`) The index of the value to return.
-
-    Return: ~
-        (`any`)
-
-Iter:nthback({n})                                             *Iter:nthback()*
-    Gets the nth value from the end of a |list-iterator| (and advances to it).
-
-    Example: >lua
-
-        local it = vim.iter({ 3, 6, 9, 12 })
-        it:nthback(2)
+        local it2 = vim.iter({ 3, 6, 9, 12 })
+        it2:nth(-2)
         -- 9
-        it:nthback(2)
+        it2:nth(-2)
         -- 3
 <
 
     Parameters: ~
-      • {n}  (`number`) The index of the value to return.
+      • {n}  (`number`) Index of the value to return. May be negative if the
+             source is a |list-iterator|.
 
     Return: ~
         (`any`)
@@ -4160,19 +4138,16 @@ Iter:peek()                                                      *Iter:peek()*
     Return: ~
         (`any`)
 
-Iter:peekback()                                              *Iter:peekback()*
-    Gets the last value of a |list-iterator| without consuming it.
-
-    See also |Iter:last()|.
+Iter:pop()                                                        *Iter:pop()*
+    "Pops" a value from a |list-iterator| (gets the last value and decrements
+    the tail).
 
     Example: >lua
         local it = vim.iter({1, 2, 3, 4})
-        it:peekback()
+        it:pop()
         -- 4
-        it:peekback()
-        -- 4
-        it:nextback()
-        -- 4
+        it:pop()
+        -- 3
 <
 
     Return: ~
@@ -4192,8 +4167,8 @@ Iter:rev()                                                        *Iter:rev()*
         (`Iter`)
 
 Iter:rfind({f})                                                 *Iter:rfind()*
-    Gets the first value in a |list-iterator| that satisfies a predicate,
-    starting from the end.
+    Gets the first value satisfying a predicate, from the end of a
+    |list-iterator|.
 
     Advances the iterator. Returns nil and drains the iterator if no value is
     found.
@@ -4216,6 +4191,42 @@ Iter:rfind({f})                                                 *Iter:rfind()*
     See also: ~
       • Iter.find
 
+Iter:rpeek()                                                    *Iter:rpeek()*
+    Gets the last value of a |list-iterator| without consuming it.
+
+    Example: >lua
+        local it = vim.iter({1, 2, 3, 4})
+        it:rpeek()
+        -- 4
+        it:rpeek()
+        -- 4
+        it:pop()
+        -- 4
+<
+
+    Return: ~
+        (`any`)
+
+    See also: ~
+      • Iter.last
+
+Iter:rskip({n})                                                 *Iter:rskip()*
+    Discards `n` values from the end of a |list-iterator| pipeline.
+
+    Example: >lua
+        local it = vim.iter({ 1, 2, 3, 4, 5 }):rskip(2)
+        it:next()
+        -- 1
+        it:pop()
+        -- 3
+<
+
+    Parameters: ~
+      • {n}  (`number`) Number of values to skip.
+
+    Return: ~
+        (`Iter`)
+
 Iter:skip({n})                                                   *Iter:skip()*
     Skips `n` values of an iterator pipeline.
 
@@ -4232,27 +4243,10 @@ Iter:skip({n})                                                   *Iter:skip()*
     Return: ~
         (`Iter`)
 
-Iter:skipback({n})                                           *Iter:skipback()*
-    Skips `n` values backwards from the end of a |list-iterator| pipeline.
-
-    Example: >lua
-        local it = vim.iter({ 1, 2, 3, 4, 5 }):skipback(2)
-        it:next()
-        -- 1
-        it:nextback()
-        -- 3
-<
-
-    Parameters: ~
-      • {n}  (`number`) Number of values to skip.
-
-    Return: ~
-        (`Iter`)
-
 Iter:slice({first}, {last})                                     *Iter:slice()*
     Sets the start and end of a |list-iterator| pipeline.
 
-    Equivalent to `:skip(first - 1):skipback(len - last + 1)`.
+    Equivalent to `:skip(first - 1):rskip(len - last + 1)`.
 
     Parameters: ~
       • {first}  (`number`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -159,6 +159,14 @@ unreleased features on Nvim HEAD.
 
 • Changed |vim.ui.open()| return-signature to match pcall() convention.
 
+• Renamed Iter:nextback() to Iter:pop()
+
+• Renamed Iter:peekback() to Iter:rpeek()
+
+• Renamed Iter:skipback() to Iter:rskip()
+
+• Removed Iter:nthback(), use Iter:nth() with negative index instead.
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -169,19 +169,19 @@ describe('vim.iter', function()
     end
   end)
 
-  it('skipback()', function()
+  it('rskip()', function()
     do
       local q = { 4, 3, 2, 1 }
-      eq(q, vim.iter(q):skipback(0):totable())
-      eq({ 4, 3, 2 }, vim.iter(q):skipback(1):totable())
-      eq({ 4, 3 }, vim.iter(q):skipback(2):totable())
-      eq({ 4 }, vim.iter(q):skipback(#q - 1):totable())
-      eq({}, vim.iter(q):skipback(#q):totable())
-      eq({}, vim.iter(q):skipback(#q + 1):totable())
+      eq(q, vim.iter(q):rskip(0):totable())
+      eq({ 4, 3, 2 }, vim.iter(q):rskip(1):totable())
+      eq({ 4, 3 }, vim.iter(q):rskip(2):totable())
+      eq({ 4 }, vim.iter(q):rskip(#q - 1):totable())
+      eq({}, vim.iter(q):rskip(#q):totable())
+      eq({}, vim.iter(q):rskip(#q + 1):totable())
     end
 
     local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
-    matches('skipback%(%) requires a list%-like table', pcall_err(it.skipback, it, 0))
+    matches('rskip%(%) requires a list%-like table', pcall_err(it.rskip, it, 0))
   end)
 
   it('slice()', function()
@@ -222,19 +222,19 @@ describe('vim.iter', function()
     end
   end)
 
-  it('nthback()', function()
+  it('nth(-x) advances in reverse order starting from end', function()
     do
       local q = { 4, 3, 2, 1 }
-      eq(nil, vim.iter(q):nthback(0))
-      eq(1, vim.iter(q):nthback(1))
-      eq(2, vim.iter(q):nthback(2))
-      eq(3, vim.iter(q):nthback(3))
-      eq(4, vim.iter(q):nthback(4))
-      eq(nil, vim.iter(q):nthback(5))
+      eq(nil, vim.iter(q):nth(0))
+      eq(1, vim.iter(q):nth(-1))
+      eq(2, vim.iter(q):nth(-2))
+      eq(3, vim.iter(q):nth(-3))
+      eq(4, vim.iter(q):nth(-4))
+      eq(nil, vim.iter(q):nth(-5))
     end
 
     local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
-    matches('skipback%(%) requires a list%-like table', pcall_err(it.nthback, it, 1))
+    matches('rskip%(%) requires a list%-like table', pcall_err(it.nth, it, -1))
   end)
 
   it('take()', function()
@@ -421,34 +421,34 @@ describe('vim.iter', function()
     end
   end)
 
-  it('nextback()', function()
+  it('pop()', function()
     do
       local it = vim.iter({ 1, 2, 3, 4 })
-      eq(4, it:nextback())
-      eq(3, it:nextback())
-      eq(2, it:nextback())
-      eq(1, it:nextback())
-      eq(nil, it:nextback())
-      eq(nil, it:nextback())
+      eq(4, it:pop())
+      eq(3, it:pop())
+      eq(2, it:pop())
+      eq(1, it:pop())
+      eq(nil, it:pop())
+      eq(nil, it:pop())
     end
 
     do
       local it = vim.iter(vim.gsplit('hi', ''))
-      matches('nextback%(%) requires a list%-like table', pcall_err(it.nextback, it))
+      matches('pop%(%) requires a list%-like table', pcall_err(it.pop, it))
     end
   end)
 
-  it('peekback()', function()
+  it('rpeek()', function()
     do
       local it = vim.iter({ 1, 2, 3, 4 })
-      eq(4, it:peekback())
-      eq(4, it:peekback())
-      eq(4, it:nextback())
+      eq(4, it:rpeek())
+      eq(4, it:rpeek())
+      eq(4, it:pop())
     end
 
     do
       local it = vim.iter(vim.gsplit('hi', ''))
-      matches('peekback%(%) requires a list%-like table', pcall_err(it.peekback, it))
+      matches('rpeek%(%) requires a list%-like table', pcall_err(it.rpeek, it))
     end
   end)
 


### PR DESCRIPTION


## Open questions

- instead of renaming `xxback` => `rxx`, could remove `xxback` and let the various functions accept negative indexes. The tradeoff is that it's a bit less obvious that the negative indexes are only supported for list-iterators. With `rxx()`, it's easy to notice that "the rxx functions only accept list-iterators".

## Problem:
vim.iter has both `rfind()` and various `*back()` methods, which work in "reverse" or "backwards" order. It's inconsistent to have both kinds of names, and "back" is fairly uncommon (rust) compared to python (rfind, rstrip, rsplit, …). https://github.com/neovim/neovim/issues/27953

## Solution:
- Remove `nthback()` and let `nth()` take a negative index.
  - Because `rnth()` looks pretty obscure, and because it's intuitive for a function named `nth()` to take negative indexes.
- Rename `xxback()` methods to `rxx()`.
  - Bonus: this groups the "list-iterator" functions under a common `r` prefix.
- Rename `peekback()` to `pop()`.
  - `pop` is chosen in duality with the existing `peek`.

### Alternatives

We could remove the `xxback()` functions and instead let the `xx()` variants accept negative indexes. That has some tradeoffs:
- complicates documentation a bit, because the "reverse" variants are only supported for *list-like iterator* (`:help list-iterator`)
- the "r" prefix has the small benefit of grouping the "family" of "reverse" functions.

closes #27953