### PR TITLE
refactor: inline short functions

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -223,61 +223,6 @@ void *xmemdupz(const void *data, size_t len)
   return memcpy(xmallocz(len), data, len);
 }
 
-/// Copies `len` bytes of `src` to `dst` and zero terminates it.
-///
-/// @see {xstrlcpy}
-/// @param[out]  dst  Buffer to store the result.
-/// @param[in]  src  Buffer to be copied.
-/// @param[in]  len  Number of bytes to be copied.
-void *xmemcpyz(void *dst, const void *src, size_t len)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
-{
-  memcpy(dst, src, len);
-  ((char *)dst)[len] = NUL;
-  return dst;
-}
-
-#ifndef HAVE_STRNLEN
-size_t xstrnlen(const char *s, size_t n)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
-{
-  const char *end = memchr(s, NUL, n);
-  if (end == NULL) {
-    return n;
-  }
-  return (size_t)(end - s);
-}
-#endif
-
-/// A version of strchr() that returns a pointer to the terminating NUL if it
-/// doesn't find `c`.
-///
-/// @param str The string to search.
-/// @param c   The char to look for.
-/// @returns a pointer to the first instance of `c`, or to the NUL terminator
-///          if not found.
-char *xstrchrnul(const char *str, char c)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
-{
-  char *p = strchr(str, c);
-  return p ? p : (char *)(str + strlen(str));
-}
-
-/// A version of memchr() that returns a pointer one past the end
-/// if it doesn't find `c`.
-///
-/// @param addr The address of the memory object.
-/// @param c    The char to look for.
-/// @param size The size of the memory object.
-/// @returns a pointer to the first instance of `c`, or one past the end if not
-///          found.
-void *xmemscan(const void *addr, char c, size_t size)
-  FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE
-{
-  char *p = memchr(addr, c, size);
-  return p ? p : (char *)addr + size;
-}
-
 /// Replaces every instance of `c` with `x`.
 ///
 /// @warning Will read past `str + strlen(str)` if `c == NUL`.

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -5,6 +5,8 @@
 #include <time.h>  // IWYU pragma: keep
 
 #include "auto/config.h"
+#include "nvim/ascii_defs.h"
+#include "nvim/func_attr.h"
 #include "nvim/macros_defs.h"
 #include "nvim/memory_defs.h"  // IWYU pragma: keep
 
@@ -66,6 +68,15 @@ EXTERN size_t arena_alloc_count INIT( = 0);
 
 #ifndef HAVE_STRNLEN
 # define strnlen xstrnlen  // Older versions of SunOS may not have strnlen
+REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
+static inline size_t xstrnlen(const char *s, size_t n)
+{
+  const char *end = memchr(s, NUL, n);
+  if (end == NULL) {
+    return n;
+  }
+  return (size_t)(end - s);
+}
 #endif
 
 #define STRCPY(d, s)        strcpy((char *)(d), (char *)(s))  // NOLINT(runtime/printf)
@@ -74,3 +85,46 @@ EXTERN size_t arena_alloc_count INIT( = 0);
 #define STRMOVE(d, s)       memmove((d), (s), strlen(s) + 1)
 
 #define STRCAT(d, s)        strcat((char *)(d), (char *)(s))  // NOLINT(runtime/printf)
