### PR TITLE
fix(filetype): fix typos in filetype detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -594,7 +594,7 @@ function M.frm(_, bufnr)
 end
 
 --- @type vim.filetype.mapfn
-function M.fvwm_1(_, _)
+function M.fvwm_v1(_, _)
   return 'fvwm', function(bufnr)
     vim.b[bufnr].fvwm_version = 1
   end
@@ -1355,7 +1355,7 @@ end
 function M.sgml(_, bufnr)
   local lines = table.concat(getlines(bufnr, 1, 5))
   if lines:find('linuxdoc') then
-    return 'smgllnx'
+    return 'sgmllnx'
   elseif lines:find('<!DOCTYPE.*DocBook') then
     return 'docbk',
       function(b)


### PR DESCRIPTION
- Function [used in 'runtime/lua/vim/filetype.lua'](https://github.com/neovim/neovim/blob/46b69aaf14a7da2c2ce800aa0eaec5eb019991b4/runtime/lua/vim/filetype.lua#L1830-L1831) is `fvwm_v1` and not `fvwm_1`.
- Correct filetype is ['sgmllnx'](https://github.com/neovim/neovim/blob/master/runtime/syntax/sgmllnx.vim).