### PR TITLE
feat(checkhealth): show summary of errors and warnings at top [skip ci]

### DIFF
--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -1,6 +1,4 @@
-" Vim syntax file
 " Language:     Nvim :checkhealth buffer
-" Last Change:  2022 Nov 10
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
This way it's easy for user to directly see the most important
information first. If they then wish to know more information they can
read in more detail further down in the checkhealth.

Alternative to https://github.com/neovim/neovim/pull/28981.
Closes https://github.com/neovim/neovim/issues/22796.

Reference:
https://github.com/neovim/neovim/pull/22866
https://github.com/neovim/neovim/pull/28232
