### PR TITLE
doc: add `~/.config/nvim/init.lua` to man page

### DIFF
--- a/src/man/nvim.1
+++ b/src/man/nvim.1
@@ -387,10 +387,10 @@ features like
 .El
 .Sh FILES
 .Bl -tag -width "~/.config/nvim/init.vim"
-.It Pa ~/.config/nvim/init.vim
+.It Pa ~/.config/nvim/init.lua
 User-local
 .Nm
-configuration file.
+Lua configuration file.
 .It Pa ~/.config/nvim
 User-local
 .Nm


### PR DESCRIPTION
Man page previously only mentioned `~/.config/nvim/init.vim`