### PR TITLE
Remove deprecated rustc arguments

### DIFF
--- a/runtime/autoload/rust.vim
+++ b/runtime/autoload/rust.vim
@@ -144,14 +144,8 @@ endfunction
 function! s:Expand(dict, pretty, args)
     try
         let rustc = exists("g:rustc_path") ? g:rustc_path : "rustc"
-
-        if a:pretty =~? '^\%(everybody_loops$\|flowgraph=\)'
-            let flag = '--xpretty'
-        else
-            let flag = '--pretty'
-        endif
         let relpath = get(a:dict, 'tmpdir_relpath', a:dict.path)
-        let args = [relpath, '-Z', 'unstable-options', l:flag, a:pretty] + a:args
+        let args = [relpath, $"-Zunpretty={a:pretty}"] + a:args
         let pwd = a:dict.istemp ? a:dict.tmpdir : ''
         let output = s:system(pwd, shellescape(rustc) . " " . join(map(args, 'shellescape(v:val)')))
         if v:shell_error

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -388,7 +388,7 @@ functionality from other plugins.
 
 :RustExpand  [args]                                              *:RustExpand*
 :RustExpand! [TYPE] [args]
-		Expands the current file using `--pretty` and displays the
+		Expands the current file using `--Zunpretty` and displays the
 		results in a new split. If the current file has unsaved
 		changes, it will be saved first using |:update|. If the
 		current file is an unnamed buffer, it will be written to a
@@ -399,7 +399,7 @@ functionality from other plugins.
 		configurations.
 
 		If ! is specified, the first argument is the expansion type to
-		pass to `rustc --pretty` . Otherwise it will default to
+		pass to `rustc --Zunpretty` . Otherwise it will default to
 		"expanded".
 
 		If |g:rustc_path| is defined, it is used as the path to rustc.


### PR DESCRIPTION
Currently the :RustExpand command doesn't work because it uses non-existing arguments.
The `--pretty` and `--xpretty` arguments have been deprecated [0] and
removed [1]. They have been renamed to '-Zunpretty' and moved to
nightly [2]. This means that currently, with the default stable compiler
this won't work. You will have to use nightly or wait until it is
stabilized (which is an ongoing effort [3]).

[0]: https://github.com/rust-lang/rust/pull/21441
[1]: https://github.com/rust-lang/rust/pull/83491
[2]: https://github.com/rust-lang/rust/pull/27392
[3]: https://github.com/rust-lang/rust/issues/43364