### PR TITLE
feat(lsp): redrawstatus on progress notifications

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -562,9 +562,8 @@ LspProgress                                                       *LspProgress*
     `result` properties. `result` will contain the request params sent by the
     server.
 
-    Example: >vim
-        autocmd LspProgress * redrawstatus
-<
+    |:redrawstatus| happens implicitly with LspProgress events.
+
 
 LspRequest                                                        *LspRequest*
     For each request sent to an LSP server, this event is triggered for


### PR DESCRIPTION
Problem:

Currently users can include `vim.lsp.status()` in their statusline, but
they won't see status changes if the statusline isn't redrawn on progress updates.

The simple solution for that is:

    autocmd LspProgress * redrawstatus

But that has the problem that the last message remains stale until
something else triggers a redraw. To fix the stale messages, users would
have to add something like this:

    local timer = vim.loop.new_timer()
    api.nvim_create_autocmd("LspProgress", {
      group = lsp_group,
      callback = function()
        vim.cmd.redrawstatus()
        if timer then
          timer:stop()
          timer:start(500, 0, vim.schedule_wrap(function()
            timer:stop()
            vim.cmd.redrawstatus()
          end))
        end
      end
    })

That's quite complex.

Solution:

Call redrawstatus by default. To avoid `redrawstatus()` burst the calls
are debounced to 60 FPS.
