### PR TITLE
feat(comment): commentstring hook for more control

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -585,6 +585,28 @@ to look up the value of 'commentstring' corresponding to the cursor position.
 (This can be different from the buffer's 'commentstring' in case of
 |treesitter-language-injections|.)
 
+The comment module can take a custom hook to allow for more control when
+determining the 'commentstring'. For example, the following can be used to get
+more accurate comments in JSX-family files (assuming the appropriate
+|treesitter| parser has been installed): >lua
+
+    require('vim._comment').cs_hook = function(row, col)
+      local ft = vim.bo.filetype
+      if ft == 'typescriptreact' or ft == 'javascriptreact' then
+        local current_node = vim.treesitter.get_node({ pos = { row, col } })
+        while current_node do
+          if current_node:type() == 'jsx_element' then
+            return '{/*%s*/}'
+          end
+          current_node = current_node:parent()
+        end
+      else
+        -- the hook is ignored when it returns `nil`
+        return nil
+      end
+    end
+<
+
 							*gc* *gc-default*
 gc{motion}		Comment or uncomment lines covered by {motion}.
 

--- a/test/functional/lua/comment_spec.lua
+++ b/test/functional/lua/comment_spec.lua
@@ -364,6 +364,19 @@ describe('commenting', function()
       toggle_lines(1, 4)
       eq(get_lines(), { ' aa  ', ' aa\t', '', '' })
     end)
+
+    it('works with custom commentstring hook', function()
+      -- Without right-hand side
+      set_commentstring('# %s')
+      require('vim._comment').cs_hook = function()
+        return '// %s'
+      end
+      set_lines({ ' aa', ' aa  ', '  ' })
+      toggle_lines(1, 3)
+      eq(get_lines(), { ' // aa', ' // aa  ', ' //' })
+      toggle_lines(1, 3)
+      eq(get_lines(), { ' aa', ' aa  ', '' })
+    end)
   end)
 
   describe('Operator', function()


### PR DESCRIPTION
Problem: it's difficult for users to customize the inbuilt commenting behavior (changing or extending)

Solution: expose a hook that can override the selected commentstring, to allow for finer control

Closes #28830