### PR TITLE
docs(signs): update sign-priority

### DIFF
--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -67,15 +67,12 @@ sign group allows Vim plugins to use unique signs without interfering with
 other plugins using signs.
 
 							*sign-priority*
-Each placed sign is assigned a priority value. When multiple signs are placed
-on the same line, the attributes of the sign with the highest priority is used
-independently of the sign group. The default priority for a sign is 10. The
-priority is assigned at the time of placing a sign.
-
-When multiple signs that each have an icon or text are present, signs are
-ordered with increasing priority from left to right, up until the maximum
-width set in 'signcolumn'. Lower priority signs that do not fit are hidden.
-Highest priority signs with highlight attributes are always shown.
+Each placed sign is assigned a priority value independently of the sign group.
+The default priority for a sign is 10. When multiple signs that each have an
+icon or text are placed on the same line, signs are ordered with decreasing
+priority from left to right, up until the maximum width set in 'signcolumn'.
+Lower priority signs that do not fit are hidden. Highest priority signs with
+highlight attributes are always shown.
 
 When the line on which the sign is placed is deleted, the sign is removed along
 with it.


### PR DESCRIPTION
A follow up to #27781. The sign priority ordering was described the wrong way around, and the paragraph before that was kind of confusing since it's not really updated for multiple signs.