### PR TITLE
fix: show swapfile warning as a warning

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -269,7 +269,10 @@ do
         return
       end
       vim.v.swapchoice = 'e' -- Choose "(E)dit".
-      vim.notify(('W325: Ignoring swapfile from Nvim process %d'):format(info.pid), vim.log.levels.WARN)
+      vim.notify(
+        ('W325: Ignoring swapfile from Nvim process %d'):format(info.pid),
+        vim.log.levels.WARN
+      )
     end,
   })
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -269,7 +269,7 @@ do
         return
       end
       vim.v.swapchoice = 'e' -- Choose "(E)dit".
-      vim.notify(('W325: Ignoring swapfile from Nvim process %d'):format(info.pid))
+      vim.notify(('W325: Ignoring swapfile from Nvim process %d'):format(info.pid), vim.log.levels.WARN)
     end,
   })
 


### PR DESCRIPTION
The new default SwapExists autocommand displays warning text (W325) but does not use the WarningMsg highlight group as other warnings do. Use the WARN log level when displaying this warning.