### PR TITLE
vim-patch:9.1.{0414,0416}

### DIFF
--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1197,4 +1197,91 @@ describe('smoothscroll', function()
                                               |
     ]])
   end)
+
+  it('works with very long line and scrolloff', function()
+    screen:try_resize(40, 8)
+    exec([[
+      set smoothscroll scrolloff=3
+      call setline(1, ['one', 'two long '->repeat(100), 'three', 'four', 'five', 'six'])
+    ]])
+    --FIXME: incorrect screen due to reset_skipcol()/curs_columns() shenanigans
+    feed(':norm j721|<CR>')
+    screen:expect([[
+      two long two long two long two long two |
+      long two long two long two long two long|
+       two long two long two long two long two|
+      ^ long two long two long two long two lon|
+      g two long two long two long two long tw|
+      o long two long two long two long two lo|
+      ng two long two long two long two long t|
+      :norm j721|                             |
+    ]])
+    feed('gj')
+    screen:expect([[
+      {1:<<<}two long two long two long two long t|
+      wo long two long two long two long two l|
+      ong two long two long two long two long |
+      two long two long two long two long two |
+      ^long two long two long two long two long|
+       two long two long two long two long two|
+       long two long two long two long two lon|
+      :norm j721|                             |
+    ]])
+    feed('gj')
+    screen:expect([[
+      {1:<<<}long two long two long two long two l|
+      ong two long two long two long two long |
+      two long two long two long two long two |
+      long two long two long two long two long|
+      ^ two long two long two long two long two|
+       long two long two long two long two lon|
+      g two long two long                     |
+      :norm j721|                             |
+    ]])
+    feed('gj')
+    screen:expect([[
+      {1:<<<}long two long two long two long two l|
+      ong two long two long two long two long |
+      two long two long two long two long two |
+      long two long two long two long two long|
+       two long two long two long two long two|
+      ^ long two long two long two long two lon|
+      g two long two long                     |
+      :norm j721|                             |
+    ]])
+    feed('gj')
+    screen:expect([[
+      {1:<<<}long two long two long two long two l|
+      ong two long two long two long two long |
+      two long two long two long two long two |
+      long two long two long two long two long|
+       two long two long two long two long two|
+       long two long two long two long two lon|
+      ^g two long two long                     |
+      :norm j721|                             |
+    ]])
+    feed('gj')
+    screen:expect([[
+      {1:<<<} long two long two long two long two |
+      long two long two long two long two long|
+       two long two long two long two long two|
+       long two long two long two long two lon|
+      g two long two long                     |
+      ^three                                   |
+      four                                    |
+      :norm j721|                             |
+    ]])
+    feed('gk')
+    --FIXME: incorrect screen due to reset_skipcol()/curs_columns() shenanigans
+    screen:expect([[
+      two long two long two long two long two |
+      long two long two long two long two long|
+       two long two long two long two long two|
+       long two long two long two long two lon|
+      g two long two long two long two long tw|
+      o long two long two long two long two lo|
+      ^ng two long two long two long two long t|
+      :norm j721|                             |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1156,4 +1156,39 @@ func Test_smoothscroll_long_line_zb()
   bwipe!
 endfunc
 
+func Test_smooth_long_scrolloff()
+  CheckScreendump
+
+  let lines =<< trim END
+    set smoothscroll scrolloff=3
+    call setline(1, ['one', 'two long '->repeat(100), 'three', 'four', 'five', 'six'])
+  END
+  call writefile(lines, 'XSmoothLongScrolloff', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothLongScrolloff', #{rows: 8, cols: 40})
+  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
+  call term_sendkeys(buf, ":norm j721|\<CR>")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_1', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_2', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_3', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_4', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_5', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_6', {})
+
+  call term_sendkeys(buf, "gk")
+  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_7', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:9.1.0414: Unable to leave long line with 'smoothscroll' and 'scrolloff'**

Problem:  Unable to leave long line with 'smoothscroll' and 'scrolloff'.
          Corrupted screen near the end of a long line with 'scrolloff'.
          (Ernie Rael, after 9.1.0280)
Solution: Only correct cursor in case scroll_cursor_bot() was not itself
          called to make the cursor visible. Avoid adjusting for
          'scrolloff' beyond the text line height (Luuk van Baal)

https://github.com/vim/vim/commit/b32055e504ebd4f6183a93b92b08d61dad61c841

**vim-patch:9.1.0416: some screen dump tests can be improved**

Problem:  some screen dump tests can be improved (after 9.1.0414)
Solution: Make sure screen state changes properly and is captured in the
          screen dumps (Luuk van Baal)

https://github.com/vim/vim/commit/2e642734f4be506483315b8881748a7ef45854f4