### PR TITLE
refactor(snippet): rename exit() => stop()

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -373,6 +373,9 @@ Use existing common {verb} names (actions) if possible:
     - add:          Appends or inserts into a collection
     - attach:       Listens to something to get events from it (TODO: rename to "on"?)
     - call:         Calls a function
+    - cancel:       Cancels or dismisses an event or interaction, typically
+                    user-initiated and without error. (Compare "abort", which
+                    cancels and signals error/failure.)
     - clear:        Clears state but does not destroy the container
     - create:       Creates a new (non-trivial) thing (TODO: rename to "def"?)
     - del:          Deletes a thing (or group of things)
@@ -388,10 +391,14 @@ Use existing common {verb} names (actions) if possible:
     - open:         Opens something (a buffer, window, …)
     - parse:        Parses something into a structured form
     - set:          Sets a thing (or group of things)
+    - start:        Spin up a long-lived process. Prefer "enable" except when
+                    "start" is obviously more appropriate.
+    - stop:         Inverse of "start". Teardown a long-lived process.
     - try_{verb}:   Best-effort operation, failure returns null or error obj
 
 Do NOT use these deprecated verbs:
     - disable:      Prefer `enable(enable: boolean)`.
+    - exit:         Prefer "cancel" (or "stop" if appropriate).
     - is_disabled:  Prefer `is_enabled()`.
     - list:         Redundant with "get"
     - notify:       Redundant with "print", "echo"

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4330,9 +4330,6 @@ vim.snippet.active({filter})                            *vim.snippet.active()*
     Return: ~
         (`boolean`)
 
-vim.snippet.exit()                                        *vim.snippet.exit()*
-    Exits the current snippet.
-
 vim.snippet.expand({input})                             *vim.snippet.expand()*
     Expands the given snippet text. Refer to
     https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax
@@ -4360,6 +4357,9 @@ vim.snippet.jump({direction})                             *vim.snippet.jump()*
     Parameters: ~
       • {direction}  (`vim.snippet.Direction`) Navigation direction. -1 for
                      previous, 1 for next.
+
+vim.snippet.stop()                                        *vim.snippet.stop()*
+    Exits the current snippet.
 
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -176,6 +176,8 @@ cycle (Nvim HEAD, the "master" branch).
 • Renamed nvim_complete_set to nvim__complete_set and marked it as
   experimental.
 
+• Renamed vim.snippet.exit() to  vim.snippet.stop().
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -343,7 +343,7 @@ local function setup_autocmds(bufnr)
         or cursor_row > snippet_range[3]
         or (cursor_row == snippet_range[3] and cursor_col > snippet_range[4])
       then
-        M.exit()
+        M.stop()
         return true
       end
 
@@ -362,7 +362,7 @@ local function setup_autocmds(bufnr)
       end
 
       -- The cursor is either not on a tabstop or we reached the end, so exit the session.
-      M.exit()
+      M.stop()
       return true
     end,
   })
@@ -378,7 +378,7 @@ local function setup_autocmds(bufnr)
         (snippet_range[1] == snippet_range[3] and snippet_range[2] == snippet_range[4])
         or snippet_range[3] + 1 > vim.fn.line('$')
       then
-        M.exit()
+        M.stop()
       end
 
       if not M.active() then
@@ -615,7 +615,7 @@ function M.active(filter)
 end
 
 --- Exits the current snippet.
-function M.exit()
+function M.stop()
   if not M.active() then
     return
   end


### PR DESCRIPTION
Reduce "vocabulary creep".