### PR TITLE
fix(win-msi): add bin to PATH per-machine after installation

### DIFF
--- a/cmake.packaging/WixPatch.xml
+++ b/cmake.packaging/WixPatch.xml
@@ -6,7 +6,7 @@
       Name='PATH'
       Action='set'
       Permanent='no'
-      System='no'
+      System='yes'
       Part='last'
       Value='[INSTALL_ROOT]bin'
     />


### PR DESCRIPTION
details:
 #22856 made possible for the msi installer to perform per-user
 installations. This caused problems when users that already had
 per-machine installations tried to update #22933 (the Windows Installer
 does not support major upgrades across installation context, see
 https://stackoverflow.com/a/15498911). This was then reverted on
 #22949, but the scope of the modification to the PATH environment
 variable was not reverted.

Fixes #27551 