### PR TITLE
fix(tui)!: correct behavior of 'nottimeout'

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -115,6 +115,8 @@ LUA
 OPTIONS
 
 • 'shelltemp' defaults to "false".
+• 'nottimeout' now consistently makes Nvim wait indefinitely for a complete
+  sequence instead of sometimes behaving as if 'ttimeoutlen' is 0.
 
 PLUGINS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6940,7 +6940,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
 
 	On very slow systems this may fail, causing cursor keys not to work
-	sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
+	sometimes.  If you discover this problem you can ":set nottimeout".
 	Nvim will wait for the next character to arrive after an <Esc>.
 
 						*'ttimeoutlen'* *'ttm'*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7530,7 +7530,7 @@ vim.go.titlestring = vim.o.titlestring
 --- a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
 ---
 --- On very slow systems this may fail, causing cursor keys not to work
---- sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
+--- sometimes.  If you discover this problem you can ":set nottimeout".
 --- Nvim will wait for the next character to arrive after an <Esc>.
 ---
 --- @type boolean

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9740,7 +9740,7 @@ local options = {
         a single <Esc> is assumed. Many TUI cursor key codes start with <Esc>.
 
         On very slow systems this may fail, causing cursor keys not to work
-        sometimes.  If you discover this problem you can ":set ttimeoutlen=9999".
+        sometimes.  If you discover this problem you can ":set nottimeout".
         Nvim will wait for the next character to arrive after an <Esc>.
       ]=],
       full_name = 'ttimeout',


### PR DESCRIPTION
Problem:  'nottimeout' causes escape sequences to time out immediately
          instead having no timeout.
Solution: Don't use termkey_getkeys_force().

Fix #29047
