### PR TITLE
feat(defaults): add LSP default mappings (again)

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -281,10 +281,11 @@ gr{char}		Replace the virtual characters under the cursor with
 			that have a special meaning in Insert mode, such as
 			most CTRL-keys, cannot be used.
 
+							*gr-default*
 			Nvim creates default mappings with "gr" as a prefix,
-			which may inhibit the behavior of |gr|. Use
-			|vim.keymap.del()| or |:unmap| to delete the default
-			mappings.
+			which may inhibit the behavior of |gr|. Use the
+			following to restore the builtin behavior: >
+				nnoremap <nowait> gr gr
 
 						*digraph-arg*
 The argument for Normal mode commands like |r| and |t| is a single character.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -281,6 +281,11 @@ gr{char}		Replace the virtual characters under the cursor with
 			that have a special meaning in Insert mode, such as
 			most CTRL-keys, cannot be used.
 
+			Nvim creates default mappings with "gr" as a prefix,
+			which may inhibit the behavior of |gr|. Use
+			|vim.keymap.del()| or |:unmap| to delete the default
+			mappings.
+
 						*digraph-arg*
 The argument for Normal mode commands like |r| and |t| is a single character.
 When 'cpo' doesn't contain the 'D' flag, this character can also be entered

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -286,6 +286,7 @@ gr{char}		Replace the virtual characters under the cursor with
 			which may inhibit the behavior of |gr|. Use the
 			following to restore the builtin behavior: >
 				nnoremap <nowait> gr gr
+<
 
 						*digraph-arg*
 The argument for Normal mode commands like |r| and |t| is a single character.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -61,6 +61,16 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
+                                                *grr* *gra* *grn* *i_CTRL-S*
+Some keymaps are created unconditionally when Nvim starts:
+- "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
+- "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
+- "grr" is mapped in Normal mode to |vim.lsp.buf.references()| |gr-default|
+- CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
+
+If not wanted, these keymaps can be removed at any time using
+|vim.keymap.del()| or |:unmap|.
+
                                                         *lsp-defaults-disable*
 To override the above defaults, set or unset the options on |LspAttach|: >lua
 
@@ -80,9 +90,6 @@ Example: >lua
     vim.api.nvim_create_autocmd('LspAttach', {
       callback = function(args)
         local client = vim.lsp.get_client_by_id(args.data.client_id)
-        if client.supports_method('textDocument/rename') then
-          -- Create a keymap for vim.lsp.buf.rename()
-        end
         if client.supports_method('textDocument/implementation') then
           -- Create a keymap for vim.lsp.buf.implementation
         end

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -65,7 +65,7 @@ options are not restored when the LSP client is stopped or detached.
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
-- "grr" is mapped in Normal mode to |vim.lsp.buf.references()| |gr-default|
+- "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -69,7 +69,7 @@ Some keymaps are created unconditionally when Nvim starts:
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using
-|vim.keymap.del()| or |:unmap|.
+|vim.keymap.del()| or |:unmap| (see also |gr-default|).
 
                                                         *lsp-defaults-disable*
 To override the above defaults, set or unset the options on |LspAttach|: >lua

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -79,7 +79,11 @@ API
 
 DEFAULTS
 
-• TODO
+• Keymaps:
+  - |grn| in Normal mode maps to |vim.lsp.buf.rename()|
+  - |grr| in Normal mode maps to |vim.lsp.buf.references()|
+  - |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
+  - CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
 
 EDITOR
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -138,9 +138,10 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - * |v_star-default|
 - gc |gc-default| |v_gc-default| |o_gc-default|
 - gcc |gcc-default|
-- |grn|
-- |grr|
-- |gra|
+- gr prefix |gr-default|
+  - |grn|
+  - |grr|
+  - |gra|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -138,6 +138,10 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - * |v_star-default|
 - gc |gc-default| |v_gc-default| |o_gc-default|
 - gcc |gcc-default|
+- |grn|
+- |grr|
+- |gra|
+- <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|
 - <C-W>d |CTRL-W_d-default|

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -146,6 +146,31 @@ do
     vim.keymap.set({ 'o' }, 'gc', textobject_rhs, { desc = 'Comment textobject' })
   end
 
+  --- Default maps for LSP functions.
+  ---
+  --- These are mapped unconditionally to avoid different behavior depending on whether an LSP
+  --- client is attached. If no client is attached, or if a server does not support a capability, an
+  --- error message is displayed rather than exhibiting different behavior.
+  ---
+  --- See |grr|, |grn|, |gra|, |i_CTRL-S|.
+  do
+    vim.keymap.set('n', 'grn', function()
+      vim.lsp.buf.rename()
+    end, { desc = 'vim.lsp.buf.rename()' })
+
+    vim.keymap.set({ 'n', 'x' }, 'gra', function()
+      vim.lsp.buf.code_action()
+    end, { desc = 'vim.lsp.buf.code_action()' })
+
+    vim.keymap.set('n', 'grr', function()
+      vim.lsp.buf.references()
+    end, { desc = 'vim.lsp.buf.references()' })
+
+    vim.keymap.set('i', '<C-S>', function()
+      vim.lsp.buf.signature_help()
+    end, { desc = 'vim.lsp.buf.signature_help()' })
+  end
+
   --- Map [d and ]d to move to the previous/next diagnostic. Map <C-W>d to open a floating window
   --- for the diagnostic under the cursor.
   ---


### PR DESCRIPTION
This is the PR to re-introduce default LSP mappings after being reverted in #28649. The goal is to merge this early in the 0.11 release cycle.

I've changed the defaults to use the `gl` prefix rather than `cr`. This avoids all of the messiness with operator-pending mode that was discussed in #28634. We had originally wanted to "reserve" `gl` for a future "align" feature, but using it as the general purpose "LSP prefix" might be more high leverage (and we can always use `gla` or `ga` for "align", falling back to `:ascii` for the default `ga` behavior).

We can still revisit these mappings (I think in particular the `<C-S>` mapping in Insert mode is a bit controversial), but at _some point_ an executive decision will need to be made. We can't please everyone with defaults, so some people are going to be unhappy, unfortunately, but the _hope_ is that providing reasonable defaults makes the onboarding experience easier for more users.