### PR TITLE
fix(lsp): remove superfluous on_detach callback from semantic tokens module

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -197,12 +197,6 @@ function STHighlighter.new(bufnr)
         highlighter:send_request()
       end
     end,
-    on_detach = function(_, buf)
-      local highlighter = STHighlighter.active[buf]
-      if highlighter then
-        highlighter:destroy()
-      end
-    end,
   })
 
   api.nvim_create_autocmd({ 'BufWinEnter', 'InsertLeave' }, {


### PR DESCRIPTION
LspDetach is now triggered by the main on_detach callback that is added when an LSP client is attached to a buffer. The semantic_tokens module already includes a LspDetach handler that does the right thing. When the LspDetach trigger was added to the main LSP on_detach, it created a race condition in semantic tokens when a buffer was deleted that would trigger both its own on_detach and the LspDetach handlers. If the former came last, an error was thrown trying to delete a non-existent augroup (destroy() was being called twice).