### PR TITLE
fix(tui): make 'nottimeout' work consistently

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -454,7 +454,7 @@ static void tk_getkeys(TermInput *input, bool force)
     uv_timer_stop(&input->timer_handle);
     uv_timer_start(&input->timer_handle, tinput_timer_cb, (uint64_t)input->ttimeoutlen, 0);
   } else {
-    tk_getkeys(input, true);
+    tk_getkeys(input, false);
   }
 }
 


### PR DESCRIPTION
Problem:  'nottimeout' causes escape sequences to time out immediately
          instead having no timeout.
Solution: Don't use termkey_getkeys_force().

Fix #29047

I tried to write a test for this, but it crashes inside libtermkey.
