### PR TITLE
fix(treesitter): indent size for inspect_tree

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -158,7 +158,8 @@ end
 
 ---@param w integer
 ---@param b integer
-local function set_dev_options(w, b)
+---@param opts nil|{ indent?: integer }
+local function set_dev_options(w, b, opts)
   vim.wo[w].scrolloff = 5
   vim.wo[w].wrap = false
   vim.wo[w].foldmethod = 'expr'
@@ -170,6 +171,11 @@ local function set_dev_options(w, b)
   vim.bo[b].bufhidden = 'wipe'
   vim.bo[b].filetype = 'query'
   vim.bo[b].swapfile = false
+
+  opts = opts or {}
+  if opts.indent then
+    vim.bo[b].shiftwidth = opts.indent
+  end
 end
 
 --- Updates the cursor position in the inspector to match the node under the cursor.
@@ -360,7 +366,7 @@ function M.inspect_tree(opts)
   vim.b[buf].dev_inspect = w
   vim.b[b].dev_base = win -- base window handle
   vim.b[b].disable_query_linter = true
-  set_dev_options(w, b)
+  set_dev_options(w, b, { indent = treeview.opts.indent })
 
   local title --- @type string?
   local opts_title = opts.title


### PR DESCRIPTION
Problem: For :InspectTree, indent size (`&shiftwidth`) for the tree
viewer may be incorrect.

This is because the tree viewer buffer with the filetype `query` does
not explicitly configures the tab size, which can mismatch with the
default indent size (2) assumed by TSTreeView's implementation.

Solution: Set shiftwidth to be the same as TSTreeViewOpts specifies,
which defaults to 2.