### PR TITLE
feat(defaults): further improve :grep defaults

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -407,7 +407,8 @@ The following changes to existing APIs or features add new behavior.
     correctly without it. (Use |gF| for filepaths suffixed with ":line:col").
   • 'comments' includes "fb:•".
   • 'shortmess' includes the "C" flag.
-  • 'grepprg' defaults to using ripgrep if available.
+  • 'grepprg' uses the -H and -I flags for grep by default,
+    and defaults to using ripgrep if available.
   • |crn| in Normal mode maps to |vim.lsp.buf.rename()|.
   • |crr| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|.
   • "gr" in Normal mode maps to |vim.lsp.buf.references()| |gr-default|

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2861,10 +2861,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	line.  The placeholder "$*" is allowed to specify where the arguments
 	will be included.  Environment variables are expanded |:set_env|.  See
 	|option-backslash| about including spaces and backslashes.
-	When your "grep" accepts the "-H" argument, use this to make ":grep"
-	also work well with a single file: >vim
-		set grepprg=grep\ -nH
-<	Special value: When 'grepprg' is set to "internal" the |:grep| command
+	Special value: When 'grepprg' is set to "internal" the |:grep| command
 	works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
 	|:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
 	See also the section |:make_makeprg|, since most of the comments there
@@ -2872,11 +2869,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 	This option defaults to:
-	- `rg --vimgrep -uuu $* ...` if ripgrep is available (|:checkhealth|),
-	- `grep -n $* /dev/null` on Unix,
+	- `rg --vimgrep -uu ` if ripgrep is available (|:checkhealth|),
+	- `grep -HIn $* /dev/null` on Unix,
 	- `findstr /n $* nul` on Windows.
 	Ripgrep can perform additional filtering such as using .gitignore rules
-	and skipping hidden or binary files. This is disabled by default (see the -u option)
+	and skipping hidden files. This is disabled by default (see the -u option)
 	to more closely match the behaviour of standard grep.
 	You can make ripgrep match Vim's case handling using the
 	-i/--ignore-case and -S/--smart-case options.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -52,7 +52,8 @@ Defaults					            *nvim-defaults*
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·,foldsep:│"
 - 'formatoptions' defaults to "tcqj"
-- 'grepprg' defaults to using ripgrep if available
+- 'grepprg' uses the -H and -I flags for regular grep,
+  and defaults to using ripgrep if available
 - 'hidden' is enabled
 - 'history' defaults to 10000 (the maximum)
 - 'hlsearch' is enabled

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -560,9 +560,8 @@ end
 do
   --- Default 'grepprg' to ripgrep if available.
   if vim.fn.executable('rg') == 1 then
-    -- Match :grep default, otherwise rg searches cwd by default
-    -- Use -uuu to make ripgrep not do its default filtering
-    vim.o.grepprg = 'rg --vimgrep -uuu $* ' .. (vim.fn.has('unix') == 1 and '/dev/null' or 'nul')
+    -- Use -uu to make ripgrep not check ignore files/skip dot-files
+    vim.o.grepprg = 'rg --vimgrep -uu '
     vim.o.grepformat = '%f:%l:%c:%m'
   end
 end

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2638,12 +2638,6 @@ vim.go.gfm = vim.go.grepformat
 --- line.  The placeholder "$*" is allowed to specify where the arguments
 --- will be included.  Environment variables are expanded `:set_env`.  See
 --- `option-backslash` about including spaces and backslashes.
---- When your "grep" accepts the "-H" argument, use this to make ":grep"
---- also work well with a single file:
----
---- ```vim
---- 	set grepprg=grep\ -nH
---- ```
 --- Special value: When 'grepprg' is set to "internal" the `:grep` command
 --- works like `:vimgrep`, `:lgrep` like `:lvimgrep`, `:grepadd` like
 --- `:vimgrepadd` and `:lgrepadd` like `:lvimgrepadd`.
@@ -2652,18 +2646,18 @@ vim.go.gfm = vim.go.grepformat
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
 --- This option defaults to:
---- - `rg --vimgrep -uuu $* ...` if ripgrep is available (`:checkhealth`),
---- - `grep -n $* /dev/null` on Unix,
+--- - `rg --vimgrep -uu ` if ripgrep is available (`:checkhealth`),
+--- - `grep -HIn $* /dev/null` on Unix,
 --- - `findstr /n $* nul` on Windows.
 --- Ripgrep can perform additional filtering such as using .gitignore rules
---- and skipping hidden or binary files. This is disabled by default (see the -u option)
+--- and skipping hidden files. This is disabled by default (see the -u option)
 --- to more closely match the behaviour of standard grep.
 --- You can make ripgrep match Vim's case handling using the
 --- -i/--ignore-case and -S/--smart-case options.
 --- An `OptionSet` autocmd can be used to set it up to match automatically.
 ---
 --- @type string
-vim.o.grepprg = "grep -n $* /dev/null"
+vim.o.grepprg = "grep -HIn $* /dev/null"
 vim.o.gp = vim.o.grepprg
 vim.bo.grepprg = vim.o.grepprg
 vim.bo.gp = vim.bo.grepprg

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3382,7 +3382,7 @@ return {
       abbreviation = 'gp',
       defaults = {
         condition = 'MSWIN',
-        if_false = 'grep -n $* /dev/null',
+        if_false = 'grep -HIn $* /dev/null',
         if_true = 'findstr /n $* nul',
         doc = [[see below]],
       },
@@ -3392,10 +3392,7 @@ return {
         line.  The placeholder "$*" is allowed to specify where the arguments
         will be included.  Environment variables are expanded |:set_env|.  See
         |option-backslash| about including spaces and backslashes.
-        When your "grep" accepts the "-H" argument, use this to make ":grep"
-        also work well with a single file: >vim
-        	set grepprg=grep\ -nH
-        <	Special value: When 'grepprg' is set to "internal" the |:grep| command
+        Special value: When 'grepprg' is set to "internal" the |:grep| command
         works like |:vimgrep|, |:lgrep| like |:lvimgrep|, |:grepadd| like
         |:vimgrepadd| and |:lgrepadd| like |:lvimgrepadd|.
         See also the section |:make_makeprg|, since most of the comments there
@@ -3403,11 +3400,11 @@ return {
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
         This option defaults to:
-        - `rg --vimgrep -uuu $* ...` if ripgrep is available (|:checkhealth|),
-        - `grep -n $* /dev/null` on Unix,
+        - `rg --vimgrep -uu ` if ripgrep is available (|:checkhealth|),
+        - `grep -HIn $* /dev/null` on Unix,
         - `findstr /n $* nul` on Windows.
         Ripgrep can perform additional filtering such as using .gitignore rules
-        and skipping hidden or binary files. This is disabled by default (see the -u option)
+        and skipping hidden files. This is disabled by default (see the -u option)
         to more closely match the behaviour of standard grep.
         You can make ripgrep match Vim's case handling using the
         -i/--ignore-case and -S/--smart-case options.


### PR DESCRIPTION
Based on feedback from https://github.com/neovim/neovim/pull/28324#pullrequestreview-2006163939, pass -H and -I to regular grep (available on all platforms officially supported by Neovim), and only pass -uu to ripgrep. This makes :grep ignore binary files by default in both cases.