### PR TITLE
vim-patch:0bdc5d8: runtime(doc): Add ft_hare.txt to Reference Manual TOC

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -127,6 +127,7 @@ PROGRAMMING LANGUAGE SUPPORT
 |filetype|		Settings for specific types of files
 |quickfix|		Commands for a quick edit-compile-fix cycle
 |ft_ada.txt|		Ada filetype plugin
+|ft_hare.txt|		Filetype plugin for Hare
 |ft_ps1.txt|		PowerShell filetype plugin
 |ft_raku.txt|		Raku filetype plugin
 |ft_rust.txt|		Rust filetype plugin


### PR DESCRIPTION
#### vim-patch:0bdc5d8: runtime(doc): Add ft_hare.txt to Reference Manual TOC

while at it, also re-align ft_context.txt with the rest of the
list.

closes: vim/vim#14863

https://github.com/vim/vim/commit/0bdc5d8241335c3451f629eed7a3734021d41679

Co-authored-by: h-east <h.east.727@gmail.com>