### PR TITLE
fix: transposed xcalloc arguments

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -790,7 +790,7 @@ void buf_signcols_count_range(buf_T *buf, int row1, int row2, int add, TriState 
   }
 
   // Allocate an array of integers holding the number of signs in the range.
-  int *count = xcalloc(sizeof(int), (size_t)(row2 + 1 - row1));
+  int *count = xcalloc((size_t)(row2 + 1 - row1), sizeof(int));
   MarkTreeIter itr[1];
   MTPair pair = { 0 };
 

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -943,7 +943,7 @@ static int adjust_types(const char ***ap_types, int arg, int *num_posarg, const 
 {
   if (*ap_types == NULL || *num_posarg < arg) {
     const char **new_types = *ap_types == NULL
-                             ? xcalloc(sizeof(const char *), (size_t)arg)
+                             ? xcalloc((size_t)arg, sizeof(const char *))
                              : xrealloc(*ap_types, (size_t)arg * sizeof(const char *));
 
     for (int idx = *num_posarg; idx < arg; idx++) {


### PR DESCRIPTION
Fix #28694
