### PR TITLE
fix: change deprecation presentation

### DIFF
--- a/runtime/lua/vim/deprecated/health.lua
+++ b/runtime/lua/vim/deprecated/health.lua
@@ -1,0 +1,42 @@
+local M = {}
+local health = vim.health
+
+local deprecated = {}
+
+function M.check()
+  if next(deprecated) == nil then
+    health.ok('No deprecated functions detected')
+    return
+  end
+
+  for name, v in vim.spairs(deprecated) do
+    health.start('')
+
+    local version, backtraces, alternative = v[1], v[2], v[3]
+    local major, minor = version:match('(%d+)%.(%d+)')
+    major, minor = tonumber(major), tonumber(minor)
+    local removal_version = string.format('nvim-%d.%d', major, minor)
+    local will_be_removed = vim.fn.has(removal_version) == 1 and 'was removed' or 'will be removed'
+
+    local msg = ('%s is deprecated. Feature %s in Nvim %s'):format(name, will_be_removed, version)
+    local msg_alternative = alternative and ('use %s instead.'):format(alternative)
+    local advice = { msg_alternative }
+    table.insert(advice, backtraces)
+    advice = vim.iter(advice):flatten():totable()
+    health.warn(msg, advice)
+  end
+end
+
+function M.add(name, version, backtrace, alternative)
+  if deprecated[name] == nil then
+    deprecated[name] = { version, { backtrace }, alternative }
+    return
+  end
+
+  local it = vim.iter(deprecated[name][2])
+  if it:find(backtrace) == nil then
+    table.insert(deprecated[name][2], backtrace)
+  end
+end
+
+return M

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1279,9 +1279,7 @@ M.handlers.signs = {
           vim.deprecate(
             'Defining diagnostic signs with :sign-define or sign_define()',
             'vim.diagnostic.config()',
-            '0.12',
-            nil,
-            false -- suppress backtrace
+            '0.12'
           )
 
           if not opts.signs.text then

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -42,7 +42,7 @@ describe(':checkhealth', function()
 
   it('completions can be listed via getcompletion()', function()
     clear()
-    eq('vim.health', getcompletion('vim', 'checkhealth')[1])
+    eq('vim.deprecated', getcompletion('vim', 'checkhealth')[1])
     eq('vim.provider', getcompletion('vim.prov', 'checkhealth')[1])
     eq('vim.lsp', getcompletion('vim.ls', 'checkhealth')[1])
   end)


### PR DESCRIPTION
Deprecation with vim.deprecate is currently too noisy. Show the
following warning instead:

[function] is deprecated. Run ":checkhealth vim.deprecated" for more information.

The important part is that the full message needs to be short enough to
fit in one line in order to not trigger the "Press ENTER or type command
to continue" prompt.

The full information and stack trace for the deprecated functions will
be shown in the new healthcheck `vim.deprecated`.