### PR TITLE
vim-patch:9.1.0439: Cannot filter the history

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -400,6 +400,7 @@ gx			Opens the current filepath or URL (decided by
 			   |:command|    - filter by command name
 			   |:files|      - filter by file name
 			   |:highlight|  - filter by highlight group
+			   |:history|    - filter by history commands
 			   |:jumps|      - filter by file name
 			   |:let|        - filter by variable name
 			   |:list|       - filter whole line

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -662,7 +662,8 @@ void ex_history(exarg_T *eap)
           i = 0;
         }
         if (hist[i].hisstr != NULL
-            && hist[i].hisnum >= j && hist[i].hisnum <= k) {
+            && hist[i].hisnum >= j && hist[i].hisnum <= k
+            && !message_filtered(hist[i].hisstr)) {
           msg_putchar('\n');
           snprintf(IObuff, IOSIZE, "%c%6d  ", i == idx ? '>' : ' ',
                    hist[i].hisnum);


### PR DESCRIPTION
#### vim-patch:9.1.0439: Cannot filter the history

Problem:  Cannot filter the history
Solution: Implement :filter :history

closes: vim/vim#14835

https://github.com/vim/vim/commit/42a5b5a6d0d05255b9c464abe71f29c7677b5833

Co-authored-by: Christian Brabandt <cb@256bit.org>