### PR TITLE
vim-patch:9.1.0375: tests: 1-second delay after Test_BufEnter_botline()

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -4113,6 +4113,9 @@ func Test_BufEnter_botline()
   edit Xxx2
   au BufEnter Xxx1 call assert_true(line('w$') > 1)
   edit Xxx1
+
+  bwipe! Xxx1
+  bwipe! Xxx2
   au! BufEnter Xxx1
   set hidden&vim
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0375: tests: 1-second delay after Test_BufEnter_botline()

Problem:  tests: 1-second delay after Test_BufEnter_botline()
          (after v9.1.0374)
Solution: Wipe the created buffers (zeertzjq).

closes: vim/vim#14647

https://github.com/vim/vim/commit/340643e9779a96710a27d0eeef24f2c08b8967c4