### PR TITLE
perf(loader): use a quicker version of vim.fs.normalize

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -455,11 +455,9 @@ end
 --- @return string Resolved path.
 local function path_resolve_dot(path)
   local is_path_absolute = vim.startswith(path, '/')
-  -- Split the path into components and process them
-  local path_components = vim.split(path, '/')
   local new_path_components = {}
 
-  for _, component in ipairs(path_components) do
+  for component in vim.gsplit(path, '/') do
     if component == '.' or component == '' then -- luacheck: ignore 542
       -- Skip `.` components and empty components
     elseif component == '..' then

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -488,6 +488,8 @@ end
 --- (default: `true`)
 --- @field expand_env? boolean
 ---
+--- @field package _fast? boolean
+---
 --- Path is a Windows path.
 --- (default: `true` in Windows, `false` otherwise)
 --- @field win? boolean
@@ -527,11 +529,13 @@ end
 function M.normalize(path, opts)
   opts = opts or {}
 
-  vim.validate({
-    path = { path, { 'string' } },
-    expand_env = { opts.expand_env, { 'boolean' }, true },
-    win = { opts.win, { 'boolean' }, true },
-  })
+  if not opts._fast then
+    vim.validate({
+      path = { path, { 'string' } },
+      expand_env = { opts.expand_env, { 'boolean' }, true },
+      win = { opts.win, { 'boolean' }, true },
+    })
+  end
 
   local win = opts.win == nil and iswin or not not opts.win
   local os_sep_local = win and '\\' or '/'
@@ -555,11 +559,17 @@ function M.normalize(path, opts)
     path = path:gsub('%$([%w_]+)', vim.uv.os_getenv)
   end
 
-  -- Convert path separator to `/`
-  path = path:gsub(os_sep_local, '/')
+  if win then
+    -- Convert path separator to `/`
+    path = path:gsub(os_sep_local, '/')
+  end
 
   -- Check for double slashes at the start of the path because they have special meaning
-  local double_slash = vim.startswith(path, '//') and not vim.startswith(path, '///')
+  local double_slash = false
+  if not opts._fast then
+    double_slash = vim.startswith(path, '//') and not vim.startswith(path, '///')
+  end
+
   local prefix = ''
 
   if win then
@@ -576,10 +586,15 @@ function M.normalize(path, opts)
     prefix = prefix:gsub('/+', '/')
   end
 
-  -- Resolve `.` and `..` components and remove extraneous slashes from path, then recombine prefix
-  -- and path. Preserve leading double slashes as they indicate UNC paths and DOS device paths in
+  if not opts._fast then
+    -- Resolve `.` and `..` components and remove extraneous slashes from path, then recombine prefix
+    -- and path.
+    path = path_resolve_dot(path)
+  end
+
+  -- Preserve leading double slashes as they indicate UNC paths and DOS device paths in
   -- Windows and have implementation-defined behavior in POSIX.
-  path = (double_slash and '/' or '') .. prefix .. path_resolve_dot(path)
+  path = (double_slash and '/' or '') .. prefix .. path
 
   -- Change empty path to `.`
   if path == '' then

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -85,7 +85,7 @@ function Loader.get_hash(path)
 end
 
 local function normalize(path)
-  return fs.normalize(path, { expand_env = false })
+  return fs.normalize(path, { expand_env = false, _fast = true })
 end
 
 --- Gets the rtp excluding after directories.


### PR DESCRIPTION
Problem:

vim.fs.normalize() normalizes too much vim.loader and is slow.

Solution:

Make it faster by doing less. This reduces the times spent in
vim.fs.normalize in vim.loader from ~13ms -> 1-2ms.

Numbers from a relative benchmark:
- Skipping `vim.validate()`: 285ms -> 230ms
- Skipping `path_resolve_dot()`: 285ms -> 60ms
- Skipping `double_slash`: 60ms -> 35ms
