### PR TITLE
fix(lsp): disable didChangeWatchedFiles on Linux

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -435,10 +435,8 @@ The following changes to existing APIs or features add new behavior.
   • Enabled treesitter highlighting for Lua files.
 
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
-  by default.
-  • On Mac or Windows, `libuv.fs_watch` is used as the backend.
-  • On Linux, `fswatch` (recommended) is used as the backend if available,
-    otherwise `libuv.fs_event` is used on each subdirectory.
+  by default on Mac and Windows. Disabled on Linux since there currently isn't
+  a viable backend for watching files that scales well for large directories.
 
 • |LspRequest| autocmd callbacks now contain additional information about the LSP
   request status update that occurred.

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -10,6 +10,8 @@ local function get_value_set(tbl)
   return value_set
 end
 
+local sysname = vim.uv.os_uname().sysname
+
 -- Protocol for the Microsoft Language Server Protocol (mslsp)
 local protocol = {}
 
@@ -835,7 +837,10 @@ function protocol.make_client_capabilities()
         refreshSupport = true,
       },
       didChangeWatchedFiles = {
-        dynamicRegistration = true,
+        -- TODO(lewis6991): do not advertise didChangeWatchedFiles on Linux
+        -- or BSD since all the current backends are too limited.
+        -- Ref: #27807, #28058, #23291, #26520
+        dynamicRegistration = sysname == 'Darwin' or sysname == 'Windows_NT',
         relativePatternSupport = true,
       },
       inlayHint = {

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5521,7 +5521,7 @@ describe('LSP', function()
         )
       end
 
-      eq(true, check_registered(nil)) -- start{_client}() defaults to make_client_capabilities().
+      eq(is_os('mac') or is_os('win'), check_registered(nil)) -- start{_client}() defaults to make_client_capabilities().
       eq(false, check_registered(vim.empty_dict()))
       eq(
         false,


### PR DESCRIPTION
Problem:

The file watcher backends for Linux have too many limitations and
doesn't work reliably.

Solution:

disable didChangeWatchedFiles on Linux

Ref: #27807, #28058, #23291, #26520
