### PR TITLE
vim-patch:8cf29e4c4a2a

### DIFF
--- a/runtime/pack/dist/opt/matchit/autoload/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/autoload/matchit.vim
@@ -1,6 +1,6 @@
 "  matchit.vim: (global plugin) Extended "%" matching
 "  autload script of matchit plugin, see ../plugin/matchit.vim
-"  Last Change: Jan 24, 2022
+"  Last Change: May 20, 2024
 
 " Neovim does not support scriptversion
 if has("vimscript-4")
@@ -87,9 +87,9 @@ function matchit#Match_wrapper(word, forward, mode) range
     let s:last_mps = &mps
     " quote the special chars in 'matchpairs', replace [,:] with \| and then
     " append the builtin pairs (/*, */, #if, #ifdef, #ifndef, #else, #elif,
-    " #endif)
+    " #elifdef, #elifndef, #endif)
     let default = escape(&mps, '[$^.*~\\/?]') .. (strlen(&mps) ? "," : "") ..
-      \ '\/\*:\*\/,#\s*if\%(n\=def\)\=:#\s*else\>:#\s*elif\>:#\s*endif\>'
+      \ '\/\*:\*\/,#\s*if\%(n\=def\)\=:#\s*else\>:#\s*elif\%(n\=def\)\=\>:#\s*endif\>'
     " s:all = pattern with all the keywords
     let match_words = match_words .. (strlen(match_words) ? "," : "") .. default
     let s:last_words = match_words
@@ -101,6 +101,8 @@ function matchit#Match_wrapper(word, forward, mode) range
       let s:pat = s:ParseWords(match_words)
     endif
     let s:all = substitute(s:pat, s:notslash .. '\zs[,:]\+', '\\|', 'g')
+    " un-escape \, to ,
+    let s:all = substitute(s:all, '\\,', ',', 'g')
     " Just in case there are too many '\(...)' groups inside the pattern, make
     " sure to use \%(...) groups, so that error E872 can be avoided
     let s:all = substitute(s:all, '\\(', '\\%(', 'g')
@@ -112,6 +114,8 @@ function matchit#Match_wrapper(word, forward, mode) range
     let s:patBR = substitute(match_words .. ',',
       \ s:notslash .. '\zs[,:]*,[,:]*', ',', 'g')
     let s:patBR = substitute(s:patBR, s:notslash .. '\zs:\{2,}', ':', 'g')
+    " un-escape \, to ,
+    let s:patBR = substitute(s:patBR, '\\,', ',', 'g')
   endif
 
   " Second step:  set the following local variables:
@@ -534,6 +538,8 @@ fun! s:Choose(patterns, string, comma, branch, prefix, suffix, ...)
   else
     let currpat = substitute(current, s:notslash .. a:branch, '\\|', 'g')
   endif
+  " un-escape \, to ,
+  let currpat = substitute(currpat, '\\,', ',', 'g')
   while a:string !~ a:prefix .. currpat .. a:suffix
     let tail = strpart(tail, i)
     let i = matchend(tail, s:notslash .. a:comma)

--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -4,7 +4,7 @@ For instructions on installing this file, type
 	`:help matchit-install`
 inside Vim.
 
-For Vim version 9.0.  Last change:  2023 June 28
+For Vim version 9.1.  Last change:  2024 May 20
 
 
 		  VIM REFERENCE MANUAL    by Benji Fisher et al
@@ -176,8 +176,8 @@ defined automatically.
 
 2.1 Temporarily disable the matchit plugin	*matchit-disable* *:MatchDisable*
 
-To temporarily reset the plugins, that are setup you can run the following
-command: >
+To temporarily disable the matchit plugin, after it hat been loaded,
+execute this command: >
 	:MatchDisable
 
 This will delete all the defined key mappings to the Vim default.

--- a/runtime/pack/dist/opt/matchit/plugin/matchit.vim
+++ b/runtime/pack/dist/opt/matchit/plugin/matchit.vim
@@ -1,7 +1,7 @@
 "  matchit.vim: (global plugin) Extended "%" matching
 "  Maintainer:  Christian Brabandt
-"  Version:     1.19
-"  Last Change: 2023, June 28th
+"  Version:     1.20
+"  Last Change: 2024 May 20
 "  Repository:  https://github.com/chrisbra/matchit
 "  Previous URL:http://www.vim.org/script.php?script_id=39
 "  Previous Maintainer:  Benji Fisher PhD   <benji@member.AMS.org>


### PR DESCRIPTION
runtime(matchit): update matchit plugin to v1.20

fixes: vim/vim#14814

https://github.com/vim/vim/commit/8cf29e4c4a2af75bf31ef16ef108aea61c165af8

Co-authored-by: Christian Brabandt <cb@256bit.org>
