### PR TITLE
fix(messages): avoid passing negative length to strnlen()

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2162,7 +2162,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
       msg_ext_last_attr = attr;
     }
     // Concat pieces with the same highlight
-    size_t len = strnlen(str, (size_t)maxlen);
+    size_t len = maxlen < 0 ? strlen(str) : strnlen(str, (size_t)maxlen);
     ga_concat_len(&msg_ext_last_chunk, str, len);
     msg_ext_cur_len += len;
     return;


### PR DESCRIPTION
Problem:  Compiler warning when building Nvim in Release mode:

    In function ‘msg_puts_display’,
        inlined from ‘disp_sb_line’ at **/src/nvim/message.c:2647:5:
    **/src/nvim/message.c:2165:18: warning: ‘strnlen’ specified bound 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overread]
     2165 |     size_t len = strnlen(str, (size_t)maxlen);
          |                  ^

Solution: Use strlen() when maxlen is negative.
