### PR TITLE
refactor(lsp): use tuple syntax in generated protocol types

### DIFF
--- a/runtime/lua/vim/lsp/_meta/protocol.lua
+++ b/runtime/lua/vim/lsp/_meta/protocol.lua
@@ -3235,7 +3235,7 @@ error('Cannot require a meta file')
 ---
 ---*Note*: a label of type string should be a substring of its containing signature label.
 ---Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
----@field label string|{ [1]: uinteger, [2]: uinteger }
+---@field label string|[uinteger, uinteger]
 ---
 ---The human-readable doc-comment of this parameter. Will be shown
 ---in the UI but can be omitted.

--- a/scripts/gen_lsp.lua
+++ b/scripts/gen_lsp.lua
@@ -297,13 +297,13 @@ function M.gen(opt)
 
     -- TupleType
     elseif type.kind == 'tuple' then
-      local tuple = '{ '
-      for i, value in ipairs(type.items) do
-        tuple = tuple .. '[' .. i .. ']: ' .. parse_type(value, prefix) .. ', '
+      local tuple = '['
+      for _, value in ipairs(type.items) do
+        tuple = tuple .. parse_type(value, prefix) .. ', '
       end
       -- remove , at the end
       tuple = tuple:sub(0, -3)
-      return tuple .. ' }'
+      return tuple .. ']'
     end
 
     vim.print('WARNING: Unknown type ', type)


### PR DESCRIPTION
This is a follow up from https://github.com/neovim/neovim/pull/29098