### PR TITLE
feat: allow gx to function for markdown links

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -107,22 +107,25 @@ do
           vim.inspect(cmd.cmd)
         )
       end
-
-      if err then
-        vim.notify(err, vim.log.levels.ERROR)
-      end
+      return err
     end
 
     local gx_desc =
       'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
     vim.keymap.set({ 'n' }, 'gx', function()
-      do_open(vim.fn.expand('<cfile>'))
+      local err = do_open(require('vim.ui')._get_url())
+      if err then
+        vim.notify(err, vim.log.levels.ERROR)
+      end
     end, { desc = gx_desc })
     vim.keymap.set({ 'x' }, 'gx', function()
       local lines =
         vim.fn.getregion(vim.fn.getpos('.'), vim.fn.getpos('v'), { type = vim.fn.mode() })
       -- Trim whitespace on each line and concatenate.
-      do_open(table.concat(vim.iter(lines):map(vim.trim):totable()))
+      local err = do_open(table.concat(vim.iter(lines):map(vim.trim):totable()))
+      if err then
+        vim.notify(err, vim.log.levels.ERROR)
+      end
     end, { desc = gx_desc })
   end
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -162,4 +162,24 @@ function M.open(path)
   return vim.system(cmd, { text = true, detach = true }), nil
 end
 
+--- Gets the URL at cursor, if any.
+function M._get_url()
+  if vim.bo.filetype == 'markdown' then
+    local range = vim.api.nvim_win_get_cursor(0)
+    vim.treesitter.get_parser():parse(range)
+    -- marking the node as `markdown_inline` is required. Setting it to `markdown` does not
+    -- work.
+    local current_node = vim.treesitter.get_node { lang = 'markdown_inline' }
+    while current_node do
+      local type = current_node:type()
+      if type == 'inline_link' or type == 'image' then
+        local child = assert(current_node:named_child(1))
+        return vim.treesitter.get_node_text(child, 0)
+      end
+      current_node = current_node:parent()
+    end
+  end
+  return vim.fn.expand('<cfile>')
+end
+
 return M


### PR DESCRIPTION
In other words, `gx` works regardless of where it was used in
`[...](https://...)`. This only works on markdown buffers.