### PR TITLE
build: remove `lintdoc` from `lint` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ add_custom_target(lintcommit
 add_dependencies(lintcommit nvim_bin)
 
 add_custom_target(lint)
-add_dependencies(lint lintc lintlua lintsh lintcommit lintdoc)
+add_dependencies(lint lintc lintlua lintsh lintcommit)
 
 # Format
 add_glob_target(


### PR DESCRIPTION
`lintdoc` takes too long to be part of `lint`. It may be reintroduced
once it's possible to only run lintdoc on files that have been changed.
