### PR TITLE
fix(lsp): check for nil response from server

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -407,7 +407,9 @@ function Client:handle_body(body)
   end
   log.debug('rpc.receive', decoded)
 
-  if type(decoded.method) == 'string' and decoded.id then
+  if type(decoded) ~= 'table' then
+    self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
+  elseif type(decoded.method) == 'string' and decoded.id then
     local err --- @type lsp.ResponseError|nil
     -- Schedule here so that the users functions don't trigger an error and
     -- we can still use the result.


### PR DESCRIPTION
This fixes #27395. OmniSharp (and possibly other LSP servers) can sometimes return a nil value, which rpc.lua chokes on with this error message:

```
Error executing luv callback:                                                                                                                                                                              
...nt_nvimGcA7m0/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:410: attempt to index local 'decoded' (a nil value)                                                                                                      
stack traceback:                                                                                                                                                                                                     
        ...nt_nvimGcA7m0/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:410: in function 'handle_body'                                                                                                                   
        ...nt_nvimGcA7m0/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:761: in function 'handle_body'                                                                                                                   
        ...nt_nvimGcA7m0/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:267: in function <...nt_nvimGcA7m0/usr/share/nvim/runtime/lua/vim/lsp/rpc.lua:251>
```

We should not crash, no matter what the LSP server throws at us. Note that #27148 would be even worse; silently ignoring the error. Rather, we should provide a proper error message stating the LSP server gave us something invalid, so that it is clear that the error is with the LSP server, rather than being a crash inside NeoVim runtime scripts. We are already doing a lot of validation in rpc.lua, it's just that nil was being overlooked here.

By adding a check first that `decoded` isn't nil, we end up falling back to the else case:

```
self:on_error(M.client_errors.INVALID_SERVER_MESSAGE, decoded)
```

which is going to correctly inform the user that the LSP server is broken, not NeoVim.