### PR TITLE
feat(lua): add buflocal

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3942,6 +3942,38 @@ describe('lua stdlib', function()
     }
     eq(expected, results)
   end)
+
+  it("vim.buflocal", function()
+    local result = exec_lua([[
+      local buflocal = vim.buflocal()
+      local buf1 = vim.api.nvim_create_buf(true, true)
+      local buf2 = vim.api.nvim_create_buf(true, true)
+
+      local state1 = buflocal:get(buf1)
+      state1.x = 10
+
+      local state2 = buflocal:get(buf2)
+      state2.x = 20
+
+      local results = {}
+      results.values = {}
+      results.x1 = buflocal:get(buf1).x
+      results.x2 = buflocal:get(buf2).x
+
+      for _, value in buflocal:pairs() do
+        table.insert(results.values, value)
+      end
+
+      vim.api.nvim_buf_delete(buf1, { force = true })
+      local ok, err = pcall(buflocal.get, buflocal, buf1)
+      results.deleted_buf = {ok, err}
+      return results
+    ]])
+    eq(10, result.x1)
+    eq(20, result.x2)
+    eq(false, result.deleted_buf[1])
+    eq(true, vim.startswith(result.deleted_buf[2], "vim/shared.lua:0: Invalid buffer id: "))
+  end)
 end)
 
 describe('lua: builtin modules', function()


### PR DESCRIPTION
This is currently more of a proof of concept to get some feedback on whether
this is a horrible idea, or somewhat reasonable.

I was mostly interested if this is possible at all and Justin mentioned using
`b:` elsewhere, which afaik has some vimscript marshalling limitations for some
types(?) and you cannot keep state completely hidden as implementation detail.

I'm also not yet sure if this can cover most cases. If there's positive feedback I'd try and convert some more spots, otherwise 🚮

---

There are a few modules, each of which is managing state per buffer and
duplicating logic like cleanup.
Properly cleaning up can be tricky - see:

https://github.com/neovim/neovim/commit/f32fd19f1eedbd75e6a37b73f28cf8761e0e875c

This introduces a `Buflocal` inspired by thread-local storage:

https://en.wikipedia.org/wiki/Thread-local_storage

The `Buflocal` can be used to access state for a buffer, which gets
cleaned up if the buffer is deleted.

(Although the name here may be a bit misleading - as the buffer number is parameterized and you can get the state of other buffers, not just current. )