### PR TITLE
fix(lsp): add textDocument/documentLink to capability map

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -64,6 +64,8 @@ lsp._request_name_to_capability = {
   [ms.textDocument_inlayHint] = { 'inlayHintProvider' },
   [ms.textDocument_diagnostic] = { 'diagnosticProvider' },
   [ms.inlayHint_resolve] = { 'inlayHintProvider', 'resolveProvider' },
+  [ms.textDocument_documentLink] = { 'documentLinkProvider' },
+  [ms.documentLink_resolve] = { 'documentLinkProvider', 'resolveProvider' },
 }
 
 -- TODO improve handling of scratch buffers with LSP attached.


### PR DESCRIPTION
The `supports_method` method returns `true` if it doesn't recognize the LSP method. As a result, the following request is sent to clients that don't support it:

``` lua
local params = { textDocument = util.make_text_document_params() }
vim.lsp.buf_request(0, "textDocument/documentLink", params, function(err, result, ctx)
    // ...
end)
```