### PR TITLE
refactor: split up `vim.deprecate` into two functions

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1276,11 +1276,10 @@ M.handlers.signs = {
         local sign = vim.fn.sign_getdefined(name)[1]
         if sign then
           local severity = M.severity[v:upper()]
-          vim.deprecate(
+          vim._deprecate(
             'Defining diagnostic signs with :sign-define or sign_define()',
             'vim.diagnostic.config()',
             '0.12',
-            nil,
             false
           )
 
@@ -1596,7 +1595,7 @@ end
 
 --- @deprecated use `vim.diagnostic.is_enabled()`
 function M.is_disabled(bufnr, namespace)
-  vim.deprecate('vim.diagnostic.is_disabled()', 'vim.diagnostic.is_enabled()', '0.12', nil, false)
+  vim._deprecate('vim.diagnostic.is_disabled()', 'vim.diagnostic.is_enabled()', '0.12', false)
   return not M.is_enabled { bufnr = bufnr or 0, ns_id = namespace }
 end
 
@@ -1987,7 +1986,7 @@ end
 
 --- @deprecated use `vim.diagnostic.enable(false, …)`
 function M.disable(bufnr, namespace)
-  vim.deprecate('vim.diagnostic.disable()', 'vim.diagnostic.enable(false, …)', '0.12', nil, false)
+  vim._deprecate('vim.diagnostic.disable()', 'vim.diagnostic.enable(false, …)', '0.12', false)
   M.enable(false, { bufnr = bufnr, ns_id = namespace })
 end
 
@@ -2008,11 +2007,10 @@ function M.enable(enable, filter)
     and vim.tbl_contains({ 'number', 'nil' }, type(filter))
 
   if legacy then
-    vim.deprecate(
+    vim._deprecate(
       'vim.diagnostic.enable(buf:number, namespace:number)',
       'vim.diagnostic.enable(enable:boolean, filter:table)',
       '0.12',
-      nil,
       false
     )
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -782,7 +782,7 @@ end
 ---@private
 ---@deprecated
 function lsp.get_active_clients(filter)
-  vim.deprecate('vim.lsp.get_active_clients()', 'vim.lsp.get_clients()', '0.12')
+  vim._deprecate('vim.lsp.get_active_clients()', 'vim.lsp.get_clients()', '0.12')
   return lsp.get_clients(filter)
 end
 
@@ -1089,7 +1089,7 @@ end
 ---@return table result is table of (client_id, client) pairs
 ---@deprecated Use |vim.lsp.get_clients()| instead.
 function lsp.buf_get_clients(bufnr)
-  vim.deprecate('vim.lsp.buf_get_clients()', 'vim.lsp.get_clients()', '0.12')
+  vim._deprecate('vim.lsp.buf_get_clients()', 'vim.lsp.get_clients()', '0.12')
   local result = {} --- @type table<integer,vim.lsp.Client>
   for _, client in ipairs(lsp.get_clients({ bufnr = resolve_bufnr(bufnr) })) do
     result[client.id] = client
@@ -1140,7 +1140,7 @@ end
 ---                   buffer number as arguments.
 ---@deprecated use lsp.get_clients({ bufnr = bufnr }) with regular loop
 function lsp.for_each_buffer_client(bufnr, fn)
-  vim.deprecate(
+  vim._deprecate(
     'vim.lsp.for_each_buffer_client()',
     'lsp.get_clients({ bufnr = bufnr }) with regular loop',
     '0.12'

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -221,7 +221,7 @@ end
 
 local function convert_severity(opt)
   if type(opt) == 'table' and not opt.severity and opt.severity_limit then
-    vim.deprecate('severity_limit', '{min = severity} See vim.diagnostic.severity', '0.11')
+    vim._deprecate('severity_limit', '{min = severity} See vim.diagnostic.severity', '0.11')
     opt.severity = { min = severity_lsp_to_vim(opt.severity_limit) }
   end
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -179,7 +179,7 @@ local _str_byteindex_enc = M._str_byteindex_enc
 ---@param new_lines (table) list of strings to replace the original
 ---@return table The modified {lines} object
 function M.set_lines(lines, A, B, new_lines)
-  vim.deprecate('vim.lsp.util.set_lines()', 'nil', '0.12')
+  vim._deprecate('vim.lsp.util.set_lines()', 'nil', '0.12')
   -- 0-indexing to 1-indexing
   local i_0 = A[1] + 1
   -- If it extends past the end, truncate it to the end. This is because the
@@ -1850,7 +1850,7 @@ end
 ---@param lines table list of lines to trim
 ---@return table trimmed list of lines
 function M.trim_empty_lines(lines)
-  vim.deprecate('vim.lsp.util.trim_empty_lines()', 'vim.split() with `trimempty`', '0.12')
+  vim._deprecate('vim.lsp.util.trim_empty_lines()', 'vim.split() with `trimempty`', '0.12')
   local start = 1
   for i = 1, #lines do
     if lines[i] ~= nil and #lines[i] > 0 then
@@ -1877,7 +1877,7 @@ end
 ---@param lines table list of lines
 ---@return string filetype or "markdown" if it was unchanged.
 function M.try_trim_markdown_code_blocks(lines)
-  vim.deprecate('vim.lsp.util.try_trim_markdown_code_blocks()', 'nil', '0.12')
+  vim._deprecate('vim.lsp.util.try_trim_markdown_code_blocks()', 'nil', '0.12')
   local language_id = lines[1]:match('^```(.*)')
   if language_id then
     local has_inner_code_fence = false
@@ -2106,7 +2106,7 @@ end
 ---@return table|string|vim.NIL The value of settings accessed via section. `vim.NIL` if not found.
 ---@deprecated
 function M.lookup_section(settings, section)
-  vim.deprecate('vim.lsp.util.lookup_section()', 'vim.tbl_get() with `vim.split`', '0.12')
+  vim._deprecate('vim.lsp.util.lookup_section()', 'vim.tbl_get() with `vim.split`', '0.12')
   for part in vim.gsplit(section, '.', { plain = true }) do
     settings = settings[part]
     if settings == nil then

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -469,7 +469,7 @@ end
 ---@param o table Table to add the reverse to
 ---@return table o
 function vim.tbl_add_reverse_lookup(o)
-  vim.deprecate('vim.tbl_add_reverse_lookup', nil, '0.12')
+  vim._deprecate('vim.tbl_add_reverse_lookup', nil, '0.12')
 
   --- @cast o table<any,any>
   --- @type any[]
@@ -553,7 +553,7 @@ end
 ---@param t table List-like table
 ---@return table Flattened copy of the given list-like table
 function vim.tbl_flatten(t)
-  vim.deprecate('vim.tbl_flatten', 'vim.iter(…):flatten():totable()', '0.13')
+  vim._deprecate('vim.tbl_flatten', 'vim.iter(…):flatten():totable()', '0.13')
   local result = {}
   --- @param _t table<any,any>
   local function _tbl_flatten(_t)
@@ -644,7 +644,7 @@ end
 
 --- @deprecated
 function vim.tbl_islist(t)
-  vim.deprecate('vim.tbl_islist', 'vim.islist', '0.12')
+  vim._deprecate('vim.tbl_islist', 'vim.islist', '0.12')
   return vim.islist(t)
 end
 

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -36,7 +36,7 @@ end
 
 ---@deprecated
 function M.require_language(lang, path, silent, symbol_name)
-  vim.deprecate(
+  vim._deprecate(
     'vim.treesitter.language.require_language()',
     'vim.treesitter.language.add()',
     '0.12'

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -131,51 +131,8 @@ describe('lua stdlib', function()
 
   --- @param prerel string | nil
   local function test_vim_deprecate(prerel)
-    -- vim.deprecate(name, alternative, version, plugin, backtrace)
-    -- See MAINTAIN.md for the soft/hard deprecation policy
-
     describe(('vim.deprecate prerel=%s,'):format(prerel or 'nil'), function()
-      it('plugin=nil', function()
-        local curver = exec_lua('return vim.version()') --[[@as {major:number, minor:number}]]
-        -- "0.10" or "0.10-dev+xxx"
-        local curstr = ('%s.%s%s'):format(curver.major, curver.minor, prerel or '')
-        -- "0.10" or "0.11"
-        local nextver = ('%s.%s'):format(curver.major, curver.minor + (prerel and 0 or 1))
-        local was_removed = prerel and 'was removed' or 'will be removed'
-
-        eq(
-          dedent([[
-            foo.bar() is deprecated, use zub.wooo{ok=yay} instead. :help deprecated
-            Feature was removed in Nvim %s]]):format(curstr),
-          exec_lua('return vim.deprecate(...)', 'foo.bar()', 'zub.wooo{ok=yay}', curstr)
-        )
-        -- Same message as above; skipped this time.
-        eq(vim.NIL, exec_lua('return vim.deprecate(...)', 'foo.bar()', 'zub.wooo{ok=yay}', curstr))
-
-        -- No error if soft-deprecated.
-        eq(
-          vim.NIL,
-          exec_lua('return vim.deprecate(...)', 'foo.baz()', 'foo.better_baz()', '0.99.0')
-        )
-
-        -- Show error if hard-deprecated.
-        eq(
-          dedent([[
-            foo.hard_dep() is deprecated, use vim.new_api() instead. :help deprecated
-            Feature %s in Nvim %s]]):format(was_removed, nextver),
-          exec_lua('return vim.deprecate(...)', 'foo.hard_dep()', 'vim.new_api()', nextver)
-        )
-
-        -- To be deleted in the next major version (1.0)
-        eq(
-          dedent [[
-            foo.baz() is deprecated. :help deprecated
-            Feature will be removed in Nvim 1.0]],
-          exec_lua [[ return vim.deprecate('foo.baz()', nil, '1.0') ]]
-        )
-      end)
-
-      it('plugin specified', function()
+      it('works', function()
         -- When `plugin` is specified, don't show ":help deprecated". #22235
         eq(
           dedent [[
@@ -209,8 +166,58 @@ describe('lua stdlib', function()
     end)
   end
 
+  --- @param prerel string | nil
+  local function test_vim_internal_deprecate(prerel)
+    -- vim._deprecate(name, alternative, version, backtrace)
+    -- See MAINTAIN.md for the soft/hard deprecation policy
+
+    describe(('vim._deprecate prerel=%s,'):format(prerel or 'nil'), function()
+      it('works', function()
+        local curver = exec_lua('return vim.version()') --[[@as {major:number, minor:number}]]
+        -- "0.10" or "0.10-dev+xxx"
+        local curstr = ('%s.%s%s'):format(curver.major, curver.minor, prerel or '')
+        -- "0.10" or "0.11"
+        local nextver = ('%s.%s'):format(curver.major, curver.minor + (prerel and 0 or 1))
+        local was_removed = prerel and 'was removed' or 'will be removed'
+
+        eq(
+          dedent([[
+            foo.bar() is deprecated, use zub.wooo{ok=yay} instead. :help deprecated
+            Feature was removed in Nvim %s]]):format(curstr),
+          exec_lua('return vim._deprecate(...)', 'foo.bar()', 'zub.wooo{ok=yay}', curstr)
+        )
+        -- Same message as above; skipped this time.
+        eq(vim.NIL, exec_lua('return vim._deprecate(...)', 'foo.bar()', 'zub.wooo{ok=yay}', curstr))
+
+        -- No error if soft-deprecated.
+        eq(
+          vim.NIL,
+          exec_lua('return vim._deprecate(...)', 'foo.baz()', 'foo.better_baz()', '0.99.0')
+        )
+
+        -- Show error if hard-deprecated.
+        eq(
+          dedent([[
+            foo.hard_dep() is deprecated, use vim.new_api() instead. :help deprecated
+            Feature %s in Nvim %s]]):format(was_removed, nextver),
+          exec_lua('return vim._deprecate(...)', 'foo.hard_dep()', 'vim.new_api()', nextver)
+        )
+
+        -- To be deleted in the next major version (1.0)
+        eq(
+          dedent [[
+            foo.baz() is deprecated. :help deprecated
+            Feature will be removed in Nvim 1.0]],
+          exec_lua [[ return vim._deprecate('foo.baz()', nil, '1.0') ]]
+        )
+      end)
+    end)
+  end
+
   test_vim_deprecate()
   test_vim_deprecate('-dev+g0000000')
+  test_vim_internal_deprecate()
+  test_vim_internal_deprecate('-dev+g0000000')
 
   it('vim.startswith', function()
     eq(true, fn.luaeval('vim.startswith("123", "1")'))


### PR DESCRIPTION
`vim.deprecate` has become too complicated, and the usecase for a
general deprecation function that plugins can use vs a deprecation
function that fits neovim's growing needs is becoming too different.