### PR TITLE
fix(lsp): clear lsp client diagnostics

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -391,8 +391,8 @@ end
 local function on_client_exit(code, signal, client_id)
   local client = all_clients[client_id]
 
-  for bufnr in pairs(client.attached_buffers) do
-    vim.schedule(function()
+  vim.schedule(function()
+    for bufnr in pairs(client.attached_buffers) do
       if client and client.attached_buffers[bufnr] then
         api.nvim_exec_autocmds('LspDetach', {
           buffer = bufnr,
@@ -401,15 +401,16 @@ local function on_client_exit(code, signal, client_id)
         })
       end
 
-      local namespace = vim.lsp.diagnostic.get_namespace(client_id)
-      vim.diagnostic.reset(namespace, bufnr)
       client.attached_buffers[bufnr] = nil
 
       if #lsp.get_clients({ bufnr = bufnr, _uninitialized = true }) == 0 then
         reset_defaults(bufnr)
       end
-    end)
-  end
+    end
+
+    local namespace = vim.lsp.diagnostic.get_namespace(client_id)
+    vim.diagnostic.reset(namespace)
+  end)
 
   local name = client.name or 'unknown'
 


### PR DESCRIPTION
Fixes neovim/neovim#29048

Problem: When an lsp client is stopped, the client will only clear the diagnostics for the attached buffers but not the unattached buffers.
Solution: Reset the diagnostics for the whole namespace rather than for only the attached buffers.
