### PR TITLE
vim-patch:8d8cb45756cb

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Enno Nagel <ennonagel+vim@gmail.com>
 "			Eisuke Kawashima
-" Last Change:		2024 Feb 27
+" Last Change:		2024 May 06 by Vim Project (MANPAGER=)
 
 if exists("b:did_ftplugin")
   finish
@@ -46,11 +46,11 @@ endif
 
 if get(b:, "is_bash", 0)
   if !has("gui_running") && executable("less")
-    command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || man "<args>"; } | LESS= less"' | redraw!
+    command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
   elseif has("terminal")
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
-    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || man "<args>"')
+    command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Latest Revision:      2024 May 06 by Vim Project (MANPAGER=)
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -24,7 +24,7 @@ if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   elseif has('terminal')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
-    command! -buffer -nargs=1 ZshKeywordPrg echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+    command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif
   if !exists('current_compiler')
     compiler zsh


### PR DESCRIPTION
#### vim-patch:8d8cb45756cb

runtime(sh,zsh): clear $MANPAGER in ftplugin before shelling out

Say you use Vim and set MANPAGER='vim -M +MANPAGER --not-a-term -'; then
:{Zs,S}hKeywordPrg (or K) will crap out and spew terminal garbage into
less when bash's "help" fails. This was introduced by 2f25e40b1
(runtime: configure keywordpg for some file types (vim/vim#5566), 2023-08-23)
and may be present in other files touched by that commit.

Make the "man" invocation sensible by unsetting MANPAGER in the
environment.

Note that changing MANPAGER for `:terminal` is not needed; Vim within
Vim is perfectly fine.

closes: vim/vim#14679

https://github.com/vim/vim/commit/8d8cb45756cb7e6fda17013b8347be3a11b29610

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>