### PR TITLE
docs(gen_help_html.lua): handle modeline and note nodes

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -530,6 +530,8 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     return ('%s<a href="%s">%s</a>%s'):format(ws(), fixed_url, fixed_url, removed_chars)
   elseif node_name == 'word' or node_name == 'uppercase_name' then
     return text
+  elseif node_name == 'note' then
+    return ('<b>%s</b>'):format(text)
   elseif node_name == 'h1' or node_name == 'h2' or node_name == 'h3' then
     if is_noise(text, stats.noise_lines) then
       return '' -- Discard common "noise" lines.
@@ -692,6 +694,8 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
       return string.format('%s</span>', s)
     end
     return s
+  elseif node_name == 'modeline' then
+    return ''
   elseif node_name == 'ERROR' then
     if ignore_parse_error(opt.fname, trimmed) then
       return text


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/28755#issuecomment-2111725105

Problem:

'modeline' and 'note' are unhandled in the online HTML documentation.

Some (not all) modelines are parsed by the vimdoc parser as a node of
type 'modeline'.

Solution:

- Ignore 'modeline' in HTML rendering.
- Render 'note' text in boldface.

Remark:

- Words like 'Deprecated' and 'Note' are parsed as 'note' rather than 'word'.
- I checked that there are no other unhandled nodes in the generated HTML files.