### PR TITLE
fix(man.vim): signcolumn causes broken wrap

### DIFF
--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -8,14 +8,16 @@ let b:did_ftplugin = 1
 
 setlocal noexpandtab tabstop=8 softtabstop=8 shiftwidth=8
 setlocal wrap breakindent linebreak
+setlocal colorcolumn=0 nolist
 
 " Parentheses and '-' for references like `git-ls-files(1)`; '@' for systemd
 " pages; ':' for Perl and C++ pages.  Here, I intentionally omit the locale
 " specific characters matched by `@`.
 setlocal iskeyword=@-@,:,a-z,A-Z,48-57,_,.,-,(,)
 
-setlocal nonumber norelativenumber
-setlocal foldcolumn=0 colorcolumn=0 nolist nofoldenable
+" man page content is likely preformatted for the terminal width, so
+" narrowing display by any additional columns leads to Embarrassing Line Wrap
+setlocal nonumber norelativenumber foldcolumn=0
 
 setlocal tagfunc=v:lua.require'man'.goto_tag
 
@@ -35,6 +37,8 @@ if get(g:, 'ft_man_folding_enable', 0)
   setlocal foldenable
   setlocal foldmethod=indent
   setlocal foldnestmax=1
+else
+  setlocal nofoldenable
 endif
 
 let b:undo_ftplugin = ''

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -17,7 +17,7 @@ setlocal iskeyword=@-@,:,a-z,A-Z,48-57,_,.,-,(,)
 
 " man page content is likely preformatted for the terminal width, so
 " narrowing display by any additional columns leads to Embarrassing Line Wrap
-setlocal nonumber norelativenumber foldcolumn=0
+setlocal nonumber norelativenumber foldcolumn=0 signcolumn=auto
 
 setlocal tagfunc=v:lua.require'man'.goto_tag
 


### PR DESCRIPTION
This is how man page looks like when using neovim as a man pager and having `signcolumn=yes`. Note the line wraps in Description:

![man man](https://github.com/neovim/neovim/assets/16609579/dd380b0c-b004-4e3b-9b4e-518b08ca7898)
Note: I did **not** resize the window after running the command.

Steps to reproduce:
1. `set signcolumn=yes` in `~/.config/nvim/init.vim`
2. `MANPAGER='nvim +Man!' man man`

The suggested solution is to `set signcolumn=auto` in `ftplugin/man.vim`, because man pages are especially sensitive to terminal width. `man` hard-wraps content (using terminal width as a default value for MANWIDTH), not taking pager's UI into account (the default MANPAGER is `less`, which displays content at full width of the terminal)

`ftplugin/man.vim` already contains similar options (e.g. `set nonumber`) to address the issue. The benefit of those tweaks is lost if ANY of UI columns appear.