### PR TITLE
feat: command parsing recognizes visual range

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1902,6 +1902,8 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
           if command doesn't accept a range. Otherwise, has no elements if no
           range was specified, one element if only a single range item was
           specified, or two elements if both range items were specified.
+        • visualrange: (boolean) (optional) Whether the range is the visual
+          selection ("'<,'>").
         • count: (number) (optional) Command <count>. Omitted if command
           cannot take a count.
         • reg: (string) (optional) Command <register>. Omitted if command

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -25,6 +25,7 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.cmd
 --- @field cmd? string
 --- @field range? any[]
+--- @field visualrange? boolean
 --- @field count? integer
 --- @field reg? string
 --- @field bang? boolean

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -53,6 +53,7 @@
 ///                          Otherwise, has no elements if no range was specified, one element if
 ///                          only a single range item was specified, or two elements if both range
 ///                          items were specified.
+///         - visualrange: (boolean) (optional) Whether the range is the visual selection ("'<,'>").
 ///         - count: (number) (optional) Command [<count>].
 ///                           Omitted if command cannot take a count.
 ///         - reg: (string) (optional) Command [<register>].
@@ -162,6 +163,9 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
       ADD_C(range, INTEGER_OBJ(ea.line2));
     }
     PUT_KEY(result, cmd, range, range);
+    if (STRNICMP(*ea.cmdlinep, "'<,'>", 5) == 0) {
+      PUT_KEY(result, cmd, visualrange, true);
+    }
   }
 
   if (ea.argt & EX_COUNT) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -271,6 +271,7 @@ typedef struct {
   OptionalKeys is_set__cmd_;
   String cmd;
   Array range;
+  Boolean visualrange;
   Integer count;
   String reg;
   Boolean bang;

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2221,6 +2221,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   lua_pushinteger(lstate, eap->addr_count);
   lua_setfield(lstate, -2, "range");
 
+  lua_pushboolean(lstate, STRNICMP(*eap->cmdlinep, "'<,'>", 5) == 0);
+  lua_setfield(lstate, -2, "visualrange");
+
   if (eap->addr_count > 0) {
     lua_pushinteger(lstate, eap->line2);
   } else {

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -249,6 +249,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -289,6 +290,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -329,6 +331,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -369,6 +372,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 1,
+        visualrange = false,
         count = 10,
         reg = '',
       },
@@ -409,6 +413,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 1,
+        visualrange = false,
         count = 42,
         reg = '',
       },
@@ -449,6 +454,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -501,6 +507,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -508,6 +515,98 @@ describe('nvim_create_user_command', function()
       vim.api.nvim_command('CommandWithOneOrNoArg hello I\'m one argument')
       return result
     ]]
+    )
+
+    -- visualrange is `true` when range is '<,'>
+    exec_lua [[
+      result = {}
+      vim.api.nvim_create_user_command('CommandWithRange', function(opts)
+        result = opts
+      end, {
+        range = true,
+      })
+    ]]
+    eq(
+      {
+        name = 'CommandWithRange',
+        args = '',
+        fargs = {},
+        bang = false,
+        line1 = 1,
+        line2 = 1,
+        mods = '',
+        smods = {
+          browse = false,
+          confirm = false,
+          emsg_silent = false,
+          hide = false,
+          horizontal = false,
+          keepalt = false,
+          keepjumps = false,
+          keepmarks = false,
+          keeppatterns = false,
+          lockmarks = false,
+          noautocmd = false,
+          noswapfile = false,
+          sandbox = false,
+          silent = false,
+          split = '',
+          tab = -1,
+          unsilent = false,
+          verbose = -1,
+          vertical = false,
+        },
+        range = 2,
+        visualrange = true,
+        count = 1,
+        reg = '',
+      },
+      exec_lua [=[
+      vim.api.nvim_buf_set_mark(0, "<", 1, 0, {})
+      vim.api.nvim_buf_set_mark(0, ">", 1, 0, {})
+      vim.api.nvim_command("'<,'>CommandWithRange")
+      return result
+    ]=]
+    )
+    eq(
+      {
+        name = 'CommandWithRange',
+        args = '',
+        fargs = {},
+        bang = false,
+        line1 = 1,
+        line2 = 1,
+        mods = '',
+        smods = {
+          browse = false,
+          confirm = false,
+          emsg_silent = false,
+          hide = false,
+          horizontal = false,
+          keepalt = false,
+          keepjumps = false,
+          keepmarks = false,
+          keeppatterns = false,
+          lockmarks = false,
+          noautocmd = false,
+          noswapfile = false,
+          sandbox = false,
+          silent = false,
+          split = '',
+          tab = -1,
+          unsilent = false,
+          verbose = -1,
+          vertical = false,
+        },
+        range = 2,
+        visualrange = false,
+        count = 1,
+        reg = '',
+      },
+      exec_lua [=[
+      vim.api.nvim_command("1,1CommandWithRange")
+      return result
+    ]=]
     )
 
     -- f-args is an empty table if no args were passed
