### PR TITLE
vim-patch:62ccaa6: runtime(termdebug): check for gdb file/dir before using as buffer name

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -427,7 +427,17 @@ func s:StartDebug_prompt(dict)
   let s:promptbuf = bufnr('')
   call prompt_setprompt(s:promptbuf, 'gdb> ')
   set buftype=prompt
-  file gdb
+
+  if empty(glob('gdb'))
+    file gdb
+  elseif empty(glob('Termdebug-gdb-console'))
+    file Termdebug-gdb-console
+  else
+    call s:Echoerr("You have a file/folder named 'gdb'
+          \ or 'Termdebug-gdb-console'.
+          \ Please exit and rename them because Termdebug may not work as expected.")
+  endif
+
   call prompt_setcallback(s:promptbuf, function('s:PromptCallback'))
   call prompt_setinterrupt(s:promptbuf, function('s:PromptInterrupt'))
 
@@ -1481,9 +1491,12 @@ func s:GotoAsmwinOrCreateIt()
 
     if s:asmbuf > 0 && bufexists(s:asmbuf)
       exe 'buffer' . s:asmbuf
-    else
+    elseif empty(glob('Termdebug-asm-listing'))
       silent file Termdebug-asm-listing
       let s:asmbuf = bufnr('Termdebug-asm-listing')
+    else
+      call s:Echoerr("You have a file/folder named 'Termdebug-asm-listing'.
+          \ Please exit and rename it because Termdebug may not work as expected.")
     endif
 
     if mdf != 'vert' && s:GetDisasmWindowHeight() > 0
@@ -1550,9 +1563,12 @@ func s:GotoVariableswinOrCreateIt()
 
     if s:varbuf > 0 && bufexists(s:varbuf)
       exe 'buffer' . s:varbuf
-    else
+    elseif empty(glob('Termdebug-variables-listing'))
       silent file Termdebug-variables-listing
       let s:varbuf = bufnr('Termdebug-variables-listing')
+    else
+      call s:Echoerr("You have a file/folder named 'Termdebug-variables-listing'.
+          \ Please exit and rename it because Termdebug may not work as expected.")
     endif
 
     if mdf != 'vert' && s:GetVariablesWindowHeight() > 0

--- a/test/old/testdir/test_termdebug.vim
+++ b/test/old/testdir/test_termdebug.vim
@@ -302,4 +302,43 @@ func Test_termdebug_mapping()
   %bw!
 endfunc
 
+func Test_termdebug_bufnames()
+  " Test if user has filename/folders named gdb, Termdebug-gdb-console,
+  " etc. in the current directory
+  let g:termdebug_config = {}
+  let g:termdebug_config['use_prompt'] = 1
+  let filename = 'gdb'
+  let replacement_filename = 'Termdebug-gdb-console'
+
+  call writefile(['This', 'is', 'a', 'test'], filename, 'D')
+  " Throw away the file once the test has done.
+  Termdebug
+  " Once termdebug has completed the startup you should have 3 windows on screen
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  " A file named filename already exists in the working directory,
+  " hence you must call the newly created buffer differently
+  call WaitForAssert({-> assert_false(bufexists(filename))})
+  call WaitForAssert({-> assert_true(bufexists(replacement_filename))})
+  quit!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+
+  " Check if error message is in :message
+  let g:termdebug_config['disasm_window'] = 1
+  let filename = 'Termdebug-asm-listing'
+  call writefile(['This', 'is', 'a', 'test'], filename, 'D')
+  " Check only the head of the error message
+  let error_message = "You have a file/folder named '" .. filename .. "'"
+  Termdebug
+  " Once termdebug has completed the startup you should have 4 windows on screen
+  call WaitForAssert({-> assert_equal(4, winnr('$'))})
+  call WaitForAssert({-> assert_notequal(-1, stridx(execute('messages'), error_message))})
+  quit!
+  wincmd b
+  wincmd q
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+
+  unlet g:termdebug_config
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:62ccaa6: runtime(termdebug): check for gdb file/dir before using as buffer name

Add test so that this doesn't regress.

closes: vim/vim#14792

https://github.com/vim/vim/commit/62ccaa60d5f7f9a13c758bd5e55b7ca6855a6de9

Co-authored-by: Ubaldo Tiberi <ubaldo.tiberi@volvo.com>