### PR TITLE
fix(treesitter): escape `\` in `:InspectTree`

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -226,7 +226,7 @@ function TSTreeView:draw(bufnr)
         text = string.format('(%s', item.node:type())
       end
     else
-      text = string.format('"%s"', item.node:type():gsub('\n', '\\n'):gsub('"', '\\"'))
+      text = string.format('%q', item.node:type()):gsub('\n', 'n')
     end
 
     local next = self:get(i + 1)


### PR DESCRIPTION
Some parsers for, e.g., LaTeX or PHP have anonymous nodes like `"\"` or `"\text"` that behave wonkily (especially the first example) in the `InspectTree` window, so this PR escapes them by adding another backslash in front of them