### PR TITLE
fix(terminal): report terminal window size in pixels

### DIFF
--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -171,7 +171,13 @@ int pty_process_spawn(PtyProcess *ptyproc)
   Process *proc = (Process *)ptyproc;
   assert(proc->err.closed);
   uv_signal_start(&proc->loop->children_watcher, chld_handler, SIGCHLD);
-  ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
+  ioctl(1, TIOCGWINSZ, &ptyproc->winsize);
+  ptyproc->winsize = (struct winsize){
+    ptyproc->height,
+    ptyproc->width,
+    ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col * ptyproc->width,
+    ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row * ptyproc->height,
+  };
   uv_disable_stdio_inheritance();
   int master;
   int pid = forkpty(&master, NULL, &termios_default, &ptyproc->winsize);
@@ -232,7 +238,13 @@ const char *pty_process_tty_name(PtyProcess *ptyproc)
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width, uint16_t height)
   FUNC_ATTR_NONNULL_ALL
 {
-  ptyproc->winsize = (struct winsize){ height, width, 0, 0 };
+  ioctl(ptyproc->tty_fd, TIOCGWINSZ, &ptyproc->winsize);
+  ptyproc->winsize = (struct winsize){
+    height,
+    width,
+    ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col * width,
+    ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row * height,
+  };
   ioctl(ptyproc->tty_fd, TIOCSWINSZ, &ptyproc->winsize);
 }
 

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -175,8 +175,8 @@ int pty_process_spawn(PtyProcess *ptyproc)
   ptyproc->winsize = (struct winsize){
     ptyproc->height,
     ptyproc->width,
-    ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col * ptyproc->width,
-    ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row * ptyproc->height,
+    (ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col) * ptyproc->width,
+    (ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row) * ptyproc->height,
   };
   uv_disable_stdio_inheritance();
   int master;
@@ -242,8 +242,8 @@ void pty_process_resize(PtyProcess *ptyproc, uint16_t width, uint16_t height)
   ptyproc->winsize = (struct winsize){
     height,
     width,
-    ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col * width,
-    ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row * height,
+    (ptyproc->winsize.ws_xpixel / ptyproc->winsize.ws_col) * width,
+    (ptyproc->winsize.ws_ypixel / ptyproc->winsize.ws_row) * height,
   };
   ioctl(ptyproc->tty_fd, TIOCSWINSZ, &ptyproc->winsize);
 }


### PR DESCRIPTION
Window size in pixels is required by some programs, reporting it can help those programs work inside NeoVim terminals.

Closes #8259.

However, this patch doesn't make [`icat`](https://sw.kovidgoyal.net/kitty/kittens/icat/) work. Instead, it just makes the program show another error, because the problem is not only related to window sizes in pixels but how escape sequences (specifically, APC) are handled.  See #4349, #20176.