### PR TITLE
build(release.sh): set VIMRUNTIME when regenerating docs

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,7 +59,7 @@ _do_release_commit() {
     $__sed -i.bk 's/(NVIM_API_PRERELEASE) true/\1 false/' CMakeLists.txt
     build/bin/nvim --api-info > "test/functional/fixtures/api_level_$__API_LEVEL.mpack"
     git add "test/functional/fixtures/api_level_${__API_LEVEL}.mpack"
-    build/bin/nvim -u NONE -l scripts/gen_vimdoc.lua
+    VIMRUNTIME=./runtime build/bin/nvim -u NONE -l scripts/gen_vimdoc.lua
     git add -u -- runtime/doc/
   fi
 


### PR DESCRIPTION
IIRC this didn't require `VIMRUNTIME` when I created #28229. IDK why it's required now. Or maybe I misremembered?