### PR TITLE
docs(gen_help_html.lua): wrap legacy help at word-boundary

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -1094,8 +1094,7 @@ local function gen_css(fname)
       word-wrap: break-word;
     }
     .old-help-para pre {
-      /* All text in .old-help-para is formatted as "white-space:pre" so text following <pre> is
-         already visually separated by the linebreak. */
+      /* Text following <pre> is already visually separated by the linebreak. */
       margin-bottom: 0;
     }
 

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -1088,9 +1088,10 @@ local function gen_css(fname)
       padding-bottom: 10px;
       /* Tabs are used for alignment in old docs, so we must match Vim's 8-char expectation. */
       tab-size: 8;
-      white-space: pre;
+      white-space: normal;
       font-size: 16px;
       font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+      word-wrap: break-word;
     }
     .old-help-para pre {
       /* All text in .old-help-para is formatted as "white-space:pre" so text following <pre> is


### PR DESCRIPTION
Problem:

On the page: https://neovim.io/doc/user/dev_vimpatch.html
The links extend beyond the container and thus end up behind the navigation to the right.

Solution: 

Adding these lines to get_help_html.lua solves the problem:
white-space: normal;
word-wrap: break-word;

Before:
<img width="1199" alt="Skärmavbild 2024-05-10 kl  13 33 46" src="https://github.com/neovim/neovim/assets/115005392/4eb62462-12f7-4bac-b119-a1a61eed58eb">

After:
<img width="1207" alt="Skärmavbild 2024-05-10 kl  13 35 21" src="https://github.com/neovim/neovim/assets/115005392/03862ae3-e54f-4fe8-ad3e-e439cf20915e">


