### PR TITLE
refactor(fileio): remove useless use of FileDescriptor

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1100,23 +1100,13 @@ static void command_line_scan(mparm_T *parmp)
           // set stdout to binary to avoid crlf in --api-info output
           _setmode(STDOUT_FILENO, _O_BINARY);
 #endif
-          FileDescriptor fp;
-          const int fof_ret = file_open_fd(&fp, STDOUT_FILENO,
-                                           kFileWriteOnly);
-          if (fof_ret != 0) {
-            semsg(_("E5421: Failed to open stdin: %s"), os_strerror(fof_ret));
-          }
 
           String data = api_metadata_raw();
-          const ptrdiff_t written_bytes = file_write(&fp, data.data, data.size);
+          const ptrdiff_t written_bytes = os_write(STDOUT_FILENO, data.data, data.size, false);
           if (written_bytes < 0) {
-            msgpack_file_write_error((int)written_bytes);
+            semsg(_("E5420: Failed to write to file: %s"), os_strerror((int)written_bytes));
           }
 
-          const int ff_ret = file_flush(&fp);
-          if (ff_ret < 0) {
-            msgpack_file_write_error(ff_ret);
-          }
           os_exit(0);
         } else if (STRICMP(argv[0] + argv_idx, "headless") == 0) {
           headless_mode = true;

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -365,14 +365,3 @@ ptrdiff_t file_skip(FileDescriptor *const fp, const size_t size)
 
   return (ptrdiff_t)read_bytes;
 }
-
-/// Print error which occurs when failing to write msgpack data
-///
-/// @param[in]  error  Error code of the error to print.
-///
-/// @return -1 (error return for msgpack_packer callbacks).
-int msgpack_file_write_error(const int error)
-{
-  semsg(_("E5420: Failed to write to file: %s"), os_strerror(error));
-  return -1;
-}


### PR DESCRIPTION
FileDescriptor is used to buffer together many small writes to fewer syscalls. if the data to write already is in a single buffer, it is perfectly fine to just use `os_write` directly (which will take care of the reverse problem: splitting a too big write into many syscalls)