### PR TITLE
feat(lsp): add related_information to vim.Diagnostic

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -350,21 +350,25 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
     0-based rows and columns). |api-indexing|
 
     Fields: ~
-      • {bufnr}?      (`integer`) Buffer number
-      • {lnum}        (`integer`) The starting line of the diagnostic
-                      (0-indexed)
-      • {end_lnum}?   (`integer`) The final line of the diagnostic (0-indexed)
-      • {col}         (`integer`) The starting column of the diagnostic
-                      (0-indexed)
-      • {end_col}?    (`integer`) The final column of the diagnostic
-                      (0-indexed)
-      • {severity}?   (`vim.diagnostic.Severity`) The severity of the
-                      diagnostic |vim.diagnostic.severity|
-      • {message}     (`string`) The diagnostic text
-      • {source}?     (`string`) The source of the diagnostic
-      • {code}?       (`string|integer`) The diagnostic code
-      • {user_data}?  (`any`) arbitrary data plugins can add
-      • {namespace}?  (`integer`)
+      • {bufnr}?                (`integer`) Buffer number
+      • {lnum}                  (`integer`) The starting line of the
+                                diagnostic (0-indexed)
+      • {end_lnum}?             (`integer`) The final line of the diagnostic
+                                (0-indexed)
+      • {col}                   (`integer`) The starting column of the
+                                diagnostic (0-indexed)
+      • {end_col}?              (`integer`) The final column of the diagnostic
+                                (0-indexed)
+      • {severity}?             (`vim.diagnostic.Severity`) The severity of
+                                the diagnostic |vim.diagnostic.severity|
+      • {message}               (`string`) The diagnostic text
+      • {related_information}?  (`vim.diagnostic.RelatedInformation[]`) An
+                                array of related diagnostic information. See
+                                |vim.diagnostic.RelatedInformation|.
+      • {source}?               (`string`) The source of the diagnostic
+      • {code}?                 (`string|integer`) The diagnostic code
+      • {user_data}?            (`any`) arbitrary data plugins can add
+      • {namespace}?            (`integer`)
 
 *vim.diagnostic.GetOpts*
     A table with the following keys:
@@ -596,6 +600,23 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                               |nvim_buf_set_extmark()|.
       • {virt_text_win_col}?  (`integer`) See |nvim_buf_set_extmark()|.
       • {virt_text_hide}?     (`boolean`) See |nvim_buf_set_extmark()|.
+
+*vim.diagnostic.RelatedInformation*
+    Related message and location for a diagnostic. This can be used to point
+    to code locations that cause or are related to a diagnostic, e.g when
+    duplicating a symbol in a scope.
+
+    Fields: ~
+      • {bufnr}?     (`integer`) Buffer number
+      • {lnum}       (`integer`) The starting line of the related information
+                     (0-indexed)
+      • {end_lnum}?  (`integer`) The final line of the related information
+                     (0-indexed)
+      • {col}        (`integer`) The starting column of the related
+                     information (0-indexed)
+      • {end_col}?   (`integer`) The final column of the related information
+                     (0-indexed)
+      • {message}    (`string`) The related information text
 
 
 config({opts}, {namespace})                          *vim.diagnostic.config()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -114,6 +114,9 @@ LSP
 • Completion side effects (including snippet expansion, execution of commands
   and application of additional text edits) is now built-in.
 • |vim.lsp.util.locations_to_items()| sets `end_col` and `end_lnum` fields.
+• Add a new `related_information` field to |vim.Diagnostic| in favor of
+  `vim.Diagnostic.user_data.lsp.relatedInformation` (now deprecated). See
+  |vim.diagnostic.RelatedInformation|.
 
 LUA
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -29,6 +29,9 @@ local M = {}
 --- The diagnostic text
 --- @field message string
 ---
+--- An array of related diagnostic information
+--- @field related_information? vim.diagnostic.RelatedInformation[]
+---
 --- The source of the diagnostic
 --- @field source? string
 ---
@@ -41,6 +44,29 @@ local M = {}
 --- @field user_data? any arbitrary data plugins can add
 ---
 --- @field namespace? integer
+
+--- Related message and location for a diagnostic.
+--- This can be used to point to code locations that cause or are related to
+--- a diagnostic, e.g when duplicating a symbol in a scope.
+--- @class vim.diagnostic.RelatedInformation
+---
+--- Buffer number
+--- @field bufnr? integer
+---
+--- The starting line of the related information (0-indexed)
+--- @field lnum integer
+---
+--- The final line of the related information (0-indexed)
+--- @field end_lnum? integer
+---
+--- The starting column of the related information (0-indexed)
+--- @field col integer
+---
+--- The final column of the related information (0-indexed)
+--- @field end_col? integer
+---
+--- The related information text
+--- @field message string
 
 --- Many of the configuration options below accept one of the following:
 --- - `false`: Disable this feature


### PR DESCRIPTION
Basically a simplified version of https://github.com/neovim/neovim/issues/19649#issuecomment-1750272564

Looking to get some initial feedback here. Instead of just appending to the message, we might instead want to store the related info in the `vim.Diagnostic` struct, and then instead extend the logic in `vim.diagnostic.open_float()`...?

This PR:
![Screenshot_2024-05-04_21-20-17](https://github.com/neovim/neovim/assets/13141438/bde8cbc2-fbf4-4264-9f5e-fb58a37f2d87)
vscode:
![Screenshot_2024-05-04_21-22-00](https://github.com/neovim/neovim/assets/13141438/efc56625-284b-4242-8a84-d824fa035dc9)

EDIT: PR now only adds the related_information field to the toplevel of vim.Diagnostic (see discussion below). We could then decide in a follow-up PR if and how we should display this to the user.

