### PR TITLE
vim-patch:802fc04: runtime(rescript): include basic rescript ftplugin file (vim/vim#14822)

### DIFF
--- a/runtime/ftplugin/rescript.vim
+++ b/runtime/ftplugin/rescript.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	rescript
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 May 21
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:// commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'


### PR DESCRIPTION
Reference: https://rescript-lang.org/docs/manual/latest/overview#comments

https://github.com/vim/vim/commit/802fc04a78a7d98673dc9171d4b89597447a5bda

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
