### PR TITLE
feat(inccommand): allow redrawing during cmdpreview

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2351,7 +2351,7 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
 
   // Redraw pending screen updates when explicitly requested or when determined
   // that it is necessary to properly draw other requested components.
-  if (opts->flush && !cmdpreview) {
+  if (opts->flush) {
     update_screen();
   }
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -70,6 +70,16 @@ typedef struct {
 // Mask to check for flags that prevent normal writing
 #define BF_WRITE_MASK   (BF_NOTEDITED + BF_NEW + BF_READERR)
 
+// values for b_cp_locked
+#define BCP_NONE        0       // Not locked by command preview.
+#define BCP_HALF_LOCKED 1       // Locked, but not currently in use
+                                // by command preview. Like BCP_FULL_LOCKED,
+                                // but can still be unloaded.
+#define BCP_FULL_LOCKED 2       // Locked and currently in use. Cannot be
+                                // unloaded or entered, and windows containing
+                                // it cannot be closed, split, or change
+                                // buffers.
+
 typedef struct wininfo_S WinInfo;
 typedef struct frame_S frame_T;
 typedef uint64_t disptick_T;  // display tick type
@@ -367,6 +377,9 @@ struct file_buffer {
                                 // a new window with it.
   int b_ro_locked;              // Non-zero when the buffer can't be changed.
                                 // Used for FileChangedRO
+  int b_cp_locked;              // Buffer locked by cmdpreview, disallowing
+                                // closing it and closing/splitting windows
+                                // that contain it
 
   // b_ffname   has the full path of the file (NULL for no name).
   // b_sfname   is the name as the user typed it (or NULL).

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -398,6 +398,9 @@ void screen_resize(int width, int height)
         }
       }
     }
+    if (cmdpreview_may_refresh()) {
+      update_screen();
+    }
     ui_flush();
   }
   resizing_screen = false;

--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -149,6 +149,8 @@ EXTERN const char e_using_number_as_bool_nr[] INIT(= N_("E1023: Using a Number a
 EXTERN const char e_not_callable_type_str[] INIT(= N_("E1085: Not a callable type: %s"));
 EXTERN const char e_auabort[] INIT(= N_("E855: Autocommands caused command to abort"));
 
+EXTERN const char e_nav_cplocked[] INIT(= N_("E1161: Can't navigate to buffer locked by 'inccomand'"));
+
 EXTERN const char e_api_error[] INIT(= N_("E5555: API call: %s"));
 
 EXTERN const char e_fast_api_disabled[] INIT(= N_("E5560: %s must not be called in a fast event context"));

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2268,6 +2268,9 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
           && curwin->w_buffer->b_nwindows > 1) {
         curwin->w_buffer->b_nwindows--;
       }
+      if (buf->b_cp_locked) {
+        emsg(_(e_nav_cplocked));
+      }
       goto theend;
     }
     if (curwin->w_alt_fnum == buf->b_fnum && prev_alt_fnum != 0) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6549,9 +6549,6 @@ static void ex_redir(exarg_T *eap)
 /// ":redraw": force redraw
 static void ex_redraw(exarg_T *eap)
 {
-  if (cmdpreview) {
-    return;  // Ignore :redraw during 'inccommand' preview. #9777
-  }
   int r = RedrawingDisabled;
   int p = p_lz;
 
@@ -6585,9 +6582,6 @@ static void ex_redraw(exarg_T *eap)
 /// ":redrawstatus": force redraw of status line(s) and window bar(s)
 static void ex_redrawstatus(exarg_T *eap)
 {
-  if (cmdpreview) {
-    return;  // Ignore :redrawstatus during 'inccommand' preview. #9777
-  }
   int r = RedrawingDisabled;
   int p = p_lz;
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2773,9 +2773,6 @@ static bool cmdpreview_may_init_or_update(CpTransition *tr)
   // Cursor may be at the end of the message grid rather than at cmdspos.
   // Place it there in case preview callback flushes it. #30696
   cursorcmd();
-  // Flush now: external cmdline may itself wish to update the screen which is
-  // currently disallowed during cmdpreview(no longer needed in case that changes).
-  cmdline_ui_flush();
 
   if (tr->prev_preview_type == 0) {
     // Save current state and prepare for command preview.
@@ -3028,6 +3025,8 @@ static int command_line_changed(CommandLineState *s)
       cmdpreview_did_not_show();
     }
     if (prev_cmdpreview) {
+      // TODO(theofabilous): is the below `todo` still applicable now that redraws
+      // aren't blocked during cmdpreview?
       // TODO(bfredl): add an immediate redraw flag for cmdline mode which will trigger
       // at next wait-for-input
       update_screen();  // Clear 'inccommand' preview.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5689,8 +5689,13 @@ void may_trigger_win_scrolled_resized(void)
   int cwsr = check_window_scroll_resize(&size_count,
                                         &first_scroll_win, &first_size_win,
                                         NULL, NULL);
-  bool trigger_resize = do_resize && size_count > 0;
-  bool trigger_scroll = do_scroll && cwsr != 0;
+  bool any_resized = size_count > 0;
+  bool any_scrolled = cwsr != 0;
+  if (any_resized || any_scrolled) {
+    (void)cmdpreview_may_refresh();
+  }
+  bool trigger_resize = do_resize && any_resized;
+  bool trigger_scroll = do_scroll && any_scrolled;
   if (!trigger_resize && !trigger_scroll) {
     return;  // no relevant changes
   }

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -679,81 +679,78 @@ describe('lua: nvim_buf_attach on_bytes', function()
       local check_events = setup_eventcheck(verify, { 'abcde', '12345' })
       api.nvim_set_option_value('inccommand', 'nosplit', {})
 
+      local function feed_esc(s)
+        feed(s)
+        n.poke_eventloop()
+        feed('<esc>')
+      end
+
       -- linewise substitute
       feed(':%s/bcd/')
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 3, 3, 0, 0, 0 },
-        { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 0, 0, 0, 3, 3 },
       }
 
-      feed('a')
+      feed_esc('a')
       check_events {
+        { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 0, 0, 0, 3, 3 },
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 3, 3, 0, 1, 1 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 1, 1, 0, 3, 3 },
       }
 
-      feed('<esc>')
-
       -- splitting lines
-      feed([[:%s/abc/\r]])
+      feed_esc([[:%s/abc/\r]])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 0, 0, 0, 3, 3, 1, 0, 1 },
         { 'test1', 'bytes', 1, 6, 0, 0, 0, 1, 0, 1, 0, 3, 3 },
       }
 
