### PR TITLE
feat(lsp): use a parameter strategy similar to `enable`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1645,13 +1645,15 @@ get({filter})                                       *vim.lsp.inlay_hint.get()*
         • {client_id} (`integer`)
         • {inlay_hint} (`lsp.InlayHint`)
 
-is_enabled({bufnr})                          *vim.lsp.inlay_hint.is_enabled()*
+is_enabled({filter})                         *vim.lsp.inlay_hint.is_enabled()*
 
     Note: ~
       • This API is pre-release (unstable).
 
     Parameters: ~
-      • {bufnr}  (`integer?`) Buffer handle, or 0 for current
+      • {filter}  (`table`) Optional filters |kwargs|, or `nil` for all.
+                  • {bufnr} (`integer?`) Buffer number, or 0 for current
+                    buffer, or nil for all.
 
     Return: ~
         (`boolean`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -148,6 +148,8 @@ BREAKING CHANGES IN HEAD                                    *news-breaking-dev*
 The following changes to UNRELEASED features were made during the development
 cycle (Nvim HEAD, the "master" branch).
 
+• Changed the signature of `vim.lsp.inlay_hint.is_enabled()`.
+
 • `vim.lsp.inlay_hint.enable()` now take effect on all buffers by default.
 
 • Removed `vim.treesitter.foldtext` as transparent foldtext is now supported

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -364,12 +364,29 @@ api.nvim_set_decoration_provider(namespace, {
   end,
 })
 
---- @param bufnr (integer|nil) Buffer handle, or 0 for current
+--- @param filter vim.lsp.inlay_hint.enable.Filter
 --- @return boolean
 --- @since 12
-function M.is_enabled(bufnr)
+function M.is_enabled(filter)
+  ---@type integer
+  local bufnr
+  if type(filter) == 'number' then
+    vim.deprecate(
+      'vim.lsp.inlay_hint.is_enabled(bufnr:number)',
+      'vim.lsp.inlay_hint.is_enabled(filter:table)',
+      '0.10-dev'
+    )
+    bufnr = filter
+  else
+    vim.validate({ filter = { filter, 'table', true } })
+    filter = filter or {}
+    bufnr = filter.bufnr
+  end
+
   vim.validate({ bufnr = { bufnr, 'number', true } })
-  if bufnr == nil or bufnr == 0 then
+  if bufnr == nil then
+    return globalstate.enabled
+  elseif bufnr == 0 then
     bufnr = api.nvim_get_current_buf()
   end
   return bufstates[bufnr].enabled

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -163,7 +163,7 @@ describe('vim.lsp.inlay_hint', function()
         screen:expect({ grid = grid_with_inlay_hints, unchanged = true })
 
         exec_lua(
-          [[vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled(bufnr), { bufnr = bufnr })]]
+          [[vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }), { bufnr = bufnr })]]
         )
         screen:expect({ grid = grid_without_inlay_hints, unchanged = true })
 


### PR DESCRIPTION
As we discussed in https://github.com/neovim/neovim/pull/28521#discussion_r1581156758

Before this, `vim.diagnostic.enable` and `vim.diagnostic.is_enabled()` use the same strategy.