### PR TITLE
fix: "popcount" name conflict on NetBSD

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2354,8 +2354,8 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
     }
   }
 
-  int count = (win != NULL) + (buf != NULL);
-  VALIDATE(popcount(opts->is_set__redraw_) > count, "%s", "at least one action required", {
+  unsigned count = (win != NULL) + (buf != NULL);
+  VALIDATE(xpopcount(opts->is_set__redraw_) > count, "%s", "at least one action required", {
     return;
   });
 

--- a/src/nvim/math.c
+++ b/src/nvim/math.c
@@ -78,13 +78,15 @@ int xctz(uint64_t x)
 }
 
 /// Count number of set bits in bit field.
-int popcount(uint64_t x)
+unsigned xpopcount(uint64_t x)
 {
   // Use compiler builtin if possible.
-#if defined(__clang__) || defined(__GNUC__)
-  return __builtin_popcountll(x);
+#if defined(__NetBSD__)
+  return popcount64(x);
+#elif defined(__clang__) || defined(__GNUC__)
+  return (unsigned)__builtin_popcountll(x);
 #else
-  int count = 0;
+  unsigned count = 0;
   for (; x != 0; x >>= 1) {
     if (x & 1) {
       count++;


### PR DESCRIPTION
The function popcount added in recent commit 037ea6e786b5d05f4a8965e4c2ba6aa60ec7c01a conflicts with a function by the same name in NetBSD's libc.  I'd like to propose the following change to avoid the issue.