### PR TITLE
feat(main): expand file ~\ or ~/ prefix on Windows

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -87,7 +87,9 @@ DEFAULTS
 
 EDITOR
 
-• TODO
+* On Windows, filename arguments on the command-line prefixed with "~\" or
+  "~/" are now expanded to the user's profile directory, not a relative path
+  to a literal "~" directory.
 
 EVENTS
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1444,6 +1444,19 @@ scripterror:
       ga_grow(&global_alist.al_ga, 1);
       char *p = xstrdup(argv[0]);
 
+      // On Windows expand "~\" or "~/" prefix in file names to profile directory.
+#ifdef MSWIN
+      if (*p == '~' && (p[1] == '\\' || p[1] == '/')) {
+        char *profile_dir = vim_getenv("HOME");
+        size_t size = strlen(profile_dir) + strlen(p);
+        char *tilde_expanded = xmalloc(size);
+        snprintf(tilde_expanded, size, "%s%s", profile_dir, p + 1);
+        xfree(p);
+        xfree(profile_dir);
+        p = tilde_expanded;
+      }
+#endif
+
       if (parmp->diff_mode && os_isdir(p) && GARGCOUNT > 0
           && !os_isdir(alist_name(&GARGLIST[0]))) {
         char *r = concat_fnames(p, path_tail(alist_name(&GARGLIST[0])), true);


### PR DESCRIPTION
In command_line_scan() for MSWIN, expand `"~\"` or `"~/"` prefixed paths to
the USERPROFILE environment variable for the user's profile directory.

Fix #23901