@@ -542,6 +641,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -594,6 +694,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '',
       },
@@ -634,6 +735,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        visualrange = false,
         count = 2,
         reg = '+',
       },

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -562,8 +562,8 @@ describe('nvim_create_user_command', function()
         reg = '',
       },
       exec_lua [=[
-      vim.api.nvim_buf_set_mark(0, "<", 1, 0, {})
-      vim.api.nvim_buf_set_mark(0, ">", 1, 0, {})
+      vim.api.nvim_buf_set_mark(0, '<', 1, 0, {})
+      vim.api.nvim_buf_set_mark(0, '>', 1, 0, {})
       vim.api.nvim_command("'<,'>CommandWithRange")
       return result
     ]=]

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3988,6 +3988,49 @@ describe('API', function()
         },
       }, api.nvim_parse_cmd('4,6s/math.random/math.max/', {}))
     end)
+    it('works with visual ranges', function()
+      api.nvim_buf_set_mark(0, "<", 1, 0, {})
+      api.nvim_buf_set_mark(0, ">", 1, 0, {})
+      eq({
+        cmd = 'substitute',
+        args = { '/math.random/math.max/' },
+        bang = false,
+        range = { 1, 1 },
+        visualrange = true,
+        addr = 'line',
+        magic = {
+          file = false,
+          bar = false,
+        },
+        nargs = '*',
+        nextcmd = '',
+        mods = {
+          browse = false,
+          confirm = false,
+          emsg_silent = false,
+          filter = {
+            pattern = '',
+            force = false,
+          },
+          hide = false,
+          horizontal = false,
+          keepalt = false,
+          keepjumps = false,
+          keepmarks = false,
+          keeppatterns = false,
+          lockmarks = false,
+          noautocmd = false,
+          noswapfile = false,
+          sandbox = false,
+          silent = false,
+          split = '',
+          tab = -1,
+          unsilent = false,
+          verbose = -1,
+          vertical = false,
+        },
+      }, api.nvim_parse_cmd("'<,'>s/math.random/math.max/", {}))
+    end)
     it('works with count', function()
       eq({
         cmd = 'buffer',

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3989,8 +3989,8 @@ describe('API', function()
       }, api.nvim_parse_cmd('4,6s/math.random/math.max/', {}))
     end)
     it('works with visual ranges', function()
-      api.nvim_buf_set_mark(0, "<", 1, 0, {})
-      api.nvim_buf_set_mark(0, ">", 1, 0, {})
+      api.nvim_buf_set_mark(0, '<', 1, 0, {})
+      api.nvim_buf_set_mark(0, '>', 1, 0, {})
       eq({
         cmd = 'substitute',
         args = { '/math.random/math.max/' },


### PR DESCRIPTION
Problem: it's not possible to determine if a command is run over a visual range, rather than an ordinary range (line1, line2). Knowing we're handling a visual range is important, so that we can read the marks to know also the columns at which the range starts and ends.

Solution: introduce a `visualrange` boolean in the output of nvim_parse_cmd, and also pass it to lua callbacks for user commands, in the arguments table.