### PR TITLE
docs: remove `-complete=behave`

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1381,7 +1381,6 @@ completion can be enabled:
 	-complete=arglist	file names in argument list
 	-complete=augroup	autocmd groups
 	-complete=buffer	buffer names
-	-complete=behave	:behave suboptions
 	-complete=color		color schemes
 	-complete=command	Ex command (and arguments)
 	-complete=compiler	compilers


### PR DESCRIPTION
`:behave` has been removed, and using `-complete=behave` throws an error. Might be a good idea to remove this.