### PR TITLE
fix(completion): make sure the info preview window is highest one

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -375,6 +375,7 @@ win_T *win_float_create(bool enter, bool new_buf)
   config.noautocmd = true;
   config.hide = true;
   config.style = kWinStyleMinimal;
+  config.zindex = 9999;  // make sure preview is the highest one
   Error err = ERROR_INIT;
 
   block_autocmds();

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1636,7 +1636,7 @@ describe('builtin popupmenu', function()
           ]],
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 9999 },
             },
             win_viewport = {
               [2] = {
@@ -1693,7 +1693,7 @@ describe('builtin popupmenu', function()
           ]],
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 15, false, 50 },
+              [4] = { 1001, 'NW', 1, 1, 15, false, 9999 },
             },
             win_viewport = {
               [2] = {
@@ -1752,7 +1752,7 @@ describe('builtin popupmenu', function()
           ]],
             float_pos = {
               [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [6] = { 1002, 'NW', 1, 1, 19, false, 50 },
+              [6] = { 1002, 'NW', 1, 1, 19, false, 9999 },
             },
             win_viewport = {
               [2] = {
@@ -1812,7 +1812,7 @@ describe('builtin popupmenu', function()
             {n:     }|
           ]],
             float_pos = {
-              [7] = { 1003, 'NW', 1, 1, 14, false, 50 },
+              [7] = { 1003, 'NW', 1, 1, 14, false, 9999 },
               [5] = { -1, 'NW', 2, 1, 19, false, 100 },
             },
             win_viewport = {


### PR DESCRIPTION
Problem: when use completion in a float window the info window will be shown under float window.

Solution: give info preview window zindex a max value.