### PR TITLE
Add file type detection for Inko

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -358,6 +358,7 @@ local extension = {
   bat = 'dosbatch',
   wrap = 'dosini',
   ini = 'dosini',
+  inko = 'inko',
   INI = 'dosini',
   vbp = 'dosini',
   dot = 'dot',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -348,6 +348,7 @@ func s:GetFilenameChecks() abort
     \ 'ipfilter': ['ipf.conf', 'ipf6.conf', 'ipf.rules'],
     \ 'iss': ['file.iss'],
     \ 'ist': ['file.ist', 'file.mst'],
+    \ 'inko': ['file.inko'],
     \ 'j': ['file.ijs'],
     \ 'jal': ['file.jal', 'file.JAL'],
     \ 'jam': ['file.jpl', 'file.jpr', 'JAM-file.file', 'JAM.file', 'Prl-file.file', 'Prl.file'],


### PR DESCRIPTION
This is so that when one uses Tree-sitter (see https://github.com/nvim-treesitter/nvim-treesitter/pull/6549 for that) instead of the Vim plugin (https://github.com/inko-lang/inko.vim), NeoVim automatically picks up on the file type.