### PR TITLE
feat(treesitter): add ability to reload parser

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -801,7 +801,7 @@ get_node_text({node}, {source}, {opts})
 get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
     Returns the parser for a specific buffer and attaches it to the buffer
 
-    If needed, this will create the parser.
+    This will create the parser if needed or if passed `opts.reload = true`
 
     Parameters: ~
       • {bufnr}  (`integer?`) Buffer the parser should be tied to (default:

--- a/runtime/lua/vim/func/_memoize.lua
+++ b/runtime/lua/vim/func/_memoize.lua
@@ -52,7 +52,15 @@ return function(hash, fn, strong)
 
   hash = resolve_hash(hash)
 
-  return function(...)
+  local reset_cache = function(...)
+    if #{ ... } == 0 then
+      cache = {}
+    else
+      cache[hash(...)] = nil
+    end
+  end
+
+  local wrapped = function(_self, ...)
     local key = hash(...)
     if cache[key] == nil then
       cache[key] = vim.F.pack_len(fn(...))
@@ -60,4 +68,6 @@ return function(hash, fn, strong)
 
     return vim.F.unpack_len(cache[key])
   end
+
+  return setmetatable({ _reset_cache = reset_cache }, { __call = wrapped })
 end

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -74,7 +74,7 @@ end
 
 --- Returns the parser for a specific buffer and attaches it to the buffer
 ---
---- If needed, this will create the parser.
+--- This will create the parser if needed or if passed `opts.reload = true`
 ---
 ---@param bufnr (integer|nil) Buffer the parser should be tied to (default: current buffer)
 ---@param lang (string|nil) Language of this parser (default: from buffer filetype)
@@ -106,6 +106,16 @@ function M.get_parser(bufnr, lang, opts)
   elseif parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
     assert(lang, 'lang should be valid')
     parsers[bufnr] = M._create_parser(bufnr, lang, opts)
+  elseif opts.reload then
+    opts.reload = nil -- do not pass reload to _create_parser
+    assert(lang, 'lang should be valid')
+    parsers[bufnr]:destroy()
+    parsers[bufnr] = M._create_parser(bufnr, lang, opts)
+
+    if M.highlighter.active[bufnr] then
+      M.highlighter.active[bufnr]:destroy()
+      M.highlighter.new(parsers[bufnr])
+    end
   end
 
   parsers[bufnr]:register_cbs(opts.buf_attach_cbs)

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -109,6 +109,9 @@ function M.get_parser(bufnr, lang, opts)
   elseif opts.reload then
     opts.reload = nil -- do not pass reload to _create_parser
     assert(lang, 'lang should be valid')
+
+    vim.treesitter.query._reset_cache(lang)
+
     parsers[bufnr]:destroy()
     parsers[bufnr] = M._create_parser(bufnr, lang, opts)
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -228,6 +228,23 @@ M.get = memoize('concat-2', function(lang, query_name)
   return M.parse(lang, query_string)
 end)
 
+---@nodoc
+---Resets query cache
+---if `lang` given - resets only for lang
+---if `query_name` given - resets only specific query
+---
+---@param lang? string
+---@param query_name? string
+function M._reset_cache(lang, query_name)
+  if lang and query_name == nil then
+    for name in vim.iter({ 'injections', 'highlights', 'folds' }) do
+      M.get._reset_cache(lang, name)
+    end
+  else
+    M.get._reset_cache(lang, query_name)
+  end
+end
+
 --- Parse {query} as a string. (If the query is in a file, the caller
 --- should read the contents into a string before calling).
 ---


### PR DESCRIPTION
Problem:
There is no way to reload current parser for buffer. This is needed when
`vim.opt.rtp` changes and new paths have treesitter queries. For example
when loading plugins lazily.

Solution:
Add options `reload` to `vim.treesitter.get_parser()`, that will
remove previous parser and create new one, effectively loading new
queries from `runtimepath`
