### PR TITLE
vim-patch:8.2.0703: Vim9: closure cannot store value in outer context

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4836,8 +4836,10 @@ bool set_ref_in_item(typval_T *tv, int copyID, ht_stack_T **ht_stack, list_stack
   case VAR_PARTIAL: {
     partial_T *pt = tv->vval.v_partial;
 
-    // A partial does not have a copyID, because it cannot contain itself.
-    if (pt != NULL) {
+    if (pt != NULL && pt->pt_copyID != copyID) {
+      // Didn't see this partial yet.
+      pt->pt_copyID = copyID;
+
       abort = set_ref_in_func(pt->pt_name, pt->pt_func, copyID);
       if (pt->pt_dict != NULL) {
         typval_T dtv;

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -364,6 +364,7 @@ struct ufunc {
 
 struct partial_S {
   int pt_refcount;    ///< Reference count.
+  int pt_copyID;
   char *pt_name;      ///< Function name; when NULL use pt_func->name.
   ufunc_T *pt_func;   ///< Function pointer; when NULL lookup function with pt_name.
   bool pt_auto;       ///< When true the partial was created by using dict.member


### PR DESCRIPTION
#### vim-patch:8.2.0703: Vim9: closure cannot store value in outer context

Problem:    Vim9: closure cannot store value in outer context.
Solution:   Make storing value in outer context work.  Make :disassemble
            accept a function reference.

https://github.com/vim/vim/commit/b68b346e6db6d3f848e0a89905fcd7777b73c5d8

Funcstack is Vim9script-only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>