### PR TITLE
fix(Tutor) show raw text when editing markdown element

### DIFF
--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -7,7 +7,7 @@ call tutor#SetupVim()
 setlocal noreadonly
 if !exists('g:tutor_debug') || g:tutor_debug == 0
     setlocal buftype=nofile
-    setlocal concealcursor+=inv
+    setlocal concealcursor&
     setlocal conceallevel=2
 else
     setlocal buftype=


### PR DESCRIPTION
Problem: In Tutor, the raw text of markdown elements is hidden while editing a line, including heading labels, link targets, and asterisks.

Solution: Alter the concealcursor setting so that text on the cursor line is never concealed while inside Tutor.

Fixes #28172