### PR TITLE
vim-patch:9.1.0438: Wrong Ex command executed when :g uses '?' as delimiter

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -774,7 +774,7 @@ char *skip_regexp_ex(char *startp, int dirc, int magic, char **newp, int *droppe
 {
   magic_T mymagic;
   char *p = startp;
-  size_t startplen = strlen(startp);
+  size_t startplen = 0;
 
   if (magic) {
     mymagic = MAGIC_ON;
@@ -796,14 +796,18 @@ char *skip_regexp_ex(char *startp, int dirc, int magic, char **newp, int *droppe
     } else if (p[0] == '\\' && p[1] != NUL) {
       if (dirc == '?' && newp != NULL && p[1] == '?') {
         // change "\?" to "?", make a copy first.
+        if (startplen == 0) {
+          startplen = strlen(startp);
+        }
         if (*newp == NULL) {
           *newp = xstrnsave(startp, startplen);
           p = *newp + (p - startp);
+          startp = *newp;
         }
         if (dropped != NULL) {
           (*dropped)++;
         }
-        memmove(p, p + 1, (startplen - (size_t)((p + 1) - *newp)) + 1);
+        memmove(p, p + 1, startplen - (size_t)((p + 1) - startp) + 1);
       } else {
         p++;            // skip next character
       }

--- a/test/old/testdir/test_global.vim
+++ b/test/old/testdir/test_global.vim
@@ -96,7 +96,16 @@ func Test_global_newline()
   close!
 endfunc
 
-func Test_wrong_delimiter()
+" Test :g with ? as delimiter.
+func Test_global_question_delimiter()
+  new
+  call setline(1, ['aaaaa', 'b?bbb', 'ccccc', 'ddd?d', 'eeeee'])
+  g?\??delete
+  call assert_equal(['aaaaa', 'ccccc', 'eeeee'], getline(1, '$'))
+  bwipe!
+endfunc
+
+func Test_global_wrong_delimiter()
   call assert_fails('g x^bxd', 'E146:')
 endfunc
 

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -174,8 +174,8 @@ func Test_substitute_repeat()
   bwipe!
 endfunc
 
-" Test :s with ? as separator.
-func Test_substitute_question_separator()
+" Test :s with ? as delimiter.
+func Test_substitute_question_delimiter()
   new
   call setline(1, '??:??')
   %s?\?\??!!?g


### PR DESCRIPTION
#### vim-patch:9.1.0438: Wrong Ex command executed when :g uses '?' as delimiter

Problem:  Wrong Ex command executed when :g uses '?' as delimiter and
          pattern contains escaped '?'.
Solution: Don't use "*newp" when it's not allocated (zeertzjq).

closes: vim/vim#14837

https://github.com/vim/vim/commit/3074137542961ce7b3b65c14ebde75f13f5e6147