### PR TITLE
vim-patch:1e34b95e4402

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -9,6 +9,7 @@
 "   2024 Feb 19 by Vim Project: (announce adoption)
 "   2024 Feb 29 by Vim Project: handle symlinks in tree mode correctly
 "   2024 Apr 03 by Vim Project: detect filetypes for remote edited files
+"   2024 May 08 by Vim Project: cleanup legacy Win9X checks
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -281,7 +282,7 @@ if !exists("g:netrw_scp_cmd")
  if executable("scp")
   call s:NetrwInit("g:netrw_scp_cmd" , "scp -q")
  elseif executable("pscp")
-  if (has("win32") || has("win95") || has("win64") || has("win16")) && filereadable('c:\private.ppk')
+  if has("win32") && filereadable('c:\private.ppk')
    call s:NetrwInit("g:netrw_scp_cmd", 'pscp -i c:\private.ppk')
   else
    call s:NetrwInit("g:netrw_scp_cmd", 'pscp -q')
@@ -294,7 +295,7 @@ endif
 call s:NetrwInit("g:netrw_sftp_cmd" , "sftp")
 call s:NetrwInit("g:netrw_ssh_cmd"  , "ssh")
 
-if (has("win32") || has("win95") || has("win64") || has("win16"))
+if has("win32")
   \ && exists("g:netrw_use_nt_rcp")
   \ && g:netrw_use_nt_rcp
   \ && executable( $SystemRoot .'/system32/rcp.exe')
@@ -309,12 +310,8 @@ endif
 " Default values for netrw's global variables {{{2
 " Cygwin Detection ------- {{{3
 if !exists("g:netrw_cygwin")
- if has("win32") || has("win95") || has("win64") || has("win16")
-  if  has("win32unix") && &shell =~ '\%(\<bash\>\|\<zsh\>\)\%(\.exe\)\=$'
-   let g:netrw_cygwin= 1
-  else
-   let g:netrw_cygwin= 0
-  endif
+ if has("win32unix") && &shell =~ '\%(\<bash\>\|\<zsh\>\)\%(\.exe\)\=$'
+  let g:netrw_cygwin= 1
  else
   let g:netrw_cygwin= 0
  endif
@@ -370,7 +367,7 @@ endif
 call s:NetrwInit("g:netrw_keepdir",1)
 if !exists("g:netrw_list_cmd")
  if g:netrw_scp_cmd =~ '^pscp' && executable("pscp")
-  if (has("win32") || has("win95") || has("win64") || has("win16")) && filereadable("c:\\private.ppk")
+  if has("win32") && filereadable("c:\\private.ppk")
    " provide a pscp-based listing command
    let g:netrw_scp_cmd ="pscp -i C:\\private.ppk"
   endif
@@ -401,7 +398,7 @@ if !exists("g:netrw_localcmdshell")
  let g:netrw_localcmdshell= ""
 endif
 if !exists("g:netrw_localcopycmd")
- if has("win32") || has("win95") || has("win64") || has("win16")
+ if has("win32")
   if g:netrw_cygwin
    let g:netrw_localcopycmd= "cp"
   else
@@ -415,7 +412,7 @@ if !exists("g:netrw_localcopycmd")
  endif
 endif
 if !exists("g:netrw_localcopydircmd")
- if has("win32") || has("win95") || has("win64") || has("win16")
+ if has("win32")
   if g:netrw_cygwin
    let g:netrw_localcopydircmd   = "cp"
    let g:netrw_localcopydircmdopt= " -R"
@@ -437,7 +434,7 @@ if exists("g:netrw_local_mkdir")
  let g:netrw_localmkdir= g:netrw_local_mkdir
  call netrw#ErrorMsg(s:NOTE,"g:netrw_local_mkdir is deprecated in favor of g:netrw_localmkdir",87)
 endif
-if has("win32") || has("win95") || has("win64") || has("win16")
+if has("win32")
   if g:netrw_cygwin
    call s:NetrwInit("g:netrw_localmkdir","mkdir")
   else
@@ -453,7 +450,7 @@ if exists("g:netrw_local_movecmd")
  call netrw#ErrorMsg(s:NOTE,"g:netrw_local_movecmd is deprecated in favor of g:netrw_localmovecmd",88)
 endif
 if !exists("g:netrw_localmovecmd")
- if has("win32") || has("win95") || has("win64") || has("win16")
+ if has("win32")
   if g:netrw_cygwin
    let g:netrw_localmovecmd= "mv"
   else
