### PR TITLE
vim-patch:0b74eec: runtime(stylus): remove remaining css code (vim/vim#14866)

### DIFF
--- a/runtime/syntax/stylus.vim
+++ b/runtime/syntax/stylus.vim
@@ -4,17 +4,7 @@
 " Filenames: *.styl, *.stylus
 " Based On: Tim Pope (sass.vim)
 " Created:	Dec 14, 2011
-" Modified:	Apr 29, 2024
-
-if main_syntax == "css"
-  syn sync minlines=10
-endif
-
-" let b:current_syntax = "css"
-"
-if main_syntax == 'css'
-  unlet main_syntax
-endif
+" Modified:	May 28, 2024
 
 syn case ignore
 


### PR DESCRIPTION
#### vim-patch:0b74eec: runtime(stylus): remove remaining css code (vim/vim#14866)

This seems to be a forgotten fixup in https://github.com/vim/vim/commit/2d919d2744a99c9bb9e79984e85b8e8f5ec14c07#r141568461

https://github.com/vim/vim/commit/0b74eeceb856e7a4c2823f5b6c2c2ee95a72331c

Fix #29055