### PR TITLE
feat(defaults): add default unimpaired style mappings

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -714,7 +714,7 @@ list of the current window.
 			omitted the current entry is used.
 			Also see |++opt| and |+cmd|.
 
-:[count]n[ext] [++opt] [+cmd]			*:n* *:ne* *:next* *E165* *E163*
+:[count]n[ext] [++opt] [+cmd]			*:n* *:ne* *:next* *]a* *E165* *E163*
 			Edit [count] next file.  This fails when changes have
 			been made and Vim does not want to |abandon| the
 			current buffer.  Also see |++opt| and |+cmd|.
@@ -740,10 +740,10 @@ list of the current window.
 			any changes to the buffer.  Also see |++opt| and
 			|+cmd|.
 
-:[count]prev[ious] [count] [++opt] [+cmd]		*:prev* *:previous*
+:[count]prev[ious] [count] [++opt] [+cmd]		*:prev* *:previous* *[a*
 			Same as :Next.  Also see |++opt| and |+cmd|.
 
-							*:rew* *:rewind*
+							*:rew* *:rewind* *[A*
 :rew[ind] [++opt] [+cmd]
 			Start editing the first file in the argument list.
 			This fails when changes have been made and Vim does
@@ -759,7 +759,7 @@ list of the current window.
 :fir[st][!] [++opt] [+cmd]
 			Other name for ":rewind".
 
-							*:la* *:last*
+							*:la* *:last* *]A*
 :la[st] [++opt] [+cmd]
 			Start editing the last file in the argument list.
 			This fails when changes have been made and Vim does

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -137,6 +137,12 @@ DEFAULTS
     on a URL.
   • Mouse |popup-menu| includes a "Go to definition" item when LSP is active
     in the buffer.
+  • Mappings inspired by Tim Pope's vim-unimpaired:
+    • |[q|, |]q|, |[Q|, |]Q|, |[CTRL-Q|, |]CTRL-Q| navigate through the |quickfix| list
+    • |[l|, |]l|, |[L|, |]L|, |[CTRL-L|, |]CTRL-L| navigate through the |location-list|
+    • |[t|, |]t|, |[T|, |]T|, |[CTRL-T|, |]CTRL-T| navigate through the |tag-matchlist|
+    • |[a|, |]a|, |[A|, |]A| navigate through the |argument-list|
+    • |[b|, |]b|, |[B|, |]B| navigate through the |buffer-list|
 
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -91,24 +91,24 @@ processing a quickfix or location list command, it will be aborted.
 :ll[!] [nr]		Same as ":cc", except the location list for the
 :[nr]ll[!]		current window is used instead of the quickfix list.
 
-						*:cn* *:cne* *:cnext* *E553*
+						*:cn* *:cne* *:cnext* *E553* *]q*
 :[count]cn[ext][!]	Display the [count] next error in the list that
 			includes a file name.  If there are no file names at
 			all, go to the [count] next error.  See |:cc| for
 			[!] and 'switchbuf'.
 
-							*:lne* *:lnext*
+							*:lne* *:lnext* *]l*
 :[count]lne[xt][!]	Same as ":cnext", except the location list for the
 			current window is used instead of the quickfix list.
 
-:[count]cN[ext][!]		*:cp* *:cprevious*  *:cprev* *:cN* *:cNext*
+:[count]cN[ext][!]		*:cp* *:cprevious*  *:cprev* *:cN* *:cNext* *[q*
 :[count]cp[revious][!]	Display the [count] previous error in the list that
 			includes a file name.  If there are no file names at
 			all, go to the [count] previous error.  See |:cc| for
 			[!] and 'switchbuf'.
 
 
-:[count]lN[ext][!]		*:lp* *:lprevious* *:lprev* *:lN* *:lNext*
+:[count]lN[ext][!]		*:lp* *:lprevious* *:lprev* *:lN* *:lNext* *[l*
 :[count]lp[revious][!]	Same as ":cNext" and ":cprevious", except the location
 			list for the current window is used instead of the
 			quickfix list.
@@ -171,18 +171,18 @@ processing a quickfix or location list command, it will be aborted.
 :[count]laf[ter]	Same as ":cafter", except the location list for the
 			current window is used instead of the quickfix list.
 
-							*:cnf* *:cnfile*
+							*:cnf* *:cnfile* *]CTRL-Q*
 :[count]cnf[ile][!]	Display the first error in the [count] next file in
 			the list that includes a file name.  If there are no
 			file names at all or if there is no next file, go to
 			the [count] next error.  See |:cc| for [!] and
 			'switchbuf'.
 
-							*:lnf* *:lnfile*
+							*:lnf* *:lnfile* *]CTRL-L*
 :[count]lnf[ile][!]	Same as ":cnfile", except the location list for the
 			current window is used instead of the quickfix list.
 
