### PR TITLE
fix(vim.json): properly treat luanil options as booleans

### DIFF
--- a/src/cjson/lua_cjson.c
+++ b/src/cjson/lua_cjson.c
@@ -174,9 +174,9 @@ typedef struct {
 
 typedef struct {
     /* convert null in json objects to lua nil instead of vim.NIL */
-    int luanil_object;
+    bool luanil_object;
     /* convert null in json arrays to lua nil instead of vim.NIL */
-    int luanil_array;
+    bool luanil_array;
 } json_options_t;
 
 typedef struct {
@@ -1453,15 +1453,11 @@ static int json_decode(lua_State *l)
         luaL_checktype(l, -1, LUA_TTABLE);
 
         lua_getfield(l, -1, "object");
-        if (!lua_isnil(l, -1)) {
-            options.luanil_object = true;
-        }
+        options.luanil_object = lua_toboolean(l, -1);
         lua_pop(l, 1);
 
         lua_getfield(l, -1, "array");
-        if (!lua_isnil(l, -1)) {
-            options.luanil_array = true;
-        }
+        options.luanil_array = lua_toboolean(l, -1);
         /* Also pop the luanil table */
         lua_pop(l, 2);
         break;

--- a/test/functional/lua/json_spec.lua
+++ b/test/functional/lua/json_spec.lua
@@ -32,6 +32,18 @@ describe('vim.json.decode()', function()
       baz = vim.NIL,
       foo = { a = 'b' },
     }, exec_lua([[return vim.json.decode(..., {})]], jsonstr))
+    eq(
+      {
+        arr = { 1, 2, vim.NIL },
+        bar = { 3, 7 },
+        baz = vim.NIL,
+        foo = { a = 'b' },
+      },
+      exec_lua(
+        [[return vim.json.decode(..., { luanil = { array = false, object = false } })]],
+        jsonstr
+      )
+    )
     eq({
       arr = { 1, 2, vim.NIL },
       bar = { 3, 7 },


### PR DESCRIPTION
Note: Upstream doesn't have this. It's an Nvim addition.

Fix #28619
