### PR TITLE
build(vim-patch.sh): include commit subject

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -122,7 +122,7 @@ commit_message() {
   if [[ "${vim_message}" == "vim-patch:${vim_version}:"* ]]; then
     printf '%s\n\n%s\n\n%s' "${vim_message}" "${vim_commit_url}" "${vim_coauthors}"
   else
-    printf 'vim-patch:%s\n\n%s\n\n%s\n\n%s' "$vim_version" "$vim_message" "$vim_commit_url" "$vim_coauthors"
+    printf 'vim-patch:%s: %s\n\n%s\n\n%s' "${vim_version:0:7}" "${vim_message}" "${vim_commit_url}" "${vim_coauthors}"
   fi
 }
 


### PR DESCRIPTION
Problem: vim-patch commits lack an informative title and summary in the
very first line of the commit message when the vim-revision is a Git SHA
hash, unlike when is a Vim version. This makes it difficult to discern
at a glance what changes are introduced by such vim-patch commits (in
git log, PR title, changelog generated by git-cliff, etc.).

e.g. Before:

    vim-patch:abcdef123456

    runtime(vim): improve performance

    <some details>
    ...

Solution: Repeat the title of the upstream commit message, to improve
the clarity and visibility of the commit message.

e.g. After:

    vim-patch:abcdef123456: runtime(vim): improve performance

    <some details>
    ...

Note: the `vim-patch:<hash>` token is still needed by `vim-patch.sh`
(but not necessarily in the very first line of the commit message) to
determine which vim patches have been applied.
