### PR TITLE
vim-patch:9.1.0444: Not enough tests for getregion() with multibyte chars

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2932,7 +2932,8 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 
 			type		Specify the region's selection type.
 					See |getregtype()| for possible values,
-					except it cannot be an empty string.
+					except that the width can be omitted
+					and an empty string cannot be used.
 					(default: "v")
 
 			exclusive	If |TRUE|, use exclusive selection

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3538,7 +3538,8 @@ function vim.fn.getreginfo(regname) end
 ---
 ---   type    Specify the region's selection type.
 ---       See |getregtype()| for possible values,
----       except it cannot be an empty string.
+---       except that the width can be omitted
+---       and an empty string cannot be used.
 ---       (default: "v")
 ---
 ---   exclusive  If |TRUE|, use exclusive selection

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4372,7 +4372,8 @@ M.funcs = {
 
       	type		Specify the region's selection type.
       			See |getregtype()| for possible values,
-      			except it cannot be an empty string.
+      			except that the width can be omitted
+      			and an empty string cannot be used.
       			(default: "v")
 
       	exclusive	If |TRUE|, use exclusive selection

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -2594,6 +2594,7 @@ func Test_getregion_after_yank()
   call feedkeys("gg0ll\<C-V>jj$y", 'tx')
   call assert_equal(1, g:checked)
   call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
 
   let g:expected_region = ['bc', 'fg', 'mn']
   let g:expected_regionpos = [
@@ -2605,6 +2606,67 @@ func Test_getregion_after_yank()
   call feedkeys("gg0l\<C-V>jjly", 'tx')
   call assert_equal(1, g:checked)
   call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
+
+  bwipe!
+
+  new
+  let lines = ['asdfghjkl', '«口=口»', 'qwertyuiop', '口口=口口', 'zxcvbnm']
+  call setline(1, lines)
+
+  let g:expected_region = lines
+  let g:expected_regionpos = [
+        \   [[bufnr('%'), 1, 1, 0], [bufnr('%'), 1, 9, 0]],
+        \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 11, 0]],
+        \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 10, 0]],
+        \   [[bufnr('%'), 4, 1, 0], [bufnr('%'), 4, 13, 0]],
+        \   [[bufnr('%'), 5, 1, 0], [bufnr('%'), 5, 7, 0]],
+        \ ]
+  let g:checked = 0
+  call feedkeys('ggyG', 'tx')
+  call assert_equal(1, g:checked)
+  call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
+
+  let g:expected_region = ['=口»', 'qwertyuiop', '口口=口']
+  let g:expected_regionpos = [
+        \   [[bufnr('%'), 2, 6, 0], [bufnr('%'), 2, 11, 0]],
+        \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 10, 0]],
+        \   [[bufnr('%'), 4, 1, 0], [bufnr('%'), 4, 10, 0]],
+        \ ]
+  let g:checked = 0
+  call feedkeys('2gg02lv2j2ly', 'tx')
+  call assert_equal(1, g:checked)
+  call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
+
+  let g:expected_region = ['asdf', '«口=', 'qwer', '口口', 'zxcv']
+  let g:expected_regionpos = [
+        \   [[bufnr('%'), 1, 1, 0], [bufnr('%'), 1, 4, 0]],
+        \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 6, 0]],
+        \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 4, 0]],
+        \   [[bufnr('%'), 4, 1, 0], [bufnr('%'), 4, 6, 0]],
+        \   [[bufnr('%'), 5, 1, 0], [bufnr('%'), 5, 4, 0]],
+        \ ]
+  let g:checked = 0
+  call feedkeys("G0\<C-V>3l4ky", 'tx')
+  call assert_equal(1, g:checked)
+  call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
+
+  let g:expected_region = ['ghjkl', '口»', 'tyuiop', '=口口', 'bnm']
+  let g:expected_regionpos = [
+        \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 9, 0]],
+        \   [[bufnr('%'), 2, 7, 0], [bufnr('%'), 2, 11, 0]],
+        \   [[bufnr('%'), 3, 5, 0], [bufnr('%'), 3, 10, 0]],
+        \   [[bufnr('%'), 4, 7, 0], [bufnr('%'), 4, 13, 0]],
+        \   [[bufnr('%'), 5, 5, 0], [bufnr('%'), 5, 7, 0]],
+        \ ]
+  let g:checked = 0
+  call feedkeys("G04l\<C-V>$4ky", 'tx')
+  call assert_equal(1, g:checked)
+  call Check_Results(getregtype('"'))
+  call assert_equal(g:expected_region, getreg('"', v:true, v:true))
 
   bwipe!
 


### PR DESCRIPTION
#### vim-patch:9.1.0444: Not enough tests for getregion() with multibyte chars

Problem:  Not enough tests for getregion() with multibyte chars.
Solution: Add a few more tests (zeertzjq).

closes: vim/vim#14844

https://github.com/vim/vim/commit/dff55a335889c746a79974f7c52cdcdebad682c2