### PR TITLE
feat(lsp): hide layout in codelenses in virtual text (#28794)

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -164,7 +164,7 @@ function M.display(lenses, bufnr, client_id)
       return a.range.start.character < b.range.start.character
     end)
     for j, lens in ipairs(line_lenses) do
-      local text = lens.command and lens.command.title or 'Unresolved lens ...'
+      local text = (lens.command and lens.command.title or 'Unresolved lens ...'):gsub('%s+', ' ')
       table.insert(chunks, { text, 'LspCodeLens' })
       if j < num_line_lenses then
         table.insert(chunks, { ' | ', 'LspCodeLensSeparator' })


### PR DESCRIPTION
Problem: layout i.e. whitespace that is part of codelenses is currently displayed as weird symbols and large amounts of spaces

Solution: replace all consecutive whitespace symbols with a single space character when trying to display codelenses as virtual text

This closes #28794 