### PR TITLE
perf(lsp): only joinpath for dirs in watchdirs

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -200,11 +200,13 @@ function M.watchdirs(path, opts, callback)
   local max_depth = 100
 
   for name, type in vim.fs.dir(path, { depth = max_depth }) do
-    local filepath = vim.fs.joinpath(path, name)
-    if type == 'directory' and not skip(filepath, opts) then
-      local handle = assert(uv.new_fs_event())
-      handles[filepath] = handle
-      handle:start(filepath, {}, create_on_change(filepath))
+    if type == 'directory' then
+      local filepath = vim.fs.joinpath(path, name)
+      if not skip(filepath, opts) then
+        local handle = assert(uv.new_fs_event())
+        handles[filepath] = handle
+        handle:start(filepath, {}, create_on_change(filepath))
+      end
     end
   end
 


### PR DESCRIPTION
Doesn't have a huge impact, but showed up in profile output using
`require("jit.p").start("i1", "/tmp/profile")`

before:

    31%  joinpath
    25%  fs.lua:0
    13%  normalize
    13%  skip
     8%  _watchfunc
     5%  gsplit
     3%  spairs

after:

    34%  skip
    29%  fs.lua:0
    12%  joinpath
     7%  normalize
     5%  _watchfunc
     5%  spairs
