### PR TITLE
feat(fs): follow symlinks in find()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2916,6 +2916,10 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
                  • {limit}? (`number`, default: `1`) Stop the search after
                    finding this many matches. Use `math.huge` to place no
                    limit on the number of matches.
+                 • {follow_symlinks}? (`boolean`, default: `false`) Follow
+                   symlinks that point to directories. This does not resolve
+                   them, i.e. doesn't change the path to the one the link
+                   points to.
 
     Return: ~
         (`string[]`) Normalized paths |vim.fs.normalize()| of all matching

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -518,6 +518,9 @@ The following changes to existing APIs or features add new behavior.
 
 • |nvim_buf_call()| and |nvim_win_call()| now preserves any return value (NB: not multiple return values)
 
+• |vim.fs.find()| accepts `opts.follow_symlinks` to find files in symlinked
+  directories.
+
 • Treesitter
   • |Query:iter_matches()|, |vim.treesitter.query.add_predicate()|, and
     |vim.treesitter.query.add_directive()| accept a new `all` option which

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -183,6 +183,11 @@ end
 --- Use `math.huge` to place no limit on the number of matches.
 --- (default: `1`)
 --- @field limit? number
+---
+--- Follow symlinks that point to directories.
+--- This does not resolve them, i.e. doesn't change the path to the one the link points to.
+--- (default: `false`)
+--- @field follow_symlinks? boolean
 
 --- Find files or directories (or other items as specified by `opts.type`) in the given path.
 ---
@@ -228,6 +233,7 @@ function M.find(names, opts)
     stop = { opts.stop, 's', true },
     type = { opts.type, 's', true },
     limit = { opts.limit, 'n', true },
+    follow_symlinks = { opts.follow_symlinks, 'b', true },
   })
 
   if type(names) == 'string' then
@@ -315,6 +321,13 @@ function M.find(names, opts)
                 return matches
               end
             end
+          end
+        end
+
+        if opts.follow_symlinks and type_ == 'link' then
+          local stat = vim.uv.fs_stat(f)
+          if stat and stat.type == 'directory' then
+            dirs[#dirs + 1] = f
           end
         end
 


### PR DESCRIPTION
Problem: 
`find` doesn't look for files in symlinked directories.

Solution:
add `opts.follow_symlinks` to `find()` method to treat links that point to directories as directories.