### PR TITLE
feat(lsp): more support for vim.lsp.ListOpts.loclist

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1235,30 +1235,30 @@ add_workspace_folder({workspace_folder})
 clear_references()                            *vim.lsp.buf.clear_references()*
     Removes document highlights from current buffer.
 
-code_action({options})                             *vim.lsp.buf.code_action()*
+code_action({opts})                                *vim.lsp.buf.code_action()*
     Selects a code action available at the current cursor position.
 
     Parameters: ~
-      • {options}  (`table?`) A table with the following fields:
-                   • {context}? (`lsp.CodeActionContext`) Corresponds to
-                     `CodeActionContext` of the LSP specification:
-                     • {diagnostics}? (`table`) LSP `Diagnostic[]`. Inferred
-                       from the current position if not provided.
-                     • {only}? (`table`) List of LSP `CodeActionKind`s used to
-                       filter the code actions. Most language servers support
-                       values like `refactor` or `quickfix`.
-                     • {triggerKind}? (`integer`) The reason why code actions
-                       were requested.
-                   • {filter}? (`fun(x: lsp.CodeAction|lsp.Command):boolean`)
-                     Predicate taking an `CodeAction` and returning a boolean.
-                   • {apply}? (`boolean`) When set to `true`, and there is
-                     just one remaining action (after filtering), the action
-                     is applied without user query.
-                   • {range}? (`{start: integer[], end: integer[]}`) Range for
-                     which code actions should be requested. If in visual mode
-                     this defaults to the active selection. Table must contain
-                     `start` and `end` keys with {row,col} tuples using
-                     mark-like indexing. See |api-indexing|
+      • {opts}  (`table?`) A table with the following fields:
+                • {context}? (`lsp.CodeActionContext`) Corresponds to
+                  `CodeActionContext` of the LSP specification:
+                  • {diagnostics}? (`table`) LSP `Diagnostic[]`. Inferred from
+                    the current position if not provided.
+                  • {only}? (`table`) List of LSP `CodeActionKind`s used to
+                    filter the code actions. Most language servers support
+                    values like `refactor` or `quickfix`.
+                  • {triggerKind}? (`integer`) The reason why code actions
+                    were requested.
+                • {filter}? (`fun(x: lsp.CodeAction|lsp.Command):boolean`)
+                  Predicate taking an `CodeAction` and returning a boolean.
+                • {apply}? (`boolean`) When set to `true`, and there is just
+                  one remaining action (after filtering), the action is
+                  applied without user query.
+                • {range}? (`{start: integer[], end: integer[]}`) Range for
+                  which code actions should be requested. If in visual mode
+                  this defaults to the active selection. Table must contain
+                  `start` and `end` keys with {row,col} tuples using mark-like
+                  indexing. See |api-indexing|
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
@@ -1277,7 +1277,7 @@ completion({context})                               *vim.lsp.buf.completion()*
     See also: ~
       • vim.lsp.protocol.CompletionTriggerKind
 
-declaration({options})                             *vim.lsp.buf.declaration()*
+declaration({opts})                                *vim.lsp.buf.declaration()*
     Jumps to the declaration of the symbol under the cursor.
 
     Note: ~
@@ -1285,13 +1285,13 @@ declaration({options})                             *vim.lsp.buf.declaration()*
         |vim.lsp.buf.definition()| instead.
 
     Parameters: ~
-      • {options}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
+      • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
-definition({options})                               *vim.lsp.buf.definition()*
+definition({opts})                                  *vim.lsp.buf.definition()*
     Jumps to the definition of the symbol under the cursor.
 
     Parameters: ~
-      • {options}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
+      • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
     Send request to the server to resolve document highlights for the current
@@ -1307,11 +1307,11 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
     highlights. |hl-LspReferenceText| |hl-LspReferenceRead|
     |hl-LspReferenceWrite|
 
-document_symbol({options})                     *vim.lsp.buf.document_symbol()*
+document_symbol({opts})                        *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the quickfix window.
 
     Parameters: ~
-      • {options}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
 execute_command({command_params})              *vim.lsp.buf.execute_command()*
     Executes an LSP server command.
