### PR TITLE
refactor(tui): use a linear buffer for buffered keys

### DIFF
--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -17,6 +17,7 @@ typedef enum {
   kKeyEncodingXterm,   ///< Xterm's modifyOtherKeys encoding (XTMODKEYS)
 } KeyEncoding;
 
+#define KEY_BUFFER_SIZE 0xfff
 typedef struct {
   int in_fd;
   // Phases: -1=all 0=disabled 1=first-chunk 2=continue 3=last-chunk
@@ -34,8 +35,9 @@ typedef struct {
   uv_timer_t timer_handle;
   Loop *loop;
   RStream read_stream;
-  RBuffer *key_buffer;
   TUIData *tui_data;
+  char key_buffer[KEY_BUFFER_SIZE];
+  size_t key_buffer_len;
 } TermInput;
 
 typedef enum {


### PR DESCRIPTION
This buffer is completely emptied every time it is read from. Thus there is no point in using a ring buffer.