### PR TITLE
docs: add missing quickref for termguicolors

### DIFF
--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -898,6 +898,7 @@ Short explanation of each option:		*option-list*
 'tagstack'	  'tgst'    push tags onto the tag stack
 'term'			    name of the terminal
 'termbidi'	  'tbidi'   terminal takes care of bi-directionality
+'termguicolors'	  'tgc'     enable 24-bit RGB color in the TUI
 'textwidth'	  'tw'	    maximum width of text that is being inserted
 'thesaurus'	  'tsr'     list of thesaurus files for keyword completion
 'thesaurusfunc'	  'tsrfu'   function to be used for thesaurus completion


### PR DESCRIPTION
Problem: `termguicolors` is missing in quickref.

Solution: Docs are added.