@@ -1322,53 +1322,53 @@ execute_command({command_params})              *vim.lsp.buf.execute_command()*
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand
 
-format({options})                                       *vim.lsp.buf.format()*
+format({opts})                                          *vim.lsp.buf.format()*
     Formats a buffer using the attached (and optionally filtered) language
     server clients.
 
     Parameters: ~
-      • {options}  (`table?`) A table with the following fields:
-                   • {formatting_options}? (`table`) Can be used to specify
-                     FormattingOptions. Some unspecified options will be
-                     automatically derived from the current Nvim options. See
-                     https://microsoft.github.io/language-server-protocol/specification/#formattingOptions
-                   • {timeout_ms}? (`integer`, default: `1000`) Time in
-                     milliseconds to block for formatting requests. No effect
-                     if async=true.
-                   • {bufnr}? (`integer`, default: current buffer) Restrict
-                     formatting to the clients attached to the given buffer.
-                   • {filter}? (`fun(client: vim.lsp.Client): boolean?`)
-                     Predicate used to filter clients. Receives a client as
-                     argument and must return a boolean. Clients matching the
-                     predicate are included. Example: >lua
-                       -- Never request typescript-language-server for formatting
-                       vim.lsp.buf.format {
-                         filter = function(client) return client.name ~= "tsserver" end
-                       }
+      • {opts}  (`table?`) A table with the following fields:
+                • {formatting_options}? (`table`) Can be used to specify
+                  FormattingOptions. Some unspecified options will be
+                  automatically derived from the current Nvim options. See
+                  https://microsoft.github.io/language-server-protocol/specification/#formattingOptions
+                • {timeout_ms}? (`integer`, default: `1000`) Time in
+                  milliseconds to block for formatting requests. No effect if
+                  async=true.
+                • {bufnr}? (`integer`, default: current buffer) Restrict
+                  formatting to the clients attached to the given buffer.
+                • {filter}? (`fun(client: vim.lsp.Client): boolean?`)
+                  Predicate used to filter clients. Receives a client as
+                  argument and must return a boolean. Clients matching the
+                  predicate are included. Example: >lua
+                    -- Never request typescript-language-server for formatting
+                    vim.lsp.buf.format {
+                      filter = function(client) return client.name ~= "tsserver" end
+                    }
 <
-                   • {async}? (`boolean`, default: false) If true the method
-                     won't block. Editing the buffer while formatting
-                     asynchronous can lead to unexpected changes.
-                   • {id}? (`integer`) Restrict formatting to the client with
-                     ID (client.id) matching this field.
-                   • {name}? (`string`) Restrict formatting to the client with
-                     name (client.name) matching this field.
-                   • {range}? (`{start:integer[],end:integer[]}`, default:
-                     current selection in visual mode, `nil` in other modes,
-                     formatting the full buffer) Range to format. Table must
-                     contain `start` and `end` keys with {row,col} tuples
-                     using (1,0) indexing.
+                • {async}? (`boolean`, default: false) If true the method
+                  won't block. Editing the buffer while formatting
+                  asynchronous can lead to unexpected changes.
+                • {id}? (`integer`) Restrict formatting to the client with ID
+                  (client.id) matching this field.
+                • {name}? (`string`) Restrict formatting to the client with
+                  name (client.name) matching this field.
+                • {range}? (`{start:integer[],end:integer[]}`, default:
+                  current selection in visual mode, `nil` in other modes,
+                  formatting the full buffer) Range to format. Table must
+                  contain `start` and `end` keys with {row,col} tuples using
+                  (1,0) indexing.
 
 hover()                                                  *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating
     window. Calling the function twice will jump into the floating window.
 
-implementation({options})                       *vim.lsp.buf.implementation()*
+implementation({opts})                          *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the
     quickfix window.
 
     Parameters: ~
-      • {options}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
+      • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
 incoming_calls()                                *vim.lsp.buf.incoming_calls()*
     Lists all the call sites of the symbol under the cursor in the |quickfix|
