### PR TITLE
vim-patch:9.1.0443: Can't use blockwise selection with width for getregion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2930,14 +2930,13 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		The optional argument {opts} is a Dict and supports the
 		following items:
 
-			type		Specify the region's selection type
-					(default: "v"):
-			    "v"		for |charwise| mode
-			    "V"		for |linewise| mode
-			    "<CTRL-V>"	for |blockwise-visual| mode
+			type		Specify the region's selection type.
+					See |getregtype()| for possible values,
+					except it cannot be an empty string.
+					(default: "v")
 
 			exclusive	If |TRUE|, use exclusive selection
-					for the end position
+					for the end position.
 					(default: follow 'selection')
 
 		You can get the last selection type by |visualmode()|.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3536,14 +3536,13 @@ function vim.fn.getreginfo(regname) end
 --- The optional argument {opts} is a Dict and supports the
 --- following items:
 ---
----   type    Specify the region's selection type
----       (default: "v"):
----       "v"    for |charwise| mode
----       "V"    for |linewise| mode
----       "<CTRL-V>"  for |blockwise-visual| mode
+---   type    Specify the region's selection type.
+---       See |getregtype()| for possible values,
+---       except it cannot be an empty string.
+---       (default: "v")
 ---
 ---   exclusive  If |TRUE|, use exclusive selection
----       for the end position
+---       for the end position.
 ---       (default: follow 'selection')
 ---
 --- You can get the last selection type by |visualmode()|.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4370,14 +4370,13 @@ M.funcs = {
       The optional argument {opts} is a Dict and supports the
       following items:
 
-      	type		Specify the region's selection type
-      			(default: "v"):
-      	    "v"		for |charwise| mode
-      	    "V"		for |linewise| mode
-      	    "<CTRL-V>"	for |blockwise-visual| mode
+      	type		Specify the region's selection type.
+      			See |getregtype()| for possible values,
+      			except it cannot be an empty string.
+      			(default: "v")
 
       	exclusive	If |TRUE|, use exclusive selection
-      			for the end position
+      			for the end position.
       			(default: follow 'selection')
 
       You can get the last selection type by |visualmode()|.


### PR DESCRIPTION
#### vim-patch:9.1.0443: Can't use blockwise selection with width for getregion()

Problem:  Can't use a blockwise selection with a width for getregion().
Solution: Add support for blockwise selection with width like the return
          value of getregtype() or the "regtype" value of TextYankPost
          (zeertzjq).

closes: vim/vim#14842

https://github.com/vim/vim/commit/afc2295c2201ae87bfbb42d5f5315ad0583ccabf