### PR TITLE
vim-patch:9.1.0399: block_editing errors out when using del

### DIFF
--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -2105,4 +2105,12 @@ func Test_getregion_maxcol()
   bwipe!
 endfunc
 
+func Test_visual_block_cursor_delete()
+  new
+  call setline(1, 'ab')
+  exe ":norm! $\<c-v>hI\<Del>\<ESC>"
+  call assert_equal(['b'], getline(1, 1))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0399: block_editing errors out when using del

Problem:  block_editing errors out when using del
          (@Jamarley)
Solution: Change ins_len from size_t to int and
          properly check that it doesn't become negative

There is a check in os.c that verifies that `ins_len` does not become
negative:
```
if (pre_textlen >= 0 && (ins_len = len - pre_textlen - offset) > 0)
```
However this only works, if ins_len can actually become negative and
unfortunately, ins_len has been declared as `size_t` so instead of
becoming negative it will wrap around and be very large.

So let's define it as integer, after which the condition above
properly catches this condition.

closes: vim/vim#14735

https://github.com/vim/vim/commit/d5c8c0920e1eee9ff7a9fa5168d8e85c01670630

Co-authored-by: Christian Brabandt <cb@256bit.org>