### PR TITLE
feat(defaults): use vim.diagnostic.jump() for default mappings

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -34,11 +34,14 @@ API
 
 DEFAULTS
 
-• TODO
+• |]d-default| and |[d-default| accept a count.
+• |[D-default| and |]D-default| jump to the first and last diagnostic in the
+  current buffer, respectively.
 
 EDITOR
 
-• The order in which signs are placed was changed. Higher priority signs will now appear left of lower priority signs.
+• The order in which signs are placed was changed. Higher priority signs will
+  now appear left of lower priority signs.
 
 EVENTS
 

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -781,15 +781,15 @@ CTRL-W i		Open a new window, with the cursor on the first line
 			count'th matching line is displayed.
 
 							*[d-default*
-			Mapped to |vim.diagnostic.goto_prev()| by default.
-			|default-mappings|
+			Jumps to the previous diagnostic in the current buffer
+			by default. |vim.diagnostic.jump()| |default-mappings|
 
 							*]d*
 ]d			like "[d", but start at the current cursor position.
 
 							*]d-default*
-			Mapped to |vim.diagnostic.goto_next()| by default.
-			|default-mappings|
+			Jumps to the next diagnostic in the current buffer by
+			default. |vim.diagnostic.jump()| |default-mappings|
 
 							*:ds* *:dsearch*
 :[range]ds[earch][!] [count] [/]string[/]
@@ -803,8 +803,16 @@ CTRL-W i		Open a new window, with the cursor on the first line
 			displayed for the found lines.  The search starts
 			from the beginning of the file.
 
+							*[D-default*
+			Jumps to the first diagnostic in the current buffer by
+			default. |vim.diagnostic.jump()| |default-mappings|
+
 							*]D*
 ]D			like "[D", but start at the current cursor position.
+
+							*]D-default*
+			Jumps to the last diagnostic in the current buffer by
+			default. |vim.diagnostic.jump()| |default-mappings|
 
 							*:dli* *:dlist*
 :[range]dli[st][!] [/]string[/]

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -145,6 +145,8 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|
+- [D |[D-default|
+- ]D |]D-default|
 - <C-W>d |CTRL-W_d-default|
 - Nvim LSP client defaults |lsp-defaults|
   - K |K-lsp-default|

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -180,12 +180,20 @@ do
   --- See |[d-default|, |]d-default|, and |CTRL-W_d-default|.
   do
     vim.keymap.set('n', ']d', function()
-      vim.diagnostic.goto_next({ float = false })
-    end, { desc = 'Jump to the next diagnostic' })
+      vim.diagnostic.jump({ count = vim.v.count1, float = false })
+    end, { desc = 'Jump to the next diagnostic in the current buffer' })
 
     vim.keymap.set('n', '[d', function()
-      vim.diagnostic.goto_prev({ float = false })
-    end, { desc = 'Jump to the previous diagnostic' })
+      vim.diagnostic.jump({ count = -vim.v.count1, float = false })
+    end, { desc = 'Jump to the previous diagnostic in the current buffer' })
+
+    vim.keymap.set('n', ']D', function()
+      vim.diagnostic.jump({ count = math.huge, wrap = false, float = false })
+    end, { desc = 'Jump to the last diagnostic in the current buffer' })
+
+    vim.keymap.set('n', '[D', function()
+      vim.diagnostic.jump({ count = -math.huge, wrap = false, float = false })
+    end, { desc = 'Jump to the first diagnostic in the current buffer' })
 
     vim.keymap.set('n', '<C-W>d', function()
       vim.diagnostic.open_float()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -969,7 +969,7 @@ describe('vim.diagnostic', function()
       eq(
         { 3, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next({_highest = true})
+        vim.diagnostic.jump({ count = 1, _highest = true })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -977,7 +977,7 @@ describe('vim.diagnostic', function()
       eq(
         { 5, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next({_highest = true})
+        vim.diagnostic.jump({ count = 1, _highest = true })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -998,7 +998,7 @@ describe('vim.diagnostic', function()
       eq(
         { 4, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next({_highest = true})
+        vim.diagnostic.jump({ count = 1, _highest = true })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -1006,7 +1006,7 @@ describe('vim.diagnostic', function()
       eq(
         { 6, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next({_highest = true})
+        vim.diagnostic.jump({ count = 1, _highest = true })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -1028,7 +1028,7 @@ describe('vim.diagnostic', function()
       eq(
         { 2, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next()
+        vim.diagnostic.jump({ count = 1 })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -1036,7 +1036,7 @@ describe('vim.diagnostic', function()
       eq(
         { 3, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next()
+        vim.diagnostic.jump({ count = 1 })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -1044,7 +1044,7 @@ describe('vim.diagnostic', function()
       eq(
         { 4, 0 },
         exec_lua([[
-        vim.diagnostic.goto_next()
+        vim.diagnostic.jump({ count = 1 })
         return vim.api.nvim_win_get_cursor(0)
       ]])
       )
@@ -1107,7 +1107,7 @@ describe('vim.diagnostic', function()
           })
           vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
           vim.api.nvim_win_set_cursor(0, {3, 1})
-          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns, wrap = false})
+          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns, wrap = false })
           return prev
         ]]
       )


### PR DESCRIPTION
This allows the mappings to work with a count and also enables new ]D and [D mappings to go to the last/first diagnostic in the buffer.