### PR TITLE
vim-patch:2e9b9e9a9ebf

### DIFF
--- a/runtime/indent/asm.vim
+++ b/runtime/indent/asm.vim
@@ -13,7 +13,7 @@ let b:did_indent = 1
 setlocal indentexpr=s:getAsmIndent()
 setlocal indentkeys=<:>,!^F,o,O
 
-let b:undo_indent = "indentexpr< indentkeys<"
+let b:undo_indent = "setlocal indentexpr< indentkeys<"
 
 function! s:getAsmIndent()
   let line = getline(v:lnum)


### PR DESCRIPTION
runtime(asm): missing setlocal in indent plugin (vim/vim#14658)

https://github.com/vim/vim/commit/2e9b9e9a9ebf3fd40437260ecd6b1e23b02c636b

Co-authored-by: Marc Sven Schulte <167623652+msschulte@users.noreply.github.com>
