### PR TITLE
docs(luacats): support backtick captured generic type

### DIFF
--- a/scripts/luacats_grammar.lua
+++ b/scripts/luacats_grammar.lua
@@ -170,7 +170,7 @@ local grammar = P {
   ltype = parenOpt(v.ty_union),
 
   ty_union = v.ty_opt * rep(Pf('|') * v.ty_opt),
-  ty = v.ty_fun + ident + v.ty_table + literal + paren(v.ty),
+  ty = v.ty_fun + ident + v.ty_table + literal + paren(v.ty) + v.ty_generic,
   ty_param = Pf('<') * comma1(v.ltype) * fill * P('>'),
   ty_opt = v.ty * opt(v.ty_param) * opt(P('[]')) * opt(P('?')),
   ty_index = (Pf('[') * (v.ltype + ident + rep1(num)) * fill * P(']')),
@@ -179,6 +179,7 @@ local grammar = P {
   ty_table = Pf('{') * comma1(v.table_elem) * fill * P('}'),
   fun_param = lname * opt(colon * v.ltype),
   ty_fun = Pf('fun') * paren(comma(lname * opt(colon * v.ltype))) * opt(colon * comma1(v.ltype)),
+  ty_generic = P('`') * letter * P('`'),
 }
 
 return grammar --[[@as nvim.luacats.grammar]]

--- a/test/functional/script/luacats_grammar_spec.lua
+++ b/test/functional/script/luacats_grammar_spec.lua
@@ -152,4 +152,11 @@ describe('luacats grammar', function()
     name = '[1]',
     type = 'integer',
   })
+
+  test('@param type `T` this is a generic type', {
+    desc = 'this is a generic type',
+    kind = 'param',
+    name = 'type',
+    type = '`T`',
+  })
 end)


### PR DESCRIPTION
Problem:
While LuaCATS's generics system are still considered WIP by luals, they currently support type captured generics.

See "Capture with Backtick" example:
https://luals.github.io/wiki/annotations/#generic

Solution:
Add support for it in the LuaCATS grammar