### PR TITLE
vim-patch:fed01960d2b0

### DIFF
--- a/runtime/doc/tabpage.txt
+++ b/runtime/doc/tabpage.txt
@@ -216,8 +216,8 @@ gT		Go to the previous tab page.  Wraps around from the first one
 :tabl[ast]	Go to the last tab page.
 
 <C-Tab>						*CTRL-<Tab>* *<C-Tab>*
-CTRL-W g<Tab>					*g<Tab>* *CTRL-W_g<Tab>*
-g<Tab>		Go to the last accessed tab page.
+g<Tab>						*g<Tab>* *CTRL-W_g<Tab>*
+CTRL-W g<Tab>	Go to the last accessed tab page.
 
 Other commands:
 							*:tabs*


### PR DESCRIPTION
#### vim-patch:fed01960d2b0

runtime(doc): add missing entries for the keys CTRL-W g<Tab> and <C-Tab>

https://github.com/vim/vim/commit/fed01960d2b0280339bba29183b1c3859366e805

Co-authored-by: Christian Brabandt <cb@256bit.org>