### PR TITLE
vim-patch:53753f6a4925

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1296,7 +1296,7 @@ The expression must evaluate to a String.  A Number is always automatically
 converted to a String.  For the "p" and ":put" command, if the result is a
 Float it's converted into a String.  If the result is a List each element is
 turned into a String and used as a line.  A Dictionary is converted into a
-String.  A FuncRef results in an error message (use string() to convert).
+String.  A Funcref results in an error message (use string() to convert).
 
 If the "= register is used for the "p" command, the String is split up at <NL>
 characters.  If the String ends in a <NL>, it is regarded as a linewise

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2144,6 +2144,10 @@ text...
 :cons[t] {var-name} = {expr1}
 :cons[t] [{name1}, {name2}, ...] = {expr1}
 :cons[t] [{name}, ..., ; {lastname}] = {expr1}
+:cons[t] {var-name} =<< [trim] [eval] {marker}
+text...
+text...
+{marker}
 			Similar to |:let|, but additionally lock the variable
 			after setting the value.  This is the same as locking
 			the variable with |:lockvar| just after |:let|, thus: >

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -1232,5 +1232,5 @@ By default, the yaml indent script does not try to detect multiline scalars.
 If you want to enable this, set the following variable: >
 
   let g:yaml_indent_multiline_scalar = 1
-
+<
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -477,7 +477,8 @@ Enables Stylus for ".astro" files. Default Value: "disable"
 NOTE: You need to install an external plugin to support stylus in astro files.
 
 
-ASPPERL and ASPVBS			*ft-aspperl-syntax* *ft-aspvbs-syntax*
+ASPPERL							*ft-aspperl-syntax*
+ASPVBS							*ft-aspvbs-syntax*
 
 `*.asp` and `*.asa` files could be either Perl or Visual Basic script.  Since it's
 hard to detect this you can set two global variables to tell Vim what you are


### PR DESCRIPTION
#### vim-patch:53753f6a4925

runtime(doc): Fix typos in help documents

closes: vim/vim#14720

https://github.com/vim/vim/commit/53753f6a49253cdb3f98f6461d3de3b07ed67451

Co-authored-by: h-east <h.east.727@gmail.com>
Co-authored-by: Christian Clason <c.clason@uni-graz.at>