### PR TITLE
perf(treesitter): use child_containing_descendant() in has-ancestor?

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -78,6 +78,8 @@ An instance `TSNode` of a treesitter node supports the following methods.
 
 TSNode:parent()                                         *TSNode:parent()*
     Get the node's immediate parent.
+    Prefer |TSNode:child_containing_descendant()|
+    for iterating over the node's ancestors.
 
 TSNode:next_sibling()                                   *TSNode:next_sibling()*
     Get the node's next sibling.
@@ -113,6 +115,9 @@ TSNode:named_child_count()                         *TSNode:named_child_count()*
 TSNode:named_child({index})                              *TSNode:named_child()*
     Get the node's named child at the given {index}, where zero represents the
     first named child.
+
+TSNode:child_containing_descendant({descendant})  *TSNode:child_containing_descendant()*
+    Get the node's child that contains {descendant}.
 
 TSNode:start()                                          *TSNode:start()*
     Get the node's start position. Return three values: the row, column and

--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -20,6 +20,7 @@ error('Cannot require a meta file')
 ---@field descendant_for_range fun(self: TSNode, start_row: integer, start_col: integer, end_row: integer, end_col: integer): TSNode?
 ---@field named_descendant_for_range fun(self: TSNode, start_row: integer, start_col: integer, end_row: integer, end_col: integer): TSNode?
 ---@field parent fun(self: TSNode): TSNode?
+---@field child_containing_descendant fun(self: TSNode, descendant: TSNode): TSNode?
 ---@field next_sibling fun(self: TSNode): TSNode?
 ---@field prev_sibling fun(self: TSNode): TSNode?
 ---@field next_named_sibling fun(self: TSNode): TSNode?

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -457,17 +457,8 @@ local predicate_handlers = {
     end
 
     for _, node in ipairs(nodes) do
-      local ancestor_types = {} --- @type table<string, boolean>
-      for _, type in ipairs({ unpack(predicate, 3) }) do
-        ancestor_types[type] = true
-      end
-
-      local cur = node:tree():root()
-      while cur do
-        if ancestor_types[cur:type()] then
-          return true
-        end
-        cur = cur:child_containing_descendant(node)
+      if node:__has_ancestor(predicate) then
+        return true
       end
     end
     return false

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -462,12 +462,12 @@ local predicate_handlers = {
         ancestor_types[type] = true
       end
 
-      local cur = node:parent()
+      local cur = node:tree():root()
       while cur do
         if ancestor_types[cur:type()] then
           return true
         end
-        cur = cur:parent()
+        cur = cur:child_containing_descendant(node)
       end
     end
     return false

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Libuv 1.28.0 REQUIRED)
 find_package(Libvterm 0.3.3 REQUIRED)
 find_package(Lpeg REQUIRED)
 find_package(Msgpack 1.0.0 REQUIRED)
-find_package(Treesitter 0.20.9 REQUIRED)
+find_package(Treesitter 0.22.6 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 
 target_link_libraries(main_lib INTERFACE

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -725,6 +725,7 @@ static struct luaL_Reg node_meta[] = {
   { "descendant_for_range", node_descendant_for_range },
   { "named_descendant_for_range", node_named_descendant_for_range },
   { "parent", node_parent },
+  { "child_containing_descendant", node_child_containing_descendant },
   { "iter_children", node_iter_children },
   { "next_sibling", node_next_sibling },
   { "prev_sibling", node_prev_sibling },
@@ -1049,6 +1050,15 @@ static int node_parent(lua_State *L)
   TSNode node = node_check(L, 1);
   TSNode parent = ts_node_parent(node);
   push_node(L, parent, 1);
+  return 1;
+}
+
+static int node_child_containing_descendant(lua_State *L)
+{
+  TSNode node = node_check(L, 1);
+  TSNode descendant = node_check(L, 2);
+  TSNode child = ts_node_child_containing_descendant(node, descendant);
+  push_node(L, child, 1);
   return 1;
 }
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -725,6 +725,7 @@ static struct luaL_Reg node_meta[] = {
   { "descendant_for_range", node_descendant_for_range },
   { "named_descendant_for_range", node_named_descendant_for_range },
   { "parent", node_parent },
+  { "__has_ancestor", __has_ancestor },
   { "child_containing_descendant", node_child_containing_descendant },
   { "iter_children", node_iter_children },
   { "next_sibling", node_next_sibling },
@@ -1050,6 +1051,40 @@ static int node_parent(lua_State *L)
   TSNode node = node_check(L, 1);
   TSNode parent = ts_node_parent(node);
   push_node(L, parent, 1);
+  return 1;
+}
+
+static int __has_ancestor(lua_State *L)
+{
+  TSNode descendant = node_check(L, 1);
+  if (lua_type(L, 2) != LUA_TTABLE) {
+    lua_pushboolean(L, false);
+    return 1;
+  }
+  int const pred_len = (int)lua_objlen(L, 2);
+
+  TSNode node = ts_tree_root_node(descendant.tree);
+  while (!ts_node_is_null(node)) {
+    char const *node_type = ts_node_type(node);
+    size_t node_type_len = strlen(node_type);
+
+    for (int i = 3; i <= pred_len; i++) {
+      lua_rawgeti(L, 2, i);
+      if (lua_type(L, -1) == LUA_TSTRING) {
+        size_t check_len;
+        char const *check_str = lua_tolstring(L, -1, &check_len);
+        if (node_type_len == check_len && memcmp(node_type, check_str, check_len) == 0) {
+          lua_pushboolean(L, true);
+          return 1;
+        }
+      }
+      lua_pop(L, 1);
+    }
+
+    node = ts_node_child_containing_descendant(node, descendant);
+  }
+
+  lua_pushboolean(L, false);
   return 1;
 }
 

--- a/test/functional/treesitter/node_spec.lua
+++ b/test/functional/treesitter/node_spec.lua
@@ -143,4 +143,30 @@ describe('treesitter node API', function()
     eq(28, lua_eval('root:byte_length()'))
     eq(3, lua_eval('child:byte_length()'))
   end)
+
+  it('child_containing_descendant() works', function()
+    insert([[
+      int main() {
+        int x = 3;
+      }]])
+
+    exec_lua([[
+      tree = vim.treesitter.get_parser(0, "c"):parse()[1]
+      root = tree:root()
+      main = root:child(0)
+      body = main:child(2)
+      statement = body:child(1)
+      declarator = statement:child(1)
+      value = declarator:child(1)
+    ]])
+
+    eq(lua_eval('main:type()'), lua_eval('root:child_containing_descendant(value):type()'))
+    eq(lua_eval('body:type()'), lua_eval('main:child_containing_descendant(value):type()'))
+    eq(lua_eval('statement:type()'), lua_eval('body:child_containing_descendant(value):type()'))
+    eq(
+      lua_eval('declarator:type()'),
+      lua_eval('statement:child_containing_descendant(value):type()')
+    )
+    eq(vim.NIL, lua_eval('declarator:child_containing_descendant(value)'))
+  end)
 end)


### PR DESCRIPTION
Closes #24965.

`has-ancestor?` is O(n²) for the depth of the tree since it iterates over each of the node's ancestors (bottom-up), and each ancestor takes O(n) time.
This happens because tree-sitter's nodes don't store their parent nodes, and the tree is searched (top-down) each time a new parent is requested.

`ts_node_child_containing_descendant()` matches how trees-sitter searches for the node's parent internally and makes `has-ancestor?` is O(n).

The predicate is also rewritten in C to avoid allocations for each ancestor node and their type strings.

For the file in the issue, decreases the time taken by `has-ancestor?` from 360ms to 6ms.