### PR TITLE
fix(defaults): do not hardcode borders in diagnostic.open_float

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -190,7 +190,7 @@ do
     })
 
     vim.keymap.set('n', '<C-W>d', function()
-      vim.diagnostic.open_float({ border = 'rounded' })
+      vim.diagnostic.open_float()
     end, {
       desc = 'Open a floating window showing diagnostics under the cursor',
     })


### PR DESCRIPTION
As per [discussion](https://github.com/neovim/neovim/pull/16230#discussion_r1581643975) in #16230