### PR TITLE
fix(tui): initialize clear attrs with current terminal background

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2003,6 +2003,39 @@ describe('TUI', function()
     ]])
   end)
 
+  it('invalidated regions are cleared with terminal background attr', function()
+    local screen = Screen.new(50, 10)
+    screen:set_default_attr_ids({ [1] = { foreground = Screen.colors.Black } })
+    screen:attach()
+    fn.termopen({
+      nvim_prog,
+      '--clean',
+      '--cmd',
+      'set termguicolors',
+      '--cmd',
+      'sleep 10',
+    }, {
+      env = {
+        VIMRUNTIME = os.getenv('VIMRUNTIME'),
+      },
+    })
+    screen:expect({
+      grid = [[
+        {1:^                                                  }|
+        {1:                                                  }|*8
+                                                          |
+      ]],
+    })
+    screen:try_resize(51, 11)
+    screen:expect({
+      grid = [[
+        {1:^                                                   }|
+        {1:                                                   }|*9
+                                                           |
+      ]],
+    })
+  end)
+
   it('argv[0] can be overridden #23953', function()
     if not exec_lua('return pcall(require, "ffi")') then
       pending('missing LuaJIT FFI')


### PR DESCRIPTION
Problem:  Invalidated regions that are flushed during startup are
          cleared with unitialized "clear_attrs", which is perceived as
          flickering.
Solution: Initialize "clear_attrs" with current terminal background color.

Fix #28667