### PR TITLE
test: override XDG_STATE_HOME as well

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -4,6 +4,7 @@ set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
 set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
 set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
+set(ENV{XDG_STATE_HOME} ${BUILD_DIR}/Xtest_xdg/state)
 unset(ENV{XDG_DATA_DIRS})
 unset(ENV{NVIM})  # Clear $NVIM in case tests are running from Nvim. #11009
 


### PR DESCRIPTION
This prevents tested Nvim from affecting ~/.local/state/