-:[count]cNf[ile][!]			*:cpf* *:cpfile* *:cNf* *:cNfile*
+:[count]cNf[ile][!]			*:cpf* *:cpfile* *:cNf* *:cNfile* *[CTRL-Q*
 :[count]cpf[ile][!]	Display the last error in the [count] previous file in
 			the list that includes a file name.  If there are no
 			file names at all or if there is no next file, go to
@@ -190,16 +190,16 @@ processing a quickfix or location list command, it will be aborted.
 			'switchbuf'.
 
 
-:[count]lNf[ile][!]			*:lpf* *:lpfile* *:lNf* *:lNfile*
+:[count]lNf[ile][!]			*:lpf* *:lpfile* *:lNf* *:lNfile* *[CTRL-L*
 :[count]lpf[ile][!]	Same as ":cNfile" and ":cpfile", except the location
 			list for the current window is used instead of the
 			quickfix list.
 
-							*:crewind* *:cr*
+							*:crewind* *:cr* *[Q*
 :cr[ewind][!] [nr]	Display error [nr].  If [nr] is omitted, the FIRST
 			error is displayed.  See |:cc|.
 
-							*:lrewind* *:lr*
+							*:lrewind* *:lr* *[L*
 :lr[ewind][!] [nr]	Same as ":crewind", except the location list for the
 			current window is used instead of the quickfix list.
 
@@ -209,11 +209,11 @@ processing a quickfix or location list command, it will be aborted.
 							*:lfirst* *:lfir*
 :lfir[st][!] [nr]	Same as ":lrewind".
 
-							*:clast* *:cla*
+							*:clast* *:cla* *]Q*
 :cla[st][!] [nr]	Display error [nr].  If [nr] is omitted, the LAST
 			error is displayed.  See |:cc|.
 
-							*:llast* *:lla*
+							*:llast* *:lla* *]L*
 :lla[st][!] [nr]	Same as ":clast", except the location list for the
 			current window is used instead of the quickfix list.
 

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -274,25 +274,25 @@ g CTRL-]		Like CTRL-], but use ":tjump" instead of ":tag".
 {Visual}g CTRL-]	Same as "g CTRL-]", but use the highlighted text as
 			the identifier.
 
-							*:tn* *:tnext*
+							*:tn* *:tnext* *]t*
 :[count]tn[ext][!]	Jump to [count] next matching tag (default 1).  See
 			|tag-!| for [!].
 
-							*:tp* *:tprevious*
+							*:tp* *:tprevious* *[t*
 :[count]tp[revious][!]	Jump to [count] previous matching tag (default 1).
 			See |tag-!| for [!].
 
 							*:tN* *:tNext*
 :[count]tN[ext][!]	Same as ":tprevious".
 
-							*:tr* *:trewind*
+							*:tr* *:trewind* *[T*
 :[count]tr[ewind][!]	Jump to first matching tag.  If [count] is given, jump
 			to [count]th matching tag.  See |tag-!| for [!].
 
 							*:tf* *:tfirst*
 :[count]tf[irst][!]	Same as ":trewind".
 
-							*:tl* *:tlast*
+							*:tl* *:tlast* *]T*
 :tl[ast][!]		Jump to last matching tag.  See |tag-!| for [!].
 
 							*:lt* *:ltag*
@@ -335,10 +335,10 @@ the same as above, with a "p" prepended.
 :ptj[ump][!] [name]	Does ":tjump[!] [name]" and shows the new tag in a
 			"Preview" window.  See |:ptag| for more info.
 
-							*:ptn* *:ptnext*
+							*:ptn* *:ptnext* *]CTRL-T*
 :[count]ptn[ext][!]	":tnext" in the preview window.  See |:ptag|.
 
