### PR TITLE
fix(defaults): do not query terminal if 'termguicolors' is already set

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -431,7 +431,9 @@ do
     --- response indicates that it does support truecolor enable 'termguicolors',
     --- but only if the user has not already disabled it.
     do
-      if tty.rgb then
+      if vim.api.nvim_get_option_info2('termguicolors', {}).was_set then -- luacheck: ignore 542
+        -- Do nothing, option was already set by the user
+      elseif tty.rgb then
         -- The TUI was able to determine truecolor support
         setoption('termguicolors', true)
       else


### PR DESCRIPTION
If 'termguicolors' is already set by the user then do not query the terminal for support.