### PR TITLE
docs(luv): remove duplicate `fs_chmod` section

### DIFF
--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -3109,22 +3109,6 @@ uv.fs_chmod({path}, {mode} [, {callback}])                       *uv.fs_chmod()*
 
                 Returns (async version): `uv_fs_t userdata`
 
-uv.fs_fchmod({fd}, {mode} [, {callback}])                       *uv.fs_fchmod()*
-
-                Parameters:
-                - `fd`: `integer`
-                - `mode`: `integer`
-                - `callback`: `callable` (async version) or `nil` (sync
-                  version)
-                  - `err`: `nil` or `string`
-                  - `success`: `boolean` or `nil`
-
-                Equivalent to `fchmod(2)`.
-
-                Returns (sync version): `boolean` or `fail`
-
-                Returns (async version): `uv_fs_t userdata`
-
 uv.fs_utime({path}, {atime}, {mtime} [, {callback}])             *uv.fs_utime()*
 
                 Parameters:


### PR DESCRIPTION
~~It is already documented on L3096.~~

Nope, they are `chmod` and `fchmod`, I need more sleep.