### PR TITLE
fix(comment): fall back to using trimmed comment markers

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -579,6 +579,10 @@ Acting on multiple lines behaves as follows:
   transformed to empty comments (e.g. `/**/`). Comment markers are aligned to
   the least indented line.
 
+Matching 'commentstring' does not account for whitespace in comment markers.
+Removing comment markers is first attempted exactly, with fallback to using
+markers trimmed from whitespace.
+
 If the filetype of the buffer is associated with a language for which a
 |treesitter| parser is installed, then |vim.filetype.get_option()| is called
 to look up the value of 'commentstring' corresponding to the cursor position.

--- a/test/functional/lua/comment_spec.lua
+++ b/test/functional/lua/comment_spec.lua
@@ -301,27 +301,34 @@ describe('commenting', function()
       eq(get_lines(), { 'aa', '', '  ', '\t', 'aa' })
     end)
 
-    it('matches comment parts strictly when detecting comment/uncomment', function()
+    it('correctly matches comment parts during checking and uncommenting', function()
       local validate = function(from, to, ref_lines)
-        set_lines({ '#aa', '# aa', '#  aa' })
+        set_lines({ '/*aa*/', '/* aa */', '/*  aa  */' })
         toggle_lines(from, to)
         eq(get_lines(), ref_lines)
       end
 
-      set_commentstring('#%s')
-      validate(1, 3, { 'aa', ' aa', '  aa' })
-      validate(2, 3, { '#aa', ' aa', '  aa' })
-      validate(3, 3, { '#aa', '# aa', '  aa' })
+      -- Should first try to match 'commentstring' parts exactly with their
+      -- whitespace, with fallback on trimmed parts
+      set_commentstring('/*%s*/')
+      validate(1, 3, { 'aa', ' aa ', '  aa  ' })
+      validate(2, 3, { '/*aa*/', ' aa ', '  aa  ' })
+      validate(3, 3, { '/*aa*/', '/* aa */', '  aa  ' })
 
-      set_commentstring('# %s')
-      validate(1, 3, { '# #aa', '# # aa', '# #  aa' })
-      validate(2, 3, { '#aa', 'aa', ' aa' })
-      validate(3, 3, { '#aa', '# aa', ' aa' })
+      set_commentstring('/* %s */')
+      validate(1, 3, { 'aa', 'aa', ' aa ' })
+      validate(2, 3, { '/*aa*/', 'aa', ' aa ' })
+      validate(3, 3, { '/*aa*/', '/* aa */', ' aa ' })
 
-      set_commentstring('#  %s')
-      validate(1, 3, { '#  #aa', '#  # aa', '#  #  aa' })
-      validate(2, 3, { '#aa', '#  # aa', '#  #  aa' })
-      validate(3, 3, { '#aa', '# aa', 'aa' })
+      set_commentstring('/*  %s  */')
+      validate(1, 3, { 'aa', ' aa ', 'aa' })
+      validate(2, 3, { '/*aa*/', ' aa ', 'aa' })
+      validate(3, 3, { '/*aa*/', '/* aa */', 'aa' })
+
+      set_commentstring(' /*%s*/ ')
+      validate(1, 3, { 'aa', ' aa ', '  aa  ' })
+      validate(2, 3, { '/*aa*/', ' aa ', '  aa  ' })
+      validate(3, 3, { '/*aa*/', '/* aa */', '  aa  ' })
     end)
 
     it('uncomments on inconsistent indent levels', function()


### PR DESCRIPTION
Problem: Currently comment detection, addition, and removal are done
  by matching 'commentstring' exactly. This has the downside when users
  want to add comment markers with space (like with `-- %s`
  commentstring) but also be able to uncomment lines that do not contain
  space (like `--aaa`).

Solution: Use the following approach:
  - Line is commented if it matches 'commentstring' with trimmed parts.
  - Adding comment is 100% relying on 'commentstring' parts (as is now).
  - Removing comment is first trying exact 'commentstring' parts with fallback on trying its trimmed parts.

------

Resolve #28872