### PR TITLE
vim-patch:04e1aaa94e3b

### DIFF
--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -246,7 +246,7 @@ code block the cursor is in: >
 
 	=a{
 
-I you have really badly indented code, you can re-indent the whole file with:
+If you have really badly indented code, you can re-indent the whole file with:
 >
 	gg=G
 


### PR DESCRIPTION
#### vim-patch:04e1aaa94e3b

runtime(doc): Fix a typo in usr_30.txt

closes: vim/vim#14662

https://github.com/vim/vim/commit/04e1aaa94e3b7bf3ae6d376f52504aeb02bc9ca5

Co-authored-by: UM-Li <um-li@tuta.io>