### PR TITLE
refactor(lsp): rename `foos_by_bar` to `bar_foos` for better consistency

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -210,8 +210,8 @@ local function clear(bufnr)
     return
   end
   local bufstate = bufstates[bufnr]
-  local client_lens = (bufstate or {}).client_hints or {}
-  local client_ids = vim.tbl_keys(client_lens) --- @type integer[]
+  local client_hints = (bufstate or {}).client_hints or {}
+  local client_ids = vim.tbl_keys(client_hints) --- @type integer[]
   for _, iter_client_id in ipairs(client_ids) do
     if bufstate then
       bufstate.client_hints[iter_client_id] = {}

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -41,13 +41,13 @@ function M.on_inlayhint(err, result, ctx, _)
     bufstate.client_hints = vim.defaulttable()
     bufstate.version = ctx.version
   end
-  local hints_by_client = bufstate.client_hints
+  local client_hints = bufstate.client_hints
   local client = assert(vim.lsp.get_client_by_id(client_id))
 
-  local new_hints_by_lnum = vim.defaulttable()
+  local new_lnum_hints = vim.defaulttable()
   local num_unprocessed = #result
   if num_unprocessed == 0 then
-    hints_by_client[client_id] = {}
+    client_hints[client_id] = {}
     bufstate.version = ctx.version
     api.nvim__buf_redraw_range(bufnr, 0, -1)
     return
@@ -73,10 +73,10 @@ function M.on_inlayhint(err, result, ctx, _)
   for _, hint in ipairs(result) do
     local lnum = hint.position.line
     hint.position.character = pos_to_byte(hint.position)
-    table.insert(new_hints_by_lnum[lnum], hint)
+    table.insert(new_lnum_hints[lnum], hint)
   end
 
-  hints_by_client[client_id] = new_hints_by_lnum
+  client_hints[client_id] = new_lnum_hints
   bufstate.version = ctx.version
   api.nvim__buf_redraw_range(bufnr, 0, -1)
 end
@@ -175,19 +175,19 @@ function M.get(filter)
   end
 
   --- @type vim.lsp.inlay_hint.get.ret[]
-  local hints = {}
+  local result = {}
   for _, client in pairs(clients) do
-    local hints_by_lnum = bufstate.client_hints[client.id]
-    if hints_by_lnum then
+    local lnum_hints = bufstate.client_hints[client.id]
+    if lnum_hints then
       for lnum = range.start.line, range['end'].line do
-        local line_hints = hints_by_lnum[lnum] or {}
-        for _, hint in pairs(line_hints) do
+        local hints = lnum_hints[lnum] or {}
+        for _, hint in pairs(hints) do
           local line, char = hint.position.line, hint.position.character
           if
             (line > range.start.line or char >= range.start.character)
             and (line < range['end'].line or char <= range['end'].character)
           then
-            table.insert(hints, {
+            table.insert(result, {
               bufnr = bufnr,
               client_id = client.id,
               inlay_hint = hint,
@@ -197,7 +197,7 @@ function M.get(filter)
       end
     end
   end
-  return hints
+  return result
 end
 
 --- Clear inlay hints
@@ -210,8 +210,8 @@ local function clear(bufnr)
     return
   end
   local bufstate = bufstates[bufnr]
-  local client_hints = (bufstate or {}).client_hints or {}
-  local client_ids = vim.tbl_keys(client_hints) --- @type integer[]
+  local client_lens = (bufstate or {}).client_hints or {}
+  local client_ids = vim.tbl_keys(client_lens) --- @type integer[]
   for _, iter_client_id in ipairs(client_ids) do
     if bufstate then
       bufstate.client_hints[iter_client_id] = {}
@@ -315,14 +315,14 @@ api.nvim_set_decoration_provider(namespace, {
     if not bufstate.client_hints then
       return
     end
-    local hints_by_client = assert(bufstate.client_hints)
+    local client_hints = assert(bufstate.client_hints)
 
     for lnum = topline, botline do
       if bufstate.applied[lnum] ~= bufstate.version then
         api.nvim_buf_clear_namespace(bufnr, namespace, lnum, lnum + 1)
-        for _, hints_by_lnum in pairs(hints_by_client) do
-          local line_hints = hints_by_lnum[lnum] or {}
-          for _, hint in pairs(line_hints) do
+        for _, lnum_hints in pairs(client_hints) do
+          local hints = lnum_hints[lnum] or {}
+          for _, hint in pairs(hints) do
             local text = ''
             local label = hint.label
             if type(label) == 'string' then


### PR DESCRIPTION
`client_hints` is an ambiguous name, because it can refer to two different meanings
* Lenses of one single client `lsp.InlayHint[]`, like in https://github.com/neovim/neovim/blob/b72ee822df933e6711ebcb0d0c8cb3a282b4890d/runtime/lua/vim/lsp/codelens.lua#L67
* Index lenses by client `table<integer, lsp.InlayHint[]>` (what it really means in this case)

It even names `hints_by_client` when assigned to a new variable
https://github.com/neovim/neovim/blob/a1c2da56ecef9c7a0e17be02f587d7c7f9eee170/runtime/lua/vim/lsp/inlay_hint.lua#L44
And there is a similar name with this naming style
https://github.com/neovim/neovim/blob/a1c2da56ecef9c7a0e17be02f587d7c7f9eee170/runtime/lua/vim/lsp/inlay_hint.lua#L180