### PR TITLE
feat: add "default" field to maparg() return value

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -46,6 +46,7 @@
 #include "nvim/lua/treesitter.h"
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
+#include "nvim/mapping.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/memory_defs.h"
@@ -2358,11 +2359,17 @@ void nlua_init_defaults(void)
   lua_State *const L = global_lstate;
   assert(L);
 
+  // All maps created here are marked as default maps.
+  map_set_default(true);
+
   lua_getglobal(L, "require");
   lua_pushstring(L, "vim._defaults");
   if (nlua_pcall(L, 1, 0)) {
     fprintf(stderr, "%s\n", lua_tostring(L, -1));
   }
+
+  // All maps created after this function exits are not default maps.
+  map_set_default(false);
 }
 
 /// check lua function exist

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -132,6 +132,16 @@ static const char e_entries_missing_in_mapset_dict_argument[]
 static const char e_illegal_map_mode_string_str[]
   = N_("E1276: Illegal map mode string: '%s'");
 
+/// Whether new mappings should be marked as "default". This is modified only in map_set_default().
+static bool create_default_maps;
+
+/// Enable or disable creationg of default mappings.
+///
+/// @param value True if new mappings should be marked as default mappings.
+void map_set_default(bool value) {
+  create_default_maps = value;
+}
+
 /// Get the start of the hashed map list for "state" and first character "c".
 mapblock_T *get_maphash_list(int state, int c)
 {
@@ -540,6 +550,8 @@ static void map_add(buf_T *buf, mapblock_T **map_table, mapblock_T **abbr_table,
   if (args->desc != NULL) {
     mp->m_desc = xstrdup(args->desc);
   }
+
+  mp->m_default = create_default_maps;
 
   // add the new entry in front of the abbrlist or maphash[] list
   if (is_abbr) {
@@ -2118,6 +2130,7 @@ static Dictionary mapblock_fill_dict(const mapblock_T *const mp, const char *lhs
   PUT_C(dict, "mode", CSTR_AS_OBJ(mapmode));
   PUT_C(dict, "abbr", INTEGER_OBJ(abbr ? 1 : 0));
   PUT_C(dict, "mode_bits", INTEGER_OBJ(mp->m_mode));
+  PUT_C(dict, "default", BOOLEAN_OBJ(mp->m_default));
 
   return dict;
 }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2130,7 +2130,9 @@ static Dictionary mapblock_fill_dict(const mapblock_T *const mp, const char *lhs
   PUT_C(dict, "mode", CSTR_AS_OBJ(mapmode));
   PUT_C(dict, "abbr", INTEGER_OBJ(abbr ? 1 : 0));
   PUT_C(dict, "mode_bits", INTEGER_OBJ(mp->m_mode));
-  PUT_C(dict, "default", BOOLEAN_OBJ(mp->m_default));
+  if (mp->m_default) {
+    PUT_C(dict, "default", INTEGER_OBJ(1));
+  }
 
   return dict;
 }

--- a/src/nvim/mapping_defs.h
+++ b/src/nvim/mapping_defs.h
@@ -24,4 +24,5 @@ struct mapblock {
   sctx_T m_script_ctx;      ///< SCTX where map was defined
   char *m_desc;             ///< description of mapping
   bool m_replace_keycodes;  ///< replace keycodes in result of expression
+  bool m_default;           ///< true if this is a |default-mapping|
 };


### PR DESCRIPTION
With so many default mappings, plugins are not able to detect if an existing mapping is one created by the user or one created by Nvim.

Add a "default" field to the dict return value of maparg() that plugins can use to determine if a mapping is a default mapping provided by Nvim (which they can safely override).