### PR TITLE
fix(lsp): update the changetracking buffer state on reload

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -554,6 +554,7 @@ local function buf_attach(bufnr)
     end,
 
     on_reload = function()
+      changetracking.reload(bufnr)
       local params = { textDocument = { uri = uri } }
       for _, client in ipairs(lsp.get_clients({ bufnr = bufnr })) do
         changetracking.reset_buf(client, bufnr)

--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -231,6 +231,8 @@ function M.reload(bufnr)
     if state.group.sync_kind == protocol.TextDocumentSyncKind.Incremental then
       local buf_state = state.buffers[bufnr]
       if buf_state then
+        buf_state.needs_flush = false
+        buf_state.pending_changes = {}
         buf_state.lines = api.nvim_buf_get_lines(bufnr, 0, -1, true)
       end
     end


### PR DESCRIPTION
Fixes #24972

When a buffer is reloaded, each client is detached from that buffer and then re-attached:

https://github.com/neovim/neovim/blob/4e5c633ed4871a948aff7338b793ac5f93484153/runtime/lua/vim/lsp.lua#L557-L561

When there’s only 1 LSP, the change tracking buffer state is deleted and re-created when the file is externally modified. This updates the `buf_state.lines` with the new buffer contents.

https://github.com/neovim/neovim/blob/4e5c633ed4871a948aff7338b793ac5f93484153/runtime/lua/vim/lsp/_changetracking.lua#L205

If there are 2 LSPs attached, the buffer state is never deleted because the `refs` count never hits zero. So the buf state is never updated with the new buffer contents.

https://github.com/neovim/neovim/blob/4e5c633ed4871a948aff7338b793ac5f93484153/runtime/lua/vim/lsp/_changetracking.lua#L202-L204