### PR TITLE
fix(treesitter): `get_node_text()` newline handling consistency

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -187,6 +187,7 @@ end
 ---@returns string
 local function buf_range_get_text(buf, range)
   local start_row, start_col, end_row, end_col = M._range.unpack4(range)
+  local insert_nl = false
   if end_col == 0 then
     if start_row == end_row then
       start_col = -1
@@ -194,8 +195,12 @@ local function buf_range_get_text(buf, range)
     end
     end_col = -1
     end_row = end_row - 1
+    insert_nl = true
   end
   local lines = api.nvim_buf_get_text(buf, start_row, start_col, end_row, end_col, {})
+  if insert_nl then
+    table.insert(lines, "")
+  end
   return table.concat(lines, '\n')
 end
 


### PR DESCRIPTION
##  Description
This pull request addresses the issue where `get_node_text()` behaves inconsistently between buffer and string sources.

Resolves #28677 

### Changes
- Modified `buf_range_get_text` to insert the trailing newline char.

### Rationale
My understanding is taht the range represents the part of the source to be captured. When set on a grid:
```
  0 1 2 3 4 5 6 7
0 " " " t e s t \n
1 " " "
```

With the range being `Range = { 0, 3, 1, 0 }`. I would then expect `\n` to be part of the output. Hence, I modified the behavior of the buffer source.

`nvim_buf_get_text` replaces `\n` with `\0`, and they are artificially recreated with `table.concat(lines, "\n")`. This function does not add the newline if there's only one input or if the last input is a newline. I added logic to remember if the part of the buffer to release ends with a newline to add it later.

### Note to reviewers
Please feel free to correct me if my understanding is incorrect. I would be happy to discuss it further.