### PR TITLE
vim-patch:9.1.0380: Calculating line height for unnecessary amount of lines

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1703,7 +1703,7 @@ static void win_update(win_T *wp)
         j = wp->w_lines[0].wl_lnum - wp->w_topline;
       }
       if (j < wp->w_grid.rows - 2) {               // not too far off
-        int i = plines_m_win(wp, wp->w_topline, wp->w_lines[0].wl_lnum - 1, true);
+        int i = plines_m_win(wp, wp->w_topline, wp->w_lines[0].wl_lnum - 1, wp->w_height_inner);
         // insert extra lines for previously invisible filler lines
         if (wp->w_lines[0].wl_lnum != wp->w_topline) {
           i += win_get_fill(wp, wp->w_lines[0].wl_lnum) - wp->w_old_topfill;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1051,7 +1051,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   linenr_T lnum = pos->lnum;
   if (lnum >= wp->w_topline && lnum <= wp->w_botline) {
     is_folded = hasFolding(wp, lnum, &lnum, NULL);
-    row = plines_m_win(wp, wp->w_topline, lnum - 1, false);
+    row = plines_m_win(wp, wp->w_topline, lnum - 1, INT_MAX);
     // "row" should be the screen line where line "lnum" begins, which can
     // be negative if "lnum" is "w_topline" and "w_skipcol" is non-zero.
     row -= adjust_plines_for_skipcol(wp);
@@ -2466,12 +2466,13 @@ int pagescroll(Direction dir, int count, bool half)
 
     int curscount = count;
     // Adjust count so as to not reveal end of buffer lines.
-    if (dir == FORWARD) {
+    if (dir == FORWARD
+        && (curwin->w_topline + curwin->w_height + count > buflen || hasAnyFolding(curwin))) {
       int n = plines_correct_topline(curwin, curwin->w_topline, NULL, false, NULL);
       if (n - count < curwin->w_height_inner && curwin->w_topline < buflen) {
-        n += plines_m_win(curwin, curwin->w_topline + 1, buflen, false);
+        n += plines_m_win(curwin, curwin->w_topline + 1, buflen, curwin->w_height_inner + count);
       }
-      if (n - count < curwin->w_height_inner) {
+      if (n < curwin->w_height_inner + count) {
         count = n - curwin->w_height_inner;
       }
     }


### PR DESCRIPTION
Problem:  Calculating line height for unnecessary amount of lines with
          half-page scrolling (zhscn, after 9.1.0280)
Solution: Replace "limit_winheight" argument with higher resolution
          "max" argument to which to limit the calculated line height
          in plines_m_win() to (Luuk van Baal)

https://github.com/vim/vim/commit/32d701f51b1ed2834071a2c5031a300936beda13