### PR TITLE
feat(lsp): include end_col and end_lnum in vim.lsp.buf.locations_to_items

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1983,7 +1983,9 @@ locations_to_items({locations}, {offset_encoding})
         (`table[]`) A list of objects with the following fields:
         • {filename} (`string`)
         • {lnum} (`integer`) 1-indexed line number
+        • {end_lnum} (`integer`) 1-indexed end line number
         • {col} (`integer`) 1-indexed column
+        • {end_col} (`integer`) 1-indexed end column
         • {text} (`string`)
         • {user_data} (`lsp.Location|lsp.LocationLink`)
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -113,6 +113,7 @@ LSP
 
 • Completion side effects (including snippet expansion, execution of commands
   and application of additional text edits) is now built-in.
+• |vim.lsp.util.locations_to_items()| sets `end_col` and `end_lnum` fields.
 
 LUA
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2681,13 +2681,15 @@ describe('LSP', function()
         {
           filename = '/fake/uri',
           lnum = 1,
+          end_lnum = 2,
           col = 3,
+          end_col = 4,
           text = 'testing',
           user_data = {
             uri = 'file:///fake/uri',
             range = {
               start = { line = 0, character = 2 },
-              ['end'] = { line = 0, character = 3 },
+              ['end'] = { line = 1, character = 3 },
             },
           },
         },
@@ -2701,7 +2703,7 @@ describe('LSP', function()
             uri = 'file:///fake/uri',
             range = {
               start = { line = 0, character = 2 },
-              ['end'] = { line = 0, character = 3 },
+              ['end'] = { line = 1, character = 3 },
             }
           },
         }
@@ -2714,7 +2716,9 @@ describe('LSP', function()
         {
           filename = '/fake/uri',
           lnum = 1,
+          end_lnum = 1,
           col = 3,
+          end_col = 4,
           text = 'testing',
           user_data = {
             targetUri = 'file:///fake/uri',


### PR DESCRIPTION
Noticed this by accident when after the Trouble v3 update, `:Trouble quickfix` would not display the correct range of items in the preview.

Might be worth a 0.10.0 backport? I assume many people upgraded to Trouble v3 and see this (currently only the first character of each item is highlighted in the preview, which looks a bit weird)