### PR TITLE
fix(colorscheme): add missing LSP groups

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4338,7 +4338,7 @@ vim.snippet.expand({input})                             *vim.snippet.expand()*
     https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax
     for the specification of valid input.
 
-    Tabstops are highlighted with hl-SnippetTabstop.
+    Tabstops are highlighted with |hl-SnippetTabstop|.
 
     Parameters: ~
       • {input}  (`string`)

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5054,6 +5054,8 @@ QuickFixLine	Current |quickfix| item in the quickfix window. Combined with
 							*hl-Search*
 Search		Last search pattern highlighting (see 'hlsearch').
 		Also used for similar items that need to stand out.
+							*hl-SnippetTabstop*
+SnippetTabstop	Tabstops in snippets. |vim.snippet|
 							*hl-SpecialKey*
 SpecialKey	Unprintable characters: Text displayed differently from what
 		it really is. But not 'listchars' whitespace. |hl-Whitespace|

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -401,7 +401,7 @@ end
 --- Refer to https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax
 --- for the specification of valid input.
 ---
---- Tabstops are highlighted with hl-SnippetTabstop.
+--- Tabstops are highlighted with |hl-SnippetTabstop|.
 ---
 --- @param input string
 function M.expand(input)

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -201,8 +201,16 @@ static const char *highlight_init_both[] = {
   "default link SpecialComment Special",
   "default link Debug          Special",
   "default link Ignore         Normal",
-  "default link LspInlayHint   NonText",
-  "default link SnippetTabstop Visual",
+
+  // Built-in LSP
+  "default link LspCodeLens                 NonText",
+  "default link LspCodeLensSeparator        LspCodeLens",
+  "default link LspInlayHint                NonText",
+  "default link LspReferenceRead            LspReferenceText",
+  "default link LspReferenceText            Visual",
+  "default link LspReferenceWrite           LspReferenceText",
+  "default link LspSignatureActiveParameter Visual",
+  "default link SnippetTabstop              Visual",
 
   // Diagnostic
   "default link DiagnosticFloatingError    DiagnosticError",


### PR DESCRIPTION
After #28500 I realized that some LSP highlight groups did not have any default definitions (for example, `LspSignatureActiveParameter` for the now built-in `<C-S>` mapping). This PR fixes the issue.