-							*:ptp* *:ptprevious*
+							*:ptp* *:ptprevious* *[CTRL-T*
 :[count]ptp[revious][!]	":tprevious" in the preview window.  See |:ptag|.
 
 							*:ptN* *:ptNext*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -156,6 +156,11 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - [D |[D-default|
 - ]D |]D-default|
 - <C-W>d |CTRL-W_d-default|
+- |[q|, |]q|, |[Q|, |]Q|, |[CTRL-Q|, |]CTRL-Q|
+- |[l|, |]l|, |[L|, |]L|, |[CTRL-L|, |]CTRL-L|
+- |[t|, |]t|, |[T|, |]T|, |[CTRL-T|, |]CTRL-T|
+- |[a|, |]a|, |[A|, |]A|
+- |[b|, |]b|, |[B|, |]B|
 - Nvim LSP client defaults |lsp-defaults|
   - K |K-lsp-default|
 

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1250,7 +1250,7 @@ list of buffers. |unlisted-buffer|
 			:w foobar | sp #
 <		Also see |+cmd|.
 
-:[N]bn[ext][!] [+cmd] [N]				*:bn* *:bnext* *E87*
+:[N]bn[ext][!] [+cmd] [N]				*:bn* *:bnext* *[b* *E87*
 		Go to [N]th next buffer in buffer list.  [N] defaults to one.
 		Wraps around the end of the buffer list.
 		See |:buffer-!| for [!].
@@ -1268,7 +1268,7 @@ list of buffers. |unlisted-buffer|
 		Wraps around the end of the buffer list.  Uses 'switchbuf'
 		Also see |+cmd|.
 
-:[N]bN[ext][!] [+cmd] [N]		*:bN* *:bNext* *:bp* *:bprevious* *E88*
+:[N]bN[ext][!] [+cmd] [N]		*:bN* *:bNext* *:bp* *:bprevious* *]b* *E88*
 :[N]bp[revious][!] [+cmd] [N]
 		Go to [N]th previous buffer in buffer list.  [N] defaults to
 		one.  Wraps around the start of the buffer list.
@@ -1282,7 +1282,7 @@ list of buffers. |unlisted-buffer|
 		Uses 'switchbuf'.
 		Also see |+cmd|.
 
-:br[ewind][!] [+cmd]					*:br* *:bre* *:brewind*
+:br[ewind][!] [+cmd]					*:br* *:bre* *:brewind* *[B*
 		Go to first buffer in buffer list.  If the buffer list is
 		empty, go to the first unlisted buffer.
 		See |:buffer-!| for [!].
@@ -1300,7 +1300,7 @@ list of buffers. |unlisted-buffer|
 :sbf[irst] [+cmd]					*:sbf* *:sbfirst*
 		Same as ":sbrewind".
 
-:bl[ast][!] [+cmd]					*:bl* *:blast*
+:bl[ast][!] [+cmd]					*:bl* *:blast* *]B*
 		Go to last buffer in buffer list.  If the buffer list is
 		empty, go to the last unlisted buffer.
 		See |:buffer-!| for [!].

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -208,6 +208,171 @@ do
       { remap = true, desc = 'Show diagnostics under the cursor' }
     )
   end
