### PR TITLE
vim-patch:9.1.0407: Stuck with long line and half-page scrolling

### DIFF
--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4270,4 +4270,12 @@ func Test_page_cursor_topbot()
   bwipe!
 endfunc
 
+" Test for Ctrl-D with long line
+func Test_halfpage_longline()
+  10new
+  call setline(1, ['long'->repeat(1000), 'short'])
+  exe "norm! \<C-D>"
+  call assert_equal(2, line('.'))
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  No scrolling happens with half-page scrolling with line
          filling entire window when 'smoothscroll' is disabled.
          (Mathias Rav, after v9.1.0285)
Solution: Adjust amount to move cursor by so that it is moved the same
          number of lines as was scrolled, even when scrolling different
          number of lines than requested with 'nosmoothscroll'.

https://github.com/vim/vim/commit/58448e09be497a8abb595ae309b6edfbc8e0e05a