### PR TITLE
feat/docs(editorconfig): add support for spelling_language

### DIFF
--- a/runtime/doc/editorconfig.txt
+++ b/runtime/doc/editorconfig.txt
@@ -80,8 +80,7 @@ root                                                       *editorconfig.root*
 
 spelling_language                             *editorconfig.spelling_language*
     A code of the format ss or ss-TT, where ss is an ISO 639 language code and
-    TT is an ISO 3166 territory identifier. Sets the 'spell' and 'spelllang'
-    options.
+    TT is an ISO 3166 territory identifier. Sets the 'spelllang' option.
 
 tab_width                                             *editorconfig.tab_width*
     The display size of a single tab character. Sets the 'tabstop' option.

--- a/runtime/doc/editorconfig.txt
+++ b/runtime/doc/editorconfig.txt
@@ -78,6 +78,11 @@ root                                                       *editorconfig.root*
     directories. This property must be at the top-level of the `.editorconfig`
     file (i.e. it must not be within a glob section).
 
+spelling_language                             *editorconfig.spelling_language*
+    A code of the format ss or ss-TT, where ss is an ISO 639 language code and
+    TT is an ISO 3166 territory identifier. Sets the 'spell' and 'spelllang'
+    options.
+
 tab_width                                             *editorconfig.tab_width*
     The display size of a single tab character. Sets the 'tabstop' option.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -128,9 +128,7 @@ PERFORMANCE
 
 PLUGINS
 
-• TODO
-
-• Editorconfig
+• EditorConfig
   • spelling_language property is now supported.
 
 STARTUP

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -130,6 +130,9 @@ PLUGINS
 
 • TODO
 
+• Editorconfig
+  • spelling_language property is now supported.
+
 STARTUP
 
 • TODO

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -203,6 +203,8 @@ function properties.spelling_language(bufnr, val)
   if val:len() == 2 then
     vim.bo[bufnr].spelllang = language_code
   else
+    assert(val:sub(3, 3) == '-', error_msg)
+
     local territory_code = val:sub(4, 5):lower()
     assert(language_code:match('%l%l'), error_msg)
     vim.bo[bufnr].spelllang = language_code .. '_' .. territory_code

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -206,7 +206,7 @@ function properties.spelling_language(bufnr, val)
     assert(val:sub(3, 3) == '-', error_msg)
 
     local territory_code = val:sub(4, 5):lower()
-    assert(language_code:match('%l%l'), error_msg)
+    assert(territory_code:match('%l%l'), error_msg)
     vim.bo[bufnr].spelllang = language_code .. '_' .. territory_code
   end
 

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -193,19 +193,19 @@ end
 --- A code of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.
 --- Sets the 'spell' and 'spelllang' options.
 function properties.spelling_language(bufnr, val)
-  local errorMsg =
+  local error_msg =
     'spelling_language must be of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.'
 
-  assert(val:len() == 2 or val:len() == 5, errorMsg)
+  assert(val:len() == 2 or val:len() == 5, error_msg)
 
-  local languageCode = val:sub(1, 2):lower()
-  assert(languageCode:match('%l%l'), errorMsg)
+  local language_code = val:sub(1, 2):lower()
+  assert(language_code:match('%l%l'), error_msg)
   if val:len() == 2 then
-    vim.bo[bufnr].spelllang = languageCode
+    vim.bo[bufnr].spelllang = language_code
   else
-    local territoryCode = val:sub(4, 5):lower()
-    assert(languageCode:match('%l%l'), errorMsg)
-    vim.bo[bufnr].spelllang = languageCode .. '_' .. territoryCode
+    local territory_code = val:sub(4, 5):lower()
+    assert(language_code:match('%l%l'), error_msg)
+    vim.bo[bufnr].spelllang = language_code .. '_' .. territory_code
   end
 
   vim.o.spell = true

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -191,7 +191,7 @@ function properties.insert_final_newline(bufnr, val)
 end
 
 --- A code of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.
---- Sets the 'spell' and 'spelllang' options.
+--- Sets the 'spelllang' option.
 function properties.spelling_language(bufnr, val)
   local error_msg =
     'spelling_language must be of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.'
@@ -209,8 +209,6 @@ function properties.spelling_language(bufnr, val)
     assert(territory_code:match('%l%l'), error_msg)
     vim.bo[bufnr].spelllang = language_code .. '_' .. territory_code
   end
-
-  vim.o.spell = true
 end
 
 --- @private

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -190,6 +190,27 @@ function properties.insert_final_newline(bufnr, val)
   end
 end
 
