### PR TITLE
refactor(gx): modify isfname with lua method

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -181,7 +181,7 @@ function M._get_url()
   end
 
   local old_isfname = vim.o.isfname
-  vim.cmd [[set isfname+=@-@]]
+  vim.opt.isfname:append('@')
   local url = vim.fn.expand('<cfile>')
   vim.o.isfname = old_isfname
 


### PR DESCRIPTION
a9c89bcbf uses `vim.cmd [[set isfname+=@-@]]`, but `vim.opt.isfname:append('@')` fits the Neovim way.