### PR TITLE
fix(api): `nvim_buf_get_text()` segfault with large negative column

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -529,21 +529,15 @@ String buf_get_text(buf_T *buf, int64_t lnum, int64_t start_col, int64_t end_col
   start_col = start_col < 0 ? line_length + start_col + 1 : start_col;
   end_col = end_col < 0 ? line_length + end_col + 1 : end_col;
 
-  if (start_col >= MAXCOL || end_col >= MAXCOL) {
-    api_set_error(err, kErrorTypeValidation, "Column index is too high");
-    return rv;
-  }
+  start_col = MIN(MAX(0, start_col), line_length);
+  end_col = MIN(MAX(0, end_col), line_length);
 
   if (start_col > end_col) {
-    api_set_error(err, kErrorTypeValidation, "start_col must be less than end_col");
+    api_set_error(err, kErrorTypeValidation, "start_col must be less than or equal to end_col");
     return rv;
   }
 
-  if (start_col >= line_length) {
-    return rv;
-  }
-
-  return cstrn_as_string(&bufstr[start_col], (size_t)(end_col - start_col));
+  return cbuf_as_string(bufstr + start_col, (size_t)(end_col - start_col));
 }
 
 void api_free_string(String value)

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -1910,6 +1910,8 @@ describe('api/buf', function()
       eq({ '' }, get_text(0, 0, 18, 0, 20, {}))
       eq({ 'ext' }, get_text(0, -2, 1, -2, 4, {}))
       eq({ 'hello foo!', 'text', 'm' }, get_text(0, 0, 0, 2, 1, {}))
+      eq({ 'hello foo!' }, get_text(0, 0, -987654321, 0, 987654321, {}))
+      eq({ '' }, get_text(0, 0, -15, 0, -20, {}))
     end)
 
     it('errors on out-of-range', function()
@@ -1923,7 +1925,7 @@ describe('api/buf', function()
 
     it('errors when start is greater than end', function()
       eq("'start' is higher than 'end'", pcall_err(get_text, 0, 1, 0, 0, 0, {}))
-      eq('start_col must be less than end_col', pcall_err(get_text, 0, 0, 1, 0, 0, {}))
+      eq('start_col must be less than or equal to end_col', pcall_err(get_text, 0, 0, 1, 0, 0, {}))
     end)
   end)
 


### PR DESCRIPTION
fix #28729

Clamp starting and ending columns in `buf_get_text()`, which is called by `nvim_buf_get_text()` and other functions.