-      feed('<esc>')
       -- multi-line regex
-      feed([[:%s/de\n123/a]])
+      feed_esc([[:%s/de\n123/a]])
 
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 3, 3, 1, 3, 6, 0, 1, 1 },
         { 'test1', 'bytes', 1, 6, 0, 3, 3, 0, 1, 1, 1, 3, 6 },
       }
 
-      feed('<esc>')
       -- replacing with unicode
-      feed(':%s/b/→')
+      feed_esc(':%s/b/→')
 
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 3, 3 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 3, 3, 0, 1, 1 },
       }
 
-      feed('<esc>')
       -- replacing with expression register
-      feed([[:%s/b/\=5+5]])
+      feed_esc([[:%s/b/\=5+5]])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 },
       }
 
-      feed('<esc>')
       -- replacing with backslash
-      feed([[:%s/b/\\]])
+      feed_esc([[:%s/b/\\]])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 1, 1 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 1, 1, 0, 1, 1 },
       }
 
-      feed('<esc>')
       -- replacing with backslash from expression register
-      feed([[:%s/b/\='\']])
+      feed_esc([[:%s/b/\='\']])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 1, 1 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 1, 1, 0, 1, 1 },
       }
 
-      feed('<esc>')
       -- replacing with backslash followed by another character
-      feed([[:%s/b/\\!]])
+      feed_esc([[:%s/b/\\!]])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 },
       }
 
-      feed('<esc>')
       -- replacing with backslash followed by another character from expression register
-      feed([[:%s/b/\='\!']])
+      feed_esc([[:%s/b/\='\!']])
       check_events {
         { 'test1', 'bytes', 1, 3, 0, 1, 1, 0, 1, 1, 0, 2, 2 },
         { 'test1', 'bytes', 1, 5, 0, 1, 1, 0, 2, 2, 0, 1, 1 },

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -4810,9 +4810,13 @@ describe('float window', function()
       feed(':%s/.')
 
       if multigrid then
+        -- grid 5 corresponds to window 1002, an autocmd window created
+        -- to rename the preview buffer when it is first created
         screen:expect{grid=[[
           ## grid 1
-            [2:----------------------------------------]|*5
+            [2:----------------------------------------]|
+            {5:[No Name]                               }|
+            [6:----------------------------------------]|*3
             {5:[Preview]                               }|
             [3:----------------------------------------]|
           ## grid 2
@@ -4823,6 +4827,10 @@ describe('float window', function()
             {17:f}{1:oo                           }|
             {17:b}{1:ar                           }|
             {1:                              }|
+          ## grid 6
+            |1| {17:f}oo                                 |
+            |2| {17:b}ar                                 |
+            {0:~                                       }|
         ]], float_pos=expected_pos}
       else
         screen:expect([[


### PR DESCRIPTION
**Problem**: The current `inccommand` implementation works by forcing a redraw right after applying changes and immediately restoring everything without a subsequent redraw, thereby relying on ephemeral screen state (the "preview" visible to the user does not represent the actual state of buffers/windows). This requires disabling redraws while command preview is active (#9777, #9783), which suppresses unrelated UI updates (#20463, #27950), complicates/prevents redrawing floating windows (#28510), and causes rendering issues for GUIs (#24802). In cases where a redraw is forced (e.g. editor resize), the command preview is cleared. Similarly, `<C-g>` and `<C-t>` during `:substitute` clear the preview.

**Solution**: Remove reliance on temporary screen state in command preview, actually keep the buffer changes after applying them. Only restore state when needed (e.g. before re-updating the preview, when leaving cmdline, ...). Allow redrawing during preview, and refresh command preview when the editor is resized or a scroll occurs.

---

> Helpful background: #28510. Notably, it highlights why refreshing command preview is required when scrolls/resizes occur (even when the preview state is persistent). In brief, commands may choose to apply previews only within the visible viewport, so when more lines are revealed the preview may need to be executed again. (If this weren't the case, the editor would basically brick on each keypress after `:%substitue/` for a sufficiently large file).

<details><summary><b>NOTE</b> about commit history</summary>

The commit history is kind of wonky, I tried to organize changes in a way that would make the implementation changes easier to follow (incrementally/chronologically) at the expense of a clean/logical commit sequence in its own right. When this PR gets closer to being ready and others have taken a look at it, I'd like to squash and rearrange some of these changes.

</details>

---

# Implementation

> **NOTE**: In this section, I often use the term "preview callback" or something similar, by which I mean the "per-command" previewing function. So for user-commands thats the `preview = ...` field in the `opts` arg of `nvim_create_user_command` (`:help :command-preview`), and for builtin functions that's `CommandDefinition.cmd_preview_func` (currently only exists for `:substitute`).

The changes in this PR can be roughly organized in 4 steps/categories, which loosely follow the commits chronologically:

1. Refactor the existing cmdpreview logic to ease the new implementation, without yet changing observable behaviour (i.e. still use the `apply + redraw + teardown/restore + disable redrawing` approach). The original approach only ever executes the command preview routines entirely and atomically, all in one go. The new approach requires executing different parts of this routine independently. Additionally, the preview state now needs to be kept alive across calls to update functions and may also be called externally (like, not within the "regular" command line event handling functions). This requires hoisting the state object to a global.

<details>

- split `cmdpreview_prepare()` in two: `cmdpreview_save()` and `cmdpreview_prepare()`. `save()` handles saving buffer information (undo, changedtick, ...), while `prepare()` sets things up only needed for the duration of the next preview execution (ensures undolevels are such that we can subsequently rollback changes, temporarily disable cursorline and incsearch, ...). Reason: later, we'll often want to only call `prepare()` without saving again.
- split `cmdpreview_restore_state()` in two, moving out memory deallocations to `cmdpreview_destroy()`. We'll eventually want to keep saved information around, but we still need to restore buffers before re-executing preview changes, so need to split restoration and deallocation.
- Use a global `CpInfo` object instead of one local to `cmdpreview_may_show()`. Move some of the local variables in that function to fields in `CpInfo` if we'll eventually need to keep track of them.
- extract part of the initial logic from `cmdpreview_may_show` to `cmdpreview_may_init`/`cmdpreview_check_cmdline`, which handle checking if the command is previewable and, if applicable, preparation for showing preview.
- reorganize where/when autocommands are blocked and messages are disabled. Before this wasn't a concern because all the subroutines where only ever called by `cmdpreview_may_show()`, so that function could simply block autocmds at the beginning and unblock them at the end. Eventually, we'll be calling some of those functions individually but still want to block events and error reporting.

</details>

At this point, the high level logic is the same: `cmdpreview_may_show()` handles the full init->show->destroy cycle at once.

2. Don't immediately tear down preview state. Now, `cmdpreview_may_show()` no longer unconditionally completes the full preview cycle. On preview success, the buffer changes are no longer reverted immediately. The `CpInfo` object is not destroyed and thus still holds the saved buffer information. On the next call, the buffer information doesn't need to be saved: instead, the buffers are just restored using the existing saved information before re-applying the preview changes.

<details>

- add `cmdpreview_transition_begin`/`_end` functions. These handle maintaining invariants that I found hard to keep track of manually. When entering the preview handling functions, we may or may not be already previewing, and when exiting the cmdpreview handling functions, we may or may not need to restore buffers, free memory, and/or close windows (for example, depending on whether the preview callback succeeded). The transition functions handle a lot these things.
- we previously didn't always call `cmdpreview_may_show` when the command line changes, this no longer works because the preview may still be active; skipping the cmdpreview updates would then keep those changes active. So, if the cmdline was updated but cmdpreview shouldn't be shown (e.g. when not interactive or input chars are available), call `cmdpreview_did_not_show` which handles cleanup, if applicable.

</details>

3. Handle buffer and window changes/invalidations between preview updates. Now that the changes are kept around, re-executing preview routines when preview is already active isn't as simple: buffers and windows may have been closed, so some of the saved buffer/window information may no longer be valid, and there may be new windows/buffers that now need to be saved.

<details>

- Use `bufref_T` instead of bufs for saved buffer information, so that we can check if the information refers to a invalid buffer. Free invalid buffer information without restoring them in these cases
- Store saved information in hashmaps instead of vecs: when preparing for updates, we want to go through open windows/buffers and check if we've already saved them. See commit message of 7d54e8b
    - **NOTE**: this is possibly less efficient in general unless you have a lot of buffers/windows open, but I'm going with naive/"obvious" solutions for the time being

</details>

4. Finally, allow redrawing while command preview is active. Also update cmdpreview when a resize or scroll occurs, if needed (see note above and/or #28510 for why the latter is required)

---

# Considerations/open questions

Now that preview changes are persistent, a lot more bookkeeping is required. Specifically, buffer and window information can arbitrarily change in between preview updates, and I'm not sure how to handle all such changes.
I have a few specific concerns/questions that I'll add in the comments when I get around to properly wording them.

Here's a rough, quick, likely non-exhaustive list of these concerns:

- What exactly is a preview function allowed to do? I think this should be documented, both for users' and devs' sake.

- In the spirit of playing nice with external UIs, I think there needs to be a way to mark windows as ignored by command preview (if there isn't already), or maybe just have a class of window/buffer option combinations that should be ignored by command preview (e.g. `nomodifiable`+`bufhidden=hide`+`buftype=nofile`+is a floating window+...)?
    - For now, nothing is ignored, but to allow UI widget modifications while cmdpreview is active, the following best effort "heuristic" approach is used (see https://github.com/neovim/neovim/pull/28856/commits/d5ea89cf300fdcd13bc0868cc7202ca168731241):
        - after the preview callback, mark all unchanged buffers (reason: we may "assume" that buffers not modified by the preview callback are more likely to be UI widget-ish)
        - on the next preview update, if a marked buffer has changed, don't attempt to restore it (reason: ui widgets may have been modified in the meantime, restoring them makes no sense and would break e.g. externalized cmdlines during preview)

- What/how do we handle the "in between preview updates" part? Preview changes are actually persistent now, and things can potentially be "messed up" in between consecutive calls to a preview callback (e.g. autocommands called after cmdline changed right before cmdpreview is executed, or a timer callback, ...). Specifically:
    - what if a buffer was changed during this time (possibly *after* being modified by cmdpreview, but *before* those changes were reverted)?