### PR TITLE
fix(treesitter): don't open fold when adding a line below it with o/O

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -87,7 +87,7 @@ end
 ---@param srow integer
 ---@param erow integer 0-indexed, exclusive
 function FoldInfo:add_range(srow, erow)
-  list_insert(self.levels, srow + 1, erow, '=')
+  list_insert(self.levels, srow + 1, erow, -1)
   list_insert(self.levels0, srow + 1, erow, -1)
 end
 

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -646,6 +646,67 @@ import hello]])
     }
   end)
 
+  it('does not extend closed fold with `o`/`O`', function()
+    local screen = Screen.new(60, 24)
+    screen:attach()
+
+    insert(test_text)
+    parse('c')
+    command([[set foldmethod=expr foldexpr=v:lua.vim.treesitter.foldexpr() foldcolumn=1]])
+
+    feed('5ggzco')
+    screen:expect({
+      grid = [[
+        {7:-}void ui_refresh(void)                                      |
+        {7:│}{                                                          |
+        {7:│}  int width = INT_MAX, height = INT_MAX;                   |
+        {7:│}  bool ext_widgets[kUIExtCount];                           |
+        {7:+}{13:+---  3 lines: for (UIExtension i = 0; (int)i < kUIExtCount}|
+        {7:│}^                                                           |
+        {7:│}                                                           |
+        {7:│}  bool inclusive = ui_override();                          |
+        {7:-}  for (size_t i = 0; i < ui_count; i++) {                  |
+        {7:2}    UI *ui = uis[i];                                       |
+        {7:2}    width = MIN(ui->width, width);                         |
+        {7:2}    height = MIN(ui->height, height);                      |
+        {7:2}    foo = BAR(ui->bazaar, bazaar);                         |
+        {7:-}    for (UIExtension j = 0; (int)j < kUIExtCount; j++) {   |
+        {7:3}      ext_widgets[j] &= (ui->ui_ext[j] || inclusive);      |
+        {7:3}    }                                                      |
+        {7:2}  }                                                        |
+        {7:│}}                                                          |
+        {1:~                                                           }|*5
+        {5:-- INSERT --}                                                |
+      ]],
+    })
+
+    feed('<Esc>O')
+    screen:expect({
+      grid = [[
+        {7:-}void ui_refresh(void)                                      |
+        {7:│}{                                                          |
+        {7:│}  int width = INT_MAX, height = INT_MAX;                   |
+        {7:│}  bool ext_widgets[kUIExtCount];                           |
+        {7:+}{13:+---  3 lines: for (UIExtension i = 0; (int)i < kUIExtCount}|
+        {7:│}^                                                           |
+        {7:│}                                                           |*2
+        {7:│}  bool inclusive = ui_override();                          |
+        {7:-}  for (size_t i = 0; i < ui_count; i++) {                  |
+        {7:2}    UI *ui = uis[i];                                       |
+        {7:2}    width = MIN(ui->width, width);                         |
+        {7:2}    height = MIN(ui->height, height);                      |
+        {7:2}    foo = BAR(ui->bazaar, bazaar);                         |
+        {7:-}    for (UIExtension j = 0; (int)j < kUIExtCount; j++) {   |
+        {7:3}      ext_widgets[j] &= (ui->ui_ext[j] || inclusive);      |
+        {7:3}    }                                                      |
+        {7:2}  }                                                        |
+        {7:│}}                                                          |
+        {1:~                                                           }|*4
+        {5:-- INSERT --}                                                |
+      ]],
+    })
+  end)
+
   it("doesn't open folds that are not touched", function()
     local screen = Screen.new(40, 8)
     screen:set_default_attr_ids({
@@ -674,7 +735,7 @@ t2]])
       grid = [[
       {1:-}# h1                                   |
       {1:│}t1                                     |
-      {1:│}^                                       |
+      {1:-}^                                       |
       {1:+}{2:+--  2 lines: # h2·····················}|
       {3:~                                       }|*3
       {4:-- INSERT --}                            |


### PR DESCRIPTION
Problem:
`o`-ing on a folded line opens the fold, because the new line gets the
fold level from the above line (level '='), which extends the fold to
the new line. `O` has a similar problem when run on the line below a
fold.

Solution:
Use -1 for the added line to get the lower level from the above/below
line.





----

Originally, `-1` was used for the added line, but I changed it to `'='` in #26506 because it looked nicer on the markdown test case (the "doesn't open folds that are not touched" test), but it turns out this is quite bad. This PR reverts that change.