### PR TITLE
feat(treesitter): support :horizontal mod for :EditQuery

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1042,7 +1042,7 @@ add_predicate({name}, {handler}, {opts})
                      compatibility). This option will eventually become the
                      default and removed.
 
-edit({lang})                                     *vim.treesitter.query.edit()*
+edit({lang}, {opts})                             *vim.treesitter.query.edit()*
     Opens a live editor to query the buffer you started from.
 
     Can also be shown with *:EditQuery*.
@@ -1055,6 +1055,10 @@ edit({lang})                                     *vim.treesitter.query.edit()*
     Parameters: ~
       • {lang}  (`string?`) language to open the query editor for. If omitted,
                 inferred from the current buffer's filetype.
+      • {opts}  (`table?`) Optional keyword arguments:
+                • {wincmd}? (`string`) command used to create a new window.
+                  Defaults to 60vnew or new depending on inspect window
+                  presence.
 
 get({lang}, {query_name})                         *vim.treesitter.query.get()*
     Returns the runtime query {query_name} for {lang}.

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -22,7 +22,11 @@ do
   end, { desc = 'Inspect treesitter language tree for buffer', count = true })
 
   vim.api.nvim_create_user_command('EditQuery', function(cmd)
-    vim.treesitter.query.edit(cmd.fargs[1])
+    local opts = {}
+    if cmd.smods.horizontal then
+      opts.wincmd = 'new'
+    end
+    vim.treesitter.query.edit(cmd.fargs[1], opts)
   end, { desc = 'Edit treesitter query', nargs = '?' })
 end
 

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -554,7 +554,9 @@ end
 
 --- @private
 --- @param lang? string language to open the query editor for.
-function M.edit_query(lang)
+--- @param opts? vim.treesitter.query.edit.Opts
+function M.edit_query(lang, opts)
+  opts = opts or {}
   local buf = api.nvim_get_current_buf()
   local win = api.nvim_get_current_win()
 
@@ -574,7 +576,7 @@ function M.edit_query(lang)
     win = base_win
     cmd = 'new'
   end
-  vim.cmd(cmd)
+  vim.cmd(opts.wincmd and opts.wincmd or cmd)
 
   local ok, parser = pcall(vim.treesitter.get_parser, buf, lang)
   if not ok then

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1024,6 +1024,14 @@ function M.omnifunc(findstart, base)
   return vim.treesitter._query_linter.omnifunc(findstart, base)
 end
 
+--- Optional keyword arguments:
+--- @class vim.treesitter.query.edit.Opts
+--- @inlinedoc
+---
+--- command used to create a new window. Defaults to 60vnew or new depending on inspect window
+--- presence.
+--- @field wincmd? string
+
 --- Opens a live editor to query the buffer you started from.
 ---
 --- Can also be shown with [:EditQuery]().
@@ -1033,8 +1041,9 @@ end
 --- example queries at `$VIMRUNTIME/queries/`.
 ---
 --- @param lang? string language to open the query editor for. If omitted, inferred from the current buffer's filetype.
-function M.edit(lang)
-  vim.treesitter.dev.edit_query(lang)
+--- @param opts? vim.treesitter.query.edit.Opts
+function M.edit(lang, opts)
+  vim.treesitter.dev.edit_query(lang, opts)
 end
 
 return M


### PR DESCRIPTION
Gives users more control over where to open the query window.

If you already have 2 or 3 splits open, adding another one can leave you
with too narrow columns and having it in a horizontal split is more
desirable.
