### PR TITLE
vim-patch:8.2.1520: Vim9: CTRL-] used in :def function does not work

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3451,8 +3451,10 @@ static void nv_ident(cmdarg_T *cap)
     } else {
       if (g_cmd) {
         STRCPY(buf, "tj ");
+      } else if (cap->count0 == 0) {
+        STRCPY(buf, "ta ");
       } else {
-        snprintf(buf, buf_size, "%" PRId64 "ta ", (int64_t)cap->count0);
+        snprintf(buf, buf_size, ":%" PRId64 "ta ", (int64_t)cap->count0);
       }
     }
   }


### PR DESCRIPTION
#### vim-patch:8.2.1520: Vim9: CTRL-] used in :def function does not work

Problem:    Vim9: CTRL-] used in :def function does not work.
Solution:   Omit count or prepend colon.

https://github.com/vim/vim/commit/b3ea36c5bcb88b6a05a66347eedd461e9385103f

Co-authored-by: Bram Moolenaar <Bram@vim.org>