### PR TITLE
fix(diagnostic): show backtrace for deprecation warnings

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1281,7 +1281,7 @@ M.handlers.signs = {
             'vim.diagnostic.config()',
             '0.12',
             nil,
-            false
+            false -- suppress backtrace
           )
 
           if not opts.signs.text then
@@ -1596,7 +1596,7 @@ end
 
 --- @deprecated use `vim.diagnostic.is_enabled()`
 function M.is_disabled(bufnr, namespace)
-  vim.deprecate('vim.diagnostic.is_disabled()', 'vim.diagnostic.is_enabled()', '0.12', nil, false)
+  vim.deprecate('vim.diagnostic.is_disabled()', 'vim.diagnostic.is_enabled()', '0.12')
   return not M.is_enabled { bufnr = bufnr or 0, ns_id = namespace }
 end
 
@@ -1987,7 +1987,7 @@ end
 
 --- @deprecated use `vim.diagnostic.enable(false, …)`
 function M.disable(bufnr, namespace)
-  vim.deprecate('vim.diagnostic.disable()', 'vim.diagnostic.enable(false, …)', '0.12', nil, false)
+  vim.deprecate('vim.diagnostic.disable()', 'vim.diagnostic.enable(false, …)', '0.12')
   M.enable(false, { bufnr = bufnr, ns_id = namespace })
 end
 
@@ -2011,9 +2011,7 @@ function M.enable(enable, filter)
     vim.deprecate(
       'vim.diagnostic.enable(buf:number, namespace:number)',
       'vim.diagnostic.enable(enable:boolean, filter:table)',
-      '0.12',
-      nil,
-      false
+      '0.12'
     )
 
     vim.validate({


### PR DESCRIPTION
Problem: On nvim 11.0-dev, deprecation warnings due to an use of hard-deprecated APIs such as:
- `vim.diagnostic.disable()`
- `vim.diagnostic.is_disabled()`

etc. are not accompanied by backtrace information.

It makes difficult for users to figure out which lines or which plugins are still using deprecated APIs.

Solution: use `backtrace = true` in vim.deprecate() call.
