### PR TITLE
feat(completion): add `pum_matches` key to `complete_info()`

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -796,6 +796,8 @@ complete_info([{what}])                                        *complete_info()*
 				dictionary containing the entries "word",
 				"abbr", "menu", "kind", "info" and "user_data".
 				See |complete-items|.
+		   pum_matches	Indices of completion matches that are put
+				in the |ins-completion-menu|.  First index is zero.
 		   selected	Selected item index.  First index is zero.
 				Index is -1 if no item is selected (showing
 				typed text only, or the last completion after

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -385,6 +385,9 @@ The following new APIs and features were added.
 • |vim.fs.root()| finds project root directories from a list of "root
   markers".
 
+• |complete_info()| returns a `pum_matches` item to indicate which items are put
+  in the |ins-completion-menu|.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1018,6 +1018,8 @@ function vim.fn.complete_check() end
 ---     dictionary containing the entries "word",
 ---     "abbr", "menu", "kind", "info" and "user_data".
 ---     See |complete-items|.
+---    pum_matches  Indices of completion matches that are put
+---     in the |ins-completion-menu|.  First index is zero.
 ---    selected  Selected item index.  First index is zero.
 ---     Index is -1 if no item is selected (showing
 ---     typed text only, or the last completion after

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1367,6 +1367,8 @@ M.funcs = {
       		dictionary containing the entries "word",
       		"abbr", "menu", "kind", "info" and "user_data".
       		See |complete-items|.
+         pum_matches	Indices of completion matches that are put
+      		in the |ins-completion-menu|.  First index is zero.
          selected	Selected item index.  First index is zero.
       		Index is -1 if no item is selected (showing
       		typed text only, or the last completion after

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1080,6 +1080,34 @@ describe('completion', function()
     ]])
   end)
 
+  describe('complete_info() pum_matches', function()
+    before_each(function()
+      source([[
+        function! TestComplete() abort
+          call complete(1, ['abcd', 'acbd', 'xyz', 'foobar'])
+          return ''
+        endfunction
+
+        set completeopt+=noinsert
+        inoremap <C-x> <c-r>=TestComplete()<cr>
+      ]])
+    end)
+
+    it('works', function()
+      feed('i<C-x>')
+      eq({ pum_matches = { 0, 1, 2, 3 } }, fn.complete_info({ 'pum_matches' }))
+
+      feed('a')
+      eq({ pum_matches = { 0, 1 } }, fn.complete_info({ 'pum_matches' }))
+
+      feed('c')
+      eq({ pum_matches = { 1 } }, fn.complete_info({ 'pum_matches' }))
+
+      feed('x')
+      eq({ pum_matches = {} }, fn.complete_info({ 'pum_matches' }))
+    end)
+  end)
+
   -- oldtest: Test_complete_changed_complete_info()
   it('no crash calling complete_info() in CompleteChanged', function()
     source([[

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -382,7 +382,7 @@ func Test_completefunc_info()
   set completeopt=menuone
   set completefunc=CompleteTest
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
-  call assert_equal("matched{'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
+  call assert_equal("matched{'pum_matches': [0], 'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   bwipe!
   set completeopt&
   set completefunc&
@@ -406,7 +406,8 @@ func CompleteInfoTestUserDefinedFn(mvmt, idx, noselect)
   set completefunc=CompleteInfoUserDefinedFn
   call feedkeys("i\<C-X>\<C-U>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
-  call assert_equal(completed. "{'pum_visible': 1, 'mode': 'function', 'selected': " . a:idx . ", 'items': [" .
+  call assert_equal(completed. "{'pum_matches': [0, 1, 2, 3], 'pum_visible': 1, " .
+        \ "'mode': 'function', 'selected': " . a:idx . ", 'items': [" .
         \ "{'word': 'foo', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .
         \ "{'word': 'bar', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .
         \ "{'word': 'baz', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1101,6 +1101,7 @@ func Test_popup_complete_info_02()
     \     {'word': 'May', 'menu': 'May', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}
     \   ],
     \   'selected': 0,
+    \   'pum_matches': [0, 1, 2, 3, 4],
     \ }
 
   let g:compl_what = []
@@ -1109,6 +1110,7 @@ func Test_popup_complete_info_02()
 
   let g:compl_what = ['mode', 'pum_visible', 'selected']
   call remove(d, 'items')
+  call remove(d, 'pum_matches')
   call feedkeys("i\<C-X>\<C-U>\<F5>", 'tx')
   call assert_equal(d, g:compl_info)
 
@@ -1129,6 +1131,7 @@ func Test_popup_complete_info_no_pum()
         \   'pum_visible': 0,
         \   'items': [],
         \   'selected': -1,
+        \   'pum_matches': [],
         \  }
   call assert_equal( d, complete_info() )
   bwipe!


### PR DESCRIPTION
Problem: Currently there is no way of getting the list of completion items that are actually put in the popupmenu. Which means completion providers have no way of knowing if a completion was exhausted.

Solution: Add a `pum_matches` key to `complete_info()` which contains the indices of items that are put in the popupmenu.

Ref: https://github.com/vim/vim/issues/10007
