### PR TITLE
fix(lsp): don't start additional client if attach failed

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -251,6 +251,8 @@ function lsp.start(config, opts)
     if reuse_client(client, config) then
       if lsp.buf_attach_client(bufnr, client.id) then
         return client.id
+      else
+        return nil
       end
     end
   end


### PR DESCRIPTION
If a client for a server was already running and lsp.start was called in
an unloaded buffer it started another client instead of bailing out.
