### PR TITLE
fix(lsp): ensure buffer is loaded before changetracking.init

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -904,11 +904,11 @@ end
 ---
 --- @param bufnr integer Number of the buffer, or 0 for current
 function Client:_text_document_did_open_handler(bufnr)
-  changetracking.init(self, bufnr)
-  if not self.supports_method(ms.textDocument_didOpen) then
+  if not api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  if not api.nvim_buf_is_loaded(bufnr) then
+  changetracking.init(self, bufnr)
+  if not self.supports_method(ms.textDocument_didOpen) then
     return
   end
   local filetype = vim.bo[bufnr].filetype


### PR DESCRIPTION
~~Fixes: https://github.com/neovim/neovim/issues/28575~~

The `changetracking.init` method calls `nvim_buf_get_name` and `nvim_buf_get_lines` which require a loaded buffer.

**edit:** this change still makes sense, but it won't fix #28575 because it will just fail [here](https://github.com/neovim/neovim/blob/5bdafaaa09723d56f45442d8370ea3aabf8549bc/runtime/lua/vim/lsp/client.lua#L944)