### PR TITLE
fix(ui): problems with handling ui_attach side effects

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -194,15 +194,6 @@ void ui_refresh(void)
     abort();
   }
 
-  if (!ui_active()) {
-    return;
-  }
-
-  if (updating_screen) {
-    ui_schedule_refresh();
-    return;
-  }
-
   int width = INT_MAX;
   int height = INT_MAX;
   bool ext_widgets[kUIExtCount];
@@ -234,9 +225,17 @@ void ui_refresh(void)
     }
     ui_ext[i] = ext_widgets[i];
     if (i < kUIGlobalCount) {
-      ui_call_option_set(cstr_as_string(ui_ext_names[i]),
-                         BOOLEAN_OBJ(ext_widgets[i]));
+      ui_call_option_set(cstr_as_string(ui_ext_names[i]), BOOLEAN_OBJ(ext_widgets[i]));
     }
+  }
+
+  if (!ui_active()) {
+    return;
+  }
+
+  if (updating_screen) {
+    ui_schedule_refresh();
+    return;
   }
 
   ui_default_colors_set();

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -218,10 +218,13 @@ void ui_refresh(void)
     if (i < kUIGlobalCount) {
       ext_widgets[i] |= ui_cb_ext[i];
     }
-    // Set 'cmdheight' to zero when ext_messages becomes active.
+    // Set 'cmdheight' to zero when ext_messages becomes active for all tabpages.
     if (i == kUIMessages && !ui_ext[i] && ext_widgets[i]) {
       set_option_value(kOptCmdheight, NUMBER_OPTVAL(0), 0);
       command_height();
+      FOR_ALL_TABS(tp) {
+        tp->tp_ch_used = 0;
+      }
     }
     ui_ext[i] = ext_widgets[i];
     if (i < kUIGlobalCount) {

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -155,6 +155,14 @@ describe('vim.ui_attach', function()
       },
     }, actual, vim.inspect(actual))
   end)
+
+  it('ui_refresh() works without remote UI', function()
+    screen:detach()
+    exec_lua('vim.ui_attach(ns, { ext_messages = true }, on_event)')
+    n.api.nvim_set_option_value('cmdheight', 1, {})
+    screen:attach()
+    eq(1, n.api.nvim_get_option_value('cmdheight', {}))
+  end)
 end)
 
 describe('vim.ui_attach', function()

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -163,6 +163,13 @@ describe('vim.ui_attach', function()
     screen:attach()
     eq(1, n.api.nvim_get_option_value('cmdheight', {}))
   end)
+
+  it("ui_refresh() sets 'cmdheight' for all open tabpages with ext_messages", function()
+    exec_lua('vim.cmd.tabnew()')
+    exec_lua('vim.ui_attach(ns, { ext_messages = true }, on_event)')
+    exec_lua('vim.cmd.tabnext()')
+    eq(0, n.api.nvim_get_option_value('cmdheight', {}))
+  end)
 end)
 
 describe('vim.ui_attach', function()


### PR DESCRIPTION
**fix(ui): update ext_ui widgets when attaching non-remote UI**

Problem:  Updating internalized UI capabilities is postponed until a
          remote UI attaches.
Solution: Always update active UI widgets in ui_refresh().

**fix(ui): set 'cmdheight' to zero for all open tabpages**

Problem:  Enabling ext_messages claims to set 'cmdheight' to zero, but
only does so for the current tabpage.
Solution: Set stored 'cmdheight' value to zero for all tabpages.

Fix #28526