### PR TITLE
fix(runtime): remove obsolete ftplugin/calender.lua

### DIFF
--- a/runtime/ftplugin/calender.lua
+++ b/runtime/ftplugin/calender.lua
@@ -1,1 +1,0 @@
-vim.bo.commentstring = '/* %s */'


### PR DESCRIPTION
fixup for #29178 (forgot to remove it -- and it had the wrong name anyway 🤦 )