### PR TITLE
ci: improve default backport pull request title

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,11 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Create backport PRs
+      - name: Create backport PR
+        id: backport
         uses: korthout/backport-action@v2
         with:
+          pull_title: "${pull_title}"
+          label_pattern: "^ci:backport ([^ ]+)$"
           # https://github.com/korthout/backport-action/pull/399
           experimental: >
             {
               "detect_merge_method": true
             }
+
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{steps.backport.outputs.created_pull_numbers}},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['backport']
+            })

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -231,7 +231,7 @@ https://github.com/neovim/neovim-backup
 
 Some github labels are used to trigger certain jobs:
 
-* `backport release-x.y` - backport to release branch
+* `ci:backport release-x.y` - backport to branch `release-x.y`
 * `ci:s390x` - enable s390x CI
 * `ci:skip-news` - skip news.yml workflows
 * `ci:windows-asan` - test windows with ASAN enabled


### PR DESCRIPTION
`[Backport release-x.y]` will no longer be part of the pull request
title. This means the PR titles will go from looking like

```
[Backport release-0.9] fix(languagetree): remove double recursion in LanguageTree:parse
```

to

```
fix(languagetree): remove double recursion in LanguageTree:parse
```

The benefit of this is that pull requests merged with the "Squash and
Merge" strategy (which uses the PR title as the commit message), will
still follow the conventional commits specification. This will help
tools that rely on conventional commits such as git-cliff.

The `backport` label is added to backported PRs to help distinguish
between backport PRs with regular PRs in the "Pull Requests" tab on
github.

To reduce confusion with the `backport` label, the label to trigger the
backporting has been changed from `backport release-x.y` to
`ci:backport release-x.y`. This is also more consistent with other
labels that trigger a CI job which all use the `ci:` prefix.