### PR TITLE
Revert "feat(extmarks): subpriorities (relative to declaration order) (#27131)"

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -253,7 +253,6 @@ error('Cannot require a meta file')
 --- @field undo_restore? boolean
 --- @field url? string
 --- @field scoped? boolean
---- @field _subpriority? integer
 
 --- @class vim.api.keyset.user_command
 --- @field addr? any

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -761,32 +761,20 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       col2 = c;
     }
 
-    DecorPriority subpriority = DECOR_PRIORITY_BASE;
-    if (HAS_KEY(opts, set_extmark, _subpriority)) {
-      VALIDATE_RANGE((opts->_subpriority >= 0 && opts->_subpriority <= UINT16_MAX),
-                     "_subpriority", {
-        goto error;
-      });
-      subpriority = (DecorPriority)opts->_subpriority;
-    }
-
     if (kv_size(virt_text.data.virt_text)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true,
-                           subpriority);
+      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true);
     }
     if (kv_size(virt_lines.data.virt_lines)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true,
-                           subpriority);
+      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
     }
     if (url != NULL) {
       DecorSignHighlight sh = DECOR_SIGN_HIGHLIGHT_INIT;
       sh.url = url;
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0, subpriority);
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, 0, 0);
     }
     if (has_hl) {
       DecorSignHighlight sh = decor_sh_from_inline(hl);
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id,
-                         subpriority);
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
     }
   } else {
     if (opts->ephemeral) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -56,8 +56,6 @@ typedef struct {
   Boolean undo_restore;
   String url;
   Boolean scoped;
-
-  Integer _subpriority;
 } Dict(set_extmark);
 
 typedef struct {

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -454,21 +454,18 @@ static void decor_range_add_from_inline(DecorState *state, int start_row, int st
   if (decor.ext) {
     DecorVirtText *vt = decor.data.ext.vt;
     while (vt) {
-      decor_range_add_virt(state, start_row, start_col, end_row, end_col, vt, owned,
-                           DECOR_PRIORITY_BASE);
+      decor_range_add_virt(state, start_row, start_col, end_row, end_col, vt, owned);
       vt = vt->next;
     }
     uint32_t idx = decor.data.ext.sh_idx;
     while (idx != DECOR_ID_INVALID) {
       DecorSignHighlight *sh = &kv_A(decor_items, idx);
-      decor_range_add_sh(state, start_row, start_col, end_row, end_col, sh, owned, ns, mark_id,
-                         DECOR_PRIORITY_BASE);
+      decor_range_add_sh(state, start_row, start_col, end_row, end_col, sh, owned, ns, mark_id);
       idx = sh->next;
     }
   } else {
     DecorSignHighlight sh = decor_sh_from_inline(decor.data.hl);
-    decor_range_add_sh(state, start_row, start_col, end_row, end_col, &sh, owned, ns, mark_id,
-                       DECOR_PRIORITY_BASE);
+    decor_range_add_sh(state, start_row, start_col, end_row, end_col, &sh, owned, ns, mark_id);
   }
 }
 
@@ -478,8 +475,7 @@ static void decor_range_insert(DecorState *state, DecorRange range)
   size_t index;
   for (index = kv_size(state->active) - 1; index > 0; index--) {
     DecorRange item = kv_A(state->active, index - 1);
-    if ((item.priority < range.priority)
-        || ((item.priority == range.priority) && (item.subpriority <= range.subpriority))) {
+    if (item.priority <= range.priority) {
       break;
     }
     kv_A(state->active, index) = kv_A(state->active, index - 1);
@@ -488,7 +484,7 @@ static void decor_range_insert(DecorState *state, DecorRange range)
 }
 
 void decor_range_add_virt(DecorState *state, int start_row, int start_col, int end_row, int end_col,
-                          DecorVirtText *vt, bool owned, DecorPriority subpriority)
+                          DecorVirtText *vt, bool owned)
 {
   bool is_lines = vt->flags & kVTIsLines;
   DecorRange range = {
@@ -498,15 +494,13 @@ void decor_range_add_virt(DecorState *state, int start_row, int start_col, int e
     .attr_id = 0,
     .owned = owned,
     .priority = vt->priority,
-    .subpriority = subpriority,
     .draw_col = -10,
   };
   decor_range_insert(state, range);
 }
 
 void decor_range_add_sh(DecorState *state, int start_row, int start_col, int end_row, int end_col,
-                        DecorSignHighlight *sh, bool owned, uint32_t ns, uint32_t mark_id,
-                        DecorPriority subpriority)
+                        DecorSignHighlight *sh, bool owned, uint32_t ns, uint32_t mark_id)
 {
   if (sh->flags & kSHIsSign) {
     return;
@@ -519,7 +513,6 @@ void decor_range_add_sh(DecorState *state, int start_row, int start_col, int end
     .attr_id = 0,
     .owned = owned,
     .priority = sh->priority,
-    .subpriority = subpriority,
     .draw_col = -10,
   };
 

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -48,8 +48,6 @@ typedef struct {
   int attr_id;  ///< cached lookup of inl.hl_id if it was a highlight
   bool owned;   ///< ephemeral decoration, free memory immediately
   DecorPriority priority;
-  DecorPriority subpriority;  ///< Secondary priority value used for ordering (#27131).
-                              ///< Reflects the order of patterns/captures in the query file.
   DecorRangeKind kind;
   /// Screen column to draw the virtual text.
   /// When -1, it should be drawn on the current screen line after deciding where.

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -727,47 +727,6 @@ describe('decorations providers', function()
     n.assert_alive()
   end)
 
-  it('supports subpriorities (order of definitions in a query file #27131)', function()
-    insert(mulholland)
-    setup_provider [[
-      local test_ns = api.nvim_create_namespace('mulholland')
-      function on_do(event, ...)
-        if event == "line" then
-          local win, buf, line = ...
-          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
-            end_row = line + 1,
-            hl_eol = true,
-            hl_group = 'Comment',
-            ephemeral = true,
-            priority = 100,
-            _subpriority = 20,
-          })
-
-          -- This extmark is set last but has a lower subpriority, so the first extmark "wins"
-          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
-            end_row = line + 1,
-            hl_eol = true,
-            hl_group = 'String',
-            ephemeral = true,
-            priority = 100,
-            _subpriority = 10,
-          })
-        end
-      end
-    ]]
-
-    screen:expect{grid=[[
-      {4:// just to see if there was an accident }|
-      {4:// on Mulholland Drive                  }|
-      {4:try_start();                            }|
-      {4:bufref_T save_buf;                      }|
-      {4:switch_buffer(&save_buf, buf);          }|
-      {4:posp = getmark(mark, false);            }|
-      {4:restore_buffer(&save_buf);^              }|
-                                              |
-    ]]}
-  end)
-
   it('is not invoked repeatedly in Visual mode with vim.schedule() #20235', function()
     exec_lua([[_G.cnt = 0]])
     setup_provider([[


### PR DESCRIPTION
This reverts commit 15e77a56b711102fdc123e15b3f37d49bc0b1df1.

Subpriorities were added in https://github.com/neovim/neovim/pull/27131 as a mechanism for enforcing query order when using iter_matches in the Tree-sitter highlighter. However, iter_matches proved to have too many complications to use in the highlighter so we eventually reverted back to using iter_captures (https://github.com/neovim/neovim/pull/27901). Thus, subpriorities are no longer needed and can be removed.
