### PR TITLE
vim-patch:8.1.0716: get warning message when 'completefunc' returns nothing

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1143,6 +1143,10 @@ that contains the List.  The Dict can have these items:
 			The only value currently recognized is "always", the
 			effect is that the function is called whenever the
 			leading text is changed.
+
+If you want to suppress the warning message for an empty result, return
+v:null.  This is useful to implement asynchronous completion with complete().
+
 Other items are ignored.
 
 For acting upon end of completion, see the |CompleteDonePre| and

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -190,12 +190,11 @@ func Test_completefunc_args()
 endfunc
 
 func s:CompleteDone_CompleteFuncNone( findstart, base )
-  throw 'skipped: Nvim does not support v:none'
   if a:findstart
     return 0
   endif
 
-  return v:none
+  return v:null
 endfunc
 
 func s:CompleteDone_CompleteFuncDict( findstart, base )
@@ -237,7 +236,6 @@ func s:CompleteDone_CheckCompletedItemDict(pre)
 endfunc
 
 func Test_CompleteDoneNone()
-  throw 'skipped: Nvim does not support v:none'
   au CompleteDone * :call <SID>CompleteDone_CheckCompletedItemNone()
   let oldline = join(map(range(&columns), 'nr2char(screenchar(&lines-1, v:val+1))'), '')
 


### PR DESCRIPTION
Problem:    Get warning message when 'completefunc' returns nothing.
Solution:   Allow for returning v:none to suppress the warning message.
(Yasuhiro Matsumoto, closes https://github.com/vim/vim/pull/3789)

https://github.com/vim/vim/commit/cee9bc2e3dc5c16a9d2a8d0e23aa0d5fdefa3a4a