### PR TITLE
test: do not set termguicolors in test runner

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4385,8 +4385,9 @@ vim.text.hexdecode({enc})                               *vim.text.hexdecode()*
     Parameters: ~
       • {enc}  (`string`) String to decode
 
-    Return: ~
-        (`string`) Decoded string
+    Return (multiple): ~
+        (`string?`) Decoded string
+        (`string?`) Error message, if any
 
 vim.text.hexencode({str})                               *vim.text.hexencode()*
     Hex encode a string.

--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -18,15 +18,19 @@ end
 --- Hex decode a string.
 ---
 --- @param enc string String to decode
---- @return string : Decoded string
+--- @return string? : Decoded string
+--- @return string? : Error message, if any
 function M.hexdecode(enc)
-  assert(#enc % 2 == 0, 'string must have an even number of hex characters')
+  if #enc % 2 ~= 0 then
+    return nil, 'string must have an even number of hex characters'
+  end
+
   local str = {} ---@type string[]
   for i = 1, #enc, 2 do
     local n = assert(tonumber(enc:sub(i, i + 1), 16))
     str[#str + 1] = string.char(n)
   end
-  return table.concat(str)
+  return table.concat(str), nil
 end
 
 return M

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -400,9 +400,6 @@ describe('startup', function()
         read_file('Xtest_startup_ttyout')
       )
     end)
-    if is_os('win') then
-      assert_log('stream write failed. RPC canceled; closing channel', testlog)
-    end
   end)
 
   it('input from pipe: has("ttyin")==0 has("ttyout")==1', function()
@@ -435,9 +432,6 @@ describe('startup', function()
         read_file('Xtest_startup_ttyout')
       )
     end)
-    if is_os('win') then
-      assert_log('stream write failed. RPC canceled; closing channel', testlog)
-    end
   end)
 
   it('input from pipe (implicit) #7679', function()

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -22,7 +22,7 @@ local runtime_set = 'set runtimepath^=./build/lib/nvim/'
 M.nvim_prog = (os.getenv('NVIM_PRG') or t.paths.test_build_dir .. '/bin/nvim')
 -- Default settings for the test session.
 M.nvim_set = (
-  'set shortmess+=IS background=light termguicolors noswapfile noautoindent startofline'
+  'set shortmess+=IS background=light noswapfile noautoindent startofline'
   .. ' laststatus=1 undodir=. directory=. viewdir=. backupdir=.'
   .. ' belloff= wildoptions-=pum joinspaces noshowcmd noruler nomore redrawdebug=invalid'
 )

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1129,7 +1129,7 @@ describe("builtin popupmenu 'pumblend'", function()
       [10] = { foreground = tonumber('0x000002') },
     })
     screen:attach({ rgb = false })
-    command('set notermguicolors pumblend=10')
+    command('set pumblend=10')
     insert([[
       Lorem ipsum dolor sit amet, consectetur
       adipisicing elit, sed do eiusmod tempor


### PR DESCRIPTION
**test: do not set termguicolors in test runner**

It's not clear why this is needed and it has adverse side effects on other tests.

**fix(vim.text): remove assert from vim.text.hexdecode**

Instead, return nil plus an error message if the input is invalid. _This change is required to fix a test failure in terminal/tui_spec caused by the first commit._