### PR TITLE
vim-patch:9.1.0458: Coverity complains about division by zero

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -282,8 +282,10 @@ void op_shift(oparg_T *oap, bool curs_top, int amount)
 /// @param call_changed_bytes  call changed_bytes()
 void shift_line(bool left, bool round, int amount, int call_changed_bytes)
 {
-  const int sw_val = get_sw_value_indent(curbuf, left);
-
+  int sw_val = get_sw_value_indent(curbuf, left);
+  if (sw_val == 0) {
+    sw_val = 1;              // shouldn't happen, just in case
+  }
   int count = get_indent();  // get current indent
 
   if (round) {  // round off indent


### PR DESCRIPTION
#### vim-patch:9.1.0458: Coverity complains about division by zero

Problem:  Coverity complains about division by zero
Solution: Check explicitly for sw_val being zero

Shouldn't happen, since tabstop value should always be larger than zero.
So just add this as a safety measure.

https://github.com/vim/vim/commit/7737ce519b9cba8ef135154d76b69f715b1a0b4d

Co-authored-by: Christian Brabandt <cb@256bit.org>