### PR TITLE
refactor(change): check all tabpages in changed_lines_invalidate_buf()

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -221,7 +221,7 @@ static void changed_lines_invalidate_win(win_T *wp, linenr_T lnum, colnr_T col, 
 void changed_lines_invalidate_buf(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnume,
                                   linenr_T xtra)
 {
-  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == buf) {
       changed_lines_invalidate_win(wp, lnum, col, lnume, xtra);
     }


### PR DESCRIPTION
This most likely doesn't matter as all windows are redrawn when
switching tabpages and w_valid is reset is entering window, but still
check all tabpages for consistency with changed_common().
