### PR TITLE
ci: change label `backport` to `target:release`

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,5 +32,5 @@ jobs:
               issue_number: ${{steps.backport.outputs.created_pull_numbers}},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['backport']
+              labels: ['target:release']
             })


### PR DESCRIPTION
`backport` is too similar `ci:backport release-x.y` and causes
confusion.