+
+/// Copies `len` bytes of `src` to `dst` and zero terminates it.
+///
+/// @see {xstrlcpy}
+/// @param[out]  dst  Buffer to store the result.
+/// @param[in]  src  Buffer to be copied.
+/// @param[in]  len  Number of bytes to be copied.
+REAL_FATTR_NONNULL_ALL REAL_FATTR_NONNULL_RET
+static inline void *xmemcpyz(void *dst, const void *src, size_t len)
+{
+  memcpy(dst, src, len);
+  ((char *)dst)[len] = NUL;
+  return dst;
+}
+
+/// A version of memchr() that returns a pointer one past the end
+/// if it doesn't find `c`.
+///
+/// @param addr The address of the memory object.
+/// @param c    The char to look for.
+/// @param size The size of the memory object.
+/// @returns a pointer to the first instance of `c`, or one past the end if not
+///          found.
+REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
+static inline void *xmemscan(const void *addr, char c, size_t size)
+{
+  char *p = memchr(addr, c, size);
+  return p ? p : (char *)addr + size;
+}
+
+/// A version of strchr() that returns a pointer to the terminating NUL if it
+/// doesn't find `c`.
+///
+/// @param str The string to search.
+/// @param c   The char to look for.
+/// @returns a pointer to the first instance of `c`, or to the NUL terminator
+///          if not found.
+REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
+static inline char *xstrchrnul(const char *str, char c)
+{
+  char *p = strchr(str, c);
+  return p ? p : (char *)(str + strlen(str));
+}

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -105,7 +105,7 @@ static inline void *xmemcpyz(void *dst, const void *src, size_t len)
 }
 
 static inline void *xmemscan(const void *addr, char c, size_t size)
-  REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
+REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
 
 /// A version of memchr() that returns a pointer one past the end
 /// if it doesn't find `c`.
@@ -122,7 +122,7 @@ static inline void *xmemscan(const void *addr, char c, size_t size)
 }
 
 static inline char *xstrchrnul(const char *str, char c)
-  REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
+REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
 
 /// A version of strchr() that returns a pointer to the terminating NUL if it
 /// doesn't find `c`.

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -68,7 +68,9 @@ EXTERN size_t arena_alloc_count INIT( = 0);
 
 #ifndef HAVE_STRNLEN
 # define strnlen xstrnlen  // Older versions of SunOS may not have strnlen
-REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
+static inline size_t xstrnlen(const char *s, size_t n)
+  REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
+
 static inline size_t xstrnlen(const char *s, size_t n)
 {
   const char *end = memchr(s, NUL, n);
@@ -86,19 +88,24 @@ static inline size_t xstrnlen(const char *s, size_t n)
 
 #define STRCAT(d, s)        strcat((char *)(d), (char *)(s))  // NOLINT(runtime/printf)
 
+static inline void *xmemcpyz(void *dst, const void *src, size_t len)
+  REAL_FATTR_NONNULL_ALL REAL_FATTR_NONNULL_RET;
+
 /// Copies `len` bytes of `src` to `dst` and zero terminates it.
 ///
 /// @see {xstrlcpy}
 /// @param[out]  dst  Buffer to store the result.
 /// @param[in]  src  Buffer to be copied.
 /// @param[in]  len  Number of bytes to be copied.
-REAL_FATTR_NONNULL_ALL REAL_FATTR_NONNULL_RET
 static inline void *xmemcpyz(void *dst, const void *src, size_t len)
 {
   memcpy(dst, src, len);
   ((char *)dst)[len] = NUL;
   return dst;
 }
+
+static inline void *xmemscan(const void *addr, char c, size_t size)
+  REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
 
 /// A version of memchr() that returns a pointer one past the end
 /// if it doesn't find `c`.
@@ -108,12 +115,14 @@ static inline void *xmemcpyz(void *dst, const void *src, size_t len)
 /// @param size The size of the memory object.
 /// @returns a pointer to the first instance of `c`, or one past the end if not
 ///          found.
-REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
 static inline void *xmemscan(const void *addr, char c, size_t size)
 {
   char *p = memchr(addr, c, size);
   return p ? p : (char *)addr + size;
 }
+
+static inline char *xstrchrnul(const char *str, char c)
+  REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE;
 
 /// A version of strchr() that returns a pointer to the terminating NUL if it
 /// doesn't find `c`.
@@ -122,7 +131,6 @@ static inline void *xmemscan(const void *addr, char c, size_t size)
 /// @param c   The char to look for.
 /// @returns a pointer to the first instance of `c`, or to the NUL terminator
 ///          if not found.
-REAL_FATTR_NONNULL_RET REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE
 static inline char *xstrchrnul(const char *str, char c)
 {
   char *p = strchr(str, c);


### PR DESCRIPTION
These are short wrapper functions that call other functions. For short strings, inlining them should make them faster because we're avoiding the overhead of calling the wrapper function, as if they were a macro.