### PR TITLE
vim-patch:8.2.3158: strange error message when using islocked() with a number

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1737,6 +1737,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
   }
 
   tv_clear(&var1);
+  lp->ll_name_len = (size_t)(p - lp->ll_name);
   return p;
 }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4119,7 +4119,7 @@ static void f_islocked(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
                                    FNE_CHECK_START);
   if (end != NULL && lv.ll_name != NULL) {
     if (*end != NUL) {
-      semsg(_(e_trailing_arg), end);
+      semsg(_(lv.ll_name_len == 0 ? e_invarg2 : e_trailing_arg), end);
     } else {
       if (lv.ll_tv == NULL) {
         dictitem_T *di = find_var(lv.ll_name, lv.ll_name_len, NULL, true);

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -98,6 +98,11 @@ func Test_err_teapot()
   call assert_fails('call err_teapot(expr)', "E503: Coffee is currently not available")
 endfunc
 
+func Test_islocked()
+  call assert_fails('call islocked(99)', 'E475:')
+  call assert_fails('call islocked("s: x")', 'E488:')
+endfunc
+
 func Test_len()
   call assert_equal(1, len(0))
   call assert_equal(2, len(12))


### PR DESCRIPTION
#### vim-patch:8.2.3158: strange error message when using islocked() with a number

Problem:    Strange error message when using islocked() with a number.
            (Yegappan Lakshmanan)
Solution:   Check that the name is empty.

https://github.com/vim/vim/commit/1840a7b4e3577e617f724c9d07ccc78195cc010a

Use ll_name_len instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>