### PR TITLE
vim-patch:ad4881cb3c04

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3014,7 +3014,7 @@ getscriptinfo([{opts}])                                        *getscriptinfo()*
 
 		Examples: >vim
 			echo getscriptinfo({'name': 'myscript'})
-			echo getscriptinfo({'sid': 15}).variables
+			echo getscriptinfo({'sid': 15})[0].variables
 <
 
 gettabinfo([{tabnr}])                                             *gettabinfo()*

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3628,7 +3628,7 @@ function vim.fn.getregtype(regname) end
 ---
 --- Examples: >vim
 ---   echo getscriptinfo({'name': 'myscript'})
----   echo getscriptinfo({'sid': 15}).variables
+---   echo getscriptinfo({'sid': 15})[0].variables
 --- <
 ---
 --- @param opts? table

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4470,7 +4470,7 @@ M.funcs = {
 
       Examples: >vim
       	echo getscriptinfo({'name': 'myscript'})
-      	echo getscriptinfo({'sid': 15}).variables
+      	echo getscriptinfo({'sid': 15})[0].variables
       <
     ]=],
     name = 'getscriptinfo',


### PR DESCRIPTION
#### vim-patch:ad4881cb3c04

runtime(doc): correct getscriptinfo() example (vim/vim#14718)

When "sid" is specified, it returns a List with a single item.

https://github.com/vim/vim/commit/ad4881cb3c04048242f69dc77af2dde889c9beea