+
+  --- vim-unimpaired style mappings. See: https://github.com/tpope/vim-unimpaired
+  do
+    -- Quickfix mappings
+    vim.keymap.set('n', '[q', function()
+      vim.cmd.cprevious({ count = vim.v.count1 })
+    end, {
+      desc = ':cprevious',
+    })
+
+    vim.keymap.set('n', ']q', function()
+      vim.cmd.cnext({ count = vim.v.count1 })
+    end, {
+      desc = ':cnext',
+    })
+
+    vim.keymap.set('n', '[Q', function()
+      vim.cmd.crewind({ args = vim.v.count ~= 0 and { vim.v.count } or nil })
+    end, {
+      desc = ':crewind',
+    })
+
+    vim.keymap.set('n', ']Q', function()
+      vim.cmd.clast({ args = vim.v.count ~= 0 and { vim.v.count } or nil })
+    end, {
+      desc = ':clast',
+    })
+
+    vim.keymap.set('n', '[<C-Q>', function()
+      vim.cmd.cpfile({ count = vim.v.count1 })
+    end, {
+      desc = ':cpfile',
+    })
+
+    vim.keymap.set('n', ']<C-Q>', function()
+      vim.cmd.cnfile({ count = vim.v.count1 })
+    end, {
+      desc = ':cnfile',
+    })
+
+    -- Location list mappings
+    vim.keymap.set('n', '[l', function()
+      vim.cmd.lprevious({ count = vim.v.count1 })
+    end, {
+      desc = ':lprevious',
+    })
+
+    vim.keymap.set('n', ']l', function()
+      vim.cmd.lnext({ count = vim.v.count1 })
+    end, {
+      desc = ':lnext',
+    })
+
+    vim.keymap.set('n', '[L', function()
+      vim.cmd.lrewind({ args = vim.v.count ~= 0 and { vim.v.count } or nil })
+    end, {
+      desc = ':lrewind',
+    })
+
+    vim.keymap.set('n', ']L', function()
+      vim.cmd.llast({ args = vim.v.count ~= 0 and { vim.v.count } or nil })
+    end, {
+      desc = ':llast',
+    })
+
+    vim.keymap.set('n', '[<C-L>', function()
+      vim.cmd.lpfile({ count = vim.v.count1 })
+    end, {
+      desc = ':lpfile',
+    })
+
+    vim.keymap.set('n', ']<C-L>', function()
+      vim.cmd.lnfile({ count = vim.v.count1 })
+    end, {
+      desc = ':lnfile',
+    })
+
+    -- Argument list
+    vim.keymap.set('n', '[a', function()
+      vim.cmd.previous({ count = vim.v.count1 })
+    end, {
+      desc = ':previous',
+    })
+
+    vim.keymap.set('n', ']a', function()
+      vim.cmd.next({ count = vim.v.count1 })
+    end, {
+      desc = ':next',
+    })
+
+    vim.keymap.set('n', '[A', function()
+      if vim.v.count ~= 0 then
+        vim.cmd.argument({ count = vim.v.count })
+      else
+        vim.cmd.rewind()
+      end
+    end, {
+      desc = ':rewind',
+    })
+
+    vim.keymap.set('n', ']A', function()
+      if vim.v.count ~= 0 then
+        vim.cmd.argument({ count = vim.v.count })
+      else
+        vim.cmd.last()
+      end
+    end, {
+      desc = ':last',
+    })
+
+    -- Tags
+    vim.keymap.set('n', '[t', function()
+      vim.cmd.tprevious({ count = vim.v.count1 })
+    end, { desc = ':tprevious' })
+
+    vim.keymap.set('n', ']t', function()
+      vim.cmd.tnext({ count = vim.v.count1 })
+    end, { desc = ':tnext' })
+
+    vim.keymap.set('n', '[T', function()
+      vim.cmd.trewind({ count = vim.v.count ~= 0 and vim.v.count or nil })
+    end, { desc = ':trewind' })
+
+    vim.keymap.set('n', ']T', function()
+      -- :tlast does not accept a count, so use :trewind if count given
+      if vim.v.count ~= 0 then
+        vim.cmd.trewind({ count = vim.v.count })
+      else
+        vim.cmd.tlast()
+      end
+    end, { desc = ':tlast' })
+
+    vim.keymap.set('n', '[<C-T>', function()
+      vim.cmd.ptprevious({ count = vim.v.count1 })
+    end, { desc = ' :ptprevious' })
+
+    vim.keymap.set('n', ']<C-T>', function()
+      vim.cmd.ptnext({ count = vim.v.count1 })
+    end, { desc = ':ptnext' })
+
+    -- Buffers
+    vim.keymap.set('n', '[b', function()
+      vim.cmd.bprevious({ count = vim.v.count1 })
+    end, { desc = ':bprevious' })
+
+    vim.keymap.set('n', ']b', function()
+      vim.cmd.bnext({ count = vim.v.count1 })
+    end, { desc = ':bnext' })
+
+    vim.keymap.set('n', '[B', function()
+      if vim.v.count ~= 0 then
+        vim.cmd.buffer({ count = vim.v.count })
+      else
+        vim.cmd.brewind()
+      end
+    end, { desc = ':brewind' })
+
+    vim.keymap.set('n', ']B', function()
+      if vim.v.count ~= 0 then
+        vim.cmd.buffer({ count = vim.v.count })
+      else
+        vim.cmd.blast()
+      end
+    end, { desc = ':blast' })
+  end
 end
 
 --- Default menus


### PR DESCRIPTION
To the best of my knowledge, these match the mappings in vim-unimpaired exactly: https://github.com/tpope/vim-unimpaired/blob/master/plugin/unimpaired.vim

This does not include _all_ of unimpaired's mappings, just the simple ones. For instance, this does not add `[f` or `]f` or any of the option mappings (e.g. `[os` or `yos`). We could perhaps do those later, but this first batch includes the least controversial mappings.
