### PR TITLE
vim-patch:9.1.0396: filetype: jj files are not recognized

### DIFF
--- a/runtime/ftplugin/jj.vim
+++ b/runtime/ftplugin/jj.vim
@@ -1,0 +1,19 @@
+" Vim filetype plugin
+" Language:	jj description
+" Maintainer:	Gregory Anders <greg@gpanders.com>
+" Last Change:	2024 May 8
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+" Use the same formatoptions and textwidth as the gitcommit ftplugin
+setlocal nomodeline formatoptions+=tl textwidth=72
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q formatoptions+=n
+setlocal formatlistpat=^\\s*\\d\\+[\\]:.)}]\\s\\+\\\|^\\s*[-*+]\\s\\+
+
+setlocal comments=b:JJ:
+setlocal commentstring=JJ:\ %s
+
+let b:undo_ftplugin = 'setl modeline< formatoptions< textwidth< formatlistpat< comments< commentstring<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -570,6 +570,7 @@ local extension = {
   jsx = 'javascriptreact',
   clp = 'jess',
   jgr = 'jgraph',
+  jjdescription = 'jj',
   j73 = 'jovial',
   jov = 'jovial',
   jovial = 'jovial',

--- a/runtime/syntax/jj.vim
+++ b/runtime/syntax/jj.vim
@@ -1,0 +1,20 @@
+" Vim syntax file
+" Language:	jj description
+" Maintainer:	Gregory Anders <greg@gpanders.com>
+" Last Change:	2024 May 8
+
+if exists('b:current_syntax')
+  finish
+endif
+let b:current_syntax = 'jj'
+
+syn match jjAdded "A .*" contained
+syn match jjRemoved "D .*" contained
+syn match jjChanged "M .*" contained
+
+syn region jjComment start="^JJ: " end="$" contains=jjAdded,jjRemoved,jjChanged
+
+hi def link jjComment Comment
+hi def link jjAdded Added
+hi def link jjRemoved Removed
+hi def link jjChanged Changed

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -360,6 +360,7 @@ func s:GetFilenameChecks() abort
     \ 'javascriptreact': ['file.jsx'],
     \ 'jess': ['file.clp'],
     \ 'jgraph': ['file.jgr'],
+    \ 'jj': ['file.jjdescription'],
     \ 'jq': ['file.jq'],
     \ 'jovial': ['file.jov', 'file.j73', 'file.jovial'],
     \ 'jproperties': ['file.properties', 'file.properties_xx', 'file.properties_xx_xx', 'some.properties_xx_xx_file', 'org.eclipse.xyz.prefs'],


### PR DESCRIPTION
Problem:  jj files are not recognized
Solution: recognize '*.jjdescription' files as jj filetype
          (Gregory Anders)

See: https://github.com/martinvonz/jj

closes: vim/vim#14733

https://github.com/vim/vim/commit/6a4ea471d28107c4078e106ace1bdc0c54bf946b

Co-authored-by: Gregory Anders <greg@gpanders.com>
