### PR TITLE
fix(vim.iter): enable optimizations for arrays (lists with holes)

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3830,6 +3830,7 @@ chained to create iterator "pipelines": the output of each pipeline stage is
 input to the next stage. The first stage depends on the type passed to
 `vim.iter()`:
 • List tables (arrays, |lua-list|) yield only the value of each element.
+  • Holes (nil values) are allowed.
   • Use |Iter:enumerate()| to also pass the index to the next stage.
   • Or initialize with ipairs(): `vim.iter(ipairs(…))`.
 • Non-list tables (|lua-dict|) yield both the key and value of each element.
@@ -4287,9 +4288,9 @@ Iter:totable()                                                *Iter:totable()*
     Collect the iterator into a table.
 
     The resulting table depends on the initial source in the iterator
-    pipeline. List-like tables and function iterators will be collected into a
-    list-like table. If multiple values are returned from the final stage in
-    the iterator pipeline, each value will be included in a table.
+    pipeline. Array-like tables and function iterators will be collected into
+    an array-like table. If multiple values are returned from the final stage
+    in the iterator pipeline, each value will be included in a table.
 
     Examples: >lua
         vim.iter(string.gmatch('100 20 50', '%d+')):map(tonumber):totable()
@@ -4302,7 +4303,7 @@ Iter:totable()                                                *Iter:totable()*
         -- { { 'a', 1 }, { 'c', 3 } }
 <
 
-    The generated table is a list-like table with consecutive, numeric
+    The generated table is an array-like table with consecutive, numeric
     indices. To create a map-like table with arbitrary keys, use
     |Iter:fold()|.
 

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -111,8 +111,9 @@ end
 
 local function sanitize(t)
   if type(t) == 'table' and getmetatable(t) == packedmt then
-    -- Remove length tag
+    -- Remove length tag and metatable
     t.n = nil
+    setmetatable(t, nil)
   end
   return t
 end
@@ -414,7 +415,7 @@ function ArrayIter:totable()
     return Iter.totable(self)
   end
 
-  local needs_sanitize = getmetatable(self._table[1]) == packedmt
+  local needs_sanitize = getmetatable(self._table[self._head]) == packedmt
 
   -- Reindex and sanitize.
   local len = self._tail - self._head

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -1031,7 +1031,7 @@ function Iter.new(src, ...)
 
     local t = {}
 
-    -- O(n): scan the source table to decide if it is an array (only integer indices).
+    -- O(n): scan the source table to decide if it is an array (only positive integer indices).
     local length = 0
     for k, v in pairs(src) do
       if type(k) ~= 'number' then
@@ -1042,7 +1042,6 @@ function Iter.new(src, ...)
       end
       t[k] = v
     end
-    -- print("creating new ArrayLiter with length", length)
     return ArrayIter.new(t, length)
   end
 
@@ -1073,7 +1072,9 @@ end
 
 --- Create a new ArrayIter
 ---
----@param t table Array-like table. Caller guarantees that this table is a valid array.
+---@param t table Array-like table. Caller guarantees that this table is a valid array. Can have
+---               holes (nil values).
+---@param length integer Length of the table (largest positive integer index).
 ---@return Iter
 ---@private
 function ArrayIter.new(t, length)

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -1033,17 +1033,13 @@ function Iter.new(src, ...)
     local t = {}
 
     -- O(n): scan the source table to decide if it is an array (only positive integer indices).
-    local length = 0
     for k, v in pairs(src) do
-      if type(k) ~= 'number' or math.floor(k) ~= k then
+      if type(k) ~= 'number' or k <= 0 or math.floor(k) ~= k then
         return Iter.new(pairs(src))
       end
