### PR TITLE
vim-patch:98b12ede3175

### DIFF
--- a/runtime/indent/asm.vim
+++ b/runtime/indent/asm.vim
@@ -1,8 +1,9 @@
 " Vim indent file
-" Language:             asm
-" Maintainer:           Philip Jones <philj56@gmail.com>
-" Upstream:             https://github.com/philj56/vim-asm-indent
-" Latest Revision:      2017-07-01
+" Language:	asm
+" Maintainer:	Philip Jones <philj56@gmail.com>
+" Upstream:	https://github.com/philj56/vim-asm-indent
+" Last Change:	2017-Jul-01
+"		2024 Apr 25 by Vim Project (undo_indent)
 
 if exists("b:did_indent")
   finish
@@ -12,7 +13,7 @@ let b:did_indent = 1
 setlocal indentexpr=s:getAsmIndent()
 setlocal indentkeys=<:>,!^F,o,O
 
-let b:undo_ftplugin .= "indentexpr< indentkeys<"
+let b:undo_indent = "indentexpr< indentkeys<"
 
 function! s:getAsmIndent()
   let line = getline(v:lnum)


### PR DESCRIPTION
runtime(asm): fix undefined variable in indent plugin

It's an indent script, so we need to set the  b:undo_indent variable
instead of the b:undo_ftplugin var.

fixes: vim/vim#14602

https://github.com/vim/vim/commit/98b12ede31754071f36fb7a73324456c1ee7b89c

Co-authored-by: Christian Brabandt <cb@256bit.org>
