### PR TITLE
docs: update ubuntu dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -291,7 +291,7 @@ Platform-specific requirements are listed below.
 ### Ubuntu / Debian
 
 ```sh
-sudo apt-get install ninja-build gettext cmake unzip curl build-essential
+sudo apt-get install ninja-build gettext cmake unzip curl build-essential libnsl-dev
 ```
 
 ### RHEL / Fedora


### PR DESCRIPTION
On a fresh install of Ubuntu 24.04 LTS, make install will not run without this extra lib included