### PR TITLE
fix(test): failure after version bump

### DIFF
--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -116,7 +116,7 @@ end
 --- @param ... any
 --- @return any
 function M.request(method, ...)
-  assert(session)
+  assert(session, 'no Nvim session')
   local status, rv = session:request(method, ...)
   if not status then
     if loop_running then


### PR DESCRIPTION
Problem:
- The test for vim.deprecate() has a "mock" which is outdated because vim.deprecate() no longer uses that.
- The tests get confused after a version bump.

Solution:
Make the tests adapt to the current version.