### PR TITLE
feat(terminal): add support for copying with OSC 52 in embedded terminal

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -138,7 +138,8 @@ STARTUP
 
 TERMINAL
 
-• TODO
+• The |terminal| now understands the OSC 52 escape sequence to write to the
+  system clipboard (copy). Querying with OSC 52 (paste) is not supported.
 
 TREESITTER
 

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -164,7 +164,22 @@ directory indicated in the request. >lua
 To try it out, select the above code and source it with `:'<,'>lua`, then run
 this command in a :terminal buffer: >
 
-   printf "\033]7;file://./foo/bar\033\\"
+    printf "\033]7;file://./foo/bar\033\\"
+
+OSC 52: write to system clipboard		*terminal-osc52*
+
+Applications in the :terminal buffer can write to the system clipboard by
+emitting an OSC 52 sequence. Example: >
+
+    printf '\033]52;;%s\033\\' "$(echo -n 'Hello world' | base64)"
+
+Nvim uses the configured |clipboard| provider to write to the system
+clipboard. Reading from the system clipboard with OSC 52 is not supported, as
+this would allow any arbitrary program in the :terminal to read the user's
+clipboard.
+
+OSC 52 sequences sent from the :terminal buffer do not emit a |TermRequest|
+event. The event is handled directly by Nvim and is not forwarded to plugins.
 
 ==============================================================================
 Status Variables				*terminal-status*

--- a/src/nvim/base64.c
+++ b/src/nvim/base64.c
@@ -142,6 +142,7 @@ char *base64_encode(const char *src, size_t src_len)
 /// @param [out] out_lenp Returns the length of the decoded string
 /// @return Decoded string
 char *base64_decode(const char *src, size_t src_len, size_t *out_lenp)
+  FUNC_ATTR_NONNULL_ALL
 {
   assert(src != NULL);
   assert(out_lenp != NULL);

--- a/test/functional/terminal/clipboard_spec.lua
+++ b/test/functional/terminal/clipboard_spec.lua
@@ -1,0 +1,65 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local eq = t.eq
+local retry = t.retry
+
+local clear = n.clear
+local fn = n.fn
+local testprg = n.testprg
+local exec_lua = n.exec_lua
+local eval = n.eval
+
+describe(':terminal', function()
+  before_each(function()
+    clear()
+
+    exec_lua([[
+      local function clipboard(reg, type)
+        if type == 'copy' then
+          return function(lines)
+            local data = table.concat(lines, '\n')
+            vim.g.clipboard_data = data
+          end
+        end
+
+        if type == 'paste' then
+          return function()
+            error()
+          end
+        end
+
+        error('invalid type: ' .. type)
+      end
+
+      vim.g.clipboard = {
+        name = 'Test',
+        copy = {
+          ['+'] = clipboard('+', 'copy'),
+          ['*'] = clipboard('*', 'copy'),
+        },
+        paste = {
+          ['+'] = clipboard('+', 'paste'),
+          ['*'] = clipboard('*', 'paste'),
+        },
+      }
+    ]])
+  end)
+
+  it('can write to the system clipboard', function()
+    eq('Test', eval('g:clipboard.name'))
+
+    local text = 'Hello, world! This is some\nexample text\nthat spans multiple\nlines'
+    local encoded = exec_lua('return vim.base64.encode(...)', text)
+
+    local function osc52(arg)
+      return string.format('\027]52;;%s\027\\', arg)
+    end
+
+    fn.termopen({ testprg('shell-test'), '-t', osc52(encoded) })
+
+    retry(nil, 1000, function()
+      eq(text, exec_lua([[ return vim.g.clipboard_data ]]))
+    end)
+  end)
+end)


### PR DESCRIPTION
When libvterm receives the OSC 52 escape sequence it ignores it because Nvim does not set any selection callbacks. Install selection callbacks that forward to the clipboard provider, so that setting the clipboard with OSC 52 in the embedded terminal writes to the system clipboard.

Fixes: #20672