### PR TITLE
fix(lsp): rename LspProgress data.result => data.params

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -544,14 +544,14 @@ LspNotify                                                          *LspNotify*
 LspProgress                                                       *LspProgress*
     Upon receipt of a progress notification from the server. Notifications can
     be polled from a `progress` ring buffer of a |vim.lsp.Client| or use
-    |vim.lsp.status()| to get an aggregate message
+    |vim.lsp.status()| to get an aggregate message.
 
     If the server sends a "work done progress", the `pattern` is set to `kind`
     (one of `begin`, `report` or `end`).
 
     When used from Lua, the event contains a `data` table with `client_id` and
-    `result` properties. `result` will contain the request params sent by the
-    server.
+    `params` properties. `params` will contain the request params sent by the
+    server (see `lsp.ProgressParams`).
 
     Example: >vim
         autocmd LspProgress * redrawstatus

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -178,6 +178,8 @@ cycle (Nvim HEAD, the "master" branch).
 
 • Renamed vim.snippet.exit() to  vim.snippet.stop().
 
+• Changed |event-data| table for |LspProgress|: renamed `result` to `params`.
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -22,16 +22,16 @@ M[ms.workspace_executeCommand] = function(_, _, _, _)
 end
 
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress
----@param result lsp.ProgressParams
+---@param params lsp.ProgressParams
 ---@param ctx lsp.HandlerContext
-M[ms.dollar_progress] = function(_, result, ctx)
+M[ms.dollar_progress] = function(_, params, ctx)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   if not client then
     err_message('LSP[id=', tostring(ctx.client_id), '] client has shut down during progress update')
     return vim.NIL
   end
   local kind = nil
-  local value = result.value
+  local value = params.value
 
   if type(value) == 'table' then
     kind = value.kind
@@ -39,21 +39,21 @@ M[ms.dollar_progress] = function(_, result, ctx)
     -- So that consumers always have it available, even if they consume a
     -- subset of the full sequence
     if kind == 'begin' then
-      client.progress.pending[result.token] = value.title
+      client.progress.pending[params.token] = value.title
     else
-      value.title = client.progress.pending[result.token]
+      value.title = client.progress.pending[params.token]
       if kind == 'end' then
-        client.progress.pending[result.token] = nil
+        client.progress.pending[params.token] = nil
       end
     end
   end
 
-  client.progress:push(result)
+  client.progress:push(params)
 
   api.nvim_exec_autocmds('LspProgress', {
     pattern = kind,
     modeline = false,
-    data = { client_id = ctx.client_id, result = result },
+    data = { client_id = ctx.client_id, params = params },
   })
 end
 


### PR DESCRIPTION
Rename the field `result` to `params` in the `data` table for
`LspProgress` autocmds.

The previous name was chosen because the initial handler implementation (#23958)
mistakenly had a parameter name `result` instead of `params` for the
`$/progress` LSP "notification" handler. However, `params` would be a
more appropriate name that is more consistent with the underlying LSP
type (`ProgressParams`). See #27101 for more context.

See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress

This change is technically a breaking change within the nvim-0.10
development versions, so any existing autocmd handlers for `LspProgress`
might break after this commit. User configs and plugins are advised to
update autocmd handlers accordingly (see `:help LspProgress`).