### PR TITLE
fix(man): remove OSC 8 hyperlink markup from output

### DIFF
--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -117,6 +117,29 @@ describe(':Man', function()
       ]])
     end)
 
+    it('clears OSC 8 hyperlink markup from text', function()
+      feed(
+        [[
+        ithis <C-v><ESC>]8;;http://example.com<C-v><ESC>\Link Title<C-v><ESC>]8;;<C-v><ESC>\<ESC>]]
+      )
+
+      screen:expect {
+        grid = [=[
+        this {c:^[}]8;;http://example.com{c:^[}\Link Title{c:^[}]8;;{c:^[}^\ |
+        {eob:~                                                   }|*3
+                                                            |
+      ]=],
+      }
+
+      exec_lua [[require'man'.init_pager()]]
+
+      screen:expect([[
+      ^this Link Title                                     |
+      {eob:~                                                   }|*3
+                                                          |
+      ]])
+    end)
+
     it('highlights multibyte text', function()
       feed(
         [[


### PR DESCRIPTION
Before/After comparison of `MANPAGER='nvim +Man!' man cmake`:
![Before/After](https://github.com/neovim/neovim/assets/37733333/87a450dc-10bb-45fe-88c1-3263ed33ac13)

Test files:
* [Pre-formatted man page with raw escape codes](https://github.com/user-attachments/files/15538976/cmake.1.txt)
* [Roff source code for cmake(1)](https://github.com/user-attachments/files/15538987/cmake.1.man.txt)

