### PR TITLE
fix(tui): skip TUI in ui_rgb_attached

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -144,7 +144,7 @@ void ui_free_all_mem(void)
 /// Returns true if any `rgb=true` UI is attached.
 bool ui_rgb_attached(void)
 {
-  if (!headless_mode && p_tgc) {
+  if (p_tgc) {
     return true;
   }
   for (size_t i = 0; i < ui_count; i++) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -148,7 +148,11 @@ bool ui_rgb_attached(void)
     return true;
   }
   for (size_t i = 0; i < ui_count; i++) {
-    if (uis[i]->rgb) {
+    // We do not consider the TUI in this loop because we already checked for 'termguicolors' at the
+    // beginning of this function. In this loop, we are checking to see if any _other_ UIs which
+    // support RGB are attached.
+    bool tui = uis[i]->stdin_tty || uis[i]->stdout_tty;
+    if (!tui && uis[i]->rgb) {
       return true;
     }
   }


### PR DESCRIPTION
The ui_rgb_attached function determines if any UI is attached which supports RGB (truecolor). We determine if the TUI supports RGB via the 'termguicolors' option which is checked at the beginning of this function. If the TUI does not support RGB ('termguicolors' is unset), we check to see if any _other_ UI is attached which supports RGB.

Normally, the TUI's "rgb" flag and the 'termguicolors' option are the same. However, they may differ during startup when the "rgb" flag is set by tui/tui.c to indicate to the core that the terminal emulator supports truecolor. The 'termguicolors' option is not actually set until _defaults.lua runs.

Fixes: https://github.com/neovim/neovim/issues/29056