+--- A code of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.
+--- Sets the 'spell' and 'spelllang' options.
+function properties.spelling_language(bufnr, val)
+  local errorMsg =
+    'spelling_language must be of the format ss or ss-TT, where ss is an ISO 639 language code and TT is an ISO 3166 territory identifier.'
+
+  assert(val:len() == 2 or val:len() == 5, errorMsg)
+
+  local languageCode = val:sub(1, 2):lower()
+  assert(languageCode:match('%l%l'), errorMsg)
+  if val:len() == 2 then
+    vim.bo[bufnr].spelllang = languageCode
+  else
+    local territoryCode = val:sub(4, 5):lower()
+    assert(languageCode:match('%l%l'), errorMsg)
+    vim.bo[bufnr].spelllang = languageCode .. '_' .. territoryCode
+  end
+
+  vim.o.spell = true
+end
+
 --- @private
 --- Modified version of [glob2regpat()] that does not match path separators on `*`.
 ---

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -103,10 +103,10 @@ setup(function()
     max_line_length = 42
 
     [short_spelling_language.txt]
-    spelling_language = en
+    spelling_language = de
 
     [long_spelling_language.txt]
-    spelling_language = en-US
+    spelling_language = en-NZ
     ]]
   )
 end)
@@ -238,7 +238,7 @@ But not this one
   end)
 
   it('sets spell, spelllang options', function()
-    test_case('short_spelling_language.txt', { spell = true, spelllang = 'en' })
-    test_case('long_spelling_language.txt', { spell = true, spelllang = 'en_us' })
+    test_case('short_spelling_language.txt', { spell = true, spelllang = 'de' })
+    test_case('long_spelling_language.txt', { spell = true, spelllang = 'en_nz' })
   end)
 end)

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -21,12 +21,10 @@ local function test_case(name, expected)
     local opt_info = api.nvim_get_option_info2(opt)
     if opt_info.scope == 'win' then
       eq(val, api.nvim_get_option_value(opt, { win = 0 }), name)
+    elseif opt_info.scope == 'buf' then
+      eq(val, api.nvim_get_option_value(opt, { buf = 0 }), name)
     else
-      if opt_info.scope == 'buf' then
-        eq(val, api.nvim_get_option_value(opt, { buf = 0 }), name)
-      else
-        eq(val, api.nvim_get_option_value(opt), name)
-      end
+      eq(val, api.nvim_get_option_value(opt), name)
     end
   end
 end

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -16,8 +16,18 @@ local testdir = 'Xtest-editorconfig'
 local function test_case(name, expected)
   local filename = testdir .. pathsep .. name
   command('edit ' .. filename)
+
   for opt, val in pairs(expected) do
-    eq(val, api.nvim_get_option_value(opt, { buf = 0 }), name)
+    local opt_info = api.nvim_get_option_info2(opt)
+    if opt_info.scope == 'win' then
+      eq(val, api.nvim_get_option_value(opt, { win = 0 }), name)
+    else
+      if opt_info.scope == 'buf' then
+        eq(val, api.nvim_get_option_value(opt, { buf = 0 }), name)
+      else
+        eq(val, api.nvim_get_option_value(opt), name)
+      end
+    end
   end
 end
 

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -237,8 +237,8 @@ But not this one
     eq(true, ok, err)
   end)
 
-  it('sets spell, spelllang options', function()
-    test_case('short_spelling_language.txt', { spell = true, spelllang = 'de' })
-    test_case('long_spelling_language.txt', { spell = true, spelllang = 'en_nz' })
+  it('sets spelllang', function()
+    test_case('short_spelling_language.txt', { spelllang = 'de' })
+    test_case('long_spelling_language.txt', { spelllang = 'en_nz' })
   end)
 end)

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -93,6 +93,12 @@ setup(function()
 
     [max_line_length.txt]
     max_line_length = 42
+
+    [short_spelling_language.txt]
+    spelling_language = en
+
+    [long_spelling_language.txt]
+    spelling_language = en-US
     ]]
   )
 end)
@@ -221,5 +227,10 @@ But not this one
     ]]))
 
     eq(true, ok, err)
+  end)
+
+  it('sets spell, spelllang options', function()
+    test_case('short_spelling_language.txt', { spell = true, spelllang = 'en' })
+    test_case('long_spelling_language.txt', { spell = true, spelllang = 'en_us' })
   end)
 end)

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -18,13 +18,13 @@ local function test_case(name, expected)
   command('edit ' .. filename)
 
   for opt, val in pairs(expected) do
-    local opt_info = api.nvim_get_option_info2(opt)
+    local opt_info = api.nvim_get_option_info2(opt, {})
     if opt_info.scope == 'win' then
       eq(val, api.nvim_get_option_value(opt, { win = 0 }), name)
     elseif opt_info.scope == 'buf' then
       eq(val, api.nvim_get_option_value(opt, { buf = 0 }), name)
     else
-      eq(val, api.nvim_get_option_value(opt), name)
+      eq(val, api.nvim_get_option_value(opt, {}), name)
     end
   end
 end


### PR DESCRIPTION
This fixes #28626.

For the other **editorconfig** properties it's easier to check for validity since they are either a number or part of an enum with few elements. The problem for `spelling_language` is that it is part of a greater enum since it's a concatenation of a [ISO 639 language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) and an optional [ISO 3166 territory identifier](https://www.iso.org/obp/ui/#search).

For now the code only checks that the value provided in `spelling_language` is of the format [a-z][a-z] or [a-z][a-z]-[a-z][a-z] (regex), but it doesn't check whether it is a valid ISO639/ISO3166 code and thus when inputting an invalid value the `spelllang` option is also set to an unknown language (this results in a prompt asking you to download the unknown language and then failing and continuing if accepted).