### PR TITLE
vim-patch:5faeb60480c6

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6962,10 +6962,11 @@ shellescape({string} [, {special}])                              *shellescape()*
 		Otherwise encloses {string} in single-quotes and replaces all
 		"'" with "'\''".
 
-		If {special} is a |non-zero-arg|:
-		- Special items such as "!", "%", "#" and "<cword>" will be
-		  preceded by a backslash. The backslash will be removed again
-		  by the |:!| command.
+		The {special} argument adds additional escaping of keywords
+		used in Vim commands. If it is a |non-zero-arg|:
+		- Special items such as "!", "%", "#" and "<cword>" (as listed
+		  in |expand()|) will be preceded by a backslash.
+		  The backslash will be removed again by the |:!| command.
 		- The <NL> character is escaped.
 
 		If 'shell' contains "csh" in the tail:

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8293,10 +8293,11 @@ function vim.fn.sha256(string) end
 --- Otherwise encloses {string} in single-quotes and replaces all
 --- "'" with "'\''".
 ---
---- If {special} is a |non-zero-arg|:
---- - Special items such as "!", "%", "#" and "<cword>" will be
----   preceded by a backslash. The backslash will be removed again
----   by the |:!| command.
+--- The {special} argument adds additional escaping of keywords
+--- used in Vim commands. If it is a |non-zero-arg|:
+--- - Special items such as "!", "%", "#" and "<cword>" (as listed
+---   in |expand()|) will be preceded by a backslash.
+---   The backslash will be removed again by the |:!| command.
 --- - The <NL> character is escaped.
 ---
 --- If 'shell' contains "csh" in the tail:

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9903,10 +9903,11 @@ M.funcs = {
       Otherwise encloses {string} in single-quotes and replaces all
       "'" with "'\''".
 
-      If {special} is a |non-zero-arg|:
-      - Special items such as "!", "%", "#" and "<cword>" will be
-        preceded by a backslash. The backslash will be removed again
-        by the |:!| command.
+      The {special} argument adds additional escaping of keywords
+      used in Vim commands. If it is a |non-zero-arg|:
+      - Special items such as "!", "%", "#" and "<cword>" (as listed
+        in |expand()|) will be preceded by a backslash.
+        The backslash will be removed again by the |:!| command.
       - The <NL> character is escaped.
 
       If 'shell' contains "csh" in the tail:


### PR DESCRIPTION
#### vim-patch:5faeb60480c6

runtime(doc): clarify {special} argument for shellescape()

closes: vim/vim#14770

https://github.com/vim/vim/commit/5faeb60480c6efba5c0468c01275120b6ace5a09

N/A patch:
vim-patch:c0e038b59f84

Co-authored-by: Enno <Konfekt@users.noreply.github.com>