### PR TITLE
fix(lsp): make the effective range determined by the loaded buffers

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -429,7 +429,7 @@ function M.enable(enable, filter)
 
   if filter.bufnr == nil then
     globalstate.enabled = enable
-    for bufnr, _ in pairs(bufstates) do
+    for _, bufnr in ipairs(api.nvim_list_bufs()) do
       if api.nvim_buf_is_loaded(bufnr) then
         if enable == false then
           _disable(bufnr)


### PR DESCRIPTION
Fix https://github.com/neovim/neovim/issues/28624.

If a buffer does not have a corresponding `bufstate` in `bufstates`, then `enable` all buffers will not take effect on it. 