### PR TITLE
fix(treesitter): make tests for memoize more robust, also fix memoize to work

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -45,6 +45,7 @@
 #include "nvim/keycodes.h"
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"
+#include "nvim/lua/treesitter.h"
 #include "nvim/macros_defs.h"
 #include "nvim/mapping.h"
 #include "nvim/mark.h"
@@ -1806,12 +1807,13 @@ Float nvim__id_float(Float flt)
 /// @return Map of various internal stats.
 Dictionary nvim__stats(Arena *arena)
 {
-  Dictionary rv = arena_dict(arena, 5);
+  Dictionary rv = arena_dict(arena, 6);
   PUT_C(rv, "fsync", INTEGER_OBJ(g_stats.fsync));
   PUT_C(rv, "log_skip", INTEGER_OBJ(g_stats.log_skip));
   PUT_C(rv, "lua_refcount", INTEGER_OBJ(nlua_get_global_ref_count()));
   PUT_C(rv, "redraw", INTEGER_OBJ(g_stats.redraw));
   PUT_C(rv, "arena_alloc_count", INTEGER_OBJ((Integer)arena_alloc_count));
+  PUT_C(rv, "ts_query_parse_count", INTEGER_OBJ((Integer)tslua_query_parse_count));
   return rv;
 }
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1318,6 +1318,7 @@ int tslua_parse_query(lua_State *L)
   size_t len;
   const char *src = lua_tolstring(L, 2, &len);
 
+  tslua_query_parse_count++;
   uint32_t error_offset;
   TSQueryError error_type;
   TSQuery *query = ts_query_new(lang, src, (uint32_t)len, &error_offset, &error_type);

--- a/src/nvim/lua/treesitter.h
+++ b/src/nvim/lua/treesitter.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include <lua.h>  // IWYU pragma: keep
+#include <stdint.h>
+
+#include "nvim/macros_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "lua/treesitter.h.generated.h"
 #endif
+
+EXTERN uint64_t tslua_query_parse_count INIT( = 0);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -63,6 +63,7 @@
 #include "nvim/log.h"
 #include "nvim/lua/executor.h"
 #include "nvim/lua/secure.h"
+#include "nvim/lua/treesitter.h"
 #include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/mark.h"


### PR DESCRIPTION
Instead of painfully messing with timing to determine if queries were reparsed, we can simply keep a counter next to the call to ts_query_new

Also memoization did not work as `__mode = "kv"` implies that if _either_ the key or the value was collected, the table entry just fucking dies. As no one ever keeps around a reference to the hash string unlike the actually useful and expensive query object, this just means the cache gets obliterated at any GC cycle. The fix is to use `__mode = "v"`.