### PR TITLE
fix(lsp): trim trailing whitespace from completion words

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -153,7 +153,8 @@ local function get_completion_word(item)
       return item.label
     end
   elseif item.textEdit then
-    return item.textEdit.newText
+    local word = item.textEdit.newText
+    return word:match('^(%S*)') or word
   elseif item.insertText and item.insertText ~= '' then
     return item.insertText
   end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -126,6 +126,41 @@ describe('vim.lsp.completion: item conversion', function()
     eq(expected, result)
   end)
 
+  it('trims trailing newline or tab from textEdit', function()
+    local range0 = {
+      start = { line = 0, character = 0 },
+      ['end'] = { line = 0, character = 0 },
+    }
+    local items = {
+      {
+        detail = 'ansible.builtin',
+        filterText = 'lineinfile ansible.builtin.lineinfile builtin ansible',
+        kind = 7,
+        label = 'ansible.builtin.lineinfile',
+        sortText = '2_ansible.builtin.lineinfile',
+        textEdit = {
+          newText = 'ansible.builtin.lineinfile:\n	',
+          range = range0,
+        },
+      },
+    }
+    local result = complete('|', items)
+    result = vim.tbl_map(function(x)
+      return {
+        abbr = x.abbr,
+        word = x.word,
+      }
+    end, result.items)
+
+    local expected = {
+      {
+        abbr = 'ansible.builtin.lineinfile',
+        word = 'ansible.builtin.lineinfile:',
+      },
+    }
+    eq(expected, result)
+  end)
+
   it('prefers wordlike components for snippets', function()
     -- There are two goals here:
     --


### PR DESCRIPTION
the `complete()` mechanism doesn't play nicely with trailing newlines or
tabs. A newline causes it to insert a null character, showing up as
`^@`.
