### PR TITLE
docs(lsp): update override mappings example

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -79,6 +79,10 @@ To override the above defaults, set or unset the options on |LspAttach|: >lua
         vim.bo[ev.buf].formatexpr = nil
         vim.bo[ev.buf].omnifunc = nil
         vim.keymap.del('n', 'K', { buffer = ev.buf })
+        vim.keymap.del('n', 'crn', { buffer = ev.buf })
+        vim.keymap.del({ 'n', 'v' }, 'crr', { buffer = ev.buf })
+        vim.keymap.del('n', 'gr', { buffer = ev.buf })
+        vim.keymap.del('i', '<C-S>', { buffer = ev.buf })
       end,
     })
 


### PR DESCRIPTION
Updating the docs to include all default keybindings in the "override" example.