### PR TITLE
docs(luv): Clarify types in luv docs and remove duplicate section

### DIFF
--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -2743,7 +2743,7 @@ uv.fs_open({path}, {flags}, {mode} [, {callback}])                *uv.fs_open()*
                 Parameters:
                 - `path`: `string`
                 - `flags`: `string` or `integer`
-                - `mode`: `integer`
+                - `mode`: `integer` (octal representation of `chmod(1)` mode)
                 - `callback`: `callable` (async version) or `nil` (sync
                   version)
                   - `err`: `nil` or `string`
@@ -2829,7 +2829,7 @@ uv.fs_mkdir({path}, {mode} [, {callback}])                       *uv.fs_mkdir()*
 
                 Parameters:
                 - `path`: `string`
-                - `mode`: `integer`
+                - `mode`: `integer` (octal representation of `chmod(1)` mode)
                 - `callback`: `callable` (async version) or `nil` (sync
                   version)
                   - `err`: `nil` or `string`
@@ -3078,7 +3078,8 @@ uv.fs_access({path}, {mode} [, {callback}])                     *uv.fs_access()*
 
                 Parameters:
                 - `path`: `string`
-                - `mode`: `integer`
+                - `mode`: `string` (a combination of the `'r'`, `'w'` and `'x'`
+		  characters denoting the symbolic mode as per `chmod(1)`)
                 - `callback`: `callable` (async version) or `nil` (sync
                   version)
                   - `err`: `nil` or `string`
@@ -3097,29 +3098,13 @@ uv.fs_chmod({path}, {mode} [, {callback}])                       *uv.fs_chmod()*
 
                 Parameters:
                 - `path`: `string`
-                - `mode`: `integer`
+                - `mode`: `integer` (octal representation of `chmod(1)` mode)
                 - `callback`: `callable` (async version) or `nil` (sync
                   version)
                   - `err`: `nil` or `string`
                   - `success`: `boolean` or `nil`
 
                 Equivalent to `chmod(2)`.
-
-                Returns (sync version): `boolean` or `fail`
-
-                Returns (async version): `uv_fs_t userdata`
-
-uv.fs_fchmod({fd}, {mode} [, {callback}])                       *uv.fs_fchmod()*
-
-                Parameters:
-                - `fd`: `integer`
-                - `mode`: `integer`
-                - `callback`: `callable` (async version) or `nil` (sync
-                  version)
-                  - `err`: `nil` or `string`
-                  - `success`: `boolean` or `nil`
-
-                Equivalent to `fchmod(2)`.
 
                 Returns (sync version): `boolean` or `fail`
 


### PR DESCRIPTION
Some libuv filesystem functions expect the numeric `mode` argument to be an octal representation of the equivalent `chmod(1)` mode. This is potentially surprising behaviour to anyone who hasn't used either `libuv` or `glibc` from C. The documentation for e.g. `fs_mkdir` in libuv defers to `mkdir(2)` which defers to `mode_t(3)` which only says "It is an integer type". Furthermore, `fs_access` uses a different `mode` type, validated using
[luv_check_amode](https://github.com/luvit/luv/blob/7233e6dea92498a244feb51b790c1ba51e8abbff/src/fs.c#L184), which can accept strings ("symbolic mode" in `chmod(1)`). I chose not to mention that this one still technically accepts an integer because I have no idea about the restrictions of said integer.