### PR TITLE
refactor(input): don't use a ring for input

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -313,7 +313,7 @@ void nvim_feedkeys(String keys, String mode, Boolean escape_ks)
     keys_esc = keys.data;
   }
   if (lowlevel) {
-    input_enqueue_raw(cstr_as_string(keys_esc));
+    input_enqueue_raw(keys_esc, strlen(keys_esc));
   } else {
     ins_typebuf(keys_esc, (remap ? REMAP_YES : REMAP_NONE),
                 insert ? 0 : typebuf.tb_len, !typed, false);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -154,7 +154,6 @@ void event_init(void)
   loop_init(&main_loop, NULL);
   resize_events = multiqueue_new_child(main_loop.events);
 
-  input_init();
   signal_init();
   // mspgack-rpc initialization
   channel_init();

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -882,7 +882,6 @@ void free_all_mem(void)
 
   decor_free_all_mem();
   drawline_free_all_mem();
-  input_free_all_mem();
 
   if (ui_client_channel_id) {
     ui_client_free_all_mem();


### PR DESCRIPTION
Since paste data is handled via a separate channel, the data processed via `input_buffer` is typically just small data in the form of explicit keys as typed in by the user. Therefore it should be fine to use `memmove()` to always put the remaining data in front when refilling the buffer.

This will remove the last usage of RBuffer which is outside of RStream, in preparation for the next PR which will remove RBuffer as a separate abstraction (spoiler alert: not even RStream was using the buffer as a ring buffer).