### PR TITLE
fix(lsp): replace the bug-prone ternary operation

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -20,7 +20,11 @@ local bufstates = vim.defaulttable(function(_)
   return setmetatable({ applied = {} }, {
     __index = globalstate,
     __newindex = function(state, key, value)
-      rawset(state, key, (globalstate[key] ~= value) and value or nil)
+      if globalstate[key] == value then
+        rawset(state, key, nil)
+      else
+        rawset(state, key, value)
+      end
     end,
   })
 end)


### PR DESCRIPTION
There is some discussion about replacing if-else statements with ternary operations.

https://github.com/neovim/neovim/pull/28543#discussion_r1587123990

But both ways of writing are wrong, as long as the left side of `or` is `nil` or `value`, the value on the right side will always be selected.