### PR TITLE
fix(lsp): handle nil root_dir in health check

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -996,7 +996,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 if the client supports workspace folders. It
                                 can be `null` if the client supports workspace
                                 folders but none are configured.
-      • {root_dir}              (`string`)
+      • {root_dir}              (`string?`)
       • {attached_buffers}      (`table<integer,true>`)
       • {commands}              (`table<string,fun(command: lsp.Command, ctx: table)>`)
                                 Table of command name to function which is

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -182,7 +182,7 @@ local validate = vim.validate
 --- It can be `null` if the client supports workspace folders but none are
 --- configured.
 --- @field workspace_folders lsp.WorkspaceFolder[]?
---- @field root_dir string
+--- @field root_dir string?
 ---
 --- @field attached_buffers table<integer,true>
 ---
@@ -470,7 +470,6 @@ function Client.create(config)
     _on_exit_cbs = ensure_list(config.on_exit),
     _on_attach_cbs = ensure_list(config.on_attach),
     _on_error_cb = config.on_error,
-    _root_dir = config.root_dir,
     _trace = get_trace(config.trace),
 
     --- Contains $/progress report messages.

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -41,7 +41,10 @@ local function check_active_clients()
       end
       report_info(table.concat({
         string.format('%s (id: %d)', client.name, client.id),
-        string.format('  Root directory: %s', vim.fn.fnamemodify(client.root_dir, ':~')),
+        string.format(
+          '  Root directory: %s',
+          client.root_dir and vim.fn.fnamemodify(client.root_dir, ':~') or nil
+        ),
         string.format('  Command: %s', cmd),
         string.format('  Settings: %s', vim.inspect(client.settings, { newline = '\n  ' })),
         string.format(


### PR DESCRIPTION
The root directory could show up as something like:

    Root directory: ~/path/to/cwd/v:null

Despite being `nil`
