### PR TITLE
vim-patch:1c5728e0c4a9

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2029,11 +2029,7 @@ passwords:
     better way to do that: I can use a regular ssh account which uses a
     password to access the material without the need to key-in the password
     each time. It's good for security and convenience. I tried ssh public key
-    authorization + ssh-agent, implementing this, and it works! Here are two
-    links with instructions:
-
-    http://www.ibm.com/developerworks/library/l-keyc2/
-    http://sial.org/howto/openssh/publickey-auth/
+    authorization + ssh-agent, implementing this, and it works!
 
 
     Ssh hints:

--- a/runtime/doc/pi_tar.txt
+++ b/runtime/doc/pi_tar.txt
@@ -147,7 +147,8 @@ Copyright 2005-2017:					*tar-copyright*
 	v2			* converted to use Vim7's new autoload feature
 				  by Bram Moolenaar
 	v1	(original)	* Michael Toren
-				  (see http://michael.toren.net/code/)
+				  (see http://michael.toren.net/code/
+				   link seems dead)
 
 ==============================================================================
 vim:tw=78:ts=8:noet:ft=help

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1014,9 +1014,9 @@ Two syntax highlighting files exist for Euphoria. One for Euphoria
 version 3.1.1, which is the default syntax highlighting file, and one for
 Euphoria version 4.0.5 or later.
 
-Euphoria version 3.1.1 (https://www.rapideuphoria.com/) is still necessary
-for developing applications for the DOS platform, which Euphoria version 4
-(https://www.openeuphoria.org/) does not support.
+Euphoria version 3.1.1 (https://www.rapideuphoria.com/ link seems dead) is
+still necessary for developing applications for the DOS platform, which
+Euphoria version 4 (https://www.openeuphoria.org/) does not support.
 
 The following file extensions are auto-detected as Euphoria file type: >
 
@@ -1073,7 +1073,8 @@ Elixir.
 
 FLEXWIKI				*flexwiki.vim* *ft-flexwiki-syntax*
 
-FlexWiki is an ASP.NET-based wiki package available at https://www.flexwiki.com
+FlexWiki is an ASP.NET-based wiki package available at
+https://www.flexwiki.com
 NOTE: This site currently doesn't work, on Wikipedia is mentioned that
 development stopped in 2009.
 

--- a/runtime/doc/usr_01.txt
+++ b/runtime/doc/usr_01.txt
@@ -85,7 +85,7 @@ The Vim user manual and reference manual are Copyright (c) 1988 by Bram
 Moolenaar.  This material may be distributed only subject to the terms and
 conditions set forth in the Open Publication License, v1.0 or later.  The
 latest version is presently available at:
-	     https://www.opencontent.org/openpub/
+	     https://opencontent.org/openpub/
 
 People who contribute to the manuals must agree with the above copyright
 notice.

--- a/scripts/check_urls.vim
+++ b/scripts/check_urls.vim
@@ -12,11 +12,11 @@ func Test_check_URLs()
   else
     let s:outdev = '/dev/null'
   endif
-" Restorer: For Windows users. If "curl" or "weget" is installed on the system
-" but not in %PATH%, add the full routes for them to this environment variable.
+" Restorer: For Windows users. If "curl" or "wget" is installed on the system
+" but not in %PATH%, add the full path to them to %PATH% environment variable.
   if executable('curl')
     " Note: does not follow redirects!
-    let s:command1 = 'curl --silent --fail --output ' ..s:outdev.. ' --head '
+    let s:command1 = 'curl --silent --max-time 5 --fail --output ' ..s:outdev.. ' --head '
     let s:command2 = ""
   elseif executable('wget')
     " Note: only allow a couple of redirects


### PR DESCRIPTION
Fix #28687

#### vim-patch:1c5728e0c4a9

runtime(doc): update and remove  some invalid links

closes: vim/vim#14748

https://github.com/vim/vim/commit/1c5728e0c4a9df930879f9f0ca108092d5902194

Co-authored-by: Christian Brabandt <cb@256bit.org>