### PR TITLE
docs: fix snippets keymap examples

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4349,7 +4349,7 @@ vim.snippet.jump({direction})                             *vim.snippet.jump()*
 
     You can use this function to navigate a snippet as follows: >lua
         vim.keymap.set({ 'i', 's' }, '<Tab>', function()
-           if vim.snippet.jumpable(1) then
+           if vim.snippet.active({ direction = 1 }) then
              return '<cmd>lua vim.snippet.jump(1)<cr>'
            else
              return '<Tab>'

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -539,7 +539,7 @@ end
 ---
 --- ```lua
 --- vim.keymap.set({ 'i', 's' }, '<Tab>', function()
----    if vim.snippet.jumpable(1) then
+---    if vim.snippet.active({ direction = 1 }) then
 ---      return '<cmd>lua vim.snippet.jump(1)<cr>'
 ---    else
 ---      return '<Tab>'


### PR DESCRIPTION
The `vim.snippet.jumpable` function was removed in
[28560](https://github.com/neovim/neovim/pull/28560) but the docs still refer to it in the examples
leading to errors when trying to jump between snippets.
