### PR TITLE
feat(defaults)!: automatically start terminal in insert mode

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -34,7 +34,7 @@ API
 
 DEFAULTS
 
-• TODO
+• |:terminal| starts in insert mode.
 
 EDITOR
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -538,3 +538,11 @@ do
     vim.o.grepformat = '%f:%l:%c:%m'
   end
 end
+
+do
+  -- terminal
+  vim.api.nvim_create_autocmd({ 'TermOpen' }, {
+    group = nvim_terminal_augroup,
+    command = 'startinsert',
+  })
+end


### PR DESCRIPTION
When opening a terminal it should drop you in insert mode so you can
start using it directly. While starting on insert mode is rare for
editors, it is the norm for terminal emulators. In other words, starting
the terminal in insert mode is likely more useful in the vast majority
of cases.
