### PR TITLE
refactor(lsp): replace util.buf_versions with changedtick

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -22,6 +22,9 @@ API
 LUA
 - vim.region()		Use |getregionpos()| instead.
 
+LSP
+- *vim.lsp.util.buf_versions*	Use |b:changedtick| instead.
+
 DIAGNOSTICS
 - *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count = 1}` instead.
 - *vim.diagnostic.goto_prev()*	Use |vim.diagnostic.jump()| with `{count = -1}` instead.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -484,7 +484,6 @@ local function text_document_did_save_handler(bufnr)
           text = lsp._buf_get_full_text(bufnr),
         },
       })
-      util.buf_versions[bufnr] = 0
     end
     local save_capability = vim.tbl_get(client.server_capabilities, 'textDocumentSync', 'save')
     if save_capability then
@@ -520,7 +519,6 @@ local function buf_detach_client(bufnr, client)
   end
 
   client.attached_buffers[bufnr] = nil
-  util.buf_versions[bufnr] = nil
 
   local namespace = lsp.diagnostic.get_namespace(client.id)
   vim.diagnostic.reset(namespace, bufnr)
@@ -576,12 +574,11 @@ local function buf_attach(bufnr)
   })
   -- First time, so attach and set up stuff.
   api.nvim_buf_attach(bufnr, false, {
-    on_lines = function(_, _, changedtick, firstline, lastline, new_lastline)
+    on_lines = function(_, _, _, firstline, lastline, new_lastline)
       if #lsp.get_clients({ bufnr = bufnr }) == 0 then
         -- detach if there are no clients
         return #lsp.get_clients({ bufnr = bufnr, _uninitialized = true }) == 0
       end
-      util.buf_versions[bufnr] = changedtick
       changetracking.send_changes(bufnr, firstline, lastline, new_lastline)
     end,
 

--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -1,6 +1,5 @@
 local protocol = require('vim.lsp.protocol')
 local sync = require('vim.lsp.sync')
-local util = require('vim.lsp.util')
 
 local api = vim.api
 local uv = vim.uv
@@ -277,7 +276,7 @@ local function send_changes(bufnr, sync_kind, state, buf_state)
       client.notify(protocol.Methods.textDocument_didChange, {
         textDocument = {
           uri = uri,
-          version = util.buf_versions[bufnr],
+          version = vim.b[bufnr].changedtick,
         },
         contentChanges = changes,
       })

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -673,8 +673,8 @@ function Client:_request(method, params, handler, bufnr)
   end
   -- Ensure pending didChange notifications are sent so that the server doesn't operate on a stale state
   changetracking.flush(self, bufnr)
-  local version = lsp.util.buf_versions[bufnr]
   bufnr = resolve_bufnr(bufnr)
+  local version = vim.b[bufnr].changedtick
   log.debug(self._log_prefix, 'client.request', self.id, method, params, handler, bufnr)
   local success, request_id = self.rpc.request(method, params, function(err, result)
     local context = {
@@ -922,14 +922,13 @@ function Client:_text_document_did_open_handler(bufnr)
 
   local params = {
     textDocument = {
-      version = 0,
+      version = vim.b[bufnr].changedtick,
       uri = vim.uri_from_bufnr(bufnr),
       languageId = self.get_language_id(bufnr, filetype),
       text = lsp._buf_get_full_text(bufnr),
     },
   }
   self.notify(ms.textDocument_didOpen, params)
-  lsp.util.buf_versions[bufnr] = params.textDocument.version
 
   -- Next chance we get, we should re-do the diagnostics
   vim.schedule(function()

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -43,7 +43,7 @@ function M.on_inlayhint(err, result, ctx, _)
     return
   end
   local bufnr = assert(ctx.bufnr)
-  if util.buf_versions[bufnr] ~= ctx.version then
+  if vim.b[bufnr].changedtick ~= ctx.version then
     return
   end
   local client_id = ctx.client_id
@@ -324,7 +324,7 @@ api.nvim_set_decoration_provider(namespace, {
       return
     end
 
-    if bufstate.version ~= util.buf_versions[bufnr] then
+    if bufstate.version ~= vim.b[bufnr].changedtick then
       return
     end
 

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -116,7 +116,7 @@ local function tokens_to_ranges(data, bufnr, client, request)
 
       if elapsed_ns > yield_interval_ns then
         vim.schedule(function()
-          coroutine.resume(co, util.buf_versions[bufnr])
+          coroutine.resume(co, vim.b[bufnr].changedtick)
         end)
         if request.version ~= coroutine.yield() then
           -- request became stale since the last time the coroutine ran.
@@ -275,7 +275,7 @@ end
 ---
 ---@package
 function STHighlighter:send_request()
-  local version = util.buf_versions[self.bufnr]
+  local version = vim.b[self.bufnr].changedtick
 
   self:reset_timer()
 
@@ -418,7 +418,7 @@ end
 function STHighlighter:on_win(topline, botline)
   for client_id, state in pairs(self.client_state) do
     local current_result = state.current_result
-    if current_result.version and current_result.version == util.buf_versions[self.bufnr] then
+    if current_result.version and current_result.version == vim.b[self.bufnr].changedtick then
       if not current_result.namespace_cleared then
         api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
         current_result.namespace_cleared = true

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -509,8 +509,7 @@ function M.apply_text_document_edit(text_document_edit, index, offset_encoding)
     and (
       text_document.version
       and text_document.version > 0
-      and M.buf_versions[bufnr]
-      and M.buf_versions[bufnr] > text_document.version
+      and vim.b[bufnr].changedtick > text_document.version
     )
   then
     print('Buffer ', text_document.uri, ' newer than edits.')
@@ -2200,9 +2199,16 @@ function M._refresh(method, opts)
   end
 end
 
-M._get_line_byte_from_position = get_line_byte_from_position
-
 ---@nodoc
-M.buf_versions = {} ---@type table<integer,integer>
+---@deprecated
+---@type table<integer,integer>
+M.buf_versions = setmetatable({}, {
+  __index = function(_, bufnr)
+    vim.deprecate('vim.lsp.util.buf_versions', 'vim.b.changedtick', '0.13')
+    return vim.b[bufnr].changedtick
+  end,
+})
+
+M._get_line_byte_from_position = get_line_byte_from_position
 
 return M

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -471,7 +471,7 @@ function tests.basic_check_buffer_open()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n') .. '\n',
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('finish')
@@ -498,7 +498,7 @@ function tests.basic_check_buffer_open_and_change()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n') .. '\n',
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {
@@ -534,7 +534,7 @@ function tests.basic_check_buffer_open_and_change_noeol()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n'),
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {
@@ -569,7 +569,7 @@ function tests.basic_check_buffer_open_and_change_multi()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n') .. '\n',
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {
@@ -614,7 +614,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n') .. '\n',
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {
@@ -672,7 +672,7 @@ function tests.basic_check_buffer_open_and_change_incremental()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n') .. '\n',
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {
@@ -715,7 +715,7 @@ function tests.basic_check_buffer_open_and_change_incremental_editing()
           languageId = '',
           text = table.concat({ 'testing', '123' }, '\n'),
           uri = 'file://',
-          version = 0,
+          version = 2,
         },
       })
       expect_notification('textDocument/didChange', {

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -111,14 +111,13 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is highlighted when attached', function()
+      insert(text)
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         vim.bo[bufnr].filetype = 'some-filetype'
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -141,6 +140,7 @@ describe('semantic token highlighting', function()
     end)
 
     it('use LspTokenUpdate and highlight_token', function()
+      insert(text)
       exec_lua([[
         vim.api.nvim_create_autocmd("LspTokenUpdate", {
           callback = function(args)
@@ -156,8 +156,6 @@ describe('semantic token highlighting', function()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -180,13 +178,16 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is unhighlighted when client is detached', function()
+      insert(text)
+
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.wait(1000, function()
+          return #server.messages > 1
+        end)
       ]])
-
-      insert(text)
 
       exec_lua([[
         vim.notify = function() end
@@ -331,13 +332,12 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is re-highlighted when force refreshed', function()
+      insert(text)
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -412,13 +412,14 @@ describe('semantic token highlighting', function()
     end)
 
     it('updates highlights with delta request on buffer change', function()
+      insert(text)
+
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
 
-      insert(text)
       screen:expect {
         grid = [[
         #include <iostream>                     |
@@ -597,6 +598,7 @@ describe('semantic token highlighting', function()
     end)
 
     it('does not send delta requests if not supported by server', function()
+      insert(text)
       exec_lua(
         [[
         local legend, response, edit_response = ...
@@ -625,7 +627,6 @@ describe('semantic token highlighting', function()
         edit_response
       )
 
-      insert(text)
       screen:expect {
         grid = [[
         #include <iostream>                     |
@@ -1449,6 +1450,7 @@ int main()
       },
     }) do
       it(test.it, function()
+        insert(test.text1)
         exec_lua(create_server_definition)
         exec_lua(
           [[
@@ -1484,8 +1486,6 @@ int main()
           test.response1,
           test.response2
         )
-
-        insert(test.text1)
 
         test.expected_screen1()
 


### PR DESCRIPTION
`lsp.util.buf_versions` was already derived from changedtick (`on_lines`
from `buf_attach` synced the version)

As far as I can tell there is no need to keep track of the state in a
separate table.
