### PR TITLE
vim-patch:9.1.0446: getregionpos() inconsistent for partly-selected multibyte char

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3042,6 +3042,7 @@ static void f_getregionpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
 
   for (linenr_T lnum = p1.lnum; lnum <= p2.lnum; lnum++) {
     pos_T ret_p1, ret_p2;
+    char *line = ml_get(lnum);
     colnr_T line_len = ml_get_len(lnum);
 
     if (region_type == kMTLineWise) {
@@ -3060,7 +3061,7 @@ static void f_getregionpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
 
       if (bd.is_oneChar) {  // selection entirely inside one char
         if (region_type == kMTBlockWise) {
-          ret_p1.col = bd.textcol;
+          ret_p1.col = (colnr_T)(mb_prevptr(line, bd.textstart) - line) + 1;
           ret_p1.coladd = bd.start_char_vcols - (bd.start_vcol - oa.start_vcol);
         } else {
           ret_p1.col = p1.col + 1;
@@ -3072,7 +3073,7 @@ static void f_getregionpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
         ret_p1.coladd = oa.start_vcol - bd.start_vcol;
         bd.is_oneChar = true;
       } else if (bd.startspaces > 0) {
-        ret_p1.col = bd.textcol;
+        ret_p1.col = (colnr_T)(mb_prevptr(line, bd.textstart) - line) + 1;
         ret_p1.coladd = bd.start_char_vcols - bd.startspaces;
       } else {
         ret_p1.col = bd.textcol + 1;

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -2077,16 +2077,40 @@ func Test_visual_getregion()
           \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
     call assert_equal([
           \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 5, 0]],
-          \   [[bufnr('%'), 2, 10, 1], [bufnr('%'), 2, 10, 2]],
+          \   [[bufnr('%'), 2, 7, 1], [bufnr('%'), 2, 7, 2]],
           \   [[bufnr('%'), 3, 5, 0], [bufnr('%'), 3, 5, 0]],
           \ ],
           \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal(['efghijk«', '🇦«🇧«🇨«🇩', '12345'],
+          \ getregion(getpos('v'), getpos('.'), {'type': 'v' }))
     call assert_equal([
           \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 13, 0]],
           \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 22, 0]],
           \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 5, 0]],
           \ ],
           \ getregionpos(getpos('v'), getpos('.'), {'type': 'v' }))
+
+    call cursor(1, 5)
+    call feedkeys("\<Esc>\<C-v>5l2j", 'xt')
+    call assert_equal(['efghij', ' «🇨« ', '567890'],
+          \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal([
+          \   [[bufnr('%'), 1, 5, 0], [bufnr('%'), 1, 10, 0]],
+          \   [[bufnr('%'), 2, 7, 1], [bufnr('%'), 2, 19, 1]],
+          \   [[bufnr('%'), 3, 5, 0], [bufnr('%'), 3, 10, 0]],
+          \ ],
+          \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+
+    call cursor(1, 4)
+    call feedkeys("\<Esc>\<C-v>02j", 'xt')
+    call assert_equal(['abcd', '🇦« ', '1234'],
+          \ getregion(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
+    call assert_equal([
+          \   [[bufnr('%'), 1, 1, 0], [bufnr('%'), 1, 4, 0]],
+          \   [[bufnr('%'), 2, 1, 0], [bufnr('%'), 2, 7, 1]],
+          \   [[bufnr('%'), 3, 1, 0], [bufnr('%'), 3, 4, 0]],
+          \ ],
+          \ getregionpos(getpos('v'), getpos('.'), {'type': "\<C-v>" }))
 
     #" characterwise selection with multibyte chars
     call cursor(1, 1)


### PR DESCRIPTION
#### vim-patch:9.1.0446: getregionpos() inconsistent for partly-selected multibyte char

Problem:  getregionpos() behaves inconsistently for a partly-selected
          multibyte char.
Solution: Always use column of the first byte for a partly-selected
          multibyte char (zeertzjq).

closes: vim/vim#14851

https://github.com/vim/vim/commit/ef73374dc3e4bf8104ba31d5b22517f8028b467a