### PR TITLE
Typo: INSTALL.md -> Updating listed 'major' version to match current choco version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ Windows 8+ is required. Windows 7 or older is not supported.
 
 ### [Chocolatey](https://chocolatey.org)
 
-- **Release (v0.9):** `choco install neovim` (use -y for automatically skipping confirmation messages)
+- **Latest Release:** `choco install neovim` (use -y for automatically skipping confirmation messages)
 - **Development (pre-release):** `choco install neovim --pre`
 
 ### [Scoop](https://scoop.sh/)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ Windows 8+ is required. Windows 7 or older is not supported.
 
 ### [Chocolatey](https://chocolatey.org)
 
-- **Release (v0.7):** `choco install neovim` (use -y for automatically skipping confirmation messages)
+- **Release (v0.9):** `choco install neovim` (use -y for automatically skipping confirmation messages)
 - **Development (pre-release):** `choco install neovim --pre`
 
 ### [Scoop](https://scoop.sh/)


### PR DESCRIPTION
I was curious if 0.7 was really the latest on choco, but `choco info neovim` shows 0.9.5 at the time of writing. Checked the contributing guidelines and there wasn't much about readme typos, so apologies if this is too informal

Given that choco is fully up to date, is choco updated as regularly as the other distribution channels? If so that's awesome news for windows users 😄 