### PR TITLE
feat(lsp): add the end location information of lsp to quickfix item

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -41,7 +41,10 @@ EVENTS
 
 LSP
 
-• TODO
+• |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|
+  |vim.lsp.buf.type_definition()|, |vim.lsp.buf.implementation()|,
+  and |vim.lsp.buf.references()| open the quickfix list containing the
+  end position.
 
 LUA
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1772,24 +1772,24 @@ function M.locations_to_items(locations, offset_encoding)
     table.sort(rows, position_sort)
     local filename = vim.uri_to_fname(uri)
 
-    local line_numbers = {}
+    local start_line_numbers = {}
     for _, temp in ipairs(rows) do
-      table.insert(line_numbers, temp.start.line)
+      table.insert(start_line_numbers, temp.start.line)
     end
 
     -- get all the lines for this uri
-    local lines = get_lines(vim.uri_to_bufnr(uri), line_numbers)
+    local start_lines = get_lines(vim.uri_to_bufnr(uri), start_line_numbers)
 
     for _, temp in ipairs(rows) do
-      local pos = temp.start
-      local row = pos.line
-      local line = lines[row] or ''
-      local col = M._str_byteindex_enc(line, pos.character, offset_encoding)
+      local start_pos = temp.start
+      local start_row = start_pos.line
+      local start_line = start_lines[start_row] or ''
+      local start_col = M._str_byteindex_enc(start_line, start_pos.character, offset_encoding)
       table.insert(items, {
         filename = filename,
-        lnum = row + 1,
-        col = col + 1,
-        text = line,
+        lnum = start_row + 1,
+        col = start_col + 1,
+        text = start_line,
         user_data = temp.location,
       })
     end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2626,6 +2626,8 @@ describe('LSP', function()
           filename = '/fake/uri',
           lnum = 1,
           col = 3,
+          end_lnum = 1,
+          end_col = 4,
           text = 'testing',
           user_data = {
             uri = 'file:///fake/uri',
@@ -2659,6 +2661,8 @@ describe('LSP', function()
           filename = '/fake/uri',
           lnum = 1,
           col = 3,
+          end_lnum = 1,
+          end_col = 4,
           text = 'testing',
           user_data = {
             targetUri = 'file:///fake/uri',


### PR DESCRIPTION
There's the support of `end_lnum` and `end_col` for quickfix already, which was originally designed to support LSP locations, see https://github.com/vim/vim/pull/8393, and it has already been patched to nvim.

After making these distinctions, this code looks ugly. I'm not sure if I need to refactor