### PR TITLE
fix(types): support named and vararg returns for `fun()` types

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4079,10 +4079,10 @@ Iter:map({f})                                                     *Iter:map()*
 <
 
     Parameters: ~
-      • {f}  (`fun(...):any`) Mapping function. Takes all values returned from
-             the previous stage in the pipeline as arguments and returns one
-             or more new values, which are used in the next pipeline stage.
-             Nil return values are filtered from the output.
+      • {f}  (`fun(...):...:any`) Mapping function. Takes all values returned
+             from the previous stage in the pipeline as arguments and returns
+             one or more new values, which are used in the next pipeline
+             stage. Nil return values are filtered from the output.
 
     Return: ~
         (`Iter`)

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -276,7 +276,7 @@ end
 --- -- { 6, 12 }
 --- ```
 ---
----@param f fun(...):any Mapping function. Takes all values returned from
+---@param f fun(...):...:any Mapping function. Takes all values returned from
 ---                      the previous stage in the pipeline as arguments
 ---                      and returns one or more new values, which are used
 ---                      in the next pipeline stage. Nil return values

--- a/scripts/luacats_grammar.lua
+++ b/scripts/luacats_grammar.lua
@@ -178,7 +178,8 @@ local grammar = P {
   table_elem = v.table_key * colon * v.ltype,
   ty_table = Pf('{') * comma1(v.table_elem) * fill * P('}'),
   fun_param = lname * opt(colon * v.ltype),
-  ty_fun = Pf('fun') * paren(comma(lname * opt(colon * v.ltype))) * opt(colon * comma1(v.ltype)),
+  fun_ret = v.ltype + (ident * colon * v.ltype) + (P('...') * opt(colon * v.ltype)),
+  ty_fun = Pf('fun') * paren(comma(lname * opt(colon * v.ltype))) * opt(colon * comma1(v.fun_ret)),
   ty_generic = P('`') * letter * P('`'),
   ty_tuple = Pf('[') * comma(v.ty_opt) * fill * P(']'),
 }


### PR DESCRIPTION
This should remove the "redundant return value" warning when returning multiple values from functions passed to `Iter:map()`.