@@ -1383,13 +1383,13 @@ outgoing_calls()                                *vim.lsp.buf.outgoing_calls()*
     |quickfix| window. If the symbol can resolve to multiple items, the user
     can pick one in the |inputlist()|.
 
-references({context}, {options})                    *vim.lsp.buf.references()*
+references({context}, {opts})                       *vim.lsp.buf.references()*
     Lists all the references to the symbol under the cursor in the quickfix
     window.
 
     Parameters: ~
       • {context}  (`table?`) Context for the request
-      • {options}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {opts}     (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -1402,13 +1402,13 @@ remove_workspace_folder({workspace_folder})
     Parameters: ~
       • {workspace_folder}  (`string?`)
 
-rename({new_name}, {options})                           *vim.lsp.buf.rename()*
+rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
     Renames all references to the symbol under the cursor.
 
     Parameters: ~
       • {new_name}  (`string?`) If not provided, the user will be prompted for
                     a new name using |vim.ui.input()|.
-      • {options}   (`table?`) Additional options:
+      • {opts}      (`table?`) Additional options:
                     • {filter}? (`fun(client: vim.lsp.Client): boolean?`)
                       Predicate used to filter clients. Receives a client as
                       argument and must return a boolean. Clients matching the
@@ -1421,11 +1421,11 @@ signature_help()                                *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
     floating window.
 
-type_definition({options})                     *vim.lsp.buf.type_definition()*
+type_definition({opts})                        *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
 
     Parameters: ~
-      • {options}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
+      • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
 typehierarchy({kind})                            *vim.lsp.buf.typehierarchy()*
     Lists all the subtypes or supertypes of the symbol under the cursor in the
@@ -1435,7 +1435,7 @@ typehierarchy({kind})                            *vim.lsp.buf.typehierarchy()*
     Parameters: ~
       • {kind}  (`"subtypes"|"supertypes"`)
 
-workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
+workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
     Lists all symbols in the current workspace in the quickfix window.
 
     The list is filtered against {query}; if the argument is omitted from the
@@ -1443,8 +1443,8 @@ workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
     string means no filtering is done.
 
     Parameters: ~
-      • {query}    (`string?`) optional
-      • {options}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+      • {query}  (`string?`) optional
+      • {opts}   (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
 
 ==============================================================================

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1201,12 +1201,11 @@ Lua module: vim.lsp.buf                                              *lsp-buf*
                         vim.lsp.buf.references(nil, { on_list = on_list })
 <
 
-                    If you prefer loclist do something like this: >lua
-                        local function on_list(options)
-                          vim.fn.setloclist(0, {}, ' ', options)
-                          vim.cmd.lopen()
-                        end
+                    If you prefer loclist instead of qflist: >lua
+                        vim.lsp.buf.definition({ loclist = true })
+                        vim.lsp.buf.references(nil, { loclist = true })
 <
+      • {loclist}?  (`boolean`)
 
 *vim.lsp.LocationOpts*
     Extends: |vim.lsp.ListOpts|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -266,6 +266,9 @@ The following new APIs and features were added.
     respective capability can be unset.
   • |vim.lsp.start()| accepts a "silent" option for suppressing messages
     if an LSP server failed to start.
+  • |vim.lsp.buf.definition()|, |vim.lsp.buf.declaration()|,
+    |vim.lsp.buf.type_definition()|, and |vim.lsp.buf.implementation()| now
+    support the `loclist` field of |vim.lsp.ListOpts|.
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -35,13 +35,13 @@ function M.hover()
   request(ms.textDocument_hover, params)
 end
 
-local function request_with_options(name, params, options)
+local function request_with_opts(name, params, opts)
   local req_handler --- @type function?
-  if options then
+  if opts then
     req_handler = function(err, result, ctx, config)
       local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
       local handler = client.handlers[name] or vim.lsp.handlers[name]
-      handler(err, result, ctx, vim.tbl_extend('force', config or {}, options))
+      handler(err, result, ctx, vim.tbl_extend('force', config or {}, opts))
     end
   end
   request(name, params, req_handler)
@@ -83,32 +83,32 @@ end
 
 --- Jumps to the declaration of the symbol under the cursor.
 --- @note Many servers do not implement this method. Generally, see |vim.lsp.buf.definition()| instead.
---- @param options? vim.lsp.LocationOpts
-function M.declaration(options)
+--- @param opts? vim.lsp.LocationOpts
+function M.declaration(opts)
   local params = util.make_position_params()
-  request_with_options(ms.textDocument_declaration, params, options)
+  request_with_opts(ms.textDocument_declaration, params, opts)
 end
 
 --- Jumps to the definition of the symbol under the cursor.
---- @param options? vim.lsp.LocationOpts
-function M.definition(options)
+--- @param opts? vim.lsp.LocationOpts
+function M.definition(opts)
   local params = util.make_position_params()
-  request_with_options(ms.textDocument_definition, params, options)
+  request_with_opts(ms.textDocument_definition, params, opts)
 end
 
 --- Jumps to the definition of the type of the symbol under the cursor.
---- @param options? vim.lsp.LocationOpts
-function M.type_definition(options)
+--- @param opts? vim.lsp.LocationOpts
+function M.type_definition(opts)
   local params = util.make_position_params()
-  request_with_options(ms.textDocument_typeDefinition, params, options)
+  request_with_opts(ms.textDocument_typeDefinition, params, opts)
 end
 
 --- Lists all the implementations for the symbol under the cursor in the
 --- quickfix window.
---- @param options? vim.lsp.LocationOpts
-function M.implementation(options)
+--- @param opts? vim.lsp.LocationOpts
+function M.implementation(opts)
   local params = util.make_position_params()
-  request_with_options(ms.textDocument_implementation, params, options)
+  request_with_opts(ms.textDocument_implementation, params, opts)
 end
 
 --- Displays signature information about the symbol under the cursor in a
@@ -213,25 +213,25 @@ end
 --- Formats a buffer using the attached (and optionally filtered) language
 --- server clients.
 ---
---- @param options? vim.lsp.buf.format.Opts
-function M.format(options)
-  options = options or {}
-  local bufnr = options.bufnr or api.nvim_get_current_buf()
+--- @param opts? vim.lsp.buf.format.Opts
+function M.format(opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or api.nvim_get_current_buf()
   local mode = api.nvim_get_mode().mode
-  local range = options.range
+  local range = opts.range
   if not range and mode == 'v' or mode == 'V' then
     range = range_from_selection(bufnr, mode)
   end
   local method = range and ms.textDocument_rangeFormatting or ms.textDocument_formatting
 
   local clients = vim.lsp.get_clients({
-    id = options.id,
+    id = opts.id,
     bufnr = bufnr,
-    name = options.name,
+    name = opts.name,
     method = method,
   })
-  if options.filter then
-    clients = vim.tbl_filter(options.filter, clients)
+  if opts.filter then
+    clients = vim.tbl_filter(opts.filter, clients)
   end
 
   if #clients == 0 then
@@ -250,12 +250,12 @@ function M.format(options)
     return params
   end
 
-  if options.async then
+  if opts.async then
     local function do_format(idx, client)
       if not client then
         return
       end
-      local params = set_range(client, util.make_formatting_params(options.formatting_options))
+      local params = set_range(client, util.make_formatting_params(opts.formatting_options))
       client.request(method, params, function(...)
         local handler = client.handlers[method] or vim.lsp.handlers[method]
         handler(...)
@@ -264,9 +264,9 @@ function M.format(options)
     end
     do_format(next(clients))
   else
-    local timeout_ms = options.timeout_ms or 1000
+    local timeout_ms = opts.timeout_ms or 1000
     for _, client in pairs(clients) do
-      local params = set_range(client, util.make_formatting_params(options.formatting_options))
+      local params = set_range(client, util.make_formatting_params(opts.formatting_options))
       local result, err = client.request_sync(method, params, timeout_ms, bufnr)
       if result and result.result then
         util.apply_text_edits(result.result, bufnr, client.offset_encoding)
@@ -295,18 +295,18 @@ end
 ---
 ---@param new_name string|nil If not provided, the user will be prompted for a new
 ---                name using |vim.ui.input()|.
----@param options? vim.lsp.buf.rename.Opts Additional options:
-function M.rename(new_name, options)
-  options = options or {}
-  local bufnr = options.bufnr or api.nvim_get_current_buf()
+---@param opts? vim.lsp.buf.rename.Opts Additional options:
+function M.rename(new_name, opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or api.nvim_get_current_buf()
   local clients = vim.lsp.get_clients({
     bufnr = bufnr,
-    name = options.name,
+    name = opts.name,
     -- Clients must at least support rename, prepareRename is optional
     method = ms.textDocument_rename,
   })
-  if options.filter then
-    clients = vim.tbl_filter(options.filter, clients)
+  if opts.filter then
+    clients = vim.tbl_filter(opts.filter, clients)
   end
 
   if #clients == 0 then
@@ -415,21 +415,21 @@ end
 ---
 ---@param context (table|nil) Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
----@param options? vim.lsp.ListOpts
-function M.references(context, options)
+---@param opts? vim.lsp.ListOpts
+function M.references(context, opts)
   validate({ context = { context, 't', true } })
   local params = util.make_position_params()
   params.context = context or {
     includeDeclaration = true,
   }
-  request_with_options(ms.textDocument_references, params, options)
+  request_with_opts(ms.textDocument_references, params, opts)
 end
 
 --- Lists all symbols in the current buffer in the quickfix window.
---- @param options? vim.lsp.ListOpts
-function M.document_symbol(options)
+--- @param opts? vim.lsp.ListOpts
+function M.document_symbol(opts)
   local params = { textDocument = util.make_text_document_params() }
-  request_with_options(ms.textDocument_documentSymbol, params, options)
+  request_with_opts(ms.textDocument_documentSymbol, params, opts)
 end
 
 --- @param call_hierarchy_items lsp.CallHierarchyItem[]?
@@ -542,7 +542,7 @@ function M.typehierarchy(kind)
         )
       end
     else
-      local opts = {
+      local select_opts = {
         prompt = 'Select a type hierarchy item:',
         kind = 'typehierarchy',
         format_item = function(item)
@@ -553,7 +553,7 @@ function M.typehierarchy(kind)
         end,
       }
 
-      vim.ui.select(merged_results, opts, function(item)
+      vim.ui.select(merged_results, select_opts, function(item)
         local client = vim.lsp.get_client_by_id(item[1])
         if client then
           --- @type lsp.TypeHierarchyItem
@@ -626,14 +626,14 @@ end
 --- string means no filtering is done.
 ---
 --- @param query string? optional
---- @param options? vim.lsp.ListOpts
-function M.workspace_symbol(query, options)
+--- @param opts? vim.lsp.ListOpts
+function M.workspace_symbol(query, opts)
   query = query or npcall(vim.fn.input, 'Query: ')
   if query == nil then
     return
   end
   local params = { query = query }
-  request_with_options(ms.workspace_symbol, params, options)
+  request_with_opts(ms.workspace_symbol, params, opts)
 end
 
 --- Send request to the server to resolve document highlights for the current
@@ -825,19 +825,19 @@ end
 --- Selects a code action available at the current
 --- cursor position.
 ---
----@param options? vim.lsp.buf.code_action.Opts
+---@param opts? vim.lsp.buf.code_action.Opts
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 ---@see vim.lsp.protocol.CodeActionTriggerKind
-function M.code_action(options)
-  validate({ options = { options, 't', true } })
-  options = options or {}
+function M.code_action(opts)
+  validate({ options = { opts, 't', true } })
+  opts = opts or {}
   -- Detect old API call code_action(context) which should now be
   -- code_action({ context = context} )
   --- @diagnostic disable-next-line:undefined-field
-  if options.diagnostics or options.only then
-    options = { options = options }
+  if opts.diagnostics or opts.only then
+    opts = { options = opts }
   end
-  local context = options.context or {}
+  local context = opts.context or {}
   if not context.triggerKind then
     context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
   end
@@ -867,17 +867,17 @@ function M.code_action(options)
     results[ctx.client_id] = { error = err, result = result, ctx = ctx }
     remaining = remaining - 1
     if remaining == 0 then
-      on_code_action_results(results, options)
+      on_code_action_results(results, opts)
     end
   end
 
   for _, client in ipairs(clients) do
     ---@type lsp.CodeActionParams
     local params
-    if options.range then
-      assert(type(options.range) == 'table', 'code_action range must be a table')
-      local start = assert(options.range.start, 'range must have a `start` property')
-      local end_ = assert(options.range['end'], 'range must have a `end` property')
+    if opts.range then
+      assert(type(opts.range) == 'table', 'code_action range must be a table')
+      local start = assert(opts.range.start, 'range must have a `start` property')
+      local end_ = assert(opts.range['end'], 'range must have a `end` property')
       params = util.make_given_range_params(start, end_, bufnr, client.offset_encoding)
     elseif mode == 'v' or mode == 'V' then
       local range = range_from_selection(bufnr, mode)

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -62,14 +62,13 @@ end
 --- vim.lsp.buf.references(nil, { on_list = on_list })
 --- ```
 ---
---- If you prefer loclist do something like this:
+--- If you prefer loclist instead of qflist:
 --- ```lua
---- local function on_list(options)
----   vim.fn.setloclist(0, {}, ' ', options)
----   vim.cmd.lopen()
---- end
+--- vim.lsp.buf.definition({ loclist = true })
+--- vim.lsp.buf.references(nil, { loclist = true })
 --- ```
 --- @field on_list? fun(t: vim.lsp.LocationOpts.OnList)
+--- @field loclist? boolean
 
 --- @class vim.lsp.LocationOpts.OnList
 --- @field items table[] Structured like |setqflist-what|

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -253,14 +253,15 @@ M[ms.textDocument_references] = function(_, result, ctx, config)
   local title = 'References'
   local items = util.locations_to_items(result, client.offset_encoding)
 
+  local list = { title = title, items = items, context = ctx }
   if config.loclist then
-    vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
+    vim.fn.setloclist(0, {}, ' ', list)
     api.nvim_command('lopen')
   elseif config.on_list then
     assert(vim.is_callable(config.on_list), 'on_list is not a function')
-    config.on_list({ title = title, items = items, context = ctx })
+    config.on_list(list)
   else
-    vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
+    vim.fn.setqflist({}, ' ', list)
     api.nvim_command('botright copen')
   end
 end
@@ -286,14 +287,15 @@ local function response_to_list(map_result, entity, title_fn)
     local title = title_fn(ctx)
     local items = map_result(result, ctx.bufnr)
 
+    local list = { title = title, items = items, context = ctx }
     if config.loclist then
-      vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
+      vim.fn.setloclist(0, {}, ' ', list)
       api.nvim_command('lopen')
     elseif config.on_list then
       assert(vim.is_callable(config.on_list), 'on_list is not a function')
-      config.on_list({ title = title, items = items, context = ctx })
+      config.on_list(list)
     else
-      vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
+      vim.fn.setqflist({}, ' ', list)
       api.nvim_command('botright copen')
     end
   end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -443,8 +443,13 @@ local function location_handler(_, result, ctx, config)
     util.jump_to_location(result[1], client.offset_encoding, config.reuse_win)
     return
   end
-  vim.fn.setqflist({}, ' ', { title = title, items = items })
-  vim.cmd('botright copen')
+  if config.loclist then
+    vim.fn.setloclist(0, {}, ' ', { title = title, items = items })
+    vim.cmd.lopen()
+  else
+    vim.fn.setqflist({}, ' ', { title = title, items = items })
+    vim.cmd('botright copen')
+  end
 end
 
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_declaration

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -257,7 +257,7 @@ M[ms.textDocument_references] = function(_, result, ctx, config)
     vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
     api.nvim_command('lopen')
   elseif config.on_list then
-    assert(type(config.on_list) == 'function', 'on_list is not a function')
+    assert(vim.is_callable(config.on_list), 'on_list is not a function')
     config.on_list({ title = title, items = items, context = ctx })
   else
     vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
@@ -290,7 +290,7 @@ local function response_to_list(map_result, entity, title_fn)
       vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
       api.nvim_command('lopen')
     elseif config.on_list then
-      assert(type(config.on_list) == 'function', 'on_list is not a function')
+      assert(vim.is_callable(config.on_list), 'on_list is not a function')
       config.on_list({ title = title, items = items, context = ctx })
     else
       vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
@@ -436,7 +436,7 @@ local function location_handler(_, result, ctx, config)
   local items = util.locations_to_items(result, client.offset_encoding)
 
   if config.on_list then
-    assert(type(config.on_list) == 'function', 'on_list is not a function')
+    assert(vim.is_callable(config.on_list), 'on_list is not a function')
     config.on_list({ title = title, items = items })
     return
   end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -268,10 +268,7 @@ end
 
 --- Return a function that converts LSP responses to list items and opens the list
 ---
---- The returned function has an optional {config} parameter that accepts a table
---- with the following keys:
----
----   loclist: (boolean) use the location list (default is to use the quickfix list)
+--- The returned function has an optional {config} parameter that accepts |vim.lsp.ListOpts|
 ---
 ---@param map_result fun(resp, bufnr: integer): table to convert the response
 ---@param entity string name of the resource used in a `not found` error message

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -256,13 +256,13 @@ M[ms.textDocument_references] = function(_, result, ctx, config)
   local list = { title = title, items = items, context = ctx }
   if config.loclist then
     vim.fn.setloclist(0, {}, ' ', list)
-    api.nvim_command('lopen')
+    vim.cmd.lopen()
   elseif config.on_list then
     assert(vim.is_callable(config.on_list), 'on_list is not a function')
     config.on_list(list)
   else
     vim.fn.setqflist({}, ' ', list)
-    api.nvim_command('botright copen')
+    vim.cmd('botright copen')
   end
 end
 
@@ -290,13 +290,13 @@ local function response_to_list(map_result, entity, title_fn)
     local list = { title = title, items = items, context = ctx }
     if config.loclist then
       vim.fn.setloclist(0, {}, ' ', list)
-      api.nvim_command('lopen')
+      vim.cmd.lopen()
     elseif config.on_list then
       assert(vim.is_callable(config.on_list), 'on_list is not a function')
       config.on_list(list)
     else
       vim.fn.setqflist({}, ' ', list)
-      api.nvim_command('botright copen')
+      vim.cmd('botright copen')
     end
   end
 end
@@ -447,7 +447,7 @@ local function location_handler(_, result, ctx, config)
     return
   end
   vim.fn.setqflist({}, ' ', { title = title, items = items })
-  api.nvim_command('botright copen')
+  vim.cmd('botright copen')
 end
 
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_declaration
@@ -557,7 +557,7 @@ local function make_call_hierarchy_handler(direction)
       end
     end
     vim.fn.setqflist({}, ' ', { title = 'LSP call hierarchy', items = items })
-    api.nvim_command('botright copen')
+    vim.cmd('botright copen')
   end
 end
 
@@ -596,7 +596,7 @@ local function make_type_hierarchy_handler()
       })
     end
     vim.fn.setqflist({}, ' ', { title = 'LSP type hierarchy', items = items })
-    api.nvim_command('botright copen')
+    vim.cmd('botright copen')
   end
 end
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -273,7 +273,7 @@ end
 ---
 ---   loclist: (boolean) use the location list (default is to use the quickfix list)
 ---
----@param map_result function `((resp, bufnr) -> list)` to convert the response
+---@param map_result fun(resp, bufnr: integer): table to convert the response
 ---@param entity string name of the resource used in a `not found` error message
 ---@param title_fn fun(ctx: lsp.HandlerContext): string Function to call to generate list title
 ---@return lsp.Handler


### PR DESCRIPTION
This PR mostly applies some suggestions mentioned in #28483 to the test of `buf.lua` and `handlers.lua`. 

Also, I noticed that the `loclist` field of `vim.lsp.ListOpts` was used in some places, but it wasn't actually documented. So I fixed that and also added support for `loclist` in a place where it was missing up to now