### PR TITLE
fix(ui): avoid recursiveness and invalid memory access

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3449,9 +3449,11 @@ void cmdline_screen_cleared(void)
 /// called by ui_flush, do what redraws necessary to keep cmdline updated.
 void cmdline_ui_flush(void)
 {
-  if (!ui_has(kUICmdline)) {
+  static bool flushing = false;
+  if (!ui_has(kUICmdline) || flushing) {
     return;
   }
+  flushing = true;
   int level = ccline.level;
   CmdlineInfo *line = &ccline;
   while (level > 0 && line) {
@@ -3466,6 +3468,7 @@ void cmdline_ui_flush(void)
     }
     line = line->prev_ccline;
   }
+  flushing = false;
 }
 
 // Put a character on the command line.  Shifts the following text to the

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -14,6 +14,7 @@
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui.h.generated.h"
 # include "ui_events_call.h.generated.h"
+EXTERN Array noargs INIT(= ARRAY_DICT_INIT);
 #endif
 // uncrustify:on
 

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -63,7 +63,6 @@ typedef struct {
   PackerBuffer packer;
 
   const char *cur_event;  ///< name of current event (might get multiple arglists)
-  Array call_buf;  ///< buffer for constructing a single arg list (max 16 elements!)
 
   // We start packing the two outermost msgpack arrays before knowing the total
   // number of elements. Thus track the location where array size will need

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -173,6 +173,21 @@ describe('vim.ui_attach', function()
     exec_lua('vim.cmd.tabnext()')
     eq(0, n.api.nvim_get_option_value('cmdheight', {}))
   end)
+
+  it('avoids recursive flushing and invalid memory access with :redraw', function()
+    exec_lua([[
+      _G.cmdline = 0
+      vim.ui_attach(ns, { ext_messages = true }, function(ev)
+        vim.cmd.redraw()
+        _G.cmdline = _G.cmdline + (ev == 'cmdline_show' and 1 or 0)
+      end
+    )]])
+    feed(':')
+    eq(1, exec_lua('return _G.cmdline'))
+    n.assert_alive()
+    feed('version<CR><CR>v<Esc>')
+    n.assert_alive()
+  end)
 end)
 
 describe('vim.ui_attach', function()


### PR DESCRIPTION
Problem:  Calling :redraw from vim.ui_attach() callback results in
          recursive cmdline/message events.
Solution: Avoid recursiveness where possible and replace global "call_buf"
          with separate, temporary buffers for each event so that when a Lua
          callback for one event fires another event, that does not result
          in invalid memory access.

Fix #21604