### PR TITLE
fix(treesitter): text alignment in checkhealth vim.treesitter

### DIFF
--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -24,7 +24,7 @@ function M.check()
     else
       local lang = ts.language.inspect(parsername)
       health.ok(
-        string.format('Parser: %-10s ABI: %d, path: %s', parsername, lang._abi_version, parser)
+        string.format('Parser: %-20s ABI: %d, path: %s', parsername, lang._abi_version, parser)
       )
     end
   end


### PR DESCRIPTION
Problem: The column width 10 for parser name (lang) is too short.
For example, `markdown_inline` has 15 characters, which results in a
slight misalignment with other lines.

e.g. it looked like:

```
- OK Parser: markdown   ABI: 14, path: .../parser/markdown.so
- OK Parser: markdown_inline  ABI: 14, path: .../parser/markdown_inline.so
- OK Parser: php        ABI: 14, path: .../parser/php.so
```

Solution: Use column width 20. As of now, the longest name among those
available in nvim-treesitter has length 18 (`haskell_persistent`).

e.g.:

```
- OK Parser: markdown             ABI: 14, path: .../parser/markdown.so
- OK Parser: markdown_inline      ABI: 14, path: .../parser/markdown_inline.so
- OK Parser: php                  ABI: 14, path: .../parser/php.so
```
