### PR TITLE
vim-patch:9.1.0397: Wrong display with 'smoothscroll' when changing quickfix list

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -286,6 +286,7 @@ void update_topline(win_T *wp)
     }
     wp->w_topline = 1;
     wp->w_botline = 2;
+    wp->w_skipcol = 0;
     wp->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;
     wp->w_viewport_invalid = true;
     wp->w_scbind_pos = 1;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4195,6 +4195,12 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
       }
     }
 
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
+      if (wp->w_buffer == curbuf) {
+        wp->w_skipcol = 0;
+      }
+    }
+
     // Remove all undo information
     u_clearallandblockfree(curbuf);
   }

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -964,6 +964,51 @@ func Test_smoothscroll_insert_bottom()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_in_qf_window()
+  CheckFeature quickfix
+  CheckScreendump
+
+  let lines =<< trim END
+    set nocompatible display=lastline
+    copen 5
+    setlocal number smoothscroll
+    let g:l = [{'text': 'foo'}] + repeat([{'text': join(range(30))}], 10)
+    call setqflist(g:l, 'r')
+    normal! G
+    wincmd t
+    let g:l1 = [{'text': join(range(1000))}]
+  END
+  call writefile(lines, 'XSmoothScrollInQfWindow', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInQfWindow', #{rows: 20, cols: 60})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_1', {})
+
+  call term_sendkeys(buf, ":call setqflist([], 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_2', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_3', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l1, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_4', {})
+
+  call term_sendkeys(buf, "\<C-W>b$\<C-W>t")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_5', {})
+
+  call term_sendkeys(buf, ":call setqflist([], 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_2', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l1, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_4', {})
+
+  call term_sendkeys(buf, "\<C-W>b$\<C-W>t")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_5', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_3', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_smoothscroll_in_zero_width_window()
   set cpo+=n number smoothscroll
   set winwidth=99999 winminwidth=0


### PR DESCRIPTION
#### vim-patch:9.1.0397: Wrong display with 'smoothscroll' when changing quickfix list

Problem:  Wrong display with 'smoothscroll' when changing quickfix list.
Solution: Reset w_skipcol when replacing quickfix list (zeertzjq).

closes: vim/vim#14730

https://github.com/vim/vim/commit/c7a8eb5ff2ddd919e6f39faec93d81c52874695a