### PR TITLE
vim-patch:8.2.{0083,0109}

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4421,17 +4421,20 @@ static bool ins_tab(void)
       // Delete following spaces.
       int i = cursor->col - fpos.col;
       if (i > 0) {
-        STRMOVE(ptr, ptr + i);
+        if (!(State & VREPLACE_FLAG)) {
+          memmove(ptr, ptr + i, (size_t)(curbuf->b_ml.ml_line_len - i
+                                         - (ptr - curbuf->b_ml.ml_line_ptr)));
+          curbuf->b_ml.ml_line_len -= i;
+          inserted_bytes(fpos.lnum, change_col,
+                         cursor->col - change_col, fpos.col - change_col);
+        } else {
+          STRMOVE(ptr, ptr + i);
+        }
         // correct replace stack.
         if ((State & REPLACE_FLAG) && !(State & VREPLACE_FLAG)) {
           for (temp = i; --temp >= 0;) {
             replace_join(repl_off);
           }
-        }
-        if (!(State & VREPLACE_FLAG)) {
-          curbuf->b_ml.ml_line_len -= i;
-          inserted_bytes(fpos.lnum, change_col,
-                         cursor->col - change_col, fpos.col - change_col);
         }
       }
       cursor->col -= i;

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -379,6 +379,25 @@ describe('lua buffer event callbacks: on_lines', function()
       ]],
     })
   end)
+
+  it('line lengths are correct when pressing TAB with folding #29119', function()
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'a', 'b' })
+
+    exec_lua([[
+      _G.res = {}
+      vim.o.foldmethod = 'indent'
+      vim.o.softtabstop = -1
+      vim.api.nvim_buf_attach(0, false, {
+        on_lines = function(_, bufnr, _, row, _, end_row)
+          local lines = vim.api.nvim_buf_get_lines(bufnr, row, end_row, true)
+          table.insert(_G.res, lines)
+        end
+      })
+    ]])
+
+    feed('i<Tab>')
+    eq({ '\ta' }, exec_lua('return _G.res[#_G.res]'))
+  end)
 end)
 
 describe('lua: nvim_buf_attach on_bytes', function()


### PR DESCRIPTION
Fix #29119

#### vim-patch:8.2.0083: text properties wrong when tabs and spaces are exchanged

Problem:    Text properties wrong when tabs and spaces are exchanged.
Solution:   Take text properties into account. (Nobuhiro Takasaki,
            closes vim/vim#5427)

https://github.com/vim/vim/commit/5cb0b93d52fa5c12ca50a18509947ee6459bb7a8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0109: corrupted text properties when expanding spaces

Problem:    Corrupted text properties when expanding spaces.
Solution:   Reallocate the line. (Nobuhiro Takasaki, closes vim/vim#5457)

https://github.com/vim/vim/commit/ac15fd8c6761763c8feedef1a2fbd8309f0a823c

Co-authored-by: Bram Moolenaar <Bram@vim.org>