### PR TITLE
vim-patch:9.1.0381

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -275,7 +275,8 @@ processing a quickfix or location list command, it will be aborted.
 			current window is used instead of the quickfix list.
 
 						*:cb* *:cbuffer* *E681*
-:cb[uffer][!] [bufnr]	Read the error list from the current buffer.
+:[range]cb[uffer][!] [bufnr]
+			Read the error list from the current buffer.
 			When [bufnr] is given it must be the number of a
 			loaded buffer.  That buffer will then be used instead
 			of the current buffer.
@@ -284,26 +285,31 @@ processing a quickfix or location list command, it will be aborted.
 			See |:cc| for [!].
 
 						*:lb* *:lbuffer*
-:lb[uffer][!] [bufnr]	Same as ":cbuffer", except the location list for the
+:[range]lb[uffer][!] [bufnr]
+			Same as ":cbuffer", except the location list for the
 			current window is used instead of the quickfix list.
 
 						*:cgetb* *:cgetbuffer*
-:cgetb[uffer] [bufnr]	Read the error list from the current buffer.  Just
+:[range]cgetb[uffer] [bufnr]
+			Read the error list from the current buffer.  Just
 			like ":cbuffer" but don't jump to the first error.
 
 						*:lgetb* *:lgetbuffer*
-:lgetb[uffer] [bufnr]	Same as ":cgetbuffer", except the location list for
+:[range]lgetb[uffer] [bufnr]
+			Same as ":cgetbuffer", except the location list for
 			the current window is used instead of the quickfix
 			list.
 
 						*:cad* *:cadd* *:caddbuffer*
-:cad[dbuffer] [bufnr]	Read the error list from the current buffer and add
+:[range]cad[dbuffer] [bufnr]
+			Read the error list from the current buffer and add
 			the errors to the current quickfix list.  If a
 			quickfix list is not present, then a new list is
 			created. Otherwise, same as ":cbuffer".
 
 							*:laddb* *:laddbuffer*
-:laddb[uffer] [bufnr]	Same as ":caddbuffer", except the location list for
+:[range]laddb[uffer] [bufnr]
+			Same as ":caddbuffer", except the location list for
 			the current window is used instead of the quickfix
 			list.
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -337,7 +337,7 @@ M.cmds = {
   {
     command = 'caddbuffer',
     flags = bit.bor(RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {
@@ -373,7 +373,7 @@ M.cmds = {
   {
     command = 'cbuffer',
     flags = bit.bor(BANG, RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {
@@ -459,7 +459,7 @@ M.cmds = {
   {
     command = 'cgetbuffer',
     flags = bit.bor(RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {
@@ -1329,7 +1329,7 @@ M.cmds = {
   {
     command = 'laddbuffer',
     flags = bit.bor(RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {
@@ -1353,7 +1353,7 @@ M.cmds = {
   {
     command = 'lbuffer',
     flags = bit.bor(BANG, RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {
@@ -1451,7 +1451,7 @@ M.cmds = {
   {
     command = 'lgetbuffer',
     flags = bit.bor(RANGE, WORD1, TRLBAR),
-    addr_type = 'ADDR_OTHER',
+    addr_type = 'ADDR_LINES',
     func = 'ex_cbuffer',
   },
   {

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -6369,4 +6369,74 @@ func Test_efm_format_b()
   call setqflist([], 'f')
 endfunc
 
+func XbufferTests_range(cchar)
+  call s:setup_commands(a:cchar)
+
+  enew!
+  let lines =<< trim END
+    Xtestfile7:700:10:Line 700
+    Xtestfile8:800:15:Line 800
+  END
+  silent! call setline(1, lines)
+  norm! Vy
+  " Note: We cannot use :Xbuffer here,
+  " it doesn't properly fail, so we need to
+  " test using the raw c/l commands.
+  " (also further down)
+  if (a:cchar == 'c')
+     exe "'<,'>cbuffer!"
+  else
+    exe "'<,'>lbuffer!"
+  endif
+  let l = g:Xgetlist()
+  call assert_true(len(l) == 1 &&
+	\ l[0].lnum == 700 && l[0].col == 10 && l[0].text ==# 'Line 700')
+
+  enew!
+  let lines =<< trim END
+    Xtestfile9:900:55:Line 900
+    Xtestfile10:950:66:Line 950
+  END
+  silent! call setline(1, lines)
+  if (a:cchar == 'c')
+    1cgetbuffer
+  else
+    1lgetbuffer
+  endif
+  let l = g:Xgetlist()
+  call assert_true(len(l) == 1 &&
+	\ l[0].lnum == 900 && l[0].col == 55 && l[0].text ==# 'Line 900')
+
+  enew!
+  let lines =<< trim END
+    Xtestfile11:700:20:Line 700
+    Xtestfile12:750:25:Line 750
+  END
+  silent! call setline(1, lines)
+  if (a:cchar == 'c')
+    1,1caddbuffer
+  else
+    1,1laddbuffer
+  endif
+  let l = g:Xgetlist()
+  call assert_true(len(l) == 2 &&
+	\ l[0].lnum == 900 && l[0].col == 55 && l[0].text ==# 'Line 900' &&
+	\ l[1].lnum == 700 && l[1].col == 20 && l[1].text ==# 'Line 700')
+  enew!
+
+  " Check for invalid range
+  " Using Xbuffer will not run the range check in the cbuffer/lbuffer
+  " commands. So directly call the commands.
+  if (a:cchar == 'c')
+      call assert_fails('900,999caddbuffer', 'E16:')
+  else
+      call assert_fails('900,999laddbuffer', 'E16:')
+  endif
+endfunc
+
+func Test_cbuffer_range()
+  call XbufferTests_range('c')
+  call XbufferTests_range('l')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fixes #28544 (problem which actually is caused by upstream)

Porting patch 9.1.0381 https://github.com/vim/vim/commit/652c821366691a8bd5474766581090df0c742fa1
```
Problem:  cbuffer and similar quickfix and locationlist commands don't
          accept a range, even so it is documented they should
          (ilan-schemoul, after 8.1.1241)
Solution: Define ex commands with ADDR_LINES instead of ADDR_OTHER

fixes: vim/vim#14638
closes: vim/vim#14657
```
