### PR TITLE
fix(defaults): make diagnostic maps move to next diagnostic

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -389,7 +389,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                             |nvim_win_get_cursor()|.
       • {wrap}?             (`boolean`, default: `true`) Whether to loop
                             around file or not. Similar to 'wrapscan'.
-      • {severity}?         (`vim.diagnostic.Severity`) See
+      • {severity}?         (`vim.diagnostic.SeverityFilter`) See
                             |diagnostic-severity|. If `nil`, go to the
                             diagnostic with the highest severity.
       • {float}?            (`boolean|vim.diagnostic.Opts.Float`, default:

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -178,15 +178,15 @@ do
   --- See |[d-default|, |]d-default|, and |CTRL-W_d-default|.
   do
     vim.keymap.set('n', ']d', function()
-      vim.diagnostic.goto_next({ float = false })
+      vim.diagnostic.goto_next({ float = false, severity = { min = vim.diagnostic.severity.HINT } })
     end, {
-      desc = 'Jump to the next diagnostic with the highest severity',
+      desc = 'Jump to the next diagnostic',
     })
 
     vim.keymap.set('n', '[d', function()
-      vim.diagnostic.goto_prev({ float = false })
+      vim.diagnostic.goto_prev({ float = false, severity = { min = vim.diagnostic.severity.HINT } })
     end, {
-      desc = 'Jump to the previous diagnostic with the highest severity',
+      desc = 'Jump to the previous diagnostic',
     })
 
     vim.keymap.set('n', '<C-W>d', function()

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1192,7 +1192,7 @@ end
 --- @field wrap? boolean
 ---
 --- See |diagnostic-severity|. If `nil`, go to the diagnostic with the highest severity.
---- @field severity? vim.diagnostic.Severity
+--- @field severity? vim.diagnostic.SeverityFilter
 ---
 --- If `true`, call |vim.diagnostic.open_float()| after moving.
 --- If a table, pass the table as the {opts} parameter to |vim.diagnostic.open_float()|.


### PR DESCRIPTION
Make the default "goto" diagnostic maps jump to the next diagnostic in the buffer regardless of severity, rather than only cycling between diagnostics with the highest severity.

Ref: https://github.com/neovim/neovim/pull/28490#issuecomment-2081497347