### PR TITLE
fix(lsp): fix reverse sorting of same position text edits

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -391,7 +391,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
       return a.range.start.character > b.range.start.character
     end
     if a._index ~= b._index then
-      return a._index > b._index
+      return a._index < b._index
     end
   end)
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1794,9 +1794,9 @@ describe('LSP', function()
       }
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
-        '',
-        '123',
-        'fooFbar',
+        '3',
+        'foo',
+        '12Fbar',
         '123irst guy',
         'baz line of text',
         'The next line of text',
@@ -1818,9 +1818,9 @@ describe('LSP', function()
       }
       exec_lua('vim.lsp.util.apply_text_edits(...)', edits, 1, 'utf-16')
       eq({
-        '',
-        '123',
-        'fooFbar',
+        '3',
+        'foo',
+        '12Fbar',
         '123irst guy',
         'baz line of text',
         'The next line of text',


### PR DESCRIPTION
### Problem
Text edits with the same position (both line and character) were being
reverse sorted prior to being applied which differs from the lsp spec

### Solution
Change the sort order for just the same position edits

Fixes #29202 