### PR TITLE
refactor(eval): use vim.json inside f_json_encode

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3881,7 +3881,23 @@ static void f_json_decode(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 static void f_json_encode(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = encode_tv2json(&argvars[0], NULL);
+  rettv->vval.v_string = NULL;
+
+  MAXSIZE_TEMP_ARRAY(args, 1);
+  Arena arena = ARENA_EMPTY;
+  ADD_C(args, vim_to_object(&argvars[0], &arena, false));
+  Error err = ERROR_INIT;
+  Object result = NLUA_EXEC_STATIC("return vim.json.encode(...)", args, kRetObject, NULL, &err);
+
+  if (ERROR_SET(&err)) {
+    semsg(_("E474: %s"), err.msg);
+  } else if (result.type == kObjectTypeString) {
+    rettv->vval.v_string = xmemdupz(result.data.string.data, result.data.string.size);
+  }
+
+  api_free_object(result);
+  api_clear_error(&err);
+  arena_mem_free(arena_finish(&arena));
 }
 
 /// "keytrans()" function


### PR DESCRIPTION
Problem: json_encode() uses a C template-based encoder that mishandles
certain invalid UTF-8 sequences (e.g. overlong encodings like \xc0\x81).

Solution: Replace the encoder path with lua_cjson (vim.json.encode).
Add a new typval_encode template (json_lua) in converter.c that performs
JSON validation (float, string, key, recursion checks) while pushing
values onto the Lua stack, then let lua_cjson serialize to JSON.

Fix #28683 