### PR TITLE
docs: more clear for parameter on on_win callback in decoration_provider

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2831,7 +2831,7 @@ nvim_set_decoration_provider({ns_id}, {opts})
                     ["buf", bufnr, tick]
 <
                  • on_win: called when starting to redraw a specific window. >
-                    ["win", winid, bufnr, topline, botline]
+                    ["win", winid, bufnr, toprow, botrow]
 <
                  • on_line: called for each buffer line being redrawn. (The
                    interaction with fold lines is subject to change) >

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1951,7 +1951,7 @@ function vim.api.nvim_set_current_win(window) end
 ---
 ---             • on_win: called when starting to redraw a specific window.
 --- ```
----                ["win", winid, bufnr, topline, botline]
+---                ["win", winid, bufnr, toprow, botrow]
 --- ```
 ---
 ---             • on_line: called for each buffer line being redrawn. (The

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1038,7 +1038,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 ///               ```
 ///             - on_win: called when starting to redraw a specific window.
 ///               ```
-///                 ["win", winid, bufnr, topline, botline]
+///                 ["win", winid, bufnr, toprow, botrow]
 ///               ```
 ///             - on_line: called for each buffer line being redrawn.
 ///                 (The interaction with fold lines is subject to change)


### PR DESCRIPTION
Problem: in on_win there pass `wp.topline - 1` as 0-based row. line usually mean 1-based.

Solution: update the description of parameter.