### PR TITLE
fix(diagnostic): fix float scope filtering

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1857,16 +1857,19 @@ function M.open_float(opts, ...)
   if scope == 'line' then
     --- @param d vim.Diagnostic
     diagnostics = vim.tbl_filter(function(d)
-      return lnum >= d.lnum and lnum <= d.end_lnum
+      return lnum >= d.lnum
+        and lnum <= d.end_lnum
+        and (d.lnum == d.end_lnum or lnum ~= d.end_lnum or d.end_col ~= 0)
     end, diagnostics)
   elseif scope == 'cursor' then
-    -- LSP servers can send diagnostics with `end_col` past the length of the line
+    -- If `col` is past the end of the line, show if the cursor is on the last char in the line
     local line_length = #api.nvim_buf_get_lines(bufnr, lnum, lnum + 1, true)[1]
     --- @param d vim.Diagnostic
     diagnostics = vim.tbl_filter(function(d)
-      return d.lnum == lnum
-        and math.min(d.col, line_length - 1) <= col
-        and (d.end_col >= col or d.end_lnum > lnum)
+      return lnum >= d.lnum
+        and lnum <= d.end_lnum
+        and (lnum ~= d.lnum or col >= math.min(d.col, line_length - 1))
+        and ((d.lnum == d.end_lnum and d.col == d.end_col) or lnum ~= d.end_lnum or col < d.end_col)
     end, diagnostics)
   end
 


### PR DESCRIPTION
This fixes two bugs with the diagnostic float popup.

The first is simple, the fix in #28301 only changed the behaviour of the default `scope = "line"`, if `scope = "cursor"` then hovering on multi-line diagnostics doesn't work.

The second is that the filtering treats the end of the range as being inclusive, when it should be exclusive (well this is what is used everywhere else, it doesn't seem to be strictly specified in the docs...).
This is easy to see when using `scope = "cursor"` - just open the popup with the cursor on the character directly after the end of the underline.
When `scope = "line"`, the easiest way to see it is to add a multi-line diagnostic that has `end_col = 0`:
```
:lua vim.diagnostic.set(vim.api.nvim_create_namespace("test"), 0, { { lnum = 1, col = 0, end_lnum = 2, end_col = 0, message = "test" } })
```
then open the popup with the cursor on the line below the underline.


A corner case that I came across was how to deal with zero-width diagnostics, where `lnum == end_lnum` and `col == end_col`. Currently, underlining treats these as having width 1, so I've made both `scope = "cursor"` and `scope = "line"` do the same. However this behaviour seems to have been deemed a bug due to #28986, and #29022 will remove underlines for zero-width diagnostics again. 

So might it be better to treat zero-width diagnostics as spanning the whole line? Meaning that opening the popup will work from anywhere in the line even when `scope = "cursor"` ? The reasoning being that since there's no underline, a user wouldn't know where to put the cursor for the popup to work, so it should just work anywhere.