### PR TITLE
vim-patch:9.1.0436: Crash when using '?' as separator for :s

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -774,6 +774,7 @@ char *skip_regexp_ex(char *startp, int dirc, int magic, char **newp, int *droppe
 {
   magic_T mymagic;
   char *p = startp;
+  size_t startplen = strlen(startp);
 
   if (magic) {
     mymagic = MAGIC_ON;
@@ -793,11 +794,9 @@ char *skip_regexp_ex(char *startp, int dirc, int magic, char **newp, int *droppe
         break;
       }
     } else if (p[0] == '\\' && p[1] != NUL) {
-      size_t startplen = 0;
       if (dirc == '?' && newp != NULL && p[1] == '?') {
         // change "\?" to "?", make a copy first.
         if (*newp == NULL) {
-          startplen = strlen(startp);
           *newp = xstrnsave(startp, startplen);
           p = *newp + (p - startp);
         }

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -173,6 +173,16 @@ func Test_substitute_repeat()
   call feedkeys("Qsc\<CR>y", 'tx')
   bwipe!
 endfunc
+
+" Test :s with ? as separator.
+func Test_substitute_question_separator()
+  new
+  call setline(1, '??:??')
+  %s?\?\??!!?g
+  call assert_equal('!!:!!', getline(1))
+  bwipe!
+endfunc
+
 " Test %s/\n// which is implemented as a special case to use a
 " more efficient join rather than doing a regular substitution.
 func Test_substitute_join()


### PR DESCRIPTION
#### vim-patch:9.1.0436: Crash when using '?' as separator for :s

Problem:  Crash when using '?' as separator for :s and pattern contains
          escaped '?'s (after 9.1.0409).
Solution: Always compute startplen. (zeertzjq).

Fix #28935
closes: 14832

https://github.com/vim/vim/commit/789679cfc4f39505b135220672b43a260d8ca3b4