### PR TITLE
fix(treesitter): allow optional directive captures

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -529,6 +529,9 @@ local directive_handlers = {
   ['offset!'] = function(match, _, _, pred, metadata)
     local capture_id = pred[2] --[[@as integer]]
     local nodes = match[capture_id]
+    if not nodes or #nodes == 0 then
+      return
+    end
     assert(#nodes == 1, '#offset! does not support captures on multiple nodes')
 
     local node = nodes[1]
@@ -562,6 +565,9 @@ local directive_handlers = {
     assert(type(id) == 'number')
 
     local nodes = match[id]
+    if not nodes or #nodes == 0 then
+      return
+    end
     assert(#nodes == 1, '#gsub! does not support captures on multiple nodes')
     local node = nodes[1]
     local text = vim.treesitter.get_node_text(node, bufnr, { metadata = metadata[id] }) or ''
@@ -584,6 +590,9 @@ local directive_handlers = {
     assert(type(capture_id) == 'number')
 
     local nodes = match[capture_id]
+    if not nodes or #nodes == 0 then
+      return
+    end
     assert(#nodes == 1, '#trim! does not support captures on multiple nodes')
     local node = nodes[1]
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -554,7 +554,7 @@ print()
       ]])
     end)
 
-    it('should not error when encountering optional captures #23100', function()
+    it('ignores optional captures #23100', function()
       local result = exec_lua([[
         parser = vim.treesitter.get_parser(0, "lua", {
           injections = {

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -554,7 +554,7 @@ print()
       ]])
     end)
 
-    it('should not error when encountering optional captures', function()
+    it('should not error when encountering optional captures #23100', function()
       local result = exec_lua([[
         parser = vim.treesitter.get_parser(0, "lua", {
           injections = {

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -547,6 +547,36 @@ int x = INT_MAX;
     end)
   end)
 
+  describe('when setting the node for an injection', function()
+    before_each(function()
+      insert([[
+print()
+      ]])
+    end)
+
+    it('should not error when encountering optional captures', function()
+      local result = exec_lua([[
+        parser = vim.treesitter.get_parser(0, "lua", {
+          injections = {
+            lua = (
+            '(function_call ' ..
+              '(arguments ' ..
+                '(string)? @injection.content ' ..
+                '(number)? @injection.content ' ..
+                '(#offset! @injection.content 0 1 0 -1) ' ..
+                '(#set! injection.language "c")))'
+            )
+          }
+        })
+        parser:parse(true)
+
+        return parser:is_valid()
+      ]])
+
+      eq(true, result)
+    end)
+  end)
+
   describe('when getting/setting match data', function()
     describe('when setting for the whole match', function()
       it('should set/get the data correctly', function()


### PR DESCRIPTION
Problem: optional Tree-sitter captures lead to nil access by directives

Solution: just return if the captured node doesn't exist

Fixes #23100