### PR TITLE
docs(gen_help_html.lua): fix broken pre text, and handle linewrap

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -1088,14 +1088,19 @@ local function gen_css(fname)
       padding-bottom: 10px;
       /* Tabs are used for alignment in old docs, so we must match Vim's 8-char expectation. */
       tab-size: 8;
-      white-space: normal;
+      white-space: pre-wrap;
       font-size: 16px;
       font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
       word-wrap: break-word;
     }
-    .old-help-para pre {
+    .old-help-para pre, .old-help-para pre:hover {
       /* Text following <pre> is already visually separated by the linebreak. */
       margin-bottom: 0;
+      /* Long lines that exceed the textwidth should not be wrapped (no "pre-wrap").
+         Since text may overflow horizontally, we make the contents to be scrollable
+         (only if necessary) to prevent overlapping with the navigation bar at the right. */
+      white-space: pre;
+      overflow-x: auto;
     }
 
     /* TODO: should this rule be deleted? help tags are rendered as <code> or <span>, not <a> */


### PR DESCRIPTION
Problem:

- Since #28678, pre-formatted text in the online documentation do not
  render whitespaces correctly: should be pre-like text, but shown like
  normal paragraph (see #28754).

- Code blocks with long lines should not be wrapped (e.g. see
  |dev-vimpatch-list-management|).

Solution:

- Use `white-space: pre-wrap`. Compared to `white-space: pre`, this
  option will make long lines including a very long URL wrapped.
  This properly fixes #28754 as well as #28678.

- Use horizontal scrollbar for the code blocks that are horizontally too
  long, instead of wrapping text. This will make the code easy to read
  while the pre-text block not interfering with the navigation bar.
