### PR TITLE
fix(snippet): do not add extra indent on newlines

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -459,8 +459,7 @@ function M.expand(input)
       end
       -- Add the base indentation.
       if i > 1 then
-        line = #line ~= 0 and base_indent .. line
-          or (expandtab and (' '):rep(shiftwidth) or '\t'):rep(vim.fn.indent('.') / shiftwidth + 1)
+        line = base_indent .. line
       end
       lines[#lines + 1] = line
     end

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -246,7 +246,7 @@ describe('vim.snippet', function()
   it('correctly indents with newlines', function()
     local curbuf = api.nvim_get_current_buf()
     test_expand_success(
-      { 'function($2)\n$3\nend' },
+      { 'function($2)\n\t$3\nend' },
       { 'function()', '  ', 'end' },
       [[
       vim.opt.sw = 2
@@ -255,8 +255,30 @@ describe('vim.snippet', function()
     )
     api.nvim_buf_set_lines(curbuf, 0, -1, false, {})
     test_expand_success(
-      { 'func main() {\n$1\n}' },
+      { 'function($2)\n$3\nend' },
+      { 'function()', '', 'end' },
+      [[
+      vim.opt.sw = 2
+      vim.opt.expandtab = true
+    ]]
+    )
+    api.nvim_buf_set_lines(curbuf, 0, -1, false, {})
+    test_expand_success(
+      { 'func main() {\n\t$1\n}' },
       { 'func main() {', '\t', '}' },
+      [[
+      vim.opt.sw = 4
+      vim.opt.ts = 4
+      vim.opt.expandtab = false
+    ]]
+    )
+    api.nvim_buf_set_lines(curbuf, 0, -1, false, {})
+    test_expand_success(
+      { '${1:name} :: ${2}\n${1:name} ${3}= ${0:undefined}' },
+      {
+        'name :: ',
+        'name = undefined',
+      },
       [[
       vim.opt.sw = 4
       vim.opt.ts = 4


### PR DESCRIPTION
Reverts parts of https://github.com/neovim/neovim/pull/27674

LSP snippets typically do include tabs or spaces to add extra
indentation and don't rely on the client using `autoindent`
functionality.

For example:

    public static void main(String[] args) {\n\t${0}\n}

Notice the `\t` after `{\n`

Adding spaces or tabs independent of that breaks snippets for languages
like Haskell where you can have snippets like:

    ${1:name} :: ${2}\n${1:name} ${3}= ${0:undefined}

To generate:

    name ::
    name = undefined