@@ -486,7 +483,7 @@ call s:NetrwInit("g:netrw_mousemaps"     , (exists("+mouse") && &mouse =~# '[anh
 call s:NetrwInit("g:netrw_retmap"        , 0)
 if has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin)
  call s:NetrwInit("g:netrw_chgperm"       , "chmod PERM FILENAME")
-elseif has("win32") || has("win95") || has("win64") || has("win16")
+elseif has("win32")
  call s:NetrwInit("g:netrw_chgperm"       , "cacls FILENAME /e /p PERM")
 else
  call s:NetrwInit("g:netrw_chgperm"       , "chmod PERM FILENAME")
@@ -545,14 +542,13 @@ if !exists("g:netrw_xstrlen")
  endif
 endif
 call s:NetrwInit("g:NetrwTopLvlMenu","Netrw.")
-call s:NetrwInit("g:netrw_win95ftp",1)
 call s:NetrwInit("g:netrw_winsize",50)
 call s:NetrwInit("g:netrw_wiw",1)
 if g:netrw_winsize > 100|let g:netrw_winsize= 100|endif
 " ---------------------------------------------------------------------
 " Default values for netrw's script variables: {{{2
 call s:NetrwInit("g:netrw_fname_escape",' ?&;%')
-if has("win32") || has("win95") || has("win64") || has("win16")
+if has("win32")
  call s:NetrwInit("g:netrw_glob_escape",'*?`{[]$')
 else
  call s:NetrwInit("g:netrw_glob_escape",'*[]?`{~$\')
@@ -684,7 +680,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
   " record current directory
   let curdir     = simplify(b:netrw_curdir)
   let curfiledir = substitute(expand("%:p"),'^\(.*[/\\]\)[^/\\]*$','\1','e')
-  if !exists("g:netrw_cygwin") && (has("win32") || has("win95") || has("win64") || has("win16"))
+  if !exists("g:netrw_cygwin") && has("win32")
    let curdir= substitute(curdir,'\','/','g')
   endif
 "  call Decho("curdir<".curdir.">  curfiledir<".curfiledir.">",'~'.expand("<slnum>"))
@@ -837,7 +833,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
    " handle .../**/.../filepat
 "   call Decho("case starpat=4: Explore .../**/.../filepat",'~'.expand("<slnum>"))
    let prefixdir= substitute(dirname,'^\(.\{-}\)\*\*.*$','\1','')
-   if prefixdir =~ '^/' || (prefixdir =~ '^\a:/' && (has("win32") || has("win95") || has("win64") || has("win16")))
+   if prefixdir =~ '^/' || (prefixdir =~ '^\a:/' && has("win32"))
     let b:netrw_curdir = prefixdir
    else
     let b:netrw_curdir= getcwd().'/'.prefixdir
@@ -874,7 +870,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
    else
     if dirname == ""
      let dirname= getcwd()
-    elseif (has("win32") || has("win95") || has("win64") || has("win16")) && !g:netrw_cygwin
+    elseif has("win32") && !g:netrw_cygwin
      " Windows : check for a drive specifier, or else for a remote share name ('\\Foo' or '//Foo',
      " depending on whether backslashes have been converted to forward slashes by earlier code).
      if dirname !~ '^[a-zA-Z]:' && dirname !~ '^\\\\\w\+' && dirname !~ '^//\w\+'
@@ -1383,7 +1379,7 @@ fun! netrw#Obtain(islocal,fname,...)
 "   call Decho("obtain a file from local ".b:netrw_curdir." to ".tgtdir,'~'.expand("<slnum>"))
    if exists("b:netrw_curdir") && getcwd() != b:netrw_curdir
     let topath= s:ComposePath(tgtdir,"")
-    if (has("win32") || has("win95") || has("win64") || has("win16"))
+    if has("win32")
      " transfer files one at time
 "     call Decho("transfer files one at a time",'~'.expand("<slnum>"))
      for fname in fnamelist
@@ -2254,7 +2250,7 @@ fun! netrw#NetRead(mode,...)
     endif
     " 'C' in 'C:\path\to\file' is handled as hostname on windows.
     " This is workaround to avoid mis-handle windows local-path:
-    if g:netrw_scp_cmd =~ '^scp' && (has("win32") || has("win95") || has("win64") || has("win16"))
+    if g:netrw_scp_cmd =~ '^scp' && has("win32")
       let tmpfile_get = substitute(tr(tmpfile, '\', '/'), '^\(\a\):[/\\]\(.*\)$', '/\1/\2', '')
     else
       let tmpfile_get = tmpfile
@@ -3174,7 +3170,7 @@ fun! s:NetrwMethod(choice)
     if exists("s:netrw_hup[host]")
      call NetUserPass("ftp:".host)
 
-    elseif (has("win32") || has("win95") || has("win64") || has("win16")) && s:netrw_ftp_cmd =~# '-[sS]:'
+    elseif has("win32") && s:netrw_ftp_cmd =~# '-[sS]:'
 "     call Decho("has -s: : s:netrw_ftp_cmd<".s:netrw_ftp_cmd.">",'~'.expand("<slnum>"))
 "     call Decho("          g:netrw_ftp_cmd<".g:netrw_ftp_cmd.">",'~'.expand("<slnum>"))
      if g:netrw_ftp_cmd =~# '-[sS]:\S*MACHINE\>'
@@ -3288,38 +3284,6 @@ fun! s:NetrwMethod(choice)
 "  call Decho("b:netrw_fname  <".b:netrw_fname.">",'~'.expand("<slnum>"))
 "  call Dret("s:NetrwMethod : b:netrw_method=".b:netrw_method." g:netrw_port=".g:netrw_port)
 endfun
-
-" ------------------------------------------------------------------------
-" NetReadFixup: this sort of function is typically written by the user {{{2
-"               to handle extra junk that their system's ftp dumps
-"               into the transfer.  This function is provided as an
-"               example and as a fix for a Windows 95 problem: in my
-"               experience, win95's ftp always dumped four blank lines
-"               at the end of the transfer.
-if has("win95") && exists("g:netrw_win95ftp") && g:netrw_win95ftp
- fun! NetReadFixup(method, line1, line2)
-"   call Dfunc("NetReadFixup(method<".a:method."> line1=".a:line1." line2=".a:line2.")")
-
-   " sanity checks -- attempt to convert inputs to integers
-   let method = a:method + 0
-   let line1  = a:line1 + 0
-   let line2  = a:line2 + 0
-   if type(method) != 0 || type(line1) != 0 || type(line2) != 0 || method < 0 || line1 <= 0 || line2 <= 0
-"    call Dret("NetReadFixup")
-    return
-   endif
-
-   if method == 3   " ftp (no <.netrc>)
-    let fourblanklines= line2 - 3
-    if fourblanklines >= line1
-     exe "sil NetrwKeepj ".fourblanklines.",".line2."g/^\s*$/d"
-     call histdel("/",-1)
-    endif
-   endif
-
-"   call Dret("NetReadFixup")
- endfun
-endif
 
 " ---------------------------------------------------------------------
 " NetUserPass: set username and password for subsequent ftp transfer {{{2
@@ -3943,7 +3907,7 @@ fun! s:NetrwBrowse(islocal,dirname)
   if b:netrw_curdir =~ '[/\\]$'
    let b:netrw_curdir= substitute(b:netrw_curdir,'[/\\]$','','e')
   endif
-  if b:netrw_curdir =~ '\a:$' && (has("win32") || has("win95") || has("win64") || has("win16"))
+  if b:netrw_curdir =~ '\a:$' && has("win32")
    let b:netrw_curdir= b:netrw_curdir."/"
   endif
   if b:netrw_curdir == ''
@@ -4097,7 +4061,7 @@ fun! s:NetrwFile(fname)
     let b:netrw_curdir= getcwd()
    endif
 
-   if !exists("g:netrw_cygwin") && (has("win32") || has("win95") || has("win64") || has("win16"))
+   if !exists("g:netrw_cygwin") && has("win32")
     if fname =~ '^\' || fname =~ '^\a:\'
      " windows, but full path given
      let ret= fname
@@ -4817,7 +4781,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
   call s:SavePosn(s:netrw_posn)
   NetrwKeepj call s:NetrwOptionsSave("s:")
   NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
-  if (has("win32") || has("win95") || has("win64") || has("win16"))
+  if has("win32")
    let dirname = substitute(b:netrw_curdir,'\\','/','ge')
   else
    let dirname = b:netrw_curdir
@@ -5064,7 +5028,7 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
     endif
 "    call Decho("go-up: amiga: dirname<".dirname."> (go up one dir)",'~'.expand("<slnum>"))
 
-   elseif !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+   elseif !g:netrw_cygwin && has("win32")
     " windows
     if a:islocal
      let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
@@ -5349,7 +5313,7 @@ fun! netrw#BrowseX(fname,remote)
   " set up the filename
   " (lower case the extension, make a local copy of a remote file)
   let exten= substitute(a:fname,'.*\.\(.\{-}\)','\1','e')
-  if has("win32") || has("win95") || has("win64") || has("win16")
+  if has("win32")
    let exten= substitute(exten,'^.*$','\L&\E','')
   endif
   if exten =~ "[\\/]"
@@ -5396,12 +5360,12 @@ fun! netrw#BrowseX(fname,remote)
   " by default, g:netrw_suppress_gx_mesg is true
   if g:netrw_suppress_gx_mesg
    if &srr =~ "%s"
-    if (has("win32") || has("win95") || has("win64") || has("win16"))
+    if has("win32")
      let redir= substitute(&srr,"%s","nul","")
     else
      let redir= substitute(&srr,"%s","/dev/null","")
     endif
-   elseif (has("win32") || has("win95") || has("win64") || has("win16"))
+   elseif has("win32")
     let redir= &srr . "nul"
    else
     let redir= &srr . "/dev/null"
@@ -5444,7 +5408,7 @@ fun! netrw#BrowseX(fname,remote)
    call s:NetrwExe("sil !".viewer." ".viewopt.s:ShellEscape(fname,1).redir)
    let ret= v:shell_error
 
-  elseif has("win32") || has("win64")
+  elseif has("win32")
 "   call Decho("(netrw#BrowseX) win".(has("win32")? "32" : "64"),'~'.expand("<slnum>"))
    if executable("start")
     call s:NetrwExe('sil! !start rundll32 url.dll,FileProtocolHandler '.s:ShellEscape(fname,1))
@@ -7167,7 +7131,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
     let args= join(map(deepcopy(s:netrwmarkfilelist_{bufnr('%')}),"s:ShellEscape(b:netrw_curdir.\"/\".v:val)"))
     let tgt = s:ShellEscape(s:netrwmftgt)
    endif
-   if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+   if !g:netrw_cygwin && has("win32")
     let args= substitute(args,'/','\\','g')
     let tgt = substitute(tgt, '/','\\','g')
    endif
@@ -7181,7 +7145,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
 "    call Decho("args<".args."> is a directory",'~'.expand("<slnum>"))
     let copycmd= g:netrw_localcopydircmd
 "    call Decho("using copydircmd<".copycmd.">",'~'.expand("<slnum>"))
-    if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+    if !g:netrw_cygwin && has("win32")
      " window's xcopy doesn't copy a directory to a target properly.  Instead, it copies a directory's
      " contents to a target.  One must append the source directory name to the target to get xcopy to
      " do the right thing.
@@ -7799,7 +7763,7 @@ fun! s:NetrwMarkFileMove(islocal)
    endif
    let tgt = s:ShellEscape(s:netrwmftgt)
 "   call Decho("tgt<".tgt.">",'~'.expand("<slnum>"))
-   if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+   if !g:netrw_cygwin && has("win32")
     let tgt= substitute(tgt, '/','\\','g')
 "    call Decho("windows exception: tgt<".tgt.">",'~'.expand("<slnum>"))
     if g:netrw_localmovecmd =~ '\s'
@@ -7820,7 +7784,7 @@ fun! s:NetrwMarkFileMove(islocal)
     " Jul 19, 2022: fixing file move when g:netrw_keepdir is 1
      let fname= b:netrw_curdir."/".fname
     endif
-    if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+    if !g:netrw_cygwin && has("win32")
      let fname= substitute(fname,'/','\\','g')
     endif
 "    call Decho("system(".movecmd." ".s:ShellEscape(fname)." ".tgt.")",'~'.expand("<slnum>"))
@@ -10239,7 +10203,7 @@ fun! s:NetrwRemoteFtpCmd(path,listcmd)
   endif
 
   " cleanup for Windows " {{{3
-  if has("win32") || has("win95") || has("win64") || has("win16")
+  if has("win32")
    sil! NetrwKeepj %s/\r$//e
    NetrwKeepj call histdel("/",-1)
   endif
@@ -10747,7 +10711,7 @@ fun! netrw#FileUrlEdit(fname)
    let fname= substitute(fname,'^file://localhost/','file:///','')
 "   call Decho("fname<".fname.">",'~'.expand("<slnum>"))
   endif
-  if (has("win32") || has("win95") || has("win64") || has("win16"))
+  if has("win32")
    if fname  =~ '^file:///\=\a[|:]/'
 "    call Decho('converting file:///\a|/   -to-  file://\a:/','~'.expand("<slnum>"))
     let fname = substitute(fname,'^file:///\=\(\a\)[|:]/','file://\1:/','')
@@ -10757,7 +10721,7 @@ fun! netrw#FileUrlEdit(fname)
   let fname2396 = netrw#RFC2396(fname)
   let fname2396e= fnameescape(fname2396)
   let plainfname= substitute(fname2396,'file://\(.*\)','\1',"")
-  if (has("win32") || has("win95") || has("win64") || has("win16"))
+  if has("win32")
 "   call Decho("windows exception for plainfname",'~'.expand("<slnum>"))
    if plainfname =~ '^/\+\a:'
 "    call Decho('removing leading "/"s','~'.expand("<slnum>"))
@@ -10969,7 +10933,7 @@ fun! s:LocalFastBrowser()
    let s:netrw_events= 1
    augroup AuNetrwEvent
     au!
-    if (has("win32") || has("win95") || has("win64") || has("win16"))
+    if has("win32")
 "     call Decho("installing autocmd: ShellCmdPost",'~'.expand("<slnum>"))
      au ShellCmdPost			*	call s:LocalBrowseRefresh()
     else
@@ -11011,7 +10975,7 @@ fun! s:LocalListing()
   let filelist   = filelist + s:NetrwGlob(dirname,".*",0)
 "  call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
 
-  if g:netrw_cygwin == 0 && (has("win32") || has("win95") || has("win64") || has("win16"))
+  if g:netrw_cygwin == 0 && has("win32")
 "   call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
   elseif index(filelist,'..') == -1 && b:netrw_curdir !~ '/'
     " include ../ in the glob() entry if its missing
@@ -11057,7 +11021,7 @@ fun! s:LocalListing()
     let pfile= filename."/"
 
    elseif exists("b:netrw_curdir") && b:netrw_curdir !~ '^.*://' && !isdirectory(s:NetrwFile(filename))
-    if (has("win32") || has("win95") || has("win64") || has("win16"))
+    if has("win32")
      if filename =~ '\.[eE][xX][eE]$' || filename =~ '\.[cC][oO][mM]$' || filename =~ '\.[bB][aA][tT]$'
       " indicate an executable
 "      call Decho("indicate <".filename."> is executable with trailing *",'~'.expand("<slnum>"))
@@ -11534,7 +11498,7 @@ endfun
 " netrw#WinPath: tries to insure that the path is windows-acceptable, whether cygwin is used or not {{{2
 fun! netrw#WinPath(path)
 "  call Dfunc("netrw#WinPath(path<".a:path.">)")
-  if (!g:netrw_cygwin || &shell !~ '\%(\<bash\>\|\<zsh\>\)\%(\.exe\)\=$') && (has("win32") || has("win95") || has("win64") || has("win16"))
+  if (!g:netrw_cygwin || &shell !~ '\%(\<bash\>\|\<zsh\>\)\%(\.exe\)\=$') && has("win32")
    " remove cygdrive prefix, if present
    let path = substitute(a:path,g:netrw_cygdrive.'/\(.\)','\1:','')
    " remove trailing slash (Win95)
@@ -11594,11 +11558,11 @@ fun! s:ComposePath(base,subdir)
    endif
 
    " COMBAK: test on windows with changing to root directory: :e C:/
-  elseif a:subdir =~ '^\a:[/\\]\([^/\\]\|$\)' && (has("win32") || has("win95") || has("win64") || has("win16"))
+  elseif a:subdir =~ '^\a:[/\\]\([^/\\]\|$\)' && has("win32")
 "   call Decho("windows",'~'.expand("<slnum>"))
    let ret= a:subdir
 
-  elseif a:base =~ '^\a:[/\\]\([^/\\]\|$\)' && (has("win32") || has("win95") || has("win64") || has("win16"))
+  elseif a:base =~ '^\a:[/\\]\([^/\\]\|$\)' && has("win32")
 "   call Decho("windows",'~'.expand("<slnum>"))
    if a:base =~ '[/\\]$'
     let ret= a:base.a:subdir
@@ -11710,7 +11674,7 @@ fun! s:GetTempfile(fname)
    " o/s dependencies
    if g:netrw_cygwin != 0
     let tmpfile = substitute(tmpfile,'^\(\a\):',g:netrw_cygdrive.'/\1','e')
-   elseif has("win32") || has("win95") || has("win64") || has("win16")
+   elseif has("win32")
     if !exists("+shellslash") || !&ssl
      let tmpfile = substitute(tmpfile,'/','\','g')
     endif
@@ -11926,7 +11890,7 @@ fun! s:NetrwDelete(path)
 "  call Dfunc("s:NetrwDelete(path<".a:path.">)")
 
   let path = netrw#WinPath(a:path)
-  if !g:netrw_cygwin && (has("win32") || has("win95") || has("win64") || has("win16"))
+  if !g:netrw_cygwin && has("win32")
    if exists("+shellslash")
     let sskeep= &shellslash
     setl noshellslash
@@ -12117,7 +12081,7 @@ fun! s:NetrwLcd(newdir)
      " 'root' (ie. '\').  The share name may start with either backslashes ('\\Foo') or
      " forward slashes ('//Foo'), depending on whether backslashes have been converted to
      " forward slashes by earlier code; so check for both.
-     if (has("win32") || has("win95") || has("win64") || has("win16")) && !g:netrw_cygwin
+     if has("win32") && !g:netrw_cygwin
        if a:newdir =~ '^\\\\\w\+' || a:newdir =~ '^//\w\+'
          let dirname = '\'
          exe 'NetrwKeepj sil lcd '.fnameescape(dirname)
@@ -12590,7 +12554,7 @@ endfun
 " ---------------------------------------------------------------------
 " s:ShellEscape: shellescape(), or special windows handling {{{2
 fun! s:ShellEscape(s, ...)
-  if (has('win32') || has('win64')) && $SHELL == '' && &shellslash
+  if has('win32') && $SHELL == '' && &shellslash
     return printf('"%s"', substitute(a:s, '"', '""', 'g'))
   endif 
   let f = a:0 > 0 ? a:1 : 0

--- a/runtime/autoload/netrwSettings.vim
+++ b/runtime/autoload/netrwSettings.vim
@@ -3,6 +3,8 @@
 " Maintainer:   This runtime file is looking for a new maintainer.
 " Former Maintainer: Charles E Campbell
 " Version:	18
+" Last Change:
+"   2024 May 08 by Vim Project: cleanup legacy Win9X checks
 " Copyright:    Copyright (C) 1999-2007 Charles E. Campbell {{{1
 "               Permission is hereby granted to use and distribute this code,
 "               with or without modifications, provided that this copyright
@@ -91,7 +93,6 @@ fun! netrwSettings#NetrwSettings()
   put = 'let g:netrw_sshport           = '.g:netrw_sshport
   put = 'let g:netrw_silent            = '.g:netrw_silent
   put = 'let g:netrw_use_nt_rcp        = '.g:netrw_use_nt_rcp
-  put = 'let g:netrw_win95ftp          = '.g:netrw_win95ftp
   let s:netrw_xfer_stop= line(".")
   put =''
   put ='+ Netrw Messages'

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -446,10 +446,6 @@ settings are described below, in |netrw-browser-options|, and in
 			      messages don't always seem to show up this
 			      way, but one doesn't have to quit the window.
 
- *g:netrw_win95ftp*	=1 if using Win95, will remove four trailing blank
-			   lines that o/s's ftp "provides" on transfers
-			=0 force normal ftp behavior (no trailing line removal)
-
  *g:netrw_cygwin*	=1 assume scp under windows is from cygwin. Also
 			   permits network browsing to use ls with time and
 			   size sorting (default if windows)
@@ -825,8 +821,6 @@ set in the user's <.vimrc> file: (see also |netrw-settings| |netrw-protocol|)
         g:netrw_uid             Holds current user-id for ftp.
         g:netrw_use_nt_rcp      =0 don't use WinNT/2K/XP's rcp (default)
                                 =1 use WinNT/2K/XP's rcp, binary mode
-        g:netrw_win95ftp        =0 use unix-style ftp even if win95/98/ME/etc
-                                =1 use default method to do ftp >
 	-----------------------------------------------------------------------
 <
 						*netrw-internal-variables*
@@ -955,21 +949,8 @@ messages) you may write a NetReadFixup() function:
     endfunction
 >
 The NetReadFixup() function will be called if it exists and thus allows you to
-customize your reading process.  As a further example, <netrw.vim> contains
-just such a function to handle Windows 95 ftp.  For whatever reason, Windows
-95's ftp dumps four blank lines at the end of a transfer, and so it is
-desirable to automate their removal.  Here's some code taken from <netrw.vim>
-itself:
->
-    if has("win95") && g:netrw_win95ftp
-     fun! NetReadFixup(method, line1, line2)
-       if method == 3   " ftp (no <.netrc>)
-        let fourblanklines= line2 - 3
-        silent fourblanklines .. "," .. line2 .. "g/^\s*/d"
-       endif
-     endfunction
-    endif
->
+customize your reading process.
+
 (Related topics: |ftp| |netrw-userpass| |netrw-start|)
 
 ==============================================================================
@@ -3397,16 +3378,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	(This section is likely to grow as I get feedback)
 	(also see |netrw-debug|)
 								*netrw-p1*
-	P1. I use windows 95, and my ftp dumps four blank lines at the      {{{2
-	    end of every read.
-
-		See |netrw-fixup|, and put the following into your
-		<.vimrc> file:
-
-			let g:netrw_win95ftp= 1
-
-								*netrw-p2*
-	P2. I use Windows, and my network browsing with ftp doesn't sort by {{{2
+	P1. I use Windows, and my network browsing with ftp doesn't sort by {{{2
 	    time or size!  -or-  The remote system is a Windows server; why
 	    don't I get sorts by time or size?
 
@@ -3432,8 +3404,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		modify its listing behavior.
 
 
-								*netrw-p3*
-	P3. I tried rcp://user@host/ (or protocol other than ftp) and netrw {{{2
+								*netrw-p2*
+	P2. I tried rcp://user@host/ (or protocol other than ftp) and netrw {{{2
 	    used ssh!  That wasn't what I asked for...
 
 		Netrw has two methods for browsing remote directories: ssh
@@ -3441,8 +3413,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		When it comes time to do download a file (not just a directory
 		listing), netrw will use the given protocol to do so.
 
-								*netrw-p4*
-	P4. I would like long listings to be the default.                   {{{2
+								*netrw-p3*
+	P3. I would like long listings to be the default.                   {{{2
 
 		Put the following statement into your |vimrc|: >
 
@@ -3451,8 +3423,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		Check out |netrw-browser-var| for more customizations that
 		you can set.
 
-								*netrw-p5*
-	P5. My times come up oddly in local browsing                        {{{2
+								*netrw-p4*
+	P4. My times come up oddly in local browsing                        {{{2
 
 		Does your system's strftime() accept the "%c" to yield dates
 		such as "Sun Apr 27 11:49:23 1997"?  If not, do a
@@ -3461,16 +3433,16 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 			let g:netrw_timefmt= "%X"  (where X is the option)
 <
-								*netrw-p6*
-	P6. I want my current directory to track my browsing.               {{{2
+								*netrw-p5*
+	P5. I want my current directory to track my browsing.               {{{2
 	    How do I do that?
 
 	    Put the following line in your |vimrc|:
 >
 		let g:netrw_keepdir= 0
 <
-								*netrw-p7*
-	P7. I use Chinese (or other non-ascii) characters in my filenames,  {{{2
+								*netrw-p6*
+	P6. I use Chinese (or other non-ascii) characters in my filenames,  {{{2
 	    and netrw (Explore, Sexplore, Hexplore, etc) doesn't display them!
 
 		(taken from an answer provided by Wu Yongwei on the vim
@@ -3484,8 +3456,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 		(...it is one more reason to recommend that people use utf-8!)
 
-								*netrw-p8*
-	P8. I'm getting "ssh is not executable on your system" -- what do I {{{2
+								*netrw-p7*
+	P7. I'm getting "ssh is not executable on your system" -- what do I {{{2
 	    do?
 
 		(Dudley Fox) Most people I know use putty for windows ssh.  It
@@ -3567,8 +3539,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		of the others will use the string in g:netrw_ssh_cmd by
 		default.
 
-						*netrw-p9* *netrw-ml_get*
-	P9. I'm browsing, changing directory, and bang!  ml_get errors      {{{2
+						*netrw-p8* *netrw-ml_get*
+	P8. I'm browsing, changing directory, and bang!  ml_get errors      {{{2
 	    appear and I have to kill vim.  Any way around this?
 
 		Normally netrw attempts to avoid writing swapfiles for
@@ -3578,8 +3550,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		in your <.vimrc>: >
 			let g:netrw_use_noswf= 0
 <
-								*netrw-p10*
-	P10. I'm being pestered with "[something] is a directory" and       {{{2
+								*netrw-p9*
+	P9. I'm being pestered with "[something] is a directory" and       {{{2
 	     "Press ENTER or type command to continue" prompts...
 
 		The "[something] is a directory" prompt is issued by Vim,
@@ -3589,8 +3561,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		I also suggest that you set your |'cmdheight'| to 2 (or more) in
 		your <.vimrc> file.
 
-								*netrw-p11*
-	P11. I want to have two windows; a thin one on the left and my      {{{2
+								*netrw-p10*
+	P10. I want to have two windows; a thin one on the left and my      {{{2
 	     editing window on the right.  How may I accomplish this?
 
 	     You probably want netrw running as in a side window.  If so, you
@@ -3615,8 +3587,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		  <middlemouse> to select the file.
 
 
-								*netrw-p12*
-	P12. My directory isn't sorting correctly, or unwanted letters are  {{{2
+								*netrw-p11*
+	P11. My directory isn't sorting correctly, or unwanted letters are  {{{2
 	     appearing in the listed filenames, or things aren't lining
 	     up properly in the wide listing, ...
 
@@ -3625,8 +3597,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	     Multibyte encodings use two (or more) bytes per character.
 	     You may need to change |g:netrw_sepchr| and/or |g:netrw_xstrlen|.
 
-								*netrw-p13*
-	P13. I'm a Windows + putty + ssh user, and when I attempt to        {{{2
+								*netrw-p12*
+	P12. I'm a Windows + putty + ssh user, and when I attempt to        {{{2
 	     browse, the directories are missing trailing "/"s so netrw treats
 	     them as file transfers instead of as attempts to browse
 	     subdirectories.  How may I fix this?
@@ -3646,8 +3618,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	    "let g:netrw_sftp_cmd = "d:\\dev\\putty\\PSFTP.exe"
 	    "let g:netrw_scp_cmd = "d:\\dev\\putty\\PSCP.exe"
 <
-								*netrw-p14*
-	P14. I would like to speed up writes using Nwrite and scp/ssh       {{{2
+								*netrw-p13*
+	P13. I would like to speed up writes using Nwrite and scp/ssh       {{{2
 	     style connections.  How?  (Thomer M. Gil)
 
 	     Try using ssh's ControlMaster and ControlPath (see the ssh_config
@@ -3673,8 +3645,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 		vim scp://host.domain.com//home/user/.bashrc
 <
-								*netrw-p15*
-	P15. How may I use a double-click instead of netrw's usual single   {{{2
+								*netrw-p14*
+	P14. How may I use a double-click instead of netrw's usual single   {{{2
 	     click to open a file or directory?  (Ben Fritz)
 
 	     First, disable netrw's mapping with >
@@ -3686,8 +3658,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	     all netrw's mouse mappings, not just the <leftmouse> one.
 	     (see |g:netrw_mousemaps|)
 
-								*netrw-p16*
-	P16. When editing remote files (ex. :e ftp://hostname/path/file),   {{{2
+								*netrw-p15*
+	P15. When editing remote files (ex. :e ftp://hostname/path/file),   {{{2
 	     under Windows I get an |E303| message complaining that its unable
 	     to open a swap file.
 
@@ -3695,8 +3667,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	     directory.  Start netrw from your $HOME or other writable
 	     directory.
 
-								*netrw-p17*
-	P17. Netrw is closing buffers on its own.                           {{{2
+								*netrw-p16*
+	P16. Netrw is closing buffers on its own.                           {{{2
 	     What steps will reproduce the problem?
 		1. :Explore, navigate directories, open a file
 		2. :Explore, open another file
@@ -3709,15 +3681,15 @@ Example: Clear netrw's marked file list via a mapping on gu >
 	            It appears that the buffers are not exactly closed;
 		    a ":ls!" will show them (although ":ls" does not).
 
-								*netrw-P18*
-	P18. How to locally edit a file that's only available via           {{{2
+								*netrw-P17*
+	P17. How to locally edit a file that's only available via           {{{2
 	     another server accessible via ssh?
 	     See http://stackoverflow.com/questions/12469645/
 	     "Using Vim to Remotely Edit A File on ServerB Only
 	      Accessible From ServerA"
 
-								*netrw-P19*
-	P19. How do I get numbering on in directory listings?               {{{2
+								*netrw-P18*
+	P18. How do I get numbering on in directory listings?               {{{2
 		With |g:netrw_bufsettings|, you can control netrw's buffer
 		settings; try putting >
 		  let g:netrw_bufsettings="noma nomod nu nobl nowrap ro nornu"
@@ -3725,8 +3697,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		instead, try >
 		  let g:netrw_bufsettings="noma nomod nonu nobl nowrap ro rnu"
 <
-								*netrw-P20*
-	P20. How may I have gvim start up showing a directory listing?      {{{2
+								*netrw-P19*
+	P19. How may I have gvim start up showing a directory listing?      {{{2
 		Try putting the following code snippet into your .vimrc: >
 		    augroup VimStartup
 		      au!
@@ -3738,8 +3710,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		This snippet assumes that you have client-server enabled
 		(ie. a "huge" vim version).
 
-								*netrw-P21*
-	P21. I've made a directory (or file) with an accented character,    {{{2
+								*netrw-P20*
+	P20. I've made a directory (or file) with an accented character,    {{{2
 		but netrw isn't letting me enter that directory/read that file:
 
 		Its likely that the shell or o/s is using a different encoding
@@ -3749,8 +3721,8 @@ Example: Clear netrw's marked file list via a mapping on gu >
 
 			au FileType netrw set enc=latin1
 <
-								*netrw-P22*
-	P22. I get an error message when I try to copy or move a file:      {{{2
+								*netrw-P21*
+	P21. I get an error message when I try to copy or move a file:      {{{2
 >
 		**error** (netrw) tried using g:netrw_localcopycmd<cp>; it doesn't work!
 <

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -2,6 +2,8 @@
 "            PLUGIN SECTION
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Date:		Feb 09, 2021
+" Last Change:
+"   2024 May 08 by Vim Project: cleanup legacy Win9X checks
 " Former Maintainer:   Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{1
@@ -35,7 +37,7 @@ augroup FileExplorer
  au BufLeave *  if &ft != "netrw"|let w:netrw_prvfile= expand("%:p")|endif
  au BufEnter *	sil call s:LocalBrowse(expand("<amatch>"))
  au VimEnter *	sil call s:VimEnter(expand("<amatch>"))
- if has("win32") || has("win95") || has("win64") || has("win16")
+ if has("win32")
   au BufEnter .* sil call s:LocalBrowse(expand("<amatch>"))
  endif
 augroup END


### PR DESCRIPTION
runtime(netrw): Remove and cleanup Win9x legacy from netrw

closes: vim/vim#14732

https://github.com/vim/vim/commit/1e34b95e4402fd8964ea4bcee0d2b6ffa6677aab

Co-authored-by: Nir Lichtman <nir@lichtman.org>
