### PR TITLE
build: simplify policy-setting for dependencies

### DIFF
--- a/cmake.deps/cmake/GettextCMakeLists.txt
+++ b/cmake.deps/cmake/GettextCMakeLists.txt
@@ -1,9 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(gettext C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/LibiconvCMakeLists.txt
+++ b/cmake.deps/cmake/LibiconvCMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(libiconv C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/LibvtermCMakeLists.txt
+++ b/cmake.deps/cmake/LibvtermCMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(libvterm C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/MarkdownParserCMakeLists.txt
+++ b/cmake.deps/cmake/MarkdownParserCMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(${PARSERLANG} C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(treesitter C)
 
 add_compile_options(-w)

--- a/cmake.deps/cmake/TreesitterParserCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterParserCMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  cmake_policy(SET CMP0092 NEW)
-endif()
 project(parser C)
 
 add_compile_options(-w)

--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -18,6 +18,11 @@ if(APPLE)
   list(APPEND DEPS_CMAKE_ARGS -D CMAKE_FIND_FRAMEWORK=${CMAKE_FIND_FRAMEWORK})
 endif()
 
+# Can be removed once minimum version is at least 3.15
+if(POLICY CMP0092)
+  list(APPEND DEPS_CMAKE_ARGS -D CMAKE_POLICY_DEFAULT_CMP0092=NEW)
+endif()
+
 # MAKE_PRG
 if(UNIX)
   find_program(MAKE_PRG NAMES gmake make)


### PR DESCRIPTION
Passing `CMAKE_POLICY_DEFAULT_CMP0092=NEW` to all dependencies is
simpler than setting it manually in each file.