### PR TITLE
docs(vvars): fix `v:completed_item` docs

### DIFF
--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -60,9 +60,10 @@ v:collate
 
 			*v:completed_item* *completed_item-variable*
 v:completed_item
-		Dictionary containing the most recent |complete-items| after
-		|CompleteDone|.  Empty if the completion failed, or after
-		leaving and re-entering insert mode.
+		Dictionary containing the |complete-items| for the most
+		recently completed word after |CompleteDone|.  Empty if the
+		completion failed, or after leaving and re-entering insert
+		mode.
 		Note: Plugins can modify the value to emulate the builtin
 		|CompleteDone| event behavior.
 

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -54,9 +54,10 @@ vim.v.cmdbang = ...
 --- @type string
 vim.v.collate = ...
 
---- Dictionary containing the most recent `complete-items` after
---- `CompleteDone`.  Empty if the completion failed, or after
---- leaving and re-entering insert mode.
+--- Dictionary containing the `complete-items` for the most
+--- recently completed word after `CompleteDone`.  Empty if the
+--- completion failed, or after leaving and re-entering insert
+--- mode.
 --- Note: Plugins can modify the value to emulate the builtin
 --- `CompleteDone` event behavior.
 --- @type any

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -64,9 +64,10 @@ M.vars = {
   },
   completed_item = {
     desc = [=[
-      Dictionary containing the most recent |complete-items| after
-      |CompleteDone|.  Empty if the completion failed, or after
-      leaving and re-entering insert mode.
+      Dictionary containing the |complete-items| for the most
+      recently completed word after |CompleteDone|.  Empty if the
+      completion failed, or after leaving and re-entering insert
+      mode.
       Note: Plugins can modify the value to emulate the builtin
       |CompleteDone| event behavior.
     ]=],


### PR DESCRIPTION
Problem: Currently the docs say that `v:completed_item` shows the most recent completion items, which implies it shows all of the completion items, this is not correct. The [Vim documentation](https://github.com/vim/vim/blob/2e9b9e9a9ebf3fd40437260ecd6b1e23b02c636b/runtime/doc/eval.txt#L2084) for `v:completed_item` is much more accurate.

Solution: Fix the documentation for `v:completed_item` and clarify that it only shows the most recently completed word, not all of the recent completion items.