### PR TITLE
fix(snippet): don't override unnamed register on tabstop select

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -315,7 +315,7 @@ local function select_tabstop(tabstop)
     move_cursor_to(range[1] + 1, range[2] + 1)
     feedkeys('v')
     move_cursor_to(range[3] + 1, range[4])
-    feedkeys('o<c-g>')
+    feedkeys('o<c-g><c-r>_')
   end
 end
 


### PR DESCRIPTION
Not sure if this is controversial. 

Some context of why I'd find not replacing the register more desirable: https://social.fussenegger.pro/@mathias/112500796424060656