### PR TITLE
vim-patch:partial:9.1.0461: too many strlen() calls in drawline.c

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1422,7 +1422,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
       line = ml_get_buf(wp->w_buffer, lnum);
       ptr = line + linecol;
 
-      if (len == 0 || (int)wp->w_cursor.col > ptr - line) {
+      if (len == 0 || wp->w_cursor.col > linecol) {
         // no bad word found at line start, don't check until end of a
         // word
         spell_hlf = HLF_COUNT;


### PR DESCRIPTION
#### vim-patch:partial:9.1.0461: too many strlen() calls in drawline.c

Problem:  too many strlen() calls in drawline.c
Solution: Refactor code to avoid strlen()
          (John Marriott)

closes: vim/vim#14890

https://github.com/vim/vim/commit/f51ff96532ab8f97f779b44d17dccdda9d8ce566

Co-authored-by: John Marriott <basilisk@internode.on.net>