### PR TITLE
docs: fix filetype.lua example for matching on contents

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2673,7 +2673,6 @@ vim.filetype.add({filetypes})                             *vim.filetype.add()*
         vim.filetype.add {
           pattern = {
             ['.*'] = {
-              priority = -math.huge,
               function(path, bufnr)
                 local content = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ''
                 if vim.regex([[^#!.*\\<mine\\>]]):match_str(content) ~= nil then
@@ -2682,6 +2681,7 @@ vim.filetype.add({filetypes})                             *vim.filetype.add()*
                   return 'drawing'
                 end
               end,
+              { priority = -math.huge },
             },
           },
         }

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2308,7 +2308,6 @@ end
 --- vim.filetype.add {
 ---   pattern = {
 ---     ['.*'] = {
----       priority = -math.huge,
 ---       function(path, bufnr)
 ---         local content = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1] or ''
 ---         if vim.regex([[^#!.*\\<mine\\>]]):match_str(content) ~= nil then
@@ -2317,6 +2316,7 @@ end
 ---           return 'drawing'
 ---         end
 ---       end,
+---       { priority = -math.huge },
 ---     },
 ---   },
 --- }


### PR DESCRIPTION
When using a table, the first value is the filetype string or function,
and the second value is the options table. The current example "works"
because the function still has index 1, but the priority field is
ignored.
