### PR TITLE
vim-patch:partial:8.2.3637: typos in test files

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -131,7 +131,7 @@ if has('win32')
 endif
 
 if has('mac')
-  " In MacOS, when starting a shell in a terminal, a bash deprecation warning
+  " In macOS, when starting a shell in a terminal, a bash deprecation warning
   " message is displayed. This breaks the terminal test. Disable the warning
   " message.
   let $BASH_SILENCE_DEPRECATION_WARNING = 1

--- a/test/old/testdir/test_debugger.vim
+++ b/test/old/testdir/test_debugger.vim
@@ -524,7 +524,7 @@ func Test_Backtrace_Through_Source()
 
   call RunDbgCmd( buf, 'down', [ 'frame is zero' ] )
 
-  " step until we have another meaninfgul trace
+  " step until we have another meaningful trace
   call RunDbgCmd(buf, 'step', ['line 5: func File2Function()'])
   call RunDbgCmd(buf, 'step', ['line 9: call File2Function()'])
   call RunDbgCmd(buf, 'backtrace', [
@@ -611,7 +611,7 @@ func Test_Backtrace_Autocmd()
                 \ ['cmd: doautocmd User TestGlobalFunction'])
   call RunDbgCmd(buf, 'step', ['cmd: call GlobalFunction() | echo "Done"'])
 
-  " At this point the ontly thing in the stack is the autocommand
+  " At this point the only thing in the stack is the autocommand
   call RunDbgCmd(buf, 'backtrace', [
         \ '>backtrace',
         \ '->0 User Autocommands for "TestGlobalFunction"',
@@ -741,7 +741,7 @@ func Test_Backtrace_Autocmd()
 
   call RunDbgCmd( buf, 'down', [ 'frame is zero' ] )
 
-  " step until we have another meaninfgul trace
+  " step until we have another meaningful trace
   call RunDbgCmd(buf, 'step', ['line 5: func File2Function()'])
   call RunDbgCmd(buf, 'step', ['line 9: call File2Function()'])
   call RunDbgCmd(buf, 'backtrace', [
@@ -867,7 +867,7 @@ func Test_Backtrace_CmdLine()
   call CheckDbgOutput(buf, ['command line',
                             \ 'cmd: call GlobalFunction()'], #{msec: 5000})
 
-  " At this point the ontly thing in the stack is the cmdline
+  " At this point the only thing in the stack is the cmdline
   call RunDbgCmd(buf, 'backtrace', [
         \ '>backtrace',
         \ '->0 command line',
@@ -1285,7 +1285,7 @@ func Test_debug_backtrace_level()
         \ #{ match: 'pattern' } )
 
   " Expression evaluation in the script frame (not the function frame)
-  " FIXME: Unexpected in this scope (a: should not be visibnle)
+  " FIXME: Unexpected in this scope (a: should not be visible)
   call RunDbgCmd(buf, 'echo a:arg', [ 'arg1' ] )
   call RunDbgCmd(buf, 'echo s:file1_var', [ 'file1' ] )
   call RunDbgCmd(buf, 'echo g:global_var', [ 'global' ] )

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -276,7 +276,7 @@ func Test_diffget_diffput_empty_buffer()
 endfunc
 
 " :diffput and :diffget completes names of buffers which
-" are in diff mode and which are different then current buffer.
+" are in diff mode and which are different than current buffer.
 " No completion when the current window is not in diff mode.
 func Test_diffget_diffput_completion()
   e            Xdiff1 | diffthis
@@ -679,7 +679,7 @@ func Test_diffexpr()
   call assert_notequal(normattr, screenattr(3, 1))
   diffoff!
 
-  " Try using an non-existing function for 'diffexpr'.
+  " Try using a non-existing function for 'diffexpr'.
   set diffexpr=NewDiffFunc()
   call assert_fails('windo diffthis', ['E117:', 'E97:'])
   diffoff!

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -665,7 +665,7 @@ func Sandbox_tests()
   if has('clientserver')
     call assert_fails('let s=remote_expr("gvim", "2+2")', 'E48:')
     if !has('win32')
-      " remote_foreground() doesn't thrown an error message on MS-Windows
+      " remote_foreground() doesn't throw an error message on MS-Windows
       call assert_fails('call remote_foreground("gvim")', 'E48:')
     endif
     call assert_fails('let s=remote_peek("gvim")', 'E48:')

--- a/test/old/testdir/test_flatten.vim
+++ b/test/old/testdir/test_flatten.vim
@@ -53,7 +53,7 @@ func Test_flatten()
   call test_garbagecollect_now()
   call assert_equal([1, 2, 3], l:list)
 
-  " Tests for checking circular reference list can be flatten.
+  " Tests for checking circular reference list can be flattened.
   let l:x = [1]
   let l:y = [x]
   let l:z = flatten(l:y)

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -1522,7 +1522,7 @@ func Test_normal18_z_fold()
   norm! j
   call assert_equal('52', getline('.'))
 
-  " zA on a opened fold when foldenable is not set
+  " zA on an opened fold when foldenable is not set
   50
   set nofoldenable
   norm! zA
@@ -1878,7 +1878,7 @@ func Test_normal23_K()
 
   let not_gnu_man = has('mac') || has('bsd')
   if not_gnu_man
-    " In MacOS and BSD, the option for specifying a pager is different
+    " In macOS and BSD, the option for specifying a pager is different
     set keywordprg=man\ -P\ cat
   else
     set keywordprg=man\ --pager=cat
@@ -2727,7 +2727,7 @@ func Test_normal33_g_cmd2()
   call assert_equal('foo       first line', getline(1))
   set virtualedit&
 
-  " Test for aboring a g command using CTRL-\ CTRL-G
+  " Test for aborting a g command using CTRL-\ CTRL-G
   exe "normal! g\<C-\>\<C-G>"
   call assert_equal('foo       first line', getline('.'))
 

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1732,7 +1732,7 @@ func Test_cmdheight()
   set cmdheight&
 endfunc
 
-" To specify a control character as a option value, '^' can be used
+" To specify a control character as an option value, '^' can be used
 func Test_opt_control_char()
   set wildchar=^v
   call assert_equal("\<C-V>", nr2char(&wildchar))

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -4353,11 +4353,9 @@ endfunc
 " Test for shortening/simplifying the file name when opening the
 " quickfix window or when displaying the quickfix list
 func Test_shorten_fname()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   %bwipe
-  " Create a quickfix list with a absolute path filename
+  " Create a quickfix list with an absolute path filename
   let fname = getcwd() . '/test_quickfix.vim'
   call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
   call assert_equal(fname, bufname('test_quickfix.vim'))
@@ -4366,7 +4364,7 @@ func Test_shorten_fname()
   call assert_equal('test_quickfix.vim', bufname('test_quickfix.vim'))
   cclose
   %bwipe
-  " Create a quickfix list with a absolute path filename
+  " Create a quickfix list with an absolute path filename
   call setqflist([], ' ', {'lines':[fname . ":20:Line20"], 'efm':'%f:%l:%m'})
   call assert_equal(fname, bufname('test_quickfix.vim'))
   " Displaying the quickfix list should simplify the file path

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -656,7 +656,7 @@ func Test_aff_file_format_error()
   let output = execute('mkspell! Xtest.spl Xtest')
   call assert_match('Different combining flag in continued affix block in Xtest.aff line 3', output)
 
-  " Try to reuse a affix used for BAD flag
+  " Try to reuse an affix used for BAD flag
   call writefile(['BAD x', 'PFX x Y 1', 'PFX x 0 re x'], 'Xtest.aff')
   let output = execute('mkspell! Xtest.spl Xtest')
   call assert_match('Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in Xtest.aff line 2: x', output)

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -549,8 +549,7 @@ endfunc
 func Test_bg_detection()
   CheckNotGui
 
-  " auto-detection of &bg, make sure sure it isn't set anywhere before
-  " this test
+  " auto-detection of &bg, make sure it isn't set anywhere before this test
   hi Normal ctermbg=0
   call assert_equal('dark', &bg)
   hi Normal ctermbg=4

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -232,7 +232,7 @@ func Test_empty_html_tag()
   normal 0f<vitsaaa
   call assert_equal('aaa', getline(1))
 
-  " selecting a tag block in an non-empty blank line should fail
+  " selecting a tag block in a non-empty blank line should fail
   call setline(1, '    ')
   call assert_beeps('normal $vaty')
 

--- a/test/old/testdir/test_trycatch.vim
+++ b/test/old/testdir/test_trycatch.vim
@@ -50,7 +50,7 @@ func T25_F()
   Xpath 'i'
 endfunc
 
-" Also try using "fina" and "final" and "finall" as abbraviations.
+" Also try using "fina" and "final" and "finall" as abbreviations.
 func T25_G()
   if 1
     try


### PR DESCRIPTION
#### vim-patch:partial:8.2.3637: typos in test files

Problem:    Typos in test files.
Solution:   Correct the typos. (Dominique Pellé, closes vim/vim#9175)

https://github.com/vim/vim/commit/923dce2b07ff185c0ef661f3eca47bc17655f01b

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>