### PR TITLE
vim-patch:22ac941: runtime(i3config/swayconfig): support floating_modifier none; revert broken highlighting

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.2.2
-" Last Change: 2024-04-14
+" Version: 1.2.3
+" Last Change: 2024-05-23
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -67,7 +67,7 @@ syn keyword i3ConfigBindKeyword bindsym bindcode contained skipwhite nextgroup=i
 syn region i3ConfigModeBlock matchgroup=i3ConfigKeyword start=/mode\ze\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^}\zs$/ contained contains=i3ConfigShParam,@i3ConfigStrVar,i3ConfigBindKeyword,i3ConfigComment,i3ConfigParen fold keepend extend
 
 " 4.7 Floating modifier
-syn keyword i3ConfigKeyword floating_modifier contained skipwhite nextgroup=i3ConfigVariable,i3ConfigBindModkey
+syn match i3ConfigKeyword /^floating_modifier [$0-9A-Za-z]*$/ contains=i3ConfigVariable,i3ConfigBindModkey
 
 " 4.8 Floating window size
 syn keyword i3ConfigSizeSpecial x contained

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.2.2
-" Last Change: 2024-05-12
+" Version: 1.2.3
+" Last Change: 2024-05-23
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -38,8 +38,8 @@ syn region swayConfigBlockOrphan start=/^\s\+\(--[a-z-]\+ \)*\([A-Z$][$a-zA-Z0-9
 
 syn region i3ConfigExec start=/ {$/ end=/^\s*}$/ contained contains=i3ConfigExecAction,@i3ConfigSh,i3ConfigComment fold keepend extend
 
-syn keyword swayConfigFloatingModifierOpts normal inverse contained
-syn match i3ConfigKeyword /floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contained contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
+syn keyword swayConfigFloatingModifierOpts normal inverse none contained
+syn match i3ConfigKeyword /floating_modifier \(none\|[$a-zA-Z0-9+]\+ \(normal\|inverse\)\)$/ contained contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
 
 syn match swayConfigI3Param /--i3/ contains=i3ConfigShParam skipwhite nextgroup=i3ConfigEdgeOpts
 syn keyword i3ConfigKeyword hide_edge_borders contained skipwhite nextgroup=swayConfigI3Param,i3ConfigEdgeOpts


### PR DESCRIPTION
- fix floating_modifier $mod normal|inverse was being hightlighted as error
  reverting the floating_modifier change from dd83b63
- will currently allow invalid syntax after floating_modifier

fixes: vim/vim#14826
closes: vim/vim#14827

https://github.com/vim/vim/commit/22ac941208fcb2c63ad172c6cf0b39b077b5b682

Co-authored-by: James Eapen <james.eapen@vai.org>
Co-authored-by: JosefLitos <litosjos@fit.cvut.cz>