-      if k > length then
-        length = k
-      end
-      t[k] = v
+      t[#t + 1] = v
     end
-    return ArrayIter.new(t, length)
+    return ArrayIter.new(t)
   end
 
   if type(src) == 'function' then
@@ -1075,14 +1071,13 @@ end
 ---
 ---@param t table Array-like table. Caller guarantees that this table is a valid array. Can have
 ---               holes (nil values).
----@param length integer Length of the table (largest positive integer index).
 ---@return Iter
 ---@private
-function ArrayIter.new(t, length)
+function ArrayIter.new(t)
   local it = {}
   it._table = t
   it._head = 1
-  it._tail = length + 1
+  it._tail = #t + 1
   setmetatable(it, ArrayIter)
   return it
 end

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -1034,7 +1034,7 @@ function Iter.new(src, ...)
     -- O(n): scan the source table to decide if it is an array (only positive integer indices).
     local length = 0
     for k, v in pairs(src) do
-      if type(k) ~= 'number' then
+      if type(k) ~= 'number' or math.floor(k) ~= k then
         return Iter.new(pairs(src))
       end
       if k > length then

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -120,28 +120,25 @@ end
 
 --- Flattens a single array-like table. Errors if it attempts to flatten a
 --- dict-like table
----@param v table table which should be flattened
+---@param t table table which should be flattened
 ---@param max_depth number depth to which the table should be flattened
 ---@param depth number current iteration depth
 ---@param result table output table that contains flattened result
 ---@return table|nil flattened table if it can be flattened, otherwise nil
-local function flatten(v, max_depth, depth, result)
-  if depth < max_depth and type(v) == 'table' then
-    local i = 0
-    for _ in pairs(v) do
-      i = i + 1
-
-      if v[i] == nil then
+local function flatten(t, max_depth, depth, result)
+  if depth < max_depth and type(t) == 'table' then
+    for k, v in pairs(t) do
+      if type(k) ~= 'number' or k <= 0 or math.floor(k) ~= k then
         -- short-circuit: this is not a list like table
         return nil
       end
 
-      if flatten(v[i], max_depth, depth + 1, result) == nil then
+      if flatten(v, max_depth, depth + 1, result) == nil then
         return nil
       end
     end
-  elseif v ~= nil then
-    result[#result + 1] = v
+  elseif t ~= nil then
+    result[#result + 1] = t
   end
 
   return result

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -117,8 +117,8 @@ describe('vim.iter', function()
       eq({ { 1, 1 }, { 2, 4 }, { 3, 9 } }, it:totable())
     end
 
-    -- Array-like tables are preserved
-    eq({ 1, nil, 2, nil, 3 }, vim.iter({ 1, nil, 2, nil, 3 }):totable())
+    -- Holes in array-like tables are removed
+    eq({ 1, 2, 3 }, vim.iter({ 1, nil, 2, nil, 3 }):totable())
 
     do
       local it = vim.iter(string.gmatch('1,4,lol,17,blah,2,9,3', '%d+')):map(tonumber)

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -498,6 +498,8 @@ describe('vim.iter', function()
     local also_not_list_like = { nil, 2 }
     eq({ 2 }, vim.iter(also_not_list_like):flatten():totable())
 
+    eq({ 1, 2, 3 }, vim.iter({ nil, { 1, nil, 2 }, 3 }):flatten():totable())
+
     local nested_non_lists = vim.iter({ 1, { { a = 2 } }, { { nil } }, { 3 } })
     eq({ 1, { a = 2 }, { nil }, 3 }, nested_non_lists:flatten():totable())
     -- only error if we're going deep enough to flatten a dict-like table

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -142,7 +142,7 @@ describe('vim.iter', function()
     eq({ 3, 2, 1 }, vim.iter({ 1, 2, 3 }):rev():totable())
 
     local it = vim.iter(string.gmatch('abc', '%w'))
-    matches('rev%(%) requires a list%-like table', pcall_err(it.rev, it))
+    matches('rev%(%) requires an array%-like table', pcall_err(it.rev, it))
   end)
 
   it('skip()', function()
@@ -181,7 +181,7 @@ describe('vim.iter', function()
     end
 
     local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
-    matches('rskip%(%) requires a list%-like table', pcall_err(it.rskip, it, 0))
+    matches('rskip%(%) requires an array%-like table', pcall_err(it.rskip, it, 0))
   end)
 
   it('slice()', function()
@@ -195,7 +195,7 @@ describe('vim.iter', function()
     eq({ 8, 9, 10 }, vim.iter(q):slice(8, 11):totable())
 
     local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
-    matches('slice%(%) requires a list%-like table', pcall_err(it.slice, it, 1, 3))
+    matches('slice%(%) requires an array%-like table', pcall_err(it.slice, it, 1, 3))
   end)
 
   it('nth()', function()
@@ -234,7 +234,7 @@ describe('vim.iter', function()
     end
 
     local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
-    matches('rskip%(%) requires a list%-like table', pcall_err(it.nth, it, -1))
+    matches('rskip%(%) requires an array%-like table', pcall_err(it.nth, it, -1))
   end)
 
   it('take()', function()
@@ -356,7 +356,7 @@ describe('vim.iter', function()
 
     do
       local it = vim.iter(vim.gsplit('hi', ''))
-      matches('peek%(%) requires a list%-like table', pcall_err(it.peek, it))
+      matches('peek%(%) requires an array%-like table', pcall_err(it.peek, it))
     end
   end)
 
@@ -417,7 +417,7 @@ describe('vim.iter', function()
 
     do
       local it = vim.iter(vim.gsplit('AbCdE', ''))
-      matches('rfind%(%) requires a list%-like table', pcall_err(it.rfind, it, 'E'))
+      matches('rfind%(%) requires an array%-like table', pcall_err(it.rfind, it, 'E'))
     end
   end)
 
@@ -434,7 +434,7 @@ describe('vim.iter', function()
 
     do
       local it = vim.iter(vim.gsplit('hi', ''))
-      matches('pop%(%) requires a list%-like table', pcall_err(it.pop, it))
+      matches('pop%(%) requires an array%-like table', pcall_err(it.pop, it))
     end
   end)
 
@@ -448,7 +448,7 @@ describe('vim.iter', function()
 
     do
       local it = vim.iter(vim.gsplit('hi', ''))
-      matches('rpeek%(%) requires a list%-like table', pcall_err(it.rpeek, it))
+      matches('rpeek%(%) requires an array%-like table', pcall_err(it.rpeek, it))
     end
   end)
 
@@ -482,18 +482,18 @@ describe('vim.iter', function()
     local m = { a = 1, b = { 2, 3 }, d = { 4 } }
     local it = vim.iter(m)
 
-    local flat_err = 'flatten%(%) requires a list%-like table'
+    local flat_err = 'flatten%(%) requires an array%-like table'
     matches(flat_err, pcall_err(it.flatten, it))
 
     -- cases from the documentation
     local simple_example = { 1, { 2 }, { { 3 } } }
     eq({ 1, 2, { 3 } }, vim.iter(simple_example):flatten():totable())
 
-    local not_list_like = vim.iter({ [2] = 2 })
-    matches(flat_err, pcall_err(not_list_like.flatten, not_list_like))
+    local not_list_like = { [2] = 2 }
+    eq({ 2 }, vim.iter(not_list_like):flatten():totable())
 
-    local also_not_list_like = vim.iter({ nil, 2 })
-    matches(flat_err, pcall_err(not_list_like.flatten, also_not_list_like))
+    local also_not_list_like = { nil, 2 }
+    eq({ 2 }, vim.iter(also_not_list_like):flatten():totable())
 
     local nested_non_lists = vim.iter({ 1, { { a = 2 } }, { { nil } }, { 3 } })
     eq({ 1, { a = 2 }, { nil }, 3 }, nested_non_lists:flatten():totable())

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -117,6 +117,9 @@ describe('vim.iter', function()
       eq({ { 1, 1 }, { 2, 4 }, { 3, 9 } }, it:totable())
     end
 
+    -- Array-like tables are preserved
+    eq({ 1, nil, 2, nil, 3 }, vim.iter({ 1, nil, 2, nil, 3 }):totable())
+
     do
       local it = vim.iter(string.gmatch('1,4,lol,17,blah,2,9,3', '%d+')):map(tonumber)
       eq({ 1, 4, 17, 2, 9, 3 }, it:totable())


### PR DESCRIPTION
The optimizations that vim.iter uses for array-like tables don't strictly require that the underlying table has no holes. The only thing that needs to change is the determination if a table is "list-like": rather than requiring consecutive, integer keys, we can simply test for integer keys only, and remove any holes in the original array when we make a copy for the iterator.

This allows `vim.iter(t):flatten():totable()` to work as a proper replacement for `vim.tbl_flatten`.

Fixes #28777.
