### PR TITLE
fix: trigger LspDetach on buffer delete

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -576,10 +576,19 @@ local function buf_attach(bufnr)
     on_detach = function()
       local params = { textDocument = { uri = uri } }
       for _, client in ipairs(lsp.get_clients({ bufnr = bufnr })) do
+        api.nvim_exec_autocmds('LspDetach', {
+          buffer = bufnr,
+          modeline = false,
+          data = { client_id = client.id },
+        })
+
         changetracking.reset_buf(client, bufnr)
         if client.supports_method(ms.textDocument_didClose) then
           client.notify(ms.textDocument_didClose, params)
         end
+
+        local namespace = lsp.diagnostic.get_namespace(client.id)
+        vim.diagnostic.reset(namespace, bufnr)
       end
       for _, client in ipairs(all_clients) do
         client.attached_buffers[bufnr] = nil

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -475,6 +475,12 @@ describe('LSP', function()
         local server = _create_server()
         local bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_set_current_buf(bufnr)
+        local detach_called = false
+        vim.api.nvim_create_autocmd("LspDetach", {
+          callback = function()
+            detach_called = true
+          end
+        })
         local client_id = vim.lsp.start({ name = 'detach-dummy', cmd = server.cmd })
         assert(client_id, "lsp.start must return client_id")
         local client = vim.lsp.get_client_by_id(client_id)
@@ -486,11 +492,13 @@ describe('LSP', function()
           client_id = client_id,
           num_attached_before = num_attached_before,
           num_attached_after = num_attached_after,
+          detach_called = detach_called,
         }
       ]])
       eq(true, result ~= nil, 'exec_lua must return result')
       eq(1, result.num_attached_before)
       eq(0, result.num_attached_after)
+      eq(true, result.detach_called)
     end)
 
     it('client should return settings via workspace/configuration handler', function()


### PR DESCRIPTION
Currently, the LspDetach autocmd is triggered when the attached client quits, or if the `vim.lsp.buf_detach_client` function is called, but not if the buffer is deleted.

I've basically just updated the `on_detach` callback to be like `buf_detach_client`. Would it perhaps be better to just call `buf_detach_client` directly? I'm also not sure if the `vim.diagnostic.reset` bit is necessary.

There should probably be a test for this, but I have no idea how any of that works... this PR is mostly because it was easier than writing up a bug report :) Please feel free to make/suggest any necessary changes.