### PR TITLE
refactor(fileio): use a linear buffer for FileDescriptor

### DIFF
--- a/src/nvim/msgpack_rpc/packer.c
+++ b/src/nvim/msgpack_rpc/packer.c
@@ -113,7 +113,6 @@ void mpack_handle(ObjectType type, handle_T handle, PackerBuffer *packer)
     mpack_w(&packer->ptr, 0xc7);
     mpack_w(&packer->ptr, packsize);
     mpack_w(&packer->ptr, exttype);
-    // check_buffer(packer);
     memcpy(packer->ptr, buf, (size_t)packsize);
     packer->ptr += packsize;
   }

--- a/src/nvim/os/fileio_defs.h
+++ b/src/nvim/os/fileio_defs.h
@@ -8,9 +8,10 @@
 
 /// Structure used to read from/write to file
 typedef struct {
-  int fd;             ///< File descriptor.
-  int _error;         ///< Error code for use with RBuffer callbacks or zero.
-  RBuffer *rv;        ///< Read or write buffer.
+  int fd;             ///< File descriptor. Can be -1 if no backing file (file_open_buffer)
+  char *buffer;       ///< Read or write buffer. always ARENA_BLOCK_SIZE if allocated
+  char *read_pos;     ///< read position in buffer
+  char *write_pos;    ///< write position in buffer
   bool wr;            ///< True if file is in write mode.
   bool eof;           ///< True if end of file was encountered.
   bool non_blocking;  ///< True if EAGAIN should not restart syscalls.
@@ -28,7 +29,7 @@ static inline bool file_eof(const FileDescriptor *fp)
 ///         performed.
 static inline bool file_eof(const FileDescriptor *const fp)
 {
-  return fp->eof && rbuffer_size(fp->rv) == 0;
+  return fp->eof && fp->read_pos == fp->write_pos;
 }
 
 static inline int file_fd(const FileDescriptor *fp)

--- a/src/nvim/rbuffer.c
+++ b/src/nvim/rbuffer.c
@@ -29,23 +29,6 @@ RBuffer *rbuffer_new(size_t capacity)
   return rv;
 }
 
-/// Creates a new `RBuffer` instance for reading from a buffer.
-///
-/// Must not be used with any write function like rbuffer_write_ptr or rbuffer_produced!
-RBuffer *rbuffer_new_wrap_buf(char *data, size_t len)
-  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_RET
-{
-  RBuffer *rv = xcalloc(1, sizeof(RBuffer));
-  rv->full_cb = rv->nonfull_cb = NULL;
-  rv->data = NULL;
-  rv->size = len;
-  rv->read_ptr = data;
-  rv->write_ptr = data + len;
-  rv->end_ptr = NULL;
-  rv->temp = NULL;
-  return rv;
-}
-
 void rbuffer_free(RBuffer *buf) FUNC_ATTR_NONNULL_ALL
 {
   xfree(buf->temp);
@@ -146,7 +129,7 @@ void rbuffer_consumed(RBuffer *buf, size_t count)
   assert(count <= buf->size);
 
   buf->read_ptr += count;
-  if (buf->end_ptr && buf->read_ptr >= buf->end_ptr) {
+  if (buf->read_ptr >= buf->end_ptr) {
     buf->read_ptr -= rbuffer_capacity(buf);
   }
 


### PR DESCRIPTION
Using a ring buffer for buffered synchronous fileio is just unnecessary complexity.

- when reading, we always consume the _entire_ buffer before getting into syscalls. Thus we reset the buffer to its initial position before when we actually read.
- when writing and buffer is full, we always flush the entire buffer before starting to buffer again. So we can reset the buffer to its initial state.

Also no static buffers are needed for writing and skipping. Needing an extra copy for each write completely defeated the purpose of a ring buffer (if there had been one)