### PR TITLE
vim-patch:9.1.0409: too many strlen() calls in the regexp engine

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -3128,3 +3128,39 @@ void f_trim(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
   rettv->vval.v_string = xstrnsave(head, (size_t)(tail - head));
 }
+
+/// compare two keyvalue_T structs by case sensitive value
+int cmp_keyvalue_value(const void *a, const void *b)
+{
+  keyvalue_T *kv1 = (keyvalue_T *)a;
+  keyvalue_T *kv2 = (keyvalue_T *)b;
+
+  return strcmp(kv1->value, kv2->value);
+}
+
+/// compare two keyvalue_T structs by value with length
+int cmp_keyvalue_value_n(const void *a, const void *b)
+{
+  keyvalue_T *kv1 = (keyvalue_T *)a;
+  keyvalue_T *kv2 = (keyvalue_T *)b;
+
+  return strncmp(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
+}
+
+/// compare two keyvalue_T structs by case insensitive value
+int cmp_keyvalue_value_i(const void *a, const void *b)
+{
+  keyvalue_T *kv1 = (keyvalue_T *)a;
+  keyvalue_T *kv2 = (keyvalue_T *)b;
+
+  return STRICMP(kv1->value, kv2->value);
+}
+
+/// compare two keyvalue_T structs by case insensitive value with length
+int cmp_keyvalue_value_ni(const void *a, const void *b)
+{
+  keyvalue_T *kv1 = (keyvalue_T *)a;
+  keyvalue_T *kv2 = (keyvalue_T *)b;
+
+  return STRNICMP(kv1->value, kv2->value, MAX(kv1->length, kv2->length));
+}

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -32,6 +32,18 @@ static inline char *strappend(char *const dst, const char *const src)
 
 typedef kvec_t(char) StringBuilder;
 
+// Return the length of a string literal
+#define STRLEN_LITERAL(s) (sizeof(s) - 1)
+
+/// Store a key/value pair
+typedef struct {
+  int key;        ///< the key
+  char *value;    ///< the value string
+  size_t length;  ///< length of the value string
+} keyvalue_T;
+
+#define KEYVALUE_ENTRY(k, v) { (k), (v), STRLEN_LITERAL(v) }
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "strings.h.generated.h"
 #endif


### PR DESCRIPTION
#### vim-patch:9.1.0409: too many strlen() calls in the regexp engine

Problem:  too many strlen() calls in the regexp engine
Solution: refactor code to retrieve strlen differently, make use
          of bsearch() for getting the character class
          (John Marriott)

closes: vim/vim#14648

https://github.com/vim/vim/commit/82792db6315f7c7b0e299cdde1566f2932a463f8

Cherry-pick keyvalue_T and its comparison functions from patch 9.1.0256.

vim-patch:9.1.0410: warning about uninitialized variable
vim-patch:9.1.0412: typo in regexp_bt.c in DEBUG code

Co-authored-by: John Marriott <basilisk@internode.on.net>