### PR TITLE
fix(completion): stop completion when completion is exhausted

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1279,7 +1279,10 @@ void ins_compl_show_pum(void)
   }
 
   if (compl_match_array == NULL) {
-    if (compl_started && has_event(EVENT_COMPLETECHANGED)) {
+    // Stop completion when completion is exhausted
+    if (ctrl_x_mode_not_default()) {
+      ins_compl_prep(' ');
+    } else if (compl_started && has_event(EVENT_COMPLETECHANGED)) {
       trigger_complete_changed_event(cur);
     }
     return;

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1192,4 +1192,45 @@ describe('completion', function()
       {3:-- INSERT --}                                                |
     ]])
   end)
+
+  it('is stopped when there are no more matches', function()
+    command([[
+      function Complete() abort
+        call complete(1, ['abcd', 'abdc', 'acbd'])
+        return ''
+      endfunction
+
+      inoremap <C-x> <C-r>=Complete()<CR>
+      set completeopt+=menuone,noselect
+      let g:completedone_count = 0
+      autocmd CompleteDone * let g:completedone_count += 1
+    ]])
+
+    feed('i<C-x>')
+    screen:expect([[
+      ^                                                            |
+      {1:abcd           }{0:                                             }|
+      {1:abdc           }{0:                                             }|
+      {1:acbd           }{0:                                             }|
+      {0:~                                                           }|*3
+      {3:-- INSERT --}                                                |
+    ]])
+    eq(0, eval('g:completedone_count'))
+
+    feed('ax')
+    screen:expect([[
+      ax^                                                          |
+      {0:~                                                           }|*6
+      {3:-- INSERT --}                                                |
+    ]])
+    eq(1, eval('g:completedone_count'))
+
+    feed('aa<ESC>')
+    screen:expect([[
+      axa^a                                                        |
+      {0:~                                                           }|*6
+                                                                  |
+    ]])
+    eq(1, eval('g:completedone_count'))
+  end)
 end)


### PR DESCRIPTION
Problem: Currently, completion is not stopped when completion is exhausted (no matching completion items), which also means `CompleteDone` is not called either. Furthermore, `CompleteDone` is called when pressing a special character (Backspace, Space, Esc) instead.

Solution: Correctly stop completion and trigger `CompleteDone` when completion is exhausted.