### PR TITLE
vim-patch:92917069b1a8

### DIFF
--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change: 2024 Jan 25
+" Last Change:  2024 Apr 27
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -11,7 +11,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bullseye', 'bookworm', 'trixie', 'forky',
       \
-      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble',
+      \ 'trusty', 'xenial', 'bionic', 'focal', 'jammy', 'mantic', 'noble', 'oracular',
       \ 'devel'
       \ ]
 let g:debSharedUnsupportedVersions = [


### PR DESCRIPTION
runtime(debversions): Add oracular (24.10) as Ubuntu release name

closes: vim/vim#14645

https://github.com/vim/vim/commit/92917069b1a89e0e6c253a585dfe0a19cc2c0699

Co-authored-by: Simon Quigley <simon@tsimonq2.net>
